### PR TITLE
export runTerragrunt (i.e. make it RunTerragrunt)

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -118,7 +118,7 @@ func parseTerragruntOptionsFromArgs(args []string, writer, errWriter io.Writer) 
 	opts.WorkingDir = filepath.ToSlash(workingDir)
 	opts.DownloadDir = filepath.ToSlash(downloadDir)
 	opts.Logger = util.CreateLoggerWithWriter(errWriter, "")
-	opts.RunTerragrunt = runTerragrunt
+	opts.RunTerragrunt = RunTerragrunt
 	opts.Source = terraformSource
 	opts.SourceUpdate = sourceUpdate
 	opts.IgnoreDependencyErrors = ignoreDependencyErrors

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -226,12 +226,12 @@ func runCommand(command string, terragruntOptions *options.TerragruntOptions) (f
 	if isMultiModuleCommand(command) {
 		return runMultiModuleCommand(command, terragruntOptions)
 	}
-	return runTerragrunt(terragruntOptions)
+	return RunTerragrunt(terragruntOptions)
 }
 
 // Downloads terraform source if necessary, then runs terraform with the given options and CLI args.
 // This will forward all the args and extra_arguments directly to Terraform.
-func runTerragrunt(terragruntOptions *options.TerragruntOptions) error {
+func RunTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 	if shouldPrintTerraformHelp(terragruntOptions) {
 		return shell.RunTerraformCommand(terragruntOptions, terragruntOptions.TerraformCliArgs...)
 	}


### PR DESCRIPTION
This PR resolves #968 by exporting `RunTerragrunt` so that terragrunt can be executed programmatically. 