### PR TITLE
Backend config should use proper types, including bool for encrypt

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -59,7 +59,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "true"
+      encrypt = true
       bucket = "my-bucket"
       key = "terraform.tfstate"
       region = "us-east-1"
@@ -78,7 +78,7 @@ terragrunt = {
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
 		assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
 		assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
-		assert.Equal(t, "true", terragruntConfig.RemoteState.Config["encrypt"])
+		assert.Equal(t, true, terragruntConfig.RemoteState.Config["encrypt"])
 		assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
 		assert.Equal(t, "terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
 		assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
@@ -145,7 +145,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "true"
+      encrypt = true
       bucket = "my-bucket"
       key = "terraform.tfstate"
       region = "us-east-1"
@@ -170,7 +170,7 @@ terragrunt = {
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
 		assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
 		assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
-		assert.Equal(t, "true", terragruntConfig.RemoteState.Config["encrypt"])
+		assert.Equal(t, true, terragruntConfig.RemoteState.Config["encrypt"])
 		assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
 		assert.Equal(t, "terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
 		assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
@@ -192,7 +192,7 @@ terraform {
 remote_state {
   backend = "s3"
   config {
-    encrypt = "true"
+    encrypt = true
     bucket = "my-bucket"
     key = "terraform.tfstate"
     region = "us-east-1"
@@ -216,7 +216,7 @@ dependencies {
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
 		assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
 		assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
-		assert.Equal(t, "true", terragruntConfig.RemoteState.Config["encrypt"])
+		assert.Equal(t, true, terragruntConfig.RemoteState.Config["encrypt"])
 		assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
 		assert.Equal(t, "terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
 		assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
@@ -251,7 +251,7 @@ terragrunt = {
 		if assert.NotNil(t, terragruntConfig.RemoteState) {
 			assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
 			assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
-			assert.Equal(t, "true", terragruntConfig.RemoteState.Config["encrypt"])
+			assert.Equal(t, true, terragruntConfig.RemoteState.Config["encrypt"])
 			assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
 			assert.Equal(t, "child/sub-child/sub-sub-child/terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
 			assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
@@ -283,7 +283,7 @@ terragrunt = {
 		if assert.NotNil(t, terragruntConfig.RemoteState) {
 			assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
 			assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
-			assert.Equal(t, "true", terragruntConfig.RemoteState.Config["encrypt"])
+			assert.Equal(t, true, terragruntConfig.RemoteState.Config["encrypt"])
 			assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
 			assert.Equal(t, "child/sub-child/sub-sub-child/terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
 			assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
@@ -306,7 +306,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "override"
+      encrypt = false
       bucket = "override"
       key = "override"
       region = "override"
@@ -327,7 +327,7 @@ terragrunt = {
 		if assert.NotNil(t, terragruntConfig.RemoteState) {
 			assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
 			assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
-			assert.Equal(t, "override", terragruntConfig.RemoteState.Config["encrypt"])
+			assert.Equal(t, false, terragruntConfig.RemoteState.Config["encrypt"])
 			assert.Equal(t, "override", terragruntConfig.RemoteState.Config["bucket"])
 			assert.Equal(t, "override", terragruntConfig.RemoteState.Config["key"])
 			assert.Equal(t, "override", terragruntConfig.RemoteState.Config["region"])
@@ -354,7 +354,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "override"
+      encrypt = false
       bucket = "override"
       key = "override"
       region = "override"
@@ -381,7 +381,7 @@ terragrunt = {
 		if assert.NotNil(t, terragruntConfig.RemoteState) {
 			assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
 			assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
-			assert.Equal(t, "override", terragruntConfig.RemoteState.Config["encrypt"])
+			assert.Equal(t, false, terragruntConfig.RemoteState.Config["encrypt"])
 			assert.Equal(t, "override", terragruntConfig.RemoteState.Config["bucket"])
 			assert.Equal(t, "override", terragruntConfig.RemoteState.Config["key"])
 			assert.Equal(t, "override", terragruntConfig.RemoteState.Config["region"])

--- a/configstack/test_helpers.go
+++ b/configstack/test_helpers.go
@@ -147,7 +147,7 @@ func canonical(t *testing.T, path string) string {
 func state(t *testing.T, bucket string, key string) *remote.RemoteState {
 	return &remote.RemoteState{
 		Backend: "s3",
-		Config: map[string]string{
+		Config: map[string]interface{}{
 			"bucket": bucket,
 			"key":    key,
 		},

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -10,15 +10,15 @@ import (
 
 // Configuration for Terraform remote state
 type RemoteState struct {
-	Backend string            `hcl:"backend"`
-	Config  map[string]string `hcl:"config"`
+	Backend string                 `hcl:"backend"`
+	Config  map[string]interface{} `hcl:"config"`
 }
 
 func (state *RemoteState) String() string {
 	return fmt.Sprintf("RemoteState{Backend = %v, Config = %v}", state.Backend, state.Config)
 }
 
-type RemoteStateInitializer func(map[string]string, *options.TerragruntOptions) error
+type RemoteStateInitializer func(map[string]interface{}, *options.TerragruntOptions) error
 
 // TODO: initialization actions for other remote state backends can be added here
 var remoteStateInitializers = map[string]RemoteStateInitializer{
@@ -113,7 +113,7 @@ func initCommand(remoteState RemoteState) []string {
 func (remoteState RemoteState) ToTerraformInitArgs() []string {
 	backendConfigArgs := []string{}
 	for key, value := range remoteState.Config {
-		arg := fmt.Sprintf("-backend-config=%s=%s", key, value)
+		arg := fmt.Sprintf("-backend-config=%s=%v", key, value)
 		backendConfigArgs = append(backendConfigArgs, arg)
 	}
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -15,7 +15,7 @@ import (
 
 // A representation of the configuration options available for S3 remote state
 type RemoteStateConfigS3 struct {
-	Encrypt   string `mapstructure:"encrypt"`
+	Encrypt   bool   `mapstructure:"encrypt"`
 	Bucket    string `mapstructure:"bucket"`
 	Key       string `mapstructure:"key"`
 	Region    string `mapstructure:"region"`
@@ -28,7 +28,7 @@ const SLEEP_BETWEEN_RETRIES_WAITING_FOR_S3_BUCKET = 5 * time.Second
 
 // Initialize the remote state S3 bucket specified in the given config. This function will validate the config
 // parameters, create the S3 bucket if it doesn't already exist, and check that versioning is enabled.
-func InitializeRemoteStateS3(config map[string]string, terragruntOptions *options.TerragruntOptions) error {
+func InitializeRemoteStateS3(config map[string]interface{}, terragruntOptions *options.TerragruntOptions) error {
 	s3Config, err := parseS3Config(config)
 	if err != nil {
 		return err
@@ -59,7 +59,7 @@ func InitializeRemoteStateS3(config map[string]string, terragruntOptions *option
 }
 
 // Parse the given map into an S3 config
-func parseS3Config(config map[string]string) (*RemoteStateConfigS3, error) {
+func parseS3Config(config map[string]interface{}) (*RemoteStateConfigS3, error) {
 	var s3Config RemoteStateConfigS3
 	if err := mapstructure.Decode(config, &s3Config); err != nil {
 		return nil, errors.WithStackTrace(err)
@@ -82,7 +82,7 @@ func validateS3Config(config *RemoteStateConfigS3, terragruntOptions *options.Te
 		return errors.WithStackTrace(MissingRequiredS3RemoteStateConfig("key"))
 	}
 
-	if config.Encrypt != "true" {
+	if !config.Encrypt {
 		terragruntOptions.Logger.Printf("WARNING: encryption is not enabled on the S3 remote state bucket %s. Terraform state files may contain secrets, so we STRONGLY recommend enabling encryption!", config.Bucket)
 	}
 

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -12,8 +12,8 @@ func TestToTerraformInitArgs(t *testing.T) {
 
 	remoteState := RemoteState{
 		Backend: "s3",
-		Config: map[string]string{
-			"encrypt": "true",
+		Config: map[string]interface{}{
+			"encrypt": true,
 			"bucket":  "my-bucket",
 			"key":     "terraform.tfstate",
 			"region":  "us-east-1",
@@ -48,41 +48,41 @@ func TestShouldOverrideExistingRemoteState(t *testing.T) {
 		{
 			TerraformBackend{
 				Type:   "s3",
-				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+				Config: map[string]interface{}{"bucket": "foo", "key": "bar", "region": "us-east-1"},
 			},
 			RemoteState{
 				Backend: "s3",
-				Config:  map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+				Config:  map[string]interface{}{"bucket": "foo", "key": "bar", "region": "us-east-1"},
 			},
 			false,
 		}, {
 			TerraformBackend{
 				Type:   "s3",
-				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+				Config: map[string]interface{}{"bucket": "foo", "key": "bar", "region": "us-east-1"},
 			},
 			RemoteState{
 				Backend: "s3",
-				Config:  map[string]string{"bucket": "different", "key": "bar", "region": "us-east-1"},
+				Config:  map[string]interface{}{"bucket": "different", "key": "bar", "region": "us-east-1"},
 			},
 			true,
 		}, {
 			TerraformBackend{
 				Type:   "s3",
-				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+				Config: map[string]interface{}{"bucket": "foo", "key": "bar", "region": "us-east-1"},
 			},
 			RemoteState{
 				Backend: "s3",
-				Config:  map[string]string{"bucket": "foo", "key": "different", "region": "us-east-1"},
+				Config:  map[string]interface{}{"bucket": "foo", "key": "different", "region": "us-east-1"},
 			},
 			true,
 		}, {
 			TerraformBackend{
 				Type:   "s3",
-				Config: map[string]string{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+				Config: map[string]interface{}{"bucket": "foo", "key": "bar", "region": "us-east-1"},
 			},
 			RemoteState{
 				Backend: "s3",
-				Config:  map[string]string{"bucket": "foo", "key": "bar", "region": "different"},
+				Config:  map[string]interface{}{"bucket": "foo", "key": "bar", "region": "different"},
 			},
 			true,
 		},

--- a/remote/terraform_state_file.go
+++ b/remote/terraform_state_file.go
@@ -29,7 +29,7 @@ type TerraformState struct {
 // The structure of the "backend" section of the Terraform .tfstate file
 type TerraformBackend struct {
 	Type   string
-	Config map[string]string
+	Config map[string]interface{}
 }
 
 // The structure of a "module" section of the Terraform .tfstate file

--- a/remote/terraform_state_file_test.go
+++ b/remote/terraform_state_file_test.go
@@ -59,7 +59,7 @@ func TestParseTerraformStateRemote(t *testing.T) {
 			"type": "s3",
 			"config": {
 				"bucket": "bucket",
-				"encrypt": "true",
+				"encrypt": true,
 				"key": "experiment-1.tfstate",
 				"region": "us-east-1"
 			}
@@ -81,9 +81,9 @@ func TestParseTerraformStateRemote(t *testing.T) {
 		Serial:  12,
 		Backend: &TerraformBackend{
 			Type: "s3",
-			Config: map[string]string{
+			Config: map[string]interface{}{
 				"bucket":  "bucket",
-				"encrypt": "true",
+				"encrypt": true,
 				"key":     "experiment-1.tfstate",
 				"region":  "us-east-1",
 			},
@@ -117,7 +117,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 		"type": "s3",
 		"config": {
 		    "bucket": "bucket",
-		    "encrypt": "true",
+		    "encrypt": true,
 		    "key": "terraform.tfstate",
 		    "region": "us-east-1"
 		}
@@ -211,9 +211,9 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 		Serial:  51,
 		Backend: &TerraformBackend{
 			Type: "s3",
-			Config: map[string]string{
+			Config: map[string]interface{}{
 				"bucket":  "bucket",
-				"encrypt": "true",
+				"encrypt": true,
 				"key":     "terraform.tfstate",
 				"region":  "us-east-1",
 			},

--- a/test/fixture-download/local-with-backend/terraform.tfvars
+++ b/test/fixture-download/local-with-backend/terraform.tfvars
@@ -9,7 +9,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "true"
+      encrypt = true
       bucket = "__FILL_IN_BUCKET_NAME__"
       key = "terraform.tfstate"
       region = "us-west-2"

--- a/test/fixture-download/remote-with-backend/terraform.tfvars
+++ b/test/fixture-download/remote-with-backend/terraform.tfvars
@@ -9,7 +9,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "true"
+      encrypt = true
       bucket = "__FILL_IN_BUCKET_NAME__"
       key = "terraform.tfstate"
       region = "us-west-2"

--- a/test/fixture-include/terraform.tfvars
+++ b/test/fixture-include/terraform.tfvars
@@ -3,7 +3,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "true"
+      encrypt = true
       bucket = "__FILL_IN_BUCKET_NAME__"
       key = "${path_relative_to_include()}/terraform.tfstate"
       region = "us-west-2"

--- a/test/fixture-old-terragrunt-config/include-child-updated/.terragrunt
+++ b/test/fixture-old-terragrunt-config/include-child-updated/.terragrunt
@@ -2,7 +2,7 @@
 remote_state {
   backend = "s3"
   config {
-    encrypt = "true"
+    encrypt = true
     bucket = "__FILL_IN_BUCKET_NAME__"
     key = "${path_relative_to_include()}/terraform.tfstate"
     region = "us-west-2"

--- a/test/fixture-old-terragrunt-config/include-parent-updated/terraform.tfvars
+++ b/test/fixture-old-terragrunt-config/include-parent-updated/terraform.tfvars
@@ -3,7 +3,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "true"
+      encrypt = true
       bucket = "__FILL_IN_BUCKET_NAME__"
       key = "${path_relative_to_include()}/terraform.tfstate"
       region = "us-west-2"

--- a/test/fixture-old-terragrunt-config/include/.terragrunt
+++ b/test/fixture-old-terragrunt-config/include/.terragrunt
@@ -2,7 +2,7 @@
 remote_state {
   backend = "s3"
   config {
-    encrypt = "true"
+    encrypt = true
     bucket = "__FILL_IN_BUCKET_NAME__"
     key = "${path_relative_to_include()}/terraform.tfstate"
     region = "us-west-2"

--- a/test/fixture-old-terragrunt-config/stack/.terragrunt
+++ b/test/fixture-old-terragrunt-config/stack/.terragrunt
@@ -2,7 +2,7 @@
 remote_state {
   backend = "s3"
   config {
-    encrypt = "true"
+    encrypt = true
     bucket = "__FILL_IN_BUCKET_NAME__"
     key = "${path_relative_to_include()}/terraform.tfstate"
     region = "us-west-2"

--- a/test/fixture-output-all/terraform.tfvars
+++ b/test/fixture-output-all/terraform.tfvars
@@ -3,7 +3,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "true"
+      encrypt = true
       bucket = "__FILL_IN_BUCKET_NAME__"
       key = "${path_relative_to_include()}/terraform.tfstate"
       region = "us-west-2"

--- a/test/fixture-parent-folders/multiple-terragrunt-in-parents/terraform.tfvars
+++ b/test/fixture-parent-folders/multiple-terragrunt-in-parents/terraform.tfvars
@@ -3,7 +3,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "true"
+      encrypt = true
       bucket = "my-bucket"
       key = "${path_relative_to_include()}/terraform.tfstate"
       region = "us-east-1"

--- a/test/fixture-parent-folders/terragrunt-in-root/terraform.tfvars
+++ b/test/fixture-parent-folders/terragrunt-in-root/terraform.tfvars
@@ -3,7 +3,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "true"
+      encrypt = true
       bucket = "my-bucket"
       key = "${path_relative_to_include()}/terraform.tfstate"
       region = "us-east-1"

--- a/test/fixture-stack/terraform.tfvars
+++ b/test/fixture-stack/terraform.tfvars
@@ -3,7 +3,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "true"
+      encrypt = true
       bucket = "__FILL_IN_BUCKET_NAME__"
       key = "${path_relative_to_include()}/terraform.tfstate"
       region = "us-west-2"

--- a/test/fixture/terraform.tfvars
+++ b/test/fixture/terraform.tfvars
@@ -3,7 +3,7 @@ terragrunt = {
   remote_state {
     backend = "s3"
     config {
-      encrypt = "true"
+      encrypt = true
       bucket = "__FILL_IN_BUCKET_NAME__"
       key = "terraform.tfstate"
       region = "us-west-2"


### PR DESCRIPTION
This is a fix for #179. While Terragrunt’s original `remote_state` config used solely strings, the `backend` config in Terraform 0.9 uses proper types, including `bool` for the `encrypt` parameter. This PR updates `remote_state` to use a `bool` for `remote_state`. 