### PR TITLE
Found another cornercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ Terragrunt allows you to use [Terraform interpolation syntax](https://www.terraf
 * [get_tfvars_dir()](#get_tfvars_dir)
 * [get_parent_tfvars_dir()](#get_parent_tfvars_dir)
 * [get_terraform_commands_that_need_vars()](#get_terraform_commands_that_need_vars)
+* [get_terraform_commands_that_need_input()](#get_terraform_commands_that_need_input)
 * [get_terraform_commands_that_need_locking()](#get_terraform_commands_that_need_locking)
 * [get_aws_account_id()](#get_aws_account_id)
 
@@ -1290,6 +1291,24 @@ terragrunt = {
     extra_arguments "common_var" {
       commands  = ["${get_terraform_commands_that_need_vars()}"]
       arguments = ["-var-file=${get_aws_account_id()}.tfvars"]
+    }
+  }
+}
+```
+
+#### get_terraform_commands_that_need_input
+
+`get_terraform_commands_that_need_input()`
+
+Returns the list of terraform commands that accept -input=(true or false) parameter. This function is used when defining [extra_arguments](#keep-your-cli-flags-dry).
+
+```hcl
+terragrunt = {
+  terraform {
+    # Force Terraform to not ask for input value if some variables are undefined.
+    extra_arguments "disable_input" {
+      commands  = ["${get_terraform_commands_that_need_input()}"]
+      arguments = ["-input=false"]
     }
   }
 }

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -92,6 +92,13 @@ func processSingleInterpolationInString(terragruntConfigString string, include *
 	// The function we pass to ReplaceAllStringFunc cannot return an error, so we have to use named error parameters to capture such errors.
 	resolved = INTERPOLATION_SYNTAX_REGEX_SINGLE.ReplaceAllStringFunc(terragruntConfigString, func(str string) string {
 		matches := INTERPOLATION_SYNTAX_REGEX_SINGLE.FindStringSubmatch(str)
+
+		if len(INTERPOLATION_SYNTAX_REGEX.FindAllString(matches[1], -1)) != 1 {
+			// If there is more that one expression we do not process it
+			// That could be the case if the user use a syntax like "${func1()}-${func2()}"
+			return str
+		}
+
 		out, err := resolveTerragruntInterpolation(matches[1], include, terragruntOptions)
 		if err != nil {
 			finalErr = err

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -13,8 +13,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 )
 
-var INTERPOLATION_SYNTAX_REGEX = regexp.MustCompile(`\$\{.*?\}`)
+var INTERPOLATION_PARAMETERS = `(\s*"[^"]*?"\s*,?\s*)*`
+var INTERPOLATION_SYNTAX_REGEX = regexp.MustCompile(fmt.Sprintf(`\$\{\s*(\w+\(%s\))\s*\}`, INTERPOLATION_PARAMETERS))
 var INTERPOLATION_SYNTAX_REGEX_SINGLE = regexp.MustCompile(fmt.Sprintf(`"(%s)"`, INTERPOLATION_SYNTAX_REGEX))
+var INTERPOLATION_SYNTAX_REGEX_REMAINING = regexp.MustCompile(`\$\{.*?\}`)
 var HELPER_FUNCTION_SYNTAX_REGEX = regexp.MustCompile(`^\$\{(.*?)\((.*?)\)\}$`)
 var HELPER_FUNCTION_GET_ENV_PARAMETERS_SYNTAX_REGEX = regexp.MustCompile(`^\s*"(?P<env>[^=]+?)"\s*\,\s*"(?P<default>.*?)"\s*$`)
 var MAX_PARENT_FOLDERS_TO_CHECK = 100
@@ -39,6 +41,15 @@ var TERRAFORM_COMMANDS_NEED_VARS = []string{
 	"import",
 	"plan",
 	"push",
+	"refresh",
+}
+
+// List of terraform commands that accept -input=
+var TERRAFORM_COMMANDS_NEED_INPUT = []string{
+	"apply",
+	"import",
+	"init",
+	"plan",
 	"refresh",
 }
 
@@ -80,6 +91,8 @@ func executeTerragruntHelperFunction(functionName string, parameters string, inc
 		return TERRAFORM_COMMANDS_NEED_VARS, nil
 	case "get_terraform_commands_that_need_locking":
 		return TERRAFORM_COMMANDS_NEED_LOCKING, nil
+	case "get_terraform_commands_that_need_input":
+		return TERRAFORM_COMMANDS_NEED_INPUT, nil
 	default:
 		return "", errors.WithStackTrace(UnknownHelperFunction(functionName))
 	}
@@ -92,12 +105,6 @@ func processSingleInterpolationInString(terragruntConfigString string, include *
 	// The function we pass to ReplaceAllStringFunc cannot return an error, so we have to use named error parameters to capture such errors.
 	resolved = INTERPOLATION_SYNTAX_REGEX_SINGLE.ReplaceAllStringFunc(terragruntConfigString, func(str string) string {
 		matches := INTERPOLATION_SYNTAX_REGEX_SINGLE.FindStringSubmatch(str)
-
-		if len(INTERPOLATION_SYNTAX_REGEX.FindAllString(matches[1], -1)) != 1 {
-			// If there is more that one expression we do not process it
-			// That could be the case if the user use a syntax like "${func1()}-${func2()}"
-			return str
-		}
 
 		out, err := resolveTerragruntInterpolation(matches[1], include, terragruntOptions)
 		if err != nil {
@@ -131,6 +138,16 @@ func processMultipleInterpolationsInString(terragruntConfigString string, includ
 
 		return fmt.Sprintf("%v", out)
 	})
+
+	if finalErr == nil {
+		// If there is no error, we check if there are remaining look-a-like interpolation strings
+		// that have not been considered. If so, they are certainly malformed.
+		remaining := INTERPOLATION_SYNTAX_REGEX_REMAINING.FindAllString(resolved, -1)
+		if len(remaining) > 0 {
+			finalErr = InvalidInterpolationSyntax(strings.Join(remaining, ", "))
+		}
+	}
+
 	return
 }
 

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -14,10 +14,10 @@ import (
 )
 
 var INTERPOLATION_PARAMETERS = `(\s*"[^"]*?"\s*,?\s*)*`
-var INTERPOLATION_SYNTAX_REGEX = regexp.MustCompile(fmt.Sprintf(`\$\{\s*(\w+\(%s\))\s*\}`, INTERPOLATION_PARAMETERS))
+var INTERPOLATION_SYNTAX_REGEX = regexp.MustCompile(fmt.Sprintf(`\$\{\s*\w+\(%s\)\s*\}`, INTERPOLATION_PARAMETERS))
 var INTERPOLATION_SYNTAX_REGEX_SINGLE = regexp.MustCompile(fmt.Sprintf(`"(%s)"`, INTERPOLATION_SYNTAX_REGEX))
 var INTERPOLATION_SYNTAX_REGEX_REMAINING = regexp.MustCompile(`\$\{.*?\}`)
-var HELPER_FUNCTION_SYNTAX_REGEX = regexp.MustCompile(`^\$\{(.*?)\((.*?)\)\}$`)
+var HELPER_FUNCTION_SYNTAX_REGEX = regexp.MustCompile(`^\$\{\s*(.*?)\((.*?)\)\s*\}$`)
 var HELPER_FUNCTION_GET_ENV_PARAMETERS_SYNTAX_REGEX = regexp.MustCompile(`^\s*"(?P<env>[^=]+?)"\s*\,\s*"(?P<default>.*?)"\s*$`)
 var MAX_PARENT_FOLDERS_TO_CHECK = 100
 

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -568,6 +568,14 @@ func TestResolveMultipleInterpolationsConfigString(t *testing.T) {
 			nil,
 		},
 		{
+			// Included within quotes
+			`"${get_env("NON_EXISTING_VAR1", "default1")}-${get_env("NON_EXISTING_VAR2", "default2")}"`,
+			nil,
+			options.TerragruntOptions{TerragruntConfigPath: DefaultTerragruntConfigPath, NonInteractive: true},
+			fmt.Sprintf(`"default1-default2"`),
+			nil,
+		},
+		{
 			// Malformed parameters
 			`${get_env("NON_EXISTING_VAR1", "default"-${get_terraform_commands_that_need_vars()}`,
 			nil,

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -347,6 +347,20 @@ func TestResolveTerragruntConfigString(t *testing.T) {
 			nil,
 		},
 		{
+			"${    find_in_parent_folders()    }",
+			nil,
+			options.TerragruntOptions{TerragruntConfigPath: "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/" + DefaultTerragruntConfigPath, NonInteractive: true},
+			"../../" + DefaultTerragruntConfigPath,
+			nil,
+		},
+		{
+			"${find_in_parent_folders ()}",
+			nil,
+			options.TerragruntOptions{TerragruntConfigPath: "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/" + DefaultTerragruntConfigPath, NonInteractive: true},
+			"",
+			InvalidInterpolationSyntax("${find_in_parent_folders ()}"),
+		},
+		{
 			"foo/${find_in_parent_folders()}/bar",
 			nil,
 			options.TerragruntOptions{TerragruntConfigPath: "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/" + DefaultTerragruntConfigPath, NonInteractive: true},

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -426,6 +426,13 @@ func TestResolveEnvInterpolationConfigString(t *testing.T) {
 			InvalidFunctionParameters(`   ""    ,   ""    `),
 		},
 		{
+			`${get_env("SOME_VAR", "SOME{VALUE}")}`,
+			nil,
+			options.TerragruntOptions{TerragruntConfigPath: "/root/child/" + DefaultTerragruntConfigPath, NonInteractive: true},
+			"SOME{VALUE}",
+			nil,
+		},
+		{
 			`foo/${get_env("TEST_ENV_TERRAGRUNT_HIT","")}/bar`,
 			nil,
 			options.TerragruntOptions{

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -402,14 +402,14 @@ func TestResolveEnvInterpolationConfigString(t *testing.T) {
 			nil,
 			options.TerragruntOptions{TerragruntConfigPath: "/root/child/" + DefaultTerragruntConfigPath, NonInteractive: true},
 			"",
-			InvalidFunctionParameters("Invalid Parameters"),
+			InvalidInterpolationSyntax("${get_env(Invalid Parameters)}"),
 		},
 		{
 			"foo/${get_env('env','')}/bar",
 			nil,
 			options.TerragruntOptions{TerragruntConfigPath: "/root/child/" + DefaultTerragruntConfigPath, NonInteractive: true},
 			"",
-			InvalidFunctionParameters("'env',''"),
+			InvalidInterpolationSyntax("${get_env('env','')}"),
 		},
 		{
 			`foo/${get_env("","")}/bar`,
@@ -456,9 +456,9 @@ TERRAGRUNT_HIT","")}/bar`,
 				NonInteractive:       true,
 				Env:                  map[string]string{"TEST_ENV_TERRAGRUNT_OTHER": "SOMETHING"},
 			},
-			`foo/${get_env("TEST_ENV_
-TERRAGRUNT_HIT","")}/bar`,
-			nil,
+			"",
+			InvalidInterpolationSyntax(`${get_env("TEST_ENV_
+TERRAGRUNT_HIT","")}`),
 		},
 		{
 			`foo/${get_env("TEST_ENV_TERRAGRUNT_HIT","DEFAULT")}/bar`,
@@ -572,7 +572,7 @@ func TestResolveMultipleInterpolationsConfigString(t *testing.T) {
 			`"${get_env("NON_EXISTING_VAR1", "default1")}-${get_env("NON_EXISTING_VAR2", "default2")}"`,
 			nil,
 			options.TerragruntOptions{TerragruntConfigPath: DefaultTerragruntConfigPath, NonInteractive: true},
-			fmt.Sprintf(`"default1-default2"`),
+			`"default1-default2"`,
 			nil,
 		},
 		{
@@ -580,8 +580,8 @@ func TestResolveMultipleInterpolationsConfigString(t *testing.T) {
 			`${get_env("NON_EXISTING_VAR1", "default"-${get_terraform_commands_that_need_vars()}`,
 			nil,
 			options.TerragruntOptions{TerragruntConfigPath: DefaultTerragruntConfigPath, NonInteractive: true},
-			"",
-			InvalidFunctionParameters(`"NON_EXISTING_VAR1", "default"-${get_terraform_commands_that_need_vars(`),
+			fmt.Sprintf(`${get_env("NON_EXISTING_VAR1", "default"-%v`, TERRAFORM_COMMANDS_NEED_VARS),
+			nil,
 		},
 		{
 			`test1 = "${get_env("NON_EXISTING_VAR1", "default")}" test2 = ["${get_terraform_commands_that_need_vars()}"]`,

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -514,6 +514,22 @@ TERRAGRUNT_HIT","")}`),
 			"foo/HIT/bar",
 			nil,
 		},
+		{
+			// Unclosed quote
+			`foo/${get_env("TEST_ENV_TERRAGRUNT_HIT}/bar`,
+			nil,
+			options.TerragruntOptions{TerragruntConfigPath: "/root/child/" + DefaultTerragruntConfigPath, NonInteractive: true},
+			"",
+			InvalidInterpolationSyntax(`${get_env("TEST_ENV_TERRAGRUNT_HIT}`),
+		},
+		{
+			// Unclosed quote and interpolation pattern
+			`foo/${get_env("TEST_ENV_TERRAGRUNT_HIT/bar`,
+			nil,
+			options.TerragruntOptions{TerragruntConfigPath: "/root/child/" + DefaultTerragruntConfigPath, NonInteractive: true},
+			`foo/${get_env("TEST_ENV_TERRAGRUNT_HIT/bar`,
+			nil,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
There was a bug in certain circumstance whit processSingleInterpolationInString.

The regex can consider multiple interpolations as only one. The main problem is that INTERPOLATION_SYNTAX_REGEX is too general. I did not change it to avoid undesired side effects. But I added a test in processSingleInterpolationInString to ensure that there is only one match between the quotes.

I also added a test that catch the misbehaviour.

Sorry for the inconvenience.