### PR TITLE
Add option to ignore the dependency order during plan-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -2292,6 +2292,8 @@ arguments that start with the prefix `--terragrunt-`. The currently available op
   under these directories (and all dependent modules) will be included during execution of the commands. If a relative
   path is specified, it should be relative from `--terragrunt-working-dir`. Flag can be specified multiple times.
 
+* `--terragrunt-ignore-dependency-order`: Ignore the depedencies between modules when running `*-all` commands.
+
 * `--terragrunt-ignore-external-dependencies`: Dont attempt to include any external dependencies when running `*-all`
   commands
 

--- a/cli/args.go
+++ b/cli/args.go
@@ -83,6 +83,8 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 
 	ignoreDependencyErrors := parseBooleanArg(args, OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ERRORS, false)
 
+	ignoreDependencyOrder := parseBooleanArg(args, OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ORDER, false)
+
 	ignoreExternalDependencies := parseBooleanArg(args, OPT_TERRAGRUNT_IGNORE_EXTERNAL_DEPENDENCIES, false)
 
 	includeExternalDependencies := parseBooleanArg(args, OPT_TERRAGRUNT_INCLUDE_EXTERNAL_DEPENDENCIES, false)
@@ -120,6 +122,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 	opts.Source = terraformSource
 	opts.SourceUpdate = sourceUpdate
 	opts.IgnoreDependencyErrors = ignoreDependencyErrors
+	opts.IgnoreDependencyOrder = ignoreDependencyOrder
 	opts.IgnoreExternalDependencies = ignoreExternalDependencies
 	opts.IncludeExternalDependencies = includeExternalDependencies
 	opts.Writer = writer

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -32,13 +32,14 @@ const OPT_TERRAGRUNT_SOURCE = "terragrunt-source"
 const OPT_TERRAGRUNT_SOURCE_UPDATE = "terragrunt-source-update"
 const OPT_TERRAGRUNT_IAM_ROLE = "terragrunt-iam-role"
 const OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ERRORS = "terragrunt-ignore-dependency-errors"
+const OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ORDER = "terragrunt-ignore-dependency-order"
 const OPT_TERRAGRUNT_IGNORE_EXTERNAL_DEPENDENCIES = "terragrunt-ignore-external-dependencies"
 const OPT_TERRAGRUNT_INCLUDE_EXTERNAL_DEPENDENCIES = "terragrunt-include-external-dependencies"
 const OPT_TERRAGRUNT_EXCLUDE_DIR = "terragrunt-exclude-dir"
 const OPT_TERRAGRUNT_INCLUDE_DIR = "terragrunt-include-dir"
 const OPT_TERRAGRUNT_CHECK = "terragrunt-check"
 
-var ALL_TERRAGRUNT_BOOLEAN_OPTS = []string{OPT_NON_INTERACTIVE, OPT_TERRAGRUNT_SOURCE_UPDATE, OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ERRORS, OPT_TERRAGRUNT_IGNORE_EXTERNAL_DEPENDENCIES, OPT_TERRAGRUNT_INCLUDE_EXTERNAL_DEPENDENCIES, OPT_TERRAGRUNT_NO_AUTO_INIT, OPT_TERRAGRUNT_NO_AUTO_RETRY, OPT_TERRAGRUNT_CHECK}
+var ALL_TERRAGRUNT_BOOLEAN_OPTS = []string{OPT_NON_INTERACTIVE, OPT_TERRAGRUNT_SOURCE_UPDATE, OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ERRORS, OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ORDER, OPT_TERRAGRUNT_IGNORE_EXTERNAL_DEPENDENCIES, OPT_TERRAGRUNT_INCLUDE_EXTERNAL_DEPENDENCIES, OPT_TERRAGRUNT_NO_AUTO_INIT, OPT_TERRAGRUNT_NO_AUTO_RETRY, OPT_TERRAGRUNT_CHECK}
 var ALL_TERRAGRUNT_STRING_OPTS = []string{OPT_TERRAGRUNT_CONFIG, OPT_TERRAGRUNT_TFPATH, OPT_WORKING_DIR, OPT_DOWNLOAD_DIR, OPT_TERRAGRUNT_SOURCE, OPT_TERRAGRUNT_IAM_ROLE, OPT_TERRAGRUNT_EXCLUDE_DIR, OPT_TERRAGRUNT_INCLUDE_DIR}
 
 const CMD_PLAN_ALL = "plan-all"
