### PR TITLE
Merge child extra_arguments with parent extra_arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,8 +487,8 @@ The child `.tfvars` file's `terragrunt.terraform` settings will be merged into t
 settings as follows:
 
 * If an `extra_arguments` block in the child has the same name as an `extra_arguments` block in the parent,
-  then the child's block will override the parents.
-  * Specifying an empty `extra_arguments` block in a child will effectively remove the parent's block.
+  then the child's block will override the parent's.
+  * Specifying an empty `extra_arguments` block in a child with the same name will effectively remove the parent's block.
 * If an `extra_arguments` block in the child has a different name than `extra_arguments` blocks in the parent,
   then both the parent and child's `extra_arguments` will be effective.
 * The `source` field in the child will override `source` field in the parent

--- a/README.md
+++ b/README.md
@@ -491,6 +491,9 @@ settings as follows:
   * Specifying an empty `extra_arguments` block in a child with the same name will effectively remove the parent's block.
 * If an `extra_arguments` block in the child has a different name than `extra_arguments` blocks in the parent,
   then both the parent and child's `extra_arguments` will be effective.
+  * The child's `extra_arguments` will be placed _after_ the parent's `extra_arguments` on the terraform command line.
+  * Therefore, if a child's and parent's `extra_arguments` include `.tfvars` files with the same variable defined,
+    the value from the `.tfvars` file from the child's `extra_arguments` will be used by terraform.
 * The `source` field in the child will override `source` field in the parent
 
 Other settings in the child `.tfvars` file's `terragrunt` block (e.g. `remote_state`) override the respective

--- a/README.md
+++ b/README.md
@@ -481,8 +481,19 @@ terragrunt = {
 
 The `include` block tells Terragrunt to use the exact same Terragrunt configuration from the `terraform.tfvars` file
 specified via the `path` parameter. It behaves exactly as if you had copy/pasted the Terraform configuration from 
-the root `terraform.tfvars` file into `mysql/terraform.tfvars`, but this approach is much easier to maintain! Note
-that if you include any other settings in the `terragrunt` block of a child `.tfvars` file, it will override the
+the root `terraform.tfvars` file into `mysql/terraform.tfvars`, but this approach is much easier to maintain!
+
+The child `.tfvars` file's `terragrunt.terraform` settings will be merged into the parent file's `terragrunt.terraform`
+settings as follows:
+
+* If an `extra_arguments` block in the child has the same name as an `extra_arguments` block in the parent,
+  then the child's block will override the parents.
+  * Specifying an empty `extra_arguments` block in a child will effectively remove the parent's block.
+* If an `extra_arguments` block in the child has a different name than `extra_arguments` blocks in the parent,
+  then both the parent and child's `extra_arguments` will be effective.
+* The `source` field in the child will override `source` field in the parent
+
+Other settings in the child `.tfvars` file's `terragrunt` block (e.g. `remote_state`) override the respective
 settings in the parent.
 
 The `terraform.tfvars` files above use two Terragrunt built-in functions:

--- a/config/config.go
+++ b/config/config.go
@@ -276,7 +276,16 @@ func mergeConfigWithIncludedConfig(config *TerragruntConfig, includedConfig *Ter
 	return includedConfig, nil
 }
 
-// Merge the extra arguments prioritizing those defined in the childExtraArgs
+// Merge the extra arguments.
+//
+// If a child's extra_arguments has the same name a parent's extra_arguments,
+// then the child's extra_arguments will be selected (and the parent's ignored)
+// If a child's extra_arguments has a different name from all of the parent's extra_arguments,
+// then the child's extra_arguments will be added to the end  of the parents.
+// Therefore, terragrunt will put the child extra_arguments after the parent's
+// extra_arguments on the terraform cli.
+// Therefore, if .tfvar files from both the parent and child contain a variable
+// with the same name, the value from the child will win.
 func mergeExtraArgs(terragruntOptions *options.TerragruntOptions, childExtraArgs []TerraformExtraArguments, parentExtraArgs *[]TerraformExtraArguments) {
 	result := *parentExtraArgs
 addExtra:


### PR DESCRIPTION
For #147, merge child `extra_arguments` with parent `extra_arguments`

Copied and isolated @jocgir's base implementation from https://github.com/coveo/terragrunt

Added documentation and unit tests.