### PR TITLE
Fix issue 1123

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -344,7 +344,7 @@ func readTerragruntConfig(configPath string, defaultVal *cty.Value, terragruntOp
 
 	// We update the context of terragruntOptions to the config being read in.
 	targetOptions := terragruntOptions.Clone(targetConfig)
-	config, err := ParseConfigFile(configPath, targetOptions, nil)
+	config, err := ParseConfigFile(targetConfig, targetOptions, nil)
 	if err != nil {
 		return cty.NilVal, err
 	}

--- a/test/fixture-read-config/from_dependency/dep/main.tf
+++ b/test/fixture-read-config/from_dependency/dep/main.tf
@@ -1,0 +1,3 @@
+variable "foo" {}
+
+output "foo" { value = var.foo }

--- a/test/fixture-read-config/from_dependency/dep/terragrunt.hcl
+++ b/test/fixture-read-config/from_dependency/dep/terragrunt.hcl
@@ -1,0 +1,7 @@
+locals {
+  vars = read_terragrunt_config("vars.hcl")
+}
+
+inputs = {
+  foo = local.vars.locals.foo
+}

--- a/test/fixture-read-config/from_dependency/dep/vars.hcl
+++ b/test/fixture-read-config/from_dependency/dep/vars.hcl
@@ -1,0 +1,3 @@
+locals {
+  foo = "hello world"
+}

--- a/test/fixture-read-config/from_dependency/main.tf
+++ b/test/fixture-read-config/from_dependency/main.tf
@@ -1,0 +1,2 @@
+variable "bar" {}
+output "bar" { value = var.bar }

--- a/test/fixture-read-config/from_dependency/terragrunt.hcl
+++ b/test/fixture-read-config/from_dependency/terragrunt.hcl
@@ -1,0 +1,7 @@
+dependency "dep" {
+  config_path = "./dep/"
+}
+
+inputs = {
+  bar = dependency.dep.outputs.foo
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2300,6 +2300,38 @@ func TestReadTerragruntConfigWithDependency(t *testing.T) {
 	assert.Equal(t, outputs["from_env"].Value, "default")
 }
 
+func TestReadTerragruntConfigFromDependency(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_READ_CONFIG)
+	tmpEnvPath := copyEnvironment(t, ".")
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_READ_CONFIG, "from_dependency")
+
+	showStdout := bytes.Buffer{}
+	showStderr := bytes.Buffer{}
+	assert.NoError(
+		t,
+		runTerragruntCommand(t, fmt.Sprintf("terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &showStdout, &showStderr),
+	)
+
+	logBufferContentsLineByLine(t, showStdout, "show stdout")
+	logBufferContentsLineByLine(t, showStderr, "show stderr")
+
+	// Now check the outputs to make sure they are as expected
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	require.NoError(
+		t,
+		runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr),
+	)
+
+	outputs := map[string]TerraformOutput{}
+	require.NoError(t, json.Unmarshal([]byte(stdout.String()), &outputs))
+
+	assert.Equal(t, outputs["bar"].Value, "hello world")
+}
+
 func TestReadTerragruntConfigWithDefault(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This fixes https://github.com/gruntwork-io/terragrunt/issues/1123, which was caused by passing the wrong argument to `ParseConfigFile`.