### PR TITLE
Add Terragrunt integration test for latest Terraform.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea
 vendor
-.terragrunt
+.terraform
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor
 .terragrunt
+.vscode

--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,8 @@ machine:
 dependencies:
   override:
     # Install the gruntwork-module-circleci-helpers and use it to configure the build environment and run tests.
-    - curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.9
-    - gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.0.10"
+    - curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.13
+    - gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --branch "place-terraform-in-path"
     - configure-environment-for-gruntwork-module --packer-version NONE --go-src-path .
 
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   override:
     # Install the gruntwork-module-circleci-helpers and use it to configure the build environment and run tests.
     - curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.13
-    - gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --branch "place-terraform-in-path"
+    - gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.0.18"
     - configure-environment-for-gruntwork-module --packer-version NONE --go-src-path .
 
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
     # Install the gruntwork-module-circleci-helpers and use it to configure the build environment and run tests.
     - curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.13
     - gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.0.18"
-    - configure-environment-for-gruntwork-module --packer-version NONE --go-src-path .
+    - configure-environment-for-gruntwork-module --packer-version NONE --terragrunt-version NONE --go-src-path .
 
   cache_directories:
     - ~/glide

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
     # Install the gruntwork-module-circleci-helpers and use it to configure the build environment and run tests.
     - curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.9
     - gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.0.10"
-    - configure-environment-for-gruntwork-module --terraform-version NONE --packer-version NONE --go-src-path .
+    - configure-environment-for-gruntwork-module --packer-version NONE --go-src-path .
 
   cache_directories:
     - ~/glide

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: a0b6052956cc547eca14fb8e727e4e60a6d9dc9d781d3aea890b2f182397e51a
-updated: 2016-05-31T14:38:06.054106296+02:00
+updated: 2016-08-05T09:46:41.417113535-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 665c623d7f3e0ee276596b006655ba4dbe0565b0
@@ -10,21 +10,83 @@ imports:
   - aws/awserr
   - aws/service/dynamodb
   - service/dynamodb
+  - service/iam
   - aws/credentials
-  - aws/corehandlers
-  - aws/credentials/ec2rolecreds
-  - aws/ec2metadata
-  - aws/request
-  - private/endpoints
-  - aws/client
-  - aws/awsutil
   - aws/client/metadata
-  - private/protocol/jsonrpc
-  - private/signer/v4
-  - private/waiter
-  - private/protocol/json/jsonutil
+  - aws/request
+  - aws/ec2metadata
+  - service/sts
+  - private/endpoints
+  - awsmigrate/awsmigrate-renamer/rename
+  - private/model/api
+  - awstesting/mock
+  - service/acm
+  - service/apigateway
+  - service/applicationdiscoveryservice
+  - service/autoscaling
+  - service/cloudformation
+  - service/cloudfront
+  - service/cloudhsm
+  - service/cloudsearch
+  - service/cloudtrail
+  - service/cloudwatch
+  - service/cloudwatchlogs
+  - service/codecommit
+  - service/codedeploy
+  - service/codepipeline
+  - service/cognitoidentity
+  - service/cognitosync
+  - service/configservice
+  - service/datapipeline
+  - service/devicefarm
+  - service/directconnect
+  - service/directoryservice
+  - service/dynamodbstreams
+  - service/ec2
+  - service/ecs
+  - service/efs
+  - service/elasticache
+  - service/elasticbeanstalk
+  - service/elb
+  - service/elastictranscoder
+  - service/emr
+  - service/elasticsearchservice
+  - service/glacier
+  - service/iot
+  - service/iotdataplane
+  - service/kinesis
+  - service/kms
+  - service/lambda
+  - service/machinelearning
+  - service/opsworks
+  - service/rds
+  - service/redshift
+  - service/route53
+  - service/route53domains
+  - service/ses
+  - service/simpledb
+  - service/sns
+  - service/sqs
+  - service/ssm
+  - service/storagegateway
+  - service/support
+  - service/swf
+  - service/waf
+  - service/workspaces
+  - service/cloudsearchdomain
+  - service/cloudwatchevents
+  - service/dynamodb/dynamodbattribute
+  - service/ecr
+  - service/firehose
+  - service/inspector
+  - service/marketplacecommerceanalytics
+  - service/mobileanalytics
+  - service/s3
+  - service/cloudfront/sign
+  - private/util
+  - private/protocol/query/queryutil
+  - private/protocol/xml/xmlutil
   - private/protocol/rest
