### PR TITLE
Partial parse version checks

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -228,8 +228,7 @@ func runApp(cliContext *cli.Context) (finalErr error) {
 
 	// If someone calls us with no args at all, show the help text and exit
 	if !cliContext.Args().Present() {
-		cli.ShowAppHelp(cliContext)
-		return nil
+		return cli.ShowAppHelp(cliContext)
 	}
 
 	terragruntOptions, err := ParseTerragruntOptions(cliContext)
@@ -276,8 +275,11 @@ func RunTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		return runGraphDependencies(terragruntOptions)
 	}
 
-	terragruntConfig, err := config.ReadTerragruntConfig(terragruntOptions)
+	if err := checkVersionConstraints(terragruntOptions); err != nil {
+		return err
+	}
 
+	terragruntConfig, err := config.ReadTerragruntConfig(terragruntOptions)
 	if err != nil {
 		return err
 	}
@@ -287,30 +289,6 @@ func RunTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 
 	if err := processHooks(terragruntConfig.Terraform.GetAfterHooks(), terragruntOptionsClone); err != nil {
 		return err
-	}
-
-	// Change the terraform binary path before checking the version
-	// if the path is not changed from default and set in the config.
-	if terragruntOptions.TerraformPath == options.TERRAFORM_DEFAULT_PATH && terragruntConfig.TerraformBinary != "" {
-		terragruntOptions.TerraformPath = terragruntConfig.TerraformBinary
-	}
-
-	if err := PopulateTerraformVersion(terragruntOptions); err != nil {
-		return err
-	}
-
-	terraformVersionConstraint := DEFAULT_TERRAFORM_VERSION_CONSTRAINT
-	if terragruntConfig.TerraformVersionConstraint != "" {
-		terraformVersionConstraint = terragruntConfig.TerraformVersionConstraint
-	}
-	if err := CheckTerraformVersion(terraformVersionConstraint, terragruntOptions); err != nil {
-		return err
-	}
-
-	if terragruntConfig.TerragruntVersionConstraint != "" {
-		if err := CheckTerragruntVersion(terragruntConfig.TerragruntVersionConstraint, terragruntOptions); err != nil {
-			return err
-		}
 	}
 
 	if terragruntConfig.Skip {
@@ -387,6 +365,46 @@ func RunTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 	}
 
 	return runTerragruntWithConfig(terragruntOptions, terragruntConfig, false)
