### PR TITLE
 Fix bug where the context for running terraform output on the child was incorrect

### DIFF
--- a/test/fixture-get-output/localstate/live/child/terragrunt.hcl
+++ b/test/fixture-get-output/localstate/live/child/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../modules/child"
+}
+
+dependency "x" {
+  config_path = "../parent"
+}
+
+inputs = {
+  x = dependency.x.outputs.x
+}

--- a/test/fixture-get-output/localstate/live/parent/terragrunt.hcl
+++ b/test/fixture-get-output/localstate/live/parent/terragrunt.hcl
@@ -1,0 +1,7 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../modules/parent"
+}

--- a/test/fixture-get-output/localstate/live/terragrunt.hcl
+++ b/test/fixture-get-output/localstate/live/terragrunt.hcl
@@ -1,0 +1,6 @@
+remote_state {
+  backend = "local"
+  config = {
+    path = "${path_relative_to_include()}/terraform.tfstate"
+  }
+}

--- a/test/fixture-get-output/localstate/modules/child/main.tf
+++ b/test/fixture-get-output/localstate/modules/child/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "local" {}
+}
+
+variable "x" {}
+
+output "y" {
+  value = var.x * 3
+}

--- a/test/fixture-get-output/localstate/modules/parent/main.tf
+++ b/test/fixture-get-output/localstate/modules/parent/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "local" {}
+}
+
+output "x" {
+  value = 14
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1855,6 +1855,28 @@ func TestDependencyOutputRegression854(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// Regression testing for bug where terragrunt output runs on dependency blocks are done in the terragrunt-cache for the
+// child, not the parent.
+func TestDependencyOutputCachePathBug(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_GET_OUTPUT)
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_GET_OUTPUT)
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "localstate", "live")
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := runTerragruntCommand(
+		t,
+		fmt.Sprintf("terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath),
+		&stdout,
+		&stderr,
+	)
+	logBufferContentsLineByLine(t, stdout, "stdout")
+	logBufferContentsLineByLine(t, stderr, "stderr")
+	require.NoError(t, err)
+}
+
 func logBufferContentsLineByLine(t *testing.T, out bytes.Buffer, label string) {
 	t.Logf("[%s] Full contents of %s:", t.Name(), label)
 	lines := strings.Split(out.String(), "\n")


### PR DESCRIPTION
This fixes the bug reported in https://community.gruntwork.io/t/backend-local-outputs-not-found/341

The main issue was that `terragruntOptions.Clone` doesn't update the `DownloadDir` to be in the context of the dependency config. This causes problems when using local state, as the state is stored in the terragrunt download directory.