### PR TITLE
Fix #1124

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -3,7 +3,10 @@ package config
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
+	"strings"
 
+	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/hcl/v2"
 	tflang "github.com/hashicorp/terraform/lang"
 	"github.com/zclconf/go-cty/cty"
@@ -404,6 +407,69 @@ func getCleanedTargetConfigPath(configPath string, workingPath string) string {
 	return util.CleanPath(targetConfig)
 }
 
+// If one of the xxx-all commands is called with the --terragrunt-source parameter, then for each module, we need to
+// build its own --terragrunt-source parameter by doing the following:
+//
+// 1. Read the source URL from the Terragrunt configuration of each module
+// 2. Extract the path from that URL (the part after a double-slash)
+// 3. Append the path to the --terragrunt-source parameter
+//
+// Example:
+//
+// --terragrunt-source: /source/infrastructure-modules
+// source param in module's terragrunt.hcl: git::git@github.com:acme/infrastructure-modules.git//networking/vpc?ref=v0.0.1
+//
+// This method will return: /source/infrastructure-modules//networking/vpc
+//
+func GetTerragruntSourceForModule(sourcePath string, modulePath string, moduleTerragruntConfig *TerragruntConfig) (string, error) {
+	if sourcePath == "" || moduleTerragruntConfig.Terraform == nil || moduleTerragruntConfig.Terraform.Source == nil || *moduleTerragruntConfig.Terraform.Source == "" {
+		return "", nil
+	}
+
+	// use go-getter to split the module source string into a valid URL and subdirectory (if // is present)
+	moduleUrl, moduleSubdir := getter.SourceDirSubdir(*moduleTerragruntConfig.Terraform.Source)
+
+	// if both URL and subdir are missing, something went terribly wrong
+	if moduleUrl == "" && moduleSubdir == "" {
+		return "", errors.WithStackTrace(InvalidSourceUrl{ModulePath: modulePath, ModuleSourceUrl: *moduleTerragruntConfig.Terraform.Source, TerragruntSource: sourcePath})
+	}
+	// if only subdir is missing, check if we can obtain a valid module name from the URL portion
+	if moduleUrl != "" && moduleSubdir == "" {
+		moduleSubdirFromUrl, err := getModulePathFromSourceUrl(moduleUrl)
+		if err != nil {
+			return moduleSubdirFromUrl, err
+		}
+		return util.JoinTerraformModulePath(sourcePath, moduleSubdirFromUrl), nil
+	}
+
+	return util.JoinTerraformModulePath(sourcePath, moduleSubdir), nil
+}
+
+// Parse sourceUrl not containing '//', and attempt to obtain a module path.
+// Example:
+//
+// sourceUrl = "git::ssh://git@ghe.ourcorp.com/OurOrg/module-name.git"
+// will return "module-name".
+
+func getModulePathFromSourceUrl(sourceUrl string) (string, error) {
+
+	// Regexp for module name extraction. It assumes that the query string has already been stripped off.
+	// Then we simply capture anything after the last slash, and before `.` or end of string.
+	var moduleNameRegexp = regexp.MustCompile(`(?:.+/)(.+?)(?:\.|$)`)
+
+	// strip off the query string if present
+	sourceUrl = strings.Split(sourceUrl, "?")[0]
+
+	matches := moduleNameRegexp.FindStringSubmatch(sourceUrl)
+
+	// if regexp returns less/more than the full match + 1 capture group, then something went wrong with regex (invalid source string)
+	if len(matches) != 2 {
+		return "", errors.WithStackTrace(ErrorParsingModulePath{ModuleSourceUrl: sourceUrl})
+	}
+
+	return matches[1], nil
+}
+
 // Custom error types
 type WrongNumberOfParams struct {
 	Func     string
@@ -456,4 +522,22 @@ type TerragruntConfigNotFound struct {
 
 func (err TerragruntConfigNotFound) Error() string {
 	return fmt.Sprintf("Terragrunt config %s not found", err.Path)
+}
+
+type InvalidSourceUrl struct {
+	ModulePath       string
+	ModuleSourceUrl  string
+	TerragruntSource string
+}
+
+func (err InvalidSourceUrl) Error() string {
+	return fmt.Sprintf("The --terragrunt-source parameter is set to '%s', but the source URL in the module at '%s' is invalid: '%s'. Note that the module URL must have a double-slash to separate the repo URL from the path within the repo!", err.TerragruntSource, err.ModulePath, err.ModuleSourceUrl)
+}
+
+type ErrorParsingModulePath struct {
+	ModuleSourceUrl string
+}
+
+func (err ErrorParsingModulePath) Error() string {
+	return fmt.Sprintf("Unable to obtain the module path from the source URL '%s'. Ensure that the URL is in a supported format.", err.ModuleSourceUrl)
 }

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -795,6 +795,44 @@ func TestReadTerragruntConfigLocals(t *testing.T) {
 	assert.Equal(t, localsMap["number_expression"].(float64), float64(42))
 }
 
+func TestGetTerragruntSourceForModuleHappyPath(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		config   *TerragruntConfig
+		source   string
+		expected string
+	}{
+		{mockConfigWithSource(""), "", ""},
+		{mockConfigWithSource(""), "/source/modules", ""},
+		{mockConfigWithSource("git::git@github.com:acme/modules.git//foo/bar"), "/source/modules", "/source/modules//foo/bar"},
+		{mockConfigWithSource("git::git@github.com:acme/modules.git//foo/bar?ref=v0.0.1"), "/source/modules", "/source/modules//foo/bar"},
+		{mockConfigWithSource("git::git@github.com:acme/emr_cluster.git?ref=feature/fix_bugs"), "/source/modules", "/source/modules//emr_cluster"},
+		{mockConfigWithSource("git::ssh://git@ghe.ourcorp.com/OurOrg/some-module.git"), "/source/modules", "/source/modules//some-module"},
+		{mockConfigWithSource("github.com/hashicorp/example"), "/source/modules", "/source/modules//example"},
+		{mockConfigWithSource("github.com/hashicorp/example//subdir"), "/source/modules", "/source/modules//subdir"},
+		{mockConfigWithSource("git@github.com:hashicorp/example.git//subdir"), "/source/modules", "/source/modules//subdir"},
+		{mockConfigWithSource("./some/path//to/modulename"), "/source/modules", "/source/modules//to/modulename"},
+	}
+
+	for _, testCase := range testCases {
+		// The following is necessary to make sure testCase's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
+		testCase := testCase
+		t.Run(fmt.Sprintf("%v-%s", *testCase.config.Terraform.Source, testCase.source), func(t *testing.T) {
+			actual, err := GetTerragruntSourceForModule(testCase.source, "mock-for-test", testCase.config)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}
+
+func mockConfigWithSource(sourceUrl string) *TerragruntConfig {
+	cfg := TerragruntConfig{IsPartial: true}
+	cfg.Terraform = &TerraformConfig{Source: &sourceUrl}
+	return &cfg
+}
+
 // Return keys as a map so it is treated like a set, and order doesn't matter when comparing equivalence
 func getKeys(valueMap map[string]cty.Value) map[string]bool {
 	keys := map[string]bool{}

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -3,7 +3,6 @@ package configstack
 import (
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
-	"github.com/hashicorp/go-getter"
 	zglob "github.com/mattn/go-zglob"
 )
 
@@ -260,7 +258,7 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 		return nil, errors.WithStackTrace(ErrorProcessingModule{UnderlyingError: err, HowThisModuleWasFound: howThisModuleWasFound, ModulePath: terragruntConfigPath})
 	}
 
-	terragruntSource, err := getTerragruntSourceForModule(modulePath, terragruntConfig, terragruntOptions)
+	terragruntSource, err := config.GetTerragruntSourceForModule(terragruntOptions.Source, modulePath, terragruntConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -293,69 +291,6 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 	}
 
 	return &TerraformModule{Path: modulePath, Config: *terragruntConfig, TerragruntOptions: opts}, nil
-}
-
-// If one of the xxx-all commands is called with the --terragrunt-source parameter, then for each module, we need to
-// build its own --terragrunt-source parameter by doing the following:
-//
-// 1. Read the source URL from the Terragrunt configuration of each module
-// 2. Extract the path from that URL (the part after a double-slash)
-// 3. Append the path to the --terragrunt-source parameter
-//
-// Example:
-//
-// --terragrunt-source: /source/infrastructure-modules
-// source param in module's terragrunt.hcl: git::git@github.com:acme/infrastructure-modules.git//networking/vpc?ref=v0.0.1
-//
-// This method will return: /source/infrastructure-modules//networking/vpc
-//
-func getTerragruntSourceForModule(modulePath string, moduleTerragruntConfig *config.TerragruntConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
-	if terragruntOptions.Source == "" || moduleTerragruntConfig.Terraform == nil || moduleTerragruntConfig.Terraform.Source == nil || *moduleTerragruntConfig.Terraform.Source == "" {
-		return "", nil
-	}
-
-	// use go-getter to split the module source string into a valid URL and subdirectory (if // is present)
-	moduleUrl, moduleSubdir := getter.SourceDirSubdir(*moduleTerragruntConfig.Terraform.Source)
-
-	// if both URL and subdir are missing, something went terribly wrong
-	if moduleUrl == "" && moduleSubdir == "" {
-		return "", errors.WithStackTrace(InvalidSourceUrl{ModulePath: modulePath, ModuleSourceUrl: *moduleTerragruntConfig.Terraform.Source, TerragruntSource: terragruntOptions.Source})
-	}
-	// if only subdir is missing, check if we can obtain a valid module name from the URL portion
-	if moduleUrl != "" && moduleSubdir == "" {
-		moduleSubdirFromUrl, err := getModulePathFromSourceUrl(moduleUrl)
-		if err != nil {
-			return moduleSubdirFromUrl, err
-		}
-		return util.JoinTerraformModulePath(terragruntOptions.Source, moduleSubdirFromUrl), nil
-	}
-
-	return util.JoinTerraformModulePath(terragruntOptions.Source, moduleSubdir), nil
-}
-
-// Parse sourceUrl not containing '//', and attempt to obtain a module path.
-// Example:
-//
-// sourceUrl = "git::ssh://git@ghe.ourcorp.com/OurOrg/module-name.git"
-// will return "module-name".
-
-func getModulePathFromSourceUrl(sourceUrl string) (string, error) {
-
-	// Regexp for module name extraction. It assumes that the query string has already been stripped off.
-	// Then we simply capture anything after the last slash, and before `.` or end of string.
-	var moduleNameRegexp = regexp.MustCompile(`(?:.+/)(.+?)(?:\.|$)`)
-
-	// strip off the query string if present
-	sourceUrl = strings.Split(sourceUrl, "?")[0]
-
-	matches := moduleNameRegexp.FindStringSubmatch(sourceUrl)
-
-	// if regexp returns less/more than the full match + 1 capture group, then something went wrong with regex (invalid source string)
-	if len(matches) != 2 {
-		return "", errors.WithStackTrace(ErrorParsingModulePath{ModuleSourceUrl: sourceUrl})
-	}
-
-	return matches[1], nil
 }
 
 // Look through the dependencies of the modules in the given map and resolve the "external" dependency paths listed in
@@ -552,24 +487,6 @@ type ErrorProcessingModule struct {
 
 func (err ErrorProcessingModule) Error() string {
 	return fmt.Sprintf("Error processing module at '%s'. How this module was found: %s. Underlying error: %v", err.ModulePath, err.HowThisModuleWasFound, err.UnderlyingError)
-}
-
-type InvalidSourceUrl struct {
-	ModulePath       string
-	ModuleSourceUrl  string
-	TerragruntSource string
-}
-
-func (err InvalidSourceUrl) Error() string {
-	return fmt.Sprintf("The --terragrunt-source parameter is set to '%s', but the source URL in the module at '%s' is invalid: '%s'. Note that the module URL must have a double-slash to separate the repo URL from the path within the repo!", err.TerragruntSource, err.ModulePath, err.ModuleSourceUrl)
-}
-
-type ErrorParsingModulePath struct {
-	ModuleSourceUrl string
-}
-
-func (err ErrorParsingModulePath) Error() string {
-	return fmt.Sprintf("Unable to obtain the module path from the source URL '%s'. Ensure that the URL is in a supported format.", err.ModuleSourceUrl)
 }
 
 type InfiniteRecursion struct {

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -1,7 +1,6 @@
 package configstack
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -769,53 +768,6 @@ func TestResolveTerraformModuleNoTerraformConfig(t *testing.T) {
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
-}
-
-func TestGetTerragruntSourceForModuleHappyPath(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		config   *config.TerragruntConfig
-		opts     *options.TerragruntOptions
-		expected string
-	}{
-		{mockConfigWithSource(""), mockOptionsWithSource(t, ""), ""},
-		{mockConfigWithSource(""), mockOptionsWithSource(t, "/source/modules"), ""},
-		{mockConfigWithSource("git::git@github.com:acme/modules.git//foo/bar"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//foo/bar"},
-		{mockConfigWithSource("git::git@github.com:acme/modules.git//foo/bar?ref=v0.0.1"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//foo/bar"},
-		{mockConfigWithSource("git::git@github.com:acme/emr_cluster.git?ref=feature/fix_bugs"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//emr_cluster"},
-		{mockConfigWithSource("git::ssh://git@ghe.ourcorp.com/OurOrg/some-module.git"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//some-module"},
-		{mockConfigWithSource("github.com/hashicorp/example"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//example"},
-		{mockConfigWithSource("github.com/hashicorp/example//subdir"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//subdir"},
-		{mockConfigWithSource("git@github.com:hashicorp/example.git//subdir"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//subdir"},
-		{mockConfigWithSource("./some/path//to/modulename"), mockOptionsWithSource(t, "/source/modules"), "/source/modules//to/modulename"},
-	}
-
-	for _, testCase := range testCases {
-		// The following is necessary to make sure testCase's values don't
-		// get updated due to concurrency within the scope of t.Run(..) below
-		testCase := testCase
-		t.Run(fmt.Sprintf("%v-%s", *testCase.config.Terraform.Source, testCase.opts.Source), func(t *testing.T) {
-			actual, err := getTerragruntSourceForModule("mock-for-test", testCase.config, testCase.opts)
-			require.NoError(t, err)
-			assert.Equal(t, testCase.expected, actual)
-		})
-	}
-}
-
-func mockOptionsWithSource(t *testing.T, sourceUrl string) *options.TerragruntOptions {
-	opts, err := options.NewTerragruntOptionsForTest("mock-for-test.hcl")
-	if err != nil {
-		t.Fatalf("Error creating terragrunt options for test %v", err)
-	}
-	opts.Source = sourceUrl
-	return opts
-}
-
-func mockConfigWithSource(sourceUrl string) *config.TerragruntConfig {
-	cfg := config.TerragruntConfig{IsPartial: true}
-	cfg.Terraform = &config.TerraformConfig{Source: &sourceUrl}
-	return &cfg
 }
 
 func ptr(str string) *string {

--- a/test/fixture-get-output/regression-1124/live/app/terragrunt.hcl
+++ b/test/fixture-get-output/regression-1124/live/app/terragrunt.hcl
@@ -1,0 +1,11 @@
+terraform {
+  source = "../../modules//app"
+}
+
+dependency "dep" {
+  config_path = "../dependency"
+}
+
+inputs = {
+  foo = dependency.dep.outputs.foo
+}

--- a/test/fixture-get-output/regression-1124/live/dependency/terragrunt.hcl
+++ b/test/fixture-get-output/regression-1124/live/dependency/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "../../modules//dependency"
+}

--- a/test/fixture-get-output/regression-1124/modules/app/main.tf
+++ b/test/fixture-get-output/regression-1124/modules/app/main.tf
@@ -1,0 +1,2 @@
+variable "foo" {}
+output "foo" { value = var.foo }

--- a/test/fixture-get-output/regression-1124/modules/dependency/main.tf
+++ b/test/fixture-get-output/regression-1124/modules/dependency/main.tf
@@ -1,0 +1,7 @@
+resource "random_string" "random" {
+  length = 16
+}
+
+output "foo" {
+  value = random_string.random.result
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2214,6 +2214,27 @@ func TestDependencyOutputCachePathBug(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDependencyOutputWithTerragruntSource(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_GET_OUTPUT)
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_GET_OUTPUT)
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "regression-1124", "live")
+	modulePath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "regression-1124", "modules")
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := runTerragruntCommand(
+		t,
+		fmt.Sprintf("terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-source %s", rootPath, modulePath),
+		&stdout,
+		&stderr,
+	)
+	logBufferContentsLineByLine(t, stdout, "stdout")
+	logBufferContentsLineByLine(t, stderr, "stderr")
+	require.NoError(t, err)
+}
+
 func TestAWSGetCallerIdentityFunctions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This fixes the bug reported in #1124. The main issue is that the `Source` attribute isn't updated in the context of the target config when retrieving the dependency, which causes it to continue to use the source value of the dependent config.

To fix this, we recompute the `Source` on the target config when it is set. Note that I had to shuffle the functions around to avoid a circular dependency.