### PR TITLE
Ensure Terragrunt picks up changes to remote config

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,16 @@ remote_state = {
   different key/value pairs, so consult the [Terraform remote state docs](https://www.terraform.io/docs/state/remote/)
   for details.
 
+## CLI Options
+
+Terragrunt forwards all arguments and options to Terraform. The only exceptions are the options that start with the
+prefix `--terragrunt-`. The currently available options are:
+
+* `--terragrunt-config`: A custom path to the `.terragrunt` file. May also be specified via the `TERRAGRUNT_CONFIG`
+  environment variable. The default path is `.terragrunt` in the current directory.
+* `--terragrunt-non-interactive`: Don't show interactive user prompts. This will default the answer for all prompts to 
+  'yes'. Useful if you need to run Terragrunt in an automated setting (e.g. from a script).  
+
 ## Developing terragrunt
 
 #### Running locally

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/urfave/cli"
 	"github.com/gruntwork-io/terragrunt/options"
+	"strings"
 )
 
 // Since Terragrunt is just a thin wrapper for Terraform, and we don't want to repeat every single Terraform command
@@ -205,7 +206,20 @@ func runTerraformCommandWithLock(cliContext *cli.Context, lock locks.Lock, terra
 
 // Run the given Terraform command
 func runTerraformCommand(cliContext *cli.Context) error {
-	return shell.RunShellCommand("terraform", cliContext.Args()...)
+	return shell.RunShellCommand("terraform", filterOutTerragruntArgs(cliContext)...)
+}
+
+// Return the args in teh given CLI Context object, filtering any args that are only meant for Terragrunt itself
+func filterOutTerragruntArgs(cliContext *cli.Context) []string {
+	args := []string{}
+
+	for _, arg := range cliContext.Args() {
+		if !strings.HasPrefix(arg, "--terragrunt") {
+			args = append(args, arg)
+		}
+	}
+
+	return args
 }
 
 // Release a lock, prompting the user for confirmation first

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -48,7 +48,7 @@ var MODULE_REGEX = regexp.MustCompile(`module ".+"`)
 const TERRAFORM_EXTENSION_GLOB = "*.tf"
 
 const OPT_TERRAGRUNT_CONFIG = "terragrunt-config"
-const OPT_NON_INTERACTIVE = "non-interactive"
+const OPT_NON_INTERACTIVE = "terragrunt-non-interactive"
 
 // Create the Terragrunt CLI App
 func CreateTerragruntCli(version string) *cli.App {
@@ -76,7 +76,7 @@ func CreateTerragruntCli(version string) *cli.App {
 		},
 		cli.BoolFlag{
 			Name:  OPT_NON_INTERACTIVE,
-			Usage: "Don't show interactive user prompts. Instead, default their answer to 'yes'.",
+			Usage: "Don't show interactive user prompts. This will default the answer for all prompts to 'yes'.",
 		},
 	}
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 
 	"github.com/gruntwork-io/terragrunt/config"
@@ -12,6 +11,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/urfave/cli"
+	"github.com/gruntwork-io/terragrunt/options"
 )
 
 // Since Terragrunt is just a thin wrapper for Terraform, and we don't want to repeat every single Terraform command
@@ -47,6 +47,9 @@ var MODULE_REGEX = regexp.MustCompile(`module ".+"`)
 
 const TERRAFORM_EXTENSION_GLOB = "*.tf"
 
+const OPT_TERRAGRUNT_CONFIG = "terragrunt-config"
+const OPT_NON_INTERACTIVE = "non-interactive"
+
 // Create the Terragrunt CLI App
 func CreateTerragruntCli(version string) *cli.App {
 	cli.AppHelpTemplate = CUSTOM_USAGE_TEXT
@@ -65,16 +68,15 @@ func CreateTerragruntCli(version string) *cli.App {
    Moreover, for the apply and destroy commands, Terragrunt will first try to acquire a lock using DynamoDB. For
    documentation, see https://github.com/gruntwork-io/terragrunt/.`
 
-	var defaultConfigFilePath = config.ConfigFilePath
-	if os.Getenv("TERRAGRUNT_CONFIG") != "" {
-		defaultConfigFilePath = os.Getenv("TERRAGRUNT_CONFIG")
-	}
-
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "terragrunt-config",
-			Value: defaultConfigFilePath,
+			Name:  OPT_TERRAGRUNT_CONFIG,
+			EnvVar: "TERRAGRUNT_CONFIG",
 			Usage: ".terragrunt file to use",
+		},
+		cli.BoolFlag{
+			Name:  OPT_NON_INTERACTIVE,
+			Usage: "Don't show interactive user prompts. Instead, default their answer to 'yes'.",
 		},
 	}
 
@@ -92,7 +94,9 @@ func runApp(cliContext *cli.Context) (finalErr error) {
 		return nil
 	}
 
-	conf, err := config.ReadTerragruntConfig(cliContext.String("terragrunt-config"))
+	terragruntOptions := parseTerragruntOptions(cliContext)
+
+	conf, err := config.ReadTerragruntConfig(terragruntOptions)
 	if err != nil {
 		return err
 	}
@@ -102,7 +106,7 @@ func runApp(cliContext *cli.Context) (finalErr error) {
 	}
 
 	if conf.RemoteState != nil {
-		if err := configureRemoteState(cliContext, conf.RemoteState); err != nil {
+		if err := configureRemoteState(cliContext, conf.RemoteState, terragruntOptions); err != nil {
 			return err
 		}
 	}
@@ -112,7 +116,22 @@ func runApp(cliContext *cli.Context) (finalErr error) {
 		return runTerraformCommand(cliContext)
 	}
 
-	return runTerraformCommandWithLock(cliContext, conf.Lock)
+	return runTerraformCommandWithLock(cliContext, conf.Lock, terragruntOptions)
+}
+
+// Parse command line options that are passed in for Terragrunt
+func parseTerragruntOptions(cliContext *cli.Context) options.TerragruntOptions {
+	terragruntConfigPath := cliContext.String(OPT_TERRAGRUNT_CONFIG)
+	if terragruntConfigPath == "" {
+		terragruntConfigPath = config.DefaultTerragruntConfigPath
+	}
+
+	nonInteractive := cliContext.Bool(OPT_NON_INTERACTIVE)
+
+	return options.TerragruntOptions{
+		TerragruntConfigPath: terragruntConfigPath,
+		NonInteractive: nonInteractive,
+	}
 }
 
 // A quick sanity check that calls `terraform get` to download modules, if they aren't already downloaded.
@@ -145,12 +164,12 @@ func shouldDownloadModules() (bool, error) {
 
 // If the user entered a Terraform command that uses state (e.g. plan, apply), make sure remote state is configured
 // before running the command.
-func configureRemoteState(cliContext *cli.Context, remoteState *remote.RemoteState) error {
+func configureRemoteState(cliContext *cli.Context, remoteState *remote.RemoteState, terragruntOptions options.TerragruntOptions) error {
 	// We only configure remote state for the commands that use the tfstate files. We do not configure it for
 	// commands such as "get" or "version".
 	switch cliContext.Args().First() {
 	case "apply", "destroy", "import", "graph", "output", "plan", "push", "refresh", "show", "taint", "untaint", "validate":
-		return remoteState.ConfigureRemoteState()
+		return remoteState.ConfigureRemoteState(terragruntOptions)
 	case "remote":
 		if cliContext.Args().Get(1) == "config" {
 			// Encourage the user to configure remote state by defining it in .terragrunt and letting
@@ -167,7 +186,7 @@ func configureRemoteState(cliContext *cli.Context, remoteState *remote.RemoteSta
 }
 
 // Run the given Terraform command with the given lock (if the command requires locking)
-func runTerraformCommandWithLock(cliContext *cli.Context, lock locks.Lock) error {
+func runTerraformCommandWithLock(cliContext *cli.Context, lock locks.Lock, terragruntOptions options.TerragruntOptions) error {
 	switch cliContext.Args().First() {
 	case "apply", "destroy", "import", "refresh":
 		return locks.WithLock(lock, func() error { return runTerraformCommand(cliContext) })
@@ -178,7 +197,7 @@ func runTerraformCommandWithLock(cliContext *cli.Context, lock locks.Lock) error
 			return runTerraformCommand(cliContext)
 		}
 	case "release-lock":
-		return runReleaseLockCommand(cliContext, lock)
+		return runReleaseLockCommand(cliContext, lock, terragruntOptions)
 	default:
 		return runTerraformCommand(cliContext)
 	}
@@ -190,8 +209,9 @@ func runTerraformCommand(cliContext *cli.Context) error {
 }
 
 // Release a lock, prompting the user for confirmation first
-func runReleaseLockCommand(cliContext *cli.Context, lock locks.Lock) error {
-	proceed, err := shell.PromptUserForYesNo(fmt.Sprintf("Are you sure you want to release %s?", lock))
+func runReleaseLockCommand(cliContext *cli.Context, lock locks.Lock, terragruntOptions options.TerragruntOptions) error {
+	prompt := fmt.Sprintf("Are you sure you want to release %s?", lock)
+	proceed, err := shell.PromptUserForYesNo(prompt, terragruntOptions)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -7,9 +7,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/locks"
 	"github.com/gruntwork-io/terragrunt/remote"
 	"github.com/hashicorp/hcl"
+	"github.com/gruntwork-io/terragrunt/options"
 )
 
-const ConfigFilePath = ".terragrunt"
+const DefaultTerragruntConfigPath = ".terragrunt"
 
 // TerragruntConfig represents a parsed and expanded configuration
 type TerragruntConfig struct {
@@ -30,8 +31,8 @@ type LockConfig struct {
 }
 
 // ReadTerragruntConfig the Terragrunt config file from its default location
-func ReadTerragruntConfig(filePath string) (*TerragruntConfig, error) {
-	return parseConfigFile(filePath)
+func ReadTerragruntConfig(terragruntOptions options.TerragruntOptions) (*TerragruntConfig, error) {
+	return parseConfigFile(terragruntOptions.TerragruntConfigPath)
 }
 
 // Parse the Terragrunt config file at the given path

--- a/options/options.go
+++ b/options/options.go
@@ -1,0 +1,8 @@
+package options
+
+// TerragruntOptions represents command-line options that are read by Terragrunt
+type TerragruntOptions struct {
+	TerragruntConfigPath string
+	NonInteractive       bool
+}
+

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/gruntwork-io/terragrunt/options"
 )
 
 func TestToTerraformRemoteConfigArgs(t *testing.T) {
@@ -31,6 +32,69 @@ func TestToTerraformRemoteConfigArgsNoBackendConfigs(t *testing.T) {
 	args := remoteState.toTerraformRemoteConfigArgs()
 
 	assertRemoteConfigArgsEqual(t, args, "remote config -backend s3")
+}
+
+func TestShouldOverrideExistingRemoteState(t *testing.T) {
+	t.Parallel()
+
+	terragruntOptions := options.TerragruntOptions{NonInteractive: true}
+
+	testCases := []struct {
+		existingState   TerraformStateRemote
+		stateFromConfig RemoteState
+		shouldOverride  bool
+	}{
+		{TerraformStateRemote{}, RemoteState{}, false},
+		{TerraformStateRemote{Type: "s3"}, RemoteState{Backend: "s3"}, false},
+		{TerraformStateRemote{Type: "s3"}, RemoteState{Backend: "atlas"}, true},
+		{
+			TerraformStateRemote{
+				Type: "s3",
+				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+			},
+			RemoteState{
+				Backend: "s3",
+				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+			},
+			false,
+		},{
+			TerraformStateRemote{
+				Type: "s3",
+				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+			},
+			RemoteState{
+				Backend: "s3",
+				Config: map[string]string{"bucket": "different", "key": "bar", "region": "us-east-1"},
+			},
+			true,
+		},{
+			TerraformStateRemote{
+				Type: "s3",
+				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+			},
+			RemoteState{
+				Backend: "s3",
+				Config: map[string]string{"bucket": "foo", "key": "different", "region": "us-east-1"},
+			},
+			true,
+		},{
+			TerraformStateRemote{
+				Type: "s3",
+				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+			},
+			RemoteState{
+				Backend: "s3",
+				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "different"},
+			},
+			true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		shouldOverride, err := shouldOverrideExistingRemoteState(&testCase.existingState, testCase.stateFromConfig, terragruntOptions)
+		assert.Nil(t, err, "Unexpected error: %v", err)
+		assert.Equal(t, testCase.shouldOverride, shouldOverride, "Expect shouldOverrideExistingRemoteState to return %t but got %t for existingRemoteState %v and remoteStateFromTerragruntConfig %v", testCase.shouldOverride, shouldOverride, testCase.existingState, testCase.stateFromConfig)
+	}
 }
 
 func assertRemoteConfigArgsEqual(t *testing.T, actualArgs []string, expectedArgs string) {

--- a/remote/terraform_state_file.go
+++ b/remote/terraform_state_file.go
@@ -29,7 +29,7 @@ type TerraformState struct {
 // The structure of the "remote" section of the Terraform .tfstate file
 type TerraformStateRemote struct {
 	Type   string
-	Config map[string]interface{}
+	Config map[string]string
 }
 
 // The structure of a "module" section of the Terraform .tfstate file

--- a/remote/terraform_state_file_test.go
+++ b/remote/terraform_state_file_test.go
@@ -81,7 +81,7 @@ func TestParseTerraformStateRemote(t *testing.T) {
 		Serial: 12,
 		Remote: &TerraformStateRemote{
 			Type: "s3",
-			Config: map[string]interface{}{
+			Config: map[string]string{
 				"bucket": "bucket",
 				"encrypt": "true",
 				"key": "experiment-1.tfstate",
@@ -211,7 +211,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 		Serial: 51,
 		Remote: &TerraformStateRemote{
 			Type: "s3",
-			Config: map[string]interface{}{
+			Config: map[string]string{
 				"bucket": "bucket",
 				"encrypt": "true",
 				"key": "terraform.tfstate",

--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -6,11 +6,20 @@ import (
 	"os"
 	"bufio"
 	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/gruntwork-io/terragrunt/options"
 )
 
 // Prompt the user for text in the CLI. Returns the text entered by the user.
-func PromptUserForInput(prompt string) (string, error) {
+func PromptUserForInput(prompt string, terragruntOptions options.TerragruntOptions) (string, error) {
 	fmt.Print(prompt)
+
+	if terragruntOptions.NonInteractive {
+		fmt.Println()
+		util.Logger.Printf("The non-interactive flag is set to true, so assuming 'yes' for all prompts")
+		return "yes", nil
+	}
+
 	reader := bufio.NewReader(os.Stdin)
 
 	text, err := reader.ReadString('\n')
@@ -22,8 +31,8 @@ func PromptUserForInput(prompt string) (string, error) {
 }
 
 // Prompt the user for a yes/no response and return true if they entered yes.
-func PromptUserForYesNo(prompt string) (bool, error) {
-	resp, err := PromptUserForInput(fmt.Sprintf("%s (y/n) ", prompt))
+func PromptUserForYesNo(prompt string, terragruntOptions options.TerragruntOptions) (bool, error) {
+	resp, err := PromptUserForInput(fmt.Sprintf("%s (y/n) ", prompt), terragruntOptions)
 
 	if err != nil {
 		return false, errors.WithStackTrace(err)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -41,7 +41,7 @@ func runTerragruntApply() error {
 
 	app := cli.CreateTerragruntCli("TEST")
 
-	return app.Run(strings.Split("terragrunt apply", " "))
+	return app.Run(strings.Split("terragrunt apply --terragrunt-non-interactive", " "))
 }
 
 // Validate that a local instance of Terraform is installed.


### PR DESCRIPTION
This PR fixes #15. Terragrunt now compares all settings of the remote configuration between what’s stored in the `.tfstate` file and in `.terragrunt`. If any of those settings don’t match up, it prompts the user whether it should re-run `terraform remote config`.

To make this code testable, I’ve also added a new `--terragrunt-non-interactive` flag that can be used to disable user prompts when running Terragrunt in an automated setting (e.g. in an automated test or script).