### PR TITLE
Revert change introduced in #866

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -324,6 +324,7 @@ func runTerragruntOutputJson(terragruntOptions *options.TerragruntOptions, targe
 	// `cloneTerragruntOptionsForDependencyOutput`. Specifically, if you have multiple terragrunt sources that point to
 	// the same dependency, then terragrunt could attempt to download the resources multiple times causing conflicts.
 	// See https://github.com/gruntwork-io/terragrunt/issues/906 for more info.
+	// IMPORTANT: When updating this, please reenable test TestDependencyOutputCachePathBug
 	targetOptions := terragruntOptions.Clone(targetConfig)
 	targetOptions.TerraformCliArgs = []string{"output", "-json"}
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1954,6 +1954,8 @@ func TestDependencyOutputRegression854(t *testing.T) {
 // Regression testing for bug where terragrunt output runs on dependency blocks are done in the terragrunt-cache for the
 // child, not the parent.
 func TestDependencyOutputCachePathBug(t *testing.T) {
+	t.Skip("Skipped because fix is not complete. See https://github.com/gruntwork-io/terragrunt/pull/930 for more info")
+
 	t.Parallel()
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_GET_OUTPUT)


### PR DESCRIPTION
This reverts #866 in favor of resolving the issues reported in https://github.com/gruntwork-io/terragrunt/issues/906 and https://github.com/gruntwork-io/terragrunt/issues/904. These two issues are caused by concurrent calls to terragrunt to update the source OR run `init` in the same working folder, caused by concurrent calls to `terragrunt output` due to dependency ordering.

The proper fix that will allow us to reimplement this are:

- Introduce locking mechanism to prevent concurrent calls to `terragrunt output` in the same module.
- Introduce a graph logic that will extract the outputs, once, prior to calling the steps in a `xxx-all`.

Both are non-trivial solutions that introduce a lot of complexity. I have decided that it will take enough time to implement that it seems better to revert the fix as suggested in https://github.com/gruntwork-io/terragrunt/issues/906#issuecomment-547482455.