### PR TITLE
[skip ci] Fix outdated docs from 0.18 days

### DIFF
--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -110,7 +110,7 @@ You can also pass an optional second `fallback` parameter which causes the funct
 
 ``` hcl
 include {
-  path = find_in_parent_folders("some-other-file-name.tfvars", "fallback.tfvars")
+  path = find_in_parent_folders("some-other-file-name.hcl", "fallback.hcl")
 }
 ```
 


### PR DESCRIPTION
This fixes an outdated example in the `find_in_parent_folders` docs that worked for terragrunt <=0.18, but no longer works for terragrunt 0.19+.