### PR TITLE
Add a fallback param to find_in_parent_folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,6 +1092,17 @@ terragrunt = {
 }
 ```
 
+You can also pass an optional second `fallback` parameter which causes the function to return the fallback value 
+(instead of exiting with an error) if the file in the `name` parameter cannot be found:
+
+```hcl
+terragrunt = {
+  include {
+    path = "${find_in_parent_folders("some-other-file-name.tfvars", "fallback.tfvars")}"
+  }
+}
+```
+
 
 #### path_relative_to_include
 


### PR DESCRIPTION
This is a follow-up to #320. A use case we’re likely to see frequently with `find_in_parent_folders(xxx)` is to use it in combination with `extra_arguments`. The catch is that you’d want to specify the `extra_arguments` block once and have it apply to all modules, even if not all the modules have an `xxx` file in a parent folder, but as it is now, `find_in_parent_folders` exits with an error if it can’t find the file. With this PR, you can specify a second param that is a fallback value to return if the file cannot be found: `find_in_parent_folders("foo.tfvars", "some-fallback.tfvars")`. 