-  - private/protocol
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -33,6 +95,10 @@ imports:
   version: a41850380601eeb43f4350f7d17c6bbd8944aaf8
 - name: github.com/go-ini/ini
   version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
+- name: github.com/gucumber/gucumber
+  version: 71608e2f6e76fd4da5b09a376aeec7a5c0b5edbc
+  subpackages:
+  - gherkin
 - name: github.com/hashicorp/hcl
   version: 9a905a34e6280ce905da1a32344b25e81011197a
   subpackages:
@@ -40,20 +106,36 @@ imports:
   - hcl/parser
   - hcl/token
   - json/parser
+  - hcl/printer
   - hcl/scanner
-  - hcl/strconv
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
   version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
+- name: github.com/lsegal/gucumber
+  version: 71608e2f6e76fd4da5b09a376aeec7a5c0b5edbc
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/shiena/ansicolor
+  version: a422bbe96644373c5753384a59d678f7d261ff10
+- name: github.com/stretchr/objx
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 8d64eb7173c7753d6419fd4a9caf057398611364
   subpackages:
   - assert
+  - http
+  - mock
 - name: github.com/urfave/cli
   version: 9a18ffad6c548ca4d458d4c30a8aa4d181cf92fa
+- name: golang.org/x/tools
+  version: 337c0124d7839ba49a64f0077b59cc02dd2d591f
+  subpackages:
+  - go/loader
+  - go/ast/astutil
+  - go/buildutil
+- name: gopkg.in/yaml.v2
+  version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
 devImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a0b6052956cc547eca14fb8e727e4e60a6d9dc9d781d3aea890b2f182397e51a
-updated: 2016-08-05T09:46:41.417113535-07:00
+hash: fc8ac779222734178cd8acdc9cd83045935b2a83b9d53935c841caa14d764c1d
+updated: 2016-08-05T10:04:10.661580636-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 665c623d7f3e0ee276596b006655ba4dbe0565b0
@@ -9,84 +9,26 @@ imports:
   - aws/session
   - aws/awserr
   - aws/service/dynamodb
+  - aws/service/s3
   - service/dynamodb
   - service/iam
+  - service/s3
   - aws/credentials
   - aws/client/metadata
   - aws/request
   - aws/ec2metadata
   - service/sts
   - private/endpoints
-  - awsmigrate/awsmigrate-renamer/rename
-  - private/model/api
-  - awstesting/mock
-  - service/acm
-  - service/apigateway
-  - service/applicationdiscoveryservice
-  - service/autoscaling
-  - service/cloudformation
-  - service/cloudfront
-  - service/cloudhsm
-  - service/cloudsearch
-  - service/cloudtrail
-  - service/cloudwatch
-  - service/cloudwatchlogs
-  - service/codecommit
-  - service/codedeploy
-  - service/codepipeline
-  - service/cognitoidentity
-  - service/cognitosync
-  - service/configservice
-  - service/datapipeline
-  - service/devicefarm
-  - service/directconnect
-  - service/directoryservice
-  - service/dynamodbstreams
-  - service/ec2
-  - service/ecs
-  - service/efs
-  - service/elasticache
-  - service/elasticbeanstalk
-  - service/elb
-  - service/elastictranscoder
-  - service/emr
-  - service/elasticsearchservice
-  - service/glacier
-  - service/iot
-  - service/iotdataplane
-  - service/kinesis
-  - service/kms
-  - service/lambda
-  - service/machinelearning
-  - service/opsworks
-  - service/rds
-  - service/redshift
-  - service/route53
-  - service/route53domains
-  - service/ses
-  - service/simpledb
-  - service/sns
-  - service/sqs
-  - service/ssm
-  - service/storagegateway
-  - service/support
-  - service/swf
-  - service/waf
-  - service/workspaces
-  - service/cloudsearchdomain
-  - service/cloudwatchevents
-  - service/dynamodb/dynamodbattribute
-  - service/ecr
-  - service/firehose
-  - service/inspector
-  - service/marketplacecommerceanalytics
-  - service/mobileanalytics
-  - service/s3
-  - service/cloudfront/sign
-  - private/util
+  - private/protocol/jsonrpc
+  - private/signer/v4
+  - private/waiter
+  - private/protocol
+  - private/protocol/query
+  - private/protocol/restxml
+  - private/protocol/json/jsonutil
+  - private/protocol/rest
   - private/protocol/query/queryutil
   - private/protocol/xml/xmlutil
