### PR TITLE
Added AWS_SECURITY_TOKEN for support old aws sdk

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -402,6 +402,7 @@ func assumeRoleIfNecessary(terragruntOptions *options.TerragruntOptions) error {
 	terragruntOptions.Env["AWS_ACCESS_KEY_ID"] = aws.StringValue(creds.AccessKeyId)
 	terragruntOptions.Env["AWS_SECRET_ACCESS_KEY"] = aws.StringValue(creds.SecretAccessKey)
 	terragruntOptions.Env["AWS_SESSION_TOKEN"] = aws.StringValue(creds.SessionToken)
+	terragruntOptions.Env["AWS_SECURITY_TOKEN"] = aws.StringValue(creds.SessionToken)
 
 	return nil
 }


### PR DESCRIPTION
Hi! 

I use credentials secured helper tools such a `vaulted` and `aws-vault` for safely store my AWS credentials on the laptop. 

I run terragrunt for multi-account setup, and authenticate  via multi assume iam roles steps. account X iam role -> account Y iam role.
So my ~/.aws/config looks like:

```
[profile test]
role_arn = arn:aws:iam::xxxxxxxxxx:role/admin
region = us-east-1
```
and my terragrunt.hcl in the root of repository looks like 

```
iam_role = "arn:aws:iam:: xxxxxxxxxx:role/terragrant-in-another-account"

remote_state {
  backend = "s3"
OUTPUT OMMITED......
````

The issue if you run terraform local-exec provider, it will spawn new shell, but it will inherit env variables from terragrunt/terraform environment and the vaulted and aws-vaulted, sets `AWS_SECURITY_TOKEN` environment variable(which is set for backward compatibility for old AWS sdk as far as I understood from commits and documentation of tools). And you have AWS_SESSION_TOKEN and AWS_SECURITY_TOKEN set with different values, and AWS throws

```An error occurred (UnrecognizedClientException) when calling the GetParameter operation: The security token included in the request is invalid.``` 


P.S. Links with code of vaulted and aws-vaulted
https://github.com/99designs/aws-vault/blob/7daf3aa7d479e48efe8e3854b01cea47e603528d/cli/exec.go#L174
https://github.com/miquella/vaulted/blob/8b8e09b8c4bcfafa613bf8d48d28c27bc8f3fab9/doc/vaulted-exec.1.md#aws-key
