### PR TITLE
Appending -auto-approve to apply-all command to silence prompts

### DIFF
--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -70,7 +70,7 @@ func (stack *Stack) summarizePlanAllErrors(terragruntOptions *options.Terragrunt
 // Apply all the modules in the given stack, making sure to apply the dependencies of each module in the stack in the
 // proper order.
 func (stack *Stack) Apply(terragruntOptions *options.TerragruntOptions) error {
-	stack.setTerraformCommand([]string{"apply", "-input=false"})
+	stack.setTerraformCommand([]string{"apply", "-input=false", "-auto-approve"})
 	return RunModules(stack.Modules)
 }
 


### PR DESCRIPTION
Built locally and used on my multi-region setup. This is relation to `apply-all does not set auto-approve parameter #386`