### PR TITLE
Check ${TF_DATA_DIR} when looking up Terraform state files

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -588,7 +588,7 @@ func needsInit(terragruntOptions *options.TerragruntOptions, terragruntConfig *c
 
 // Returns true if we need to run `terraform init` to download providers
 func providersNeedInit(terragruntOptions *options.TerragruntOptions) bool {
-	providersPath := util.JoinPath(terragruntOptions.WorkingDir, ".terraform/plugins")
+	providersPath := util.JoinPath(terragruntOptions.DataDir(), "plugins")
 	return !util.FileExists(providersPath)
 }
 
@@ -660,7 +660,7 @@ func runMultiModuleCommand(command string, terragruntOptions *options.Terragrunt
 // modules at all. Detecting if your downloaded modules are out of date (as opposed to missing entirely) is more
 // complicated and not something we handle at the moment.
 func modulesNeedInit(terragruntOptions *options.TerragruntOptions) (bool, error) {
-	modulesPath := util.JoinPath(terragruntOptions.WorkingDir, ".terraform/modules")
+	modulesPath := util.JoinPath(terragruntOptions.DataDir(), "modules")
 	if util.FileExists(modulesPath) {
 		return false, nil
 	}

--- a/options/options.go
+++ b/options/options.go
@@ -250,6 +250,14 @@ func (terragruntOptions *TerragruntOptions) AppendTerraformCliArgs(argsToAppend 
 	terragruntOptions.TerraformCliArgs = append(terragruntOptions.TerraformCliArgs, argsToAppend...)
 }
 
+// DataDir returns Terraform data dir (.terraform by default, overridden by $TF_DATA_DIR envvar)
+func (terragruntOptions *TerragruntOptions) DataDir() string {
+	if tfDataDir, ok := os.LookupEnv("TF_DATA_DIR"); ok {
+		return tfDataDir
+	}
+	return util.JoinPath(terragruntOptions.WorkingDir, ".terraform")
+}
+
 // Custom error types
 
 var RunTerragruntCommandNotSet = fmt.Errorf("The RunTerragrunt option has not been set on this TerragruntOptions object")

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -69,7 +69,7 @@ func (remoteState *RemoteState) Initialize(terragruntOptions *options.Terragrunt
 // 2. Remote state has been configured, but with a different configuration
 // 3. The remote state initializer for this backend type, if there is one, says initialization is necessary
 func (remoteState *RemoteState) NeedsInit(terragruntOptions *options.TerragruntOptions) (bool, error) {
-	state, err := ParseTerraformStateFileFromLocation(remoteState.Backend, remoteState.Config, terragruntOptions.WorkingDir)
+	state, err := ParseTerraformStateFileFromLocation(remoteState.Backend, remoteState.Config, terragruntOptions.WorkingDir, terragruntOptions.DataDir())
 	if err != nil {
 		return false, err
 	}

--- a/remote/terraform_state_file.go
+++ b/remote/terraform_state_file.go
@@ -3,9 +3,10 @@ package remote
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/util"
-	"io/ioutil"
 )
 
 // TODO: this file could be changed to use the Terraform Go code to read state files, but that code is relatively
@@ -16,7 +17,7 @@ import (
 const DEFAULT_PATH_TO_LOCAL_STATE_FILE = "terraform.tfstate"
 
 // When using remote state storage, Terraform keeps a local copy of the state file in this folder
-const DEFAULT_PATH_TO_REMOTE_STATE_FILE = ".terraform/terraform.tfstate"
+const DEFAULT_PATH_TO_REMOTE_STATE_FILE = "terraform.tfstate"
 
 // The structure of the Terraform .tfstate file
 type TerraformState struct {
@@ -48,14 +49,14 @@ func (state *TerraformState) IsRemote() bool {
 // return nil if the file is missing. If the backend is not local then parse the Terraform .tfstate
 // file from the location specified by workingDir. If no location is specified, search the current
 // directory. If the file doesn't exist at any of the default locations, return nil.
-func ParseTerraformStateFileFromLocation(backend string, config map[string]interface{}, workingDir string) (*TerraformState, error) {
+func ParseTerraformStateFileFromLocation(backend string, config map[string]interface{}, workingDir, dataDir string) (*TerraformState, error) {
 	stateFile, ok := config["path"].(string)
 	if backend == "local" && ok && util.FileExists(stateFile) {
 		return ParseTerraformStateFile(stateFile)
 	} else if util.FileExists(util.JoinPath(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE)) {
 		return ParseTerraformStateFile(util.JoinPath(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE))
-	} else if util.FileExists(util.JoinPath(workingDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE)) {
-		return ParseTerraformStateFile(util.JoinPath(workingDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE))
+	} else if util.FileExists(util.JoinPath(dataDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE)) {
+		return ParseTerraformStateFile(util.JoinPath(dataDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE))
 	} else {
 		return nil, nil
 	}

--- a/test/fixture-dirs/main.tf
+++ b/test/fixture-dirs/main.tf
@@ -1,0 +1,6 @@
+terraform {
+}
+
+provider "null" {
+  version = "~> 2.1"
+}


### PR DESCRIPTION
This prevents incessant reinitialization on every invocation of Terragrunt if
TF_DATA_DIR is set

Closes #838