### PR TITLE
Handle empty args for get_terraform_cli_args function

### DIFF
--- a/config/cty_helpers.go
+++ b/config/cty_helpers.go
@@ -54,7 +54,7 @@ func wrapVoidToStringSliceAsFuncImpl(toWrap func(include *IncludeConfig, terragr
 		Type: function.StaticReturnType(cty.List(cty.String)),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			outVals, err := toWrap(include, terragruntOptions)
-			if err != nil {
+			if err != nil || len(outVals) == 0 {
 				return cty.ListValEmpty(cty.String), err
 			}
 			outCtyVals := []cty.Value{}


### PR DESCRIPTION
Closes #1214

When the `get_terraform_cli_args()` function is called and the list of CLI args is empty, the function previously caused Terragrunt to crash. With the change in this MR, the function would now just return an empty list to the caller when the list of CLI args is empty.