### PR TITLE
enables multiple includes

### DIFF
--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -237,7 +237,7 @@ func TestFindInParentFolders(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.terragruntOptions.TerragruntConfigPath, func(t *testing.T) {
-			actualPath, actualErr := findInParentFolders(testCase.params, testCase.terragruntOptions)
+			actualPath, actualErr := findInParentFolders(testCase.params, nil, testCase.terragruntOptions)
 			if testCase.expectedErr != nil {
 				if assert.Error(t, actualErr) {
 					assert.IsType(t, testCase.expectedErr, errors.Unwrap(actualErr))

--- a/test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/terraform.tfvars
+++ b/test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/terraform.tfvars
@@ -2,5 +2,14 @@ terragrunt = {
   include {
     path = "${find_in_parent_folders()}"
   }
-}
 
+  terraform {
+    extra_arguments "sub-child" {
+      commands = ["${get_terraform_commands_that_need_vars()}"]
+      env_vars = {
+        TF_VAR_sub_child_from = "${path_relative_from_include()}"
+        TF_VAR_sub_child_to = "${path_relative_to_include()}"
+      }
+    }
+  }
+}

--- a/test/fixture-parent-folders/multiple-terragrunt-in-parents/child/terraform.tfvars
+++ b/test/fixture-parent-folders/multiple-terragrunt-in-parents/child/terraform.tfvars
@@ -2,4 +2,21 @@ terragrunt = {
   include {
     path = "${find_in_parent_folders()}"
   }
+
+  remote_state {
+    config {
+      region = "us-east-1"
+    }
+  }
+
+  terraform {
+    extra_arguments "child" {
+      commands = ["${get_terraform_commands_that_need_vars()}"]
+      env_vars = {
+        TF_VAR_child_from = "${path_relative_from_include()}"
+        TF_VAR_child_to = "${path_relative_to_include()}"
+      }
+    }
+  }
 }
+

--- a/test/fixture-parent-folders/multiple-terragrunt-in-parents/terraform.tfvars
+++ b/test/fixture-parent-folders/multiple-terragrunt-in-parents/terraform.tfvars
@@ -6,7 +6,17 @@ terragrunt = {
       encrypt = true
       bucket = "my-bucket"
       key = "${path_relative_to_include()}/terraform.tfstate"
-      region = "us-east-1"
+      region = "none"
+    }
+  }
+
+  terraform {
+    extra_arguments "root" {
+      commands = ["${get_terraform_commands_that_need_vars()}"]
+      env_vars = {
+        TF_VAR_root_from = "${path_relative_from_include()}"
+        TF_VAR_root_to = "${path_relative_to_include()}"
+      }
     }
   }
 }


### PR DESCRIPTION
Allows for multiple includes.  Should fix #303.

`path_relative_from_include()` and `path_relative_to_include` include tested.  Behavior should be to evaluate within the context of the included file.