### PR TITLE
Fix #854: Dependency TerragruntOptions was not updated in cycle check

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -78,7 +78,8 @@ func checkForDependencyBlockCycles(filename string, decodedDependency terragrunt
 	currentTraversalPaths := []string{filename}
 	for _, dependency := range decodedDependency.Dependencies {
 		dependencyPath := cleanDependencyTerragruntConfigPath(filename, dependency.ConfigPath)
-		if err := checkForDependencyBlockCyclesUsingDFS(dependencyPath, &visitedPaths, &currentTraversalPaths, terragruntOptions); err != nil {
+		dependencyOptions := terragruntOptions.Clone(dependencyPath)
+		if err := checkForDependencyBlockCyclesUsingDFS(dependencyPath, &visitedPaths, &currentTraversalPaths, dependencyOptions); err != nil {
 			return err
 		}
 	}
@@ -109,7 +110,9 @@ func checkForDependencyBlockCyclesUsingDFS(
 		return err
 	}
 	for _, dependency := range dependencyPaths {
-		if err := checkForDependencyBlockCyclesUsingDFS(cleanDependencyTerragruntConfigPath(currentConfigPath, dependency), visitedPaths, currentTraversalPaths, terragruntOptions); err != nil {
+		nextPath := cleanDependencyTerragruntConfigPath(currentConfigPath, dependency)
+		nextOptions := terragruntOptions.Clone(nextPath)
+		if err := checkForDependencyBlockCyclesUsingDFS(nextPath, visitedPaths, currentTraversalPaths, nextOptions); err != nil {
 			return err
 		}
 	}

--- a/test/fixture-get-output/regression-854/root/environments/network/main.tf
+++ b/test/fixture-get-output/regression-854/root/environments/network/main.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = 42
+}

--- a/test/fixture-get-output/regression-854/root/environments/network/terragrunt.hcl
+++ b/test/fixture-get-output/regression-854/root/environments/network/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = "../../terragrunt.hcl"
+}

--- a/test/fixture-get-output/regression-854/root/environments/web/main.tf
+++ b/test/fixture-get-output/regression-854/root/environments/web/main.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = 42
+}

--- a/test/fixture-get-output/regression-854/root/environments/web/sg/main.tf
+++ b/test/fixture-get-output/regression-854/root/environments/web/sg/main.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = 42
+}

--- a/test/fixture-get-output/regression-854/root/environments/web/sg/terragrunt.hcl
+++ b/test/fixture-get-output/regression-854/root/environments/web/sg/terragrunt.hcl
@@ -1,0 +1,7 @@
+include {
+  path = "../../../terragrunt.hcl"
+}
+
+dependency "network" {
+  config_path = "../../network"
+}

--- a/test/fixture-get-output/regression-854/root/environments/web/terragrunt.hcl
+++ b/test/fixture-get-output/regression-854/root/environments/web/terragrunt.hcl
@@ -1,0 +1,11 @@
+include {
+  path = "../../terragrunt.hcl"
+}
+
+dependency "network" {
+  config_path = "../network"
+}
+
+dependency "sg" {
+  config_path = "./sg"
+}

--- a/test/fixture-get-output/regression-854/root/terragrunt.hcl
+++ b/test/fixture-get-output/regression-854/root/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1832,6 +1832,29 @@ func TestDependencyOutputCycleHandling(t *testing.T) {
 	}
 }
 
+// Regression testing for https://github.com/gruntwork-io/terragrunt/issues/854: Referencing a dependency that is a
+// subdirectory of the current config, which includes an `include` block has problems resolving the correct relative
+// path.
+func TestDependencyOutputRegression854(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_GET_OUTPUT)
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_GET_OUTPUT)
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "regression-854", "root")
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := runTerragruntCommand(
+		t,
+		fmt.Sprintf("terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath),
+		&stdout,
+		&stderr,
+	)
+	logBufferContentsLineByLine(t, stdout, "stdout")
+	logBufferContentsLineByLine(t, stderr, "stderr")
+	require.NoError(t, err)
+}
+
 func logBufferContentsLineByLine(t *testing.T, out bytes.Buffer, label string) {
 	t.Logf("[%s] Full contents of %s:", t.Name(), label)
 	lines := strings.Split(out.String(), "\n")


### PR DESCRIPTION
This fixes the bug identified in #854. Specifically, the cycle logic was not properly updating `TerragruntOptions.TerragruntConfigPath` each time it recursed through the dependencies. This caused the subsequent parsing of `include` blocks to fail because it was appending the path to the wrong reference point.