### PR TITLE
implement exclude-dir cli flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1801,6 +1801,7 @@ start with the prefix `--terragrunt-`. The currently available options are:
   specified via the `TERRAGRUNT_IAM_ROLE` environment variable. This is a convenient way to use Terragrunt and 
   Terraform with multiple AWS accounts.
 
+* `--terragrunt-exclude-dir`: Unix-style glob of directories to exclude when running `*-all` commands. Modules under these direcotires will be excluded during execution of the commands. Flag can be specified multiple times.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -1801,7 +1801,7 @@ start with the prefix `--terragrunt-`. The currently available options are:
   specified via the `TERRAGRUNT_IAM_ROLE` environment variable. This is a convenient way to use Terragrunt and 
   Terraform with multiple AWS accounts.
 
-* `--terragrunt-exclude-dir`: Unix-style glob of directories to exclude when running `*-all` commands. Modules under these direcotires will be excluded during execution of the commands. Flag can be specified multiple times.
+* `--terragrunt-exclude-dir`: Unix-style glob of directories to exclude when running `*-all` commands. Modules under these directories will be excluded during execution of the commands. If a relative path is specified, it should be relative from `--terragrunt-working-dir`. Flag can be specified multiple times.
 
 ### Configuration
 

--- a/cli/args.go
+++ b/cli/args.go
@@ -87,7 +87,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 		return nil, err
 	}
 
-	excludeDirs, err := parseMultiStringArg(args, OPT_TERRAGRUNT_EXCLUDE_DIR, []string{os.Getenv("TERRAGRUNT_EXCLUDE_DIR")})
+	excludeDirs, err := parseMultiStringArg(args, OPT_TERRAGRUNT_EXCLUDE_DIR, []string{})
 	if err != nil {
 		return nil, err
 	}
@@ -236,6 +236,7 @@ func parseStringArg(args []string, argName string, defaultValue string) (string,
 // return a list of all values. If there are any present, but one of them has no value, return an error. If there aren't any present, return defaultValue.
 func parseMultiStringArg(args []string, argName string, defaultValue []string) ([]string, error) {
 	stringArgs := []string{}
+	fmt.Println(args)
 	for i, arg := range args {
 		if arg == fmt.Sprintf("--%s", argName) {
 			if (i + 1) < len(args) {
@@ -248,6 +249,9 @@ func parseMultiStringArg(args []string, argName string, defaultValue []string) (
 	if len(stringArgs) == 0 {
 		return defaultValue, nil
 	}
+
+	fmt.Printf("STRING ARGS: %s \n", stringArgs)
+
 	return stringArgs, nil
 }
 

--- a/cli/args.go
+++ b/cli/args.go
@@ -87,6 +87,11 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 		return nil, err
 	}
 
+	excludeDir, err := parseStringArg(args, OPT_TERRAGRUNT_EXCLUDE_DIR, os.Getenv("TERRAGRUNT_EXCLUDE_DIR"))
+	if err != nil {
+		return nil, err
+	}
+
 	opts, err := options.NewTerragruntOptions(filepath.ToSlash(terragruntConfigPath))
 	if err != nil {
 		return nil, err
@@ -108,6 +113,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 	opts.ErrWriter = errWriter
 	opts.Env = parseEnvironmentVariables(os.Environ())
 	opts.IamRole = iamRole
+	opts.ExcludeDir = excludeDir
 
 	return opts, nil
 }

--- a/cli/args.go
+++ b/cli/args.go
@@ -87,7 +87,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 		return nil, err
 	}
 
-	excludeDir, err := parseStringArg(args, OPT_TERRAGRUNT_EXCLUDE_DIR, os.Getenv("TERRAGRUNT_EXCLUDE_DIR"))
+	excludeDir, err := parseMultiStringArg(args, OPT_TERRAGRUNT_EXCLUDE_DIR, []string{os.Getenv("TERRAGRUNT_EXCLUDE_DIR")})
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 	opts.ErrWriter = errWriter
 	opts.Env = parseEnvironmentVariables(os.Environ())
 	opts.IamRole = iamRole
-	opts.ExcludeDir = excludeDir
+	opts.ExcludeDirs = ExcludeDirs
 
 	return opts, nil
 }
@@ -230,6 +230,29 @@ func parseStringArg(args []string, argName string, defaultValue string) (string,
 		}
 	}
 	return defaultValue, nil
+}
+
+// Find multiple string arguments of the same type (e.g. --foo "VALUE_A" --foo "VALUE_B") of the given name in the given list of arguments. If there are any present,
+// return a list of all values. If there are any present, but one of them has no value, return an error. If there aren't any present, return defaultValue.
+func parseMultiStringArg(args []string, argName string, defaultValue []string) ([]string, error) {
+
+	stringArgs := []string{}
+
+	for i, arg := range args {
+		if arg == fmt.Sprintf("--%s", argName) {
+			if (i + 1) < len(args) {
+				stringArgs = append(stringArgs, args[i+1])
+			} else {
+				return nil, errors.WithStackTrace(ArgMissingValue(argName))
+			}
+		}
+	}
+
+	if len(stringArgs) == 0 {
+		return defaultValue, nil
+	}
+
+	return stringArgs, nil
 }
 
 // Custom error types

