### PR TITLE
Remove the error after successful terragrunt plan-all execution

### DIFF
--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -58,8 +58,8 @@ func (stack *Stack) Plan(terragruntOptions *options.TerragruntOptions) error {
 func (stack *Stack) summarizePlanAllErrors(terragruntOptions *options.TerragruntOptions, errorStreams []bytes.Buffer) {
 	for i, errorStream := range errorStreams {
 		output := errorStream.String()
+		terragruntOptions.Logger.Println(output)
 		if strings.Contains(output, "Error running plan:") {
-			terragruntOptions.Logger.Println(output)
 			if strings.Contains(output, ": Resource 'data.terraform_remote_state.") {
 				var dependenciesMsg string
 				if len(stack.Modules[i].Dependencies) > 0 {
@@ -71,8 +71,6 @@ func (stack *Stack) summarizePlanAllErrors(terragruntOptions *options.Terragrunt
 					dependenciesMsg,
 				)
 			}
-		} else if errorStream.Len() > 0 {
-			terragruntOptions.Logger.Printf("Error with plan: %s", output)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?
- This PR provides a fix for issue [1220](https://github.com/gruntwork-io/terragrunt/issues/1220).
### Description of task to be completed?
- Remove the `Error with plan:` error that appears when `terragrunt plan-all` is successfully executed.



