### PR TITLE
Add get_terraform_cli_args function

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -100,6 +100,7 @@ func CreateTerragruntEvalContext(
 		"read_terragrunt_config":                       readTerragruntConfigAsFuncImpl(terragruntOptions),
 		"get_terragrunt_dir":                           wrapVoidToStringAsFuncImpl(getTerragruntDir, extensions.Include, terragruntOptions),
 		"get_terraform_command":                        wrapVoidToStringAsFuncImpl(getTerraformCommand, extensions.Include, terragruntOptions),
+		"get_terraform_cli_args":                       wrapVoidToStringSliceAsFuncImpl(getTerraformCliArgs, extensions.Include, terragruntOptions),
 		"get_parent_terragrunt_dir":                    wrapVoidToStringAsFuncImpl(getParentTerragruntDir, extensions.Include, terragruntOptions),
 		"get_aws_account_id":                           wrapVoidToStringAsFuncImpl(getAWSAccountID, extensions.Include, terragruntOptions),
 		"get_aws_caller_identity_arn":                  wrapVoidToStringAsFuncImpl(getAWSCallerIdentityARN, extensions.Include, terragruntOptions),
@@ -316,6 +317,11 @@ func pathRelativeFromInclude(include *IncludeConfig, terragruntOptions *options.
 // getTerraformCommand returns the current terraform command in execution
 func getTerraformCommand(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
 	return terragruntOptions.TerraformCommand, nil
+}
+
+// getTerraformCommand returns the current terraform command in execution
+func getTerraformCliArgs(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) ([]string, error) {
+	return terragruntOptions.TerraformCliArgs, nil
 }
 
 // Return the AWS account id associated to the current set of credentials

--- a/config/cty_helpers.go
+++ b/config/cty_helpers.go
@@ -48,6 +48,25 @@ func wrapVoidToStringAsFuncImpl(toWrap func(include *IncludeConfig, terragruntOp
 }
 
 // Create a cty Function that takes no input parameters and returns as output a string slice. The implementation of the
+// function calls the given toWrap function, passing it the given include and terragruntOptions.
+func wrapVoidToStringSliceAsFuncImpl(toWrap func(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) ([]string, error), include *IncludeConfig, terragruntOptions *options.TerragruntOptions) function.Function {
+	return function.New(&function.Spec{
+		Type: function.StaticReturnType(cty.List(cty.String)),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			outVals, err := toWrap(include, terragruntOptions)
+			if err != nil {
+				return cty.ListValEmpty(cty.String), err
+			}
+			outCtyVals := []cty.Value{}
+			for _, val := range outVals {
+				outCtyVals = append(outCtyVals, cty.StringVal(val))
+			}
+			return cty.ListVal(outCtyVals), nil
+		},
+	})
+}
+
+// Create a cty Function that takes no input parameters and returns as output a string slice. The implementation of the
 // function returns the given string slice.
 func wrapStaticValueToStringSliceAsFuncImpl(out []string) function.Function {
 	return function.New(&function.Spec{

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -36,6 +36,8 @@ Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, ju
   
   - [get\_terraform\_command()](#get_terraform_command)
 
+  - [get\_terraform\_cli\_args()](#get_terraform_cli_args)
+
   - [get\_aws\_account\_id()](#get_aws_account_id)
 
   - [get\_aws\_caller\_identity\_arn()](#get_aws_caller_identity_arn)
@@ -410,6 +412,16 @@ inputs = {
 ``` hcl
 inputs = {
   current_command = get_terraform_command()
+}
+```
+
+## get\_terraform\_cli\_args
+
+`get_terraform_cli_args()` returns cli args for the current terraform command in execution. Example:
+
+``` hcl
+inputs = {
+  current_cli_args = get_terraform_cli_args()
 }
 ```
 

--- a/test/fixture-locals/local-in-include/qa/my-app/main.tf
+++ b/test/fixture-locals/local-in-include/qa/my-app/main.tf
@@ -1,6 +1,7 @@
 variable "parent_terragrunt_dir" {}
 variable "terragrunt_dir" {}
 variable "terraform_command" {}
+variable "terraform_cli_args" {}
 
 output "parent_terragrunt_dir" {
   value = var.parent_terragrunt_dir
@@ -12,4 +13,8 @@ output "terragrunt_dir" {
 
 output "terraform_command" {
   value = var.terraform_command
+}
+
+output "terraform_cli_args" {
+  value = var.terraform_cli_args
 }

--- a/test/fixture-locals/local-in-include/terragrunt.hcl
+++ b/test/fixture-locals/local-in-include/terragrunt.hcl
@@ -2,10 +2,12 @@ locals {
   parent_terragrunt_dir = get_parent_terragrunt_dir()
   terragrunt_dir = get_terragrunt_dir()
   terraform_command = get_terraform_command()
+  terraform_cli_args = get_terraform_cli_args()
 }
 
 inputs = {
   parent_terragrunt_dir = local.parent_terragrunt_dir
   terragrunt_dir = local.terragrunt_dir
   terraform_command = local.terraform_command
+  terraform_cli_args = local.terraform_cli_args
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1324,7 +1324,7 @@ func TestLocalsInInclude(t *testing.T) {
 	cleanupTerraformFolder(t, TEST_FIXTURE_LOCALS_IN_INCLUDE)
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_LOCALS_IN_INCLUDE)
 	childPath := filepath.Join(tmpEnvPath, TEST_FIXTURE_LOCALS_IN_INCLUDE, TEST_FIXTURE_LOCALS_IN_INCLUDE_CHILD_REL_PATH)
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", childPath))
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply -no-color --terragrunt-non-interactive --terragrunt-working-dir %s", childPath))
 
 	// Check the outputs of the dir functions referenced in locals to make sure they return what is expected
 	stdout := bytes.Buffer{}
@@ -1352,6 +1352,11 @@ func TestLocalsInInclude(t *testing.T) {
 		t,
 		"apply",
 		outputs["terraform_command"].Value,
+	)
+	assert.Equal(
+		t,
+		"[\"apply\",\"-no-color\"]",
+		outputs["terraform_cli_args"].Value,
 	)
 }
 


### PR DESCRIPTION
Similar to #1154, this PR provides a new function that returns the cli args that are passed to the current Terraform command.

We have some cases where we need to add before and after hooks to the `terraform` block in our Terragrunt configuration. Some of those hooks need to behave differently based on CLI arguments that would be passed along to Terraform. For example, a `terragrunt plan` vs. a `terragrunt plan --destroy` needs to be handled differently. We could handle this by ensuring that the extra args are always set through the `TF_CLI_ARGS` environment variable instead of the Terragrunt command line, e.g., `TF_CLI_ARGS=--destroy terragrunt plan`, so that the hooks could see the same args that would be used by Terraform. It would be nicer, though, to be able to use standard Terragrunt CLI args while still being able to interpret those from hooks as needed.

Thank you for considering this PR and for all of your work on this project!