### PR TITLE
Add more debug logging to help debug issues in the future

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -176,26 +176,6 @@
   version = "v2.0.4"
 
 [[projects]]
-  digest = "1:336fe3365d1ed4fab9a54f6b1aa3031c84354493a7123e357afc8d8390510264"
-  name = "github.com/gruntwork-io/terragrunt"
-  packages = [
-    "aws_helper",
-    "cli",
-    "config",
-    "configstack",
-    "dynamodb",
-    "errors",
-    "options",
-    "remote",
-    "shell",
-    "test/helpers",
-    "util",
-  ]
-  pruneopts = "UT"
-  revision = "84e77303a8c1ce634522612a19f0c12e1ce20a4b"
-  version = "v0.21.0"
-
-[[projects]]
   digest = "1:91e98ea76af524d88f4eeb4240bcd0ab04a8091954dc845c32b3283c7c4ebf8c"
   name = "github.com/gruntwork-io/terratest"
   packages = ["modules/files"]
@@ -646,17 +626,6 @@
     "github.com/aws/aws-sdk-go/service/sts",
     "github.com/fatih/color",
     "github.com/go-errors/errors",
-    "github.com/gruntwork-io/terragrunt/aws_helper",
-    "github.com/gruntwork-io/terragrunt/cli",
-    "github.com/gruntwork-io/terragrunt/config",
-    "github.com/gruntwork-io/terragrunt/configstack",
-    "github.com/gruntwork-io/terragrunt/dynamodb",
-    "github.com/gruntwork-io/terragrunt/errors",
-    "github.com/gruntwork-io/terragrunt/options",
-    "github.com/gruntwork-io/terragrunt/remote",
-    "github.com/gruntwork-io/terragrunt/shell",
-    "github.com/gruntwork-io/terragrunt/test/helpers",
-    "github.com/gruntwork-io/terragrunt/util",
     "github.com/gruntwork-io/terratest/modules/files",
     "github.com/hashicorp/go-getter",
     "github.com/hashicorp/go-getter/helper/url",

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -276,6 +276,7 @@ func shouldReturnMockOutputs(dependencyConfig Dependency, terragruntOptions *opt
 // terragrunt config and extract the desired output from the remote state. Note that this will error if the targetted
 // module hasn't been applied yet.
 func getTerragruntOutput(dependencyConfig Dependency, terragruntOptions *options.TerragruntOptions) (*cty.Value, bool, error) {
+
 	// target config check: make sure the target config exists
 	targetConfig := getCleanedTargetConfigPath(dependencyConfig, terragruntOptions)
 	if !util.FileExists(targetConfig) {
@@ -308,6 +309,11 @@ func getOutputJsonWithCaching(targetConfig string, terragruntOptions *options.Te
 	actualLock := rawActualLock.(*sync.Mutex)
 	defer actualLock.Unlock()
 	actualLock.Lock()
+
+	// This debug log is useful for validating if the locking mechanism is working. If the locking mechanism is working,
+	// we should only see one pair of logs at a time that begin with this statement, and then the relevant "terraform
+	// output" log for the dependency.
+	util.Debugf(terragruntOptions.Logger, "Getting output of dependency %s for config %s", targetConfig, terragruntOptions.TerragruntConfigPath)
 
 	// Look up if we have already run terragrunt output for this target config
 	rawJsonBytes, hasRun := jsonOutputCache.Load(targetConfig)

--- a/main.go
+++ b/main.go
@@ -17,6 +17,10 @@ var VERSION string
 
 // The main entrypoint for Terragrunt
 func main() {
+	// Log the terragrunt version in debug mode. This helps with debugging issues and ensuring a specific version of
+	// terragrunt used.
+	util.Debugf(util.CreateLogger(""), "Terragrunt Version: %s", VERSION)
+
 	defer errors.Recover(checkForErrorsAndExit)
 
 	app := cli.CreateTerragruntCli(VERSION, os.Stdout, os.Stderr)


### PR DESCRIPTION
This introduces two new debug logs that would be helpful for debugging https://github.com/gruntwork-io/terragrunt/issues/906:

- Log the terragrunt version if `TG_LOG=debug`
- Log the start of output retrieval for a dependency block