### PR TITLE
Load .terragrunt file relative to working dir

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/util"
 	"strings"
+	"path/filepath"
 )
 
 // Parse command line options that are passed in for Terragrunt
@@ -28,22 +29,6 @@ func ParseTerragruntOptions(cliContext *cli.Context) (*options.TerragruntOptions
 // and look for the ones we need, but in the future, we should change to a different CLI library to avoid this
 // limitation.
 func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, error) {
-	terragruntConfigPath, err := parseStringArg(args, OPT_TERRAGRUNT_CONFIG, os.Getenv("TERRAGRUNT_CONFIG"))
-	if err != nil {
-		return nil, err
-	}
-	if terragruntConfigPath == "" {
-		terragruntConfigPath = config.DefaultTerragruntConfigPath
-	}
-
-	terraformPath, err := parseStringArg(args, OPT_TERRAGRUNT_TFPATH, os.Getenv("TERRAGRUNT_TFPATH"))
-	if err != nil {
-		return nil, err
-	}
-	if terraformPath == "" {
-		terraformPath = "terraform"
-	}
-
 	currentDir, err := os.Getwd()
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
@@ -52,6 +37,22 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 	workingDir, err := parseStringArg(args, OPT_WORKING_DIR, currentDir)
 	if err != nil {
 		return nil, err
+	}
+
+	terragruntConfigPath, err := parseStringArg(args, OPT_TERRAGRUNT_CONFIG, os.Getenv("TERRAGRUNT_CONFIG"))
+	if err != nil {
+		return nil, err
+	}
+	if terragruntConfigPath == "" {
+		terragruntConfigPath = filepath.Join(workingDir, config.DefaultTerragruntConfigPath)
+	}
+
+	terraformPath, err := parseStringArg(args, OPT_TERRAGRUNT_TFPATH, os.Getenv("TERRAGRUNT_TFPATH"))
+	if err != nil {
+		return nil, err
+	}
+	if terraformPath == "" {
+		terraformPath = "terraform"
 	}
 
 	return &options.TerragruntOptions{

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/config"
 	"os"
+	"path/filepath"
 )
 
 func TestParseTerragruntOptionsFromArgs(t *testing.T) {
@@ -24,31 +25,31 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 	}{
 		{
 			[]string{},
-			mockOptions(config.DefaultTerragruntConfigPath, workingDir, []string{}, false),
+			mockOptions(filepath.Join(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false),
 			nil,
 		},
 
 		{
 			[]string{"foo", "bar"},
-			mockOptions(config.DefaultTerragruntConfigPath, workingDir, []string{"foo", "bar"}, false),
+			mockOptions(filepath.Join(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"foo", "bar"}, false),
 			nil,
 		},
 
 		{
 			[]string{"--foo", "--bar"},
-			mockOptions(config.DefaultTerragruntConfigPath, workingDir, []string{"--foo", "--bar"}, false),
+			mockOptions(filepath.Join(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"--foo", "--bar"}, false),
 			nil,
 		},
 
 		{
 			[]string{"--foo", "apply", "--bar"},
-			mockOptions(config.DefaultTerragruntConfigPath, workingDir, []string{"--foo", "apply", "--bar"}, false),
+			mockOptions(filepath.Join(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"--foo", "apply", "--bar"}, false),
 			nil,
 		},
 
 		{
 			[]string{"--terragrunt-non-interactive"},
-			mockOptions(config.DefaultTerragruntConfigPath, workingDir, []string{}, true),
+			mockOptions(filepath.Join(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, true),
 			nil,
 		},
 
@@ -60,7 +61,7 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 
 		{
 			[]string{"--terragrunt-working-dir", "/some/path"},
-			mockOptions(config.DefaultTerragruntConfigPath, "/some/path", []string{}, false),
+			mockOptions(filepath.Join("/some/path", config.DefaultTerragruntConfigPath), "/some/path", []string{}, false),
 			nil,
 		},
 


### PR DESCRIPTION
This fixes a bug where Terragrunt’s default path for the config file is `.terragrunt` in the current working directory rather than the working directory specified by the `—terragrunt-working-dir` parameter.