### PR TITLE
Alternate messages when lock item or table doesn't exist

### DIFF
--- a/locks/dynamodb/dynamo_lock.go
+++ b/locks/dynamodb/dynamo_lock.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/gruntwork-io/terragrunt/aws_helper"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/locks"
-	"github.com/gruntwork-io/terragrunt/aws_helper"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -86,8 +87,19 @@ func (dynamoDbLock DynamoDbLock) ReleaseLock(terragruntOptions *options.Terragru
 		return err
 	}
 
-	if err := removeItemFromLockTable(dynamoDbLock.StateFileId, dynamoDbLock.TableName, client); err != nil {
-		return err
+	err = removeItemFromLockTable(dynamoDbLock.StateFileId, dynamoDbLock.TableName, client)
+
+	// If the table or lock doesn't exist log it, else return the error
+	if err != nil {
+		if awsErr, isAwsErr := errors.Unwrap(err).(awserr.Error); isAwsErr && awsErr.Code() == "ResourceNotFoundException" {
+			terragruntOptions.Logger.Printf("Table %s does not exist in DynamoDB!", dynamoDbLock.TableName)
+			return nil
+		} else if awsErr, isAwsErr := errors.Unwrap(err).(awserr.Error); isAwsErr && awsErr.Code() == "ConditionalCheckFailedException" {
+			terragruntOptions.Logger.Printf("Nothing to release, specified lock does not exist in table %s", dynamoDbLock.TableName)
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	terragruntOptions.Logger.Printf("Lock released!")

--- a/locks/dynamodb/dynamo_lock_table.go
+++ b/locks/dynamodb/dynamo_lock_table.go
@@ -1,14 +1,14 @@
 package dynamodb
 
 import (
-	"time"
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
+	"time"
 )
 
 // DynamoDB only allows 10 table creates/deletes simultaneously. To ensure we don't hit this error, especially when
@@ -61,11 +61,11 @@ func CreateLockTable(tableName string, readCapacityUnits int, writeCapacityUnits
 	}
 
 	_, err := client.CreateTable(&dynamodb.CreateTableInput{
-		TableName: aws.String(tableName),
+		TableName:            aws.String(tableName),
 		AttributeDefinitions: attributeDefinitions,
-		KeySchema: keySchema,
+		KeySchema:            keySchema,
 		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
-			ReadCapacityUnits: aws.Int64(int64(readCapacityUnits)),
+			ReadCapacityUnits:  aws.Int64(int64(readCapacityUnits)),
 			WriteCapacityUnits: aws.Int64(int64(writeCapacityUnits)),
 		},
 	})
@@ -129,9 +129,19 @@ func waitForTableToBeActiveWithRandomSleep(tableName string, client *dynamodb.Dy
 func removeItemFromLockTable(itemId string, tableName string, client *dynamodb.DynamoDB) error {
 	// TODO: should we check that the entry has our own metadata and not someone else's?
 
-	_, err := client.DeleteItem(&dynamodb.DeleteItemInput{
-		Key: createKeyFromItemId(itemId),
-		TableName: aws.String(tableName),
+	// Verify the table actually exists
+	_, err := client.DescribeTable(&dynamodb.DescribeTableInput{TableName: aws.String(tableName)})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	// Unless you specify conditions, the DeleteItem is an idempotent operation;
+	// running it multiple times on the same item or attribute does not result in an error response.
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/dynamodb/#DynamoDB.DeleteItem
+	_, err = client.DeleteItem(&dynamodb.DeleteItemInput{
+		Key:                 createKeyFromItemId(itemId),
+		TableName:           aws.String(tableName),
+		ConditionExpression: aws.String(fmt.Sprintf("attribute_exists(%s)", ATTR_STATE_FILE_ID)),
 	})
 
 	return errors.WithStackTrace(err)
@@ -147,8 +157,8 @@ func writeItemToLockTable(itemId string, tableName string, client *dynamodb.Dyna
 	// Conditional writes in DynamoDB should be strongly consistent: http://stackoverflow.com/a/23371813/483528
 	// https://r.32k.io/locking-with-dynamodb
 	_, err = client.PutItem(&dynamodb.PutItemInput{
-		TableName: aws.String(tableName),
-		Item: item,
+		TableName:           aws.String(tableName),
+		Item:                item,
 		ConditionExpression: aws.String(fmt.Sprintf("attribute_not_exists(%s)", ATTR_STATE_FILE_ID)),
 	})
 

--- a/locks/dynamodb/dynamo_lock_table.go
+++ b/locks/dynamodb/dynamo_lock_table.go
@@ -129,20 +129,26 @@ func waitForTableToBeActiveWithRandomSleep(tableName string, client *dynamodb.Dy
 func removeItemFromLockTable(itemId string, tableName string, client *dynamodb.DynamoDB) error {
 	// TODO: should we check that the entry has our own metadata and not someone else's?
 
-	// Verify the table actually exists
-	_, err := client.DescribeTable(&dynamodb.DescribeTableInput{TableName: aws.String(tableName)})
-	if err != nil {
-		return errors.WithStackTrace(err)
-	}
-
 	// Unless you specify conditions, the DeleteItem is an idempotent operation;
 	// running it multiple times on the same item or attribute does not result in an error response.
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/dynamodb/#DynamoDB.DeleteItem
-	_, err = client.DeleteItem(&dynamodb.DeleteItemInput{
+	_, err := client.DeleteItem(&dynamodb.DeleteItemInput{
 		Key:                 createKeyFromItemId(itemId),
 		TableName:           aws.String(tableName),
 		ConditionExpression: aws.String(fmt.Sprintf("attribute_exists(%s)", ATTR_STATE_FILE_ID)),
 	})
+
+	// handle expected errors
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			switch awsErr.Code() {
+			case "ConditionalCheckFailedException":
+				err = ItemDoesNotExist{itemId, tableName, awsErr}
+			case "ResourceNotFoundException":
+				err = TableDoesNotExist{tableName, awsErr}
+			}
+		}
+	}
 
 	return errors.WithStackTrace(err)
 }
@@ -217,4 +223,23 @@ type AcquireLockRetriesExceeded struct {
 
 func (err AcquireLockRetriesExceeded) Error() string {
 	return fmt.Sprintf("Unable to acquire lock for item %s after %d retries.", err.ItemId, err.Retries)
+}
+
+type TableDoesNotExist struct {
+	TableName string
+	Underlying error
+}
+
+func (err TableDoesNotExist) Error() string {
+	return fmt.Sprintf("Table %s does not exist in DynamoDB! Original error from AWS: %v", err.TableName, err.Underlying)
+}
+
+type ItemDoesNotExist struct {
+	ItemName string
+	TableName string
+	Underlying error
+}
+
+func (err ItemDoesNotExist) Error() string {
+	return fmt.Sprintf("Item %s does not exist in %s DynamoDB table! Original error from AWS: %v", err.ItemName, err.TableName, err.Underlying)
 }

--- a/locks/dynamodb/dynamo_lock_table.go
+++ b/locks/dynamodb/dynamo_lock_table.go
@@ -235,11 +235,11 @@ func (err TableDoesNotExist) Error() string {
 }
 
 type ItemDoesNotExist struct {
-	ItemName string
+	ItemId string
 	TableName string
 	Underlying error
 }
 
 func (err ItemDoesNotExist) Error() string {
-	return fmt.Sprintf("Item %s does not exist in %s DynamoDB table! Original error from AWS: %v", err.ItemName, err.TableName, err.Underlying)
+	return fmt.Sprintf("Item %s does not exist in %s DynamoDB table! Original error from AWS: %v", err.ItemId, err.TableName, err.Underlying)
 }

--- a/locks/dynamodb/dynamo_lock_table_test.go
+++ b/locks/dynamodb/dynamo_lock_table_test.go
@@ -1,14 +1,15 @@
 package dynamodb
 
 import (
-	"testing"
-	"github.com/stretchr/testify/assert"
-	"time"
-	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/stretchr/testify/assert"
+	"reflect"
 	"sync"
 	"sync/atomic"
-	"reflect"
+	"testing"
+	"time"
 )
 
 func TestCreateLockTableIfNecessaryTableDoesntAlreadyExist(t *testing.T) {
@@ -52,7 +53,7 @@ func TestWaitForTableToBeActiveTableDoesNotExist(t *testing.T) {
 	tableName := "table-does-not-exist"
 	retries := 5
 
-	err := waitForTableToBeActiveWithRandomSleep(tableName, client, retries, 1 * time.Millisecond, 500 * time.Millisecond, mockOptions)
+	err := waitForTableToBeActiveWithRandomSleep(tableName, client, retries, 1*time.Millisecond, 500*time.Millisecond, mockOptions)
 
 	assert.True(t, errors.IsError(err, TableActiveRetriesExceeded{TableName: tableName, Retries: retries}), "Unexpected error of type %s: %s", reflect.TypeOf(err), err)
 }
@@ -106,6 +107,22 @@ func TestWriteAndRemoveItemFromLockTable(t *testing.T) {
 
 		// Finally, check the item no longer exists
 		assertItemNotExistsInTable(t, itemId, tableName, client)
+
+		// Additionally, verify removing an item that doesn't exist returns an expected error
+		err = removeItemFromLockTable(itemId, tableName, client)
+		if assert.NotNil(t, err, "Error expected") {
+			awsErr, isAwsErr := errors.Unwrap(err).(awserr.Error)
+			assert.True(t, isAwsErr, "Expected error to be an awserr error")
+			assert.Equal(t, awsErr.Code(), "ConditionalCheckFailedException", "Unexpected awsErr code")
+		}
+
+		// And then, verify removing an item from a non-existent table returns an expected error
+		err = removeItemFromLockTable(itemId, uniqueTableNameForTest(), client)
+		if assert.NotNil(t, err, "Error expected") {
+			awsErr, isAwsErr := errors.Unwrap(err).(awserr.Error)
+			assert.True(t, isAwsErr, "Expected error to be an awserr error")
+			assert.Equal(t, awsErr.Code(), "ResourceNotFoundException", "Unexpected awsErr code")
+		}
 	})
 }
 
@@ -117,7 +134,7 @@ func TestWriteItemToLockTableUntilSuccessItemDoesntAlreadyExist(t *testing.T) {
 		itemId := uniqueId()
 
 		// Now write an item to the table. Allow no retries, as the item shouldn't already exit.
-		err := writeItemToLockTableUntilSuccess(itemId, tableName, client, 1, 1 * time.Millisecond, mockOptions)
+		err := writeItemToLockTableUntilSuccess(itemId, tableName, client, 1, 1*time.Millisecond, mockOptions)
 		assert.Nil(t, err, "Unexpected error: %v", err)
 
 		// Finally, check the item exists
@@ -140,7 +157,7 @@ func TestWriteItemToLockTableUntilSuccessItemAlreadyExists(t *testing.T) {
 		assertItemExistsInTable(t, itemId, tableName, client)
 
 		// Now try to write the item to the table again. Allow no retries to ensure this fails immediately.
-		err = writeItemToLockTableUntilSuccess(itemId, tableName, client, 1, 1 * time.Millisecond, mockOptions)
+		err = writeItemToLockTableUntilSuccess(itemId, tableName, client, 1, 1*time.Millisecond, mockOptions)
 		assert.True(t, errors.IsError(err, AcquireLockRetriesExceeded{ItemId: itemId, Retries: 1}), "Unexpected error of type %s: %s", reflect.TypeOf(err), err)
 	})
 }
@@ -169,12 +186,12 @@ func TestWriteItemToLockTableUntilSuccessItemAlreadyExistsButGetsDeleted(t *test
 		// In the meantime, try to write the item to the table again. This should fail initially, so allow 18
 		// retries. At 10 seconds per retry, that's 3 minutes, which should be enough time for the goroutine to
 		// delete the item and for that info to make it to the majority of the DynamoDB nodes.
-		err = writeItemToLockTableUntilSuccess(itemId, tableName, client, 18, 10 * time.Second, mockOptions)
+		err = writeItemToLockTableUntilSuccess(itemId, tableName, client, 18, 10*time.Second, mockOptions)
 		assert.Nil(t, err, "Got unexpected error: %v", err)
 	})
 }
 
-func TestWriteItemToLockTableConcurrency(t * testing.T) {
+func TestWriteItemToLockTableConcurrency(t *testing.T) {
 	t.Parallel()
 
 	concurrency := 20

--- a/locks/dynamodb/dynamo_lock_table_test.go
+++ b/locks/dynamodb/dynamo_lock_table_test.go
@@ -1,7 +1,6 @@
 package dynamodb
 
 import (
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/stretchr/testify/assert"
@@ -110,18 +109,14 @@ func TestWriteAndRemoveItemFromLockTable(t *testing.T) {
 
 		// Additionally, verify removing an item that doesn't exist returns an expected error
 		err = removeItemFromLockTable(itemId, tableName, client)
-		if assert.NotNil(t, err, "Error expected") {
-			awsErr, isAwsErr := errors.Unwrap(err).(awserr.Error)
-			assert.True(t, isAwsErr, "Expected error to be an awserr error")
-			assert.Equal(t, awsErr.Code(), "ConditionalCheckFailedException", "Unexpected awsErr code")
+		if assert.NotNil(t, err) {
+			assert.IsType(t, errors.Unwrap(err), ItemDoesNotExist{})
 		}
 
 		// And then, verify removing an item from a non-existent table returns an expected error
 		err = removeItemFromLockTable(itemId, uniqueTableNameForTest(), client)
-		if assert.NotNil(t, err, "Error expected") {
-			awsErr, isAwsErr := errors.Unwrap(err).(awserr.Error)
-			assert.True(t, isAwsErr, "Expected error to be an awserr error")
-			assert.Equal(t, awsErr.Code(), "ResourceNotFoundException", "Unexpected awsErr code")
+		if assert.NotNil(t, err) {
+			assert.IsType(t, errors.Unwrap(err), TableDoesNotExist{})
 		}
 	})
 }


### PR DESCRIPTION
Fixes #16 

When a non-existent lock is released via `terragrunt release-lock` this will emit a corresponding message indicating that:

```
[terragrunt]  Are you sure you want to release DynamoDB lock for state file .? (y/n) y
[terragrunt] 2017/01/19 20:58:40 Attempting to release lock for state file . in DynamoDB
[terragrunt] 2017/01/19 20:58:40 Nothing to release, specified lock does not exist in table terragrunt_lock_table
```

Additionally, if attempting to release a lock on a non-existent table, the message will reflect this:

```
[terragrunt]  Are you sure you want to release DynamoDB lock for state file .? (y/n) y
[terragrunt] 2017/01/19 20:56:46 Attempting to release lock for state file . in DynamoDB
[terragrunt] 2017/01/19 20:56:47 Table non_existent_table does not exist in DynamoDB!
```
