### PR TITLE
Set AWS credentials in the environment so go-getter can use them

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -366,6 +367,9 @@ func assumeRoleIfNecessary(terragruntOptions *options.TerragruntOptions) error {
 	terragruntOptions.Env["AWS_ACCESS_KEY_ID"] = aws.StringValue(creds.AccessKeyId)
 	terragruntOptions.Env["AWS_SECRET_ACCESS_KEY"] = aws.StringValue(creds.SecretAccessKey)
 	terragruntOptions.Env["AWS_SESSION_TOKEN"] = aws.StringValue(creds.SessionToken)
+	os.Setenv("AWS_ACCESS_KEY_ID", aws.StringValue(creds.AccessKeyId))
+	os.Setenv("AWS_SECRET_ACCESS_KEY", aws.StringValue(creds.SecretAccessKey))
+	os.Setenv("AWS_SESSION_TOKEN", aws.StringValue(creds.SessionToken))
 
 	return nil
 }


### PR DESCRIPTION
In going from 0.18.7 to 0.19.0, the method for downloading Terraform sources changed from `terraform init` to the hashicorp/go-getter library. This introduces a regression where an artifact in S3 can no longer be fetched using an assumed role.

.ssh/config
```
[ops]
aws_access_key_id=...
aws_secret_access_key=...
```

Failing output with Terragrunt 0.19.8 and Terraform 0.12.3:
```
$ export AWS_PROFILE=ops TERRAGRUNT_IAM_ROLE=arn:aws:iam::1234567890:role/my_role
$ terragrunt -version AWS_SDK_LOAD_CONFIG=true
terragrunt version v0.19.8
$ terragrunt init
[terragrunt] [/path/to/tfvars] 2019/07/03 17:29:27 Running command: /bin/terraform --version
[terragrunt] 2019/07/03 17:29:28 Reading Terragrunt config file at /path/to/tfvars/terragrunt.hcl
[terragrunt] 2019/07/03 17:29:28 Assuming IAM role arn:aws:iam::1234567890:role/my_role
[terragrunt] 2019/07/03 17:29:28 Downloading Terraform configurations from s3::https://s3-us-west-2.amazonaws.com/bucket/path/to/artifact.zip into /path/to/tfvars/.terragrunt-cache/uDnJlgn36Yz7t4-tE1QuPQJn2Ys/zTAc8OMcrkmYXjA_RJsARenWbMw
[terragrunt] 2019/07/03 17:29:28 Hit multiple errors:
AccessDenied: Access Denied
    status code: 403, request id: 06341E42B14F7178, host id: AxrAQ5qj61+r1buzdVlxun2Qr+GZhUUdME+OpqPibQDnjMKQl6lwSpCcn7oqbRIPsCW/pN5uQg8=
[terragrunt] 2019/07/03 17:29:28 Unable to determine underlying exit code, so Terragrunt will exit with error code 1
```

Output with Terragrunt built off of this PR:
```
$ terragrunt init 
[terragrunt] [/path/to/tfvars] 2019/07/03 17:16:00 Running command: /bin/terraform --version
[terragrunt] 2019/07/03 17:16:01 Reading Terragrunt config file at /path/to/tfvars/terragrunt.hcl
[terragrunt] 2019/07/03 17:16:01 Assuming IAM role arn:aws:iam::1234567890:role/my_role
[terragrunt] 2019/07/03 17:16:01 Downloading Terraform configurations from s3::https://s3-us-west-2.amazonaws.com/bucket/path/to/artifact.zip into /path/to/tfvars/.terragrunt-cache/uDnJlgn36Yz7t4-tE1QuPQJn2Ys/zTAc8OMcrkmYXjA_RJsARenWbMw
[terragrunt] 2019/07/03 17:16:02 Copying files from /path/to/tfvars into /path/to/tfvars/.terragrunt-cache/uDnJlgn36Yz7t4-tE1QuPQJn2Ys/zTAc8OMcrkmYXjA_RJsARenWbMw/modules
[terragrunt] 2019/07/03 17:16:02 Setting working directory to /path/to/tfvars/.terragrunt-cache/uDnJlgn36Yz7t4-tE1QuPQJn2Ys/zTAc8OMcrkmYXjA_RJsARenWbMw/modules
[terragrunt] 2019/07/03 17:16:02 Initializing remote state for the s3 backend
[terragrunt] 2019/07/03 17:16:02 Running command: /bin/terraform init -backend-config=region=us-west-2 -backend-config=bucket=... -backend-config=dynamodb_table=... -backend-config=encrypt=true -backend-config=key=...
Initializing modules...
```

This is likely actually an issue with the go-getter library not properly handling AWS credentials, but the change in this PR is a lower effort fix. I've tested that this fixes the issue in my setup. I've also tested separately that having Terragrunt pull in https://github.com/hashicorp/go-getter/pull/185 (which looks related) does not fix my issue.
