### PR TITLE
Move bucket creation check

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -328,7 +328,7 @@ func CreateS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOpti
 // Determine if this is an error that implies you've already made a request to create the S3 bucket and it succeeded
 // or is in progress. This usually happens when running many tests in parallel or xxx-all commands.
 func isBucketAlreadyOwnedByYourError(err error) bool {
-	awsErr, isAwsErr := err.(awserr.Error)
+	awsErr, isAwsErr := errors.Unwrap(err).(awserr.Error)
 	return isAwsErr && (awsErr.Code() == "BucketAlreadyOwnedByYou" || awsErr.Code() == "OperationAborted")
 }
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -240,7 +240,7 @@ func CreateS3BucketWithVersioning(s3Client *s3.S3, config *ExtendedRemoteStateCo
 			terragruntOptions.Logger.Printf("Looks like someone is creating bucket %s at the same time. Will not attempt to create it again.", config.remoteStateConfigS3.Bucket)
 			return WaitUntilS3BucketExists(s3Client, &config.remoteStateConfigS3, terragruntOptions)
 		}
-		
+
 		return err
 	}
 


### PR DESCRIPTION
Terragrunt has a method that checks if someone is already creating an S3 bucket concurrently. However, even if that error is detected, after detecting it, we continued to try to configure the bucket in other ways (e.g., enable versioning) anyway. This PR updates the code to to skip all the other bucket creation steps if someone else is already doing them concurrently.

This will hopefully fix the intermittent test failures we were seeing that had errors such as "OperationAborted: A conflicting conditional operation is currently in progress against this resource. Please try again." (e.g., https://circleci.com/gh/gruntwork-io/terragrunt/609). 