### PR TITLE
Fix NeedsInit method

### DIFF
--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -3,7 +3,7 @@ package remote
 import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/go-playground/assert.v1"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -2,8 +2,8 @@ package remote
 
 import (
 	"github.com/gruntwork-io/terragrunt/options"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -1,0 +1,88 @@
+package remote
+
+import (
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/go-playground/assert.v1"
+	"testing"
+)
+
+func TestConfigValuesEqual(t *testing.T) {
+	t.Parallel()
+
+	terragruntOptions, err := options.NewTerragruntOptionsForTest("remote_state_test")
+	require.Nil(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
+
+	testCases := []struct {
+		name          string
+		config        map[string]interface{}
+		backend       TerraformBackend
+		shouldBeEqual bool
+	}{
+		{
+			"equal-both-empty",
+			map[string]interface{}{},
+			TerraformBackend{Type: "s3", Config: map[string]interface{}{}},
+			true,
+		},
+		{
+			"equal-empty-and-nil",
+			map[string]interface{}{},
+			TerraformBackend{Type: "s3"},
+			true,
+		},
+		{
+			"equal-one-key",
+			map[string]interface{}{"foo": "bar"},
+			TerraformBackend{Type: "s3", Config: map[string]interface{}{"foo": "bar"}},
+			true,
+		},
+		{
+			"equal-multiple-keys",
+			map[string]interface{}{"foo": "bar", "baz": []string{"a", "b", "c"}, "blah": 123, "bool": true},
+			TerraformBackend{Type: "s3", Config: map[string]interface{}{"foo": "bar", "baz": []string{"a", "b", "c"}, "blah": 123, "bool": true}},
+			true,
+		},
+		{
+			"equal-encrypt-bool-handling",
+			map[string]interface{}{"encrypt": true},
+			TerraformBackend{Type: "s3", Config: map[string]interface{}{"encrypt": "true"}},
+			true,
+		},
+		{
+			"equal-ignore-s3-tags",
+			map[string]interface{}{"foo": "bar", "s3_bucket_tags": []map[string]string{{"foo": "bar"}}},
+			TerraformBackend{Type: "s3", Config: map[string]interface{}{"foo": "bar"}},
+			true,
+		},
+		{
+			"equal-ignore-dynamodb-tags",
+			map[string]interface{}{"dynamodb_table_tags": []map[string]string{{"foo": "bar"}}},
+			TerraformBackend{Type: "s3", Config: map[string]interface{}{}},
+			true,
+		},
+		{
+			"unequal-wrong-backend",
+			map[string]interface{}{"foo": "bar"},
+			TerraformBackend{Type: "wrong", Config: map[string]interface{}{"foo": "bar"}},
+			false,
+		},
+		{
+			"unequal-values",
+			map[string]interface{}{"foo": "bar"},
+			TerraformBackend{Type: "s3", Config: map[string]interface{}{"foo": "different"}},
+			false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		// Save the testCase in local scope so all the t.Run calls don't end up with the last item in the list
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			actual := configValuesEqual(testCase.config, &testCase.backend, terragruntOptions)
+			assert.Equal(t, testCase.shouldBeEqual, actual)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #501.

The `NeedsInit` now properly deletages to the underlying initializer (namely, the `S3Initializer`) to decide whether we need to run `init`. The `S3Initializer` should now properly ignore the new `s3_bucket_tags` and `dynamodb_table_tags` configs when making this decision.