### PR TITLE
When cleaning up files, don't delete files in .terraform folders

### DIFF
--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -318,7 +318,17 @@ func cleanupTerraformFiles(path string, terragruntOptions *options.TerragruntOpt
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
-	return util.DeleteFiles(files)
+
+	// Filter out files in .terraform folders, since those are from modules downloaded via a call to terraform get,
+	// and we don't want to re-download them.
+	filteredFiles := []string{}
+	for _, file := range files {
+		if !strings.Contains(file, ".terraform") {
+			filteredFiles = append(filteredFiles, file)
+		}
+	}
+
+	return util.DeleteFiles(filteredFiles)
 }
 
 // There are two ways a user can tell Terragrunt that it needs to download Terraform configurations from a specific

--- a/test/fixture-download/hello-world/main.tf
+++ b/test/fixture-download/hello-world/main.tf
@@ -13,3 +13,8 @@ output "test" {
 module "hello" {
   source = "./hello"
 }
+
+module "remote" {
+  source = "github.com/gruntwork-io/terragrunt.git//test/fixture-download/hello-world?ref=v0.9.9"
+  name = "${var.name}"
+}


### PR DESCRIPTION
This PR fixes a bug in Terragrunt’s support for remote source directories where it was deleting `*.tf` files in the tmp download folder so it could update them with the latest code. Unfortunately, this also deleted files downloaded from modules into `.terraform` folders, so you would get “you need to run terraform get” style errors after multiple re-runs. 

I’ve updated the test cases to catch this error.