### PR TITLE
Update README.md to add snap install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ multiple Terraform modules, remote state, and locking.
 
 1. Install [Terraform](https://www.terraform.io/).
 
-1. Install Terragrunt by going to the [Releases Page](https://github.com/gruntwork-io/terragrunt/releases), downloading
+1. Install Terragrunt on [snap enabled](https://snapcraft.io/docs/core/install) systems using ```snap install terragrunt``` or manually by going to the [Releases Page](https://github.com/gruntwork-io/terragrunt/releases), downloading
    the binary for your OS, renaming it to `terragrunt`, and adding it to your PATH.
 
 1. Go into a folder with your Terraform configurations (`.tf` files) and create a `terraform.tfvars` file with a


### PR DESCRIPTION
This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of stable desktop applications will also be available via the desktop Software Center, improving the discover-ability of your software. Your software can be installed with a simple `snap install terragrunt` simplifying the installation instructions for your users.