### PR TITLE
Fix "go vet" problems

### DIFF
--- a/configstack/test_helpers.go
+++ b/configstack/test_helpers.go
@@ -1,13 +1,14 @@
 package configstack
 
 import (
+	"sort"
+	"testing"
+
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/remote"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/stretchr/testify/assert"
-	"sort"
-	"testing"
 )
 
 type TerraformModuleByPath []*TerraformModule
@@ -59,7 +60,7 @@ func assertModulesEqual(t *testing.T, expected *TerraformModule, actual *Terrafo
 // contains some fields (e.g. TerragruntOptions) that cannot be compared directly
 func assertRunningModuleMapsEqual(t *testing.T, expectedModules map[string]*runningModule, actualModules map[string]*runningModule, doDeepCheck bool, messageAndArgs ...interface{}) {
 	if !assert.Equal(t, len(expectedModules), len(actualModules), messageAndArgs...) {
-		t.Logf("%s != %s", expectedModules, actualModules)
+		t.Logf("%v != %v", expectedModules, actualModules)
 		return
 	}
 
@@ -75,7 +76,7 @@ func assertRunningModuleMapsEqual(t *testing.T, expectedModules map[string]*runn
 // contains some fields (e.g. TerragruntOptions) that cannot be compared directly
 func assertRunningModuleListsEqual(t *testing.T, expectedModules []*runningModule, actualModules []*runningModule, doDeepCheck bool, messageAndArgs ...interface{}) {
 	if !assert.Equal(t, len(expectedModules), len(actualModules), messageAndArgs...) {
-		t.Logf("%s != %s", expectedModules, actualModules)
+		t.Logf("%v != %v", expectedModules, actualModules)
 		return
 	}
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1,16 +1,15 @@
 package test
 
 import (
-	"fmt"
-	"strings"
-	"testing"
-
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
+	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -152,7 +151,7 @@ func TestTerragruntReportsTerraformErrorsWithPlanAll(t *testing.T) {
 	)
 	// Call runTerragruntCommand directly because this command contains failures (which causes runTerragruntRedirectOutput to abort) but we don't care.
 	if err := runTerragruntCommand(t, cmd, &stdout, &stderr); err == nil {
-		t.Fatalf("Failed to properly fail command.  The terraform should be bad", cmd)
+		t.Fatalf("Failed to properly fail command: %v. The terraform should be bad", cmd)
 	}
 	output := stdout.String()
 	errOutput := stderr.String()


### PR DESCRIPTION
Go tip now automatically runs "go vet" when you run the tests, so they
failed on my machine (I run go tip). Fix vet errors, so they don't
interfere with another change I would like to land.