### PR TITLE
Update regex that checks Terraform version compat

### DIFF
--- a/cli/version_check.go
+++ b/cli/version_check.go
@@ -9,8 +9,9 @@ import (
 	"regexp"
 )
 
-// The terraform --version output is of the format: Terraform v0.9.3
-var TERRAFORM_VERSION_REGEX = regexp.MustCompile("Terraform (.+)")
+// The terraform --version output is of the format: Terraform v0.9.5-dev (cad024a5fe131a546936674ef85445215bbc4226+CHANGES)
+// where -dev and (commitid+CHANGES) is for custom builds or if TF_LOG is set for debug purposes
+var TERRAFORM_VERSION_REGEX = regexp.MustCompile("Terraform (v?[\\d.]+)(-dev)?( .+)?")
 
 // Check that the currently installed Terraform version works meets the specified version constraint and return an error
 // if it doesn't

--- a/cli/version_check_test.go
+++ b/cli/version_check_test.go
@@ -12,6 +12,21 @@ func TestCheckTerraformVersionMeetsConstraintEqual(t *testing.T) {
 	testCheckTerraformVersionMeetsConstraint(t, "v0.9.3", ">= v0.9.3", true)
 }
 
+func TestCheckTerraformVersionMeetsConstraintGreaterWithDebug(t *testing.T) {
+        t.Parallel()
+        testCheckTerraformVersionMeetsConstraint(t, "v0.9.4 cad024a5fe131a546936674ef85445215bbc4226", ">= v0.9.3", true)
+}
+
+func TestCheckTerraformVersionMeetsConstraintGreaterDevWithChanges(t *testing.T) {
+	t.Parallel()
+	testCheckTerraformVersionMeetsConstraint(t, "v0.9.4-dev (cad024a5fe131a546936674ef85445215bbc4226+CHANGES)", ">= v0.9.3", true)
+}
+
+func TestCheckTerraformVersionMeetsConstraintGreaterDev(t *testing.T) {
+	t.Parallel()
+	testCheckTerraformVersionMeetsConstraint(t, "v0.9.4-dev", ">= v0.9.3", true)
+}
+
 func TestCheckTerraformVersionMeetsConstraintGreaterPatch(t *testing.T) {
 	t.Parallel()
 	testCheckTerraformVersionMeetsConstraint(t, "v0.9.4", ">= v0.9.3", true)


### PR DESCRIPTION
This PR is meant to fix #200 as well as to provide the functionality to run user compiled terraform binaries e.g. when fixing terraform bugs or adding extra functionality locally and before it is merged into the mainline terraform codebase.