### PR TITLE
Bugfix: show help for terraform commands

### DIFF
--- a/util/collections.go
+++ b/util/collections.go
@@ -55,7 +55,7 @@ func removeDuplicatesFromList(list []string, keepLast bool) []string {
 	return out
 }
 
-// CommaSeparatedStrings returns an HCL compliant formated list of strings (each string within double quote)
+// CommaSeparatedStrings returns an HCL compliant formatted list of strings (each string within double quote)
 func CommaSeparatedStrings(list []string) string {
 	values := make([]string, 0, len(list))
 	for _, value := range list {


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/gruntwork-io/terragrunt/issues/314:

If there is a --help, -help or -h flag provided by a user
for a command that is forwarded to terraform (e.g. terragrunt plan --help),
don't throw any error because a config file is missing
or other checks fail, but show the help text (this should have
precedence).