### PR TITLE
Always use the Logger rather than writing directly to stdout

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -159,15 +159,15 @@ func runApp(cliContext *cli.Context) (finalErr error) {
 	}
 
 	givenCommand := cliContext.Args().First()
-	command := checkDeprecated(givenCommand)
+	command := checkDeprecated(givenCommand, terragruntOptions)
 	return runCommand(command, terragruntOptions)
 }
 
 // checkDeprecated checks if the given command is deprecated.  If so: prints a message and returns the new command.
-func checkDeprecated(command string) string {
+func checkDeprecated(command string, terragruntOptions *options.TerragruntOptions) string {
 	newCommand, deprecated := DEPRECATED_COMMANDS[command]
 	if deprecated {
-		fmt.Printf("%v is deprecated; running %v instead.\n", command, newCommand)
+		terragruntOptions.Logger.Printf("%v is deprecated; running %v instead.\n", command, newCommand)
 		return newCommand
 	}
 	return command

--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -14,10 +14,10 @@ func PromptUserForInput(prompt string, terragruntOptions *options.TerragruntOpti
 	if terragruntOptions.Logger.Prefix() != "" {
 		prompt = fmt.Sprintf("%s %s", terragruntOptions.Logger.Prefix(), prompt)
 	}
-	fmt.Print(prompt)
+	terragruntOptions.Logger.Print(prompt)
 
 	if terragruntOptions.NonInteractive {
-		fmt.Println()
+		terragruntOptions.Logger.Println()
 		terragruntOptions.Logger.Printf("The non-interactive flag is set to true, so assuming 'yes' for all prompts")
 		return "yes", nil
 	}


### PR DESCRIPTION
Fix a couple places in Terragrunt where we were writing directly to `stdout` instead of using a `Logger`. Everything in Terragrunt should go through the `Logger`, especially as we’ve configured Terragrunt to log everything to `stderr` so that it’s output does not interfere with Terraform’s output (e.g. so it doesn’t interfere with the output of the `terraform output` command).