### PR TITLE
Feature/tfbinary in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2152,6 +2152,12 @@ If you run `terragrunt hclfmt` at the `root`, this will update:
 Additionally, there's a flag `--terragrunt-check`. It allows to validating if files are properly formatted. It does not
 rewrite files and in case of invalid format, it will return an error with exit status 0.
 
+#### terraform_binary
+
+The terragrunt `terraform_binary` string option can be used to override the default terraform binary path (which is `terraform`).
+
+The precedence is as follows: `--terragrunt-tfpath` command line option -> `TERRAGRUNT_TFPATH` env variable -> `terragrunt.hcl` in the module directory -> included `terragrunt.hcl`
+
 ### Clearing the Terragrunt cache
 
 Terragrunt creates a `.terragrunt-cache` folder in the current working directory as its scratch directory. It downloads

--- a/README.md
+++ b/README.md
@@ -115,15 +115,16 @@ downloading the binary for your OS, renaming it to `terragrunt`, and adding it t
 
 
 
-## Migrating to Terraform 0.12 and Terragrunt 0.19.x 
+## Migrating to Terraform 0.12 and Terragrunt 0.19.x
 
-If you were using Terraform <= 0.11.x with Terragrunt <= 0.18.x, and you wish to upgrade to Terraform 0.12.x newer, 
+If you were using Terraform <= 0.11.x with Terragrunt <= 0.18.x, and you wish to upgrade to Terraform 0.12.x newer,
 you'll need to upgrade to Terragrunt 0.19.x or newer. Due to some changes in Terraform 0.12.x, this is a backwards
 incompatible upgrade that requires some manual migration steps. Check out our [Upgrading to Terragrunt 0.19.x 
 Guide](/_docs/migration_guides/upgrading_to_terragrunt_0.19.x.md) for instructions.
 
+## Required terraform version
 
-
+We only support and test against the latest version of terraform, however older versions might still work.
 
 ## Use cases
 
@@ -661,9 +662,9 @@ remote_state {
 }
 ```
 
-If you experience an error for any of these configurations, confirm you are using Terraform v0.11.2 or greater.
+If you experience an error for any of these configurations, confirm you are using Terraform v0.12.2 or greater.
 
-Further, the config options `s3_bucket_tags`, `dynamodb_table_tags`, `skip_bucket_versioning`, 
+Further, the config options `s3_bucket_tags`, `dynamodb_table_tags`, `skip_bucket_versioning`,
 `skip_bucket_ssencryption`, `skip_bucket_accesslogging`, and `enable_lock_table_ssencryption` are only valid for 
 backend `s3`. They are used by terragrunt and are **not** passed on to
 terraform. See section [Create remote state and locking resources automatically](#create-remote-state-and-locking-resources-automatically).
@@ -2157,6 +2158,17 @@ rewrite files and in case of invalid format, it will return an error with exit s
 The terragrunt `terraform_binary` string option can be used to override the default terraform binary path (which is `terraform`).
 
 The precedence is as follows: `--terragrunt-tfpath` command line option -> `TERRAGRUNT_TFPATH` env variable -> `terragrunt.hcl` in the module directory -> included `terragrunt.hcl`
+
+#### terraform_version_constraint
+
+The terragrunt `terraform_version_constraint` string overrides the default minimum supported version of terraform.
+Terragrunt only officially supports the latest version of terraform, however in some cases an old terraform is needed.
+
+For example:
+
+```hcl
+terraform_version_constraint = ">= 0.11"
+```
 
 ### Clearing the Terragrunt cache
 

--- a/_docs/migration_guides/upgrading_to_terragrunt_0.19.x.md
+++ b/_docs/migration_guides/upgrading_to_terragrunt_0.19.x.md
@@ -276,12 +276,14 @@ Make sure to make the corresponding updates in your `terragrunt.hcl` file!
 
 ### Use older Terraform
 
-Although it is not officiall supported and not tested, it is still possible to use terraform<0.12 with terragrunt >=0.19.
+Although it is not officially supported and not tested, it is still possible to use terraform<0.12 with terragrunt >=0.19.
 
-Just install a different version of terraform into a directory of your choice outside of `PATH` and specify path to the binary in `terragrunt.hcl` as `terraform_binary`:
+Just install a different version of terraform into a directory of your choice outside of `PATH` and specify path to the binary in `terragrunt.hcl` as `terraform_binary`, plus you need to lower the version check constraint:
 
 ```hcl
 
 terraform_binary = "~/bin/terraform-v11/terraform"
