### PR TITLE
Don’t auto add terraform args to apply-all

### DIFF
--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"strings"
 
+	"sort"
+
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
-	"sort"
 )
 
 // Represents a stack of Terraform modules (i.e. folders with Terraform templates) that you can "spin up" or
@@ -74,7 +75,7 @@ func (stack *Stack) summarizePlanAllErrors(terragruntOptions *options.Terragrunt
 // Apply all the modules in the given stack, making sure to apply the dependencies of each module in the stack in the
 // proper order.
 func (stack *Stack) Apply(terragruntOptions *options.TerragruntOptions) error {
-	stack.setTerraformCommand([]string{"apply", "-input=false", "-auto-approve"})
+	stack.setTerraformCommand([]string{"apply"})
 	if terragruntOptions.IgnoreDependencyOrder {
 		return RunModulesIgnoreOrder(stack.Modules)
 	} else {
@@ -85,7 +86,7 @@ func (stack *Stack) Apply(terragruntOptions *options.TerragruntOptions) error {
 // Destroy all the modules in the given stack, making sure to destroy the dependencies of each module in the stack in
 // the proper order.
 func (stack *Stack) Destroy(terragruntOptions *options.TerragruntOptions) error {
-	stack.setTerraformCommand([]string{"destroy", "-force", "-input=false"})
+	stack.setTerraformCommand([]string{"destroy"})
 	if terragruntOptions.IgnoreDependencyOrder {
 		return RunModulesIgnoreOrder(stack.Modules)
 	} else {


### PR DESCRIPTION
#### what

When using apply-all, and setting plan files to be used as 
extra_arguments, these arguments are automatically being added to our TF
command, which we could add manually if we wanted via extra_args etc.
Because these args are automatically added and using a planfile via 
extra_args for apply ends up like[1] when using apply-all, which fails.

[1]
```
terraform apply tfplan -input=false -auto-approve
```

#### tests

https://gist.github.com/joshmyers/72408e85a90c5ac9686c80a9c91c39f1

Some failing tests but they seem to be failing on master too...

#### Related

https://github.com/gruntwork-io/terragrunt/issues/386