### PR TITLE
Fix source of panic

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -528,10 +528,7 @@ func runTerraformWithRetry(terragruntOptions *options.TerragruntOptions) error {
 	// Retry the command configurable time with sleep in between
 	for i := 0; i < terragruntOptions.MaxRetryAttempts; i++ {
 		if out, tferr := shell.RunTerraformCommandWithOutput(terragruntOptions, terragruntOptions.TerraformCliArgs...); tferr != nil {
-			if out == nil {
-				return tferr
-			}
-			if isRetryable(out.Stderr, tferr, terragruntOptions) {
+			if out != nil && isRetryable(out.Stderr, tferr, terragruntOptions) {
 				terragruntOptions.Logger.Printf("Encountered an error eligible for retrying. Sleeping %v before retrying.\n", terragruntOptions.Sleep)
 				time.Sleep(terragruntOptions.Sleep)
 			} else {

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -528,6 +528,9 @@ func runTerraformWithRetry(terragruntOptions *options.TerragruntOptions) error {
 	// Retry the command configurable time with sleep in between
 	for i := 0; i < terragruntOptions.MaxRetryAttempts; i++ {
 		if out, tferr := shell.RunTerraformCommandWithOutput(terragruntOptions, terragruntOptions.TerraformCliArgs...); tferr != nil {
+			if out == nil {
+				return tferr
+			}
 			if isRetryable(out.Stderr, tferr, terragruntOptions) {
 				terragruntOptions.Logger.Printf("Encountered an error eligible for retrying. Sleeping %v before retrying.\n", terragruntOptions.Sleep)
 				time.Sleep(terragruntOptions.Sleep)

--- a/cli/cli_app_test.go
+++ b/cli/cli_app_test.go
@@ -1,11 +1,12 @@
 package cli
 
 import (
+	"testing"
+
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestSetTerragruntInputsAsEnvVars(t *testing.T) {
@@ -71,4 +72,16 @@ func TestSetTerragruntInputsAsEnvVars(t *testing.T) {
 			assert.Equal(t, testCase.expected, opts.Env)
 		})
 	}
+}
+
+func TestTerragruntHandlesCatastrophicTerraformFailure(t *testing.T) {
+	t.Parallel()
+
+	tgOptions, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	// Use a path that doesn't exist to induce error
+	tgOptions.TerraformPath = "i-dont-exist"
+	err = runTerraformWithRetry(tgOptions)
+	require.Error(t, err)
 }

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -39,7 +39,11 @@ func RunShellCommand(terragruntOptions *options.TerragruntOptions, command strin
 // Run the given Terraform command, writing its stdout/stderr to the terminal AND returning stdout/stderr to this
 // method's caller
 func RunTerraformCommandWithOutput(terragruntOptions *options.TerragruntOptions, args ...string) (*CmdOutput, error) {
-	return RunShellCommandWithOutput(terragruntOptions, "", false, isTerraformCommandThatNeedsPty(args[0]), terragruntOptions.TerraformPath, args...)
+	needPty := false
+	if len(args) > 0 {
+		needPty = isTerraformCommandThatNeedsPty(args[0])
+	}
+	return RunShellCommandWithOutput(terragruntOptions, "", false, needPty, terragruntOptions.TerraformPath, args...)
 }
 
 // Run the specified shell command with the specified arguments. Connect the command's stdin, stdout, and stderr to


### PR DESCRIPTION
This fixes the cause of the panic in https://github.com/gruntwork-io/terragrunt/issues/1079, where a catastrophic exit from `terraform` causes the shell command to return the error without output, but `runTerraformWithRetry` was expecting an output always.