### PR TITLE
Update Auto-Init Documentation to add known issues

### DIFF
--- a/docs/_docs/02_features/auto-init.md
+++ b/docs/_docs/02_features/auto-init.md
@@ -23,7 +23,12 @@ When Auto-Init is enabled (the default), terragrunt will automatically call [`te
 
 As [mentioned]({{site.baseurl}}/docs/features/keep-your-cli-flags-dry/#extra_arguments-for-init), `extra_arguments` can be configured to allow customization of the `terraform init` command.
 
-Note that there might be cases where terragrunt does not properly detect that `terraform init` needs be called. In this case, terraform would fail. Running `terragrunt init` again corrects this situation.
+Note that there might be cases where terragrunt does not properly detect that `terraform init` needs be called. Examples of such cases include the following in the terragrunt source:
+* Local references (e.g `source = ../module`)
+* Remote references with no ref tag
+* Remote references with a ref tag that is a branch
+
+In this case, terraform would fail. Running `terragrunt init` again corrects this situation.
 
 For some use cases, it might be desirable to disable Auto-Init. For example, if each user wants to specify a different `-plugin-dir` option to `terraform init` (and therefore it cannot be put in `extra_arguments`). To disable Auto-Init, use the `--terragrunt-no-auto-init` command line option or set the `TERRAGRUNT_AUTO_INIT` environment variable to `false`.
 


### PR DESCRIPTION
This PR addresses https://github.com/gruntwork-io/terragrunt/issues/936 by amending documentation to include 
known cases when auto-init fails to work.