### PR TITLE
Add ability for Terragrunt to download Terraform configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,9 +783,10 @@ prefix `--terragrunt-`. The currently available options are:
   current working directory. Note that for the `spin-up` and `tear-down` directories, this parameter has a different 
   meaning: Terragrunt will apply or destroy all the Terraform modules in the subfolders of the 
   `terragrunt-working-dir`, running `terraform` in the root of each module it finds.
-* `--terragrunt-source`: Check out templates from the specified source, which uses the [module 
-  source](https://www.terraform.io/docs/modules/sources.html) syntax, into a temporary folder, and run Terraform in
-  that temporary folder. May also be specified via the `TERRAGRUNT_SOURCE` environment variable.  
+* `--terragrunt-source`: Download Terraform configurations from the specified source into a temporary folder, and run 
+  Terraform in that temporary folder. May also be specified via the `TERRAGRUNT_SOURCE` environment variable. The 
+  source should use the same syntax as the [Terraform module source](https://www.terraform.io/docs/modules/sources.html) 
+  parameter.  
 
 ## Developing terragrunt
 

--- a/README.md
+++ b/README.md
@@ -682,9 +682,7 @@ infrastructure-live
         └ vars.tf
         └ outputs.tf
     └ backend-app
-    └ search-app
     └ mysql
-    └ redis
     └ vpc
   └ prod
     └ frontend-app
@@ -692,9 +690,7 @@ infrastructure-live
         └ vars.tf
         └ outputs.tf
     └ backend-app
-    └ search-app
     └ mysql
-    └ redis
     └ vpc
 ```
 
@@ -716,9 +712,7 @@ infrastructure-modules
       └ vars.tf
       └ outputs.tf
   └ backend-app
-  └ search-app
   └ mysql
-  └ redis
   └ vpc
 ```
 
@@ -756,18 +750,14 @@ infrastructure-live
         └ .terragrunt
         └ terraform.tfvars
     └ backend-app
-    └ search-app
     └ mysql
-    └ redis
     └ vpc
   └ prod
     └ frontend-app
         └ .terragrunt
         └ terraform.tfvars
     └ backend-app
-    └ search-app
     └ mysql
-    └ redis
     └ vpc
 ```
  

--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ For each environment, you have to copy/paste `main.tf`, `vars.tf`, and `outputs.
 frontend-app, backend-app, vpc, etc). As the number of components and environments grows, having to maintain more and 
 more code can become error prone. You can significantly reduce the amount of copy paste using [Terraform 
 modules](https://blog.gruntwork.io/how-to-create-reusable-infrastructure-with-terraform-modules-25526d65f73d), but even 
-the code to use the module module and set up input variables, output variables, providers, and remote state can still
+the code to instantiate the module and set up input variables, output variables, providers, and remote state can still
 create a lot of maintenance overhead.  
 
 To solve this problem, Terragrunt has the ability to download Terraform configurations. How does that help? Well, 

--- a/README.md
+++ b/README.md
@@ -718,11 +718,11 @@ infrastructure-modules
 
 This repo contains typical Terraform code, with one difference: anything in your code that should be different between 
 environments should be exposed as an input variable. For example, the frontend-app might expose a variable called
-`instance_count` to determine how many instance to run and `instance_type` to determine what kind of server to deploy,
+`instance_count` to determine how many instances to run and `instance_type` to determine what kind of server to deploy,
 as you may want to run smaller/fewer servers in staging than in prod to save money.
 
 In a separate repo, called, for example, infrastructure-live, you define the code for all of your environments, which
-now consists of just two files:
+now consists of just two files per component:
 
 1. `terraform.tfvars`: This file defines the environment-specific values for all of your input variables. For example,
    for `stage/frontend-app/terraform.tfvars`, you might have:
@@ -792,7 +792,7 @@ Just as importantly, since the Terraform code is now defined in a single repo, y
 tags and referencing them using the `ref` parameter in the `source` URL), and promote a single, immutable version 
 through each environment (e.g. qa -> stage -> prod). This idea is inspired by Kief Morris' blog post [Using Pipelines 
 to Manage Environments with Infrastructure as 
-Code](https://medium.com/@kief/https-medium-com-kief-using-pipelines-to-manage-environments-with-infrastructure-as-code-b37285a1cbf5)).
+Code](https://medium.com/@kief/https-medium-com-kief-using-pipelines-to-manage-environments-with-infrastructure-as-code-b37285a1cbf5).
 
 Note that you can also use the `--terragrunt-source` command-line option or the `TERRAGRUNT_SOURCE` environment variable
 to override the `source` parameter. This is useful to point Terragrunt at a local checkout of your code so you can do 

--- a/cli/args.go
+++ b/cli/args.go
@@ -55,6 +55,11 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 		terraformPath = "terraform"
 	}
 
