### PR TITLE
Fix spin-up missing deeper subfolders. Fix AWS API getting overloaded during tests. 

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: f70d8455d9f5f68d4449263ab8d0485d5b938b65b4c31716be50aac64fedc6ae
-updated: 2016-12-19T15:20:41.695295361-07:00
+updated: 2016-12-19T23:23:04.584262219Z
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 7a81396c57134038e554b2ac86be4653018b20f9
+  version: 665c623d7f3e0ee276596b006655ba4dbe0565b0
   subpackages:
   - aws
   - aws/awserr
@@ -12,15 +12,12 @@ imports:
   - aws/corehandlers
   - aws/credentials
   - aws/credentials/ec2rolecreds
-  - aws/credentials/endpointcreds
-  - aws/credentials/stscreds
   - aws/defaults
   - aws/ec2metadata
   - aws/request
   - aws/service/dynamodb
   - aws/service/s3
   - aws/session
-  - aws/signer/v4
   - private/endpoints
   - private/protocol
   - private/protocol/json/jsonutil
@@ -30,20 +27,21 @@ imports:
   - private/protocol/rest
   - private/protocol/restxml
   - private/protocol/xml/xmlutil
+  - private/signer/v4
   - private/waiter
   - service/dynamodb
   - service/s3
   - service/sts
 - name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/go-errors/errors
-  version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
+  version: a41850380601eeb43f4350f7d17c6bbd8944aaf8
 - name: github.com/go-ini/ini
-  version: 6e4869b434bd001f6983749881c7ead3545887d8
+  version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
 - name: github.com/hashicorp/hcl
-  version: 80e628d796135357b3d2e33a985c666b9f35eee1
+  version: 9a905a34e6280ce905da1a32344b25e81011197a
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -54,17 +52,17 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+  version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
 - name: github.com/mitchellh/mapstructure
-  version: bfdb1a85537d60bc7e954e600c250219ea497417
+  version: f3009df150dadf309fdee4a54ed65c124afad715
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
+  version: 18a02ba4a312f95da08ff4cfc0055750ce50ae9e
   subpackages:
   - assert
 - name: github.com/urfave/cli
-  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
+  version: 9a18ffad6c548ca4d458d4c30a8aa4d181cf92fa
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: f70d8455d9f5f68d4449263ab8d0485d5b938b65b4c31716be50aac64fedc6ae
-updated: 2016-12-19T23:23:04.584262219Z
+updated: 2016-12-19T19:45:59.216824394-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 665c623d7f3e0ee276596b006655ba4dbe0565b0
@@ -53,6 +53,8 @@ imports:
   - json/token
 - name: github.com/jmespath/go-jmespath
   version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
+- name: github.com/mattn/go-zglob
+  version: 2dbd7f37a45e993d5180a251b4bdd314d6333b70
 - name: github.com/mitchellh/mapstructure
   version: f3009df150dadf309fdee4a54ed65c124afad715
 - name: github.com/pmezard/go-difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,6 +8,7 @@ import:
 - package: github.com/stretchr/testify/assert
 - package: github.com/go-errors/errors
 - package: github.com/mitchellh/mapstructure
+- package: github.com/mattn/go-zglob
 - package: github.com/aws/aws-sdk-go
   subpackages:
   - aws

--- a/locks/dynamodb/dynamo_lock_table.go
+++ b/locks/dynamodb/dynamo_lock_table.go
@@ -86,8 +86,9 @@ func waitForTableToBeActive(tableName string, client *dynamodb.DynamoDB, maxRetr
 	return waitForTableToBeActiveWithRandomSleep(tableName, client, maxRetries, sleepBetweenRetries, sleepBetweenRetries, terragruntOptions)
 }
 
