### PR TITLE
RFC Template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,18 +3,31 @@
 Contributions to this repo are very welcome! We follow a fairly standard [pull request 
 process](https://help.github.com/articles/about-pull-requests/) for contributions, subject to the following guidelines:
  
-1. [File a GitHub issue](#file-a-github-issue)
+1. [File a GitHub issue or write an RFC](#file-a-github-issue-or-write-an-rfc)
 1. [Update the documentation](#update-the-documentation)
 1. [Update the tests](#update-the-tests)
 1. [Update the code](#update-the-code)
 1. [Create a pull request](#create-a-pull-request)
 1. [Merge and release](#merge-and-release)
 
-## File a GitHub issue
+## File a GitHub issue or write an RFC
 
 Before starting any work, we recommend filing a GitHub issue in this repo. This is your chance to ask questions and
 get feedback from the maintainers and the community before you sink a lot of time into writing (possibly the wrong) 
 code. If there is anything you're unsure about, just ask!
+
+Sometimes, the scope of the feature proposal is large enough that it requires major updates to the code base to
+implement. In these situations, a maintainer may suggest writing up an RFC that describes the feature in more details
+than what can be reasonably captured in a Github Issue. RFCs are written in markdown and live in the directory
+`_docs/rfc`.
+
+To write an RFC:
+
+- Clone the repository
+- Create a new branch
+- Copy the template (`_docs/rfc/TEMPLATE.md`) to a new file in the same directory.
+- Fill out the template
+- Open a PR for comments, prefixing the title with the term `[RFC]` to indicate that it is an RFC PR.
 
 ## Update the documentation
 

--- a/_docs/rfc/TEMPLATE.md
+++ b/_docs/rfc/TEMPLATE.md
@@ -1,0 +1,44 @@
+# RFC Template
+
+This is a template you can use for proposing new major features to Terragrunt. When creating a new RFC, copy this
+template and fill in each respective section.
+
+**STATUS**: In proposal _(This should be updated when you open a PR for the implementation)_
+
+
+## Background
+
+This section should describe why you need this feature in Terragrunt. This should include a description of:
+
+- The problem you are trying to solve.
+- The reason why Terraform can't solve this problem, or data points that suggest there is a long enough time horizon for
+  implementation that it makes sense to workaround it in Terragrunt.
+- Use cases for the problem. Why is it important that we have this feature?
+
+
+## Proposed solution
+
+This section should describe which solution you are ultimately picking for implementation. This should describe in
+detail how this solution addresses the problem. Additionally, this section should include implementation details. Be
+sure to include code samples so that it is clear how users are intended to use the solution you are proposing!
+
+Note: This section can be left blank in the initial PR, if you are unsure what the best solution is. In this case,
+include all the possible solutions you can think of as a part of the `Alternatives` section below. You can fill this
+section out once you feel confident in a potential approach after discussion on the PR.
+
+
+## Alternatives
+
+This section should describe various options for resolving the problem stated in the `Background` section. Be sure to
+include various alternatives here and not just the one you are ultimately proposing. This helps communicate what
+tradeoffs you are making in picking your solution. Any reasonably complex problem that requires an RFC have multiple
+solutions that appear to be valid, so it helps to be explicit about why certain solutions were not chosen.
+
+
+## References
+
+This section should include any links that are helpful for background reading such as:
+
+- Relevant issues
+- Links to PRs: at a minimum, the initial PR for the RFC, and the implementation PR.
+- Links to Terragrunt releases, if the proposed solution has been implemented.


### PR DESCRIPTION
This proposes a new practice of writing RFCs for proposing reasonably complex Terragrunt features that may be difficult to capture in a single Github Issue.

This PR includes:

- Update to the Contribution guideline to mention RFC practice.
- A template that future RFCs can use. This ensures a standardization of the format and makes sure all the information we expect from RFCs are included.