### PR TITLE
Fix two bugs: recursive dependencies, concurrent S3 errors

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -174,7 +174,7 @@ func resolveExternalDependenciesForModules(moduleMap map[string]*TerraformModule
 	}
 
 	if len(allExternalDependencies) > 0 {
-		recursiveDependencies, err := resolveExternalDependenciesForModules(allExternalDependencies, moduleMap, recursionLevel + 1, terragruntOptions)
+		recursiveDependencies, err := resolveExternalDependenciesForModules(allExternalDependencies, moduleMap, recursionLevel+1, terragruntOptions)
 		if err != nil {
 			return allExternalDependencies, err
 		}
@@ -314,8 +314,8 @@ func (err InvalidSourceUrl) Error() string {
 }
 
 type InfiniteRecursion struct {
-	RecursionLevel	int
-	Modules			map[string]*TerraformModule
+	RecursionLevel int
+	Modules        map[string]*TerraformModule
 }
 
 func (err InfiniteRecursion) Error() string {

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/gruntwork-io/terragrunt/aws_helper"
 	"github.com/gruntwork-io/terragrunt/dynamodb"
@@ -11,7 +12,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/mitchellh/mapstructure"
 	"time"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 // A representation of the configuration options available for S3 remote state

--- a/test/fixture-stack/mgmt/kms-master-key/main.tf
+++ b/test/fixture-stack/mgmt/kms-master-key/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  backend "s3" {}
+}
+
+# Create an arbitrary local resource
+data "template_file" "text" {
+  template = "[I am a kms-master-key template.]"
+}
+
+output "text" {
+  value = "${data.template_file.text.rendered}"
+}

--- a/test/fixture-stack/mgmt/kms-master-key/terraform.tfvars
+++ b/test/fixture-stack/mgmt/kms-master-key/terraform.tfvars
@@ -2,8 +2,4 @@ terragrunt = {
   include {
     path = "${find_in_parent_folders()}"
   }
-
-  dependencies {
-    paths = ["../vpc", "../kms-master-key"]
-  }
 }


### PR DESCRIPTION
This PR fixes two bugs:

1. Terragrunt was not properly loading recursive dependencies of external modules. E.g., if module A depended on module B, where B was outside of the current folder structure, and B depended on C, Terragrunt would throw an error upon finding C. I added a new failing test case to repro this issue and this PR fixes the failure.

1. While fixing the above, I triggered another issue where `xxx-all` methods would try to create the same S3 bucket in parallel, leading to “operation in progress” style errors that Terragrunt wasn’t handling correctly.