### PR TITLE
Made sure external_id and session_name are respected when s3 backend needs assuming role

### DIFF
--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -201,6 +201,15 @@ supports additional keys that are used to configure the automatic initialization
 
 For the `s3` backend, the following additional properties are supported in the `config` attribute:
 
+- `region` - (Optional) The region of the S3 bucket.
+- `profile` - (Optional) This is the AWS profile name as set in the shared credentials file.
+- `endpoint` - (Optional) A custom endpoint for the S3 API.
+- `encrypt` - (Optional) Whether to enable server side encryption of the state file.
+- `role_arn` - (Optional) The role to be assumed.
+- `shared_credentials_file` - (Optional) This is the path to the shared credentials file. If this is not set and a profile is specified, `~/.aws/credentials` will be used.
+- `external_id` - (Optional) The external ID to use when assuming the role.
+- `session_name` - (Optional) The session name to use when assuming the role.
+- `dynamodb_table` - (Optional) The name of a DynamoDB table to use for state locking and consistency. The table must have a primary key named LockID. If not present, locking will be disabled.
 - `skip_bucket_versioning`: When `true`, the S3 bucket that is created to store the state will not be versioned.
 - `skip_bucket_ssencryption`: When `true`, the S3 bucket that is created to store the state will not be configured with server-side encryption.
 - `skip_bucket_accesslogging`: When `true`, the S3 bucket that is created to store the state will not be configured with

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -59,6 +59,8 @@ type RemoteStateConfigS3 struct {
 	Endpoint         string `mapstructure:"endpoint"`
 	Profile          string `mapstructure:"profile"`
 	RoleArn          string `mapstructure:"role_arn"`
+	ExternalID       string `mapstructure:"external_id"`
+	SessionName      string `mapstructure:"session_name"`
 	LockTable        string `mapstructure:"lock_table"`
 	DynamoDBTable    string `mapstructure:"dynamodb_table"`
 	CredsFilename    string `mapstructure:"shared_credentials_file"`
@@ -72,6 +74,8 @@ func (c *ExtendedRemoteStateConfigS3) GetAwsSessionConfig() *aws_helper.AwsSessi
 		CustomS3Endpoint:        c.remoteStateConfigS3.Endpoint,
 		Profile:                 c.remoteStateConfigS3.Profile,
 		RoleArn:                 c.remoteStateConfigS3.RoleArn,
+		ExternalID:              c.remoteStateConfigS3.ExternalID,
+		SessionName:             c.remoteStateConfigS3.SessionName,
 		CredsFilename:           c.remoteStateConfigS3.CredsFilename,
 		S3ForcePathStyle:        c.remoteStateConfigS3.S3ForcePathStyle,
 		DisableComputeChecksums: c.DisableAWSClientChecksums,


### PR DESCRIPTION
Certain roles can be set up such that an additional `external_id` parameter is required, before assuming role can go ahead. Terraforms S3 backend [supports this functionality](https://www.terraform.io/docs/backends/types/s3.html#external_id). Terragrunt seems to ignore it.