### PR TITLE
add documentation on github ssh authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,9 +301,10 @@ In particular:
 
 
 
-#### Github using SSH
-To use terragrunt with SSH github authentication, use the following syntax. Note the `/` after 
-github.com instead of `:` and the uses of `//`. 
+#### Using Terragrunt with private Git repos
+The easiest way to use Terragrunt with private Git repos is to use SSH authentication. 
+Configure your Git account so you can use it with SSH (see the [guide for GitHub here](https://help.github.com/articles/connecting-to-github-with-ssh/)) and use the SSH URL for your repo, 
+prepended with `git::ssh://`: 
 
 ```hcl
 terragrunt = {
@@ -312,10 +313,11 @@ terragrunt = {
   }
 }
 ```
-For private git repositories, replace github.com with the private repository host. 
+Look up the Git repo for your repository to find the proper format. 
 
-Note: In automated pipelines, you may need to run the following command prior to calling
-`terragrunt` to ensure that the ssh host is registered locally:
+Note: In automated pipelines, you may need to run the following command for your 
+Git repository prior to calling `terragrunt` to ensure that the ssh host is registered 
+locally, e.g.:
 
 ```
 $ ssh -T -oStrictHostKeyChecking=no git@github.com || true

--- a/README.md
+++ b/README.md
@@ -301,6 +301,25 @@ In particular:
 
 
 
+#### Github using SSH
+To use terragrunt with SSH github authentication, use the following syntax. Note the `/` after 
+github.com instead of `:` and the uses of `//`. 
+
+```hcl
+terragrunt = {
+  terraform {
+    source = "git::ssh://git@github.com/foo/modules.git//path/to/module?ref=v0.0.1"
+  }
+}
+```
+For private git repositories, replace github.com with the private repository host. 
+
+Note: In automated pipelines, you may need to run the following command prior to calling
+`terragrunt` to ensure that the ssh host is registered locally:
+
+```
+$ ssh -T -oStrictHostKeyChecking=no git@github.com || true
+```
 
 
 


### PR DESCRIPTION
@brikis98 This PR addresses https://github.com/gruntwork-io/terragrunt/issues/166#issuecomment-301110407 adding documentation on using ssh with terragrunt.