### PR TITLE
config: tweak remote_state bindings to be consistent with Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ lock = {
 }
 
 # Configure Terragrunt to automatically store tfstate files in an S3 bucket
-remoteState = {
+remote_state = {
   backend = "s3"
-  backendConfigs = {
+  config {
     encrypt = "true"
     bucket = "my-bucket"
     key = "terraform.tfstate"
@@ -214,9 +214,9 @@ docs](https://www.terraform.io/docs/state/remote/) for the requirements to use a
 For remote state management, Terragrunt supports the following settings in `.terragrunt`:
 
 ```hcl
-remoteState = {
+remote_state = {
   backend = "s3"
-  backendConfigs = {
+  config {
     key1 = "value1"
     key2 = "value2"
     key3 = "value3"

--- a/config/config.go
+++ b/config/config.go
@@ -19,14 +19,14 @@ type TerragruntConfig struct {
 
 // terragruntConfigFile represents the configuration supported in the .terragrunt file
 type terragruntConfigFile struct {
-	Lock        *LockConfig `json:"lock,omitempty"`
-	RemoteState *remote.RemoteState
+	Lock        *LockConfig         `hcl:"lock,omitempty"`
+	RemoteState *remote.RemoteState `hcl:"remote_state"`
 }
 
 // LockConfig represents generic configuration for Lock providers
 type LockConfig struct {
-	Backend string            `json:"backend"`
-	Config  map[string]string `json:"config"`
+	Backend string            `hcl:"backend"`
+	Config  map[string]string `hcl:"config"`
 }
 
 // ReadTerragruntConfig the Terragrunt config file from its default location

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -85,7 +85,7 @@ func TestParseTerragruntConfigRemoteStateMinimalConfig(t *testing.T) {
 
 	config :=
 		`
-	remoteState = {
+    remote_state = {
 	  backend = "s3"
 	}
 	`
@@ -96,7 +96,7 @@ func TestParseTerragruntConfigRemoteStateMinimalConfig(t *testing.T) {
 	assert.Nil(t, terragruntConfig.Lock)
 	assert.NotNil(t, terragruntConfig.RemoteState)
 	assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
-	assert.Empty(t, terragruntConfig.RemoteState.BackendConfigs)
+	assert.Empty(t, terragruntConfig.RemoteState.Config)
 }
 
 func TestParseTerragruntConfigRemoteStateMissingBackend(t *testing.T) {
@@ -104,7 +104,7 @@ func TestParseTerragruntConfigRemoteStateMissingBackend(t *testing.T) {
 
 	config :=
 		`
-	remoteState = {
+	remote_state = {
 	}
 	`
 
@@ -117,9 +117,9 @@ func TestParseTerragruntConfigRemoteStateFullConfig(t *testing.T) {
 
 	config :=
 		`
-	remoteState = {
+	remote_state = {
 	  backend = "s3"
-	  backendConfigs = {
+	  config = {
 	    encrypt = "true"
 	    bucket = "my-bucket"
 	    key = "terraform.tfstate"
@@ -134,11 +134,11 @@ func TestParseTerragruntConfigRemoteStateFullConfig(t *testing.T) {
 	assert.Nil(t, terragruntConfig.Lock)
 	assert.NotNil(t, terragruntConfig.RemoteState)
 	assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
-	assert.NotEmpty(t, terragruntConfig.RemoteState.BackendConfigs)
-	assert.Equal(t, "true", terragruntConfig.RemoteState.BackendConfigs["encrypt"])
-	assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.BackendConfigs["bucket"])
-	assert.Equal(t, "terraform.tfstate", terragruntConfig.RemoteState.BackendConfigs["key"])
-	assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.BackendConfigs["region"])
+	assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
+	assert.Equal(t, "true", terragruntConfig.RemoteState.Config["encrypt"])
+	assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
+	assert.Equal(t, "terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
+	assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
 }
 
 func TestParseTerragruntConfigRemoteStateAndDynamoDbFullConfig(t *testing.T) {
@@ -156,9 +156,9 @@ func TestParseTerragruntConfigRemoteStateAndDynamoDbFullConfig(t *testing.T) {
       }
 	}
 
-	remoteState = {
+	remote_state = {
 	  backend = "s3"
-	  backendConfigs = {
+	  config {
 	    encrypt = "true"
 	    bucket = "my-bucket"
 	    key = "terraform.tfstate"
@@ -180,11 +180,11 @@ func TestParseTerragruntConfigRemoteStateAndDynamoDbFullConfig(t *testing.T) {
 
 	assert.NotNil(t, terragruntConfig.RemoteState)
 	assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
-	assert.NotEmpty(t, terragruntConfig.RemoteState.BackendConfigs)
-	assert.Equal(t, "true", terragruntConfig.RemoteState.BackendConfigs["encrypt"])
-	assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.BackendConfigs["bucket"])
-	assert.Equal(t, "terraform.tfstate", terragruntConfig.RemoteState.BackendConfigs["key"])
-	assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.BackendConfigs["region"])
+	assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
+	assert.Equal(t, "true", terragruntConfig.RemoteState.Config["encrypt"])
+	assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
+	assert.Equal(t, "terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
+	assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
 }
 
 func TestParseTerragruntConfigInvalidLockBackend(t *testing.T) {

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -1,16 +1,17 @@
 package remote
 
 import (
-	"github.com/gruntwork-io/terragrunt/util"
-	"github.com/gruntwork-io/terragrunt/shell"
 	"fmt"
+
 	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/shell"
+	"github.com/gruntwork-io/terragrunt/util"
 )
 
 // Configuration for Terraform remote state
 type RemoteState struct {
-	Backend        string
-	BackendConfigs map[string]string
+	Backend string            `hcl:"backend"`
+	Config  map[string]string `hcl:"config"`
 }
 
 // Fill in any default configuration for remote state
@@ -79,7 +80,7 @@ func (remoteState RemoteState) toTerraformRemoteConfigArgs() []string {
 	baseArgs := []string{"remote", "config", "-backend", remoteState.Backend}
 
 	backendConfigArgs := []string{}
-	for key, value := range remoteState.BackendConfigs {
+	for key, value := range remoteState.Config {
 		arg := fmt.Sprintf("-backend-config=%s=%s", key, value)
 		backendConfigArgs = append(backendConfigArgs, arg)
 	}

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -1,9 +1,10 @@
 package remote
 
 import (
-	"testing"
-	"github.com/stretchr/testify/assert"
 	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToTerraformRemoteConfigArgs(t *testing.T) {
@@ -11,11 +12,11 @@ func TestToTerraformRemoteConfigArgs(t *testing.T) {
 
 	remoteState := RemoteState{
 		Backend: "s3",
-		BackendConfigs: map[string]string {
+		Config: map[string]string{
 			"encrypt": "true",
-			"bucket": "my-bucket",
-			"key": "terraform.tfstate",
-			"region": "us-east-1",
+			"bucket":  "my-bucket",
+			"key":     "terraform.tfstate",
+			"region":  "us-east-1",
 		},
 	}
 	args := remoteState.toTerraformRemoteConfigArgs()

--- a/test/fixture/.terragrunt
+++ b/test/fixture/.terragrunt
@@ -10,9 +10,9 @@ lock = {
 }
 
 # Configure Terragrunt to automatically store tfstate files in an S3 bucket
-remoteState = {
+remote_state = {
   backend = "s3"
-  backendConfigs = {
+  config {
     encrypt = "true"
     bucket = "gruntwork-terragrunt-tests"
     key = "terraform.tfstate"


### PR DESCRIPTION
- snake_case used in favour of camelCase
- backendConfigs renamed to config to read better
- config tags changed from json to hcl for clarity
- updated README examples
- go fmt shuffled some imports in the remote state files