### PR TITLE
Add a --terragrunt-source-update flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,8 @@ prefix `--terragrunt-`. The currently available options are:
   Terraform in that temporary folder. May also be specified via the `TERRAGRUNT_SOURCE` environment variable. The 
   source should use the same syntax as the [Terraform module source](https://www.terraform.io/docs/modules/sources.html) 
   parameter.  
+* `--terragrunt-source-update`: Delete the contents of the temporary folder before downloading Terraform source code
+  into it.
 
 ## Developing terragrunt
 

--- a/cli/args.go
+++ b/cli/args.go
@@ -60,6 +60,8 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 		return nil, err
 	}
 
+	updateSource := parseBooleanArg(args, OPT_TERRAGRUNT_SOURCE_UPDATE, false)
+
 	return &options.TerragruntOptions{
 		TerragruntConfigPath: filepath.ToSlash(terragruntConfigPath),
 		TerraformPath: filepath.ToSlash(terraformPath),
@@ -69,6 +71,7 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 		Logger: util.CreateLogger(""),
 		RunTerragrunt: runTerragrunt,
 		Source: terraformSource,
+		UpdateSource: updateSource,
 		Env: parseEnvironmentVariables(os.Environ()),
 	}, nil
 }

--- a/cli/args.go
+++ b/cli/args.go
@@ -60,7 +60,7 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 		return nil, err
 	}
 
-	updateSource := parseBooleanArg(args, OPT_TERRAGRUNT_SOURCE_UPDATE, false)
+	sourceUpdate := parseBooleanArg(args, OPT_TERRAGRUNT_SOURCE_UPDATE, false)
 
 	return &options.TerragruntOptions{
 		TerragruntConfigPath: filepath.ToSlash(terragruntConfigPath),
@@ -71,7 +71,7 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 		Logger: util.CreateLogger(""),
 		RunTerragrunt: runTerragrunt,
 		Source: terraformSource,
-		UpdateSource: updateSource,
+		SourceUpdate: sourceUpdate,
 		Env: parseEnvironmentVariables(os.Environ()),
 	}, nil
 }

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -20,7 +20,8 @@ const OPT_TERRAGRUNT_TFPATH = "terragrunt-tfpath"
 const OPT_NON_INTERACTIVE = "terragrunt-non-interactive"
 const OPT_WORKING_DIR = "terragrunt-working-dir"
 const OPT_TERRAGRUNT_SOURCE = "terragrunt-source"
-var ALL_TERRAGRUNT_BOOLEAN_OPTS = []string{OPT_NON_INTERACTIVE}
+const OPT_TERRAGRUNT_SOURCE_UPDATE = "terragrunt-source-update"
+var ALL_TERRAGRUNT_BOOLEAN_OPTS = []string{OPT_NON_INTERACTIVE, OPT_TERRAGRUNT_SOURCE_UPDATE}
 var ALL_TERRAGRUNT_STRING_OPTS = []string{OPT_TERRAGRUNT_CONFIG, OPT_TERRAGRUNT_TFPATH, OPT_WORKING_DIR, OPT_TERRAGRUNT_SOURCE}
 
 const CMD_ACQUIRE_LOCK = "acquire-lock"
@@ -56,6 +57,7 @@ GLOBAL OPTIONS:
    terragrunt-non-interactive    Assume "yes" for all prompts.
    terragrunt-working-dir        The path to the Terraform templates. Default is current directory.
    terragrunt-source             Download Terraform configurations from the specified source into a temporary folder, and run Terraform in that temporary folder
+   terragrunt-source-update      Delete the contents of the temporary folder before downloading source code into it
 
 VERSION:
    {{.Version}}{{if len .Authors}}

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -57,7 +57,7 @@ GLOBAL OPTIONS:
    terragrunt-non-interactive    Assume "yes" for all prompts.
    terragrunt-working-dir        The path to the Terraform templates. Default is current directory.
    terragrunt-source             Download Terraform configurations from the specified source into a temporary folder, and run Terraform in that temporary folder
