### PR TITLE
Add support for AssumeRole for DynamoDB locks and S3 remote state

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -2,12 +2,15 @@ package aws_helper
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gruntwork-io/terragrunt/errors"
 )
 
 // Returns an AWS session object for the given region, ensuring that the credentials are available
-func CreateAwsSession(awsRegion, awsProfile string) (*session.Session, error) {
+func CreateAwsSession(awsRegion, awsProfile, awsRoleArn string) (*session.Session, error) {
 	session, err := session.NewSessionWithOptions(session.Options{
 		Config:            aws.Config{Region: aws.String(awsRegion)},
 		Profile:           awsProfile,
@@ -22,5 +25,29 @@ func CreateAwsSession(awsRegion, awsProfile string) (*session.Session, error) {
 		return nil, errors.WithStackTraceAndPrefix(err, "Error finding AWS credentials (did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables?)")
 	}
 
+	if awsRoleArn != "" {
+		err = assumeRole(session, awsRoleArn)
+		if err != nil {
+			return nil, errors.WithStackTraceAndPrefix(err, "Error assuming given AWS role")
+		}
+	}
+
 	return session, nil
+}
+
+func assumeRole(s *session.Session, awsRoleArn string) (err error) {
+	client := sts.New(s)
+	assumeRoleProvider := &stscreds.AssumeRoleProvider{
+		Client:  client,
+		RoleARN: awsRoleArn,
+	}
+	credentials := credentials.NewChainCredentials([]credentials.Provider{assumeRoleProvider})
+
+	_, err = credentials.Get()
+	if err != nil {
+		return err
+	}
+
+	s.Config.WithCredentials(credentials)
+	return nil
 }

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -2,52 +2,31 @@ package aws_helper
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gruntwork-io/terragrunt/errors"
 )
 
 // Returns an AWS session object for the given region, ensuring that the credentials are available
 func CreateAwsSession(awsRegion, awsProfile, awsRoleArn string) (*session.Session, error) {
-	session, err := session.NewSessionWithOptions(session.Options{
+	sess, err := session.NewSessionWithOptions(session.Options{
 		Config:            aws.Config{Region: aws.String(awsRegion)},
 		Profile:           awsProfile,
 		SharedConfigState: session.SharedConfigEnable,
 	})
+
 	if err != nil {
 		return nil, errors.WithStackTraceAndPrefix(err, "Error intializing session")
 	}
 
-	_, err = session.Config.Credentials.Get()
+	if awsRoleArn != "" {
+		sess.Config.Credentials = stscreds.NewCredentials(sess, awsRoleArn)
+	}
+
+	_, err = sess.Config.Credentials.Get()
 	if err != nil {
 		return nil, errors.WithStackTraceAndPrefix(err, "Error finding AWS credentials (did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables?)")
 	}
 
-	if awsRoleArn != "" {
-		err = assumeRole(session, awsRoleArn)
-		if err != nil {
-			return nil, errors.WithStackTraceAndPrefix(err, "Error assuming given AWS role")
-		}
-	}
-
-	return session, nil
-}
-
-func assumeRole(s *session.Session, awsRoleArn string) (err error) {
-	client := sts.New(s)
-	assumeRoleProvider := &stscreds.AssumeRoleProvider{
-		Client:  client,
-		RoleARN: awsRoleArn,
-	}
-	credentials := credentials.NewChainCredentials([]credentials.Provider{assumeRoleProvider})
-
-	_, err = credentials.Get()
-	if err != nil {
-		return err
-	}
-
-	s.Config.WithCredentials(credentials)
-	return nil
+	return sess, nil
 }

--- a/locks/dynamodb/dynamo_lock_test.go
+++ b/locks/dynamodb/dynamo_lock_test.go
@@ -17,6 +17,8 @@ func TestAcquireLockHappyPath(t *testing.T) {
 	lock := DynamoDbLock{
 		StateFileId:    uniqueId(),
 		AwsRegion:      DEFAULT_TEST_REGION,
+		AwsProfile:     DEFAULT_TEST_PROFILE,
+		AwsRoleARN:     DEFAULT_TEST_ROLE_ARN,
 		TableName:      uniqueTableNameForTest(),
 		MaxLockRetries: 1,
 	}
@@ -35,6 +37,8 @@ func TestAcquireLockWhenLockIsAlreadyTaken(t *testing.T) {
 	lock := DynamoDbLock{
 		StateFileId:    stateFileId,
 		AwsRegion:      DEFAULT_TEST_REGION,
+		AwsProfile:     DEFAULT_TEST_PROFILE,
+		AwsRoleARN:     DEFAULT_TEST_ROLE_ARN,
 		TableName:      uniqueTableNameForTest(),
 		MaxLockRetries: 1,
 	}
@@ -58,6 +62,8 @@ func TestAcquireAndReleaseLock(t *testing.T) {
 	lock := DynamoDbLock{
 		StateFileId:    stateFileId,
 		AwsRegion:      DEFAULT_TEST_REGION,
+		AwsProfile:     DEFAULT_TEST_PROFILE,
+		AwsRoleARN:     DEFAULT_TEST_ROLE_ARN,
 		TableName:      uniqueTableNameForTest(),
 		MaxLockRetries: 1,
 	}
@@ -91,6 +97,8 @@ func TestAcquireLockConcurrency(t *testing.T) {
 		lock := DynamoDbLock{
 			StateFileId:    stateFileId,
 			AwsRegion:      DEFAULT_TEST_REGION,
+			AwsProfile:     DEFAULT_TEST_PROFILE,
+			AwsRoleARN:     DEFAULT_TEST_ROLE_ARN,
 			TableName:      uniqueTableNameForTest(),
 			MaxLockRetries: 1,
 		}

--- a/locks/dynamodb/dynamo_lock_test_utils.go
+++ b/locks/dynamodb/dynamo_lock_test_utils.go
@@ -14,6 +14,8 @@ import (
 
 // For simplicity, do all testing in the us-east-1 region
 const DEFAULT_TEST_REGION = "us-east-1"
+const DEFAULT_TEST_PROFILE = ""
+const DEFAULT_TEST_ROLE_ARN = ""
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -39,7 +41,7 @@ func uniqueId() string {
 
 // Create a DynamoDB client we can use at test time. If there are any errors creating the client, fail the test.
 func createDynamoDbClientForTest(t *testing.T) *dynamodb.DynamoDB {
-	client, err := createDynamoDbClient(DEFAULT_TEST_REGION, "")
+	client, err := createDynamoDbClient(DEFAULT_TEST_REGION, DEFAULT_TEST_PROFILE, DEFAULT_TEST_ROLE_ARN)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -19,6 +19,7 @@ type RemoteStateConfigS3 struct {
 	Key     string
 	Region  string
 	Profile string
+	Role_Arn string
 }
 
 const MAX_RETRIES_WAITING_FOR_S3_BUCKET = 12
@@ -36,7 +37,7 @@ func InitializeRemoteStateS3(config map[string]string, terragruntOptions *option
 		return err
 	}
 
-	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile)
+	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile, s3Config.Role_Arn)
 	if err != nil {
 		return err
 	}
@@ -176,8 +177,8 @@ func DoesS3BucketExist(s3Client *s3.S3, config *RemoteStateConfigS3) bool {
 }
 
 // Create an authenticated client for DynamoDB
-func CreateS3Client(awsRegion, awsProfile string) (*s3.S3, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile)
+func CreateS3Client(awsRegion, awsProfile, awsRoleArn string) (*s3.S3, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, awsRoleArn)
 	if err != nil {
 		return nil, err
 	}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -14,11 +14,11 @@ import (
 
 // A representation of the configuration options available for S3 remote state
 type RemoteStateConfigS3 struct {
-	Encrypt string
-	Bucket  string
-	Key     string
-	Region  string
-	Profile string
+	Encrypt  string
+	Bucket   string
+	Key      string
+	Region   string
+	Profile  string
 	Role_Arn string
 }
 

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -17,12 +17,12 @@ func TestToTerraformRemoteConfigArgs(t *testing.T) {
 			"bucket":   "my-bucket",
 			"key":      "terraform.tfstate",
 			"region":   "us-east-1",
-			"role_arn": "",
+			"role_arn": "arn:aws:iam::123456789:role/terragrunt",
 		},
 	}
 	args := remoteState.toTerraformRemoteConfigArgs()
 
-	assertRemoteConfigArgsEqual(t, args, "remote config -backend s3 -backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1")
+	assertRemoteConfigArgsEqual(t, args, "remote config -backend s3 -backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1 -backend-config=role_arn=arn:aws:iam::123456789:role/terragrunt")
 }
 
 func TestToTerraformRemoteConfigArgsNoBackendConfigs(t *testing.T) {
@@ -85,6 +85,17 @@ func TestShouldOverrideExistingRemoteState(t *testing.T) {
 			RemoteState{
 				Backend: "s3",
 				Config:  map[string]string{"bucket": "foo", "key": "bar", "region": "different"},
+			},
+			true,
+		},
+		{
+			TerraformStateRemote{
+				Type:   "s3",
+				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1", "role_arn": "arn:aws:iam::123456789:role/terragrunt"},
+			},
+			RemoteState{
+				Backend: "s3",
+				Config:  map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1", "role_arn": "arn:aws:iam::987654321:role/gruntterra"},
 			},
 			true,
 		},

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -13,10 +13,10 @@ func TestToTerraformRemoteConfigArgs(t *testing.T) {
 	remoteState := RemoteState{
 		Backend: "s3",
 		Config: map[string]string{
-			"encrypt": "true",
-			"bucket":  "my-bucket",
-			"key":     "terraform.tfstate",
-			"region":  "us-east-1",
+			"encrypt":  "true",
+			"bucket":   "my-bucket",
+			"key":      "terraform.tfstate",
+			"region":   "us-east-1",
 			"role_arn": "arn:aws:iam::318125143396:role/delegated-admin.apps-sandbox",
 		},
 	}

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -17,6 +17,7 @@ func TestToTerraformRemoteConfigArgs(t *testing.T) {
 			"bucket":  "my-bucket",
 			"key":     "terraform.tfstate",
 			"region":  "us-east-1",
+			"role_arn": "arn:aws:iam::318125143396:role/delegated-admin.apps-sandbox",
 		},
 	}
 	args := remoteState.toTerraformRemoteConfigArgs()

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -17,7 +17,7 @@ func TestToTerraformRemoteConfigArgs(t *testing.T) {
 			"bucket":   "my-bucket",
 			"key":      "terraform.tfstate",
 			"region":   "us-east-1",
-			"role_arn": "arn:aws:iam::318125143396:role/delegated-admin.apps-sandbox",
+			"role_arn": "",
 		},
 	}
 	args := remoteState.toTerraformRemoteConfigArgs()

--- a/remote/terraform_state_file_test.go
+++ b/remote/terraform_state_file_test.go
@@ -61,7 +61,8 @@ func TestParseTerraformStateRemote(t *testing.T) {
 				"bucket": "bucket",
 				"encrypt": "true",
 				"key": "experiment-1.tfstate",
-				"region": "us-east-1"
+				"region": "us-east-1",
+				"role_arn": "arn:aws:iam::123456789:role/terragrunt"
 			}
 		},
 		"modules": [
@@ -82,10 +83,11 @@ func TestParseTerraformStateRemote(t *testing.T) {
 		Remote: &TerraformStateRemote{
 			Type: "s3",
 			Config: map[string]string{
-				"bucket":  "bucket",
-				"encrypt": "true",
-				"key":     "experiment-1.tfstate",
-				"region":  "us-east-1",
+				"bucket":   "bucket",
+				"encrypt":  "true",
+				"key":      "experiment-1.tfstate",
+				"region":   "us-east-1",
+				"role_arn": "arn:aws:iam::123456789:role/terragrunt",
 			},
 		},
 		Modules: []TerraformStateModule{
@@ -119,7 +121,8 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 		    "bucket": "bucket",
 		    "encrypt": "true",
 		    "key": "terraform.tfstate",
-		    "region": "us-east-1"
+		    "region": "us-east-1",
+		    "role_arn": "arn:aws:iam::123456789:role/terragrunt"
 		}
 	    },
 	    "modules": [
@@ -212,10 +215,11 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 		Remote: &TerraformStateRemote{
 			Type: "s3",
 			Config: map[string]string{
-				"bucket":  "bucket",
-				"encrypt": "true",
-				"key":     "terraform.tfstate",
-				"region":  "us-east-1",
+				"bucket":   "bucket",
+				"encrypt":  "true",
+				"key":      "terraform.tfstate",
+				"region":   "us-east-1",
+				"role_arn": "arn:aws:iam::123456789:role/terragrunt",
 			},
 		},
 		Modules: []TerraformStateModule{

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -468,7 +468,7 @@ func uniqueId() string {
 
 // Check that the S3 Bucket of the given name and region exists. Terragrunt should create this bucket during the test.
 func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {
-	s3Client, err := remote.CreateS3Client(awsRegion, "")
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "")
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -479,7 +479,7 @@ func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {
 
 // Delete the specified S3 bucket to clean up after a test
 func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
-	s3Client, err := remote.CreateS3Client(awsRegion, "")
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "")
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -515,8 +515,8 @@ func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
 }
 
 // Create an authenticated client for DynamoDB
-func createDynamoDbClient(awsRegion, awsProfile string) (*dynamodb.DynamoDB, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile)
+func createDynamoDbClient(awsRegion, awsProfile, awsRoleArn string) (*dynamodb.DynamoDB, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, awsRoleArn)
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +525,7 @@ func createDynamoDbClient(awsRegion, awsProfile string) (*dynamodb.DynamoDB, err
 }
 
 func createDynamoDbClientForTest(t *testing.T) *dynamodb.DynamoDB {
-	client, err := createDynamoDbClient(DEFAULT_TEST_REGION, "")
+	client, err := createDynamoDbClient(DEFAULT_TEST_REGION, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
As it says, adds basic support for aws_role_arn (DynamoDB config) and role_arn (S3 remote state config), similar to the terraform AWS provider.

I realise it's not particularly well tested, but reading through the current tests, I was unsure about the way to go there. I'm nowhere near a Go expert, so I'll defer to your judgement, and gladly make any necessary adjustments.