### PR TITLE
Fix bug where dependency output call runs hooks 

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -337,6 +337,7 @@ func getOutputJsonWithCaching(targetConfig string, terragruntOptions *options.Te
 // Clone terragrunt options and update context for dependency block so that the outputs can be read correctly
 func cloneTerragruntOptionsForDependencyOutput(terragruntOptions *options.TerragruntOptions, targetConfig string) (*options.TerragruntOptions, error) {
 	targetOptions := terragruntOptions.Clone(targetConfig)
+	targetOptions.TerraformCommand = "output"
 	targetOptions.TerraformCliArgs = []string{"output", "-json"}
 
 	// DownloadDir needs to be updated to be in the context of the new config, if using default

--- a/test/fixture-get-output/regression-1273/dep/main.tf
+++ b/test/fixture-get-output/regression-1273/dep/main.tf
@@ -1,0 +1,3 @@
+output "output" {
+  value = "hello, world"
+}

--- a/test/fixture-get-output/regression-1273/dep/terragrunt.hcl
+++ b/test/fixture-get-output/regression-1273/dep/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  # This hook configures Terragrunt to create an empty file called file.out
+  # after execution of terragrunt
+  before_hook "before_hook_1" {
+    commands = ["apply", "plan"]
+    execute = ["touch", "file.out"]
+  }
+}

--- a/test/fixture-get-output/regression-1273/main/main.tf
+++ b/test/fixture-get-output/regression-1273/main/main.tf
@@ -1,0 +1,4 @@
+variable "input" {}
+output "output" {
+  value = var.input
+}

--- a/test/fixture-get-output/regression-1273/main/terragrunt.hcl
+++ b/test/fixture-get-output/regression-1273/main/terragrunt.hcl
@@ -1,0 +1,7 @@
+dependency "dep" {
+  config_path = "../dep"
+}
+
+inputs = {
+  input = dependency.dep.outputs.output
+}


### PR DESCRIPTION
Fixes #1273 and #1274

The cause of the bug is that we weren't setting `TerraformCommand` on the cloned options when retrieving the outputs, so the `terraform output` call was running in the context of the current command.