### PR TITLE
Look for terragrunt.hcl.json when resolving dependency config

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -334,7 +334,7 @@ func readTerragruntConfig(configPath string, defaultVal *cty.Value, terragruntOp
 	// target config check: make sure the target config exists. If the file does not exist, and there is no default val,
 	// return an error. If the file does not exist but there is a default val, return the default val. Otherwise,
 	// proceed to parse the file as a terragrunt config file.
-	targetConfig := getCleanedTargetConfigPath(configPath, terragruntOptions)
+	targetConfig := getCleanedTargetConfigPath(configPath, terragruntOptions.TerragruntConfigPath)
 	targetConfigFileExists := util.FileExists(targetConfig)
 	if !targetConfigFileExists && defaultVal == nil {
 		return cty.NilVal, errors.WithStackTrace(TerragruntConfigNotFound{Path: targetConfig})
@@ -392,8 +392,8 @@ func readTerragruntConfigAsFuncImpl(terragruntOptions *options.TerragruntOptions
 // Returns a cleaned path to the target config (the `terragrunt.hcl` or `terragrunt.hcl.json` file), handling relative
 // paths correctly. This will automatically append `terragrunt.hcl` or `terragrunt.hcl.json` to the path if the target
 // path is a directory.
-func getCleanedTargetConfigPath(configPath string, terragruntOptions *options.TerragruntOptions) string {
-	cwd := filepath.Dir(terragruntOptions.TerragruntConfigPath)
+func getCleanedTargetConfigPath(configPath string, workingPath string) string {
+	cwd := filepath.Dir(workingPath)
 	targetConfig := configPath
 	if !filepath.IsAbs(targetConfig) {
 		targetConfig = util.JoinPath(cwd, targetConfig)

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -389,8 +389,9 @@ func readTerragruntConfigAsFuncImpl(terragruntOptions *options.TerragruntOptions
 	})
 }
 
-// Returns a cleaned path to the target config (the `terragrunt.hcl` file), handling relative paths correctly. This will
-// automatically append `terragrunt.hcl` to the path if the target path is a directory.
+// Returns a cleaned path to the target config (the `terragrunt.hcl` or `terragrunt.hcl.json` file), handling relative
+// paths correctly. This will automatically append `terragrunt.hcl` or `terragrunt.hcl.json` to the path if the target
+// path is a directory.
 func getCleanedTargetConfigPath(configPath string, terragruntOptions *options.TerragruntOptions) string {
 	cwd := filepath.Dir(terragruntOptions.TerragruntConfigPath)
 	targetConfig := configPath
@@ -398,7 +399,7 @@ func getCleanedTargetConfigPath(configPath string, terragruntOptions *options.Te
 		targetConfig = util.JoinPath(cwd, targetConfig)
 	}
 	if util.IsDir(targetConfig) {
-		targetConfig = util.JoinPath(targetConfig, DefaultTerragruntConfigPath)
+		targetConfig = GetDefaultConfigPath(targetConfig)
 	}
 	return util.CleanPath(targetConfig)
 }

--- a/docs/_docs/01_getting-started/configuration.md
+++ b/docs/_docs/01_getting-started/configuration.md
@@ -26,6 +26,8 @@ dependencies {
 }
 ```
 
+Terragrunt also supports [JSON-serialized HCL](https://github.com/hashicorp/hcl/blob/hcl2/json/spec.md) defined in a `terragrunt.hcl.json` file: where `terragrunt.hcl` is mentioned you can always use `terragrunt.hcl.json` instead.
+
 Terragrunt figures out the path to its config file according to the following rules:
 
 1.  The value of the `--terragrunt-config` command-line option, if specified.
@@ -34,7 +36,9 @@ Terragrunt figures out the path to its config file according to the following ru
 
 3.  A `terragrunt.hcl` file in the current working directory, if it exists.
 
-4.  If none of these are found, exit with an error.
+4.  A `terragrunt.hcl.json` file in the current working directory, if it exists.
+
+5.  If none of these are found, exit with an error.
 
 ## Configuration parsing order
 

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -38,8 +38,8 @@ Terragrunt forwards all arguments and options to Terraform. The only exceptions 
 **CLI Arg**: `--terragrunt-config`<br/>
 **Requires an argument**: `--terragrunt-config /path/to/terragrunt.hcl`
 
-A custom path to the `terragrunt.hcl` file. May also be specified via the `TERRAGRUNT_CONFIG` environment variable. The
-default path is `terragrunt.hcl` in the current directory (see
+A custom path to the `terragrunt.hcl` or `terragrunt.hcl.json` file. May also be specified via the `TERRAGRUNT_CONFIG` environment variable. The
+default path is `terragrunt.hcl` (preferred) or `terragrunt.hcl.json` in the current directory (see
 [Configuration]({{site.baseurl}}/docs/getting-started/configuration/#configuration) for a slightly more nuanced
 explanation). This argument is not used with the `apply-all`, `destroy-all`, `output-all`, `validate-all`, and
 `plan-all` commands.

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -11,8 +11,11 @@ nav_title: Documentation
 nav_title_link: /docs/
 ---
 
-The Terragrunt configuration file uses the same HCL syntax as Terraform itself. The following is a reference of all the
-supported blocks and attributes in the `terragrunt.hcl` configuration file:
+The Terragrunt configuration file uses the same HCL syntax as Terraform itself in `terragrunt.hcl`.
+Terragrunt also supports [JSON-serialized HCL](https://github.com/hashicorp/hcl/blob/hcl2/json/spec.md) in a `terragrunt.hcl.json` file:
+where `terragrunt.hcl` is mentioned you can always use `terragrunt.hcl.json` instead.
+
+The following is a reference of all the supported blocks and attributes in the configuration file:
 
 ## Blocks
 


### PR DESCRIPTION
Given a module tree

```
.
├── a
│   ├── .here.tf
│   ├── main.tf.json
│   └── terragrunt.hcl.json
└── b
    ├── .here.tf
    ├── main.tf.json
    └── terragrunt.hcl.json
```

With `b/terragrunt.hcl.json`:

```json
{
  "dependency": {
    "a": {
      "config_path": "../a"
    }
  }
}
```

Running `terragrunt validate-all` produces an error `Error reading file at path [..]/a/terragrunt.hcl: open [..]/a/terragrunt.hcl: no such file or directory`.

Extending the search for dependency config files to include `terragrunt.hcl.json` makes `validate-all` complete successfully.