--- a/cli/args.go
+++ b/cli/args.go
@@ -236,7 +236,7 @@ func parseStringArg(args []string, argName string, defaultValue string) (string,
 // return a list of all values. If there are any present, but one of them has no value, return an error. If there aren't any present, return defaultValue.
 func parseMultiStringArg(args []string, argName string, defaultValue []string) ([]string, error) {
 	stringArgs := []string{}
-	fmt.Println(args)
+
 	for i, arg := range args {
 		if arg == fmt.Sprintf("--%s", argName) {
 			if (i + 1) < len(args) {
@@ -249,8 +249,6 @@ func parseMultiStringArg(args []string, argName string, defaultValue []string) (
 	if len(stringArgs) == 0 {
 		return defaultValue, nil
 	}
-
-	fmt.Printf("STRING ARGS: %s \n", stringArgs)
 
 	return stringArgs, nil
 }

--- a/cli/args.go
+++ b/cli/args.go
@@ -87,7 +87,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 		return nil, err
 	}
 
-	excludeDir, err := parseMultiStringArg(args, OPT_TERRAGRUNT_EXCLUDE_DIR, []string{os.Getenv("TERRAGRUNT_EXCLUDE_DIR")})
+	ExcludeDirs, err := parseStringArg(args, OPT_TERRAGRUNT_EXCLUDE_DIR, os.Getenv("TERRAGRUNT_EXCLUDE_DIR"))
 	if err != nil {
 		return nil, err
 	}
@@ -230,29 +230,6 @@ func parseStringArg(args []string, argName string, defaultValue string) (string,
 		}
 	}
 	return defaultValue, nil
-}
-
-// Find multiple string arguments of the same type (e.g. --foo "VALUE_A" --foo "VALUE_B") of the given name in the given list of arguments. If there are any present,
-// return a list of all values. If there are any present, but one of them has no value, return an error. If there aren't any present, return defaultValue.
-func parseMultiStringArg(args []string, argName string, defaultValue []string) ([]string, error) {
-
-	stringArgs := []string{}
-
-	for i, arg := range args {
-		if arg == fmt.Sprintf("--%s", argName) {
-			if (i + 1) < len(args) {
-				stringArgs = append(stringArgs, args[i+1])
-			} else {
-				return nil, errors.WithStackTrace(ArgMissingValue(argName))
-			}
-		}
-	}
-
-	if len(stringArgs) == 0 {
-		return defaultValue, nil
-	}
-
-	return stringArgs, nil
 }
 
 // Custom error types

--- a/cli/args.go
+++ b/cli/args.go
@@ -87,7 +87,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 		return nil, err
 	}
 
-	ExcludeDirs, err := parseStringArg(args, OPT_TERRAGRUNT_EXCLUDE_DIR, os.Getenv("TERRAGRUNT_EXCLUDE_DIR"))
+	excludeDirs, err := parseMultiStringArg(args, OPT_TERRAGRUNT_EXCLUDE_DIR, []string{os.Getenv("TERRAGRUNT_EXCLUDE_DIR")})
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 	opts.ErrWriter = errWriter
 	opts.Env = parseEnvironmentVariables(os.Environ())
 	opts.IamRole = iamRole
-	opts.ExcludeDirs = ExcludeDirs
+	opts.ExcludeDirs = excludeDirs
 
 	return opts, nil
 }