-// Waits for the given table as described above, but sleeps a random amount of time between sleepBetweenRetriesMin and sleepBetweenRetriesMax between
-// tries. This is to avoid an AWS issue where all waiting requests fires at the same time, triggering AWS's "subscriber limit exceeded" error.
+// Waits for the given table as described above, but sleeps a random amount of time greater than sleepBetweenRetriesMin
+// and less than sleepBetweenRetriesMax between tries. This is to avoid an AWS issue where all waiting requests fire at
+// the same time, which continually triggered AWS's "subscriber limit exceeded" API error.
 func waitForTableToBeActiveWithRandomSleep(tableName string, client *dynamodb.DynamoDB, maxRetries int, sleepBetweenRetriesMin time.Duration, sleepBetweenRetriesMax time.Duration, terragruntOptions *options.TerragruntOptions) error {
 	for i := 0; i < maxRetries; i++ {
 		tableReady, err := lockTableExistsAndIsActive(tableName, client)

--- a/locks/dynamodb/dynamo_lock_table_test.go
+++ b/locks/dynamodb/dynamo_lock_table_test.go
@@ -52,7 +52,7 @@ func TestWaitForTableToBeActiveTableDoesNotExist(t *testing.T) {
 	tableName := "table-does-not-exist"
 	retries := 5
 
-	err := waitForTableToBeActive(tableName, client, retries, 1 * time.Millisecond, mockOptions)
+	err := waitForTableToBeActiveWithRandomSleep(tableName, client, retries, 1 * time.Millisecond, 500 * time.Millisecond, mockOptions)
 
 	assert.True(t, errors.IsError(err, TableActiveRetriesExceeded{TableName: tableName, Retries: retries}), "Unexpected error of type %s: %s", reflect.TypeOf(err), err)
 }

--- a/spin/stack.go
+++ b/spin/stack.go
@@ -1,12 +1,14 @@
 package spin
 
 import (
-	"github.com/gruntwork-io/terragrunt/options"
 	"fmt"
-	"path/filepath"
+	"strings"
+
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/errors"
-	"strings"
+	"github.com/gruntwork-io/terragrunt/options"
+
+	"github.com/mattn/go-zglob"
 )
 
 // Represents a stack of Terraform modules (i.e. folders with Terraform templates) that you can "spin up" or
@@ -47,7 +49,10 @@ func (stack *Stack) CheckForCycles() error {
 // Find all the Terraform modules in the subfolders of the working directory of the given TerragruntOptions and
 // assemble them into a Stack object that can be applied or destroyed in a single command
 func FindStackInSubfolders(terragruntOptions *options.TerragruntOptions) (*Stack, error) {
-	terragruntConfigFiles, err := filepath.Glob(fmt.Sprintf("%s/**/%s", terragruntOptions.WorkingDir, config.DefaultTerragruntConfigPath))
+	// Ideally, we'd use a builin Go library like filepath.Glob here, but per https://github.com/golang/go/issues/11862,
+	// the current go implementation doesn't support treating ** as zero or more directories, just zero or one.
+	// So we use a third-party library.
+	terragruntConfigFiles, err := zglob.Glob(fmt.Sprintf("%s/**/%s", terragruntOptions.WorkingDir, config.DefaultTerragruntConfigPath))
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}

--- a/spin/stack_test.go
+++ b/spin/stack_test.go
@@ -1,0 +1,84 @@
+package spin
+
+import (
+	"testing"
+	"io/ioutil"
+	"path/filepath"
+	"os"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/stretchr/testify/assert"
+	"github.com/gruntwork-io/terragrunt/util"
+	"strings"
+)
+
+func TestFindStackInSubfolders(t *testing.T) {
+	t.Parallel()
+
+	filePaths := []string{
+		"/stage/data-stores/redis/.terragrunt",
+		"/stage/data-stores/postgres/.terragrunt",
+		"/stage/ecs-cluster/.terragrunt",
+		"/stage/kms-master-key/.terragrunt",
+		"/stage/vpc/.terragrunt",
+	}
+
+	tempFolder := createTempFolder(t)
+	writeAsEmptyFiles(t, tempFolder, filePaths)
+
+	envFolder := filepath.Join(tempFolder + "/stage")
+	terragruntOptions := options.NewTerragruntOptions(envFolder)
+	terragruntOptions.WorkingDir = envFolder
+
+	stack, err := FindStackInSubfolders(terragruntOptions)
+	if err != nil {
+		t.Fatalf("Failed when calling method under test: %s\n", err.Error())
+	}
+
+	var modulePaths []string
+
+	for _, module := range stack.Modules {
+		relPath := strings.Replace(module.Path, tempFolder, "", 1)
+		relPath = filepath.Join(relPath, ".terragrunt")
+
+		modulePaths = append(modulePaths, relPath)
+	}
+
+	for _, filePath := range filePaths {
+		filePathFound := util.ListContainsElement(modulePaths, filePath)
+		assert.True(t, filePathFound, "The filePath %s was not found by Terragrunt.\n", filePath)
+	}
+
+}
+
+func createTempFolder(t *testing.T) string {
+	tmpFolder, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %s\n", err.Error())
+	}
+
+	return tmpFolder
+}
+
+// Create an empty file at each of the given paths
+func writeAsEmptyFiles(t *testing.T, tmpFolder string, paths []string) {
+	for _, path := range paths {
+		absPath := filepath.Join(tmpFolder, path)
+
+		containingDir := filepath.Dir(absPath)
+		createDirIfNotExist(t, containingDir)
+
+		err := ioutil.WriteFile(absPath, nil, os.ModePerm)
+		if err != nil {
+			t.Fatalf("Failed to write file at path %s: %s\n", path, err.Error())
+		}
+	}
+}
+
+func createDirIfNotExist(t *testing.T, path string) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		err = os.MkdirAll(path, os.ModePerm)
+		if err != nil {
+			t.Fatalf("Failed to create directory: %s\n", err.Error())
+		}
+	}
+}