-  - private/protocol/rest
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -95,10 +37,6 @@ imports:
   version: a41850380601eeb43f4350f7d17c6bbd8944aaf8
 - name: github.com/go-ini/ini
   version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
-- name: github.com/gucumber/gucumber
-  version: 71608e2f6e76fd4da5b09a376aeec7a5c0b5edbc
-  subpackages:
-  - gherkin
 - name: github.com/hashicorp/hcl
   version: 9a905a34e6280ce905da1a32344b25e81011197a
   subpackages:
@@ -112,30 +50,16 @@ imports:
   - json/token
 - name: github.com/jmespath/go-jmespath
   version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
-- name: github.com/lsegal/gucumber
-  version: 71608e2f6e76fd4da5b09a376aeec7a5c0b5edbc
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
-- name: github.com/shiena/ansicolor
-  version: a422bbe96644373c5753384a59d678f7d261ff10
-- name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 8d64eb7173c7753d6419fd4a9caf057398611364
   subpackages:
   - assert
-  - http
-  - mock
 - name: github.com/urfave/cli
   version: 9a18ffad6c548ca4d458d4c30a8aa4d181cf92fa
-- name: golang.org/x/tools
-  version: 337c0124d7839ba49a64f0077b59cc02dd2d591f
-  subpackages:
-  - go/loader
-  - go/ast/astutil
-  - go/buildutil
 - name: gopkg.in/yaml.v2
   version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
-devImports: []
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,3 +14,4 @@ import:
   - aws/session
   - aws/awserr
   - aws/service/dynamodb
+  - aws/service/s3

--- a/test/fixture/.terragrunt
+++ b/test/fixture/.terragrunt
@@ -1,0 +1,18 @@
+# Configure Terragrunt to use DynamoDB for locking
+dynamoDbLock = {
+   stateFileId = "terragrunt-test-fixture"
+   awsRegion = "us-east-1"
+   tableName = "terragrunt_locks"
+   maxLockRetries = 360
+}
+
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remoteState = {
+  backend = "s3"
+  backendConfigs = {
+    encrypt = "true"
+    bucket = "gruntwork-terragrunt-tests"
+    key = "terraform.tfstate"
+    region = "us-west-2"
+  }
+}

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -1,0 +1,8 @@
+# Create an arbitrary local resource
+data "template_file" "test" {
+    template = "Hello, I am a template. My sample_var value = ${sample_var}"
+
+    vars {
+        sample_var = "${var.sample_var}"
+    }
+}

--- a/test/fixture/outputs.tf
+++ b/test/fixture/outputs.tf
@@ -1,0 +1,3 @@
+output "rendered_template" {
+    value = "${data.template_file.test.rendered}"
+}

