### PR TITLE
Fix nil pointer. Wait for encryption. Make DynamoDB encryption off by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,10 +522,10 @@ For backend `s3`, the following config options can be used for S3-compatible obj
 remote_state {
   # ...
 
-  skip_bucket_versioning        = true # use only if the object store does not support versioning
-  skip_bucket_ssencryption      = true # use only if non-encrypted Terraform State is required and/or the object store does not support server-side encryption
-  skip_bucket_accesslogging     = true # use only if the cost for the extra object space is undesirable or the object store does not support access logging
-  skip_lock_table_ssencryption  = true # use only if non-encrypted DynamoDB Lock Table for the Terraform State is required and/or the NoSQL database service does not support server-side encryption
+  skip_bucket_versioning         = true # use only if the object store does not support versioning
+  skip_bucket_ssencryption       = true # use only if non-encrypted Terraform State is required and/or the object store does not support server-side encryption
+  skip_bucket_accesslogging      = true # use only if the cost for the extra object space is undesirable or the object store does not support access logging
+  enable_lock_table_ssencryption = true # use only if non-encrypted DynamoDB Lock Table for the Terraform State is required and/or the NoSQL database service does not support server-side encryption
 
   shared_credentials_file     = "/path/to/credentials/file"
   skip_region_validation      = true
@@ -540,7 +540,7 @@ remote_state {
 If you experience an error for any of these configurations, confirm you are using Terraform v0.11.2 or greater.
 
 Further, the config options `s3_bucket_tags`,
-`dynamodb_table_tags`, `skip_bucket_versioning`, `skip_bucket_ssencryption`, `skip_bucket_accesslogging`, and `skip_lock_table_ssencryption` are only valid for backend `s3`. They are used by terragrunt and are **not** passed on to
+`dynamodb_table_tags`, `skip_bucket_versioning`, `skip_bucket_ssencryption`, `skip_bucket_accesslogging`, and `enable_lock_table_ssencryption` are only valid for backend `s3`. They are used by terragrunt and are **not** passed on to
 terraform. See section [Create remote state and locking resources automatically](#create-remote-state-and-locking-resources-automatically).
 
 In each of the **child** `terraform.tfvars` files, such as `mysql/terraform.tfvars`, you can tell Terragrunt to

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -227,9 +227,14 @@ func UpdateLockTableSetSSEncryptionOnIfNecessary(tableName string, client *dynam
 		return errors.WithStackTrace(err)
 	}
 
-	return waitForEncryptionToBeEnabled(tableName, client, terragruntOptions)
+	if err := waitForEncryptionToBeEnabled(tableName, client, terragruntOptions); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return waitForTableToBeActive(tableName, client, MAX_RETRIES_WAITING_FOR_TABLE_TO_BE_ACTIVE, SLEEP_BETWEEN_TABLE_STATUS_CHECKS, terragruntOptions)
 }
 
+// Wait until encryption is enabled for the given table and the table is in ACTIVE status
 func waitForEncryptionToBeEnabled(tableName string, client *dynamodb.DynamoDB, terragruntOptions *options.TerragruntOptions) error {
 	maxRetries := 15
 	sleepBetweenRetries := 20 * time.Second

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -474,20 +474,11 @@ func EnableSSEForS3BucketWide(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 
 // Enable bucket-wide Access Logging for the AWS S3 bucket specified in the given config
 func EnableAccessLoggingForS3BucketWide(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Enabling bucket-wide Access Logging on AWS S3 bucket \"%s\" - using as TargetBucket \"%s\"", config.Bucket, config.Bucket)
-
-	// To enable access logging in an S3 bucket, you must grant WRITE and READ_ACP permissions to the Log Delivery
-	// Group. For more info, see:
-	// https://docs.aws.amazon.com/AmazonS3/latest/dev/enable-logging-programming.html
-	uri := fmt.Sprintf("uri=%s", s3LogDeliveryGranteeUri)
-	aclInput := s3.PutBucketAclInput{
-		Bucket:       aws.String(config.Bucket),
-		GrantWrite:   aws.String(uri),
-		GrantReadACP: aws.String(uri),
-	}
-	if _, err := s3Client.PutBucketAcl(&aclInput); err != nil {
+	if err := configureBucketAccessLoggingAcl(s3Client, config, terragruntOptions); err != nil {
 		return errors.WithStackTrace(err)
 	}
+
+	terragruntOptions.Logger.Printf("Enabling bucket-wide Access Logging on AWS S3 bucket \"%s\" - using as TargetBucket \"%s\"", config.Bucket, config.Bucket)
 
 	loggingInput := s3.PutBucketLoggingInput{
 		Bucket: aws.String(config.Bucket),
@@ -504,6 +495,65 @@ func EnableAccessLoggingForS3BucketWide(s3Client *s3.S3, config *RemoteStateConf
 	}
 
 	return nil
+}
+
+// To enable access logging in an S3 bucket, you must grant WRITE and READ_ACP permissions to the Log Delivery
+// Group. For more info, see:
+// https://docs.aws.amazon.com/AmazonS3/latest/dev/enable-logging-programming.html
+func configureBucketAccessLoggingAcl(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
+	terragruntOptions.Logger.Printf("Granting WRITE and READ_ACP permissions to S3 Log Delivery (%s) for bucket %s. This is required for access logging.", s3LogDeliveryGranteeUri, config.Bucket)
+
+	uri := fmt.Sprintf("uri=%s", s3LogDeliveryGranteeUri)
+	aclInput := s3.PutBucketAclInput{
+		Bucket:       aws.String(config.Bucket),
+		GrantWrite:   aws.String(uri),
+		GrantReadACP: aws.String(uri),
+	}
+
+	if _, err := s3Client.PutBucketAcl(&aclInput); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return waitUntilBucketHasAccessLoggingAcl(s3Client, config, terragruntOptions)
+}
+
+
+func waitUntilBucketHasAccessLoggingAcl(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
+	terragruntOptions.Logger.Printf("Waiting for ACL bucket %s to have the updated ACL for access logging.", config.Bucket)
+
+	maxRetries := 10
+	timeBetweenRetries := 5 * time.Second
+
+	for i := 0; i < maxRetries; i++ {
+		out, err := s3Client.GetBucketAcl(&s3.GetBucketAclInput{Bucket: aws.String(config.Bucket)})
+		if err != nil {
+			return errors.WithStackTrace(err)
+		}
+
+		hasReadAcp := false
+		hasWrite := false
+
+		for _, grant := range out.Grants {
+			if aws.StringValue(grant.Grantee.URI) == s3LogDeliveryGranteeUri {
+				if aws.StringValue(grant.Permission) == s3.PermissionReadAcp {
+					hasReadAcp = true
+				}
+				if aws.StringValue(grant.Permission) == s3.PermissionWrite {
+					hasWrite = true
+				}
+			}
+		}
+
+		if hasReadAcp && hasWrite {
+			terragruntOptions.Logger.Printf("Bucket %s now has the proper ACL permissions for access logging!", config.Bucket)
+			return nil
+		}
+
+		terragruntOptions.Logger.Printf("Bucket %s still does not have the ACL permissions for access logging. Will sleep for %v and check again.", config.Bucket, timeBetweenRetries)
+		time.Sleep(timeBetweenRetries)
+	}
+
+	return errors.WithStackTrace(MaxRetriesWaitingForS3ACLExceeded(config.Bucket))
 }
 
 // Returns true if the S3 bucket specified in the given config exists and the current user has the ability to access
@@ -580,3 +630,10 @@ type MaxRetriesWaitingForS3BucketExceeded string
 func (err MaxRetriesWaitingForS3BucketExceeded) Error() string {
 	return fmt.Sprintf("Exceeded max retries (%d) waiting for bucket S3 bucket %s", MAX_RETRIES_WAITING_FOR_S3_BUCKET, string(err))
 }
+
+type MaxRetriesWaitingForS3ACLExceeded string
+
+func (err MaxRetriesWaitingForS3ACLExceeded) Error() string {
+	return fmt.Sprintf("Exceeded max retries waiting for bucket S3 bucket %s to have proper ACL for access logging", string(err))
+}
+

--- a/test/fixture/terraform.tfvars
+++ b/test/fixture/terraform.tfvars
@@ -8,6 +8,7 @@ terragrunt = {
       key = "terraform.tfstate"
       region = "us-west-2"
       dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
+      enable_lock_table_ssencryption = true
 
       s3_bucket_tags {
         owner = "terragrunt integration test"


### PR DESCRIPTION
Follow-up fixes for #647:

1. Fix a nil pointer dereference when looking up tables that don't have encryption enabled.
1. It turns out that it takes 1-2 minutes to actually enable encryption, so add a wait. Otherwise, we start using the table before it's ready.
1. Disable DynamoDB encryption by default as (a) Terraform doesn't store any sensitive data in DynamoDB and (b) it takes 1-2 minutes to enable it, which makes using Terragrunt a lot slower. It can be enabled on-demand using the `enable_lock_table_ssencryption` setting.