### PR TITLE
Update find_in_parent_folders to return absolute path

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -259,7 +259,7 @@ func findInParentFolders(params []string, include *IncludeConfig, terragruntOpti
 		}
 
 		if util.FileExists(fileToFind) {
-			return util.GetPathRelativeTo(fileToFind, filepath.Dir(terragruntOptions.TerragruntConfigPath))
+			return fileToFind, nil
 		}
 
 		previousDir = currentDir

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -161,6 +161,13 @@ func TestRunCommand(t *testing.T) {
 		})
 	}
 }
+
+func absPath(t *testing.T, path string) string {
+	out, err := filepath.Abs(path)
+	require.NoError(t, err)
+	return out
+}
+
 func TestFindInParentFolders(t *testing.T) {
 	t.Parallel()
 
@@ -173,13 +180,13 @@ func TestFindInParentFolders(t *testing.T) {
 		{
 			nil,
 			terragruntOptionsForTest(t, "../test/fixture-parent-folders/terragrunt-in-root/child/"+DefaultTerragruntConfigPath),
-			"../" + DefaultTerragruntConfigPath,
+			absPath(t, "../test/fixture-parent-folders/terragrunt-in-root/"+DefaultTerragruntConfigPath),
 			nil,
 		},
 		{
 			nil,
 			terragruntOptionsForTest(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath),
-			"../../../" + DefaultTerragruntConfigPath,
+			absPath(t, "../test/fixture-parent-folders/terragrunt-in-root/"+DefaultTerragruntConfigPath),
 			nil,
 		},
 		{
@@ -191,25 +198,25 @@ func TestFindInParentFolders(t *testing.T) {
 		{
 			nil,
 			terragruntOptionsForTest(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+DefaultTerragruntConfigPath),
-			"../" + DefaultTerragruntConfigPath,
+			absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/"+DefaultTerragruntConfigPath),
 			nil,
 		},
 		{
 			nil,
 			terragruntOptionsForTest(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+DefaultTerragruntConfigPath),
-			"../" + DefaultTerragruntConfigPath,
+			absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+DefaultTerragruntConfigPath),
 			nil,
 		},
 		{
 			nil,
 			terragruntOptionsForTest(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath),
-			"../" + DefaultTerragruntConfigPath,
+			absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+DefaultTerragruntConfigPath),
 			nil,
 		},
 		{
 			[]string{"foo.txt"},
 			terragruntOptionsForTest(t, "../test/fixture-parent-folders/other-file-names/child/"+DefaultTerragruntConfigPath),
-			"../foo.txt",
+			absPath(t, "../test/fixture-parent-folders/other-file-names/foo.txt"),
 			nil,
 		},
 		{
@@ -275,7 +282,7 @@ func TestResolveTerragruntInterpolation(t *testing.T) {
 			"terraform { source = find_in_parent_folders() }",
 			nil,
 			terragruntOptionsForTest(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/"+DefaultTerragruntConfigPath),
-			"../../" + DefaultTerragruntConfigPath,
+			absPath(t, "../test/fixture-parent-folders/terragrunt-in-root/"+DefaultTerragruntConfigPath),
 			"",
 		},
 		{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -528,8 +528,8 @@ func TestParseTerragruntConfigTwoLevels(t *testing.T) {
 	_, actualErr := ParseConfigString(config, opts, nil, configPath)
 	expectedErr := TooManyLevelsOfInheritance{
 		ConfigPath:             configPath,
-		FirstLevelIncludePath:  "../" + DefaultTerragruntConfigPath,
-		SecondLevelIncludePath: "../" + DefaultTerragruntConfigPath,
+		FirstLevelIncludePath:  absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+DefaultTerragruntConfigPath),
+		SecondLevelIncludePath: absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+DefaultTerragruntConfigPath),
 	}
 	assert.True(t, errors.IsError(actualErr, expectedErr), "Expected error %v but got %v", expectedErr, actualErr)
 }
@@ -549,8 +549,8 @@ func TestParseTerragruntConfigThreeLevels(t *testing.T) {
 	_, actualErr := ParseConfigString(config, opts, nil, configPath)
 	expectedErr := TooManyLevelsOfInheritance{
 		ConfigPath:             configPath,
-		FirstLevelIncludePath:  "../" + DefaultTerragruntConfigPath,
-		SecondLevelIncludePath: "../" + DefaultTerragruntConfigPath,
+		FirstLevelIncludePath:  absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+DefaultTerragruntConfigPath),
+		SecondLevelIncludePath: absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+DefaultTerragruntConfigPath),
 	}
 	assert.True(t, errors.IsError(actualErr, expectedErr), "Expected error %v but got %v", expectedErr, actualErr)
 }

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -82,7 +82,7 @@ file("assets/mysql/assets.txt")
 
 ## find\_in\_parent\_folders
 
-`find_in_parent_folders()` searches up the directory tree from the current `terragrunt.hcl` file and returns the relative path to the first `terragrunt.hcl` in a parent folder or exit with an error if no such file is found. This is primarily useful in an `include` block to automatically find the path to a parent `terragrunt.hcl` file:
+`find_in_parent_folders()` searches up the directory tree from the current `terragrunt.hcl` file and returns the absolute path to the first `terragrunt.hcl` in a parent folder or exit with an error if no such file is found. This is primarily useful in an `include` block to automatically find the path to a parent `terragrunt.hcl` file:
 
 ``` hcl
 include {


### PR DESCRIPTION
Currently, the `find_in_parent_folders` function returns a relative path to the file it finds. This PR updates it to return the absolute path to that file. Depending on where you are using `find_in_parent_folders`, this can be important: e.g., one place I saw the relative path cause an issue is:

1. I had a child `terragrunt.hcl` that used `include` on a parent `terragrunt.hcl`.
1. The parent `terragrunt.hcl` called `read_terragrunt_config(find_in_parent_folder("foo.hcl"))`
1. `foo.hcl` called `read_terragrunt_config(find_in_parent_folder("bar.hcl"))`

This led to an error where Terragrunt said `read_terragrunt_config` could not find `../../bar.hcl`, even though that file existed. I believe the error was because we were returning a relative path for it, but with `.terragrunt-cache/xxx/yyy` as the working dir, that ended up being the wrong path. The change in this PR to an absolute path fixed the issue.

I'm not aware of any case where a relative path would have an advantage over an absolute path, so this is a backwards incompatible change to always return an absolute path.