### PR TITLE
Fix init command used to download remote configurations

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -157,7 +157,7 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 	}
 
 	if sourceUrl, hasSourceUrl := getTerraformSourceUrl(terragruntOptions, conf); hasSourceUrl {
-		if err := downloadTerraformSource(sourceUrl, terragruntOptions); err != nil {
+		if err := downloadTerraformSource(sourceUrl, conf, terragruntOptions); err != nil {
 			return err
 		}
 	}

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -356,6 +356,5 @@ func terraformInit(terraformSource *TerraformSource, terragruntConfig *config.Te
 	}
 	terragruntInitOptions.TerraformCliArgs = append(terragruntInitOptions.TerraformCliArgs, terraformSource.CanonicalSourceURL.String(), terraformSource.DownloadDir)
 
-
 	return runTerraformCommand(terragruntInitOptions)
 }

--- a/cli/download_source_test.go
+++ b/cli/download_source_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"github.com/gruntwork-io/terragrunt/config"
 )
 
 func TestAlreadyHaveLatestCodeLocalFilePath(t *testing.T) {

--- a/cli/download_source_test.go
+++ b/cli/download_source_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"github.com/gruntwork-io/terragrunt/config"
 )
 
 func TestAlreadyHaveLatestCodeLocalFilePath(t *testing.T) {
@@ -156,8 +157,9 @@ func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, d
 
 	terragruntOptions := options.NewTerragruntOptionsForTest("./should-not-be-used")
 	terragruntOptions.SourceUpdate = sourceUpdate
+	terragruntConfig := config.TerragruntConfig{}
 
-	err := downloadTerraformSourceIfNecessary(terraformSource, terragruntOptions)
+	err := downloadTerraformSourceIfNecessary(terraformSource, &terragruntConfig, terragruntOptions)
 	assert.Nil(t, err, "For terraform source %v: %v", terraformSource, err)
 
 	expectedFilePath := util.JoinPath(downloadDir, "main.tf")

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -64,7 +64,7 @@ func (remoteState RemoteState) ConfigureRemoteState(terragruntOptions *options.T
 		}
 
 		terragruntOptions.Logger.Printf("Configuring remote state for the %s backend", remoteState.Backend)
-		return shell.RunShellCommand(terragruntOptions, terragruntOptions.TerraformPath, remoteState.toTerraformRemoteConfigArgs()...)
+		return shell.RunShellCommand(terragruntOptions, terragruntOptions.TerraformPath, initCommand(remoteState)...)
 	}
 
 	return nil
@@ -105,17 +105,19 @@ func shouldOverrideExistingRemoteState(existingRemoteState *TerraformStateRemote
 	return false, nil
 }
 
-// Convert the RemoteState config into the format used by Terraform
-func (remoteState RemoteState) toTerraformRemoteConfigArgs() []string {
-	baseArgs := []string{"init"}
+func initCommand(remoteState RemoteState) []string {
+	return append([]string{"init"}, remoteState.ToTerraformInitArgs()...)
+}
 
+// Convert the RemoteState config into the format used by the terraform init command
+func (remoteState RemoteState) ToTerraformInitArgs() []string {
 	backendConfigArgs := []string{}
 	for key, value := range remoteState.Config {
 		arg := fmt.Sprintf("-backend-config=%s=%s", key, value)
 		backendConfigArgs = append(backendConfigArgs, arg)
 	}
 
-	return append(baseArgs, backendConfigArgs...)
+	return backendConfigArgs
 }
 
 var RemoteBackendMissing = fmt.Errorf("The remote_state.backend field cannot be empty")

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -29,8 +29,7 @@ func TestToTerraformInitArgsNoBackendConfigs(t *testing.T) {
 
 	remoteState := RemoteState{Backend: "s3"}
 	args := remoteState.ToTerraformInitArgs()
-
-	assertTerraformInitArgsEqual(t, args, "")
+	assert.Empty(t, args)
 }
 
 func TestShouldOverrideExistingRemoteState(t *testing.T) {

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -19,7 +19,7 @@ func TestToTerraformRemoteConfigArgs(t *testing.T) {
 			"region":  "us-east-1",
 		},
 	}
-	args := remoteState.toTerraformRemoteConfigArgs()
+	args := remoteState.ToTerraformInitArgs()
 
 	assertRemoteConfigArgsEqual(t, args, "init -backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1")
 }
