### PR TITLE
Include session configuration for aws helpers

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -118,8 +118,8 @@ func AssumeIamRole(iamRoleArn string) (*sts.Credentials, error) {
 }
 
 // Return the AWS caller identity associated with the current set of credentials
-func GetAWSCallerIdentity(terragruntOptions *options.TerragruntOptions) (sts.GetCallerIdentityOutput, error) {
-	sess, err := session.NewSession()
+func GetAWSCallerIdentity(config *AwsSessionConfig, terragruntOptions *options.TerragruntOptions) (sts.GetCallerIdentityOutput, error) {
+	sess, err := CreateAwsSession(config, terragruntOptions)
 	if err != nil {
 		return sts.GetCallerIdentityOutput{}, errors.WithStackTrace(err)
 	}
@@ -137,8 +137,8 @@ func GetAWSCallerIdentity(terragruntOptions *options.TerragruntOptions) (sts.Get
 }
 
 // Get the AWS account ID of the current session configuration
-func GetAWSAccountID(terragruntOptions *options.TerragruntOptions) (string, error) {
-	identity, err := GetAWSCallerIdentity(terragruntOptions)
+func GetAWSAccountID(config *AwsSessionConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
+	identity, err := GetAWSCallerIdentity(config, terragruntOptions)
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
@@ -147,8 +147,8 @@ func GetAWSAccountID(terragruntOptions *options.TerragruntOptions) (string, erro
 }
 
 // Get the ARN of the AWS identity associated with the current set of credentials
-func GetAWSIdentityArn(terragruntOptions *options.TerragruntOptions) (string, error) {
-	identity, err := GetAWSCallerIdentity(terragruntOptions)
+func GetAWSIdentityArn(config *AwsSessionConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
+	identity, err := GetAWSCallerIdentity(config, terragruntOptions)
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
@@ -157,8 +157,8 @@ func GetAWSIdentityArn(terragruntOptions *options.TerragruntOptions) (string, er
 }
 
 // Get the AWS user ID of the current session configuration
-func GetAWSUserID(terragruntOptions *options.TerragruntOptions) (string, error) {
-	identity, err := GetAWSCallerIdentity(terragruntOptions)
+func GetAWSUserID(config *AwsSessionConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
+	identity, err := GetAWSCallerIdentity(config, terragruntOptions)
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -330,7 +330,7 @@ func getTerraformCliArgs(include *IncludeConfig, terragruntOptions *options.Terr
 
 // Return the AWS account id associated to the current set of credentials
 func getAWSAccountID(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
-	accountID, err := aws_helper.GetAWSAccountID(terragruntOptions)
+	accountID, err := aws_helper.GetAWSAccountID(&aws_helper.AwsSessionConfig{}, terragruntOptions)
 	if err == nil {
 		return accountID, nil
 	}
@@ -339,7 +339,7 @@ func getAWSAccountID(include *IncludeConfig, terragruntOptions *options.Terragru
 
 // Return the ARN of the AWS identity associated with the current set of credentials
 func getAWSCallerIdentityARN(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
-	identityARN, err := aws_helper.GetAWSIdentityArn(terragruntOptions)
+	identityARN, err := aws_helper.GetAWSIdentityArn(&aws_helper.AwsSessionConfig{}, terragruntOptions)
 	if err == nil {
 		return identityARN, nil
 	}
@@ -348,7 +348,7 @@ func getAWSCallerIdentityARN(include *IncludeConfig, terragruntOptions *options.
 
 // Return the UserID of the AWS identity associated with the current set of credentials
 func getAWSCallerIdentityUserID(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
-	userID, err := aws_helper.GetAWSUserID(terragruntOptions)
+	userID, err := aws_helper.GetAWSUserID(&aws_helper.AwsSessionConfig{}, terragruntOptions)
 	if err == nil {
 		return userID, nil
 	}


### PR DESCRIPTION
Fixes #1191.

In #978, we added a bucket policy giving the root user of an account access to the bucket. However, this introduced a bug in which certain credentials configurations would fail to create the policy because the session configuration was not included. 

This resolves the issue by passing the session configuration to the relevant functions. When not needed, an empty session configuration is passed.