### PR TITLE
GH-493: do not add -var or -var-file extra_arguments during "apply" if plan is provided

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -130,7 +130,7 @@ func filterTerraformExtraArgs(terragruntOptions *options.TerragruntOptions, terr
 				// The following is a fix for GH-493.
 				// If the first argument is "apply" and the second argument is a file (plan),
 				// we don't add any -var-file to the command.
-				secondArg := secondArg(terragruntOptions.TerraformCliArgs)
+				secondArg := util.SecondArg(terragruntOptions.TerraformCliArgs)
 				if !(cmd == "apply" && util.IsFile(secondArg)) {
 					// If RequiredVarFiles is specified, add -var-file=<file> for each specified files
 					for _, file := range util.RemoveDuplicatesFromListKeepLast(arg.RequiredVarFiles) {

--- a/cli/args.go
+++ b/cli/args.go
@@ -128,14 +128,13 @@ func filterTerraformExtraArgs(terragruntOptions *options.TerragruntOptions, terr
 				secondArg := util.SecondArg(terragruntOptions.TerraformCliArgs)
 				skipVars := cmd == "apply" && util.IsFile(secondArg)
 
-
 				// The following is a fix for GH-493.
 				// If the first argument is "apply" and the second argument is a file (plan),
 				// we don't add any -var-file to the command.
 				if skipVars {
 					// If we have to skip vars, we need to iterate over all elements of array...
 					for _, a := range arg.Arguments {
-						if (!strings.HasPrefix(a, "-var")) {
+						if !strings.HasPrefix(a, "-var") {
 							out = append(out, a)
 						}
 					}

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -393,7 +393,7 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 			Terraform: &config.TerraformConfig{ExtraArgs: []config.TerraformExtraArguments{testCase.extraArgs}},
 		}
 
-		out := filterTerraformExtraArgs(testCase.options, &config);
+		out := filterTerraformExtraArgs(testCase.options, &config)
 
 		assert.Equal(t, testCase.expectedArgs, out)
 	}
@@ -416,9 +416,9 @@ func mockCmdOptions(t *testing.T, workingDir string, terraformCliArgs []string) 
 
 func mockExtraArgs(arguments, commands, requiredVarFiles, optionalVarFiles []string) config.TerraformExtraArguments {
 	a := config.TerraformExtraArguments{
-		Name: "test",
-		Arguments: arguments,
-		Commands: commands,
+		Name:             "test",
+		Arguments:        arguments,
+		Commands:         commands,
 		RequiredVarFiles: requiredVarFiles,
 		OptionalVarFiles: optionalVarFiles,
 	}

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -324,8 +324,6 @@ func TestTerraformHelp_wrongHelpFlag(t *testing.T) {
 }
 
 func TestFilterTerraformExtraArgs(t *testing.T) {
-	t.Parallel()
-
 	workingDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -373,14 +371,14 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 		// apply providing a folder, var files should stay included
 		{
 			mockCmdOptions(t, workingDir, []string{"apply", workingDir}),
-			mockExtraArgs([]string{"--foo", "bar"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
-			[]string{"--foo", "bar", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "-var='key=value'"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "-var-file=test.tfvars", "-var='key=value'", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
 		},
 		// apply providing a file, no var files included
 		{
 			mockCmdOptions(t, workingDir, []string{"apply", temporaryFile}),
-			mockExtraArgs([]string{"--foo", "bar"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
-			[]string{"--foo", "bar"},
+			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "bar", "foo"},
 		},
 
 		// Command not included in commands list

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -320,4 +321,109 @@ func TestTerraformHelp_wrongHelpFlag(t *testing.T) {
 
 	err := app.Run([]string{"terragrunt", "plan", "help"})
 	require.Error(t, err)
+}
+
+func TestFilterTerraformExtraArgs(t *testing.T) {
+	t.Parallel()
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workingDir = filepath.ToSlash(workingDir)
+
+	temporaryFile := createTempFile(t)
+
+	testCases := []struct {
+		options      *options.TerragruntOptions
+		extraArgs    config.TerraformExtraArguments
+		expectedArgs []string
+	}{
+		// Standard scenario
+		{
+			mockCmdOptions(t, workingDir, []string{"apply"}),
+			mockExtraArgs([]string{"--foo", "bar"}, []string{"apply", "plan", "destroy"}, []string{}, []string{}),
+			[]string{"--foo", "bar"},
+		},
+		// optional existing var file
+		{
+			mockCmdOptions(t, workingDir, []string{"apply"}),
+			mockExtraArgs([]string{"--foo", "bar"}, []string{"apply", "plan"}, []string{}, []string{temporaryFile}),
+			[]string{"--foo", "bar", fmt.Sprintf("-var-file=%s", temporaryFile)},
+		},
+		// required var file + optional existing var file
+		{
+			mockCmdOptions(t, workingDir, []string{"apply"}),
+			mockExtraArgs([]string{"--foo", "bar"}, []string{"apply", "plan"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "bar", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+		},
+		// non existing required var file + non existing optional var file
+		{
+			mockCmdOptions(t, workingDir, []string{"apply"}),
+			mockExtraArgs([]string{"--foo", "bar"}, []string{"apply", "plan"}, []string{"required.tfvars"}, []string{"optional.tfvars"}),
+			[]string{"--foo", "bar", "-var-file=required.tfvars"},
+		},
+		// plan providing a folder, var files should stay included
+		{
+			mockCmdOptions(t, workingDir, []string{"plan", workingDir}),
+			mockExtraArgs([]string{"--foo", "bar"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "bar", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+		},
+		// apply providing a folder, var files should stay included
+		{
+			mockCmdOptions(t, workingDir, []string{"apply", workingDir}),
+			mockExtraArgs([]string{"--foo", "bar"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "bar", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+		},
+		// apply providing a file, no var files included
+		{
+			mockCmdOptions(t, workingDir, []string{"apply", temporaryFile}),
+			mockExtraArgs([]string{"--foo", "bar"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "bar"},
+		},
+
+		// Command not included in commands list
+		{
+			mockCmdOptions(t, workingDir, []string{"apply"}),
+			mockExtraArgs([]string{"--foo", "bar"}, []string{"plan", "destroy"}, []string{"required.tfvars"}, []string{"optional.tfvars"}),
+			[]string{},
+		},
+	}
+	for _, testCase := range testCases {
+		config := config.TerragruntConfig{
+			Terraform: &config.TerraformConfig{ExtraArgs: []config.TerraformExtraArguments{testCase.extraArgs}},
+		}
+
+		out := filterTerraformExtraArgs(testCase.options, &config);
+
+		assert.Equal(t, testCase.expectedArgs, out)
+	}
+
+}
+
+func createTempFile(t *testing.T) string {
+	tmpFile, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %s\n", err.Error())
+	}
+
+	return filepath.ToSlash(tmpFile.Name())
+}
+
+func mockCmdOptions(t *testing.T, workingDir string, terraformCliArgs []string) *options.TerragruntOptions {
+	o := mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, terraformCliArgs, true, "", false)
+	return o
+}
+
+func mockExtraArgs(arguments, commands, requiredVarFiles, optionalVarFiles []string) config.TerraformExtraArguments {
+	a := config.TerraformExtraArguments{
+		Name: "test",
+		Arguments: arguments,
+		Commands: commands,
+		RequiredVarFiles: requiredVarFiles,
+		OptionalVarFiles: optionalVarFiles,
+	}
+
+	return a
 }

--- a/util/file.go
+++ b/util/file.go
@@ -94,6 +94,12 @@ func IsDir(path string) bool {
 	return err == nil && fileInfo.IsDir()
 }
 
+// Return true if the path points to a file
+func IsFile(path string) bool {
+	fileInfo, err := os.Stat(path)
+	return err == nil && !fileInfo.IsDir()
+}
+
 // Return the relative path you would have to take to get from basePath to path
 func GetPathRelativeTo(path string, basePath string) (string, error) {
 	if path == "" {


### PR DESCRIPTION
Fixes #493 

This PR adds a "special case" as discussed in https://github.com/gruntwork-io/terragrunt/issues/493#issuecomment-417814191 

The script now checks if the command in question is `apply` and if the second argument is a file. If so, `-var` and `-var-file` appends are skipped. 

I also added some tests on the function to be sure. 