### PR TITLE
Add support for role_arn

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -2,25 +2,31 @@ package aws_helper
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/gruntwork-io/terragrunt/errors"
 )
 
-// Returns an AWS session object for the given region, ensuring that the credentials are available
-func CreateAwsSession(awsRegion, awsProfile string) (*session.Session, error) {
-	session, err := session.NewSessionWithOptions(session.Options{
+// Returns an AWS session object for the given region (required), profile name (optional), and IAM role to assume
+// (optional), ensuring that the credentials are available
+func CreateAwsSession(awsRegion, awsProfile string, iamRoleArn string) (*session.Session, error) {
+	sess, err := session.NewSessionWithOptions(session.Options{
 		Config:            aws.Config{Region: aws.String(awsRegion)},
 		Profile:           awsProfile,
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {
-		return nil, errors.WithStackTraceAndPrefix(err, "Error intializing session")
+		return nil, errors.WithStackTraceAndPrefix(err, "Error initializing session")
 	}
 
-	_, err = session.Config.Credentials.Get()
+	if iamRoleArn != "" {
+		sess.Config.Credentials = stscreds.NewCredentials(sess, iamRoleArn)
+	}
+
+	_, err = sess.Config.Credentials.Get()
 	if err != nil {
 		return nil, errors.WithStackTraceAndPrefix(err, "Error finding AWS credentials (did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables?)")
 	}
 
-	return session, nil
+	return sess, nil
 }

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -345,12 +345,12 @@ func pathRelativeFromInclude(include *IncludeConfig, terragruntOptions *options.
 
 // Return the AWS account id associated to the current set of credentials
 func getAWSAccountID() (string, error) {
-	session, err := session.NewSession()
+	sess, err := session.NewSession()
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
 
-	identity, err := sts.New(session).GetCallerIdentity(nil)
+	identity, err := sts.New(sess).GetCallerIdentity(nil)
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -27,8 +27,8 @@ const DEFAULT_READ_CAPACITY_UNITS = 1
 const DEFAULT_WRITE_CAPACITY_UNITS = 1
 
 // Create an authenticated client for DynamoDB
-func CreateDynamoDbClient(awsRegion, awsProfile string) (*dynamodb.DynamoDB, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile)
+func CreateDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string) (*dynamodb.DynamoDB, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn)
 	if err != nil {
 		return nil, err
 	}

--- a/dynamodb/dynamo_lock_test_utils.go
+++ b/dynamodb/dynamo_lock_test_utils.go
@@ -39,7 +39,7 @@ func uniqueId() string {
 
 // Create a DynamoDB client we can use at test time. If there are any errors creating the client, fail the test.
 func createDynamoDbClientForTest(t *testing.T) *dynamodb.DynamoDB {
-	client, err := CreateDynamoDbClient(DEFAULT_TEST_REGION, "")
+	client, err := CreateDynamoDbClient(DEFAULT_TEST_REGION, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -20,6 +20,7 @@ type RemoteStateConfigS3 struct {
 	Key           string `mapstructure:"key"`
 	Region        string `mapstructure:"region"`
 	Profile       string `mapstructure:"profile"`
+	RoleArn       string `mapstructure:"role_arn"`
 	LockTable     string `mapstructure:"lock_table"`
 	DynamoDBTable string `mapstructure:"dynamodb_table"`
 }
@@ -45,7 +46,7 @@ func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interfa
 		return false, err
 	}
 
-	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile)
+	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile, s3Config.RoleArn)
 	if err != nil {
 		return false, err
 	}
@@ -55,7 +56,7 @@ func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interfa
 	}
 
 	if s3Config.GetLockTableName() != "" {
-		dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile)
+		dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile, s3Config.RoleArn)
 		if err != nil {
 			return false, err
 		}
@@ -84,7 +85,7 @@ func (s3Initializer S3Initializer) Initialize(config map[string]interface{}, ter
 		return err
 	}
 
-	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile)
+	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile, s3Config.RoleArn)
 	if err != nil {
 		return err
 	}
@@ -233,7 +234,7 @@ func createLockTableIfNecessary(s3Config *RemoteStateConfigS3, terragruntOptions
 		return nil
 	}
 
-	dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile)
+	dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile, s3Config.RoleArn)
 	if err != nil {
 		return err
 	}
@@ -242,8 +243,8 @@ func createLockTableIfNecessary(s3Config *RemoteStateConfigS3, terragruntOptions
 }
 
 // Create an authenticated client for DynamoDB
-func CreateS3Client(awsRegion, awsProfile string) (*s3.S3, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile)
+func CreateS3Client(awsRegion, awsProfile string, iamRoleArn string) (*s3.S3, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -605,7 +605,7 @@ func uniqueId() string {
 
 // Check that the S3 Bucket of the given name and region exists. Terragrunt should create this bucket during the test.
 func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {
-	s3Client, err := remote.CreateS3Client(awsRegion, "")
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "")
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -616,7 +616,7 @@ func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {
 
 // Delete the specified S3 bucket to clean up after a test
 func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
-	s3Client, err := remote.CreateS3Client(awsRegion, "")
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "")
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -652,8 +652,8 @@ func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
 }
 
 // Create an authenticated client for DynamoDB
-func createDynamoDbClient(awsRegion, awsProfile string) (*dynamodb.DynamoDB, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile)
+func createDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string) (*dynamodb.DynamoDB, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn)
 	if err != nil {
 		return nil, err
 	}
@@ -662,7 +662,7 @@ func createDynamoDbClient(awsRegion, awsProfile string) (*dynamodb.DynamoDB, err
 }
 
 func createDynamoDbClientForTest(t *testing.T, awsRegion string) *dynamodb.DynamoDB {
-	client, err := createDynamoDbClient(awsRegion, "")
+	client, err := createDynamoDbClient(awsRegion, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #290. If you specify the `role_arn` parameter in your S3 backend config, Terragrunt will now automatically assume that IAM role before configuring remote state, creating the S3 bucket, creating the DynamoDB table, etc. This is very useful for multi-account setups where you may need to assume an IAM role in another account.