### PR TITLE
Fix how we execute Terraform commands so stdout isn't dirtied with unrelated output

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -197,7 +197,7 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		}
 	}
 
-	return runTerraformCommand(terragruntOptions)
+	return shell.RunTerraformCommand(terragruntOptions, terragruntOptions.TerraformCliArgs...)
 }
 
 // Returns true if the command the user wants to execute is supposed to affect multiple Terraform modules, such as the
@@ -229,7 +229,7 @@ func downloadModules(terragruntOptions *options.TerragruntOptions) error {
 			return err
 		}
 		if shouldDownload {
-			return shell.RunShellCommand(terragruntOptions, terragruntOptions.TerraformPath, "get", "-update")
+			return shell.RunTerraformCommand(terragruntOptions, "get", "-update")
 		}
 	}
 
@@ -312,16 +312,6 @@ func outputAll(terragruntOptions *options.TerragruntOptions) error {
 
 	terragruntOptions.Logger.Printf("%s", stack.String())
 	return stack.Output(terragruntOptions)
-}
-
-// Run the given Terraform command
-func runTerraformCommand(terragruntOptions *options.TerragruntOptions) error {
-	return shell.RunShellCommand(terragruntOptions, terragruntOptions.TerraformPath, terragruntOptions.TerraformCliArgs...)
-}
-
-// Run the given Terraform command and return the stdout as a string
-func runTerraformCommandAndCaptureOutput(terragruntOptions *options.TerragruntOptions) (string, error) {
-	return shell.RunShellCommandAndCaptureOutput(terragruntOptions, terragruntOptions.TerraformPath, terragruntOptions.TerraformCliArgs...)
 }
 
 // Custom error types

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/hashicorp/go-getter"
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
@@ -14,7 +15,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"github.com/gruntwork-io/terragrunt/shell"
 )
 
 // This struct represents information about Terraform source code that needs to be downloaded

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"github.com/gruntwork-io/terragrunt/shell"
 )
 
 // This struct represents information about Terraform source code that needs to be downloaded
@@ -348,11 +349,6 @@ func getTerraformSourceUrl(terragruntOptions *options.TerragruntOptions, terragr
 func terraformInit(terraformSource *TerraformSource, terragruntOptions *options.TerragruntOptions) error {
 	terragruntOptions.Logger.Printf("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
 
-	terragruntInitOptions := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
-
 	// Backend and get configuration will be handled separately
-	terragruntInitOptions.TerraformCliArgs = []string{"init", "-backend=false", "-get=false"}
-	terragruntInitOptions.TerraformCliArgs = append(terragruntInitOptions.TerraformCliArgs, terraformSource.CanonicalSourceURL.String(), terraformSource.DownloadDir)
-
-	return runTerraformCommand(terragruntInitOptions)
+	return shell.RunTerraformCommand(terragruntOptions, "init", "-backend=false", "-get=false", terraformSource.CanonicalSourceURL.String(), terraformSource.DownloadDir)
 }

--- a/cli/version_check.go
+++ b/cli/version_check.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/hashicorp/go-version"
 	"regexp"
+	"github.com/gruntwork-io/terragrunt/shell"
 )
 
 // The terraform --version output is of the format: Terraform v0.9.3
@@ -38,10 +39,7 @@ func checkTerraformVersionMeetsConstraint(currentVersion *version.Version, const
 
 // Get the currently installed version of Terraform
 func getTerraformVersion(terragruntOptions *options.TerragruntOptions) (*version.Version, error) {
-	terragruntOptionsCopy := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
-	terragruntOptionsCopy.TerraformCliArgs = []string{"--version"}
-
-	output, err := runTerraformCommandAndCaptureOutput(terragruntOptionsCopy)
+	output, err := shell.RunTerraformCommandAndCaptureOutput(terragruntOptions, "--version")
 	if err != nil {
 		return nil, err
 	}

--- a/cli/version_check.go
+++ b/cli/version_check.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/hashicorp/go-version"
 	"regexp"
-	"github.com/gruntwork-io/terragrunt/shell"
 )
 
 // The terraform --version output is of the format: Terraform v0.9.3

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -64,7 +64,7 @@ func (remoteState RemoteState) ConfigureRemoteState(terragruntOptions *options.T
 		}
 
 		terragruntOptions.Logger.Printf("Configuring remote state for the %s backend", remoteState.Backend)
-		return shell.RunShellCommand(terragruntOptions, terragruntOptions.TerraformPath, initCommand(remoteState)...)
+		return shell.RunTerraformCommand(terragruntOptions, initCommand(remoteState)...)
 	}
 
 	return nil

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -14,6 +14,16 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
+// Run the given Terraform command
+func RunTerraformCommand(terragruntOptions *options.TerragruntOptions, args ...string) error {
+	return RunShellCommand(terragruntOptions, terragruntOptions.TerraformPath, args...)
+}
+
+// Run the given Terraform command and return the stdout as a string
+func RunTerraformCommandAndCaptureOutput(terragruntOptions *options.TerragruntOptions, args ...string) (string, error) {
+	return RunShellCommandAndCaptureOutput(terragruntOptions, terragruntOptions.TerraformPath, args...)
+}
+
 // Run the specified shell command with the specified arguments. Connect the command's stdin, stdout, and stderr to
 // the currently running app.
 func RunShellCommand(terragruntOptions *options.TerragruntOptions, command string, args ...string) error {

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -62,6 +62,7 @@ func RunShellCommandAndCaptureOutput(terragruntOptions *options.TerragruntOption
 
 	terragruntOptionsCopy := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
 	terragruntOptionsCopy.Writer = stdout
+	terragruntOptionsCopy.ErrWriter = stdout
 
 	if err := RunShellCommand(terragruntOptionsCopy, command, args...); err != nil {
 		return "", err

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -40,7 +40,7 @@ func RunShellCommand(terragruntOptions *options.TerragruntOptions, command strin
 	// command requested by the user. The output of these other commands should not end up on stdout as this
 	// breaks scripts relying on terraform's output.
 	if !reflect.DeepEqual(terragruntOptions.TerraformCliArgs, args) {
-		cmd.Stdout = os.Stderr
+		cmd.Stdout = cmd.Stderr
 	}
 
 	cmd.Dir = terragruntOptions.WorkingDir


### PR DESCRIPTION
When you run a single `terragrunt` command, under the hood, Terragrunt may execute several `terraform` commands. For example, when you run `terragrunt apply`, Terragrunt may run `terraform init`, `terraform get`, and finally, `terraform apply`. 

Only the original Terraform command should log to `stdout`. All other commands should log to `stderr`. We already have this logic in the `shell` package, but due to some dumb usage of cloning the `TerragruntOptions` object, we accidentally worked around this logic. This PR should fix that.