@@ -135,6 +136,7 @@ GLOBAL OPTIONS:
    terragrunt-source-update                     Delete the contents of the temporary folder to clear out any old, cached source code before downloading new source code into it.
    terragrunt-iam-role             	    	    Assume the specified IAM role before executing Terraform. Can also be set via the TERRAGRUNT_IAM_ROLE environment variable.
    terragrunt-ignore-dependency-errors          *-all commands continue processing components even if a dependency fails.
+   terragrunt-ignore-dependency-order           *-all commands will be run disregarding the dependencies
    terragrunt-ignore-external-dependencies      *-all commands will not attempt to include external dependencies
    terragrunt-include-external-dependencies     *-all commands will include external dependencies
    terragrunt-exclude-dir                       Unix-style glob of directories to exclude when running *-all commands

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -35,6 +35,7 @@ type DependencyOrder int
 const (
 	NormalOrder DependencyOrder = iota
 	ReverseOrder
+	IgnoreOrder
 )
 
 // Create a new RunningModule struct for the given module. This will initialize all fields to reasonable defaults,
@@ -73,6 +74,16 @@ func RunModulesReverseOrder(modules []*TerraformModule) error {
 	return runModules(runningModules)
 }
 
+// Run the given map of module path to runningModule. To "run" a module, execute the RunTerragrunt command in its
+// TerragruntOptions object. The modules will be executed without caring for inter-dependencies.
+func RunModulesIgnoreOrder(modules []*TerraformModule) error {
+	runningModules, err := toRunningModules(modules, IgnoreOrder)
+	if err != nil {
+		return err
+	}
+	return runModules(runningModules)
+}
+
 // Convert the list of modules to a map from module path to a runningModule struct. This struct contains information
 // about executing the module, such as whether it has finished running or not and any errors that happened. Note that
 // this does NOT actually run the module. For that, see the RunModules method.
