### PR TITLE
Add Terraform beta releases to version checking

### DIFF
--- a/cli/version_check.go
+++ b/cli/version_check.go
@@ -11,9 +11,12 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-// The terraform --version output is of the format: Terraform v0.9.5-dev (cad024a5fe131a546936674ef85445215bbc4226+CHANGES)
-// where -dev and (commitid+CHANGES) is for custom builds or if TF_LOG is set for debug purposes
-var TERRAFORM_VERSION_REGEX = regexp.MustCompile("Terraform (v?[\\d\\.]+)(?:-dev)?(?: .+)?")
+// TerraformVersionRegex verifies that terraform --version output is in one of the following formats:
+// - Terraform v0.9.5-dev (cad024a5fe131a546936674ef85445215bbc4226+CHANGES)
+// - Terraform v0.13.0-beta2
+// - Terraform v0.12.27
+// We only make sure the "v#.#.#" part is present in the output.
+var TerraformVersionRegex = regexp.MustCompile(`Terraform (v\d+\.\d+\.\d+).*`)
 
 // Populate the currently installed version of Terraform into the given terragruntOptions
 func PopulateTerraformVersion(terragruntOptions *options.TerragruntOptions) error {
@@ -78,7 +81,7 @@ func checkTerraformVersionMeetsConstraint(currentVersion *version.Version, const
 
 // Parse the output of the terraform --version command
 func parseTerraformVersion(versionCommandOutput string) (*version.Version, error) {
-	matches := TERRAFORM_VERSION_REGEX.FindStringSubmatch(versionCommandOutput)
+	matches := TerraformVersionRegex.FindStringSubmatch(versionCommandOutput)
 
 	if len(matches) != 2 {
 		return nil, errors.WithStackTrace(InvalidTerraformVersionSyntax(versionCommandOutput))

--- a/cli/version_check.go
+++ b/cli/version_check.go
@@ -16,7 +16,7 @@ import (
 // - Terraform v0.13.0-beta2
 // - Terraform v0.12.27
 // We only make sure the "v#.#.#" part is present in the output.
-var TerraformVersionRegex = regexp.MustCompile(`Terraform (v\d+\.\d+\.\d+).*`)
+var TerraformVersionRegex = regexp.MustCompile(`Terraform (v?\d+\.\d+\.\d+).*`)
 
 // Populate the currently installed version of Terraform into the given terragruntOptions
 func PopulateTerraformVersion(terragruntOptions *options.TerragruntOptions) error {

--- a/cli/version_check_test.go
+++ b/cli/version_check_test.go
@@ -59,6 +59,16 @@ func TestParseTerraformVersionWithDev(t *testing.T) {
 	testParseTerraformVersion(t, "Terraform v0.9.4-dev", "v0.9.4", nil)
 }
 
+func TestParseTerraformVersionWithBeta(t *testing.T) {
+	t.Parallel()
+	testParseTerraformVersion(t, "Terraform v0.13.0-beta1", "v0.13.0", nil)
+}
+
+func TestParseTerraformVersionWithUnexpectedName(t *testing.T) {
+	t.Parallel()
+	testParseTerraformVersion(t, "Terraform v0.15.0-rc1", "v0.15.0", nil)
+}
+
 func TestParseTerraformVersionInvalidSyntax(t *testing.T) {
 	t.Parallel()
 	testParseTerraformVersion(t, "invalid-syntax", "", InvalidTerraformVersionSyntax("invalid-syntax"))


### PR DESCRIPTION
Fixes #1224

https://gist.github.com/artemsablin/914fa8fb3cbf479d9023f75920a6cc6c

NB: It won't work with v0.13.0-beta2 due to a bug with terraform's  `--version` (see: https://github.com/hashicorp/terraform/issues/25276 - this is already fixed).
