### PR TITLE
Make xxx-all commands ignore modules with skip=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -1946,6 +1946,43 @@ terragrunt = {
 }
 ```
 
+#### skip
+
+The terragrunt `skip` boolean flag can be used to protect modules you don't want any changes to or just to skip modules
+that don't define any infrastructure by themselves. When set to true, all terragrunt commands will skip the selected module.
+
+Consider the following file structure:
+
+```
+root
+├── terraform.tfvars
+├── prod
+│   └── terraform.tfvars
+├── dev
+│   └── terraform.tfvars
+└── qa
+    └── terraform.tfvars
+```
+
+In some cases, the root level terraform.tfvars is simply used to DRY up your terraform configuration and is simply
+included by the other terraform.tfvars files. In this case, you do not want the `xxx-all` commands to process the root
+level terraform.tfvars since it does not define any infrastructure by itself. To make the `xxx-all` commands skip the
+root level terraform.tfvars file, you can set skip = true in the terragrunt { ... } block as shown in this example:
+
+```hcl
+terragrunt = {
+  skip = true
+
+  remote-state {
+    ...
+  }
+}
+```
+
+The `skip` flag must be set explicitly in terragrunt modules that should be skipped. If you set `skip = true` in a
+terraform.tfvars file that is included by another terraform.tfvars file, only the terraform.tfvars file that explicitly
+set `skip = true` will be skipped.
+
 ### Clearing the Terragrunt cache
 
 Terragrunt creates a `.terragrunt-cache` folder in the current working directory as its scratch directory. It downloads

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -228,6 +228,12 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		return err
 	}
 
+	if terragruntConfig.Skip {
+		terragruntOptions.Logger.Printf("Skipping terragrunt module %s due to skip = true.",
+			terragruntOptions.TerragruntConfigPath)
+		return nil
+	}
+
 	if terragruntOptions.IamRole == "" {
 		terragruntOptions.IamRole = terragruntConfig.IamRole
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type TerragruntConfig struct {
 	RemoteState    *remote.RemoteState
 	Dependencies   *ModuleDependencies
 	PreventDestroy bool
+	Skip           bool
 	IamRole        string
 }
 
@@ -38,6 +39,7 @@ type terragruntConfigFile struct {
 	RemoteState    *remote.RemoteState `hcl:"remote_state,omitempty"`
 	Dependencies   *ModuleDependencies `hcl:"dependencies,omitempty"`
 	PreventDestroy bool                `hcl:"prevent_destroy,omitempty"`
+	Skip           bool                `hcl:"skip,omitempty"`
 	IamRole        string              `hcl:"iam_role"`
 }
 
@@ -348,6 +350,9 @@ func mergeConfigWithIncludedConfig(config *TerragruntConfig, includedConfig *Ter
 		includedConfig.PreventDestroy = config.PreventDestroy
 	}
 
+	// Skip has to be set specifically in each file that should be skipped
+	includedConfig.Skip = config.Skip
+
 	if config.Terraform != nil {
 		if includedConfig.Terraform == nil {
 			includedConfig.Terraform = config.Terraform
@@ -494,6 +499,7 @@ func convertToTerragruntConfig(terragruntConfigFromFile *terragruntConfigFile, t
 	terragruntConfig.Terraform = terragruntConfigFromFile.Terraform
 	terragruntConfig.Dependencies = terragruntConfigFromFile.Dependencies
 	terragruntConfig.PreventDestroy = terragruntConfigFromFile.PreventDestroy
+	terragruntConfig.Skip = terragruntConfigFromFile.Skip
 	terragruntConfig.IamRole = terragruntConfigFromFile.IamRole
 
 	return terragruntConfig, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -593,6 +593,31 @@ func TestMergeConfigIntoIncludedConfig(t *testing.T) {
 			&TerragruntConfig{PreventDestroy: true},
 		},
 		{
+			&TerragruntConfig{},
+			nil,
+			&TerragruntConfig{Skip: false},
+		},
+		{
+			&TerragruntConfig{Skip: true},
+			nil,
+			&TerragruntConfig{Skip: true},
+		},
+		{
+			&TerragruntConfig{},
+			&TerragruntConfig{Skip: true},
+			&TerragruntConfig{Skip: false},
+		},
+		{
+			&TerragruntConfig{Skip: false},
+			&TerragruntConfig{Skip: true},
+			&TerragruntConfig{Skip: false},
+		},
+		{
+			&TerragruntConfig{Skip: true},
+			&TerragruntConfig{Skip: true},
+			&TerragruntConfig{Skip: true},
+		},
+		{
 			&TerragruntConfig{IamRole: "role1"},
 			nil,
 			&TerragruntConfig{IamRole: "role1"},
@@ -910,4 +935,44 @@ terragrunt = {
 	assert.Nil(t, terragruntConfig.RemoteState)
 	assert.Nil(t, terragruntConfig.Dependencies)
 	assert.Equal(t, false, terragruntConfig.PreventDestroy)
+}
+
+func TestParseTerragruntConfigSkipTrue(t *testing.T) {
+	t.Parallel()
+
+	config := `
+terragrunt = {
+  skip = true
+}
+`
+
+	terragruntConfig, err := parseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Dependencies)
+	assert.Equal(t, true, terragruntConfig.Skip)
+}
+
+func TestParseTerragruntConfigSkipFalse(t *testing.T) {
+	t.Parallel()
+
+	config := `
+terragrunt = {
+  skip = false
+}
+`
+
+	terragruntConfig, err := parseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Dependencies)
+	assert.Equal(t, false, terragruntConfig.Skip)
 }

--- a/test/fixture-skip/base-module/main.tf
+++ b/test/fixture-skip/base-module/main.tf
@@ -1,0 +1,9 @@
+variable "person" {}
+
+data "template_file" "example" {
+  template = "hello, ${var.person}"
+}
+
+output "example" {
+  value = "${data.template_file.example.rendered}"
+}

--- a/test/fixture-skip/skip-false/resource1/terraform.tfvars
+++ b/test/fixture-skip/skip-false/resource1/terraform.tfvars
@@ -1,0 +1,12 @@
+terragrunt = {
+  include {
+    path = "${find_in_parent_folders()}"
+  }
+
+  terraform {
+    source = "../../base-module"
+  }
+}
+
+person = "Ernie"
+

--- a/test/fixture-skip/skip-false/resource2/terraform.tfvars
+++ b/test/fixture-skip/skip-false/resource2/terraform.tfvars
@@ -1,0 +1,11 @@
+terragrunt = {
+  include {
+    path = "${find_in_parent_folders()}"
+  }
+
+  terraform {
+    source = "../../base-module"
+  }
+}
+
+person = "Bert"

--- a/test/fixture-skip/skip-false/terraform.tfvars
+++ b/test/fixture-skip/skip-false/terraform.tfvars
@@ -1,0 +1,10 @@
+terragrunt = {
+    skip = false
+
+    terraform {
+        source = "../base-module"
+    }
+}
+
+person = "Hobbs"
+

--- a/test/fixture-skip/skip-true/resource1/terraform.tfvars
+++ b/test/fixture-skip/skip-true/resource1/terraform.tfvars
@@ -1,0 +1,8 @@
+terragrunt = {
+  include {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+person = "Ernie"
+

--- a/test/fixture-skip/skip-true/resource2/terraform.tfvars
+++ b/test/fixture-skip/skip-true/resource2/terraform.tfvars
@@ -1,0 +1,7 @@
+terragrunt = {
+  include {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+person = "Bert"

--- a/test/fixture-skip/skip-true/terraform.tfvars
+++ b/test/fixture-skip/skip-true/terraform.tfvars
@@ -1,0 +1,7 @@
+terragrunt = {
+    skip = true
+
+    terraform {
+        source = "../../base-module"
+    }
+}


### PR DESCRIPTION
Some terraform.tfvars files exist just to DRY up the config. In those
cases, we need a way to tell the xxx-all commands that those files don't
actually represent any infrastructure, they are just included in other
terraform.tfvars files. This change allows you to specify skip = true in
the terragrunt { ... } block to accomplish this. This addresses #623.