### PR TITLE
Log terragrunt output to stderr

### DIFF
--- a/util/logger.go
+++ b/util/logger.go
@@ -1,9 +1,9 @@
 package util
 
 import (
-	"os"
-	"log"
 	"fmt"
+	"log"
+	"os"
 )
 
 // Create a logger with the given prefix
@@ -11,5 +11,5 @@ func CreateLogger(prefix string) *log.Logger {
 	if prefix != "" {
 		prefix = fmt.Sprintf("[%s] ", prefix)
 	}
-	return log.New(os.Stdout, fmt.Sprintf("[terragrunt] %s", prefix), log.LstdFlags)
+	return log.New(os.Stderr, fmt.Sprintf("[terragrunt] %s", prefix), log.LstdFlags)
 }


### PR DESCRIPTION
Logging to stderr is a potential solution for #24. We alias `terraform -> terragrunt` everywhere to avoid any mistakes (we love terragrunt) and would like to still be able to rely on piping and reading from terraform's stdout.

This should fix commands like `terragrunt graph | dot -Tpng > mygraph.png` and allow reading json from stdout from commands like `terragrunt output -json | json "my-key.my-value"`.

I also wouldn't mind helping with a `-silent` flag if that is a preferred approach, or something that could be implemented as well as writing terragrunt output to stderr.