### PR TITLE
Fix the situation where get_parent_tfvars() is called from within the…

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -76,6 +76,9 @@ type TerragruntOptions struct {
 	// packages can use the command without a direct reference back to the cli package (which would create a
 	// circular dependency).
 	RunTerragrunt func(*TerragruntOptions) error
+
+	// Keep the last found parent folder to be able to return it when get_parent_tfvars() is called from within the child
+	LastIncludedParentFolder string
 }
 
 // Create a new TerragruntOptions object with reasonable defaults for real usage

--- a/test/fixture-parent-folders/parent-vs-child/children/child-1/output.tf
+++ b/test/fixture-parent-folders/parent-vs-child/children/child-1/output.tf
@@ -1,0 +1,26 @@
+variable "foo_parent" {}
+variable "foo_child" {}
+variable "foo_from_include" {}
+variable "foo_to_include" {}
+variable "bar_parent" {}
+variable "bar_child" {}
+variable "bar_from_include" {}
+variable "bar_to_include" {}
+
+output "parent" {
+  value = {
+    parent       = "${var.foo_parent}"
+    child        = "${var.foo_child}"
+    from_include = "${var.foo_from_include}"
+    to_include   = "${var.foo_to_include}"
+  }
+}
+
+output "child" {
+  value = {
+    parent       = "${var.bar_parent}"
+    child        = "${var.bar_child}"
+    from_include = "${var.bar_from_include}"
+    to_include   = "${var.bar_to_include}"
+  }
+}

--- a/test/fixture-parent-folders/parent-vs-child/children/child-1/terraform.tfvars
+++ b/test/fixture-parent-folders/parent-vs-child/children/child-1/terraform.tfvars
@@ -1,0 +1,12 @@
+terragrunt = {
+  include {
+    path = "${find_in_parent_folders()}"
+  }
+
+  terraform {
+    extra_arguments "extra-from-child" {
+      commands  = ["plan", "apply"]
+      arguments = ["-var", "bar_parent=${get_parent_tfvars_dir()}", "-var", "bar_child=${get_tfvars_dir()}", "-var", "bar_from_include=${path_relative_from_include()}", "-var", "bar_to_include=${path_relative_to_include()}"]
+    }
+  }
+}

--- a/test/fixture-parent-folders/parent-vs-child/terraform.tfvars
+++ b/test/fixture-parent-folders/parent-vs-child/terraform.tfvars
@@ -1,0 +1,8 @@
+terragrunt = {
+  terraform {
+    extra_arguments "extra-from-parent" {
+      commands  = ["plan", "apply"]
+      arguments = ["-var", "foo_parent=${get_parent_tfvars_dir()}", "-var", "foo_child=${get_tfvars_dir()}", "-var", "foo_from_include=${path_relative_from_include()}", "-var", "foo_to_include=${path_relative_to_include()}"]
+    }
+  }
+}


### PR DESCRIPTION
… child configuration file. Also apply to path_relative_from_include().

Add test case.

Solve issue #332 