### PR TITLE
Fix of issue #402: load given state file when specified.

### DIFF
--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -65,7 +65,7 @@ func (remoteState *RemoteState) Initialize(terragruntOptions *options.Terragrunt
 // 2. Remote state has been configured, but with a different configuration
 // 3. The remote state initializer for this backend type, if there is one, says initialization is necessary
 func (remoteState *RemoteState) NeedsInit(terragruntOptions *options.TerragruntOptions) (bool, error) {
-	state, err := ParseTerraformStateFileFromLocation(terragruntOptions.WorkingDir)
+	state, err := ParseTerraformStateFileFromLocation(remoteState.Backend, remoteState.Config, terragruntOptions.WorkingDir)
 	if err != nil {
 		return false, err
 	}

--- a/remote/terraform_state_file.go
+++ b/remote/terraform_state_file.go
@@ -44,16 +44,15 @@ func (state *TerraformState) IsRemote() bool {
 	return state.Backend != nil && state.Backend.Type != "local"
 }
 
-// Parse the Terraform .tfstate file from the location specified by workingDir. If no location is specified,
-// search the current directory. If the file doesn't exist at any of the default locations, return nil.
+// Parses the Terraform .tfstate file. If a local backend is used then search the given path, or
+// return nil if the file is missing. If the backend is not local then parse the Terraform .tfstate
+// file from the location specified by workingDir. If no location is specified, search the current
+// directory. If the file doesn't exist at any of the default locations, return nil.
 func ParseTerraformStateFileFromLocation(backend string, config map[string]interface{}, workingDir string) (*TerraformState, error) {
 	stateFile, ok := config["path"].(string)
-	if backend == "local" && ok {
-		if util.FileExists(stateFile) {
-			return ParseTerraformStateFile(stateFile)
-		}
-	}
-	if util.FileExists(util.JoinPath(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE)) {
+	if backend == "local" && ok && util.FileExists(stateFile) {
+		return ParseTerraformStateFile(stateFile)
+	} else if util.FileExists(util.JoinPath(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE)) {
 		return ParseTerraformStateFile(util.JoinPath(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE))
 	} else if util.FileExists(util.JoinPath(workingDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE)) {
 		return ParseTerraformStateFile(util.JoinPath(workingDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE))

--- a/remote/terraform_state_file.go
+++ b/remote/terraform_state_file.go
@@ -46,7 +46,13 @@ func (state *TerraformState) IsRemote() bool {
 
 // Parse the Terraform .tfstate file from the location specified by workingDir. If no location is specified,
 // search the current directory. If the file doesn't exist at any of the default locations, return nil.
-func ParseTerraformStateFileFromLocation(workingDir string) (*TerraformState, error) {
+func ParseTerraformStateFileFromLocation(backend string, config map[string]interface{}, workingDir string) (*TerraformState, error) {
+	stateFile, ok := config["path"].(string)
+	if backend == "local" && ok {
+		if util.FileExists(stateFile) {
+			return ParseTerraformStateFile(stateFile)
+		}
+	}
 	if util.FileExists(util.JoinPath(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE)) {
 		return ParseTerraformStateFile(util.JoinPath(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE))
 	} else if util.FileExists(util.JoinPath(workingDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE)) {


### PR DESCRIPTION
This is a bugfix for "Getting json.SyntaxError unexpected end of JSON input" Issue #402

When using a local backend and a path is given, terragrunt should load that file instead of looking in the default working directory.

As a Go beginner, feel free to suggest any correction or semantic mistake.