### PR TITLE
Fix potential concurrency bug in RunShellCommandWithOutput

### DIFF
--- a/shell/run_shell_cmd_output_test.go
+++ b/shell/run_shell_cmd_output_test.go
@@ -3,8 +3,10 @@
 package shell
 
 import (
-	"bufio"
+	"bytes"
+	"github.com/stretchr/testify/require"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/options"
@@ -15,23 +17,61 @@ func TestCommandOutputOrder(t *testing.T) {
 	t.Parallel()
 
 	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
-	assert.Nil(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
+	require.NoError(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
+
+	// Specify a single (locking) buffer for both as a way to check that the output is being written in the correct
+	// order
+	var allOutputBuffer BufferWithLocking
+	terragruntOptions.Writer = &allOutputBuffer
+	terragruntOptions.ErrWriter = &allOutputBuffer
+
 	terragruntOptions.TerraformCliArgs = append(terragruntOptions.TerraformCliArgs, "same")
 	out, err := RunShellCommandWithOutput(terragruntOptions, "../testdata/test_outputs.sh", "same")
 
-	assert.NotNil(t, out, "Should get output")
+	require.NotNil(t, out, "Should get output")
 	assert.Nil(t, err, "Should have no error")
 
-	scanner := bufio.NewScanner(strings.NewReader(out))
-	var outputs = []string{}
-	for scanner.Scan() {
-		outputs = append(outputs, scanner.Text())
-	}
+	allOutputs := strings.Split(strings.TrimSpace(allOutputBuffer.String()), "\n")
 
-	assert.True(t, len(outputs) == 5, "Should have 5 entries")
-	assert.Equal(t, "stdout1", outputs[0], "First one from stdout")
-	assert.Equal(t, "stderr1", outputs[1], "First one from stderr")
-	assert.Equal(t, "stdout2", outputs[2], "Second one from stdout")
-	assert.Equal(t, "stderr2", outputs[3], "Second one from stderr")
-	assert.Equal(t, "stderr3", outputs[4], "Third one from stderr")
+	require.True(t, len(allOutputs) == 5, "Expected 5 entries, but got %d: %v", len(allOutputs), allOutputs)
+	assert.Equal(t, "stdout1", allOutputs[0], "First one from stdout")
+	assert.Equal(t, "stderr1", allOutputs[1], "First one from stderr")
+	assert.Equal(t, "stdout2", allOutputs[2], "Second one from stdout")
+	assert.Equal(t, "stderr2", allOutputs[3], "Second one from stderr")
+	assert.Equal(t, "stderr3", allOutputs[4], "Third one from stderr")
+
+	stdOutputs := strings.Split(strings.TrimSpace(out.Stdout), "\n")
+
+	require.True(t, len(stdOutputs) == 2, "Expected 2 entries, but got %d: %v", len(stdOutputs), stdOutputs)
+	assert.Equal(t, "stdout1", stdOutputs[0], "First one from stdout")
+	assert.Equal(t, "stdout2", stdOutputs[1], "Second one from stdout")
+
+	stdErrs := strings.Split(strings.TrimSpace(out.Stderr), "\n")
+
+	require.True(t, len(stdErrs) == 3, "Expected 3 entries, but got %d: %v", len(stdErrs), stdErrs)
+	assert.Equal(t, "stderr1", stdErrs[0], "First one from stderr")
+	assert.Equal(t, "stderr2", stdErrs[1], "Second one from stderr")
+	assert.Equal(t, "stderr3", stdErrs[2], "Second one from stderr")
+}
+
+// A goroutine-safe bytes.Buffer
+type BufferWithLocking struct {
+	buffer bytes.Buffer
+	mutex  sync.Mutex
+}
+
+// Write appends the contents of p to the buffer, growing the buffer as needed. It returns
+// the number of bytes written.
+func (s *BufferWithLocking) Write(p []byte) (n int, err error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.buffer.Write(p)
+}
+
+// String returns the contents of the unread portion of the buffer
+// as a string.  If the Buffer is a nil pointer, it returns "<nil>".
+func (s *BufferWithLocking) String() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.buffer.String()
 }


### PR DESCRIPTION
This hopefully fixes #611. In `RunShellCommandWithOutput`, we were writing both `stdout` and `stderr` to a single `bytes.Buffer`. Since `bytes.Buffer` is not guaranteed to be goroutine-safe, it's possible this was sometimes causing a race condition where some of the output was lost or overwritten, which led to weird behavior downstream. In this PR, I update `RunShellCommandWithOutput` to use two `bytes.Buffer`, one for stdout and one for stderr.