### PR TITLE
hclfmt

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -150,6 +150,14 @@
   version = "v2.0.4"
 
 [[projects]]
+  digest = "1:91e98ea76af524d88f4eeb4240bcd0ab04a8091954dc845c32b3283c7c4ebf8c"
+  name = "github.com/gruntwork-io/terratest"
+  packages = ["modules/files"]
+  pruneopts = "UT"
+  revision = "a02960d4ef0711ae95ae2651271b4e073f88da4e"
+  version = "v0.18.0"
+
+[[projects]]
   digest = "1:0ade334594e69404d80d9d323445d2297ff8161637f9b2d347cc6973d2d6f05b"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
@@ -398,11 +406,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9d5b5d543996dd584da1db1e0de1926f3e4c3a8dba0fa2f8db70f3ebee2342e0"
+  digest = "1:b7cda6bf367836ce3675325f6f7aec675af1ff2fde841524800f499a1acf0ee2"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
     "blowfish",
+    "ssh/terminal",
   ]
   pruneopts = "UT"
   revision = "5c40567a22f818bd14a1ea7245dad9f8ef0691aa"
@@ -440,9 +449,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:010311506e3917b54487c35a4277e2709678a40c1587d82492c40b78b6a0a01d"
+  digest = "1:2a96b14fed8617c9e499777c03ec21f35dfd5b396f0b05fcdd7eff9e6c67f196"
   name = "golang.org/x/sys"
-  packages = ["unix"]
+  packages = [
+    "unix",
+    "windows",
+  ]
   pruneopts = "UT"
   revision = "93c9922d18aeb82498a065f07aec7ad7fa60dfb7"
 
@@ -578,12 +590,14 @@
     "github.com/aws/aws-sdk-go/service/s3",
     "github.com/aws/aws-sdk-go/service/sts",
     "github.com/go-errors/errors",
+    "github.com/gruntwork-io/terratest/modules/files",
     "github.com/hashicorp/go-getter",
     "github.com/hashicorp/go-getter/helper/url",
     "github.com/hashicorp/go-version",
     "github.com/hashicorp/hcl2/gohcl",
     "github.com/hashicorp/hcl2/hcl",
     "github.com/hashicorp/hcl2/hclparse",
+    "github.com/hashicorp/hcl2/hclwrite",
     "github.com/hashicorp/terraform/lang",
     "github.com/mattn/go-zglob",
     "github.com/mitchellh/mapstructure",
@@ -593,6 +607,7 @@
     "github.com/zclconf/go-cty/cty",
     "github.com/zclconf/go-cty/cty/function",
     "github.com/zclconf/go-cty/cty/json",
