### PR TITLE
Remove subdirectories before copying files to them

### DIFF
--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/go-getter"
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
 	"github.com/mattn/go-zglob"
-	"path/filepath"
 )
 
 // This struct represents information about Terraform source code that needs to be downloaded

--- a/util/file.go
+++ b/util/file.go
@@ -1,13 +1,13 @@
 package util
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
-	"fmt"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/mattn/go-zglob"
 )
@@ -146,6 +146,11 @@ func CopyFolderContents(source string, destination string) error {
 		if PathContainsHiddenFileOrFolder(src) {
 			continue
 		} else if file.IsDir() {
+			// Permission and stale cache problems otherwise; see
+			// https://github.com/gruntwork-io/terragrunt/issues/337
+			if err := os.RemoveAll(dest); err != nil {
+				return errors.WithStackTrace(err)
+			}
 			if err := os.MkdirAll(dest, file.Mode()); err != nil {
 				return errors.WithStackTrace(err)
 			}


### PR DESCRIPTION
If a file in a subdirectory has permissions of 444, we will attempt to
open it for writing in util.CopyFile before overwriting it. This
fails because the file is read-only.

Instead remove all files in subdirectories. This shouldn't be much
slower than the current procedure, because we are still overwriting
every file every time, we're just starting from an empty file tree
instead of a full file tree. This also avoids the problem where run
1 produces file A, and run 2 does not have file A, but it exists in
the cache.

Fixes #337.