### PR TITLE
Update AWS SDK to latest - v1.6.10

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: f70d8455d9f5f68d4449263ab8d0485d5b938b65b4c31716be50aac64fedc6ae
-updated: 2016-12-19T19:45:59.216824394-07:00
+hash: 86932a90d9bfe69d9f4a0bbf6e103c3b0670d47e8e1e2176fdd0b2637257d3a9
+updated: 2017-01-05T10:16:18.659229152-08:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 665c623d7f3e0ee276596b006655ba4dbe0565b0
+  version: 8649d278323ebf6bd20c9cd56ecb152b1c617375
   subpackages:
   - aws
   - aws/awserr
@@ -12,13 +12,16 @@ imports:
   - aws/corehandlers
   - aws/credentials
   - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
   - aws/defaults
   - aws/ec2metadata
+  - aws/endpoints
   - aws/request
   - aws/service/dynamodb
   - aws/service/s3
   - aws/session
-  - private/endpoints
+  - aws/signer/v4
   - private/protocol
   - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
@@ -27,24 +30,30 @@ imports:
   - private/protocol/rest
   - private/protocol/restxml
   - private/protocol/xml/xmlutil
-  - private/signer/v4
   - private/waiter
   - service/dynamodb
+  - service/kms
+  - service/kms/kmsiface
   - service/s3
+  - service/s3/s3iface
+  - service/s3/s3manager
   - service/sts
+- name: github.com/BurntSushi/toml
+  version: 99064174e013895bbd9b025c31100bd1d9b590ca
 - name: github.com/davecgh/go-spew
   version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/go-errors/errors
-  version: a41850380601eeb43f4350f7d17c6bbd8944aaf8
+  version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
 - name: github.com/go-ini/ini
-  version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
+  version: 6f66b0e091edb3c7b380f7c4f0f884274d550b67
 - name: github.com/hashicorp/hcl
-  version: 9a905a34e6280ce905da1a32344b25e81011197a
+  version: 80e628d796135357b3d2e33a985c666b9f35eee1
   subpackages:
   - hcl/ast
   - hcl/parser
+  - hcl/printer
   - hcl/scanner
   - hcl/strconv
   - hcl/token
@@ -52,19 +61,23 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
-  version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/mattn/go-zglob
   version: 2dbd7f37a45e993d5180a251b4bdd314d6333b70
 - name: github.com/mitchellh/mapstructure
-  version: f3009df150dadf309fdee4a54ed65c124afad715
+  version: bfdb1a85537d60bc7e954e600c250219ea497417
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 18a02ba4a312f95da08ff4cfc0055750ce50ae9e
+  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
   subpackages:
   - assert
 - name: github.com/urfave/cli
-  version: 9a18ffad6c548ca4d458d4c30a8aa4d181cf92fa
+  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
+- name: gopkg.in/urfave/cli.v1
+  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
+- name: gopkg.in/yaml.v2
+  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 testImports: []


### PR DESCRIPTION
In order to fix #92, AWS GO SDK was updated to the latest by running `glide up --all-dependencies`

Built a binary as suggest on OS X and seems to run fine as expected.

