### PR TITLE
Switch from symlink and file copy to just file copy; upgrade dependencies; fix stack traces.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,22 @@
 
 
 [[projects]]
+  digest = "1:f4f038d23c9943c7150feb47c6d44eae9eee531c4e745b27217a2ac9ae2d2794"
+  name = "cloud.google.com/go"
+  packages = [
+    "compute/metadata",
+    "iam",
+    "internal",
+    "internal/optional",
+    "internal/trace",
+    "internal/version",
+    "storage",
+  ]
+  pruneopts = "UT"
+  revision = "457ea5c15ccf3b87db582c450e80101989da35f7"
+  version = "v0.40.0"
+
+[[projects]]
   digest = "1:90afd0cfdffcc3df7855160ee2954cbca286e23c4eb9cb3d075536c9e4e1b04f"
   name = "github.com/agext/levenshtein"
   packages = ["."]
@@ -18,7 +34,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:fd4666db511d77a745ffe0cb5a1230cf6709d9ab34b2851849744eb557dfedcd"
+  digest = "1:b23b81f47109efc6b4768653c95f87a2b6cf5052d653eab69373889f8b52e553"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -61,8 +77,8 @@
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "949cbce4e4443b72f6da12adbeb5d416dd506fbe"
-  version = "v1.16.27"
+  revision = "bdafd99f31a0103ec73bcabfc9498aef3252d515"
+  version = "v1.19.47"
 
 [[projects]]
   branch = "master"
@@ -73,18 +89,35 @@
   revision = "9fd32a8b3d3d3f9d43c341bfe098430e07609480"
 
 [[projects]]
-  digest = "1:511f7e1ca840c3b8c5761870d8606aa8bdf95f5d422a74fbe0ef3cf210cfe2c9"
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   pruneopts = "UT"
-  revision = "04cdfd42973bb9c8589fd6a731800cf222fde1a9"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
 
 [[projects]]
-  digest = "1:b8f33acf2b17bbb180b70c72572af8ec88839a0bd0864d2665ce6e328cd0660a"
+  digest = "1:aacef5f5e45685f2aeda5534d0a750dee6859de7e9088cdd06192787bb01ae6d"
   name = "github.com/go-errors/errors"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8fa88b06e5974e97fbf9899a7f86a344bfd1f105"
