### PR TITLE
Bump all dependency versions, and AWS SDK in particular.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,65 +1,69 @@
-hash: fc8ac779222734178cd8acdc9cd83045935b2a83b9d53935c841caa14d764c1d
-updated: 2016-08-05T10:04:10.661580636-07:00
+hash: 666953d8f40b0f514bae75d3cfad7ad396a809a56538c176e2aafd0babb1a591
+updated: 2016-10-03T10:44:33.610775636-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 665c623d7f3e0ee276596b006655ba4dbe0565b0
+  version: 74a703abb31ea9faf7622930e5daba1559b01b37
+  repo: git@github.com:aws/aws-sdk-go
   subpackages:
   - aws
-  - aws/defaults
-  - aws/session
   - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/request
   - aws/service/dynamodb
   - aws/service/s3
-  - service/dynamodb
-  - service/iam
-  - service/s3
-  - aws/credentials
-  - aws/client/metadata
-  - aws/request
-  - aws/ec2metadata
-  - service/sts
+  - aws/session
+  - aws/signer/v4
   - private/endpoints
-  - private/protocol/jsonrpc
-  - private/signer/v4
-  - private/waiter
   - private/protocol
-  - private/protocol/query
-  - private/protocol/restxml
   - private/protocol/json/jsonutil
-  - private/protocol/rest
+  - private/protocol/jsonrpc
+  - private/protocol/query
   - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
   - private/protocol/xml/xmlutil
+  - private/waiter
+  - service/dynamodb
+  - service/s3
+  - service/sts
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 2df174808ee097f90d259e432cc04442cf60be21
   subpackages:
   - spew
 - name: github.com/go-errors/errors
   version: a41850380601eeb43f4350f7d17c6bbd8944aaf8
 - name: github.com/go-ini/ini
-  version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
+  version: 6e4869b434bd001f6983749881c7ead3545887d8
 - name: github.com/hashicorp/hcl
-  version: 9a905a34e6280ce905da1a32344b25e81011197a
+  version: ef8133da8cda503718a74741312bf50821e6de79
   subpackages:
   - hcl/ast
   - hcl/parser
+  - hcl/scanner
+  - hcl/strconv
   - hcl/token
   - json/parser
-  - hcl/printer
-  - hcl/scanner
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
-  version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 8d64eb7173c7753d6419fd4a9caf057398611364
+  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
   subpackages:
   - assert
 - name: github.com/urfave/cli
-  version: 9a18ffad6c548ca4d458d4c30a8aa4d181cf92fa
-- name: gopkg.in/yaml.v2
-  version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
+  version: d53eb991652b1d438abdd34ce4bfa3ef1539108e
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,6 +8,8 @@ import:
 - package: github.com/stretchr/testify/assert
 - package: github.com/go-errors/errors
 - package: github.com/aws/aws-sdk-go
+  version: 1.4.14
+  repo:    git@github.com:aws/aws-sdk-go
   subpackages:
   - aws
   - aws/defaults


### PR DESCRIPTION
One user was reporting random panics when `STS.GetCallerIdentity()` was being called, so hopefully updating to the latest AWS SDK for Golang will resolve the issue. 

BTW, note the new explicit specification of a tag in `glide.yaml`. We should probably do this for all dependencies going forward. 

'cc @brikis98 