### PR TITLE
hclfmt should run before parsing the terragrunt config

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -232,6 +232,10 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		return shell.RunTerraformCommand(terragruntOptions, terragruntOptions.TerraformCliArgs...)
 	}
 
+	if shouldRunHCLFmt(terragruntOptions) {
+		return runHCLFmt(terragruntOptions)
+	}
+
 	terragruntConfig, err := config.ReadTerragruntConfig(terragruntOptions)
 
 	if err != nil {
@@ -292,10 +296,6 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		}
 		fmt.Fprintf(terragruntOptions.Writer, "%s\n", b)
 		return nil
-	}
-
-	if shouldRunHCLFmt(terragruntOptions) {
-		return runHCLFmt(terragruntOptions)
 	}
 
 	if err := checkFolderContainsTerraformCode(terragruntOptions); err != nil {


### PR DESCRIPTION
The formatting tool should not be concerned with decoding the terragrunt config, and should only deal with HCL2 syntax errors.