### PR TITLE
update Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ Note that third-party Terragrunt packages may not be updated with the latest ver
 Please check your version against the latest available on the
 [Releases Page](https://github.com/gruntwork-io/terragrunt/releases).
 
-### OSX
-You can install Terragrunt on OSX using [Homebrew](https://brew.sh/): `brew install terragrunt`.
+### macOS
+You can install Terragrunt on macOS using [Homebrew](https://brew.sh/): `brew install terragrunt`.
 
 ### Linux
-You can install Terragrunt on Linux using [Linuxbrew](https://linuxbrew.sh/): `brew install terragrunt`.
+You can install Terragrunt on Linux using [Homebrew](https://docs.brew.sh/Homebrew-on-Linux): `brew install terragrunt`.
 
 ### Manual
 You can install Terragrunt manually by going to the [Releases Page](https://github.com/gruntwork-io/terragrunt/releases),


### PR DESCRIPTION
- `macOS` is the current official name
- `Linuxbrew` has merged into `Homebrew`