### PR TITLE
Support Existing Buckets for the GCS backend

### DIFF
--- a/remote/remote_state_gcs.go
+++ b/remote/remote_state_gcs.go
@@ -193,11 +193,6 @@ func parseExtendedGCSConfig(config map[string]interface{}) (*ExtendedRemoteState
 
 // Validate all the parameters of the given GCS remote state configuration
 func validateGCSConfig(extendedConfig *ExtendedRemoteStateConfigGCS, terragruntOptions *options.TerragruntOptions) error {
-	// A project must be specified in order for terragrunt to automatically create a storage bucket.
-	if extendedConfig.Project == "" {
-		return errors.WithStackTrace(MissingRequiredGCSRemoteStateConfig("project"))
-	}
-
 	var config = extendedConfig.remoteStateConfigGCS
 
 	if config.Bucket == "" {
@@ -215,6 +210,19 @@ func validateGCSConfig(extendedConfig *ExtendedRemoteStateConfigGCS, terragruntO
 // confirms, create the bucket and enable versioning for it.
 func createGCSBucketIfNecessary(gcsClient *storage.Client, config *ExtendedRemoteStateConfigGCS, terragruntOptions *options.TerragruntOptions) error {
 	if !DoesGCSBucketExist(gcsClient, &config.remoteStateConfigGCS) {
+		terragruntOptions.Logger.Printf("Remote state GCS bucket %s does not exist. Attempting to create it", config.remoteStateConfigGCS.Bucket)
+
+		terragruntOptions.Logger.Printf("%v", config.Project)
+		// A project must be specified in order for terragrunt to automatically create a storage bucket.
+		if config.Project == "" {
+			return errors.WithStackTrace(MissingRequiredGCSRemoteStateConfig("project"))
+		}
+
+		// A location must be specified in order for terragrunt to automatically create a storage bucket.
+		if config.Location == "" {
+			return errors.WithStackTrace(MissingRequiredGCSRemoteStateConfig("location"))
+		}
+
 		prompt := fmt.Sprintf("Remote state GCS bucket %s does not exist or you don't have permissions to access it. Would you like Terragrunt to create it?", config.remoteStateConfigGCS.Bucket)
 		shouldCreateBucket, err := shell.PromptUserForYesNo(prompt, terragruntOptions)
 		if err != nil {
@@ -390,16 +398,4 @@ type MissingRequiredGCSRemoteStateConfig string
 
 func (configName MissingRequiredGCSRemoteStateConfig) Error() string {
 	return fmt.Sprintf("Missing required GCS remote state configuration %s", string(configName))
-}
-
-type MaxRetriesWaitingForGCSBucketExceeded string
-
-func (err MaxRetriesWaitingForGCSBucketExceeded) Error() string {
-	return fmt.Sprintf("Exceeded max retries (%d) waiting for GCS bucket %s", MAX_RETRIES_WAITING_FOR_GCS_BUCKET, string(err))
-}
-
-type MaxRetriesWaitingForGCSACLExceeded string
-
-func (err MaxRetriesWaitingForGCSACLExceeded) Error() string {
-	return fmt.Sprintf("Exceeded max retries waiting for GCS bucket %s to have proper ACL for access logging", string(err))
 }

--- a/remote/remote_state_gcs.go
+++ b/remote/remote_state_gcs.go
@@ -316,6 +316,7 @@ func CreateGCSBucket(gcsClient *storage.Client, config *ExtendedRemoteStateConfi
 
 	if config.Location != "" {
 		terragruntOptions.Logger.Printf("Creating GCS bucket in location %s.", config.Location)
+		bucketAttrs.Location = config.Location
 	}
 
 	if config.SkipBucketVersioning {

--- a/test/fixture-gcs-byo-bucket/main.tf
+++ b/test/fixture-gcs-byo-bucket/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  backend "gcs" {}
+}
+
+# Create an arbitrary local resource
+data "template_file" "test" {
+  template = "Hello, I am a template. My sample_var value = $${sample_var}"
+
+  vars = {
+    sample_var = var.sample_var
+  }
+}

--- a/test/fixture-gcs-byo-bucket/outputs.tf
+++ b/test/fixture-gcs-byo-bucket/outputs.tf
@@ -1,0 +1,3 @@
+output "rendered_template" {
+  value = data.template_file.test.rendered
+}

--- a/test/fixture-gcs-byo-bucket/terragrunt.hcl
+++ b/test/fixture-gcs-byo-bucket/terragrunt.hcl
@@ -1,0 +1,13 @@
+# Configure Terragrunt to automatically store tfstate files in an existing GCS bucket
+remote_state {
+  backend = "gcs"
+
+  config = {
+    # we are explictly testing that a GCS bucket already exists and terragrunt should
+    # work without project and location.
+    #project  = ""
+    #location = ""
+    bucket = "__FILL_IN_BUCKET_NAME__"
+    prefix = "terraform.tfstate"
+  }
+}

--- a/test/fixture-gcs-byo-bucket/vars.tf
+++ b/test/fixture-gcs-byo-bucket/vars.tf
@@ -1,0 +1,5 @@
+# Configure these variables
+variable "sample_var" {
+  description = "A sample_var to pass to the template."
+  default     = "hello"
+}


### PR DESCRIPTION
Ensure `project` and `location` are optional when using the GCS backend. This allows users to use Terragrunt with an existing GCS bucket they may have already created.

This PR also fixes a bug that may lead to Terragrunt creating a GCS bucket in the wrong location.

## Fixes
 * https://github.com/gruntwork-io/terragrunt/issues/767