### PR TITLE
Fix panic when credentials expired with get_aws_account_id functions

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -335,7 +335,7 @@ func getAWSAccountID(include *IncludeConfig, terragruntOptions *options.Terragru
 func getAWSCallerIdentityARN(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
 	identity, err := getAWSCallerID(include, terragruntOptions)
 	if err == nil {
-		return *identity.Account, nil
+		return *identity.Arn, nil
 	}
 	return "", err
 }
@@ -344,7 +344,7 @@ func getAWSCallerIdentityARN(include *IncludeConfig, terragruntOptions *options.
 func getAWSCallerIdentityUserID(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
 	identity, err := getAWSCallerID(include, terragruntOptions)
 	if err == nil {
-		return *identity.Account, nil
+		return *identity.UserId, nil
 	}
 	return "", err
 }

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -325,19 +325,28 @@ func getAWSCallerID(include *IncludeConfig, terragruntOptions *options.Terragrun
 // Return the AWS account id associated to the current set of credentials
 func getAWSAccountID(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
 	identity, err := getAWSCallerID(include, terragruntOptions)
-	return *identity.Account, err
+	if err == nil {
+		return *identity.Account, nil
+	}
+	return "", err
 }
 
 // Return the ARN of the AWS identity associated with the current set of credentials
 func getAWSCallerIdentityARN(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
 	identity, err := getAWSCallerID(include, terragruntOptions)
-	return *identity.Arn, err
+	if err == nil {
+		return *identity.Account, nil
+	}
+	return "", err
 }
 
 // Return the UserID of the AWS identity associated with the current set of credentials
 func getAWSCallerIdentityUserID(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
 	identity, err := getAWSCallerID(include, terragruntOptions)
-	return *identity.UserId, err
+	if err == nil {
+		return *identity.Account, nil
+	}
+	return "", err
 }
 
 // Custom error types


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/terragrunt/issues/960

NOTE: I could not find a good way to write an automated test for this since it depends on having no credentials and we automatically inherit credentials in the environment, but I have tested this manually to verify this fixes the issue.

Before:
```
%~> go test -v -run TestAWSGetCallerIdentityFunctions .
=== RUN   TestAWSGetCallerIdentityFunctions
=== PAUSE TestAWSGetCallerIdentityFunctions
=== CONT  TestAWSGetCallerIdentityFunctions
[terragrunt] 2019/12/03 18:28:02 Setting download directory for module /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity to /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity/.terragrunt-cache
[terragrunt] 2019/12/03 18:28:02 Stack at /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity:
  => Module /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity (excluded: false, dependencies: [])
[terragrunt] 2019/12/03 18:28:02 [terragrunt]  Are you sure you want to run 'terragrunt apply' in each folder of the stack described above? (y/n)
[terragrunt] 2019/12/03 18:28:02
[terragrunt] 2019/12/03 18:28:02 The non-interactive flag is set to true, so assuming 'yes' for all prompts
[terragrunt] [/var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity] 2019/12/03 18:28:02 Module /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity must wait for 0 dependencies to finish
[terragrunt] [/var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity] 2019/12/03 18:28:02 Running module /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity now
[terragrunt] [/var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity] 2019/12/03 18:28:02 Reading Terragrunt config file at /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity/terragrunt.hcl
[terragrunt] [/var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity] 2019/12/03 18:28:03 Module /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity has finished with an error: /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity/terragrunt.hcl:2,13-32: Error in function call; Call to function "get_aws_account_id" failed: panic in function implementation: runtime error: invalid memory address or nil pointer dereference
goroutine 37 [running]:
runtime/debug.Stack(0xc0004a3a30, 0x1b1d220, 0x2693930)
        /usr/local/Cellar/go/1.13/libexec/src/runtime/debug/stack.go:24 +0x9d
github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function.errorForPanic(...)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function/error.go:44
github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function.Function.Call.func1(0xc0004a3db8, 0xc0004a3dd8)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function/function.go:239 +0x8e
panic(0x1b1d220, 0x2693930)
        /usr/local/Cellar/go/1.13/libexec/src/runtime/panic.go:679 +0x1b2
github.com/gruntwork-io/terragrunt/config.getAWSAccountID(0x0, 0xc0000f38c0, 0x0, 0x0, 0x0, 0x0)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config_helpers.go:328 +0x44
github.com/gruntwork-io/terragrunt/config.wrapVoidToStringAsFuncImpl.func1(0x26c8aa8, 0x0, 0x0, 0x1f085c0, 0xc0000b98b9, 0xc0000b98b9, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/cty_helpers.go:39 +0x3b
github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function.Function.Call(0xc0004ae540, 0x26c8aa8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function/function.go:243 +0x30c
github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax.(*FunctionCallExpr).Value(0xc00048e000, 0xc0004b0760, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/expression.go:385 +0x10c3
github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax.(*ObjectConsExpr).Value(0xc0003c4a00, 0xc0004b0760, 0x2e8ec923b8036294, 0x1010171, 0xc0004a5408, 0xc0004a5370, 0xc0002d7a05, 0xc0002d7ab0, 0x269ee10)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/expression.go:703 +0x285
github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl.DecodeExpression(0x2f82648, 0xc0003c4a00, 0xc0004b0760, 0xc0004ba0c0, 0xc00010cb18, 0xc00010cb18, 0x196, 0x1c54c20)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl/decode.go:273 +0x59
github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl.decodeBodyToStruct(0x1f07a80, 0xc00031f810, 0xc0004b0760, 0x1c33480, 0xc00010cb00, 0x199, 0x0, 0x0, 0x0)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl/decode.go:111 +0x692
github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl.decodeBodyToValue(0x1f07a80, 0xc00031f810, 0xc0004b0760, 0x1c33480, 0xc00010cb00, 0x199, 0x0, 0x0, 0x0)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl/decode.go:43 +0xd5
github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl.DecodeBody(0x1f07a80, 0xc00031f810, 0xc0004b0760, 0x1a696a0, 0xc00010cb00, 0xc000475fe0, 0xc0004b0760, 0x26acbe0)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl/decode.go:36 +0xe2
github.com/gruntwork-io/terragrunt/config.decodeHcl(0xc000359d00, 0xc0000d3080, 0x78, 0x1a696a0, 0xc00010cb00, 0xc0000f38c0, 0x0, 0x0, 0xc000475fe0, 0x0, ...)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config.go:417 +0x127
github.com/gruntwork-io/terragrunt/config.decodeAsTerragruntConfigFile(0xc000359d00, 0xc0000d3080, 0x78, 0xc0000f38c0, 0x0, 0x0, 0xc000475fe0, 0xc000475fe0, 0x0, 0x0)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config.go:392 +0xa5
github.com/gruntwork-io/terragrunt/config.ParseConfigString(0xc000290510, 0x82, 0xc0000f38c0, 0x0, 0xc0000d3080, 0x78, 0x0, 0x0, 0x9a)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config.go:341 +0x1d7
github.com/gruntwork-io/terragrunt/config.ParseConfigFile(0xc0000d3080, 0x78, 0xc0000f38c0, 0x0, 0x1, 0x1, 0x2)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config.go:279 +0x8c
github.com/gruntwork-io/terragrunt/config.ReadTerragruntConfig(0xc0000f38c0, 0x3, 0x3, 0x1c6531d)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config.go:268 +0xc4
github.com/gruntwork-io/terragrunt/cli.runTerragrunt(0xc0000f38c0, 0x1c73cbd, 0x15)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/cli/cli_app.go:243 +0xa6
github.com/gruntwork-io/terragrunt/configstack.(*runningModule).runNow(0xc00047a0f0, 0x0, 0x0)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/configstack/running_module.go:238 +0x16f
github.com/gruntwork-io/terragrunt/configstack.(*runningModule).runModuleWhenReady(0xc00047a0f0)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/configstack/running_module.go:201 +0x6a
github.com/gruntwork-io/terragrunt/configstack.runModules.func1(0xc0003b2bd0, 0xc00047a0f0)
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/configstack/running_module.go:171 +0x5b
created by github.com/gruntwork-io/terragrunt/configstack.runModules
        /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/configstack/running_module.go:169 +0xe1
., and 2 other diagnostic(s)
--- FAIL: TestAWSGetCallerIdentityFunctions (0.99s)
    integration_test.go:2258: Copying fixture-get-aws-caller-identity to /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640
    integration_test.go:2248: Failed to run Terragrunt command 'terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity' due to error: Encountered the following errors:
        /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test314266640/fixture-get-aws-caller-identity/terragrunt.hcl:2,13-32: Error in function call; Call to function "get_aws_account_id" failed: panic in function implementation: runtime error: invalid memory address or nil pointer dereference
        goroutine 37 [running]:
        runtime/debug.Stack(0xc0004a3a30, 0x1b1d220, 0x2693930)
                /usr/local/Cellar/go/1.13/libexec/src/runtime/debug/stack.go:24 +0x9d
        github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function.errorForPanic(...)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function/error.go:44
        github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function.Function.Call.func1(0xc0004a3db8, 0xc0004a3dd8)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function/function.go:239 +0x8e
        panic(0x1b1d220, 0x2693930)
                /usr/local/Cellar/go/1.13/libexec/src/runtime/panic.go:679 +0x1b2
        github.com/gruntwork-io/terragrunt/config.getAWSAccountID(0x0, 0xc0000f38c0, 0x0, 0x0, 0x0, 0x0)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config_helpers.go:328 +0x44
        github.com/gruntwork-io/terragrunt/config.wrapVoidToStringAsFuncImpl.func1(0x26c8aa8, 0x0, 0x0, 0x1f085c0, 0xc0000b98b9, 0xc0000b98b9, 0x0, 0x0, 0x0, 0x0, ...)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/cty_helpers.go:39 +0x3b
        github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function.Function.Call(0xc0004ae540, 0x26c8aa8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/zclconf/go-cty/cty/function/function.go:243 +0x30c
        github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax.(*FunctionCallExpr).Value(0xc00048e000, 0xc0004b0760, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/expression.go:385 +0x10c3
        github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax.(*ObjectConsExpr).Value(0xc0003c4a00, 0xc0004b0760, 0x2e8ec923b8036294, 0x1010171, 0xc0004a5408, 0xc0004a5370, 0xc0002d7a05, 0xc0002d7ab0, 0x269ee10)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/expression.go:703 +0x285
        github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl.DecodeExpression(0x2f82648, 0xc0003c4a00, 0xc0004b0760, 0xc0004ba0c0, 0xc00010cb18, 0xc00010cb18, 0x196, 0x1c54c20)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl/decode.go:273 +0x59
        github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl.decodeBodyToStruct(0x1f07a80, 0xc00031f810, 0xc0004b0760, 0x1c33480, 0xc00010cb00, 0x199, 0x0, 0x0, 0x0)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl/decode.go:111 +0x692
        github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl.decodeBodyToValue(0x1f07a80, 0xc00031f810, 0xc0004b0760, 0x1c33480, 0xc00010cb00, 0x199, 0x0, 0x0, 0x0)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl/decode.go:43 +0xd5
        github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl.DecodeBody(0x1f07a80, 0xc00031f810, 0xc0004b0760, 0x1a696a0, 0xc00010cb00, 0xc000475fe0, 0xc0004b0760, 0x26acbe0)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/vendor/github.com/hashicorp/hcl2/gohcl/decode.go:36 +0xe2
        github.com/gruntwork-io/terragrunt/config.decodeHcl(0xc000359d00, 0xc0000d3080, 0x78, 0x1a696a0, 0xc00010cb00, 0xc0000f38c0, 0x0, 0x0, 0xc000475fe0, 0x0, ...)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config.go:417 +0x127
        github.com/gruntwork-io/terragrunt/config.decodeAsTerragruntConfigFile(0xc000359d00, 0xc0000d3080, 0x78, 0xc0000f38c0, 0x0, 0x0, 0xc000475fe0, 0xc000475fe0, 0x0, 0x0)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config.go:392 +0xa5
        github.com/gruntwork-io/terragrunt/config.ParseConfigString(0xc000290510, 0x82, 0xc0000f38c0, 0x0, 0xc0000d3080, 0x78, 0x0, 0x0, 0x9a)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config.go:341 +0x1d7
        github.com/gruntwork-io/terragrunt/config.ParseConfigFile(0xc0000d3080, 0x78, 0xc0000f38c0, 0x0, 0x1, 0x1, 0x2)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config.go:279 +0x8c
        github.com/gruntwork-io/terragrunt/config.ReadTerragruntConfig(0xc0000f38c0, 0x3, 0x3, 0x1c6531d)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/config/config.go:268 +0xc4
        github.com/gruntwork-io/terragrunt/cli.runTerragrunt(0xc0000f38c0, 0x1c73cbd, 0x15)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/cli/cli_app.go:243 +0xa6
        github.com/gruntwork-io/terragrunt/configstack.(*runningModule).runNow(0xc00047a0f0, 0x0, 0x0)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/configstack/running_module.go:238 +0x16f
        github.com/gruntwork-io/terragrunt/configstack.(*runningModule).runModuleWhenReady(0xc00047a0f0)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/configstack/running_module.go:201 +0x6a
        github.com/gruntwork-io/terragrunt/configstack.runModules.func1(0xc0003b2bd0, 0xc00047a0f0)
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/configstack/running_module.go:171 +0x5b
        created by github.com/gruntwork-io/terragrunt/configstack.runModules
                /Users/yoriy/go/src/github.com/gruntwork-io/terragrunt/configstack/running_module.go:169 +0xe1
        ., and 2 other diagnostic(s)

        Stdout: (see log output above)

        Stderr: (see log output above)
FAIL
FAIL    github.com/gruntwork-io/terragrunt/test 1.024s
FAIL
```

After:
```
%~> go test -v -run TestAWSGetCallerIdentityFunctions .
=== RUN   TestAWSGetCallerIdentityFunctions
=== PAUSE TestAWSGetCallerIdentityFunctions
=== CONT  TestAWSGetCallerIdentityFunctions
[terragrunt] 2019/12/03 18:31:51 Setting download directory for module /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity to /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity/.terragrunt-cache
[terragrunt] 2019/12/03 18:31:51 Stack at /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity:
  => Module /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity (excluded: false, dependencies: [])
[terragrunt] 2019/12/03 18:31:51 [terragrunt]  Are you sure you want to run 'terragrunt apply' in each folder of the stack described above? (y/n)
[terragrunt] 2019/12/03 18:31:51
[terragrunt] 2019/12/03 18:31:51 The non-interactive flag is set to true, so assuming 'yes' for all prompts
[terragrunt] [/var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity] 2019/12/03 18:31:51 Module /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity must wait for 0 dependencies to finish
[terragrunt] [/var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity] 2019/12/03 18:31:51 Running module /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity now
[terragrunt] [/var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity] 2019/12/03 18:31:51 Reading Terragrunt config file at /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity/terragrunt.hcl
[terragrunt] [/var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity] 2019/12/03 18:31:56 Module /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity has finished with an error: /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity/terragrunt.hcl:2,13-32: Error in function call; Call to function "get_aws_account_id" failed: NoCredentialProviders: no valid providers in chain. Deprecated.
        For verbose messaging see aws.Config.CredentialsChainVerboseErrors., and 2 other diagnostic(s)
--- FAIL: TestAWSGetCallerIdentityFunctions (5.95s)
    integration_test.go:2258: Copying fixture-get-aws-caller-identity to /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283
    integration_test.go:2248: Failed to run Terragrunt command 'terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity' due to error: Encountered the following errors:
        /var/folders/n2/pljz6dq52bd1ksmw23qyr3sr0000gn/T/terragrunt-test896743283/fixture-get-aws-caller-identity/terragrunt.hcl:2,13-32: Error in function call; Call to function "get_aws_account_id" failed: NoCredentialProviders: no valid providers in chain. Deprecated.
                For verbose messaging see aws.Config.CredentialsChainVerboseErrors., and 2 other diagnostic(s)

        Stdout: (see log output above)

        Stderr: (see log output above)
FAIL
FAIL    github.com/gruntwork-io/terragrunt/test 5.975s
FAIL
```