### PR TITLE
Only perform exact match when [in|ex]cluding directories

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -198,7 +198,7 @@ func flagIncludedDirs(modules []*TerraformModule, terragruntOptions *options.Ter
 // Returns true if a module is located under one of the target directories
 func findModuleinPath(module *TerraformModule, targetDirs []string) bool {
 	for _, targetDir := range targetDirs {
-		if strings.Contains(module.Path, targetDir) {
+		if module.Path == targetDir {
 			return true
 		}
 	}

--- a/test/fixture-modules/module-abba/terragrunt.hcl
+++ b/test/fixture-modules/module-abba/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "temp"
+}
+
+dependencies {
+  paths = ["../module-a"]
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1308,8 +1308,8 @@ func TestExcludeDirs(t *testing.T) {
 		excludeArgs           string
 		excludedModuleOutputs []string
 	}{
-		{TEST_FIXTURE_LOCAL_WITH_EXCLUDE_DIR, "--terragrunt-exclude-dir */gce", []string{"Module GCE B", "Module GCE C", "Module GCE E"}},
-		{TEST_FIXTURE_LOCAL_WITH_EXCLUDE_DIR, "--terragrunt-exclude-dir production-env --terragrunt-exclude-dir **/module-gce-c", []string{"Module GCE C", "Module AWS D", "Module GCE E"}},
+		{TEST_FIXTURE_LOCAL_WITH_EXCLUDE_DIR, "--terragrunt-exclude-dir **/gce/**/*", []string{"Module GCE B", "Module GCE C", "Module GCE E"}},
+		{TEST_FIXTURE_LOCAL_WITH_EXCLUDE_DIR, "--terragrunt-exclude-dir production-env/**/* --terragrunt-exclude-dir **/module-gce-c", []string{"Module GCE C", "Module AWS D", "Module GCE E"}},
 		{TEST_FIXTURE_LOCAL_WITH_EXCLUDE_DIR, "--terragrunt-exclude-dir integration-env/gce/module-gce-b --terragrunt-exclude-dir integration-env/gce/module-gce-c --terragrunt-exclude-dir **/module-aws*", []string{"Module AWS A", "Module GCE B", "Module GCE C", "Module AWS D"}},
 	}
 


### PR DESCRIPTION
The flags `--terragrunt-include-dir` and `--terragrunt-exclude-dir` are
“Unix-style glob of directories to include (resp. exclude) when running
*-all commands”

Currently, the matching on which directories to include/exclude is done
using `string.Contains`, which means that this excluding `module-a` would
also exclude `module-abba`.

We should really be doing an exact match, since we can get the multi-match
behaviour by using Unix-style globs.

Also add two unit-tests confirming the old and new behaviours.

Ref #905