### PR TITLE
Don't copy hidden files and folders into temp folder

### DIFF
--- a/test/fixture-download/local-with-hidden-folder/.hidden-folder/README.md
+++ b/test/fixture-download/local-with-hidden-folder/.hidden-folder/README.md
@@ -1,0 +1,7 @@
+# Hidden folder
+
+This is a "hidden folder" (one that starts with a dot) that we use to check that Terragrunt does not copy hidden 
+folders--such as .git or .terraform--to the temporary folder when downloading remote Terraform configurations.
+ 
+This file has intentionally been made read-only so that if it is copied to the temp folder, the second time you run 
+Terragrunt, it will exit with an error as it tries to overwrite this read-only file.

--- a/test/fixture-download/local-with-hidden-folder/terraform.tfvars
+++ b/test/fixture-download/local-with-hidden-folder/terraform.tfvars
@@ -1,0 +1,7 @@
+name = "World"
+
+terragrunt = {
+  terraform {
+    source = "../hello-world"
+  }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -41,6 +41,7 @@ const (
 	TEST_FIXTURE_LOCAL_RELATIVE_ARGS_DOWNLOAD_PATH      = "fixture-download/local-with-relative-extra-args"
 	TEST_FIXTURE_LOCAL_WITH_BACKEND                     = "fixture-download/local-with-backend"
 	TEST_FIXTURE_REMOTE_WITH_BACKEND                    = "fixture-download/remote-with-backend"
+	TEST_FIXTURE_LOCAL_WITH_HIDDEN_FOLDER               = "fixture-download/local-with-hidden-folder"
 	TEST_FIXTURE_OLD_CONFIG_INCLUDE_PATH                = "fixture-old-terragrunt-config/include"
 	TEST_FIXTURE_OLD_CONFIG_INCLUDE_CHILD_UPDATED_PATH  = "fixture-old-terragrunt-config/include-child-updated"
 	TEST_FIXTURE_OLD_CONFIG_INCLUDE_PARENT_UPDATED_PATH = "fixture-old-terragrunt-config/include-parent-updated"
@@ -246,6 +247,17 @@ func TestLocalDownload(t *testing.T) {
 
 	// Run a second time to make sure the temporary folder can be reused without errors
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_DOWNLOAD_PATH))
+}
+
+func TestLocalDownloadWithHiddenFolder(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_LOCAL_WITH_HIDDEN_FOLDER)
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_WITH_HIDDEN_FOLDER))
+
+	// Run a second time to make sure the temporary folder can be reused without errors
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_WITH_HIDDEN_FOLDER))
 }
 
 func TestLocalDownloadWithOldConfig(t *testing.T) {

--- a/util/file.go
+++ b/util/file.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 // Return true if the given file exists
@@ -115,7 +116,8 @@ func ReadFileAsString(path string) (string, error) {
 	return string(bytes), nil
 }
 
-// Copy the files and folders within the source folder into the destination folder
+// Copy the files and folders within the source folder into the destination folder. Note that hidden files and folders
+// (those starting with a dot) will be skipped.
 func CopyFolderContents(source string, destination string) error {
 	files, err := ioutil.ReadDir(source)
 	if err != nil {
@@ -126,7 +128,9 @@ func CopyFolderContents(source string, destination string) error {
 		src := JoinPath(source, file.Name())
 		dest := JoinPath(destination, file.Name())
 
-		if file.IsDir() {
+		if PathContainsHiddenFileOrFolder(src) {
+			continue
+		} else if file.IsDir() {
 			if err := os.MkdirAll(dest, file.Mode()); err != nil {
 				return errors.WithStackTrace(err)
 			}
@@ -142,6 +146,16 @@ func CopyFolderContents(source string, destination string) error {
 	}
 
 	return nil
+}
+
+func PathContainsHiddenFileOrFolder(path string) bool {
+	pathParts := strings.Split(path, string(filepath.Separator))
+	for _, pathPart := range pathParts {
+		if strings.HasPrefix(pathPart, ".") && pathPart != "." && pathPart != ".." {
+			return true
+		}
+	}
+	return false
 }
 
 // Copy a file from source to destination

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -59,3 +59,30 @@ func TestCanonicalPath(t *testing.T) {
 		assert.Equal(t, testCase.expected, actual, "For path %s and basePath %s", testCase.path, testCase.basePath)
 	}
 }
+
+func TestPathContainsHiddenFileOrFolder(t *testing.T) {
+	testCases := []struct {
+		path     string
+		expected bool
+	}{
+		{"", false},
+		{".", false},
+		{".foo", true},
+		{".foo/", true},
+		{"foo/bar", false},
+		{"/foo/bar", false},
+		{".foo/bar", true},
+		{"foo/.bar", true},
+		{"/foo/.bar", true},
+		{"/foo/./bar", false},
+		{"/foo/../bar", false},
+		{"/foo/.././bar", false},
+		{"/foo/.././.bar", true},
+		{"/foo/.././.bar/", true},
+	}
+
+	for _, testCase := range testCases {
+		actual := PathContainsHiddenFileOrFolder(testCase.path)
+		assert.Equal(t, testCase.expected, actual, "For path %s", testCase.path)
+	}
+}


### PR DESCRIPTION
When Terragrunt downloads Terraform configurations from a `source` URL into a temp folder, it also copies the files in the current working directory (e.g. `terraform.tfvars`) into that temp folder. Unfortunately, as part of the copy process, Terragrunt would also copy hidden files and folders, such as `.git` or `.terraform`, which would lead to confusing errors. This PR updates Terragrunt to ensure it no longer copies hidden files & folders.