### PR TITLE
Adding `extra_arguments` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,57 @@ terragrunt = {
 }
 ```
 
+### Passing extra command line arguments to Terraform
+
+Sometimes you may need to pass extra arguments to Terraform on each run. For example if you have a separate file with
+secret variables you may use extra_arguments option in terraform section of Terragrunt configuration to do it
+automatically.
+
+Each set of arguments will be appended only if current Terraform command is in `commands` list. If more than one set is
+applicable, they will be added in the order of of appearance in config.
+
+Sample config:
+
+``` hcl
+terragrunt= {
+  terraform = {
+    {
+      extra_arguments "secrets" {
+        arguments = [
+          "-var-file=terraform.tfvars",
+          "-var-file=terraform-secret.tfvars"
+        ]
+        commands = [
+          "apply",
+          "plan",
+          "import",
+          "push",
+          "refresh"
+        ]
+      }
+
+      extra_arguments "json_output" {
+        arguments = [
+          "-json"
+        ]
+        commands = [
+          "output"
+        ]
+      }
+
+      extra_arguments "fmt_diff" {
+        arguments = [
+          "-diff=true"
+        ]
+        commands = [
+          "fmt"
+        ]
+      }
+
+    }
+  }
+```
+
 ### The spin-up and tear-down commands
 
 Let's say you have a single environment (e.g. `stage` or `prod`) that has a number of Terraform modules within it:

--- a/cli/args.go
+++ b/cli/args.go
@@ -76,6 +76,23 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 	}, nil
 }
 
+func filterTerraformExtraArgs(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) []string {
+	out := []string{}
+	cmd := firstArg(terragruntOptions.TerraformCliArgs)
+
+	for _, arg := range terragruntConfig.Terraform.ExtraArgs {
+		if arg.Commands != nil && arg.Arguments != nil {
+			for _, arg_cmd := range arg.Commands {
+				if cmd == arg_cmd {
+					out = append(out, arg.Arguments...)
+				}
+			}
+		}
+	}
+
+	return out
+}
+
 func parseEnvironmentVariables(environment []string) map[string]string {
 	environmentMap := make(map[string]string)
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -132,6 +132,10 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		return err
 	}
 
+  if conf.Terraform != nil && conf.Terraform.ExtraArgs != nil && len(conf.Terraform.ExtraArgs) > 0	{
+    terragruntOptions.TerraformCliArgs = append(terragruntOptions.TerraformCliArgs,	filterTerraformExtraArgs(terragruntOptions, conf)...)
+  }
+
 	if sourceUrl, hasSourceUrl := getTerraformSourceUrl(terragruntOptions, conf); hasSourceUrl {
 		if err := downloadTerraformSource(sourceUrl, terragruntOptions); err != nil {
 			return err

--- a/config/config.go
+++ b/config/config.go
@@ -65,10 +65,22 @@ func (deps *ModuleDependencies) String() string {
 
 // TerraformConfig specifies where to find the Terraform configuration files
 type TerraformConfig struct {
-	Source string `hcl:"source"`
+	ExtraArgs []TerraformExtraArguments `hcl:"extra_arguments"`
+	Source    string                    `hcl:"source"`
 }
+
 func (conf *TerraformConfig) String() string {
 	return fmt.Sprintf("TerraformConfig{Source = %v}", conf.Source)
+}
+
+// TerraformExtraArguments sets a list of arguments to pass to Terraform if command fits any in the `Commands` list
+type TerraformExtraArguments struct {
+	Name      string   `hcl:",key"`
+	Arguments []string `hcl:"arguments,omitempty"`
+	Commands   []string `hcl:"commands,omitempty"`
+}
+func (conf *TerraformExtraArguments) String() string {
+	return fmt.Sprintf("TerraformArguments{Name = %s, Arguments = %v, Commands = %v}", conf.Name, conf.Arguments, conf.Commands)
 }
 
 // Return the default path to use for the Terragrunt configuration file. The reason this is a method rather than a

--- a/test/fixture-extra-args/extra.tfvars
+++ b/test/fixture-extra-args/extra.tfvars
@@ -1,0 +1,1 @@
+extra_var = "Hello, World!"

--- a/test/fixture-extra-args/main.tf
+++ b/test/fixture-extra-args/main.tf
@@ -1,0 +1,7 @@
+variable "extra_var" {
+  description = "Should be loaded from extra.tfvars"
+}
+
+output "test" {
+  value = "${var.extra_var}"
+}

--- a/test/fixture-extra-args/terraform.tfvars
+++ b/test/fixture-extra-args/terraform.tfvars
@@ -1,0 +1,17 @@
+terragrunt= {
+  terraform = {
+    extra_arguments "test" {
+      arguments = [
+        "-var-file=terraform.tfvars",
+        "-var-file=extra.tfvars"
+      ]
+      commands = [
+        "apply",
+        "plan",
+        "import",
+        "push",
+        "refresh"
+      ]
+    }
+  }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -31,6 +31,7 @@ const (
 	TEST_FIXTURE_INCLUDE_PATH                           = "fixture-include/"
 	TEST_FIXTURE_INCLUDE_CHILD_REL_PATH                 = "qa/my-app"
 	TEST_FIXTURE_STACK                                  = "fixture-stack/"
+	TEST_FIXTURE_EXTRA_ARGS_PATH                        = "fixture-extra-args/"
 	TEST_FIXTURE_LOCAL_DOWNLOAD_PATH                    = "fixture-download/local"
 	TEST_FIXTURE_REMOTE_DOWNLOAD_PATH                   = "fixture-download/remote"
 	TEST_FIXTURE_OVERRIDE_DOWNLOAD_PATH                 = "fixture-download/override"
@@ -279,6 +280,11 @@ func TestRemoteDownloadOverride(t *testing.T) {
 
 	// Run a second time to make sure the temporary folder can be reused without errors
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-source %s", TEST_FIXTURE_OVERRIDE_DOWNLOAD_PATH, "../hello-world"))
+}
+
+func TestExtraArguments(t *testing.T) {
+	t.Parallel()
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_EXTRA_ARGS_PATH))
 }
 
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {


### PR DESCRIPTION
Sometimes you may need to pass extra arguments to Terraform on each run.
For example if you have a separate file with secret variables you may
use `extra_arguments` option in `terraform` section of Terragrunt
configuration to do it automatically.

Example:

  terraform = {
    extra_arguments = [
      "-var-file=terraform.tfvars",
      "-var-file=terraform-secret.tfvars"
    ]
  }