-   terragrunt-source-update      Delete the contents of the temporary folder before downloading source code into it
+   terragrunt-source-update      Delete the contents of the temporary folder to clear out any old, cached source code before downloading new source code into it
 
 VERSION:
    {{.Version}}{{if len .Authors}}

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -59,6 +59,13 @@ func downloadTerraformSource(source string, terragruntOptions *options.Terragrun
 
 // Download the specified TerraformSource if the latest code hasn't already been downloaded.
 func downloadTerraformSourceIfNecessary(terraformSource *TerraformSource, terragruntOptions *options.TerragruntOptions) error {
+	if terragruntOptions.UpdateSource {
+		terragruntOptions.Logger.Printf("The --%s flag is set, so deleting the temporary folder %s before downloading source.", OPT_TERRAGRUNT_SOURCE_UPDATE, terraformSource.DownloadDir)
+		if err := os.RemoveAll(terraformSource.DownloadDir); err != nil {
+			return errors.WithStackTrace(err)
+		}
+	}
+
 	alreadyLatest, err := alreadyHaveLatestCode(terraformSource)
 	if err != nil {
 		return err

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -59,7 +59,7 @@ func downloadTerraformSource(source string, terragruntOptions *options.Terragrun
 
 // Download the specified TerraformSource if the latest code hasn't already been downloaded.
 func downloadTerraformSourceIfNecessary(terraformSource *TerraformSource, terragruntOptions *options.TerragruntOptions) error {
-	if terragruntOptions.UpdateSource {
+	if terragruntOptions.SourceUpdate {
 		terragruntOptions.Logger.Printf("The --%s flag is set, so deleting the temporary folder %s before downloading source.", OPT_TERRAGRUNT_SOURCE_UPDATE, terraformSource.DownloadDir)
 		if err := os.RemoveAll(terraformSource.DownloadDir); err != nil {
 			return errors.WithStackTrace(err)

--- a/cli/download_source_test.go
+++ b/cli/download_source_test.go
@@ -146,7 +146,7 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlOverrideSource(t *testing.T)
 	testDownloadTerraformSourceIfNecessary(t, canonicalUrl, downloadDir, true, "# Hello, World")
 }
 
-func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, downloadDir string, updateSource bool, expectedFileContents string) {
+func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, downloadDir string, sourceUpdate bool, expectedFileContents string) {
 	terraformSource := &TerraformSource{
 		CanonicalSourceURL: parseUrl(t, canonicalUrl),
 		DownloadDir: downloadDir,
@@ -154,7 +154,7 @@ func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, d
 	}
 
 	terragruntOptions := options.NewTerragruntOptionsForTest("./should-not-be-used")
-	terragruntOptions.UpdateSource = updateSource
+	terragruntOptions.SourceUpdate = sourceUpdate
 
 	err := downloadTerraformSourceIfNecessary(terraformSource, terragruntOptions)
 	assert.Nil(t, err, "For terraform source %v: %v", terraformSource, err)

--- a/options/options.go
+++ b/options/options.go
@@ -36,7 +36,7 @@ type TerragruntOptions struct {
 	Source               string
 
 	// If set to true, delete the contents of the temporary folder before downloading Terraform source code into it
-	UpdateSource         bool
+	SourceUpdate  bool
 
 	// A command that can be used to run Terragrunt with the given options. This is useful for running Terragrunt
 	// multiple times (e.g. when spinning up a stack of Terraform modules). The actual command is normally defined
@@ -59,7 +59,7 @@ func NewTerragruntOptions(terragruntConfigPath string) *TerragruntOptions {
 		Logger: util.CreateLogger(""),
 		Env: map[string]string{},
 		Source: "",
-		UpdateSource: false,
+		SourceUpdate: false,
 		RunTerragrunt: func(terragruntOptions *TerragruntOptions) error {
 			return errors.WithStackTrace(RunTerragruntCommandNotSet)
 		},
@@ -89,7 +89,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		Logger: util.CreateLogger(workingDir),
 		Env: terragruntOptions.Env,
 		Source: terragruntOptions.Source,
-		UpdateSource: terragruntOptions.UpdateSource,
+		SourceUpdate: terragruntOptions.SourceUpdate,
 		RunTerragrunt: terragruntOptions.RunTerragrunt,
 	}
 }

--- a/options/options.go
+++ b/options/options.go
@@ -35,12 +35,15 @@ type TerragruntOptions struct {
 	// Terraform in that temporary folder
 	Source               string
 
+	// If set to true, delete the contents of the temporary folder before downloading Terraform source code into it
+	UpdateSource         bool
+
 	// A command that can be used to run Terragrunt with the given options. This is useful for running Terragrunt
 	// multiple times (e.g. when spinning up a stack of Terraform modules). The actual command is normally defined
 	// in the cli package, which depends on almost all other packages, so we declare it here so that other
 	// packages can use the command without a direct reference back to the cli package (which would create a
 	// circular dependency).
-	RunTerragrunt        func(*TerragruntOptions) error
+	RunTerragrunt func(*TerragruntOptions) error
 }
 
 // Create a new TerragruntOptions object with reasonable defaults for real usage
@@ -56,6 +59,7 @@ func NewTerragruntOptions(terragruntConfigPath string) *TerragruntOptions {
 		Logger: util.CreateLogger(""),
 		Env: map[string]string{},
 		Source: "",
+		UpdateSource: false,
 		RunTerragrunt: func(terragruntOptions *TerragruntOptions) error {
 			return errors.WithStackTrace(RunTerragruntCommandNotSet)
 		},
@@ -85,6 +89,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		Logger: util.CreateLogger(workingDir),
 		Env: terragruntOptions.Env,
 		Source: terragruntOptions.Source,
+		UpdateSource: terragruntOptions.UpdateSource,
 		RunTerragrunt: terragruntOptions.RunTerragrunt,
 	}
 }


### PR DESCRIPTION
In https://github.com/gruntwork-io/terragrunt/pull/114, I added the ability for Terraform to cache the temporary folder so we don’t have to redownload code unnecessarily. This PR adds a new flag that I (naively) hoped wouldn’t be necessary: `—terragrunt-source-update`. This flag is a bit like the `-update` flag in terraform. It deletes the temporary folder before downloading into it. 