### PR TITLE
Fix problem on Windows with temp directory name encoding

### DIFF
--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -195,7 +195,7 @@ func processTerraformSource(source string, terragruntOptions *options.Terragrunt
 		return nil, err
 	}
 
-	encodedWorkingDir := util.EncodeBase64Sha1AlphaNum(canonicalWorkingDir)
+	encodedWorkingDir := util.EncodeBase64Sha1(canonicalWorkingDir)
 	downloadDir := util.JoinPath(os.TempDir(), "terragrunt-download", encodedWorkingDir, rootPath)
 	workingDir := util.JoinPath(downloadDir, modulePath)
 	versionFile := util.JoinPath(downloadDir, ".terragrunt-source-version")
@@ -280,7 +280,7 @@ func splitSourceUrl(sourceUrl *url.URL, terragruntOptions *options.TerragruntOpt
 // so the same file path (/foo/bar) is always considered the same version. See also the encodeSourceName and
 // processTerraformSource methods.
 func encodeSourceVersion(sourceUrl *url.URL) string {
-	return util.EncodeBase64Sha1AlphaNum(sourceUrl.Query().Encode())
+	return util.EncodeBase64Sha1(sourceUrl.Query().Encode())
 }
 
 // Encode a the module name for the given source URL. When calculating a module name, we calculate the base 64 encoded
@@ -297,7 +297,7 @@ func encodeSourceName(sourceUrl *url.URL) (string, error) {
 
 	sourceUrlNoQuery.RawQuery = ""
 
-	return util.EncodeBase64Sha1AlphaNum(sourceUrlNoQuery.String()), nil
+	return util.EncodeBase64Sha1(sourceUrlNoQuery.String()), nil
 }
 
 // Returns true if the given URL refers to a path on the local file system

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -195,7 +195,7 @@ func processTerraformSource(source string, terragruntOptions *options.Terragrunt
 		return nil, err
 	}
 
-	encodedWorkingDir := util.EncodeBase64Sha1(canonicalWorkingDir)
+	encodedWorkingDir := util.EncodeBase64Sha1AlphaNum(canonicalWorkingDir)
 	downloadDir := util.JoinPath(os.TempDir(), "terragrunt-download", encodedWorkingDir, rootPath)
 	workingDir := util.JoinPath(downloadDir, modulePath)
 	versionFile := util.JoinPath(downloadDir, ".terragrunt-source-version")
@@ -280,7 +280,7 @@ func splitSourceUrl(sourceUrl *url.URL, terragruntOptions *options.TerragruntOpt
 // so the same file path (/foo/bar) is always considered the same version. See also the encodeSourceName and
 // processTerraformSource methods.
 func encodeSourceVersion(sourceUrl *url.URL) string {
-	return util.EncodeBase64Sha1(sourceUrl.Query().Encode())
+	return util.EncodeBase64Sha1AlphaNum(sourceUrl.Query().Encode())
 }
 
 // Encode a the module name for the given source URL. When calculating a module name, we calculate the base 64 encoded
@@ -297,7 +297,7 @@ func encodeSourceName(sourceUrl *url.URL) (string, error) {
 
 	sourceUrlNoQuery.RawQuery = ""
 
-	return util.EncodeBase64Sha1(sourceUrlNoQuery.String()), nil
+	return util.EncodeBase64Sha1AlphaNum(sourceUrlNoQuery.String()), nil
 }
 
 // Returns true if the given URL refers to a path on the local file system

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -64,11 +64,8 @@ func RunShellCommandAndCaptureOutput(terragruntOptions *options.TerragruntOption
 	terragruntOptionsCopy.Writer = stdout
 	terragruntOptionsCopy.ErrWriter = stdout
 
-	if err := RunShellCommand(terragruntOptionsCopy, command, args...); err != nil {
-		return "", err
-	}
-
-	return stdout.String(), nil
+	err := RunShellCommand(terragruntOptionsCopy, command, args...)
+	return stdout.String(), err
 }
 
 // Return the exit code of a command. If the error does not implement errors.IErrorCode or is not an exec.ExitError type,

--- a/util/hash.go
+++ b/util/hash.go
@@ -3,10 +3,18 @@ package util
 import (
 	"crypto/sha1"
 	"encoding/base64"
+	"regexp"
 )
 
 // Returns the base 64 encoded sha1 hash of the given string
 func EncodeBase64Sha1(str string) string {
 	hash := sha1.Sum([]byte(str))
 	return base64.URLEncoding.EncodeToString(hash[:])
+}
+
+var removeNonAlphaNumericCharsRegex = regexp.MustCompile("[^a-zA-Z0-9]+")
+
+// Returns the base 64 encoded sha1 hash of the given string keeping only alphanumeric characters
+func EncodeBase64Sha1AlphaNum(str string) string {
+	return removeNonAlphaNumericCharsRegex.ReplaceAllString(EncodeBase64Sha1(str), "")
 }

--- a/util/hash.go
+++ b/util/hash.go
@@ -3,18 +3,10 @@ package util
 import (
 	"crypto/sha1"
 	"encoding/base64"
-	"regexp"
 )
 
 // Returns the base 64 encoded sha1 hash of the given string
 func EncodeBase64Sha1(str string) string {
 	hash := sha1.Sum([]byte(str))
-	return base64.URLEncoding.EncodeToString(hash[:])
-}
-
-var removeNonAlphaNumericCharsRegex = regexp.MustCompile("[^a-zA-Z0-9]+")
-
-// Returns the base 64 encoded sha1 hash of the given string keeping only alphanumeric characters
-func EncodeBase64Sha1AlphaNum(str string) string {
-	return removeNonAlphaNumericCharsRegex.ReplaceAllString(EncodeBase64Sha1(str), "")
+	return base64.RawURLEncoding.EncodeToString(hash[:])
 }


### PR DESCRIPTION
I just found out that there is a bug on Windows.

The algorithm used to encode directory name use a base 64 encoding. But this generates names with non alphanumeric characters that are invalid for some command on Windows.

When we call `terraform get`, it tries to issue a `mklink` command to link the `.terraform\modules\<tempname>` to the actual module source folder. Since `terragrunt` is working in a temp directory with mangled names containing invalid characters (especially the = at the end), that cause the `mklink` command to fail on windows.

Also, I fixed a problem with `RunShellCommandAndCaptureOutput()`. In case of error, this function didn't return any captured output. I think the function should returns the captured buffer in any circumstance otherwise, we are loosing the output to stderr.