### PR TITLE
Allow s3 remote state key to be configured in child

### DIFF
--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -109,9 +109,18 @@ func (remoteState *RemoteState) differsFrom(existingBackend *TerraformBackend, t
 		}
 	}
 
-	if !reflect.DeepEqual(existingBackend.Config, remoteState.Config) {
-		terragruntOptions.Logger.Printf("Backend config has changed from %s to %s", existingBackend.Config, remoteState.Config)
-		return true
+	// Compare the states by looping through the map, assume it is different if either a key doesn't exist in the `existingBackend` or a value
+	// is different
+	for key, value := range remoteState.Config {
+		if existingValue, found := existingBackend.Config[key]; found {
+			if existingValue != value {
+				terragruntOptions.Logger.Printf("Backend config has changed from %s to %s", existingBackend.Config, remoteState.Config)
+				return true
+			}
+		} else {
+			terragruntOptions.Logger.Printf("Backend config has new key from %s to %s", existingBackend.Config, remoteState.Config)
+			return true
+		}
 	}
 
 	terragruntOptions.Logger.Printf("Backend %s has not changed.", existingBackend.Type)

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -2,6 +2,8 @@ package remote
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -11,7 +13,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/mitchellh/mapstructure"
-	"time"
 )
 
 // A representation of the configuration options available for S3 remote state
@@ -125,10 +126,6 @@ func validateS3Config(config *RemoteStateConfigS3, terragruntOptions *options.Te
 
 	if config.Bucket == "" {
 		return errors.WithStackTrace(MissingRequiredS3RemoteStateConfig("bucket"))
-	}
-
-	if config.Key == "" {
-		return errors.WithStackTrace(MissingRequiredS3RemoteStateConfig("key"))
 	}
 
 	if !config.Encrypt {


### PR DESCRIPTION
Allows S3 remote state key to be part of the actual terraform module rather than specified in the terraform.tfvars.

To make it easier to use terraform_remote_state with nested module 