### PR TITLE
delete .tf.json files when cleaning up terragrunt cache

### DIFF
--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -371,6 +371,11 @@ func cleanupDownloadDir(terraformSource *TerraformSource, terragruntOptions *opt
 		if err != nil {
 			return errors.WithStackTrace(err)
 		}
+		terraformJsonFiles, err := zglob.Glob("**/*.tf.json")
+		if err != nil {
+			return errors.WithStackTrace(err)
+		}
+		terraformFiles = append(terraformFiles, terraformJsonFiles...)
 		filteredTerraformFiles := []string{}
 
 		// Filter out files in .terraform folders, since those are from modules downloaded via a call to terraform init,


### PR DESCRIPTION
Closes #725.

Note: ` zglob` does not seem to support `{}` or `?()` syntax, so an additional glob expression to get `.tf.json` files is added.