### PR TITLE
get_aws_caller_identity_arn and get_aws_caller_identity_user_id functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,12 +104,13 @@ workflows:
               only: /^v.*/
       - integration_test:
           requires:
-            - unit_test
+            - install_dependencies
           filters:
             tags:
               only: /^v.*/
       - build:
           requires:
+            - unit_test
             - integration_test
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,35 +1,34 @@
-workspace_root: &workspace_root
-  /go/src/github.com/gruntwork-io/terragrunt
+workspace_root: &workspace_root /go/src/github.com/gruntwork-io/terragrunt
 
 defaults: &defaults
   working_directory: *workspace_root
   docker:
-  - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.11
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.11
 
 version: 2
 jobs:
   install_dependencies:
     <<: *defaults
     steps:
-    - checkout
-    - attach_workspace:
-        at: *workspace_root
-    - restore_cache:
-        keys:
-        - dep-{{ checksum "Gopkg.lock" }}
-    - run: dep ensure
-    - run: gruntwork-install --binary-name 'terratest_log_parser' --repo 'https://github.com/gruntwork-io/terratest' --tag 'v0.13.8' --download-dir .
-    - save_cache:
-        key: dep-{{ checksum "Gopkg.lock" }}
-        paths:
-        - /go/src/github.com/gruntwork-io/terragrunt/vendor
-    - persist_to_workspace:
-        root: *workspace_root
-        paths: vendor
-# We're running unit tests separately from integration tests - with no parallelization.
-# With heavy parallelization coupled with re-use of test fixtures we've witnessed slight
-# instability with the tests. The unit tests are fast to execute, so there is negligible
-# performance penalty.
+      - checkout
+      - attach_workspace:
+          at: *workspace_root
+      - restore_cache:
+          keys:
+            - dep-{{ checksum "Gopkg.lock" }}
+      - run: dep ensure
+      - run: gruntwork-install --binary-name 'terratest_log_parser' --repo 'https://github.com/gruntwork-io/terratest' --tag 'v0.13.8' --download-dir .
+      - save_cache:
+          key: dep-{{ checksum "Gopkg.lock" }}
+          paths:
+            - /go/src/github.com/gruntwork-io/terragrunt/vendor
+      - persist_to_workspace:
+          root: *workspace_root
+          paths: vendor
+  # We're running unit tests separately from integration tests - with no parallelization.
+  # With heavy parallelization coupled with re-use of test fixtures we've witnessed slight
+  # instability with the tests. The unit tests are fast to execute, so there is negligible
+  # performance penalty.
   unit_test:
     <<: *defaults
     steps:
@@ -72,71 +71,71 @@ jobs:
   build:
     <<: *defaults
     steps:
-    - checkout
-    - attach_workspace:
-        at: *workspace_root
-    - run: build-go-binaries --circle-ci-2 --app-name terragrunt --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
-    - persist_to_workspace:
-        root: *workspace_root
-        paths: bin
+      - checkout
+      - attach_workspace:
+          at: *workspace_root
+      - run: build-go-binaries --circle-ci-2 --app-name terragrunt --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
+      - persist_to_workspace:
+          root: *workspace_root
+          paths: bin
 
   deploy:
     <<: *defaults
     steps:
-    - checkout
-    - attach_workspace:
-        at: *workspace_root
-    - run: cd bin && sha256sum * > SHA256SUMS
-    - run: upload-github-release-assets bin/*
+      - checkout
+      - attach_workspace:
+          at: *workspace_root
+      - run: cd bin && sha256sum * > SHA256SUMS
+      - run: upload-github-release-assets bin/*
 
 workflows:
   version: 2
   build-and-test:
     jobs:
-    - install_dependencies:
-        filters:
-          tags:
-            only: /^v.*/
-    - unit_test:
-        requires:
-          - install_dependencies
-        filters:
-          tags:
-            only: /^v.*/
-    - integration_test:
-        requires:
-          - unit_test
-        filters:
-          tags:
-            only: /^v.*/
-    - build:
-        requires:
-        - integration_test
-        filters:
-          tags:
-            only: /^v.*/
+      - install_dependencies:
+          filters:
+            tags:
+              only: /^v.*/
+      - unit_test:
+          requires:
+            - install_dependencies
+          filters:
+            tags:
+              only: /^v.*/
+      - integration_test:
+          requires:
+            - unit_test
+          filters:
+            tags:
+              only: /^v.*/
+      - build:
+          requires:
+            - integration_test
+          filters:
+            tags:
+              only: /^v.*/
 
