### PR TITLE
Features/cond varfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,8 +494,8 @@ terragrunt = {
 ```
 
 Each `extra_arguments` block includes an arbitrary name (in the example above, `retry_lock`), a list of `commands` to
-which the extra arguments should be add, and the list of `arguments` to add. With the configuration above, when you 
-run `terragrunt apply`, Terragrunt will call Terraform as follows:
+which the extra arguments should be add, a list of `arguments` or `required_var_files` or `optional_var_files` to add.
+With the configuration above, when you run `terragrunt apply`, Terragrunt will call Terraform as follows:
 
 ```
 > terragrunt apply
@@ -542,8 +542,8 @@ terragrunt = {
       ]
       
       arguments = [
-        "-var-file=terraform.tfvars",
-        "-var-file=terraform-secret.tfvars"
+        "-var", "foo=bar",
+        "-var", "region=us-west-1"
       ]
     }
   }
@@ -558,12 +558,13 @@ With the configuration above, when you run `terragrunt apply`, Terragrunt will c
 terraform apply -lock-timeout=20m -var-file=terraform.tfvars -var-file=terraform-secret.tfvars
 ```
 
-#### Required and conditional var-files
+#### Required and optional var-files
 
-Sometime, it is required to include variables to terraform conditionally. The problem is that if we use
--var-file=<file.tfvars>, <file.tfvars> must have to exist, otherwise, we get an error from terraform.
-
-For example, you may want to include files if they are available only.
+One common usage of extra_arguments is to include tfvars files. instead of using arguments, it is simpler to use either `required_var_files`
+or `optional_var_files`. Both options require only to provide the list of file to include. The only difference is that `required_var_files`
+will add the extra argument `-var-file=<your file>` for each file specified and if they don't exist, terraform will complain. Using
+`optional_var_files` instead, terragrunt will only the `-var-file=<your file>` for existing files. This allows many conditional configurations
+based on environment variables as you can see in the following example:
 
 ```
 /my/tf

--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ With the configuration above, when you run `terragrunt apply`, Terragrunt will c
 terraform apply -lock-timeout=20m -var-file=terraform.tfvars -var-file=terraform-secret.tfvars
 ```
 
-#### Conditional var-files
+#### Required and conditional var-files
 
 Sometime, it is required to include variables to terraform conditionally. The problem is that if we use
 -var-file=<file.tfvars>, <file.tfvars> must have to exist, otherwise, we get an error from terraform.
@@ -566,7 +566,7 @@ Sometime, it is required to include variables to terraform conditionally. The pr
 For example, you may want to include files if they are available only.
 
 ```
-/my_project/terraform
+/my/tf
 ├── terraform.tfvars
 ├── prod.tfvars
 ├── us-west-2.tfvars
@@ -592,7 +592,11 @@ terragrunt = {
         "refresh"
       ]
 
