### PR TITLE
New interpolation function for parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,6 +1304,7 @@ Terragrunt allows you to use [Terraform interpolation syntax](https://www.terraf
 * [get_terraform_commands_that_need_vars()](#get_terraform_commands_that_need_vars)
 * [get_terraform_commands_that_need_input()](#get_terraform_commands_that_need_input)
 * [get_terraform_commands_that_need_locking()](#get_terraform_commands_that_need_locking)
+* [get_terraform_commands_that_need_parallelism()](#get_terraform_commands_that_need_parallelism)
 * [get_aws_account_id()](#get_aws_account_id)
 * [run_cmd()](#run_cmd)
 
@@ -1678,6 +1679,23 @@ commands = "Some text ${get_terraform_commands_that_need_locking()}"
 commands = "Some text [apply destroy import init plan refresh taint untaint]"
 ```
 
+#### get_terraform_commands_that_need_parallelism
+
+`get_terraform_commands_that_need_parallelism()`
+
+Returns the list of terraform commands that accept -parallelism parameter. This function is used when defining [extra_arguments](#keep-your-cli-flags-dry).
+
+```hcl
+terragrunt = {
+  terraform {
+    # Force Terraform to run with reduced parallelism
+    extra_arguments "parallelism" {
+      commands  = ["${get_terraform_commands_that_need_parallelism()}"]
+      arguments = ["-parallelism=5"]
+    }
+  }
+}
+```
 
 #### get_aws_account_id
 

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -56,6 +56,13 @@ var TERRAFORM_COMMANDS_NEED_INPUT = []string{
 	"refresh",
 }
 
+// List of terraform commands that accept -parallelism=
+var TERRAFORM_COMMANDS_NEED_PARALLELISM = []string{
+	"apply",
+	"plan",
+	"destroy",
+}
+
 type EnvVar struct {
 	Name         string
 	DefaultValue string
@@ -98,6 +105,8 @@ func executeTerragruntHelperFunction(functionName string, parameters string, inc
 		return TERRAFORM_COMMANDS_NEED_LOCKING, nil
 	case "get_terraform_commands_that_need_input":
 		return TERRAFORM_COMMANDS_NEED_INPUT, nil
+	case "get_terraform_commands_that_need_parallelism":
+		return TERRAFORM_COMMANDS_NEED_PARALLELISM, nil
 	default:
 		return "", errors.WithStackTrace(UnknownHelperFunction(functionName))
 	}

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -708,6 +708,13 @@ func TestResolveCommandsInterpolationConfigString(t *testing.T) {
 			fmt.Sprintf(`commands = "test-%v"`, TERRAFORM_COMMANDS_NEED_VARS),
 			nil,
 		},
+		{
+			`"${get_terraform_commands_that_need_parallelism()}"`,
+			nil,
+			terragruntOptionsForTest(t, DefaultTerragruntConfigPath),
+			util.CommaSeparatedStrings(TERRAFORM_COMMANDS_NEED_PARALLELISM),
+			nil,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
We do run have a huge deployment with GCP. To avoid any issues with GCP APIs we need to trottle each terraform command invoked.

New function `get_terraform_commands_that_need_parallelism` returns all terraform commands that support -parallelism