### PR TITLE
Terragrunt will now create remote state S3 bucket if it doesn't exist

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -1,0 +1,19 @@
+package aws_helper
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/gruntwork-io/terragrunt/errors"
+)
+
+// Returns an AWS config object for the given region, ensuring that the config has credentials
+func CreateAwsConfig(awsRegion string) (*aws.Config, error) {
+	config := defaults.Get().Config.WithRegion(awsRegion)
+
+	_, err := config.Credentials.Get()
+	if err != nil {
+		return nil, errors.WithStackTraceAndPrefix(err, "Error finding AWS credentials (did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables?)")
+	}
+
+	return config, nil
+}

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -113,18 +113,21 @@ func runApp(cliContext *cli.Context) (finalErr error) {
 
 // Parse command line options that are passed in for Terragrunt
 func parseTerragruntOptions(cliContext *cli.Context) (*options.TerragruntOptions, error) {
-	// TODO: replace the urfave CLI library with something else.
-	//
-	// EXPLANATION: The normal way to parse flags with the urfave CLI library would be to define the flags in the
-	// CreateTerragruntCLI method and to read the values of those flags using cliContext.String(...),
-	// cliContext.Bool(...), etc. Unfortunately, this does not work here due to a limitation in the urfave
-	// CLI library: if the user passes in any "command" whatsever, (e.g. the "apply" in "terragrunt apply"), then
-	// any flags that come after it are not parsed (e.g. the "--foo" is not parsed in "terragrunt apply --foo").
-	// Therefore, we have to parse options ourselves, which is infuriating. For more details on this limitation,
-	// see: https://github.com/urfave/cli/issues/533. For now, our workaround is to dumbly loop over the arguments
-	// and look for the ones we need, but in the future, we should change to a different CLI library to avoid this
-	// limitation.
+	return parseTerragruntOptionsFromArgs(cliContext.Args())
+}
 
+// TODO: replace the urfave CLI library with something else.
+//
+// EXPLANATION: The normal way to parse flags with the urfave CLI library would be to define the flags in the
+// CreateTerragruntCLI method and to read the values of those flags using cliContext.String(...),
+// cliContext.Bool(...), etc. Unfortunately, this does not work here due to a limitation in the urfave
+// CLI library: if the user passes in any "command" whatsever, (e.g. the "apply" in "terragrunt apply"), then
+// any flags that come after it are not parsed (e.g. the "--foo" is not parsed in "terragrunt apply --foo").
+// Therefore, we have to parse options ourselves, which is infuriating. For more details on this limitation,
+// see: https://github.com/urfave/cli/issues/533. For now, our workaround is to dumbly loop over the arguments
+// and look for the ones we need, but in the future, we should change to a different CLI library to avoid this
+// limitation.
+func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, error) {
 	nonInteractive := false
 	terragruntConfigPath := os.Getenv("TERRAGRUNT_CONFIG")
 	if terragruntConfigPath == "" {
@@ -133,12 +136,12 @@ func parseTerragruntOptions(cliContext *cli.Context) (*options.TerragruntOptions
 	nonTerragruntArgs := []string{}
 	skipArg := false
 
-	for i, arg := range cliContext.Args() {
+	for i, arg := range args {
 		if arg == fmt.Sprintf("--%s", OPT_NON_INTERACTIVE) {
 			nonInteractive = true
 		} else if arg == fmt.Sprintf("--%s", OPT_TERRAGRUNT_CONFIG) {
-			if (i + 1) < cliContext.NArg() {
-				terragruntConfigPath = cliContext.Args()[i + 1]
+			if (i + 1) < len(args) {
+				terragruntConfigPath = args[i + 1]
 				skipArg = true
 			}  else {
 				return nil, errors.WithStackTrace(MissingTerragruntConfigValue)

--- a/cli/cli_app_test.go
+++ b/cli/cli_app_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"testing"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/stretchr/testify/assert"
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/config"
+)
+
+func TestParseTerragruntOptionsFromArgs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		args 		[]string
+		expectedOptions *options.TerragruntOptions
+		expectedErr     error
+	}{
+		{
+			[]string{},
+			&options.TerragruntOptions{
+				TerragruntConfigPath: config.DefaultTerragruntConfigPath,
+				NonInteractive: false,
+				NonTerragruntArgs: []string{},
+			},
+			nil,
+		},
+
+		{
+			[]string{"foo", "bar"},
+			&options.TerragruntOptions{
+				TerragruntConfigPath: config.DefaultTerragruntConfigPath,
+				NonInteractive: false,
+				NonTerragruntArgs: []string{"foo", "bar"},
+			},
+			nil,
+		},
+
+		{
+			[]string{"--foo", "--bar"},
+			&options.TerragruntOptions{
+				TerragruntConfigPath: config.DefaultTerragruntConfigPath,
+				NonInteractive: false,
+				NonTerragruntArgs: []string{"--foo", "--bar"},
+			},
+			nil,
+		},
+
+		{
+			[]string{"--foo", "apply", "--bar"},
+			&options.TerragruntOptions{
+				TerragruntConfigPath: config.DefaultTerragruntConfigPath,
+				NonInteractive: false,
+				NonTerragruntArgs: []string{"--foo", "apply", "--bar"},
+			},
+			nil,
+		},
+
+		{
+			[]string{"--terragrunt-non-interactive"},
+			&options.TerragruntOptions{
+				TerragruntConfigPath: config.DefaultTerragruntConfigPath,
+				NonInteractive: true,
+				NonTerragruntArgs: []string{},
+			},
+			nil,
+		},
+
+		{
+			[]string{"--terragrunt-config", "/some/path/.terragrunt"},
+			&options.TerragruntOptions{
+				TerragruntConfigPath: "/some/path/.terragrunt",
+				NonInteractive: false,
+				NonTerragruntArgs: []string{},
+			},
+			nil,
+		},
+
+		{
+			[]string{"--terragrunt-config", "/some/path/.terragrunt", "--terragrunt-non-interactive"},
+			&options.TerragruntOptions{
+				TerragruntConfigPath: "/some/path/.terragrunt",
+				NonInteractive: true,
+				NonTerragruntArgs: []string{},
+			},
+			nil,
+		},
+
+		{
+			[]string{"--foo", "--terragrunt-config", "/some/path/.terragrunt", "bar", "--terragrunt-non-interactive", "--baz"},
+			&options.TerragruntOptions{
+				TerragruntConfigPath: "/some/path/.terragrunt",
+				NonInteractive: true,
+				NonTerragruntArgs: []string{"--foo", "bar", "--baz"},
+			},
+			nil,
+		},
+
+		{
+			[]string{"--terragrunt-config"},
+			nil,
+			MissingTerragruntConfigValue,
+		},
+
+		{
+			[]string{"--foo", "bar", "--terragrunt-config"},
+			nil,
+			MissingTerragruntConfigValue,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualOptions, actualErr := parseTerragruntOptionsFromArgs(testCase.args)
+		if testCase.expectedErr != nil {
+			assert.True(t, errors.IsError(actualErr, testCase.expectedErr), "Expected error %v but got error %v", testCase.expectedErr, actualErr)
+		} else {
+			assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
+			assert.Equal(t, testCase.expectedOptions, actualOptions, "Expected options %v but got %v", testCase.expectedOptions, actualOptions)
+		}
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/remote"
 	"github.com/hashicorp/hcl"
 	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/util"
 )
 
 const DefaultTerragruntConfigPath = ".terragrunt"
@@ -31,7 +32,8 @@ type LockConfig struct {
 }
 
 // ReadTerragruntConfig the Terragrunt config file from its default location
-func ReadTerragruntConfig(terragruntOptions options.TerragruntOptions) (*TerragruntConfig, error) {
+func ReadTerragruntConfig(terragruntOptions *options.TerragruntOptions) (*TerragruntConfig, error) {
+	util.Logger.Printf("Reading Terragrunt config file at %s", terragruntOptions.TerragruntConfigPath)
 	return parseConfigFile(terragruntOptions.TerragruntConfigPath)
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,69 +1,144 @@
-hash: 666953d8f40b0f514bae75d3cfad7ad396a809a56538c176e2aafd0babb1a591
-updated: 2016-10-03T10:44:33.610775636-07:00
+hash: f70d8455d9f5f68d4449263ab8d0485d5b938b65b4c31716be50aac64fedc6ae
+updated: 2016-11-22T14:42:34.38236539Z
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 74a703abb31ea9faf7622930e5daba1559b01b37
-  repo: git@github.com:aws/aws-sdk-go
+  version: 665c623d7f3e0ee276596b006655ba4dbe0565b0
   subpackages:
   - aws
-  - aws/awserr
-  - aws/awsutil
-  - aws/client
-  - aws/client/metadata
-  - aws/corehandlers
-  - aws/credentials
-  - aws/credentials/ec2rolecreds
-  - aws/credentials/endpointcreds
-  - aws/credentials/stscreds
   - aws/defaults
-  - aws/ec2metadata
-  - aws/request
+  - aws/session
+  - aws/awserr
   - aws/service/dynamodb
   - aws/service/s3
-  - aws/session
-  - aws/signer/v4
-  - private/endpoints
-  - private/protocol
-  - private/protocol/json/jsonutil
-  - private/protocol/jsonrpc
-  - private/protocol/query
-  - private/protocol/query/queryutil
-  - private/protocol/rest
-  - private/protocol/restxml
-  - private/protocol/xml/xmlutil
-  - private/waiter
   - service/dynamodb
-  - service/s3
   - service/sts
+  - aws/credentials
+  - aws/client/metadata
+  - aws/request
+  - aws/ec2metadata
+  - private/endpoints
+  - awsmigrate/awsmigrate-renamer/rename
+  - private/model/api
+  - awstesting/mock
+  - service/acm
+  - service/apigateway
+  - service/applicationdiscoveryservice
+  - service/autoscaling
+  - service/cloudformation
+  - service/cloudfront
+  - service/cloudhsm
+  - service/cloudsearch
+  - service/cloudtrail
+  - service/cloudwatch
+  - service/cloudwatchlogs
+  - service/codecommit
+  - service/codedeploy
+  - service/codepipeline
+  - service/cognitoidentity
+  - service/cognitosync
+  - service/configservice
+  - service/datapipeline
+  - service/devicefarm
+  - service/directconnect
+  - service/directoryservice
+  - service/dynamodbstreams
+  - service/ec2
+  - service/ecs
+  - service/efs
+  - service/elasticache
+  - service/elasticbeanstalk
+  - service/elb
+  - service/elastictranscoder
+  - service/emr
+  - service/elasticsearchservice
+  - service/glacier
+  - service/iam
+  - service/iot
+  - service/iotdataplane
+  - service/kinesis
+  - service/kms
+  - service/lambda
+  - service/machinelearning
+  - service/opsworks
+  - service/rds
+  - service/redshift
+  - service/route53
+  - service/route53domains
+  - service/ses
+  - service/simpledb
+  - service/sns
+  - service/sqs
+  - service/ssm
+  - service/storagegateway
+  - service/support
+  - service/swf
+  - service/waf
+  - service/workspaces
+  - service/cloudsearchdomain
+  - service/cloudwatchevents
+  - service/dynamodb/dynamodbattribute
+  - service/ecr
+  - service/firehose
+  - service/inspector
+  - service/marketplacecommerceanalytics
+  - service/mobileanalytics
+  - service/s3
+  - service/cloudfront/sign
+  - private/util
+  - private/protocol/query/queryutil
+  - private/protocol/xml/xmlutil
+  - private/protocol/rest
 - name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/go-errors/errors
   version: a41850380601eeb43f4350f7d17c6bbd8944aaf8
 - name: github.com/go-ini/ini
-  version: 6e4869b434bd001f6983749881c7ead3545887d8
+  version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
+- name: github.com/gucumber/gucumber
+  version: 71608e2f6e76fd4da5b09a376aeec7a5c0b5edbc
+  subpackages:
+  - gherkin
 - name: github.com/hashicorp/hcl
-  version: ef8133da8cda503718a74741312bf50821e6de79
+  version: 9a905a34e6280ce905da1a32344b25e81011197a
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/scanner
-  - hcl/strconv
   - hcl/token
   - json/parser
+  - hcl/printer
+  - hcl/scanner
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+  version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
+- name: github.com/lsegal/gucumber
+  version: 71608e2f6e76fd4da5b09a376aeec7a5c0b5edbc
+- name: github.com/mitchellh/mapstructure
+  version: f3009df150dadf309fdee4a54ed65c124afad715
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/shiena/ansicolor
+  version: a422bbe96644373c5753384a59d678f7d261ff10
+- name: github.com/stretchr/objx
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
+  version: 18a02ba4a312f95da08ff4cfc0055750ce50ae9e
   subpackages:
   - assert
+  - http
+  - mock
 - name: github.com/urfave/cli
-  version: d53eb991652b1d438abdd34ce4bfa3ef1539108e
-testImports: []
+  version: 9a18ffad6c548ca4d458d4c30a8aa4d181cf92fa
+- name: golang.org/x/tools
+  version: 8b84dae17391c154ca50b0162662aa1fc9ff84c2
+  subpackages:
+  - go/loader
+  - go/ast/astutil
+  - go/buildutil
+- name: gopkg.in/yaml.v2
+  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,9 +7,8 @@ import:
 - package: github.com/hashicorp/hcl
 - package: github.com/stretchr/testify/assert
 - package: github.com/go-errors/errors
+- package: github.com/mitchellh/mapstructure
 - package: github.com/aws/aws-sdk-go
-  version: 1.4.14
-  repo:    git@github.com:aws/aws-sdk-go
   subpackages:
   - aws
   - aws/defaults

--- a/locks/dynamodb/dynamo_lock.go
+++ b/locks/dynamodb/dynamo_lock.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/locks"
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/gruntwork-io/terragrunt/aws_helper"
 )
 
 // A lock that uses AWS's DynamoDB to acquire and release locks
@@ -102,24 +101,12 @@ func (dynamoLock DynamoDbLock) String() string {
 
 // Create an authenticated client for DynamoDB
 func createDynamoDbClient(awsRegion string) (*dynamodb.DynamoDB, error) {
-	config, err := createAwsConfig(awsRegion)
+	config, err := aws_helper.CreateAwsConfig(awsRegion)
 	if err != nil {
 		return nil, err
 	}
 
 	return dynamodb.New(session.New(), config), nil
-}
-
-// Returns an AWS config object for the given region, ensuring that the config has credentials
-func createAwsConfig(awsRegion string) (*aws.Config, error) {
-	config := defaults.Get().Config.WithRegion(awsRegion)
-
-	_, err := config.Credentials.Get()
-	if err != nil {
-		return nil, errors.WithStackTraceAndPrefix(err, "Error finding AWS credentials (did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables?)")
-	}
-
-	return config, nil
 }
 
 var StateFileIdMissing = fmt.Errorf("state_file_id cannot be empty")

--- a/options/options.go
+++ b/options/options.go
@@ -4,5 +4,6 @@ package options
 type TerragruntOptions struct {
 	TerragruntConfigPath string
 	NonInteractive       bool
+	NonTerragruntArgs    []string
 }
 

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -16,6 +16,13 @@ type RemoteState struct {
 	Config  map[string]string `hcl:"config"`
 }
 
+type RemoteStateInitializer func(map[string]string, *options.TerragruntOptions) error
+
+// TODO: initialization actions for other remote state backends can be added here
+var remoteStateInitializers = map[string]RemoteStateInitializer {
+	"s3": InitializeRemoteStateS3,
+}
+
 // Fill in any default configuration for remote state
 func (remoteState *RemoteState) FillDefaults() {
 	// Nothing to do
@@ -27,20 +34,33 @@ func (remoteState *RemoteState) Validate() error {
 		return errors.WithStackTrace(RemoteBackendMissing)
 	}
 
-	// TODO: for the S3 backend, check that encryption is enabled
-	// TODO: for the S3 backend, use the AWS API to verify the S3 bucket has versioning enabled
+	return nil
+}
+
+// Perform any actions necessary to initialize the remote state before it's used for storage. For example, if you're
+// using S3 for remote state storage, this may create the S3 bucket if it doesn't exist already.
+func (remoteState *RemoteState) Initialize(terragruntOptions *options.TerragruntOptions) error {
+	initializer, hasInitializer := remoteStateInitializers[remoteState.Backend]
+	if hasInitializer {
+		return initializer(remoteState.Config, terragruntOptions)
+	}
 
 	return nil
 }
 
 // Configure Terraform remote state
-func (remoteState RemoteState) ConfigureRemoteState(terragruntOptions options.TerragruntOptions) error {
+func (remoteState RemoteState) ConfigureRemoteState(terragruntOptions *options.TerragruntOptions) error {
 	shouldConfigure, err := shouldConfigureRemoteState(remoteState, terragruntOptions)
 	if err != nil {
 		return err
 	}
 
 	if shouldConfigure {
+		util.Logger.Printf("Initializing remote state for the %s backend", remoteState.Backend)
+		if err := remoteState.Initialize(terragruntOptions); err != nil {
+			return err
+		}
+
 		util.Logger.Printf("Configuring remote state for the %s backend", remoteState.Backend)
 		return shell.RunShellCommand("terraform", remoteState.toTerraformRemoteConfigArgs()...)
 	}
@@ -52,7 +72,7 @@ func (remoteState RemoteState) ConfigureRemoteState(terragruntOptions options.Te
 //
 // 1. Remote state has not already been configured
 // 2. Remote state has been configured, but for a different backend type, and the user confirms it's OK to overwrite it.
-func shouldConfigureRemoteState(remoteStateFromTerragruntConfig RemoteState, terragruntOptions options.TerragruntOptions) (bool, error) {
+func shouldConfigureRemoteState(remoteStateFromTerragruntConfig RemoteState, terragruntOptions *options.TerragruntOptions) (bool, error) {
 	state, err := ParseTerraformStateFileFromDefaultLocations()
 	if err != nil {
 		return false, err
@@ -68,7 +88,7 @@ func shouldConfigureRemoteState(remoteStateFromTerragruntConfig RemoteState, ter
 // Check if the remote state that is already configured matches the one specified in the Terragrunt config. If it does,
 // return false to indicate remote state does not need to be configured again. If it doesn't, prompt the user whether
 // we should override the existing remote state setting.
-func shouldOverrideExistingRemoteState(existingRemoteState *TerraformStateRemote, remoteStateFromTerragruntConfig RemoteState, terragruntOptions options.TerragruntOptions) (bool, error) {
+func shouldOverrideExistingRemoteState(existingRemoteState *TerraformStateRemote, remoteStateFromTerragruntConfig RemoteState, terragruntOptions *options.TerragruntOptions) (bool, error) {
 	if existingRemoteState.Type != remoteStateFromTerragruntConfig.Backend {
 		prompt := fmt.Sprintf("WARNING: Terraform remote state is already configured, but for backend %s, whereas your .terragrunt file specifies %s. Overwrite?", existingRemoteState.Type, remoteStateFromTerragruntConfig.Backend)
 		return shell.PromptUserForYesNo(prompt, terragruntOptions)

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -1,0 +1,168 @@
+package remote
+
+import (
+	"github.com/mitchellh/mapstructure"
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws"
+	"fmt"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/gruntwork-io/terragrunt/shell"
+	"github.com/gruntwork-io/terragrunt/aws_helper"
+)
+
+// A representation of the configuration options available for S3 remote state
+type RemoteStateConfigS3 struct {
+	Encrypt string
+	Bucket  string
+	Key     string
+	Region  string
+}
+
+// Initialize the remote state S3 bucket specified in the given config. This function will validate the config
+// parameters, create the S3 bucket if it doesn't already exist, and check that versioning is enabled.
+func InitializeRemoteStateS3(config map[string]string, terragruntOptions *options.TerragruntOptions) error {
+	s3Config, err := parseS3Config(config)
+	if err != nil {
+		return err
+	}
+
+	if err := validateS3Config(s3Config, terragruntOptions); err != nil {
+		return err
+	}
+
+	s3Client, err := CreateS3Client(s3Config.Region)
+	if err != nil {
+		return err
+	}
+
+	if err := createS3BucketIfNecessary(s3Client, s3Config, terragruntOptions); err != nil {
+		return err
+	}
+
+	if err := checkIfVersioningEnabled(s3Client, s3Config, terragruntOptions); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Parse the given map into an S3 config
+func parseS3Config(config map[string]string) (*RemoteStateConfigS3, error) {
+	var s3Config RemoteStateConfigS3
+	if err := mapstructure.Decode(config, &s3Config); err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	return &s3Config, nil
+}
+
+// Validate all the parameters of the given S3 remote state configuration
+func validateS3Config(config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
+	if config.Region == "" {
+		return errors.WithStackTrace(MissingRequiredS3RemoteStateConfig("region"))
+	}
+
+	if config.Bucket == "" {
+		return errors.WithStackTrace(MissingRequiredS3RemoteStateConfig("bucket"))
+	}
+
+	if config.Key == "" {
+		return errors.WithStackTrace(MissingRequiredS3RemoteStateConfig("key"))
+	}
+
+	if config.Encrypt != "true" {
+		util.Logger.Printf("WARNING: encryption is not enabled on the S3 remote state bucket %s. Terraform state files may contain secrets, so we STRONGLY recommend enablying encryption!", config.Bucket)
+	}
+
+	return nil
+}
+
+// If the bucket specified in the given config doesn't already exist, prompt the user to create it, and if the user
+// confirms, create the bucket and enable versioning for it.
+func createS3BucketIfNecessary(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
+	if !DoesS3BucketExist(s3Client, config) {
+		prompt := fmt.Sprintf("Remote state S3 bucket %s does not exist or you don't have permissions to access it. Would you Terragrunt to create it?", config.Bucket)
+		shouldCreateBucket, err := shell.PromptUserForYesNo(prompt, terragruntOptions)
+		if err != nil {
+			return err
+		}
+
+		if shouldCreateBucket {
+			return CreateS3BucketWithVersioning(s3Client, config)
+		}
+	}
+
+	return nil
+}
+
+// Check if versioning is enabled for the S3 bucket specified in the given config and warn the user if it is not
+func checkIfVersioningEnabled(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
+	out, err := s3Client.GetBucketVersioning(&s3.GetBucketVersioningInput{Bucket: aws.String(config.Bucket)})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	if *out.Status != s3.BucketVersioningStatusEnabled {
+		util.Logger.Printf("WARNING: Versioning is not enabled for the remote state S3 bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
+	}
+
+	return nil
+}
+
+// Create the given S3 bucket and enable versioning for it
+func CreateS3BucketWithVersioning(s3Client *s3.S3, config *RemoteStateConfigS3) error {
+	if err := CreateS3Bucket(s3Client, config); err != nil {
+		return err
+	}
+
+	if err := EnableVersioningForS3Bucket(s3Client, config); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Create the S3 bucket specified in the given config
+func CreateS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3) error {
+	util.Logger.Printf("Creating S3 bucket %s", config.Bucket)
+	_, err := s3Client.CreateBucket(&s3.CreateBucketInput{Bucket: aws.String(config.Bucket)})
+	return errors.WithStackTrace(err)
+}
+
+// Enable versioning for the S3 bucket specified in the given config
+func EnableVersioningForS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3) error {
+	util.Logger.Printf("Enabling versioning on S3 bucket %s", config.Bucket)
+	input := s3.PutBucketVersioningInput{
+		Bucket: aws.String(config.Bucket),
+		VersioningConfiguration: &s3.VersioningConfiguration{Status: aws.String(s3.BucketVersioningStatusEnabled)},
+	}
+	_, err := s3Client.PutBucketVersioning(&input)
+	return errors.WithStackTrace(err)
+}
+
+// Returns true if the S3 bucket specified in the given config exists and the current user has the ability to access
+// it.
+func DoesS3BucketExist(s3Client *s3.S3, config *RemoteStateConfigS3) bool {
+	_, err := s3Client.HeadBucket(&s3.HeadBucketInput{Bucket: aws.String(config.Bucket)})
+	return err == nil
+}
+
+// Create an authenticated client for DynamoDB
+func CreateS3Client(awsRegion string) (*s3.S3, error) {
+	config, err := aws_helper.CreateAwsConfig(awsRegion)
+	if err != nil {
+		return nil, err
+	}
+
+	return s3.New(session.New(), config), nil
+}
+
+// Custom error types
+
+type MissingRequiredS3RemoteStateConfig string
+func (configName MissingRequiredS3RemoteStateConfig) Error() string {
+	return fmt.Sprintf("Missing required S3 remote state configuration %s", string(configName))
+}

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -91,7 +91,7 @@ func TestShouldOverrideExistingRemoteState(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		shouldOverride, err := shouldOverrideExistingRemoteState(&testCase.existingState, testCase.stateFromConfig, terragruntOptions)
+		shouldOverride, err := shouldOverrideExistingRemoteState(&testCase.existingState, testCase.stateFromConfig, &terragruntOptions)
 		assert.Nil(t, err, "Unexpected error: %v", err)
 		assert.Equal(t, testCase.shouldOverride, shouldOverride, "Expect shouldOverrideExistingRemoteState to return %t but got %t for existingRemoteState %v and remoteStateFromTerragruntConfig %v", testCase.shouldOverride, shouldOverride, testCase.existingState, testCase.stateFromConfig)
 	}

--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Prompt the user for text in the CLI. Returns the text entered by the user.
-func PromptUserForInput(prompt string, terragruntOptions options.TerragruntOptions) (string, error) {
+func PromptUserForInput(prompt string, terragruntOptions *options.TerragruntOptions) (string, error) {
 	fmt.Print(prompt)
 
 	if terragruntOptions.NonInteractive {
@@ -31,7 +31,7 @@ func PromptUserForInput(prompt string, terragruntOptions options.TerragruntOptio
 }
 
 // Prompt the user for a yes/no response and return true if they entered yes.
-func PromptUserForYesNo(prompt string, terragruntOptions options.TerragruntOptions) (bool, error) {
+func PromptUserForYesNo(prompt string, terragruntOptions *options.TerragruntOptions) (bool, error) {
 	resp, err := PromptUserForInput(fmt.Sprintf("%s (y/n) ", prompt), terragruntOptions)
 
 	if err != nil {

--- a/test/fixture/.terragrunt
+++ b/test/fixture/.terragrunt
@@ -14,7 +14,7 @@ remote_state = {
   backend = "s3"
   config {
     encrypt = "true"
-    bucket = "gruntwork-terragrunt-tests"
+    bucket = "__FILL_IN_BUCKET_NAME__"
     key = "terraform.tfstate"
     region = "us-west-2"
   }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -8,108 +8,137 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/defaults"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/gruntwork-io/terragrunt/cli"
+	"bytes"
+	"time"
+	"math/rand"
+	"io/ioutil"
+	"path"
+	"github.com/gruntwork-io/terragrunt/remote"
+	"github.com/stretchr/testify/assert"
 )
 
 // hard-code this to match the test fixture for now
 const (
 	TERRAFORM_REMOTE_STATE_S3_REGION      = "us-west-2"
-	TERRAFORM_REMOTE_STATE_S3_BUCKET_NAME = "gruntwork-terragrunt-tests"
 	TEST_FIXTURE_PATH                     = "fixture/"
 )
 
 func TestTerragruntWorksWithLocalTerraformVersion(t *testing.T) {
-	if err := validateTerraformIsInstalled(t); err != nil {
-		t.Fatalf("A local instance of Terraform is not in the system PATH. Please install Terraform to continue.\n")
-	}
+	validateCommandInstalled(t, "terraform")
 
-	if err := validateS3BucketExists(t, TERRAFORM_REMOTE_STATE_S3_REGION, TERRAFORM_REMOTE_STATE_S3_BUCKET_NAME); err != nil {
-		t.Fatalf("The S3 Bucket in the .terragrunt file does not exist. %s", err)
-	}
+	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
+	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, TEST_FIXTURE_PATH, s3BucketName)
 
-	if err := runTerragruntApply(); err != nil {
+	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
+	runTerragruntApply(t, TEST_FIXTURE_PATH, tmpTerragruntConfigPath)
+	validateS3BucketExists(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
+}
+
+// Run Terragrunt Apply directory in the test fixture path
+func runTerragruntApply(t *testing.T, templatesPath string, terragruntConfigPath string) {
+	os.Chdir(templatesPath)
+
+	app := cli.CreateTerragruntCli("TEST")
+
+	cmd := fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-config %s", terragruntConfigPath)
+	args := strings.Split(cmd, " ")
+
+	if err := app.Run(args); err != nil {
 		t.Fatalf("Failed to run terragrunt: %s", err)
 	}
 }
 
-// Run Terragrunt Apply directory in the test fixture path
-func runTerragruntApply() error {
-	os.Chdir(TEST_FIXTURE_PATH)
-
-	app := cli.CreateTerragruntCli("TEST")
-
-	return app.Run(strings.Split("terragrunt apply --terragrunt-non-interactive", " "))
-}
-
-// Validate that a local instance of Terraform is installed.
-func validateTerraformIsInstalled(t *testing.T) error {
-	if err := runShellCommandWithNoOutput(t, "terraform", "version"); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Run the given "command" plus any "args" passed to it. Print the output to stdout.
-func runShellCommandWithOutput(t *testing.T, command string, args ...string) error {
-	cmd := exec.Command(command, args...)
-
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
-}
-
-// Run the given "command" plus any "args" passed to it. Suppress output.
-func runShellCommandWithNoOutput(t *testing.T, command string, args ...string) error {
-	cmd := exec.Command(command, args...)
-
-	cmd.Stdout = nil
-	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
-}
-
-// Check that the S3 Bucket of the given name and region exists by attempting to list objects from it.
-func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) error {
-	client, err := createS3Client(awsRegion)
+func createTmpTerragruntConfig(t *testing.T, templatesPath string, s3BucketName string) string {
+	tmpTerragruntConfigFile, err := ioutil.TempFile("", ".terragrunt")
 	if err != nil {
-		return err
+		t.Fatalf("Failed to create temp file due to error: %v", err)
 	}
 
-	params := &s3.ListObjectsInput{
+	originalTerragruntConfigPath := path.Join(templatesPath, ".terragrunt")
+	originalTerragruntConfigBytes, err := ioutil.ReadFile(originalTerragruntConfigPath)
+	if err != nil {
+		t.Fatalf("Error reading Terragrunt config at %s: %v", originalTerragruntConfigPath, err)
+	}
+
+	originalTerragruntConfigString := string(originalTerragruntConfigBytes)
+	newTerragruntConfigString := strings.Replace(originalTerragruntConfigString, "__FILL_IN_BUCKET_NAME__", s3BucketName, -1)
+
+	if err := ioutil.WriteFile(tmpTerragruntConfigFile.Name(), []byte(newTerragruntConfigString), 0444); err != nil {
+		t.Fatalf("Error writing temp Terragrunt config to %s: %v", tmpTerragruntConfigFile.Name(), err)
+	}
+
+	return tmpTerragruntConfigFile.Name()
+}
+
+// Returns a unique (ish) id we can attach to resources and tfstate files so they don't conflict with each other
+// Uses base 62 to generate a 6 character string that's unlikely to collide with the handful of tests we run in
+// parallel. Based on code here: http://stackoverflow.com/a/9543797/483528
+func uniqueId() string {
+	const BASE_62_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	const UNIQUE_ID_LENGTH = 6 // Should be good for 62^6 = 56+ billion combinations
+
+	var out bytes.Buffer
+
+	randInstance := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < UNIQUE_ID_LENGTH; i++ {
+		out.WriteByte(BASE_62_CHARS[randInstance.Intn(len(BASE_62_CHARS))])
+	}
+
+	return out.String()
+}
+
+// Validate that the given command is available in PATH
+func validateCommandInstalled(t *testing.T, command string) {
+	_, err := exec.LookPath(command)
+	if err != nil {
+		t.Fatalf("Command '%s' not found in PATH", command)
+	}
+}
+
+// Check that the S3 Bucket of the given name and region exists. Terragrunt should create this bucket during the test.
+func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {
+	s3Client, err := remote.CreateS3Client(awsRegion)
+	if err != nil {
+		t.Fatalf("Error creating S3 client: %v", err)
+	}
+
+	remoteStateConfig := remote.RemoteStateConfigS3{Bucket: bucketName, Region: awsRegion}
+	assert.True(t, remote.DoesS3BucketExist(s3Client, &remoteStateConfig), "Terragrunt failed to create remote state S3 bucket %s", bucketName)
+}
+
+// Delete the specified S3 bucket to clean up after a test
+func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
+	s3Client, err := remote.CreateS3Client(awsRegion)
+	if err != nil {
+		t.Fatalf("Error creating S3 client: %v", err)
+	}
+
+	t.Logf("Deleting test s3 bucket %s", bucketName)
+
+	out, err := s3Client.ListObjectVersions(&s3.ListObjectVersionsInput{Bucket: aws.String(bucketName)})
+	if err != nil {
+		t.Fatalf("Failed to list object versions in s3 bucket %s: %v", bucketName, err)
+	}
+
+	objectIdentifiers := []*s3.ObjectIdentifier{}
+	for _, version := range out.Versions {
+		objectIdentifiers = append(objectIdentifiers, &s3.ObjectIdentifier{
+			Key: version.Key,
+			VersionId: version.VersionId,
+		})
+	}
+
+	deleteInput := &s3.DeleteObjectsInput{
 		Bucket: aws.String(bucketName),
+		Delete: &s3.Delete{Objects: objectIdentifiers},
+	}
+	if _, err := s3Client.DeleteObjects(deleteInput); err != nil {
+		t.Fatalf("Error deleting all versions of all objects in bucket %s: %v", bucketName, err)
 	}
 
-	_, err = client.ListObjects(params)
-	if err != nil {
-		return fmt.Errorf("S3 Bucket Name = '%s'. S3 Bucket Region = '%s'. Full Error Message = %s", bucketName, awsRegion, err)
+	if _, err := s3Client.DeleteBucket(&s3.DeleteBucketInput{Bucket: aws.String(bucketName)}); err != nil {
+		t.Fatalf("Failed to delete S3 bucket %s: %v", bucketName, err)
 	}
-
-	return nil
-}
-
-// Create an authenticated client for S3
-func createS3Client(awsRegion string) (*s3.S3, error) {
-	config, err := createAwsConfig(awsRegion)
-	if err != nil {
-		return nil, err
-	}
-
-	return s3.New(session.New(), config), nil
-}
-
-// Returns an AWS config object for the given region, ensuring that the config has credentials
-func createAwsConfig(awsRegion string) (*aws.Config, error) {
-	config := defaults.Get().Config.WithRegion(awsRegion)
-
-	_, err := config.Credentials.Get()
-	if err != nil {
-		return nil, fmt.Errorf("Error finding AWS credentials (did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables?): %s", err)
-	}
-
-	return config, nil
 }


### PR DESCRIPTION
I’ve also updated the integration test to use this functionality so the
S3 bucket we use at test time is not hard-coded.

Fixes #35 and #43.

I also worked around a bug/limitation in urfave CLI where command-line flags passed in after the name of a command (e.g. `terragrunt apply --foo`) are not parsed, at all.