### PR TITLE
Improve the global behaviour of -all commands

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -233,7 +233,7 @@ func downloadModules(terragruntOptions *options.TerragruntOptions) error {
 			return err
 		}
 		if shouldDownload {
-			return shell.RunTerraformCommand(terragruntOptions, "get", "-update")
+			return shell.RunTerraformCommandAndIgnoreOutput(terragruntOptions, "get", "-update")
 		}
 	}
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -233,7 +233,7 @@ func downloadModules(terragruntOptions *options.TerragruntOptions) error {
 			return err
 		}
 		if shouldDownload {
-			return shell.RunTerraformCommandAndIgnoreOutput(terragruntOptions, "get", "-update")
+			return shell.RunTerraformCommandAndRedirectOutputToLogger(terragruntOptions, "get", "-update")
 		}
 	}
 

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -350,5 +350,5 @@ func terraformInit(terraformSource *TerraformSource, terragruntOptions *options.
 	terragruntOptions.Logger.Printf("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
 
 	// Backend and get configuration will be handled separately
-	return shell.RunTerraformCommand(terragruntOptions, "init", "-backend=false", "-get=false", terraformSource.CanonicalSourceURL.String(), terraformSource.DownloadDir)
+	return shell.RunTerraformCommandAndIgnoreOutput(terragruntOptions, "init", "-backend=false", "-get=false", terraformSource.CanonicalSourceURL.String(), terraformSource.DownloadDir)
 }

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -350,5 +350,5 @@ func terraformInit(terraformSource *TerraformSource, terragruntOptions *options.
 	terragruntOptions.Logger.Printf("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
 
 	// Backend and get configuration will be handled separately
-	return shell.RunTerraformCommandAndIgnoreOutput(terragruntOptions, "init", "-backend=false", "-get=false", terraformSource.CanonicalSourceURL.String(), terraformSource.DownloadDir)
+	return shell.RunTerraformCommandAndRedirectOutputToLogger(terragruntOptions, "init", "-backend=false", "-get=false", terraformSource.CanonicalSourceURL.String(), terraformSource.DownloadDir)
 }

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -257,7 +257,9 @@ func (this MultiError) ExitStatus() (int, error) {
 	for i := range this.Errors {
 		if code, err := shell.GetExitCode(this.Errors[i]); err != nil {
 			return -1, this
-		} else if code > exitCode {
+		} else if code == 1 || code == 2 && exitCode == 0 {
+			// The exit code 1 is more significant that the exit code 2 because it represents an error
+			// while 2 represent a warning.
 			exitCode = code
 		}
 	}

--- a/configstack/stack_plan.go
+++ b/configstack/stack_plan.go
@@ -141,9 +141,9 @@ func (err countError) Error() string {
 // If there are changes, the exit status must be = 2
 func (err countError) ExitStatus() (int, error) {
 	if err.count > 0 {
-		return 2, nil
+		return CHANGE_EXIT_CODE, nil
 	}
-	return 0, nil
+	return NORMAL_EXIT_CODE, nil
 }
 
 // This is a specialized version of MultiError type

--- a/configstack/stack_plan.go
+++ b/configstack/stack_plan.go
@@ -44,7 +44,7 @@ func (stack *Stack) planWithSummary(terragruntOptions *options.TerragruntOptions
 	return err
 }
 
-// Returns the handler and the list of results
+// Returns the handler that will be executed after each completion of `terraform plan`
 func getResultHandler(detailedExitCode bool, results *[]moduleResult, mutex *sync.Mutex) ModuleHandler {
 	return func(module TerraformModule, output string, err error) error {
 		inspectPlanResult(module, output)

--- a/configstack/stack_plan.go
+++ b/configstack/stack_plan.go
@@ -1,0 +1,139 @@
+package configstack
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/shell"
+	"github.com/gruntwork-io/terragrunt/util"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// The returned information for each module
+type moduleResult struct {
+	Module    TerraformModule
+	Err       error
+	Message   string
+	NbChanges int
+}
+
+func (stack *Stack) planWithSummary(terragruntOptions *options.TerragruntOptions) error {
+	// We do a special treatment for -detailed-exitcode since we do not want to interrupt the processing of dependant
+	// stacks if one dependency has changes
+	detailedExitCode := util.ListContainsElement(terragruntOptions.TerraformCliArgs, "-detailed-exitcode")
+	if detailedExitCode {
+		util.RemoveElementFromList(terragruntOptions.TerraformCliArgs, "-detailed-exitcode")
+	}
+
+	results := make([]moduleResult, 0, len(stack.Modules))
+	var mutex sync.Mutex
+	err := RunModulesWithHandler(stack.Modules, getResultHandler(detailedExitCode, &results, &mutex), NormalOrder)
+	printSummary(terragruntOptions, results)
+
+	// If there is no error, but -detail-exitcode is specified, we return an error with the number of changes.
+	if err == nil && detailedExitCode {
+		sum := 0
+		for _, status := range results {
+			sum += status.NbChanges
+		}
+		err = countError{sum}
+	}
+
+	return err
+}
+
+// Returns the handler and the list of results
+func getResultHandler(detailedExitCode bool, results *[]moduleResult, mutex *sync.Mutex) ModuleHandler {
+	return func(module TerraformModule, output string, err error) error {
+		inspectPlanResult(module, output)
+		if exitCode, convErr := shell.GetExitCode(err); convErr == nil && detailedExitCode && exitCode == 2 {
+			err = nil
+		}
+
+		message, count := extractSummaryResultFromPlan(output)
+
+		// We add the result to the result list (using mutex to ensure that there is no conflict while appending to the result array)
+		mutex.Lock()
+		defer mutex.Unlock()
+		*results = append(*results, moduleResult{module, err, message, count})
+
+		return err
+	}
+}
+
+// Print a little summary of the plan execution
+func printSummary(terragruntOptions *options.TerragruntOptions, results []moduleResult) {
+	fmt.Fprintln(terragruntOptions.Writer, "Summary:")
+	for _, result := range results {
+		errMsg := ""
+		if result.Err != nil {
+			errMsg = fmt.Sprintf(", Error: %v", result.Err)
+		}
+
+		fmt.Fprintf(terragruntOptions.Writer, "    %v : %v%v\n", result.Module.Path, result.Message, errMsg)
+	}
+}
+
+// Check the output message
+func inspectPlanResult(module TerraformModule, output string) {
+	if strings.Contains(output, ": Resource 'data.terraform_remote_state.") {
+		var dependenciesMsg string
+		if len(module.Dependencies) > 0 {
+			dependenciesMsg = fmt.Sprintf(" contains dependencies to %v and", module.Config.Dependencies.Paths)
+		}
+		module.TerragruntOptions.Logger.Printf("%v%v refers to remote state "+
+			"you may have to apply your changes in the dependencies prior running terragrunt plan-all.\n",
+			module.Path,
+			dependenciesMsg,
+		)
+	}
+}
+
+// Parse the output message to extract a summary
+func extractSummaryResultFromPlan(output string) (string, int) {
+	const noChange = "No changes. Infrastructure is up-to-date."
+	if strings.Contains(output, noChange) {
+		return "No change", 0
+	}
+
+	re := regexp.MustCompile(`(\d+) to add, (\d+) to change, (\d+) to destroy.`)
+	result := re.FindStringSubmatch(output)
+	if len(result) == 0 {
+		return "Unable to determine the plan status", -1
+	}
+
+	// Count the total number of changes
+	sum := 0
+	for _, value := range result[1:] {
+		count, _ := strconv.Atoi(value)
+		sum += count
+	}
+	if sum != 0 {
+		return result[0], sum
+	}
+
+	// Sometimes, terraform returns 0 add, 0 change and 0 destroy. We return a more explicit message
+	return "No effective change", 0
+}
+
+// This is used to return the total number of changes if -detail-exitcode is specified and return an exit code of 2
+// to be compliant with the terraform specification.
+type countError struct{ count int }
+
+func (err countError) Error() string {
+	article, s := "is", ""
+	if err.count > 1 {
+		article, s = "are", "s"
+	}
+	return fmt.Sprintf("There %s %v change%s to apply", article, err.count, s)
+}
+
+// If there are changes, the exit status must be = 2
+func (err countError) ExitStatus() (int, error) {
+	if err.count > 0 {
+		return 2, nil
+	}
+	return 0, nil
+}

--- a/main.go
+++ b/main.go
@@ -41,5 +41,4 @@ func checkForErrorsAndExit(err error) {
 		}
 		os.Exit(exitCode)
 	}
-
 }

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -66,7 +66,7 @@ func (remoteState RemoteState) ConfigureRemoteState(terragruntOptions *options.T
 		}
 
 		terragruntOptions.Logger.Printf("Configuring remote state for the %s backend", remoteState.Backend)
-		return shell.RunTerraformCommandAndIgnoreOutput(terragruntOptions, initCommand(remoteState)...)
+		return shell.RunTerraformCommandAndRedirectOutputToLogger(terragruntOptions, initCommand(remoteState)...)
 	}
 
 	return nil

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -66,7 +66,7 @@ func (remoteState RemoteState) ConfigureRemoteState(terragruntOptions *options.T
 		}
 
 		terragruntOptions.Logger.Printf("Configuring remote state for the %s backend", remoteState.Backend)
-		return shell.RunTerraformCommand(terragruntOptions, initCommand(remoteState)...)
+		return shell.RunTerraformCommandAndIgnoreOutput(terragruntOptions, initCommand(remoteState)...)
 	}
 
 	return nil

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"bytes"
 	"log"
 	"os"
 	"os/exec"
@@ -9,8 +10,6 @@ import (
 	"strings"
 	"syscall"
 
-	"bytes"
-	"fmt"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 )
@@ -20,13 +19,13 @@ func RunTerraformCommand(terragruntOptions *options.TerragruntOptions, args ...s
 	return RunShellCommand(terragruntOptions, terragruntOptions.TerraformPath, args...)
 }
 
-// Run the given Terraform command and ignore the output unless there is an error
-func RunTerraformCommandAndIgnoreOutput(terragruntOptions *options.TerragruntOptions, args ...string) error {
+// Run the given Terraform command but redirect all outputs (both stdout and stderr) to the logger instead of
+// the default stream. This allows us to isolate the true output of terrraform command from the artefact of commands
+// like init and get during the preparation steps.
+// If the user redirect the stdout, he will only get the output for the terraform desired command.
+func RunTerraformCommandAndRedirectOutputToLogger(terragruntOptions *options.TerragruntOptions, args ...string) error {
 	output, err := runShellCommandAndCaptureOutput(terragruntOptions, true, terragruntOptions.TerraformPath, args...)
-	if err != nil {
-		fmt.Fprintln(terragruntOptions.ErrWriter, output)
-	}
-
+	terragruntOptions.Logger.Println(output)
 	return err
 }
 


### PR DESCRIPTION
The output of -all command could be very difficult to read. I modified several files to implement a new mechanism and improve the global readability.

I think that this implementation could help for #80. However, I did not implemented a summary for apply-all and destroy-all. It works very well with output-all and plan-all. And the same technique could easily be applied to summarize apply-all and destroy-all.

It works especially well when we redirect the stderr to /dev/null. The output of the distinct terraform command are then grouped together and easier to associate with the source module.

Since the addition of the new remote state, a lot of output related to the terraform init are displayed. I changed the behaviour to only display this output if there is a problem.

I also refactored the newly added plan-all to implement a summary at the end and also support correctly the -detailed-exitcode option from terraform.

Finally, this new implementation should solve the problem #198.