### PR TITLE
Redirect the output of `terraform remote config` to stderr

### DIFF
--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -5,14 +5,16 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"reflect"
 	"strings"
+
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
 // Run the specified shell command with the specified arguments. Connect the command's stdin, stdout, and stderr to
 // the currently running app.
-func RunShellCommand(terragruntOptions *options.TerragruntOptions, command string, args ... string) error {
+func RunShellCommand(terragruntOptions *options.TerragruntOptions, command string, args ...string) error {
 	terragruntOptions.Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
 
 	cmd := exec.Command(command, args...)
@@ -21,6 +23,13 @@ func RunShellCommand(terragruntOptions *options.TerragruntOptions, command strin
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
+	// Terragrunt can run some commands (such as terraform remote config) before running the actual terraform
+	// command requested by the user. The output of these other commands should not end up on stdout as this
+	// breaks scripts relying on terraform's output.
+	if !reflect.DeepEqual(terragruntOptions.TerraformCliArgs, args) {
+		cmd.Stdout = os.Stderr
+	}
 
 	cmd.Dir = terragruntOptions.WorkingDir
 


### PR DESCRIPTION
@brikis98 alternative solution to #109 