### PR TITLE
Only parse terraform source during stack generation

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -247,7 +247,7 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 		nil,
 		[]config.PartialDecodeSectionType{
 			// Need for initializing the modules
-			config.TerraformBlock,
+			config.TerraformSource,
 
 			// Need for parsing out the dependencies
 			config.DependenciesBlock,


### PR DESCRIPTION
Fixes #992

This updates the partial parsing step during module stack generation to only parse the terraform source and ignore the other blocks/attributes. This allows usage of `dependency` references in the sub blocks of the `terraform` block, but not the `source`.