### PR TITLE
Fixing get_env function to accept single env var name as parameter an…

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -161,9 +161,9 @@ func parseGetEnvParameters(parameters []string) (EnvVar, error) {
 
 	envVariable.Name = parameters[0]
 
-    if len(parameters) == 1 {
-    	envVariable.IsRequired = true
-    } else {
+	if len(parameters) == 1 {
+		envVariable.IsRequired = true
+	} else {
 		envVariable.DefaultValue = parameters[1]
 	}
 
@@ -517,7 +517,7 @@ type InvalidGetEnvParams struct {
 }
 
 type EnvVarNotFound struct {
-	EnvVar	string
+	EnvVar string
 }
 
 func (err InvalidGetEnvParams) Error() string {

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -61,6 +61,7 @@ var TERRAFORM_COMMANDS_NEED_PARALLELISM = []string{
 type EnvVar struct {
 	Name         string
 	DefaultValue string
+	IsRequired   bool
 }
 
 // EvalContextExtensions provides various extensions to the evaluation context to enhance the parsing capabilities.
@@ -157,12 +158,18 @@ func getParentTerragruntDir(include *IncludeConfig, terragruntOptions *options.T
 
 func parseGetEnvParameters(parameters []string) (EnvVar, error) {
 	envVariable := EnvVar{}
-	if len(parameters) != 2 {
-		return envVariable, errors.WithStackTrace(InvalidGetEnvParams{ExpectedNumParams: 2, ActualNumParams: 2, Example: `getEnv("<NAME>", "<DEFAULT>")`})
-	}
 
 	envVariable.Name = parameters[0]
-	envVariable.DefaultValue = parameters[1]
+
+    if len(parameters) == 1 {
+    	envVariable.IsRequired = true
+    } else {
+		envVariable.DefaultValue = parameters[1]
+	}
+
+	if len(parameters) > 2 {
+		return envVariable, errors.WithStackTrace(InvalidGetEnvParams{ExpectedNumParams: 2, ActualNumParams: 2, Example: `getEnv("<NAME>", "<DEFAULT>")`})
+	}
 
 	if envVariable.Name == "" {
 		return envVariable, errors.WithStackTrace(InvalidGetEnvParams{ExpectedNumParams: 2, ActualNumParams: 2, Example: `getEnv("<NAME>", "<DEFAULT>")`})
@@ -209,6 +216,9 @@ func getEnvironmentVariable(parameters []string, include *IncludeConfig, terragr
 	envValue, exists := terragruntOptions.Env[parameterMap.Name]
 
 	if !exists {
+		if parameterMap.IsRequired {
+			return "", errors.WithStackTrace(EnvVarNotFound{EnvVar: parameterMap.Name})
+		}
 		envValue = parameterMap.DefaultValue
 	}
 
@@ -506,8 +516,16 @@ type InvalidGetEnvParams struct {
 	Example           string
 }
 
+type EnvVarNotFound struct {
+	EnvVar	string
+}
+
 func (err InvalidGetEnvParams) Error() string {
 	return fmt.Sprintf("InvalidGetEnvParams: Expected %d parameters (%s) for get_env but got %d.", err.ExpectedNumParams, err.Example, err.ActualNumParams)
+}
+
+func (err EnvVarNotFound) Error() string {
+	return fmt.Sprintf("EnvVarNotFound: Required environment variable %s - not found", err.EnvVar)
 }
 
 type EmptyStringNotAllowed string

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -343,7 +343,28 @@ func TestResolveEnvInterpolationConfigString(t *testing.T) {
 			nil,
 			terragruntOptionsForTest(t, "/root/child/"+DefaultTerragruntConfigPath),
 			"",
+			"InvalidEnvParamName",
+		},
+		{
+			`iam_role = get_env()`,
+			nil,
+			terragruntOptionsForTest(t, "/root/child/"+DefaultTerragruntConfigPath),
+			"",
 			"InvalidGetEnvParams",
+		},
+		{
+			`iam_role = get_env("TEST_VAR_1", "TEST_VAR_2", "TEST_VAR_3")`,
+			nil,
+			terragruntOptionsForTest(t, "/root/child/"+DefaultTerragruntConfigPath),
+			"",
+			"InvalidGetEnvParams",
+		},
+		{
+			`iam_role = get_env("TEST_ENV_TERRAGRUNT_VAR")`,
+			nil,
+			terragruntOptionsForTestWithEnv(t, "/root/child/"+DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_VAR": "SOMETHING"}),
+			"SOMETHING",
+			"",
 		},
 		{
 			`iam_role = get_env("SOME_VAR", "SOME_VALUE")`,
@@ -364,6 +385,13 @@ func TestResolveEnvInterpolationConfigString(t *testing.T) {
 			nil,
 			terragruntOptionsForTestWithEnv(t, "/root/child/"+DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_OTHER": "SOMETHING"}),
 			"foo/DEFAULT/bar",
+			"",
+		},
+		{
+			`iam_role = "foo/${get_env("TEST_ENV_TERRAGRUNT_VAR")}/bar"`,
+			nil,
+			terragruntOptionsForTestWithEnv(t, "/root/child/"+DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_VAR": "SOMETHING"}),
+			"foo/SOMETHING/bar",
 			"",
 		},
 	}

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -202,6 +202,17 @@ This allows proper retrieval of the `common.tfvars` from whatever the level of s
 
 ## get\_env
 
+`get_env(NAME)` return the value of variable named `NAME` or throws exceptions if that variable is not set. Example:
+
+``` hcl
+remote_state {
+  backend = "s3"
+  config = {
+    bucket = get_env("BUCKET")
+  }
+}
+```
+ 
 `get_env(NAME, DEFAULT)` returns the value of the environment variable named `NAME` or `DEFAULT` if that environment variable is not set. Example:
 
 ``` hcl


### PR DESCRIPTION
…d making it required;

If the parameter is not found it throws exception making it explicitly needed with value provided and not 'defaulting'

@yorinasub17 