### PR TITLE
Remove manual definition of KMSMasterKeyID when creating new bucket

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -527,7 +527,7 @@ func EnableVersioningForS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, t
 func EnableSSEForS3BucketWide(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
 	terragruntOptions.Logger.Printf("Enabling bucket-wide SSE on AWS S3 bucket %s", config.Bucket)
 	// Encrypt with KMS by default
-	defEnc := &s3.ServerSideEncryptionByDefault{KMSMasterKeyID: aws.String("aws/s3"), SSEAlgorithm: aws.String(s3.ServerSideEncryptionAwsKms)}
+	defEnc := &s3.ServerSideEncryptionByDefault{SSEAlgorithm: aws.String(s3.ServerSideEncryptionAwsKms)}
 	rule := &s3.ServerSideEncryptionRule{ApplyServerSideEncryptionByDefault: defEnc}
 	rules := []*s3.ServerSideEncryptionRule{rule}
 	serverConfig := &s3.ServerSideEncryptionConfiguration{Rules: rules}


### PR DESCRIPTION
Simplest resolution to https://github.com/gruntwork-io/terragrunt/issues/1143

I tried hard to think how to test this, it's extremely difficult to test because it needs an AWS account which has never had the aws/s3 key created. An integration test would look something like:

1. create an AWS account
2. create an IAM admin user on that account
3. run any terragrunt apply to create the s3 bucket
4. try and copy a file to the s3 bucket without manually specifying any encryption (so it tries to use the bucket default)