+terraform_version_constraint = ">= 0.11"
+
 
 ```

--- a/_docs/migration_guides/upgrading_to_terragrunt_0.19.x.md
+++ b/_docs/migration_guides/upgrading_to_terragrunt_0.19.x.md
@@ -27,6 +27,7 @@ to Terragrunt 0.19.x and newer:
 1. [Use first-class expressions](#use-first-class-expressions)
 1. [Check attributes vs blocks usage](#check-attributes-vs-blocks-usage)
 1. [Rename a few built-in functions ](#rename-a-few-built-in-functions)
+1. [Use terraform \<0.12](#use-older-terraform)
 
 Check out [this PR in the terragrunt-infrastructure-live-example 
 repo](https://github.com/gruntwork-io/terragrunt-infrastructure-live-example/pull/17) for an example of what the code 
@@ -272,3 +273,15 @@ Two built-in functions were renamed:
 1. `get_parent_tfvars_dir()` is now called `get_parent_terragrunt_dir()`.   
 
 Make sure to make the corresponding updates in your `terragrunt.hcl` file!
+
+### Use older Terraform
+
+Although it is not officiall supported and not tested, it is still possible to use terraform<0.12 with terragrunt >=0.19.
+
+Just install a different version of terraform into a directory of your choice outside of `PATH` and specify path to the binary in `terragrunt.hcl` as `terraform_binary`:
+
+```hcl
+
+terraform_binary = "~/bin/terraform-v11/terraform"
+
+```

--- a/cli/args.go
+++ b/cli/args.go
@@ -71,7 +71,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 		return nil, err
 	}
 	if terraformPath == "" {
-		terraformPath = "terraform"
+		terraformPath = options.TERRAFORM_DEFAULT_PATH
 	}
 
 	terraformSource, err := parseStringArg(args, OPT_TERRAGRUNT_SOURCE, os.Getenv("TERRAGRUNT_SOURCE"))

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -201,14 +201,6 @@ func runApp(cliContext *cli.Context) (finalErr error) {
 		return err
 	}
 
-	if err := PopulateTerraformVersion(terragruntOptions); err != nil {
-		return err
-	}
-
-	if err := CheckTerraformVersion(DEFAULT_TERRAFORM_VERSION_CONSTRAINT, terragruntOptions); err != nil {
-		return err
-	}
-
 	givenCommand := cliContext.Args().First()
 	command := checkDeprecated(givenCommand, terragruntOptions)
 	return runCommand(command, terragruntOptions)
@@ -246,10 +238,22 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		return err
 	}
 
-	if terragruntOptions.TerraformPath == options.TERRAFORM_DEFAULT_PATH { // not changed from default
-		if terragruntConfig.TerraformBinary != "" {
-			terragruntOptions.TerraformPath = terragruntConfig.TerraformBinary
-		}
+	// Change the terraform binary path before checking the version
+	// if the path is not changed from default and set in the config.
+	if terragruntOptions.TerraformPath == options.TERRAFORM_DEFAULT_PATH && terragruntConfig.TerraformBinary != "" {
+		terragruntOptions.TerraformPath = terragruntConfig.TerraformBinary
+	}
+
+	if err := PopulateTerraformVersion(terragruntOptions); err != nil {
+		return err
+	}
+
+	versionConstraint := DEFAULT_TERRAFORM_VERSION_CONSTRAINT
+	if terragruntConfig.TerraformVersionConstraint != "" {
+		versionConstraint = terragruntConfig.TerraformVersionConstraint
+	}
+	if err := CheckTerraformVersion(versionConstraint, terragruntOptions); err != nil {
+		return err
 	}
 
 	if terragruntConfig.Skip {

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -150,7 +150,7 @@ AUTHOR(S):
 var MODULE_REGEX = regexp.MustCompile(`module[[:blank:]]+".+"`)
 
 // This uses the constraint syntax from https://github.com/hashicorp/go-version
-// This version of Terragrunt only works with Terraform 0.12.0 and above
+// This version of Terragrunt was tested to work with Terraform 0.12.0 and above only
 const DEFAULT_TERRAFORM_VERSION_CONSTRAINT = ">= v0.12.0"
 
 const TERRAFORM_EXTENSION_GLOB = "*.tf"
@@ -241,8 +241,15 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 	}
 
 	terragruntConfig, err := config.ReadTerragruntConfig(terragruntOptions)
+
 	if err != nil {
 		return err
+	}
+
+	if terragruntOptions.TerraformPath == options.TERRAFORM_DEFAULT_PATH { // not changed from default
+		if terragruntConfig.TerraformBinary != "" {
+			terragruntOptions.TerraformPath = terragruntConfig.TerraformBinary
+		}
 	}
 
 	if terragruntConfig.Skip {

--- a/config/config.go
+++ b/config/config.go
@@ -22,15 +22,16 @@ const DefaultTerragruntConfigPath = "terragrunt.hcl"
 
 // TerragruntConfig represents a parsed and expanded configuration
 type TerragruntConfig struct {
-	Terraform       *TerraformConfig
-	TerraformBinary string
-	RemoteState     *remote.RemoteState
-	Dependencies    *ModuleDependencies
-	PreventDestroy  bool
-	Skip            bool
-	IamRole         string
-	Inputs          map[string]interface{}
-	Locals          map[string]interface{}
+	Terraform                  *TerraformConfig
+	TerraformBinary            string
+	TerraformVersionConstraint string
+	RemoteState                *remote.RemoteState
+	Dependencies               *ModuleDependencies
+	PreventDestroy             bool
+	Skip                       bool
+	IamRole                    string
+	Inputs                     map[string]interface{}
+	Locals                     map[string]interface{}
 }
 
 func (conf *TerragruntConfig) String() string {
@@ -40,15 +41,16 @@ func (conf *TerragruntConfig) String() string {
 // terragruntConfigFile represents the configuration supported in a Terragrunt configuration file (i.e.
 // terragrunt.hcl)
 type terragruntConfigFile struct {
-	Terraform       *TerraformConfig       `hcl:"terraform,block"`
-	TerraformBinary *string                `hcl:"terraform_binary,attr"`
-	Inputs          *cty.Value             `hcl:"inputs,attr"`
-	Include         *IncludeConfig         `hcl:"include,block"`
-	RemoteState     *remoteStateConfigFile `hcl:"remote_state,block"`
-	Dependencies    *ModuleDependencies    `hcl:"dependencies,block"`
-	PreventDestroy  *bool                  `hcl:"prevent_destroy,attr"`
-	Skip            *bool                  `hcl:"skip,attr"`
-	IamRole         *string                `hcl:"iam_role,attr"`
+	Terraform                  *TerraformConfig       `hcl:"terraform,block"`
+	TerraformBinary            *string                `hcl:"terraform_binary,attr"`
+	TerraformVersionConstraint *string                `hcl:"terraform_version_constraint,attr"`
+	Inputs                     *cty.Value             `hcl:"inputs,attr"`
+	Include                    *IncludeConfig         `hcl:"include,block"`
+	RemoteState                *remoteStateConfigFile `hcl:"remote_state,block"`
+	Dependencies               *ModuleDependencies    `hcl:"dependencies,block"`
+	PreventDestroy             *bool                  `hcl:"prevent_destroy,attr"`
+	Skip                       *bool                  `hcl:"skip,attr"`
+	IamRole                    *string                `hcl:"iam_role,attr"`
 
 	// This struct is used for validating and parsing the entire terragrunt config. Since locals are evaluated in a
 	// completely separate cycle, it should not be evaluated here. Otherwise, we can't support self referencing other
@@ -435,6 +437,10 @@ func mergeConfigWithIncludedConfig(config *TerragruntConfig, includedConfig *Ter
 		includedConfig.IamRole = config.IamRole
 	}
 
+	if config.TerraformVersionConstraint != "" {
+		includedConfig.TerraformVersionConstraint = config.TerraformVersionConstraint
+	}
+
 	if config.TerraformBinary != "" {
 		includedConfig.TerraformBinary = config.TerraformBinary
 	}
@@ -594,6 +600,9 @@ func convertToTerragruntConfig(terragruntConfigFromFile *terragruntConfigFile, c
 
 	if terragruntConfigFromFile.TerraformBinary != nil {
 		terragruntConfig.TerraformBinary = *terragruntConfigFromFile.TerraformBinary
+	}
+	if terragruntConfigFromFile.TerraformVersionConstraint != nil {
+		terragruntConfig.TerraformVersionConstraint = *terragruntConfigFromFile.TerraformVersionConstraint
 	}
 
 	if terragruntConfigFromFile.PreventDestroy != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -22,14 +22,15 @@ const DefaultTerragruntConfigPath = "terragrunt.hcl"
 
 // TerragruntConfig represents a parsed and expanded configuration
 type TerragruntConfig struct {
-	Terraform      *TerraformConfig
-	RemoteState    *remote.RemoteState
-	Dependencies   *ModuleDependencies
-	PreventDestroy bool
-	Skip           bool
-	IamRole        string
-	Inputs         map[string]interface{}
-	Locals         map[string]interface{}
+	Terraform       *TerraformConfig
+	TerraformBinary string
+	RemoteState     *remote.RemoteState
+	Dependencies    *ModuleDependencies
+	PreventDestroy  bool
+	Skip            bool
+	IamRole         string
+	Inputs          map[string]interface{}
+	Locals          map[string]interface{}
 }
 
 func (conf *TerragruntConfig) String() string {
@@ -39,14 +40,15 @@ func (conf *TerragruntConfig) String() string {
 // terragruntConfigFile represents the configuration supported in a Terragrunt configuration file (i.e.
 // terragrunt.hcl)
 type terragruntConfigFile struct {
-	Terraform      *TerraformConfig       `hcl:"terraform,block"`
-	Inputs         *cty.Value             `hcl:"inputs,attr"`
-	Include        *IncludeConfig         `hcl:"include,block"`
-	RemoteState    *remoteStateConfigFile `hcl:"remote_state,block"`
-	Dependencies   *ModuleDependencies    `hcl:"dependencies,block"`
-	PreventDestroy *bool                  `hcl:"prevent_destroy,attr"`
-	Skip           *bool                  `hcl:"skip,attr"`
-	IamRole        *string                `hcl:"iam_role,attr"`
+	Terraform       *TerraformConfig       `hcl:"terraform,block"`
+	TerraformBinary *string                `hcl:"terraform_binary,attr"`
+	Inputs          *cty.Value             `hcl:"inputs,attr"`
+	Include         *IncludeConfig         `hcl:"include,block"`
+	RemoteState     *remoteStateConfigFile `hcl:"remote_state,block"`
+	Dependencies    *ModuleDependencies    `hcl:"dependencies,block"`
+	PreventDestroy  *bool                  `hcl:"prevent_destroy,attr"`
+	Skip            *bool                  `hcl:"skip,attr"`
+	IamRole         *string                `hcl:"iam_role,attr"`
 
 	// This struct is used for validating and parsing the entire terragrunt config. Since locals are evaluated in a
 	// completely separate cycle, it should not be evaluated here. Otherwise, we can't support self referencing other
@@ -433,6 +435,10 @@ func mergeConfigWithIncludedConfig(config *TerragruntConfig, includedConfig *Ter
 		includedConfig.IamRole = config.IamRole
 	}
 
+	if config.TerraformBinary != "" {
+		includedConfig.TerraformBinary = config.TerraformBinary
+	}
+
 	if config.Inputs != nil {
 		includedConfig.Inputs = mergeInputs(config.Inputs, includedConfig.Inputs)
 	}
@@ -585,6 +591,10 @@ func convertToTerragruntConfig(terragruntConfigFromFile *terragruntConfigFile, c
 
 	terragruntConfig.Terraform = terragruntConfigFromFile.Terraform
 	terragruntConfig.Dependencies = terragruntConfigFromFile.Dependencies
+
+	if terragruntConfigFromFile.TerraformBinary != nil {
+		terragruntConfig.TerraformBinary = *terragruntConfigFromFile.TerraformBinary
+	}
 
 	if terragruntConfigFromFile.PreventDestroy != nil {
 		terragruntConfig.PreventDestroy = *terragruntConfigFromFile.PreventDestroy

--- a/options/options.go
+++ b/options/options.go
@@ -21,6 +21,9 @@ var TERRAFORM_COMMANDS_WITH_SUBCOMMAND = []string{
 
 const DEFAULT_MAX_FOLDERS_TO_CHECK = 100
 
+// TERRAFORM_DEFAULT_PATH just takes terraform from the path
+const TERRAFORM_DEFAULT_PATH = "terraform"
+
 const TerragruntCacheDir = ".terragrunt-cache"
 
 // TerragruntOptions represents options that configure the behavior of the Terragrunt program
@@ -124,7 +127,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 
 	return &TerragruntOptions{
 		TerragruntConfigPath:       terragruntConfigPath,
-		TerraformPath:              "terraform",
+		TerraformPath:              TERRAFORM_DEFAULT_PATH,
 		TerraformCommand:           "",
 		AutoInit:                   true,
 		NonInteractive:             false,
@@ -137,16 +140,16 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		DownloadDir:                downloadDir,
 		IgnoreDependencyErrors:     false,
 		IgnoreExternalDependencies: false,
-		Writer:                     os.Stdout,
-		ErrWriter:                  os.Stderr,
-		MaxFoldersToCheck:          DEFAULT_MAX_FOLDERS_TO_CHECK,
-		AutoRetry:                  true,
-		MaxRetryAttempts:           DEFAULT_MAX_RETRY_ATTEMPTS,
-		Sleep:                      DEFAULT_SLEEP,
-		RetryableErrors:            util.CloneStringList(RETRYABLE_ERRORS),
-		ExcludeDirs:                []string{},
-		IncludeDirs:                []string{},
-		Check:                      false,
+		Writer:            os.Stdout,
+		ErrWriter:         os.Stderr,
+		MaxFoldersToCheck: DEFAULT_MAX_FOLDERS_TO_CHECK,
+		AutoRetry:         true,
+		MaxRetryAttempts:  DEFAULT_MAX_RETRY_ATTEMPTS,
+		Sleep:             DEFAULT_SLEEP,
+		RetryableErrors:   util.CloneStringList(RETRYABLE_ERRORS),
+		ExcludeDirs:       []string{},
+		IncludeDirs:       []string{},
+		Check:             false,
 		RunTerragrunt: func(terragruntOptions *TerragruntOptions) error {
 			return errors.WithStackTrace(RunTerragruntCommandNotSet)
 		},
@@ -205,16 +208,16 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		IamRole:                    terragruntOptions.IamRole,
 		IgnoreDependencyErrors:     terragruntOptions.IgnoreDependencyErrors,
 		IgnoreExternalDependencies: terragruntOptions.IgnoreExternalDependencies,
-		Writer:                     terragruntOptions.Writer,
-		ErrWriter:                  terragruntOptions.ErrWriter,
-		MaxFoldersToCheck:          terragruntOptions.MaxFoldersToCheck,
-		AutoRetry:                  terragruntOptions.AutoRetry,
-		MaxRetryAttempts:           terragruntOptions.MaxRetryAttempts,
-		Sleep:                      terragruntOptions.Sleep,
-		RetryableErrors:            util.CloneStringList(terragruntOptions.RetryableErrors),
-		ExcludeDirs:                terragruntOptions.ExcludeDirs,
-		IncludeDirs:                terragruntOptions.IncludeDirs,
-		RunTerragrunt:              terragruntOptions.RunTerragrunt,
+		Writer:            terragruntOptions.Writer,
+		ErrWriter:         terragruntOptions.ErrWriter,
+		MaxFoldersToCheck: terragruntOptions.MaxFoldersToCheck,
+		AutoRetry:         terragruntOptions.AutoRetry,
+		MaxRetryAttempts:  terragruntOptions.MaxRetryAttempts,
+		Sleep:             terragruntOptions.Sleep,
+		RetryableErrors:   util.CloneStringList(terragruntOptions.RetryableErrors),
+		ExcludeDirs:       terragruntOptions.ExcludeDirs,
+		IncludeDirs:       terragruntOptions.IncludeDirs,
+		RunTerragrunt:     terragruntOptions.RunTerragrunt,
 	}
 }
 


### PR DESCRIPTION
This change allows setting `terraform_binary` in `terragrunt.hcl` (a module-level one or in an included `terragrunt.hcl`.

Adds thisto the migration doc, allowing using a mix of terraform-0.11 and terraform-0.12 modules together, for example set `terraform_binary=~/bin/terraform-v11/terraform` in an included root `terragrunt.hcl` and allows to override it in specific modules.

Lowers the required terraform version to 0.11 to make it work with the previous version of terraform.

A note: checking for terraform version doesn't really make sense in this case, as it checks for only the default version of it. Maybe increase the minimum version to `0.12` again? But it will make it unclear that different terraform is checked for before running modules runs.

Makes supporting terragrunt `0.18` irrelevant as well, as per #743.
