### PR TITLE
Update Terraform state parsing to use backends

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -175,7 +175,7 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 	}
 
 	if sourceUrl, hasSourceUrl := getTerraformSourceUrl(terragruntOptions, conf); hasSourceUrl {
-		if err := downloadTerraformSource(sourceUrl, conf, terragruntOptions); err != nil {
+		if err := downloadTerraformSource(sourceUrl, terragruntOptions); err != nil {
 			return err
 		}
 	}

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -43,13 +43,13 @@ var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
 //
 // See the processTerraformSource method for how we determine the temporary folder so we can reuse it across multiple
 // runs of Terragrunt to avoid downloading everything from scratch every time.
-func downloadTerraformSource(source string, terragruntConfig *config.TerragruntConfig, terragruntOptions *options.TerragruntOptions) error {
+func downloadTerraformSource(source string, terragruntOptions *options.TerragruntOptions) error {
 	terraformSource, err := processTerraformSource(source, terragruntOptions)
 	if err != nil {
 		return err
 	}
 
-	if err := downloadTerraformSourceIfNecessary(terraformSource, terragruntConfig, terragruntOptions); err != nil {
+	if err := downloadTerraformSourceIfNecessary(terraformSource, terragruntOptions); err != nil {
 		return err
 	}
 
@@ -65,7 +65,7 @@ func downloadTerraformSource(source string, terragruntConfig *config.TerragruntC
 }
 
 // Download the specified TerraformSource if the latest code hasn't already been downloaded.
-func downloadTerraformSourceIfNecessary(terraformSource *TerraformSource, terragruntConfig *config.TerragruntConfig, terragruntOptions *options.TerragruntOptions) error {
+func downloadTerraformSourceIfNecessary(terraformSource *TerraformSource, terragruntOptions *options.TerragruntOptions) error {
 	if terragruntOptions.SourceUpdate {
 		terragruntOptions.Logger.Printf("The --%s flag is set, so deleting the temporary folder %s before downloading source.", OPT_TERRAGRUNT_SOURCE_UPDATE, terraformSource.DownloadDir)
 		if err := os.RemoveAll(terraformSource.DownloadDir); err != nil {
@@ -87,7 +87,7 @@ func downloadTerraformSourceIfNecessary(terraformSource *TerraformSource, terrag
 		return err
 	}
 
-	if err := terraformInit(terraformSource, terragruntConfig, terragruntOptions); err != nil {
+	if err := terraformInit(terraformSource, terragruntOptions); err != nil {
 		return err
 	}
 
@@ -345,15 +345,13 @@ func getTerraformSourceUrl(terragruntOptions *options.TerragruntOptions, terragr
 }
 
 // Download the code from the Canonical Source URL into the Download Folder using the terraform init command
-func terraformInit(terraformSource *TerraformSource, terragruntConfig *config.TerragruntConfig, terragruntOptions *options.TerragruntOptions) error {
+func terraformInit(terraformSource *TerraformSource, terragruntOptions *options.TerragruntOptions) error {
 	terragruntOptions.Logger.Printf("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
 
 	terragruntInitOptions := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
 
-	terragruntInitOptions.TerraformCliArgs = []string{"init"}
-	if terragruntConfig.RemoteState != nil {
-		terragruntInitOptions.TerraformCliArgs = append(terragruntInitOptions.TerraformCliArgs, terragruntConfig.RemoteState.ToTerraformInitArgs()...)
-	}
+	// Backend and get configuration will be handled separately
+	terragruntInitOptions.TerraformCliArgs = []string{"init", "-backend=false", "-get=false"}
 	terragruntInitOptions.TerraformCliArgs = append(terragruntInitOptions.TerraformCliArgs, terraformSource.CanonicalSourceURL.String(), terraformSource.DownloadDir)
 
 	return runTerraformCommand(terragruntInitOptions)

--- a/cli/download_source_test.go
+++ b/cli/download_source_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/stretchr/testify/assert"
@@ -157,9 +156,8 @@ func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, d
 
 	terragruntOptions := options.NewTerragruntOptionsForTest("./should-not-be-used")
 	terragruntOptions.SourceUpdate = sourceUpdate
-	terragruntConfig := config.TerragruntConfig{}
 
-	err := downloadTerraformSourceIfNecessary(terraformSource, &terragruntConfig, terragruntOptions)
+	err := downloadTerraformSourceIfNecessary(terraformSource, terragruntOptions)
 	assert.Nil(t, err, "For terraform source %v: %v", terraformSource, err)
 
 	expectedFilePath := util.JoinPath(downloadDir, "main.tf")

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -81,7 +81,7 @@ func shouldConfigureRemoteState(remoteStateFromTerragruntConfig RemoteState, ter
 	}
 
 	if state != nil && state.IsRemote() {
-		return shouldOverrideExistingRemoteState(state.Remote, remoteStateFromTerragruntConfig, terragruntOptions)
+		return shouldOverrideExistingRemoteState(state.Backend, remoteStateFromTerragruntConfig, terragruntOptions)
 	} else {
 		return true, nil
 	}
@@ -90,18 +90,18 @@ func shouldConfigureRemoteState(remoteStateFromTerragruntConfig RemoteState, ter
 // Check if the remote state that is already configured matches the one specified in the Terragrunt config. If it does,
 // return false to indicate remote state does not need to be configured again. If it doesn't, prompt the user whether
 // we should override the existing remote state setting.
-func shouldOverrideExistingRemoteState(existingRemoteState *TerraformStateRemote, remoteStateFromTerragruntConfig RemoteState, terragruntOptions *options.TerragruntOptions) (bool, error) {
-	if existingRemoteState.Type != remoteStateFromTerragruntConfig.Backend {
-		prompt := fmt.Sprintf("WARNING: Terraform remote state is already configured, but for backend %s, whereas your Terragrunt configuration specifies %s. Overwrite?", existingRemoteState.Type, remoteStateFromTerragruntConfig.Backend)
+func shouldOverrideExistingRemoteState(existingBackend *TerraformBackend, remoteStateFromTerragruntConfig RemoteState, terragruntOptions *options.TerragruntOptions) (bool, error) {
+	if existingBackend.Type != remoteStateFromTerragruntConfig.Backend {
+		prompt := fmt.Sprintf("WARNING: Terraform remote state is already configured, but for backend %s, whereas your Terragrunt configuration specifies %s. Overwrite?", existingBackend.Type, remoteStateFromTerragruntConfig.Backend)
 		return shell.PromptUserForYesNo(prompt, terragruntOptions)
 	}
 
-	if !reflect.DeepEqual(existingRemoteState.Config, remoteStateFromTerragruntConfig.Config) {
-		prompt := fmt.Sprintf("WARNING: Terraform remote state is already configured for backend %s with config %v, but your Terragrunt configuration specifies config %v. Overwrite?", existingRemoteState.Type, existingRemoteState.Config, remoteStateFromTerragruntConfig.Config)
+	if !reflect.DeepEqual(existingBackend.Config, remoteStateFromTerragruntConfig.Config) {
+		prompt := fmt.Sprintf("WARNING: Terraform remote state is already configured for backend %s with config %v, but your Terragrunt configuration specifies config %v. Overwrite?", existingBackend.Type, existingBackend.Config, remoteStateFromTerragruntConfig.Config)
 		return shell.PromptUserForYesNo(prompt, terragruntOptions)
 	}
 
-	terragruntOptions.Logger.Printf("Remote state is already configured for backend %s", existingRemoteState.Type)
+	terragruntOptions.Logger.Printf("Remote state is already configured for backend %s", existingBackend.Type)
 	return false, nil
 }
 

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -38,15 +38,15 @@ func TestShouldOverrideExistingRemoteState(t *testing.T) {
 	terragruntOptions := options.NewTerragruntOptionsForTest("remote_state_test")
 
 	testCases := []struct {
-		existingState   TerraformStateRemote
+		existingBackend TerraformBackend
 		stateFromConfig RemoteState
 		shouldOverride  bool
 	}{
-		{TerraformStateRemote{}, RemoteState{}, false},
-		{TerraformStateRemote{Type: "s3"}, RemoteState{Backend: "s3"}, false},
-		{TerraformStateRemote{Type: "s3"}, RemoteState{Backend: "atlas"}, true},
+		{TerraformBackend{}, RemoteState{}, false},
+		{TerraformBackend{Type: "s3"}, RemoteState{Backend: "s3"}, false},
+		{TerraformBackend{Type: "s3"}, RemoteState{Backend: "atlas"}, true},
 		{
-			TerraformStateRemote{
+			TerraformBackend{
 				Type:   "s3",
 				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
 			},
@@ -56,7 +56,7 @@ func TestShouldOverrideExistingRemoteState(t *testing.T) {
 			},
 			false,
 		}, {
-			TerraformStateRemote{
+			TerraformBackend{
 				Type:   "s3",
 				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
 			},
@@ -66,7 +66,7 @@ func TestShouldOverrideExistingRemoteState(t *testing.T) {
 			},
 			true,
 		}, {
-			TerraformStateRemote{
+			TerraformBackend{
 				Type:   "s3",
 				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
 			},
@@ -76,7 +76,7 @@ func TestShouldOverrideExistingRemoteState(t *testing.T) {
 			},
 			true,
 		}, {
-			TerraformStateRemote{
+			TerraformBackend{
 				Type:   "s3",
 				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
 			},
@@ -89,9 +89,9 @@ func TestShouldOverrideExistingRemoteState(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		shouldOverride, err := shouldOverrideExistingRemoteState(&testCase.existingState, testCase.stateFromConfig, terragruntOptions)
+		shouldOverride, err := shouldOverrideExistingRemoteState(&testCase.existingBackend, testCase.stateFromConfig, terragruntOptions)
 		assert.Nil(t, err, "Unexpected error: %v", err)
-		assert.Equal(t, testCase.shouldOverride, shouldOverride, "Expect shouldOverrideExistingRemoteState to return %t but got %t for existingRemoteState %v and remoteStateFromTerragruntConfig %v", testCase.shouldOverride, shouldOverride, testCase.existingState, testCase.stateFromConfig)
+		assert.Equal(t, testCase.shouldOverride, shouldOverride, "Expect shouldOverrideExistingRemoteState to return %t but got %t for existingRemoteState %v and remoteStateFromTerragruntConfig %v", testCase.shouldOverride, shouldOverride, testCase.existingBackend, testCase.stateFromConfig)
 	}
 }
 

--- a/remote/terraform_state_file.go
+++ b/remote/terraform_state_file.go
@@ -22,12 +22,12 @@ const DEFAULT_PATH_TO_REMOTE_STATE_FILE = ".terraform/terraform.tfstate"
 type TerraformState struct {
 	Version int
 	Serial  int
-	Remote  *TerraformStateRemote
+	Backend *TerraformBackend
 	Modules []TerraformStateModule
 }
 
-// The structure of the "remote" section of the Terraform .tfstate file
-type TerraformStateRemote struct {
+// The structure of the "backend" section of the Terraform .tfstate file
+type TerraformBackend struct {
 	Type   string
 	Config map[string]string
 }
@@ -41,7 +41,7 @@ type TerraformStateModule struct {
 
 // Return true if this Terraform state is configured for remote state storage
 func (state *TerraformState) IsRemote() bool {
-	return state.Remote != nil
+	return state.Backend != nil && state.Backend.Type != "local"
 }
 
 // Parse the Terraform .tfstate file from the location specified by workingDir. If no location is specified,

--- a/remote/terraform_state_file_test.go
+++ b/remote/terraform_state_file_test.go
@@ -30,7 +30,7 @@ func TestParseTerraformStateLocal(t *testing.T) {
 	expectedTerraformState := &TerraformState{
 		Version: 1,
 		Serial:  0,
-		Remote:  nil,
+		Backend: nil,
 		Modules: []TerraformStateModule{
 			TerraformStateModule{
 				Path:      []string{"root"},
@@ -55,7 +55,7 @@ func TestParseTerraformStateRemote(t *testing.T) {
 	{
 		"version": 5,
 		"serial": 12,
-		"remote": {
+		"backend": {
 			"type": "s3",
 			"config": {
 				"bucket": "bucket",
@@ -79,7 +79,7 @@ func TestParseTerraformStateRemote(t *testing.T) {
 	expectedTerraformState := &TerraformState{
 		Version: 5,
 		Serial:  12,
-		Remote: &TerraformStateRemote{
+		Backend: &TerraformBackend{
 			Type: "s3",
 			Config: map[string]string{
 				"bucket":  "bucket",
@@ -113,7 +113,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 	{
 	    "version": 1,
 	    "serial": 51,
-	    "remote": {
+	    "backend": {
 		"type": "s3",
 		"config": {
 		    "bucket": "bucket",
@@ -209,7 +209,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 	expectedTerraformState := &TerraformState{
 		Version: 1,
 		Serial:  51,
-		Remote: &TerraformStateRemote{
+		Backend: &TerraformBackend{
 			Type: "s3",
 			Config: map[string]string{
 				"bucket":  "bucket",


### PR DESCRIPTION
Terragrunt parses the `.terraform/terraform.tfstate` file to check whether the remote state configuration has changed and `terraform init` needs to be run. Before Terraform 0.9, the `.terraform/terraform.tfstate` file stored remote state configuration under the `remote` key. As of Terraform 0.9, it is now under the `backend` key. This PR updates Terragrunt accordingly.

As a result of applying this fix, I realized that my fix for #177 was not quite right. Trying to download the source code and init backends in one command is a bad idea, as some of our checks (e.g. whether an s3 bucket should be created or modules downloaded) depend on the code already being in place. Therefore, I've changed that fix to call `init` to download the source code *without* doing any remote state setup, which then allows the `init` call later on to handle all the remote state stuff separately.