### PR TITLE
remote: Check whether input is a TTY before prompting

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 00b02dc4909284a30b3510930e41851bf67a35e1bd72dc45d5ebff80ef506f10
-updated: 2017-04-23T16:27:54.825537907+01:00
+hash: a89e95ac15288027c4efb727d15971a273be3021d179dd30f842f129c254f31f
+updated: 2017-10-13T13:24:38.288952273-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 00fb2125993965df739fa3398b03bef3eb2e198f
@@ -83,4 +83,13 @@ imports:
   - assert
 - name: github.com/urfave/cli
   version: 8ba6f23b6e36d03666a14bd9421f5e3efcb59aca
+- name: golang.org/x/crypto
+  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
+  subpackages:
+  - ssh/terminal
+- name: golang.org/x/sys
+  version: 9a2e24c3733eddc63871eda99f253e2db29bd3b9
+  subpackages:
+  - unix
+  - windows
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,9 @@ owners:
 - name: Gruntwork
   homepage: http://www.gruntwork.io
 import:
+- package: golang.org/x/crypto
+  subpackages:
+  - ssh/terminal
 - package: github.com/urfave/cli
 - package: github.com/hashicorp/hcl
 - package: github.com/hashicorp/go-getter

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -2,6 +2,8 @@ package remote
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/gruntwork-io/terragrunt/aws_helper"
@@ -10,7 +12,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/mitchellh/mapstructure"
-	"time"
 )
 
 // A representation of the configuration options available for S3 remote state
@@ -139,6 +140,9 @@ func validateS3Config(config *RemoteStateConfigS3, terragruntOptions *options.Te
 // confirms, create the bucket and enable versioning for it.
 func createS3BucketIfNecessary(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
 	if !DoesS3BucketExist(s3Client, config) {
+		if !shell.CanAcceptPrompt() {
+			return fmt.Errorf("remote: S3 bucket does not exist, or you don't have permissions to access it: %q", config.Bucket)
+		}
 		prompt := fmt.Sprintf("Remote state S3 bucket %s does not exist or you don't have permissions to access it. Would you like Terragrunt to create it?", config.Bucket)
 		shouldCreateBucket, err := shell.PromptUserForYesNo(prompt, terragruntOptions)
 		if err != nil {

--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -3,11 +3,19 @@ package shell
 import (
 	"bufio"
 	"fmt"
-	"github.com/gruntwork-io/terragrunt/errors"
-	"github.com/gruntwork-io/terragrunt/options"
 	"os"
 	"strings"
+
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/options"
+	"golang.org/x/crypto/ssh/terminal"
 )
+
+// CanAcceptPrompt tells whether the program can receive input on the standard
+// input.
+func CanAcceptPrompt() bool {
+	return terminal.IsTerminal(int(os.Stdin.Fd()))
+}
 
 // Prompt the user for text in the CLI. Returns the text entered by the user.
 func PromptUserForInput(prompt string, terragruntOptions *options.TerragruntOptions) (string, error) {


### PR DESCRIPTION
Add a new CanAcceptPrompt API for determining whether the user can
type in things to send to the running process. If the user cannot do
that, exit with an error immediately, rather than hanging forever.

I haven't checked whether this code is used in other parts of the
program, but if so we should probably update those as well.

This work was sponsored by [Otto](https://meetotto.com).

Fixes #317.