### PR TITLE
Check to see if symlinks are directories

### DIFF
--- a/util/file.go
+++ b/util/file.go
@@ -149,14 +149,9 @@ func CopyFolderContents(source string, destination string) error {
 		src := filepath.Join(source, file.Name())
 		dest := filepath.Join(destination, file.Name())
 
-		fileInfo, err := os.Stat(src)
-		if err != nil {
-			return err
-		}
-
 		if PathContainsHiddenFileOrFolder(file.Name()) {
 			continue
-		} else if fileInfo.IsDir() {
+		} else if IsDir(src) {
 			if err := os.MkdirAll(dest, file.Mode()); err != nil {
 				return errors.WithStackTrace(err)
 			}

--- a/util/file.go
+++ b/util/file.go
@@ -149,9 +149,14 @@ func CopyFolderContents(source string, destination string) error {
 		src := filepath.Join(source, file.Name())
 		dest := filepath.Join(destination, file.Name())
 
+		fileInfo, err := os.Stat(src)
+		if err != nil {
+			return err
+		}
+
 		if PathContainsHiddenFileOrFolder(file.Name()) {
 			continue
-		} else if file.IsDir() {
+		} else if fileInfo.IsDir() {
 			if err := os.MkdirAll(dest, file.Mode()); err != nil {
 				return errors.WithStackTrace(err)
 			}


### PR DESCRIPTION
Verify if a symlink is a directory and copy the file correctly. Before this patch you would receive the following for symlinks:-

```
[terragrunt] [/Users/damianmyerscough/Development/panw/panw/infra/network/us/dev/vpcs] 2019/05/30 14:28:19 Ignoring error from call to init, as this is a known Terraform bug: https://github.com/hashicorp/terraform/issues/18460
[terragrunt] 2019/05/30 14:28:19 Copying files from /Users/damianmyerscough/Development/panw/panw/infra/network/us/dev/vpcs into /Users/damianmyerscough/Development/panw/panw/infra/network/us/dev/vpcs/.terragrunt-cache/5oHzwSSOmD3uGskQ_bC74SZOJwc/XEQVXshD_EJIaErY-io8P3Sp52Y
[terragrunt] 2019/05/30 14:28:19 read /Users/damianmyerscough/Development/panw/panw/infra/network/us/dev/vpcs/test: is a directory
[terragrunt] 2019/05/30 14:28:19 Unable to determine underlying exit code, so Terragrunt will exit with error code 1
```

```bash
$ ls -l test
lrwxr-xr-x  1 damianmyerscough  staff  26 May 29 23:39 test -> ../../../modules/net/test/
```

