### PR TITLE
Make sure Terragrunt redownloads code if no .tf files in tmp folder

### DIFF
--- a/cli/download_source_test.go
+++ b/cli/download_source_test.go
@@ -66,6 +66,15 @@ func TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersi
 	canonicalUrl := "http://www.some-url.com?ref=v0.0.1"
 	downloadDir := "../test/fixture-download-source/download-dir-version-file"
 
+	testAlreadyHaveLatestCode(t, canonicalUrl, downloadDir, false)
+}
+
+func TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersionFileAndTfCode(t *testing.T) {
+	t.Parallel()
+
+	canonicalUrl := "http://www.some-url.com?ref=v0.0.1"
+	downloadDir := "../test/fixture-download-source/download-dir-version-file-tf-code"
+
 	testAlreadyHaveLatestCode(t, canonicalUrl, downloadDir, true)
 }
 
@@ -188,7 +197,7 @@ func testAlreadyHaveLatestCode(t *testing.T, canonicalUrl string, downloadDir st
 		VersionFile:        util.JoinPath(downloadDir, "version-file.txt"),
 	}
 
-	actual, err := alreadyHaveLatestCode(terraformSource)
+	actual, err := alreadyHaveLatestCode(terraformSource, options.NewTerragruntOptionsForTest("./should-not-be-used"))
 	assert.Nil(t, err, "Unexpected error for terraform source %v: %v", terraformSource, err)
 	assert.Equal(t, expected, actual, "For terraform source %v", terraformSource)
 }

--- a/test/fixture-download-source/download-dir-version-file-no-query/main.tf
+++ b/test/fixture-download-source/download-dir-version-file-no-query/main.tf
@@ -1,0 +1,1 @@
+# This file is just a placeholder

--- a/test/fixture-download-source/download-dir-version-file-tf-code/main.tf
+++ b/test/fixture-download-source/download-dir-version-file-tf-code/main.tf
@@ -1,0 +1,1 @@
+# This file is just a placeholder

--- a/test/fixture-download-source/download-dir-version-file-tf-code/version-file.txt
+++ b/test/fixture-download-source/download-dir-version-file-tf-code/version-file.txt
@@ -1,0 +1,1 @@
+zqg_v-R2bnqTbCe-ZO3mHRTRKX0


### PR DESCRIPTION
This is a fix for #266. The typical cause is that OS X deletes the *contents* of a tmp folder, but not the tmp folder itself, so Terragrunt thought the download source was still there, even though the folder was empty. 