@@ -95,6 +106,7 @@ func toRunningModules(modules []*TerraformModule, dependencyOrder DependencyOrde
 // * If dependencyOrder is NormalOrder, plug in all the modules M depends on into the Dependencies field and all the
 //   modules that depend on M into the NotifyWhenDone field.
 // * If dependencyOrder is ReverseOrder, do the reverse.
+// * If dependencyOrder is IgnoreOrder, do nothing.
 func crossLinkDependencies(modules map[string]*runningModule, dependencyOrder DependencyOrder) (map[string]*runningModule, error) {
 	for _, module := range modules {
 		for _, dependency := range module.Module.Dependencies {
@@ -105,6 +117,8 @@ func crossLinkDependencies(modules map[string]*runningModule, dependencyOrder De
 			if dependencyOrder == NormalOrder {
 				module.Dependencies[runningDependency.Module.Path] = runningDependency
 				runningDependency.NotifyWhenDone = append(runningDependency.NotifyWhenDone, module)
+			} else if dependencyOrder == IgnoreOrder {
+				// Nothing
 			} else {
 				runningDependency.Dependencies[module.Module.Path] = module
 				module.NotifyWhenDone = append(module.NotifyWhenDone, runningDependency)

--- a/configstack/running_module_test.go
+++ b/configstack/running_module_test.go
@@ -162,6 +162,45 @@ func TestToRunningModulesTwoModulesWithDependenciesReverseOrder(t *testing.T) {
 	testToRunningModules(t, modules, ReverseOrder, expected)
 }
 
+func TestToRunningModulesTwoModulesWithDependenciesIgnoreOrder(t *testing.T) {
+	t.Parallel()
+
+	moduleA := &TerraformModule{
+		Path:              "a",
+		Dependencies:      []*TerraformModule{},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: mockOptions,
+	}
+
+	runningModuleA := &runningModule{
+		Module:         moduleA,
+		Status:         Waiting,
+		Err:            nil,
+		Dependencies:   map[string]*runningModule{},
+		NotifyWhenDone: []*runningModule{},
+	}
+
+	moduleB := &TerraformModule{
+		Path:              "b",
+		Dependencies:      []*TerraformModule{moduleA},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: mockOptions,
+	}
+
+	runningModuleB := &runningModule{
+		Module:         moduleB,
+		Status:         Waiting,
+		Err:            nil,
+		Dependencies:   map[string]*runningModule{},
+		NotifyWhenDone: []*runningModule{},
+	}
+
+	modules := []*TerraformModule{moduleA, moduleB}
+	expected := map[string]*runningModule{"a": runningModuleA, "b": runningModuleB}
+
+	testToRunningModules(t, modules, IgnoreOrder, expected)
+}
+
 func TestToRunningModulesMultipleModulesWithAndWithoutDependencies(t *testing.T) {
 	t.Parallel()
 
@@ -357,6 +396,96 @@ func TestToRunningModulesMultipleModulesWithAndWithoutDependenciesReverseOrder(t
 	testToRunningModules(t, modules, ReverseOrder, expected)
 }
 
+func TestToRunningModulesMultipleModulesWithAndWithoutDependenciesIgnoreOrder(t *testing.T) {
+	t.Parallel()
+
+	moduleA := &TerraformModule{
+		Path:              "a",
+		Dependencies:      []*TerraformModule{},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: mockOptions,
+	}
+
+	runningModuleA := &runningModule{
+		Module:         moduleA,
+		Status:         Waiting,
+		Err:            nil,
+		Dependencies:   map[string]*runningModule{},
+		NotifyWhenDone: []*runningModule{},
+	}
+
+	moduleB := &TerraformModule{
+		Path:              "b",
+		Dependencies:      []*TerraformModule{moduleA},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: mockOptions,
+	}
+
+	runningModuleB := &runningModule{
+		Module:         moduleB,
+		Status:         Waiting,
+		Err:            nil,
+		Dependencies:   map[string]*runningModule{},
+		NotifyWhenDone: []*runningModule{},
+	}
+
+	moduleC := &TerraformModule{
+		Path:              "c",
+		Dependencies:      []*TerraformModule{moduleA},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: mockOptions,
+	}
+
+	runningModuleC := &runningModule{
+		Module:         moduleC,
+		Status:         Waiting,
+		Err:            nil,
+		Dependencies:   map[string]*runningModule{},
+		NotifyWhenDone: []*runningModule{},
+	}
+
+	moduleD := &TerraformModule{
+		Path:              "d",
+		Dependencies:      []*TerraformModule{moduleC},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: mockOptions,
+	}
+
+	runningModuleD := &runningModule{
+		Module:         moduleD,
+		Status:         Waiting,
+		Err:            nil,
+		Dependencies:   map[string]*runningModule{},
+		NotifyWhenDone: []*runningModule{},
+	}
+
+	moduleE := &TerraformModule{
+		Path:              "e",
+		Dependencies:      []*TerraformModule{moduleA, moduleB, moduleC, moduleD},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: mockOptions,
+	}
+
+	runningModuleE := &runningModule{
+		Module:         moduleE,
+		Status:         Waiting,
+		Err:            nil,
+		Dependencies:   map[string]*runningModule{},
+		NotifyWhenDone: []*runningModule{},
+	}
+
+	modules := []*TerraformModule{moduleA, moduleB, moduleC, moduleD, moduleE}
+	expected := map[string]*runningModule{
+		"a": runningModuleA,
+		"b": runningModuleB,
+		"c": runningModuleC,
+		"d": runningModuleD,
+		"e": runningModuleE,
+	}
+
+	testToRunningModules(t, modules, IgnoreOrder, expected)
+}
+
 func testToRunningModules(t *testing.T, modules []*TerraformModule, order DependencyOrder, expected map[string]*runningModule) {
 	actual, err := toRunningModules(modules, order)
 	if assert.Nil(t, err, "For modules %v and order %v", modules, order) {
@@ -420,6 +549,22 @@ func TestRunModulesReverseOrderOneModuleSuccess(t *testing.T) {
 	assert.True(t, aRan)
 }
 
+func TestRunModulesIgnoreOrderOneModuleSuccess(t *testing.T) {
+	t.Parallel()
+
+	aRan := false
+	moduleA := &TerraformModule{
+		Path:              "a",
+		Dependencies:      []*TerraformModule{},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "a", nil, &aRan),
+	}
+
+	err := RunModulesIgnoreOrder([]*TerraformModule{moduleA})
+	assert.Nil(t, err, "Unexpected error: %v", err)
+	assert.True(t, aRan)
+}
+
 func TestRunModulesOneModuleError(t *testing.T) {
 	t.Parallel()
 
@@ -450,6 +595,23 @@ func TestRunModulesReverseOrderOneModuleError(t *testing.T) {
 	}
 
 	err := RunModulesReverseOrder([]*TerraformModule{moduleA})
+	assertMultiErrorContains(t, err, expectedErrA)
+	assert.True(t, aRan)
+}
+
+func TestRunModulesIgnoreOrderOneModuleError(t *testing.T) {
+	t.Parallel()
+
+	aRan := false
+	expectedErrA := fmt.Errorf("Expected error for module a")
+	moduleA := &TerraformModule{
+		Path:              "a",
+		Dependencies:      []*TerraformModule{},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "a", expectedErrA, &aRan),
+	}
+
+	err := RunModulesIgnoreOrder([]*TerraformModule{moduleA})
 	assertMultiErrorContains(t, err, expectedErrA)
 	assert.True(t, aRan)
 }
@@ -517,6 +679,41 @@ func TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess(t *testing.T
 	}
 
 	err := RunModulesReverseOrder([]*TerraformModule{moduleA, moduleB, moduleC})
+	assert.Nil(t, err, "Unexpected error: %v", err)
+
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
+}
+
+func TestRunModulesIgnoreOrderMultipleModulesNoDependenciesSuccess(t *testing.T) {
+	t.Parallel()
+
+	aRan := false
+	moduleA := &TerraformModule{
+		Path:              "a",
+		Dependencies:      []*TerraformModule{},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "a", nil, &aRan),
+	}
+
+	bRan := false
+	moduleB := &TerraformModule{
+		Path:              "b",
+		Dependencies:      []*TerraformModule{},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "b", nil, &bRan),
+	}
+
+	cRan := false
+	moduleC := &TerraformModule{
+		Path:              "c",
+		Dependencies:      []*TerraformModule{},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "c", nil, &cRan),
+	}
+
+	err := RunModulesIgnoreOrder([]*TerraformModule{moduleA, moduleB, moduleC})
 	assert.Nil(t, err, "Unexpected error: %v", err)
 
 	assert.True(t, aRan)
@@ -713,6 +910,41 @@ func TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess(t *testing
 	assert.True(t, cRan)
 }
 
+func TestRunModulesIgnoreOrderMultipleModulesWithDependenciesSuccess(t *testing.T) {
+	t.Parallel()
+
+	aRan := false
+	moduleA := &TerraformModule{
+		Path:              "a",
+		Dependencies:      []*TerraformModule{},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "a", nil, &aRan),
+	}
+
+	bRan := false
+	moduleB := &TerraformModule{
+		Path:              "b",
+		Dependencies:      []*TerraformModule{moduleA},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "b", nil, &bRan),
+	}
+
+	cRan := false
+	moduleC := &TerraformModule{
+		Path:              "c",
+		Dependencies:      []*TerraformModule{moduleB},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "c", nil, &cRan),
+	}
+
+	err := RunModulesIgnoreOrder([]*TerraformModule{moduleA, moduleB, moduleC})
+	assert.Nil(t, err, "Unexpected error: %v", err)
+
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
+}
+
 func TestRunModulesMultipleModulesWithDependenciesOneFailure(t *testing.T) {
 	t.Parallel()
 
@@ -831,6 +1063,42 @@ func TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure(t *test
 	assert.True(t, cRan)
 }
 
+func TestRunModulesIgnoreOrderMultipleModulesWithDependenciesOneFailure(t *testing.T) {
+	t.Parallel()
+
+	aRan := false
+	moduleA := &TerraformModule{
+		Path:              "a",
+		Dependencies:      []*TerraformModule{},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "a", nil, &aRan),
+	}
+
+	bRan := false
+	expectedErrB := fmt.Errorf("Expected error for module b")
+	moduleB := &TerraformModule{
+		Path:              "b",
+		Dependencies:      []*TerraformModule{moduleA},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "b", expectedErrB, &bRan),
+	}
+
+	cRan := false
+	moduleC := &TerraformModule{
+		Path:              "c",
+		Dependencies:      []*TerraformModule{moduleB},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "c", nil, &cRan),
+	}
+
+	err := RunModulesIgnoreOrder([]*TerraformModule{moduleA, moduleB, moduleC})
+	assertMultiErrorContains(t, err, expectedErrB)
+
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
+}
+
 func TestRunModulesMultipleModulesWithDependenciesMultipleFailures(t *testing.T) {
 	t.Parallel()
 
@@ -868,6 +1136,42 @@ func TestRunModulesMultipleModulesWithDependenciesMultipleFailures(t *testing.T)
 	assert.True(t, aRan)
 	assert.False(t, bRan)
 	assert.False(t, cRan)
+}
+
+func TestRunModulesIgnoreOrderMultipleModulesWithDependenciesMultipleFailures(t *testing.T) {
+	t.Parallel()
+
+	aRan := false
+	expectedErrA := fmt.Errorf("Expected error for module a")
+	moduleA := &TerraformModule{
+		Path:              "a",
+		Dependencies:      []*TerraformModule{},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "a", expectedErrA, &aRan),
+	}
+
+	bRan := false
+	moduleB := &TerraformModule{
+		Path:              "b",
+		Dependencies:      []*TerraformModule{moduleA},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "b", nil, &bRan),
+	}
+
+	cRan := false
+	moduleC := &TerraformModule{
+		Path:              "c",
+		Dependencies:      []*TerraformModule{moduleB},
+		Config:            config.TerragruntConfig{},
+		TerragruntOptions: optionsWithMockTerragruntCommand(t, "c", nil, &cRan),
+	}
+
+	err := RunModulesIgnoreOrder([]*TerraformModule{moduleA, moduleB, moduleC})
+	assertMultiErrorContains(t, err, expectedErrA)
+
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess(t *testing.T) {

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -39,7 +39,11 @@ func (stack *Stack) Plan(terragruntOptions *options.TerragruntOptions) error {
 		module.TerragruntOptions.ErrWriter = &errorStreams[n]
 	}
 	defer stack.summarizePlanAllErrors(terragruntOptions, errorStreams)
-	return RunModules(stack.Modules)
+	if terragruntOptions.IgnoreDependencyOrder {
+		return RunModulesIgnoreOrder(stack.Modules)
+	} else {
+		return RunModules(stack.Modules)
+	}
 }
 
 // We inspect the error streams to give an explicit message if the plan failed because there were references to