+  revision = "a6af135bd4e28680facf08a3d206b454abc877a4"
+  version = "v1.0.1"
+
+[[projects]]
+  digest = "1:64c2b533ffd17023738c534548ab2455d7f519bc15ed4225145425ed2222448b"
+  name = "github.com/golang/protobuf"
+  packages = [
+    "proto",
+    "protoc-gen-go/descriptor",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = "UT"
+  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
+  version = "v1.3.1"
 
 [[projects]]
   digest = "1:bf40199583e5143d1472fc34d10d6f4b69d97572142acf343b3e43136da40823"
@@ -101,61 +134,70 @@
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:ae263e6b149fb7aadfc0f2284a8891cc3b9d2700e58b9a613fecf70fcc6e495d"
+  digest = "1:f1f70abea1ab125d48396343b4c053f8fecfbdb943037bf3d29dc80c90fe60b3"
+  name = "github.com/googleapis/gax-go"
+  packages = ["v2"]
+  pruneopts = "UT"
+  revision = "beaecbbdd8af86aa3acf14180d53828ce69400b2"
+  version = "v2.0.4"
+
+[[projects]]
+  digest = "1:af105c7c5dc0b4ae41991f122cae860b9600f7d226072c2a83127048c991660c"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3573b8b52aa7b37b9358d966a898feb387f62437"
+  revision = "eda1e5db218aad1db63ca4642c8906b26bcf2744"
+  version = "v0.5.1"
 
 [[projects]]
-  digest = "1:e552a7d3d8156dac33fb7ed47fc16f432a8d18ead42cfad71536f584e5923fbe"
+  digest = "1:3d262ac70f6f9c970031d83c4decf4027209d58e4b3fea3a90de4461295df848"
   name = "github.com/hashicorp/go-getter"
   packages = [
     ".",
     "helper/url",
   ]
   pruneopts = "UT"
-  revision = "2f449c791e6af9e532bc1aca36d1d3865b8537f9"
+  revision = "f9ec369200fd2163b8f452e5e45696d83ae3f4b6"
+  version = "v1.3.0"
 
 [[projects]]
-  digest = "1:ada37ea3db98b606d2b61577fbd87c0aabaa95e03b409033ebf58c6e5420b033"
+  digest = "1:605c47454db9040e30b20dc1b29e3e9d42d6ee742545729cdef74afb1b898ad0"
+  name = "github.com/hashicorp/go-safetemp"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c9a55de4fe06c920a71964b53cfe3dd293a3c743"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:88e0b0baeb9072f0a4afbcf12dda615fc8be001d1802357538591155998da21b"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
   pruneopts = "UT"
-  revision = "fc61389e27c71d120f87031ca8c88a3428f372dd"
+  revision = "ac23dc3fea5d1a983c43f6a0f6e2c13f0195d8bd"
+  version = "v1.2.0"
 
 [[projects]]
-  digest = "1:145eff5207977eb95c3649a27cdc2e467d8a1c104810bc12b6a53745a91d823a"
-  name = "github.com/hashicorp/hcl"
-  packages = [
-    ".",
-    "hcl/ast",
-    "hcl/parser",
-    "hcl/scanner",
-    "hcl/strconv",
-    "hcl/token",
-    "json/parser",
-    "json/scanner",
-    "json/token",
-  ]
+  digest = "1:67474f760e9ac3799f740db2c489e6423a4cde45520673ec123ac831ad849cb8"
+  name = "github.com/hashicorp/golang-lru"
+  packages = ["simplelru"]
   pruneopts = "UT"
-  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
+  revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
+  version = "v0.5.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:fcf2a2da62c4d31251aa37a61fe03eb3527f621d6566a73fc69e0ecbdde3fef2"
+  digest = "1:c617804ff4d0adbed51b6409672dd1a1a15c88bf53331bd11bf41da146eb8c18"
   name = "github.com/hashicorp/hcl2"
   packages = [
     "gohcl",
     "hcl",
     "hcl/hclsyntax",
     "hcl/json",
-    "hcldec",
     "hclparse",
     "hclwrite",
   ]
   pruneopts = "UT"
-  revision = "4b22149b7cef7272799ac85dca150e553d667971"
+  revision = "318e80eefe28c3aa01b434c61bcf4c83a0cc6b25"
 
 [[projects]]
   digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
@@ -165,29 +207,31 @@
   revision = "c2b33e84"
 
 [[projects]]
-  digest = "1:cf31637c5b44a0b7e9aa64fdd7194c22cfdb75ddb2a58e5fc5cbf003c86c4dba"
+  digest = "1:36aebe90a13cf9128280ac834399b8bebf83685283c78df279d61c46bb2a8d83"
   name = "github.com/mattn/go-zglob"
   packages = [
     ".",
     "fastwalk",
   ]
   pruneopts = "UT"
-  revision = "4ecb59231939b2e499b1f2fd8f075565977d2452"
+  revision = "2ea3427bfa539cca900ca2768d8663ecc8a708c1"
+  version = "v0.0.1"
 
 [[projects]]
-  digest = "1:12ae6210bdbdad658a9a67fd95cd9c99f7fdbf12f6d36eaf0af704e69dacf4f5"
+  digest = "1:5d231480e1c64a726869bc4142d270184c419749d34f167646baa21008eb0a79"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   pruneopts = "UT"
-  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
+  revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
+  version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:cae1afe858922bd10e9573b87130f730a6e4183a00eba79920d6656629468bfa"
+  digest = "1:42eb1f52b84a06820cedc9baec2e710bfbda3ee6dac6cdb97f8b9a5066134ec6"
   name = "github.com/mitchellh/go-testing-interface"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a61a99592b77c9ba629d254a693acffaeb4b7e28"
+  revision = "6d0b8010fcc857872e42fc6c931227569016843c"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:abf08734a6527df70ed361d7c369fb580e6840d8f7a6012e5f609fdfd93b4e48"
@@ -198,31 +242,34 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:56a0bd1a1f3809171d1abe0bfd389558be0cd672e858e1f831b88f806aa8764f"
+  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   pruneopts = "UT"
-  revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
 
 [[projects]]
-  digest = "1:08413c4235cad94a96c39e1e2f697789733c4a87d1fdf06b412d2cf2ba49826a"
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   pruneopts = "UT"
-  revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
 
 [[projects]]
-  digest = "1:498565cf249f70c3008005cf92a90ef6c04fd0f310c4fcbf384cef62645bdf71"
+  digest = "1:5da8ce674952566deae4dbc23d07c85caafc6cfa815b0b3e03e41979cedb8750"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "require",
   ]
   pruneopts = "UT"
