### PR TITLE
Extend remote_state backend check to include *.tf.json files

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -307,12 +307,24 @@ func checkTerraformCodeDefinesBackend(terragruntOptions *options.TerragruntOptio
 	if err != nil {
 		return err
 	}
-
-	if !definesBackend {
-		return errors.WithStackTrace(BackendNotDefined{Opts: terragruntOptions, BackendType: backendType})
+	if definesBackend {
+		return nil
 	}
 
-	return nil
+	terraformJSONBackendRegexp, err := regexp.Compile(fmt.Sprintf(`(?m)"backend":[[:space:]]*{[[:space:]]*"%s"`, backendType))
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	definesJSONBackend, err := util.Grep(terraformJSONBackendRegexp, fmt.Sprintf("%s/**/*.tf.json", terragruntOptions.WorkingDir))
+	if err != nil {
+		return err
+	}
+	if definesJSONBackend {
+		return nil
+	}
+
+	return errors.WithStackTrace(BackendNotDefined{Opts: terragruntOptions, BackendType: backendType})
 }
 
 // Prepare for running any command other than 'terraform init' by


### PR DESCRIPTION
Original test in #302 only examined files matching `**/*.tf`.

This PR adds support for `*.tf.json` files.

Neither test parses the HCL or json, and instead looks for a hardcoded regex.
Given that the test is a best-effort at helping folks, I don't think we should start parsing anything.

https://github.com/gruntwork-io/terragrunt/pull/302#issuecomment-356720889

`make fmt` clean.

Test output clean:
[go-test-output.txt](https://github.com/gruntwork-io/terragrunt/files/1620412/go-test-output.txt)
