### PR TITLE
Some adjustments to make config_helpers tests pass on Windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ fmt:
 	gofmt -w $(GOFMT_FILES)
 
 install-pre-commit-hook:
-	@if [ -f .git/hooks/pre-commit ]; then \
+	@if [ -f .git/hooks/pre-commit -o -L .git/hooks/pre-commit ]; then \
        echo ""; \
        echo "There is already a pre-commit hook installed. Remove it and run 'make"; \
        echo "install-pre-commit-hook again, or manually alter it to add the contents"; \
@@ -22,7 +22,7 @@ install-pre-commit-hook:
        echo ""; \
        exit 1; \
    fi
-	@ln -s ../../scripts/pre-commit .git/hooks/pre-commit
+	@ln -s scripts/pre-commit .git/hooks/pre-commit
 	@echo "pre-commit hook installed."
 
 .PHONY: help fmtcheck fmt install-fmt-hook

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -78,7 +78,7 @@ func getTfVarsDir(terragruntOptions *options.TerragruntOptions) (string, error) 
 		return "", errors.WithStackTrace(err)
 	}
 
-	return filepath.Dir(terragruntConfigFileAbsPath), nil
+	return filepath.ToSlash(filepath.Dir(terragruntConfigFileAbsPath)), nil
 }
 
 // Return the parent directory where the Terragrunt configuration file lives

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -507,13 +507,16 @@ TERRAGRUNT_HIT","")}/bar`,
 
 func TestGetTfVarsDirAbsPath(t *testing.T) {
 	t.Parallel()
-	testGetTfVarsDir(t, "/foo/bar/terraform.tfvars", "/foo/bar")
+	workingDir, err := os.Getwd()
+	assert.Nil(t, err, "Could not get current working dir: %v", err)
+	testGetTfVarsDir(t, "/foo/bar/terraform.tfvars", fmt.Sprintf("%s/foo/bar", filepath.VolumeName(workingDir)))
 }
 
 func TestGetTfVarsDirRelPath(t *testing.T) {
 	t.Parallel()
 	workingDir, err := os.Getwd()
 	assert.Nil(t, err, "Could not get current working dir: %v", err)
+	workingDir = filepath.ToSlash(workingDir)
 
 	testGetTfVarsDir(t, "foo/bar/terraform.tfvars", fmt.Sprintf("%s/foo/bar", workingDir))
 }
@@ -566,7 +569,7 @@ func TestGetParentTfVarsDir(t *testing.T) {
 		{
 			&IncludeConfig{Path: "../../other-child/" + DefaultTerragruntConfigPath},
 			options.TerragruntOptions{TerragruntConfigPath: helpers.RootFolder + "child/sub-child/" + DefaultTerragruntConfigPath, NonInteractive: true},
-			"/other-child",
+			fmt.Sprintf("%s/other-child", filepath.VolumeName(parentDir)),
 		},
 		{
 			&IncludeConfig{Path: "../../" + DefaultTerragruntConfigPath},


### PR DESCRIPTION
Change getTfVarsDir() to convert result to unix format path (forward ……slash).
Fix test for config_helpers that were not processed correctly on Windows.
Fix Makefile (install hook was not working)