### PR TITLE
[WIP] Use a DAG to resolve `locals`, `globals`, and `include`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -242,11 +242,12 @@
   revision = "318e80eefe28c3aa01b434c61bcf4c83a0cc6b25"
 
 [[projects]]
-  digest = "1:93a7a26ca378c3e071b5f1477b98aea19e4e038da6e3baad91225b76bf4cce7e"
+  digest = "1:3959a3507d970eb64414055c11e53d8505a42becd4843a376692f112cd84347e"
   name = "github.com/hashicorp/terraform"
   packages = [
     "addrs",
     "configs/configschema",
+    "dag",
     "helper/didyoumean",
     "lang",
     "lang/blocktoattr",
@@ -599,6 +600,7 @@
     "github.com/hashicorp/hcl2/hcl/hclsyntax",
     "github.com/hashicorp/hcl2/hclparse",
     "github.com/hashicorp/hcl2/hclwrite",
+    "github.com/hashicorp/terraform/dag",
     "github.com/hashicorp/terraform/lang",
     "github.com/mattn/go-zglob",
     "github.com/mitchellh/mapstructure",

--- a/config/config_graph.go
+++ b/config/config_graph.go
@@ -1,0 +1,270 @@
+package config
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
+)
+import "github.com/hashicorp/terraform/dag"
+
+const locals = "locals"
+const local = "local"
+const globals = "globals"
+const global = "global"
+const include = "include"
+const path = "path"
+
+type RootVertex struct {
+}
+
+type VariableVertex struct {
+	Type string
+	Name string
+	Expr hcl.Expression
+}
+
+// basicEdge is a basic implementation of Edge that has the source and
+// target vertex.
+type BasicEdge struct {
+	S, T dag.Vertex
+}
+
+func (e *BasicEdge) Hashcode() interface{} {
+	return fmt.Sprintf("%p-%p", e.S, e.T)
+}
+
+func (e *BasicEdge) Source() dag.Vertex {
+	return e.S
+}
+
+func (e *BasicEdge) Target() dag.Vertex {
+	return e.T
+}
+
+func getValuesFromHclFile(file *hcl.File) map[string]map[string]cty.Value {
+	localsBlock, globalsBlock, includeBlock, _ := getBlocks(file)
+	graph := dag.AcyclicGraph{}
+	root := RootVertex{}
+
+	verticies := map[string]map[string]VariableVertex{
+		local: {},
+		global: {},
+		include: {},
+	}
+
+	// Add root vertex
+	graph.Add(root)
+
+	// TODO: diagnostics
+	_ = addVerticies(graph, verticies[local], local, localsBlock)
+	_ = addVerticies(graph, verticies[global], global, globalsBlock)
+	_ = addVerticies(graph, verticies[include], include, includeBlock)
+
+	// TODO validate include
+	_ = addEdges(graph, root, verticies, local, localsBlock)
+	_ = addEdges(graph, root, verticies, global, globalsBlock)
+	_ = addEdges(graph, root, verticies, include, includeBlock)
+
+	// TODO: diagnostics
+
+
+	// TODO: validate that includes only depend on locals
+
+	values := map[string]map[string]cty.Value{
+		local: {},
+		global: {},
+		include: {},
+	}
+
+	err := graph.Validate()
+	if err != nil {
+		panic(err)
+	}
+
+	graph.TransitiveReduction()
+
+	diags := hcl.Diagnostics{}
+	walkBreadthFirst(&graph, root, func(v dag.Vertex) (shouldContinue bool) {
+
+		if _, isRoot := v.(RootVertex); isRoot {
+			return true
+		}
+
+		vertex, ok := v.(VariableVertex)
+		if !ok {
+			// TODO: diags
+			return false
+		}
+
+		valuesCty, err := convertValuesToVariables(values)
+		if err != nil {
+			// TODO
+			return false
+		}
+
+		ctx := hcl.EvalContext{
+			Variables: *valuesCty,
+		}
+
+		value, currentDiags := vertex.Expr.Value(&ctx)
+		if currentDiags != nil && currentDiags.HasErrors() {
+			diags = diags.Extend(currentDiags)
+			return false
+		}
+
+		switch vertex.Type {
+		case local, global:
+			values[vertex.Type][vertex.Name] = value
+		case include:
+			values[include] = map[string]cty.Value{
+				"relative": cty.StringVal("relative/path"),
+			}
+		default:
+			// TODO
+			return false
+		}
+
+		return true
+	})
+
+	return values
+}
+
+func getBlocks(file *hcl.File) (hcl.Body, hcl.Body, hcl.Body, hcl.Diagnostics) {
+	blocksSchema := &hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{
+			{Type: "locals"},
+			{Type: "globals"},
+			{Type: "include"},
+		},
+	}
+
+	// TODO: err, diags
+	parsedBlocks, _, diags := file.Body.PartialContent(blocksSchema)
+	blocksByType := map[string][]*hcl.Block{}
+
+	for _, block := range parsedBlocks.Blocks {
+		if block.Type == locals || block.Type == globals || block.Type == include {
+			blocks := blocksByType[block.Type]
+			if blocks == nil {
+				blocks = []*hcl.Block{}
+			}
+
+			blocksByType[block.Type] = append(blocks, block)
+		}
+	}
+
+	// TODO: validate blocks
+
+	return blocksByType[locals][0].Body, blocksByType[globals][0].Body, blocksByType[include][0].Body, diags
+}
+
+func addVerticies(graph dag.AcyclicGraph, verticies map[string]VariableVertex, typ string, block hcl.Body) hcl.Diagnostics {
+	attrs, diags := block.JustAttributes()
+	if diags != nil && diags.HasErrors() {
+		return diags
+	}
+
+	for name, attr := range attrs {
+		vertex := VariableVertex{
+			Type: typ,
+			Name: name,
+			Expr: attr.Expr,
+		}
+		verticies[name] = vertex
+		graph.Add(vertex)
+	}
+
+	return nil
+}
+
+func addEdges(graph dag.AcyclicGraph, root RootVertex, verticies map[string]map[string]VariableVertex, typ string, block hcl.Body) hcl.Diagnostics {
+	attrs, _ := block.JustAttributes()
+	for targetName := range attrs {
+		target := verticies[typ][targetName]
+		variables := target.Expr.Variables()
+
+		if variables == nil || len(variables) <= 0 {
+			graph.Connect(&BasicEdge{
+				S: root,
+				T: target,
+			})
+			continue
+		}
+
+		for _, variable := range variables {
+			// TODO: validation
+			sourceType := variable.RootName()
+			switch sourceType {
+			case local, global:
+				sourceName := variable[1].(hcl.TraverseAttr).Name
+				source, exists := verticies[sourceType][sourceName]
+				if !exists {
+					// TODO
+					return hcl.Diagnostics{}
+				}
+
+				graph.Connect(&BasicEdge{
+					S: source,
+					T: target,
+				})
+			case include:
+				// TODO validate options
+				graph.Connect(&BasicEdge{
+					S: verticies[include][path],
+					T: target,
+				})
+			default:
+				// TODO
+				return hcl.Diagnostics{}
+			}
+		}
+	}
+
+	return nil
+}
+
+func walkBreadthFirst(g *dag.AcyclicGraph, root dag.Vertex, cb func(vertex dag.Vertex) (shouldContinue bool)) {
+	visited := map[dag.Vertex]struct{}{}
+	queue := []dag.Vertex{root}
+
+	for len(queue) > 0 {
+		v := queue[0]
+		queue = queue[1:] // pop
+
+		if _, contained := visited[v]; !contained {
+			visited[v] = struct{}{}
+			shouldContinue := cb(v)
+
+			if shouldContinue {
+				for _, child := range g.DownEdges(v).List() {
+					queue = append(queue, child)
+				}
+			}
+		}
+	}
+}
+
+func convertValuesToVariables(values map[string]map[string]cty.Value) (*map[string]cty.Value, error) {
+	variables := map[string]cty.Value{}
+	for k, v := range values {
+		variable, err := gocty.ToCtyValue(v, generateTypeFromMap(v))
+		if err != nil {
+			return nil, errors.WithStackTrace(err)
+		}
+
+		variables[k] = variable
+	}
+
+	return &variables, nil
+}
+
+func generateTypeFromMap(value map[string]cty.Value) cty.Type {
+	typeMap := map[string]cty.Type{}
+	for k, v := range value {
+		typeMap[k] = v.Type()
+	}
+	return cty.Object(typeMap)
+}