@@ -230,6 +230,25 @@ func parseStringArg(args []string, argName string, defaultValue string) (string,
 		}
 	}
 	return defaultValue, nil
+}
+
+// Find multiple string arguments of the same type (e.g. --foo "VALUE_A" --foo "VALUE_B") of the given name in the given list of arguments. If there are any present,
+// return a list of all values. If there are any present, but one of them has no value, return an error. If there aren't any present, return defaultValue.
+func parseMultiStringArg(args []string, argName string, defaultValue []string) ([]string, error) {
+	stringArgs := []string{}
+	for i, arg := range args {
+		if arg == fmt.Sprintf("--%s", argName) {
+			if (i + 1) < len(args) {
+				stringArgs = append(stringArgs, args[i+1])
+			} else {
+				return nil, errors.WithStackTrace(ArgMissingValue(argName))
+			}
+		}
+	}
+	if len(stringArgs) == 0 {
+		return defaultValue, nil
+	}
+	return stringArgs, nil
 }
 
 // Custom error types

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -7,13 +7,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"strings"
+
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"strings"
 )
 
 func TestParseTerragruntOptionsFromArgs(t *testing.T) {
@@ -188,6 +189,27 @@ func TestFilterTerragruntArgs(t *testing.T) {
 
 	for _, testCase := range testCases {
 		actual := filterTerragruntArgs(testCase.args)
+		assert.Equal(t, testCase.expected, actual, "For args %v", testCase.args)
+	}
+}
+
+func TestParseMultiStringArg(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		args         []string
+		argName      string
+		defaultValue []string
+		expected     []string
+	}{
+		{[]string{"apply-all", "--foo", "bar"}, "foo", []string{"default_bar"}, []string{"bar"}},
+		{[]string{"apply-all", "--test", "bar"}, "foo", []string{"default_bar"}, []string{"default_bar"}},
+		{[]string{"plan-all", "--test", "--foo", "bar1", "--foo", "bar2"}, "foo", []string{"default_bar"}, []string{"bar1", "bar2"}},
+		{[]string{"plan-all", "--test", "value", "--foo", "bar1", "--foo"}, "foo", []string{"default_bar"}, nil},
+	}
+
+	for _, testCase := range testCases {
+		actual, _ := parseMultiStringArg(testCase.args, testCase.argName, testCase.defaultValue)
 		assert.Equal(t, testCase.expected, actual, "For args %v", testCase.args)
 	}
 }

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -200,17 +200,24 @@ func TestParseMultiStringArg(t *testing.T) {
 		args         []string
 		argName      string
 		defaultValue []string
-		expected     []string
+		expectedVals []string
+		expectedErr  error
 	}{
-		{[]string{"apply-all", "--foo", "bar"}, "foo", []string{"default_bar"}, []string{"bar"}},
-		{[]string{"apply-all", "--test", "bar"}, "foo", []string{"default_bar"}, []string{"default_bar"}},
-		{[]string{"plan-all", "--test", "--foo", "bar1", "--foo", "bar2"}, "foo", []string{"default_bar"}, []string{"bar1", "bar2"}},
-		{[]string{"plan-all", "--test", "value", "--foo", "bar1", "--foo"}, "foo", []string{"default_bar"}, nil},
+		{[]string{"apply-all", "--foo", "bar"}, "foo", []string{"default_bar"}, []string{"bar"}, nil},
+		{[]string{"apply-all", "--test", "bar"}, "foo", []string{"default_bar"}, []string{"default_bar"}, nil},
+		{[]string{"plan-all", "--test", "--foo", "bar1", "--foo", "bar2"}, "foo", []string{"default_bar"}, []string{"bar1", "bar2"}, nil},
+		{[]string{"plan-all", "--test", "value", "--foo", "bar1", "--foo"}, "foo", []string{"default_bar"}, nil, ArgMissingValue("foo")},
 	}
 
 	for _, testCase := range testCases {
-		actual, _ := parseMultiStringArg(testCase.args, testCase.argName, testCase.defaultValue)
-		assert.Equal(t, testCase.expected, actual, "For args %v", testCase.args)
+		actual, actualErr := parseMultiStringArg(testCase.args, testCase.argName, testCase.defaultValue)
+
+		if testCase.expectedErr != nil {
+			assert.True(t, errors.IsError(actualErr, testCase.expectedErr), "Expected error %v but got error %v", testCase.expectedErr, actualErr)
+		} else {
+			assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
+			assert.Equal(t, testCase.expectedVals, actual, "For args %v", testCase.args)
+		}
 	}
 }
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -32,9 +32,10 @@ const OPT_TERRAGRUNT_SOURCE = "terragrunt-source"
 const OPT_TERRAGRUNT_SOURCE_UPDATE = "terragrunt-source-update"
 const OPT_TERRAGRUNT_IAM_ROLE = "terragrunt-iam-role"
 const OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ERRORS = "terragrunt-ignore-dependency-errors"
