### PR TITLE
Fixing gcs bucket checking when credentials are provided

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -611,6 +611,7 @@
     "github.com/zclconf/go-cty/cty/json",
     "golang.org/x/crypto/ssh/terminal",
     "google.golang.org/api/iterator",
+    "google.golang.org/api/option",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -616,7 +616,8 @@ they don't already exist:
   state storage and the `bucket` you specify in `remote_state.config` doesn't already exist, Terragrunt will create it
   automatically, with [versioning](https://cloud.google.com/storage/docs/object-versioning) enabled. For this to work
   correctly you must also specify `project` and `location` keys in `remote_state.config`, so terragrunt knows where to
-  create the bucket.
+  create the bucket. If you don't want to check if bucket already exist you can set `skip_bucket_creation` to `true` and terragrunt will assume that the bucket is already created.
+  If you don't specify `bucket` in `remote_state` then terragrunt will assume that you will pass `bucket` through `-backend-config` in `extra_arguments`.
 
   We also strongly recommend you enable [Cloud Audit Logs](https://cloud.google.com/storage/docs/access-logs) to audit
   and track API operations performed against the state bucket.

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ they don't already exist:
   state storage and the `bucket` you specify in `remote_state.config` doesn't already exist, Terragrunt will create it
   automatically, with [versioning](https://cloud.google.com/storage/docs/object-versioning) enabled. For this to work
   correctly you must also specify `project` and `location` keys in `remote_state.config`, so terragrunt knows where to
-  create the bucket. If you don't want to check if bucket already exist you can set `skip_bucket_creation` to `true` and terragrunt will assume that the bucket is already created.
+  create the bucket. You will also need to specify either If you don't specify `remote_state.credentials` or set `GOOGLE_APPLICATION_CREDENTIALS`. If you don't want to check if bucket already exist you can set `skip_bucket_creation` to `true` and terragrunt will assume that the bucket is already created.
   If you don't specify `bucket` in `remote_state` then terragrunt will assume that you will pass `bucket` through `-backend-config` in `extra_arguments`.
 
   We also strongly recommend you enable [Cloud Audit Logs](https://cloud.google.com/storage/docs/access-logs) to audit


### PR DESCRIPTION
This PR:
* if specified use `remote_state.config.credentials` to check if GCS bucket exist. If not specified assume `GOOGLE_APPLICATION_CREDENTIALS` is assumed.
* Remove throwing error if `remote_state.config.bucket` is not specified.
* if `remote_state.config.bucket` is not specified assume that it is specified through `extra_arguments ` `-backend-config` variable.

This PR addressed https://github.com/gruntwork-io/terragrunt/issues/780.