### PR TITLE
read_terragrunt_config

### DIFF
--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -46,10 +46,11 @@ const (
 
 // Configuration for generating code
 type GenerateConfig struct {
-	Path          string
+	Path          string `cty:"path"`
 	IfExists      GenerateConfigExists
-	CommentPrefix string
-	Contents      string
+	IfExistsStr   string `cty:"if_exists"`
+	CommentPrefix string `cty:"comment_prefix"`
+	Contents      string `cty:"contents"`
 }
 
 // WriteToFile will generate a new file at the given target path with the given contents. If a file already exists at
@@ -75,7 +76,7 @@ func WriteToFile(logger *log.Logger, basePath string, config GenerateConfig) err
 	}
 
 	// Add the signature as a prefix to the file
-	contentsToWrite := fmt.Sprintf("%s%s\n%s", DefaultCommentPrefix, TerragruntGeneratedSignature, config.Contents)
+	contentsToWrite := fmt.Sprintf("%s%s\n%s", config.CommentPrefix, TerragruntGeneratedSignature, config.Contents)
 
 	if err := ioutil.WriteFile(targetPath, []byte(contentsToWrite), 0644); err != nil {
 		return errors.WithStackTrace(err)

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ const DefaultTerragruntConfigPath = "terragrunt.hcl"
 const DefaultTerragruntJsonConfigPath = "terragrunt.hcl.json"
 
 // TerragruntConfig represents a parsed and expanded configuration
+// NOTE: if any attributes are added, make sure to update terragruntConfigAsCty in config_as_cty.go
 type TerragruntConfig struct {
 	Terraform                  *TerraformConfig
 	TerraformBinary            string
@@ -116,7 +117,7 @@ func (cfg *IncludeConfig) String() string {
 // ModuleDependencies represents the paths to other Terraform modules that must be applied before the current module
 // can be applied
 type ModuleDependencies struct {
-	Paths []string `hcl:"paths,attr"`
+	Paths []string `hcl:"paths,attr" cty:"paths"`
 }
 
 // Merge appends the paths in the provided ModuleDependencies object into this ModuleDependencies object.
@@ -138,10 +139,10 @@ func (deps *ModuleDependencies) String() string {
 
 // Hook specifies terraform commands (apply/plan) and array of os commands to execute
 type Hook struct {
-	Name       string   `hcl:"name,label"`
-	Commands   []string `hcl:"commands,attr"`
-	Execute    []string `hcl:"execute,attr"`
-	RunOnError *bool    `hcl:"run_on_error,attr"`
+	Name       string   `hcl:"name,label" cty:"name"`
+	Commands   []string `hcl:"commands,attr" cty:"commands"`
+	Execute    []string `hcl:"execute,attr" cty:"execute"`
+	RunOnError *bool    `hcl:"run_on_error,attr" cty:"run_on_error"`
 }
 
 func (conf *Hook) String() string {
@@ -149,6 +150,8 @@ func (conf *Hook) String() string {
 }
 
 // TerraformConfig specifies where to find the Terraform configuration files
+// NOTE: If any attributes or blocks are added here, be sure to add it to ctyTerraformConfig in config_as_cty.go as
+// well.
 type TerraformConfig struct {
 	ExtraArgs   []TerraformExtraArguments `hcl:"extra_arguments,block"`
 	Source      *string                   `hcl:"source,attr"`
@@ -190,12 +193,12 @@ func (conf *TerraformConfig) ValidateHooks() error {
 
 // TerraformExtraArguments sets a list of arguments to pass to Terraform if command fits any in the `Commands` list
 type TerraformExtraArguments struct {
-	Name             string             `hcl:"name,label"`
-	Arguments        *[]string          `hcl:"arguments,attr"`
-	RequiredVarFiles *[]string          `hcl:"required_var_files,attr"`
-	OptionalVarFiles *[]string          `hcl:"optional_var_files,attr"`
-	Commands         []string           `hcl:"commands,attr"`
-	EnvVars          *map[string]string `hcl:"env_vars,attr"`
+	Name             string             `hcl:"name,label" cty:"name"`
+	Arguments        *[]string          `hcl:"arguments,attr" cty:"arguments"`
+	RequiredVarFiles *[]string          `hcl:"required_var_files,attr" cty:"required_var_files"`
+	OptionalVarFiles *[]string          `hcl:"optional_var_files,attr" cty:"optional_var_files"`
+	Commands         []string           `hcl:"commands,attr" cty:"commands"`
+	EnvVars          *map[string]string `hcl:"env_vars,attr" cty:"env_vars"`
 }
 
 func (conf *TerraformExtraArguments) String() string {

--- a/config/config.go
+++ b/config/config.go
@@ -724,11 +724,14 @@ func convertToTerragruntConfig(
 			return nil, err
 		}
 		genConfig := codegen.GenerateConfig{
-			Path:     block.Path,
-			IfExists: ifExists,
-			Contents: block.Contents,
+			Path:        block.Path,
+			IfExists:    ifExists,
+			IfExistsStr: block.IfExists,
+			Contents:    block.Contents,
 		}
-		if block.CommentPrefix != nil {
+		if block.CommentPrefix == nil {
+			genConfig.CommentPrefix = codegen.DefaultCommentPrefix
+		} else {
 			genConfig.CommentPrefix = *block.CommentPrefix
 		}
 		terragruntConfig.GenerateConfigs[block.Name] = genConfig

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -1,0 +1,183 @@
+package config
+
+import (
+	"encoding/json"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/remote"
+)
+
+// Serialize TerragruntConfig struct to a cty Value that can be used to reference the attributes in other config. Note
+// that we can't straight up convert the struct using cty tags due to differences in the desired representation.
+// Specifically, we want to reference blocks by named attributes, but blocks are rendered to lists in the
+// TerragruntConfig struct, so we need to do some massaging of the data to convert the list of blocks in to a map going
+// from the block name label to the block value.
+func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
+	output := map[string]cty.Value{}
+
+	// Convert attributes that are primitive types
+	output["terraform_binary"] = gostringToCty(config.TerraformBinary)
+	output["terraform_version_constraint"] = gostringToCty(config.TerraformVersionConstraint)
+	output["download_dir"] = gostringToCty(config.DownloadDir)
+	output["iam_role"] = gostringToCty(config.IamRole)
+	output["prevent_destroy"] = goboolToCty(config.PreventDestroy)
+	output["skip"] = goboolToCty(config.Skip)
+
+	terraformConfigCty, err := terraformConfigAsCty(config.Terraform)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	output["terraform"] = terraformConfigCty
+
+	remoteStateCty, err := remoteStateAsCty(config.RemoteState)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	output["remote_state"] = remoteStateCty
+
+	dependenciesCty, err := gostructToCty(config.Dependencies)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	output["dependencies"] = dependenciesCty
+
+	dependencyCty, err := dependencyBlocksAsCty(config.TerragruntDependencies)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	output["dependency"] = dependencyCty
+
+	inputsCty, err := convertToCtyWithJson(config.Inputs)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	output["inputs"] = inputsCty
+
+	localsCty, err := convertToCtyWithJson(config.Locals)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	output["locals"] = localsCty
+
+	return convertValuesMapToCtyVal(output)
+}
+
+// ctyTerraformConfig is an alternate representation of TerraformConfig that converts internal blocks into a map that
+// maps the name to the underlying struct, as opposed to a list representation.
+type ctyTerraformConfig struct {
+	ExtraArgs   map[string]TerraformExtraArguments `cty:"extra_arguments"`
+	Source      *string                            `cty:"source"`
+	BeforeHooks map[string]Hook                    `cty:"before_hook"`
+	AfterHooks  map[string]Hook                    `cty:"after_hook"`
+}
+
+// Serialize TerraformConfig to a cty Value, but with maps instead of lists for the blocks.
+func terraformConfigAsCty(config *TerraformConfig) (cty.Value, error) {
+	if config == nil {
+		return cty.NilVal, nil
+	}
+
+	configCty := ctyTerraformConfig{
+		Source:      config.Source,
+		ExtraArgs:   map[string]TerraformExtraArguments{},
+		BeforeHooks: map[string]Hook{},
+		AfterHooks:  map[string]Hook{},
+	}
+
+	for _, arg := range config.ExtraArgs {
+		configCty.ExtraArgs[arg.Name] = arg
+	}
+	for _, hook := range config.BeforeHooks {
+		configCty.BeforeHooks[hook.Name] = hook
+	}
+	for _, hook := range config.AfterHooks {
+		configCty.AfterHooks[hook.Name] = hook
+	}
+
+	return gostructToCty(configCty)
+}
+
+// Serialize RemoteState to a cty Value. We can't directly serialize the struct because `config` is an arbitrary
+// interface whose type we do not know, so we have to do a hack to go through json.
+func remoteStateAsCty(remoteState *remote.RemoteState) (cty.Value, error) {
+	if remoteState == nil {
+		return cty.NilVal, nil
+	}
+
+	output := map[string]cty.Value{}
+	output["backend"] = gostringToCty(remoteState.Backend)
+	output["disable_init"] = goboolToCty(remoteState.DisableInit)
+
+	ctyJsonVal, err := convertToCtyWithJson(remoteState.Config)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	output["config"] = ctyJsonVal
+
+	return convertValuesMapToCtyVal(output)
+}
+
+// Serialize the list of dependency blocks to a cty Value as a map that maps the block names to the cty representation.
+func dependencyBlocksAsCty(dependencyBlocks []Dependency) (cty.Value, error) {
+	out := map[string]cty.Value{}
+	for _, block := range dependencyBlocks {
+		blockCty, err := gostructToCty(block)
+		if err != nil {
+			return cty.NilVal, err
+		}
+		out[block.Name] = blockCty
+	}
+	return convertValuesMapToCtyVal(out)
+}
+
+// Converts arbitrary go types that are json serializable to a cty Value by using json as an intermediary
+// representation. This avoids the strict type nature of cty, where you need to know the output type beforehand to
+// serialize to cty.
+func convertToCtyWithJson(val interface{}) (cty.Value, error) {
+	jsonBytes, err := json.Marshal(val)
+	if err != nil {
+		return cty.NilVal, errors.WithStackTrace(err)
+	}
+	var ctyJsonVal ctyjson.SimpleJSONValue
+	if err := ctyJsonVal.UnmarshalJSON(jsonBytes); err != nil {
+		return cty.NilVal, errors.WithStackTrace(err)
+	}
+	return ctyJsonVal.Value, nil
+}
+
+// Converts an arbitrary go struct that has cty tags to a cty Value.
+func gostructToCty(val interface{}) (cty.Value, error) {
+	ctyType, err := gocty.ImpliedType(val)
+	if err != nil {
+		return cty.NilVal, errors.WithStackTrace(err)
+	}
+	ctyOut, err := gocty.ToCtyValue(val, ctyType)
+	if err != nil {
+		return cty.NilVal, errors.WithStackTrace(err)
+	}
+	return ctyOut, nil
+}
+
+// Converts primitive go strings to a cty Value.
+func gostringToCty(val string) cty.Value {
+	ctyOut, err := gocty.ToCtyValue(val, cty.String)
+	if err != nil {
+		// Since we are converting primitive strings, we should never get an error in this conversion.
+		panic(err)
+	}
+	return ctyOut
+}
+
+// Converts primitive go bools to a cty Value.
+func goboolToCty(val bool) cty.Value {
+	ctyOut, err := gocty.ToCtyValue(val, cty.Bool)
+	if err != nil {
+		// Since we are converting primitive bools, we should never get an error in this conversion.
+		panic(err)
+	}
+	return ctyOut
+}

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -31,37 +31,49 @@ func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 	if err != nil {
 		return cty.NilVal, err
 	}
-	output["terraform"] = terraformConfigCty
+	if terraformConfigCty != cty.NilVal {
+		output["terraform"] = terraformConfigCty
+	}
 
 	remoteStateCty, err := remoteStateAsCty(config.RemoteState)
 	if err != nil {
 		return cty.NilVal, err
 	}
-	output["remote_state"] = remoteStateCty
+	if remoteStateCty != cty.NilVal {
+		output["remote_state"] = remoteStateCty
+	}
 
 	dependenciesCty, err := gostructToCty(config.Dependencies)
 	if err != nil {
 		return cty.NilVal, err
 	}
-	output["dependencies"] = dependenciesCty
+	if dependenciesCty != cty.NilVal {
+		output["dependencies"] = dependenciesCty
+	}
 
 	dependencyCty, err := dependencyBlocksAsCty(config.TerragruntDependencies)
 	if err != nil {
 		return cty.NilVal, err
 	}
-	output["dependency"] = dependencyCty
+	if dependencyCty != cty.NilVal {
+		output["dependency"] = dependencyCty
+	}
 
 	inputsCty, err := convertToCtyWithJson(config.Inputs)
 	if err != nil {
 		return cty.NilVal, err
 	}
-	output["inputs"] = inputsCty
+	if inputsCty != cty.NilVal {
+		output["inputs"] = inputsCty
+	}
 
 	localsCty, err := convertToCtyWithJson(config.Locals)
 	if err != nil {
 		return cty.NilVal, err
 	}
-	output["locals"] = localsCty
+	if localsCty != cty.NilVal {
+		output["locals"] = localsCty
+	}
 
 	return convertValuesMapToCtyVal(output)
 }

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -59,6 +59,14 @@ func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 		output["dependency"] = dependencyCty
 	}
 
+	generateCty, err := gostructToCty(config.GenerateConfigs)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	if generateCty != cty.NilVal {
+		output["generate"] = generateCty
+	}
+
 	inputsCty, err := convertToCtyWithJson(config.Inputs)
 	if err != nil {
 		return cty.NilVal, err
@@ -123,6 +131,12 @@ func remoteStateAsCty(remoteState *remote.RemoteState) (cty.Value, error) {
 	output := map[string]cty.Value{}
 	output["backend"] = gostringToCty(remoteState.Backend)
 	output["disable_init"] = goboolToCty(remoteState.DisableInit)
+
+	generateCty, err := gostructToCty(remoteState.Generate)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	output["generate"] = generateCty
 
 	ctyJsonVal, err := convertToCtyWithJson(remoteState.Config)
 	if err != nil {

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -1,0 +1,197 @@
+package config
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/fatih/structs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/gruntwork-io/terragrunt/remote"
+)
+
+// This test makes sure that all the fields from the TerragruntConfig struct are accounted for in the conversion to
+// cty.Value.
+func TestTerragruntConfigAsCtyDrift(t *testing.T) {
+	testSource := "./foo"
+	testTrue := true
+	mockOutputs := cty.Zero
+	mockOutputsAllowedTerraformCommands := []string{"init"}
+	testConfig := TerragruntConfig{
+		Terraform: &TerraformConfig{
+			Source: &testSource,
+			ExtraArgs: []TerraformExtraArguments{
+				TerraformExtraArguments{
+					Name:     "init",
+					Commands: []string{"init"},
+				},
+			},
+			BeforeHooks: []Hook{
+				Hook{
+					Name:     "init",
+					Commands: []string{"init"},
+					Execute:  []string{"true"},
+				},
+			},
+			AfterHooks: []Hook{
+				Hook{
+					Name:     "init",
+					Commands: []string{"init"},
+					Execute:  []string{"true"},
+				},
+			},
+		},
+		TerraformBinary:            "terraform",
+		TerraformVersionConstraint: "= 0.12.20",
+		RemoteState: &remote.RemoteState{
+			Backend:     "foo",
+			DisableInit: true,
+			Config: map[string]interface{}{
+				"bar": "baz",
+			},
+		},
+		Dependencies: &ModuleDependencies{
+			Paths: []string{"foo"},
+		},
+		DownloadDir:    ".terragrunt-cache",
+		PreventDestroy: true,
+		Skip:           true,
+		IamRole:        "terragruntRole",
+		Inputs: map[string]interface{}{
+			"aws_region": "us-east-1",
+		},
+		Locals: map[string]interface{}{
+			"quote": "the answer is 42",
+		},
+		TerragruntDependencies: []Dependency{
+			Dependency{
+				Name:                                "foo",
+				ConfigPath:                          "foo",
+				SkipOutputs:                         &testTrue,
+				MockOutputs:                         &mockOutputs,
+				MockOutputsAllowedTerraformCommands: &mockOutputsAllowedTerraformCommands,
+				RenderedOutputs:                     &mockOutputs,
+			},
+		},
+	}
+	ctyVal, err := terragruntConfigAsCty(&testConfig)
+	require.NoError(t, err)
+
+	ctyMap, err := parseCtyValueToMap(ctyVal)
+	require.NoError(t, err)
+
+	// Test the root properties
+	testConfigStructInfo := structs.New(testConfig)
+	testConfigFields := testConfigStructInfo.Names()
+	checked := map[string]bool{} // used to track which fields of the ctyMap were seen
+	for _, field := range testConfigFields {
+		mapKey, isConverted := terragruntConfigStructFieldToMapKey(t, field)
+		if isConverted {
+			_, hasKey := ctyMap[mapKey]
+			assert.Truef(t, hasKey, "Struct field %s (convert of map key %s) did not convert to cty val", field, mapKey)
+			checked[mapKey] = true
+		}
+	}
+	for key, _ := range ctyMap {
+		_, hasKey := checked[key]
+		assert.Truef(t, hasKey, "cty value key %s is not accounted for from struct field", key)
+	}
+}
+
+// This test makes sure that all the fields in RemoteState are converted to cty
+func TestRemoteStateAsCtyDrift(t *testing.T) {
+	testConfig := remote.RemoteState{
+		Backend:     "foo",
+		DisableInit: true,
+		Config: map[string]interface{}{
+			"bar": "baz",
+		},
+	}
+
+	ctyVal, err := remoteStateAsCty(&testConfig)
+	require.NoError(t, err)
+
+	ctyMap, err := parseCtyValueToMap(ctyVal)
+	require.NoError(t, err)
+
+	// Test the root properties
+	testConfigStructInfo := structs.New(testConfig)
+	testConfigFields := testConfigStructInfo.Names()
+	checked := map[string]bool{} // used to track which fields of the ctyMap were seen
+	for _, field := range testConfigFields {
+		mapKey, isConverted := remoteStateStructFieldToMapKey(t, field)
+		if isConverted {
+			_, hasKey := ctyMap[mapKey]
+			assert.Truef(t, hasKey, "Struct field %s (convert of map key %s) did not convert to cty val", field, mapKey)
+			checked[mapKey] = true
+		}
+	}
+	for key, _ := range ctyMap {
+		_, hasKey := checked[key]
+		assert.Truef(t, hasKey, "cty value key %s is not accounted for from struct field", key)
+	}
+
+}
+
+// This test makes sure that all the fields in TerraformConfig exist in ctyTerraformConfig.
+func TestTerraformConfigAsCtyDrift(t *testing.T) {
+	terraformConfigStructInfo := structs.New(TerraformConfig{})
+	terraformConfigFields := terraformConfigStructInfo.Names()
+	sort.Strings(terraformConfigFields)
+	ctyTerraformConfigStructInfo := structs.New(ctyTerraformConfig{})
+	ctyTerraformConfigFields := ctyTerraformConfigStructInfo.Names()
+	sort.Strings(ctyTerraformConfigFields)
+	assert.Equal(t, terraformConfigFields, ctyTerraformConfigFields)
+}
+
+func terragruntConfigStructFieldToMapKey(t *testing.T, fieldName string) (string, bool) {
+	switch fieldName {
+	case "Terraform":
+		return "terraform", true
+	case "TerraformBinary":
+		return "terraform_binary", true
+	case "TerraformVersionConstraint":
+		return "terraform_version_constraint", true
+	case "RemoteState":
+		return "remote_state", true
+	case "Dependencies":
+		return "dependencies", true
+	case "DownloadDir":
+		return "download_dir", true
+	case "PreventDestroy":
+		return "prevent_destroy", true
+	case "Skip":
+		return "skip", true
+	case "IamRole":
+		return "iam_role", true
+	case "Inputs":
+		return "inputs", true
+	case "Locals":
+		return "locals", true
+	case "TerragruntDependencies":
+		return "dependency", true
+	case "IsPartial":
+		return "", false
+	default:
+		t.Fatalf("Unknown struct property: %s", fieldName)
+		// This should not execute
+		return "", false
+	}
+}
+
+func remoteStateStructFieldToMapKey(t *testing.T, fieldName string) (string, bool) {
+	switch fieldName {
+	case "Backend":
+		return "backend", true
+	case "DisableInit":
+		return "disable_init", true
+	case "Config":
+		return "config", true
+	default:
+		t.Fatalf("Unknown struct property: %s", fieldName)
+		// This should not execute
+		return "", false
+	}
+}

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -673,6 +673,121 @@ func TestTerraformOutputJsonToCtyValueMap(t *testing.T) {
 	}
 }
 
+func TestReadTerragruntConfigInputs(t *testing.T) {
+	t.Parallel()
+
+	options := terragruntOptionsForTest(t, DefaultTerragruntConfigPath)
+	tgConfigCty, err := readTerragruntConfig("../test/fixture-inputs/terragrunt.hcl", nil, options)
+	require.NoError(t, err)
+
+	tgConfigMap, err := parseCtyValueToMap(tgConfigCty)
+	require.NoError(t, err)
+
+	inputsMap := tgConfigMap["inputs"].(map[string]interface{})
+	assert.Equal(t, inputsMap["string"].(string), "string")
+	assert.Equal(t, inputsMap["number"].(float64), float64(42))
+	assert.Equal(t, inputsMap["bool"].(bool), true)
+	assert.Equal(t, inputsMap["list_string"].([]interface{}), []interface{}{"a", "b", "c"})
+	assert.Equal(t, inputsMap["list_number"].([]interface{}), []interface{}{float64(1), float64(2), float64(3)})
+	assert.Equal(t, inputsMap["list_bool"].([]interface{}), []interface{}{true, false})
+	assert.Equal(t, inputsMap["map_string"].(map[string]interface{}), map[string]interface{}{"foo": "bar"})
+	assert.Equal(
+		t,
+		inputsMap["map_number"].(map[string]interface{}),
+		map[string]interface{}{"foo": float64(42), "bar": float64(12345)},
+	)
+	assert.Equal(
+		t,
+		inputsMap["map_bool"].(map[string]interface{}),
+		map[string]interface{}{"foo": true, "bar": false, "baz": true},
+	)
+	assert.Equal(
+		t,
+		inputsMap["object"].(map[string]interface{}),
+		map[string]interface{}{
+			"str":  "string",
+			"num":  float64(42),
+			"list": []interface{}{float64(1), float64(2), float64(3)},
+			"map":  map[string]interface{}{"foo": "bar"},
+		},
+	)
+	assert.Equal(t, inputsMap["from_env"].(string), "default")
+}
+
+func TestReadTerragruntConfigRemoteState(t *testing.T) {
+	t.Parallel()
+
+	options := terragruntOptionsForTest(t, DefaultTerragruntConfigPath)
+	tgConfigCty, err := readTerragruntConfig("../test/fixture/terragrunt.hcl", nil, options)
+	require.NoError(t, err)
+
+	tgConfigMap, err := parseCtyValueToMap(tgConfigCty)
+	require.NoError(t, err)
+
+	remoteStateMap := tgConfigMap["remote_state"].(map[string]interface{})
+	assert.Equal(t, remoteStateMap["backend"].(string), "s3")
+	configMap := remoteStateMap["config"].(map[string]interface{})
+	assert.Equal(t, configMap["encrypt"].(bool), true)
+	assert.Equal(t, configMap["key"].(string), "terraform.tfstate")
+	assert.Equal(
+		t,
+		configMap["s3_bucket_tags"].(map[string]interface{}),
+		map[string]interface{}{"owner": "terragrunt integration test", "name": "Terraform state storage"},
+	)
+}
+
+func TestReadTerragruntConfigHooks(t *testing.T) {
+	t.Parallel()
+
+	options := terragruntOptionsForTest(t, DefaultTerragruntConfigPath)
+	tgConfigCty, err := readTerragruntConfig("../test/fixture-hooks/before-and-after/terragrunt.hcl", nil, options)
+	require.NoError(t, err)
+
+	tgConfigMap, err := parseCtyValueToMap(tgConfigCty)
+	require.NoError(t, err)
+
+	terraformMap := tgConfigMap["terraform"].(map[string]interface{})
+	beforeHooksMap := terraformMap["before_hook"].(map[string]interface{})
+	assert.Equal(
+		t,
+		beforeHooksMap["before_hook_1"].(map[string]interface{})["execute"].([]interface{}),
+		[]interface{}{"touch", "before.out"},
+	)
+	assert.Equal(
+		t,
+		beforeHooksMap["before_hook_2"].(map[string]interface{})["execute"].([]interface{}),
+		[]interface{}{"echo", "BEFORE_TERRAGRUNT_READ_CONFIG"},
+	)
+
+	afterHooksMap := terraformMap["after_hook"].(map[string]interface{})
+	assert.Equal(
+		t,
+		afterHooksMap["after_hook_1"].(map[string]interface{})["execute"].([]interface{}),
+		[]interface{}{"touch", "after.out"},
+	)
+	assert.Equal(
+		t,
+		afterHooksMap["after_hook_2"].(map[string]interface{})["execute"].([]interface{}),
+		[]interface{}{"echo", "AFTER_TERRAGRUNT_READ_CONFIG"},
+	)
+}
+
+func TestReadTerragruntConfigLocals(t *testing.T) {
+	t.Parallel()
+
+	options := terragruntOptionsForTest(t, DefaultTerragruntConfigPath)
+	tgConfigCty, err := readTerragruntConfig("../test/fixture-locals/canonical/terragrunt.hcl", nil, options)
+	require.NoError(t, err)
+
+	tgConfigMap, err := parseCtyValueToMap(tgConfigCty)
+	require.NoError(t, err)
+
+	localsMap := tgConfigMap["locals"].(map[string]interface{})
+	assert.Equal(t, localsMap["x"].(float64), float64(2))
+	assert.Equal(t, localsMap["file_contents"].(string), "Hello world\n")
+	assert.Equal(t, localsMap["number_expression"].(float64), float64(42))
+}
+
 // Return keys as a map so it is treated like a set, and order doesn't matter when comparing equivalence
 func getKeys(valueMap map[string]cty.Value) map[string]bool {
 	keys := map[string]bool{}

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -88,12 +88,12 @@ func DecodeBaseBlocks(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	localsAsCty, err := convertLocalsMapToCtyVal(locals)
+	localsAsCty, err := convertValuesMapToCtyVal(locals)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	return localsAsCty, terragruntInclude, includeForDecode, nil
+	return &localsAsCty, terragruntInclude, includeForDecode, nil
 }
 
 func PartialParseConfigFile(

--- a/config/cty_helpers.go
+++ b/config/cty_helpers.go
@@ -137,13 +137,13 @@ func convertValuesMapToCtyVal(valMap map[string]cty.Value) (cty.Value, error) {
 	return valMapAsCty, nil
 }
 
-// generateTypeFromValuesMap takes the locals map and returns an object type that has the same number of fields, but
+// generateTypeFromValuesMap takes a values map and returns an object type that has the same number of fields, but
 // bound to each type of the underlying evaluated expression. This is the only way the HCL decoder will be happy, as
 // object type is the only map type that allows different types for each attribute (cty.Map requires all attributes to
 // have the same type.
-func generateTypeFromValuesMap(locals map[string]cty.Value) cty.Type {
+func generateTypeFromValuesMap(valMap map[string]cty.Value) cty.Type {
 	outType := map[string]cty.Type{}
-	for k, v := range locals {
+	for k, v := range valMap {
 		outType[k] = v.Type()
 	}
 	return cty.Object(outType)

--- a/config/cty_helpers.go
+++ b/config/cty_helpers.go
@@ -62,27 +62,6 @@ func wrapStaticValueToStringSliceAsFuncImpl(out []string) function.Function {
 	})
 }
 
-// Create a cty Function that takes as input parameters a slice of strings (var args, so this slice could be of any
-// length) and returns as output a dynamic value. The implementation of the function calls the given toWrap function, passing
-// it the input parameters string slice as well as the given include and terragruntOptions.
-func wrapStringSliceToDynamicValueAsFuncImpl(
-	toWrap func(params []string, include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (cty.Value, error),
-	include *IncludeConfig,
-	terragruntOptions *options.TerragruntOptions,
-) function.Function {
-	return function.New(&function.Spec{
-		VarParam: &function.Parameter{Type: cty.String},
-		Type:     function.StaticReturnType(cty.DynamicPseudoType),
-		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			params, err := ctySliceToStringSlice(args)
-			if err != nil {
-				return cty.NilVal, err
-			}
-			return toWrap(params, include, terragruntOptions)
-		},
-	})
-}
-
 // Convert the slice of cty values to a slice of strings. If any of the values in the given slice is not a string,
 // return an error.
 func ctySliceToStringSlice(args []cty.Value) ([]string, error) {

--- a/config/locals.go
+++ b/config/locals.go
@@ -1,14 +1,12 @@
 package config
 
 import (
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 	"github.com/hashicorp/hcl2/hclparse"
 	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/gocty"
 
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -135,7 +133,7 @@ func attemptEvaluateLocals(
 		}
 	}()
 
-	evaluatedLocalsAsCty, err := convertLocalsMapToCtyVal(evaluatedLocals)
+	evaluatedLocalsAsCty, err := convertValuesMapToCtyVal(evaluatedLocals)
 	if err != nil {
 		terragruntOptions.Logger.Printf("Could not convert evaluated locals to the execution context to evaluate additional locals")
 		return nil, evaluatedLocals, false, err
@@ -143,7 +141,7 @@ func attemptEvaluateLocals(
 	evalCtx := CreateTerragruntEvalContext(
 		filename,
 		terragruntOptions,
-		EvalContextExtensions{Include: included, Locals: evaluatedLocalsAsCty},
+		EvalContextExtensions{Include: included, Locals: &evaluatedLocalsAsCty},
 	)
 
 	// Track the locals that were evaluated for logging purposes
@@ -307,46 +305,6 @@ func decodeLocalsBlock(localsBlock *hcl.Block) ([]*Local, hcl.Diagnostics) {
 		})
 	}
 	return locals, diags
-}
-
-// convertLocalsMapToCtyVal takes the name - cty.Value pairs evaluated out of the locals block and converts to a single
-// cty.Value object that can be passed in as a Variable to the HCL evaluation context.
-func convertLocalsMapToCtyVal(locals map[string]cty.Value) (*cty.Value, error) {
-	var localsAsCty *cty.Value
-	localsAsCty = nil
-	if locals != nil && len(locals) > 0 {
-		localsAsCtyRaw, err := gocty.ToCtyValue(locals, generateTypeFromValuesMap(locals))
-		if err != nil {
-			return nil, errors.WithStackTrace(err)
-		}
-		localsAsCty = &localsAsCtyRaw
-	}
-	return localsAsCty, nil
-}
-
-// generateTypeFromValuesMap takes the locals map and returns an object type that has the same number of fields, but
-// bound to each type of the underlying evaluated expression. This is the only way the HCL decoder will be happy, as
-// object type is the only map type that allows different types for each attribute (cty.Map requires all attributes to
-// have the same type.
-func generateTypeFromValuesMap(locals map[string]cty.Value) cty.Type {
-	outType := map[string]cty.Type{}
-	for k, v := range locals {
-		outType[k] = v.Type()
-	}
-	return cty.Object(outType)
-}
-
-// Return the keys for the given locals map, sorted alphabetically
-func keysOfLocalsMap(m map[string]cty.Value) []string {
-	out := []string{}
-
-	for key, _ := range m {
-		out = append(out, key)
-	}
-
-	sort.Strings(out)
-
-	return out
 }
 
 // ------------------------------------------------

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -42,6 +42,8 @@ Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, ju
 
   - [run\_cmd()](#run_cmd)
 
+  - [read\_terragrunt\_config()](#read_terragrunt_config)
+
 ## Terraform built-in functions
 
 All [Terraform built-in functions](https://www.terraform.io/docs/configuration/functions.html) are supported in Terragrunt config files:
@@ -434,3 +436,70 @@ super_secret_value = run_cmd("--terragrunt-quiet", "./decrypt_secret.sh", "foo")
 ```
 
 **Note:** This will prevent terragrunt from displaying the output from the command in its output. However, the value could still be displayed in the Terraform output if Terraform does not treat it as a [sensitive value](https://www.terraform.io/docs/configuration/outputs.html#sensitive-suppressing-values-in-cli-output).
+
+
+## read\_terragrunt\_config
+
+`read_terragrunt_config(config_path, [default_val])` parses the terragrunt config at the given path and serializes the
+result into a map that can be used to reference the values of the parsed config. This function will expose all blocks
+and attributes of a terragrunt config.
+
+For example, suppose you had a config file called `common.hcl` that contains common input variables:
+
+```hcl
+inputs = {
+  stack_name = "staging"
+  account_id = "1234567890"
+}
+```
+
+You can read these inputs in another config by using `read_terragrunt_config`, and merge them into the inputs:
+
+```hcl
+locals {
+  common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))
+}
+
+inputs = merge(
+  local.common_vars.inputs,
+  {
+    # additional inputs
+  }
+)
+```
+
+This function also takes in an optional second parameter which will be returned if the file does not exist:
+
+```hcl
+locals {
+  common_vars = read_terragrunt_config(find_in_parent_folders("i-dont-exist.hcl", "i-dont-exist.hcl"), {inputs = {}})
+}
+
+inputs = merge(
+  local.common_vars.inputs, # This will be {}
+  {
+    # additional inputs
+  }
+)
+```
+
+Note that this function will also render `dependency` blocks. That is, the parsed config will make the outputs of the
+`dependency` blocks available. For example, suppose you had the following config in a file called `common_deps.hcl`:
+
+```hcl
+dependency "vpc" {
+  config_path = "${get_terragrunt_dir()}/../vpc"
+}
+```
+
+You can access the outputs of the vpc dependency through the parsed outputs of `read_terragrunt_config`:
+
+```hcl
+locals {
+  common_deps = read_terragrunt_config(find_in_parent_folders("common_deps.hcl"))
+}
+
+inputs = {
+  vpc_id = local.common_deps.dependency.vpc.outputs.vpc_id
+}
+```

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -10,6 +10,7 @@ import (
 )
 
 // Configuration for Terraform remote state
+// NOTE: If any attributes are added here, be sure to add it to ctyRemoteState in config/config_as_cty.go
 type RemoteState struct {
 	Backend     string
 	DisableInit bool

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -24,8 +24,8 @@ func (remoteState *RemoteState) String() string {
 
 // Code gen configuration for Terraform remote state
 type RemoteStateGenerate struct {
-	Path     string
-	IfExists string
+	Path     string `cty:"path"`
+	IfExists string `cty:"if_exists"`
 }
 
 type RemoteStateInitializer interface {
@@ -193,9 +193,11 @@ func (remoteState *RemoteState) GenerateTerraformCode(terragruntOptions *options
 		return err
 	}
 	codegenConfig := codegen.GenerateConfig{
-		Path:     remoteState.Generate.Path,
-		IfExists: ifExistsEnum,
-		Contents: string(configBytes),
+		Path:          remoteState.Generate.Path,
+		IfExists:      ifExistsEnum,
+		IfExistsStr:   remoteState.Generate.IfExists,
+		Contents:      string(configBytes),
+		CommentPrefix: codegen.DefaultCommentPrefix,
 	}
 	return codegen.WriteToFile(terragruntOptions.Logger, terragruntOptions.WorkingDir, codegenConfig)
 }

--- a/test/fixture-read-config/full/main.tf
+++ b/test/fixture-read-config/full/main.tf
@@ -1,0 +1,32 @@
+variable "localstg" {}
+output "localstg" { value = var.localstg }
+
+variable "remote_state" {}
+output "remote_state" { value = var.remote_state }
+
+variable "terraformtg" {}
+output "terraformtg" { value = var.terraformtg }
+
+variable "dependencies" {}
+output "dependencies" { value = var.dependencies }
+
+variable "terraform_binary" {}
+output "terraform_binary" { value = var.terraform_binary }
+
+variable "terraform_version_constraint" {}
+output "terraform_version_constraint" { value = var.terraform_version_constraint }
+
+variable "download_dir" {}
+output "download_dir" { value = var.download_dir }
+
+variable "prevent_destroy" {}
+output "prevent_destroy" { value = var.prevent_destroy }
+
+variable "skip" {}
+output "skip" { value = var.skip }
+
+variable "iam_role" {}
+output "iam_role" { value = var.iam_role }
+
+variable "inputs" {}
+output "inputs" { value = var.inputs }

--- a/test/fixture-read-config/full/main.tf
+++ b/test/fixture-read-config/full/main.tf
@@ -1,6 +1,9 @@
 variable "localstg" {}
 output "localstg" { value = var.localstg }
 
+variable "generate" {}
+output "generate" { value = var.generate }
+
 variable "remote_state" {}
 output "remote_state" { value = var.remote_state }
 

--- a/test/fixture-read-config/full/source.hcl
+++ b/test/fixture-read-config/full/source.hcl
@@ -2,8 +2,22 @@ locals {
   the_answer = 42
 }
 
+generate "provider" {
+  path = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents = <<EOF
+provider "aws" {
+  region = "us-east-1"
+}
+EOF
+}
+
 remote_state {
   backend = "local"
+  generate = {
+    path = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
   config = {
     path = "foo.tfstate"
   }

--- a/test/fixture-read-config/full/source.hcl
+++ b/test/fixture-read-config/full/source.hcl
@@ -1,0 +1,50 @@
+locals {
+  the_answer = 42
+}
+
+remote_state {
+  backend = "local"
+  config = {
+    path = "foo.tfstate"
+  }
+}
+
+terraform {
+  source = "./delorean"
+
+  extra_arguments "var-files" {
+    commands = ["apply", "plan"]
+    required_var_files = ["extra.tfvars"]
+    optional_var_files = ["optional.tfvars"]
+    env_vars = {
+      TF_VAR_custom_var = "I'm set in extra_arguments env_vars"
+    }
+  }
+
+  before_hook "before_hook_1" {
+    commands = ["apply", "plan"]
+    execute = ["touch", "before.out"]
+    run_on_error = true
+  }
+
+  after_hook "after_hook_1" {
+    commands = ["apply", "plan"]
+    execute = ["touch", "after.out"]
+    run_on_error = true
+  }
+}
+
+dependencies {
+  paths = ["../module-a"]
+}
+
+terraform_binary = "terragrunt"
+terraform_version_constraint = "= 0.12.20"
+download_dir = ".terragrunt-cache"
+prevent_destroy = true
+skip = true
+iam_role = "TerragruntIAMRole"
+
+inputs = {
+  doc = "Emmett Brown"
+}

--- a/test/fixture-read-config/full/terragrunt.hcl
+++ b/test/fixture-read-config/full/terragrunt.hcl
@@ -4,6 +4,7 @@ locals {
 
 inputs = {
   localstg                     = local.config.locals
+  generate                     = local.config.generate
   remote_state                 = local.config.remote_state
   terraformtg                  = local.config.terraform
   dependencies                 = local.config.dependencies

--- a/test/fixture-read-config/full/terragrunt.hcl
+++ b/test/fixture-read-config/full/terragrunt.hcl
@@ -1,0 +1,17 @@
+locals {
+  config = read_terragrunt_config("${get_terragrunt_dir()}/source.hcl")
+}
+
+inputs = {
+  localstg                     = local.config.locals
+  remote_state                 = local.config.remote_state
+  terraformtg                  = local.config.terraform
+  dependencies                 = local.config.dependencies
+  terraform_binary             = local.config.terraform_binary
+  terraform_version_constraint = local.config.terraform_version_constraint
+  download_dir                 = local.config.download_dir
+  prevent_destroy              = local.config.prevent_destroy
+  skip                         = local.config.skip
+  iam_role                     = local.config.iam_role
+  inputs                       = local.config.inputs
+}

--- a/test/fixture-read-config/with_default/main.tf
+++ b/test/fixture-read-config/with_default/main.tf
@@ -1,0 +1,4 @@
+variable "data" {}
+output "data" {
+  value = var.data
+}

--- a/test/fixture-read-config/with_default/terragrunt.hcl
+++ b/test/fixture-read-config/with_default/terragrunt.hcl
@@ -1,0 +1,5 @@
+locals {
+  config_does_not_exist = read_terragrunt_config("${get_terragrunt_dir()}/i-dont-exist.hcl", {data = "default value"})
+}
+
+inputs = local.config_does_not_exist

--- a/test/fixture-read-config/with_dependency/dep/terragrunt.hcl
+++ b/test/fixture-read-config/with_dependency/dep/terragrunt.hcl
@@ -1,0 +1,3 @@
+dependency "inputs" {
+  config_path = "../../../fixture-inputs"
+}

--- a/test/fixture-read-config/with_dependency/terragrunt.hcl
+++ b/test/fixture-read-config/with_dependency/terragrunt.hcl
@@ -1,0 +1,9 @@
+locals {
+  config_with_dependency = read_terragrunt_config("${get_terragrunt_dir()}/dep/terragrunt.hcl")
+}
+
+terraform {
+  source = "${get_terragrunt_dir()}/../../fixture-inputs"
+}
+
+inputs = local.config_with_dependency.dependency.inputs.outputs

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2324,6 +2324,23 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 			"paths": []interface{}{"../module-a"},
 		},
 	)
+	generateOut := map[string]interface{}{}
+	require.NoError(t, json.Unmarshal([]byte(outputs["generate"].Value.(string)), &generateOut))
+	assert.Equal(
+		t,
+		generateOut,
+		map[string]interface{}{
+			"provider": map[string]interface{}{
+				"path":           "provider.tf",
+				"if_exists":      "overwrite_terragrunt",
+				"comment_prefix": "# ",
+				"contents": `provider "aws" {
+  region = "us-east-1"
+}
+`,
+			},
+		},
+	)
 	remoteStateOut := map[string]interface{}{}
 	require.NoError(t, json.Unmarshal([]byte(outputs["remote_state"].Value.(string)), &remoteStateOut))
 	assert.Equal(
@@ -2332,6 +2349,7 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 		map[string]interface{}{
 			"backend":      "local",
 			"disable_init": false,
+			"generate":     map[string]interface{}{"path": "backend.tf", "if_exists": "overwrite_terragrunt"},
 			"config":       map[string]interface{}{"path": "foo.tfstate"},
 		},
 	)


### PR DESCRIPTION
This implements `read_terragrunt_config`, a helper function that can be used for reading in another terragrunt config and accessing its blocks and attributes for reuse.

This is one of the suggested improvements coming out of https://github.com/gruntwork-io/terragrunt/pull/1025

### TODO

- [x] Update when https://github.com/gruntwork-io/terragrunt/pull/1050 merges (there are some conflicts in that `generate` blocks will need to be added to the converter).