### PR TITLE
Normalize path usage to use forward slashes to make things more platform agnostic

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -44,7 +44,7 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 		return nil, err
 	}
 	if terragruntConfigPath == "" {
-		terragruntConfigPath = filepath.Join(workingDir, config.DefaultTerragruntConfigPath)
+		terragruntConfigPath = util.JoinPath(workingDir, config.DefaultTerragruntConfigPath)
 	}
 
 	terraformPath, err := parseStringArg(args, OPT_TERRAGRUNT_TFPATH, os.Getenv("TERRAGRUNT_TFPATH"))
@@ -56,11 +56,11 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 	}
 
 	return &options.TerragruntOptions{
-		TerragruntConfigPath: terragruntConfigPath,
-		TerraformPath: terraformPath,
+		TerragruntConfigPath: filepath.ToSlash(terragruntConfigPath),
+		TerraformPath: filepath.ToSlash(terraformPath),
 		NonInteractive: parseBooleanArg(args, OPT_NON_INTERACTIVE, false),
 		TerraformCliArgs: filterTerragruntArgs(args),
-		WorkingDir: workingDir,
+		WorkingDir: filepath.ToSlash(workingDir),
 		Logger: util.CreateLogger(""),
 		RunTerragrunt: runTerragrunt,
 	}, nil

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -19,6 +19,8 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	workingDir = filepath.ToSlash(workingDir)
+
 	testCases := []struct {
 		args 		[]string
 		expectedOptions *options.TerragruntOptions

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/config"
 	"os"
 	"path/filepath"
+	"github.com/gruntwork-io/terragrunt/util"
 )
 
 func TestParseTerragruntOptionsFromArgs(t *testing.T) {
@@ -25,31 +26,31 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 	}{
 		{
 			[]string{},
-			mockOptions(filepath.Join(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false),
+			mockOptions(util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false),
 			nil,
 		},
 
 		{
 			[]string{"foo", "bar"},
-			mockOptions(filepath.Join(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"foo", "bar"}, false),
+			mockOptions(util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"foo", "bar"}, false),
 			nil,
 		},
 
 		{
 			[]string{"--foo", "--bar"},
-			mockOptions(filepath.Join(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"--foo", "--bar"}, false),
+			mockOptions(util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"--foo", "--bar"}, false),
 			nil,
 		},
 
 		{
 			[]string{"--foo", "apply", "--bar"},
-			mockOptions(filepath.Join(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"--foo", "apply", "--bar"}, false),
+			mockOptions(util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"--foo", "apply", "--bar"}, false),
 			nil,
 		},
 
 		{
 			[]string{"--terragrunt-non-interactive"},
-			mockOptions(filepath.Join(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, true),
+			mockOptions(util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, true),
 			nil,
 		},
 
@@ -61,7 +62,7 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 
 		{
 			[]string{"--terragrunt-working-dir", "/some/path"},
-			mockOptions(filepath.Join("/some/path", config.DefaultTerragruntConfigPath), "/some/path", []string{}, false),
+			mockOptions(util.JoinPath("/some/path", config.DefaultTerragruntConfigPath), "/some/path", []string{}, false),
 			nil,
 		},
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -182,7 +182,7 @@ func downloadModules(terragruntOptions *options.TerragruntOptions) error {
 // modules at all. Detecting if your downloaded modules are out of date (as opposed to missing entirely) is more
 // complicated and not something we handle at the moment.
 func shouldDownloadModules(terragruntOptions *options.TerragruntOptions) (bool, error) {
-	if util.FileExists(filepath.Join(terragruntOptions.WorkingDir, ".terraform/modules")) {
+	if util.FileExists(util.JoinPath(terragruntOptions.WorkingDir, ".terraform/modules")) {
 		return false, nil
 	}
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -13,7 +13,6 @@ import (
 	"github.com/urfave/cli"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/spin"
-	"path/filepath"
 )
 
 const OPT_TERRAGRUNT_CONFIG = "terragrunt-config"

--- a/config/config.go
+++ b/config/config.go
@@ -147,7 +147,7 @@ func parseIncludedConfig(includedConfig *IncludeConfig, terragruntOptions *optio
 	}
 
 	if !filepath.IsAbs(resolvedIncludePath) {
-		resolvedIncludePath = filepath.Join(filepath.Dir(terragruntOptions.TerragruntConfigPath), resolvedIncludePath)
+		resolvedIncludePath = util.JoinPath(filepath.Dir(terragruntOptions.TerragruntConfigPath), resolvedIncludePath)
 	}
 
 	return ParseConfigFile(resolvedIncludePath, terragruntOptions, includedConfig)

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -51,6 +51,8 @@ func executeTerragruntHelperFunction(functionName string, include *IncludeConfig
 // Find a parent .terragrunt file in the parent folders above the current .terragrunt file and return its path
 func findInParentFolders(terragruntOptions *options.TerragruntOptions) (string, error) {
 	previousDir, err := filepath.Abs(filepath.Dir(terragruntOptions.TerragruntConfigPath))
+	previousDir = filepath.ToSlash(previousDir)
+
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
@@ -58,12 +60,12 @@ func findInParentFolders(terragruntOptions *options.TerragruntOptions) (string, 
 	// To avoid getting into an accidental infinite loop (e.g. do to cyclical symlinks), set a max on the number of
 	// parent folders we'll check
 	for i := 0; i < MAX_PARENT_FOLDERS_TO_CHECK; i++ {
-		currentDir := filepath.Dir(previousDir)
+		currentDir := filepath.ToSlash(filepath.Dir(previousDir))
 		if currentDir == previousDir {
 			return "", errors.WithStackTrace(ParentTerragruntConfigNotFound(terragruntOptions.TerragruntConfigPath))
 		}
 
-		configPath := filepath.Join(currentDir, DefaultTerragruntConfigPath)
+		configPath := util.JoinPath(currentDir, DefaultTerragruntConfigPath)
 		if util.FileExists(configPath) {
 			return util.GetPathRelativeTo(configPath, filepath.Dir(terragruntOptions.TerragruntConfigPath))
 		}
@@ -89,7 +91,7 @@ func pathRelativeToInclude(include *IncludeConfig, terragruntOptions *options.Te
 	currentPath := filepath.Dir(terragruntOptions.TerragruntConfigPath)
 
 	if !filepath.IsAbs(includePath) {
-		includePath = filepath.Join(currentPath, includePath)
+		includePath = util.JoinPath(currentPath, includePath)
 	}
 
 	return util.GetPathRelativeTo(currentPath, includePath)

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
 )
 
 func TestPathRelativeToInclude(t *testing.T) {
@@ -17,32 +18,32 @@ func TestPathRelativeToInclude(t *testing.T) {
 	}{
 		{
 			nil,
-			options.TerragruntOptions{TerragruntConfigPath: "/root/child/.terragrunt", NonInteractive: true},
+			options.TerragruntOptions{TerragruntConfigPath: helpers.RootFolder + "child/.terragrunt", NonInteractive: true},
 			".",
 		},
 		{
 			&IncludeConfig{Path: "../.terragrunt"},
-			options.TerragruntOptions{TerragruntConfigPath: "/root/child/.terragrunt", NonInteractive: true},
+			options.TerragruntOptions{TerragruntConfigPath: helpers.RootFolder + "child/.terragrunt", NonInteractive: true},
 			"child",
 		},
 		{
-			&IncludeConfig{Path: "/root/.terragrunt"},
-			options.TerragruntOptions{TerragruntConfigPath: "/root/child/.terragrunt", NonInteractive: true},
+			&IncludeConfig{Path: helpers.RootFolder + ".terragrunt"},
+			options.TerragruntOptions{TerragruntConfigPath: helpers.RootFolder + "child/.terragrunt", NonInteractive: true},
 			"child",
 		},
 		{
 			&IncludeConfig{Path: "../../../.terragrunt"},
-			options.TerragruntOptions{TerragruntConfigPath: "/root/child/sub-child/sub-sub-child/.terragrunt", NonInteractive: true},
+			options.TerragruntOptions{TerragruntConfigPath: helpers.RootFolder + "child/sub-child/sub-sub-child/.terragrunt", NonInteractive: true},
 			"child/sub-child/sub-sub-child",
 		},
 		{
-			&IncludeConfig{Path: "/root/.terragrunt"},
-			options.TerragruntOptions{TerragruntConfigPath: "/root/child/sub-child/sub-sub-child/.terragrunt", NonInteractive: true},
+			&IncludeConfig{Path: helpers.RootFolder + ".terragrunt"},
+			options.TerragruntOptions{TerragruntConfigPath: helpers.RootFolder + "child/sub-child/sub-sub-child/.terragrunt", NonInteractive: true},
 			"child/sub-child/sub-sub-child",
 		},
 		{
 			&IncludeConfig{Path: "../../other-child/.terragrunt"},
-			options.TerragruntOptions{TerragruntConfigPath: "/root/child/sub-child/.terragrunt", NonInteractive: true},
+			options.TerragruntOptions{TerragruntConfigPath: helpers.RootFolder + "child/sub-child/.terragrunt", NonInteractive: true},
 			"../child/sub-child",
 		},
 		{

--- a/locks/dynamodb/dynamo_lock_test_utils.go
+++ b/locks/dynamodb/dynamo_lock_test_utils.go
@@ -15,6 +15,10 @@ import (
 // For simplicity, do all testing in the us-east-1 region
 const DEFAULT_TEST_REGION = "us-east-1"
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 var mockOptions = options.NewTerragruntOptionsForTest("dynamo_lock_test_utils")
 
 // Returns a unique (ish) id we can use to name resources so they don't conflict with each other. Uses base 62 to
@@ -26,9 +30,8 @@ func uniqueId() string {
 
 	var out bytes.Buffer
 
-	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < UNIQUE_ID_LENGTH; i++ {
-		out.WriteByte(BASE_62_CHARS[random.Intn(len(BASE_62_CHARS))])
+		out.WriteByte(BASE_62_CHARS[rand.Intn(len(BASE_62_CHARS))])
 	}
 
 	return out.String()

--- a/spin/module.go
+++ b/spin/module.go
@@ -137,7 +137,7 @@ func resolveExternalDependenciesForModule(module *TerraformModule, canonicalTerr
 			return map[string]*TerraformModule{}, err
 		}
 
-		terragruntConfigPath := filepath.Join(dependencyPath, config.DefaultTerragruntConfigPath)
+		terragruntConfigPath := util.JoinPath(dependencyPath, config.DefaultTerragruntConfigPath)
 		if !util.ListContainsElement(canonicalTerragruntConfigPaths, terragruntConfigPath) {
 			externalTerragruntConfigPaths = append(externalTerragruntConfigPaths, terragruntConfigPath)
 		}

--- a/spin/stack_test.go
+++ b/spin/stack_test.go
@@ -25,7 +25,7 @@ func TestFindStackInSubfolders(t *testing.T) {
 	tempFolder := createTempFolder(t)
 	writeAsEmptyFiles(t, tempFolder, filePaths)
 
-	envFolder := filepath.Join(tempFolder + "/stage")
+	envFolder := filepath.ToSlash(util.JoinPath(tempFolder + "/stage"))
 	terragruntOptions := options.NewTerragruntOptions(envFolder)
 	terragruntOptions.WorkingDir = envFolder
 
@@ -38,7 +38,7 @@ func TestFindStackInSubfolders(t *testing.T) {
 
 	for _, module := range stack.Modules {
 		relPath := strings.Replace(module.Path, tempFolder, "", 1)
-		relPath = filepath.Join(relPath, ".terragrunt")
+		relPath = filepath.ToSlash(util.JoinPath(relPath, ".terragrunt"))
 
 		modulePaths = append(modulePaths, relPath)
 	}
@@ -56,13 +56,13 @@ func createTempFolder(t *testing.T) string {
 		t.Fatalf("Failed to create temp directory: %s\n", err.Error())
 	}
 
-	return tmpFolder
+	return filepath.ToSlash(tmpFolder)
 }
 
 // Create an empty file at each of the given paths
 func writeAsEmptyFiles(t *testing.T, tmpFolder string, paths []string) {
 	for _, path := range paths {
-		absPath := filepath.Join(tmpFolder, path)
+		absPath := util.JoinPath(tmpFolder, path)
 
 		containingDir := filepath.Dir(absPath)
 		createDirIfNotExist(t, containingDir)

--- a/test/helpers/test_helpers_unix.go
+++ b/test/helpers/test_helpers_unix.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package helpers
+
+var RootFolder = "/"

--- a/test/helpers/test_helpers_windows.go
+++ b/test/helpers/test_helpers_windows.go
@@ -1,0 +1,5 @@
+// +build windows
+
+package helpers
+
+var RootFolder = "C:/"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -82,7 +82,7 @@ func TestAcquireAndReleaseLock(t *testing.T) {
 func TestTerragruntWorksWithIncludes(t *testing.T) {
 	t.Parallel()
 
-	childPath := filepath.Join(TEST_FIXTURE_INCLUDE_PATH, TEST_FIXTURE_INCLUDE_CHILD_REL_PATH)
+	childPath := util.JoinPath(TEST_FIXTURE_INCLUDE_PATH, TEST_FIXTURE_INCLUDE_CHILD_REL_PATH)
 	cleanupTerraformFolder(t, childPath)
 
 	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
@@ -102,7 +102,7 @@ func TestTerragruntSpinUpAndTearDown(t *testing.T) {
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_STACK)
 
-	rootTerragruntConfigPath := filepath.Join(tmpEnvPath, "fixture-stack", config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, "fixture-stack", config.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName)
 
 	mgmtEnvironmentPath := fmt.Sprintf("%s/fixture-stack/mgmt", tmpEnvPath)
@@ -119,7 +119,7 @@ func TestTerragruntSpinUpAndTearDown(t *testing.T) {
 }
 
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {
-	terraformFolder := filepath.Join(templatesPath, TERRAFORM_FOLDER)
+	terraformFolder := util.JoinPath(templatesPath, TERRAFORM_FOLDER)
 	if !util.FileExists(terraformFolder) {
 		return
 	}
@@ -157,7 +157,7 @@ func copyEnvironment(t *testing.T, environmentPath string) string {
 			return nil
 		}
 
-		destPath := filepath.Join(tmpDir, path)
+		destPath := util.JoinPath(tmpDir, path)
 
 		destPathDir := filepath.Dir(destPath)
 		if err := os.MkdirAll(destPathDir, 0777); err != nil {
@@ -188,18 +188,18 @@ func createTmpTerragruntConfigWithParentAndChild(t *testing.T, parentPath string
 		t.Fatalf("Failed to create temp dir due to error: %v", err)
 	}
 
-	childDestPath := filepath.Join(tmpDir, childRelPath)
+	childDestPath := util.JoinPath(tmpDir, childRelPath)
 
 	if err := os.MkdirAll(childDestPath, 0777); err != nil {
 		t.Fatalf("Failed to create temp dir %s due to error %v", childDestPath, err)
 	}
 
-	parentTerragruntSrcPath := filepath.Join(parentPath, config.DefaultTerragruntConfigPath)
-	parentTerragruntDestPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
+	parentTerragruntSrcPath := util.JoinPath(parentPath, config.DefaultTerragruntConfigPath)
+	parentTerragruntDestPath := util.JoinPath(tmpDir, config.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, parentTerragruntSrcPath, parentTerragruntDestPath, s3BucketName)
 
-	childTerragruntSrcPath := filepath.Join(filepath.Join(parentPath, childRelPath), config.DefaultTerragruntConfigPath)
-	childTerragruntDestPath := filepath.Join(childDestPath, config.DefaultTerragruntConfigPath)
+	childTerragruntSrcPath := util.JoinPath(util.JoinPath(parentPath, childRelPath), config.DefaultTerragruntConfigPath)
+	childTerragruntDestPath := util.JoinPath(childDestPath, config.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, childTerragruntSrcPath, childTerragruntDestPath, s3BucketName)
 
 	return childTerragruntDestPath

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"bytes"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -22,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"bytes"
 	"time"
 )
 
@@ -36,6 +36,10 @@ const (
 	TERRAFORM_FOLDER                    = ".terraform"
 	DEFAULT_TEST_REGION                 = "us-east-1"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func TestTerragruntWorksWithLocalTerraformVersion(t *testing.T) {
 	t.Parallel()
@@ -239,13 +243,14 @@ func uniqueId() string {
 
 	var out bytes.Buffer
 
-	randInstance := rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	for i := 0; i < UNIQUE_ID_LENGTH; i++ {
-		out.WriteByte(BASE_62_CHARS[randInstance.Intn(len(BASE_62_CHARS))])
+		out.WriteByte(BASE_62_CHARS[rand.Intn(len(BASE_62_CHARS))])
 	}
 
 	return out.String()
 }
+
 
 // Check that the S3 Bucket of the given name and region exists. Terragrunt should create this bucket during the test.
 func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {

--- a/util/file.go
+++ b/util/file.go
@@ -19,13 +19,14 @@ func FileExists(path string) bool {
 // components (e.g. "../") fully resolved, which makes it safe to compare paths as strings.
 func CanonicalPath(path string, basePath string) (string, error) {
 	if !filepath.IsAbs(path) {
-		path = filepath.Join(basePath, path)
+		path = JoinPath(basePath, path)
 	}
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Clean(absPath), nil
+
+	return CleanPath(absPath), nil
 }
 
 // Return the canonical version of the given paths, relative to the given base path. That is, if a given path is a
@@ -83,7 +84,7 @@ func GetPathRelativeTo(path string, basePath string) (string, error) {
 		return "", errors.WithStackTrace(err)
 	}
 
-	return relPath, nil
+	return filepath.ToSlash(relPath), nil
 }
 
 // Return the contents of the file at the given path as a string
@@ -94,4 +95,12 @@ func ReadFileAsString(path string) (string, error) {
 	}
 
 	return string(bytes), nil
+}
+
+func JoinPath(elem ...string) string {
+	return filepath.ToSlash(filepath.Join(elem...))
+}
+
+func CleanPath(path string) string {
+	return filepath.ToSlash(filepath.Clean(path))
 }

--- a/util/file.go
+++ b/util/file.go
@@ -104,10 +104,14 @@ func ReadFileAsString(path string) (string, error) {
 	return string(bytes), nil
 }
 
+// Windows systems use \ as the path separator *nix uses /
+// Use this function when joining paths to force the returned path to use / as the path separator
+// This will improve cross-platform compatibility
 func JoinPath(elem ...string) string {
 	return filepath.ToSlash(filepath.Join(elem...))
 }
 
+// Use this function when cleaning paths to ensure the returned path uses / as the path separator to improve cross-platform compatibility
 func CleanPath(path string) string {
 	return filepath.ToSlash(filepath.Clean(path))
 }

--- a/util/file.go
+++ b/util/file.go
@@ -69,6 +69,13 @@ func Grep(regex *regexp.Regexp, glob string) (bool, error) {
 
 // Return the relative path you would have to take to get from basePath to path
 func GetPathRelativeTo(path string, basePath string) (string, error) {
+	if path == "" {
+		path = "."
+	}
+	if basePath == "" {
+		basePath = "."
+	}
+
 	inputFolderAbs, err := filepath.Abs(basePath)
 	if err != nil {
 		return "", errors.WithStackTrace(err)

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -27,7 +27,7 @@ func TestGetPathRelativeTo(t *testing.T) {
 	for _, testCase := range testCases {
 		actual, err := GetPathRelativeTo(testCase.path, testCase.basePath)
 		assert.Nil(t, err, "Unexpected error for path %s and basePath %s: %v", testCase.path, testCase.basePath, err)
-		assert.Equal(t, helpers.CleanPath(testCase.expected), actual, "For path %s and basePath %s", testCase.path, testCase.basePath)
+		assert.Equal(t, testCase.expected, actual, "For path %s and basePath %s", testCase.path, testCase.basePath)
 	}
 }
 
@@ -56,6 +56,6 @@ func TestCanonicalPath(t *testing.T) {
 	for _, testCase := range testCases {
 		actual, err := CanonicalPath(testCase.path, testCase.basePath)
 		assert.Nil(t, err, "Unexpected error for path %s and basePath %s: %v", testCase.path, testCase.basePath, err)
-		assert.Equal(t, helpers.CleanPath(testCase.expected), actual, "For path %s and basePath %s", testCase.path, testCase.basePath)
+		assert.Equal(t, testCase.expected, actual, "For path %s and basePath %s", testCase.path, testCase.basePath)
 	}
 }

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
 )
 
 func TestGetPathRelativeTo(t *testing.T) {
@@ -14,19 +15,19 @@ func TestGetPathRelativeTo(t *testing.T) {
 		expected string
 	}{
 		{"", "", "."},
-		{"/root", "/root", "."},
-		{"/root", "/root/child", ".."},
-		{"/root", "/root/child/sub-child/sub-sub-child", "../../.."},
-		{"/root/other-child", "/root/child", "../other-child"},
-		{"/root/other-child/sub-child", "/root/child/sub-child", "../../other-child/sub-child"},
-		{"/root", "/other-root", "../root"},
-		{"/root", "/other-root/sub-child/sub-sub-child", "../../../root"},
+		{helpers.RootFolder, helpers.RootFolder, "."},
+		{helpers.RootFolder, helpers.RootFolder + "child", ".."},
+		{helpers.RootFolder, helpers.RootFolder + "child/sub-child/sub-sub-child", "../../.."},
+		{helpers.RootFolder + "other-child", helpers.RootFolder + "child", "../other-child"},
+		{helpers.RootFolder + "other-child/sub-child", helpers.RootFolder + "child/sub-child", "../../other-child/sub-child"},
+		{helpers.RootFolder + "root", helpers.RootFolder + "other-root", "../root"},
+		{helpers.RootFolder + "root", helpers.RootFolder + "other-root/sub-child/sub-sub-child", "../../../root"},
 	}
 
 	for _, testCase := range testCases {
 		actual, err := GetPathRelativeTo(testCase.path, testCase.basePath)
 		assert.Nil(t, err, "Unexpected error for path %s and basePath %s: %v", testCase.path, testCase.basePath, err)
-		assert.Equal(t, testCase.expected, actual, "For path %s and basePath %s", testCase.path, testCase.basePath)
+		assert.Equal(t, helpers.CleanPath(testCase.expected), actual, "For path %s and basePath %s", testCase.path, testCase.basePath)
 	}
 }
 
@@ -38,23 +39,23 @@ func TestCanonicalPath(t *testing.T) {
 		basePath string
 		expected string
 	}{
-		{"", "/foo", "/foo"},
-		{".", "/foo", "/foo"},
-		{"bar", "/foo", "/foo/bar"},
-		{"bar/baz/blah", "/foo", "/foo/bar/baz/blah"},
-		{"bar/../blah", "/foo", "/foo/blah"},
-		{"bar/../..", "/foo", "/"},
-		{"bar/.././../baz", "/foo", "/baz"},
-		{"bar", "/foo/../baz", "/baz/bar"},
-		{"a/b/../c/d/..", "/foo/../baz/.", "/baz/a/c"},
-		{"/other", "/foo", "/other"},
-		{"/other/bar/blah", "/foo", "/other/bar/blah"},
-		{"/other/../blah", "/foo", "/blah"},
+		{"", helpers.RootFolder + "foo", helpers.RootFolder + "foo"},
+		{".", helpers.RootFolder + "foo", helpers.RootFolder + "foo"},
+		{"bar", helpers.RootFolder + "foo", helpers.RootFolder + "foo/bar"},
+		{"bar/baz/blah", helpers.RootFolder + "foo", helpers.RootFolder + "foo/bar/baz/blah"},
+		{"bar/../blah", helpers.RootFolder + "foo", helpers.RootFolder + "foo/blah"},
+		{"bar/../..", helpers.RootFolder + "foo", helpers.RootFolder },
+		{"bar/.././../baz", helpers.RootFolder + "foo", helpers.RootFolder + "baz"},
+		{"bar", helpers.RootFolder + "foo/../baz", helpers.RootFolder + "baz/bar"},
+		{"a/b/../c/d/..", helpers.RootFolder + "foo/../baz/.", helpers.RootFolder + "baz/a/c"},
+		{helpers.RootFolder + "other", helpers.RootFolder + "foo", helpers.RootFolder + "other"},
+		{helpers.RootFolder + "other/bar/blah", helpers.RootFolder + "foo", helpers.RootFolder + "other/bar/blah"},
+		{helpers.RootFolder + "other/../blah", helpers.RootFolder + "foo", helpers.RootFolder + "blah"},
 	}
 
 	for _, testCase := range testCases {
 		actual, err := CanonicalPath(testCase.path, testCase.basePath)
 		assert.Nil(t, err, "Unexpected error for path %s and basePath %s: %v", testCase.path, testCase.basePath, err)
-		assert.Equal(t, testCase.expected, actual, "For path %s and basePath %s", testCase.path, testCase.basePath)
+		assert.Equal(t, helpers.CleanPath(testCase.expected), actual, "For path %s and basePath %s", testCase.path, testCase.basePath)
 	}
 }


### PR DESCRIPTION
For your consideration, this is a different approach that fixes #89 .

I've changed the relevant filepath calls to route through a helper method which calls filepath.ToSlash to convert them to forward slashes. 

The path/filepath pkg will convert slashes back and forth dependent upon the underlying OS so converting them all to forward slashes for the purposes of manipulating them within the application should be okay and also passes the tests!

I think this is a better approach than trying to explicitly handle two different path types throughout the app.

There are a few test failures around concurrency with dynamodb and deleting tables that are still in use.