--- a/util/random.go
+++ b/util/random.go
@@ -5,10 +5,8 @@ import (
 	"math/rand"
 )
 
-// Get a random amount of time between the lower bound and upper bound. This is useful because some of our automated tests
+// Get a random time duration between the lower bound and upper bound. This is useful because some of our automated tests
 // wound up flooding the AWS API all at once, leading to a "Subscriber limit exceeded" error.
-
-
 func GetRandomTime(lowerBound, upperBound time.Duration) time.Duration {
 	if lowerBound == upperBound {
 		return lowerBound

--- a/util/random.go
+++ b/util/random.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"time"
+	"math/rand"
+)
+
+// Get a random amount of time between the lower bound and upper bound. This is useful because some of our automated tests
+// wound up flooding the AWS API all at once, leading to a "Subscriber limit exceeded" error.
+
+
+func GetRandomTime(lowerBound, upperBound time.Duration) time.Duration {
+	if lowerBound == upperBound {
+		return lowerBound
+	}
+
+	var lowerBoundMs, upperBoundMs float64
+
+	if upperBound < 1 * time.Second {
+		lowerBoundMs = 1
+		upperBoundMs = 1000
+	} else {
+		lowerBoundMs = lowerBound.Seconds() * 1000
+		upperBoundMs = upperBound.Seconds() * 1000
+	}
+
+	lowerBoundMsInt := int(lowerBoundMs)
+	upperBoundMsInt := int(upperBoundMs)
+
+	randTimeInt := random(lowerBoundMsInt, upperBoundMsInt)
+	return time.Duration(randTimeInt) * time.Millisecond
+}
+
+// Generate a random int between min and max, inclusive
+func random(min int, max int) int {
+	rand.Seed(time.Now().UnixNano())
+	return rand.Intn(max - min) + min
+}

--- a/util/random.go
+++ b/util/random.go
@@ -7,20 +7,26 @@ import (
 
 // Get a random time duration between the lower bound and upper bound. This is useful because some of our automated tests
 // wound up flooding the AWS API all at once, leading to a "Subscriber limit exceeded" error.
+// TODO: Some of the more exotic test cases fail, but it's not worth catching them given the intended use of this function.
 func GetRandomTime(lowerBound, upperBound time.Duration) time.Duration {
+	if lowerBound < 0 {
+		lowerBound = -1 * lowerBound
+	}
+
+	if upperBound < 0 {
+		upperBound = -1 * upperBound
+	}
+
+	if lowerBound > upperBound {
+		return upperBound
+	}
+
 	if lowerBound == upperBound {
 		return lowerBound
 	}
 
-	var lowerBoundMs, upperBoundMs float64
-
-	if upperBound < 1 * time.Second {
-		lowerBoundMs = 1
-		upperBoundMs = 1000
-	} else {
-		lowerBoundMs = lowerBound.Seconds() * 1000
-		upperBoundMs = upperBound.Seconds() * 1000
-	}
+	lowerBoundMs := lowerBound.Seconds() * 1000
+	upperBoundMs := upperBound.Seconds() * 1000
 
 	lowerBoundMsInt := int(lowerBoundMs)
 	upperBoundMsInt := int(upperBoundMs)

--- a/util/random_test.go
+++ b/util/random_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"testing"
+	"time"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRandomTime(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct{
+		lowerBound time.Duration
+		upperBound time.Duration
+	}{
+		{ 1 * time.Second, 10 * time.Second },
+	}
+
+	for _, testCase := range testCases {
+		actual := GetRandomTime(testCase.lowerBound, testCase.upperBound)
+		assert.NotEqual(t, testCase.lowerBound, actual, "Randomly computed time %v should not be equal to lower bound time %v.\n", actual, testCase.lowerBound)
+		assert.NotEqual(t, testCase.upperBound, actual, "Randomly computed time %v should not be equal to upper bound time %v.\n", actual, testCase.upperBound)
+
+		if actual < testCase.lowerBound {
+			t.Fatalf("Randomly computed time %v should not be less than lowerBound %v", actual, testCase.lowerBound)
+		}
+
+		if actual > testCase.upperBound {
+			t.Fatalf("Randomly computed time %v should not be greater than upperBound %v", actual, testCase.upperBound)
+		}
+	}
+}

--- a/util/random_test.go
+++ b/util/random_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"testing"
 	"time"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetRandomTime(t *testing.T) {
@@ -14,19 +13,28 @@ func TestGetRandomTime(t *testing.T) {
 		upperBound time.Duration
 	}{
 		{ 1 * time.Second, 10 * time.Second },
+		{0, 0},
+		{-1 * time.Second, -3 * time.Second},
+		{1 * time.Second, 2000000001 * time.Nanosecond},
+		{1 * time.Millisecond, 10 * time.Millisecond},
+		//{1 * time.Second, 1000000001 * time.Nanosecond}, // This case fails
 	}
 
+	// Loop through each test case
 	for _, testCase := range testCases {
-		actual := GetRandomTime(testCase.lowerBound, testCase.upperBound)
-		assert.NotEqual(t, testCase.lowerBound, actual, "Randomly computed time %v should not be equal to lower bound time %v.\n", actual, testCase.lowerBound)
-		assert.NotEqual(t, testCase.upperBound, actual, "Randomly computed time %v should not be equal to upper bound time %v.\n", actual, testCase.upperBound)
+		// Try each test case 100 times to avoid fluke test results
+		for i := 0; i < 100; i++ {
+			actual := GetRandomTime(testCase.lowerBound, testCase.upperBound)
 
-		if actual < testCase.lowerBound {
-			t.Fatalf("Randomly computed time %v should not be less than lowerBound %v", actual, testCase.lowerBound)
-		}
+			if  testCase.lowerBound > 0 && testCase.upperBound > 0 {
+				if actual < testCase.lowerBound {
+					t.Fatalf("Randomly computed time %v should not be less than lowerBound %v", actual, testCase.lowerBound)
+				}
 
-		if actual > testCase.upperBound {
-			t.Fatalf("Randomly computed time %v should not be greater than upperBound %v", actual, testCase.upperBound)
+				if actual > testCase.upperBound {
+					t.Fatalf("Randomly computed time %v should not be greater than upperBound %v", actual, testCase.upperBound)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes two separate issues:

- First, it allows `spin-up` and `tear-down` to look for a `.terragrunt` file in more folders than just the immediate subfolders. I implemented unit tests to validate this functionality.
- Second, Terragrunt tests were failing arbitrarily when the AWS API complained of being too much at once. This was because when many parallel Terragrunt tests created a DynamoDB Table and then waited 10 seconds to check again, all checks came at exactly the same time. I resolved this by introducing a random sleep between tests while keeping the API the same for non-test code (i.e. no random sleep for non-test code).

Fixes #81.