-  revision = "2aa2c176b9dab406a6970f6a55f513e8a8c8b18f"
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
 
 [[projects]]
-  digest = "1:4aeb3860275fa1fd60cccfb5a6ef85da438bf17402e1e84412ade4d4b55066a0"
+  digest = "1:2643d81498e38e44bdcf480be199cac55f29e97403b0342d962824bfe9960722"
   name = "github.com/ulikunitz/xz"
   packages = [
     ".",
@@ -231,18 +278,18 @@
     "lzma",
   ]
   pruneopts = "UT"
-  revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
-  version = "v0.5.4"
+  revision = "6f934d456d51e742b4eeab20d925a827ef22320a"
+  version = "v0.5.6"
 
 [[projects]]
-  digest = "1:312f66cdea01bc34c72762385569faa2efc0cd57310ad6e4525854f96207efba"
+  digest = "1:b24d38b282bacf9791408a080f606370efa3d364e4b5fd9ba0f7b87786d3b679"
   name = "github.com/urfave/cli"
   packages = ["."]
   pruneopts = "UT"
-  revision = "7bc6a0acffa589f415f88aca16cc1de5ffd66f9c"
+  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
+  version = "v1.20.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:02d9d3d26ba39e42d06613a6a81688490d0a4dfc3e9cda0c674698b46fa0d92c"
   name = "github.com/zclconf/go-cty"
   packages = [
@@ -255,22 +302,190 @@
     "cty/set",
   ]
   pruneopts = "UT"
-  revision = "4fecf87372ec204b46eb9e8ff264cdc3cafdccfe"
+  revision = "6fd39ad70c3a6bbdb1b4e47444e4cce72f901200"
+  version = "v1.0.0"
 
 [[projects]]
-  digest = "1:1093f2eb4b344996604f7d8b29a16c5b22ab9e1b25652140d3fede39f640d5cd"
+  digest = "1:74055050ea547bb04600be79cc501965cb3de8988018262f2ca430f0a0b48ec3"
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "internal",
+    "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricproducer",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "resource",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/propagation",
+    "trace/tracestate",
+  ]
+  pruneopts = "UT"
+  revision = "9c377598961b706d1542bd2d84d538b5094d596e"
+  version = "v0.22.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2f357867bf425774d35beca5be718402a4488b8b23b1563ce8c5bb91d09285a7"
+  name = "golang.org/x/net"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "trace",
+  ]
+  pruneopts = "UT"
+  revision = "461777fb6f67e8cb9d70cda16573678d085a74cf"
+
+[[projects]]
+  branch = "master"
+  digest = "1:31e33f76456ccf54819ab4a646cf01271d1a99d7712ab84bf1a9e7b61cd2031b"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt",
+  ]
+  pruneopts = "UT"
+  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
+
+[[projects]]
+  branch = "master"
+  digest = "1:010311506e3917b54487c35a4277e2709678a40c1587d82492c40b78b6a0a01d"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  pruneopts = "UT"
+  revision = "93c9922d18aeb82498a065f07aec7ad7fa60dfb7"
+
+[[projects]]
+  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
   name = "golang.org/x/text"
   packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
     "internal/gen",
+    "internal/language",
+    "internal/language/compact",
+    "internal/tag",
     "internal/triegen",
     "internal/ucd",
+    "language",
+    "secure/bidirule",
     "transform",
+    "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
+    "unicode/rangetable",
   ]
   pruneopts = "UT"
   revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
   version = "v0.3.2"