-    - deploy:
-        requires:
-        - build
-        filters:
-          tags:
-            only: /^v.*/
-          branches:
-            ignore: /.*/
+      - deploy:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
 
   nightly:
     triggers:
-    - schedule:
-        cron: "0 6 * * *"
-        filters:
-          branches:
-            only: master
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only: master
     jobs:
-    - install_dependencies
-    - unit_test:
-        requires:
-          - install_dependencies
-    - integration_test:
-        requires:
-          - unit_test
+      - install_dependencies
+      - unit_test:
+          requires:
+            - install_dependencies
+      - integration_test:
+          requires:
+            - install_dependencies

--- a/README.md
+++ b/README.md
@@ -2036,8 +2036,8 @@ remote_state {
     bucket = "mycompany-${get_aws_account_id()}"
   }
 }
-
 ```
+
 #### get_aws_caller_identity
 
 `get_aws_caller_identity()` returns the ARN of the AWS identity associated with the current set of credentials. Example:

--- a/README.md
+++ b/README.md
@@ -1650,7 +1650,7 @@ currently available are:
 * [get_terraform_commands_that_need_locking()](#get_terraform_commands_that_need_locking)
 * [get_terraform_commands_that_need_parallelism()](#get_terraform_commands_that_need_parallelism)
 * [get_aws_account_id()](#get_aws_account_id)
-* [get_aws_caller_identity()](#get_aws_caller_identity)
+* [get_aws_caller_identity_arn()](#get_aws_caller_identity_arn)
 * [run_cmd()](#run_cmd)
 
 
@@ -2038,9 +2038,9 @@ remote_state {
 }
 ```
 
-#### get_aws_caller_identity
+#### get_aws_caller_identity_arn
 
-`get_aws_caller_identity()` returns the ARN of the AWS identity associated with the current set of credentials. Example:
+`get_aws_caller_identity_arn()` returns the ARN of the AWS identity associated with the current set of credentials. Example:
 
 ```hcl
 data "aws_iam_policy_document" "master_key_policy" {
@@ -2056,7 +2056,7 @@ data "aws_iam_policy_document" "master_key_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = "${get_aws_caller_identity()}"
+      identifiers = "${get_aws_caller_identity_arn()}"
     }
   }
 ```