-      var_files = [
+      required_var_files = [
+        "${get_parent_tfvars_dir()}/terraform.tfvars"
+      ]
+
+      optional_var_files = [
         "${get_parent_tfvars_dir()}/${get_env("TF_VAR_env", "dev")}.tfvars",
         "${get_parent_tfvars_dir()}/${get_env("TF_VAR_region", "us-east-1")}.tfvars"
         "${get_tfvars_dir()}/${get_env("TF_VAR_env", "dev")}.tfvars",
@@ -611,16 +615,16 @@ With the configuration above, when you run `terragrunt apply-all`, Terragrunt wi
 
 ```
 > terragrunt apply-all
-[backend-app]  terraform apply -var-file=/my_project/terraform/backend-app/dev.tfvars
-[frontend-app] terraform apply -var-file=/my_project/terraform/frontend-app/us-east-1.tfvars
+[backend-app]  terraform apply -var-file=/my/tf/terraform.tfvars -var-file=/my/tf/backend-app/dev.tfvars
+[frontend-app] terraform apply -var-file=/my/tf/terraform.tfvars -var-file=/my/tf/frontend-app/us-east-1.tfvars
 
 > TF_VAR_env=prod terragrunt apply-all
-[backend-app]  terraform apply -var-file=/my_project/terraform/prod.tfvars
-[frontend-app] terraform apply -var-file=/my_project/terraform/prod.tfvars -var-file=/my_project/terraform/frontend-app/us-east-1.tfvars
+[backend-app]  terraform apply -var-file=/my/tf/terraform.tfvars -var-file=/my/tf/prod.tfvars
+[frontend-app] terraform apply -var-file=/my/tf/terraform.tfvars -var-file=/my/tf/prod.tfvars -var-file=/my/tf/frontend-app/us-east-1.tfvars
 
 > TF_VAR_env=prod TF_VAR_region=us-west-2 terragrunt apply-all
-[backend-app]  terraform apply -var-file=/my_project/terraform/prod.tfvars -var-file=/my_project/terraform/us-west-2.tfvars
-[frontend-app] terraform apply -var-file=/my_project/terraform/prod.tfvars -var-file=/my_project/terraform/us-west-2.tfvars
+[backend-app]  terraform apply -var-file=/my/tf/terraform.tfvars -var-file=/my/tf/prod.tfvars -var-file=/my/tf/us-west-2.tfvars
+[frontend-app] terraform apply -var-file=/my/tf/terraform.tfvars -var-file=/my/tf/prod.tfvars -var-file=/my/tf/us-west-2.tfvars
 ```
 
 #### Handling whitespace

--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ With the configuration above, when you run `terragrunt apply`, Terragrunt will c
 ```
 > terragrunt apply
 
-terraform apply -lock-timeout=20m -var-file=terraform.tfvars -var-file=terraform-secret.tfvars
+terraform apply -lock-timeout=20m -var foo=bar -var region=us-west-1
 ```
 
 #### Required and optional var-files
@@ -563,8 +563,8 @@ terraform apply -lock-timeout=20m -var-file=terraform.tfvars -var-file=terraform
 One common usage of extra_arguments is to include tfvars files. instead of using arguments, it is simpler to use either `required_var_files`
 or `optional_var_files`. Both options require only to provide the list of file to include. The only difference is that `required_var_files`
 will add the extra argument `-var-file=<your file>` for each file specified and if they don't exist, terraform will complain. Using
-`optional_var_files` instead, terragrunt will only the `-var-file=<your file>` for existing files. This allows many conditional configurations
-based on environment variables as you can see in the following example:
+`optional_var_files` instead, terragrunt will only add the `-var-file=<your file>` for existing files. This allows many conditional
+configurations based on environment variables as you can see in the following example:
 
 ```
 /my/tf

--- a/cli/args.go
+++ b/cli/args.go
@@ -101,8 +101,10 @@ func filterTerraformExtraArgs(terragruntOptions *options.TerragruntOptions, terr
 				// If OptionalVarFiles is specified, check for each file if it exists and if so, add -var-file=<file>
 				// It is possible that many files resolve to the same path, so we remove duplicates.
 				for _, file := range util.RemoveDuplicatesFromListKeepLast(arg.OptionalVarFiles) {
-					if _, err := os.Stat(file); err == nil {
+					if util.FileExists(file) {
 						out = append(out, fmt.Sprintf("-var-file=%s", file))
+					} else {
+						terragruntOptions.Logger.Printf("Skipping var-file %s as it does not exist", file)
 					}
 				}
 			}

--- a/cli/args.go
+++ b/cli/args.go
@@ -89,10 +89,17 @@ func filterTerraformExtraArgs(terragruntOptions *options.TerragruntOptions, terr
 	cmd := firstArg(terragruntOptions.TerraformCliArgs)
 
 	for _, arg := range terragruntConfig.Terraform.ExtraArgs {
-		if arg.Commands != nil && arg.Arguments != nil {
+		if arg.Commands != nil && (arg.Arguments != nil || arg.VarFiles != nil) {
 			for _, arg_cmd := range arg.Commands {
 				if cmd == arg_cmd {
 					out = append(out, arg.Arguments...)
+
+					// If VarFiles are specified, check for each file if it exists and if so, add a -var-file=<file>
+					for _, file := range arg.VarFiles {
+						if _, err := os.Stat(file); err == nil {
+							out = append(out, fmt.Sprintf("-var-file=%s", file))
+						}
+					}
 				}
 			}
 		}

--- a/cli/args.go
+++ b/cli/args.go
@@ -89,17 +89,20 @@ func filterTerraformExtraArgs(terragruntOptions *options.TerragruntOptions, terr
 	cmd := firstArg(terragruntOptions.TerraformCliArgs)
 
 	for _, arg := range terragruntConfig.Terraform.ExtraArgs {
-		if arg.Commands != nil && (arg.Arguments != nil || arg.VarFiles != nil) {
-			for _, arg_cmd := range arg.Commands {
-				if cmd == arg_cmd {
-					out = append(out, arg.Arguments...)
+		for _, arg_cmd := range arg.Commands {
+			if cmd == arg_cmd {
+				out = append(out, arg.Arguments...)
 
-					// If VarFiles is specified, check for each file if it exists and if so, add -var-file=<file>
-					// It is possible that many files resolve to the same path, so we remove duplicates.
-					for _, file := range util.RemoveDuplicatesFromListKeepLast(arg.VarFiles) {
-						if _, err := os.Stat(file); err == nil {
-							out = append(out, fmt.Sprintf("-var-file=%s", file))
-						}
+				// If RequiredVarFiles is specified, add -var-file=<file> for each specified files
+				for _, file := range util.RemoveDuplicatesFromListKeepLast(arg.RequiredVarFiles) {
+					out = append(out, fmt.Sprintf("-var-file=%s", file))
+				}
+
+				// If OptionalVarFiles is specified, check for each file if it exists and if so, add -var-file=<file>
+				// It is possible that many files resolve to the same path, so we remove duplicates.
+				for _, file := range util.RemoveDuplicatesFromListKeepLast(arg.OptionalVarFiles) {
+					if _, err := os.Stat(file); err == nil {
+						out = append(out, fmt.Sprintf("-var-file=%s", file))
 					}
 				}
 			}

--- a/cli/args.go
+++ b/cli/args.go
@@ -94,8 +94,9 @@ func filterTerraformExtraArgs(terragruntOptions *options.TerragruntOptions, terr
 				if cmd == arg_cmd {
 					out = append(out, arg.Arguments...)
 
-					// If VarFiles are specified, check for each file if it exists and if so, add a -var-file=<file>
-					for _, file := range arg.VarFiles {
+					// If VarFiles is specified, check for each file if it exists and if so, add -var-file=<file>
+					// It is possible that many files resolve to the same path, so we remove duplicates.
+					for _, file := range util.RemoveDuplicatesFromListKeepLast(arg.VarFiles) {
 						if _, err := os.Stat(file); err == nil {
 							out = append(out, fmt.Sprintf("-var-file=%s", file))
 						}

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,7 @@ func (conf *TerraformConfig) String() string {
 type TerraformExtraArguments struct {
 	Name      string   `hcl:",key"`
 	Arguments []string `hcl:"arguments,omitempty"`
+	VarFiles  []string `hcl:"var_files,omitempty"`
 	Commands  []string `hcl:"commands,omitempty"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -74,10 +74,11 @@ func (conf *TerraformConfig) String() string {
 
 // TerraformExtraArguments sets a list of arguments to pass to Terraform if command fits any in the `Commands` list
 type TerraformExtraArguments struct {
-	Name      string   `hcl:",key"`
-	Arguments []string `hcl:"arguments,omitempty"`
-	VarFiles  []string `hcl:"var_files,omitempty"`
-	Commands  []string `hcl:"commands,omitempty"`
+	Name             string   `hcl:",key"`
+	Arguments        []string `hcl:"arguments,omitempty"`
+	RequiredVarFiles []string `hcl:"required_var_files,omitempty"`
+	OptionalVarFiles []string `hcl:"optional_var_files,omitempty"`
+	Commands         []string `hcl:"commands,omitempty"`
 }
 
 func (conf *TerraformExtraArguments) String() string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -631,13 +631,23 @@ terragrunt = {
       ]
     }
 
-    extra_arguments "conditional_tfvars" {
-      var_files = [
+    extra_arguments "required_tfvars" {
+      required_var_files = [
         "file1.tfvars",
 				"file2.tfvars"
       ]
       commands = [
         "apply"
+      ]
+    }
+
+    extra_arguments "optional_tfvars" {
+      optional_var_files = [
+        "opt1.tfvars",
+				"opt2.tfvars"
+      ]
+      commands = [
+        "plan"
       ]
     }
   }
@@ -659,9 +669,12 @@ terragrunt = {
 		assert.Equal(t, "fmt_diff", terragruntConfig.Terraform.ExtraArgs[1].Name)
 		assert.Equal(t, []string{"-diff=true"}, terragruntConfig.Terraform.ExtraArgs[1].Arguments)
 		assert.Equal(t, []string{"fmt"}, terragruntConfig.Terraform.ExtraArgs[1].Commands)
-		assert.Equal(t, "conditional_tfvars", terragruntConfig.Terraform.ExtraArgs[2].Name)
-		assert.Equal(t, []string{"file1.tfvars", "file2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[2].VarFiles)
+		assert.Equal(t, "required_tfvars", terragruntConfig.Terraform.ExtraArgs[2].Name)
+		assert.Equal(t, []string{"file1.tfvars", "file2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[2].RequiredVarFiles)
 		assert.Equal(t, []string{"apply"}, terragruntConfig.Terraform.ExtraArgs[2].Commands)
+		assert.Equal(t, "optional_tfvars", terragruntConfig.Terraform.ExtraArgs[3].Name)
+		assert.Equal(t, []string{"opt1.tfvars", "opt2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[3].OptionalVarFiles)
+		assert.Equal(t, []string{"plan"}, terragruntConfig.Terraform.ExtraArgs[3].Commands)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -630,6 +630,16 @@ terragrunt = {
         "fmt"
       ]
     }
+
+    extra_arguments "conditional_tfvars" {
+      var_files = [
+        "file1.tfvars",
+				"file2.tfvars"
+      ]
+      commands = [
+        "apply"
+      ]
+    }
   }
 }
 `
@@ -649,6 +659,9 @@ terragrunt = {
 		assert.Equal(t, "fmt_diff", terragruntConfig.Terraform.ExtraArgs[1].Name)
 		assert.Equal(t, []string{"-diff=true"}, terragruntConfig.Terraform.ExtraArgs[1].Arguments)
 		assert.Equal(t, []string{"fmt"}, terragruntConfig.Terraform.ExtraArgs[1].Commands)
+		assert.Equal(t, "conditional_tfvars", terragruntConfig.Terraform.ExtraArgs[2].Name)
+		assert.Equal(t, []string{"file1.tfvars", "file2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[2].VarFiles)
+		assert.Equal(t, []string{"apply"}, terragruntConfig.Terraform.ExtraArgs[2].Commands)
 	}
 }
 

--- a/test/fixture-extra-args/dev.tfvars
+++ b/test/fixture-extra-args/dev.tfvars
@@ -1,0 +1,1 @@
+extra_var = "Hello, World from dev!"

--- a/test/fixture-extra-args/terraform.tfvars
+++ b/test/fixture-extra-args/terraform.tfvars
@@ -1,16 +1,32 @@
-terragrunt= {
+terragrunt = {
   terraform = {
     extra_arguments "test" {
       arguments = [
         "-var-file=terraform.tfvars",
-        "-var-file=extra.tfvars"
+        "-var-file=extra.tfvars",
       ]
+
       commands = [
         "apply",
         "plan",
         "import",
         "push",
-        "refresh"
+        "refresh",
+      ]
+    }
+
+    extra_arguments "conditional-tfvars" {
+      var_files = [
+        "${get_tfvars_dir()}/${get_env("TF_VAR_env", "dev")}.tfvars",
+        "${get_tfvars_dir()}/${get_env("TF_VAR_region", "us-east-1")}.tfvars",
+      ]
+
+      commands = [
+        "apply",
+        "plan",
+        "import",
+        "push",
+        "refresh",
       ]
     }
   }

--- a/test/fixture-extra-args/terraform.tfvars
+++ b/test/fixture-extra-args/terraform.tfvars
@@ -3,7 +3,6 @@ terragrunt = {
     extra_arguments "test" {
       arguments = [
         "-var-file=terraform.tfvars",
-        "-var-file=extra.tfvars",
       ]
 
       commands = [
@@ -15,8 +14,12 @@ terragrunt = {
       ]
     }
 
-    extra_arguments "conditional-tfvars" {
-      var_files = [
+    extra_arguments "var-files" {
+      required_var_files = [
+        "extra.tfvars",
+      ]
+
+      optional_var_files = [
         "${get_tfvars_dir()}/${get_env("TF_VAR_env", "dev")}.tfvars",
         "${get_tfvars_dir()}/${get_env("TF_VAR_region", "us-east-1")}.tfvars",
       ]

--- a/test/fixture-extra-args/us-west-2.tfvars
+++ b/test/fixture-extra-args/us-west-2.tfvars
@@ -1,0 +1,1 @@
+extra_var = "Hello, World from Oregon!"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -327,6 +327,7 @@ func TestRemoteWithBackend(t *testing.T) {
 }
 
 func TestExtraArguments(t *testing.T) {
+	// Do not use t.Parallel() on this test, it will infers with the other TestExtraArguments.* tests
 	out := new(bytes.Buffer)
 	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_EXTRA_ARGS_PATH), out, os.Stderr)
 	t.Log(out.String())
@@ -334,21 +335,23 @@ func TestExtraArguments(t *testing.T) {
 }
 
 func TestExtraArgumentsWithEnv(t *testing.T) {
+	// Do not use t.Parallel() on this test, it will infers with the other TestExtraArguments.* tests
 	out := new(bytes.Buffer)
 	os.Setenv("TF_VAR_env", "prod")
+	defer os.Unsetenv("TF_VAR_env")
 	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_EXTRA_ARGS_PATH), out, os.Stderr)
 	t.Log(out.String())
 	assert.Contains(t, out.String(), "Hello, World!")
-	os.Unsetenv("TF_VAR_env")
 }
 
 func TestExtraArgumentsWithRegion(t *testing.T) {
+	// Do not use t.Parallel() on this test, it will infers with the other TestExtraArguments.* tests
 	out := new(bytes.Buffer)
 	os.Setenv("TF_VAR_region", "us-west-2")
+	defer os.Unsetenv("TF_VAR_region")
 	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_EXTRA_ARGS_PATH), out, os.Stderr)
 	t.Log(out.String())
 	assert.Contains(t, out.String(), "Hello, World from Oregon!")
-	os.Unsetenv("TF_VAR_region")
 }
 
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -327,8 +327,28 @@ func TestRemoteWithBackend(t *testing.T) {
 }
 
 func TestExtraArguments(t *testing.T) {
-	t.Parallel()
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_EXTRA_ARGS_PATH))
+	out := new(bytes.Buffer)
+	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_EXTRA_ARGS_PATH), out, os.Stderr)
+	t.Log(out.String())
+	assert.Contains(t, out.String(), "Hello, World from dev!")
+}
+
+func TestExtraArgumentsWithEnv(t *testing.T) {
+	out := new(bytes.Buffer)
+	os.Setenv("TF_VAR_env", "prod")
+	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_EXTRA_ARGS_PATH), out, os.Stderr)
+	t.Log(out.String())
+	assert.Contains(t, out.String(), "Hello, World!")
+	os.Unsetenv("TF_VAR_env")
+}
+
+func TestExtraArgumentsWithRegion(t *testing.T) {
+	out := new(bytes.Buffer)
+	os.Setenv("TF_VAR_region", "us-west-2")
+	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_EXTRA_ARGS_PATH), out, os.Stderr)
+	t.Log(out.String())
+	assert.Contains(t, out.String(), "Hello, World from Oregon!")
+	os.Unsetenv("TF_VAR_region")
 }
 
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {

--- a/util/collections.go
+++ b/util/collections.go
@@ -24,38 +24,28 @@ func RemoveElementFromList(list []string, element string) []string {
 
 // Returns a copy of the given list with all duplicates removed (keeping the first encountereds)
 func RemoveDuplicatesFromList(list []string) []string {
-	return removeDuplicatesFromList(list, true)
+	return removeDuplicatesFromList(list, false)
 }
 
 // Returns a copy of the given list with all duplicates removed (keeping the last encountereds)
 func RemoveDuplicatesFromListKeepLast(list []string) []string {
-	return removeDuplicatesFromList(list, false)
+	return removeDuplicatesFromList(list, true)
 }
 
-func removeDuplicatesFromList(list []string, fromStart bool) []string {
-	out := make([]*string, len(list))
+func removeDuplicatesFromList(list []string, keepLast bool) []string {
+	out := make([]string, 0, len(list))
 	present := make(map[string]bool)
 
-	for i := range list {
-		if !fromStart { // We change the index to start from the end
-			i = len(list) - i - 1
+	for _, value := range list {
+		if _, ok := present[value]; ok {
+			if keepLast {
+				out = RemoveElementFromList(out, value)
+			} else {
+				continue
+			}
 		}
-
-		if _, ok := present[list[i]]; !ok {
-			out[i] = &list[i]
-			present[list[i]] = true // Indicates that element is already in the list
-		}
+		out = append(out, value)
+		present[value] = true
 	}
-	return removeNil(out)
-}
-
-// Remove the nil element from the array
-func removeNil(list []*string) (out []string) {
-	out = make([]string, 0, len(list))
-	for _, element := range list {
-		if element != nil {
-			out = append(out, *element)
-		}
-	}
-	return
+	return out
 }

--- a/util/collections.go
+++ b/util/collections.go
@@ -21,3 +21,41 @@ func RemoveElementFromList(list []string, element string) []string {
 	}
 	return out
 }
+
+// Returns a copy of the given list with all duplicates removed (keeping the first encountereds)
+func RemoveDuplicatesFromList(list []string) []string {
+	return removeDuplicatesFromList(list, true)
+}
+
+// Returns a copy of the given list with all duplicates removed (keeping the last encountereds)
+func RemoveDuplicatesFromListKeepLast(list []string) []string {
+	return removeDuplicatesFromList(list, false)
+}
+
+func removeDuplicatesFromList(list []string, fromStart bool) []string {
+	out := make([]*string, len(list))
+	present := make(map[string]bool)
+
+	for i := range list {
+		if !fromStart { // We change the index to start from the end
+			i = len(list) - i - 1
+		}
+
+		if _, ok := present[list[i]]; !ok {
+			out[i] = &list[i]
+			present[list[i]] = true // Indicates that element is already in the list
+		}
+	}
+	return removeNil(out)
+}
+
+// Remove the nil element from the array
+func removeNil(list []*string) (out []string) {
+	out = make([]string, 0, len(list))
+	for _, element := range list {
+		if element != nil {
+			out = append(out, *element)
+		}
+	}
+	return
+}

--- a/util/collections_test.go
+++ b/util/collections_test.go
@@ -61,8 +61,10 @@ func TestRemoveDuplicatesFromList(t *testing.T) {
 		{[]string{}, []string{}, false},
 		{[]string{"foo"}, []string{"foo"}, false},
 		{[]string{"foo", "bar"}, []string{"foo", "bar"}, false},
-		{[]string{"foo", "bar", "foo", "bar"}, []string{"foo", "bar"}, false},
-		{[]string{"foo", "bar", "foo", "bar"}, []string{"bar", "foo"}, true},
+		{[]string{"foo", "bar", "foobar", "bar", "foo"}, []string{"foo", "bar", "foobar"}, false},
+		{[]string{"foo", "bar", "foobar", "foo", "bar"}, []string{"foo", "bar", "foobar"}, false},
+		{[]string{"foo", "bar", "foobar", "bar", "foo"}, []string{"foobar", "bar", "foo"}, true},
+		{[]string{"foo", "bar", "foobar", "foo", "bar"}, []string{"foobar", "foo", "bar"}, true},
 	}
 
 	for _, testCase := range testCases {

--- a/util/collections_test.go
+++ b/util/collections_test.go
@@ -49,3 +49,28 @@ func TestRemoveElementFromList(t *testing.T) {
 		assert.Equal(t, testCase.expected, actual, "For list %v and element %s", testCase.list, testCase.element)
 	}
 }
+
+func TestRemoveDuplicatesFromList(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		list     []string
+		expected []string
+		reverse  bool
+	}{
+		{[]string{}, []string{}, false},
+		{[]string{"foo"}, []string{"foo"}, false},
+		{[]string{"foo", "bar"}, []string{"foo", "bar"}, false},
+		{[]string{"foo", "bar", "foo", "bar"}, []string{"foo", "bar"}, false},
+		{[]string{"foo", "bar", "foo", "bar"}, []string{"bar", "foo"}, true},
+	}
+
+	for _, testCase := range testCases {
+		f := RemoveDuplicatesFromList
+		if testCase.reverse {
+			f = RemoveDuplicatesFromListKeepLast
+		}
+		assert.Equal(t, f(testCase.list), testCase.expected, "For list %v", testCase.list)
+		t.Logf("%v passed", testCase.list)
+	}
+}


### PR DESCRIPTION
Hi,

I added another feature that we use frequently. It allows us to include tfvars files only if they exist.

It is useful to inject variables depending of the current configuration (env, region, account, etc.).

Here is the result of the new tests
`
go test -timeout 30s -run "^TestExtraArguments.*$" -v
=== RUN   TestExtraArguments
[terragrunt] [fixture-extra-args] 2017/04/24 11:12:28 Running command: terraform --version
[terragrunt] 2017/04/24 11:12:29 Reading Terragrunt config file at fixture-extra-args/terraform.tfvars
[terragrunt] 2017/04/24 11:12:29 Running command: terraform apply -var-file=terraform.tfvars -var-file=extra.tfvars -var-file=/Users/jgiroux/go/src/github.com/gruntwork-io/terragrunt/test/fixture-extra-args/dev.tfvars
--- PASS: TestExtraArguments (0.36s)
	integration_test.go:332:
		Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

		Outputs:

		test = Hello, World from dev!

=== RUN   TestExtraArgumentsWithEnv
[terragrunt] [fixture-extra-args] 2017/04/24 11:12:29 Running command: terraform --version
[terragrunt] 2017/04/24 11:12:29 Reading Terragrunt config file at fixture-extra-args/terraform.tfvars
[terragrunt] 2017/04/24 11:12:29 Running command: terraform apply -var-file=terraform.tfvars -var-file=extra.tfvars
--- PASS: TestExtraArgumentsWithEnv (0.36s)
	integration_test.go:340:
		Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

		Outputs:

		test = Hello, World!

=== RUN   TestExtraArgumentsWithRegion
[terragrunt] [fixture-extra-args] 2017/04/24 11:12:29 Running command: terraform --version
[terragrunt] 2017/04/24 11:12:29 Reading Terragrunt config file at fixture-extra-args/terraform.tfvars
[terragrunt] 2017/04/24 11:12:29 Running command: terraform apply -var-file=terraform.tfvars -var-file=extra.tfvars -var-file=/Users/jgiroux/go/src/github.com/gruntwork-io/terragrunt/test/fixture-extra-args/dev.tfvars -var-file=/Users/jgiroux/go/src/github.com/gruntwork-io/terragrunt/test/fixture-extra-args/us-west-2.tfvars
--- PASS: TestExtraArgumentsWithRegion (0.43s)
	integration_test.go:349:
		Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

		Outputs:

		test = Hello, World from Oregon!

PASS
ok  	github.com/gruntwork-io/terragrunt/test	1.167s
`