+	terraformSource, err := parseStringArg(args, OPT_TERRAGRUNT_SOURCE, os.Getenv("TERRAGRUNT_SOURCE"))
+	if err != nil {
+		return nil, err
+	}
+
 	return &options.TerragruntOptions{
 		TerragruntConfigPath: filepath.ToSlash(terragruntConfigPath),
 		TerraformPath: filepath.ToSlash(terraformPath),
@@ -63,6 +68,7 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 		WorkingDir: filepath.ToSlash(workingDir),
 		Logger: util.CreateLogger(""),
 		RunTerragrunt: runTerragrunt,
+		Source: terraformSource,
 		Env: parseEnvironmentVariables(os.Environ()),
 	}, nil
 }

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -233,7 +233,7 @@ func checkoutTerraformSource(source string, terragruntOptions *options.Terragrun
 	}
 
 	terragruntOptions.Logger.Printf("Copying files from %s into %s", terragruntOptions.WorkingDir, tmpFolder)
-	if err := util.CopyFolder(terragruntOptions.WorkingDir, tmpFolder); err != nil {
+	if err := util.CopyFolderContents(terragruntOptions.WorkingDir, tmpFolder); err != nil {
 		return err
 	}
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -127,16 +127,6 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		return err
 	}
 
-	if err := downloadModules(terragruntOptions); err != nil {
-		return err
-	}
-
-	if conf.RemoteState != nil {
-		if err := configureRemoteState(conf.RemoteState, terragruntOptions); err != nil {
-			return err
-		}
-	}
-
 	if terragruntOptions.Source != "" {
 		if err := checkoutTerraformSource(terragruntOptions.Source, terragruntOptions); err != nil {
 			return err
@@ -145,6 +135,16 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 
 	if terragruntOptions.Source == "" && conf.Terraform != nil && len(conf.Terraform.Source) > 0 {
 		if err := checkoutTerraformSource(conf.Terraform.Source, terragruntOptions); err != nil {
+			return err
+		}
+	}
+
+	if err := downloadModules(terragruntOptions); err != nil {
+		return err
+	}
+
+	if conf.RemoteState != nil {
+		if err := configureRemoteState(conf.RemoteState, terragruntOptions); err != nil {
 			return err
 		}
 	}

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -20,8 +20,9 @@ const OPT_TERRAGRUNT_CONFIG = "terragrunt-config"
 const OPT_TERRAGRUNT_TFPATH = "terragrunt-tfpath"
 const OPT_NON_INTERACTIVE = "terragrunt-non-interactive"
 const OPT_WORKING_DIR = "terragrunt-working-dir"
+const OPT_TERRAGRUNT_SOURCE = "terragrunt-source"
 var ALL_TERRAGRUNT_BOOLEAN_OPTS = []string{OPT_NON_INTERACTIVE}
-var ALL_TERRAGRUNT_STRING_OPTS = []string{OPT_TERRAGRUNT_CONFIG, OPT_TERRAGRUNT_TFPATH, OPT_WORKING_DIR}
+var ALL_TERRAGRUNT_STRING_OPTS = []string{OPT_TERRAGRUNT_CONFIG, OPT_TERRAGRUNT_TFPATH, OPT_WORKING_DIR, OPT_TERRAGRUNT_SOURCE}
 
 const CMD_ACQUIRE_LOCK = "acquire-lock"
 const CMD_RELEASE_LOCK = "release-lock"
@@ -55,6 +56,7 @@ GLOBAL OPTIONS:
    terragrunt-tfpath             Path to the Terraform binary. Default is terraform (on PATH).
    terragrunt-non-interactive    Assume "yes" for all prompts.
    terragrunt-working-dir        The path to the Terraform templates. Default is current directory.
+   terragrunt-source             Download Terraform configurations from the specified source into a temporary folder, and run Terraform in that temporary folder
 
 VERSION:
    {{.Version}}{{if len .Authors}}
@@ -135,7 +137,13 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		}
 	}
 
