### PR TITLE
Read remote state file from specified working dir

### DIFF
--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -71,7 +71,7 @@ func (remoteState RemoteState) ConfigureRemoteState(terragruntOptions *options.T
 // 1. Remote state has not already been configured
 // 2. Remote state has been configured, but for a different backend type, and the user confirms it's OK to overwrite it.
 func shouldConfigureRemoteState(remoteStateFromTerragruntConfig RemoteState, terragruntOptions *options.TerragruntOptions) (bool, error) {
-	state, err := ParseTerraformStateFileFromDefaultLocations()
+	state, err := ParseTerraformStateFileFromLocation(terragruntOptions.WorkingDir)
 	if err != nil {
 		return false, err
 	}

--- a/remote/terraform_state_file.go
+++ b/remote/terraform_state_file.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"fmt"
+	"path"
 	"github.com/gruntwork-io/terragrunt/util"
 )
 
@@ -44,10 +45,18 @@ func (state *TerraformState) IsRemote() bool {
 	return state.Remote != nil
 }
 
-// Parse the Terraform .tfstate file from its default locations. If the file doesn't exist at any of the default
-// locations, return nil.
-func ParseTerraformStateFileFromDefaultLocations() (*TerraformState, error) {
-	if util.FileExists(DEFAULT_PATH_TO_LOCAL_STATE_FILE) {
+// Parse the Terraform .tfstate file from the specified locations. If no location is specified,
+// search the default locations. If the file doesn't exist at any of the default locations, return nil.
+func ParseTerraformStateFileFromLocation(workingDir string) (*TerraformState, error) {
+	if workingDir != "" && util.FileExists(workingDir) {
+		if util.FileExists(path.Join(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE)) {
+			return ParseTerraformStateFile(path.Join(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE))
+		} else if util.FileExists(path.Join(workingDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE)) {
+			return ParseTerraformStateFile(path.Join(workingDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE))
+		} else {
+			return nil, nil
+		}
+	} else if util.FileExists(DEFAULT_PATH_TO_LOCAL_STATE_FILE) {
 		return ParseTerraformStateFile(DEFAULT_PATH_TO_LOCAL_STATE_FILE)
 	} else if util.FileExists(DEFAULT_PATH_TO_REMOTE_STATE_FILE) {
 		return ParseTerraformStateFile(DEFAULT_PATH_TO_REMOTE_STATE_FILE)

--- a/remote/terraform_state_file.go
+++ b/remote/terraform_state_file.go
@@ -45,21 +45,13 @@ func (state *TerraformState) IsRemote() bool {
 	return state.Remote != nil
 }
 
-// Parse the Terraform .tfstate file from the specified locations. If no location is specified,
-// search the default locations. If the file doesn't exist at any of the default locations, return nil.
+// Parse the Terraform .tfstate file from the location specified by workingDir. If no location is specified,
+// search the current directory. If the file doesn't exist at any of the default locations, return nil.
 func ParseTerraformStateFileFromLocation(workingDir string) (*TerraformState, error) {
-	if workingDir != "" && util.FileExists(workingDir) {
-		if util.FileExists(path.Join(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE)) {
-			return ParseTerraformStateFile(path.Join(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE))
-		} else if util.FileExists(path.Join(workingDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE)) {
-			return ParseTerraformStateFile(path.Join(workingDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE))
-		} else {
-			return nil, nil
-		}
-	} else if util.FileExists(DEFAULT_PATH_TO_LOCAL_STATE_FILE) {
-		return ParseTerraformStateFile(DEFAULT_PATH_TO_LOCAL_STATE_FILE)
-	} else if util.FileExists(DEFAULT_PATH_TO_REMOTE_STATE_FILE) {
-		return ParseTerraformStateFile(DEFAULT_PATH_TO_REMOTE_STATE_FILE)
+	if util.FileExists(path.Join(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE)) {
+		return ParseTerraformStateFile(path.Join(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE))
+	} else if util.FileExists(path.Join(workingDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE)) {
+		return ParseTerraformStateFile(path.Join(workingDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE))
 	} else {
 		return nil, nil
 	}


### PR DESCRIPTION
This changes `shouldConfigureRemoteState` in `remote_state.go` to always pass the `WorkingDir` option to `ParseTerraformStateFileFromLocation` in `terraform_state_file.go`. If `--terragrunt-working-dir` is specified the path to state files in that working dir should always take precedence over `DEFAULT_PATH_TO_LOCAL_STATE_FILE` and `DEFAULT_PATH_TO_REMOTE_STATE_FILE`.

Fixes #95. 