### PR TITLE
GH-1147: do not add -var or -var-file extra_arguments during "destroy" if plan is provided

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -153,7 +153,7 @@ func filterTerraformExtraArgs(terragruntOptions *options.TerragruntOptions, terr
 		for _, arg_cmd := range arg.Commands {
 			if cmd == arg_cmd {
 				lastArg := util.LastArg(terragruntOptions.TerraformCliArgs)
-				skipVars := cmd == "apply" && util.IsFile(lastArg)
+				skipVars := (cmd == "apply" || cmd == "destroy") && util.IsFile(lastArg)
 
 				// The following is a fix for GH-493.
 				// If the first argument is "apply" and the second argument is a file (plan),

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -407,6 +407,31 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
 			[]string{"--foo", "bar", "foo"},
 		},
+		// destroy providing a folder, var files should stay included
+		{
+			mockCmdOptions(t, workingDir, []string{"destroy", workingDir}),
+			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "-var='key=value'"}, []string{"plan", "destroy"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "-var-file=test.tfvars", "-var='key=value'", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+		},
+		// destroy providing a file, no var files included
+		{
+			mockCmdOptions(t, workingDir, []string{"destroy", temporaryFile}),
+			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo"}, []string{"plan", "destroy"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "bar", "foo"},
+		},
+
+		// destroy providing no params, var files should stay included
+		{
+			mockCmdOptions(t, workingDir, []string{"destroy"}),
+			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo"}, []string{"plan", "destroy"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+		},
+		// destroy with some parameters, providing a file => no var files included
+		{
+			mockCmdOptions(t, workingDir, []string{"destroy", "-no-color", "-foo", temporaryFile}),
+			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo"}, []string{"plan", "destroy"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "bar", "foo"},
+		},
 
 		// Command not included in commands list
 		{


### PR DESCRIPTION
Fixes #1147 

The script now checks if the command in question is destroy and if the second argument is a file. If so, -var and -var-file appends are skipped.

Tests have been updated.