### PR TITLE
saving userArn instead of userid into db items

### DIFF
--- a/locks/dynamodb/dynamo_lock_item.go
+++ b/locks/dynamodb/dynamo_lock_item.go
@@ -108,7 +108,7 @@ func createItemAttributes(itemId string, client *dynamodb.DynamoDB) (map[string]
 	}, nil
 }
 
-// Return the UserID
+// Return the UserArn
 func getCallerIdentity(client *dynamodb.DynamoDB) (string, error) {
 	stsconn := sts.New(session.New(), &client.Config)
 	output, err := stsconn.GetCallerIdentity(&sts.GetCallerIdentityInput{})
@@ -116,7 +116,7 @@ func getCallerIdentity(client *dynamodb.DynamoDB) (string, error) {
 		return "", errors.WithStackTrace(err)
 	}
 
-	return *output.UserId, nil
+	return *output.Arn, nil
 }
 
 type AttributeMissing struct {


### PR DESCRIPTION
Changes
- Extract the `userArn` from STS response to make it easier to identify who is locking the TF state file

- Output msg for acquire lock
```[terragrunt] 2016/12/02 20:26:13 Someone already has a lock on state file my-app! arn:aws:iam::123456789012:user/username@domain.com@127.0.0.1 acquired the lock on 2016-12-03 04:20:01.018442478 +0000 UTC.```

- DB Item

| StateFileId     | CreationDate  | Ip             |  Username
| ------------- |:-------------: | -------:    |  -------: 
| my-app          | 2016-12-03 04:20:01.018442478 +0000 UTC                   | 127.0.0.1  | arn:aws:iam::123456789012:user/username
