### PR TITLE
locks: add azure_blob lock provider

### DIFF
--- a/config/builtin_locks.go
+++ b/config/builtin_locks.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/locks"
+	"github.com/gruntwork-io/terragrunt/locks/azure"
 	"github.com/gruntwork-io/terragrunt/locks/dynamodb"
 )
 
@@ -26,5 +27,6 @@ func lookupLock(name string, conf map[string]string) (locks.Lock, error) {
 }
 
 var builtinLocks = map[string]lockFactory{
-	"dynamodb": dynamodb.New,
+	"dynamodb":   dynamodb.New,
+	"azure_blob": azure.New,
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,34 +1,41 @@
-hash: fc8ac779222734178cd8acdc9cd83045935b2a83b9d53935c841caa14d764c1d
-updated: 2016-08-05T10:04:10.661580636-07:00
+hash: 1409991dc7fe52324d517cbc0a567415db1ba257834c1edeef870674bd5c8de3
+updated: 2016-09-23T14:26:55.677530851+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 665c623d7f3e0ee276596b006655ba4dbe0565b0
   subpackages:
   - aws
-  - aws/defaults
-  - aws/session
   - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/request
   - aws/service/dynamodb
   - aws/service/s3
-  - service/dynamodb
-  - service/iam
-  - service/s3
-  - aws/credentials
-  - aws/client/metadata
-  - aws/request
-  - aws/ec2metadata
-  - service/sts
+  - aws/session
   - private/endpoints
+  - private/protocol
+  - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
+  - private/protocol/xml/xmlutil
   - private/signer/v4
   - private/waiter
-  - private/protocol
-  - private/protocol/query
-  - private/protocol/restxml
-  - private/protocol/json/jsonutil
-  - private/protocol/rest
-  - private/protocol/query/queryutil
-  - private/protocol/xml/xmlutil
+  - service/dynamodb
+  - service/s3
+  - service/sts
+- name: github.com/Azure/azure-sdk-for-go
+  version: 23dddbb0f51799ace6588d35f2fea3d425c4fb54
+  subpackages:
+  - storage
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -42,10 +49,10 @@ imports:
   subpackages:
   - hcl/ast
   - hcl/parser
+  - hcl/scanner
+  - hcl/strconv
   - hcl/token
   - json/parser
-  - hcl/printer
-  - hcl/scanner
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
@@ -60,6 +67,4 @@ imports:
   - assert
 - name: github.com/urfave/cli
   version: 9a18ffad6c548ca4d458d4c30a8aa4d181cf92fa
-- name: gopkg.in/yaml.v2
-  version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,9 @@ owners:
 import:
 - package: github.com/urfave/cli
 - package: github.com/hashicorp/hcl
-- package: github.com/stretchr/testify/assert
+- package: github.com/stretchr/testify
+  subpackages:
+  - assert
 - package: github.com/go-errors/errors
 - package: github.com/aws/aws-sdk-go
   subpackages:
@@ -15,3 +17,7 @@ import:
   - aws/awserr
   - aws/service/dynamodb
   - aws/service/s3
+- package: github.com/Azure/azure-sdk-for-go
+  version: ^4.0.0-beta
+  subpackages:
+  - storage

--- a/locks/azure/azure_storage_lock.go
+++ b/locks/azure/azure_storage_lock.go
@@ -1,0 +1,114 @@
+package azure
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/locks"
+	"github.com/gruntwork-io/terragrunt/util"
+)
+
+// StorageLock provides a lock backed by Azure Storage
+// Validate must be called prior to the lock being used
+type StorageLock struct {
+	StorageAccountName string
+	ContainerName      string
+	Key                string
+}
+
+// New is the factory function for StorageLock
+func New(conf map[string]string) (locks.Lock, error) {
+	lock := &StorageLock{
+		StorageAccountName: conf["storage_account_name"],
+		ContainerName:      conf["container_name"],
+		Key:                conf["key"],
+	}
+
+	if lock.StorageAccountName == "" {
+		return nil, errors.WithStackTrace(ErrRequiredFieldMissing("storage_account_name"))
+	}
+
+	if lock.ContainerName == "" {
+		return nil, errors.WithStackTrace(ErrRequiredFieldMissing("container_name"))
+	}
+
+	if lock.Key == "" {
+		return nil, errors.WithStackTrace(ErrRequiredFieldMissing("key"))
+	}
+
+	return lock, nil
+}
+
+// AcquireLock attempts to create a Blob in the Storage Container
+func (lock *StorageLock) AcquireLock() error {
+	util.Logger.Printf("Attempting to acquire lock for Blob key %s", lock.Key)
+
+	client, err := lock.createStorageClient()
+	if err != nil {
+		return err
+	}
+
+	exists, err := client.BlobExists(lock.ContainerName, lock.Key)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return ErrCannotLock
+	}
+
+	if err = client.CreateBlockBlob(lock.ContainerName, lock.Key); err != nil {
+		return err
+	}
+
+	util.Logger.Printf("Lock acquired!")
+	return nil
+}
+
+// ReleaseLock attempts to delete the Blob in the Storage Container
+func (lock *StorageLock) ReleaseLock() error {
+	util.Logger.Printf("Attempting to release lock for Blob key %s", lock.Key)
+
+	client, err := lock.createStorageClient()
+	if err != nil {
+		return err
+	}
+
+	if _, err = client.DeleteBlobIfExists(lock.ContainerName, lock.Key, nil); err != nil {
+		return err
+	}
+
+	util.Logger.Printf("Lock released!")
+	return nil
+}
+
+// String returns a description of this lock
+func (lock *StorageLock) String() string {
+	return fmt.Sprintf("AzureStorageLock lock for state file %s", lock.Key)
+}
+
+// createStorageClient creates a new Blob Storage Client from the Azure SDK
+// returns and error if ARM_ACCESS_KEY is empty
+func (lock *StorageLock) createStorageClient() (*storage.BlobStorageClient, error) {
+	accessKey := os.Getenv("ARM_ACCESS_KEY")
+	if accessKey == "" {
+		return nil, errors.WithStackTrace(ErrRequiredFieldMissing("ARM_ACCESS_KEY environment variable"))
+	}
+
+	client, err := storage.NewBasicClient(lock.StorageAccountName, accessKey)
+	if err != nil {
+		return nil, err
+	}
+
+	blobClient := client.GetBlobService()
+	return &blobClient, nil
+}
+
+var ErrCannotLock = fmt.Errorf("cannot acquire lock as it is currently held by another process")
+
+type ErrRequiredFieldMissing string
+
+func (err ErrRequiredFieldMissing) Error() string {
+	return fmt.Sprintf("%s must be set", err)
+}

