### PR TITLE
fixing typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ terragrunt = {
 
       optional_var_files = [
         "${get_parent_tfvars_dir()}/${get_env("TF_VAR_env", "dev")}.tfvars",
-        "${get_parent_tfvars_dir()}/${get_env("TF_VAR_region", "us-east-1")}.tfvars"
+        "${get_parent_tfvars_dir()}/${get_env("TF_VAR_region", "us-east-1")}.tfvars",
         "${get_tfvars_dir()}/${get_env("TF_VAR_env", "dev")}.tfvars",
         "${get_tfvars_dir()}/${get_env("TF_VAR_region", "us-east-1")}.tfvars"
       ]


### PR DESCRIPTION
In the docs on using optional_var_files there's a missing comma that would cause a message like

`[terragrunt] 2017/09/04 12:41:24 At 16:9: error parsing list, expected comma or list end, got: STRING`