### PR TITLE
Provide ability to disable backend init so that validate-all can be run without a backend

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,7 @@ type terragruntInclude struct {
 // Configuration for Terraform remote state as parsed from a terragrunt.hcl config file
 type remoteStateConfigFile struct {
 	Backend string    `hcl:"backend,attr"`
+	Enabled *bool     `hcl:"enabled,attr"`
 	Config  cty.Value `hcl:"config,attr"`
 }
 
@@ -520,10 +521,15 @@ func convertToTerragruntConfig(terragruntConfigFromFile *terragruntConfigFile, c
 		}
 
 		remoteState := &remote.RemoteState{}
+		remoteState.FillDefaults()
+
 		remoteState.Backend = terragruntConfigFromFile.RemoteState.Backend
 		remoteState.Config = remoteStateConfig
 
-		remoteState.FillDefaults()
+		if terragruntConfigFromFile.RemoteState.Enabled != nil {
+			remoteState.Enabled = *terragruntConfigFromFile.RemoteState.Enabled
+		}
+
 		if err := remoteState.Validate(); err != nil {
 			return nil, err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -54,9 +54,9 @@ type terragruntInclude struct {
 
 // Configuration for Terraform remote state as parsed from a terragrunt.hcl config file
 type remoteStateConfigFile struct {
-	Backend string    `hcl:"backend,attr"`
-	Enabled *bool     `hcl:"enabled,attr"`
-	Config  cty.Value `hcl:"config,attr"`
+	Backend     string    `hcl:"backend,attr"`
+	DisableInit *bool     `hcl:"disable_init,attr"`
+	Config      cty.Value `hcl:"config,attr"`
 }
 
 func (remoteState *remoteStateConfigFile) String() string {
@@ -521,15 +521,14 @@ func convertToTerragruntConfig(terragruntConfigFromFile *terragruntConfigFile, c
 		}
 
 		remoteState := &remote.RemoteState{}
-		remoteState.FillDefaults()
-
 		remoteState.Backend = terragruntConfigFromFile.RemoteState.Backend
 		remoteState.Config = remoteStateConfig
 
-		if terragruntConfigFromFile.RemoteState.Enabled != nil {
-			remoteState.Enabled = *terragruntConfigFromFile.RemoteState.Enabled
+		if terragruntConfigFromFile.RemoteState.DisableInit != nil {
+			remoteState.DisableInit = *terragruntConfigFromFile.RemoteState.DisableInit
 		}
 
+		remoteState.FillDefaults()
 		if err := remoteState.Validate(); err != nil {
 			return nil, err
 		}

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -10,19 +10,20 @@ import (
 // Configuration for Terraform remote state
 type RemoteState struct {
 	Backend string
+	Enabled bool
 	Config  map[string]interface{}
 }
 
 func (remoteState *RemoteState) String() string {
-	return fmt.Sprintf("RemoteState{Backend = %v, Config = %v}", remoteState.Backend, remoteState.Config)
+	return fmt.Sprintf("RemoteState{Backend = %v, Enabled = %v, Config = %v}", remoteState.Backend, remoteState.Enabled, remoteState.Config)
 }
 
 type RemoteStateInitializer interface {
 	// Return true if remote state needs to be initialized
-	NeedsInitialization(config map[string]interface{}, existingBackend *TerraformBackend, terragruntOptions *options.TerragruntOptions) (bool, error)
+	NeedsInitialization(remoteState *RemoteState, existingBackend *TerraformBackend, terragruntOptions *options.TerragruntOptions) (bool, error)
 
 	// Initialize the remote state
-	Initialize(config map[string]interface{}, terragruntOptions *options.TerragruntOptions) error
+	Initialize(remoteState *RemoteState, terragruntOptions *options.TerragruntOptions) error
 
 	// Return the config that should be passed on to terraform via -backend-config cmd line param
 	// Allows the Backends to filter and/or modify the configuration given from the user
@@ -36,7 +37,7 @@ var remoteStateInitializers = map[string]RemoteStateInitializer{
 
 // Fill in any default configuration for remote state
 func (remoteState *RemoteState) FillDefaults() {
-	// Nothing to do
+	remoteState.Enabled = true
 }
 
 // Validate that the remote state is configured correctly
@@ -54,7 +55,7 @@ func (remoteState *RemoteState) Initialize(terragruntOptions *options.Terragrunt
 	terragruntOptions.Logger.Printf("Initializing remote state for the %s backend", remoteState.Backend)
 	initializer, hasInitializer := remoteStateInitializers[remoteState.Backend]
 	if hasInitializer {
-		return initializer.Initialize(remoteState.Config, terragruntOptions)
+		return initializer.Initialize(remoteState, terragruntOptions)
 	}
 
 	return nil
@@ -71,6 +72,10 @@ func (remoteState *RemoteState) NeedsInit(terragruntOptions *options.TerragruntO
 		return false, err
 	}
 
+	if !remoteState.Enabled {
+		return false, nil
+	}
+
 	// Remote state not configured
 	if state == nil {
 		return true, nil
@@ -78,7 +83,7 @@ func (remoteState *RemoteState) NeedsInit(terragruntOptions *options.TerragruntO
 
 	if initializer, hasInitializer := remoteStateInitializers[remoteState.Backend]; hasInitializer {
 		// Remote state initializer says initialization is necessary
-		return initializer.NeedsInitialization(remoteState.Config, state.Backend, terragruntOptions)
+		return initializer.NeedsInitialization(remoteState, state.Backend, terragruntOptions)
 	} else if state.IsRemote() && remoteState.differsFrom(state.Backend, terragruntOptions) {
 		// If there's no remote state initializer, then just compare the the config values
 		return true, nil
@@ -127,8 +132,10 @@ func terraformStateConfigEqual(existingConfig map[string]interface{}, newConfig 
 
 // Convert the RemoteState config into the format used by the terraform init command
 func (remoteState RemoteState) ToTerraformInitArgs() []string {
-
 	config := remoteState.Config
+	if !remoteState.Enabled {
+		return []string{"-backend=false"}
+	}
 
 	initializer, hasInitializer := remoteStateInitializers[remoteState.Backend]
 	if hasInitializer {

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -9,13 +9,13 @@ import (
 
 // Configuration for Terraform remote state
 type RemoteState struct {
-	Backend string
-	Enabled bool
-	Config  map[string]interface{}
+	Backend     string
+	DisableInit bool
+	Config      map[string]interface{}
 }
 
 func (remoteState *RemoteState) String() string {
-	return fmt.Sprintf("RemoteState{Backend = %v, Enabled = %v, Config = %v}", remoteState.Backend, remoteState.Enabled, remoteState.Config)
+	return fmt.Sprintf("RemoteState{Backend = %v, DisableInit = %v, Config = %v}", remoteState.Backend, remoteState.DisableInit, remoteState.Config)
 }
 
 type RemoteStateInitializer interface {
@@ -37,7 +37,7 @@ var remoteStateInitializers = map[string]RemoteStateInitializer{
 
 // Fill in any default configuration for remote state
 func (remoteState *RemoteState) FillDefaults() {
-	remoteState.Enabled = true
+	// Nothing to do
 }
 
 // Validate that the remote state is configured correctly
@@ -72,7 +72,7 @@ func (remoteState *RemoteState) NeedsInit(terragruntOptions *options.TerragruntO
 		return false, err
 	}
 
-	if !remoteState.Enabled {
+	if remoteState.DisableInit {
 		return false, nil
 	}
 
@@ -133,7 +133,7 @@ func terraformStateConfigEqual(existingConfig map[string]interface{}, newConfig 
 // Convert the RemoteState config into the format used by the terraform init command
 func (remoteState RemoteState) ToTerraformInitArgs() []string {
 	config := remoteState.Config
-	if !remoteState.Enabled {
+	if remoteState.DisableInit {
 		return []string{"-backend=false"}
 	}
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -96,7 +96,7 @@ type S3Initializer struct{}
 // 1. Any of the existing backend settings are different than the current config
 // 2. The configured S3 bucket or DynamoDB table does not exist
 func (s3Initializer S3Initializer) NeedsInitialization(remoteState *RemoteState, existingBackend *TerraformBackend, terragruntOptions *options.TerragruntOptions) (bool, error) {
-	if !remoteState.Enabled {
+	if remoteState.DisableInit {
 		return false, nil
 	}
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -95,12 +95,16 @@ type S3Initializer struct{}
 //
 // 1. Any of the existing backend settings are different than the current config
 // 2. The configured S3 bucket or DynamoDB table does not exist
-func (s3Initializer S3Initializer) NeedsInitialization(config map[string]interface{}, existingBackend *TerraformBackend, terragruntOptions *options.TerragruntOptions) (bool, error) {
-	if !configValuesEqual(config, existingBackend, terragruntOptions) {
+func (s3Initializer S3Initializer) NeedsInitialization(remoteState *RemoteState, existingBackend *TerraformBackend, terragruntOptions *options.TerragruntOptions) (bool, error) {
+	if !remoteState.Enabled {
+		return false, nil
+	}
+
+	if !configValuesEqual(remoteState.Config, existingBackend, terragruntOptions) {
 		return true, nil
 	}
 
-	s3Config, err := parseS3Config(config)
+	s3Config, err := parseS3Config(remoteState.Config)
 	if err != nil {
 		return false, err
 	}
@@ -186,8 +190,8 @@ func configValuesEqual(config map[string]interface{}, existingBackend *Terraform
 
 // Initialize the remote state S3 bucket specified in the given config. This function will validate the config
 // parameters, create the S3 bucket if it doesn't already exist, and check that versioning is enabled.
-func (s3Initializer S3Initializer) Initialize(config map[string]interface{}, terragruntOptions *options.TerragruntOptions) error {
-	s3ConfigExtended, err := parseExtendedS3Config(config)
+func (s3Initializer S3Initializer) Initialize(remoteState *RemoteState, terragruntOptions *options.TerragruntOptions) error {
+	s3ConfigExtended, err := parseExtendedS3Config(remoteState.Config)
 	if err != nil {
 		return err
 	}

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -61,6 +61,23 @@ func TestToTerraformInitArgsUnknownBackend(t *testing.T) {
 	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1")
 }
 
+func TestToTerraformInitArgsInitDisabled(t *testing.T) {
+	t.Parallel()
+
+	remoteState := RemoteState{
+		Backend:     "s3",
+		DisableInit: true,
+		Config: map[string]interface{}{
+			"encrypt": true,
+			"bucket":  "my-bucket",
+			"key":     "terraform.tfstate",
+			"region":  "us-east-1"},
+	}
+	args := remoteState.ToTerraformInitArgs()
+
+	assertTerraformInitArgsEqual(t, args, "-backend=false")
+}
+
 func TestToTerraformInitArgsNoBackendConfigs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
As an attempt to solve https://github.com/gruntwork-io/terragrunt/issues/597 and https://github.com/gruntwork-io/terragrunt/issues/732 this change provides the abilty to disable a backend using something like this, I set DISABLE_BACKEND in my CI process when running validate-all.

```
remote_state {
  backend = "s3"
  enabled = get_env("DISABLE_BACKEND", "false") != "true"
  ...
}
```

@yorinasub17 I ran with your idea but ended up in a slightly different direction, would appreicate some feedback on if this is close to what we want or if I should consider another solution as I would love to get this working so I can add an validate-all step to our CI process that does not require a backend.