### PR TITLE
Reverse the dependency questions to match non-interactive behavior

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -197,12 +197,12 @@ func resolveExternalDependenciesForModules(moduleMap map[string]*TerraformModule
 				continue
 			}
 
-			alreadyApplied, err := confirmExternalDependencyAlreadyApplied(module, externalDependency, terragruntOptions)
+			shouldApply, err := confirmShouldApplyExternalDependency(module, externalDependency, terragruntOptions)
 			if err != nil {
 				return externalDependencies, err
 			}
 
-			externalDependency.AssumeAlreadyApplied = alreadyApplied
+			externalDependency.AssumeAlreadyApplied = !shouldApply
 			allExternalDependencies[externalDependency.Path] = externalDependency
 		}
 	}
@@ -247,8 +247,8 @@ func resolveExternalDependenciesForModule(module *TerraformModule, moduleMap map
 
 // Confirm with the user whether they want Terragrunt to assume the given dependency of the given module is already
 // applied. If the user selects "no", then Terragrunt will apply that module as well.
-func confirmExternalDependencyAlreadyApplied(module *TerraformModule, dependency *TerraformModule, terragruntOptions *options.TerragruntOptions) (bool, error) {
-	prompt := fmt.Sprintf("Module %s depends on module %s, which is an external dependency outside of the current working directory. Should Terragrunt skip over this external dependency? Warning, if you say 'no', Terragrunt will make changes in %s as well!", module.Path, dependency.Path, dependency.Path)
+func confirmShouldApplyExternalDependency(module *TerraformModule, dependency *TerraformModule, terragruntOptions *options.TerragruntOptions) (bool, error) {
+	prompt := fmt.Sprintf("Module %s depends on module %s, which is an external dependency outside of the current working directory. Should Terragrunt run this external dependency? Warning, if you say 'yes', Terragrunt will make changes in %s as well!", module.Path, dependency.Path, dependency.Path)
 	return shell.PromptUserForYesNo(prompt, terragruntOptions)
 }
 


### PR DESCRIPTION
Since non-interactive answers "yes" to questions, we want the running of dependencies to depend on a "yes" answer instead of "no".

https://github.com/gruntwork-io/terragrunt/issues/471

I have run these test cases with `plan-all`:
* w/o --terragrunt-non-interactive: answer 'y' to all dependency questions
* w/o --terragrunt-non-interactive: answer 'n' to all dependency questions
* w/o --terragrunt-non-interactive: answer 'y' to first dependency question then 'n' to all others
* w/ --terragrunt-non-interactive

In all cases, dependencies were run or not-run as expected.
