### PR TITLE
Don't silently swallow errors during xxx-all methods

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -393,6 +393,7 @@ type ErrorParsingTerragruntConfig struct {
 	ConfigPath string
 	Underlying error
 }
+
 func (err ErrorParsingTerragruntConfig) Error() string {
 	return fmt.Sprintf("Error parsing Terragrunt config at %s: %v", err.ConfigPath, err.Underlying)
 }

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
+	"sort"
 )
 
 // Represents a stack of Terraform modules (i.e. folders with Terraform templates) that you can "spin up" or
@@ -23,6 +24,7 @@ func (stack *Stack) String() string {
 	for _, module := range stack.Modules {
 		modules = append(modules, fmt.Sprintf("  => %s", module.String()))
 	}
+	sort.Strings(modules)
 	return fmt.Sprintf("Stack at %s:\n%s", stack.Path, strings.Join(modules, "\n"))
 }
 


### PR DESCRIPTION
This PR fixes a bug where the `xxx-all` methods (e.g., `apply-all`, `plan-all`) would silently swallow errors found while parsing `terraform.tfvars` files. For example, if you had a syntax error in one of your `terraform.tfvars` files, the `apply-all` method would simply skip that entire module, rather than telling you there is a problem.

Also, to make it easier to spot this sort of thing, the `xxx-all` methods will now print out the modules that were found in alphabetical order.