### PR TITLE
GCS remote state improvements

### DIFF
--- a/remote/remote_state_gcs.go
+++ b/remote/remote_state_gcs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/hashicorp/terraform/helper/pathorcontents"
 	"github.com/mitchellh/mapstructure"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/option"
 )
@@ -423,6 +424,11 @@ func CreateGCSClient(gcsConfigRemote RemoteStateConfigGCS) (*storage.Client, err
 
 	if gcsConfigRemote.Credentials != "" {
 		client, err = storage.NewClient(ctx, option.WithCredentialsFile(gcsConfigRemote.Credentials))
+	} else if oauthAccessToken := os.Getenv("GOOGLE_OAUTH_ACCESS_TOKEN"); oauthAccessToken != "" {
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{
+			AccessToken: oauthAccessToken,
+		})
+		client, err = storage.NewClient(ctx, option.WithTokenSource(tokenSource))
 	} else if os.Getenv("GOOGLE_CREDENTIALS") != "" {
 		var account accountFile
 		// to mirror how Terraform works, we have to accept either the file path or the contents

--- a/remote/remote_state_gcs.go
+++ b/remote/remote_state_gcs.go
@@ -130,12 +130,17 @@ func gcsConfigValuesEqual(config map[string]interface{}, existingBackend *Terraf
 		}
 	}
 
-	// Delete custom GCS labels that are only used in Terragrunt config and not in Terraform's backend
-	for _, key := range terragruntGCSOnlyConfigs {
-		delete(config, key)
+	// Construct a new map excluding custom GCS labels that are only used in Terragrunt config and not in Terraform's backend
+	comparisonConfig := make(map[string]interface{})
+	for key, value := range config {
+		comparisonConfig[key] = value
 	}
 
-	if !terraformStateConfigEqual(existingBackend.Config, config) {
+	for _, key := range terragruntGCSOnlyConfigs {
+		delete(comparisonConfig, key)
+	}
+
+	if !terraformStateConfigEqual(existingBackend.Config, comparisonConfig) {
 		terragruntOptions.Logger.Printf("Backend config has changed from %s to %s", existingBackend.Config, config)
 		return false
 	}

--- a/remote/remote_state_gcs_test.go
+++ b/remote/remote_state_gcs_test.go
@@ -98,6 +98,12 @@ func TestGCSConfigValuesEqual(t *testing.T) {
 			&TerraformBackend{Type: "gcs", Config: map[string]interface{}{"something": "foo", "ignored-because-null": nil}},
 			true,
 		},
+		{
+			"terragrunt-only-configs-remain-intact",
+			map[string]interface{}{"something": "foo", "skip_bucket_creation": true},
+			&TerraformBackend{Type: "gcs", Config: map[string]interface{}{"something": "foo"}},
+			true,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -106,8 +112,18 @@ func TestGCSConfigValuesEqual(t *testing.T) {
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			actual := gcsConfigValuesEqual(testCase.config, testCase.backend, terragruntOptions)
+
+			// Create a copy of the new config
+			config := make(map[string]interface{})
+			for key, value := range testCase.config {
+				config[key] = value
+			}
+
+			actual := gcsConfigValuesEqual(config, testCase.backend, terragruntOptions)
 			assert.Equal(t, testCase.shouldBeEqual, actual)
+
+			// Ensure the config remains unchanged by the comparison
+			assert.Equal(t, testCase.config, config)
 		})
 	}
 }


### PR DESCRIPTION
This PR has two improvements for GCS remote state.

1. Fixes a bug in the config comparison function `gcsConfigValuesEqual` that was deleting Terragrunt specific config values from the source configuration. This bug was resulting in options such as `skip_bucket_creation` being ignored.

2. Enables GCS authentication using a fixed token defined in the `GOOGLE_OAUTH_ACCESS_TOKEN` env var, which is an option for both the Terraform GCS remote state and Google Cloud provider.