-	if conf.Terraform != nil && len(conf.Terraform.Source) > 0 {
+	if terragruntOptions.Source != "" {
+		if err := checkoutTerraformSource(terragruntOptions.Source, terragruntOptions); err != nil {
+			return err
+		}
+	}
+
+	if terragruntOptions.Source == "" && conf.Terraform != nil && len(conf.Terraform.Source) > 0 {
 		if err := checkoutTerraformSource(conf.Terraform.Source, terragruntOptions); err != nil {
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -15,13 +15,18 @@ const DefaultTerragruntConfigPath = ".terragrunt"
 
 // TerragruntConfig represents a parsed and expanded configuration
 type TerragruntConfig struct {
+	Terraform    *TerraformConfig
 	Lock         locks.Lock
 	RemoteState  *remote.RemoteState
 	Dependencies *ModuleDependencies
 }
+func (conf *TerragruntConfig) String() string {
+	return fmt.Sprintf("TerragruntConfig{Terraform = %v, Lock = %v, RemoteState = %v, Dependencies = %v}", conf.Terraform, conf.Lock, conf.RemoteState, conf.Dependencies)
+}
 
 // terragruntConfigFile represents the configuration supported in the .terragrunt file
 type terragruntConfigFile struct {
+	Terraform    *TerraformConfig    `hcl:"terraform,omitempty"`
 	Include      *IncludeConfig      `hcl:"include,omitempty"`
 	Lock         *LockConfig         `hcl:"lock,omitempty"`
 	RemoteState  *remote.RemoteState `hcl:"remote_state,omitempty"`
@@ -44,6 +49,17 @@ type LockConfig struct {
 // can be applied
 type ModuleDependencies struct {
 	Paths []string `hcl:"paths"`
+}
+func (deps *ModuleDependencies) String() string {
+	return fmt.Sprintf("ModuleDependencies{Paths = %v}", deps.Paths)
+}
+
+// TerraformConfig specifies where to find the Terraform configuration files
+type TerraformConfig struct {
+	Source string `hcl:"source"`
+}
+func (conf *TerraformConfig) String() string {
+	return fmt.Sprintf("TerraformConfig{Source = %v}", conf.Source)
 }
 
 // Read the Terragrunt config file from its default location
@@ -125,6 +141,10 @@ func mergeConfigWithIncludedConfig(config *TerragruntConfig, includedConfig *Ter
 		includedConfig.RemoteState = config.RemoteState
 	}
 
+	if config.Terraform != nil {
+		includedConfig.Terraform = config.Terraform
+	}
+
 	if config.Dependencies != nil {
 		includedConfig.Dependencies = config.Dependencies
 	}
@@ -175,6 +195,7 @@ func convertToTerragruntConfig(terragruntConfigFromFile *terragruntConfigFile, t
 		terragruntConfig.RemoteState = terragruntConfigFromFile.RemoteState
 	}
 
+	terragruntConfig.Terraform = terragruntConfigFromFile.Terraform
 	terragruntConfig.Dependencies = terragruntConfigFromFile.Dependencies
 
 	return terragruntConfig, nil

--- a/options/options.go
+++ b/options/options.go
@@ -31,6 +31,10 @@ type TerragruntOptions struct {
 	// Environment variables at runtime
 	Env                  map[string]string
 
+	// Download Terraform configurations from the specified source location into a temporary folder and run
+	// Terraform in that temporary folder
+	Source               string
+
 	// A command that can be used to run Terragrunt with the given options. This is useful for running Terragrunt
 	// multiple times (e.g. when spinning up a stack of Terraform modules). The actual command is normally defined
 	// in the cli package, which depends on almost all other packages, so we declare it here so that other
@@ -51,6 +55,7 @@ func NewTerragruntOptions(terragruntConfigPath string) *TerragruntOptions {
 		WorkingDir: workingDir,
 		Logger: util.CreateLogger(""),
 		Env: map[string]string{},
+		Source: "",
 		RunTerragrunt: func(terragruntOptions *TerragruntOptions) error {
 			return errors.WithStackTrace(RunTerragruntCommandNotSet)
 		},
@@ -79,6 +84,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		WorkingDir: workingDir,
 		Logger: util.CreateLogger(workingDir),
 		Env: terragruntOptions.Env,
+		Source: terragruntOptions.Source,
 		RunTerragrunt: terragruntOptions.RunTerragrunt,
 	}
 }

--- a/options/options.go
+++ b/options/options.go
@@ -50,6 +50,7 @@ func NewTerragruntOptions(terragruntConfigPath string) *TerragruntOptions {
 		TerraformCliArgs: []string{},
 		WorkingDir: workingDir,
 		Logger: util.CreateLogger(""),
+		Env: map[string]string{},
 		RunTerragrunt: func(terragruntOptions *TerragruntOptions) error {
 			return errors.WithStackTrace(RunTerragruntCommandNotSet)
 		},
@@ -77,6 +78,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		TerraformCliArgs: terragruntOptions.TerraformCliArgs,
 		WorkingDir: workingDir,
 		Logger: util.CreateLogger(workingDir),
+		Env: terragruntOptions.Env,
 		RunTerragrunt: terragruntOptions.RunTerragrunt,
 	}
 }

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -13,6 +13,9 @@ type RemoteState struct {
 	Backend string            `hcl:"backend"`
 	Config  map[string]string `hcl:"config"`
 }
+func (state *RemoteState) String() string {
+	return fmt.Sprintf("RemoteState{Backend = %v, Config = %v}", state.Backend, state.Config)
+}
 
 type RemoteStateInitializer func(map[string]string, *options.TerragruntOptions) error
 

--- a/test/fixture-checkout/hello-world/hello/main.tf
+++ b/test/fixture-checkout/hello-world/hello/main.tf
@@ -1,0 +1,3 @@
+output "hello" {
+  value = "Hello"
+}

--- a/test/fixture-checkout/hello-world/main.tf
+++ b/test/fixture-checkout/hello-world/main.tf
@@ -1,6 +1,5 @@
-# Create an arbitrary local resource
 data "template_file" "test" {
-  template = "Hello, ${var.name}"
+  template = "${module.hello.hello}, ${var.name}"
 }
 
 variable "name" {
@@ -9,4 +8,8 @@ variable "name" {
 
 output "test" {
   value = "${data.template_file.test.rendered}"
+}
+
+module "hello" {
+  source = "./hello"
 }

--- a/test/fixture-checkout/hello-world/main.tf
+++ b/test/fixture-checkout/hello-world/main.tf
@@ -1,0 +1,12 @@
+# Create an arbitrary local resource
+data "template_file" "test" {
+  template = "Hello, ${var.name}"
+}
+
+variable "name" {
+  description = "Specify a name"
+}
+
+output "test" {
+  value = "${data.template_file.test.rendered}"
+}

--- a/test/fixture-checkout/local/.terragrunt
+++ b/test/fixture-checkout/local/.terragrunt
@@ -1,0 +1,3 @@
+terraform {
+  source = "../hello-world"
+}

--- a/test/fixture-checkout/local/terraform.tfvars
+++ b/test/fixture-checkout/local/terraform.tfvars
@@ -1,0 +1,1 @@
+name = "World"

--- a/test/fixture-checkout/override/.terragrunt
+++ b/test/fixture-checkout/override/.terragrunt
@@ -1,0 +1,4 @@
+# This URL is intentionally invalid, as it should be overridden in the test case via command-line params
+terraform {
+  source = "invalid-url-should-be-overridden-at-test-time"
+}

--- a/test/fixture-checkout/override/terraform.tfvars
+++ b/test/fixture-checkout/override/terraform.tfvars
@@ -1,0 +1,1 @@
+name = "World"

--- a/test/fixture-checkout/remote/.terragrunt
+++ b/test/fixture-checkout/remote/.terragrunt
@@ -1,4 +1,4 @@
 # TODO: update the ref from a branch name to a specific release of Terragrunt as soon as this test is merged into master!
 terraform {
-  source = "https://github.com/gruntwork-io/terragrunt.git?ref=checkout"
+  source = "github.com/gruntwork-io/terragrunt.git//test/fixture-checkout/hello-world?ref=checkout"
 }

--- a/test/fixture-checkout/remote/.terragrunt
+++ b/test/fixture-checkout/remote/.terragrunt
@@ -1,4 +1,4 @@
 # TODO: update the ref from a branch name to a specific release of Terragrunt as soon as this test is merged into master!
 terraform {
-  source = "https://github.com/gruntwork-io/terragrunt.git?ref=new-file-layout"
+  source = "https://github.com/gruntwork-io/terragrunt.git?ref=checkout"
 }

--- a/test/fixture-checkout/remote/.terragrunt
+++ b/test/fixture-checkout/remote/.terragrunt
@@ -1,0 +1,4 @@
+# TODO: update the ref from a branch name to a specific release of Terragrunt as soon as this test is merged into master!
+terraform {
+  source = "https://github.com/gruntwork-io/terragrunt.git?ref=new-file-layout"
+}

--- a/test/fixture-checkout/remote/terraform.tfvars
+++ b/test/fixture-checkout/remote/terraform.tfvars
@@ -1,0 +1,1 @@
+name = "World"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -33,7 +33,11 @@ const (
 	TEST_FIXTURE_INCLUDE_PATH           = "fixture-include/"
 	TEST_FIXTURE_INCLUDE_CHILD_REL_PATH = "qa/my-app"
 	TEST_FIXTURE_STACK                  = "fixture-stack/"
+	TEST_FIXTURE_LOCAL_CHECKOUT_PATH    = "fixture-checkout/local"
+	TEST_FIXTURE_REMOTE_CHECKOUT_PATH   = "fixture-checkout/remote"
 	TERRAFORM_FOLDER                    = ".terraform"
+	TERRAFORM_STATE                     = "terraform.tfstate"
+	TERRAFORM_STATE_BACKUP              = "terraform.tfstate.backup"
 	DEFAULT_TEST_REGION                 = "us-east-1"
 )
 
@@ -122,14 +126,41 @@ func TestTerragruntSpinUpAndTearDown(t *testing.T) {
 	runTerragrunt(t, fmt.Sprintf("terragrunt tear-down --terragrunt-non-interactive --terragrunt-working-dir %s -var terraform_remote_state_s3_bucket=\"%s\"", mgmtEnvironmentPath, s3BucketName))
 }
 
-func cleanupTerraformFolder(t *testing.T, templatesPath string) {
-	terraformFolder := util.JoinPath(templatesPath, TERRAFORM_FOLDER)
-	if !util.FileExists(terraformFolder) {
-		return
-	}
+func TestLocalCheckout(t *testing.T) {
+	t.Parallel()
 
-	if err := os.RemoveAll(terraformFolder); err != nil {
-		t.Fatalf("Error while removing %s folder: %v", terraformFolder, err)
+	cleanupTerraformFolder(t, TEST_FIXTURE_LOCAL_CHECKOUT_PATH)
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_CHECKOUT_PATH))
+}
+
+func TestRemoteCheckout(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_REMOTE_CHECKOUT_PATH)
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_CHECKOUT_PATH))
+}
+
+func cleanupTerraformFolder(t *testing.T, templatesPath string) {
+	removeFile(t, util.JoinPath(templatesPath, TERRAFORM_STATE))
+	removeFile(t, util.JoinPath(templatesPath, TERRAFORM_STATE_BACKUP))
+	removeFolder(t, util.JoinPath(templatesPath, TERRAFORM_FOLDER))
+}
+
+func removeFile(t *testing.T, path string) {
+	if util.FileExists(path) {
+		if err := os.Remove(path); err != nil {
+			t.Fatalf("Error while removing %s: %v", path, err)
+		}
+	}
+}
+
+func removeFolder(t *testing.T, path string) {
+	if util.FileExists(path) {
+		if err := os.RemoveAll(path); err != nil {
+			t.Fatalf("Error while removing %s: %v", path, err)
+		}
 	}
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -35,6 +35,7 @@ const (
 	TEST_FIXTURE_STACK                  = "fixture-stack/"
 	TEST_FIXTURE_LOCAL_CHECKOUT_PATH    = "fixture-checkout/local"
 	TEST_FIXTURE_REMOTE_CHECKOUT_PATH   = "fixture-checkout/remote"
+	TEST_FIXTURE_OVERRIDE_CHECKOUT_PATH = "fixture-checkout/override"
 	TERRAFORM_FOLDER                    = ".terraform"
 	TERRAFORM_STATE                     = "terraform.tfstate"
 	TERRAFORM_STATE_BACKUP              = "terraform.tfstate.backup"
@@ -140,6 +141,14 @@ func TestRemoteCheckout(t *testing.T) {
 	cleanupTerraformFolder(t, TEST_FIXTURE_REMOTE_CHECKOUT_PATH)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_REMOTE_CHECKOUT_PATH))
+}
+
+func TestRemoteCheckoutOverride(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_OVERRIDE_CHECKOUT_PATH)
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-source %s", TEST_FIXTURE_OVERRIDE_CHECKOUT_PATH, "../hello-world"))
 }
 
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -139,7 +139,7 @@ func TestRemoteCheckout(t *testing.T) {
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_REMOTE_CHECKOUT_PATH)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_CHECKOUT_PATH))
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_REMOTE_CHECKOUT_PATH))
 }
 
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {


### PR DESCRIPTION
This PR adds a new element you can specify in the `.terragrunt` file:

```hcl
terraform {
  source = "git::git@github.com:foo/bar.git//my-terraform-configurations?ref=v0.0.1"
}
```

When you specify this parameter, Terragrunt will download the Terraform configurations at the `source` URL to a temporary folder and run Terraform in that temporary folder. 

This makes it easy to version all of your Terraform configurations and deploy a specific version automatically, similar to Kief Morris’ [pipelines idea](https://medium.com/@kief/https-medium-com-kief-using-pipelines-to-manage-environments-with-infrastructure-as-code-b37285a1cbf5). 

You can also override the `source` parameter with the `--terragrunt-source` command-line flag and `TERRAGRUNT_SOURCE` environment variable, which makes it easy to use a local checkout for iterative development.

See the Readme for full details.