### PR TITLE
Fix the prevent_default flag functionality

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -884,7 +884,7 @@ func checkProtectedModule(terragruntOptions *options.TerragruntOptions, terragru
 	if util.FirstArg(terragruntOptions.TerraformCliArgs) != "destroy" {
 		return nil
 	}
-	if terragruntConfig.PreventDestroy {
+	if terragruntConfig.PreventDestroy != nil && *terragruntConfig.PreventDestroy {
 		return errors.WithStackTrace(ModuleIsProtected{Opts: terragruntOptions})
 	}
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ type TerragruntConfig struct {
 	RemoteState                 *remote.RemoteState
 	Dependencies                *ModuleDependencies
 	DownloadDir                 string
-	PreventDestroy              bool
+	PreventDestroy              *bool
 	Skip                        bool
 	IamRole                     string
 	Inputs                      map[string]interface{}
@@ -493,7 +493,8 @@ func mergeConfigWithIncludedConfig(config *TerragruntConfig, includedConfig *Ter
 	if config.RemoteState != nil {
 		includedConfig.RemoteState = config.RemoteState
 	}
-	if config.PreventDestroy {
+
+	if config.PreventDestroy != nil {
 		includedConfig.PreventDestroy = config.PreventDestroy
 	}
 
@@ -730,7 +731,7 @@ func convertToTerragruntConfig(
 	}
 
 	if terragruntConfigFromFile.PreventDestroy != nil {
-		terragruntConfig.PreventDestroy = *terragruntConfigFromFile.PreventDestroy
+		terragruntConfig.PreventDestroy = terragruntConfigFromFile.PreventDestroy
 	}
 
 	if terragruntConfigFromFile.Skip != nil {

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -25,7 +25,7 @@ func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 	output["terragrunt_version_constraint"] = gostringToCty(config.TerragruntVersionConstraint)
 	output["download_dir"] = gostringToCty(config.DownloadDir)
 	output["iam_role"] = gostringToCty(config.IamRole)
-	output["prevent_destroy"] = goboolToCty(config.PreventDestroy)
+	output["prevent_destroy"] = goboolToCty(*config.PreventDestroy)
 	output["skip"] = goboolToCty(config.Skip)
 
 	terraformConfigCty, err := terraformConfigAsCty(config.Terraform)

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -25,7 +25,6 @@ func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 	output["terragrunt_version_constraint"] = gostringToCty(config.TerragruntVersionConstraint)
 	output["download_dir"] = gostringToCty(config.DownloadDir)
 	output["iam_role"] = gostringToCty(config.IamRole)
-	output["prevent_destroy"] = goboolToCty(*config.PreventDestroy)
 	output["skip"] = goboolToCty(config.Skip)
 
 	terraformConfigCty, err := terraformConfigAsCty(config.Terraform)
@@ -50,6 +49,10 @@ func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 	}
 	if dependenciesCty != cty.NilVal {
 		output["dependencies"] = dependenciesCty
+	}
+	
+	if config.PreventDestroy != nil {
+		output["prevent_destroy"] = goboolToCty(*config.PreventDestroy)
 	}
 
 	dependencyCty, err := dependencyBlocksAsCty(config.TerragruntDependencies)

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -58,7 +58,7 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 			Paths: []string{"foo"},
 		},
 		DownloadDir:    ".terragrunt-cache",
-		PreventDestroy: true,
+		PreventDestroy: &testTrue,
 		Skip:           true,
 		IamRole:        "terragruntRole",
 		Inputs: map[string]interface{}{

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -217,7 +217,7 @@ func PartialParseConfigString(
 				return nil, err
 			}
 			if decoded.PreventDestroy != nil {
-				output.PreventDestroy = *decoded.PreventDestroy
+				output.PreventDestroy = decoded.PreventDestroy
 			}
 			if decoded.Skip != nil {
 				output.Skip = *decoded.Skip

--- a/config/config_partial_test.go
+++ b/config/config_partial_test.go
@@ -29,7 +29,7 @@ dependencies {
 	assert.Equal(t, terragruntConfig.Dependencies.Paths[0], "../app1")
 
 	assert.False(t, terragruntConfig.Skip)
-	assert.False(t, terragruntConfig.PreventDestroy)
+	assert.Nil(t, terragruntConfig.PreventDestroy)
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Nil(t, terragruntConfig.RemoteState)
 	assert.Nil(t, terragruntConfig.Inputs)
@@ -76,7 +76,7 @@ skip = true
 	assert.Equal(t, terragruntConfig.Dependencies.Paths[0], "../app1")
 
 	assert.True(t, terragruntConfig.Skip)
-	assert.True(t, terragruntConfig.PreventDestroy)
+	assert.True(t, *terragruntConfig.PreventDestroy)
 
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Nil(t, terragruntConfig.RemoteState)
@@ -92,7 +92,7 @@ func TestPartialParseOmittedItems(t *testing.T) {
 	assert.True(t, terragruntConfig.IsPartial)
 	assert.Nil(t, terragruntConfig.Dependencies)
 	assert.False(t, terragruntConfig.Skip)
-	assert.False(t, terragruntConfig.PreventDestroy)
+	assert.Nil(t, terragruntConfig.PreventDestroy)
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Nil(t, terragruntConfig.RemoteState)
 	assert.Nil(t, terragruntConfig.Inputs)
@@ -119,7 +119,7 @@ func TestPartialParseOnlyInheritsSelectedBlocksFlags(t *testing.T) {
 	assert.True(t, terragruntConfig.IsPartial)
 	assert.Nil(t, terragruntConfig.Dependencies)
 	assert.False(t, terragruntConfig.Skip)
-	assert.True(t, terragruntConfig.PreventDestroy)
+	assert.True(t, *terragruntConfig.PreventDestroy)
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Nil(t, terragruntConfig.RemoteState)
 	assert.Nil(t, terragruntConfig.Inputs)
@@ -139,7 +139,7 @@ func TestPartialParseOnlyInheritsSelectedBlocksDependencies(t *testing.T) {
 	assert.Equal(t, terragruntConfig.Dependencies.Paths[0], "../app1")
 
 	assert.False(t, terragruntConfig.Skip)
-	assert.False(t, terragruntConfig.PreventDestroy)
+	assert.Nil(t, terragruntConfig.PreventDestroy)
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Nil(t, terragruntConfig.RemoteState)
 	assert.Nil(t, terragruntConfig.Inputs)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -568,7 +568,7 @@ func TestParseTerragruntConfigEmptyConfig(t *testing.T) {
 	assert.Nil(t, cfg.Terraform)
 	assert.Nil(t, cfg.RemoteState)
 	assert.Nil(t, cfg.Dependencies)
-	assert.False(t, cfg.PreventDestroy)
+	assert.Nil(t, cfg.PreventDestroy)
 	assert.False(t, cfg.Skip)
 	assert.Empty(t, cfg.IamRole)
 }
@@ -1137,7 +1137,7 @@ prevent_destroy = true
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Nil(t, terragruntConfig.RemoteState)
 	assert.Nil(t, terragruntConfig.Dependencies)
-	assert.Equal(t, true, terragruntConfig.PreventDestroy)
+	assert.Equal(t, true, *terragruntConfig.PreventDestroy)
 }
 
 func TestParseTerragruntConfigPreventDestroyFalse(t *testing.T) {
@@ -1155,7 +1155,7 @@ prevent_destroy = false
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Nil(t, terragruntConfig.RemoteState)
 	assert.Nil(t, terragruntConfig.Dependencies)
-	assert.Equal(t, false, terragruntConfig.PreventDestroy)
+	assert.Equal(t, false, *terragruntConfig.PreventDestroy)
 }
 
 func TestParseTerragruntConfigSkipTrue(t *testing.T) {

--- a/test/fixture-prevent-destroy-not-set/child/main.tf
+++ b/test/fixture-prevent-destroy-not-set/child/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "example" {}
+
+output "foo" {
+  value = "bar"
+}

--- a/test/fixture-prevent-destroy-not-set/child/terragrunt.hcl
+++ b/test/fixture-prevent-destroy-not-set/child/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}

--- a/test/fixture-prevent-destroy-not-set/terragrunt.hcl
+++ b/test/fixture-prevent-destroy-not-set/terragrunt.hcl
@@ -1,0 +1,1 @@
+prevent_destroy = true

--- a/test/fixture-prevent-destroy-override/child/main.tf
+++ b/test/fixture-prevent-destroy-override/child/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "example" {}
+
+output "foo" {
+  value = "bar"
+}

--- a/test/fixture-prevent-destroy-override/child/terragrunt.hcl
+++ b/test/fixture-prevent-destroy-override/child/terragrunt.hcl
@@ -1,0 +1,5 @@
+include {
+  path = find_in_parent_folders()
+}
+
+prevent_destroy = false

--- a/test/fixture-prevent-destroy-override/terragrunt.hcl
+++ b/test/fixture-prevent-destroy-override/terragrunt.hcl
@@ -1,0 +1,1 @@
+prevent_destroy = true


### PR DESCRIPTION
### What does this PR do?
- This PR provides a fix for issue [1217](https://github.com/gruntwork-io/terragrunt/issues/1217).
### Description of task to be completed?
- The issue was that the ```child``` module configuration was not configured to override the `prevent_destroy` flag in the `parent` `terragrunt.hcl` file for the destroy commands to destroy resources . 

- It is important to not that the `find_in_parent_folders()` helper in the `child` module automatically searches up the directory tree to find the `parent` `terragrunt.hcl` file and inherit the `remote_state` configuration from it. 
- So for the `terragrunt detroy` command to actually destroy resources of the `child` module with `prevent_destroy` flag set to `false`, the `prevent_destroy = true` flag in the `parent` `terragrunt.hcl` file has to be overriden.

