### PR TITLE
Fix panic when S3 Bucket Versioning is not enabled.

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -111,7 +111,7 @@ func checkIfVersioningEnabled(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 
 	// NOTE: There must be a bug in the AWS SDK since out == nil when versioning is not enabled. In the future,
 	// check the AWS SDK for updates to see if we can remove "out == nil ||".
-	if out == nil || *out.Status != s3.BucketVersioningStatusEnabled {
+	if out == nil || out.Status == nil || *out.Status != s3.BucketVersioningStatusEnabled {
 		util.Logger.Printf("WARNING: Versioning is not enabled for the remote state S3 bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
 	}
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -109,7 +109,9 @@ func checkIfVersioningEnabled(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 		return errors.WithStackTrace(err)
 	}
 
-	if *out.Status != s3.BucketVersioningStatusEnabled {
+	// NOTE: There must be a bug in the AWS SDK since out == nil when versioning is not enabled. In the future,
+	// check the AWS SDK for updates to see if we can remove "out == nil ||".
+	if out == nil || *out.Status != s3.BucketVersioningStatusEnabled {
 		util.Logger.Printf("WARNING: Versioning is not enabled for the remote state S3 bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
 	}
 


### PR DESCRIPTION
Fixes #65. My guess is that this is a bug with the AWS SDK for Golang since the interface seems to allow checking a `Status` field, but in practice this field is `nil` unless S3 Bucket Versioning is enabled.

Do NOT merge this until we resolve #64 so that we can write a failing unit test for this to validate that the change.