### PR TITLE
Revert init changes

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -502,11 +502,6 @@ func runTerraformInit(terragruntOptions *options.TerragruntOptions, terragruntCo
 			}
 		}
 
-		// We will run init separately to download modules, plugins, backend state, etc, so don't run it at this point
-		initOptions.AppendTerraformCliArgs("-get=false")
-		initOptions.AppendTerraformCliArgs("-get-plugins=false")
-		initOptions.AppendTerraformCliArgs("-backend=false")
-
 		v0_10_0, err := version.NewVersion("v0.10.0")
 		if err != nil {
 			return err

--- a/cli/download_source_test.go
+++ b/cli/download_source_test.go
@@ -168,20 +168,20 @@ func TestSplitSourceUrl(t *testing.T) {
 		expectedRootRepo   string
 		expectedModulePath string
 	}{
-		{"root-path-only-no-double-slash", "/foo", "/", "foo"},
-		{"parent-path-one-child-no-double-slash", "/foo/bar", "/foo", "bar"},
-		{"parent-path-multiple-children-no-double-slash", "/foo/bar/baz/blah", "/foo/bar/baz", "blah"},
-		{"relative-path-no-children-no-double-slash", "../foo", "..", "foo"},
-		{"relative-path-one-child-no-double-slash", "../foo/bar", "../foo", "bar"},
-		{"relative-path-multiple-children-no-double-slash", "../foo/bar/baz/blah", "../foo/bar/baz", "blah"},
+		{"root-path-only-no-double-slash", "/foo", "/foo", ""},
+		{"parent-path-one-child-no-double-slash", "/foo/bar", "/foo/bar", ""},
+		{"parent-path-multiple-children-no-double-slash", "/foo/bar/baz/blah", "/foo/bar/baz/blah", ""},
+		{"relative-path-no-children-no-double-slash", "../foo", "../foo", ""},
+		{"relative-path-one-child-no-double-slash", "../foo/bar", "../foo/bar", ""},
+		{"relative-path-multiple-children-no-double-slash", "../foo/bar/baz/blah", "../foo/bar/baz/blah", ""},
 		{"root-path-only-with-double-slash", "/foo//", "/foo", ""},
 		{"parent-path-one-child-with-double-slash", "/foo//bar", "/foo", "bar"},
 		{"parent-path-multiple-children-with-double-slash", "/foo/bar//baz/blah", "/foo/bar", "baz/blah"},
 		{"relative-path-no-children-with-double-slash", "..//foo", "..", "foo"},
 		{"relative-path-one-child-with-double-slash", "../foo//bar", "../foo", "bar"},
 		{"relative-path-multiple-children-with-double-slash", "../foo/bar//baz/blah", "../foo/bar", "baz/blah"},
-		{"parent-url-one-child-no-double-slash", "ssh://git@github.com:foo/modules.git/foo", "ssh://git@github.com:foo/modules.git", "foo"},
-		{"parent-url-multiple-children-no-double-slash", "ssh://git@github.com:foo/modules.git/foo/bar/baz/blah", "ssh://git@github.com:foo/modules.git/foo/bar/baz", "blah"},
+		{"parent-url-one-child-no-double-slash", "ssh://git@github.com:foo/modules.git/foo", "ssh://git@github.com:foo/modules.git/foo", ""},
+		{"parent-url-multiple-children-no-double-slash", "ssh://git@github.com:foo/modules.git/foo/bar/baz/blah", "ssh://git@github.com:foo/modules.git/foo/bar/baz/blah", ""},
 		{"parent-url-one-child-with-double-slash", "ssh://git@github.com:foo/modules.git//foo", "ssh://git@github.com:foo/modules.git", "foo"},
 		{"parent-url-multiple-children-with-double-slash", "ssh://git@github.com:foo/modules.git//foo/bar/baz/blah", "ssh://git@github.com:foo/modules.git", "foo/bar/baz/blah"},
 	}

--- a/test/fixture-download/remote-module-in-root/terraform.tfvars
+++ b/test/fixture-download/remote-module-in-root/terraform.tfvars
@@ -1,0 +1,5 @@
+terragrunt = {
+  terraform {
+    source = "github.com/gruntwork-io/terraform-module-in-root-for-terragrunt-test.git"
+  }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -44,6 +44,7 @@ const (
 	TEST_FIXTURE_REMOTE_RELATIVE_DOWNLOAD_PATH          = "fixture-download/remote-relative"
 	TEST_FIXTURE_LOCAL_WITH_BACKEND                     = "fixture-download/local-with-backend"
 	TEST_FIXTURE_REMOTE_WITH_BACKEND                    = "fixture-download/remote-with-backend"
+	TEST_FIXTURE_REMOTE_MODULE_IN_ROOT                  = "fixture-download/remote-module-in-root"
 	TEST_FIXTURE_LOCAL_MISSING_BACKEND                  = "fixture-download/local-with-missing-backend"
 	TEST_FIXTURE_LOCAL_WITH_HIDDEN_FOLDER               = "fixture-download/local-with-hidden-folder"
 	TEST_FIXTURE_OLD_CONFIG_INCLUDE_PATH                = "fixture-old-terragrunt-config/include"
@@ -634,6 +635,18 @@ func TestRemoteWithBackend(t *testing.T) {
 
 	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName)
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+
+	// Run a second time to make sure the temporary folder can be reused without errors
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+}
+
+func TestRemoteWithModuleInRoot(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_REMOTE_MODULE_IN_ROOT)
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_REMOTE_MODULE_IN_ROOT)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
 


### PR DESCRIPTION
Terragrunt calls `terraform init` twice:

1. Once with the `-from-module` parameter to download any remote Terraform configurations specified via the `source` parameter in the Terragrunt config.

1. Once to for the normal purpose of `init`, which is to configure the backend, download providers, download modules, etc.

In #516, I tried to change the first call to `init` so it did not duplicate what the second call did by adding `-get=false`, `-backend=false`, and `-providers=false`. The goal was to speed up local iteration. Unfortunately, this change exposed some strange behavior with `terraform init`:

1. If you set it to a parent folder in a repo—that is, a folder that doesn't contain an `*.tf` files itself, but has subfolders that contain Terraform modules—the `init` command would download the code you requested and do nothing else.
2. If you set the `-from-module` parameter directly to an individual module—that is, a folder with `*.tf` files within it—then Terraform would not only download the code, but also do some sort of validation. This validation would fail with the error `module xxx: not found, may need to run 'terraform init'` if you had run `init` with the `-get=false` parameter. I've filed https://github.com/hashicorp/terraform/issues/18460 about this issue. 

In #516, I tried to work around (2) by messing with the way Terragrunt downloads code, but as a result, I caused #522. The way I was hacking paths does not work for download modules in the root of a repo. 

This PR fixes #522 by rolling back my path hackery, but also means we'll be calling `init` twice with everything enabled, making every Terragrunt command slower. If https://github.com/hashicorp/terraform/issues/18460 is fixed, I can re-add `-get=false`, `-backend=false`, etc without the path hackery. 