### PR TITLE
Fix how Terragrunt checks for remote state initialization

### DIFF
--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -38,7 +38,7 @@ func CreateDynamoDbClient(awsRegion, awsProfile string) (*dynamodb.DynamoDB, err
 
 // Create the lock table in DynamoDB if it doesn't already exist
 func CreateLockTableIfNecessary(tableName string, client *dynamodb.DynamoDB, terragruntOptions *options.TerragruntOptions) error {
-	tableExists, err := lockTableExistsAndIsActive(tableName, client)
+	tableExists, err := LockTableExistsAndIsActive(tableName, client)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func CreateLockTableIfNecessary(tableName string, client *dynamodb.DynamoDB, ter
 }
 
 // Return true if the lock table exists in DynamoDB and is in "active" state
-func lockTableExistsAndIsActive(tableName string, client *dynamodb.DynamoDB) (bool, error) {
+func LockTableExistsAndIsActive(tableName string, client *dynamodb.DynamoDB) (bool, error) {
 	output, err := client.DescribeTable(&dynamodb.DescribeTableInput{TableName: aws.String(tableName)})
 	if err != nil {
 		if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "ResourceNotFoundException" {
@@ -128,7 +128,7 @@ func waitForTableToBeActive(tableName string, client *dynamodb.DynamoDB, maxRetr
 // the same time, which continually triggered AWS's "subscriber limit exceeded" API error.
 func waitForTableToBeActiveWithRandomSleep(tableName string, client *dynamodb.DynamoDB, maxRetries int, sleepBetweenRetriesMin time.Duration, sleepBetweenRetriesMax time.Duration, terragruntOptions *options.TerragruntOptions) error {
 	for i := 0; i < maxRetries; i++ {
-		tableReady, err := lockTableExistsAndIsActive(tableName, client)
+		tableReady, err := LockTableExistsAndIsActive(tableName, client)
 		if err != nil {
 			return err
 		}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -26,7 +26,7 @@ type RemoteStateConfigS3 struct {
 const MAX_RETRIES_WAITING_FOR_S3_BUCKET = 12
 const SLEEP_BETWEEN_RETRIES_WAITING_FOR_S3_BUCKET = 5 * time.Second
 
-type S3Initializer struct {}
+type S3Initializer struct{}
 
 // Returns true if the S3 bucket or DynamoDB table does not exist
 func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interface{}, terragruntOptions *options.TerragruntOptions) (bool, error) {

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -26,9 +26,45 @@ type RemoteStateConfigS3 struct {
 const MAX_RETRIES_WAITING_FOR_S3_BUCKET = 12
 const SLEEP_BETWEEN_RETRIES_WAITING_FOR_S3_BUCKET = 5 * time.Second
 
+type S3Initializer struct {}
+
+// Returns true if the S3 bucket or DynamoDB table does not exist
+func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interface{}, terragruntOptions *options.TerragruntOptions) (bool, error) {
+	s3Config, err := parseS3Config(config)
+	if err != nil {
+		return false, err
+	}
+
+	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile)
+	if err != nil {
+		return false, err
+	}
+
+	if !DoesS3BucketExist(s3Client, s3Config) {
+		return true, nil
+	}
+
+	if s3Config.LockTable != "" {
+		dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile)
+		if err != nil {
+			return false, err
+		}
+
+		tableExists, err := dynamodb.LockTableExistsAndIsActive(s3Config.LockTable, dynamodbClient)
+		if err != nil {
+			return false, err
+		}
+		if !tableExists {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // Initialize the remote state S3 bucket specified in the given config. This function will validate the config
 // parameters, create the S3 bucket if it doesn't already exist, and check that versioning is enabled.
-func InitializeRemoteStateS3(config map[string]interface{}, terragruntOptions *options.TerragruntOptions) error {
+func (s3Initializer S3Initializer) Initialize(config map[string]interface{}, terragruntOptions *options.TerragruntOptions) error {
 	s3Config, err := parseS3Config(config)
 	if err != nil {
 		return err


### PR DESCRIPTION
Originally, Terragrunt would only initialize remote state if remote
state wasn’t initialized at all or if the config has changed. Now it
will also query each “initializer” to see if it needs initialization.
The only initializer we have right now is the one for S3, and it will
now return true if either the configured S3 bucket or DynamoDB table
don’t exist. I believe this will fix #229.