### PR TITLE
Auto-Retry fix failing tests

### DIFF
--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -13,4 +13,5 @@ var RETRYABLE_ERRORS = []string{
 	"(?s).*Creating metric alarm failed.*request to update this alarm is in progress.*",
 	"(?s).*Error installing provider.*TLS handshake timeout.*",
 	"(?s).*Error configuring the backend.*TLS handshake timeout.*",
+	"(?s).*Error installing provider.*tcp.*timeout.*",
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -892,7 +892,6 @@ func TestAutoRetryFlagWithRecoverableError(t *testing.T) {
 }
 
 func TestAutoRetryEnvVarWithRecoverableError(t *testing.T) {
-	t.Parallel()
 	os.Setenv("TERRAGRUNT_AUTO_RETRY", "false")
 	defer os.Unsetenv("TERRAGRUNT_AUTO_RETRY")
 	out := new(bytes.Buffer)


### PR DESCRIPTION
Remove parallel from a test case that uses environment variables. 
Add one more transient error expression.