+
+[[projects]]
+  digest = "1:06b06a112ad8f420557af56ad06bb8b16b77d11b0a2f11edf335095f7772e9b5"
+  name = "google.golang.org/api"
+  packages = [
+    "gensupport",
+    "googleapi",
+    "googleapi/internal/uritemplates",
+    "googleapi/transport",
+    "internal",
+    "iterator",
+    "option",
+    "storage/v1",
+    "transport/http",
+    "transport/http/internal/propagation",
+  ]
+  pruneopts = "UT"
+  revision = "aac82e61c0c8fe133c297b4b59316b9f481e1f0a"
+  version = "v0.6.0"
+
+[[projects]]
+  digest = "1:498b722d33dde4471e7d6e5d88a5e7132d2a8306fea5ff5ee82d1f418b4f41ed"
+  name = "google.golang.org/appengine"
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = "UT"
+  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
+  version = "v1.6.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:1d7e4e8b75502678019b764e524684c25aeeb855ef93f0d5b52fd66e834a5d17"
+  name = "google.golang.org/genproto"
+  packages = [
+    "googleapis/api/annotations",
+    "googleapis/iam/v1",
+    "googleapis/rpc/code",
+    "googleapis/rpc/status",
+    "googleapis/type/expr",
+  ]
+  pruneopts = "UT"
+  revision = "eb0b1bdb6ae60fcfc41b8d907b50dfb346112301"
+
+[[projects]]
+  digest = "1:e8800ddadd6bce3bc0c5ffd7bc55dbdddc6e750956c10cc10271cade542fccbe"
+  name = "google.golang.org/grpc"
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
+    "codes",
+    "connectivity",
+    "credentials",
+    "credentials/internal",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "internal",
+    "internal/backoff",
+    "internal/balancerload",
+    "internal/binarylog",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/syscall",
+    "internal/transport",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+  ]
+  pruneopts = "UT"
+  revision = "501c41df7f472c740d0674ff27122f3f48c80ce7"
+  version = "v1.21.1"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -288,10 +503,8 @@
     "github.com/hashicorp/go-getter",
     "github.com/hashicorp/go-getter/helper/url",
     "github.com/hashicorp/go-version",
-    "github.com/hashicorp/hcl",
     "github.com/hashicorp/hcl2/gohcl",
     "github.com/hashicorp/hcl2/hcl",
-    "github.com/hashicorp/hcl2/hcldec",
     "github.com/hashicorp/hcl2/hclparse",
     "github.com/mattn/go-zglob",
     "github.com/mitchellh/mapstructure",
@@ -300,7 +513,7 @@
     "github.com/urfave/cli",
     "github.com/zclconf/go-cty/cty",
     "github.com/zclconf/go-cty/cty/function",
-    "github.com/zclconf/go-cty/cty/gocty",
+    "github.com/zclconf/go-cty/cty/json",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 # Gopkg.toml example
 #
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
+# Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
 # for detailed Gopkg.toml documentation.
 #
 # required = ["github.com/user/thing/cmd/thing"]
@@ -24,6 +24,46 @@
 #   go-tests = true
 #   unused-packages = true
 