--- a/config/config_graph.go
+++ b/config/config_graph.go
@@ -3,158 +3,336 @@ package config
 import (
 	"fmt"
 	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hclparse"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
+	"path/filepath"
 )
 import "github.com/hashicorp/terraform/dag"
 
-const locals = "locals"
 const local = "local"
-const globals = "globals"
 const global = "global"
 const include = "include"
-const path = "path"
 
-type RootVertex struct {
+type rootVertex struct {
 }
 
-type VariableVertex struct {
-	Type string
-	Name string
-	Expr hcl.Expression
+type variableVertex struct {
+	Evaluator *configEvaluator
+	Type   string
+	Name   string
+	Expr   hcl.Expression
+	Evaluated bool
 }
 
-// BasicEdge is a basic implementation of Edge that has the source and
+// basicEdge is a basic implementation of Edge that has the source and
 // target vertex.
-type BasicEdge struct {
+type basicEdge struct {
 	S, T dag.Vertex
 }
 
-func (e *BasicEdge) Hashcode() interface{} {
+func (e *basicEdge) Hashcode() interface{} {
 	return fmt.Sprintf("%p-%p", e.S, e.T)
 }
 
-func (e *BasicEdge) Source() dag.Vertex {
+func (e *basicEdge) Source() dag.Vertex {
 	return e.S
 }
 
-func (e *BasicEdge) Target() dag.Vertex {
+func (e *basicEdge) Target() dag.Vertex {
 	return e.T
+}
+
+type evaluatorGlobals struct {
+	options  *options.TerragruntOptions
+	parser   *hclparse.Parser
+	graph    dag.AcyclicGraph
+	root     rootVertex
+	vertices map[string]variableVertex
+	values   map[string]cty.Value
+}
+
+type configEvaluator struct {
+	globals evaluatorGlobals
+
+	configPath   string
+	configFile   *hcl.File
+
+	localVertices  map[string]variableVertex
+	localValues    map[string]cty.Value
+	includeVertex  *variableVertex
+	includePath    *string
+	includeValue   *map[string]cty.Value
+}
+
+type EvaluationResult struct {
+	ConfigFile *hcl.File
+	Variables  map[string]cty.Value
+}
+
+func newConfigEvaluator(configPath string, globals evaluatorGlobals, includeValue *map[string]cty.Value) *configEvaluator {
+	eval := configEvaluator{}
+	eval.globals = globals
+	eval.configPath = configPath
+
+	eval.localVertices = map[string]variableVertex{}
+	eval.localValues = map[string]cty.Value{}
+
+	eval.includeVertex = nil
+	eval.includeValue = includeValue
+
+	return &eval
 }
 
 // Evaluation Steps:
 // 1. Parse child HCL, extract locals, globals, and include
 // 2. Add vertices for child locals, globals, and include
-// 3. Add edges for child variables based on interpolations used, creating verticies with empty expressions for missing globals
-// 4. Verify and reduce graph
-// 5. Walk reverse from include vertex to root, collect vertices into list, and evaluate down to include - verify no globals are used
-// 6. Find parent HCL, parse, and extract locals and globals
+// 3. Add edges for child variables based on interpolations used
+//     a. When encountering globals that aren't defined in this config, create a vertex for them with an empty expression
+// 4. Verify DAG and reduce graph
+//     a. Verify no globals are used in path to include (if exists)
+// 5. Evaluate everything except globals
+// 6. If include exists, find parent HCL, parse, and extract locals and globals
 // 7. Add vertices for parent locals
-// 8. Add vertices for parent globals that don't already exist, or add expressions to empty globals, noting that they have to be evaluated with the parent locals
-// 9. Verify that there are no globals that are empty.
-// 10. Verify and reduce graph
-// 11. Evaluate everything, skipping things that were evaluated in (5)
-func getValuesFromHclFile(file *hcl.File) map[string]map[string]cty.Value {
-	localsBlock, globalsBlock, includeBlock, _ := getBlocks(file)
-	graph := dag.AcyclicGraph{}
-	root := RootVertex{}
-
-	vertices := map[string]map[string]VariableVertex{
-		local: {},
-		global: {},
-		include: {},
+// 8. Add vertices for parent globals that don't already exist, or add expressions to empty globals
+// 9. Verify and reduce graph
+//     a. Verify that there are no globals that are empty.
+// 10. Evaluate everything, skipping things that were evaluated in (5)
+func ParseConfigVariables(filename string, terragruntOptions *options.TerragruntOptions) (*EvaluationResult, *EvaluationResult, error) {
+	globals := evaluatorGlobals{
+		options:  terragruntOptions,
+		parser:   hclparse.NewParser(),
+		graph:    dag.AcyclicGraph{},
+		root:     rootVertex{},
+		vertices: map[string]variableVertex{},
+		values:   map[string]cty.Value{},
 	}
 
-	// Add root vertex
-	graph.Add(root)
+	// Add root of graph
+	globals.graph.Add(globals.root)
 
-	// TODO: diagnostics
-	_ = addVerticies(graph, vertices[local], local, localsBlock)
-	_ = addVerticies(graph, vertices[global], global, globalsBlock)
-	_ = addVerticies(graph, vertices[include], include, includeBlock)
+	child := *newConfigEvaluator(filename, globals, nil)
+	var childResult *EvaluationResult = nil
+
+	// 1, 2, 3, 4
+	err := child.parseConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// 5
+	diags := globals.evaluateVariables(false)
+	if diags != nil {
+		return nil, nil, diags
+	}
+
+	var parent *configEvaluator = nil
+	var parentResult *EvaluationResult = nil
+	if child.includePath != nil {
+		// 6, 7, 8, 9
+		parent = newConfigEvaluator(*child.includePath, globals, child.includeValue)
+		err = (*parent).parseConfig()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// 10
+	diags = globals.evaluateVariables(true)
+	if diags != nil {
+		return nil, nil, diags
+	}
+
+	childResult, err = child.toResult()
+	if err != nil {
+		return nil, nil, err
+	}
+	if parent != nil {
+		parentResult, err = parent.toResult()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return childResult, parentResult, nil
+}
+
+func (eval *configEvaluator) parseConfig() error {
+	configString, err := util.ReadFileAsString(eval.configPath)
+	if err != nil {
+		return err
+	}
+
+	configFile, err := parseHcl(eval.globals.parser, configString, eval.configPath)
+	if err != nil {
+		return err
+	}
+
+	eval.configFile = configFile
+
+	localsBlock, globalsBlock, includeBlock, diags := eval.getBlocks(configFile)
+	if diags != nil && diags.HasErrors() {
+		return diags
+	}
+
+	var addedVertices []variableVertex
+	err = eval.addVertices(local, localsBlock, func(vertex variableVertex) error {
+		eval.localVertices[vertex.Name] = vertex
+		addedVertices = append(addedVertices, vertex)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if includeBlock != nil {
+		err = eval.addVertices(include, includeBlock, func(vertex variableVertex) error {
+			// TODO: validate include name and ensure only setting this once
+			eval.includeVertex = &vertex
+			addedVertices = append(addedVertices, vertex)
+			return nil
+		})
+	}
+	if err != nil {
+		return err
+	}
+	err = eval.addVertices(global, globalsBlock, func(vertex variableVertex) error {
+		eval.globals.vertices[vertex.Name] = vertex
+		addedVertices = append(addedVertices, vertex)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
 
 	// TODO validate include
-	_ = addEdges(graph, root, vertices, local, localsBlock)
-	_ = addEdges(graph, root, vertices, global, globalsBlock)
-	_ = addEdges(graph, root, vertices, include, includeBlock)
 
-	// TODO: diagnostics
-
+	err = eval.addAllEdges(eval.localVertices)
+	if err != nil {
+		return err
+	}
+	if eval.includeVertex != nil {
+		err = eval.addEdges(*eval.includeVertex)
+		if err != nil {
+			return err
+		}
+	}
+	err = eval.addAllEdges(eval.globals.vertices)
+	if err != nil {
+		return err
+	}
 
 	// TODO: validate that includes only depend on locals
 
-	values := map[string]map[string]cty.Value{
-		local: {},
-		global: {},
-		include: {},
-	}
-
-	err := graph.Validate()
+	err = eval.globals.graph.Validate()
 	if err != nil {
-		panic(err)
+		return err
 	}
 
-	graph.TransitiveReduction()
+	eval.globals.graph.TransitiveReduction()
 
-	diags := hcl.Diagnostics{}
-	walkBreadthFirst(&graph, root, func(v dag.Vertex) (shouldContinue bool) {
-
-		if _, isRoot := v.(RootVertex); isRoot {
-			return true
-		}
-
-		vertex, ok := v.(VariableVertex)
-		if !ok {
-			// TODO: diags
-			return false
-		}
-
-		valuesCty, err := convertValuesToVariables(values)
-		if err != nil {
-			// TODO
-			return false
-		}
-
-		ctx := hcl.EvalContext{
-			Variables: *valuesCty,
-		}
-
-		value, currentDiags := vertex.Expr.Value(&ctx)
-		if currentDiags != nil && currentDiags.HasErrors() {
-			diags = diags.Extend(currentDiags)
-			return false
-		}
-
-		switch vertex.Type {
-		case local, global:
-			values[vertex.Type][vertex.Name] = value
-		case include:
-			values[include] = map[string]cty.Value{
-				"relative": cty.StringVal("relative/path"),
-			}
-		default:
-			// TODO
-			return false
-		}
-
-		return true
-	})
-
-	return values
+	return nil
 }
 
-func getBlocks(file *hcl.File) (hcl.Body, hcl.Body, hcl.Body, hcl.Diagnostics) {
+func (eval *configEvaluator) evaluateVariable(vertex variableVertex, diags hcl.Diagnostics, evaluateGlobals bool) bool {
+	if vertex.Type == global && !evaluateGlobals {
+		return false
+	}
+
+	if vertex.Evaluated {
+		return true
+	}
+
+	valuesCty, err := eval.convertValuesToVariables()
+	if err != nil {
+		// TODO: diags.Extend(??)
+		return false
+	}
+
+	ctx := hcl.EvalContext{
+		Variables: valuesCty,
+	}
+
+	value, currentDiags := vertex.Expr.Value(&ctx)
+	if currentDiags != nil && currentDiags.HasErrors() {
+		_ = diags.Extend(currentDiags)
+		return false
+	}
+
+	vertex.Evaluated = true
+
+	switch vertex.Type {
+	case global:
+		eval.globals.values[vertex.Name] = value
+
+	case local:
+		eval.localValues[vertex.Name] = value
+	case include:
+		includePath, includeValue, err := eval.evaluateInclude(value)
+		if err != nil {
+			// TODO: diags.Extend(??)
+			return false
+		}
+
+		eval.includePath = &includePath
+		eval.includeValue = &includeValue
+	default:
+		// TODO: diags.Extend(??)
+		return false
+	}
+
+	return true
+}
+
+func (eval *configEvaluator) evaluateInclude(value cty.Value) (string, map[string]cty.Value, error) {
+	// TODO: validate this is a string?
+	includePath := value.AsString()
+	configPath := eval.configPath
+
+	if includePath == "" {
+		return "", nil, IncludedConfigMissingPath(configPath)
+	}
+
+	childConfigPathAbs, err := filepath.Abs(configPath)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if !filepath.IsAbs(includePath) {
+		includePath = util.JoinPath(filepath.Dir(childConfigPathAbs), includePath)
+	}
+
+	relative, err := util.GetPathRelativeTo(filepath.Dir(configPath), filepath.Dir(includePath))
+	if err != nil {
+		return "", nil, err
+	}
+
+	includeValue := map[string]cty.Value{
+		"parent": cty.StringVal(filepath.ToSlash(filepath.Dir(includePath))),
+		"relative": cty.StringVal(relative),
+	}
+
+	return includePath, includeValue, nil
+}
+
+func (eval *configEvaluator) getBlocks(file *hcl.File) (hcl.Body, hcl.Body, hcl.Body, hcl.Diagnostics) {
+	const locals = "locals"
+	const globals = "globals"
+
 	blocksSchema := &hcl.BodySchema{
 		Blocks: []hcl.BlockHeaderSchema{
-			{Type: "locals"},
-			{Type: "globals"},
-			{Type: "include"},
+			{Type: locals},
+			{Type: globals},
+			{Type: include},
 		},
 	}
 
-	// TODO: err, diags
 	parsedBlocks, _, diags := file.Body.PartialContent(blocksSchema)
+	if diags != nil && diags.HasErrors() {
+		return nil, nil, nil, diags
+	}
 	blocksByType := map[string][]*hcl.Block{}
 
 	for _, block := range parsedBlocks.Blocks {
@@ -170,75 +348,195 @@ func getBlocks(file *hcl.File) (hcl.Body, hcl.Body, hcl.Body, hcl.Diagnostics) {
 
 	// TODO: validate blocks
 
-	return blocksByType[locals][0].Body, blocksByType[globals][0].Body, blocksByType[include][0].Body, diags
+
+	if _, exists := blocksByType[include]; exists {
+		return blocksByType[locals][0].Body, blocksByType[globals][0].Body, blocksByType[include][0].Body, diags
+	} else {
+		return blocksByType[locals][0].Body, blocksByType[globals][0].Body, nil, diags
+	}
 }
 
-func addVerticies(graph dag.AcyclicGraph, vertices map[string]VariableVertex, typ string, block hcl.Body) hcl.Diagnostics {
+func (eval *configEvaluator) addVertices(vertexType string, block hcl.Body, consumer func(vertex variableVertex) error) error {
 	attrs, diags := block.JustAttributes()
 	if diags != nil && diags.HasErrors() {
 		return diags
 	}
 
 	for name, attr := range attrs {
-		vertex := VariableVertex{
-			Type: typ,
-			Name: name,
-			Expr: attr.Expr,
-		}
-		vertices[name] = vertex
-		graph.Add(vertex)
-	}
+		var vertex *variableVertex = nil
 
-	return nil
-}
-
-func addEdges(graph dag.AcyclicGraph, root RootVertex, vertices map[string]map[string]VariableVertex, typ string, block hcl.Body) hcl.Diagnostics {
-	attrs, _ := block.JustAttributes()
-	for targetName := range attrs {
-		target := vertices[typ][targetName]
-		variables := target.Expr.Variables()
-
-		if variables == nil || len(variables) <= 0 {
-			graph.Connect(&BasicEdge{
-				S: root,
-				T: target,
-			})
-			continue
-		}
-
-		for _, variable := range variables {
-			// TODO: validation
-			sourceType := variable.RootName()
-			switch sourceType {
-			case local, global:
-				sourceName := variable[1].(hcl.TraverseAttr).Name
-				source, exists := vertices[sourceType][sourceName]
-				if !exists {
-					// TODO
-					return hcl.Diagnostics{}
-				}
-
-				graph.Connect(&BasicEdge{
-					S: source,
-					T: target,
-				})
-			case include:
-				// TODO validate options
-				graph.Connect(&BasicEdge{
-					S: vertices[include][path],
-					T: target,
-				})
-			default:
-				// TODO
-				return hcl.Diagnostics{}
+		if vertexType == global {
+			globalVertex, exists := eval.globals.vertices[name]
+			if exists && globalVertex.Expr == nil {
+				// This was referenced by a child but not overridden there
+				vertex = &globalVertex
+				globalVertex.Evaluator = eval
+				globalVertex.Expr = attr.Expr
 			}
 		}
+
+		if vertex == nil {
+			vertex = &variableVertex{
+				Evaluator: eval,
+				Type: vertexType,
+				Name: name,
+				Expr: attr.Expr,
+				Evaluated: false,
+			}
+		}
+
+		eval.globals.graph.Add(*vertex)
+		err := consumer(*vertex)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func walkBreadthFirst(g *dag.AcyclicGraph, root dag.Vertex, cb func(vertex dag.Vertex) (shouldContinue bool)) {
+func (eval *configEvaluator) addAllEdges(vertices map[string]variableVertex) error {
+	for _, vertex := range vertices {
+		err := eval.addEdges(vertex)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (eval *configEvaluator) addEdges(target variableVertex) error {
+	if target.Expr == nil {
+		return nil
+	}
+
+	variables := target.Expr.Variables()
+
+	if variables == nil || len(variables) <= 0 {
+		eval.globals.graph.Connect(&basicEdge{
+			S: eval.globals.root,
+			T: target,
+		})
+		return nil
+	}
+
+	for _, variable := range variables {
+		sourceType, sourceName, err := getVariableRootAndName(variable)
+		if err != nil {
+			return err
+		}
+
+		switch sourceType {
+		case global:
+			source, exists := eval.globals.vertices[sourceName]
+			if !exists {
+				// Could come from parent context, add empty node for now.
+				source = variableVertex{
+					Evaluator: nil,
+					Type: global,
+					Name: sourceName,
+					Expr: nil,
+					Evaluated: false,
+				}
+			}
+			eval.globals.graph.Connect(&basicEdge{
+				S: source,
+				T: target,
+			})
+		case local:
+			source, exists := eval.localVertices[sourceName]
+			if !exists {
+				// TODO: error
+				return nil
+			}
+
+			eval.globals.graph.Connect(&basicEdge{
+				S: source,
+				T: target,
+			})
+		case include:
+			// TODO validate options
+			eval.globals.graph.Connect(&basicEdge{
+				S: eval.includeVertex,
+				T: target,
+			})
+		default:
+			// TODO: error
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func getVariableRootAndName(variable hcl.Traversal) (string, string, error) {
+	// TODO: validation
+	sourceType := variable.RootName()
+	sourceName := variable[1].(hcl.TraverseAttr).Name
+	return sourceType, sourceName, nil
+}
+
+func (eval *configEvaluator) convertValuesToVariables() (map[string]cty.Value, error) {
+	values := map[string]map[string]cty.Value{
+		local: eval.localValues,
+		global: eval.globals.values,
+	}
+
+	if eval.includeValue != nil {
+		values[include] = *eval.includeValue
+	}
+
+	variables := map[string]cty.Value{}
+	for k, v := range values {
+		variable, err := gocty.ToCtyValue(v, generateTypeFromMap(v))
+		if err != nil {
+			return nil, errors.WithStackTrace(err)
+		}
+
+		variables[k] = variable
+	}
+
+	return variables, nil
+}
+
+func (eval *configEvaluator) toResult() (*EvaluationResult, error) {
+	variables, err := eval.convertValuesToVariables()
+	if err != nil {
+		return nil, err
+	}
+
+	return &EvaluationResult{
+		ConfigFile: eval.configFile,
+		Variables:  variables,
+	}, nil
+}
+
+func (globals *evaluatorGlobals) evaluateVariables(evaluateGlobals bool) hcl.Diagnostics {
+	diags := hcl.Diagnostics{}
+
+	walkBreadthFirst(globals.graph, globals.root, func(v dag.Vertex) (shouldContinue bool) {
+		if _, isRoot := v.(rootVertex); isRoot {
+			return true
+		}
+
+		vertex, ok := v.(variableVertex)
+		if !ok {
+			// TODO: diags.Extend(??)
+			return false
+		}
+
+		return vertex.Evaluator.evaluateVariable(vertex, diags, evaluateGlobals)
+	})
+
+	if diags.HasErrors() {
+		return diags
+	}
+
+	return nil
+}
+
+func walkBreadthFirst(g dag.AcyclicGraph, root dag.Vertex, cb func(vertex dag.Vertex) (shouldContinue bool)) {
 	visited := map[dag.Vertex]struct{}{}
 	queue := []dag.Vertex{root}
 
@@ -257,20 +555,6 @@ func walkBreadthFirst(g *dag.AcyclicGraph, root dag.Vertex, cb func(vertex dag.V
 			}
 		}
 	}
-}
-
-func convertValuesToVariables(values map[string]map[string]cty.Value) (*map[string]cty.Value, error) {
-	variables := map[string]cty.Value{}
-	for k, v := range values {
-		variable, err := gocty.ToCtyValue(v, generateTypeFromMap(v))
-		if err != nil {
-			return nil, errors.WithStackTrace(err)
-		}
-
-		variables[k] = variable
-	}
-
-	return &variables, nil
 }
 
 func generateTypeFromMap(value map[string]cty.Value) cty.Type {

--- a/config/config_graph.go
+++ b/config/config_graph.go
@@ -7,11 +7,11 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hcl2/hclparse"
+	"github.com/hashicorp/terraform/dag"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 	"path/filepath"
 )
-import "github.com/hashicorp/terraform/dag"
 
 const local = "local"
 const global = "global"

--- a/config/config_graph_test.go
+++ b/config/config_graph_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"github.com/hashicorp/hcl2/hclparse"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGraphCreation(t *testing.T) {
+	config := `
+locals {
+	full-name = "${local.name}-${local.region}"
+	name = "test"
+	region = "us-east-1"
+}
+globals {
+	region = local.region
+}
+include {
+	path = "../${global.region}/terragrunt.hcl"
+}
+input = {
+	region = global.region
+}
+`
+
+	file, _ := parseHcl(hclparse.NewParser(), config, "terragrunt.hcl")
+	values := getValuesFromHclFile(file)
+	assert.Equal(t,"test-us-east-1", values["local"]["full-name"].AsString())
+}

--- a/test/fixture-config-graph/one/two/three/terragrunt.hcl
+++ b/test/fixture-config-graph/one/two/three/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = "${find_in_parent_folders()}"
+}

--- a/test/fixture-config-graph/one/two/three/terragrunt.hcl
+++ b/test/fixture-config-graph/one/two/three/terragrunt.hcl
@@ -2,11 +2,12 @@ locals {
   full-name = "${local.name}-${local.region}"
   name = "test"
   region = "us-east-1"
-  parent = "${local.parent}/terragrunt.hcl"
+  parent = "${local.parent-dir}/terragrunt.hcl"
   parent-dir = "../../.."
 }
 globals {
   region = local.region
+  source-postfix = "${local.parent}-${include.relative}"
 }
 include {
   path = "${local.parent}"

--- a/test/fixture-config-graph/one/two/three/terragrunt.hcl
+++ b/test/fixture-config-graph/one/two/three/terragrunt.hcl
@@ -1,3 +1,16 @@
+locals {
+  full-name = "${local.name}-${local.region}"
+  name = "test"
+  region = "us-east-1"
+  parent = "${local.parent}/terragrunt.hcl"
+  parent-dir = "../../.."
+}
+globals {
+  region = local.region
+}
 include {
-  path = "${find_in_parent_folders()}"
+  path = "${local.parent}"
+}
+input = {
+  region = global.region
 }

--- a/test/fixture-config-graph/terragrunt.hcl
+++ b/test/fixture-config-graph/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "source"
+}

--- a/test/fixture-config-graph/terragrunt.hcl
+++ b/test/fixture-config-graph/terragrunt.hcl
@@ -1,3 +1,10 @@
+local {
+  source-prefix = "src-"
+}
+globals {
+  region = "us-west-2"
+  source-postfix = null
+}
 terraform {
-  source = "source"
+  source = "${local.source-prefix}${global.source-postfix}"
 }

--- a/test/fixture-config-graph/terragrunt.hcl
+++ b/test/fixture-config-graph/terragrunt.hcl
@@ -1,4 +1,4 @@
-local {
+locals {
   source-prefix = "src-"
 }
 globals {


### PR DESCRIPTION
This is a possible solution to #814.

This PR uses the same DAG that terraform uses to perform dependency resolution.  All `locals`, `globals`, and `include` block attributes are added to the graph, and then edges are generated between nodes by extracting variable references in the attribute's expression (this is supported natively in HCL2).

The graph is then evaluated and updated in a few stages:
1. Child `locals`/`include` are evaluated, to see if an include exists.
2. Parent `locals` and `globals` are added to the graph if a parent is included
3. All variables are evaluated

This allows any variable to depend on any other variable, with a few exceptions:
1. No dependency loops
2. Nothing used in an `include` expression can depend on a `global` variable, necessarily

Docs from the code:
```
// Evaluation Steps:
// 1. Parse child HCL, extract locals, globals, and include
// 2. Add vertices for child locals, globals, and include
// 3. Add edges for child variables based on interpolations used
//     a. When encountering globals that aren't defined in this config, create a vertex for them with an empty expression
// 4. Verify DAG and reduce graph
//     a. Verify no globals are used in path to include (if exists)
// 5. Evaluate everything except globals
// 6. If include exists, find parent HCL, parse, and extract locals and globals
// 7. Add vertices for parent locals
// 8. Add vertices for parent globals that don't already exist, or add expressions to empty globals
// 9. Verify and reduce graph
//     a. Verify that there are no globals that are empty.
// 10. Evaluate everything, skipping things that were evaluated in (5)
```

There's more cleanup/validation/documentation that needs to be done, but a POC can be found in `config/config_graph_test.go` and `test/fixture-config-graph` that shows how a config might be structured with this PR.

Note: `include` now has to be a variable instead of a function because AFAIK there's no way to extract function references from an HCL2 expression.