### PR TITLE
Add ability to assume an IAM role

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Terragrunt is a thin wrapper for [Terraform](https://www.terraform.io/) that pro
    1. [Keep your remote state configuration DRY](#keep-your-remote-state-configuration-dry)
    1. [Keep your CLI flags DRY](#keep-your-cli-flags-dry)
    1. [Execute Terraform commands on multiple modules at once](#execute-terraform-commands-on-multiple-modules-at-once)
+   1. [Work with multiple AWS accounts](#work-with-multiple-aws-accounts)
 1. [Terragrunt details](#terragrunt-details)
    1. [AWS credentials](#aws-credentials)
    1. [AWS IAM policies](#aws-iam-policies)
@@ -94,6 +95,7 @@ Terragrunt supports the following use cases:
 1. [Keep your remote state configuration DRY](#keep-your-remote-state-configuration-dry)
 1. [Keep your CLI flags DRY](#keep-your-cli-flags-dry)
 1. [Execute Terraform commands on multiple modules at once](#execute-terraform-commands-on-multiple-modules-at-once)
+1. [Work with multiple AWS accounts](#work-with-multiple-aws-accounts)
 
 
 ### Keep your Terraform code DRY
@@ -988,6 +990,71 @@ no-op for the modules that already deployed successfully, and should only affect
 time around.
 
 
+
+### Work with multiple AWS accounts
+
+#### Motivation
+
+The most secure way to manage infrastructure in AWS is to use [multiple AWS 
+accounts](https://aws.amazon.com/answers/account-management/aws-multi-account-security-strategy/). You define all your 
+IAM users in one account (e.g., the "security" account) and deploy all of your infrastructure into a number of other
+accounts (e.g., the "dev", "stage", and "prod" accounts). To access those accounts, you login to the security account
+and [assume an IAM role](http://docs.aws.amazon.com/cli/latest/userguide/cli-roles.html) in the other accounts.
+
+There are a few ways to assume IAM roles when using AWS CLI tools, such as Terraform:  
+
+1. One option is to create a named [profile](http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html),
+   each with a different [role_arn](http://docs.aws.amazon.com/cli/latest/userguide/cli-roles.html) parameter. You then
+   tell Terraform which profile to use via the `AWS_PROFILE` environment variable. The downside to using profiles is 
+   that you have to store your AWS credentials in plaintext on your hard drive.  
+
+1. Another option is to use environment variables and the [AWS CLI](https://aws.amazon.com/cli/). You first set the
+   credentials for the security account (the one where your IAM users are defined) as the environment variables
+   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and run `aws sts assume-role --role-arn <ROLE>`. This gives you 
+   back a blob of JSON that contains new `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` values you can set as 
+   environment variables to allow Terraform to use that role. The advantage of this approach is that you can store your
+   AWS credentials in a secret store and never write them to disk in plaintext. The disadvantage is that assuming an
+   IAM role requires several tedious steps. Worse yet, the credentials you get back from the `assume-role` command are
+   only good for up to 1 hour, so you have to repeat this process often.
+
+1. A final option is to modify your AWS provider with the [assume_role 
+   configuration](https://www.terraform.io/docs/providers/aws/#assume-role) and your S3 backend with the [role_arn
+   parameter](https://www.terraform.io/docs/backends/types/s3.html#role_arn). You can then set the credentials for the 
+   security account (the one where your IAM users are defined) as the environment variables `AWS_ACCESS_KEY_ID` and 
+   `AWS_SECRET_ACCESS_KEY` and when you run `terraform apply` or `terragrunt apply`, Terraform/Terragrunt will assume
+   the IAM role you specify automatically. The advantage of this approach is that you can store your
+   AWS credentials in a secret store and never write them to disk in plaintext, and you get fresh credentials on every
+   run of `apply`, without the complexity of calling `assume-role`. The disadvantage is that you have to modify all
+   your Terraform / Terragrunt code to set the `role_arn` param and your Terraform backend configuration will change
+   (and prompt you to manually confirm the update!) every time you change the IAM role you're using.
+
+To avoid these frustrating trade-offs, you can configure Terragrunt to assume an IAM role for you, as described next.
+
+
+#### Configuring Terragrunt to assume an IAM role
+
+To tell Terragrunt to assume an IAM role, just set the `--terragrunt-iam-role` command line argument:
+
+```bash
+terragrunt --terragrunt-iam-role "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME" apply
+```
+
+Alternatively, you can set the `TERRAGRUNT_IAM_ROLE` environment variable:
+
+```bash
+export TERRAGRUNT_IAM_ROLE="arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+terragrunt apply
+```
+
+Terragrunt will call the `sts assume-role` API on your behalf and expose the credentials it gets back as environment 
+variables when running Terraform. The advantage of this approach is that you can store your AWS credentials in a secret 
+store and never write them to disk in plaintext, you get fresh credentials on every run of Terragrunt, without the 
+complexity of calling `assume-role` yourself, and you don't have to modify your Terraform code or backend configuration
+at all.
+ 
+
+
+
 ## Terragrunt details
 
 This section contains detailed documentation for the following aspects of Terragrunt:
@@ -1535,6 +1602,10 @@ start with the prefix `--terragrunt-`. The currently available options are:
   into it.
 
 * `--terragrunt-ignore-dependency-errors`: `*-all` commands continue processing components even if a dependency fails
+
+* `--terragrunt-iam-role`: Assume the specified IAM role ARN before running Terraform or AWS commands. May also be 
+  specified via the `TERRAGRUNT_IAM_ROLE` environment variable. This is a convenient way to use Terragrunt and 
+  Terraform with multiple AWS accounts.
 
 
 ### Configuration

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -1,13 +1,13 @@
 package aws_helper
 
 import (
+	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
-	"fmt"
 	"time"
 )
 
@@ -52,7 +52,7 @@ func AssumeIamRole(iamRoleArn string) (*sts.Credentials, error) {
 	stsClient := sts.New(sess)
 
 	input := sts.AssumeRoleInput{
-		RoleArn: aws.String(iamRoleArn),
+		RoleArn:         aws.String(iamRoleArn),
 		RoleSessionName: aws.String(fmt.Sprintf("terragrunt-%d", time.Now().UTC().UnixNano())),
 	}
 

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -4,12 +4,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/options"
 )
 
 // Returns an AWS session object for the given region (required), profile name (optional), and IAM role to assume
 // (optional), ensuring that the credentials are available
-func CreateAwsSession(awsRegion, awsProfile string, iamRoleArn string) (*session.Session, error) {
+func CreateAwsSession(awsRegion, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Config:            aws.Config{Region: aws.String(awsRegion)},
 		Profile:           awsProfile,
@@ -21,6 +23,8 @@ func CreateAwsSession(awsRegion, awsProfile string, iamRoleArn string) (*session
 
 	if iamRoleArn != "" {
 		sess.Config.Credentials = stscreds.NewCredentials(sess, iamRoleArn)
+	} else if terragruntOptions.IamRole != "" {
+		sess.Config.Credentials = stscreds.NewCredentials(sess, terragruntOptions.IamRole)
 	}
 
 	_, err = sess.Config.Credentials.Get()
@@ -29,4 +33,26 @@ func CreateAwsSession(awsRegion, awsProfile string, iamRoleArn string) (*session
 	}
 
 	return sess, nil
+}
+
+// Make API calls to AWS to assume the IAM role specified and return the temporary AWS credentials to use that role
+func AssumeIamRole(iamRoleArn string) (*sts.Credentials, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	_, err = sess.Config.Credentials.Get()
+	if err != nil {
+		return nil, errors.WithStackTraceAndPrefix(err, "Error finding AWS credentials (did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables?)")
+	}
+
+	stsClient := sts.New(sess)
+
+	output, err := stsClient.AssumeRole(&sts.AssumeRoleInput{RoleArn: aws.String(iamRoleArn)})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	return output.Credentials, nil
 }

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
+	"fmt"
+	"time"
 )
 
 // Returns an AWS session object for the given region (required), profile name (optional), and IAM role to assume
@@ -49,7 +51,12 @@ func AssumeIamRole(iamRoleArn string) (*sts.Credentials, error) {
 
 	stsClient := sts.New(sess)
 
-	output, err := stsClient.AssumeRole(&sts.AssumeRoleInput{RoleArn: aws.String(iamRoleArn)})
+	input := sts.AssumeRoleInput{
+		RoleArn: aws.String(iamRoleArn),
+		RoleSessionName: aws.String(fmt.Sprintf("terragrunt-%d", time.Now().UTC().UnixNano())),
+	}
+
+	output, err := stsClient.AssumeRole(&input)
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}

--- a/cli/args.go
+++ b/cli/args.go
@@ -70,6 +70,11 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 
 	ignoreDependencyErrors := parseBooleanArg(args, OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ERRORS, false)
 
+	iamRole, err := parseStringArg(args, OPT_TERRAGRUNT_IAM_ROLE, os.Getenv("TERRAGRUNT_IAM_ROLE"))
+	if err != nil {
+		return nil, err
+	}
+
 	opts := options.NewTerragruntOptions(filepath.ToSlash(terragruntConfigPath))
 
 	opts.TerraformPath = filepath.ToSlash(terraformPath)
@@ -85,6 +90,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 	opts.Writer = writer
 	opts.ErrWriter = errWriter
 	opts.Env = parseEnvironmentVariables(os.Environ())
+	opts.IamRole = iamRole
 
 	return opts, nil
 }

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -84,6 +84,12 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		},
 
 		{
+			[]string{"--terragrunt-iam-role", "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"},
+			mockOptionsWithIamRole(util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"),
+			nil,
+		},
+
+		{
 			[]string{"--terragrunt-config", fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), "--terragrunt-non-interactive"},
 			mockOptions(fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), workingDir, []string{}, true, "", false),
 			nil,
@@ -137,6 +143,7 @@ func assertOptionsEqual(t *testing.T, expected options.TerragruntOptions, actual
 	assert.Equal(t, expected.WorkingDir, actual.WorkingDir, msgAndArgs...)
 	assert.Equal(t, expected.Source, actual.Source, msgAndArgs...)
 	assert.Equal(t, expected.IgnoreDependencyErrors, actual.IgnoreDependencyErrors, msgAndArgs...)
+	assert.Equal(t, expected.IamRole, actual.IamRole, msgAndArgs...)
 }
 
 func mockOptions(terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool) *options.TerragruntOptions {
@@ -148,6 +155,12 @@ func mockOptions(terragruntConfigPath string, workingDir string, terraformCliArg
 	opts.Source = terragruntSource
 	opts.IgnoreDependencyErrors = ignoreDependencyErrors
 
+	return opts
+}
+
+func mockOptionsWithIamRole(terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool, iamRole string) *options.TerragruntOptions {
+	opts := mockOptions(terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors)
+	opts.IamRole = iamRole
 	return opts
 }
 

--- a/cli/download_source_test.go
+++ b/cli/download_source_test.go
@@ -168,6 +168,7 @@ func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, d
 
 	terragruntOptions := options.NewTerragruntOptionsForTest("./should-not-be-used")
 	terragruntOptions.SourceUpdate = sourceUpdate
+	terragruntOptions.Env = parseEnvironmentVariables(os.Environ())
 
 	terragruntConfig := &config.TerragruntConfig{
 		Terraform: &config.TerraformConfig{

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -27,8 +27,8 @@ const DEFAULT_READ_CAPACITY_UNITS = 1
 const DEFAULT_WRITE_CAPACITY_UNITS = 1
 
 // Create an authenticated client for DynamoDB
-func CreateDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string) (*dynamodb.DynamoDB, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn)
+func CreateDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*dynamodb.DynamoDB, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn, terragruntOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/dynamodb/dynamo_lock_test_utils.go
+++ b/dynamodb/dynamo_lock_test_utils.go
@@ -39,7 +39,7 @@ func uniqueId() string {
 
 // Create a DynamoDB client we can use at test time. If there are any errors creating the client, fail the test.
 func createDynamoDbClientForTest(t *testing.T) *dynamodb.DynamoDB {
-	client, err := CreateDynamoDbClient(DEFAULT_TEST_REGION, "", "")
+	client, err := CreateDynamoDbClient(DEFAULT_TEST_REGION, "", "", mockOptions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,86 +1,86 @@
-hash: 00b02dc4909284a30b3510930e41851bf67a35e1bd72dc45d5ebff80ef506f10
-updated: 2017-04-23T16:27:54.825537907+01:00
+hash: 3ec23ed9524b96844ab5cef37f5be2323a36cf7aed4a06fdc9b102b39c899d1e
+updated: 2017-10-18T17:02:01.636409203+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 00fb2125993965df739fa3398b03bef3eb2e198f
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
   subpackages:
   - aws
-  - aws/awserr
-  - aws/awsutil
-  - aws/client
-  - aws/client/metadata
-  - aws/corehandlers
-  - aws/credentials
-  - aws/credentials/ec2rolecreds
-  - aws/credentials/endpointcreds
-  - aws/credentials/stscreds
   - aws/defaults
-  - aws/ec2metadata
-  - aws/endpoints
-  - aws/request
+  - aws/session
+  - aws/awserr
   - aws/service/dynamodb
   - aws/service/s3
-  - aws/session
-  - aws/signer/v4
-  - private/protocol
-  - private/protocol/json/jsonutil
-  - private/protocol/jsonrpc
-  - private/protocol/query
-  - private/protocol/query/queryutil
-  - private/protocol/rest
-  - private/protocol/restxml
-  - private/protocol/xml/xmlutil
-  - private/waiter
+  - service/sts
+  - aws/credentials/stscreds
   - service/dynamodb
   - service/s3
-  - service/sts
+  - aws/credentials
+  - aws/endpoints
+  - aws/client
+  - aws/corehandlers
+  - aws/request
+  - aws/awsutil
+  - aws/client/metadata
+  - aws/signer/v4
+  - private/protocol/query
+  - private/protocol
+  - private/protocol/jsonrpc
+  - private/waiter
+  - private/protocol/restxml
+  - aws/credentials/ec2rolecreds
+  - aws/ec2metadata
+  - aws/credentials/endpointcreds
+  - private/protocol/rest
+  - private/protocol/query/queryutil
+  - private/protocol/xml/xmlutil
+  - private/protocol/json/jsonutil
 - name: github.com/bgentry/go-netrc
-  version: 9fd32a8b3d3d3f9d43c341bfe098430e07609480
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
   subpackages:
   - netrc
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: ""
   subpackages:
   - spew
 - name: github.com/go-errors/errors
-  version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
 - name: github.com/go-ini/ini
-  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
 - name: github.com/hashicorp/go-getter
-  version: e48f67b534e614bf7fbd978fd0020f61a17b7527
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
   subpackages:
   - helper/url
 - name: github.com/hashicorp/go-version
-  version: 03c5bf6be031b6dd45afec16b1cf94fc8938bc77
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
 - name: github.com/hashicorp/hcl
-  version: 7fa7fff964d035e8a162cce3a164b3ad02ad651b
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/scanner
-  - hcl/strconv
   - hcl/token
   - json/parser
+  - hcl/scanner
+  - hcl/strconv
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
 - name: github.com/mattn/go-zglob
-  version: 95345c4e1c0ebc9d16a3284177f09360f4d20fab
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
   subpackages:
   - fastwalk
 - name: github.com/mitchellh/go-homedir
-  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
 - name: github.com/mitchellh/mapstructure
-  version: cc8532a8e9a55ea36402aa21efdf403a60d34096
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: ""
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
   subpackages:
   - assert
 - name: github.com/urfave/cli
-  version: 8ba6f23b6e36d03666a14bd9421f5e3efcb59aca
+  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 3ec23ed9524b96844ab5cef37f5be2323a36cf7aed4a06fdc9b102b39c899d1e
-updated: 2017-10-18T17:27:13.819640718+01:00
+updated: 2017-10-18T17:34:37.848019211+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: a28db88bdcd87b7023011ebc987b155d6d52411b
   subpackages:
   - aws
   - aws/defaults
@@ -18,12 +18,12 @@ imports:
   - aws/endpoints
   - aws/client/metadata
   - aws/request
+  - internal/shareddefaults
   - aws/ec2metadata
   - private/protocol/rest
   - private/protocol/query
   - private/protocol
   - private/protocol/jsonrpc
-  - private/waiter
   - private/protocol/restxml
   - service/kms
   - service/kms/kmsiface
@@ -31,27 +31,29 @@ imports:
   - private/protocol/query/queryutil
   - private/protocol/xml/xmlutil
 - name: github.com/bgentry/go-netrc
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: 9fd32a8b3d3d3f9d43c341bfe098430e07609480
   subpackages:
   - netrc
 - name: github.com/BurntSushi/toml
   version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
 - name: github.com/davecgh/go-spew
-  version: ""
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/go-errors/errors
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
 - name: github.com/go-ini/ini
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: 5b3e00af70a9484542169a976dcab8d03e601a17
+- name: github.com/hashicorp/go-cleanhttp
+  version: 3573b8b52aa7b37b9358d966a898feb387f62437
 - name: github.com/hashicorp/go-getter
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: 2f449c791e6af9e532bc1aca36d1d3865b8537f9
   subpackages:
   - helper/url
 - name: github.com/hashicorp/go-version
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: fc61389e27c71d120f87031ca8c88a3428f372dd
 - name: github.com/hashicorp/hcl
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -62,25 +64,34 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/mattn/go-zglob
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: 4ecb59231939b2e499b1f2fd8f075565977d2452
   subpackages:
   - fastwalk
 - name: github.com/mitchellh/go-homedir
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+- name: github.com/mitchellh/go-testing-interface
+  version: a61a99592b77c9ba629d254a693acffaeb4b7e28
 - name: github.com/mitchellh/mapstructure
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: 06020f85339e21b2478f756a78e295255ffa4d6a
 - name: github.com/pmezard/go-difflib
-  version: ""
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: 2aa2c176b9dab406a6970f6a55f513e8a8c8b18f
   subpackages:
   - assert
+- name: github.com/ulikunitz/xz
+  version: 0c6b41e72360850ca4f98dc341fd999726ea007f
+  subpackages:
+  - internal/xlog
+  - lzma
+  - internal/gflag
+  - internal/term
 - name: github.com/urfave/cli
-  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+  version: 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 - name: gopkg.in/urfave/cli.v1
   version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
 - name: gopkg.in/yaml.v2

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 3ec23ed9524b96844ab5cef37f5be2323a36cf7aed4a06fdc9b102b39c899d1e
-updated: 2017-10-18T17:02:01.636409203+01:00
+updated: 2017-10-18T17:27:13.819640718+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
   subpackages:
   - aws
   - aws/defaults
@@ -16,71 +16,73 @@ imports:
   - service/s3
   - aws/credentials
   - aws/endpoints
-  - aws/client
-  - aws/corehandlers
-  - aws/request
-  - aws/awsutil
   - aws/client/metadata
-  - aws/signer/v4
+  - aws/request
+  - aws/ec2metadata
+  - private/protocol/rest
   - private/protocol/query
   - private/protocol
   - private/protocol/jsonrpc
   - private/waiter
   - private/protocol/restxml
-  - aws/credentials/ec2rolecreds
-  - aws/ec2metadata
-  - aws/credentials/endpointcreds
-  - private/protocol/rest
+  - service/kms
+  - service/kms/kmsiface
+  - service/s3/s3iface
   - private/protocol/query/queryutil
   - private/protocol/xml/xmlutil
-  - private/protocol/json/jsonutil
 - name: github.com/bgentry/go-netrc
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
   subpackages:
   - netrc
+- name: github.com/BurntSushi/toml
+  version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
 - name: github.com/davecgh/go-spew
   version: ""
   subpackages:
   - spew
 - name: github.com/go-errors/errors
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
 - name: github.com/go-ini/ini
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
 - name: github.com/hashicorp/go-getter
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
   subpackages:
   - helper/url
 - name: github.com/hashicorp/go-version
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
 - name: github.com/hashicorp/hcl
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
   subpackages:
   - hcl/ast
   - hcl/parser
   - hcl/token
   - json/parser
+  - hcl/printer
   - hcl/scanner
-  - hcl/strconv
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
 - name: github.com/mattn/go-zglob
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
   subpackages:
   - fastwalk
 - name: github.com/mitchellh/go-homedir
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
 - name: github.com/mitchellh/mapstructure
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
 - name: github.com/pmezard/go-difflib
   version: ""
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
   subpackages:
   - assert
 - name: github.com/urfave/cli
-  version: 3b3391cf648ca0ddf7f4f2e08abcbf3d3f19adac
+  version: 507c74a8d37ffe25e5f3e395a7dda3a6844836b2
+- name: gopkg.in/urfave/cli.v1
+  version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
+- name: gopkg.in/yaml.v2
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,3 +19,4 @@ import:
   - aws/awserr
   - aws/service/dynamodb
   - aws/service/s3
+  - service/sts

--- a/options/options.go
+++ b/options/options.go
@@ -58,6 +58,9 @@ type TerragruntOptions struct {
 	// Download Terraform configurations specified in the Source parameter into this folder
 	DownloadDir string
 
+	// The ARN of an IAM Role to assume before running Terraform
+	IamRole string
+
 	// If set to true, continue running *-all commands even if a dependency has errors. This is mostly useful for 'output-all <some_variable>'. See https://github.com/gruntwork-io/terragrunt/issues/193
 	IgnoreDependencyErrors bool
 
@@ -136,6 +139,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		Source:                 terragruntOptions.Source,
 		SourceUpdate:           terragruntOptions.SourceUpdate,
 		DownloadDir:            terragruntOptions.DownloadDir,
+		IamRole:                terragruntOptions.IamRole,
 		IgnoreDependencyErrors: terragruntOptions.IgnoreDependencyErrors,
 		Writer:                 terragruntOptions.Writer,
 		ErrWriter:              terragruntOptions.ErrWriter,

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -46,7 +46,7 @@ func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interfa
 		return false, err
 	}
 
-	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile, s3Config.RoleArn)
+	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 	if err != nil {
 		return false, err
 	}
@@ -56,7 +56,7 @@ func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interfa
 	}
 
 	if s3Config.GetLockTableName() != "" {
-		dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile, s3Config.RoleArn)
+		dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 		if err != nil {
 			return false, err
 		}
@@ -85,7 +85,7 @@ func (s3Initializer S3Initializer) Initialize(config map[string]interface{}, ter
 		return err
 	}
 
-	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile, s3Config.RoleArn)
+	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 	if err != nil {
 		return err
 	}
@@ -234,7 +234,7 @@ func createLockTableIfNecessary(s3Config *RemoteStateConfigS3, terragruntOptions
 		return nil
 	}
 
-	dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile, s3Config.RoleArn)
+	dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 	if err != nil {
 		return err
 	}
@@ -243,8 +243,8 @@ func createLockTableIfNecessary(s3Config *RemoteStateConfigS3, terragruntOptions
 }
 
 // Create an authenticated client for DynamoDB
-func CreateS3Client(awsRegion, awsProfile string, iamRoleArn string) (*s3.S3, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn)
+func CreateS3Client(awsRegion, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*s3.S3, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn, terragruntOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -11,6 +11,7 @@ import (
 
 	"bytes"
 
+	"fmt"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 )
@@ -36,6 +37,7 @@ func RunShellCommand(terragruntOptions *options.TerragruntOptions, command strin
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = terragruntOptions.Writer
 	cmd.Stderr = terragruntOptions.ErrWriter
+	cmd.Env = toEnvVarsList(terragruntOptions.Env)
 
 	// Terragrunt can run some commands (such as terraform remote config) before running the actual terraform
 	// command requested by the user. The output of these other commands should not end up on stdout as this
@@ -54,6 +56,14 @@ func RunShellCommand(terragruntOptions *options.TerragruntOptions, command strin
 	cmdChannel <- err
 
 	return errors.WithStackTrace(err)
+}
+
+func toEnvVarsList(envVarsAsMap map[string]string) []string {
+	envVarsAsList := []string{}
+	for key, value := range envVarsAsMap {
+		envVarsAsList = append(envVarsAsList, fmt.Sprintf("%s=%s", key, value))
+	}
+	return envVarsAsList
 }
 
 // Run the specified shell command with the specified arguments. Capture the command's stdout and return it as a

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/config"
 	terragruntDynamoDb "github.com/gruntwork-io/terragrunt/dynamodb"
 	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/remote"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/stretchr/testify/assert"
@@ -55,6 +56,8 @@ const (
 	TERRAFORM_STATE                                     = "terraform.tfstate"
 	TERRAFORM_STATE_BACKUP                              = "terraform.tfstate.backup"
 )
+
+var mockOptions = options.NewTerragruntOptionsForTest("integration_test")
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -605,7 +608,7 @@ func uniqueId() string {
 
 // Check that the S3 Bucket of the given name and region exists. Terragrunt should create this bucket during the test.
 func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {
-	s3Client, err := remote.CreateS3Client(awsRegion, "", "")
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "", mockOptions)
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -616,7 +619,7 @@ func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {
 
 // Delete the specified S3 bucket to clean up after a test
 func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
-	s3Client, err := remote.CreateS3Client(awsRegion, "", "")
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "", mockOptions)
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -653,7 +656,7 @@ func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
 
 // Create an authenticated client for DynamoDB
 func createDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string) (*dynamodb.DynamoDB, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn)
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn, mockOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In #322, I added the ability for Terragrunt to assume an IAM role specified in the S3 backend configuration. In this PR, I’m adding first-class support to Terragrunt so it can assume an IAM for use not only with the backend configuration, but with Terraform itself. 

See the motivation section in the README for why this addition is useful.