### PR TITLE
fix(docs): title at incorrect heading level

### DIFF
--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -541,7 +541,7 @@ inputs = {
 }
 ```
 
-# sops\_decrypt\_file
+## sops\_decrypt\_file
 
 `sops_decrypt_file(file_path)` decrypts a yaml or json file encrypted with `sops`.
 


### PR DESCRIPTION
HI 👋 

Fixes the `sops_decrypt_file` heading in the docs.