### PR TITLE
Remove reference to _ci/build-and-push-release-asset.sh.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2088,7 +2088,7 @@ create a new release. The CircleCI job for this repo has been configured to:
 1. Build binaries for every OS using that tag as a version number.
 1. Upload the binaries to the release in GitHub.
 
-See `circle.yml` and `_ci/build-and-push-release-asset.sh` for details.
+See `.circleci/config.yml` for details.
 
 
 ### License


### PR DESCRIPTION
The `build-and-push-release-asset.sh` script was removed in commit 0f70acf35c7ab5459b196ea15312398917b84644 back in 2016.

This pull-request removes the reference to that script, and instead points at the explicit circleci file.