### PR TITLE
Speed up init usage

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -355,7 +355,9 @@ func runTerraformCommandIfNoErrors(possibleErrors error, terragruntOptions *opti
 	// sometimes results in Terraform trying to download/validate modules anyway, so we need to ignore that error.
 	if util.ListContainsElement(terragruntOptions.TerraformCliArgs, "init") && util.ListContainsElement(terragruntOptions.TerraformCliArgs, "-get=false") {
 		out, err := shell.RunTerraformCommandAndCaptureOutput(terragruntOptions, terragruntOptions.TerraformCliArgs...)
-		terragruntOptions.Logger.Println(out)
+
+		// Write the log output to stderr to make sure we don't pollute stdout
+		terragruntOptions.ErrWriter.Write([]byte(out))
 
 		// If we got an error and the error output included this error message, ignore the error and keep going
 		if err != nil && len(moduleNotFoundErr.FindStringSubmatch(out)) > 0 {

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -343,7 +343,7 @@ func runTerragruntWithConfig(terragruntOptions *options.TerragruntOptions, terra
 	return errors.NewMultiError(beforeHookErrors, terraformError, postHookErrors)
 }
 
-var moduleNotFoundErr = regexp.MustCompile(`Error: Error loading modules: module .+?: not found, may need to run 'terraform init'`)
+var moduleNotFoundErr = regexp.MustCompile(`Error loading modules: module .+?: not found, may need to run 'terraform init'`)
 
 func runTerraformCommandIfNoErrors(possibleErrors error, terragruntOptions *options.TerragruntOptions) error {
 	if possibleErrors != nil {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -948,7 +948,9 @@ func copyEnvironment(t *testing.T, environmentPath string) string {
 			return err
 		}
 
-		if info.IsDir() {
+		// The info.Mode() check is to catch symlinks to directories:
+		// https://stackoverflow.com/questions/32908277/fileinfo-isdir-isnt-detecting-directory
+		if info.IsDir() || (info.Mode()&os.ModeSymlink) == os.ModeSymlink {
 			return nil
 		}
 


### PR DESCRIPTION
When we use init to download modules, set `-get=false`, `-get-plugins=false`, and `-backend=false` so that all of those can be handled in the second call to `init` (if necessary). I tried this before in https://github.com/gruntwork-io/terragrunt/pull/516, but had to revert it due to a Terraform bug (https://github.com/hashicorp/terraform/issues/18460). I realize now that I can simply catch the error from that Terraform bug and ignore it!