### PR TITLE
Lookup remote outputs concurrently

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1033,7 +1033,7 @@ func TestFindConfigFilesIgnoresDownloadDir(t *testing.T) {
 func mockOptionsForTestWithConfigPath(t *testing.T, configPath string) *options.TerragruntOptions {
 	opts, err := options.NewTerragruntOptionsForTest(configPath)
 	if err != nil {
-		t.Fatalf("Faile to create TerragruntOptions: %v", err)
+		t.Fatalf("Failed to create TerragruntOptions: %v", err)
 	}
 	return opts
 }

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -176,11 +176,11 @@ func dependencyBlocksToCtyValue(dependencyConfigs []Dependency, terragruntOption
 	// various attributes for accessing information about the target config (including the module outputs).
 	dependencyMap := map[string]cty.Value{}
 	lock := sync.Mutex{}
-	g, _ := errgroup.WithContext(context.Background())
+	dependencyErrGroup, _ := errgroup.WithContext(context.Background())
 
 	for _, dependencyConfig := range dependencyConfigs {
 		dependencyConfig := dependencyConfig // https://golang.org/doc/faq#closures_and_goroutines
-		g.Go(func() error {
+		dependencyErrGroup.Go(func() error {
 			// Loose struct to hold the attributes of the dependency. This includes:
 			// - outputs: The module outputs of the target config
 			dependencyEncodingMap := map[string]cty.Value{}
@@ -212,7 +212,7 @@ func dependencyBlocksToCtyValue(dependencyConfigs []Dependency, terragruntOption
 		})
 	}
 
-	if err := g.Wait(); err != nil {
+	if err := dependencyErrGroup.Wait(); err != nil {
 		return nil, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -21,5 +21,6 @@ require (
 	github.com/zclconf/go-cty v1.3.1
 	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	google.golang.org/api v0.20.0
 )

--- a/go.sum
+++ b/go.sum
@@ -645,6 +645,7 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
At transcend-io, we have >300 terragrunt modules with fairly deep dependency chains. In fact, our primary backend ECS module requires looking up the `terraform output -json` of 52 modules (after caching).

Here are some benchmarks of running the code on my local laptop. All benchmarks were taken on the module with 52 `output` calls, all after the terragrunt-cache was completely made to minimize the effects of downloading providers, external modules, etc.

Using `terragrunt version v0.23.2`:
terragrunt plan  53.33s user 12.51s system 28% cpu 3:54.80 total
terragrunt plan  52.82s user 12.22s system 26% cpu 4:04.88 total
terragrunt plan  54.26s user 12.33s system 30% cpu 3:38.67 total

Using a binary made from `go build main.go`:
~/transcend/terragrunt/main plan  59.45s user 12.95s system 91% cpu 1:18.80 total
~/transcend/terragrunt/main plan  58.19s user 13.15s system 90% cpu 1:18.77 total
~/transcend/terragrunt/main plan  57.66s user 12.78s system 83% cpu 1:23.94 total

This change adds a dependency on golang.org/x/sync, which is very useful for running concurrent operations with easy error handling