--- a/test/fixture/vars.tf
+++ b/test/fixture/vars.tf
@@ -1,0 +1,5 @@
+# Configure these variables
+variable "sample_var" {
+  description = "A sample_var to pass to the tempalte."
+  default = "hello"
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1,0 +1,120 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/gruntwork-io/terragrunt/cli"
+)
+
+// hard-code this to match the test fixture for now
+const (
+	TERRAFORM_REMOTE_STATE_S3_REGION      = "us-west-2"
+	TERRAFORM_REMOTE_STATE_S3_BUCKET_NAME = "gruntwork-terragrunt-tests"
+	TEST_FIXTURE_PATH                     = "fixture/"
+)
+
+func TestTerragruntWorksWithLocalTerraformVersion(t *testing.T) {
+	if err := validateTerraformIsInstalled(t); err != nil {
+		t.Fatalf("A local instance of Terraform is not in the system PATH. Please install Terraform to continue.\n")
+	}
+
+	if err := validateS3BucketExists(t, TERRAFORM_REMOTE_STATE_S3_REGION, TERRAFORM_REMOTE_STATE_S3_BUCKET_NAME); err != nil {
+		t.Fatalf("The S3 Bucket in the .terragrunt file does not exist. %s", err)
+	}
+
+	if err := runTerragruntApply(); err != nil {
+		t.Fatalf("Failed to run terragrunt: %s", err)
+	}
+}
+
+// Run Terragrunt Apply directory in the test fixture path
+func runTerragruntApply() error {
+	os.Chdir(TEST_FIXTURE_PATH)
+
+	app := cli.CreateTerragruntCli("TEST")
+	err := app.Run(strings.Split("terragrunt apply", " "))
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Validate that a local instance of Terraform is installed.
+func validateTerraformIsInstalled(t *testing.T) error {
+	if err := runShellCommandWithNoOutput(t, "terraform", "version"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run the given "command" plus any "args" passed to it. Print the output to stdout.
+func runShellCommandWithOutput(t *testing.T, command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+// Run the given "command" plus any "args" passed to it. Suppress output.
+func runShellCommandWithNoOutput(t *testing.T, command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+
+	cmd.Stdout = nil
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+// Check that the S3 Bucket of the given name and region exists by attempting to list objects from it.
+func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) error {
+	client, err := createS3Client(awsRegion)
+	if err != nil {
+		return err
+	}
+
+	params := &s3.ListObjectsInput{
+		Bucket: aws.String(bucketName),
+	}
+
+	_, err = client.ListObjects(params)
+	if err != nil {
+		return fmt.Errorf("S3 Bucket Name = '%s'. S3 Bucket Region = '%s'. Full Error Message = %s", bucketName, awsRegion, err)
+	}
+
+	return nil
+}
+
+// Create an authenticated client for S3
+func createS3Client(awsRegion string) (*s3.S3, error) {
+	config, err := createAwsConfig(awsRegion)
+	if err != nil {
+		return nil, err
+	}
+
+	return s3.New(session.New(), config), nil
+}
+
+// Returns an AWS config object for the given region, ensuring that the config has credentials
+func createAwsConfig(awsRegion string) (*aws.Config, error) {
+	config := defaults.Get().Config.WithRegion(awsRegion)
+
+	_, err := config.Credentials.Get()
+	if err != nil {
+		return nil, fmt.Errorf("Error finding AWS credentials (did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables?): %s", err)
+	}
+
+	return config, nil
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -40,13 +40,8 @@ func runTerragruntApply() error {
 	os.Chdir(TEST_FIXTURE_PATH)
 
 	app := cli.CreateTerragruntCli("TEST")
-	err := app.Run(strings.Split("terragrunt apply", " "))
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return app.Run(strings.Split("terragrunt apply", " "))
 }
 
 // Validate that a local instance of Terraform is installed.


### PR DESCRIPTION
This PR adds a simple integration test to validate that Terragrunt works with the latest version of Terraform. It executes a trivial Terraform template that just renders a `data.template_file` resource.

Do NOT merge this PR until https://github.com/gruntwork-io/module-ci/pull/6 is merged and a new release is tagged in https://github.com/gruntwork-io/module-ci since running this integration test successfully depended on an update to `configure-environment-for-gruntwork-module` in github.com/gruntwork-io/module-ci.