### PR TITLE
Bug/exit status on modules

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -72,3 +72,8 @@ func Recover(onPanic func(cause error)) {
 		onPanic(WithStackTrace(err))
 	}
 }
+
+// Interface to determine if we can retrieve an exit status from an error
+type IErrorCode interface {
+	ExitStatus() (int, error)
+}

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -71,7 +71,7 @@ func RunShellCommandAndCaptureOutput(terragruntOptions *options.TerragruntOption
 	return stdout.String(), nil
 }
 
-// Return the exit code of a command. If the error is not an exec.ExitError type,
+// Return the exit code of a command. If the error does not implement errors.IErrorCode or is not an exec.ExitError type,
 // the error is returned.
 func GetExitCode(err error) (int, error) {
 	if exiterr, ok := errors.Unwrap(err).(errors.IErrorCode); ok {

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -74,6 +74,10 @@ func RunShellCommandAndCaptureOutput(terragruntOptions *options.TerragruntOption
 // Return the exit code of a command. If the error is not an exec.ExitError type,
 // the error is returned.
 func GetExitCode(err error) (int, error) {
+	if exiterr, ok := errors.Unwrap(err).(errors.IErrorCode); ok {
+		return exiterr.ExitStatus()
+	}
+
 	if exiterr, ok := errors.Unwrap(err).(*exec.ExitError); ok {
 		status := exiterr.Sys().(syscall.WaitStatus)
 		return status.ExitStatus(), nil
@@ -83,7 +87,7 @@ func GetExitCode(err error) (int, error) {
 
 type SignalsForwarder chan os.Signal
 
-// Fowards signals to a command, waiting for the command to finish.
+// Forwards signals to a command, waiting for the command to finish.
 func NewSignalsForwarder(signals []os.Signal, c *exec.Cmd, logger *log.Logger, cmdChannel chan error) SignalsForwarder {
 	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, signals...)


### PR DESCRIPTION
Here is a fix to better handle the exit code when using xxx-all command. I simply added an interface to get the exit code and implemented it in `DependencyFinishedWithError` and `MultiError`.

That does not solve totally the problem with `terraform plan -detailed-exitcode` since if terraform detects changes on dependencies, terragrunt will simply not process the dependants. But the messages are easy to understand and the final result code is the good one.