### PR TITLE
Fix problem with incorrect detection of change in the remote state configuration

### DIFF
--- a/util/reflect.go
+++ b/util/reflect.go
@@ -1,0 +1,12 @@
+package util
+
+import "reflect"
+
+// Return the kind of the type or Invalid if value is nil
+func KindOf(value interface{}) reflect.Kind {
+	valueType := reflect.TypeOf(value)
+	if valueType == nil {
+		return reflect.Invalid
+	}
+	return valueType.Kind()
+}

--- a/util/reflect_test.go
+++ b/util/reflect_test.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestKindOf(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value    interface{}
+		expected reflect.Kind
+	}{
+		{1, reflect.Int},
+		{2.0, reflect.Float64},
+		{'A', reflect.Int32},
+		{math.Pi, reflect.Float64},
+		{true, reflect.Bool},
+		{nil, reflect.Invalid},
+		{"Hello World!", reflect.String},
+		{new(string), reflect.Ptr},
+		{*new(string), reflect.String},
+		{interface{}(false), reflect.Bool},
+	}
+	for _, testCase := range testCases {
+		actual := KindOf(testCase.value).String()
+		assert.Equal(t, testCase.expected.String(), actual, "For value %v", testCase.value)
+		t.Logf("%v passed", testCase.value)
+	}
+}


### PR DESCRIPTION
On our setup (latest terragrunt and terraform 0.9.3), since the encrypt field has been changed to a bool, terragrunt always detect a difference between the terragrunt configuration and the terraform remote state configuration. 

`[terragrunt] 2017/04/25 16:10:53 Setting working directory to /var/folders/4.../terragrunt-...

[terragrunt]  WARNING: Terraform remote state is already configured for backend s3 with config map[bucket:bucket-name encrypt:true key:dev/us-east-1/keyfile lock_table:terraform_locks region:us-east-1], but your Terragrunt configuration specifies config map[encrypt:true bucket:bucket-name region:us-east-1 key:dev/us-east-1/keyfile lock_table:terraform_locks]. Overwrite? (y/n)`

As you can see, both configuration appears to be equal except the order of element, which is not a problem for DeepEqual. The problem is caused by the fact that the type of encrypt is different, bool vs string.

We don't have the problem if we cleanup the folder using --terragrunt-source-update.

To solve the problem, I just converted the field from string to bool before the DeepEqual comparison. There is probably a better solution, but I don't know why the encrypt field has been forced to be a bool initially.