### PR TITLE
Add basic support for minimum version number check

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -97,6 +97,8 @@ AUTHOR(S):
 
 var MODULE_REGEX = regexp.MustCompile(`module[[:blank:]]+".+"`)
 
+const DEFAULT_TERRAFORM_VERSION_CONSTRAINT = ">= v0.9.3"
+
 const TERRAFORM_EXTENSION_GLOB = "*.tf"
 
 // Create the Terragrunt CLI App
@@ -135,6 +137,10 @@ func runApp(cliContext *cli.Context) (finalErr error) {
 
 	terragruntOptions, err := ParseTerragruntOptions(cliContext)
 	if err != nil {
+		return err
+	}
+
+	if err := CheckTerraformVersion(DEFAULT_TERRAFORM_VERSION_CONSTRAINT, terragruntOptions); err != nil {
 		return err
 	}
 
@@ -310,6 +316,11 @@ func outputAll(terragruntOptions *options.TerragruntOptions) error {
 // Run the given Terraform command
 func runTerraformCommand(terragruntOptions *options.TerragruntOptions) error {
 	return shell.RunShellCommand(terragruntOptions, terragruntOptions.TerraformPath, terragruntOptions.TerraformCliArgs...)
+}
+
+// Run the given Terraform command and return the stdout as a string
+func runTerraformCommandAndCaptureOutput(terragruntOptions *options.TerragruntOptions) (string, error) {
+	return shell.RunShellCommandAndCaptureOutput(terragruntOptions, terragruntOptions.TerraformPath, terragruntOptions.TerraformCliArgs...)
 }
 
 // Custom error types

--- a/cli/version_check.go
+++ b/cli/version_check.go
@@ -1,11 +1,11 @@
 package cli
 
 import (
-	"github.com/gruntwork-io/terragrunt/options"
-	"regexp"
-	"github.com/hashicorp/go-version"
 	"fmt"
 	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/hashicorp/go-version"
+	"regexp"
 )
 
 // The terraform --version output is of the format: Terraform v0.9.3
@@ -63,6 +63,7 @@ func parseTerraformVersion(versionCommandOutput string) (*version.Version, error
 // Custom error types
 
 type InvalidTerraformVersionSyntax string
+
 func (err InvalidTerraformVersionSyntax) Error() string {
 	return fmt.Sprintf("Unable to parse Terraform version output: %s", string(err))
 }
@@ -71,6 +72,7 @@ type InvalidTerraformVersion struct {
 	CurrentVersion     *version.Version
 	VersionConstraints version.Constraints
 }
+
 func (err InvalidTerraformVersion) Error() string {
 	return fmt.Sprintf("The currently installed version of Terraform (%s) is not compatible with the version Terragrunt requires (%s).", err.CurrentVersion.String(), err.VersionConstraints.String())
 }

--- a/cli/version_check.go
+++ b/cli/version_check.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"github.com/gruntwork-io/terragrunt/options"
+	"regexp"
+	"github.com/hashicorp/go-version"
+	"fmt"
+	"github.com/gruntwork-io/terragrunt/errors"
+)
+
+// The terraform --version output is of the format: Terraform v0.9.3
+var TERRAFORM_VERSION_REGEX = regexp.MustCompile("Terraform (.+)")
+
+// Check that the currently installed Terraform version works meets the specified version constraint and return an error
+// if it doesn't
+func CheckTerraformVersion(constraint string, terragruntOptions *options.TerragruntOptions) error {
+	currentVersion, err := getTerraformVersion(terragruntOptions)
+	if err != nil {
+		return err
+	}
+
+	return checkTerraformVersionMeetsConstraint(currentVersion, constraint)
+}
+
+// Check that the current version of Terraform meets the specified constraint and return an error if it doesn't
+func checkTerraformVersionMeetsConstraint(currentVersion *version.Version, constraint string) error {
+	versionConstraint, err := version.NewConstraint(constraint)
+	if err != nil {
+		return err
+	}
+
+	if !versionConstraint.Check(currentVersion) {
+		return errors.WithStackTrace(InvalidTerraformVersion{CurrentVersion: currentVersion, VersionConstraints: versionConstraint})
+	}
+
+	return nil
+}
+
+// Get the currently installed version of Terraform
+func getTerraformVersion(terragruntOptions *options.TerragruntOptions) (*version.Version, error) {
+	terragruntOptionsCopy := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
+	terragruntOptionsCopy.TerraformCliArgs = []string{"--version"}
+
+	output, err := runTerraformCommandAndCaptureOutput(terragruntOptionsCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseTerraformVersion(output)
+}
+
+// Parse the output of the terraform --version command
+func parseTerraformVersion(versionCommandOutput string) (*version.Version, error) {
+	matches := TERRAFORM_VERSION_REGEX.FindStringSubmatch(versionCommandOutput)
+
+	if len(matches) != 2 {
+		return nil, errors.WithStackTrace(InvalidTerraformVersionSyntax(versionCommandOutput))
+	}
+
+	return version.NewVersion(matches[1])
+}
+
+// Custom error types
+
+type InvalidTerraformVersionSyntax string
+func (err InvalidTerraformVersionSyntax) Error() string {
+	return fmt.Sprintf("Unable to parse Terraform version output: %s", string(err))
+}
+
+type InvalidTerraformVersion struct {
+	CurrentVersion     *version.Version
+	VersionConstraints version.Constraints
+}
+func (err InvalidTerraformVersion) Error() string {
+	return fmt.Sprintf("The currently installed version of Terraform (%s) is not compatible with the version Terragrunt requires (%s).", err.CurrentVersion.String(), err.VersionConstraints.String())
+}

--- a/cli/version_check_test.go
+++ b/cli/version_check_test.go
@@ -1,10 +1,10 @@
 package cli
 
 import (
-	"testing"
+	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
-	"github.com/gruntwork-io/terragrunt/errors"
+	"testing"
 )
 
 func TestCheckTerraformVersionMeetsConstraintEqual(t *testing.T) {

--- a/cli/version_check_test.go
+++ b/cli/version_check_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"testing"
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
+	"github.com/gruntwork-io/terragrunt/errors"
+)
+
+func TestCheckTerraformVersionMeetsConstraintEqual(t *testing.T) {
+	t.Parallel()
+	testCheckTerraformVersionMeetsConstraint(t, "v0.9.3", ">= v0.9.3", true)
+}
+
+func TestCheckTerraformVersionMeetsConstraintGreaterPatch(t *testing.T) {
+	t.Parallel()
+	testCheckTerraformVersionMeetsConstraint(t, "v0.9.4", ">= v0.9.3", true)
+}
+
+func TestCheckTerraformVersionMeetsConstraintGreaterMajor(t *testing.T) {
+	t.Parallel()
+	testCheckTerraformVersionMeetsConstraint(t, "v1.0.0", ">= v0.9.3", true)
+}
+
+func TestCheckTerraformVersionMeetsConstraintLessPatch(t *testing.T) {
+	t.Parallel()
+	testCheckTerraformVersionMeetsConstraint(t, "v0.9.2", ">= v0.9.3", false)
+}
+
+func TestCheckTerraformVersionMeetsConstraintLessMajor(t *testing.T) {
+	t.Parallel()
+	testCheckTerraformVersionMeetsConstraint(t, "v0.8.8", ">= v0.9.3", false)
+}
+
+func TestParseTerraformVersionNormal(t *testing.T) {
+	t.Parallel()
+	testParseTerraformVersion(t, "Terraform v0.9.3", "v0.9.3", nil)
+}
+
+func TestParseTerraformVersionWithoutV(t *testing.T) {
+	t.Parallel()
+	testParseTerraformVersion(t, "Terraform 0.9.3", "0.9.3", nil)
+}
+
+func TestParseTerraformVersionInvalidSyntax(t *testing.T) {
+	t.Parallel()
+	testParseTerraformVersion(t, "invalid-syntax", "", InvalidTerraformVersionSyntax("invalid-syntax"))
+}
+
+func testCheckTerraformVersionMeetsConstraint(t *testing.T, currentVersion string, versionConstraint string, versionMeetsConstraint bool) {
+	current, err := version.NewVersion(currentVersion)
+	if err != nil {
+		t.Fatalf("Invalid current version specified in test: %v", err)
+	}
+
+	err = checkTerraformVersionMeetsConstraint(current, versionConstraint)
+	if versionMeetsConstraint && err != nil {
+		assert.Nil(t, err, "Expected Terraform version %s to meet constraint %s, but got error: %v", currentVersion, versionConstraint, err)
+	} else if !versionMeetsConstraint && err == nil {
+		assert.NotNil(t, err, "Expected Terraform version %s to NOT meet constraint %s, but got back a nil error", currentVersion, versionConstraint)
+	}
+}
+
+func testParseTerraformVersion(t *testing.T, versionString string, expectedVersion string, expectedErr error) {
+	actualVersion, actualErr := parseTerraformVersion(versionString)
+	if expectedErr == nil {
+		expected, err := version.NewVersion(expectedVersion)
+		if err != nil {
+			t.Fatalf("Invalid expected version specified in test: %v", err)
+		}
+
+		assert.Nil(t, actualErr)
+		assert.Equal(t, expected, actualVersion)
+	} else {
+		assert.True(t, errors.IsError(actualErr, expectedErr))
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,39 +1,39 @@
-hash: b50c74fff3d496405d1bc9dadfb044d56f1557317f22e34c186b8744af9acaa0
-updated: 2017-02-01T00:01:23.320944332Z
+hash: 00b02dc4909284a30b3510930e41851bf67a35e1bd72dc45d5ebff80ef506f10
+updated: 2017-04-23T16:27:54.825537907+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 7524cb911daddd6e5c9195def8e59ae892bef8d9
+  version: 00fb2125993965df739fa3398b03bef3eb2e198f
   subpackages:
   - aws
-  - aws/defaults
-  - aws/session
   - aws/awserr
-  - aws/service/dynamodb
-  - aws/service/s3
-  - service/dynamodb
-  - service/sts
-  - service/s3
-  - aws/credentials
-  - aws/endpoints
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
   - aws/corehandlers
+  - aws/credentials
   - aws/credentials/ec2rolecreds
   - aws/credentials/endpointcreds
-  - aws/ec2metadata
-  - aws/request
-  - aws/client
   - aws/credentials/stscreds
-  - aws/awsutil
-  - aws/client/metadata
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/endpoints
+  - aws/request
+  - aws/service/dynamodb
+  - aws/service/s3
+  - aws/session
   - aws/signer/v4
   - private/protocol
-  - private/protocol/jsonrpc
-  - private/waiter
-  - private/protocol/query
-  - private/protocol/restxml
-  - private/protocol/rest
   - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
   - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
   - private/protocol/xml/xmlutil
+  - private/waiter
+  - service/dynamodb
+  - service/s3
+  - service/sts
 - name: github.com/bgentry/go-netrc
   version: 9fd32a8b3d3d3f9d43c341bfe098430e07609480
   subpackages:
@@ -45,22 +45,22 @@ imports:
 - name: github.com/go-errors/errors
   version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
 - name: github.com/go-ini/ini
-  version: e3c2d47c61e5333f9aa2974695dd94396eb69c75
+  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
 - name: github.com/hashicorp/go-getter
-  version: cc80f38c726badeae53775d179755e1c4953d6cf
+  version: e48f67b534e614bf7fbd978fd0020f61a17b7527
   subpackages:
   - helper/url
 - name: github.com/hashicorp/go-version
-  version: e96d3840402619007766590ecea8dd7af1292276
+  version: 03c5bf6be031b6dd45afec16b1cf94fc8938bc77
 - name: github.com/hashicorp/hcl
-  version: 88e9565e9965f4054f86c72ff1ad1bb50e560d6f
+  version: 7fa7fff964d035e8a162cce3a164b3ad02ad651b
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/token
-  - json/parser
   - hcl/scanner
   - hcl/strconv
+  - hcl/token
+  - json/parser
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
@@ -72,7 +72,7 @@ imports:
 - name: github.com/mitchellh/go-homedir
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: github.com/mitchellh/mapstructure
-  version: db1efb556f84b25a0a13a04aad883943538ad2e0
+  version: cc8532a8e9a55ea36402aa21efdf403a60d34096
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -82,5 +82,5 @@ imports:
   subpackages:
   - assert
 - name: github.com/urfave/cli
-  version: 347a9884a87374d000eec7e6445a34487c1f4a2b
-devImports: []
+  version: 8ba6f23b6e36d03666a14bd9421f5e3efcb59aca
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,6 +6,7 @@ import:
 - package: github.com/urfave/cli
 - package: github.com/hashicorp/hcl
 - package: github.com/hashicorp/go-getter
+- package: github.com/hashicorp/go-version
 - package: github.com/stretchr/testify/assert
 - package: github.com/go-errors/errors
 - package: github.com/mitchellh/mapstructure

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
+	"bytes"
 )
 
 // Run the specified shell command with the specified arguments. Connect the command's stdin, stdout, and stderr to
@@ -42,6 +43,21 @@ func RunShellCommand(terragruntOptions *options.TerragruntOptions, command strin
 	cmdChannel <- err
 
 	return errors.WithStackTrace(err)
+}
+
+// Run the specified shell command with the specified arguments. Capture the command's stdout and return it as a
+// string.
+func RunShellCommandAndCaptureOutput(terragruntOptions *options.TerragruntOptions, command string, args ...string) (string, error) {
+	stdout := new(bytes.Buffer)
+
+	terragruntOptionsCopy := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
+	terragruntOptionsCopy.Writer = stdout
+
+	if err := RunShellCommand(terragruntOptionsCopy, command, args...); err != nil {
+		return "", err
+	}
+
+	return stdout.String(), nil
 }
 
 // Return the exit code of a command. If the error is not an exec.ExitError type,

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"syscall"
 
+	"bytes"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
-	"bytes"
 )
 
 // Run the specified shell command with the specified arguments. Connect the command's stdin, stdout, and stderr to


### PR DESCRIPTION
This is a fix for #172. 

This PR updates Terragrunt to check that a minimum version of Terraform is installed. For now, this is hard-coded to `v0.9.3`. 

In the future, we could make this configurable. That said, Terraform has its own [required_version](https://www.terraform.io/docs/configuration/terraform.html) support, so perhaps more fine-grained control should be specified in the `.tf` files themselves. 