### PR TITLE
Added support for endpoint and credentials variables in S3 remote state 

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -21,7 +21,7 @@ func CreateAwsSession(awsRegion, awsEndpoint string, awsAccessKey string, awsSec
 		if service == "s3" {
 			return endpoints.ResolvedEndpoint{
 				URL:           awsEndpoint,
-				SigningRegion: "custom-signing-region",
+				SigningRegion: awsRegion,
 			}, nil
 		}
 

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -15,12 +15,22 @@ import (
 // Returns an AWS session object for the given region (required), profile name (optional), and IAM role to assume
 // (optional), ensuring that the credentials are available
 func CreateAwsSession(awsRegion, awsEndpoint string, awsAccessKey string, awsSecretKey string, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {
-	sess, err := session.NewSessionWithOptions(session.Options{
-		Config: aws.Config{
+	var awsConfig aws.Config
+	if awsAccessKey != "" && awsSecretKey != "" {
+		awsConfig = aws.Config{
 			Region:      aws.String(awsRegion),
 			Endpoint:    aws.String(awsEndpoint),
 			Credentials: credentials.NewStaticCredentials(awsAccessKey, awsSecretKey, ""),
-		},
+		}
+	} else {
+		awsConfig = aws.Config{
+			Region:   aws.String(awsRegion),
+			Endpoint: aws.String(awsEndpoint),
+		}
+	}
+
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config:            awsConfig,
 		Profile:           awsProfile,
 		SharedConfigState: session.SharedConfigEnable,
 	})

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -3,6 +3,7 @@ package aws_helper
 import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -13,9 +14,13 @@ import (
 
 // Returns an AWS session object for the given region (required), profile name (optional), and IAM role to assume
 // (optional), ensuring that the credentials are available
-func CreateAwsSession(awsRegion, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {
+func CreateAwsSession(awsRegion, awsEndpoint string, awsAccessKey string, awsSecretKey string, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {
 	sess, err := session.NewSessionWithOptions(session.Options{
-		Config:            aws.Config{Region: aws.String(awsRegion)},
+		Config: aws.Config{
+			Region:      aws.String(awsRegion),
+			Endpoint:    aws.String(awsEndpoint),
+			Credentials: credentials.NewStaticCredentials(awsAccessKey, awsSecretKey, ""),
+		},
 		Profile:           awsProfile,
 		SharedConfigState: session.SharedConfigEnable,
 	})

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -3,7 +3,6 @@ package aws_helper
 import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -15,7 +14,7 @@ import (
 
 // Returns an AWS session object for the given region (required), profile name (optional), and IAM role to assume
 // (optional), ensuring that the credentials are available
-func CreateAwsSession(awsRegion, awsEndpoint string, awsAccessKey string, awsSecretKey string, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {
+func CreateAwsSession(awsRegion, awsEndpoint string, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {
 	defaultResolver := endpoints.DefaultResolver()
 	s3CustResolverFn := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 		if service == "s3" {
@@ -28,18 +27,9 @@ func CreateAwsSession(awsRegion, awsEndpoint string, awsAccessKey string, awsSec
 		return defaultResolver.EndpointFor(service, region, optFns...)
 	}
 
-	var awsConfig aws.Config
-	if awsAccessKey != "" && awsSecretKey != "" {
-		awsConfig = aws.Config{
-			Region:           aws.String(awsRegion),
-			EndpointResolver: endpoints.ResolverFunc(s3CustResolverFn),
-			Credentials:      credentials.NewStaticCredentials(awsAccessKey, awsSecretKey, ""),
-		}
-	} else {
-		awsConfig = aws.Config{
-			Region:           aws.String(awsRegion),
-			EndpointResolver: endpoints.ResolverFunc(s3CustResolverFn),
-		}
+	var awsConfig = aws.Config{
+		Region:           aws.String(awsRegion),
+		EndpointResolver: endpoints.ResolverFunc(s3CustResolverFn),
 	}
 
 	sess, err := session.NewSessionWithOptions(session.Options{

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -27,8 +27,8 @@ const DEFAULT_READ_CAPACITY_UNITS = 1
 const DEFAULT_WRITE_CAPACITY_UNITS = 1
 
 // Create an authenticated client for DynamoDB
-func CreateDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*dynamodb.DynamoDB, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, "", "", "", awsProfile, iamRoleArn, terragruntOptions)
+func CreateDynamoDbClient(awsRegion, awsAccessKey, awsSecretKey, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*dynamodb.DynamoDB, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, "", awsAccessKey, awsSecretKey, awsProfile, iamRoleArn, terragruntOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -28,7 +28,7 @@ const DEFAULT_WRITE_CAPACITY_UNITS = 1
 
 // Create an authenticated client for DynamoDB
 func CreateDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*dynamodb.DynamoDB, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn, terragruntOptions)
+	session, err := aws_helper.CreateAwsSession(awsRegion, "", "", "", awsProfile, iamRoleArn, terragruntOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -27,8 +27,8 @@ const DEFAULT_READ_CAPACITY_UNITS = 1
 const DEFAULT_WRITE_CAPACITY_UNITS = 1
 
 // Create an authenticated client for DynamoDB
-func CreateDynamoDbClient(awsRegion, awsAccessKey, awsSecretKey, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*dynamodb.DynamoDB, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, "", awsAccessKey, awsSecretKey, awsProfile, iamRoleArn, terragruntOptions)
+func CreateDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*dynamodb.DynamoDB, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, "", awsProfile, iamRoleArn, terragruntOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/dynamodb/dynamo_lock_test_utils.go
+++ b/dynamodb/dynamo_lock_test_utils.go
@@ -42,7 +42,7 @@ func createDynamoDbClientForTest(t *testing.T) *dynamodb.DynamoDB {
 		t.Fatal(err)
 	}
 
-	client, err := CreateDynamoDbClient(DEFAULT_TEST_REGION, "", "", "", "", mockOptions)
+	client, err := CreateDynamoDbClient(DEFAULT_TEST_REGION, "", "", mockOptions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dynamodb/dynamo_lock_test_utils.go
+++ b/dynamodb/dynamo_lock_test_utils.go
@@ -42,7 +42,7 @@ func createDynamoDbClientForTest(t *testing.T) *dynamodb.DynamoDB {
 		t.Fatal(err)
 	}
 
-	client, err := CreateDynamoDbClient(DEFAULT_TEST_REGION, "", "", mockOptions)
+	client, err := CreateDynamoDbClient(DEFAULT_TEST_REGION, "", "", "", "", mockOptions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -60,7 +60,7 @@ func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interfa
 	}
 
 	if s3Config.GetLockTableName() != "" {
-		dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
+		dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.AccessKey, s3Config.SecretKey, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 		if err != nil {
 			return false, err
 		}
@@ -255,7 +255,7 @@ func createLockTableIfNecessary(s3Config *RemoteStateConfigS3, terragruntOptions
 		return nil
 	}
 
-	dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
+	dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.AccessKey, s3Config.SecretKey, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 	if err != nil {
 		return err
 	}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -21,8 +21,6 @@ type RemoteStateConfigS3 struct {
 	Key           string `mapstructure:"key"`
 	Region        string `mapstructure:"region"`
 	Endpoint      string `mapstructure:"endpoint"`
-	AccessKey     string `mapstructure:"access_key"`
-	SecretKey     string `mapstructure:"secret_key"`
 	Profile       string `mapstructure:"profile"`
 	RoleArn       string `mapstructure:"role_arn"`
 	LockTable     string `mapstructure:"lock_table"`
@@ -50,7 +48,7 @@ func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interfa
 		return false, err
 	}
 
-	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Endpoint, s3Config.AccessKey, s3Config.SecretKey, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
+	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Endpoint, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 	if err != nil {
 		return false, err
 	}
@@ -60,7 +58,7 @@ func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interfa
 	}
 
 	if s3Config.GetLockTableName() != "" {
-		dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.AccessKey, s3Config.SecretKey, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
+		dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 		if err != nil {
 			return false, err
 		}
@@ -89,7 +87,7 @@ func (s3Initializer S3Initializer) Initialize(config map[string]interface{}, ter
 		return err
 	}
 
-	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Endpoint, s3Config.AccessKey, s3Config.SecretKey, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
+	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Endpoint, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 	if err != nil {
 		return err
 	}
@@ -255,7 +253,7 @@ func createLockTableIfNecessary(s3Config *RemoteStateConfigS3, terragruntOptions
 		return nil
 	}
 
-	dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.AccessKey, s3Config.SecretKey, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
+	dynamodbClient, err := dynamodb.CreateDynamoDbClient(s3Config.Region, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 	if err != nil {
 		return err
 	}
@@ -264,8 +262,8 @@ func createLockTableIfNecessary(s3Config *RemoteStateConfigS3, terragruntOptions
 }
 
 // Create an authenticated client for DynamoDB
-func CreateS3Client(awsRegion, awsEndpoint string, awsAccessKey string, awsSecretKey string, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*s3.S3, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsEndpoint, awsAccessKey, awsSecretKey, awsProfile, iamRoleArn, terragruntOptions)
+func CreateS3Client(awsRegion, awsEndpoint string, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*s3.S3, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsEndpoint, awsProfile, iamRoleArn, terragruntOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -20,6 +20,9 @@ type RemoteStateConfigS3 struct {
 	Bucket        string `mapstructure:"bucket"`
 	Key           string `mapstructure:"key"`
 	Region        string `mapstructure:"region"`
+	Endpoint      string `mapstructure:"endpoint"`
+	AccessKey     string `mapstructure:"access_key"`
+	SecretKey     string `mapstructure:"secret_key"`
 	Profile       string `mapstructure:"profile"`
 	RoleArn       string `mapstructure:"role_arn"`
 	LockTable     string `mapstructure:"lock_table"`
@@ -47,7 +50,7 @@ func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interfa
 		return false, err
 	}
 
-	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
+	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Endpoint, s3Config.AccessKey, s3Config.SecretKey, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 	if err != nil {
 		return false, err
 	}
@@ -86,7 +89,7 @@ func (s3Initializer S3Initializer) Initialize(config map[string]interface{}, ter
 		return err
 	}
 
-	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
+	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Endpoint, s3Config.AccessKey, s3Config.SecretKey, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 	if err != nil {
 		return err
 	}
@@ -261,8 +264,8 @@ func createLockTableIfNecessary(s3Config *RemoteStateConfigS3, terragruntOptions
 }
 
 // Create an authenticated client for DynamoDB
-func CreateS3Client(awsRegion, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*s3.S3, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn, terragruntOptions)
+func CreateS3Client(awsRegion, awsEndpoint string, awsAccessKey string, awsSecretKey string, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*s3.S3, error) {
+	session, err := aws_helper.CreateAwsSession(awsRegion, awsEndpoint, awsAccessKey, awsSecretKey, awsProfile, iamRoleArn, terragruntOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -623,7 +623,7 @@ func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {
 		t.Fatalf("Error creating mockOptions: %v", err)
 	}
 
-	s3Client, err := remote.CreateS3Client(awsRegion, "", "", mockOptions)
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", "", "", mockOptions)
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -639,7 +639,7 @@ func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
 		t.Fatalf("Error creating mockOptions: %v", err)
 	}
 
-	s3Client, err := remote.CreateS3Client(awsRegion, "", "", mockOptions)
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", "", "", mockOptions)
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -681,7 +681,7 @@ func createDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string) (*dyn
 		return nil, err
 	}
 
-	session, err := aws_helper.CreateAwsSession(awsRegion, awsProfile, iamRoleArn, mockOptions)
+	session, err := aws_helper.CreateAwsSession(awsRegion, "", "", "", awsProfile, iamRoleArn, mockOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -623,7 +623,7 @@ func validateS3BucketExists(t *testing.T, awsRegion string, bucketName string) {
 		t.Fatalf("Error creating mockOptions: %v", err)
 	}
 
-	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", "", "", mockOptions)
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", mockOptions)
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -639,7 +639,7 @@ func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
 		t.Fatalf("Error creating mockOptions: %v", err)
 	}
 
-	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", "", "", mockOptions)
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", mockOptions)
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -681,7 +681,7 @@ func createDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string) (*dyn
 		return nil, err
 	}
 
-	session, err := aws_helper.CreateAwsSession(awsRegion, "", "", "", awsProfile, iamRoleArn, mockOptions)
+	session, err := aws_helper.CreateAwsSession(awsRegion, "", awsProfile, iamRoleArn, mockOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I added support for custom endpoint and credentials variable in the S3 remote state backend for Terragrunt which is used to create bucket and enable versioning if bucket does not exist.

This feature was also asked in issue [#112](https://github.com/gruntwork-io/terragrunt/issues/112).

It uses the following variable as specified in the [Terraform S3 backend documentation](https://www.terraform.io/docs/backends/types/s3.html):
* endpoint (only for S3)
* access_key
* secret_key

This update was successfully tested with integration tests.