### PR TITLE
Build binaries with CGO_ENABLED=0 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   override:
     # Install the gruntwork-module-circleci-helpers and use it to configure the build environment and run tests.
     - curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.13
-    - gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.3.2"
+    - gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.3.10"
     # Have to stick with Terraform 0.8.x, as Terraform 0.9 has backwards incompatible changes that Terragrunt does not yet support
     - configure-environment-for-gruntwork-module --terraform-version 0.8.8 --packer-version NONE --terragrunt-version NONE --go-src-path .
 


### PR DESCRIPTION
This PR updates circle.yml to use the latest `build-go-binaries` module (v0.3.10). That version has been updated to build Go binaries with CGO_ENABLED=0 by default. Fixes #161.