### PR TITLE
Implement Get Terraform Command

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -98,6 +98,7 @@ func CreateTerragruntEvalContext(
 		"run_cmd":                                      wrapStringSliceToStringAsFuncImpl(runCommand, extensions.Include, terragruntOptions),
 		"read_terragrunt_config":                       readTerragruntConfigAsFuncImpl(terragruntOptions),
 		"get_terragrunt_dir":                           wrapVoidToStringAsFuncImpl(getTerragruntDir, extensions.Include, terragruntOptions),
+		"get_terraform_command":                        wrapVoidToStringAsFuncImpl(getTerraformCommand, extensions.Include, terragruntOptions),
 		"get_parent_terragrunt_dir":                    wrapVoidToStringAsFuncImpl(getParentTerragruntDir, extensions.Include, terragruntOptions),
 		"get_aws_account_id":                           wrapVoidToStringAsFuncImpl(getAWSAccountID, extensions.Include, terragruntOptions),
 		"get_aws_caller_identity_arn":                  wrapVoidToStringAsFuncImpl(getAWSCallerIdentityARN, extensions.Include, terragruntOptions),
@@ -302,6 +303,11 @@ func pathRelativeFromInclude(include *IncludeConfig, terragruntOptions *options.
 	}
 
 	return util.GetPathRelativeTo(includePath, currentPath)
+}
+
+// getTerraformCommand returns the current terraform command in execution
+func getTerraformCommand(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
+	return terragruntOptions.TerraformCommand, nil
 }
 
 // Return the AWS account id associated to the current set of credentials

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -33,6 +33,8 @@ Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, ju
   - [get\_terraform\_commands\_that\_need\_locking()](#get_terraform_commands_that_need_locking)
 
   - [get\_terraform\_commands\_that\_need\_parallelism()](#get_terraform_commands_that_need_parallelism)
+  
+  - [get\_terraform\_command()](#get_terraform_command)
 
   - [get\_aws\_account\_id()](#get_aws_account_id)
 
@@ -387,6 +389,16 @@ remote_state {
 ``` hcl
 inputs = {
   caller_arn = get_aws_caller_identity_arn()
+}
+```
+
+## get\_terraform\_command
+
+`get_terraform_command()` returns the current terraform command in execution. Example:
+
+``` hcl
+inputs = {
+  current_command = get_terraform_command()
 }
 ```
 

--- a/test/fixture-locals/local-in-include/qa/my-app/main.tf
+++ b/test/fixture-locals/local-in-include/qa/my-app/main.tf
@@ -1,5 +1,6 @@
 variable "parent_terragrunt_dir" {}
 variable "terragrunt_dir" {}
+variable "terraform_command" {}
 
 output "parent_terragrunt_dir" {
   value = var.parent_terragrunt_dir
@@ -7,4 +8,8 @@ output "parent_terragrunt_dir" {
 
 output "terragrunt_dir" {
   value = var.terragrunt_dir
+}
+
+output "terraform_command" {
+  value = var.terraform_command
 }

--- a/test/fixture-locals/local-in-include/terragrunt.hcl
+++ b/test/fixture-locals/local-in-include/terragrunt.hcl
@@ -1,9 +1,11 @@
 locals {
   parent_terragrunt_dir = get_parent_terragrunt_dir()
   terragrunt_dir = get_terragrunt_dir()
+  terraform_command = get_terraform_command()
 }
 
 inputs = {
   parent_terragrunt_dir = local.parent_terragrunt_dir
   terragrunt_dir = local.terragrunt_dir
+  terraform_command = local.terraform_command
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1340,13 +1340,18 @@ func TestLocalsInInclude(t *testing.T) {
 
 	assert.Equal(
 		t,
-		outputs["parent_terragrunt_dir"].Value,
 		filepath.Join(tmpEnvPath, TEST_FIXTURE_LOCALS_IN_INCLUDE),
+		outputs["parent_terragrunt_dir"].Value,
 	)
 	assert.Equal(
 		t,
-		outputs["terragrunt_dir"].Value,
 		childPath,
+		outputs["terragrunt_dir"].Value,
+	)
+	assert.Equal(
+		t,
+		"apply",
+		outputs["terraform_command"].Value,
 	)
 }
 


### PR DESCRIPTION
This PR provides a new function that simply returns the current terraform command.

This will be handy in two of our use-cases. First, we use different IAM Roles a read-only and a read-write, knowing the terraform commands help us set the correct role. Second, we want to define a global variable with the terraform command to pass to some modules that need to assume cross-account roles (vpc peering accept is an example). The variable helps the module decide the IAM Role that needs to be assumed in our IAM organization.

PS: The docs use to be in the README, where are the docs now? Should I worry about documenting the function?