+    "golang.org/x/crypto/ssh/terminal",
     "google.golang.org/api/iterator",
   ]
   solver-name = "gps-cdcl"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ for a quick introduction to Terragrunt.
    1. [Auto-Retry](#auto-retry)
    1. [CLI options](#cli-options)
    1. [Configuration](#configuration)
+   1. [Formatting terragrunt.hcl](#formatting-terragrunt-hcl)
    1. [Clearing the Terragrunt cache](#clearing-the-terragrunt-cache)
    1. [Contributing](#contributing)
    1. [Developing Terragrunt](#developing-terragrunt)
@@ -1211,6 +1212,7 @@ This section contains detailed documentation for the following aspects of Terrag
 1. [Auto-Init](#auto-init)
 1. [CLI options](#cli-options)
 1. [Configuration](#configuration)
+1. [Formatting terragrunt.hcl](#formatting-terragrunt-hcl)
 1. [Migrating from Terragrunt v0.11.x and Terraform 0.8.x and older](#migrating-from-terragrunt-v011x-and-terraform-08x-and-older)
 1. [Clearing the Terragrunt cache](#clearing-the-terragrunt-cache)
 1. [Contributing](#contributing)
@@ -2044,6 +2046,34 @@ skip = true
 The `skip` flag must be set explicitly in terragrunt modules that should be skipped. If you set `skip = true` in a
 `terragrunt.hcl` file that is included by another `terragrunt.hcl` file, only the `terragrunt.hcl` file that explicitly
 set `skip = true` will be skipped.
+
+### Formatting terragrunt.hcl
+
+You can rewrite `terragrunt.hcl` files to a canonical format using the `hclfmt` command built into `terragrunt`. Similar
+to `terraform fmt`, this command applies a subset of [the Terraform language style
+conventions](https://www.terraform.io/docs/configuration/style.html), along with other minor adjustments for
+readability.
+
+This command will recursively search for `terragrunt.hcl` files and format all of them under a given directory tree.
+Consider the following file structure:
+
+```
+root
+├── terragrunt.hcl
+├── prod
+│   └── terragrunt.hcl
+├── dev
+│   └── terragrunt.hcl
+└── qa
+    └── terragrunt.hcl
+```
+
+If you run `terragrunt hclfmt` at the `root`, this will update:
+
+- `root/terragrunt.hcl`
+- `root/prod/terragrunt.hcl`
+- `root/dev/terragrunt.hcl`
+- `root/qa/terragrunt.hcl`
 
 ### Clearing the Terragrunt cache
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -314,17 +314,11 @@ func shouldPrintTerraformHelp(terragruntOptions *options.TerragruntOptions) bool
 }
 
 func shouldPrintTerragruntInfo(terragruntOptions *options.TerragruntOptions) bool {
-	if util.ListContainsElement(terragruntOptions.TerraformCliArgs, CMD_TERRAGRUNT_INFO) {
-		return true
-	}
-	return false
+	return util.ListContainsElement(terragruntOptions.TerraformCliArgs, CMD_TERRAGRUNT_INFO)
 }
 
 func shouldRunHCLFmt(terragruntOptions *options.TerragruntOptions) bool {
-	if util.ListContainsElement(terragruntOptions.TerraformCliArgs, CMD_HCLFMT) {
-		return true
-	}
-	return false
+	return util.ListContainsElement(terragruntOptions.TerraformCliArgs, CMD_HCLFMT)
 }
 
 func processHooks(hooks []config.Hook, terragruntOptions *options.TerragruntOptions, previousExecError ...error) error {

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -283,12 +283,7 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 	}
 
 	if shouldRunHCLFmt(terragruntOptions) {
-		cwd, err := os.Getwd()
-		if err != nil {
-			terragruntOptions.Logger.Printf("Error retrieving current working directory")
-			return err
-		}
-		return runHCLFmt(terragruntOptions, cwd)
+		return runHCLFmt(terragruntOptions)
 	}
 
 	if err := checkFolderContainsTerraformCode(terragruntOptions); err != nil {

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -281,7 +282,12 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 	}
 
 	if shouldRunHCLFmt(terragruntOptions) {
-		return runHCLFmt(terragruntOptions)
+		cwd, err := os.Getwd()
+		if err != nil {
+			terragruntOptions.Logger.Printf("Error retrieving current working directory")
+			return err
+		}
+		return runHCLFmt(terragruntOptions, cwd)
 	}
 
 	if err := checkFolderContainsTerraformCode(terragruntOptions); err != nil {

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -48,6 +48,7 @@ const CMD_VALIDATE_ALL = "validate-all"
 const CMD_INIT = "init"
 const CMD_INIT_FROM_MODULE = "init-from-module"
 const CMD_TERRAGRUNT_INFO = "terragrunt-info"
+const CMD_HCLFMT = "hclfmt"
 
 // CMD_SPIN_UP is deprecated.
 const CMD_SPIN_UP = "spin-up"
@@ -279,6 +280,10 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		return nil
 	}
 
+	if shouldRunHCLFmt(terragruntOptions) {
+		return runHCLFmt(terragruntOptions)
+	}
+
 	if err := checkFolderContainsTerraformCode(terragruntOptions); err != nil {
 		return err
 	}
@@ -303,6 +308,13 @@ func shouldPrintTerraformHelp(terragruntOptions *options.TerragruntOptions) bool
 
 func shouldPrintTerragruntInfo(terragruntOptions *options.TerragruntOptions) bool {
 	if util.ListContainsElement(terragruntOptions.TerraformCliArgs, CMD_TERRAGRUNT_INFO) {
+		return true
+	}
+	return false
+}
+
+func shouldRunHCLFmt(terragruntOptions *options.TerragruntOptions) bool {
+	if util.ListContainsElement(terragruntOptions.TerraformCliArgs, CMD_HCLFMT) {
 		return true
 	}
 	return false

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -119,6 +119,7 @@ COMMANDS:
    destroy-all          Destroy a 'stack' by running 'terragrunt destroy' in each subfolder
    validate-all         Validate 'stack' by running 'terragrunt validate' in each subfolder
    terragrunt-info      Emits limited terragrunt state on stdout and exits
+   hclfmt               Recursively find terragrunt.hcl files and rewrite them into a canonical format.
    *                    Terragrunt forwards all other commands directly to Terraform
 
 GLOBAL OPTIONS:

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 	"time"

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -17,7 +17,7 @@ import (
 // runHCLFmt recursively looks for terragrunt.hcl files in the directory tree starting at workingDir, and formats them
 // based on the language style guides provided by Hashicorp. This is done using the official hcl2 library.
 func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Formatting terragrunt.hcl files in the current directory tree.")
+	terragruntOptions.Logger.Printf("Formatting terragrunt.hcl files from the directory tree %s.", terragruntOptions.WorkingDir)
 
 	workingDir := terragruntOptions.WorkingDir
 	tgHclFiles, err := zglob.Glob(util.JoinPath(workingDir, "**", "*.hcl"))

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+// runHCLFmt recursively looks for terragrunt.hcl files in the directory tree starting at workingDir, and formats them
+// based on the language style guides provided by Hashicorp. This is done using the official hcl2 library.
 func runHCLFmt(terragruntOptions *options.TerragruntOptions, workingDir string) error {
 	terragruntOptions.Logger.Printf("Formatting terragrunt.hcl files in the current directory tree.")
 
@@ -32,6 +34,7 @@ func runHCLFmt(terragruntOptions *options.TerragruntOptions, workingDir string) 
 	return nil
 }
 
+// findTerragruntHclFiles will recursively look for terragrunt.hcl files in the directory tree starting at workingDir.
 func findTerragruntHclFiles(terragruntOptions *options.TerragruntOptions, workingDir string) ([]string, error) {
 	tgHclFiles := []string{}
 
@@ -52,6 +55,8 @@ func findTerragruntHclFiles(terragruntOptions *options.TerragruntOptions, workin
 	return tgHclFiles, err
 }
 
+// formatTgHCL uses the hcl2 library to format the terragrunt.hcl file. This will attempt to parse the HCL file first to
+// ensure that there are no syntax errors, before attempting to format it.
 func formatTgHCL(terragruntOptions *options.TerragruntOptions, tgHclFile string) error {
 	terragruntOptions.Logger.Printf("Formatting %s", tgHclFile)
 
@@ -77,6 +82,7 @@ func formatTgHCL(terragruntOptions *options.TerragruntOptions, tgHclFile string)
 	return ioutil.WriteFile(tgHclFile, newContents, info.Mode())
 }
 
+// readAllFromFile will read the contents of the file at the given path.
 func readAllFromFile(path string) ([]byte, error) {
 	f, err := os.Open(path)
 	defer f.Close()
@@ -86,6 +92,7 @@ func readAllFromFile(path string) ([]byte, error) {
 	return ioutil.ReadAll(f)
 }
 
+// getDiagnosticsWriter returns a hcl2 parsing diagnostics emitter for the current terminal.
 func getDiagnosticsWriter(parser *hclparse.Parser) hcl.DiagnosticWriter {
 	termColor := terminal.IsTerminal(int(os.Stderr.Fd()))
 	termWidth, _, err := terminal.GetSize(int(os.Stdout.Fd()))
@@ -95,6 +102,7 @@ func getDiagnosticsWriter(parser *hclparse.Parser) hcl.DiagnosticWriter {
 	return hcl.NewDiagnosticTextWriter(os.Stderr, parser.Files(), uint(termWidth), termColor)
 }
 
+// checkErrors takes in the contents of a terragrunt.hcl file and looks for syntax errors.
 func checkErrors(contents []byte, tgHclFile string) error {
 	parser := hclparse.NewParser()
 	_, diags := parser.ParseHCL(contents, tgHclFile)

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -20,7 +19,7 @@ import (
 func runHCLFmt(terragruntOptions *options.TerragruntOptions, workingDir string) error {
 	terragruntOptions.Logger.Printf("Formatting terragrunt.hcl files in the current directory tree.")
 
-	tgHclFiles, err := zglob.Glob(fmt.Sprintf("%s/**/*.hcl", workingDir))
+	tgHclFiles, err := zglob.Glob(util.JoinPath(workingDir, "**", "*.hcl"))
 	if err != nil {
 		return err
 	}

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hclparse"
+	"github.com/hashicorp/hcl2/hclwrite"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
+	terragruntOptions.Logger.Printf("Formatting terragrunt.hcl files in the current directory tree.")
+
+	tgHclFiles, err := findTerragruntHclFiles(terragruntOptions)
+	if err != nil {
+		return err
+	}
+
+	terragruntOptions.Logger.Printf("Found %d terragrunt.hcl files", len(tgHclFiles))
+
+	for _, tgHclFile := range tgHclFiles {
+		err := formatTgHCL(terragruntOptions, tgHclFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func findTerragruntHclFiles(terragruntOptions *options.TerragruntOptions) ([]string, error) {
+	tgHclFiles := []string{}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return tgHclFiles, err
+	}
+	terragruntOptions.Logger.Printf("Walking directory tree in %s to look for terragrunt.hcl files", cwd)
+
+	err = filepath.Walk(
+		cwd,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if filepath.Base(path) == "terragrunt.hcl" && !info.IsDir() {
+				tgHclFiles = append(tgHclFiles, path)
+			}
+			return nil
+		},
+	)
+	return tgHclFiles, err
+}
+
+func formatTgHCL(terragruntOptions *options.TerragruntOptions, tgHclFile string) error {
+	terragruntOptions.Logger.Printf("Formatting %s", tgHclFile)
+
+	info, err := os.Stat(tgHclFile)
+	if err != nil {
+		return err
+	}
+
+	contents, err := readAllFromFile(tgHclFile)
+	if err != nil {
+		return err
+	}
+
+	err := checkErrors(contents, tgHclFile)
+	if err != nil {
+		terragruntOptions.Logger.Printf("Error parsing %s", tgHclFile)
+		return err
+	}
+
+	newContents := hclwrite.Format(contents)
+	return ioutil.WriteFile(tgHclFile, newContents, info.Mode())
+}
+
+func readAllFromFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	defer f.Close()
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(f)
+}
+
+func getDiagnosticsWriter(parser hclparse.Parser) hcl.DiagnosticWriter {
+	termColor := terminal.IsTerminal(int(os.Stderr.Fd()))
+	termWidth, _, err := terminal.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		termWidth = 80
+	}
+	return hcl.NewDiagnosticTextWriter(os.Stderr, parser.Files(), uint(termWidth), termColor)
+}
+
+func checkErrors(contents string, tgHclFile string) error {
+	parser := hclparse.NewParser()
+	_, diags := parser.ParseHCL(contents, tgHclFile)
+	diagWriter := getDiagnosticsWriter(parser)
+	diagWriter.WriteDiagnostics(diags)
+	if diags.HasErrors() {
+		return diags
+	}
+	return nil
+}

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -16,9 +16,10 @@ import (
 
 // runHCLFmt recursively looks for terragrunt.hcl files in the directory tree starting at workingDir, and formats them
 // based on the language style guides provided by Hashicorp. This is done using the official hcl2 library.
-func runHCLFmt(terragruntOptions *options.TerragruntOptions, workingDir string) error {
+func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
 	terragruntOptions.Logger.Printf("Formatting terragrunt.hcl files in the current directory tree.")
 
+	workingDir := terragruntOptions.WorkingDir
 	tgHclFiles, err := zglob.Glob(util.JoinPath(workingDir, "**", "*.hcl"))
 	if err != nil {
 		return err

--- a/cli/hclfmt_test.go
+++ b/cli/hclfmt_test.go
@@ -25,8 +25,9 @@ func TestHCLFmt(t *testing.T) {
 
 	tgOptions, err := options.NewTerragruntOptionsForTest("")
 	require.NoError(t, err)
+	tgOptions.WorkingDir = tmpPath
 
-	err = runHCLFmt(tgOptions, tmpPath)
+	err = runHCLFmt(tgOptions)
 	require.NoError(t, err)
 
 	dirs := []string{
@@ -79,7 +80,9 @@ func TestHCLFmtErrors(t *testing.T) {
 				t.Parallel()
 
 				tgHclDir := filepath.Join(tmpPath, dir)
-				err := runHCLFmt(tgOptions, tgHclDir)
+				newTgOptions := tgOptions.Clone(tgOptions.TerragruntConfigPath)
+				newTgOptions.WorkingDir = tgHclDir
+				err := runHCLFmt(tgOptions)
 				require.Error(t, err)
 			})
 		})

--- a/cli/hclfmt_test.go
+++ b/cli/hclfmt_test.go
@@ -82,7 +82,7 @@ func TestHCLFmtErrors(t *testing.T) {
 				tgHclDir := filepath.Join(tmpPath, dir)
 				newTgOptions := tgOptions.Clone(tgOptions.TerragruntConfigPath)
 				newTgOptions.WorkingDir = tgHclDir
-				err := runHCLFmt(tgOptions)
+				err := runHCLFmt(newTgOptions)
 				require.Error(t, err)
 			})
 		})

--- a/cli/hclfmt_test.go
+++ b/cli/hclfmt_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/files"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/options"
+)
+
+func TestHCLFmt(t *testing.T) {
+	t.Parallel()
+
+	tmpPath, err := files.CopyFolderToTemp("../test/fixture-hclfmt", t.Name(), func(path string) bool { return true })
+	defer os.RemoveAll(tmpPath)
+	require.NoError(t, err)
+
+	expected, err := ioutil.ReadFile("../test/fixture-hclfmt/expected.hcl")
+	require.NoError(t, err)
+
+	tgOptions, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	err = runHCLFmt(tgOptions, tmpPath)
+	require.NoError(t, err)
+
+	dirs := []string{
+		"terragrunt.hcl",
+		"a/terragrunt.hcl",
+		"a/b/c/terragrunt.hcl",
+	}
+	for _, dir := range dirs {
+		// Capture range variable into for block so it doesn't change while looping
+		dir := dir
+
+		// Create a synchronous subtest to group the child tests so that they can run in parallel while honoring cleanup
+		// routines in the main test.
+		t.Run("group", func(t *testing.T) {
+			t.Run(dir, func(t *testing.T) {
+				t.Parallel()
+
+				tgHclPath := filepath.Join(tmpPath, dir)
+				actual, err := ioutil.ReadFile(tgHclPath)
+				require.NoError(t, err)
+				assert.Equal(t, expected, actual)
+			})
+		})
+	}
+}

--- a/test/fixture-hclfmt-errors/dangling-attribute/terragrunt.hcl
+++ b/test/fixture-hclfmt-errors/dangling-attribute/terragrunt.hcl
@@ -1,0 +1,2 @@
+# Dangling attribute, where no value is set
+inputs =

--- a/test/fixture-hclfmt-errors/invalid-character/terragrunt.hcl
+++ b/test/fixture-hclfmt-errors/invalid-character/terragrunt.hcl
@@ -1,0 +1,2 @@
+# Invalid starting character
+$foo = "bar"

--- a/test/fixture-hclfmt-errors/invalid-key/terragrunt.hcl
+++ b/test/fixture-hclfmt-errors/invalid-key/terragrunt.hcl
@@ -1,0 +1,2 @@
+# Invalid key
+foo.bar.baz = "xyz"

--- a/test/fixture-hclfmt/a/b/c/terragrunt.hcl
+++ b/test/fixture-hclfmt/a/b/c/terragrunt.hcl
@@ -5,4 +5,9 @@ inputs = {
 
   inputs = "disjoint"
   disjoint = true
+
+  listInput = [
+"foo",
+"bar",
+]
 }

--- a/test/fixture-hclfmt/a/b/c/terragrunt.hcl
+++ b/test/fixture-hclfmt/a/b/c/terragrunt.hcl
@@ -1,0 +1,8 @@
+inputs = {
+# comments
+  foo =                               "bar"
+  bar="baz"
+
+  inputs = "disjoint"
+  disjoint = true
+}

--- a/test/fixture-hclfmt/a/terragrunt.hcl
+++ b/test/fixture-hclfmt/a/terragrunt.hcl
@@ -5,4 +5,9 @@ inputs = {
 
   inputs = "disjoint"
   disjoint = true
+
+  listInput = [
+"foo",
+"bar",
+]
 }

--- a/test/fixture-hclfmt/a/terragrunt.hcl
+++ b/test/fixture-hclfmt/a/terragrunt.hcl
@@ -1,0 +1,8 @@
+inputs = {
+# comments
+  foo =                               "bar"
+  bar="baz"
+
+  inputs = "disjoint"
+  disjoint = true
+}

--- a/test/fixture-hclfmt/expected.hcl
+++ b/test/fixture-hclfmt/expected.hcl
@@ -1,8 +1,13 @@
 inputs = {
-  # comments 
+  # comments
   foo = "bar"
   bar = "baz"
 
   inputs   = "disjoint"
   disjoint = true
+
+  listInput = [
+    "foo",
+    "bar",
+  ]
 }

--- a/test/fixture-hclfmt/expected.hcl
+++ b/test/fixture-hclfmt/expected.hcl
@@ -1,0 +1,8 @@
+inputs = {
+  # comments 
+  foo = "bar"
+  bar = "baz"
+
+  inputs   = "disjoint"
+  disjoint = true
+}

--- a/test/fixture-hclfmt/terragrunt.hcl
+++ b/test/fixture-hclfmt/terragrunt.hcl
@@ -5,4 +5,9 @@ inputs = {
 
   inputs = "disjoint"
   disjoint = true
+
+  listInput = [
+"foo",
+"bar",
+]
 }

--- a/test/fixture-hclfmt/terragrunt.hcl
+++ b/test/fixture-hclfmt/terragrunt.hcl
@@ -1,0 +1,8 @@
+inputs = {
+# comments
+  foo =                               "bar"
+  bar="baz"
+
+  inputs = "disjoint"
+  disjoint = true
+}


### PR DESCRIPTION
According to https://github.com/hashicorp/terraform/pull/22092, it seems unlikely that `terraform fmt` would support formatting `terragrunt.hcl` directly. In that PR, it was suggested that [we should standardize to using `hclfmt`](https://github.com/hashicorp/terraform/pull/22092#issuecomment-512028847). However, this is an additional utility that one needs to install, not to mention that it is not officially released yet.

As such, this PR bakes the functionality of `hclfmt` as a sub command of `terragrunt`, so that you can run `terragrunt hclfmt` to format your `terragrunt.hcl` files in the directory tree.

Reference: https://github.com/gruntwork-io/terragrunt/issues/768