### PR TITLE
output-all should process module stack in regular order.

### DIFF
--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -42,7 +42,7 @@ func (stack *Stack) Destroy(terragruntOptions *options.TerragruntOptions) error 
 // Output prints the outputs of all the modules in the given stack in their specified order.
 func (stack *Stack) Output(terragruntOptions *options.TerragruntOptions) error {
 	stack.setTerraformCommand([]string{"output"})
-	return RunModulesReverseOrder(stack.Modules)
+	return RunModules(stack.Modules)
 }
 
 // Return an error if there is a dependency cycle in the modules of this stack.

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -159,6 +159,8 @@ func TestTerragruntOutputAllCommand(t *testing.T) {
 	assert.True(t, strings.Contains(output, "app1 output"))
 	assert.True(t, strings.Contains(output, "app2 output"))
 	assert.True(t, strings.Contains(output, "app3 output"))
+
+	assert.True(t, (strings.Index(output, "app3 output") < strings.Index(output, "app1 output")) && (strings.Index(output, "app1 output") < strings.Index(output, "app2 output")))
 }
 
 func TestTerragruntStackCommands(t *testing.T) {


### PR DESCRIPTION
### Repro case

Minimal terraform code is [here](https://github.com/mrtyler/terragrunt-star-all-minimal) but it's just this:

```
### ./base/main.tf
output "base_var" { value = "i am base_var" }

### ./base/terraform.tfvars
terragrunt {}

### ./worker/main.tf
output "worker_var" { value = "i am worker_var" }

### ./worker/terraform.tfvars
terragrunt {
  dependencies {
    paths = ["../base"]
  }
}
```

Here's what happens when I run `terragrunt output-all` against that terraform config using current master:
```
$ go run ~/code/go/src/github.com/gruntwork-io/terragrunt/main.go output-all
[terragrunt] [/Users/tyler/rtf/tg-all] 2017/04/25 22:17:18 Running command: terraform --version
[terragrunt] 2017/04/25 22:17:18 Stack at /Users/tyler/rtf/tg-all:
  => Module /Users/tyler/rtf/tg-all/worker (dependencies: [/Users/tyler/rtf/tg-all/base])
  => Module /Users/tyler/rtf/tg-all/base (dependencies: [])
```

So far so good. `worker` depends on `base`.

```
[terragrunt] [/Users/tyler/rtf/tg-all/base] 2017/04/25 22:17:18 Module /Users/tyler/rtf/tg-all/base must wait for 1 dependencies to finish
[terragrunt] [/Users/tyler/rtf/tg-all/worker] 2017/04/25 22:17:18 Module /Users/tyler/rtf/tg-all/worker must wait for 0 dependencies to finish
```

Hey, that's backwards!

I don't think this behavior is deliberate; I think it was a copy/paste error when `output-all` was introduced (in `df7b6ee9`). The `Output` function was added below `Destroy`, which uses `RunModulesReverseOrder` instead of `RunModules`. Reverse order is correct for `destroy` but not for `output`.

### With the fix

Here's what happens when I run `terragrunt output-all` using the change in this PR:
```
$ go run ~/code/go/src/github.com/gruntwork-io/terragrunt/main.go output-all
...
[terragrunt] [/Users/tyler/rtf/tg-all/base] 2017/04/25 22:21:11 Module /Users/tyler/rtf/tg-all/base must wait for 0 dependencies to finish
[terragrunt] [/Users/tyler/rtf/tg-all/base] 2017/04/25 22:21:11 Running module /Users/tyler/rtf/tg-all/base now
[terragrunt] [/Users/tyler/rtf/tg-all/base] 2017/04/25 22:21:11 Reading Terragrunt config file at /Users/tyler/rtf/tg-all/base/terraform.tfvars
[terragrunt] [/Users/tyler/rtf/tg-all/worker] 2017/04/25 22:21:11 Module /Users/tyler/rtf/tg-all/worker must wait for 1 dependencies to finish
```

### Testing

The test suite passes, but I didn't have to change it. It looks like `output-all` functionality is only covered by `integration_test.go::TestTerragruntOutputAllCommand`, which only verifies that output from each module is returned. I admit I'm not really sure what else to test, though. Arguably this "bug" has no impact since all the outputs are returned even if the order is "wrong". I found the dependency ordering problem while discovering #193.

A couple other notes on terragrunt's test framework (I'm happy to spin off separate issues for these but first I wanted to check if these problems are already known and/or tracked elsewhere):

* `TestNewSignalsForwarderMultiple` seems to be flaky. I observed two failures out of six test runs using `go test -v -parallel 128 $(glide novendor)`:
```
--- FAIL: TestNewSignalsForwarderMultiple (7.54s)
        assertions.go:226: ^M                          ^M       Error Trace:    run_shell_cmd_test.go:121
                ^M      Error:          Not equal:
                ^M                      expected: 10
                ^M                      received: 12
FAIL
FAIL    github.com/gruntwork-io/terragrunt/shell        7.564s
```

* The `go test` process exits 0 even when tests fail (such as the test above). I wouldn't have known about those test failures at all if I hadn't happened to notice them scrolling by.