### PR TITLE
Allow to specify a different .terragrunt config file

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 
 	"github.com/gruntwork-io/terragrunt/config"
@@ -61,6 +62,19 @@ func CreateTerragruntCli(version string) *cli.App {
    Moreover, for the apply and destroy commands, Terragrunt will first try to acquire a lock using DynamoDB. For
    documentation, see https://github.com/gruntwork-io/terragrunt/.`
 
+	var defaultConfigFilePath = config.ConfigFilePath
+	if os.Getenv("TERRAGRUNT_CONFIG") != "" {
+		defaultConfigFilePath = os.Getenv("TERRAGRUNT_CONFIG")
+	}
+
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "terragrunt-config",
+			Value: defaultConfigFilePath,
+			Usage: ".terragrunt file to use",
+		},
+	}
+
 	return app
 }
 
@@ -75,7 +89,7 @@ func runApp(cliContext *cli.Context) (finalErr error) {
 		return nil
 	}
 
-	conf, err := config.ReadTerragruntConfig()
+	conf, err := config.ReadTerragruntConfig(cliContext.String("terragrunt-config"))
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/hcl"
 )
 
-const configFilePath = ".terragrunt"
+const ConfigFilePath = ".terragrunt"
 
 // TerragruntConfig represents a parsed and expanded configuration
 type TerragruntConfig struct {
@@ -30,8 +30,8 @@ type LockConfig struct {
 }
 
 // ReadTerragruntConfig the Terragrunt config file from its default location
-func ReadTerragruntConfig() (*TerragruntConfig, error) {
-	return parseConfigFile(configFilePath)
+func ReadTerragruntConfig(filePath string) (*TerragruntConfig, error) {
+	return parseConfigFile(filePath)
 }
 
 // Parse the Terragrunt config file at the given path


### PR DESCRIPTION
`--config` on command line or `TERRAGRUNT_CONFIG` environment variable

For issue #25 