### PR TITLE
Wait for shell when forwarding signals; shell package test coverage

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func checkForErrorsAndExit(err error) {
 		exitCode, exitCodeErr := shell.GetExitCode(err)
 		if exitCodeErr != nil {
 			exitCode = 1
+			logger.Println("Unable to determine underlying exit code, so Terragrunt will exit with error code 1")
 		}
 		os.Exit(exitCode)
 	}

--- a/main.go
+++ b/main.go
@@ -34,12 +34,11 @@ func checkForErrorsAndExit(err error) {
 			logger.Println(err)
 		}
 		// exit with the underlying error code
-		var retCode int
-		retCode, err := shell.GetExitCode(err)
-		if err != nil {
-			retCode = 1
+		exitCode, exitCodeErr := shell.GetExitCode(err)
+		if exitCodeErr != nil {
+			exitCode = 1
 		}
-		os.Exit(retCode)
+		os.Exit(exitCode)
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"os"
-	"os/exec"
-	"syscall"
+	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/gruntwork-io/terragrunt/cli"
 	"github.com/gruntwork-io/terragrunt/errors"
@@ -35,10 +34,10 @@ func checkForErrorsAndExit(err error) {
 			logger.Println(err)
 		}
 		// exit with the underlying error code
-		var retCode int = 1
-		if exiterr, ok := errors.Unwrap(err).(*exec.ExitError); ok {
-			status := exiterr.Sys().(syscall.WaitStatus)
-			retCode = status.ExitStatus()
+		var retCode int
+		retCode, err := shell.GetExitCode(err)
+		if err != nil {
+			retCode = 1
 		}
 		os.Exit(retCode)
 	}

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -48,13 +48,11 @@ func RunShellCommand(terragruntOptions *options.TerragruntOptions, command strin
 // Return the exit code of a command. If the error is not an exec.ExitError type,
 // the error is returned.
 func GetExitCode(err error) (int, error) {
-	var retCode int
 	if exiterr, ok := errors.Unwrap(err).(*exec.ExitError); ok {
-	status := exiterr.Sys().(syscall.WaitStatus)
-	retCode = status.ExitStatus()
-	return retCode, nil
-		}
-	return retCode, err
+		status := exiterr.Sys().(syscall.WaitStatus)
+		return status.ExitStatus(), nil
+	}
+	return 0, err
 }
 
 type SignalsForwarder chan os.Signal

--- a/shell/run_shell_cmd_test.go
+++ b/shell/run_shell_cmd_test.go
@@ -1,0 +1,121 @@
+package shell
+
+import (
+	goerrors "errors"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestRunShellCommand(t *testing.T) {
+	t.Parallel()
+
+	terragruntOptions := options.NewTerragruntOptionsForTest("")
+	cmd := RunShellCommand(terragruntOptions, "/bin/bash", "-c", "true")
+	assert.Nil(t, cmd)
+
+	cmd = RunShellCommand(terragruntOptions, "/bin/bash", "-c", "false")
+	assert.Error(t, cmd)
+}
+
+func TestExitCode(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i <= 255; i++ {
+		cmd := exec.Command("../testdata/test_exit_code.sh", strconv.Itoa(i))
+		err := cmd.Run()
+
+		if i == 0 {
+			assert.Nil(t, err)
+		} else {
+			assert.Error(t, err)
+		}
+		retCode, err := GetExitCode(err)
+		assert.Nil(t, err)
+		assert.Equal(t, i, retCode)
+	}
+
+	// assert a non exec.ExitError returns an error
+	err := goerrors.New("This is an explicit error")
+	retCode, retErr := GetExitCode(err)
+	assert.Error(t, retErr, "An error was expected")
+	assert.Equal(t, err, retErr)
+	assert.Equal(t, 0, retCode)
+}
+
+func TestNewSignalsForwarderWait(t *testing.T) {
+	t.Parallel()
+
+	expectedWait := 5
+
+	terragruntOptions := options.NewTerragruntOptionsForTest("")
+	cmd := exec.Command("../testdata/test_sigint_wait.sh", strconv.Itoa(expectedWait))
+
+	cmdChannel := make(chan error)
+	runChannel := make(chan error)
+
+	signalChannel := NewSignalsForwarder(forwardSignals, cmd, terragruntOptions.Logger, cmdChannel)
+	defer signalChannel.Close()
+
+	go func() {
+		runChannel <- cmd.Run()
+	}()
+
+	time.Sleep(1000 * time.Millisecond)
+	start := time.Now()
+	cmd.Process.Signal(os.Interrupt)
+	err := <-runChannel
+	cmdChannel <- err
+	assert.Error(t, err)
+	retCode, err := GetExitCode(err)
+	assert.Nil(t, err)
+	assert.Equal(t, retCode, expectedWait)
+	assert.WithinDuration(t, time.Now(), start.Add(time.Duration(expectedWait)*time.Second), time.Second,
+		"Expected to wait 5 (+/-1) seconds after SIGINT")
+
+}
+
+func TestNewSignalsForwarderMultiple(t *testing.T) {
+	t.Parallel()
+
+	expectedInterrupts := 10
+	terragruntOptions := options.NewTerragruntOptionsForTest("")
+	cmd := exec.Command("../testdata/test_sigint_multiple.sh", strconv.Itoa(expectedInterrupts))
+
+	cmdChannel := make(chan error)
+	runChannel := make(chan error)
+
+	signalChannel := NewSignalsForwarder(forwardSignals, cmd, terragruntOptions.Logger, cmdChannel)
+	defer signalChannel.Close()
+
+	go func() {
+		runChannel <- cmd.Run()
+	}()
+
+	time.Sleep(1000 * time.Millisecond)
+	var interrupts int
+	var err error
+
+loop:
+	for {
+		time.Sleep(500 * time.Millisecond)
+		select {
+		case err = <-runChannel:
+			break loop
+		default:
+			cmd.Process.Signal(os.Interrupt)
+			interrupts++
+		}
+	}
+
+	cmdChannel <- err
+	assert.Error(t, err)
+	retCode, err := GetExitCode(err)
+	assert.Nil(t, err)
+	assert.Equal(t, retCode, interrupts)
+
+}

--- a/shell/signal_unix.go
+++ b/shell/signal_unix.go
@@ -7,4 +7,4 @@ import (
 	"syscall"
 )
 
-var forwardSignals []os.Signal = []os.Signal{syscall.SIGTERM}
+var forwardSignals []os.Signal = []os.Signal{syscall.SIGTERM, syscall.SIGINT}

--- a/testdata/test_exit_code.sh
+++ b/testdata/test_exit_code.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit $1

--- a/testdata/test_exit_code.sh
+++ b/testdata/test_exit_code.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/bash -e
 
 exit $1

--- a/testdata/test_sigint_multiple.sh
+++ b/testdata/test_sigint_multiple.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 INT_REQUIRED=$1
 INT_COUNTER=0

--- a/testdata/test_sigint_multiple.sh
+++ b/testdata/test_sigint_multiple.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+INT_REQUIRED=$1
+INT_COUNTER=0
+
+trap int_handler INT
+
+function int_handler() {
+    INT_COUNTER=$((INT_COUNTER + 1))
+}
+
+while [ $INT_COUNTER -lt $INT_REQUIRED ]
+    do sleep 0.1
+done
+
+exit $INT_COUNTER

--- a/testdata/test_sigint_wait.sh
+++ b/testdata/test_sigint_wait.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 WAIT_TIME=$1
 

--- a/testdata/test_sigint_wait.sh
+++ b/testdata/test_sigint_wait.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+WAIT_TIME=$1
+
+trap int_handler INT
+
+function int_handler() {
+        sleep $WAIT_TIME
+        exit $WAIT_TIME
+}
+
+while true; do sleep 0.1; done


### PR DESCRIPTION
This PR fixes #120.

The changes include:

* Modifying the `NewSignalsForwarder` so that the signal forwarder waits for the command to finish. It is possible that multiple signals need to be passed the command. Additionally, this fixes a bug where the signal forwarder previously panicked by passed the `*exec.Cmd`, instead of `os.Process`, to the signal forwarder since `os.Process` is only allocated after the command starts running.
* Adds test coverage for the `shell` package
* Creates a `GetExitCode` function, the exit code logic in `main.go` was migrated into the `shell` package so it could be tested.
