### PR TITLE
A helper function to run arbitrary commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1713,10 +1713,11 @@ terragrunt = {
 
 #### run_cmd
 
-`run_cmd(command, arg1, arg2...)` runs a shell command and returns the stdout as the result of the interpolation.
+`run_cmd(command, arg1, arg2...)` runs a shell command and returns the stdout as the result of the interpolation. The command is executed at the same folder of the interpolated `terraform.tfvars` file.
 
-This is useful when you want to have a generic `terraform.tfvars` for all accounts and use a script to determine
-information that changes from account to account, like the bucket name and the DynamoDB table:
+This is useful whenever you want to dynamically fill in arbitrary information in your Terragrunt configuration.
+
+As an example, you could write a script that determines the bucket and DynamoDB table name based on the AWS account, instead of hardcoding the name of every account:
 
 ```
 terragrunt = {
@@ -1728,7 +1729,7 @@ terragrunt = {
     }
   }
 }
-````
+```
 
 ### Before and After Hooks
 

--- a/README.md
+++ b/README.md
@@ -1305,6 +1305,7 @@ Terragrunt allows you to use [Terraform interpolation syntax](https://www.terraf
 * [get_terraform_commands_that_need_input()](#get_terraform_commands_that_need_input)
 * [get_terraform_commands_that_need_locking()](#get_terraform_commands_that_need_locking)
 * [get_aws_account_id()](#get_aws_account_id)
+* [run_cmd()](#run_cmd)
 
 
 #### find_in_parent_folders
@@ -1709,6 +1710,25 @@ terragrunt = {
   }
 }
 ```
+
+#### run_cmd
+
+`run_cmd(command, arg1, arg2...)` runs a shell command and returns the stdout as the result of the interpolation.
+
+This is useful when you want to have a generic `terraform.tfvars` for all accounts and use a script to determine
+information that changes from account to account, like the bucket name and the DynamoDB table:
+
+```
+terragrunt = {
+  remote_state {
+    backend = "s3"
+    config {
+      bucket = "${run_cmd("./get_names.sh", "bucket")}"
+      dynamodb_table "${run_cmd("./get_names.sh", "dynamodb")}"
+    }
+  }
+}
+````
 
 ### Before and After Hooks
 

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -82,6 +83,8 @@ func executeTerragruntHelperFunction(functionName string, parameters string, inc
 		return pathRelativeFromInclude(include, terragruntOptions)
 	case "get_env":
 		return getEnvironmentVariable(parameters, terragruntOptions)
+	case "run_cmd":
+		return runCommand(parameters, terragruntOptions)
 	case "get_tfvars_dir":
 		return getTfVarsDir(terragruntOptions)
 	case "get_parent_tfvars_dir":
@@ -208,6 +211,30 @@ func parseGetEnvParameters(parameters string) (EnvVar, error) {
 	return envVariable, nil
 }
 
+// runCommand is a helper function that runs a command and returns the stdout as the interporation
+// result
+func runCommand(parameters string, terragruntOptions *options.TerragruntOptions) (string, error) {
+	args := parseParamList(parameters)
+
+	if len(args) == 0 {
+		return "", errors.WithStackTrace(EmptyStringNotAllowed("parameter to the run_cmd function"))
+	}
+
+	currentPath := filepath.Dir(terragruntOptions.TerragruntConfigPath)
+
+	command := &exec.Cmd{
+		Path: args[0],
+		Args: args,
+		Dir:  currentPath,
+	}
+	stdout, err := command.Output()
+
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+	return string(stdout), nil
+}
+
 func getEnvironmentVariable(parameters string, terragruntOptions *options.TerragruntOptions) (string, error) {
 	parameterMap, err := parseGetEnvParameters(parameters)
 
@@ -274,6 +301,7 @@ func findInParentFolders(parameters string, terragruntOptions *options.Terragrun
 
 var oneQuotedParamRegex = regexp.MustCompile(`^"([^"]*?)"$`)
 var twoQuotedParamsRegex = regexp.MustCompile(`^"([^"]*?)"\s*,\s*"([^"]*?)"$`)
+var listQuotedParamRegex = regexp.MustCompile(`^"([^"]*?)"\s*,\s*(.*)$`)
 
 // Parse two optional parameters, wrapped in quotes, passed to a function, and return the parameter values and how many
 // of the parameters were actually set. For example, if you have a function foo(bar, baz), where bar and baz are
@@ -300,6 +328,44 @@ func parseOptionalQuotedParam(parameters string) (string, string, int, error) {
 	}
 
 	return "", "", 0, errors.WithStackTrace(InvalidStringParams(parameters))
+}
+
+// parseParamList parses a string of comma separated parameters wrapped in quote and
+// return them as a list of strings. For example:
+// foo() -> return []string{""}, nil
+// foo("a") -> return []string{"foo"}, nil
+// foo("a", "b", "c", "d") -> return []string{"a", "b", "c", "d"}, nil
+func parseParamList(parameters string) []string {
+	trimmedParameters := strings.TrimSpace(parameters)
+	if trimmedParameters == "" {
+		return []string{}
+	}
+
+	matches := oneQuotedParamRegex.FindStringSubmatch(trimmedParameters)
+	if len(matches) > 0 {
+		return matches[1:]
+	}
+
+	matches = listQuotedParamRegex.FindStringSubmatch(trimmedParameters)
+	if len(matches) != 3 {
+		return []string{}
+	}
+	var trimmedArgs []string
+	trimmedArgs = append(trimmedArgs, matches[1])
+
+	args := matches[2]
+	args = strings.Replace(args, `"`, "", -1)
+
+	parsedArgs := strings.Split(args, ",")
+
+	for _, arg := range parsedArgs {
+		trimmedArg := strings.TrimSpace(arg)
+		if trimmedArg != "" {
+			trimmedArgs = append(trimmedArgs, trimmedArg)
+		}
+	}
+
+	return trimmedArgs
 }
 
 // Return the relative path between the included Terragrunt configuration file and the current Terragrunt configuration

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/gruntwork-io/terragrunt/shell"
 
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -222,17 +223,13 @@ func runCommand(parameters string, terragruntOptions *options.TerragruntOptions)
 
 	currentPath := filepath.Dir(terragruntOptions.TerragruntConfigPath)
 
-	command := &exec.Cmd{
-		Path: args[0],
-		Args: args,
-		Dir:  currentPath,
-	}
-	stdout, err := command.Output()
-
+	cmdOutput, err := shell.RunShellCommandWithOutput(terragruntOptions, currentPath, args[0], args[1:]...)
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
-	return string(stdout), nil
+
+	terragruntOptions.Logger.Printf("run_cmd output: [%s]", cmdOutput.Stdout)
+	return cmdOutput.Stdout, nil
 }
 
 func getEnvironmentVariable(parameters string, terragruntOptions *options.TerragruntOptions) (string, error) {

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -18,25 +18,25 @@ import (
 
 // Run the given Terraform command
 func RunTerraformCommand(terragruntOptions *options.TerragruntOptions, args ...string) error {
-	_, err := RunShellCommandWithOutput(terragruntOptions, terragruntOptions.TerraformPath, args...)
+	_, err := RunShellCommandWithOutput(terragruntOptions, "", terragruntOptions.TerraformPath, args...)
 	return err
 }
 
 // Run the given shell command
 func RunShellCommand(terragruntOptions *options.TerragruntOptions, command string, args ...string) error {
-	_, err := RunShellCommandWithOutput(terragruntOptions, command, args...)
+	_, err := RunShellCommandWithOutput(terragruntOptions, "", command, args...)
 	return err
 }
 
 // Run the given Terraform command, writing its stdout/stderr to the terminal AND returning stdout/stderr to this
 // method's caller
 func RunTerraformCommandWithOutput(terragruntOptions *options.TerragruntOptions, args ...string) (*CmdOutput, error) {
-	return RunShellCommandWithOutput(terragruntOptions, terragruntOptions.TerraformPath, args...)
+	return RunShellCommandWithOutput(terragruntOptions, "", terragruntOptions.TerraformPath, args...)
 }
 
 // Run the specified shell command with the specified arguments. Connect the command's stdin, stdout, and stderr to
-// the currently running app.
-func RunShellCommandWithOutput(terragruntOptions *options.TerragruntOptions, command string, args ...string) (*CmdOutput, error) {
+// the currently running app. The command can be executed in a custom working directory by using the parameter `workingDir`. Terragrunt working directory will be assumed if empty empty.
+func RunShellCommandWithOutput(terragruntOptions *options.TerragruntOptions, workingDir string, command string, args ...string) (*CmdOutput, error) {
 	terragruntOptions.Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
 
 	var stdoutBuf bytes.Buffer
@@ -57,7 +57,11 @@ func RunShellCommandWithOutput(terragruntOptions *options.TerragruntOptions, com
 		outWriter = terragruntOptions.ErrWriter
 	}
 
-	cmd.Dir = terragruntOptions.WorkingDir
+	if workingDir == "" {
+		cmd.Dir = terragruntOptions.WorkingDir
+	} else {
+		cmd.Dir = workingDir
+	}
 	// Inspired by https://blog.kowalczyk.info/article/wOYk/advanced-command-execution-in-go-with-osexec.html
 	cmd.Stderr = io.MultiWriter(errWriter, &stderrBuf)
 	cmd.Stdout = io.MultiWriter(outWriter, &stdoutBuf)


### PR DESCRIPTION
In my use case, we'll have multiple `live-infrastructure` repos. One particular drawback of such implementation is that you can end up with a lack of pattern.

To cope with that, I wanted to implement generic `terraform.tfvars` that can be easily copy-pasted, everywhere and upgraded to a new version when needed. Since there's information that changes from account to account and repo per repo, like the bucket name and the dynamoDB table I plan to write a script that determines such information based on the path and the repo name.

This PR provides this functionality with a simple helper function that runs any command with a list of arguments and returns the stdout as the result.