### PR TITLE
fix: reorg cli arguments

### DIFF
--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -77,7 +77,7 @@ func (stack *Stack) Apply(terragruntOptions *options.TerragruntOptions) error {
 // Destroy all the modules in the given stack, making sure to destroy the dependencies of each module in the stack in
 // the proper order.
 func (stack *Stack) Destroy(terragruntOptions *options.TerragruntOptions) error {
-	stack.setTerraformCommand([]string{"destroy", "-force", "-input=false"})
+	stack.setTerraformCommand([]string{"destroy", "-input=false", "-auto-approve"})
 	return RunModulesReverseOrder(stack.Modules)
 }
 

--- a/options/options.go
+++ b/options/options.go
@@ -235,8 +235,8 @@ func (terragruntOptions *TerragruntOptions) InsertTerraformCliArgs(argsToInsert 
 	// command is either 1 word or 2 words
 	var args []string
 	args = append(args, terragruntOptions.TerraformCliArgs[:commandLength]...)
-	args = append(args, argsToInsert...)
 	args = append(args, terragruntOptions.TerraformCliArgs[commandLength:]...)
+	args = append(args, argsToInsert...)
 	terragruntOptions.TerraformCliArgs = args
 }
 


### PR DESCRIPTION
Related to https://github.com/gruntwork-io/terragrunt/issues/454

This fix follows the recommendation mentioned in this comment https://github.com/gruntwork-io/terragrunt/issues/454#issuecomment-450831599 where we reorganize the hardcoded options `-input=false -auto-approve` to avoid the following error:

```
Running command: terraform apply terraform.tfplan -input=false -auto-approve
Too many command line arguments. Configuration path expected.
```

So we end instead with the following order in the command

```
terraform apply -input=false -auto-approve terraform.tfplan
```

Which follows the `terraform` help usage for the apply command `Usage: terraform apply [options] [DIR-OR-PLAN]`

This is the requested `gist` with the result of running the tests: https://gist.github.com/zot24/b6b2d90ba1b5b1008602dc0b8b031809 however there are a bunch of failing test that I don't see how those might be related with these changes :/ if someone can point me out in the right direction here if you thing they are I'll be happy to go over those

---

**Note:** there is a minor change as well added to this PR which is the swap of `-force` by `-auto-approve` on the `destroy` command as it will be deprecated in future versions of `terraform` as recommended on `help`

```
  -force                 Deprecated: same as auto-approve.
```