### PR TITLE
Make sure terragrunt calls "get" in proper folder during spin-up and tear-down

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/urfave/cli"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/spin"
+	"path/filepath"
 )
 
 const OPT_TERRAGRUNT_CONFIG = "terragrunt-config"
@@ -157,7 +158,7 @@ func runMultiModuleCommand(command string, terragruntOptions *options.Terragrunt
 func downloadModules(terragruntOptions *options.TerragruntOptions) error {
 	switch firstArg(terragruntOptions.TerraformCliArgs) {
 	case "apply", "destroy", "graph", "output", "plan", "show", "taint", "untaint", "validate":
-		shouldDownload, err := shouldDownloadModules()
+		shouldDownload, err := shouldDownloadModules(terragruntOptions)
 		if err != nil {
 			return err
 		}
@@ -173,12 +174,12 @@ func downloadModules(terragruntOptions *options.TerragruntOptions) error {
 // Note that to keep the logic in this code very simple, this code ONLY detects the case where you haven't downloaded
 // modules at all. Detecting if your downloaded modules are out of date (as opposed to missing entirely) is more
 // complicated and not something we handle at the moment.
-func shouldDownloadModules() (bool, error) {
-	if util.FileExists(".terraform/modules") {
+func shouldDownloadModules(terragruntOptions *options.TerragruntOptions) (bool, error) {
+	if util.FileExists(filepath.Join(terragruntOptions.WorkingDir, ".terraform/modules")) {
 		return false, nil
 	}
 
-	return util.Grep(MODULE_REGEX, TERRAFORM_EXTENSION_GLOB)
+	return util.Grep(MODULE_REGEX, fmt.Sprintf("%s/%s", terragruntOptions.WorkingDir, TERRAFORM_EXTENSION_GLOB))
 }
 
 // If the user entered a Terraform command that uses state (e.g. plan, apply), make sure remote state is configured

--- a/test/fixture-stack/stage/search-app/example-module/main.tf
+++ b/test/fixture-stack/stage/search-app/example-module/main.tf
@@ -1,0 +1,8 @@
+# Create an arbitrary local resource
+data "template_file" "text" {
+  template = "Example text from a module"
+}
+
+output "text" {
+  value = "${data.template_file.text.rendered}"
+}

--- a/test/fixture-stack/stage/search-app/main.tf
+++ b/test/fixture-stack/stage/search-app/main.tf
@@ -1,6 +1,10 @@
 # Create an arbitrary local resource
 data "template_file" "text" {
-  template = "[I am a search-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.text}, redis = ${data.terraform_remote_state.redis.text}]"
+  template = "[I am a search-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.text}, redis = ${data.terraform_remote_state.redis.text}, example_module = ${module.example_module.text}]"
+}
+
+module "example_module" {
+  source = "./example-module"
 }
 
 output "text" {

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -1,6 +1,6 @@
 # Create an arbitrary local resource
 data "template_file" "test" {
-    template = "Hello, I am a template. My sample_var value = ${sample_var}"
+    template = "Hello, I am a template. My sample_var value = $${sample_var}"
 
     vars {
         sample_var = "${var.sample_var}"


### PR DESCRIPTION
This is a fix for #71. The `shouldDownloadModules` method in Terragrunt was using the (implicit) current working directory rather than the `WorkingDir` set in `TerragruntOptions`. When running the `spin-up` and `tear-down` commands, you must use `WorkingDir`, or you’ll be looking in the wrong folder.

I added a failing test case, implemented the fix, and now the test case passes.