### PR TITLE
Features/new remote state support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ a simple, free locking mechanism, and enforcing best practices around CLI usage 
 
 ## Install
 
-**NOTE**: Terraform 0.9 includes backwards incompatible changes and is NOT currently supported by Terragrunt. 
-
 1. Install [Terraform](https://www.terraform.io/), and let Terragrunt know where to find it using one of the following options:
 
     * Place `terraform` in a directory on your PATH.

--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,7 @@ dependencies:
     # Install the gruntwork-module-circleci-helpers and use it to configure the build environment and run tests.
     - curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.13
     - gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.3.2"
-    # Have to stick with Terraform 0.8.x, as Terraform 0.9 has backwards incompatible changes that Terragrunt does not yet support
-    - configure-environment-for-gruntwork-module --terraform-version 0.8.8 --packer-version NONE --terragrunt-version NONE --go-src-path .
+    - configure-environment-for-gruntwork-module --terraform-version 0.9.2 --packer-version NONE --terragrunt-version NONE --go-src-path .
 
   cache_directories:
     - ~/glide

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"io"
-
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/configstack"
 	"github.com/gruntwork-io/terragrunt/errors"
@@ -15,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/urfave/cli"
+	"io"
 )
 
 const OPT_TERRAGRUNT_CONFIG = "terragrunt-config"
