### PR TITLE
Fix working dir

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -216,13 +216,10 @@ func runTerragruntWithConfig(terragruntOptions *options.TerragruntOptions, terra
 	}
 
 	if firstArg(terragruntOptions.TerraformCliArgs) == CMD_INIT {
-
 		if err := prepareInitCommand(terragruntOptions, terragruntConfig, allowSourceDownload); err != nil {
 			return err
 		}
-
 	} else {
-
 		if err := prepareNonInitCommand(terragruntOptions, terragruntConfig); err != nil {
 			return err
 		}
@@ -322,6 +319,8 @@ func runTerraformInit(terragruntOptions *options.TerragruntOptions, terragruntCo
 	// Only add the arguments to download source if terraformSource was specified
 	downloadSource := terraformSource != nil
 	if downloadSource {
+		initOptions.WorkingDir = terraformSource.WorkingDir
+
 		v0_10_0, err := version.NewVersion("v0.10.0")
 		if err != nil {
 			return err

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 	version "github.com/hashicorp/go-version"
 	"github.com/urfave/cli"
+	"os"
 )
 
 const OPT_TERRAGRUNT_CONFIG = "terragrunt-config"
@@ -320,6 +321,11 @@ func runTerraformInit(terragruntOptions *options.TerragruntOptions, terragruntCo
 	downloadSource := terraformSource != nil
 	if downloadSource {
 		initOptions.WorkingDir = terraformSource.WorkingDir
+		if !util.FileExists(terraformSource.WorkingDir) {
+			if err := os.MkdirAll(terraformSource.WorkingDir, 0777); err != nil {
+				return errors.WithStackTrace(err)
+			}
+		}
 
 		v0_10_0, err := version.NewVersion("v0.10.0")
 		if err != nil {


### PR DESCRIPTION
After the upgrade to support terraform 0.10.0, when Terragrunt ran `init` to download remote configurations, it was running `init` with the wrong working dir.