### PR TITLE
Fix error output in plan-all..

### DIFF
--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -95,6 +95,7 @@ func downloadTerraformSourceIfNecessary(terraformSource *TerraformSource, terrag
 	// before and after hooks (if any).
 	terragruntOptionsForDownload := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
 	terragruntOptionsForDownload.TerraformCommand = CMD_INIT_FROM_MODULE
+	terragruntOptionsForDownload.Logger = terragruntOptions.Logger
 	downloadErr := runActionWithHooks("download source", terragruntOptionsForDownload, terragruntConfig, func() error {
 		return downloadSource(terraformSource, terragruntOptions, terragruntConfig)
 	})

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -62,7 +62,7 @@ func (stack *Stack) summarizePlanAllErrors(terragruntOptions *options.Terragrunt
 				)
 			}
 		} else if errorStream.Len() > 0 {
-			terragruntOptions.Logger.Printf("Error with plan: %s", output)
+			terragruntOptions.Logger.Printf("Error Summary of plan in %s\n%s", stack.Modules[i].Path, output)
 		}
 	}
 }

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -61,6 +61,10 @@ func RunShellCommandWithOutput(terragruntOptions *options.TerragruntOptions, wor
 		outWriter = os.Stdout
 	}
 
+	if terragruntOptions.ErrWriter != os.Stderr {
+		errWriter = io.MultiWriter(terragruntOptions.ErrWriter, os.Stderr)
+	}
+
 	if workingDir == "" {
 		cmd.Dir = terragruntOptions.WorkingDir
 	} else {

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -57,7 +57,8 @@ func RunShellCommandWithOutput(terragruntOptions *options.TerragruntOptions, wor
 	// command requested by the user. The output of these other commands should not end up on stdout as this
 	// breaks scripts relying on terraform's output.
 	if !reflect.DeepEqual(terragruntOptions.TerraformCliArgs, args) {
-		outWriter = terragruntOptions.ErrWriter
+		errWriter = os.Stderr
+		outWriter = os.Stdout
 	}
 
 	if workingDir == "" {


### PR DESCRIPTION
tries to fix issues mentioned in #397: 

when runnign `plan-all` every run states "Errors with plan".. which is due to capturing wrong output.
This patch series fixes several issues and add minor improvements in output:
- fix wrongly detected error by not capturing output for non terraform commands
- fix wrongly captured output for "init-from-module" pseudo-command run
- improve plan-all error output by adding module path of captured error
- improve plan-all output by displaying errors while happening and repeating them in final summary.

it's my first go code ;) so feel free to just take it as a hint how this was fixed for me.