@@ -30,7 +29,6 @@ var ALL_TERRAGRUNT_STRING_OPTS = []string{OPT_TERRAGRUNT_CONFIG, OPT_TERRAGRUNT_
 const CMD_ACQUIRE_LOCK = "acquire-lock"
 const CMD_RELEASE_LOCK = "release-lock"
 
-const CMD_PLAN_ALL = "plan-all"
 const CMD_APPLY_ALL = "apply-all"
 const CMD_DESTROY_ALL = "destroy-all"
 const CMD_OUTPUT_ALL = "output-all"
@@ -41,7 +39,7 @@ const CMD_SPIN_UP = "spin-up"
 // CMD_TEAR_DOWN is deprecated.
 const CMD_TEAR_DOWN = "tear-down"
 
-var MULTI_MODULE_COMMANDS = []string{CMD_APPLY_ALL, CMD_DESTROY_ALL, CMD_OUTPUT_ALL, CMD_PLAN_ALL}
+var MULTI_MODULE_COMMANDS = []string{CMD_APPLY_ALL, CMD_DESTROY_ALL, CMD_OUTPUT_ALL}
 
 // DEPRECATED_COMMANDS is a map of deprecated commands to the commands that replace them.
 var DEPRECATED_COMMANDS = map[string]string{
@@ -70,7 +68,6 @@ COMMANDS:
    remote push          Acquire a lock and run 'terraform remote push'
    acquire-lock         Acquire a long-term lock for these templates
    release-lock         Release a long-term lock or a lock that failed to clean up
-   plan-all             Display the plans of a 'stack' by running 'terragrunt plan' in each subfolder
    apply-all            Apply a 'stack' by running 'terragrunt apply' in each subfolder
    output-all           Display the outputs of a 'stack' by running 'terragrunt output' in each subfolder
    destroy-all          Destroy a 'stack' by running 'terragrunt destroy' in each subfolder
@@ -215,8 +212,6 @@ func runMultiModuleCommand(command string, terragruntOptions *options.Terragrunt
 		return destroyAll(terragruntOptions)
 	case CMD_OUTPUT_ALL:
 		return outputAll(terragruntOptions)
-	case CMD_PLAN_ALL:
-		return planAll(terragruntOptions)
 	default:
 		return errors.WithStackTrace(UnrecognizedCommand(command))
 	}
@@ -345,18 +340,6 @@ func outputAll(terragruntOptions *options.TerragruntOptions) error {
 
 	terragruntOptions.Logger.Printf("%s", stack.String())
 	return stack.Output(terragruntOptions)
-}
-
-// planAll prints the plans from all configuration in a stack, in the order
-// specified in the terraform_remote_state dependencies
-func planAll(terragruntOptions *options.TerragruntOptions) error {
-	stack, err := configstack.FindStackInSubfolders(terragruntOptions)
-	if err != nil {
-		return err
-	}
-
-	terragruntOptions.Logger.Printf("%s", stack.String())
-	return stack.Plan(terragruntOptions)
 }
 
 // Acquire a lock. This can be useful for locking down a deploy for a long time, such as during a major deployment.

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"io"
+
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/configstack"
 	"github.com/gruntwork-io/terragrunt/errors"
@@ -13,7 +15,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/urfave/cli"
-	"io"
 )
 
 const OPT_TERRAGRUNT_CONFIG = "terragrunt-config"
@@ -29,6 +30,7 @@ var ALL_TERRAGRUNT_STRING_OPTS = []string{OPT_TERRAGRUNT_CONFIG, OPT_TERRAGRUNT_
 const CMD_ACQUIRE_LOCK = "acquire-lock"
 const CMD_RELEASE_LOCK = "release-lock"
 
+const CMD_PLAN_ALL = "plan-all"
 const CMD_APPLY_ALL = "apply-all"
 const CMD_DESTROY_ALL = "destroy-all"
 const CMD_OUTPUT_ALL = "output-all"
@@ -39,7 +41,7 @@ const CMD_SPIN_UP = "spin-up"
 // CMD_TEAR_DOWN is deprecated.
 const CMD_TEAR_DOWN = "tear-down"
 
-var MULTI_MODULE_COMMANDS = []string{CMD_APPLY_ALL, CMD_DESTROY_ALL, CMD_OUTPUT_ALL}
+var MULTI_MODULE_COMMANDS = []string{CMD_APPLY_ALL, CMD_DESTROY_ALL, CMD_OUTPUT_ALL, CMD_PLAN_ALL}
 
 // DEPRECATED_COMMANDS is a map of deprecated commands to the commands that replace them.
 var DEPRECATED_COMMANDS = map[string]string{
@@ -68,6 +70,7 @@ COMMANDS:
    remote push          Acquire a lock and run 'terraform remote push'
    acquire-lock         Acquire a long-term lock for these templates
    release-lock         Release a long-term lock or a lock that failed to clean up
+   plan-all             Display the plans of a 'stack' by running 'terragrunt plan' in each subfolder
    apply-all            Apply a 'stack' by running 'terragrunt apply' in each subfolder
    output-all           Display the outputs of a 'stack' by running 'terragrunt output' in each subfolder
    destroy-all          Destroy a 'stack' by running 'terragrunt destroy' in each subfolder
@@ -212,6 +215,8 @@ func runMultiModuleCommand(command string, terragruntOptions *options.Terragrunt
 		return destroyAll(terragruntOptions)
 	case CMD_OUTPUT_ALL:
 		return outputAll(terragruntOptions)
+	case CMD_PLAN_ALL:
+		return planAll(terragruntOptions)
 	default:
 		return errors.WithStackTrace(UnrecognizedCommand(command))
 	}
@@ -340,6 +345,18 @@ func outputAll(terragruntOptions *options.TerragruntOptions) error {
 
 	terragruntOptions.Logger.Printf("%s", stack.String())
 	return stack.Output(terragruntOptions)
+}
+
+// planAll prints the plans from all configuration in a stack, in the order
+// specified in the terraform_remote_state dependencies
+func planAll(terragruntOptions *options.TerragruntOptions) error {
+	stack, err := configstack.FindStackInSubfolders(terragruntOptions)
+	if err != nil {
+		return err
+	}
+
+	terragruntOptions.Logger.Printf("%s", stack.String())
+	return stack.Plan(terragruntOptions)
 }
 
 // Acquire a lock. This can be useful for locking down a deploy for a long time, such as during a major deployment.

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -255,7 +255,7 @@ func configureRemoteState(remoteState *remote.RemoteState, terragruntOptions *op
 	// We only configure remote state for the commands that use the tfstate files. We do not configure it for
 	// commands such as "get" or "version".
 	switch firstArg(terragruntOptions.TerraformCliArgs) {
-	case "apply", "destroy", "import", "graph", "output", "plan", "push", "refresh", "show", "taint", "untaint", "validate":
+	case "apply", "destroy", "env", "import", "graph", "output", "plan", "push", "refresh", "show", "taint", "untaint", "validate", "console", "state":
 		return remoteState.ConfigureRemoteState(terragruntOptions)
 	case "remote":
 		if secondArg(terragruntOptions.TerraformCliArgs) == "config" {

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -187,6 +187,10 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		if err := configureRemoteState(conf.RemoteState, terragruntOptions); err != nil {
 			return err
 		}
+
+		// If there is a remote state configuration, a temporary file will be created,
+		// so we delete it once the terraform command is executed.
+		defer conf.RemoteState.RemoveTemporaryConfigFile()
 	}
 
 	if conf.Lock == nil {

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -45,6 +45,12 @@ func (stack *Stack) Output(terragruntOptions *options.TerragruntOptions) error {
 	return RunModulesReverseOrder(stack.Modules)
 }
 
+// Plan execute plan in the given stack in their specified order.
+func (stack *Stack) Plan(terragruntOptions *options.TerragruntOptions) error {
+	stack.setTerraformCommand([]string{"plan"})
+	return RunModulesReverseOrder(stack.Modules)
+}
+
 // Return an error if there is a dependency cycle in the modules of this stack.
 func (stack *Stack) CheckForCycles() error {
 	return CheckForCycles(stack.Modules)

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -45,12 +45,6 @@ func (stack *Stack) Output(terragruntOptions *options.TerragruntOptions) error {
 	return RunModulesReverseOrder(stack.Modules)
 }
 
-// Plan execute plan in the given stack in their specified order.
-func (stack *Stack) Plan(terragruntOptions *options.TerragruntOptions) error {
-	stack.setTerraformCommand([]string{"plan"})
-	return RunModulesReverseOrder(stack.Modules)
-}
-
 // Return an error if there is a dependency cycle in the modules of this stack.
 func (stack *Stack) CheckForCycles() error {
 	return CheckForCycles(stack.Modules)

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -2,11 +2,21 @@ package remote
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
-	"reflect"
 )
+
+// NewRemoteStateFormatTerraformVersion : The terraform version that implements new format for remote state
+const NewRemoteStateFormatTerraformVersion = "0.9.0"
+
+// TerraformVersion : Version of the terraform tool
+var TerraformVersion string
 
 // Configuration for Terraform remote state
 type RemoteState struct {
@@ -59,15 +69,48 @@ func (remoteState RemoteState) ConfigureRemoteState(terragruntOptions *options.T
 
 	if shouldConfigure {
 		terragruntOptions.Logger.Printf("Initializing remote state for the %s backend", remoteState.Backend)
-		if err := remoteState.Initialize(terragruntOptions); err != nil {
+		if err = remoteState.Initialize(terragruntOptions); err != nil {
 			return err
 		}
 
 		terragruntOptions.Logger.Printf("Configuring remote state for the %s backend", remoteState.Backend)
-		return shell.RunShellCommand(terragruntOptions, terragruntOptions.TerraformPath, remoteState.toTerraformRemoteConfigArgs()...)
+		version, err := getTerraformVersion(terragruntOptions)
+		if err != nil {
+			return err
+		}
+		if version < NewRemoteStateFormatTerraformVersion {
+			// Legacy remote state management (Before terraform v0.9.0)
+			err = shell.RunShellCommand(terragruntOptions, terragruntOptions.TerraformPath, remoteState.toTerraformRemoteConfigArgs()...)
+		} else {
+			// Inject a temporary file to configure the remote state backend
+			var config string
+			for key, value := range remoteState.Config {
+				config += fmt.Sprintf("    %s = \"%s\"\n", key, value)
+			}
+			text := fmt.Sprintf("terraform {\n  backend \"%s\" {\n%s  }\n}\n", remoteState.Backend, config)
+			tempFile := "terragrunt-temp-remote-state.tf"
+			if outputFile, err := os.Create(tempFile); err == nil {
+				//defer os.Remove(tempFile)
+				outputFile.WriteString(text)
+				outputFile.Close()
+				err = shell.RunShellCommand(terragruntOptions, terragruntOptions.TerraformPath, "init")
+			}
+		}
+		return err
 	}
 
 	return nil
+}
+
+// Get the terraform version
+func getTerraformVersion(terragruntOptions *options.TerragruntOptions) (version string, err error) {
+	if TerraformVersion == "" {
+		if out, err := exec.Command(terragruntOptions.TerraformPath, "version").Output(); err == nil {
+			TerraformVersion = strings.Fields(string(out))[1][1:]
+		}
+	}
+	version = TerraformVersion
+	return
 }
 
 // Returns true if remote state needs to be configured. This will be the case when:
@@ -81,27 +124,40 @@ func shouldConfigureRemoteState(remoteStateFromTerragruntConfig RemoteState, ter
 	}
 
 	if state != nil && state.IsRemote() {
-		return shouldOverrideExistingRemoteState(state.Remote, remoteStateFromTerragruntConfig, terragruntOptions)
-	} else {
-		return true, nil
+		return shouldOverrideExistingRemoteState(state, remoteStateFromTerragruntConfig, terragruntOptions)
 	}
+	return true, nil
 }
 
 // Check if the remote state that is already configured matches the one specified in the Terragrunt config. If it does,
 // return false to indicate remote state does not need to be configured again. If it doesn't, prompt the user whether
 // we should override the existing remote state setting.
-func shouldOverrideExistingRemoteState(existingRemoteState *TerraformStateRemote, remoteStateFromTerragruntConfig RemoteState, terragruntOptions *options.TerragruntOptions) (bool, error) {
-	if existingRemoteState.Type != remoteStateFromTerragruntConfig.Backend {
-		prompt := fmt.Sprintf("WARNING: Terraform remote state is already configured, but for backend %s, whereas your Terragrunt configuration specifies %s. Overwrite?", existingRemoteState.Type, remoteStateFromTerragruntConfig.Backend)
+func shouldOverrideExistingRemoteState(existingState *TerraformState, remoteStateFromTerragruntConfig RemoteState, terragruntOptions *options.TerragruntOptions) (bool, error) {
+	version, err := getTerraformVersion(terragruntOptions)
+	if err != nil {
+		return false, err
+	}
+
+	if existingState.Terraform_Version != nil && *existingState.Terraform_Version < version {
+		prompt := fmt.Sprintf("WARNING: Terraform remote state is already configured, but for an older version of terraform (v%s), you currently run (v%s). Overwrite?", *existingState.Terraform_Version, version)
+		answer, err := shell.PromptUserForYesNo(prompt, terragruntOptions)
+		if answer {
+			ReplaceRemoteStateFile()
+		}
+		return answer, err
+	}
+
+	if existingState.Remote.Type != remoteStateFromTerragruntConfig.Backend {
+		prompt := fmt.Sprintf("WARNING: Terraform remote state is already configured, but for backend %s, whereas your Terragrunt configuration specifies %s. Overwrite?", existingState.Remote.Type, remoteStateFromTerragruntConfig.Backend)
 		return shell.PromptUserForYesNo(prompt, terragruntOptions)
 	}
 
-	if !reflect.DeepEqual(existingRemoteState.Config, remoteStateFromTerragruntConfig.Config) {
-		prompt := fmt.Sprintf("WARNING: Terraform remote state is already configured for backend %s with config %v, but your Terragrunt configuration specifies config %v. Overwrite?", existingRemoteState.Type, existingRemoteState.Config, remoteStateFromTerragruntConfig.Config)
+	if !reflect.DeepEqual(existingState.Remote.Config, remoteStateFromTerragruntConfig.Config) {
+		prompt := fmt.Sprintf("WARNING: Terraform remote state is already configured for backend %s with config %v, but your Terragrunt configuration specifies config %v. Overwrite?", existingState.Remote.Type, existingState.Remote.Config, remoteStateFromTerragruntConfig.Config)
 		return shell.PromptUserForYesNo(prompt, terragruntOptions)
 	}
 
-	terragruntOptions.Logger.Printf("Remote state is already configured for backend %s", existingRemoteState.Type)
+	terragruntOptions.Logger.Printf("Remote state is already configured for backend %s", existingState.Remote.Type)
 	return false, nil
 }
 

--- a/remote/terraform_state_file.go
+++ b/remote/terraform_state_file.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-
 	"os"
 
 	"github.com/gruntwork-io/terragrunt/errors"

--- a/remote/terraform_state_file.go
+++ b/remote/terraform_state_file.go
@@ -3,9 +3,12 @@ package remote
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+
+	"os"
+
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/util"
-	"io/ioutil"
 )
 
 // TODO: this file could be changed to use the Terraform Go code to read state files, but that code is relatively
@@ -20,10 +23,12 @@ const DEFAULT_PATH_TO_REMOTE_STATE_FILE = ".terraform/terraform.tfstate"
 
 // The structure of the Terraform .tfstate file
 type TerraformState struct {
-	Version int
-	Serial  int
-	Remote  *TerraformStateRemote
-	Modules []TerraformStateModule
+	Version           int
+	Serial            int
+	Terraform_Version *string
+	Remote            *TerraformStateRemote // Legacy (prior 0.9.0) data for remote configuration
+	Backend           *TerraformStateRemote // Current (>= 0.9.0) data for remote configuration
+	Modules           []TerraformStateModule
 }
 
 // The structure of the "remote" section of the Terraform .tfstate file
@@ -56,6 +61,12 @@ func ParseTerraformStateFileFromLocation(workingDir string) (*TerraformState, er
 	}
 }
 
+// ReplaceRemoteStateFile :
+// Rename the outdated remote state file to configure the folder using a newer version of the file
+func ReplaceRemoteStateFile() {
+	os.Rename(DEFAULT_PATH_TO_REMOTE_STATE_FILE, DEFAULT_PATH_TO_REMOTE_STATE_FILE+".backup")
+}
+
 // Parse the Terraform .tfstate file at the given path
 func ParseTerraformStateFile(path string) (*TerraformState, error) {
 	bytes, err := ioutil.ReadFile(path)
@@ -72,6 +83,9 @@ func parseTerraformState(terraformStateData []byte) (*TerraformState, error) {
 
 	if err := json.Unmarshal(terraformStateData, terraformState); err != nil {
 		return nil, errors.WithStackTrace(err)
+	}
+	if terraformState.Backend != nil {
+		terraformState.Remote = terraformState.Backend
 	}
 
 	return terraformState, nil


### PR DESCRIPTION
Hi, here is our proposition to add support for terraform 0.9.0+.

Basically, we inject a temporary file into the current folder with the required terraform 0.9+ configuration to support the new remote state format. We rely on tarraform init instead of terraform remote for new versions.

The temporary file is always generated based on the terragrunt configuration.

The code continue to support oldest terraform versions.

Comments are welcome.