### PR TITLE
Bug fix: If S3 endpoint is not specified use default resolver

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -17,7 +17,7 @@ import (
 func CreateAwsSession(awsRegion, awsEndpoint string, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {
 	defaultResolver := endpoints.DefaultResolver()
 	s3CustResolverFn := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
-		if service == "s3" {
+		if service == "s3" && awsEndpoint != "" {
 			return endpoints.ResolvedEndpoint{
 				URL:           awsEndpoint,
 				SigningRegion: awsRegion,

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,3774 @@
+?   	github.com/gruntwork-io/terragrunt/errors	[no test files]
+?   	github.com/gruntwork-io/terragrunt/options	[no test files]
+=== RUN   TestTerragruntWorksWithLocalTerraformVersion
+=== PAUSE TestTerragruntWorksWithLocalTerraformVersion
+=== RUN   TestTerragruntWorksWithIncludes
+=== PAUSE TestTerragruntWorksWithIncludes
+=== RUN   TestTerragruntWorksWithIncludesAndOldConfig
+=== PAUSE TestTerragruntWorksWithIncludesAndOldConfig
+=== RUN   TestTerragruntWorksWithIncludesChildUpdatedAndOldConfig
+=== PAUSE TestTerragruntWorksWithIncludesChildUpdatedAndOldConfig
+=== RUN   TestTerragruntWorksWithIncludesParentUpdatedAndOldConfig
+=== PAUSE TestTerragruntWorksWithIncludesParentUpdatedAndOldConfig
+=== RUN   TestTerragruntReportsTerraformErrorsWithPlanAll
+STDERR is [terragrunt] [/tmp/terragrunt-test656119823/fixture-failure] 2018/02/27 16:50:39 Running command: terraform --version
+[terragrunt] 2018/02/27 16:50:39 Stack at /tmp/terragrunt-test656119823/fixture-failure:
+  => Module /tmp/terragrunt-test656119823/fixture-failure (dependencies: [])
+  => Module /tmp/terragrunt-test656119823/fixture-failure/missingvars (dependencies: [])
+[terragrunt] [/tmp/terragrunt-test656119823/fixture-failure/missingvars] 2018/02/27 16:50:39 Module /tmp/terragrunt-test656119823/fixture-failure/missingvars must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test656119823/fixture-failure/missingvars] 2018/02/27 16:50:39 Running module /tmp/terragrunt-test656119823/fixture-failure/missingvars now
+[terragrunt] [/tmp/terragrunt-test656119823/fixture-failure/missingvars] 2018/02/27 16:50:39 Reading Terragrunt config file at /tmp/terragrunt-test656119823/fixture-failure/missingvars/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test656119823/fixture-failure] 2018/02/27 16:50:39 Module /tmp/terragrunt-test656119823/fixture-failure must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test656119823/fixture-failure] 2018/02/27 16:50:39 Running module /tmp/terragrunt-test656119823/fixture-failure now
+[terragrunt] [/tmp/terragrunt-test656119823/fixture-failure] 2018/02/27 16:50:39 Reading Terragrunt config file at /tmp/terragrunt-test656119823/fixture-failure/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test656119823/fixture-failure] 2018/02/27 16:50:39 Running command: terraform plan
+[terragrunt] [/tmp/terragrunt-test656119823/fixture-failure/missingvars] 2018/02/27 16:50:39 Module /tmp/terragrunt-test656119823/fixture-failure/missingvars has finished with an error: exit status 1
+[terragrunt] [/tmp/terragrunt-test656119823/fixture-failure] 2018/02/27 16:50:39 Module /tmp/terragrunt-test656119823/fixture-failure has finished successfully!
+[terragrunt] 2018/02/27 16:50:39 Error with plan: [terragrunt] [/tmp/terragrunt-test656119823/fixture-failure/missingvars] 2018/02/27 16:50:39 Running command: terraform init
+[0m[1mInitializing modules...[0m
+- module.sub
+  Getting source "..//submod"
+[31m
+[1m[31mError: [0m[0m[1mmodule "sub": missing required argument "missingvar1"[0m
+
+[0m[0m[0m
+[31m
+[1m[31mError: [0m[0m[1mmodule "sub": missing required argument "missingvar2"[0m
+
+[0m[0m[0m
+.
+ STDOUT is [0m[1mRefreshing Terraform state in-memory prior to plan...[0m
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+[0m
+
+------------------------------------------------------------------------
+
+[0m[1m[32mNo changes. Infrastructure is up-to-date.[0m[32m
+
+This means that Terraform did not detect any differences between your
+configuration and real physical resources that exist. As a result, no
+actions need to be performed.[0m
+--- PASS: TestTerragruntReportsTerraformErrorsWithPlanAll (0.06s)
+	integration_test.go:517: Copying fixture-failure to /tmp/terragrunt-test656119823
+=== RUN   TestTerragruntOutputAllCommand
+=== PAUSE TestTerragruntOutputAllCommand
+=== RUN   TestTerragruntValidateAllCommand
+=== PAUSE TestTerragruntValidateAllCommand
+=== RUN   TestTerragruntStdOut
+=== PAUSE TestTerragruntStdOut
+=== RUN   TestTerragruntOutputAllCommandSpecificVariableIgnoreDependencyErrors
+=== PAUSE TestTerragruntOutputAllCommandSpecificVariableIgnoreDependencyErrors
+=== RUN   TestTerragruntStackCommands
+=== PAUSE TestTerragruntStackCommands
+=== RUN   TestTerragruntStackCommandsWithOldConfig
+=== PAUSE TestTerragruntStackCommandsWithOldConfig
+=== RUN   TestLocalDownload
+=== PAUSE TestLocalDownload
+=== RUN   TestLocalDownloadWithHiddenFolder
+=== PAUSE TestLocalDownloadWithHiddenFolder
+=== RUN   TestLocalDownloadWithOldConfig
+=== PAUSE TestLocalDownloadWithOldConfig
+=== RUN   TestLocalDownloadWithRelativePath
+=== PAUSE TestLocalDownloadWithRelativePath
+=== RUN   TestRemoteDownload
+=== PAUSE TestRemoteDownload
+=== RUN   TestRemoteDownloadWithRelativePath
+=== PAUSE TestRemoteDownloadWithRelativePath
+=== RUN   TestRemoteDownloadOverride
+=== PAUSE TestRemoteDownloadOverride
+=== RUN   TestLocalWithBackend
+=== PAUSE TestLocalWithBackend
+=== RUN   TestLocalWithMissingBackend
+=== PAUSE TestLocalWithMissingBackend
+=== RUN   TestRemoteWithBackend
+=== PAUSE TestRemoteWithBackend
+=== RUN   TestExtraArguments
+[terragrunt] [fixture-extra-args] 2018/02/27 16:50:39 Running command: terraform --version
+[terragrunt] 2018/02/27 16:50:39 Reading Terragrunt config file at fixture-extra-args/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:39 Skipping var-file /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-extra-args/us-east-1.tfvars as it does not exist
+[terragrunt] 2018/02/27 16:50:39 Running command: terraform apply -var-file=terraform.tfvars -var-file=extra.tfvars -var-file=/root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-extra-args/dev.tfvars
+--- PASS: TestExtraArguments (0.05s)
+	integration_test.go:437: [0m[1m[32m
+		Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+		[0m[1m[32m
+		Outputs:
+		
+		test = Hello, World from dev![0m
+		
+=== RUN   TestExtraArgumentsWithEnv
+[terragrunt] [fixture-extra-args] 2018/02/27 16:50:39 Running command: terraform --version
+[terragrunt] 2018/02/27 16:50:39 Reading Terragrunt config file at fixture-extra-args/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:39 Skipping var-file /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-extra-args/prod.tfvars as it does not exist
+[terragrunt] 2018/02/27 16:50:39 Skipping var-file /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-extra-args/us-east-1.tfvars as it does not exist
+[terragrunt] 2018/02/27 16:50:39 Running command: terraform apply -var-file=terraform.tfvars -var-file=extra.tfvars
+--- PASS: TestExtraArgumentsWithEnv (0.05s)
+	integration_test.go:447: [0m[1m[32m
+		Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+		[0m[1m[32m
+		Outputs:
+		
+		test = Hello, World![0m
+		
+=== RUN   TestExtraArgumentsWithRegion
+[terragrunt] [fixture-extra-args] 2018/02/27 16:50:39 Running command: terraform --version
+[terragrunt] 2018/02/27 16:50:39 Reading Terragrunt config file at fixture-extra-args/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:39 Running command: terraform apply -var-file=terraform.tfvars -var-file=extra.tfvars -var-file=/root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-extra-args/dev.tfvars -var-file=/root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-extra-args/us-west-2.tfvars
+--- PASS: TestExtraArgumentsWithRegion (0.05s)
+	integration_test.go:457: [0m[1m[32m
+		Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+		[0m[1m[32m
+		Outputs:
+		
+		test = Hello, World from Oregon![0m
+		
+=== RUN   TestPriorityOrderOfArgument
+[terragrunt] [fixture-extra-args] 2018/02/27 16:50:39 Running command: terraform --version
+[terragrunt] 2018/02/27 16:50:39 Reading Terragrunt config file at fixture-extra-args/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:39 Skipping var-file /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-extra-args/us-east-1.tfvars as it does not exist
+[terragrunt] 2018/02/27 16:50:39 Running command: terraform apply -var-file=terraform.tfvars -var-file=extra.tfvars -var-file=/root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-extra-args/dev.tfvars -var extra_var=Injected-directly-by-argument
+--- PASS: TestPriorityOrderOfArgument (0.05s)
+	integration_test.go:466: [0m[1m[32m
+		Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+		[0m[1m[32m
+		Outputs:
+		
+		test = Injected-directly-by-argument[0m
+		
+=== RUN   TestLocalWithRelativeExtraArgsUnix
+=== PAUSE TestLocalWithRelativeExtraArgsUnix
+=== CONT  TestTerragruntWorksWithLocalTerraformVersion
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:39 Running command: terraform --version
+=== CONT  TestLocalWithRelativeExtraArgsUnix
+[terragrunt] [fixture-download/local-relative-extra-args-unix] 2018/02/27 16:50:39 Running command: terraform --version
+=== CONT  TestRemoteWithBackend
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:39 Running command: terraform --version
+=== CONT  TestLocalWithMissingBackend
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:39 Running command: terraform --version
+=== CONT  TestLocalWithBackend
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:39 Running command: terraform --version
+=== CONT  TestRemoteDownloadOverride
+[terragrunt] [fixture-download/override] 2018/02/27 16:50:39 Running command: terraform --version
+=== CONT  TestRemoteDownloadWithRelativePath
+[terragrunt] [fixture-download/remote-relative] 2018/02/27 16:50:39 Running command: terraform --version
+=== CONT  TestRemoteDownload
+[terragrunt] [fixture-download/remote] 2018/02/27 16:50:39 Running command: terraform --version
+=== CONT  TestLocalDownloadWithRelativePath
+[terragrunt] [fixture-download/local-relative] 2018/02/27 16:50:40 Running command: terraform --version
+=== CONT  TestLocalDownloadWithOldConfig
+[terragrunt] [fixture-old-terragrunt-config/download] 2018/02/27 16:50:40 Running command: terraform --version
+=== CONT  TestLocalDownloadWithHiddenFolder
+[terragrunt] [fixture-download/local-with-hidden-folder] 2018/02/27 16:50:40 Running command: terraform --version
+=== CONT  TestLocalDownload
+[terragrunt] [fixture-download/local] 2018/02/27 16:50:40 Running command: terraform --version
+=== CONT  TestTerragruntStackCommandsWithOldConfig
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage] 2018/02/27 16:50:40 Running command: terraform --version
+=== CONT  TestTerragruntStackCommands
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt] 2018/02/27 16:50:40 Running command: terraform --version
+=== CONT  TestTerragruntOutputAllCommandSpecificVariableIgnoreDependencyErrors
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1] 2018/02/27 16:50:40 Running command: terraform --version
+=== CONT  TestTerragruntStdOut
+=== CONT  TestTerragruntValidateAllCommand
+=== CONT  TestTerragruntOutputAllCommand
+=== CONT  TestTerragruntWorksWithIncludesParentUpdatedAndOldConfig
+=== CONT  TestTerragruntWorksWithIncludesChildUpdatedAndOldConfig
+=== CONT  TestTerragruntWorksWithIncludesAndOldConfig
+=== CONT  TestTerragruntWorksWithIncludes
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-test376171289/fixture-download/remote-with-backend/terraform.tfvars
+[terragrunt] [fixture-download/stdout-test] 2018/02/27 16:50:40 Running command: terraform --version
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1] 2018/02/27 16:50:40 Running command: terraform --version
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1] 2018/02/27 16:50:40 Running command: terraform --version
+[terragrunt] [/tmp/terragrunt-parent-child-test365574113/child] 2018/02/27 16:50:40 Running command: terraform --version
+[terragrunt] [/tmp/terragrunt-parent-child-test966849484/child] 2018/02/27 16:50:40 Running command: terraform --version
+[terragrunt] [/tmp/terragrunt-parent-child-test430611643/child] 2018/02/27 16:50:40 Running command: terraform --version
+[terragrunt] [/tmp/terragrunt-parent-child-test536743134/qa/my-app] 2018/02/27 16:50:40 Running command: terraform --version
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at fixture-download/local-relative-extra-args-unix/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:40 WARNING: no double-slash (//) found in source URL /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:40 Cleaning up existing *.tf files in /root/.terragrunt/273voYQqBY5Hzn3abZM2LaGq5gY/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:40 Downloading Terraform configurations from git::https://github.com/gruntwork-io/terragrunt.git?ref=v0.12.3 into /root/.terragrunt/UMVhHSb8cw2XQeUiQqlDmVSwiwE/p_piCTTWVab2Hmnj1OtnAruj8J4 using terraform init
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:40 WARNING: no double-slash (//) found in source URL /tmp/terragrunt-test635046820/fixture-download/hello-world. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:40 Downloading Terraform configurations from file:///tmp/terragrunt-test635046820/fixture-download/hello-world into /root/.terragrunt/gp7vmxAe_17Hwi_8dPJETPtD928/IbutZqb1WVwgG6pasXbWd7abixQ using terraform init
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at fixture-download/override/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:40 WARNING: no double-slash (//) found in source URL /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:40 Cleaning up existing *.tf files in /root/.terragrunt/q6CM5Ul52IVG9DJOHLls-ghte0Q/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:40 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world into /root/.terragrunt/q6CM5Ul52IVG9DJOHLls-ghte0Q/VIDIUyib3UjyaBai-LHALXXYy1c using terraform init
+[terragrunt] [fixture-download/override] 2018/02/27 16:50:40 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world /root/.terragrunt/q6CM5Ul52IVG9DJOHLls-ghte0Q/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-test117789730/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-test114910899/fixture-download/local-with-backend/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:40 WARNING: no double-slash (//) found in source URL /tmp/terragrunt-test114910899/fixture-download/hello-world-with-backend. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:40 Downloading Terraform configurations from file:///tmp/terragrunt-test114910899/fixture-download/hello-world-with-backend into /root/.terragrunt/2EptIbp9lVUT0jNEI5cByVzzmCk/6v8ujI6iBARtCGZfWp7s0Mel118 using terraform init
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at fixture-download/remote/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:40 Terraform files in /root/.terragrunt/eUl8mGBA-TRKjtDBqpevCkibmG4/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/hello-world are up to date. Will not download again.
+[terragrunt] 2018/02/27 16:50:40 Copying files from fixture-download/remote into /root/.terragrunt/eUl8mGBA-TRKjtDBqpevCkibmG4/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/hello-world
+[terragrunt] 2018/02/27 16:50:40 Setting working directory to /root/.terragrunt/eUl8mGBA-TRKjtDBqpevCkibmG4/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/hello-world
+[terragrunt] 2018/02/27 16:50:40 Running command: terraform apply
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at fixture-download/remote-relative/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:40 Terraform files in /root/.terragrunt/UXpJhfTAs87ayV8lCFjioxfVmdI/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/relative are up to date. Will not download again.
+[terragrunt] 2018/02/27 16:50:40 Copying files from fixture-download/remote-relative into /root/.terragrunt/UXpJhfTAs87ayV8lCFjioxfVmdI/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/relative
+[terragrunt] 2018/02/27 16:50:40 Setting working directory to /root/.terragrunt/UXpJhfTAs87ayV8lCFjioxfVmdI/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/relative
+[terragrunt] 2018/02/27 16:50:40 Running command: terraform apply
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at fixture-download/local-relative/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:40 Cleaning up existing *.tf files in /root/.terragrunt/gPxmyAL5cGw77jHOa5PUr68iWt4/adX-C2qwk_C6rDxkE-Zqe4eLGBs
+[terragrunt] 2018/02/27 16:50:40 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download into /root/.terragrunt/gPxmyAL5cGw77jHOa5PUr68iWt4/adX-C2qwk_C6rDxkE-Zqe4eLGBs using terraform init
+[terragrunt] [fixture-download/local-relative] 2018/02/27 16:50:40 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download /root/.terragrunt/gPxmyAL5cGw77jHOa5PUr68iWt4/adX-C2qwk_C6rDxkE-Zqe4eLGBs
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at fixture-old-terragrunt-config/download/.terragrunt
+[terragrunt] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format fixture-old-terragrunt-config/download/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] 2018/02/27 16:50:40 WARNING: no double-slash (//) found in source URL /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-old-terragrunt-config/hello-world. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:40 Cleaning up existing *.tf files in /root/.terragrunt/nquDuVyT-rbd5RlsXu77Jx6XQec/Jd4brG6pM3EesbexWwAOORj6REw
+[terragrunt] 2018/02/27 16:50:40 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-old-terragrunt-config/hello-world into /root/.terragrunt/nquDuVyT-rbd5RlsXu77Jx6XQec/Jd4brG6pM3EesbexWwAOORj6REw using terraform init
+[terragrunt] [fixture-old-terragrunt-config/download] 2018/02/27 16:50:40 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-old-terragrunt-config/hello-world /root/.terragrunt/nquDuVyT-rbd5RlsXu77Jx6XQec/Jd4brG6pM3EesbexWwAOORj6REw
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at fixture-download/local-with-hidden-folder/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:40 WARNING: no double-slash (//) found in source URL /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:40 Cleaning up existing *.tf files in /root/.terragrunt/GWi1REmMX6wLEU-ANLYVuHzV7j8/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:40 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world into /root/.terragrunt/GWi1REmMX6wLEU-ANLYVuHzV7j8/VIDIUyib3UjyaBai-LHALXXYy1c using terraform init
+[terragrunt] [fixture-download/local-with-hidden-folder] 2018/02/27 16:50:40 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world /root/.terragrunt/GWi1REmMX6wLEU-ANLYVuHzV7j8/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at fixture-download/local/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:40 WARNING: no double-slash (//) found in source URL /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:40 Cleaning up existing *.tf files in /root/.terragrunt/AQvrCsQntIEFLVnR2eLNihb4D2U/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:40 Stack at /tmp/terragrunt-test045069661/fixture-stack/mgmt:
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key (dependencies: [])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc (dependencies: [])
+[terragrunt] 2018/02/27 16:50:40 [terragrunt]  Are you sure you want to run 'terragrunt apply' in each folder of the stack described above? (y/n) 
+[terragrunt] 2018/02/27 16:50:40 
+[terragrunt] 2018/02/27 16:50:40 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:40 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:40 Running module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world"...[0m
+[0m[1mInitializing modules...[0m
+- module.hello
+- module.remote
+- module.remote.hello
+
+[0m[1mInitializing provider plugins...[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] 2018/02/27 16:50:40 Stack at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage:
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app (dependencies: [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc, /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis, /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql])
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql (dependencies: [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc])
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis (dependencies: [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc])
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc (dependencies: [])
+[terragrunt] 2018/02/27 16:50:40 [terragrunt]  Are you sure you want to run 'terragrunt apply' in each folder of the stack described above? (y/n) 
+[terragrunt] 2018/02/27 16:50:40 
+[terragrunt] 2018/02/27 16:50:40 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:50:40 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-parent-child-test536743134/qa/my-app/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-parent-child-test536743134/qa/my-app] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] 2018/02/27 16:50:40 Stack at /tmp/terragrunt-test066622232/fixture-output-all/env1:
+  => Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app1 (dependencies: [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3])
+  => Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app2 (dependencies: [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3, /tmp/terragrunt-test066622232/fixture-output-all/env1/app1])
+  => Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app3 (dependencies: [])
+[terragrunt] 2018/02/27 16:50:40 [terragrunt]  Are you sure you want to run 'terragrunt apply' in each folder of the stack described above? (y/n) 
+[terragrunt] 2018/02/27 16:50:40 
+[terragrunt] 2018/02/27 16:50:40 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app3 must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Running module /tmp/terragrunt-test066622232/fixture-output-all/env1/app3 now
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-test066622232/fixture-output-all/env1/app3/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at fixture-download/stdout-test/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:40 WARNING: no double-slash (//) found in source URL /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/stdout. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:40 Cleaning up existing *.tf files in /root/.terragrunt/mu8Rz-9mFvKhy4zdGXRn0ldg5eM/mmsHBvvRxr_8a7dmNrmuwoDjmM0
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download"...[0m
+[0m[1mTerraform initialized in an empty directory![0m
+
+The directory has no Terraform configuration files. You may begin working
+with Terraform immediately by creating Terraform configuration files.[0m
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-old-terragrunt-config/hello-world"...[0m
+[0m[1mInitializing modules...[0m
+- module.hello
+
+[0m[1mInitializing provider plugins...[0m
+[terragrunt] 2018/02/27 16:50:40 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/stdout into /root/.terragrunt/mu8Rz-9mFvKhy4zdGXRn0ldg5eM/mmsHBvvRxr_8a7dmNrmuwoDjmM0 using terraform init
+[terragrunt] [fixture-download/stdout-test] 2018/02/27 16:50:40 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/stdout /root/.terragrunt/mu8Rz-9mFvKhy4zdGXRn0ldg5eM/mmsHBvvRxr_8a7dmNrmuwoDjmM0
+[terragrunt] 2018/02/27 16:50:40 Stack at /tmp/terragrunt-test933448714/fixture-output-all/env1:
+  => Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app1 (dependencies: [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3])
+  => Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app2 (dependencies: [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3, /tmp/terragrunt-test933448714/fixture-output-all/env1/app1])
+  => Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app3 (dependencies: [])
+[terragrunt] 2018/02/27 16:50:40 [terragrunt]  Are you sure you want to run 'terragrunt apply' in each folder of the stack described above? (y/n) 
+[terragrunt] 2018/02/27 16:50:40 
+[terragrunt] 2018/02/27 16:50:40 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app2] 2018/02/27 16:50:40 Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app2 must wait for 2 dependencies to finish
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-parent-child-test430611643/child/.terragrunt
+[terragrunt] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-parent-child-test430611643/child/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-parent-child-test430611643/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-parent-child-test430611643/child] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] 2018/02/27 16:50:40 Copying files from fixture-download/local-relative into /root/.terragrunt/gPxmyAL5cGw77jHOa5PUr68iWt4/adX-C2qwk_C6rDxkE-Zqe4eLGBs/relative
+[terragrunt] 2018/02/27 16:50:40 Setting working directory to /root/.terragrunt/gPxmyAL5cGw77jHOa5PUr68iWt4/adX-C2qwk_C6rDxkE-Zqe4eLGBs/relative
+[terragrunt] 2018/02/27 16:50:40 Running command: terraform apply
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world"...[0m
+[0m[1mInitializing modules...[0m
+- module.hello
+- module.remote
+- module.remote.hello
+
+[0m[1mInitializing provider plugins...[0m
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app2] 2018/02/27 16:50:40 Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app2 must wait for 2 dependencies to finish
+[terragrunt] 2018/02/27 16:50:40 Stack at /tmp/terragrunt-test372076439/fixture-output-all/env1:
+  => Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app1 (dependencies: [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3])
+  => Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app2 (dependencies: [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3, /tmp/terragrunt-test372076439/fixture-output-all/env1/app1])
+  => Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app3 (dependencies: [])
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app2] 2018/02/27 16:50:40 Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app2 must wait for 2 dependencies to finish
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-parent-child-test365574113/child/.terragrunt
+[terragrunt] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-parent-child-test365574113/child/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-parent-child-test365574113/child] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-parent-child-test966849484/child/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-parent-child-test966849484/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-parent-child-test966849484/child] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:50:40 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait for 2 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:40 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:40 Running module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app3 must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Running module /tmp/terragrunt-test933448714/fixture-output-all/env1/app3 now
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-test933448714/fixture-output-all/env1/app3/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app1] 2018/02/27 16:50:40 Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app1 must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:50:40 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:40 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:40 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc/.terragrunt
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:40 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:50:40 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app must wait for 3 dependencies to finish
+[terragrunt] 2018/02/27 16:50:40 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world into /root/.terragrunt/273voYQqBY5Hzn3abZM2LaGq5gY/VIDIUyib3UjyaBai-LHALXXYy1c using terraform init
+[terragrunt] [fixture-download/local-relative-extra-args-unix] 2018/02/27 16:50:40 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world /root/.terragrunt/273voYQqBY5Hzn3abZM2LaGq5gY/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app1] 2018/02/27 16:50:40 Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app1 must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app3 must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Running module /tmp/terragrunt-test372076439/fixture-output-all/env1/app3 now
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Reading Terragrunt config file at /tmp/terragrunt-test372076439/fixture-output-all/env1/app3/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:40 Initializing remote state for the s3 backend
+[terragrunt] 2018/02/27 16:50:40 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world into /root/.terragrunt/AQvrCsQntIEFLVnR2eLNihb4D2U/VIDIUyib3UjyaBai-LHALXXYy1c using terraform init
+[terragrunt] [fixture-download/local] 2018/02/27 16:50:40 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world /root/.terragrunt/AQvrCsQntIEFLVnR2eLNihb4D2U/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app1] 2018/02/27 16:50:40 Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app1 must wait for 1 dependencies to finish
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/stdout"...[0m
+
+[0m[1mInitializing provider plugins...[0m
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world"...[0m
+[0m[1mInitializing modules...[0m
+- module.hello
+- module.remote
+- module.remote.hello
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world"...[0m
+[0m[1mInitializing modules...[0m
+- module.hello
+- module.remote
+- module.remote.hello
+
+[0m[1mInitializing provider plugins...[0m
+
+[0m[1mInitializing provider plugins...[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:40 Copying files from fixture-download/override into /root/.terragrunt/q6CM5Ul52IVG9DJOHLls-ghte0Q/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:40 Setting working directory to /root/.terragrunt/q6CM5Ul52IVG9DJOHLls-ghte0Q/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:40 Running command: terraform apply
+[terragrunt] 2018/02/27 16:50:40 Copying files from fixture-old-terragrunt-config/download into /root/.terragrunt/nquDuVyT-rbd5RlsXu77Jx6XQec/Jd4brG6pM3EesbexWwAOORj6REw
+[terragrunt] 2018/02/27 16:50:40 Setting working directory to /root/.terragrunt/nquDuVyT-rbd5RlsXu77Jx6XQec/Jd4brG6pM3EesbexWwAOORj6REw
+[terragrunt] 2018/02/27 16:50:40 Running command: terraform apply
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:41 Copying files from fixture-download/local-with-hidden-folder into /root/.terragrunt/GWi1REmMX6wLEU-ANLYVuHzV7j8/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:41 Setting working directory to /root/.terragrunt/GWi1REmMX6wLEU-ANLYVuHzV7j8/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:41 Running command: terraform apply
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:41 Copying files from fixture-download/stdout-test into /root/.terragrunt/mu8Rz-9mFvKhy4zdGXRn0ldg5eM/mmsHBvvRxr_8a7dmNrmuwoDjmM0
+[terragrunt] 2018/02/27 16:50:41 Setting working directory to /root/.terragrunt/mu8Rz-9mFvKhy4zdGXRn0ldg5eM/mmsHBvvRxr_8a7dmNrmuwoDjmM0
+[terragrunt] 2018/02/27 16:50:41 Running command: terraform apply
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+[terragrunt] [fixture-download/remote-relative] 2018/02/27 16:50:41 Running command: terraform --version
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [fixture-download/remote] 2018/02/27 16:50:41 Running command: terraform --version
+[terragrunt] 2018/02/27 16:50:41 Copying files from fixture-download/local-relative-extra-args-unix into /root/.terragrunt/273voYQqBY5Hzn3abZM2LaGq5gY/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:41 Setting working directory to /root/.terragrunt/273voYQqBY5Hzn3abZM2LaGq5gY/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:41 Running command: terraform apply -var-file=/root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/local-relative-extra-args-unix/../extra-args/common.tfvars -var-file=terraform.tfvars
+[terragrunt] 2018/02/27 16:50:41 Copying files from fixture-download/local into /root/.terragrunt/AQvrCsQntIEFLVnR2eLNihb4D2U/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:41 Setting working directory to /root/.terragrunt/AQvrCsQntIEFLVnR2eLNihb4D2U/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:41 Running command: terraform apply
+[terragrunt] 2018/02/27 16:50:41 Reading Terragrunt config file at fixture-download/remote-relative/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:41 Terraform files in /root/.terragrunt/UXpJhfTAs87ayV8lCFjioxfVmdI/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/relative are up to date. Will not download again.
+[terragrunt] 2018/02/27 16:50:41 Copying files from fixture-download/remote-relative into /root/.terragrunt/UXpJhfTAs87ayV8lCFjioxfVmdI/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/relative
+[terragrunt] 2018/02/27 16:50:41 Setting working directory to /root/.terragrunt/UXpJhfTAs87ayV8lCFjioxfVmdI/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/relative
+[terragrunt] 2018/02/27 16:50:41 Running command: terraform apply
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[terragrunt] 2018/02/27 16:50:41 Reading Terragrunt config file at fixture-download/remote/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:41 Terraform files in /root/.terragrunt/eUl8mGBA-TRKjtDBqpevCkibmG4/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/hello-world are up to date. Will not download again.
+[terragrunt] 2018/02/27 16:50:41 Copying files from fixture-download/remote into /root/.terragrunt/eUl8mGBA-TRKjtDBqpevCkibmG4/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/hello-world
+[terragrunt] 2018/02/27 16:50:41 Setting working directory to /root/.terragrunt/eUl8mGBA-TRKjtDBqpevCkibmG4/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/hello-world
+[terragrunt] 2018/02/27 16:50:41 Running command: terraform apply
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+[terragrunt] [fixture-download/local-relative] 2018/02/27 16:50:41 Running command: terraform --version
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[terragrunt] 2018/02/27 16:50:41 Reading Terragrunt config file at fixture-download/local-relative/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:41 Cleaning up existing *.tf files in /root/.terragrunt/gPxmyAL5cGw77jHOa5PUr68iWt4/adX-C2qwk_C6rDxkE-Zqe4eLGBs
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+[terragrunt] [fixture-old-terragrunt-config/download] 2018/02/27 16:50:41 Running command: terraform --version
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.foo: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[terragrunt] 2018/02/27 16:50:41 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download into /root/.terragrunt/gPxmyAL5cGw77jHOa5PUr68iWt4/adX-C2qwk_C6rDxkE-Zqe4eLGBs using terraform init
+[terragrunt] [fixture-download/local-relative] 2018/02/27 16:50:41 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download /root/.terragrunt/gPxmyAL5cGw77jHOa5PUr68iWt4/adX-C2qwk_C6rDxkE-Zqe4eLGBs
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+foo = foo[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+[terragrunt] [fixture-download/override] 2018/02/27 16:50:42 Running command: terraform --version
+[terragrunt] 2018/02/27 16:50:42 Reading Terragrunt config file at fixture-old-terragrunt-config/download/.terragrunt
+[terragrunt] 2018/02/27 16:50:42 DEPRECATION WARNING: Found deprecated config file format fixture-old-terragrunt-config/download/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] 2018/02/27 16:50:42 WARNING: no double-slash (//) found in source URL /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-old-terragrunt-config/hello-world. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:42 Cleaning up existing *.tf files in /root/.terragrunt/nquDuVyT-rbd5RlsXu77Jx6XQec/Jd4brG6pM3EesbexWwAOORj6REw
+[terragrunt] 2018/02/27 16:50:42 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-old-terragrunt-config/hello-world into /root/.terragrunt/nquDuVyT-rbd5RlsXu77Jx6XQec/Jd4brG6pM3EesbexWwAOORj6REw using terraform init
+[terragrunt] [fixture-old-terragrunt-config/download] 2018/02/27 16:50:42 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-old-terragrunt-config/hello-world /root/.terragrunt/nquDuVyT-rbd5RlsXu77Jx6XQec/Jd4brG6pM3EesbexWwAOORj6REw
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download"...[0m
+[0m[1mTerraform initialized in an empty directory![0m
+
+The directory has no Terraform configuration files. You may begin working
+with Terraform immediately by creating Terraform configuration files.[0m
+[terragrunt] 2018/02/27 16:50:42 Copying files from fixture-download/local-relative into /root/.terragrunt/gPxmyAL5cGw77jHOa5PUr68iWt4/adX-C2qwk_C6rDxkE-Zqe4eLGBs/relative
+[terragrunt] 2018/02/27 16:50:42 Setting working directory to /root/.terragrunt/gPxmyAL5cGw77jHOa5PUr68iWt4/adX-C2qwk_C6rDxkE-Zqe4eLGBs/relative
+[terragrunt] 2018/02/27 16:50:42 Running command: terraform apply
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend]  Remote state S3 bucket terragrunt-test-bucket-pe7vjd does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-pe7vjd
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-test117789730]  Remote state S3 bucket terragrunt-test-bucket-yv0haz does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-yv0haz
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc]  Remote state S3 bucket terragrunt-test-bucket-3bdtre does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-3bdtre
+[terragrunt] [/tmp/terragrunt-parent-child-test966849484/child] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-parent-child-test966849484/child]  Remote state S3 bucket terragrunt-test-bucket-m8xaco does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-parent-child-test966849484/child] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-parent-child-test966849484/child] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-parent-child-test966849484/child] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-m8xaco
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3]  Remote state S3 bucket terragrunt-test-bucket-zhxsxt does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-zhxsxt
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3]  Remote state S3 bucket terragrunt-test-bucket-gn4tiz does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-gn4tiz
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend]  Remote state S3 bucket terragrunt-test-bucket-pzqz7u does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-pzqz7u
+[terragrunt] [/tmp/terragrunt-parent-child-test365574113/child] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-parent-child-test365574113/child]  Remote state S3 bucket terragrunt-test-bucket-ohlfp1 does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-parent-child-test365574113/child] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-parent-child-test365574113/child] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-parent-child-test365574113/child] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-ohlfp1
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3]  Remote state S3 bucket terragrunt-test-bucket-9grorg does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-9grorg
+[terragrunt] [/tmp/terragrunt-parent-child-test430611643/child] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-parent-child-test430611643/child]  Remote state S3 bucket terragrunt-test-bucket-oq8iuv does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-parent-child-test430611643/child] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-parent-child-test430611643/child] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-parent-child-test430611643/child] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-oq8iuv
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc]  Remote state S3 bucket terragrunt-test-bucket-taqstt does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-taqstt
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key]  Remote state S3 bucket terragrunt-test-bucket-3bdtre does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-3bdtre
+[terragrunt] [/tmp/terragrunt-parent-child-test536743134/qa/my-app] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-parent-child-test536743134/qa/my-app]  Remote state S3 bucket terragrunt-test-bucket-rom6tk does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-parent-child-test536743134/qa/my-app] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-parent-child-test536743134/qa/my-app] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-parent-child-test536743134/qa/my-app] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-rom6tk
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+[terragrunt] [fixture-download/local-with-hidden-folder] 2018/02/27 16:50:42 Running command: terraform --version
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[terragrunt] 2018/02/27 16:50:42 Reading Terragrunt config file at fixture-download/override/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:42 WARNING: no double-slash (//) found in source URL /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:42 Cleaning up existing *.tf files in /root/.terragrunt/q6CM5Ul52IVG9DJOHLls-ghte0Q/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:42 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world into /root/.terragrunt/q6CM5Ul52IVG9DJOHLls-ghte0Q/VIDIUyib3UjyaBai-LHALXXYy1c using terraform init
+[terragrunt] [fixture-download/override] 2018/02/27 16:50:42 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world /root/.terragrunt/q6CM5Ul52IVG9DJOHLls-ghte0Q/VIDIUyib3UjyaBai-LHALXXYy1c
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-old-terragrunt-config/hello-world"...[0m
+[0m[1mInitializing modules...[0m
+- module.hello
+
+[0m[1mInitializing provider plugins...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+--- PASS: TestRemoteDownloadWithRelativePath (2.48s)
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, extra args[0m
+[terragrunt] [fixture-download/local-relative-extra-args-unix] 2018/02/27 16:50:42 Running command: terraform --version
+[terragrunt] 2018/02/27 16:50:42 Reading Terragrunt config file at fixture-download/local-with-hidden-folder/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:42 WARNING: no double-slash (//) found in source URL /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:42 Cleaning up existing *.tf files in /root/.terragrunt/GWi1REmMX6wLEU-ANLYVuHzV7j8/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:42 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world into /root/.terragrunt/GWi1REmMX6wLEU-ANLYVuHzV7j8/VIDIUyib3UjyaBai-LHALXXYy1c using terraform init
+[terragrunt] [fixture-download/local-with-hidden-folder] 2018/02/27 16:50:42 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world /root/.terragrunt/GWi1REmMX6wLEU-ANLYVuHzV7j8/VIDIUyib3UjyaBai-LHALXXYy1c
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+[terragrunt] [fixture-download/local] 2018/02/27 16:50:42 Running command: terraform --version
+--- PASS: TestRemoteDownload (2.55s)
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world"...[0m
+[0m[1mInitializing modules...[0m
+- module.hello
+- module.remote
+- module.remote.hello
+
+[0m[1mInitializing provider plugins...[0m
+[terragrunt] 2018/02/27 16:50:42 Reading Terragrunt config file at fixture-download/local-relative-extra-args-unix/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:42 WARNING: no double-slash (//) found in source URL /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:42 Cleaning up existing *.tf files in /root/.terragrunt/273voYQqBY5Hzn3abZM2LaGq5gY/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:42 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world into /root/.terragrunt/273voYQqBY5Hzn3abZM2LaGq5gY/VIDIUyib3UjyaBai-LHALXXYy1c using terraform init
+[terragrunt] [fixture-download/local-relative-extra-args-unix] 2018/02/27 16:50:42 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world /root/.terragrunt/273voYQqBY5Hzn3abZM2LaGq5gY/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:42 [terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend]  Remote state S3 bucket terragrunt-test-bucket-pslooc does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:42 
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:42 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:42 Creating S3 bucket terragrunt-test-bucket-pslooc
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world"...[0m
+[0m[1mInitializing modules...[0m
+- module.hello
+- module.remote
+- module.remote.hello
+
+[0m[1mInitializing provider plugins...[0m
+[terragrunt] 2018/02/27 16:50:42 Reading Terragrunt config file at fixture-download/local/terraform.tfvars
+[terragrunt] 2018/02/27 16:50:42 WARNING: no double-slash (//) found in source URL /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:50:42 Cleaning up existing *.tf files in /root/.terragrunt/AQvrCsQntIEFLVnR2eLNihb4D2U/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:42 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world into /root/.terragrunt/AQvrCsQntIEFLVnR2eLNihb4D2U/VIDIUyib3UjyaBai-LHALXXYy1c using terraform init
+[terragrunt] [fixture-download/local] 2018/02/27 16:50:42 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world /root/.terragrunt/AQvrCsQntIEFLVnR2eLNihb4D2U/VIDIUyib3UjyaBai-LHALXXYy1c
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world"...[0m
+[0m[1mInitializing modules...[0m
+- module.hello
+- module.remote
+- module.remote.hello
+
+[0m[1mInitializing provider plugins...[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:42 Copying files from fixture-old-terragrunt-config/download into /root/.terragrunt/nquDuVyT-rbd5RlsXu77Jx6XQec/Jd4brG6pM3EesbexWwAOORj6REw
+[terragrunt] 2018/02/27 16:50:42 Setting working directory to /root/.terragrunt/nquDuVyT-rbd5RlsXu77Jx6XQec/Jd4brG6pM3EesbexWwAOORj6REw
+[terragrunt] 2018/02/27 16:50:42 Running command: terraform apply
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/hello-world"...[0m
+[0m[1mInitializing modules...[0m
+- module.hello
+- module.remote
+- module.remote.hello
+
+[0m[1mInitializing provider plugins...[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:42 Copying files from fixture-download/override into /root/.terragrunt/q6CM5Ul52IVG9DJOHLls-ghte0Q/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:42 Setting working directory to /root/.terragrunt/q6CM5Ul52IVG9DJOHLls-ghte0Q/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:42 Running command: terraform apply
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:42 Copying files from fixture-download/local-with-hidden-folder into /root/.terragrunt/GWi1REmMX6wLEU-ANLYVuHzV7j8/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:42 Setting working directory to /root/.terragrunt/GWi1REmMX6wLEU-ANLYVuHzV7j8/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:42 Running command: terraform apply
+--- PASS: TestTerragruntStdOut (2.89s)
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:43 Copying files from fixture-download/local-relative-extra-args-unix into /root/.terragrunt/273voYQqBY5Hzn3abZM2LaGq5gY/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:43 Setting working directory to /root/.terragrunt/273voYQqBY5Hzn3abZM2LaGq5gY/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:43 Running command: terraform apply -var-file=/root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download/local-relative-extra-args-unix/../extra-args/common.tfvars -var-file=terraform.tfvars
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:43 Copying files from fixture-download/local into /root/.terragrunt/AQvrCsQntIEFLVnR2eLNihb4D2U/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:43 Setting working directory to /root/.terragrunt/AQvrCsQntIEFLVnR2eLNihb4D2U/VIDIUyib3UjyaBai-LHALXXYy1c
+[terragrunt] 2018/02/27 16:50:43 Running command: terraform apply
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+--- PASS: TestLocalDownloadWithRelativePath (3.16s)
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:43 Looks like someone created bucket terragrunt-test-bucket-3bdtre at the same time. Will wait for it to be in active state.
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+--- PASS: TestLocalDownloadWithOldConfig (3.34s)
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-3bdtre has not been created yet. Sleeping for 5s and will check again.
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-pzqz7u created.
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-pzqz7u
+[terragrunt] [/tmp/terragrunt-parent-child-test966849484/child] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-m8xaco created.
+[terragrunt] [/tmp/terragrunt-parent-child-test966849484/child] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-m8xaco
+[terragrunt] [/tmp/terragrunt-parent-child-test430611643/child] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-oq8iuv created.
+[terragrunt] [/tmp/terragrunt-parent-child-test430611643/child] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-oq8iuv
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-3bdtre created.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-3bdtre
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-9grorg created.
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-9grorg
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+--- PASS: TestRemoteDownloadOverride (3.56s)
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-taqstt created.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-taqstt
+[terragrunt] [/tmp/terragrunt-parent-child-test365574113/child] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-ohlfp1 created.
+[terragrunt] [/tmp/terragrunt-parent-child-test365574113/child] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-ohlfp1
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-gn4tiz created.
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-gn4tiz
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+--- PASS: TestLocalDownloadWithHiddenFolder (3.54s)
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-zhxsxt created.
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-zhxsxt
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-pe7vjd created.
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-pe7vjd
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, extra args[0m
+--- PASS: TestLocalWithRelativeExtraArgsUnix (3.74s)
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+test = Hello, World[0m
+--- PASS: TestLocalDownload (3.60s)
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-yv0haz created.
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-yv0haz
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-pslooc created.
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-pslooc
+[terragrunt] [/tmp/terragrunt-parent-child-test536743134/qa/my-app] 2018/02/27 16:50:43 S3 bucket terragrunt-test-bucket-rom6tk created.
+[terragrunt] [/tmp/terragrunt-parent-child-test536743134/qa/my-app] 2018/02/27 16:50:43 Enabling versioning on S3 bucket terragrunt-test-bucket-rom6tk
+[terragrunt] [/tmp/terragrunt-parent-child-test966849484/child] 2018/02/27 16:50:44 Running command: terraform init -backend-config=bucket=terragrunt-test-bucket-m8xaco -backend-config=key=child/terraform.tfstate -backend-config=region=us-west-2 -backend-config=encrypt=true
+
+[0m[1mInitializing the backend...[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:44 Running command: terraform init -backend-config=region=us-west-2 -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-taqstt -backend-config=key=stage/vpc/terraform.tfstate
+
+[0m[1mInitializing the backend...[0m
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:44 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-gn4tiz -backend-config=key=env1/app3/terraform.tfstate -backend-config=region=us-west-2
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:44 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-zhxsxt -backend-config=key=env1/app3/terraform.tfstate -backend-config=region=us-west-2
+
+[0m[1mInitializing the backend...[0m
+
+[0m[1mInitializing the backend...[0m
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:44 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-9grorg -backend-config=key=env1/app3/terraform.tfstate -backend-config=region=us-west-2
+
+[0m[1mInitializing the backend...[0m
+[terragrunt] [/tmp/terragrunt-parent-child-test365574113/child] 2018/02/27 16:50:44 Running command: terraform init -backend-config=key=child/terraform.tfstate -backend-config=region=us-west-2 -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-ohlfp1
+
+[0m[1mInitializing the backend...[0m
+[terragrunt] [/tmp/terragrunt-parent-child-test430611643/child] 2018/02/27 16:50:44 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-oq8iuv -backend-config=key=child/terraform.tfstate -backend-config=region=us-west-2
+
+[0m[1mInitializing the backend...[0m
+[terragrunt] [/tmp/terragrunt-parent-child-test536743134/qa/my-app] 2018/02/27 16:50:44 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-rom6tk -backend-config=key=qa/my-app/terraform.tfstate -backend-config=region=us-west-2
+
+[0m[1mInitializing the backend...[0m
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:44 Lock table terragrunt-lock-table-za3nzl does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:44 Creating table terragrunt-lock-table-za3nzl in DynamoDB
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:44 Lock table terragrunt-test-locks-jocs1d does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:44 Creating table terragrunt-test-locks-jocs1d in DynamoDB
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:44 Lock table terragrunt-lock-table-5jir2y does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:44 Creating table terragrunt-lock-table-5jir2y in DynamoDB
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:44 Lock table terragrunt-test-locks-abyso8 does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:44 Creating table terragrunt-test-locks-abyso8 in DynamoDB
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:45 Lock table terragrunt-lock-table-lnxjxq does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:45 Creating table terragrunt-lock-table-lnxjxq in DynamoDB
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:45 Table terragrunt-test-locks-jocs1d is not yet in active state. Will check again after 10s.
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:45 Table terragrunt-lock-table-5jir2y is not yet in active state. Will check again after 10s.
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:45 Table terragrunt-test-locks-abyso8 is not yet in active state. Will check again after 10s.
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:45 Table terragrunt-lock-table-lnxjxq is not yet in active state. Will check again after 10s.
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:45 Table terragrunt-lock-table-za3nzl is not yet in active state. Will check again after 10s.
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:47 Running command: terraform apply
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:47 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-gn4tiz"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:47 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-zhxsxt"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:47 Running command: terraform validate -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-9grorg"
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app3] 2018/02/27 16:50:47 Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app3 has finished successfully!
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app2] 2018/02/27 16:50:47 Dependency /tmp/terragrunt-test372076439/fixture-output-all/env1/app3 of module /tmp/terragrunt-test372076439/fixture-output-all/env1/app2 just finished successfully. Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app2 must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app1] 2018/02/27 16:50:47 Dependency /tmp/terragrunt-test372076439/fixture-output-all/env1/app3 of module /tmp/terragrunt-test372076439/fixture-output-all/env1/app1 just finished successfully. Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app1 must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app1] 2018/02/27 16:50:47 Running module /tmp/terragrunt-test372076439/fixture-output-all/env1/app1 now
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app1] 2018/02/27 16:50:47 Reading Terragrunt config file at /tmp/terragrunt-test372076439/fixture-output-all/env1/app1/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app1] 2018/02/27 16:50:47 Initializing remote state for the s3 backend
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:48 Running command: terraform apply
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:48 Running command: terraform apply
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app1] 2018/02/27 16:50:48 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-9grorg -backend-config=key=env1/app1/terraform.tfstate -backend-config=region=us-west-2
+
+[0m[1mInitializing the backend...[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:48 S3 bucket terragrunt-test-bucket-3bdtre created.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:48 Enabling versioning on S3 bucket terragrunt-test-bucket-3bdtre
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:49 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-taqstt"
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:50:49 Running command: terraform apply
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:49 Lock table terragrunt-test-locks-jocs1d does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:49 Creating table terragrunt-test-locks-jocs1d in DynamoDB
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:49 Looks like someone created table terragrunt-test-locks-jocs1d at the same time. Will wait for it to be in active state.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:49 Table terragrunt-test-locks-jocs1d is not yet in active state. Will check again after 10s.
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+hello = Hello, World[0m
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app1] 2018/02/27 16:50:52 Running command: terraform validate -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-9grorg"
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app1] 2018/02/27 16:50:52 Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app1 has finished successfully!
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app2] 2018/02/27 16:50:52 Dependency /tmp/terragrunt-test372076439/fixture-output-all/env1/app1 of module /tmp/terragrunt-test372076439/fixture-output-all/env1/app2 just finished successfully. Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app2 must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app2] 2018/02/27 16:50:52 Running module /tmp/terragrunt-test372076439/fixture-output-all/env1/app2 now
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app2] 2018/02/27 16:50:52 Reading Terragrunt config file at /tmp/terragrunt-test372076439/fixture-output-all/env1/app2/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app2] 2018/02/27 16:50:52 Initializing remote state for the s3 backend
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+app3_text = app3 output[0m
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app3] 2018/02/27 16:50:52 Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app3 has finished successfully!
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app2] 2018/02/27 16:50:52 Dependency /tmp/terragrunt-test933448714/fixture-output-all/env1/app3 of module /tmp/terragrunt-test933448714/fixture-output-all/env1/app2 just finished successfully. Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app2 must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app1] 2018/02/27 16:50:52 Dependency /tmp/terragrunt-test933448714/fixture-output-all/env1/app3 of module /tmp/terragrunt-test933448714/fixture-output-all/env1/app1 just finished successfully. Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app1 must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app1] 2018/02/27 16:50:52 Running module /tmp/terragrunt-test933448714/fixture-output-all/env1/app1 now
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app1] 2018/02/27 16:50:52 Reading Terragrunt config file at /tmp/terragrunt-test933448714/fixture-output-all/env1/app1/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app1] 2018/02/27 16:50:52 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app2] 2018/02/27 16:50:52 Running command: terraform init -backend-config=region=us-west-2 -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-9grorg -backend-config=key=env1/app2/terraform.tfstate
+
+[0m[1mInitializing the backend...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+app3_text = app3 output[0m
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app3] 2018/02/27 16:50:52 Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app3 has finished successfully!
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app2] 2018/02/27 16:50:52 Dependency /tmp/terragrunt-test066622232/fixture-output-all/env1/app3 of module /tmp/terragrunt-test066622232/fixture-output-all/env1/app2 just finished successfully. Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app2 must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app1] 2018/02/27 16:50:52 Dependency /tmp/terragrunt-test066622232/fixture-output-all/env1/app3 of module /tmp/terragrunt-test066622232/fixture-output-all/env1/app1 just finished successfully. Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app1 must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app1] 2018/02/27 16:50:52 Running module /tmp/terragrunt-test066622232/fixture-output-all/env1/app1 now
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app1] 2018/02/27 16:50:52 Reading Terragrunt config file at /tmp/terragrunt-test066622232/fixture-output-all/env1/app1/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app1] 2018/02/27 16:50:52 Initializing remote state for the s3 backend
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+hello = Hello, World[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+hello = Hello, World[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+text = [I am a vpc template.][0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:50:53 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc has finished successfully!
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:50:53 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:50:53 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:50:53 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis/.terragrunt
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:50:53 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:50:53 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:50:53 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:50:53 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app must wait on 2 more dependencies.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:50:53 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:50:53 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:50:53 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:50:53 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:50:53 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app1] 2018/02/27 16:50:53 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-gn4tiz -backend-config=key=env1/app1/terraform.tfstate -backend-config=region=us-west-2
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app1] 2018/02/27 16:50:53 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-zhxsxt -backend-config=key=env1/app1/terraform.tfstate -backend-config=region=us-west-2
+
+[0m[1mInitializing the backend...[0m
+
+[0m[1mInitializing the backend...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+--- PASS: TestTerragruntWorksWithIncludesChildUpdatedAndOldConfig (13.73s)
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-m8xaco
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:50:54 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-taqstt -backend-config=key=stage/redis/terraform.tfstate -backend-config=region=us-west-2
+
+[0m[1mInitializing the backend...[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:50:54 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-taqstt -backend-config=key=stage/mysql/terraform.tfstate -backend-config=region=us-west-2
+
+[0m[1mInitializing the backend...[0m
+--- PASS: TestTerragruntWorksWithIncludesParentUpdatedAndOldConfig (14.40s)
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-ohlfp1
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+--- PASS: TestTerragruntWorksWithIncludesAndOldConfig (14.63s)
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-oq8iuv
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:50:55 Table terragrunt-test-locks-jocs1d is not yet in active state. Will check again after 10s.
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:55 Success! Table terragrunt-lock-table-5jir2y is now in active state.
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:50:55 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-pe7vjd -backend-config=key=terraform.tfstate -backend-config=region=us-west-2 -backend-config=dynamodb_table=terragrunt-lock-table-5jir2y -from-module=file:///tmp/terragrunt-test114910899/fixture-download/hello-world-with-backend /root/.terragrunt/2EptIbp9lVUT0jNEI5cByVzzmCk/6v8ujI6iBARtCGZfWp7s0Mel118
+[0m[1mCopying configuration[0m from "file:///tmp/terragrunt-test114910899/fixture-download/hello-world-with-backend"...[0m
+
+[0m[1mInitializing the backend...[0m
+--- PASS: TestTerragruntWorksWithIncludes (15.46s)
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-rom6tk
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:55 Success! Table terragrunt-test-locks-abyso8 is now in active state.
+[terragrunt] [/tmp/terragrunt-test117789730] 2018/02/27 16:50:55 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-yv0haz -backend-config=key=terraform.tfstate -backend-config=region=us-west-2 -backend-config=dynamodb_table=terragrunt-test-locks-abyso8
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:55 Success! Table terragrunt-lock-table-lnxjxq is now in active state.
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:50:55 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-pslooc -backend-config=key=terraform.tfstate -backend-config=region=us-west-2 -backend-config=lock_table=terragrunt-lock-table-lnxjxq -from-module=git::https://github.com/gruntwork-io/terragrunt.git?ref=v0.12.3 /root/.terragrunt/UMVhHSb8cw2XQeUiQqlDmVSwiwE/p_piCTTWVab2Hmnj1OtnAruj8J4
+
+[0m[1mInitializing the backend...[0m
+[0m[1mCopying configuration[0m from "git::https://github.com/gruntwork-io/terragrunt.git?ref=v0.12.3"...[0m
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:50:55 Table terragrunt-lock-table-za3nzl is not yet in active state. Will check again after 10s.
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app2] 2018/02/27 16:50:56 Running command: terraform validate -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-9grorg"
+[terragrunt] [/tmp/terragrunt-test372076439/fixture-output-all/env1/app2] 2018/02/27 16:50:56 Module /tmp/terragrunt-test372076439/fixture-output-all/env1/app2 has finished successfully!
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app1] 2018/02/27 16:50:56 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-gn4tiz"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app1] 2018/02/27 16:50:56 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-zhxsxt"
+--- PASS: TestTerragruntValidateAllCommand (16.67s)
+	integration_test.go:517: Copying fixture-output-all to /tmp/terragrunt-test372076439
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-9grorg
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+- Downloading plugin for provider "template" (1.0.0)...
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:50:58 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-taqstt"
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:50:58 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-taqstt"
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:59 Success! Table terragrunt-test-locks-jocs1d is now in active state.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:50:59 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-3bdtre -backend-config=key=mgmt/kms-master-key/terraform.tfstate -backend-config=region=us-west-2 -backend-config=lock_table=terragrunt-test-locks-jocs1d
+
+[0m[1mInitializing the backend...[0m
+[33m"lock_table": [DEPRECATED] please use the dynamodb_table attribute[0m[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:51:00 Copying files from /tmp/terragrunt-test114910899/fixture-download/local-with-backend into /root/.terragrunt/2EptIbp9lVUT0jNEI5cByVzzmCk/6v8ujI6iBARtCGZfWp7s0Mel118
+[terragrunt] 2018/02/27 16:51:00 Setting working directory to /root/.terragrunt/2EptIbp9lVUT0jNEI5cByVzzmCk/6v8ujI6iBARtCGZfWp7s0Mel118
+[terragrunt] 2018/02/27 16:51:00 Backend s3 has not changed.
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:51:00 Running command: terraform apply
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+app1_text = app1 output[0m
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app1] 2018/02/27 16:51:00 Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app1 has finished successfully!
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app2] 2018/02/27 16:51:00 Dependency /tmp/terragrunt-test066622232/fixture-output-all/env1/app1 of module /tmp/terragrunt-test066622232/fixture-output-all/env1/app2 just finished successfully. Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app2 must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app2] 2018/02/27 16:51:00 Running module /tmp/terragrunt-test066622232/fixture-output-all/env1/app2 now
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app2] 2018/02/27 16:51:00 Reading Terragrunt config file at /tmp/terragrunt-test066622232/fixture-output-all/env1/app2/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app2] 2018/02/27 16:51:00 Initializing remote state for the s3 backend
+[0m[1mTerraform initialized in an empty directory![0m
+
+The directory has no Terraform configuration files. You may begin working
+with Terraform immediately by creating Terraform configuration files.[0m
+[terragrunt] 2018/02/27 16:51:00 Copying files from /tmp/terragrunt-test376171289/fixture-download/remote-with-backend into /root/.terragrunt/UMVhHSb8cw2XQeUiQqlDmVSwiwE/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/hello-world-with-backend
+[terragrunt] 2018/02/27 16:51:00 Setting working directory to /root/.terragrunt/UMVhHSb8cw2XQeUiQqlDmVSwiwE/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/hello-world-with-backend
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:51:00 Initializing remote state for the s3 backend
+[terragrunt] 2018/02/27 16:51:01 Running command: terraform apply
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app2] 2018/02/27 16:51:01 Running command: terraform init -backend-config=bucket=terragrunt-test-bucket-gn4tiz -backend-config=key=env1/app2/terraform.tfstate -backend-config=region=us-west-2 -backend-config=encrypt=true
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+app1_text = app1 output[0m
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app1] 2018/02/27 16:51:01 Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app1 has finished successfully!
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app2] 2018/02/27 16:51:01 Dependency /tmp/terragrunt-test933448714/fixture-output-all/env1/app1 of module /tmp/terragrunt-test933448714/fixture-output-all/env1/app2 just finished successfully. Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app2 must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app2] 2018/02/27 16:51:01 Running module /tmp/terragrunt-test933448714/fixture-output-all/env1/app2 now
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app2] 2018/02/27 16:51:01 Reading Terragrunt config file at /tmp/terragrunt-test933448714/fixture-output-all/env1/app2/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app2] 2018/02/27 16:51:01 Initializing remote state for the s3 backend
+
+[0m[1mInitializing the backend...[0m
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:51:01 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-pslooc -backend-config=key=terraform.tfstate -backend-config=region=us-west-2 -backend-config=lock_table=terragrunt-lock-table-lnxjxq
+
+[0m[1mInitializing the backend...[0m
+[33m"lock_table": [DEPRECATED] please use the dynamodb_table attribute[0m[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app2] 2018/02/27 16:51:02 Running command: terraform init -backend-config=key=env1/app2/terraform.tfstate -backend-config=region=us-west-2 -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-zhxsxt
+
+[0m[1mInitializing the backend...[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:51:04 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app2] 2018/02/27 16:51:04 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-gn4tiz"
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+text = [I am a redis template. Data from my dependencies: vpc = [I am a vpc template.]][0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:05 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis has finished successfully!
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:05 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app must wait on 1 more dependencies.
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+text = [I am a mysql template. Data from my dependencies: vpc = [I am a vpc template.]][0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:05 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql has finished successfully!
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:05 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:05 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:05 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app/.terragrunt
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:05 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:05 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:05 Initializing remote state for the s3 backend
+Acquiring state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:51:05 Success! Table terragrunt-test-locks-jocs1d is now in active state.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:51:05 Running command: terraform init -backend-config=key=mgmt/vpc/terraform.tfstate -backend-config=region=us-west-2 -backend-config=lock_table=terragrunt-test-locks-jocs1d -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-3bdtre
+
+[0m[1mInitializing the backend...[0m
+[33m"lock_table": [DEPRECATED] please use the dynamodb_table attribute[0m[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app2] 2018/02/27 16:51:05 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-zhxsxt"
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:51:05 Success! Table terragrunt-lock-table-za3nzl is now in active state.
+[terragrunt] [/tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend] 2018/02/27 16:51:05 Running command: terraform init -backend-config=bucket=terragrunt-test-bucket-pzqz7u -backend-config=key=terraform.tfstate -backend-config=region=us-west-2 -backend-config=dynamodb_table=terragrunt-lock-table-za3nzl -backend-config=encrypt=true -from-module=file:///tmp/terragrunt-test635046820/fixture-download/hello-world /root/.terragrunt/gp7vmxAe_17Hwi_8dPJETPtD928/IbutZqb1WVwgG6pasXbWd7abixQ
+[0m[1mCopying configuration[0m from "file:///tmp/terragrunt-test635046820/fixture-download/hello-world"...[0m
+[0m[1mInitializing modules...[0m
+- module.hello
+  Getting source "./hello"
+- module.remote
+  Getting source "github.com/gruntwork-io/terragrunt.git//test/fixture-download/hello-world?ref=v0.9.9"
+Acquiring state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:06 Running command: terraform init -backend-config=key=stage/frontend-app/terraform.tfstate -backend-config=region=us-west-2 -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-taqstt
+
+[0m[1mInitializing the backend...[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:51:06 Running command: terraform apply
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+Releasing state lock. This may take a few moments...
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[1m[32m
+Outputs:
+
+test = hello, World[0m
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:51:08 Running command: terraform --version
+[terragrunt] 2018/02/27 16:51:08 Reading Terragrunt config file at /tmp/terragrunt-test114910899/fixture-download/local-with-backend/terraform.tfvars
+[terragrunt] 2018/02/27 16:51:08 WARNING: no double-slash (//) found in source URL /tmp/terragrunt-test114910899/fixture-download/hello-world-with-backend. Relative paths in downloaded Terraform code may not work.
+[terragrunt] 2018/02/27 16:51:08 Cleaning up existing *.tf files in /root/.terragrunt/2EptIbp9lVUT0jNEI5cByVzzmCk/6v8ujI6iBARtCGZfWp7s0Mel118
+[terragrunt] 2018/02/27 16:51:08 Downloading Terraform configurations from file:///tmp/terragrunt-test114910899/fixture-download/hello-world-with-backend into /root/.terragrunt/2EptIbp9lVUT0jNEI5cByVzzmCk/6v8ujI6iBARtCGZfWp7s0Mel118 using terraform init
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:51:08 Backend s3 has not changed.
+Acquiring state lock. This may take a few moments...
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+app2_text = app2 output[0m
+[terragrunt] [/tmp/terragrunt-test066622232/fixture-output-all/env1/app2] 2018/02/27 16:51:09 Module /tmp/terragrunt-test066622232/fixture-output-all/env1/app2 has finished successfully!
+[0m[1mdata.template_file.text: Refreshing state...[0m
+Releasing state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test114910899/fixture-download/local-with-backend] 2018/02/27 16:51:09 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-pe7vjd -backend-config=key=terraform.tfstate -backend-config=region=us-west-2 -backend-config=dynamodb_table=terragrunt-lock-table-5jir2y -from-module=file:///tmp/terragrunt-test114910899/fixture-download/hello-world-with-backend /root/.terragrunt/2EptIbp9lVUT0jNEI5cByVzzmCk/6v8ujI6iBARtCGZfWp7s0Mel118
+[0m[1mCopying configuration[0m from "file:///tmp/terragrunt-test114910899/fixture-download/hello-world-with-backend"...[0m
+
+[0m[1mInitializing the backend...[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+app2_text = app2 output[0m
+[terragrunt] [/tmp/terragrunt-test933448714/fixture-output-all/env1/app2] 2018/02/27 16:51:09 Module /tmp/terragrunt-test933448714/fixture-output-all/env1/app2 has finished successfully!
+[0m[1m[32m
+Outputs:
+
+rendered_template = Hello, I am a template. My sample_var value = hello[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:51:10 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:10 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-taqstt"
+Releasing state lock. This may take a few moments...
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.template_file.test: Refreshing state...[0m
+- module.remote.hello
+  Getting source "./hello"
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+[0m[1m[32m
+Outputs:
+
+text = [I am a kms-master-key template.][0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:51:11 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:11 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait on 1 more dependencies.
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:51:12 Copying files from /tmp/terragrunt-test635046820/fixture-download/local-with-missing-backend into /root/.terragrunt/gp7vmxAe_17Hwi_8dPJETPtD928/IbutZqb1WVwgG6pasXbWd7abixQ
+[terragrunt] 2018/02/27 16:51:12 Setting working directory to /root/.terragrunt/gp7vmxAe_17Hwi_8dPJETPtD928/IbutZqb1WVwgG6pasXbWd7abixQ
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+--- PASS: TestTerragruntWorksWithLocalTerraformVersion (32.88s)
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-yv0haz
+Releasing state lock. This may take a few moments...
+
+[0m[1mInitializing provider plugins...[0m
+[0m[1m[32m
+Outputs:
+
+test = hello, World[0m
+[terragrunt] [/tmp/terragrunt-test376171289/fixture-download/remote-with-backend] 2018/02/27 16:51:14 Running command: terraform --version
+[terragrunt] 2018/02/27 16:51:14 Reading Terragrunt config file at /tmp/terragrunt-test376171289/fixture-download/remote-with-backend/terraform.tfvars
+[terragrunt] 2018/02/27 16:51:14 Terraform files in /root/.terragrunt/UMVhHSb8cw2XQeUiQqlDmVSwiwE/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/hello-world-with-backend are up to date. Will not download again.
+[terragrunt] 2018/02/27 16:51:14 Copying files from /tmp/terragrunt-test376171289/fixture-download/remote-with-backend into /root/.terragrunt/UMVhHSb8cw2XQeUiQqlDmVSwiwE/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/hello-world-with-backend
+[terragrunt] 2018/02/27 16:51:14 Setting working directory to /root/.terragrunt/UMVhHSb8cw2XQeUiQqlDmVSwiwE/p_piCTTWVab2Hmnj1OtnAruj8J4/test/fixture-download/hello-world-with-backend
+[terragrunt] 2018/02/27 16:51:14 Backend s3 has not changed.
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] 2018/02/27 16:51:14 Copying files from /tmp/terragrunt-test114910899/fixture-download/local-with-backend into /root/.terragrunt/2EptIbp9lVUT0jNEI5cByVzzmCk/6v8ujI6iBARtCGZfWp7s0Mel118
+[terragrunt] 2018/02/27 16:51:14 Setting working directory to /root/.terragrunt/2EptIbp9lVUT0jNEI5cByVzzmCk/6v8ujI6iBARtCGZfWp7s0Mel118
+[terragrunt] 2018/02/27 16:51:14 Backend s3 has not changed.
+--- PASS: TestLocalWithMissingBackend (34.39s)
+	integration_test.go:517: Copying fixture-download to /tmp/terragrunt-test635046820
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-pzqz7u
+[0m[1mdata.terraform_remote_state.redis: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.mysql: Refreshing state...[0m
+[terragrunt] 2018/02/27 16:51:14 Running command: terraform apply
+[terragrunt] 2018/02/27 16:51:14 Running command: terraform apply
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Outputs:
+
+text = [I am a frontend-app template. Data from my dependencies: vpc = [I am a vpc template.], mysql = [I am a mysql template. Data from my dependencies: vpc = [I am a vpc template.]], redis = [I am a redis template. Data from my dependencies: vpc = [I am a vpc template.]]][0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:18 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage] 2018/02/27 16:51:18 Running command: terraform --version
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:18 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:18 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:18 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:18 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:18 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:18 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:18 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] 2018/02/27 16:51:18 Stack at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage:
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app (dependencies: [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc, /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis, /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql])
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql (dependencies: [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc])
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis (dependencies: [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc])
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc (dependencies: [])
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:18 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app must wait for 3 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:18 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:18 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:18 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:18 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:18 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc/.terragrunt
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:18 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:18 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:18 Backend s3 has not changed.
+[0m[1m[32m
+Outputs:
+
+text = [I am a mgmt vpc template. I have no dependencies.][0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:51:18 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:18 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:18 Running module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:18 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:18 Initializing remote state for the s3 backend
+Acquiring state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:19 Running command: terraform output
+[0m[1mdata.template_file.test: Refreshing state...[0m
+Acquiring state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:19 Running command: terraform init -backend-config=key=mgmt/bastion-host/terraform.tfstate -backend-config=region=us-west-2 -backend-config=lock_table=terragrunt-test-locks-jocs1d -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-3bdtre
+
+[0m[1mInitializing the backend...[0m
+[33m"lock_table": [DEPRECATED] please use the dynamodb_table attribute[0m[0m
+[0m[1mdata.template_file.test: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+Releasing state lock. This may take a few moments...
+[0m[1m[32m
+Outputs:
+
+test = hello, World[0m
+text = [I am a vpc template.]
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:22 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc has finished successfully!
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:22 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:22 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:22 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:22 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:22 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:22 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:22 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:22 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis/.terragrunt
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:22 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:22 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:22 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:22 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app must wait on 2 more dependencies.
+--- PASS: TestTerragruntOutputAllCommandSpecificVariableIgnoreDependencyErrors (42.29s)
+	integration_test.go:517: Copying fixture-output-all to /tmp/terragrunt-test066622232
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-gn4tiz
+[0m[1m[32m
+Outputs:
+
+test = hello, World[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:22 Running command: terraform output
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:22 Running command: terraform output
+--- PASS: TestTerragruntOutputAllCommand (42.88s)
+	integration_test.go:517: Copying fixture-output-all to /tmp/terragrunt-test933448714
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-zhxsxt
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:23 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+--- PASS: TestLocalWithBackend (44.37s)
+	integration_test.go:517: Copying fixture-download to /tmp/terragrunt-test114910899
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-pe7vjd
+--- PASS: TestRemoteWithBackend (44.91s)
+	integration_test.go:517: Copying fixture-download/remote-with-backend to /tmp/terragrunt-test376171289
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-pslooc
+text = [I am a mysql template. Data from my dependencies: vpc = [I am a vpc template.]]
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:25 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql has finished successfully!
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:25 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app must wait on 1 more dependencies.
+text = [I am a redis template. Data from my dependencies: vpc = [I am a vpc template.]]
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:25 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis has finished successfully!
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:25 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:25 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:25 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app/.terragrunt
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:25 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:25 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:25 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:26 Running command: terraform output
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+text = [I am a frontend-app template. Data from my dependencies: vpc = [I am a vpc template.], mysql = [I am a mysql template. Data from my dependencies: vpc = [I am a vpc template.]], redis = [I am a redis template. Data from my dependencies: vpc = [I am a vpc template.]]]
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:29 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage] 2018/02/27 16:51:29 Running command: terraform --version
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:29 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:29 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:29 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:29 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:29 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:29 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:29 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] 2018/02/27 16:51:29 Stack at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage:
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app (dependencies: [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc, /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis, /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql])
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql (dependencies: [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc])
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis (dependencies: [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc])
+  => Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc (dependencies: [])
+[terragrunt] 2018/02/27 16:51:29 [terragrunt]  WARNING: Are you sure you want to run `terragrunt destroy` in each folder of the stack described above? There is no undo! (y/n) 
+[terragrunt] 2018/02/27 16:51:29 
+[terragrunt] 2018/02/27 16:51:29 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:29 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:29 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:29 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app/.terragrunt
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:29 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:29 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:29 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:29 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:29 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:29 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc must wait for 3 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:29 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-taqstt"
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.mysql: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.redis: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[0m[1m[32m
+Outputs:
+
+text = [I am a bastion-host template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]][0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage] 2018/02/27 16:51:34 Running command: terraform --version
+[terragrunt] 2018/02/27 16:51:34 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc as well! (y/n) 
+[terragrunt] 2018/02/27 16:51:34 
+[terragrunt] 2018/02/27 16:51:34 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:51:34 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host as well! (y/n) 
+[terragrunt] 2018/02/27 16:51:34 
+[terragrunt] 2018/02/27 16:51:34 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:51:34 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host as well! (y/n) 
+[terragrunt] 2018/02/27 16:51:34 
+[terragrunt] 2018/02/27 16:51:34 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:51:34 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key as well! (y/n) 
+[terragrunt] 2018/02/27 16:51:34 
+[terragrunt] 2018/02/27 16:51:34 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:51:34 Stack at /tmp/terragrunt-test045069661/fixture-stack/stage:
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key (dependencies: [])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc (dependencies: [])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, /tmp/terragrunt-test045069661/fixture-stack/stage/mysql, /tmp/terragrunt-test045069661/fixture-stack/stage/search-app])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc, /tmp/terragrunt-test045069661/fixture-stack/stage/redis])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc])
+[terragrunt] 2018/02/27 16:51:34 [terragrunt]  Are you sure you want to run 'terragrunt apply' in each folder of the stack described above? (y/n) 
+[terragrunt] 2018/02/27 16:51:34 
+[terragrunt] 2018/02/27 16:51:34 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait for 4 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:51:34 Assuming module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc has already been applied and skipping it
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait for 2 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:34 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app must wait for 3 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:51:34 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:51:34 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:51:34 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/vpc/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:51:34 Assuming module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key has already been applied and skipping it
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:34 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:34 Assuming module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host has already been applied and skipping it
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:51:34 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host of module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app must wait on 2 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app must wait for 2 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:51:34 Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:51:34 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:51:34 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host of module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait on 3 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:51:35 Running command: terraform init -backend-config=key=stage/vpc/terraform.tfstate -backend-config=region=us-west-2 -backend-config=lock_table=terragrunt-test-locks-jocs1d -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-3bdtre
+
+[0m[1mInitializing the backend...[0m
+[33m"lock_table": [DEPRECATED] please use the dynamodb_table attribute[0m[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app] 2018/02/27 16:51:36 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:36 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:36 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:36 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:36 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:36 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:36 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc must wait on 2 more dependencies.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:36 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/frontend-app of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:36 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:36 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis/.terragrunt
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:36 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:36 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:36 Backend s3 has not changed.
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:37 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-taqstt"
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:37 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-taqstt"
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:51:39 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.mgmt_vpc: Refreshing state...[0m
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis] 2018/02/27 16:51:44 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis has finished successfully!
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:44 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/redis of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc must wait on 1 more dependencies.
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql] 2018/02/27 16:51:44 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql has finished successfully!
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:44 Dependency /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/mysql of module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc just finished successfully. Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:44 Running module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc now
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:44 Reading Terragrunt config file at /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc/.terragrunt
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:44 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:44 DEPRECATION WARNING: Found deprecated config file format /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/.terragrunt. This old config format will not be supported in the future. Please move your config files into a terraform.tfvars file.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:44 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:45 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-taqstt"
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+[terragrunt] [/tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc] 2018/02/27 16:51:49 Module /tmp/terragrunt-test004502134/fixture-old-terragrunt-config/stack/stage/vpc has finished successfully!
+[0m[1m[32m
+Outputs:
+
+text = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]][0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:51:50 Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:51:50 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:51:50 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/redis just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:51:50 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/redis now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:51:50 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/redis/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:51:50 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:51:50 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait on 2 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:51:50 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:51:50 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:51:50 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/mysql/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:51:50 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:51:50 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app must wait on 1 more dependencies.
+--- PASS: TestTerragruntStackCommandsWithOldConfig (71.18s)
+	integration_test.go:517: Copying fixture-old-terragrunt-config/stack to /tmp/terragrunt-test004502134
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-taqstt
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:51:51 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-3bdtre -backend-config=key=stage/redis/terraform.tfstate -backend-config=region=us-west-2 -backend-config=lock_table=terragrunt-test-locks-jocs1d
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:51:51 Running command: terraform init -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-3bdtre -backend-config=key=stage/mysql/terraform.tfstate -backend-config=region=us-west-2 -backend-config=lock_table=terragrunt-test-locks-jocs1d
+
+[0m[1mInitializing the backend...[0m
+[33m"lock_table": [DEPRECATED] please use the dynamodb_table attribute[0m[0m
+
+[0m[1mInitializing the backend...[0m
+[33m"lock_table": [DEPRECATED] please use the dynamodb_table attribute[0m[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+- Downloading plugin for provider "template" (1.0.0)...
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:51:56 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:51:56 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+Acquiring state lock. This may take a few moments...
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+Releasing state lock. This may take a few moments...
+[0m[1m[32m
+Outputs:
+
+text = [I am a redis template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]][0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:52:07 Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:52:07 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/redis of module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:52:07 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:52:07 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/search-app/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:52:07 Initializing remote state for the s3 backend
+[0m[1m[32m
+Outputs:
+
+text = [I am a mysql template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]][0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:52:07 Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:52:07 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/mysql of module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:52:08 Running command: terraform init -backend-config=region=us-west-2 -backend-config=lock_table=terragrunt-test-locks-jocs1d -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-3bdtre -backend-config=key=stage/search-app/terraform.tfstate
+[0m[1mInitializing modules...[0m
+- module.example_module
+  Getting source "./example-module"
+
+[0m[1mInitializing the backend...[0m
+[33m"lock_table": [DEPRECATED] please use the dynamodb_table attribute[0m[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:52:12 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.redis: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[0m[1m[32m
+Outputs:
+
+text = [I am a search-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], redis = [I am a redis template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]], example_module = Example text from a module][0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:52:23 Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:52:23 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/search-app of module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:52:23 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:52:23 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:52:23 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:52:24 Running command: terraform init -backend-config=lock_table=terragrunt-test-locks-jocs1d -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-3bdtre -backend-config=key=stage/backend-app/terraform.tfstate -backend-config=region=us-west-2
+
+[0m[1mInitializing the backend...[0m
+[33m"lock_table": [DEPRECATED] please use the dynamodb_table attribute[0m[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:52:28 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.bastion_host: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.search_app: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.mysql: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[0m[1m[32m
+Outputs:
+
+text = [I am a backend-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], bastion-host = [I am a bastion-host template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], mysql = [I am a mysql template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]], search-app = [I am a search-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], redis = [I am a redis template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]], example_module = Example text from a module]][0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:52:39 Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:52:39 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app of module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:52:39 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:52:39 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:52:39 Initializing remote state for the s3 backend
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:52:40 Running command: terraform init -backend-config=region=us-west-2 -backend-config=lock_table=terragrunt-test-locks-jocs1d -backend-config=encrypt=true -backend-config=bucket=terragrunt-test-bucket-3bdtre -backend-config=key=stage/frontend-app/terraform.tfstate
+
+[0m[1mInitializing the backend...[0m
+[33m"lock_table": [DEPRECATED] please use the dynamodb_table attribute[0m[0m
+[0m[32m
+Successfully configured the backend "s3"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "template" (1.0.0)...
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.template: version = "~> 1.0"
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:52:44 Running command: terraform apply -input=false -auto-approve -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.bastion_host: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.backend_app: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[0m[1m[32m
+Outputs:
+
+text = [I am a frontend-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], bastion-host = [I am a bastion-host template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], backend-app = [I am a backend-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], bastion-host = [I am a bastion-host template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], mysql = [I am a mysql template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]], search-app = [I am a search-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], redis = [I am a redis template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]], example_module = Example text from a module]]][0m
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:52:55 Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt] 2018/02/27 16:52:55 Running command: terraform --version
+[terragrunt] 2018/02/27 16:52:55 Stack at /tmp/terragrunt-test045069661/fixture-stack/mgmt:
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key (dependencies: [])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc (dependencies: [])
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:52:55 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:52:55 Running module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:52:55 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:52:55 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:52:55 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait for 2 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:52:55 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:52:55 Running module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:52:55 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:52:55 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:52:56 Running command: terraform output
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:52:56 Running command: terraform output
+text = [I am a kms-master-key template.]
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:53:00 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:00 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait on 1 more dependencies.
+text = [I am a mgmt vpc template. I have no dependencies.]
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:53:00 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:00 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:00 Running module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:00 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:00 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:00 Running command: terraform output
+text = [I am a bastion-host template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage] 2018/02/27 16:53:04 Running command: terraform --version
+[terragrunt] 2018/02/27 16:53:04 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host as well! (y/n) 
+[terragrunt] 2018/02/27 16:53:04 
+[terragrunt] 2018/02/27 16:53:04 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:53:04 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host as well! (y/n) 
+[terragrunt] 2018/02/27 16:53:04 
+[terragrunt] 2018/02/27 16:53:04 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:53:04 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc as well! (y/n) 
+[terragrunt] 2018/02/27 16:53:04 
+[terragrunt] 2018/02/27 16:53:04 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:53:04 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key as well! (y/n) 
+[terragrunt] 2018/02/27 16:53:04 
+[terragrunt] 2018/02/27 16:53:04 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:53:04 Stack at /tmp/terragrunt-test045069661/fixture-stack/stage:
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key (dependencies: [])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc (dependencies: [])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, /tmp/terragrunt-test045069661/fixture-stack/stage/mysql, /tmp/terragrunt-test045069661/fixture-stack/stage/search-app])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc, /tmp/terragrunt-test045069661/fixture-stack/stage/redis])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc])
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait for 4 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app must wait for 3 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app must wait for 2 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:53:04 Assuming module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key has already been applied and skipping it
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait for 2 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:04 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:53:04 Assuming module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc has already been applied and skipping it
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:53:04 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:53:04 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:53:04 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/vpc/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:53:04 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:04 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:04 Assuming module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host has already been applied and skipping it
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:04 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:04 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host of module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app must wait on 2 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:04 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host of module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait on 3 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:53:05 Running command: terraform output
+text = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:53:09 Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:09 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:53:09 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/redis just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:53:09 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/redis now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:53:09 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/redis/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:53:09 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:09 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait on 2 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:09 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:09 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:09 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/mysql/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:09 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:09 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/vpc of module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:53:09 Running command: terraform output
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:09 Running command: terraform output
+text = [I am a redis template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]]
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:53:13 Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:13 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/redis of module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:13 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:13 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/search-app/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:13 Backend s3 has not changed.
+text = [I am a mysql template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]]
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:13 Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:13 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/mysql of module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:13 Running command: terraform output
+text = [I am a search-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], redis = [I am a redis template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]], example_module = Example text from a module]
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:18 Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:18 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/search-app of module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:18 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:18 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:18 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:18 Running command: terraform output
+text = [I am a backend-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], bastion-host = [I am a bastion-host template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], mysql = [I am a mysql template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]], search-app = [I am a search-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], redis = [I am a redis template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]], example_module = Example text from a module]]
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:22 Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:22 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app of module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:22 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:22 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:22 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:22 Running command: terraform output
+text = [I am a frontend-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], bastion-host = [I am a bastion-host template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], backend-app = [I am a backend-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], bastion-host = [I am a bastion-host template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], mysql = [I am a mysql template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]], search-app = [I am a search-app template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]], redis = [I am a redis template. Data from my dependencies: vpc = [I am a stage vpc template. Data from my dependencies: vpc = [I am a mgmt vpc template. I have no dependencies.]]], example_module = Example text from a module]]]
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:26 Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage] 2018/02/27 16:53:26 Running command: terraform --version
+[terragrunt] 2018/02/27 16:53:26 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc as well! (y/n) 
+[terragrunt] 2018/02/27 16:53:26 
+[terragrunt] 2018/02/27 16:53:26 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:53:26 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host as well! (y/n) 
+[terragrunt] 2018/02/27 16:53:26 
+[terragrunt] 2018/02/27 16:53:26 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:53:26 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host as well! (y/n) 
+[terragrunt] 2018/02/27 16:53:26 
+[terragrunt] 2018/02/27 16:53:26 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:53:26 [terragrunt]  Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host depends on module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key as well! (y/n) 
+[terragrunt] 2018/02/27 16:53:26 
+[terragrunt] 2018/02/27 16:53:26 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] 2018/02/27 16:53:26 Stack at /tmp/terragrunt-test045069661/fixture-stack/stage:
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key (dependencies: [])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc (dependencies: [])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, /tmp/terragrunt-test045069661/fixture-stack/stage/mysql, /tmp/terragrunt-test045069661/fixture-stack/stage/search-app])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host, /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc, /tmp/terragrunt-test045069661/fixture-stack/stage/redis])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc])
+[terragrunt] 2018/02/27 16:53:26 [terragrunt]  WARNING: Are you sure you want to run `terragrunt destroy` in each folder of the stack described above? There is no undo! (y/n) 
+[terragrunt] 2018/02/27 16:53:26 
+[terragrunt] 2018/02/27 16:53:26 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:53:26 Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc must wait for 5 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:53:26 Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:26 Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:53:26 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc must wait for 2 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:26 Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:26 Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:26 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait for 2 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:26 Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:26 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:26 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:26 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:53:26 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:27 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.backend_app: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.bastion_host: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app] 2018/02/27 16:53:37 Module /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:37 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app of module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:37 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:37 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:37 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:53:37 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app of module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc must wait on 4 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:37 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/frontend-app of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:38 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.bastion_host: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.search_app: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.mysql: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/backend-app] 2018/02/27 16:53:50 Module /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:50 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app of module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:50 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:50 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/search-app/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:50 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:53:50 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app of module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc must wait on 3 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:50 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:50 Assuming module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host has already been applied and skipping it
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:53:50 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:53:50 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:53:50 Assuming module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key has already been applied and skipping it
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:53:50 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:50 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/backend-app of module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:50 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:50 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/mysql/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:50 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:53:50 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:53:50 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:53:50 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+Acquiring state lock. This may take a few moments...
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.terraform_remote_state.redis: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+Releasing state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/mysql] 2018/02/27 16:54:01 Module /tmp/terragrunt-test045069661/fixture-stack/stage/mysql has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:54:01 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/mysql of module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc must wait on 2 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/search-app] 2018/02/27 16:54:01 Module /tmp/terragrunt-test045069661/fixture-stack/stage/search-app has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:54:01 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/search-app of module /tmp/terragrunt-test045069661/fixture-stack/stage/redis just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:54:01 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/redis now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:54:01 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/redis/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:54:01 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:54:01 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/search-app of module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc must wait on 1 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:54:02 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/redis] 2018/02/27 16:54:13 Module /tmp/terragrunt-test045069661/fixture-stack/stage/redis has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:54:13 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/redis of module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:54:13 Running module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:54:13 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/stage/vpc/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:54:13 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:54:14 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.mgmt_vpc: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/stage/vpc] 2018/02/27 16:54:25 Module /tmp/terragrunt-test045069661/fixture-stack/stage/vpc has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:54:25 Dependency /tmp/terragrunt-test045069661/fixture-stack/stage/vpc of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:54:25 Assuming module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc has already been applied and skipping it
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:54:25 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt] 2018/02/27 16:54:25 Running command: terraform --version
+[terragrunt] 2018/02/27 16:54:25 Stack at /tmp/terragrunt-test045069661/fixture-stack/mgmt:
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host (dependencies: [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc, /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key (dependencies: [])
+  => Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc (dependencies: [])
+[terragrunt] 2018/02/27 16:54:25 [terragrunt]  WARNING: Are you sure you want to run `terragrunt destroy` in each folder of the stack described above? There is no undo! (y/n) 
+[terragrunt] 2018/02/27 16:54:25 
+[terragrunt] 2018/02/27 16:54:25 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:54:25 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host must wait for 0 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:54:25 Running module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:54:25 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:54:25 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:54:25 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:54:25 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc must wait for 1 dependencies to finish
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:54:26 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.terraform_remote_state.vpc: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host] 2018/02/27 16:54:36 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:54:36 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:54:36 Running module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:54:36 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:54:36 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:54:36 Dependency /tmp/terragrunt-test045069661/fixture-stack/mgmt/bastion-host of module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc just finished successfully. Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc must wait on 0 more dependencies.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:54:36 Running module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc now
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:54:36 Reading Terragrunt config file at /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc/terraform.tfvars
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:54:36 Backend s3 has not changed.
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:54:37 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:54:37 Running command: terraform destroy -force -input=false -var terraform_remote_state_s3_bucket="terragrunt-test-bucket-3bdtre"
+Acquiring state lock. This may take a few moments...
+Acquiring state lock. This may take a few moments...
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1mdata.template_file.text: Refreshing state...[0m
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+[0m[1m[32m
+Destroy complete! Resources: 0 destroyed.[0m
+Releasing state lock. This may take a few moments...
+Releasing state lock. This may take a few moments...
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key] 2018/02/27 16:54:45 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/kms-master-key has finished successfully!
+[terragrunt] [/tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc] 2018/02/27 16:54:45 Module /tmp/terragrunt-test045069661/fixture-stack/mgmt/vpc has finished successfully!
+--- PASS: TestTerragruntStackCommands (247.44s)
+	integration_test.go:517: Copying fixture-stack/ to /tmp/terragrunt-test045069661
+	integration_test.go:647: Deleting test s3 bucket terragrunt-test-bucket-3bdtre
+PASS
+ok  	github.com/gruntwork-io/terragrunt/test	247.875s
+?   	github.com/gruntwork-io/terragrunt/test/helpers	[no test files]
+?   	github.com/gruntwork-io/terragrunt/aws_helper	[no test files]
+=== RUN   TestToTerraformInitArgs
+=== PAUSE TestToTerraformInitArgs
+=== RUN   TestToTerraformInitArgsNoBackendConfigs
+=== PAUSE TestToTerraformInitArgsNoBackendConfigs
+=== RUN   TestDiffersFrom
+=== PAUSE TestDiffersFrom
+=== RUN   TestParseTerraformStateLocal
+=== PAUSE TestParseTerraformStateLocal
+=== RUN   TestParseTerraformStateRemote
+=== PAUSE TestParseTerraformStateRemote
+=== RUN   TestParseTerraformStateRemoteFull
+=== PAUSE TestParseTerraformStateRemoteFull
+=== RUN   TestParseTerraformStateEmpty
+=== PAUSE TestParseTerraformStateEmpty
+=== RUN   TestParseTerraformStateInvalid
+=== PAUSE TestParseTerraformStateInvalid
+=== CONT  TestToTerraformInitArgs
+--- PASS: TestToTerraformInitArgs (0.00s)
+=== CONT  TestParseTerraformStateInvalid
+--- PASS: TestParseTerraformStateInvalid (0.00s)
+=== CONT  TestParseTerraformStateEmpty
+--- PASS: TestParseTerraformStateEmpty (0.00s)
+=== CONT  TestParseTerraformStateRemoteFull
+--- PASS: TestParseTerraformStateRemoteFull (0.00s)
+=== CONT  TestParseTerraformStateRemote
+--- PASS: TestParseTerraformStateRemote (0.00s)
+=== CONT  TestParseTerraformStateLocal
+--- PASS: TestParseTerraformStateLocal (0.00s)
+=== CONT  TestDiffersFrom
+[terragrunt] 2018/02/27 16:54:48 Backend  has not changed.
+[terragrunt] 2018/02/27 16:54:48 Backend s3 has not changed.
+[terragrunt] 2018/02/27 16:54:48 Backend type has changed from s3 to atlas
+[terragrunt] 2018/02/27 16:54:48 Backend s3 has not changed.
+[terragrunt] 2018/02/27 16:54:48 Backend config has changed from map[region:us-east-1 bucket:foo key:bar] to map[region:us-east-1 bucket:different key:bar]
+[terragrunt] 2018/02/27 16:54:48 Backend config has changed from map[bucket:foo key:bar region:us-east-1] to map[bucket:foo key:different region:us-east-1]
+[terragrunt] 2018/02/27 16:54:48 Backend config has changed from map[bucket:foo key:bar region:us-east-1] to map[bucket:foo key:bar region:different]
+--- PASS: TestDiffersFrom (0.00s)
+=== CONT  TestToTerraformInitArgsNoBackendConfigs
+--- PASS: TestToTerraformInitArgsNoBackendConfigs (0.00s)
+PASS
+ok  	github.com/gruntwork-io/terragrunt/remote	0.005s
+=== RUN   TestParseTerragruntOptionsFromArgs
+=== PAUSE TestParseTerragruntOptionsFromArgs
+=== RUN   TestFilterTerragruntArgs
+=== PAUSE TestFilterTerragruntArgs
+=== RUN   TestParseEnvironmentVariables
+--- PASS: TestParseEnvironmentVariables (0.00s)
+=== RUN   TestAlreadyHaveLatestCodeLocalFilePath
+=== PAUSE TestAlreadyHaveLatestCodeLocalFilePath
+=== RUN   TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirDoesNotExist
+=== PAUSE TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirDoesNotExist
+=== RUN   TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsNoVersionNoVersionFile
+=== PAUSE TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsNoVersionNoVersionFile
+=== RUN   TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsNoVersionWithVersionFile
+=== PAUSE TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsNoVersionWithVersionFile
+=== RUN   TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionNoVersionFile
+=== PAUSE TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionNoVersionFile
+=== RUN   TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersionFile
+=== PAUSE TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersionFile
+=== RUN   TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersionFileAndTfCode
+=== PAUSE TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersionFileAndTfCode
+=== RUN   TestDownloadTerraformSourceIfNecessaryLocalDirToEmptyDir
+=== PAUSE TestDownloadTerraformSourceIfNecessaryLocalDirToEmptyDir
+=== RUN   TestDownloadTerraformSourceIfNecessaryLocalDirToAlreadyDownloadedDir
+=== PAUSE TestDownloadTerraformSourceIfNecessaryLocalDirToAlreadyDownloadedDir
+=== RUN   TestDownloadTerraformSourceIfNecessaryRemoteUrlToEmptyDir
+=== PAUSE TestDownloadTerraformSourceIfNecessaryRemoteUrlToEmptyDir
+=== RUN   TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDir
+=== PAUSE TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDir
+=== RUN   TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirDifferentVersion
+=== PAUSE TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirDifferentVersion
+=== RUN   TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVersion
+=== PAUSE TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVersion
+=== RUN   TestDownloadTerraformSourceIfNecessaryRemoteUrlOverrideSource
+=== PAUSE TestDownloadTerraformSourceIfNecessaryRemoteUrlOverrideSource
+=== RUN   TestCheckTerraformVersionMeetsConstraintEqual
+=== PAUSE TestCheckTerraformVersionMeetsConstraintEqual
+=== RUN   TestCheckTerraformVersionMeetsConstraintGreaterDev
+=== PAUSE TestCheckTerraformVersionMeetsConstraintGreaterDev
+=== RUN   TestCheckTerraformVersionMeetsConstraintGreaterPatch
+=== PAUSE TestCheckTerraformVersionMeetsConstraintGreaterPatch
+=== RUN   TestCheckTerraformVersionMeetsConstraintGreaterMajor
+=== PAUSE TestCheckTerraformVersionMeetsConstraintGreaterMajor
+=== RUN   TestCheckTerraformVersionMeetsConstraintLessPatch
+=== PAUSE TestCheckTerraformVersionMeetsConstraintLessPatch
+=== RUN   TestCheckTerraformVersionMeetsConstraintLessMajor
+=== PAUSE TestCheckTerraformVersionMeetsConstraintLessMajor
+=== RUN   TestParseTerraformVersionNormal
+=== PAUSE TestParseTerraformVersionNormal
+=== RUN   TestParseTerraformVersionWithoutV
+=== PAUSE TestParseTerraformVersionWithoutV
+=== RUN   TestParseTerraformVersionWithDebug
+=== PAUSE TestParseTerraformVersionWithDebug
+=== RUN   TestParseTerraformVersionWithChanges
+=== PAUSE TestParseTerraformVersionWithChanges
+=== RUN   TestParseTerraformVersionWithDev
+=== PAUSE TestParseTerraformVersionWithDev
+=== RUN   TestParseTerraformVersionInvalidSyntax
+=== PAUSE TestParseTerraformVersionInvalidSyntax
+=== CONT  TestParseTerragruntOptionsFromArgs
+--- PASS: TestParseTerragruntOptionsFromArgs (0.00s)
+=== CONT  TestParseTerraformVersionInvalidSyntax
+--- PASS: TestParseTerraformVersionInvalidSyntax (0.00s)
+=== CONT  TestParseTerraformVersionWithDev
+--- PASS: TestParseTerraformVersionWithDev (0.00s)
+=== CONT  TestParseTerraformVersionWithChanges
+--- PASS: TestParseTerraformVersionWithChanges (0.00s)
+=== CONT  TestParseTerraformVersionWithDebug
+--- PASS: TestParseTerraformVersionWithDebug (0.00s)
+=== CONT  TestParseTerraformVersionWithoutV
+--- PASS: TestParseTerraformVersionWithoutV (0.00s)
+=== CONT  TestParseTerraformVersionNormal
+--- PASS: TestParseTerraformVersionNormal (0.00s)
+=== CONT  TestCheckTerraformVersionMeetsConstraintLessMajor
+--- PASS: TestCheckTerraformVersionMeetsConstraintLessMajor (0.00s)
+=== CONT  TestCheckTerraformVersionMeetsConstraintLessPatch
+--- PASS: TestCheckTerraformVersionMeetsConstraintLessPatch (0.00s)
+=== CONT  TestCheckTerraformVersionMeetsConstraintGreaterMajor
+--- PASS: TestCheckTerraformVersionMeetsConstraintGreaterMajor (0.00s)
+=== CONT  TestCheckTerraformVersionMeetsConstraintGreaterPatch
+--- PASS: TestCheckTerraformVersionMeetsConstraintGreaterPatch (0.00s)
+=== CONT  TestCheckTerraformVersionMeetsConstraintGreaterDev
+--- PASS: TestCheckTerraformVersionMeetsConstraintGreaterDev (0.00s)
+=== CONT  TestCheckTerraformVersionMeetsConstraintEqual
+--- PASS: TestCheckTerraformVersionMeetsConstraintEqual (0.00s)
+=== CONT  TestDownloadTerraformSourceIfNecessaryRemoteUrlOverrideSource
+[terragrunt] [.] 2018/02/27 16:54:49 Running command: terraform --version
+=== CONT  TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVersion
+[terragrunt] [.] 2018/02/27 16:54:49 Running command: terraform --version
+=== CONT  TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirDifferentVersion
+[terragrunt] [.] 2018/02/27 16:54:49 Running command: terraform --version
+=== CONT  TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDir
+[terragrunt] [.] 2018/02/27 16:54:49 Running command: terraform --version
+=== CONT  TestDownloadTerraformSourceIfNecessaryRemoteUrlToEmptyDir
+[terragrunt] [.] 2018/02/27 16:54:49 Running command: terraform --version
+=== CONT  TestDownloadTerraformSourceIfNecessaryLocalDirToAlreadyDownloadedDir
+[terragrunt] [.] 2018/02/27 16:54:49 Running command: terraform --version
+=== CONT  TestDownloadTerraformSourceIfNecessaryLocalDirToEmptyDir
+[terragrunt] [.] 2018/02/27 16:54:49 Running command: terraform --version
+=== CONT  TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersionFileAndTfCode
+=== CONT  TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersionFile
+[terragrunt] 2018/02/27 16:54:49 Working dir ../test/fixture-download-source/download-dir-version-file exists but contains no Terraform files, so assuming code needs to be downloaded again.
+--- PASS: TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersionFile (0.00s)
+=== CONT  TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionNoVersionFile
+--- PASS: TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionNoVersionFile (0.00s)
+=== CONT  TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsNoVersionWithVersionFile
+=== CONT  TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsNoVersionNoVersionFile
+--- PASS: TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsNoVersionNoVersionFile (0.00s)
+=== CONT  TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirDoesNotExist
+--- PASS: TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirDoesNotExist (0.00s)
+=== CONT  TestAlreadyHaveLatestCodeLocalFilePath
+--- PASS: TestAlreadyHaveLatestCodeLocalFilePath (0.00s)
+=== CONT  TestFilterTerragruntArgs
+--- PASS: TestFilterTerragruntArgs (0.00s)
+[terragrunt] 2018/02/27 16:54:49 Terraform files in /tmp/download-source-test918971500 are up to date. Will not download again.
+--- PASS: TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVersion (0.10s)
+[terragrunt] 2018/02/27 16:54:49 The --terragrunt-source-update flag is set, so deleting the temporary folder /tmp/download-source-test003067137 before downloading source.
+[terragrunt] 2018/02/27 16:54:49 Downloading Terraform configurations from github.com/gruntwork-io/terragrunt//test/fixture-download-source/hello-world?ref=v0.9.7 into /tmp/download-source-test003067137 using terraform init
+[terragrunt] [.] 2018/02/27 16:54:49 Running command: terraform init -from-module=github.com/gruntwork-io/terragrunt//test/fixture-download-source/hello-world?ref=v0.9.7 /tmp/download-source-test003067137
+--- PASS: TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersionFileAndTfCode (0.02s)
+[terragrunt] 2018/02/27 16:54:49 Cleaning up existing *.tf files in /tmp/download-source-test656005851
+[terragrunt] 2018/02/27 16:54:49 Downloading Terraform configurations from github.com/gruntwork-io/terragrunt//test/fixture-download-source/hello-world?ref=v0.9.7 into /tmp/download-source-test656005851 using terraform init
+[terragrunt] [.] 2018/02/27 16:54:49 Running command: terraform init -from-module=github.com/gruntwork-io/terragrunt//test/fixture-download-source/hello-world?ref=v0.9.7 /tmp/download-source-test656005851
+--- PASS: TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsNoVersionWithVersionFile (0.02s)
+[terragrunt] 2018/02/27 16:54:49 Terraform files in /tmp/download-source-test847574142 are up to date. Will not download again.
+--- PASS: TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDir (0.11s)
+[terragrunt] 2018/02/27 16:54:49 Cleaning up existing *.tf files in /tmp/download-source-test008728517
+[terragrunt] 2018/02/27 16:54:49 Downloading Terraform configurations from github.com/gruntwork-io/terragrunt//test/fixture-download-source/hello-world into /tmp/download-source-test008728517 using terraform init
+[terragrunt] [.] 2018/02/27 16:54:49 Running command: terraform init -from-module=github.com/gruntwork-io/terragrunt//test/fixture-download-source/hello-world /tmp/download-source-test008728517
+[terragrunt] 2018/02/27 16:54:50 Cleaning up existing *.tf files in /tmp/download-source-test017336416
+[terragrunt] 2018/02/27 16:54:50 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download-source/hello-world into /tmp/download-source-test017336416 using terraform init
+[terragrunt] [.] 2018/02/27 16:54:50 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download-source/hello-world /tmp/download-source-test017336416
+[terragrunt] 2018/02/27 16:54:50 Cleaning up existing *.tf files in /tmp/download-source-test235019327
+[terragrunt] 2018/02/27 16:54:50 Downloading Terraform configurations from file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download-source/hello-world into /tmp/download-source-test235019327 using terraform init
+[terragrunt] [.] 2018/02/27 16:54:50 Running command: terraform init -from-module=file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download-source/hello-world /tmp/download-source-test235019327
+[0m[1mCopying configuration[0m from "github.com/gruntwork-io/terragrunt//test/fixture-download-source/hello-world?ref=v0.9.7"...[0m
+[0m[1mCopying configuration[0m from "github.com/gruntwork-io/terragrunt//test/fixture-download-source/hello-world?ref=v0.9.7"...[0m
+[0m[1mCopying configuration[0m from "github.com/gruntwork-io/terragrunt//test/fixture-download-source/hello-world"...[0m
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download-source/hello-world"...[0m
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+--- PASS: TestDownloadTerraformSourceIfNecessaryLocalDirToAlreadyDownloadedDir (0.20s)
+[0m[1mCopying configuration[0m from "file:///root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-download-source/hello-world"...[0m
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+--- PASS: TestDownloadTerraformSourceIfNecessaryLocalDirToEmptyDir (0.20s)
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+--- PASS: TestDownloadTerraformSourceIfNecessaryRemoteUrlOverrideSource (5.12s)
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+--- PASS: TestDownloadTerraformSourceIfNecessaryRemoteUrlToEmptyDir (5.29s)
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+--- PASS: TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirDifferentVersion (6.90s)
+PASS
+ok  	github.com/gruntwork-io/terragrunt/cli	6.912s
+=== RUN   TestListContainsElement
+=== PAUSE TestListContainsElement
+=== RUN   TestRemoveElementFromList
+=== PAUSE TestRemoveElementFromList
+=== RUN   TestRemoveDuplicatesFromList
+=== PAUSE TestRemoveDuplicatesFromList
+=== RUN   TestCommaSeparatedStrings
+=== PAUSE TestCommaSeparatedStrings
+=== RUN   TestGetPathRelativeTo
+=== PAUSE TestGetPathRelativeTo
+=== RUN   TestCanonicalPath
+=== PAUSE TestCanonicalPath
+=== RUN   TestPathContainsHiddenFileOrFolder
+=== PAUSE TestPathContainsHiddenFileOrFolder
+=== RUN   TestJoinTerraformModulePath
+=== PAUSE TestJoinTerraformModulePath
+=== RUN   TestGetRandomTime
+=== PAUSE TestGetRandomTime
+=== RUN   TestKindOf
+=== PAUSE TestKindOf
+=== CONT  TestListContainsElement
+--- PASS: TestListContainsElement (0.00s)
+=== CONT  TestKindOf
+--- PASS: TestKindOf (0.00s)
+	reflect_test.go:31: 1 passed
+	reflect_test.go:31: 2 passed
+	reflect_test.go:31: 65 passed
+	reflect_test.go:31: 3.141592653589793 passed
+	reflect_test.go:31: true passed
+	reflect_test.go:31: <nil> passed
+	reflect_test.go:31: Hello World! passed
+	reflect_test.go:31: 0xc420046f40 passed
+	reflect_test.go:31:  passed
+	reflect_test.go:31: false passed
+=== CONT  TestGetRandomTime
+--- PASS: TestGetRandomTime (0.00s)
+=== CONT  TestJoinTerraformModulePath
+=== RUN   TestJoinTerraformModulePath/foo-bar
+=== RUN   TestJoinTerraformModulePath/foo/-bar
+=== RUN   TestJoinTerraformModulePath/foo-/bar
+=== RUN   TestJoinTerraformModulePath/foo/-/bar
+=== RUN   TestJoinTerraformModulePath/foo//-/bar
+=== RUN   TestJoinTerraformModulePath/foo//-//bar
+=== RUN   TestJoinTerraformModulePath//foo/bar/baz-/a/b/c
+=== RUN   TestJoinTerraformModulePath//foo/bar/baz/-//a/b/c
+--- PASS: TestJoinTerraformModulePath (0.00s)
+    --- PASS: TestJoinTerraformModulePath/foo-bar (0.00s)
+    --- PASS: TestJoinTerraformModulePath/foo/-bar (0.00s)
+    --- PASS: TestJoinTerraformModulePath/foo-/bar (0.00s)
+    --- PASS: TestJoinTerraformModulePath/foo/-/bar (0.00s)
+    --- PASS: TestJoinTerraformModulePath/foo//-/bar (0.00s)
+    --- PASS: TestJoinTerraformModulePath/foo//-//bar (0.00s)
+    --- PASS: TestJoinTerraformModulePath//foo/bar/baz-/a/b/c (0.00s)
+    --- PASS: TestJoinTerraformModulePath//foo/bar/baz/-//a/b/c (0.00s)
+=== CONT  TestPathContainsHiddenFileOrFolder
+--- PASS: TestPathContainsHiddenFileOrFolder (0.00s)
+=== CONT  TestCanonicalPath
+--- PASS: TestCanonicalPath (0.00s)
+=== CONT  TestGetPathRelativeTo
+--- PASS: TestGetPathRelativeTo (0.00s)
+=== CONT  TestCommaSeparatedStrings
+--- PASS: TestCommaSeparatedStrings (0.00s)
+	collections_test.go:94: [] passed
+	collections_test.go:94: [foo] passed
+	collections_test.go:94: [foo bar] passed
+=== CONT  TestRemoveDuplicatesFromList
+--- PASS: TestRemoveDuplicatesFromList (0.00s)
+	collections_test.go:76: [] passed
+	collections_test.go:76: [foo] passed
+	collections_test.go:76: [foo bar] passed
+	collections_test.go:76: [foo bar foobar bar foo] passed
+	collections_test.go:76: [foo bar foobar foo bar] passed
+	collections_test.go:76: [foo bar foobar bar foo] passed
+	collections_test.go:76: [foo bar foobar foo bar] passed
+=== CONT  TestRemoveElementFromList
+--- PASS: TestRemoveElementFromList (0.00s)
+PASS
+ok  	github.com/gruntwork-io/terragrunt/util	(cached)
+=== RUN   TestRunShellCommand
+=== PAUSE TestRunShellCommand
+=== RUN   TestExitCodeUnix
+=== PAUSE TestExitCodeUnix
+=== RUN   TestNewSignalsForwarderWaitUnix
+=== PAUSE TestNewSignalsForwarderWaitUnix
+=== RUN   TestNewSignalsForwarderMultipleUnix
+=== PAUSE TestNewSignalsForwarderMultipleUnix
+=== CONT  TestRunShellCommand
+[terragrunt] 2018/02/27 15:18:59 Running command: terraform --version
+=== CONT  TestNewSignalsForwarderMultipleUnix
+=== CONT  TestNewSignalsForwarderWaitUnix
+=== CONT  TestExitCodeUnix
+Terraform v0.11.3
+
+[terragrunt] 2018/02/27 15:18:59 Running command: terraform not-a-real-command
+Usage: terraform [--version] [--help] <command> [args]
+
+The available commands for execution are listed below.
+The most common, useful commands are shown first, followed by
+less common or more advanced commands. If you're just getting
+started with Terraform, stick with the common commands. For the
+other commands, please read the help and docs before usage.
+
+Common commands:
+    apply              Builds or changes infrastructure
+    console            Interactive console for Terraform interpolations
+    destroy            Destroy Terraform-managed infrastructure
+    env                Workspace management
+    fmt                Rewrites config files to canonical format
+    get                Download and install modules for the configuration
+    graph              Create a visual graph of Terraform resources
+    import             Import existing infrastructure into Terraform
+    init               Initialize a Terraform working directory
+    output             Read an output from a state file
+    plan               Generate and show an execution plan
+    providers          Prints a tree of the providers used in the configuration
+    push               Upload this Terraform module to Atlas to run
+    refresh            Update local state file against real resources
+    show               Inspect Terraform state or plan
+    taint              Manually mark a resource for recreation
+    untaint            Manually unmark a resource as tainted
+    validate           Validates the Terraform files
+    version            Prints the Terraform version
+    workspace          Workspace management
+
+All other commands:
+    debug              Debug output management (experimental)
+    force-unlock       Manually unlock the terraform state
+    state              Advanced state management
+--- PASS: TestRunShellCommand (0.05s)
+--- PASS: TestExitCodeUnix (0.28s)
+--- PASS: TestNewSignalsForwarderWaitUnix (6.02s)
+--- PASS: TestNewSignalsForwarderMultipleUnix (6.50s)
+PASS
+ok  	github.com/gruntwork-io/terragrunt/shell	(cached)
+=== RUN   TestCountingSemaphoreHappyPath
+=== PAUSE TestCountingSemaphoreHappyPath
+=== RUN   TestCountingSemaphoreConcurrency
+=== PAUSE TestCountingSemaphoreConcurrency
+=== RUN   TestCreateLockTableIfNecessaryTableDoesntAlreadyExist
+=== PAUSE TestCreateLockTableIfNecessaryTableDoesntAlreadyExist
+=== RUN   TestCreateLockTableConcurrency
+=== PAUSE TestCreateLockTableConcurrency
+=== RUN   TestWaitForTableToBeActiveTableDoesNotExist
+=== PAUSE TestWaitForTableToBeActiveTableDoesNotExist
+=== RUN   TestCreateLockTableIfNecessaryTableAlreadyExists
+=== PAUSE TestCreateLockTableIfNecessaryTableAlreadyExists
+=== CONT  TestCountingSemaphoreHappyPath
+--- PASS: TestCountingSemaphoreHappyPath (0.00s)
+=== CONT  TestCreateLockTableIfNecessaryTableAlreadyExists
+=== CONT  TestWaitForTableToBeActiveTableDoesNotExist
+=== CONT  TestCreateLockTableConcurrency
+=== CONT  TestCreateLockTableIfNecessaryTableDoesntAlreadyExist
+=== CONT  TestCountingSemaphoreConcurrency
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_4puH9a does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Creating table terragrunt_test_4puH9a in DynamoDB
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_pD7sKb does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Creating table terragrunt_test_pD7sKb in DynamoDB
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt-table-does-not-exist is not yet in active state. Will check again after 235ms.
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+--- PASS: TestCountingSemaphoreConcurrency (0.56s)
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Lock table terragrunt_test_VIpwFn does not exist in DynamoDB. Will need to create it just this first time.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt_test_pD7sKb is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:54:58 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:54:58 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:54:58 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:54:58 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt_test_4puH9a is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:54:58 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt-table-does-not-exist is not yet in active state. Will check again after 499ms.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:54:58 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:54:58 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:54:58 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:54:59 Table terragrunt-table-does-not-exist is not yet in active state. Will check again after 258ms.
+[terragrunt] 2018/02/27 16:54:59 Table terragrunt-table-does-not-exist is not yet in active state. Will check again after 80ms.
+[terragrunt] 2018/02/27 16:54:59 Table terragrunt-table-does-not-exist is not yet in active state. Will check again after 262ms.
+--- PASS: TestWaitForTableToBeActiveTableDoesNotExist (2.31s)
+[terragrunt] 2018/02/27 16:55:08 Table terragrunt_test_pD7sKb is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:08 Table terragrunt_test_4puH9a is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:08 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:08 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:08 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:08 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:08 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:08 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:08 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:08 Table terragrunt_test_VIpwFn is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:18 Table terragrunt_test_pD7sKb is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:18 Table terragrunt_test_4puH9a is not yet in active state. Will check again after 10s.
+[terragrunt] 2018/02/27 16:55:18 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:18 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:18 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:18 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:18 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:18 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:18 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:18 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:18 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:19 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:19 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:19 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:19 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:19 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Creating table terragrunt_test_VIpwFn in DynamoDB
+[terragrunt] 2018/02/27 16:55:19 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:19 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:19 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:19 Looks like someone created table terragrunt_test_VIpwFn at the same time. Will wait for it to be in active state.
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+[terragrunt] 2018/02/27 16:55:19 Success! Table terragrunt_test_VIpwFn is now in active state.
+--- PASS: TestCreateLockTableConcurrency (21.96s)
+[terragrunt] 2018/02/27 16:55:28 Success! Table terragrunt_test_pD7sKb is now in active state.
+[terragrunt] 2018/02/27 16:55:28 Success! Table terragrunt_test_4puH9a is now in active state.
+--- PASS: TestCreateLockTableIfNecessaryTableAlreadyExists (31.29s)
+--- PASS: TestCreateLockTableIfNecessaryTableDoesntAlreadyExist (31.47s)
+PASS
+ok  	github.com/gruntwork-io/terragrunt/dynamodb	31.481s
+=== RUN   TestCheckForCycles
+=== PAUSE TestCheckForCycles
+=== RUN   TestResolveTerraformModulesNoPaths
+=== PAUSE TestResolveTerraformModulesNoPaths
+=== RUN   TestResolveTerraformModulesOneModuleNoDependencies
+=== PAUSE TestResolveTerraformModulesOneModuleNoDependencies
+=== RUN   TestResolveTerraformModulesOneModuleWithIncludesNoDependencies
+=== PAUSE TestResolveTerraformModulesOneModuleWithIncludesNoDependencies
+=== RUN   TestResolveTerraformModulesTwoModulesWithDependencies
+=== PAUSE TestResolveTerraformModulesTwoModulesWithDependencies
+=== RUN   TestResolveTerraformModulesMultipleModulesWithDependencies
+=== PAUSE TestResolveTerraformModulesMultipleModulesWithDependencies
+=== RUN   TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes
+=== PAUSE TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes
+=== RUN   TestResolveTerraformModulesMultipleModulesWithExternalDependencies
+=== PAUSE TestResolveTerraformModulesMultipleModulesWithExternalDependencies
+=== RUN   TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies
+=== PAUSE TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies
+=== RUN   TestResolveTerraformModulesInvalidPaths
+=== PAUSE TestResolveTerraformModulesInvalidPaths
+=== RUN   TestResolveTerraformModuleNoTerraformConfig
+=== PAUSE TestResolveTerraformModuleNoTerraformConfig
+=== RUN   TestGetTerragruntSourceForModuleHappyPath
+=== PAUSE TestGetTerragruntSourceForModuleHappyPath
+=== RUN   TestGetTerragruntSourceForModuleErrors
+=== PAUSE TestGetTerragruntSourceForModuleErrors
+=== RUN   TestToRunningModulesNoModules
+=== PAUSE TestToRunningModulesNoModules
+=== RUN   TestToRunningModulesOneModuleNoDependencies
+=== PAUSE TestToRunningModulesOneModuleNoDependencies
+=== RUN   TestToRunningModulesTwoModulesNoDependencies
+=== PAUSE TestToRunningModulesTwoModulesNoDependencies
+=== RUN   TestToRunningModulesTwoModulesWithDependencies
+=== PAUSE TestToRunningModulesTwoModulesWithDependencies
+=== RUN   TestToRunningModulesTwoModulesWithDependenciesReverseOrder
+=== PAUSE TestToRunningModulesTwoModulesWithDependenciesReverseOrder
+=== RUN   TestToRunningModulesMultipleModulesWithAndWithoutDependencies
+=== PAUSE TestToRunningModulesMultipleModulesWithAndWithoutDependencies
+=== RUN   TestToRunningModulesMultipleModulesWithAndWithoutDependenciesReverseOrder
+=== PAUSE TestToRunningModulesMultipleModulesWithAndWithoutDependenciesReverseOrder
+=== RUN   TestRunModulesNoModules
+=== PAUSE TestRunModulesNoModules
+=== RUN   TestRunModulesOneModuleSuccess
+=== PAUSE TestRunModulesOneModuleSuccess
+=== RUN   TestRunModulesOneModuleAssumeAlreadyRan
+=== PAUSE TestRunModulesOneModuleAssumeAlreadyRan
+=== RUN   TestRunModulesReverseOrderOneModuleSuccess
+=== PAUSE TestRunModulesReverseOrderOneModuleSuccess
+=== RUN   TestRunModulesOneModuleError
+=== PAUSE TestRunModulesOneModuleError
+=== RUN   TestRunModulesReverseOrderOneModuleError
+=== PAUSE TestRunModulesReverseOrderOneModuleError
+=== RUN   TestRunModulesMultipleModulesNoDependenciesSuccess
+=== PAUSE TestRunModulesMultipleModulesNoDependenciesSuccess
+=== RUN   TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess
+=== PAUSE TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess
+=== RUN   TestRunModulesMultipleModulesNoDependenciesOneFailure
+=== PAUSE TestRunModulesMultipleModulesNoDependenciesOneFailure
+=== RUN   TestRunModulesMultipleModulesNoDependenciesMultipleFailures
+=== PAUSE TestRunModulesMultipleModulesNoDependenciesMultipleFailures
+=== RUN   TestRunModulesMultipleModulesWithDependenciesSuccess
+=== PAUSE TestRunModulesMultipleModulesWithDependenciesSuccess
+=== RUN   TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess
+=== PAUSE TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess
+=== RUN   TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess
+=== PAUSE TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess
+=== RUN   TestRunModulesMultipleModulesWithDependenciesOneFailure
+=== PAUSE TestRunModulesMultipleModulesWithDependenciesOneFailure
+=== RUN   TestRunModulesMultipleModulesWithDependenciesOneFailureIgnoreDependencyErrors
+=== PAUSE TestRunModulesMultipleModulesWithDependenciesOneFailureIgnoreDependencyErrors
+=== RUN   TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure
+=== PAUSE TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure
+=== RUN   TestRunModulesMultipleModulesWithDependenciesMultipleFailures
+=== PAUSE TestRunModulesMultipleModulesWithDependenciesMultipleFailures
+=== RUN   TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess
+=== PAUSE TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess
+=== RUN   TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure
+=== PAUSE TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure
+=== RUN   TestRunModulesReverseOrderMultipleModulesWithDependenciesLargeGraphPartialFailure
+=== PAUSE TestRunModulesReverseOrderMultipleModulesWithDependenciesLargeGraphPartialFailure
+=== RUN   TestFindStackInSubfolders
+=== PAUSE TestFindStackInSubfolders
+=== CONT  TestCheckForCycles
+--- PASS: TestCheckForCycles (0.00s)
+=== CONT  TestFindStackInSubfolders
+--- PASS: TestFindStackInSubfolders (0.00s)
+=== CONT  TestRunModulesReverseOrderMultipleModulesWithDependenciesLargeGraphPartialFailure
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 1 dependencies to finish
+=== CONT  TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module large-graph-a now
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-a has finished successfully!
+=== CONT  TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess
+[terragrunt] 2018/02/27 16:55:29 Module d must wait for 3 dependencies to finish
+=== CONT  TestRunModulesMultipleModulesWithDependenciesMultipleFailures
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 1 dependencies to finish
+=== CONT  TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 1 dependencies to finish
+=== CONT  TestRunModulesMultipleModulesWithDependenciesOneFailureIgnoreDependencyErrors
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 1 dependencies to finish
+=== CONT  TestRunModulesMultipleModulesWithDependenciesOneFailure
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 1 dependencies to finish
+=== CONT  TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 1 dependencies to finish
+=== CONT  TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess
+[terragrunt] 2018/02/27 16:55:29 Module d must wait for 1 dependencies to finish
+=== CONT  TestRunModulesMultipleModulesWithDependenciesSuccess
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 1 dependencies to finish
+=== CONT  TestRunModulesMultipleModulesNoDependenciesMultipleFailures
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module c now
+[terragrunt] 2018/02/27 16:55:29 Module c has finished with an error: Expected error for module c
+=== CONT  TestRunModulesMultipleModulesNoDependenciesOneFailure
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module b now
+[terragrunt] 2018/02/27 16:55:29 Module b has finished with an error: Expected error for module b
+=== CONT  TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module c now
+[terragrunt] 2018/02/27 16:55:29 Module c has finished successfully!
+=== CONT  TestRunModulesMultipleModulesNoDependenciesSuccess
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module c now
+[terragrunt] 2018/02/27 16:55:29 Module c has finished successfully!
+=== CONT  TestRunModulesReverseOrderOneModuleError
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished with an error: Expected error for module a
+--- PASS: TestRunModulesReverseOrderOneModuleError (0.00s)
+=== CONT  TestRunModulesOneModuleError
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished with an error: Expected error for module a
+--- PASS: TestRunModulesOneModuleError (0.00s)
+=== CONT  TestRunModulesReverseOrderOneModuleSuccess
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+--- PASS: TestRunModulesReverseOrderOneModuleSuccess (0.00s)
+=== CONT  TestRunModulesOneModuleAssumeAlreadyRan
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Assuming module a has already been applied and skipping it
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+--- PASS: TestRunModulesOneModuleAssumeAlreadyRan (0.00s)
+=== CONT  TestRunModulesOneModuleSuccess
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+--- PASS: TestRunModulesOneModuleSuccess (0.00s)
+=== CONT  TestRunModulesNoModules
+--- PASS: TestRunModulesNoModules (0.00s)
+=== CONT  TestToRunningModulesMultipleModulesWithAndWithoutDependenciesReverseOrder
+--- PASS: TestToRunningModulesMultipleModulesWithAndWithoutDependenciesReverseOrder (0.00s)
+=== CONT  TestToRunningModulesMultipleModulesWithAndWithoutDependencies
+--- PASS: TestToRunningModulesMultipleModulesWithAndWithoutDependencies (0.00s)
+=== CONT  TestToRunningModulesTwoModulesWithDependenciesReverseOrder
+--- PASS: TestToRunningModulesTwoModulesWithDependenciesReverseOrder (0.00s)
+=== CONT  TestToRunningModulesTwoModulesWithDependencies
+--- PASS: TestToRunningModulesTwoModulesWithDependencies (0.00s)
+=== CONT  TestToRunningModulesTwoModulesNoDependencies
+--- PASS: TestToRunningModulesTwoModulesNoDependencies (0.00s)
+=== CONT  TestToRunningModulesOneModuleNoDependencies
+--- PASS: TestToRunningModulesOneModuleNoDependencies (0.00s)
+=== CONT  TestToRunningModulesNoModules
+--- PASS: TestToRunningModulesNoModules (0.00s)
+=== CONT  TestGetTerragruntSourceForModuleErrors
+=== RUN   TestGetTerragruntSourceForModuleErrors/git::git@github.com:acme/modules.git/foo/bar-/source/modules
+=== RUN   TestGetTerragruntSourceForModuleErrors//foo/bar-/source/modules
+--- PASS: TestGetTerragruntSourceForModuleErrors (0.00s)
+    --- PASS: TestGetTerragruntSourceForModuleErrors/git::git@github.com:acme/modules.git/foo/bar-/source/modules (0.00s)
+    --- PASS: TestGetTerragruntSourceForModuleErrors//foo/bar-/source/modules (0.00s)
+=== CONT  TestGetTerragruntSourceForModuleHappyPath
+=== RUN   TestGetTerragruntSourceForModuleHappyPath/-
+=== RUN   TestGetTerragruntSourceForModuleHappyPath/-/source/modules
+=== RUN   TestGetTerragruntSourceForModuleHappyPath/git::git@github.com:acme/modules.git//foo/bar-/source/modules
+=== RUN   TestGetTerragruntSourceForModuleHappyPath/git::git@github.com:acme/modules.git//foo/bar?ref=v0.0.1-/source/modules
+--- PASS: TestGetTerragruntSourceForModuleHappyPath (0.00s)
+    --- PASS: TestGetTerragruntSourceForModuleHappyPath/- (0.00s)
+    --- PASS: TestGetTerragruntSourceForModuleHappyPath/-/source/modules (0.00s)
+    --- PASS: TestGetTerragruntSourceForModuleHappyPath/git::git@github.com:acme/modules.git//foo/bar-/source/modules (0.00s)
+    --- PASS: TestGetTerragruntSourceForModuleHappyPath/git::git@github.com:acme/modules.git//foo/bar?ref=v0.0.1-/source/modules (0.00s)
+=== CONT  TestResolveTerraformModuleNoTerraformConfig
+=== CONT  TestResolveTerraformModulesInvalidPaths
+--- PASS: TestResolveTerraformModulesInvalidPaths (0.00s)
+=== CONT  TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies
+=== CONT  TestResolveTerraformModulesMultipleModulesWithExternalDependencies
+=== CONT  TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes
+=== CONT  TestResolveTerraformModulesMultipleModulesWithDependencies
+=== CONT  TestResolveTerraformModulesTwoModulesWithDependencies
+--- PASS: TestResolveTerraformModulesTwoModulesWithDependencies (0.00s)
+=== CONT  TestResolveTerraformModulesOneModuleWithIncludesNoDependencies
+--- PASS: TestResolveTerraformModulesOneModuleWithIncludesNoDependencies (0.00s)
+=== CONT  TestResolveTerraformModulesOneModuleNoDependencies
+--- PASS: TestResolveTerraformModulesOneModuleNoDependencies (0.00s)
+=== CONT  TestResolveTerraformModulesNoPaths
+--- PASS: TestResolveTerraformModulesNoPaths (0.00s)
+[terragrunt] 2018/02/27 16:55:29 Module d must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Module e must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Module f must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module f now
+[terragrunt] 2018/02/27 16:55:29 Module f has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Dependency f of module d just finished successfully. Module d must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module d now
+[terragrunt] 2018/02/27 16:55:29 Module d has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Dependency d of module c just finished successfully. Module c must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module c now
+[terragrunt] 2018/02/27 16:55:29 Module c has finished with an error: Expected error for module c
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 2 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency d of module a just finished successfully. Module a must wait on 1 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 2 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency d of module b just finished successfully. Module b must wait on 1 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Dependency c of module b just finished with an error. Module b will have to return an error too.
+[terragrunt] 2018/02/27 16:55:29 Module b has finished with an error: Cannot process module Module b (dependencies: [a]) because one of its dependencies, Module c (dependencies: [b]), finished with an error: Expected error for module c
+[terragrunt] 2018/02/27 16:55:29 Dependency b of module a just finished with an error. Module a will have to return an error too.
+[terragrunt] 2018/02/27 16:55:29 Module a has finished with an error: Cannot process module Module a (dependencies: []) because one of its dependencies, Module b (dependencies: [a]), finished with an error: Cannot process module Module b (dependencies: [a]) because one of its dependencies, Module c (dependencies: [b]), finished with an error: Expected error for module c
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-b must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency large-graph-a of module large-graph-b just finished successfully. Module large-graph-b must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module large-graph-b now
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-b has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-c must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency large-graph-b of module large-graph-c just finished successfully. Module large-graph-c must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module large-graph-c now
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-c has finished with an error: Expected error for module large-graph-c
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-d must wait for 3 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency large-graph-a of module large-graph-d just finished successfully. Module large-graph-d must wait on 2 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Dependency large-graph-b of module large-graph-d just finished successfully. Module large-graph-d must wait on 1 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Dependency large-graph-c of module large-graph-d just finished with an error. Module large-graph-d will have to return an error too.
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-d has finished with an error: Cannot process module Module large-graph-d (dependencies: [large-graph-a, large-graph-b, large-graph-c]) because one of its dependencies, Module large-graph-c (dependencies: [large-graph-b]), finished with an error: Expected error for module large-graph-c
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-e must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Assuming module large-graph-e has already been applied and skipping it
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-e has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-f must wait for 2 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency large-graph-d of module large-graph-f just finished with an error. Module large-graph-f will have to return an error too.
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-f has finished with an error: Cannot process module Module large-graph-f (dependencies: [large-graph-e, large-graph-d]) because one of its dependencies, Module large-graph-d (dependencies: [large-graph-a, large-graph-b, large-graph-c]), finished with an error: Cannot process module Module large-graph-d (dependencies: [large-graph-a, large-graph-b, large-graph-c]) because one of its dependencies, Module large-graph-c (dependencies: [large-graph-b]), finished with an error: Expected error for module large-graph-c
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-g must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency large-graph-e of module large-graph-g just finished successfully. Module large-graph-g must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module large-graph-g now
+[terragrunt] 2018/02/27 16:55:29 Module large-graph-g has finished successfully!
+--- PASS: TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module e must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module e now
+[terragrunt] 2018/02/27 16:55:29 Module e has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Module f must wait for 2 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency e of module f just finished successfully. Module f must wait on 1 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Dependency a of module d just finished successfully. Module d must wait on 2 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency a of module b just finished successfully. Module b must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module b now
+[terragrunt] 2018/02/27 16:55:29 Module b has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Dependency b of module d just finished successfully. Module d must wait on 1 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency b of module c just finished successfully. Module c must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module c now
+[terragrunt] 2018/02/27 16:55:29 Module c has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Module /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-modules/module-l does not have an associated terraform configuration and will be skipped.
+--- PASS: TestResolveTerraformModuleNoTerraformConfig (0.00s)
+[terragrunt] 2018/02/27 16:55:29 Dependency c of module d just finished successfully. Module d must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module d now
+[terragrunt] 2018/02/27 16:55:29 Module d has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Dependency d of module f just finished successfully. Module f must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module f now
+[terragrunt] 2018/02/27 16:55:29 Module f has finished successfully!
+--- PASS: TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished with an error: Expected error for module a
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency a of module b just finished with an error. Module b will have to return an error too.
+[terragrunt] 2018/02/27 16:55:29 Module b has finished with an error: Cannot process module Module b (dependencies: [a]) because one of its dependencies, Module a (dependencies: []), finished with an error: Expected error for module a
+[terragrunt] 2018/02/27 16:55:29 Dependency b of module c just finished with an error. Module c will have to return an error too.
+[terragrunt] 2018/02/27 16:55:29 Module c has finished with an error: Cannot process module Module c (dependencies: [b]) because one of its dependencies, Module b (dependencies: [a]), finished with an error: Cannot process module Module b (dependencies: [a]) because one of its dependencies, Module a (dependencies: []), finished with an error: Expected error for module a
+--- PASS: TestRunModulesMultipleModulesWithDependenciesMultipleFailures (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module c now
+[terragrunt] 2018/02/27 16:55:29 Module c has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Dependency c of module b just finished successfully. Module b must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module b now
+[terragrunt] 2018/02/27 16:55:29 Module b has finished with an error: Expected error for module b
+[terragrunt] 2018/02/27 16:55:29 Dependency b of module a just finished with an error. Module a will have to return an error too.
+[terragrunt] 2018/02/27 16:55:29 Module a has finished with an error: Cannot process module Module a (dependencies: []) because one of its dependencies, Module b (dependencies: [a]), finished with an error: Expected error for module b
+--- PASS: TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Dependency a of module b just finished successfully. Module b must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module b now
+[terragrunt] 2018/02/27 16:55:29 Module b has finished with an error: Expected error for module b
+[terragrunt] 2018/02/27 16:55:29 Dependency b of module c just finished with an error. Module c will have to return an error too. However, because of --terragrunt-ignore-dependency-errors, module c will run anyway.
+[terragrunt] 2018/02/27 16:55:29 Running module c now
+[terragrunt] 2018/02/27 16:55:29 Module c has finished successfully!
+--- PASS: TestRunModulesMultipleModulesWithDependenciesOneFailureIgnoreDependencyErrors (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Dependency a of module b just finished successfully. Module b must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module b now
+[terragrunt] 2018/02/27 16:55:29 Module b has finished with an error: Expected error for module b
+[terragrunt] 2018/02/27 16:55:29 Dependency b of module c just finished with an error. Module c will have to return an error too.
+[terragrunt] 2018/02/27 16:55:29 Module c has finished with an error: Cannot process module Module c (dependencies: [b]) because one of its dependencies, Module b (dependencies: [a]), finished with an error: Expected error for module b
+--- PASS: TestRunModulesMultipleModulesWithDependenciesOneFailure (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module c now
+[terragrunt] 2018/02/27 16:55:29 Module c has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Dependency c of module b just finished successfully. Module b must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module b now
+[terragrunt] 2018/02/27 16:55:29 Module b has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency b of module a just finished successfully. Module a must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+--- PASS: TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency a of module b just finished successfully. Module b must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module b now
+[terragrunt] 2018/02/27 16:55:29 Module b has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency b of module c just finished successfully. Module c must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Assuming module c has already been applied and skipping it
+[terragrunt] 2018/02/27 16:55:29 Module c has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Dependency c of module d just finished successfully. Module d must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module d now
+[terragrunt] 2018/02/27 16:55:29 Module d has finished successfully!
+--- PASS: TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 1 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Dependency a of module b just finished successfully. Module b must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module b now
+[terragrunt] 2018/02/27 16:55:29 Module b has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Dependency b of module c just finished successfully. Module c must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module c now
+[terragrunt] 2018/02/27 16:55:29 Module c has finished successfully!
+--- PASS: TestRunModulesMultipleModulesWithDependenciesSuccess (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished with an error: Expected error for module a
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module b now
+[terragrunt] 2018/02/27 16:55:29 Module b has finished with an error: Expected error for module b
+--- PASS: TestRunModulesMultipleModulesNoDependenciesMultipleFailures (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module c must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module c now
+[terragrunt] 2018/02/27 16:55:29 Module c has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+--- PASS: TestRunModulesMultipleModulesNoDependenciesOneFailure (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module b now
+[terragrunt] 2018/02/27 16:55:29 Module b has finished successfully!
+--- PASS: TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Module a must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module a now
+[terragrunt] 2018/02/27 16:55:29 Module a has finished successfully!
+[terragrunt] 2018/02/27 16:55:29 Module b must wait for 0 dependencies to finish
+[terragrunt] 2018/02/27 16:55:29 Running module b now
+[terragrunt] 2018/02/27 16:55:29 Module b has finished successfully!
+--- PASS: TestRunModulesMultipleModulesNoDependenciesSuccess (0.01s)
+[terragrunt] 2018/02/27 16:55:29 Dependency f of module e just finished successfully. Module e must wait on 0 more dependencies.
+[terragrunt] 2018/02/27 16:55:29 Running module e now
+[terragrunt] 2018/02/27 16:55:29 Module e has finished successfully!
+--- PASS: TestRunModulesReverseOrderMultipleModulesWithDependenciesLargeGraphPartialFailure (0.01s)
+[terragrunt] 2018/02/27 16:55:29 [terragrunt]  Module /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-modules/module-g depends on module /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-modules/module-f, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-modules/module-f as well! (y/n) 
+[terragrunt] 2018/02/27 16:55:29 
+[terragrunt] 2018/02/27 16:55:29 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+--- PASS: TestResolveTerraformModulesMultipleModulesWithExternalDependencies (0.00s)
+[terragrunt] 2018/02/27 16:55:29 [terragrunt]  Module /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-modules/module-j depends on module /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-modules/module-i, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-modules/module-i as well! (y/n) 
+[terragrunt] 2018/02/27 16:55:29 
+[terragrunt] 2018/02/27 16:55:29 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+--- PASS: TestResolveTerraformModulesMultipleModulesWithDependencies (0.00s)
+--- PASS: TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes (0.00s)
+[terragrunt] 2018/02/27 16:55:29 [terragrunt]  Module /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-modules/module-k depends on module /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-modules/module-h, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in /root/go/src/github.com/gruntwork-io/terragrunt/test/fixture-modules/module-h as well! (y/n) 
+[terragrunt] 2018/02/27 16:55:29 
+[terragrunt] 2018/02/27 16:55:29 The non-interactive flag is set to true, so assuming 'yes' for all prompts
+--- PASS: TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies (0.01s)
+PASS
+ok  	github.com/gruntwork-io/terragrunt/configstack	0.017s
+=== RUN   TestPathRelativeToInclude
+=== PAUSE TestPathRelativeToInclude
+=== RUN   TestPathRelativeFromInclude
+=== PAUSE TestPathRelativeFromInclude
+=== RUN   TestFindInParentFolders
+=== PAUSE TestFindInParentFolders
+=== RUN   TestParseOptionalQuotedParamsHappyPath
+=== PAUSE TestParseOptionalQuotedParamsHappyPath
+=== RUN   TestParseOptionalQuotedParamsErrors
+=== PAUSE TestParseOptionalQuotedParamsErrors
+=== RUN   TestResolveTerragruntInterpolation
+=== PAUSE TestResolveTerragruntInterpolation
+=== RUN   TestResolveTerragruntConfigString
+=== PAUSE TestResolveTerragruntConfigString
+=== RUN   TestResolveEnvInterpolationConfigString
+=== PAUSE TestResolveEnvInterpolationConfigString
+=== RUN   TestResolveCommandsInterpolationConfigString
+=== PAUSE TestResolveCommandsInterpolationConfigString
+=== RUN   TestResolveMultipleInterpolationsConfigString
+=== PAUSE TestResolveMultipleInterpolationsConfigString
+=== RUN   TestGetTfVarsDirAbsPath
+=== PAUSE TestGetTfVarsDirAbsPath
+=== RUN   TestGetTfVarsDirRelPath
+=== PAUSE TestGetTfVarsDirRelPath
+=== RUN   TestGetParentTfVarsDir
+=== PAUSE TestGetParentTfVarsDir
+=== RUN   TestParseTerragruntConfigRemoteStateMinimalConfig
+=== PAUSE TestParseTerragruntConfigRemoteStateMinimalConfig
+=== RUN   TestParseTerragruntConfigRemoteStateMissingBackend
+=== PAUSE TestParseTerragruntConfigRemoteStateMissingBackend
+=== RUN   TestParseTerragruntConfigRemoteStateFullConfig
+=== PAUSE TestParseTerragruntConfigRemoteStateFullConfig
+=== RUN   TestParseTerragruntConfigDependenciesOnePath
+=== PAUSE TestParseTerragruntConfigDependenciesOnePath
+=== RUN   TestParseTerragruntConfigDependenciesMultiplePaths
+=== PAUSE TestParseTerragruntConfigDependenciesMultiplePaths
+=== RUN   TestParseTerragruntConfigRemoteStateDynamoDbTerraformConfigAndDependenciesFullConfig
+=== PAUSE TestParseTerragruntConfigRemoteStateDynamoDbTerraformConfigAndDependenciesFullConfig
+=== RUN   TestParseTerragruntConfigRemoteStateDynamoDbTerraformConfigAndDependenciesFullConfigOldConfigFormat
+=== PAUSE TestParseTerragruntConfigRemoteStateDynamoDbTerraformConfigAndDependenciesFullConfigOldConfigFormat
+=== RUN   TestParseTerragruntConfigInclude
+=== PAUSE TestParseTerragruntConfigInclude
+=== RUN   TestParseTerragruntConfigIncludeWithFindInParentFolders
+=== PAUSE TestParseTerragruntConfigIncludeWithFindInParentFolders
+=== RUN   TestParseTerragruntConfigIncludeOverrideRemote
+=== PAUSE TestParseTerragruntConfigIncludeOverrideRemote
+=== RUN   TestParseTerragruntConfigIncludeOverrideAll
+=== PAUSE TestParseTerragruntConfigIncludeOverrideAll
+=== RUN   TestParseTerragruntConfigTwoLevels
+=== PAUSE TestParseTerragruntConfigTwoLevels
+=== RUN   TestParseTerragruntConfigThreeLevels
+=== PAUSE TestParseTerragruntConfigThreeLevels
+=== RUN   TestParseTerragruntConfigEmptyConfig
+=== PAUSE TestParseTerragruntConfigEmptyConfig
+=== RUN   TestParseTerragruntConfigEmptyConfigOldConfig
+=== PAUSE TestParseTerragruntConfigEmptyConfigOldConfig
+=== RUN   TestMergeConfigIntoIncludedConfig
+=== PAUSE TestMergeConfigIntoIncludedConfig
+=== RUN   TestParseTerragruntConfigTerraformNoSource
+=== PAUSE TestParseTerragruntConfigTerraformNoSource
+=== RUN   TestParseTerragruntConfigTerraformWithSource
+=== PAUSE TestParseTerragruntConfigTerraformWithSource
+=== RUN   TestParseTerragruntConfigTerraformWithExtraArguments
+=== PAUSE TestParseTerragruntConfigTerraformWithExtraArguments
+=== RUN   TestParseTerragruntConfigTerraformWithMultipleExtraArguments
+=== PAUSE TestParseTerragruntConfigTerraformWithMultipleExtraArguments
+=== RUN   TestFindConfigFilesInPathNone
+=== PAUSE TestFindConfigFilesInPathNone
+=== RUN   TestFindConfigFilesInPathOneNewConfig
+=== PAUSE TestFindConfigFilesInPathOneNewConfig
+=== RUN   TestFindConfigFilesInPathOneOldConfig
+=== PAUSE TestFindConfigFilesInPathOneOldConfig
+=== RUN   TestFindConfigFilesInPathMultipleConfigs
+=== PAUSE TestFindConfigFilesInPathMultipleConfigs
+=== CONT  TestPathRelativeToInclude
+--- PASS: TestPathRelativeToInclude (0.00s)
+=== CONT  TestFindConfigFilesInPathMultipleConfigs
+=== CONT  TestFindConfigFilesInPathOneOldConfig
+--- PASS: TestFindConfigFilesInPathOneOldConfig (0.00s)
+=== CONT  TestFindConfigFilesInPathOneNewConfig
+--- PASS: TestFindConfigFilesInPathOneNewConfig (0.00s)
+=== CONT  TestFindConfigFilesInPathNone
+=== CONT  TestParseTerragruntConfigTerraformWithMultipleExtraArguments
+--- PASS: TestParseTerragruntConfigTerraformWithMultipleExtraArguments (0.00s)
+=== CONT  TestParseTerragruntConfigTerraformWithExtraArguments
+--- PASS: TestParseTerragruntConfigTerraformWithExtraArguments (0.00s)
+=== CONT  TestParseTerragruntConfigTerraformWithSource
+--- PASS: TestParseTerragruntConfigTerraformWithSource (0.00s)
+=== CONT  TestParseTerragruntConfigTerraformNoSource
+--- PASS: TestParseTerragruntConfigTerraformNoSource (0.00s)
+=== CONT  TestMergeConfigIntoIncludedConfig
+[terragrunt] 2018/02/27 16:55:30 extra_arguments 'overrideArgs' from child overriding parent
+--- PASS: TestMergeConfigIntoIncludedConfig (0.00s)
+=== CONT  TestParseTerragruntConfigEmptyConfigOldConfig
+--- PASS: TestParseTerragruntConfigEmptyConfigOldConfig (0.00s)
+=== CONT  TestParseTerragruntConfigEmptyConfig
+--- PASS: TestParseTerragruntConfigEmptyConfig (0.00s)
+=== CONT  TestParseTerragruntConfigThreeLevels
+=== CONT  TestParseTerragruntConfigTwoLevels
+=== CONT  TestParseTerragruntConfigIncludeOverrideAll
+=== CONT  TestParseTerragruntConfigIncludeOverrideRemote
+=== CONT  TestParseTerragruntConfigIncludeWithFindInParentFolders
+=== CONT  TestParseTerragruntConfigInclude
+=== CONT  TestParseTerragruntConfigRemoteStateDynamoDbTerraformConfigAndDependenciesFullConfigOldConfigFormat
+--- PASS: TestParseTerragruntConfigRemoteStateDynamoDbTerraformConfigAndDependenciesFullConfigOldConfigFormat (0.00s)
+=== CONT  TestParseTerragruntConfigRemoteStateDynamoDbTerraformConfigAndDependenciesFullConfig
+--- PASS: TestParseTerragruntConfigRemoteStateDynamoDbTerraformConfigAndDependenciesFullConfig (0.00s)
+=== CONT  TestParseTerragruntConfigDependenciesMultiplePaths
+--- PASS: TestParseTerragruntConfigDependenciesMultiplePaths (0.00s)
+=== CONT  TestParseTerragruntConfigDependenciesOnePath
+--- PASS: TestParseTerragruntConfigDependenciesOnePath (0.00s)
+=== CONT  TestParseTerragruntConfigRemoteStateFullConfig
+--- PASS: TestParseTerragruntConfigRemoteStateFullConfig (0.00s)
+=== CONT  TestParseTerragruntConfigRemoteStateMissingBackend
+--- PASS: TestParseTerragruntConfigRemoteStateMissingBackend (0.00s)
+=== CONT  TestParseTerragruntConfigRemoteStateMinimalConfig
+--- PASS: TestParseTerragruntConfigRemoteStateMinimalConfig (0.00s)
+=== CONT  TestGetParentTfVarsDir
+=== CONT  TestGetTfVarsDirRelPath
+=== CONT  TestGetTfVarsDirAbsPath
+=== CONT  TestResolveMultipleInterpolationsConfigString
+--- PASS: TestResolveMultipleInterpolationsConfigString (0.00s)
+=== CONT  TestResolveCommandsInterpolationConfigString
+--- PASS: TestResolveCommandsInterpolationConfigString (0.00s)
+=== CONT  TestResolveEnvInterpolationConfigString
+--- PASS: TestResolveEnvInterpolationConfigString (0.00s)
+=== CONT  TestResolveTerragruntConfigString
+=== RUN   TestResolveTerragruntConfigString/--/root/child/terraform.tfvars
+=== RUN   TestResolveTerragruntConfigString/foo_bar--/root/child/terraform.tfvars
+=== RUN   TestResolveTerragruntConfigString/$foo_{bar}--/root/child/terraform.tfvars
+=== RUN   TestResolveTerragruntConfigString/${path_relative_to_include()}--/root/child/terraform.tfvars
+=== RUN   TestResolveTerragruntConfigString/${path_relative_to_include()}--/root/child/terraform.tfvars#01
+=== RUN   TestResolveTerragruntConfigString/${path_relative_to_include()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars
+=== CONT  TestResolveTerragruntInterpolation
+=== RUN   TestResolveTerragruntInterpolation/${path_relative_to_include()}--/root/child/terraform.tfvars
+=== RUN   TestResolveTerragruntInterpolation/${path_relative_to_include()}--/root/child/terraform.tfvars#01
+=== RUN   TestResolveTerragruntInterpolation/${path_relative_to_include()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars
+=== CONT  TestParseOptionalQuotedParamsErrors
+=== RUN   TestParseOptionalQuotedParamsErrors/abc
+=== RUN   TestParseOptionalQuotedParamsErrors/"
+=== RUN   TestParseOptionalQuotedParamsErrors/"foo",_"
+=== RUN   TestParseOptionalQuotedParamsErrors/"foo"_"bar"
+=== RUN   TestParseOptionalQuotedParamsErrors/"foo",_"bar",_"baz"
+--- PASS: TestParseOptionalQuotedParamsErrors (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsErrors/abc (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsErrors/" (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsErrors/"foo",_" (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsErrors/"foo"_"bar" (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsErrors/"foo",_"bar",_"baz" (0.00s)
+=== CONT  TestParseOptionalQuotedParamsHappyPath
+=== RUN   TestParseOptionalQuotedParamsHappyPath/#00
+=== RUN   TestParseOptionalQuotedParamsHappyPath/___
+=== RUN   TestParseOptionalQuotedParamsHappyPath/""
+=== RUN   TestParseOptionalQuotedParamsHappyPath/"foo.txt"
+=== RUN   TestParseOptionalQuotedParamsHappyPath/"foo_bar_baz"
+=== RUN   TestParseOptionalQuotedParamsHappyPath/"",""
+=== RUN   TestParseOptionalQuotedParamsHappyPath/""_,_____""
+=== RUN   TestParseOptionalQuotedParamsHappyPath/"foo","bar"
+=== RUN   TestParseOptionalQuotedParamsHappyPath/"foo",_____"bar"
+=== RUN   TestParseOptionalQuotedParamsHappyPath/"","bar"
+--- PASS: TestParseOptionalQuotedParamsHappyPath (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsHappyPath/#00 (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsHappyPath/___ (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsHappyPath/"" (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsHappyPath/"foo.txt" (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsHappyPath/"foo_bar_baz" (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsHappyPath/"","" (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsHappyPath/""_,_____"" (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsHappyPath/"foo","bar" (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsHappyPath/"foo",_____"bar" (0.00s)
+    --- PASS: TestParseOptionalQuotedParamsHappyPath/"","bar" (0.00s)
+=== CONT  TestFindInParentFolders
+=== RUN   TestFindInParentFolders/../test/fixture-parent-folders/terragrunt-in-root/child/terraform.tfvars
+=== CONT  TestPathRelativeFromInclude
+--- PASS: TestFindConfigFilesInPathMultipleConfigs (0.00s)
+--- PASS: TestFindConfigFilesInPathNone (0.00s)
+--- PASS: TestParseTerragruntConfigThreeLevels (0.00s)
+--- PASS: TestParseTerragruntConfigIncludeOverrideAll (0.00s)
+--- PASS: TestParseTerragruntConfigIncludeOverrideRemote (0.00s)
+--- PASS: TestParseTerragruntConfigIncludeWithFindInParentFolders (0.00s)
+--- PASS: TestParseTerragruntConfigInclude (0.00s)
+--- PASS: TestGetParentTfVarsDir (0.00s)
+--- PASS: TestGetTfVarsDirRelPath (0.00s)
+--- PASS: TestGetTfVarsDirAbsPath (0.00s)
+=== RUN   TestResolveTerragruntConfigString/foo/${path_relative_to_include()}/bar--/root/child/terraform.tfvars
+=== RUN   TestResolveTerragruntConfigString/foo/${path_relative_to_include()}/bar--/root/child/terraform.tfvars#01
+=== RUN   TestResolveTerragruntConfigString/foo/${path_relative_to_include()}/bar/${path_relative_to_include()}--/root/child/terraform.tfvars
+=== RUN   TestResolveTerragruntConfigString/${find_in_parent_folders()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars
+=== RUN   TestResolveTerragruntConfigString/${____find_in_parent_folders()____}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars
+=== RUN   TestResolveTerragruntConfigString/${find_in_parent_folders_()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars
+=== RUN   TestResolveTerragruntConfigString/foo/${find_in_parent_folders()}/bar--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars
+=== RUN   TestResolveTerragruntConfigString/${find_in_parent_folders()}--../test/fixture-parent-folders/no-terragrunt-in-root/child/sub-child/terraform.tfvars
+=== RUN   TestResolveTerragruntConfigString/foo/${unknown}/bar--/root/child/terraform.tfvars
+--- PASS: TestResolveTerragruntConfigString (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/--/root/child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/foo_bar--/root/child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/$foo_{bar}--/root/child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/${path_relative_to_include()}--/root/child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/${path_relative_to_include()}--/root/child/terraform.tfvars#01 (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/${path_relative_to_include()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/foo/${path_relative_to_include()}/bar--/root/child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/foo/${path_relative_to_include()}/bar--/root/child/terraform.tfvars#01 (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/foo/${path_relative_to_include()}/bar/${path_relative_to_include()}--/root/child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/${find_in_parent_folders()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/${____find_in_parent_folders()____}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/${find_in_parent_folders_()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/foo/${find_in_parent_folders()}/bar--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/${find_in_parent_folders()}--../test/fixture-parent-folders/no-terragrunt-in-root/child/sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntConfigString/foo/${unknown}/bar--/root/child/terraform.tfvars (0.00s)
+=== RUN   TestResolveTerragruntInterpolation/${find_in_parent_folders()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars
+=== RUN   TestResolveTerragruntInterpolation/${find_in_parent_folders()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars#01
+=== RUN   TestResolveTerragruntInterpolation/${find_in_parent_folders()}--../test/fixture-parent-folders/no-terragrunt-in-root/child/sub-child/terraform.tfvars
+=== RUN   TestResolveTerragruntInterpolation/${find_in_parent_folders}--/root/child/terraform.tfvars
+=== RUN   TestResolveTerragruntInterpolation/{find_in_parent_folders()}--/root/child/terraform.tfvars
+=== RUN   TestResolveTerragruntInterpolation/find_in_parent_folders()--/root/child/terraform.tfvars
+--- PASS: TestResolveTerragruntInterpolation (0.00s)
+    --- PASS: TestResolveTerragruntInterpolation/${path_relative_to_include()}--/root/child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntInterpolation/${path_relative_to_include()}--/root/child/terraform.tfvars#01 (0.00s)
+    --- PASS: TestResolveTerragruntInterpolation/${path_relative_to_include()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntInterpolation/${find_in_parent_folders()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntInterpolation/${find_in_parent_folders()}--../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/terraform.tfvars#01 (0.00s)
+    --- PASS: TestResolveTerragruntInterpolation/${find_in_parent_folders()}--../test/fixture-parent-folders/no-terragrunt-in-root/child/sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntInterpolation/${find_in_parent_folders}--/root/child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntInterpolation/{find_in_parent_folders()}--/root/child/terraform.tfvars (0.00s)
+    --- PASS: TestResolveTerragruntInterpolation/find_in_parent_folders()--/root/child/terraform.tfvars (0.00s)
+=== RUN   TestFindInParentFolders/../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/terraform.tfvars
+=== RUN   TestFindInParentFolders/../test/fixture-parent-folders/no-terragrunt-in-root/child/sub-child/terraform.tfvars
+=== RUN   TestFindInParentFolders/../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/terraform.tfvars
+=== RUN   TestFindInParentFolders/../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/terraform.tfvars
+=== RUN   TestFindInParentFolders/../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/sub-sub-child/terraform.tfvars
+=== RUN   TestFindInParentFolders/../test/fixture-parent-folders/other-file-names/child/terraform.tfvars
+=== RUN   TestFindInParentFolders//
+=== RUN   TestFindInParentFolders//fake/path
+=== RUN   TestFindInParentFolders//fake/path#01
+--- PASS: TestFindInParentFolders (0.00s)
+    --- PASS: TestFindInParentFolders/../test/fixture-parent-folders/terragrunt-in-root/child/terraform.tfvars (0.00s)
+    --- PASS: TestFindInParentFolders/../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestFindInParentFolders/../test/fixture-parent-folders/no-terragrunt-in-root/child/sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestFindInParentFolders/../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/terraform.tfvars (0.00s)
+    --- PASS: TestFindInParentFolders/../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestFindInParentFolders/../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/sub-sub-child/terraform.tfvars (0.00s)
+    --- PASS: TestFindInParentFolders/../test/fixture-parent-folders/other-file-names/child/terraform.tfvars (0.00s)
+    --- PASS: TestFindInParentFolders// (0.00s)
+    --- PASS: TestFindInParentFolders//fake/path (0.00s)
+    --- PASS: TestFindInParentFolders//fake/path#01 (0.00s)
+--- PASS: TestPathRelativeFromInclude (0.00s)
+--- PASS: TestParseTerragruntConfigTwoLevels (0.01s)
+PASS
+ok  	github.com/gruntwork-io/terragrunt/config	0.015s
+?   	github.com/gruntwork-io/terragrunt	[no test files]


### PR DESCRIPTION
Bug fix: If S3 endpoint is not specified use default resolver.

It is related to PR [#422](https://github.com/gruntwork-io/terragrunt/pull/422).