### PR TITLE
improve string escape handling for run_cmd

### DIFF
--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -138,9 +138,15 @@ func TestRunCommand(t *testing.T) {
 		expectedErr       error
 	}{
 		{
-			`"/bin/bash", "-c", ""echo -n foo""`,
+			`"/bin/bash", "-c", "echo -n foo"`,
 			terragruntOptionsForTest(t, homeDir),
 			"foo",
+			nil,
+		},
+		{
+			`"/bin/bash", "-c", "FOO=\"a test\"; echo -n $FOO"`,
+			terragruntOptionsForTest(t, homeDir),
+			`a test`,
 			nil,
 		},
 		{
@@ -535,6 +541,13 @@ func TestResolveTerragruntConfigString(t *testing.T) {
 			"",
 			InvalidInterpolationSyntax("${unknown}"),
 		},
+		{
+			`foo/${run_cmd("/bin/bash", "-c", "A=\"1 2\"; B=3; echo -n $A,$B")}/bar`,
+			nil,
+			terragruntOptionsForTest(t, "/"+DefaultTerragruntConfigPath),
+			"foo/1 2,3/bar",
+			nil,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -624,8 +637,8 @@ TERRAGRUNT_HIT","")}/bar`,
 			nil,
 			terragruntOptionsForTestWithEnv(t, "/root/child/"+DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_OTHER": "SOMETHING"}),
 			"",
-			InvalidInterpolationSyntax(`${get_env("TEST_ENV_
-TERRAGRUNT_HIT","")}`),
+			InvalidGetEnvParams(`"TEST_ENV_
+TERRAGRUNT_HIT",""`),
 		},
 		{
 			`foo/${get_env("TEST_ENV_TERRAGRUNT_HIT","DEFAULT")}/bar`,


### PR DESCRIPTION
While #684 addresses the real issues here, I made a small change for better handling of escapes in run_cmd.

This allowed me to use run_cmd in the following way:

```
$ tree .
.
├── child
│   ├── config.json
│   └── terraform.tfvars
├── plans
│   └── testplan
│       ├── v0.1
│       │   └── main.tf
│       └── v0.2
│           └── main.tf
└── terraform.tfvars
```

The child's terraform.tfvars is nothing special
```
$ cat child/terraform.tfvars
terragrunt {
  include {
    path = "${find_in_parent_folders}
```

The config.json specifies the data the run_cmd fetches:
```
$ cat child/config.json
{
    "source": "testplan",
    "version": "v0.1"
}
```

The two plans are simple:
```
$ cat plans/testplan/v0.1/main.tf
output "version" {
    value = "v0.1"
}
$ cat plans/testplan/v0.2/main.tf
output "version" {
    value = "v0.2"
}
```

Finally, the magic is in the root terraform.tfvars:
```
$ cat terraform.tfvars
terragrunt {
    terraform {
        source = "${path_relative_from_include()}/plans//${run_cmd("jq", "-j", ". | \"\\(.source)/\\(.version)\"", "config.json")}/"
    }
}
```

If you're unfamiliar with jq, the command is:

```
$ jq -j '. | "\(.source)/\(.version)" config.json
testplan/v0.1
```

This basically works by having run_cmd extract the source & version key from config.json and build a path starting from the plans// directory.

I believe this resolves #684, as I have both prefixes and suffixes around run_cmd.  It further allows better handling of escaped quotes within the run_cmd parameters.

The PR is a bit dense with regex, so I'll try to comment inline.

Lastly, I was able to run all the tests (and even added a few) in the config directory, but I was unable to pass all tests from the root.  I believe there are several tests that actually rely on AWS -- and I am unable to do so.