### PR TITLE
Correctly Mirror Terraform GCP Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ they don't already exist:
 - **GCS bucket**: If you are using the [GCS backend](https://www.terraform.io/docs/backends/types/gcs.html) for remote
   state storage and the `bucket` you specify in `remote_state.config` doesn't already exist, Terragrunt will create it
   automatically, with [versioning](https://cloud.google.com/storage/docs/object-versioning) enabled. For this to work
-  correctly you must also specify `project` and `location` keys in `remote_state.config`, so terragrunt knows where to
+  correctly you must also specify `project` and `location` keys in `remote_state.config`, so Terragrunt knows where to
   create the bucket. You will also need to supply valid credentials using either `remote_state.config.credentials` or by
   setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. If you want to skip creating the bucket entirely,
   simply set `skip_bucket_creation` to `true` and Terragrunt will assume the bucket has already been created. If you

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -480,10 +480,10 @@ func TestTerragruntWorksWithExistingGCSBucket(t *testing.T) {
 }
 
 func TestTerragruntCorrectlyMirrorsTerraformGCPAuth(t *testing.T) {
-	t.Parallel()
+	// Note: We don't run this test in parallel with the other tests as it affects the environment.
 
 	// We need to ensure Terragrunt works correctly when GOOGLE_CREDENTIALS are specified.
-	// There is no true way to properly unset creds from the environment, but we still try
+	// There is no true way to properly unset env vars from the environment, but we still try
 	// to unset the CI credentials during this test.
 	defaultCreds := os.Getenv("GCLOUD_SERVICE_KEY")
 	defer os.Setenv("GCLOUD_SERVICE_KEY", defaultCreds)


### PR DESCRIPTION
This PR adds support for correctly mirroring the Terraform GCP authentication behavior by supporting the `GOOGLE_CREDENTIALS` environment variable. Users can either pass in the contents or path to a credentials file.