### PR TITLE
Shared credentials file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,7 @@ remote_state {
 
   skip_bucket_versioning = true # use only if the object store does not support versioning
 
+  shared_credentials_file     = "/path/to/credentials/file"
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_requesting_account_id  = true

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -41,6 +41,7 @@ type RemoteStateConfigS3 struct {
 	RoleArn          string `mapstructure:"role_arn"`
 	LockTable        string `mapstructure:"lock_table"`
 	DynamoDBTable    string `mapstructure:"dynamodb_table"`
+	CredsFilename    string `mapstructure:"shared_credentials_file"`
 	S3ForcePathStyle bool   `mapstructure:"force_path_style"`
 }
 
@@ -51,6 +52,7 @@ func (c *RemoteStateConfigS3) GetAwsSessionConfig() *aws_helper.AwsSessionConfig
 		CustomS3Endpoint: c.Endpoint,
 		Profile:          c.Profile,
 		RoleArn:          c.RoleArn,
+		CredsFilename:    c.CredsFilename,
 		S3ForcePathStyle: c.S3ForcePathStyle,
 	}
 }

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -168,7 +168,7 @@ func TestGetAwsSessionConfig(t *testing.T) {
 	}{
 		{
 			"all-values",
-			map[string]interface{}{"region": "foo", "endpoint": "bar", "profile": "baz", "role_arn": "arn::it", "force_path_style": true},
+			map[string]interface{}{"region": "foo", "endpoint": "bar", "profile": "baz", "role_arn": "arn::it", "shared_credentials_file": "my-file", "force_path_style": true},
 		},
 		{
 			"no-values",
@@ -176,7 +176,7 @@ func TestGetAwsSessionConfig(t *testing.T) {
 		},
 		{
 			"extra-values",
-			map[string]interface{}{"something": "unexpected", "region": "foo", "endpoint": "bar", "profile": "baz", "role_arn": "arn::it", "force_path_style": false},
+			map[string]interface{}{"something": "unexpected", "region": "foo", "endpoint": "bar", "profile": "baz", "role_arn": "arn::it", "shared_credentials_file": "my-file", "force_path_style": false},
 		},
 	}
 
@@ -194,6 +194,7 @@ func TestGetAwsSessionConfig(t *testing.T) {
 				CustomS3Endpoint: s3Config.Endpoint,
 				Profile:          s3Config.Profile,
 				RoleArn:          s3Config.RoleArn,
+				CredsFilename:    s3Config.CredsFilename,
 				S3ForcePathStyle: s3Config.S3ForcePathStyle,
 			}
 

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -34,13 +34,14 @@ func TestToTerraformInitArgs(t *testing.T) {
 
 			"skip_bucket_versioning": true,
 
-			"force_path_style": true,
+			"shared_credentials_file": "my-file",
+			"force_path_style":        true,
 		},
 	}
 	args := remoteState.ToTerraformInitArgs()
 
 	// must not contain s3_bucket_tags or dynamodb_table_tags or skip_bucket_versioning
-	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1 -backend-config=force_path_style=true")
+	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1 -backend-config=force_path_style=true -backend-config=shared_credentials_file=my-file")
 }
 
 func TestToTerraformInitArgsUnknownBackend(t *testing.T) {


### PR DESCRIPTION
Supports user specified credentials file location for terragrunt-specific calls to object store. Formatted and all tests passing.

You will want to review this after merging https://github.com/gruntwork-io/terragrunt/pull/567, but all changes in 07c1db3 here, regardless.