### PR TITLE
Add unit tests for `removeFlagExcluded`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2286,7 +2286,8 @@ arguments that start with the prefix `--terragrunt-`. The currently available op
 
 * `--terragrunt-exclude-dir`: Unix-style glob of directories to exclude when running `*-all` commands. Modules under
   these directories will be excluded during execution of the commands. If a relative path is specified, it should be
-  relative from `--terragrunt-working-dir`. Flag can be specified multiple times.
+  relative from `--terragrunt-working-dir`. Flag can be specified multiple times. This will only exclude the module,
+  not its dependencies.
 
 * `--terragrunt-include-dir`: Unix-style glob of directories to include when running `*-all` commands. Only modules
   under these directories (and all dependent modules) will be included during execution of the commands. If a relative


### PR DESCRIPTION
When using the `--terragrunt-exclude-dir`, modules are flagged
with a `FlagExcluded` boolean. Later on, when Terragrunt converts
the modules into runningModules (in the `toRunningModules` method),
it calls as last step the method `removeFlagExcluded`.

That method returns a modified map of `runningModules` map,
with the ones marked with the boolean removed and modules
which depend on them have their `Dependencies` fixed accordingly.

This adds unit tests for three use cases for `removeFlagExcluded`:
 - No module is marked with `FlagExcluded`:
   nothing happens, the output is the same as the input
 - One module, with no dependencies, is marked with `FlagExcluded`:
   that module is removed from the map
 - One module, with dependencies, is marked with `FlagExcluded`:
   that module is removed from the map and its direct depedency
   is altered to not depend on the excluded module anymore.