### PR TITLE
Obey s3 backend skip_bucket_versioning flag

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -211,8 +211,10 @@ func (s3Initializer S3Initializer) Initialize(remoteState *RemoteState, terragru
 		return err
 	}
 
-	if err := checkIfVersioningEnabled(s3Client, &s3Config, terragruntOptions); err != nil {
-		return err
+	if !s3ConfigExtended.SkipBucketVersioning {
+		if err := checkIfVersioningEnabled(s3Client, &s3Config, terragruntOptions); err != nil {
+			return err
+		}
 	}
 
 	if err := createLockTableIfNecessary(&s3Config, s3ConfigExtended.DynamotableTags, terragruntOptions); err != nil {


### PR DESCRIPTION
Simple patch to ensure that the s3 backend skip_bucket_versioning flag
is obeyed.