+const OPT_TERRAGRUNT_EXCLUDE_DIR = "terragrunt-exclude-dir"
 
 var ALL_TERRAGRUNT_BOOLEAN_OPTS = []string{OPT_NON_INTERACTIVE, OPT_TERRAGRUNT_SOURCE_UPDATE, OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ERRORS, OPT_TERRAGRUNT_NO_AUTO_INIT}
-var ALL_TERRAGRUNT_STRING_OPTS = []string{OPT_TERRAGRUNT_CONFIG, OPT_TERRAGRUNT_TFPATH, OPT_WORKING_DIR, OPT_DOWNLOAD_DIR, OPT_TERRAGRUNT_SOURCE, OPT_TERRAGRUNT_IAM_ROLE}
+var ALL_TERRAGRUNT_STRING_OPTS = []string{OPT_TERRAGRUNT_CONFIG, OPT_TERRAGRUNT_TFPATH, OPT_WORKING_DIR, OPT_DOWNLOAD_DIR, OPT_TERRAGRUNT_SOURCE, OPT_TERRAGRUNT_IAM_ROLE, OPT_TERRAGRUNT_EXCLUDE_DIR}
 
 const CMD_PLAN_ALL = "plan-all"
 const CMD_APPLY_ALL = "apply-all"
@@ -114,6 +115,7 @@ GLOBAL OPTIONS:
    terragrunt-source-update             Delete the contents of the temporary folder to clear out any old, cached source code before downloading new source code into it.
    terragrunt-iam-role             		Assume the specified IAM role before executing Terraform. Can also be set via the TERRAGRUNT_IAM_ROLE environment variable.
    terragrunt-ignore-dependency-errors  *-all commands continue processing components even if a dependency fails.
+   terragrunt-exclude-dir               Unix-style glob of directories to exclude when running *-all commands
 
 VERSION:
    {{.Version}}{{if len .Authors}}

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -117,12 +117,12 @@ func flagExcludedDirs(modules []*TerraformModule, terragruntOptions *options.Ter
 		if shouldExcludeModuleBecauseOfPath(module, canonicalExcludeDirs) {
 			// Mark module itself as excluded
 			module.FlagExcluded = true
-		} else {
-			// Mark all affected dependencies as excluded
-			for _, dependency := range module.Dependencies {
-				if shouldExcludeModuleBecauseOfPath(dependency, canonicalExcludeDirs) {
-					dependency.FlagExcluded = true
-				}
+		}
+
+		// Mark all affected dependencies as excluded
+		for _, dependency := range module.Dependencies {
+			if shouldExcludeModuleBecauseOfPath(dependency, canonicalExcludeDirs) {
+				dependency.FlagExcluded = true
 			}
 		}
 	}

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -120,11 +120,12 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 	}
 
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
-	expected := []*TerraformModule{}
-
-	t.Logf("The following modules should be ignored because of dependencies: %v %v", moduleA, moduleC)
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, mockHowThesePathsWereFound)
+
+	// construct the expected list
+	moduleA.FlagExcluded = true
+	expected := []*TerraformModule{moduleA, moduleC}
 
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
@@ -157,11 +158,12 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithNoDepe
 	}
 
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
-	expected := []*TerraformModule{moduleA}
-
-	t.Logf("The following module should be excluded: %v", moduleC)
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, mockHowThesePathsWereFound)
+
+	// construct the expected list
+	moduleC.FlagExcluded = true
+	expected := []*TerraformModule{moduleA, moduleC}
 
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -2,12 +2,13 @@ package configstack
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 var mockHowThesePathsWereFound = "mock-values-for-test"
@@ -97,7 +98,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 
 	opts, _ := options.NewTerragruntOptionsForTest("running_module_test")
 	opts.WorkingDir, _ = os.Getwd()
