### PR TITLE
Fix #1204

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -222,6 +222,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		TerraformPath:               terragruntOptions.TerraformPath,
 		TerraformCommand:            terragruntOptions.TerraformCommand,
 		TerraformVersion:            terragruntOptions.TerraformVersion,
+		TerragruntVersion:           terragruntOptions.TerragruntVersion,
 		AutoInit:                    terragruntOptions.AutoInit,
 		NonInteractive:              terragruntOptions.NonInteractive,
 		TerraformCliArgs:            util.CloneStringList(terragruntOptions.TerraformCliArgs),

--- a/test/fixture-version-check/a/main.tf
+++ b/test/fixture-version-check/a/main.tf
@@ -1,0 +1,3 @@
+output "foo" {
+  value = "Hello, World"
+}

--- a/test/fixture-version-check/a/terragrunt.hcl
+++ b/test/fixture-version-check/a/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}

--- a/test/fixture-version-check/b/main.tf
+++ b/test/fixture-version-check/b/main.tf
@@ -1,0 +1,3 @@
+output "foo" {
+  value = "Hello, World"
+}

--- a/test/fixture-version-check/b/terragrunt.hcl
+++ b/test/fixture-version-check/b/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}

--- a/test/fixture-version-check/terragrunt.hcl
+++ b/test/fixture-version-check/terragrunt.hcl
@@ -1,0 +1,2 @@
+terraform_version_constraint  = ">= 0.12.20"
+terragrunt_version_constraint = ">= 0.23.20"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2875,6 +2875,19 @@ func TestTerragruntRemoteStateCodegenDoesNotGenerateWithSkip(t *testing.T) {
 	assert.False(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
 }
 
+func TestTerragruntValidateAllWithVersionChecks(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := copyEnvironment(t, "fixture-version-check")
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := runTerragruntVersionCommand(t, "v0.23.21", fmt.Sprintf("terragrunt validate-all --terragrunt-non-interactive --terragrunt-working-dir %s", tmpEnvPath), &stdout, &stderr)
+	logBufferContentsLineByLine(t, stdout, "stdout")
+	logBufferContentsLineByLine(t, stderr, "stderr")
+	require.NoError(t, err)
+}
+
 func TestTerragruntVersionConstraints(t *testing.T) {
 	testCases := []struct {
 		name                 string


### PR DESCRIPTION
`TerragruntVersion` was left out of the list of attributes to clone for `terragruntOptions`, which causes terragrunt to crash when version checks need to happen.