Unit test output in case it is needed
```shell
mechastorm@nerv terragrunt (aws-sdk-update) $ glide up --all-dependencies
[WARN]	The name listed in the config file (github.com/gruntwork-io/terragrunt) does not match the current location (github.com/mechastorm/terragrunt)
[INFO]	Downloading dependencies. Please wait...
[INFO]	--> Fetching updates for github.com/mitchellh/mapstructure.
[INFO]	--> Fetching updates for github.com/go-errors/errors.
[INFO]	--> Fetching updates for github.com/hashicorp/hcl.
[INFO]	--> Fetching updates for github.com/aws/aws-sdk-go.
[INFO]	--> Fetching updates for github.com/urfave/cli.
[INFO]	--> Fetching updates for github.com/mattn/go-zglob.
[INFO]	--> Fetching updates for github.com/stretchr/testify.
[INFO]	Resolving imports
[INFO]	--> Fetching updates for github.com/jmespath/go-jmespath.
[INFO]	--> Fetching updates for github.com/go-ini/ini.
[INFO]	--> Fetching updates for github.com/BurntSushi/toml.
[INFO]	--> Fetching updates for gopkg.in/urfave/cli.v1.
[INFO]	--> Fetching updates for gopkg.in/yaml.v2.
[INFO]	Found Godeps.json file in /Users/mechastorm/.glide/cache/src/https-github.com-stretchr-testify
[INFO]	--> Parsing Godeps metadata...
[INFO]	--> Fetching updates for github.com/davecgh/go-spew.
[INFO]	--> Setting version for github.com/davecgh/go-spew to 04cdfd42973bb9c8589fd6a731800cf222fde1a9.
[INFO]	--> Fetching updates for github.com/pmezard/go-difflib.
[INFO]	--> Setting version for github.com/pmezard/go-difflib to d8ed2627bdf02c080bf22230dbb337003b7aba2d.
[INFO]	Downloading dependencies. Please wait...
[INFO]	Setting references for remaining imports
[INFO]	Exporting resolved dependencies...
[INFO]	--> Exporting github.com/hashicorp/hcl
[INFO]	--> Exporting github.com/urfave/cli
[INFO]	--> Exporting github.com/stretchr/testify
[INFO]	--> Exporting github.com/pmezard/go-difflib
[INFO]	--> Exporting github.com/go-errors/errors
[INFO]	--> Exporting github.com/go-ini/ini
[INFO]	--> Exporting github.com/davecgh/go-spew
[INFO]	--> Exporting github.com/mitchellh/mapstructure
[INFO]	--> Exporting github.com/jmespath/go-jmespath
[INFO]	--> Exporting github.com/BurntSushi/toml
[INFO]	--> Exporting github.com/mattn/go-zglob
[INFO]	--> Exporting github.com/aws/aws-sdk-go
[INFO]	--> Exporting gopkg.in/urfave/cli.v1
[INFO]	--> Exporting gopkg.in/yaml.v2
[INFO]	Replacing existing vendor dependencies
[INFO]	Project relies on 14 dependencies.
mechastorm@nerv terragrunt (aws-sdk-update) $ go test -v -parallel 128 $(glide novendor)
?   	github.com/mechastorm/terragrunt/aws_helper	[no test files]
# github.com/mechastorm/terragrunt/locks/dynamodb
locks/dynamodb/dynamo_lock.go:109: cannot use config (type *"github.com/gruntwork-io/terragrunt/vendor/github.com/aws/aws-sdk-go/aws".Config) as type *"github.com/mechastorm/terragrunt/vendor/github.com/aws/aws-sdk-go/aws".Config in argument to dynamodb.New
=== RUN   TestParseTerragruntOptionsFromArgs
=== RUN   TestFilterTerragruntArgs
--- PASS: TestFilterTerragruntArgs (0.00s)
--- PASS: TestParseTerragruntOptionsFromArgs (0.00s)
PASS
ok  	github.com/mechastorm/terragrunt/cli	0.024s
=== RUN   TestPathRelativeToInclude
=== RUN   TestFindInParentFolders
=== RUN   TestResolveTerragruntInterpolation
=== RUN   TestResolveTerragruntConfigString
=== RUN   TestParseTerragruntConfigDynamoLockMinimalConfig
=== RUN   TestParseTerragruntConfigDynamoLockFullConfig
=== RUN   TestParseTerragruntConfigDynamoLockMissingStateFileId
=== RUN   TestParseTerragruntConfigRemoteStateMinimalConfig
=== RUN   TestParseTerragruntConfigRemoteStateMissingBackend
=== RUN   TestParseTerragruntConfigRemoteStateFullConfig
=== RUN   TestParseTerragruntConfigDependenciesOnePath
=== RUN   TestParseTerragruntConfigDependenciesMultiplePaths
=== RUN   TestParseTerragruntConfigRemoteStateDynamoDbAndDependenciesFullConfig
=== RUN   TestParseTerragruntConfigInvalidLockBackend
=== RUN   TestParseTerragruntConfigInclude
=== RUN   TestParseTerragruntConfigIncludeWithFindInParentFolders
=== RUN   TestParseTerragruntConfigIncludeOverrideRemote
=== RUN   TestParseTerragruntConfigIncludeOverrideAll
=== RUN   TestParseTerragruntConfigTwoLevels
=== RUN   TestParseTerragruntConfigThreeLevels
=== RUN   TestParseTerragruntConfigEmptyConfig
=== RUN   TestMergeConfigIntoIncludedConfig
--- PASS: TestPathRelativeToInclude (0.00s)
--- PASS: TestParseTerragruntConfigDynamoLockMissingStateFileId (0.00s)
--- PASS: TestParseTerragruntConfigDependenciesMultiplePaths (0.00s)
--- PASS: TestParseTerragruntConfigDependenciesOnePath (0.00s)
--- PASS: TestParseTerragruntConfigRemoteStateFullConfig (0.00s)
--- PASS: TestParseTerragruntConfigRemoteStateDynamoDbAndDependenciesFullConfig (0.00s)
--- PASS: TestParseTerragruntConfigRemoteStateMissingBackend (0.00s)
--- PASS: TestMergeConfigIntoIncludedConfig (0.00s)
--- PASS: TestParseTerragruntConfigEmptyConfig (0.00s)
--- PASS: TestParseTerragruntConfigRemoteStateMinimalConfig (0.00s)
--- PASS: TestResolveTerragruntInterpolation (0.00s)
--- PASS: TestResolveTerragruntConfigString (0.00s)
--- PASS: TestParseTerragruntConfigDynamoLockFullConfig (0.00s)
--- PASS: TestParseTerragruntConfigDynamoLockMinimalConfig (0.00s)
--- PASS: TestFindInParentFolders (0.00s)
--- PASS: TestParseTerragruntConfigIncludeOverrideRemote (0.00s)
--- PASS: TestParseTerragruntConfigThreeLevels (0.00s)
--- PASS: TestParseTerragruntConfigInclude (0.00s)
--- PASS: TestParseTerragruntConfigIncludeOverrideAll (0.00s)
--- PASS: TestParseTerragruntConfigInvalidLockBackend (0.00s)
--- PASS: TestParseTerragruntConfigIncludeWithFindInParentFolders (0.00s)
--- PASS: TestParseTerragruntConfigTwoLevels (0.00s)
PASS
ok  	github.com/mechastorm/terragrunt/config	0.025s
?   	github.com/mechastorm/terragrunt/errors	[no test files]
=== RUN   TestGetIpAddress
=== RUN   TestCreateLockMetadata
=== RUN   TestWithLockNoop
=== RUN   TestWithLockErrorOnAcquire
=== RUN   TestWithLockErrorOnRelease
=== RUN   TestWithLockErrorOnReleaseAndErrorInAction
=== RUN   TestWithLockErrorOnReleaseAndPanicInAction
--- PASS: TestWithLockErrorOnAcquire (0.00s)
--- PASS: TestWithLockErrorOnRelease (0.00s)
--- PASS: TestWithLockNoop (0.00s)
--- PASS: TestWithLockErrorOnReleaseAndPanicInAction (0.00s)
--- PASS: TestGetIpAddress (0.00s)
--- PASS: TestCreateLockMetadata (0.00s)
[terragrunt] 2017/01/05 10:16:44 ERROR: failed to release lock ErrorOnRelease: error-on-release
--- PASS: TestWithLockErrorOnReleaseAndErrorInAction (0.00s)
PASS
ok  	github.com/mechastorm/terragrunt/locks	0.029s
FAIL	github.com/mechastorm/terragrunt/locks/dynamodb [build failed]
?   	github.com/mechastorm/terragrunt/options	[no test files]
# github.com/mechastorm/terragrunt/remote
remote/remote_state_s3.go:185: cannot use config (type *"github.com/gruntwork-io/terragrunt/vendor/github.com/aws/aws-sdk-go/aws".Config) as type *"github.com/mechastorm/terragrunt/vendor/github.com/aws/aws-sdk-go/aws".Config in argument to s3.New
FAIL	github.com/mechastorm/terragrunt/remote [build failed]
?   	github.com/mechastorm/terragrunt/shell	[no test files]
=== RUN   TestCheckForCycles
=== RUN   TestResolveTerraformModulesNoPaths
=== RUN   TestResolveTerraformModulesOneModuleNoDependencies
=== RUN   TestResolveTerraformModulesOneModuleWithIncludesNoDependencies
=== RUN   TestResolveTerraformModulesTwoModulesWithDependencies
=== RUN   TestResolveTerraformModulesMultipleModulesWithDependencies
=== RUN   TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes
=== RUN   TestResolveTerraformModulesMultipleModulesWithExternalDependencies
=== RUN   TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies
=== RUN   TestResolveTerraformModulesInvalidPaths
=== RUN   TestToRunningModulesNoModules
=== RUN   TestToRunningModulesOneModuleNoDependencies
=== RUN   TestToRunningModulesTwoModulesNoDependencies
=== RUN   TestToRunningModulesTwoModulesWithDependencies
=== RUN   TestToRunningModulesTwoModulesWithDependenciesReverseOrder
=== RUN   TestToRunningModulesMultipleModulesWithAndWithoutDependencies
=== RUN   TestToRunningModulesMultipleModulesWithAndWithoutDependenciesReverseOrder
=== RUN   TestRunModulesNoModules
=== RUN   TestRunModulesOneModuleSuccess
=== RUN   TestRunModulesOneModuleAssumeAlreadyRan
=== RUN   TestRunModulesReverseOrderOneModuleSuccess
=== RUN   TestRunModulesOneModuleError
=== RUN   TestRunModulesReverseOrderOneModuleError
=== RUN   TestRunModulesMultipleModulesNoDependenciesSuccess
=== RUN   TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess
=== RUN   TestRunModulesMultipleModulesNoDependenciesOneFailure
=== RUN   TestRunModulesMultipleModulesNoDependenciesMultipleFailures
=== RUN   TestRunModulesMultipleModulesWithDependenciesSuccess
=== RUN   TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess
=== RUN   TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess
=== RUN   TestRunModulesMultipleModulesWithDependenciesOneFailure
=== RUN   TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure
=== RUN   TestRunModulesMultipleModulesWithDependenciesMultipleFailures
=== RUN   TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess
=== RUN   TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure
=== RUN   TestRunModulesReverseOrderMultipleModulesWithDependenciesLargeGraphPartialFailure
=== RUN   TestFindStackInSubfolders
--- PASS: TestCheckForCycles (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished successfully!
--- PASS: TestRunModulesOneModuleSuccess (0.00s)
--- PASS: TestRunModulesNoModules (0.00s)
--- PASS: TestToRunningModulesMultipleModulesWithAndWithoutDependenciesReverseOrder (0.00s)
[terragrunt]  Module /Users/mechastorm/work/go/src/github.com/mechastorm/terragrunt/test/fixture-modules/module-g depends on module /Users/mechastorm/work/go/src/github.com/mechastorm/terragrunt/test/fixture-modules/module-f, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /Users/mechastorm/work/go/src/github.com/mechastorm/terragrunt/test/fixture-modules/module-f as well! (y/n) 
[terragrunt] 2017/01/05 10:16:48 The non-interactive flag is set to true, so assuming 'yes' for all prompts
--- PASS: TestResolveTerraformModulesMultipleModulesWithExternalDependencies (0.00s)
--- PASS: TestFindStackInSubfolders (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 2 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module large-graph-f must wait for 2 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module f must wait for 2 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module c now
[terragrunt] 2017/01/05 10:16:48 Module c has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module c now
[terragrunt] 2017/01/05 10:16:48 Module c has finished with an error: Expected error for module c
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module c now
[terragrunt] 2017/01/05 10:16:48 Module c has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module c now
[terragrunt] 2017/01/05 10:16:48 Module c has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module c now
[terragrunt] 2017/01/05 10:16:48 Module c has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished with an error: Expected error for module a
[terragrunt]  Module /Users/mechastorm/work/go/src/github.com/mechastorm/terragrunt/test/fixture-modules/module-j depends on module /Users/mechastorm/work/go/src/github.com/mechastorm/terragrunt/test/fixture-modules/module-i, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /Users/mechastorm/work/go/src/github.com/mechastorm/terragrunt/test/fixture-modules/module-i as well! (y/n) 
[terragrunt] 2017/01/05 10:16:48 The non-interactive flag is set to true, so assuming 'yes' for all prompts
--- PASS: TestRunModulesReverseOrderOneModuleError (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished with an error: Expected error for module a
--- PASS: TestRunModulesOneModuleError (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished successfully!
--- PASS: TestRunModulesReverseOrderOneModuleSuccess (0.00s)
--- PASS: TestToRunningModulesTwoModulesNoDependencies (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module d must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module e must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module f must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module f now
[terragrunt] 2017/01/05 10:16:48 Module f has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Dependency f of module d just finished succesfully. Module d must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module d now
[terragrunt] 2017/01/05 10:16:48 Module d has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Dependency d of module c just finished succesfully. Module c must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module c now
[terragrunt] 2017/01/05 10:16:48 Module c has finished with an error: Expected error for module c
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 2 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency d of module a just finished succesfully. Module a must wait on 1 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Module large-graph-g must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module large-graph-a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module large-graph-a now
[terragrunt] 2017/01/05 10:16:48 Module large-graph-a has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module large-graph-b must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency large-graph-a of module large-graph-b just finished succesfully. Module large-graph-b must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module large-graph-b now
[terragrunt] 2017/01/05 10:16:48 Module large-graph-b has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module large-graph-c must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency large-graph-b of module large-graph-c just finished succesfully. Module large-graph-c must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module large-graph-c now
[terragrunt] 2017/01/05 10:16:48 Module large-graph-c has finished with an error: Expected error for module large-graph-c
[terragrunt] 2017/01/05 10:16:48 Module large-graph-d must wait for 3 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency large-graph-a of module large-graph-d just finished succesfully. Module large-graph-d must wait on 2 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Dependency large-graph-b of module large-graph-d just finished succesfully. Module large-graph-d must wait on 1 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Dependency large-graph-c of module large-graph-d just finished with an error. Module large-graph-d will have to return an error too.
[terragrunt] 2017/01/05 10:16:48 Module large-graph-d has finished with an error: Cannot process module Module large-graph-d (dependencies: [large-graph-a, large-graph-b, large-graph-c]) because one of its dependencies, Module large-graph-c (dependencies: [large-graph-b]), finished with an error: Expected error for module large-graph-c
[terragrunt] 2017/01/05 10:16:48 Dependency large-graph-d of module large-graph-f just finished with an error. Module large-graph-f will have to return an error too.
[terragrunt] 2017/01/05 10:16:48 Module large-graph-f has finished with an error: Cannot process module Module large-graph-f (dependencies: [large-graph-e, large-graph-d]) because one of its dependencies, Module large-graph-d (dependencies: [large-graph-a, large-graph-b, large-graph-c]), finished with an error: Cannot process module Module large-graph-d (dependencies: [large-graph-a, large-graph-b, large-graph-c]) because one of its dependencies, Module large-graph-c (dependencies: [large-graph-b]), finished with an error: Expected error for module large-graph-c
[terragrunt] 2017/01/05 10:16:48 Module large-graph-e must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Assuming module large-graph-e has already been applied and skipping it
[terragrunt] 2017/01/05 10:16:48 Module large-graph-e has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Dependency large-graph-e of module large-graph-g just finished succesfully. Module large-graph-g must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module large-graph-g now
[terragrunt] 2017/01/05 10:16:48 Module large-graph-g has finished successfully!
--- PASS: TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency a of module b just finished succesfully. Module b must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module b now
[terragrunt] 2017/01/05 10:16:48 Module b has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency b of module c just finished succesfully. Module c must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module c now
[terragrunt] 2017/01/05 10:16:48 Module c has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module d must wait for 3 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency a of module d just finished succesfully. Module d must wait on 2 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Dependency b of module d just finished succesfully. Module d must wait on 1 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Dependency c of module d just finished succesfully. Module d must wait on 0 more dependencies.
[terragrunt]  Module /Users/mechastorm/work/go/src/github.com/mechastorm/terragrunt/test/fixture-modules/module-k depends on module /Users/mechastorm/work/go/src/github.com/mechastorm/terragrunt/test/fixture-modules/module-h, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /Users/mechastorm/work/go/src/github.com/mechastorm/terragrunt/test/fixture-modules/module-h as well! (y/n) [terragrunt] 2017/01/05 10:16:48 Running module d now

[terragrunt] 2017/01/05 10:16:48 Module d has finished successfully!
[terragrunt] 2017/01/05 10:16:48 The non-interactive flag is set to true, so assuming 'yes' for all prompts
[terragrunt] 2017/01/05 10:16:48 Dependency d of module f just finished succesfully. Module f must wait on 1 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Module e must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module e now
[terragrunt] 2017/01/05 10:16:48 Module e has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Dependency e of module f just finished succesfully. Module f must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module f now
[terragrunt] 2017/01/05 10:16:48 Module f has finished successfully!
--- PASS: TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished with an error: Expected error for module a
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 1 dependencies to finish
--- PASS: TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies (0.00s)
[terragrunt] 2017/01/05 10:16:48 Dependency a of module b just finished with an error. Module b will have to return an error too.
[terragrunt] 2017/01/05 10:16:48 Module b has finished with an error: Cannot process module Module b (dependencies: [a]) because one of its dependencies, Module a (dependencies: []), finished with an error: Expected error for module a
[terragrunt] 2017/01/05 10:16:48 Dependency b of module c just finished with an error. Module c will have to return an error too.
--- PASS: TestToRunningModulesOneModuleNoDependencies (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module c has finished with an error: Cannot process module Module c (dependencies: [b]) because one of its dependencies, Module b (dependencies: [a]), finished with an error: Cannot process module Module b (dependencies: [a]) because one of its dependencies, Module a (dependencies: []), finished with an error: Expected error for module a
--- PASS: TestRunModulesMultipleModulesWithDependenciesMultipleFailures (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 1 dependencies to finish
--- PASS: TestToRunningModulesNoModules (0.00s)
[terragrunt] 2017/01/05 10:16:48 Dependency c of module b just finished succesfully. Module b must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module b now
[terragrunt] 2017/01/05 10:16:48 Module b has finished with an error: Expected error for module b
[terragrunt] 2017/01/05 10:16:48 Dependency b of module a just finished with an error. Module a will have to return an error too.
[terragrunt] 2017/01/05 10:16:48 Module a has finished with an error: Cannot process module Module a (dependencies: []) because one of its dependencies, Module b (dependencies: [a]), finished with an error: Expected error for module b
--- PASS: TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency a of module b just finished succesfully. Module b must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module b now
[terragrunt] 2017/01/05 10:16:48 Module b has finished with an error: Expected error for module b
[terragrunt] 2017/01/05 10:16:48 Dependency b of module c just finished with an error. Module c will have to return an error too.
[terragrunt] 2017/01/05 10:16:48 Module c has finished with an error: Cannot process module Module c (dependencies: [b]) because one of its dependencies, Module b (dependencies: [a]), finished with an error: Expected error for module b
--- PASS: TestRunModulesMultipleModulesWithDependenciesOneFailure (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module c now
[terragrunt] 2017/01/05 10:16:48 Module c has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Dependency c of module b just finished succesfully. Module b must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module b now
[terragrunt] 2017/01/05 10:16:48 Module b has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Dependency b of module a just finished succesfully. Module a must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished successfully!
--- PASS: TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency a of module b just finished succesfully. Module b must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module b now
[terragrunt] 2017/01/05 10:16:48 Module b has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module c must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency b of module c just finished succesfully. Module c must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Assuming module c has already been applied and skipping it
[terragrunt] 2017/01/05 10:16:48 Module c has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module d must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency c of module d just finished succesfully. Module d must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module d now
[terragrunt] 2017/01/05 10:16:48 Module d has finished successfully!
--- PASS: TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished successfully!
--- PASS: TestResolveTerraformModulesInvalidPaths (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 1 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Dependency a of module b just finished succesfully. Module b must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module b now
[terragrunt] 2017/01/05 10:16:48 Module b has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Dependency b of module c just finished succesfully. Module c must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module c now
[terragrunt] 2017/01/05 10:16:48 Module c has finished successfully!
--- PASS: TestRunModulesMultipleModulesWithDependenciesSuccess (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
--- PASS: TestToRunningModulesTwoModulesWithDependenciesReverseOrder (0.00s)
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished with an error: Expected error for module a
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module b now
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module b has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module b now
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Module b has finished with an error: Expected error for module b
[terragrunt] 2017/01/05 10:16:48 Running module b now
[terragrunt] 2017/01/05 10:16:48 Module b has finished successfully!
--- PASS: TestRunModulesMultipleModulesNoDependenciesSuccess (0.00s)
--- PASS: TestRunModulesMultipleModulesNoDependenciesMultipleFailures (0.00s)
[terragrunt] 2017/01/05 10:16:48 Dependency f of module e just finished succesfully. Module e must wait on 0 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Running module e now
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Module b must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module b now
[terragrunt] 2017/01/05 10:16:48 Module b has finished with an error: Expected error for module b
--- PASS: TestRunModulesMultipleModulesNoDependenciesOneFailure (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Running module a now
[terragrunt] 2017/01/05 10:16:48 Module a has finished successfully!
--- PASS: TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module e has finished successfully!
[terragrunt] 2017/01/05 10:16:48 Dependency d of module b just finished succesfully. Module b must wait on 1 more dependencies.
[terragrunt] 2017/01/05 10:16:48 Dependency c of module b just finished with an error. Module b will have to return an error too.
[terragrunt] 2017/01/05 10:16:48 Module b has finished with an error: Cannot process module Module b (dependencies: [a]) because one of its dependencies, Module c (dependencies: [b]), finished with an error: Expected error for module c
[terragrunt] 2017/01/05 10:16:48 Dependency b of module a just finished with an error. Module a will have to return an error too.
[terragrunt] 2017/01/05 10:16:48 Module a has finished with an error: Cannot process module Module a (dependencies: []) because one of its dependencies, Module b (dependencies: [a]), finished with an error: Cannot process module Module b (dependencies: [a]) because one of its dependencies, Module c (dependencies: [b]), finished with an error: Expected error for module c
--- PASS: TestRunModulesReverseOrderMultipleModulesWithDependenciesLargeGraphPartialFailure (0.00s)
--- PASS: TestToRunningModulesTwoModulesWithDependencies (0.00s)
--- PASS: TestResolveTerraformModulesOneModuleWithIncludesNoDependencies (0.00s)
--- PASS: TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes (0.00s)
--- PASS: TestResolveTerraformModulesOneModuleNoDependencies (0.00s)
--- PASS: TestResolveTerraformModulesNoPaths (0.00s)
[terragrunt] 2017/01/05 10:16:48 Module a must wait for 0 dependencies to finish
[terragrunt] 2017/01/05 10:16:48 Assuming module a has already been applied and skipping it
[terragrunt] 2017/01/05 10:16:48 Module a has finished successfully!
--- PASS: TestRunModulesOneModuleAssumeAlreadyRan (0.01s)
--- PASS: TestResolveTerraformModulesTwoModulesWithDependencies (0.00s)
--- PASS: TestResolveTerraformModulesMultipleModulesWithDependencies (0.00s)
--- PASS: TestToRunningModulesMultipleModulesWithAndWithoutDependencies (0.00s)
PASS
ok  	github.com/mechastorm/terragrunt/spin	0.038s
# github.com/mechastorm/terragrunt/test
test/integration_test.go:276: cannot use "github.com/mechastorm/terragrunt/vendor/github.com/aws/aws-sdk-go/service/s3".ListObjectVersionsInput literal (type *"github.com/mechastorm/terragrunt/vendor/github.com/aws/aws-sdk-go/service/s3".ListObjectVersionsInput) as type *"github.com/gruntwork-io/terragrunt/vendor/github.com/aws/aws-sdk-go/service/s3".ListObjectVersionsInput in argument to s3Client.ListObjectVersions
test/integration_test.go:294: cannot use deleteInput (type *"github.com/mechastorm/terragrunt/vendor/github.com/aws/aws-sdk-go/service/s3".DeleteObjectsInput) as type *"github.com/gruntwork-io/terragrunt/vendor/github.com/aws/aws-sdk-go/service/s3".DeleteObjectsInput in argument to s3Client.DeleteObjects
test/integration_test.go:299: cannot use "github.com/mechastorm/terragrunt/vendor/github.com/aws/aws-sdk-go/service/s3".DeleteBucketInput literal (type *"github.com/mechastorm/terragrunt/vendor/github.com/aws/aws-sdk-go/service/s3".DeleteBucketInput) as type *"github.com/gruntwork-io/terragrunt/vendor/github.com/aws/aws-sdk-go/service/s3".DeleteBucketInput in argument to s3Client.DeleteBucket
test/integration_test.go:311: cannot use config (type *"github.com/gruntwork-io/terragrunt/vendor/github.com/aws/aws-sdk-go/aws".Config) as type *"github.com/mechastorm/terragrunt/vendor/github.com/aws/aws-sdk-go/aws".Config in argument to dynamodb.New
FAIL	github.com/mechastorm/terragrunt/test [build failed]
=== RUN   TestListContainsElement
=== RUN   TestRemoveElementFromList
=== RUN   TestGetPathRelativeTo
=== RUN   TestCanonicalPath
=== RUN   TestGetRandomTime
--- PASS: TestCanonicalPath (0.00s)
--- PASS: TestListContainsElement (0.00s)
--- PASS: TestRemoveElementFromList (0.00s)
--- PASS: TestGetPathRelativeTo (0.00s)
--- PASS: TestGetRandomTime (0.00s)
PASS
ok  	github.com/mechastorm/terragrunt/util	0.023s
?   	github.com/mechastorm/terragrunt	[no test files]
```