--- a/locks/azure/azure_storage_lock_test.go
+++ b/locks/azure/azure_storage_lock_test.go
@@ -1,0 +1,163 @@
+package azure
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigMissingStorageAccountName(t *testing.T) {
+	t.Parallel()
+
+	conf := map[string]string{}
+
+	_, err := New(conf)
+	assert.NotNil(t, err)
+	assert.True(t, errors.IsError(err, ErrRequiredFieldMissing("storage_account_name")))
+}
+
+func TestConfigMissingContainerName(t *testing.T) {
+	t.Parallel()
+
+	conf := map[string]string{
+		"storage_account_name": "account",
+	}
+
+	_, err := New(conf)
+	assert.NotNil(t, err)
+	assert.True(t, errors.IsError(err, ErrRequiredFieldMissing("container_name")))
+}
+
+func TestConfigMissingKey(t *testing.T) {
+	t.Parallel()
+
+	conf := map[string]string{
+		"storage_account_name": "account",
+		"container_name":       "container",
+	}
+
+	_, err := New(conf)
+	assert.NotNil(t, err)
+	assert.True(t, errors.IsError(err, ErrRequiredFieldMissing("key")))
+}
+
+func TestConfigValid(t *testing.T) {
+	t.Parallel()
+
+	conf := map[string]string{
+		"storage_account_name": "account",
+		"container_name":       "container",
+		"key":                  "key",
+	}
+
+	lock, err := New(conf)
+	assert.NotNil(t, lock)
+	assert.IsType(t, &StorageLock{}, lock)
+	assert.Nil(t, err)
+
+	storageLock := lock.(*StorageLock)
+	assert.Equal(t, "account", storageLock.StorageAccountName)
+	assert.Equal(t, "container", storageLock.ContainerName)
+	assert.Equal(t, "key", storageLock.Key)
+}
+
+func TestAcquireLockContainerNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	err := setupAzureAccTest(func(storageAccount, container string, client storage.BlobStorageClient) {
+		lock := StorageLock{
+			StorageAccountName: storageAccount,
+			ContainerName:      "bad-container-name",
+			Key:                "TestAcquireLockContainerNotFoundError.lock",
+		}
+
+		err := lock.AcquireLock()
+		assert.NotNil(t, err)
+		assert.Regexp(t, "The specified container does not exist", err.Error())
+	})
+
+	assert.Nil(t, err)
+}
+
+func TestAcquireAndReleaseLock(t *testing.T) {
+	t.Parallel()
+
+	err := setupAzureAccTest(func(storageAccount, container string, client storage.BlobStorageClient) {
+		lock := StorageLock{
+			StorageAccountName: storageAccount,
+			ContainerName:      container,
+			Key:                "TestAcquireLock.lock",
+		}
+
+		// acquire, confirm lock file was created
+		err := lock.AcquireLock()
+		assert.Nil(t, err)
+		exists, err := client.BlobExists(container, lock.Key)
+		assert.Nil(t, err)
+		assert.True(t, exists)
+
+		// release, confirm lock file was deleted
+		err = lock.ReleaseLock()
+		assert.Nil(t, err)
+		exists, err = client.BlobExists(container, lock.Key)
+		assert.Nil(t, err)
+		assert.False(t, exists)
+	})
+
+	assert.Nil(t, err)
+}
+
+func TestAcquireLockAlreadyLockedError(t *testing.T) {
+	t.Parallel()
+
+	err := setupAzureAccTest(func(storageAccount, container string, client storage.BlobStorageClient) {
+		lock := StorageLock{
+			StorageAccountName: storageAccount,
+			ContainerName:      container,
+			Key:                "TestAcquireLockAlreadyLockedError.lock",
+		}
+
+		err := lock.AcquireLock()
+		assert.Nil(t, err)
+
+		err = lock.AcquireLock()
+		assert.NotNil(t, err)
+		assert.True(t, err == ErrCannotLock)
+
+		// cleanup
+		err = lock.ReleaseLock()
+		assert.Nil(t, err)
+	})
+
+	assert.Nil(t, err)
+}
+
+func setupAzureAccTest(testFunc func(storageAccount, container string, client storage.BlobStorageClient)) error {
+	storageAccount := os.Getenv("AZURE_STORAGE_ACCOUNT")
+	if storageAccount == "" {
+		return fmt.Errorf("AZURE_STORAGE_ACCOUNT must be set for Azure lock tests")
+	}
+
+	container := os.Getenv("AZURE_STORAGE_CONTAINER")
+	if container == "" {
+		return fmt.Errorf("AZURE_STORAGE_CONTAINER must be set for Azure lock tests")
+	}
+
+	// uses ARM_ prefix to match Terraform
+	accessKey := os.Getenv("ARM_ACCESS_KEY")
+	if accessKey == "" {
+		return fmt.Errorf("ARM_ACCESS_KEY must be set for Azure lock tests")
+	}
+
+	client, err := storage.NewBasicClient(storageAccount, accessKey)
+	if err != nil {
+		return err
+	}
+
+	testFunc(storageAccount, container, client.GetBlobService())
+	return nil
+}


### PR DESCRIPTION
Lock is backed by Azure Blob Storage, a Blob is created with the desired name
to acquire the lock and deleted to release it.
