### PR TITLE
configure s3 client session to support force_path_style

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,8 +509,29 @@ terragrunt = {
 The `remote_state` block supports all the same [backend types](https://www.terraform.io/docs/backends/types/index.html)
 as Terraform. The next time you run `terragrunt`, it will automatically configure all the settings in the
 `remote_state.config` block, if they aren't configured already, by calling [terraform
-init](https://www.terraform.io/docs/commands/init.html). The config options `s3_bucket_tags` and 
-`dynamodb_table_tags` are only valid for backend `s3`. They are used by terragrunt and are **not** passed on to 
+init](https://www.terraform.io/docs/commands/init.html). 
+
+For backend `s3`, the following config options can be used for S3-compatible object stores, as necessary:
+
+```hcl
+remote_state {
+  # ...
+
+  skip_bucket_versioning = true # use only if the object store does not support versioning
+
+  skip_region_validation      = true
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_metadata_api_check     = true
+  force_path_style            = true
+}
+```
+
+If you experience an error for any of these configurations, confirm you are using Terraform v0.11.2 or greater.
+
+Further, the config options `s3_bucket_tags`, 
+`dynamodb_table_tags`, and `skip_bucket_versioning` are only valid for backend `s3`. They are used by terragrunt and are **not** passed on to 
 terraform. See section [Create remote state and locking resources automatically](#create-remote-state-and-locking-resources-automatically).
 
 In each of the **child** `terraform.tfvars` files, such as `mysql/terraform.tfvars`, you can tell Terragrunt to

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -12,15 +12,24 @@ import (
 	"time"
 )
 
-// Returns an AWS session object for the given region (required), profile name (optional), and IAM role to assume
+// A representation of the configuration options for an AWS Session
+type AwsSessionConfig struct {
+	Region           string
+	CustomS3Endpoint string
+	Profile          string
+	RoleArn          string
+	S3ForcePathStyle bool
+}
+
+// Returns an AWS session object for the given config region (required), profile name (optional), and IAM role to assume
 // (optional), ensuring that the credentials are available
-func CreateAwsSession(awsRegion, customS3Endpoint string, awsProfile string, iamRoleArn string, s3ForcePathStyle bool, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {
+func CreateAwsSession(config *AwsSessionConfig, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {
 	defaultResolver := endpoints.DefaultResolver()
 	s3CustResolverFn := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
-		if service == "s3" && customS3Endpoint != "" {
+		if service == "s3" && config.CustomS3Endpoint != "" {
 			return endpoints.ResolvedEndpoint{
-				URL:           customS3Endpoint,
-				SigningRegion: awsRegion,
+				URL:           config.CustomS3Endpoint,
+				SigningRegion: config.Region,
 			}, nil
 		}
 
@@ -28,22 +37,22 @@ func CreateAwsSession(awsRegion, customS3Endpoint string, awsProfile string, iam
 	}
 
 	var awsConfig = aws.Config{
-		Region:           aws.String(awsRegion),
+		Region:           aws.String(config.Region),
 		EndpointResolver: endpoints.ResolverFunc(s3CustResolverFn),
-		S3ForcePathStyle: aws.Bool(s3ForcePathStyle),
+		S3ForcePathStyle: aws.Bool(config.S3ForcePathStyle),
 	}
 
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Config:            awsConfig,
-		Profile:           awsProfile,
+		Profile:           config.Profile,
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {
 		return nil, errors.WithStackTraceAndPrefix(err, "Error initializing session")
 	}
 
-	if iamRoleArn != "" {
-		sess.Config.Credentials = stscreds.NewCredentials(sess, iamRoleArn)
+	if config.RoleArn != "" {
+		sess.Config.Credentials = stscreds.NewCredentials(sess, config.RoleArn)
 	} else if terragruntOptions.IamRole != "" {
 		sess.Config.Credentials = stscreds.NewCredentials(sess, terragruntOptions.IamRole)
 	}

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -14,7 +14,7 @@ import (
 
 // Returns an AWS session object for the given region (required), profile name (optional), and IAM role to assume
 // (optional), ensuring that the credentials are available
-func CreateAwsSession(awsRegion, customS3Endpoint string, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {
+func CreateAwsSession(awsRegion, customS3Endpoint string, awsProfile string, iamRoleArn string, s3ForcePathStyle bool, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {
 	defaultResolver := endpoints.DefaultResolver()
 	s3CustResolverFn := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 		if service == "s3" && customS3Endpoint != "" {
@@ -30,6 +30,7 @@ func CreateAwsSession(awsRegion, customS3Endpoint string, awsProfile string, iam
 	var awsConfig = aws.Config{
 		Region:           aws.String(awsRegion),
 		EndpointResolver: endpoints.ResolverFunc(s3CustResolverFn),
+		S3ForcePathStyle: aws.Bool(s3ForcePathStyle),
 	}
 
 	sess, err := session.NewSessionWithOptions(session.Options{

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -27,8 +27,8 @@ const DEFAULT_READ_CAPACITY_UNITS = 1
 const DEFAULT_WRITE_CAPACITY_UNITS = 1
 
 // Create an authenticated client for DynamoDB
-func CreateDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*dynamodb.DynamoDB, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, "", awsProfile, iamRoleArn, false, terragruntOptions)
+func CreateDynamoDbClient(config *aws_helper.AwsSessionConfig, terragruntOptions *options.TerragruntOptions) (*dynamodb.DynamoDB, error) {
+	session, err := aws_helper.CreateAwsSession(config, terragruntOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -28,7 +28,7 @@ const DEFAULT_WRITE_CAPACITY_UNITS = 1
 
 // Create an authenticated client for DynamoDB
 func CreateDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string, terragruntOptions *options.TerragruntOptions) (*dynamodb.DynamoDB, error) {
-	session, err := aws_helper.CreateAwsSession(awsRegion, "", awsProfile, iamRoleArn, terragruntOptions)
+	session, err := aws_helper.CreateAwsSession(awsRegion, "", awsProfile, iamRoleArn, false, terragruntOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/dynamodb/dynamo_lock_test_utils.go
+++ b/dynamodb/dynamo_lock_test_utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/gruntwork-io/terragrunt/aws_helper"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
 	"math/rand"
@@ -42,7 +43,11 @@ func createDynamoDbClientForTest(t *testing.T) *dynamodb.DynamoDB {
 		t.Fatal(err)
 	}
 
-	client, err := CreateDynamoDbClient(DEFAULT_TEST_REGION, "", "", mockOptions)
+	sessionConfig := &aws_helper.AwsSessionConfig{
+		Region: DEFAULT_TEST_REGION,
+	}
+
+	client, err := CreateDynamoDbClient(sessionConfig, mockOptions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -124,13 +124,11 @@ func configValuesEqual(config map[string]interface{}, existingBackend *Terraform
 		} else {
 			terragruntOptions.Logger.Printf("Remote state configuration encrypt contains invalid value %v, should be boolean.", existingBackend.Config["encrypt"])
 		}
+	}
 
-		// If other keys are bools, DeepEqual also will consider the maps to be different.
-		for key, value := range existingBackend.Config {
-			if _, isBool := value.(bool); isBool {
-				continue // We know this is already converted to a bool, e.g. encrypt
-			}
-
+	// If other keys in config are bools, DeepEqual also will consider the maps to be different.
+	for key, value := range existingBackend.Config {
+		if util.KindOf(existingBackend.Config[key]) == reflect.String && util.KindOf(config[key]) == reflect.Bool {
 			if convertedValue, err := strconv.ParseBool(value.(string)); err == nil {
 				existingBackend.Config[key] = convertedValue
 			}

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -32,12 +32,14 @@ func TestToTerraformInitArgs(t *testing.T) {
 				"name":    "Terraform state storage",
 				"service": "Terraform"},
 
+			"skip_bucket_versioning": true,
+
 			"force_path_style": true,
 		},
 	}
 	args := remoteState.ToTerraformInitArgs()
 
-	// must not contain s3_bucket_tags or dynamodb_table_tags
+	// must not contain s3_bucket_tags or dynamodb_table_tags or skip_bucket_versioning
 	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1 -backend-config=force_path_style=true")
 }
 

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -30,12 +30,15 @@ func TestToTerraformInitArgs(t *testing.T) {
 			"dynamodb_table_tags": map[string]interface{}{
 				"team":    "team name",
 				"name":    "Terraform state storage",
-				"service": "Terraform"}},
+				"service": "Terraform"},
+
+			"force_path_style": true,
+		},
 	}
 	args := remoteState.ToTerraformInitArgs()
 
 	// must not contain s3_bucket_tags or dynamodb_table_tags
-	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1")
+	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1 -backend-config=force_path_style=true")
 }
 
 func TestToTerraformInitArgsUnknownBackend(t *testing.T) {
@@ -115,6 +118,17 @@ func TestDiffersFrom(t *testing.T) {
 			RemoteState{
 				Backend: "s3",
 				Config:  map[string]interface{}{"bucket": "foo", "key": "bar", "region": "different"},
+			},
+			true,
+		},
+		{
+			TerraformBackend{
+				Type:   "s3",
+				Config: map[string]interface{}{"something": "true"},
+			},
+			RemoteState{
+				Backend: "s3",
+				Config:  map[string]interface{}{"something": false},
 			},
 			true,
 		},

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1180,7 +1180,7 @@ func validateS3BucketExistsAndIsTagged(t *testing.T, awsRegion string, bucketNam
 		t.Fatalf("Error creating mockOptions: %v", err)
 	}
 
-	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", mockOptions)
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", false, mockOptions)
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -1247,7 +1247,7 @@ func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
 		t.Fatalf("Error creating mockOptions: %v", err)
 	}
 
-	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", mockOptions)
+	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", false, mockOptions)
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -1289,7 +1289,7 @@ func createDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string) (*dyn
 		return nil, err
 	}
 
-	session, err := aws_helper.CreateAwsSession(awsRegion, "", awsProfile, iamRoleArn, mockOptions)
+	session, err := aws_helper.CreateAwsSession(awsRegion, "", awsProfile, iamRoleArn, false, mockOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1180,7 +1180,11 @@ func validateS3BucketExistsAndIsTagged(t *testing.T, awsRegion string, bucketNam
 		t.Fatalf("Error creating mockOptions: %v", err)
 	}
 
-	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", false, mockOptions)
+	sessionConfig := &aws_helper.AwsSessionConfig{
+		Region: awsRegion,
+	}
+
+	s3Client, err := remote.CreateS3Client(sessionConfig, mockOptions)
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -1247,7 +1251,11 @@ func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string) {
 		t.Fatalf("Error creating mockOptions: %v", err)
 	}
 
-	s3Client, err := remote.CreateS3Client(awsRegion, "", "", "", false, mockOptions)
+	sessionConfig := &aws_helper.AwsSessionConfig{
+		Region: awsRegion,
+	}
+
+	s3Client, err := remote.CreateS3Client(sessionConfig, mockOptions)
 	if err != nil {
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
@@ -1289,7 +1297,13 @@ func createDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string) (*dyn
 		return nil, err
 	}
 
-	session, err := aws_helper.CreateAwsSession(awsRegion, "", awsProfile, iamRoleArn, false, mockOptions)
+	sessionConfig := &aws_helper.AwsSessionConfig{
+		Region:  awsRegion,
+		Profile: awsProfile,
+		RoleArn: iamRoleArn,
+	}
+
+	session, err := aws_helper.CreateAwsSession(sessionConfig, mockOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
@brikis98 This correctly implements `force_path_style`. It maintains all the current terragrunt functionality with the following changes:
1. It graciously fails if a third party s3 API does not support versioning
2. It allows other boolean configurations without incorrectly triggering an init everytime when comparing with string based existing configuration.

Relates to https://github.com/gruntwork-io/terragrunt/issues/565

This supports the following config:

```
terragrunt = {
  remote_state {
    backend = "s3"
    config {
      bucket   = "terraform-state2"
      key      = "${path_relative_to_include()}/terraform.tfstate"
      region   = "us-west-2"
      encrypt  = true
      endpoint = "https://s3-us-west-2.amazonaws.com"

      skip_region_validation      = true
      skip_credentials_validation = true
      skip_requesting_account_id  = true
      skip_get_ec2_platforms      = true
      skip_metadata_api_check     = true
      force_path_style            = true
    }
  }
```

I have not written tests, but will if you are comfortable with this. I have manually tested this on our third party object store and on AWS (with both regular and path style configuration). 