### PR TITLE
Adds Appveyor support for testing on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+version: 1.0.{build}
+clone_folder: c:\gopath\src\github.com\%APPVEYOR_REPO_NAME%
+init:
+  - go version
+  - go env
+  - pwsh: Invoke-RestMethod -Method Get -Uri "https://releases.hashicorp.com/terraform/$($env:TERRAFORMVERSION)/terraform_$($env:TERRAFORMVERSION)_windows_amd64.zip" -OutFile "c:/terraform_windows_amd64.zip"
+  - pwsh: Expand-Archive -Path "c:/terraform_windows_amd64.zip" -Destination "C:/Tools/terraform"
+  - mkdir "C:/Tools/logparser"
+  - pwsh: Invoke-WebRequest -Method Get -Uri "https://github.com/gruntwork-io/terratest/releases/download/$($env:LOGPARSERVERSION)/terratest_log_parser_windows_amd64.exe" -OutFile "C:/Tools/logparser/terratest_log_parser.exe"
+  - set PATH=%PATH%;C:\Tools\terraform\;C:\Tools\logparser\
+install:
+  - choco install dep
+environment:
+  GOPATH: c:\gopath
+  GOTESTTIMEOUT: 45m
+  LOGPARSERVERSION: v0.13.8
+  TERRAGRUNT_DOWNLOAD: C:\.terragrunt-cache
+  matrix:
+  - TERRAFORMVERSION: 0.11.13
+build_script:
+  - dep ensure
+test_script:
+  - mkdir logs
+  - pwsh: go test -v -parallel 1 $(go list ./... | where-object { $_ -notlike "*/test" }) | Tee-Object -FilePath 'logs/unit.log'
+  - terratest_log_parser.exe --testlog logs/unit.log --outputdir ./logs/unit/
+  - pwsh: go test -v $(go list ./... | where-object { $_ -like "*/test" }) | Tee-Object -FilePath 'logs/integration.log'
+  - terratest_log_parser.exe --testlog logs/integration.log --outputdir ./logs/integration/
+artifacts:
+  - path: logs
+    name: test_logs
+deploy: off
+on_finish:
+  - ps: $wc = New-Object 'System.Net.WebClient'
+  - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path ./logs/unit/report.xml))
+  - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path ./logs/integration/report.xml))


### PR DESCRIPTION
Added preliminary support for running tests on Windows via Appveyor.

**Configuring Appveyor**
With this configuration, you'll want to enable the project in your Appveyor account and set the following environment variables for running the integration tests:

- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`

**Example execution:**
https://ci.appveyor.com/project/Jakauppila/terragrunt/builds/23092218

Of interest is the Tests tab and Artifacts where you can download the output of the tests and results of the log parser.

**Notables:**
- Largely it looks pretty good, only 7 test failures coming through
- With `gruntwork-install` being bash, I decided just to pull `terratest_log_parser` directly from the project releases
- Definitely ran into the `Filename too long` issue reported in #581 
  - Due to this, I did set the `GRUNTWORK_DOWNLOAD` environment variable for now, though there are still occurrences of it
- I see there are a handful of bash scripts in the tests which are failing
- I didn't configure any of the branch restrictions or cron execution settings

Fixes #97 