### PR TITLE
Add TERRAGRUNT_SOURCE_UPDATE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1655,7 +1655,7 @@ start with the prefix `--terragrunt-`. The currently available options are:
   module to the `--terragrunt-source` parameter you passed in.
 
 * `--terragrunt-source-update`: Delete the contents of the temporary folder before downloading Terraform source code
-  into it.
+  into it. Can also be enabled by setting the `TERRAGRUNT_SOURCE_UPDATE` environment variable to `true`.
 
 * `--terragrunt-ignore-dependency-errors`: `*-all` commands continue processing components even if a dependency fails
 

--- a/cli/args.go
+++ b/cli/args.go
@@ -66,7 +66,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 		return nil, err
 	}
 
-	sourceUpdate := parseBooleanArg(args, OPT_TERRAGRUNT_SOURCE_UPDATE, false)
+	sourceUpdate := parseBooleanArg(args, OPT_TERRAGRUNT_SOURCE_UPDATE, os.Getenv("TERRAGRUNT_SOURCE_UPDATE") == "true" || os.Getenv("TERRAGRUNT_SOURCE_UPDATE") == "1")
 
 	ignoreDependencyErrors := parseBooleanArg(args, OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ERRORS, false)
 


### PR DESCRIPTION
You can now use the environment variable `TERRAGRUNT_SOURCE_UPDATE` instead of the flag `--terragrunt-source-update`. This is useful when some other script is calling Terragrunt on your behalf and you can’t override the flags it uses. 