+
+[[constraint]]
+  name = "github.com/aws/aws-sdk-go"
+  version = "1.19.47"
+
+[[constraint]]
+  name = "github.com/go-errors/errors"
+  version = "1.0.1"
+
+[[constraint]]
+  name = "github.com/hashicorp/go-getter"
+  version = "1.3.0"
+
+[[constraint]]
+  name = "github.com/hashicorp/go-version"
+  version = "1.2.0"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/hashicorp/hcl2"
+
+[[constraint]]
+  name = "github.com/mattn/go-zglob"
+  version = "0.0.1"
+
+[[constraint]]
+  name = "github.com/mitchellh/mapstructure"
+  version = "1.1.2"
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.3.0"
+
+[[constraint]]
+  name = "github.com/urfave/cli"
+  version = "1.20.0"
+
+[[constraint]]
+  name = "github.com/zclconf/go-cty"
+  version = "1.0.0"
 
 [prune]
   go-tests = true

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -338,12 +338,15 @@ func cleanupDownloadDir(terraformSource *TerraformSource, terragruntOptions *opt
 	// Backup the working dir if it exists
 	backupWorkingDirFolder := util.JoinPath(terragruntOptions.DownloadDir, ".working-dir-backup")
 	if util.FileExists(terraformSource.WorkingDir) {
+		if err := os.MkdirAll(terragruntOptions.DownloadDir, 0700); err != nil {
+			return errors.WithStackTrace(err)
+		}
 		if err := os.Rename(terraformSource.WorkingDir, backupWorkingDirFolder); err != nil {
 			return errors.WithStackTrace(err)
 		}
 	}
 
-	// Delete everything in the DownloadDir
+	// Delete everything that was in the download dir
 	files, err := zglob.Glob(util.JoinPath(terraformSource.DownloadDir, "*"))
 	if err != nil {
 		return errors.WithStackTrace(err)

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 
+	"path/filepath"
+
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -15,7 +17,6 @@ import (
 	"github.com/hashicorp/go-getter"
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
 	"github.com/mattn/go-zglob"
-	"path/filepath"
 )
 
 // This struct represents information about Terraform source code that needs to be downloaded
@@ -375,7 +376,7 @@ func cleanupDownloadDir(terraformSource *TerraformSource, terragruntOptions *opt
 		// Filter out files in .terraform folders, since those are from modules downloaded via a call to terraform init,
 		// and we don't want to re-download them.
 		for _, terraformFile := range terraformFiles {
-			if !strings.Contains(terraformFile, ".terraform") {
+			if !util.PathContains(terraformFile, ".terraform") {
 				filteredTerraformFiles = append(filteredTerraformFiles, terraformFile)
 			}
 		}

--- a/cli/file_copy_getter.go
+++ b/cli/file_copy_getter.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/hashicorp/go-getter"
+	"net/url"
+	"os"
+)
+
+// A custom getter.Getter implementation that uses file copying instead of symlinks. Symlinks are
+// faster and use less disk space, but they cause issues in Windows and with infinite loops, so we copy files/folders
+// instead.
+type FileCopyGetter struct {
+	getter.FileGetter
+}
+
+// The original FileGetter does NOT know how to do folder copying (it only does symlinks), so we provide a copy
+// implementation here
+func (g *FileCopyGetter) Get(dst string, u *url.URL) error {
+	path := u.Path
+	if u.RawPath != "" {
+		path = u.RawPath
+	}
+
+	// The source path must exist and be a directory to be usable.
+	if fi, err := os.Stat(path); err != nil {
+		return fmt.Errorf("source path error: %s", err)
+	} else if !fi.IsDir() {
+		return fmt.Errorf("source path must be a directory")
+	}
+
+	return util.CopyFolderContents(path, dst)
+}
+
+// The original FileGetter already knows how to do file copying so long as we set the Copy flag to true, so just
+// delegate to it
+func (g *FileCopyGetter) GetFile(dst string, u *url.URL) error {
+	underlying := &getter.FileGetter{Copy: true}
+	return underlying.GetFile(dst, u)
+}

--- a/cli/version_check_test.go
+++ b/cli/version_check_test.go
@@ -12,11 +12,6 @@ func TestCheckTerraformVersionMeetsConstraintEqual(t *testing.T) {
 	testCheckTerraformVersionMeetsConstraint(t, "v0.9.3", ">= v0.9.3", true)
 }
 
-func TestCheckTerraformVersionMeetsConstraintGreaterDev(t *testing.T) {
-	t.Parallel()
-	testCheckTerraformVersionMeetsConstraint(t, "v0.9.4-dev", ">= v0.9.3", true)
-}
-
 func TestCheckTerraformVersionMeetsConstraintGreaterPatch(t *testing.T) {
 	t.Parallel()
 	testCheckTerraformVersionMeetsConstraint(t, "v0.9.4", ">= v0.9.3", true)

--- a/errors/multierror.go
+++ b/errors/multierror.go
@@ -21,7 +21,7 @@ func NewMultiError(errs ...error) error {
 		return nil
 	}
 
-	return MultiError{Errors: nilsRemoved}
+	return WithStackTrace(MultiError{Errors: nilsRemoved})
 }
 
 func (errs MultiError) Error() string {

--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -14,4 +14,6 @@ var RETRYABLE_ERRORS = []string{
 	"(?s).*Error installing provider.*TLS handshake timeout.*",
 	"(?s).*Error configuring the backend.*TLS handshake timeout.*",
 	"(?s).*Error installing provider.*tcp.*timeout.*",
+	"(?s).*Error installing provider.*tcp.*timeout.*",
+	"NoSuchBucket: The specified bucket does not exist",
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1497,7 +1497,17 @@ func runTerragrunt(t *testing.T, command string) {
 
 func runTerragruntRedirectOutput(t *testing.T, command string, writer io.Writer, errwriter io.Writer) {
 	if err := runTerragruntCommand(t, command, writer, errwriter); err != nil {
-		t.Fatalf("Failed to run Terragrunt command '%s' due to error: %s", command, err)
+		stdout := "(see log output above)"
+		if stdoutAsBuffer, stdoutIsBuffer := writer.(*bytes.Buffer); stdoutIsBuffer {
+			stdout = stdoutAsBuffer.String()
+		}
+
+		stderr := "(see log output above)"
+		if stderrAsBuffer, stderrIsBuffer := errwriter.(*bytes.Buffer); stderrIsBuffer {
+			stderr = stderrAsBuffer.String()
+		}
+
+		t.Fatalf("Failed to run Terragrunt command '%s' due to error: %s\n\nStdout: %s\n\nStderr: %s", command, err, stdout, stderr)
 	}
 }
 

--- a/util/file.go
+++ b/util/file.go
@@ -50,11 +50,10 @@ func CanonicalPaths(paths []string, basePath string) ([]string, error) {
 	return canonicalPaths, nil
 }
 
-// Delete the given list of files. Note: this function ONLY deletes files and will return an error if you pass in a
-// folder path.
-func DeleteFiles(files []string) error {
+// Delete the given list of files and folders
+func DeleteFilesAndFolders(files []string) error {
 	for _, file := range files {
-		if err := os.Remove(file); err != nil {
+		if err := os.RemoveAll(file); err != nil {
 			return errors.WithStackTrace(err)
 		}
 	}

--- a/util/file.go
+++ b/util/file.go
@@ -161,7 +161,7 @@ func CopyFolderContentsWithFilter(source string, destination string, filter func
 			return err
 		}
 
-		if !filter(fileRelativePath) || IsSymLink(file) {
+		if !filter(fileRelativePath) {
 			continue
 		}
 

--- a/util/file.go
+++ b/util/file.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"fmt"
+
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/mattn/go-zglob"
 )
@@ -250,4 +251,22 @@ func JoinTerraformModulePath(modulesFolder string, path string) string {
 	cleanModulesFolder := strings.TrimRight(modulesFolder, `/\`)
 	cleanPath := strings.TrimLeft(path, `/\`)
 	return fmt.Sprintf("%s//%s", cleanModulesFolder, cleanPath)
+}
+
+// Returns true if the given path contains the given folder name.
+//
+// Examples:
+//
+// PathContains("/foo/bar", "foo") => returns true
+// PathContains("/foo/bar", "baz") => returns false
+func PathContains(path string, folderName string) bool {
+	pathParts := strings.Split(path, string(filepath.Separator))
+
+	for _, pathPart := range pathParts {
+		if pathPart == folderName {
+			return true
+		}
+	}
+
+	return false
 }

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"fmt"
+
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 )
@@ -114,6 +115,35 @@ func TestJoinTerraformModulePath(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(fmt.Sprintf("%s-%s", testCase.modulesFolder, testCase.path), func(t *testing.T) {
 			actual := JoinTerraformModulePath(testCase.modulesFolder, testCase.path)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}
+
+func TestPathContains(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		description string
+		path        string
+		folderName  string
+		expected    bool
+	}{
+		{"both empty", "", "", true},
+		{"path empty, folder name not empty", "", "foo", false},
+		{"path non empty, folder name empty", "/foo", "", true},
+		{"path contains one part that matches folder name", "foo", "foo", true},
+		{"path contains one part that doesn't match folder name", "foo", "bar", false},
+		{"path contains multiple parts, one of which matches folder name", "/foo/bar/baz", "bar", true},
+		{"path contains multiple parts, none of which match folder name", "/foo/bar/baz", "will-not-match", false},
+	}
+
+	for _, testCase := range testCases {
+		// The following is necessary to make sure testCase's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
+		testCase := testCase
+		t.Run(testCase.description, func(t *testing.T) {
+			actual := PathContains(testCase.path, testCase.folderName)
 			assert.Equal(t, testCase.expected, actual)
 		})
 	}


### PR DESCRIPTION
1. By default, `go-getter` uses symlinks for local files. This is fast and disk-space friendly, but it [doesn't seem to work on windows](https://github.com/gruntwork-io/terragrunt/issues/733). Moreover, you can't copy anything into a symlinked folder, as it would end up copying it back into the original, so this caused issues for Terragrunt. As a workaround, I was letting `go-getter` create the symlink in one folder and then copying the files to another, but this was effectively the worst of both worlds—slow, not friendly to disk space, and complicated. In this PR, I've added by own `Getter` implementation that does file copying instead of using symlinks. I'm _hoping_ this fixes #733. It also allow us to copy existing symlinks without hitting infinite cycles, which I _think_ fixes #736. 
1. Update all our dependency versions. Turns out we had some really old dependencies in there, including a several-year-old version of `go-getter`.
1. Fix a bug where stack traces were being lost due to `MultiError` usage.
