### PR TITLE
Add ability to disable request response checksums to workaround SDK bug

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -198,17 +198,6 @@
   version = "v2.0.4"
 
 [[projects]]
-  digest = "1:a669bf34b31b6051aa7902ba8c99aff9f344e6ef766c337e08543dc75197d592"
-  name = "github.com/gruntwork-io/gruntwork-cli"
-  packages = [
-    "errors",
-    "files",
-  ]
-  pruneopts = "UT"
-  revision = "00c7cf83f6832942954ee890cf6e8a525b5caec1"
-  version = "v0.6.1"
-
-[[projects]]
   digest = "1:91e98ea76af524d88f4eeb4240bcd0ab04a8091954dc845c32b3283c7c4ebf8c"
   name = "github.com/gruntwork-io/terratest"
   packages = ["modules/files"]
@@ -779,7 +768,6 @@
     "github.com/creack/pty",
     "github.com/fatih/color",
     "github.com/go-errors/errors",
-    "github.com/gruntwork-io/gruntwork-cli/files",
     "github.com/gruntwork-io/terratest/modules/files",
     "github.com/hashicorp/go-getter",
     "github.com/hashicorp/go-getter/helper/url",

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -15,12 +15,13 @@ import (
 
 // A representation of the configuration options for an AWS Session
 type AwsSessionConfig struct {
-	Region           string
-	CustomS3Endpoint string
-	Profile          string
-	RoleArn          string
-	CredsFilename    string
-	S3ForcePathStyle bool
+	Region                  string
+	CustomS3Endpoint        string
+	Profile                 string
+	RoleArn                 string
+	CredsFilename           string
+	S3ForcePathStyle        bool
+	DisableComputeChecksums bool
 }
 
 // Returns an AWS session object for the given config region (required), profile name (optional), and IAM role to assume
@@ -39,9 +40,10 @@ func CreateAwsSession(config *AwsSessionConfig, terragruntOptions *options.Terra
 	}
 
 	var awsConfig = aws.Config{
-		Region:           aws.String(config.Region),
-		EndpointResolver: endpoints.ResolverFunc(s3CustResolverFn),
-		S3ForcePathStyle: aws.Bool(config.S3ForcePathStyle),
+		Region:                  aws.String(config.Region),
+		EndpointResolver:        endpoints.ResolverFunc(s3CustResolverFn),
+		S3ForcePathStyle:        aws.Bool(config.S3ForcePathStyle),
+		DisableComputeChecksums: aws.Bool(config.DisableComputeChecksums),
 	}
 
 	var sessionOptions = session.Options{

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -209,6 +209,9 @@ For the `s3` backend, the following additional properties are supported in the `
 - `enable_lock_table_ssencryption`: When `true`, the synchronization lock table in DynamoDB used for remote state concurrent access will not be configured with server side encryption.
 - `s3_bucket_tags`: A map of key value pairs to associate as tags on the created S3 bucket.
 - `dynamodb_table_tags`: A map of key value pairs to associate as tags on the created DynamoDB remote state lock table.
+- `disable_aws_client_checksums`: When `true`, disable computing and checking checksums on the request and response,
+  such as the CRC32 check for DynamoDB. This can be used to workaround
+  https://github.com/gruntwork-io/terragrunt/issues/1059.
 
 For the `gcs` backend, the following additional properties are supported in the `config` attribute:
 

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -1,12 +1,13 @@
 package remote
 
 import (
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gruntwork-io/terragrunt/aws_helper"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestConfigValuesEqual(t *testing.T) {
@@ -155,10 +156,10 @@ func TestForcePathStyleClientSession(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			s3Config, err := parseS3Config(testCase.config)
+			s3ConfigExtended, err := parseExtendedS3Config(testCase.config)
 			require.Nil(t, err, "Unexpected error parsing config for test: %v", err)
 
-			s3Client, err := CreateS3Client(s3Config.GetAwsSessionConfig(), terragruntOptions)
+			s3Client, err := CreateS3Client(s3ConfigExtended.GetAwsSessionConfig(), terragruntOptions)
 			require.Nil(t, err, "Unexpected error creating client for test: %v", err)
 
 			actual := aws.BoolValue(s3Client.Config.S3ForcePathStyle)
@@ -196,19 +197,20 @@ func TestGetAwsSessionConfig(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			s3Config, err := parseS3Config(testCase.config)
+			s3ConfigExtended, err := parseExtendedS3Config(testCase.config)
 			require.Nil(t, err, "Unexpected error parsing config for test: %v", err)
 
 			expected := &aws_helper.AwsSessionConfig{
-				Region:           s3Config.Region,
-				CustomS3Endpoint: s3Config.Endpoint,
-				Profile:          s3Config.Profile,
-				RoleArn:          s3Config.RoleArn,
-				CredsFilename:    s3Config.CredsFilename,
-				S3ForcePathStyle: s3Config.S3ForcePathStyle,
+				Region:                  s3ConfigExtended.remoteStateConfigS3.Region,
+				CustomS3Endpoint:        s3ConfigExtended.remoteStateConfigS3.Endpoint,
+				Profile:                 s3ConfigExtended.remoteStateConfigS3.Profile,
+				RoleArn:                 s3ConfigExtended.remoteStateConfigS3.RoleArn,
+				CredsFilename:           s3ConfigExtended.remoteStateConfigS3.CredsFilename,
+				S3ForcePathStyle:        s3ConfigExtended.remoteStateConfigS3.S3ForcePathStyle,
+				DisableComputeChecksums: s3ConfigExtended.DisableAWSClientChecksums,
 			}
 
-			actual := s3Config.GetAwsSessionConfig()
+			actual := s3ConfigExtended.GetAwsSessionConfig()
 			assert.Equal(t, expected, actual)
 		})
 	}


### PR DESCRIPTION
A workaround for https://github.com/gruntwork-io/terragrunt/issues/1059 by exposing the configuration to disable CRC32 checks, as suggested in the Ruby SDK issue: https://github.com/aws/aws-sdk-ruby/issues/243