### PR TITLE
New interpolation functions to handle terraform commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ when creating the S3 bucket or DynamoDB table.
 
 ### Keep your CLI flags DRY
 
-#### <a name="extra_arguments"></a>Motivation
+#### Motivation
 
 Sometimes you may need to pass extra CLI arguments every time you run certain `terraform` commands. For example, you
 may want to set the `lock-timeout` setting to 20 minutes for all commands that may modify remote state so that
@@ -507,7 +507,7 @@ terragrunt = {
   terraform {
     # Force Terraform to keep trying to acquire a lock for up to 20 minutes if someone else already has the lock
     extra_arguments "retry_lock" {
-      commands  = "${get_terraform_commands_that_need_locking()}"
+      commands  = ["${get_terraform_commands_that_need_locking()}"]
       arguments = ["-lock-timeout=20m"]
     }
   }
@@ -1169,18 +1169,43 @@ The common.tfvars located in the terraform root folder will be included by all a
 
 `get_terraform_commands_that_need_vars()`
 
-Returns the list of terraform commands that accept -var and -var-file parameters. This function is used when defining [extra_arguments](#extra_arguments):
+Returns the list of terraform commands that accept -var and -var-file parameters. This function is used when defining [extra_arguments](#keep-your-cli-flags-dry).
+
+```
+terragrunt = {
+  terraform = {
+    ...
+
+    extra_arguments "common_var" {
+      commands  = ["${get_terraform_commands_that_need_vars()}"]
+      arguments = ["-var-file=${get_aws_account_id()}.tfvars"]
+    }
+  }
+}
+```
 
 #### get_terraform_commands_that_need_locking
 
 `get_terraform_commands_that_need_locking()`
 
-Returns the list of terraform commands that accept -lock-timeout parameter. This function is used when defining [extra_arguments](#extra_arguments):
+Returns the list of terraform commands that accept -lock-timeout parameter. This function is used when defining [extra_arguments](#keep-your-cli-flags-dry).
+
+```hcl
+terragrunt = {
+  terraform {
+    # Force Terraform to keep trying to acquire a lock for up to 20 minutes if someone else already has the lock
+    extra_arguments "retry_lock" {
+      commands  = ["${get_terraform_commands_that_need_locking()}"]
+      arguments = ["-lock-timeout=20m"]
+    }
+  }
+}
+```
 
 _Note: Functions that return a list of values must be used in a single declaration like:_
 
 ```hcl
-commands = "${get_terraform_commands_that_need_vars()}"
+commands = ["${get_terraform_commands_that_need_vars()}"]
 
 # which result in:
 commands = ["apply", "console", "destroy", "import", "plan", "push", "refresh"]
@@ -1218,7 +1243,7 @@ terragrunt = {
     ...
 
     extra_arguments "common_var" {
-      commands = "${get_terraform_commands_that_need_vars()}"
+      commands = ["${get_terraform_commands_that_need_vars()}"]
       arguments = ["-var-file=${get_aws_account_id()}.tfvars"]
     }
   }

--- a/README.md
+++ b/README.md
@@ -1321,10 +1321,10 @@ commands = ["${get_terraform_commands_that_need_vars()}"]
 # which result in:
 commands = ["apply", "console", "destroy", "import", "plan", "push", "refresh"]
 
-# They shall not be used to do string composition like:
+# We do not recommend using them in string composition like:
 commands = "Some text ${get_terraform_commands_that_need_locking()}"
 
-# which result in:
+# which result in something useless like:
 commands = "Some text [apply destroy import init plan refresh taint untaint]"
 ```
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -192,13 +192,14 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		if util.ListContainsElement(TERRAFORM_COMMANDS_WITH_SUBCOMMAND, terragruntOptions.TerraformCliArgs[0]) {
 			commandLength = 2
 		}
-		var args []string
-		args = append(args, terragruntOptions.TerraformCliArgs[:commandLength]...)
 
 		// Options must be inserted after command but before the other args
 		// command is either 1 word or 2 words
+		var args []string
+		args = append(args, terragruntOptions.TerraformCliArgs[:commandLength]...)
 		args = append(args, filterTerraformExtraArgs(terragruntOptions, conf)...)
-		terragruntOptions.TerraformCliArgs = append(args, terragruntOptions.TerraformCliArgs[commandLength:]...)
+		args = append(args, terragruntOptions.TerraformCliArgs[commandLength:]...)
+		terragruntOptions.TerraformCliArgs = args
 	}
 
 	if sourceUrl, hasSourceUrl := getTerraformSourceUrl(terragruntOptions, conf); hasSourceUrl {

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -15,8 +15,8 @@ import (
 
 var INTERPOLATION_SYNTAX_REGEX = regexp.MustCompile(`\$\{.*?\}`)
 var INTERPOLATION_SYNTAX_REGEX_SINGLE = regexp.MustCompile(fmt.Sprintf(`"(%s)"`, INTERPOLATION_SYNTAX_REGEX))
-var HELPER_FUNCTION_SYNTAX_REGEX = regexp.MustCompile(`\$\{(.*?)\((.*?)\)\}`)
-var HELPER_FUNCTION_GET_ENV_PARAMETERS_SYNTAX_REGEX = regexp.MustCompile(`\s*"(?P<env>[^=]+?)"\s*\,\s*"(?P<default>.*?)"\s*`)
+var HELPER_FUNCTION_SYNTAX_REGEX = regexp.MustCompile(`^\$\{(.*?)\((.*?)\)\}$`)
+var HELPER_FUNCTION_GET_ENV_PARAMETERS_SYNTAX_REGEX = regexp.MustCompile(`^\s*"(?P<env>[^=]+?)"\s*\,\s*"(?P<default>.*?)"\s*$`)
 var MAX_PARENT_FOLDERS_TO_CHECK = 100
 
 // List of terraform commands that accept -lock-timeout
@@ -59,7 +59,7 @@ func ResolveTerragruntConfigString(terragruntConfigString string, include *Inclu
 	return processMultipleInterpolationsInString(terragruntConfigString, include, terragruntOptions)
 }
 
-// Execute a single Terragrunt helper function and return its value as a string
+// Execute a single Terragrunt helper function and return the result
 func executeTerragruntHelperFunction(functionName string, parameters string, include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (interface{}, error) {
 	switch functionName {
 	case "find_in_parent_folders":

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
@@ -490,6 +491,27 @@ TERRAGRUNT_HIT","")}/bar`,
 				Env:                  map[string]string{"TEST_ENV_TERRAGRUNT_HIT": "HIT"},
 			},
 			"foo/HIT/bar",
+			nil,
+		},
+		{
+			`"${get_terraform_commands_that_need_locking()}"`,
+			nil,
+			options.TerragruntOptions{TerragruntConfigPath: "/root/child/" + DefaultTerragruntConfigPath, NonInteractive: true},
+			util.CommaSeparatedStrings(TERRAFORM_COMMANDS_NEED_LOCKING),
+			nil,
+		},
+		{
+			`commands = ["${get_terraform_commands_that_need_vars()}"]`,
+			nil,
+			options.TerragruntOptions{TerragruntConfigPath: "/root/child/" + DefaultTerragruntConfigPath, NonInteractive: true},
+			fmt.Sprintf("commands = [%s]", util.CommaSeparatedStrings(TERRAFORM_COMMANDS_NEED_VARS)),
+			nil,
+		},
+		{
+			`commands = "test-${get_terraform_commands_that_need_vars()}"`,
+			nil,
+			options.TerragruntOptions{TerragruntConfigPath: "/root/child/" + DefaultTerragruntConfigPath, NonInteractive: true},
+			fmt.Sprintf(`commands = "test-%v"`, TERRAFORM_COMMANDS_NEED_VARS),
 			nil,
 		},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -567,13 +567,7 @@ terragrunt = {
         "-var-file=terraform.tfvars",
         "-var-file=terraform-secret.tfvars"
       ]
-      commands = [
-        "apply",
-        "plan",
-        "import",
-        "push",
-        "refresh"
-      ]
+      commands = ["${get_terraform_commands_that_need_vars()}"]
     }
   }
 }
@@ -596,13 +590,7 @@ terragrunt = {
 			},
 			terragruntConfig.Terraform.ExtraArgs[0].Arguments)
 		assert.Equal(t,
-			[]string{
-				"apply",
-				"plan",
-				"import",
-				"push",
-				"refresh",
-			},
+			TERRAFORM_COMMANDS_NEED_VARS,
 			terragruntConfig.Terraform.ExtraArgs[0].Commands)
 	}
 }
@@ -636,9 +624,7 @@ terragrunt = {
         "file1.tfvars",
 				"file2.tfvars"
       ]
-      commands = [
-        "apply"
-      ]
+      commands = ["${get_terraform_commands_that_need_vars()}"]
     }
 
     extra_arguments "optional_tfvars" {
@@ -646,9 +632,7 @@ terragrunt = {
         "opt1.tfvars",
 				"opt2.tfvars"
       ]
-      commands = [
-        "plan"
-      ]
+      commands = ["${get_terraform_commands_that_need_vars()}"]
     }
   }
 }
