### PR TITLE
Changing SSH host key guidance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Git repository prior to calling `terragrunt` to ensure that the ssh host is regi
 locally, e.g.:
 
 ```
-$ ssh -T -oStrictHostKeyChecking=no git@github.com || true
+$ ssh -T -oStrictHostKeyChecking=accept-new git@github.com || true
 ```
 
 


### PR DESCRIPTION
Changing the SSH host key guidance for CI pipelines/automated builds to
use accept-new rather than off as this is more secure.