@@ -71,26 +75,42 @@ func (stack *Stack) summarizePlanAllErrors(terragruntOptions *options.Terragrunt
 // proper order.
 func (stack *Stack) Apply(terragruntOptions *options.TerragruntOptions) error {
 	stack.setTerraformCommand([]string{"apply", "-input=false", "-auto-approve"})
-	return RunModules(stack.Modules)
+	if terragruntOptions.IgnoreDependencyOrder {
+		return RunModulesIgnoreOrder(stack.Modules)
+	} else {
+		return RunModules(stack.Modules)
+	}
 }
 
 // Destroy all the modules in the given stack, making sure to destroy the dependencies of each module in the stack in
 // the proper order.
 func (stack *Stack) Destroy(terragruntOptions *options.TerragruntOptions) error {
 	stack.setTerraformCommand([]string{"destroy", "-force", "-input=false"})
-	return RunModulesReverseOrder(stack.Modules)
+	if terragruntOptions.IgnoreDependencyOrder {
+		return RunModulesIgnoreOrder(stack.Modules)
+	} else {
+		return RunModulesReverseOrder(stack.Modules)
+	}
 }
 
 // Output prints the outputs of all the modules in the given stack in their specified order.
 func (stack *Stack) Output(terragruntOptions *options.TerragruntOptions) error {
 	stack.setTerraformCommand([]string{"output"})
-	return RunModules(stack.Modules)
+	if terragruntOptions.IgnoreDependencyOrder {
+		return RunModulesIgnoreOrder(stack.Modules)
+	} else {
+		return RunModules(stack.Modules)
+	}
 }
 
 // Validate runs terraform validate on each module
 func (stack *Stack) Validate(terragruntOptions *options.TerragruntOptions) error {
 	stack.setTerraformCommand([]string{"validate"})
-	return RunModules(stack.Modules)
+	if terragruntOptions.IgnoreDependencyOrder {
+		return RunModulesIgnoreOrder(stack.Modules)
+	} else {
+		return RunModules(stack.Modules)
+	}
 }
 
 // Return an error if there is a dependency cycle in the modules of this stack.

--- a/options/options.go
+++ b/options/options.go
@@ -74,6 +74,9 @@ type TerragruntOptions struct {
 	// If set to true, continue running *-all commands even if a dependency has errors. This is mostly useful for 'output-all <some_variable>'. See https://github.com/gruntwork-io/terragrunt/issues/193
 	IgnoreDependencyErrors bool
 
+	// If set to true, ignore the dependency order when running *-all command.
+	IgnoreDependencyOrder bool
+
 	// If set to true, skip any external dependencies when running *-all commands
 	IgnoreExternalDependencies bool
 
@@ -142,6 +145,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		SourceUpdate:                false,
 		DownloadDir:                 downloadDir,
 		IgnoreDependencyErrors:      false,
+		IgnoreDependencyOrder:       false,
 		IgnoreExternalDependencies:  false,
 		IncludeExternalDependencies: false,
 		Writer:                      os.Stdout,
@@ -211,6 +215,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		DownloadDir:                 terragruntOptions.DownloadDir,
 		IamRole:                     terragruntOptions.IamRole,
 		IgnoreDependencyErrors:      terragruntOptions.IgnoreDependencyErrors,
+		IgnoreDependencyOrder:       terragruntOptions.IgnoreDependencyOrder,
 		IgnoreExternalDependencies:  terragruntOptions.IgnoreExternalDependencies,
 		IncludeExternalDependencies: terragruntOptions.IncludeExternalDependencies,
 		Writer:                      terragruntOptions.Writer,


### PR DESCRIPTION
When running `plan-all`, we may want to run the modules while ignoring the dependency order: since the state is not altered between each `plan`, we might as well run all the plans at once.

This adds an option, `IgnoreDependencyOrder` (defaulting to False), which when set makes `plan-all` disregard the dependencies. 

To achieve that, this adds an `IgnoreOrder` run strategy and an associated `RunModulesIgnoreOrder` method.

Contributes to #868