+}
+
+// Check the version constraints of both terragrunt and terraform. Note that as a side effect this will set the
+// following settings on terragruntOptions:
+// - TerraformPath
+// - TerraformVersion
+func checkVersionConstraints(terragruntOptions *options.TerragruntOptions) error {
+	partialTerragruntConfig, err := config.PartialParseConfigFile(
+		terragruntOptions.TerragruntConfigPath,
+		terragruntOptions,
+		nil,
+		[]config.PartialDecodeSectionType{config.TerragruntVersionConstraints},
+	)
+	if err != nil {
+		return err
+	}
+
+	// Change the terraform binary path before checking the version
+	// if the path is not changed from default and set in the config.
+	if terragruntOptions.TerraformPath == options.TERRAFORM_DEFAULT_PATH && partialTerragruntConfig.TerraformBinary != "" {
+		terragruntOptions.TerraformPath = partialTerragruntConfig.TerraformBinary
+	}
+	if err := PopulateTerraformVersion(terragruntOptions); err != nil {
+		return err
+	}
+
+	terraformVersionConstraint := DEFAULT_TERRAFORM_VERSION_CONSTRAINT
+	if partialTerragruntConfig.TerraformVersionConstraint != "" {
+		terraformVersionConstraint = partialTerragruntConfig.TerraformVersionConstraint
+	}
+	if err := CheckTerraformVersion(terraformVersionConstraint, terragruntOptions); err != nil {
+		return err
+	}
+
+	if partialTerragruntConfig.TerragruntVersionConstraint != "" {
+		if err := CheckTerragruntVersion(partialTerragruntConfig.TerragruntVersionConstraint, terragruntOptions); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Run graph dependencies prints the dependency graph to stdout

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -371,6 +371,7 @@ func RunTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 // following settings on terragruntOptions:
 // - TerraformPath
 // - TerraformVersion
+// TODO: Look into a way to refactor this function to avoid the side effect.
 func checkVersionConstraints(terragruntOptions *options.TerragruntOptions) error {
 	partialTerragruntConfig, err := config.PartialParseConfigFile(
 		terragruntOptions.TerragruntConfigPath,

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -22,6 +22,7 @@ const (
 	DependencyBlock
 	TerraformBlock
 	TerragruntFlags
+	TerragruntVersionConstraints
 )
 
 // terragruntInclude is a struct that can be used to only decode the include block.
@@ -47,6 +48,15 @@ type terragruntFlags struct {
 	PreventDestroy *bool    `hcl:"prevent_destroy,attr"`
 	Skip           *bool    `hcl:"skip,attr"`
 	Remain         hcl.Body `hcl:",remain"`
+}
+
+// terragruntVersionConstraints is a struct that can be used to only decode the attributes related to constraining the
+// versions of terragrunt and terraform.
+type terragruntVersionConstraints struct {
+	TerragruntVersionConstraint *string  `hcl:"terragrunt_version_constraint,attr"`
+	TerraformVersionConstraint  *string  `hcl:"terraform_version_constraint,attr"`
+	TerraformBinary             *string  `hcl:"terraform_binary,attr"`
+	Remain                      hcl.Body `hcl:",remain"`
 }
 
 // terragruntDependency is a struct that can be used to only decode the dependency blocks in the terragrunt config
@@ -122,6 +132,8 @@ func PartialParseConfigFile(
 // - DependencyBlock: Parses the `dependency` block in the config
 // - TerraformBlock: Parses the `terraform` block in the config
 // - TerragruntFlags: Parses the boolean flags `prevent_destroy` and `skip` in the config
+// - TerragruntVersionConstraints: Parses the attributes related to constraining terragrunt and terraform versions in
+//                                 the config.
 // Note that the following blocks are always decoded:
 // - locals
 // - include
@@ -209,6 +221,22 @@ func PartialParseConfigString(
 			}
 			if decoded.Skip != nil {
 				output.Skip = *decoded.Skip
+			}
+
+		case TerragruntVersionConstraints:
+			decoded := terragruntVersionConstraints{}
+			err := decodeHcl(file, filename, &decoded, terragruntOptions, contextExtensions)
+			if err != nil {
+				return nil, err
+			}
+			if decoded.TerragruntVersionConstraint != nil {
+				output.TerragruntVersionConstraint = *decoded.TerragruntVersionConstraint
+			}
+			if decoded.TerraformVersionConstraint != nil {
+				output.TerraformVersionConstraint = *decoded.TerraformVersionConstraint
+			}
+			if decoded.TerraformBinary != nil {
+				output.TerraformBinary = *decoded.TerraformBinary
 			}
 
 		default:

--- a/test/fixture-partial-parse/terragrunt-version-constraint/terragrunt.hcl
+++ b/test/fixture-partial-parse/terragrunt-version-constraint/terragrunt.hcl
@@ -1,0 +1,2 @@
+terragrunt_version_constraint                                                              = ">= 0.23.0"
+i_am_an_attribute_that_terragrunt_doesnt_understand_that_might_be_introduced_in_the_future = "Hello World"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2912,6 +2912,23 @@ func TestTerragruntVersionConstraints(t *testing.T) {
 	}
 }
 
+func TestTerragruntVersionConstraintsPartialParse(t *testing.T) {
+	fixturePath := "fixture-partial-parse/terragrunt-version-constraint"
+	cleanupTerragruntFolder(t, fixturePath)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntVersionCommand(t, "0.21.23", fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", fixturePath), &stdout, &stderr)
+	logBufferContentsLineByLine(t, stdout, "stdout")
+	logBufferContentsLineByLine(t, stderr, "stderr")
+
+	assert.Error(t, err)
+
+	_, isTgVersionError := errors.Unwrap(err).(cli.InvalidTerragruntVersion)
+	assert.True(t, isTgVersionError)
+}
+
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {
 	removeFile(t, util.JoinPath(templatesPath, TERRAFORM_STATE))
 	removeFile(t, util.JoinPath(templatesPath, TERRAFORM_STATE_BACKUP))
@@ -2939,10 +2956,7 @@ func removeFolder(t *testing.T, path string) {
 }
 
 func runTerragruntCommand(t *testing.T, command string, writer io.Writer, errwriter io.Writer) error {
-	args := strings.Split(command, " ")
-
-	app := cli.CreateTerragruntCli("TEST", writer, errwriter)
-	return app.Run(args)
+	return runTerragruntVersionCommand(t, "TEST", command, writer, errwriter)
 }
 
 func runTerragruntVersionCommand(t *testing.T, version string, command string, writer io.Writer, errwriter io.Writer) error {


### PR DESCRIPTION
This improves on the recent version check functionalities that were added by leveraging partial parsing. This is especially useful for the  `terragrunt_version_constraint` functionality that was added in https://github.com/gruntwork-io/terragrunt/pull/1192 .

Specifically, this will now error out with the version error message, instead of a parsing error when using an incompatible terragrunt version.