### PR TITLE
Adding simple environment dump functionality to 'init' when called wi…

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -496,6 +496,15 @@ func runTerragruntWithConfig(terragruntOptions *options.TerragruntOptions, terra
 		if err := prepareInitCommand(terragruntOptions, terragruntConfig, allowSourceDownload); err != nil {
 			return err
 		}
+		if logval, ok := terragruntOptions.Env["TG_LOG"]; ok && logval == "env"{
+			fmt.Println("=======================================TF_VARs=======================================")
+			for env, val := range terragruntOptions.Env {
+				if (strings.HasPrefix(env, "TF_VAR_")) {
+					fmt.Printf("%s = %s\n", env, val)
+				}
+			}
+			fmt.Println("======================================================================================")
+		}
 	} else {
 		if err := prepareNonInitCommand(terragruntOptions, terragruntConfig); err != nil {
 			return err


### PR DESCRIPTION
…th TG_LOG=env

In a situation where parts of the input maps are expected to be pushed from parental terragrunt.hcl files
with local includes itself the transperancy of pushed variables is requirement.

I know this commit is not on par with the coding standards but please consider implementing this functionality.