### PR TITLE
Explicitly mention iam:GetUser permission in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ To use DynamoDB for locking, you must:
             "Sid": "GetSelfIamUser",
             "Effect": "Allow",
             "Action": "iam:GetUser",
-            "Resource": "arn:aws:iam::123456789012:user/${aws:username}"
+            "Resource": "*"
           }
       ]
     }


### PR DESCRIPTION
While setting up terragrunt in CircleCI, my build failed because the `iam:GetUser` permission was missing, but the docs didn't mention it. I believe this is the only doc file that needs updating, but please let me know if there are others.

'cc @brikis98 
