### PR TITLE
Depdendency Output Variables

### DIFF
--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"os"
 	"os/exec"
+	"bytes"
 	"strings"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -23,4 +24,22 @@ func RunShellCommand(terragruntOptions *options.TerragruntOptions, command strin
 	cmd.Dir = terragruntOptions.WorkingDir
 
 	return errors.WithStackTrace(cmd.Run())
+}
+
+// Run the specified shell command with the specified arguments. Connect the command's stdin to
+// the current running app, and return the fully read stdout and stderr streams as strings.
+func GetShellOutput(terragruntOptions *options.TerragruntOptions, command string, args ... string) (string, string, error) {
+	terragruntOptions.Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
+
+	cmd := exec.Command(command, args...)
+
+	var stdout, stderr bytes.Buffer
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := errors.WithStackTrace(cmd.Run())
+
+	return stdout.String(), stderr.String(), err
 }

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -1,17 +1,17 @@
 package shell
 
 import (
-	"os"
-	"os/exec"
 	"bytes"
-	"strings"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
+	"os"
+	"os/exec"
+	"strings"
 )
 
 // Run the specified shell command with the specified arguments. Connect the command's stdin, stdout, and stderr to
 // the currently running app.
-func RunShellCommand(terragruntOptions *options.TerragruntOptions, command string, args ... string) error {
+func RunShellCommand(terragruntOptions *options.TerragruntOptions, command string, args ...string) error {
 	terragruntOptions.Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
 
 	cmd := exec.Command(command, args...)
@@ -28,7 +28,7 @@ func RunShellCommand(terragruntOptions *options.TerragruntOptions, command strin
 
 // Run the specified shell command with the specified arguments. Connect the command's stdin to
 // the current running app, and return the fully read stdout and stderr streams as strings.
-func GetShellOutput(terragruntOptions *options.TerragruntOptions, command string, args ... string) (string, string, error) {
+func GetShellOutput(terragruntOptions *options.TerragruntOptions, command string, args ...string) (string, string, error) {
 	terragruntOptions.Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
 
 	cmd := exec.Command(command, args...)


### PR DESCRIPTION
I've created this PR not with the intent of it being merged, but more as an illustration of something I'm trying to accomplish which will hopefully result in either me either being re-educated or an actual Go programmer picking up the torch to implement such functionality in a more idiomatic way.

My not-so-contrived example I'd like to use `terragrunt` for is as follows:

```
my-terraform-repo
  └ .terragrunt
  └ qa
      └ vpc
          └ main.tf
          └ outputs.tf
          └ .terragrunt
      └ app
          └ main.tf
          └ inputs.tf
          └ .terragrunt
```

**qa/vpc/outputs.tf:**

```terraform
output "vpc_id" {}
```

**qa/app/inputs.tf:**

```terraform
variable "vpc_id" {}
```

**qa/app/.terragrunt:**

```
include = {
  path = "${find_in_parent_folders()}"
}

dependencies = {
  paths = ["../vpc"]
}
```

**Questions:**

1. If I run `terragrunt spin-up` currently, my understanding is it will error since `-var 'vpc_id=vpc-foo'` needs to be satisfied somehow, is this correct?
2. If I want to run `cd qa/app; terragrunt apply` it will also error (or prompt), for the same reason as above.

Point 1. results in dependencies being not particularly useful for my current use-case where it'd be nice to run `terragrunt apply` for piecemeal infrastructure components (say, just `app` reconfiguration) independently of everything else.

Since `terraform output` has the ability to retrieve all the necessary variables it would be handy if dependencies simply forwarded/threaded any outputs into their dependents. This PR contains an illustrative code change which hopefully demonstrates this and provides a solution for point 1. above, but it specifically does it by refreshing a modules dependencies before a module run as opposed to recording all outputs for a given module after it's run. (See point 2.)

For point 2. it would be nice to be able to run `terragrunt spin-up <stack-component>` where stack component is a dir (`.` or `app`, say) and it would also take care of running up to and including that module + dependencies, as well as obtaining the necessary `terraform output`.

There's quite a few caveats with the approach here, but first I'd like to know if any of this makes sense? Apologies and carry on if not.