@@ -28,7 +28,7 @@ func TestToTerraformRemoteConfigArgsNoBackendConfigs(t *testing.T) {
 	t.Parallel()
 
 	remoteState := RemoteState{Backend: "s3"}
-	args := remoteState.toTerraformRemoteConfigArgs()
+	args := remoteState.ToTerraformInitArgs()
 
 	assertRemoteConfigArgsEqual(t, args, "init")
 }

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestToTerraformRemoteConfigArgs(t *testing.T) {
+func TestToTerraformInitArgs(t *testing.T) {
 	t.Parallel()
 
 	remoteState := RemoteState{
@@ -21,16 +21,16 @@ func TestToTerraformRemoteConfigArgs(t *testing.T) {
 	}
 	args := remoteState.ToTerraformInitArgs()
 
-	assertRemoteConfigArgsEqual(t, args, "init -backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1")
+	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1")
 }
 
-func TestToTerraformRemoteConfigArgsNoBackendConfigs(t *testing.T) {
+func TestToTerraformInitArgsNoBackendConfigs(t *testing.T) {
 	t.Parallel()
 
 	remoteState := RemoteState{Backend: "s3"}
 	args := remoteState.ToTerraformInitArgs()
 
-	assertRemoteConfigArgsEqual(t, args, "init")
+	assertTerraformInitArgsEqual(t, args, "")
 }
 
 func TestShouldOverrideExistingRemoteState(t *testing.T) {
@@ -96,7 +96,7 @@ func TestShouldOverrideExistingRemoteState(t *testing.T) {
 	}
 }
 
-func assertRemoteConfigArgsEqual(t *testing.T, actualArgs []string, expectedArgs string) {
+func assertTerraformInitArgsEqual(t *testing.T, actualArgs []string, expectedArgs string) {
 	expected := strings.Split(expectedArgs, " ")
 	assert.Len(t, actualArgs, len(expected))
 

--- a/test/fixture-download/hello-world-with-backend/main.tf
+++ b/test/fixture-download/hello-world-with-backend/main.tf
@@ -1,5 +1,5 @@
 data "template_file" "test" {
-  template = "${module.hello.hello}, ${var.name}"
+  template = "hello, ${var.name}"
 }
 
 variable "name" {

--- a/test/fixture-download/hello-world-with-backend/main.tf
+++ b/test/fixture-download/hello-world-with-backend/main.tf
@@ -1,0 +1,16 @@
+data "template_file" "test" {
+  template = "${module.hello.hello}, ${var.name}"
+}
+
+variable "name" {
+  description = "Specify a name"
+}
+
+output "test" {
+  value = "${data.template_file.test.rendered}"
+}
+
+terraform {
+  # These settings will be filled in by Terragrunt
+  backend "s3" {}
+}

--- a/test/fixture-download/local-with-backend/terraform.tfvars
+++ b/test/fixture-download/local-with-backend/terraform.tfvars
@@ -1,0 +1,19 @@
+name = "World"
+
+terragrunt = {
+  terraform {
+    source = "../hello-world-with-backend"
+  }
+
+  # Configure Terragrunt to automatically store tfstate files in an S3 bucket
+  remote_state {
+    backend = "s3"
+    config {
+      encrypt = "true"
+      bucket = "__FILL_IN_BUCKET_NAME__"
+      key = "terraform.tfstate"
+      region = "us-west-2"
+      lock_table = "__FILL_IN_LOCK_TABLE_NAME__"
+    }
+  }
+}

--- a/test/fixture-download/remote-with-backend/terraform.tfvars
+++ b/test/fixture-download/remote-with-backend/terraform.tfvars
@@ -1,0 +1,20 @@
+name = "World"
+
+terragrunt = {
+  terraform {
+    # TODO: Update the ref to a tag once the fix-init branch has been merged
+    source = "github.com/gruntwork-io/terragrunt.git//test/fixture-download/hello-world-with-backend?ref=fix-init"
+  }
+
+  # Configure Terragrunt to automatically store tfstate files in an S3 bucket
+  remote_state {
+    backend = "s3"
+    config {
+      encrypt = "true"
+      bucket = "__FILL_IN_BUCKET_NAME__"
+      key = "terraform.tfstate"
+      region = "us-west-2"
+      lock_table = "__FILL_IN_LOCK_TABLE_NAME__"
+    }
+  }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -39,6 +39,7 @@ const (
 	TEST_FIXTURE_LOCAL_RELATIVE_DOWNLOAD_PATH           = "fixture-download/local-relative"
 	TEST_FIXTURE_REMOTE_RELATIVE_DOWNLOAD_PATH          = "fixture-download/remote-relative"
 	TEST_FIXTURE_LOCAL_RELATIVE_ARGS_DOWNLOAD_PATH      = "fixture-download/local-with-relative-extra-args"
+	TEST_FIXTURE_REMOTE_WITH_BACKEND                    = "fixture-download/remote-with-backend"
 	TEST_FIXTURE_OLD_CONFIG_INCLUDE_PATH                = "fixture-old-terragrunt-config/include"
 	TEST_FIXTURE_OLD_CONFIG_INCLUDE_CHILD_UPDATED_PATH  = "fixture-old-terragrunt-config/include-child-updated"
 	TEST_FIXTURE_OLD_CONFIG_INCLUDE_PARENT_UPDATED_PATH = "fixture-old-terragrunt-config/include-parent-updated"
@@ -280,6 +281,17 @@ func TestLocalWithRelativeExtraArgs(t *testing.T) {
 
 	// Run a second time to make sure the temporary folder can be reused without errors
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_RELATIVE_ARGS_DOWNLOAD_PATH))
+}
+
+func TestRemoteWithBackend(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_REMOTE_WITH_BACKEND)
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_REMOTE_WITH_BACKEND))
+
+	// Run a second time to make sure the temporary folder can be reused without errors
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_REMOTE_WITH_BACKEND))
 }
 
 func TestExtraArguments(t *testing.T) {


### PR DESCRIPTION
This PR fixes #174 and #176. We’ve been using the `terraform init` command to download remote Terraform configurations for a while now. As of Terraform 0.9, this same command also tries to configure backends, download modules, etc. When updating Terragrunt to support Terraform 0.9, we forgot to update this original `init` call to pass `backend` parameters.