### PR TITLE
WIP: Allow tagging of s3 bucket and dynamo db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*.sw?
 .idea
+terragrunt.iml
 vendor
 .terraform
 .vscode

--- a/README.md
+++ b/README.md
@@ -486,6 +486,16 @@ terragrunt = {
       region         = "us-east-1"
       encrypt        = true
       dynamodb_table = "my-lock-table"
+      
+      s3_bucket_tags {
+        owner = "terragrunt integration test"
+        name = "Terraform state storage"
+      }
+
+      dynamotable_tags {
+        owner = "terragrunt integration test"
+        name = "Terraform lock table"
+      }
     }
   }
 }
@@ -494,7 +504,9 @@ terragrunt = {
 The `remote_state` block supports all the same [backend types](https://www.terraform.io/docs/backends/types/index.html)
 as Terraform. The next time you run `terragrunt`, it will automatically configure all the settings in the
 `remote_state.config` block, if they aren't configured already, by calling [terraform
-init](https://www.terraform.io/docs/commands/init.html).
+init](https://www.terraform.io/docs/commands/init.html). The config options `s3_bucket_tags` and 
+`dynamotable_tags` are only valid for backend `s3`. They are used by terragrunt and are **not** passed on to 
+terraform. See section [Create remote state and locking resources automatically](#create-remote-state-and-locking-resources-automatically).
 
 In each of the **child** `terraform.tfvars` files, such as `mysql/terraform.tfvars`, you can tell Terragrunt to
 automatically include all the settings from the root `terraform.tfvars` file as follows:
@@ -562,11 +574,19 @@ they don't already exist:
 * **S3 bucket**: If you are using the [S3 backend](https://www.terraform.io/docs/backends/types/s3.html) for remote
   state storage and the `bucket` you specify in `remote_state.config` doesn't already exist, Terragrunt will create it
   automatically, with [versioning enabled](http://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html).
+  
+  In addition, you can let terragrunt tag the bucket with custom tags that you specify in 
+  `remote_state.config.s3_bucket_tags`. See sample configuration in section 
+  [Filling in remote state settings with Terragrunt](#filling-in-remote-state-settings-with-terragrunt).
 
 * **DynamoDB table**: If you are using the [S3 backend](https://www.terraform.io/docs/backends/types/s3.html) for
   remote state storage and you specify a `dynamodb_table` (a [DynamoDB table used for
   locking](https://www.terraform.io/docs/backends/types/s3.html#dynamodb_table)) in `remote_state.config`, if that table
   doesn't already exist, Terragrunt will create it automatically, including a primary key called `LockID`.
+  
+  In addition, you can let terragrunt tag the DynamoDB table with custom tags that you specify in
+  `remote_state.config.dynamotable_tags`. See sample configuration in section 
+  [Filling in remote state settings with Terragrunt](#filling-in-remote-state-settings-with-terragrunt).
 
 **Note**: If you specify a `profile` key in `remote_state.config`, Terragrunt will automatically use this AWS profile
 when creating the S3 bucket or DynamoDB table.

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ terragrunt = {
         name = "Terraform state storage"
       }
 
-      dynamotable_tags {
+      dynamodb_table_tags {
         owner = "terragrunt integration test"
         name = "Terraform lock table"
       }
@@ -505,7 +505,7 @@ The `remote_state` block supports all the same [backend types](https://www.terra
 as Terraform. The next time you run `terragrunt`, it will automatically configure all the settings in the
 `remote_state.config` block, if they aren't configured already, by calling [terraform
 init](https://www.terraform.io/docs/commands/init.html). The config options `s3_bucket_tags` and 
-`dynamotable_tags` are only valid for backend `s3`. They are used by terragrunt and are **not** passed on to 
+`dynamodb_table_tags` are only valid for backend `s3`. They are used by terragrunt and are **not** passed on to 
 terraform. See section [Create remote state and locking resources automatically](#create-remote-state-and-locking-resources-automatically).
 
 In each of the **child** `terraform.tfvars` files, such as `mysql/terraform.tfvars`, you can tell Terragrunt to
@@ -585,7 +585,7 @@ they don't already exist:
   doesn't already exist, Terragrunt will create it automatically, including a primary key called `LockID`.
   
   In addition, you can let terragrunt tag the DynamoDB table with custom tags that you specify in
-  `remote_state.config.dynamotable_tags`. See sample configuration in section 
+  `remote_state.config.dynamodb_table_tags`. See sample configuration in section 
   [Filling in remote state settings with Terragrunt](#filling-in-remote-state-settings-with-terragrunt).
 
 **Note**: If you specify a `profile` key in `remote_state.config`, Terragrunt will automatically use this AWS profile

--- a/README.md
+++ b/README.md
@@ -489,12 +489,12 @@ terragrunt = {
       
       s3_bucket_tags {
         owner = "terragrunt integration test"
-        name = "Terraform state storage"
+        name  = "Terraform state storage"
       }
 
       dynamodb_table_tags {
         owner = "terragrunt integration test"
-        name = "Terraform lock table"
+        name  = "Terraform lock table"
       }
     }
   }

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -105,7 +105,7 @@ func CreateLockTable(tableName string, tags map[string]string, readCapacityUnits
 		return err
 	}
 
-	err = tagTableITagsGiven(tags, createTableOutput, client, terragruntOptions)
+	err = tagTableIfTagsGiven(tags, createTableOutput, client, terragruntOptions)
 
 	if err != nil {
 		return errors.WithStackTrace(err)
@@ -114,9 +114,9 @@ func CreateLockTable(tableName string, tags map[string]string, readCapacityUnits
 	return nil
 }
 
-func tagTableITagsGiven(tags map[string]string, createTableOutput *dynamodb.CreateTableOutput, client *dynamodb.DynamoDB, terragruntOptions *options.TerragruntOptions) error {
+func tagTableIfTagsGiven(tags map[string]string, createTableOutput *dynamodb.CreateTableOutput, client *dynamodb.DynamoDB, terragruntOptions *options.TerragruntOptions) error {
 
-	if tags == nil {
+	if tags == nil || len(tags) == 0 {
 		terragruntOptions.Logger.Printf("No tags for lock table given.")
 		return nil
 	}

--- a/dynamodb/dynamo_lock_table_test.go
+++ b/dynamodb/dynamo_lock_table_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -94,8 +95,7 @@ func TestTableTagging(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var tags = make(map[string]string)
-	tags["team"] = "team A"
+	tags := map[string]string{"team": "team A"}
 
 	// Create the table the first time
 	withLockTableTagged(t, tags, func(tableName string, client *dynamodb.DynamoDB) {
@@ -110,7 +110,7 @@ func TestTableTagging(t *testing.T) {
 }
 
 func assertTags(expectedTags map[string]string, tableName string, client *dynamodb.DynamoDB, t *testing.T) {
-	var description, err = client.DescribeTable(&dynamodb.DescribeTableInput{TableName: &tableName})
+	var description, err = client.DescribeTable(&dynamodb.DescribeTableInput{TableName: aws.String(tableName)})
 
 	if err != nil {
 		t.Fatal(err)

--- a/dynamodb/dynamo_lock_test_utils.go
+++ b/dynamodb/dynamo_lock_test_utils.go
@@ -78,7 +78,7 @@ func withLockTable(t *testing.T, action func(tableName string, client *dynamodb.
 		t.Fatal(err)
 	}
 
-	err = CreateLockTableIfNecessary(tableName, client, mockOptions)
+	err = CreateLockTableIfNecessary(tableName, nil, client, mockOptions)
 	assert.Nil(t, err, "Unexpected error: %v", err)
 	defer cleanupTableForTest(t, tableName, client)
 

--- a/dynamodb/dynamo_lock_test_utils.go
+++ b/dynamodb/dynamo_lock_test_utils.go
@@ -70,6 +70,10 @@ func assertCanWriteToTable(t *testing.T, tableName string, client *dynamodb.Dyna
 }
 
 func withLockTable(t *testing.T, action func(tableName string, client *dynamodb.DynamoDB)) {
+	withLockTableTagged(t, nil, action)
+}
+
+func withLockTableTagged(t *testing.T, tags map[string]string, action func(tableName string, client *dynamodb.DynamoDB)) {
 	client := createDynamoDbClientForTest(t)
 	tableName := uniqueTableNameForTest()
 
@@ -78,7 +82,7 @@ func withLockTable(t *testing.T, action func(tableName string, client *dynamodb.
 		t.Fatal(err)
 	}
 
-	err = CreateLockTableIfNecessary(tableName, nil, client, mockOptions)
+	err = CreateLockTableIfNecessary(tableName, tags, client, mockOptions)
 	assert.Nil(t, err, "Unexpected error: %v", err)
 	defer cleanupTableForTest(t, tableName, client)
 

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -122,6 +122,11 @@ func (remoteState *RemoteState) differsFrom(existingBackend *TerraformBackend, t
 func (remoteState RemoteState) ToTerraformInitArgs() []string {
 	backendConfigArgs := []string{}
 	for key, value := range remoteState.Config {
+
+		if key == "s3_bucket_tags" || key == "dynamotable_tags" {
+			continue
+		}
+
 		arg := fmt.Sprintf("-backend-config=%s=%v", key, value)
 		backendConfigArgs = append(backendConfigArgs, arg)
 	}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -15,6 +15,13 @@ import (
 )
 
 // A representation of the configuration options available for S3 remote state
+type ExtendedRemoteStateConfigS3 struct {
+	remoteStateConfigS3 RemoteStateConfigS3
+
+	S3BucketTags    [] map[string]string `mapstructure:"s3_bucket_tags"`
+	DynamotableTags [] map[string]string `mapstructure:"dynamotable_tags"`
+}
+
 type RemoteStateConfigS3 struct {
 	Encrypt       bool   `mapstructure:"encrypt"`
 	Bucket        string `mapstructure:"bucket"`
@@ -78,29 +85,31 @@ func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interfa
 // Initialize the remote state S3 bucket specified in the given config. This function will validate the config
 // parameters, create the S3 bucket if it doesn't already exist, and check that versioning is enabled.
 func (s3Initializer S3Initializer) Initialize(config map[string]interface{}, terragruntOptions *options.TerragruntOptions) error {
-	s3Config, err := parseS3Config(config)
+	s3ConfigExtended, err := parseExtendedS3Config(config)
 	if err != nil {
 		return err
 	}
 
-	if err := validateS3Config(s3Config, terragruntOptions); err != nil {
+	if err := validateS3Config(s3ConfigExtended, terragruntOptions); err != nil {
 		return err
 	}
+
+	var s3Config = s3ConfigExtended.remoteStateConfigS3
 
 	s3Client, err := CreateS3Client(s3Config.Region, s3Config.Endpoint, s3Config.Profile, s3Config.RoleArn, terragruntOptions)
 	if err != nil {
 		return err
 	}
 
-	if err := createS3BucketIfNecessary(s3Client, s3Config, terragruntOptions); err != nil {
+	if err := createS3BucketIfNecessary(s3Client, s3ConfigExtended, terragruntOptions); err != nil {
 		return err
 	}
 
-	if err := checkIfVersioningEnabled(s3Client, s3Config, terragruntOptions); err != nil {
+	if err := checkIfVersioningEnabled(s3Client, &s3Config, terragruntOptions); err != nil {
 		return err
 	}
 
-	if err := createLockTableIfNecessary(s3Config, terragruntOptions); err != nil {
+	if err := createLockTableIfNecessary(&s3Config, terragruntOptions); err != nil {
 		return err
 	}
 
@@ -117,8 +126,28 @@ func parseS3Config(config map[string]interface{}) (*RemoteStateConfigS3, error) 
 	return &s3Config, nil
 }
 
+// Parse the given map into an extended S3 config
+func parseExtendedS3Config(config map[string]interface{}) (*ExtendedRemoteStateConfigS3, error) {
+	var s3Config RemoteStateConfigS3
+	var extendedConfig ExtendedRemoteStateConfigS3
+
+	if err := mapstructure.Decode(config, &s3Config); err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	if err := mapstructure.Decode(config, &extendedConfig); err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	extendedConfig.remoteStateConfigS3 = s3Config
+
+	return &extendedConfig, nil
+}
+
 // Validate all the parameters of the given S3 remote state configuration
-func validateS3Config(config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
+func validateS3Config(extendedConfig *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
+	var config = extendedConfig.remoteStateConfigS3
+
 	if config.Region == "" {
 		return errors.WithStackTrace(MissingRequiredS3RemoteStateConfig("region"))
 	}
@@ -135,14 +164,19 @@ func validateS3Config(config *RemoteStateConfigS3, terragruntOptions *options.Te
 		terragruntOptions.Logger.Printf("WARNING: encryption is not enabled on the S3 remote state bucket %s. Terraform state files may contain secrets, so we STRONGLY recommend enabling encryption!", config.Bucket)
 	}
 
+	if len(extendedConfig.S3BucketTags) > 1 {
+		return errors.WithStackTrace(MissingRequiredS3RemoteStateConfig("key"))
+
+	}
+
 	return nil
 }
 
 // If the bucket specified in the given config doesn't already exist, prompt the user to create it, and if the user
 // confirms, create the bucket and enable versioning for it.
-func createS3BucketIfNecessary(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	if !DoesS3BucketExist(s3Client, config) {
-		prompt := fmt.Sprintf("Remote state S3 bucket %s does not exist or you don't have permissions to access it. Would you like Terragrunt to create it?", config.Bucket)
+func createS3BucketIfNecessary(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
+	if !DoesS3BucketExist(s3Client, &config.remoteStateConfigS3) {
+		prompt := fmt.Sprintf("Remote state S3 bucket %s does not exist or you don't have permissions to access it. Would you like Terragrunt to create it?", config.remoteStateConfigS3.Bucket)
 		shouldCreateBucket, err := shell.PromptUserForYesNo(prompt, terragruntOptions)
 		if err != nil {
 			return err
@@ -173,20 +207,44 @@ func checkIfVersioningEnabled(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 }
 
 // Create the given S3 bucket and enable versioning for it
-func CreateS3BucketWithVersioning(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	if err := CreateS3Bucket(s3Client, config, terragruntOptions); err != nil {
+func CreateS3BucketWithVersioning(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
+	if err := CreateS3Bucket(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
 
-	if err := WaitUntilS3BucketExists(s3Client, config, terragruntOptions); err != nil {
+	if err := TagS3Bucket(s3Client, config); err != nil {
 		return err
 	}
 
-	if err := EnableVersioningForS3Bucket(s3Client, config, terragruntOptions); err != nil {
+	if err := WaitUntilS3BucketExists(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
+		return err
+	}
+
+	if err := EnableVersioningForS3Bucket(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func TagS3Bucket(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3) error {
+
+	putBucketTaggingInput := s3.PutBucketTaggingInput{
+		Bucket: aws.String(config.remoteStateConfigS3.Bucket),
+		Tagging: &s3.Tagging{
+			TagSet: []*s3.Tag{
+				{
+					Key:   aws.String("owner"),
+					Value: aws.String("team name")}}}}
+
+	_, err := s3Client.PutBucketTagging(&putBucketTaggingInput)
+
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+
 }
 
 // AWS is eventually consistent, so after creating an S3 bucket, this method can be used to wait until the information
@@ -277,6 +335,12 @@ type MissingRequiredS3RemoteStateConfig string
 
 func (configName MissingRequiredS3RemoteStateConfig) Error() string {
 	return fmt.Sprintf("Missing required S3 remote state configuration %s", string(configName))
+}
+
+type MultipleTagsDeclarations string
+
+func (target MultipleTagsDeclarations) Error() string {
+	return fmt.Sprintf("Tags for %s got declared multiple times. Please do only declare in one block.", target)
 }
 
 type MaxRetriesWaitingForS3BucketExceeded string

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -121,6 +121,21 @@ func (s3Initializer S3Initializer) Initialize(config map[string]interface{}, ter
 	return nil
 }
 
+func (s3Initializer S3Initializer) GetTerraformInitArgs(config map[string]interface{}) map[string]interface{} {
+	var filteredConfig = make(map[string]interface{})
+
+	for key, val := range config {
+
+		if key == "s3_bucket_tags" || key == "dynamotable_tags" {
+			continue
+		}
+
+		filteredConfig[key] = val
+	}
+
+	return filteredConfig
+}
+
 // Parse the given map into an S3 config
 func parseS3Config(config map[string]interface{}) (*RemoteStateConfigS3, error) {
 	var s3Config RemoteStateConfigS3

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -217,11 +217,11 @@ func CreateS3BucketWithVersioning(s3Client *s3.S3, config *ExtendedRemoteStateCo
 		return err
 	}
 
-	if err := TagS3Bucket(s3Client, config, terragruntOptions); err != nil {
+	if err := WaitUntilS3BucketExists(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
 
-	if err := WaitUntilS3BucketExists(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
+	if err := TagS3Bucket(s3Client, config, terragruntOptions); err != nil {
 		return err
 	}
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -15,7 +15,7 @@ import (
 )
 
 /*
- * We use this construct to separate the two config keys 's3_bucket_tags' and 'dynamotable_tags'
+ * We use this construct to separate the two config keys 's3_bucket_tags' and 'dynamodb_table_tags'
  * from the others, as they are specific to the s3 backend, but only used by terragrunt to tag
  * the s3 bucket and the dynamo db, in case it has to create them.
  */
@@ -23,7 +23,7 @@ type ExtendedRemoteStateConfigS3 struct {
 	remoteStateConfigS3 RemoteStateConfigS3
 
 	S3BucketTags    []map[string]string `mapstructure:"s3_bucket_tags"`
-	DynamotableTags []map[string]string `mapstructure:"dynamotable_tags"`
+	DynamotableTags []map[string]string `mapstructure:"dynamodb_table_tags"`
 }
 
 // A representation of the configuration options available for S3 remote state
@@ -126,7 +126,7 @@ func (s3Initializer S3Initializer) GetTerraformInitArgs(config map[string]interf
 
 	for key, val := range config {
 
-		if key == "s3_bucket_tags" || key == "dynamotable_tags" {
+		if key == "s3_bucket_tags" || key == "dynamodb_table_tags" {
 			continue
 		}
 

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+/**
+ * Test for s3, also tests that the terragrunt-specific options are not passed on to terraform
+ */
 func TestToTerraformInitArgs(t *testing.T) {
 	t.Parallel()
 
@@ -18,10 +21,20 @@ func TestToTerraformInitArgs(t *testing.T) {
 			"bucket":  "my-bucket",
 			"key":     "terraform.tfstate",
 			"region":  "us-east-1",
-		},
+
+			"s3_bucket_tags": map[string]interface{}{
+				"team":    "team name",
+				"name":    "Terraform state storage",
+				"service": "Terraform"},
+
+			"dynamotable_tags": map[string]interface{}{
+				"team":    "team name",
+				"name":    "Terraform state storage",
+				"service": "Terraform"}},
 	}
 	args := remoteState.ToTerraformInitArgs()
 
+	// must not contain s3_bucket_tags or dynamotable_tags
 	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1")
 }
 

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -38,6 +38,23 @@ func TestToTerraformInitArgs(t *testing.T) {
 	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1")
 }
 
+func TestToTerraformInitArgsUnknownBackend(t *testing.T) {
+	t.Parallel()
+
+	remoteState := RemoteState{
+		Backend: "s4",
+		Config: map[string]interface{}{
+			"encrypt": true,
+			"bucket":  "my-bucket",
+			"key":     "terraform.tfstate",
+			"region":  "us-east-1"},
+	}
+	args := remoteState.ToTerraformInitArgs()
+
+	// no Backend initializer available, but command line args should still be passed on
+	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1")
+}
+
 func TestToTerraformInitArgsNoBackendConfigs(t *testing.T) {
 	t.Parallel()
 

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -27,14 +27,14 @@ func TestToTerraformInitArgs(t *testing.T) {
 				"name":    "Terraform state storage",
 				"service": "Terraform"},
 
-			"dynamotable_tags": map[string]interface{}{
+			"dynamodb_table_tags": map[string]interface{}{
 				"team":    "team name",
 				"name":    "Terraform state storage",
 				"service": "Terraform"}},
 	}
 	args := remoteState.ToTerraformInitArgs()
 
-	// must not contain s3_bucket_tags or dynamotable_tags
+	// must not contain s3_bucket_tags or dynamodb_table_tags
 	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1")
 }
 

--- a/test/fixture/terraform.tfvars
+++ b/test/fixture/terraform.tfvars
@@ -8,6 +8,16 @@ terragrunt = {
       key = "terraform.tfstate"
       region = "us-west-2"
       dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
+
+      s3_bucket_tags {
+        owner = "terragrunt integration test"
+        name = "Terraform state storage"
+      }
+
+      dynamodb_table_tags {
+        owner = "terragrunt integration test"
+        name = "Terraform lock table"
+      }
     }
   }
 }


### PR DESCRIPTION
This is WIP - no tests were created for this yet, but the tagging itself works already.

Please give some feedback if that looks ok, then I will start adding some tests too.

And remember I'm totally new to go...

**Note**: I decided against putting the tags outside of config, but inside of remote_state, for two reasons:

1. (Minor) - I was not able to get access to the whole remote_state object in the remote_state_s3 file
2. (Major) - I think it does not make sense to have an option which is s3-specific top-level in remote_state - if you ever add another provider, you would have to explain that these two config items can be set only if the backend is s3, which I find worse than putting it inside of config and filtering out later (which I do in two places, when reading the config in remote_state_s3, and when iterating over the config items to prepare the command line options for terraform)

If you still think I should place them outside of remote_state, I will change that, but I find the second argument quite strong.

So configuration looks like this now:

```
terragrunt = {

  remote_state {
    backend = "s3"
    config {
      bucket = "..."
      [...]

      s3_bucket_tags {
        owner = "team name"
        name = "Terraform state storage"
      }

      dynamotable_tags {
        owner = "team name"
        name = "Terraform lock table"
      }

    }
  }
}
```

You can set arbitrary tags (just follow the limitations of AWS, I do not check e.g. if a tag value is too long etc.

In case the tag mappings are missing, nothing is tagged (when they are there but are empty, an empty tagging is made, which could be prevented if you think that's necessary). 

In case they appear multiple times (like, if s3_bucket_tags appears twice or more), an error is printed and we stop.
