### PR TITLE
Add support for specifying the AWS profile to use in the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ using AWS. We take no responsibility for any charges you may incur.
 To use DynamoDB for locking, you must:
 
 1. Set your AWS credentials in the environment using one of the following options:
-    1. Set your credentials as the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (and also `AWS_SESSION_TOKEN` if using [STS temporary credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html)), or et the environment variable `AWS_PROFILE`.
-    1. Specify the profile using the `aws_profile` key in `.terragrunt` (see below).
+    1. Set your credentials as the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (and also `AWS_SESSION_TOKEN` if using [STS temporary credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html)).
+    1. Specify the AWS profile to use using the environment variable `AWS_PROFILE`.
+    1. Specify the AWS profile to use using the `aws_profile` key in `.terragrunt` (see below).
     1. Run `aws configure` and fill in the details it asks for.
     1. Run Terragrunt on an EC2 instance with an IAM Role.
 1. Your AWS user must have an [IAM 
@@ -176,9 +177,9 @@ lock = {
   config {
     state_file_id = "my-app"
     aws_region = "us-east-1"
-    aws_profile = "production"
     table_name = "terragrunt_locks"
     max_lock_retries = 360
+    aws_profile = "production"    
   }
 }
 ```
@@ -191,6 +192,7 @@ lock = {
   `terragrunt_locks`.
 * `max_lock_retries`: (Optional) The maximum number of times to retry acquiring a lock. Terragrunt waits 10 seconds
   between retries. Default: 360 retries (one hour).
+* `aws_profile`: (Optional) The AWS login profile to use.  
 
 #### How DynamoDB locking works
 

--- a/README.md
+++ b/README.md
@@ -140,14 +140,15 @@ using AWS. We take no responsibility for any charges you may incur.
 To use DynamoDB for locking, you must:
 
 1. Set your AWS credentials in the environment using one of the following options:
-    1. Set your credentials as the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (and also `AWS_SESSION_TOKEN` if using [STS temporary credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html))
+    1. Set your credentials as the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (and also `AWS_SESSION_TOKEN` if using [STS temporary credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html)), or et the environment variable `AWS_PROFILE`.
+    1. Specify the profile using the `aws_profile` key in `.terragrunt` (see below).
     1. Run `aws configure` and fill in the details it asks for.
     1. Run Terragrunt on an EC2 instance with an IAM Role.
 1. Your AWS user must have an [IAM 
    policy](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-identity-based.html) 
    granting all DynamoDB actions (`dynamodb:*`) on the table `terragrunt_locks` (see the
    [DynamoDB locking configuration](#dynamodb-locking-configuration) for how to configure this table name).
-   
+
    Here is an example IAM policy that grants the necessary permissions on the `terragrunt_locks` table in region `us-west-2` for
    an account with account id `1234567890`:
 
@@ -175,6 +176,7 @@ lock = {
   config {
     state_file_id = "my-app"
     aws_region = "us-east-1"
+    aws_profile = "production"
     table_name = "terragrunt_locks"
     max_lock_retries = 360
   }
@@ -257,6 +259,8 @@ remote_state = {
 * `config`: (Optional) A map of additional key/value pairs to pass to the backend. Each backend requires
   different key/value pairs, so consult the [Terraform remote state docs](https://www.terraform.io/docs/state/remote/)
   for details.
+  
+  > Note: Terragrunt will use the value provided in the `profile` key to configure the AWS SDK when using the S3 backend.
 
 ## Managing multiple .terragrunt files
 

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -2,18 +2,25 @@ package aws_helper
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/gruntwork-io/terragrunt/errors"
 )
 
-// Returns an AWS config object for the given region, ensuring that the config has credentials
-func CreateAwsConfig(awsRegion string) (*aws.Config, error) {
-	config := defaults.Get().Config.WithRegion(awsRegion)
+// Returns an AWS session object for the given region, ensuring that the credentials are available
+func CreateAwsSession(awsRegion, awsProfile string) (*session.Session, error) {
+	session, err := session.NewSessionWithOptions(session.Options{
+		Config:            aws.Config{Region: aws.String(awsRegion)},
+		Profile:           awsProfile,
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		return nil, errors.WithStackTraceAndPrefix(err, "Error intializing session")
+	}
 
-	_, err := config.Credentials.Get()
+	_, err = session.Config.Credentials.Get()
 	if err != nil {
 		return nil, errors.WithStackTraceAndPrefix(err, "Error finding AWS credentials (did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables?)")
 	}
 
-	return config, nil
+	return session, nil
 }

--- a/locks/dynamodb/dynamo_lock_test_utils.go
+++ b/locks/dynamodb/dynamo_lock_test_utils.go
@@ -39,7 +39,7 @@ func uniqueId() string {
 
 // Create a DynamoDB client we can use at test time. If there are any errors creating the client, fail the test.
 func createDynamoDbClientForTest(t *testing.T) *dynamodb.DynamoDB {
-	client, err := createDynamoDbClient(DEFAULT_TEST_REGION)
+	client, err := createDynamoDbClient(DEFAULT_TEST_REGION, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -5,7 +5,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/aws"
 	"fmt"
 	"github.com/gruntwork-io/terragrunt/shell"
@@ -19,6 +18,7 @@ type RemoteStateConfigS3 struct {
 	Bucket  string
 	Key     string
 	Region  string
+	Profile string
 }
 
 const MAX_RETRIES_WAITING_FOR_S3_BUCKET = 12
@@ -36,7 +36,7 @@ func InitializeRemoteStateS3(config map[string]string, terragruntOptions *option
 		return err
 	}
 
-	s3Client, err := CreateS3Client(s3Config.Region)
+	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile)
 	if err != nil {
 		return err
 	}
@@ -176,13 +176,13 @@ func DoesS3BucketExist(s3Client *s3.S3, config *RemoteStateConfigS3) bool {
 }
 
 // Create an authenticated client for DynamoDB
-func CreateS3Client(awsRegion string) (*s3.S3, error) {
-	config, err := aws_helper.CreateAwsConfig(awsRegion)
+func CreateS3Client(awsRegion, awsProfile string) (*s3.S3, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile)
 	if err != nil {
 		return nil, err
 	}
 
-	return s3.New(session.New(), config), nil
+	return s3.New(session), nil
 }
 
 // Custom error types

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/gruntwork-io/terragrunt/aws_helper"
@@ -251,10 +250,9 @@ func uniqueId() string {
 	return out.String()
 }
 
-
 // Check that the S3 Bucket of the given name and region exists. Terragrunt should create this bucket during the test.
 func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {
-	s3Client, err := remote.CreateS3Client(awsRegion)
+	s3Client, err := remote.CreateS3Client(awsRegion, "")
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -265,7 +263,7 @@ func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {
 
 // Delete the specified S3 bucket to clean up after a test
 func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
-	s3Client, err := remote.CreateS3Client(awsRegion)
+	s3Client, err := remote.CreateS3Client(awsRegion, "")
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -301,17 +299,17 @@ func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
 }
 
 // Create an authenticated client for DynamoDB
-func createDynamoDbClient(awsRegion string) (*dynamodb.DynamoDB, error) {
-	config, err := aws_helper.CreateAwsConfig(awsRegion)
+func createDynamoDbClient(awsRegion, awsProfile string) (*dynamodb.DynamoDB, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile)
 	if err != nil {
 		return nil, err
 	}
 
-	return dynamodb.New(session.New(), config), nil
+	return dynamodb.New(session), nil
 }
 
 func createDynamoDbClientForTest(t *testing.T) *dynamodb.DynamoDB {
-	client, err := createDynamoDbClient(DEFAULT_TEST_REGION)
+	client, err := createDynamoDbClient(DEFAULT_TEST_REGION, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This adds support for specifying the AWS profile to use in the config file, in two places:
- Specifying an `aws_profile` in the `lock` config. This profile will be used by the SDK to provide credentials.
- Specifying a `profile` in the `config` section for the S3 backend. Terraform supports this, and terragrunt should as well.

I believe this addresses #48

Note: I tried to not introduce extraneous changes, but my editor is configured to run `goimport` on the files that I edit, and `goimport` seems to disagree with the formatting in this repo.