@@ -671,10 +655,10 @@ terragrunt = {
 		assert.Equal(t, []string{"fmt"}, terragruntConfig.Terraform.ExtraArgs[1].Commands)
 		assert.Equal(t, "required_tfvars", terragruntConfig.Terraform.ExtraArgs[2].Name)
 		assert.Equal(t, []string{"file1.tfvars", "file2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[2].RequiredVarFiles)
-		assert.Equal(t, []string{"apply"}, terragruntConfig.Terraform.ExtraArgs[2].Commands)
+		assert.Equal(t, TERRAFORM_COMMANDS_NEED_VARS, terragruntConfig.Terraform.ExtraArgs[2].Commands)
 		assert.Equal(t, "optional_tfvars", terragruntConfig.Terraform.ExtraArgs[3].Name)
 		assert.Equal(t, []string{"opt1.tfvars", "opt2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[3].OptionalVarFiles)
-		assert.Equal(t, []string{"plan"}, terragruntConfig.Terraform.ExtraArgs[3].Commands)
+		assert.Equal(t, TERRAFORM_COMMANDS_NEED_VARS, terragruntConfig.Terraform.ExtraArgs[3].Commands)
 	}
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -384,6 +384,17 @@ func TestExtraArgumentsWithRegion(t *testing.T) {
 	assert.Contains(t, out.String(), "Hello, World from Oregon!")
 }
 
+func TestPriorityOrderOfArgument(t *testing.T) {
+	// Do not use t.Parallel() on this test, it will infers with the other TestExtraArguments.* tests
+	out := new(bytes.Buffer)
+	injectedValue := "Injected-directly-by-argument"
+	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply -var extra_var=%s --terragrunt-non-interactive --terragrunt-working-dir %s", injectedValue, TEST_FIXTURE_EXTRA_ARGS_PATH), out, os.Stderr)
+	t.Log(out.String())
+	// And the result value for test should be the injected variable since the injected arguments are injected before the suplied parameters,
+	// so our override of extra_var should be the last argument.
+	assert.Contains(t, out.String(), fmt.Sprintf("test = %s", injectedValue))
+}
+
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {
 	removeFile(t, util.JoinPath(templatesPath, TERRAFORM_STATE))
 	removeFile(t, util.JoinPath(templatesPath, TERRAFORM_STATE_BACKUP))

--- a/util/collections.go
+++ b/util/collections.go
@@ -61,5 +61,5 @@ func ListToHCLArray(list []string) string {
 	for _, value := range list {
 		values = append(values, fmt.Sprintf(`"%s"`, value))
 	}
-	return fmt.Sprintf("[%v]", strings.Join(values, ", "))
+	return strings.Join(values, ", ")
 }

--- a/util/collections.go
+++ b/util/collections.go
@@ -1,5 +1,10 @@
 package util
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Return true if the given list contains the given element
 func ListContainsElement(list []string, element string) bool {
 	for _, item := range list {
@@ -48,4 +53,13 @@ func removeDuplicatesFromList(list []string, keepLast bool) []string {
 		present[value] = true
 	}
 	return out
+}
+
+// Returns an HCL compliant formated list of strings
+func ListToHCLArray(list []string) string {
+	values := make([]string, 0, len(list))
+	for _, value := range list {
+		values = append(values, fmt.Sprintf(`"%s"`, value))
+	}
+	return fmt.Sprintf("[%v]", strings.Join(values, ", "))
 }

--- a/util/collections.go
+++ b/util/collections.go
@@ -55,8 +55,8 @@ func removeDuplicatesFromList(list []string, keepLast bool) []string {
 	return out
 }
 
-// Returns an HCL compliant formated list of strings
-func ListToHCLArray(list []string) string {
+// CommaSeparatedStrings returns an HCL compliant formated list of strings (each string within double quote)
+func CommaSeparatedStrings(list []string) string {
 	values := make([]string, 0, len(list))
 	for _, value := range list {
 		values = append(values, fmt.Sprintf(`"%s"`, value))

--- a/util/collections_test.go
+++ b/util/collections_test.go
@@ -76,3 +76,21 @@ func TestRemoveDuplicatesFromList(t *testing.T) {
 		t.Logf("%v passed", testCase.list)
 	}
 }
+
+func TestListToHCLArray(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		list     []string
+		expected string
+	}{
+		{[]string{}, `[]`},
+		{[]string{"foo"}, `["foo"]`},
+		{[]string{"foo", "bar"}, `["foo", "bar"]`},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, ListToHCLArray(testCase.list), testCase.expected, "For list %v", testCase.list)
+		t.Logf("%v passed", testCase.list)
+	}
+}

--- a/util/collections_test.go
+++ b/util/collections_test.go
@@ -84,9 +84,9 @@ func TestListToHCLArray(t *testing.T) {
 		list     []string
 		expected string
 	}{
-		{[]string{}, `[]`},
-		{[]string{"foo"}, `["foo"]`},
-		{[]string{"foo", "bar"}, `["foo", "bar"]`},
+		{[]string{}, ``},
+		{[]string{"foo"}, `"foo"`},
+		{[]string{"foo", "bar"}, `"foo", "bar"`},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
This should solve #171.

Add new interpolation functions to list terraform commands that make use of -var, -var-file and -lock-timeout.

`get_terraform_commands_that_need_locking()`
`get_terraform_commands_that_need_vars()`

```hcl
terragrunt = {
  terraform {
    # Force Terraform to keep trying to acquire a lock for up to 20 minutes if someone else already has the lock
    extra_arguments "retry_lock" {
      commands  = "${get_terraform_commands_that_need_locking()}"
      arguments = ["-lock-timeout=20m"]
    }
  }
}
```

Note that the implementation has been a little bit complicated by the fact that we cannot just implement it as suggested:
```hcl
      commands  = ${get_terraform_commands_that_need_locking()}
```

This syntax is not compliant with HCL as interpolation function should be between quotes.
```hcl
      commands  = "${get_terraform_commands_that_need_locking()}"
```

But, since these functions are returning a list of string, we do not want to get this as result:
```hcl
      commands  = "["apply", "plan", ...]"
```

Which is invalid. We expect to get rid of the surrounding quotes and get:
```hcl
      commands  = ["apply", "plan", ...]
```

So, I had to change the return of `resolveTerragruntInterpolation` and `executeTerragruntHelperFunction` to handle `interface{}` instead of `string`.


