### PR TITLE
Improve docs by linking to DRY definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@
 # Terragrunt
 
 Terragrunt is a thin wrapper for [Terraform](https://www.terraform.io/) that provides extra tools for keeping your
-Terraform configurations DRY, working with multiple Terraform modules, and managing remote state. Check out
+Terraform configurations [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself),
+working with multiple Terraform modules, and managing remote state. Check out
 [Terragrunt: how to keep your Terraform code DRY and
 maintainable](https://blog.gruntwork.io/terragrunt-how-to-keep-your-terraform-code-dry-and-maintainable-f61ae06959d8)
 for a quick introduction to Terragrunt.
-
-
-
 
 ## Quick start
 


### PR DESCRIPTION
Beginners and people less knowlegdable about industry jargon (like DRY)
might be confused when they encounter abbreviations without any
explanation to them at first use of said abbreviation.

It is good practice to introduce abbreviations with either writing them
out in full and putting the abbreviation in parentheses, or with
hypertext simply by making the abbreviation a link and pointing to the
full form.

The latter approach was chosen for this change.