### PR TITLE
GH-493 : handle CLI arguments

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -125,8 +125,8 @@ func filterTerraformExtraArgs(terragruntOptions *options.TerragruntOptions, terr
 	for _, arg := range terragruntConfig.Terraform.ExtraArgs {
 		for _, arg_cmd := range arg.Commands {
 			if cmd == arg_cmd {
-				secondArg := util.SecondArg(terragruntOptions.TerraformCliArgs)
-				skipVars := cmd == "apply" && util.IsFile(secondArg)
+				lastArg := util.LastArg(terragruntOptions.TerraformCliArgs)
+				skipVars := cmd == "apply" && util.IsFile(lastArg)
 
 				// The following is a fix for GH-493.
 				// If the first argument is "apply" and the second argument is a file (plan),

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -381,6 +381,19 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 			[]string{"--foo", "bar", "foo"},
 		},
 
+		// apply providing no params, var files should stay included
+		{
+			mockCmdOptions(t, workingDir, []string{"apply"}),
+			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+		},
+		// apply with some parameters, providing a file => no var files included
+		{
+			mockCmdOptions(t, workingDir, []string{"apply", "-no-color", "-foo", temporaryFile}),
+			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "bar", "foo"},
+		},
+
 		// Command not included in commands list
 		{
 			mockCmdOptions(t, workingDir, []string{"apply"}),

--- a/test/helpers/test_helpers_windows.go
+++ b/test/helpers/test_helpers_windows.go
@@ -2,4 +2,15 @@
 
 package helpers
 
-var RootFolder = "C:/"
+import (
+	"fmt"
+	"os"
+)
+
+var RootFolder = retrieveRootFolder()
+
+func retrieveRootFolder() string {
+	cwd, _ := os.Getwd();
+
+	return fmt.Sprintf("%s:/", cwd[0:1])
+}

--- a/util/collections.go
+++ b/util/collections.go
@@ -99,3 +99,11 @@ func SecondArg(args []string) string {
 	}
 	return ""
 }
+
+// A convenience method that returns the last item in the given list or an empty string if this is an empty list
+func LastArg(args []string) string {
+	if len(args) > 0 {
+		return args[len(args) - 1]
+	}
+	return ""
+}


### PR DESCRIPTION
Second fix for #493 - Handles the case in which the second argument to the cli is not a plan but an option, for example: `terragrunt apply -no-color plan.out`.

The check is now done on the latest CLI argument.

This PR also fixes an issue with Windows Testing on a drive different than `C:`.

Tests output (still run on WSL due to #581):
```
?       github.com/gruntwork-io/terragrunt      [no test files]
?       github.com/gruntwork-io/terragrunt/aws_helper   [no test files]
ok      github.com/gruntwork-io/terragrunt/cli  79.165s
ok      github.com/gruntwork-io/terragrunt/config       0.071s
ok      github.com/gruntwork-io/terragrunt/configstack  0.077s
ok      github.com/gruntwork-io/terragrunt/dynamodb     (cached)
?       github.com/gruntwork-io/terragrunt/errors       [no test files]
?       github.com/gruntwork-io/terragrunt/options      [no test files]
ok      github.com/gruntwork-io/terragrunt/remote       (cached)
ok      github.com/gruntwork-io/terragrunt/shell        (cached)
ok      github.com/gruntwork-io/terragrunt/test 369.584s
?       github.com/gruntwork-io/terragrunt/test/helpers [no test files]
ok      github.com/gruntwork-io/terragrunt/util (cached)
```