### PR TITLE
Removes Terragrunt's requirement for "//" in all module sources when using --terragrunt-source

### DIFF
--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -294,6 +294,12 @@ func TestGetTerragruntSourceForModuleHappyPath(t *testing.T) {
 		{mockConfigWithSource(""), mockOptionsWithSource(t, "/source/modules"), ""},
 		{mockConfigWithSource("git::git@github.com:acme/modules.git//foo/bar"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//foo/bar"},
 		{mockConfigWithSource("git::git@github.com:acme/modules.git//foo/bar?ref=v0.0.1"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//foo/bar"},
+		{mockConfigWithSource("git::git@github.com:acme/emr_cluster.git?ref=feature/fix_bugs"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//emr_cluster"},
+		{mockConfigWithSource("git::ssh://git@ghe.ourcorp.com/OurOrg/some-module.git"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//some-module"},
+		{mockConfigWithSource("github.com/hashicorp/example"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//example"},
+		{mockConfigWithSource("github.com/hashicorp/example//subdir"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//subdir"},
+		{mockConfigWithSource("git@github.com:hashicorp/example.git//subdir"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//subdir"},
+		{mockConfigWithSource("./some/path//to/modulename"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//to/modulename"},
 	}
 
 	for _, testCase := range testCases {
@@ -301,25 +307,6 @@ func TestGetTerragruntSourceForModuleHappyPath(t *testing.T) {
 			actual, err := getTerragruntSourceForModule("mock-for-test", testCase.config, testCase.opts)
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.expected, actual)
-		})
-	}
-}
-
-func TestGetTerragruntSourceForModuleErrors(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		config *config.TerragruntConfig
-		opts   *options.TerragruntOptions
-	}{
-		{mockConfigWithSource("git::git@github.com:acme/modules.git/foo/bar"), mockOptionsWithSource(t, "/source/modules")},
-		{mockConfigWithSource("/foo/bar"), mockOptionsWithSource(t, "/source/modules")},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(fmt.Sprintf("%s-%s", testCase.config.Terraform.Source, testCase.opts.Source), func(t *testing.T) {
-			_, err := getTerragruntSourceForModule("mock-for-test", testCase.config, testCase.opts)
-			assert.Error(t, err)
 		})
 	}
 }


### PR DESCRIPTION
## Overview

Removes Terragrunt's requirement for "//" in all module sources when using --terragrunt-source.

This is accomplished by utilizing Hashicorp's go-getter to parse the module URLs.

The regex was updated to also parse out the module name from each URL if the
module lives at the root of a repo.
Test cases were updated to account for HTTP paths, forward slashes in ?ref=, as well as local file sources. 

The error check for a missing "//" was removed, as there are too many edge cases based on a large amount of source formats supported by Terraform. Terraform itself does not perform this validation on module download. It's possible that there is a place for an error suggesting potential missing `//` somewhere else in the code (e.g. when Terragrunt does not find the expected modules under a path).

The testing edge cases involved paths such as `github.com/hashicorp/modules/subdir/module` or `github.com/org/some_module?ref=feature/some_feature`.

While it is possible for Terragrunt to utilize an expanded set of URL validation functions (likely one for each type of supported module source), I thought this was going out of scope of this bugfix PR.

## Regex update

The regex will only run _if_ go-getter fails to obtain a subdir for a parsed module source (e.g. the module source does not contain `//`. Terraform normally does not care about this, but Terragrunt needs a valid name to use in the local module path later.

`(?:.+/)(.+?)(?:\?.+|\.)|(?:.+/)(.+)`

The regex basically matches everything after the last slash in the URL, but before a valid termination, such as end-of-line, `?`, or `.`.
The second capture group (and the conditional) are needed, because it is possible to include slashes in an otherwise valid source string via the ` ?ref=` parameter, e.g. `?ref=feature/some_branch`.

Fixes #445. 