### PR TITLE
Clarify working directory of hooks

### DIFF
--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -47,7 +47,8 @@ func RunTerraformCommandWithOutput(terragruntOptions *options.TerragruntOptions,
 }
 
 // Run the specified shell command with the specified arguments. Connect the command's stdin, stdout, and stderr to
-// the currently running app. The command can be executed in a custom working directory by using the parameter `workingDir`. Terragrunt working directory will be assumed if empty empty.
+// the currently running app. The command can be executed in a custom working directory by using the parameter
+// `workingDir`. Terragrunt working directory will be assumed if empty string.
 func RunShellCommandWithOutput(
 	terragruntOptions *options.TerragruntOptions,
 	workingDir string,


### PR DESCRIPTION
This PR updates the docs to clarify what the working directory of hooks are.

After some experimentation and code review, I found that the working directory of the hooks actually depended on which hook was running.

It turns out that all hooks run after the `init-from-module` stage is complete will be run in the terraform directory, while anything before that is run in the terragrunt config directory. Note that because the `terragruntOptions` struct is updated AFTER `init-from-module` is done, but is passed in to the hook function BEFORE `init-from-module` is run, `after_hooks` for `init-from-module` still run in the terragrunt config directory.

I verified this using the following config:

```
terraform {
  source = "git::git@github.com:gruntwork-io/terragrunt.git//test/fixture-get-output/regression-1124/modules/app?ref=master"

  after_hook "which_dir_init_from_module" {
    commands = ["init-from-module"]
    execute  = ["pwd"]
  }

  after_hook "which_dir_init" {
    commands = ["init"]
    execute  = ["pwd"]
  }

  before_hook "which_dir_plan" {
    commands = ["plan"]
    execute  = ["pwd"]
  }
}

inputs = {
  foo = "foo"
}
```