### PR TITLE
Add access logging permissions

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/config"
@@ -34,7 +35,7 @@ func (module *TerraformModule) String() string {
 	for _, dependency := range module.Dependencies {
 		dependencies = append(dependencies, dependency.Path)
 	}
-	return fmt.Sprintf("Module %s (dependencies: [%s])", module.Path, strings.Join(dependencies, ", "))
+	return fmt.Sprintf("Module %s (excluded: %v, dependencies: [%s])", module.Path, module.FlagExcluded, strings.Join(dependencies, ", "))
 }
 
 // Go through each of the given Terragrunt configuration files and resolve the module that configuration file represents
@@ -351,7 +352,9 @@ func resolveExternalDependenciesForModules(moduleMap map[string]*TerraformModule
 		return allExternalDependencies, errors.WithStackTrace(InfiniteRecursion{RecursionLevel: maxLevelsOfRecursion, Modules: modulesToSkip})
 	}
 
-	for _, module := range moduleMap {
+	sortedKeys := getSortedKeys(moduleMap)
+	for _, key := range sortedKeys {
+		module := moduleMap[key]
 		externalDependencies, err := resolveExternalDependenciesForModule(module, modulesToSkip, terragruntOptions)
 		if err != nil {
 			return externalDependencies, err
@@ -438,7 +441,9 @@ func mergeMaps(modules map[string]*TerraformModule, externalDependencies map[str
 func crosslinkDependencies(moduleMap map[string]*TerraformModule, canonicalTerragruntConfigPaths []string) ([]*TerraformModule, error) {
 	modules := []*TerraformModule{}
 
-	for _, module := range moduleMap {
+	keys := getSortedKeys(moduleMap)
+	for _, key := range keys {
+		module := moduleMap[key]
 		dependencies, err := getDependenciesForModule(module, moduleMap, canonicalTerragruntConfigPaths)
 		if err != nil {
 			return modules, err
@@ -478,6 +483,19 @@ func getDependenciesForModule(module *TerraformModule, moduleMap map[string]*Ter
 	}
 
 	return dependencies, nil
+}
+
+// Return the keys for the given map in sorted order. This is used to ensure we always iterate over maps of modules
+// in a consistent order (Go does not guarantee iteration order for maps, and usually makes it random)
+func getSortedKeys(modules map[string]*TerraformModule) []string {
+	keys := []string{}
+	for key, _ := range modules {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
 }
 
 // Custom error types

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -97,7 +97,6 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 	t.Parallel()
 
 	opts, _ := options.NewTerragruntOptionsForTest("running_module_test")
-	opts.WorkingDir, _ = os.Getwd()
 	opts.ExcludeDirs = []string{canonical(t, "../test/fixture-modules/module-a")}
 
 	moduleA := &TerraformModule{
@@ -135,7 +134,6 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithNoDepe
 	t.Parallel()
 
 	opts, _ := options.NewTerragruntOptionsForTest("running_module_test")
-	opts.WorkingDir, _ = os.Getwd()
 	opts.ExcludeDirs = []string{canonical(t, "../test/fixture-modules/module-c")}
 
 	moduleA := &TerraformModule{
@@ -173,7 +171,6 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithDepend
 	t.Parallel()
 
 	opts, _ := options.NewTerragruntOptionsForTest("running_module_test")
-	opts.WorkingDir, _ = os.Getwd()
 	opts.IncludeDirs = []string{canonical(t, "../test/fixture-modules/module-c")}
 
 	moduleA := &TerraformModule{
@@ -211,7 +208,6 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithNoDepe
 	t.Parallel()
 
 	opts, _ := options.NewTerragruntOptionsForTest("running_module_test")
-	opts.WorkingDir, _ = os.Getwd()
 	opts.IncludeDirs = []string{canonical(t, "../test/fixture-modules/module-a")}
 
 	moduleA := &TerraformModule{
@@ -249,7 +245,6 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithDepend
 	t.Parallel()
 
 	opts, _ := options.NewTerragruntOptionsForTest("running_module_test")
-	opts.WorkingDir, _ = os.Getwd()
 	opts.IncludeDirs = []string{canonical(t, "../test/fixture-modules/module-c"), canonical(t, "../test/fixture-modules/module-f")}
 	opts.ExcludeDirs = []string{canonical(t, "../test/fixture-modules/module-f")}
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -463,13 +463,14 @@ func EnableSSEForS3BucketWide(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 func EnableAccessLoggingForS3BucketWide(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
 	terragruntOptions.Logger.Printf("Enabling bucket-wide Access Logging on AWS S3 bucket \"%s\" - using as TargetBucket \"%s\"", config.Bucket, config.Bucket)
 
-	// To enable access logging in an S3 bucket, you must grant WRITE and READ_ACP permissions to the Log Delivery Group,
-	// which is represented by the following URI. For more info, see:
+	// To enable access logging in an S3 bucket, you must grant WRITE and READ_ACP permissions to the Log Delivery
+	// Group. For more info, see:
 	// https://docs.aws.amazon.com/AmazonS3/latest/dev/enable-logging-programming.html
+	uri := fmt.Sprintf("uri=%s", s3LogDeliveryGranteeUri)
 	aclInput := s3.PutBucketAclInput{
 		Bucket:       aws.String(config.Bucket),
-		GrantWrite:   aws.String(s3LogDeliveryGranteeUri),
-		GrantReadACP: aws.String(s3LogDeliveryGranteeUri),
+		GrantWrite:   aws.String(uri),
+		GrantReadACP: aws.String(uri),
 	}
 	if _, err := s3Client.PutBucketAcl(&aclInput); err != nil {
 		return errors.WithStackTrace(err)

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -72,6 +72,11 @@ func (s3Config *RemoteStateConfigS3) GetLockTableName() string {
 const MAX_RETRIES_WAITING_FOR_S3_BUCKET = 12
 const SLEEP_BETWEEN_RETRIES_WAITING_FOR_S3_BUCKET = 5 * time.Second
 
+// To enable access logging in an S3 bucket, you must grant WRITE and READ_ACP permissions to the Log Delivery Group,
+// which is represented by the following URI. For more info, see:
+// https://docs.aws.amazon.com/AmazonS3/latest/dev/enable-logging-programming.html
+const s3LogDeliveryGranteeUri = "http://acs.amazonaws.com/groups/s3/LogDelivery"
+
 type S3Initializer struct{}
 
 // Returns true if:
@@ -457,7 +462,20 @@ func EnableSSEForS3BucketWide(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 // Enable bucket-wide Access Logging for the AWS S3 bucket specified in the given config
 func EnableAccessLoggingForS3BucketWide(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
 	terragruntOptions.Logger.Printf("Enabling bucket-wide Access Logging on AWS S3 bucket \"%s\" - using as TargetBucket \"%s\"", config.Bucket, config.Bucket)
-	input := s3.PutBucketLoggingInput{
+
+	// To enable access logging in an S3 bucket, you must grant WRITE and READ_ACP permissions to the Log Delivery Group,
+	// which is represented by the following URI. For more info, see:
+	// https://docs.aws.amazon.com/AmazonS3/latest/dev/enable-logging-programming.html
+	aclInput := s3.PutBucketAclInput{
+		Bucket:       aws.String(config.Bucket),
+		GrantWrite:   aws.String(s3LogDeliveryGranteeUri),
+		GrantReadACP: aws.String(s3LogDeliveryGranteeUri),
+	}
+	if _, err := s3Client.PutBucketAcl(&aclInput); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	loggingInput := s3.PutBucketLoggingInput{
 		Bucket: aws.String(config.Bucket),
 		BucketLoggingStatus: &s3.BucketLoggingStatus{
 			LoggingEnabled: &s3.LoggingEnabled{
@@ -467,8 +485,11 @@ func EnableAccessLoggingForS3BucketWide(s3Client *s3.S3, config *RemoteStateConf
 		},
 	}
 
-	_, err := s3Client.PutBucketLogging(&input)
-	return errors.WithStackTrace(err)
+	if _, err := s3Client.PutBucketLogging(&loggingInput); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
 }
 
 // Returns true if the S3 bucket specified in the given config exists and the current user has the ability to access


### PR DESCRIPTION
This is a follow-up to #645. The tests were failing with the error:

```
InvalidTargetBucketForLogging: You must give the log-delivery group WRITE and READ_ACP permissions to the target bucket
```

This PR is an attempt to grant those permissions.