--- a/README.md
+++ b/README.md
@@ -1651,6 +1651,7 @@ currently available are:
 * [get_terraform_commands_that_need_parallelism()](#get_terraform_commands_that_need_parallelism)
 * [get_aws_account_id()](#get_aws_account_id)
 * [get_aws_caller_identity_arn()](#get_aws_caller_identity_arn)
+* [get_aws_caller_identity_user_id()](#get_aws_caller_identity_user_id)
 * [run_cmd()](#run_cmd)
 
 
@@ -2044,7 +2045,17 @@ remote_state {
 
 ```hcl
 inputs = {
-  caller_identity = get_aws_caller_identity_arn()
+  caller_arn = get_aws_caller_identity_arn()
+}
+```
+
+#### get_aws_caller_identity_user_id
+
+`get_aws_caller_identity_user_id()` returns the UserId of the AWS identity associated with the current set of credentials. Example:
+
+```hcl
+inputs = {
+  caller_user_id = get_aws_caller_identity_user_id()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1650,6 +1650,7 @@ currently available are:
 * [get_terraform_commands_that_need_locking()](#get_terraform_commands_that_need_locking)
 * [get_terraform_commands_that_need_parallelism()](#get_terraform_commands_that_need_parallelism)
 * [get_aws_account_id()](#get_aws_account_id)
+* [get_aws_caller_identity()](#get_aws_caller_identity)
 * [run_cmd()](#run_cmd)
 
 
@@ -2035,6 +2036,29 @@ remote_state {
     bucket = "mycompany-${get_aws_account_id()}"
   }
 }
+
+```
+#### get_aws_caller_identity
+
+`get_aws_caller_identity()` returns the ARN of the AWS identity associated with the current set of credentials. Example:
+
+```hcl
+data "aws_iam_policy_document" "master_key_policy" {
+  # Grant CMK Administrators full management rights, but no usage rights.
+  statement {
+    sid       = "AllowAccessForKeyAdministrators"
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "kms:*"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = "${get_aws_caller_identity()}"
+    }
+  }
 ```
 
 This allows uniqueness of the storage bucket per AWS account (since bucket name must be globally unique).

--- a/README.md
+++ b/README.md
@@ -2043,22 +2043,9 @@ remote_state {
 `get_aws_caller_identity_arn()` returns the ARN of the AWS identity associated with the current set of credentials. Example:
 
 ```hcl
-data "aws_iam_policy_document" "master_key_policy" {
-  # Grant CMK Administrators full management rights, but no usage rights.
-  statement {
-    sid       = "AllowAccessForKeyAdministrators"
-    effect    = "Allow"
-    resources = ["*"]
-
-    actions = [
-      "kms:*"
-    ]
-
-    principals {
-      type        = "AWS"
-      identifiers = "${get_aws_caller_identity_arn()}"
-    }
-  }
+inputs = {
+  caller_identity = get_aws_caller_identity_arn()
+}
 ```
 
 This allows uniqueness of the storage bucket per AWS account (since bucket name must be globally unique).

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -324,13 +325,13 @@ func getAWSCallerID(include *IncludeConfig, terragruntOptions *options.Terragrun
 // Return the AWS account id associated to the current set of credentials
 func getAWSAccountID(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
 	identity, err := getAWSCallerID(include, terragruntOptions)
-	return *identity.Account, err
+	return awsutil.StringValue(identity.Account), err
 }
 
 // Return the ARN of the AWS identity associated with the current set of credentials
 func getAWSCallerIdentityARN(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
 	identity, err := getAWSCallerID(include, terragruntOptions)
-	return *identity.Arn, err
+	return awsutil.StringValue(identity.Arn), err
 }
 
 // Custom error types

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -99,7 +99,7 @@ func CreateTerragruntEvalContext(
 		"get_terragrunt_dir":                           wrapVoidToStringAsFuncImpl(getTerragruntDir, extensions.Include, terragruntOptions),
 		"get_parent_terragrunt_dir":                    wrapVoidToStringAsFuncImpl(getParentTerragruntDir, extensions.Include, terragruntOptions),
 		"get_aws_account_id":                           wrapVoidToStringAsFuncImpl(getAWSAccountID, extensions.Include, terragruntOptions),
-		"get_aws_caller_identity":                      wrapVoidToStringAsFuncImpl(getAWSCallerIdentity, extensions.Include, terragruntOptions),
+		"get_aws_caller_identity_arn":                  wrapVoidToStringAsFuncImpl(getAWSCallerIdentityARN, extensions.Include, terragruntOptions),
 		"get_terraform_commands_that_need_vars":        wrapStaticValueToStringSliceAsFuncImpl(TERRAFORM_COMMANDS_NEED_VARS),
 		"get_terraform_commands_that_need_locking":     wrapStaticValueToStringSliceAsFuncImpl(TERRAFORM_COMMANDS_NEED_LOCKING),
 		"get_terraform_commands_that_need_input":       wrapStaticValueToStringSliceAsFuncImpl(TERRAFORM_COMMANDS_NEED_INPUT),
@@ -322,7 +322,7 @@ func getAWSAccountID(include *IncludeConfig, terragruntOptions *options.Terragru
 }
 
 // Return the ARN of the AWS identity associated with the current set of credentials
-func getAWSCallerIdentity(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
+func getAWSCallerIdentityARN(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
 	sess, err := session.NewSession()
 	if err != nil {
 		return "", errors.WithStackTrace(err)
@@ -341,7 +341,6 @@ func getAWSCallerIdentity(include *IncludeConfig, terragruntOptions *options.Ter
 }
 
 // Custom error types
-
 type WrongNumberOfParams struct {
 	Func     string
 	Expected string

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -101,6 +101,7 @@ func CreateTerragruntEvalContext(
 		"get_parent_terragrunt_dir":                    wrapVoidToStringAsFuncImpl(getParentTerragruntDir, extensions.Include, terragruntOptions),
 		"get_aws_account_id":                           wrapVoidToStringAsFuncImpl(getAWSAccountID, extensions.Include, terragruntOptions),
 		"get_aws_caller_identity_arn":                  wrapVoidToStringAsFuncImpl(getAWSCallerIdentityARN, extensions.Include, terragruntOptions),
+		"get_aws_caller_identity_user_id":              wrapVoidToStringAsFuncImpl(getAWSCallerIdentityUserID, extensions.Include, terragruntOptions),
 		"get_terraform_commands_that_need_vars":        wrapStaticValueToStringSliceAsFuncImpl(TERRAFORM_COMMANDS_NEED_VARS),
 		"get_terraform_commands_that_need_locking":     wrapStaticValueToStringSliceAsFuncImpl(TERRAFORM_COMMANDS_NEED_LOCKING),
 		"get_terraform_commands_that_need_input":       wrapStaticValueToStringSliceAsFuncImpl(TERRAFORM_COMMANDS_NEED_INPUT),
@@ -332,6 +333,12 @@ func getAWSAccountID(include *IncludeConfig, terragruntOptions *options.Terragru
 func getAWSCallerIdentityARN(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
 	identity, err := getAWSCallerID(include, terragruntOptions)
 	return awsutil.StringValue(identity.Arn), err
+}
+
+// Return the UserID of the AWS identity associated with the current set of credentials
+func getAWSCallerIdentityUserID(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
+	identity, err := getAWSCallerID(include, terragruntOptions)
+	return awsutil.StringValue(identity.UserId), err
 }
 
 // Custom error types

--- a/test/fixture-get-aws-caller-identity/main.tf
+++ b/test/fixture-get-aws-caller-identity/main.tf
@@ -1,0 +1,23 @@
+variable "account" {
+  type = string
+}
+
+variable "arn" {
+  type = string
+}
+
+variable "user_id" {
+  type = string
+}
+
+output "account" {
+  value = var.account
+}
+
+output "arn" {
+  value = var.arn
+}
+
+output "user_id" {
+  value = var.user_id
+}

--- a/test/fixture-get-aws-caller-identity/terragrunt.hcl
+++ b/test/fixture-get-aws-caller-identity/terragrunt.hcl
@@ -1,8 +1,5 @@
-terraform {
-
-  inputs = {
-    account = get_aws_account_id()
-    arn = get_aws_account_arn()
-    user_id = get_aws_account_user_id()
-  }
+inputs = {
+  account = get_aws_account_id()
+  arn = get_aws_caller_identity_arn()
+  user_id = get_aws_caller_identity_user_id()
 }

--- a/test/fixture-get-aws-caller-identity/terragrunt.hcl
+++ b/test/fixture-get-aws-caller-identity/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+
+  inputs = {
+    account = get_aws_account_id()
+    arn = get_aws_account_arn()
+    user_id = get_aws_account_user_id()
+  }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1928,7 +1928,7 @@ func TestAWSGetCallerIdentityFunctions(t *testing.T) {
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_AWS_GET_CALLER_IDENTITY)
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_AWS_GET_CALLER_IDENTITY)
-	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_AWS_GET_CALLER_IDENTITY, "integration")
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_AWS_GET_CALLER_IDENTITY)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
 
@@ -1936,10 +1936,9 @@ func TestAWSGetCallerIdentityFunctions(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	app3Path := util.JoinPath(rootPath, "app3")
 	require.NoError(
 		t,
-		runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir %s", app3Path), &stdout, &stderr),
+		runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr),
 	)
 
 	outputs := map[string]TerraformOutput{}


### PR DESCRIPTION
This PR:
* adds new `get_aws_caller_identity_arn` and `get_aws_caller_identity_user_id` functions that will return the ARN and UserId, respectively, of the currently configured user or IAM role similar to the existing `get_aws_account` function.
* updates the circle config to run unit and integration tests in parallel to save times on each CI run