-	opts.ExcludeDir = canonical(t, "../test/fixture-modules/module-a")
+	opts.ExcludeDirs = []string{canonical(t, "../test/fixture-modules/module-a")}
 
 	moduleA := &TerraformModule{
 		Path:         canonical(t, "../test/fixture-modules/module-a"),
@@ -134,7 +135,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithNoDepe
 
 	opts, _ := options.NewTerragruntOptionsForTest("running_module_test")
 	opts.WorkingDir, _ = os.Getwd()
-	opts.ExcludeDir = canonical(t, "../test/fixture-modules/module-c")
+	opts.ExcludeDirs = []string{canonical(t, "../test/fixture-modules/module-c")}
 
 	moduleA := &TerraformModule{
 		Path:         canonical(t, "../test/fixture-modules/module-a"),

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -85,8 +85,7 @@ func toRunningModules(modules []*TerraformModule, dependencyOrder DependencyOrde
 		return crossLinkedModules, err
 	}
 
-	finalModules := removeFlagExcluded(crossLinkedModules)
-	return finalModules, nil
+	return removeFlagExcluded(crossLinkedModules), nil
 }
 
 // Loop through the map of runningModules and for each module M:
@@ -116,17 +115,20 @@ func crossLinkDependencies(modules map[string]*runningModule, dependencyOrder De
 
 // Return a cleaned-up map that only contains modules and dependencies that should not be excluded
 func removeFlagExcluded(modules map[string]*runningModule) map[string]*runningModule {
-
 	var finalModules = make(map[string]*runningModule)
 
 	for key, module := range modules {
 
 		// Only add modules that should not be excluded
 		if !module.Module.FlagExcluded {
-			finalModules[key] = module
-
-			var finalDependencies = make(map[string]*runningModule)
-			finalModules[key].Dependencies = finalDependencies
+			finalModules[key] = &runningModule{
+				Module:         module.Module,
+				Dependencies:   make(map[string]*runningModule),
+				DependencyDone: module.DependencyDone,
+				Err:            module.Err,
+				NotifyWhenDone: module.NotifyWhenDone,
+				Status:         module.Status,
+			}
 
 			// Only add dependencies that should not be excluded
 			for _, dependency := range module.Module.Dependencies {

--- a/configstack/running_module_test.go
+++ b/configstack/running_module_test.go
@@ -2,10 +2,11 @@ package configstack
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var mockOptions, _ = options.NewTerragruntOptionsForTest("running_module_test")

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -39,7 +39,6 @@ func (stack *Stack) Plan(terragruntOptions *options.TerragruntOptions) error {
 		module.TerragruntOptions.ErrWriter = &errorStreams[n]
 	}
 	defer stack.summarizePlanAllErrors(terragruntOptions, errorStreams)
-
 	return RunModules(stack.Modules)
 }
 

--- a/configstack/test_helpers.go
+++ b/configstack/test_helpers.go
@@ -50,6 +50,7 @@ func assertModulesEqual(t *testing.T, expected *TerraformModule, actual *Terrafo
 		assert.Equal(t, expected.Config, actual.Config, messageAndArgs...)
 		assert.Equal(t, expected.Path, actual.Path, messageAndArgs...)
 		assert.Equal(t, expected.AssumeAlreadyApplied, actual.AssumeAlreadyApplied, messageAndArgs...)
+		assert.Equal(t, expected.FlagExcluded, actual.FlagExcluded, messageAndArgs...)
 
 		assertOptionsEqual(t, *expected.TerragruntOptions, *actual.TerragruntOptions, messageAndArgs...)
 		assertModuleListsEqual(t, expected.Dependencies, actual.Dependencies, messageAndArgs...)

--- a/options/options.go
+++ b/options/options.go
@@ -81,7 +81,7 @@ type TerragruntOptions struct {
 	MaxFoldersToCheck int
 
 	// Unix-style glob of directories to exclude when running *-all commands
-	ExcludeDir string
+	ExcludeDirs []string
 
 	// A command that can be used to run Terragrunt with the given options. This is useful for running Terragrunt
 	// multiple times (e.g. when spinning up a stack of Terraform modules). The actual command is normally defined
@@ -117,7 +117,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		Writer:                 os.Stdout,
 		ErrWriter:              os.Stderr,
 		MaxFoldersToCheck:      DEFAULT_MAX_FOLDERS_TO_CHECK,
-		ExcludeDir:             "",
+		ExcludeDirs:            []string{},
 		RunTerragrunt: func(terragruntOptions *TerragruntOptions) error {
 			return errors.WithStackTrace(RunTerragruntCommandNotSet)
 		},
@@ -178,7 +178,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		Writer:                 terragruntOptions.Writer,
 		ErrWriter:              terragruntOptions.ErrWriter,
 		MaxFoldersToCheck:      terragruntOptions.MaxFoldersToCheck,
-		ExcludeDir:             terragruntOptions.ExcludeDir,
+		ExcludeDirs:            terragruntOptions.ExcludeDirs,
 		RunTerragrunt:          terragruntOptions.RunTerragrunt,
 	}
 }

--- a/options/options.go
+++ b/options/options.go
@@ -80,6 +80,9 @@ type TerragruntOptions struct {
 	// exposed here primarily so we can set it to a low value at test time.
 	MaxFoldersToCheck int
 
+	// Unix-style glob of directories to exclude when running *-all commands
+	ExcludeDir string
+
 	// A command that can be used to run Terragrunt with the given options. This is useful for running Terragrunt
 	// multiple times (e.g. when spinning up a stack of Terraform modules). The actual command is normally defined
 	// in the cli package, which depends on almost all other packages, so we declare it here so that other
@@ -114,6 +117,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		Writer:                 os.Stdout,
 		ErrWriter:              os.Stderr,
 		MaxFoldersToCheck:      DEFAULT_MAX_FOLDERS_TO_CHECK,
+		ExcludeDir:             "",
 		RunTerragrunt: func(terragruntOptions *TerragruntOptions) error {
 			return errors.WithStackTrace(RunTerragruntCommandNotSet)
 		},
@@ -174,6 +178,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		Writer:                 terragruntOptions.Writer,
 		ErrWriter:              terragruntOptions.ErrWriter,
 		MaxFoldersToCheck:      terragruntOptions.MaxFoldersToCheck,
+		ExcludeDir:             terragruntOptions.ExcludeDir,
 		RunTerragrunt:          terragruntOptions.RunTerragrunt,
 	}
 }

--- a/test/fixture-download/hello-world-no-remote/main.tf
+++ b/test/fixture-download/hello-world-no-remote/main.tf
@@ -1,0 +1,15 @@
+data "template_file" "test" {
+  template = "${module.hello.hello}, ${var.name}"
+}
+
+variable "name" {
+  description = "Specify a name"
+}
+
+output "test" {
+  value = "${data.template_file.test.rendered}"
+}
+
+module    "hello" {
+  source = "..//hello-world/hello"
+}

--- a/test/fixture-download/local-with-exclude-dir/integration-env/aws/module-aws-a/terraform.tfvars
+++ b/test/fixture-download/local-with-exclude-dir/integration-env/aws/module-aws-a/terraform.tfvars
@@ -1,0 +1,7 @@
+name = "Module AWS A"
+
+terragrunt = {
+  terraform {
+    source = "../../../../hello-world"
+  }
+}

--- a/test/fixture-download/local-with-exclude-dir/integration-env/aws/module-aws-a/terraform.tfvars
+++ b/test/fixture-download/local-with-exclude-dir/integration-env/aws/module-aws-a/terraform.tfvars
@@ -2,6 +2,6 @@ name = "Module AWS A"
 
 terragrunt = {
   terraform {
-    source = "../../../../hello-world"
+    source = "../../../..//hello-world-no-remote"
   }
 }

--- a/test/fixture-download/local-with-exclude-dir/integration-env/gce/module-gce-b/terraform.tfvars
+++ b/test/fixture-download/local-with-exclude-dir/integration-env/gce/module-gce-b/terraform.tfvars
@@ -2,7 +2,7 @@ name = "Module GCE B"
 
 terragrunt = {
   terraform {
-    source = "../../../../hello-world"
+    source = "../../../..//hello-world-no-remote"
   }
 
   dependencies {

--- a/test/fixture-download/local-with-exclude-dir/integration-env/gce/module-gce-b/terraform.tfvars
+++ b/test/fixture-download/local-with-exclude-dir/integration-env/gce/module-gce-b/terraform.tfvars
@@ -1,0 +1,11 @@
+name = "Module GCE B"
+
+terragrunt = {
+  terraform {
+    source = "../../../../hello-world"
+  }
+
+  dependencies {
+    paths = ["../../aws/module-aws-a"]
+  }
+}

--- a/test/fixture-download/local-with-exclude-dir/integration-env/gce/module-gce-c/terraform.tfvars
+++ b/test/fixture-download/local-with-exclude-dir/integration-env/gce/module-gce-c/terraform.tfvars
@@ -2,6 +2,6 @@ name = "Module GCE C"
 
 terragrunt = {
   terraform {
-    source = "../../../../hello-world"
+    source = "../../../..//hello-world-no-remote"
   }
 }

--- a/test/fixture-download/local-with-exclude-dir/integration-env/gce/module-gce-c/terraform.tfvars
+++ b/test/fixture-download/local-with-exclude-dir/integration-env/gce/module-gce-c/terraform.tfvars
@@ -1,0 +1,7 @@
+name = "Module GCE C"
+
+terragrunt = {
+  terraform {
+    source = "../../../../hello-world"
+  }
+}

--- a/test/fixture-download/local-with-exclude-dir/production-env/aws/module-aws-d/terraform.tfvars
+++ b/test/fixture-download/local-with-exclude-dir/production-env/aws/module-aws-d/terraform.tfvars
@@ -2,6 +2,6 @@ name = "Module AWS D"
 
 terragrunt = {
   terraform {
-    source = "../../../../hello-world"
+    source = "../../../..//hello-world-no-remote"
   }
 }

--- a/test/fixture-download/local-with-exclude-dir/production-env/aws/module-aws-d/terraform.tfvars
+++ b/test/fixture-download/local-with-exclude-dir/production-env/aws/module-aws-d/terraform.tfvars
@@ -1,0 +1,7 @@
+name = "Module AWS D"
+
+terragrunt = {
+  terraform {
+    source = "../../../../hello-world"
+  }
+}

--- a/test/fixture-download/local-with-exclude-dir/production-env/gce/module-gce-e/terraform.tfvars
+++ b/test/fixture-download/local-with-exclude-dir/production-env/gce/module-gce-e/terraform.tfvars
@@ -2,7 +2,7 @@ name = "Module GCE E"
 
 terragrunt = {
   terraform {
-    source = "../../../../hello-world"
+    source = "../../../..//hello-world-no-remote"
   }
 
   dependencies {

--- a/test/fixture-download/local-with-exclude-dir/production-env/gce/module-gce-e/terraform.tfvars
+++ b/test/fixture-download/local-with-exclude-dir/production-env/gce/module-gce-e/terraform.tfvars
@@ -1,0 +1,11 @@
+name = "Module GCE E"
+
+terragrunt = {
+  terraform {
+    source = "../../../../hello-world"
+  }
+
+  dependencies {
+    paths = ["../../aws/module-aws-d"]
+  }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1017,7 +1017,7 @@ func TestPreventDestroyDependencies(t *testing.T) {
 }
 
 func TestExcludeDirs(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 
 	// Populate module paths.
 	moduleNames := []string{

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -45,6 +45,7 @@ const (
 	TEST_FIXTURE_LOCAL_RELATIVE_DOWNLOAD_PATH             = "fixture-download/local-relative"
 	TEST_FIXTURE_REMOTE_RELATIVE_DOWNLOAD_PATH            = "fixture-download/remote-relative"
 	TEST_FIXTURE_LOCAL_WITH_BACKEND                       = "fixture-download/local-with-backend"
+	TEST_FIXTURE_LOCAL_WITH_EXCLUDE_DIR                   = "fixture-download/local-with-exclude-dir"
 	TEST_FIXTURE_REMOTE_WITH_BACKEND                      = "fixture-download/remote-with-backend"
 	TEST_FIXTURE_REMOTE_MODULE_IN_ROOT                    = "fixture-download/remote-module-in-root"
 	TEST_FIXTURE_LOCAL_MISSING_BACKEND                    = "fixture-download/local-with-missing-backend"
@@ -1010,6 +1011,71 @@ func TestPreventDestroyDependencies(t *testing.T) {
 			assert.NotContains(t, output, "Hello, Module D")
 		case "module-e":
 			assert.NotContains(t, output, "Hello, Module E")
+		}
+	}
+}
+
+func TestExcludeDirs(t *testing.T) {
+	t.Parallel()
+
+	// Populate module paths.
+	moduleNames := []string{
+		"integration-env/aws/module-aws-a",
+		"integration-env/gce/module-gce-b",
+		"integration-env/gce/module-gce-c",
+		"production-env/aws/module-aws-d",
+		"production-env/gce/module-gce-e",
+	}
+
+	testCases := []struct {
+		workingDir            string
+		excludeArgs           string
+		excludedModuleOutputs []string
+	}{
+		{TEST_FIXTURE_LOCAL_WITH_EXCLUDE_DIR, "--terragrunt-exclude-dir '*/gce'", []string{"Module GCE B", "Module AWS A", "Module GCE C", "Module GCE E"}},
+		//{TEST_FIXTURE_LOCAL_WITH_EXCLUDE_DIR, "--terragrunt-exclude-dir 'production-env' --terragrunt-exclude-dir '**/module-gce-c', []string{"Module GCE C"}},
+	}
+
+	modulePaths := make(map[string]string, len(moduleNames))
+	for _, moduleName := range moduleNames {
+		modulePaths[moduleName] = util.JoinPath(TEST_FIXTURE_LOCAL_WITH_EXCLUDE_DIR, moduleName)
+	}
+
+	var (
+		applyAllStdout bytes.Buffer
+		applyAllStderr bytes.Buffer
+		showStdout     bytes.Buffer
+		showStderr     bytes.Buffer
+	)
+
+	for _, testCase := range testCases {
+		// Cleanup all modules directories.
+		cleanupTerraformFolder(t, TEST_FIXTURE_LOCAL_WITH_EXCLUDE_DIR)
+		for _, modulePath := range modulePaths {
+			cleanupTerraformFolder(t, modulePath)
+		}
+
+		// Apply modules according to test cases
+		err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir %s %s", testCase.workingDir, testCase.excludeArgs), &applyAllStdout, &applyAllStderr)
+		logBufferContentsLineByLine(t, applyAllStdout, "apply-all stdout")
+		logBufferContentsLineByLine(t, applyAllStderr, "apply-all stderr")
+
+		if err != nil {
+			t.Fatalf("apply-all in TestExcludeDirs failed with error: %v. Full std", err)
+		}
+
+		// Check that the excluded module output is not present
+		for _, modulePath := range modulePaths {
+			err = runTerragruntCommand(t, fmt.Sprintf("terragrunt show --terragrunt-non-interactive --terragrunt-working-dir %s", modulePath), &showStdout, &showStderr)
+			logBufferContentsLineByLine(t, showStdout, fmt.Sprintf("show stdout for %s", modulePath))
+			logBufferContentsLineByLine(t, showStderr, fmt.Sprintf("show stderr for %s", modulePath))
+
+			assert.NoError(t, err)
+			output := showStdout.String()
+
+			for _, excludedModuleOutput := range testCase.excludedModuleOutputs {
+				assert.NotContains(t, output, excludedModuleOutput)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This implements https://github.com/gruntwork-io/terragrunt/issues/355 by adding a `-terragrunt-exclude-dir` CLI flag.

It supports unix-style globs and will exclude all modules within or under the specified directories during execution.

Let me know if additional things need to be adjusted.