### PR TITLE
Code improvements - redundant nil check & multiple redundant append()

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,10 @@
+version = 1
+
+test_patterns = ["test/**"]
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_paths = ["github.com/chsatyap/terragrunt"]

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -264,7 +264,7 @@ func parseSourceUrl(source string) (*url.URL, error) {
 // rest of the URL. This code is copied from the getForcedGetter method of go-getter/get.go, as that method is not
 // exported publicly.
 func getForcedGetter(sourceUrl string) (string, string) {
-	if matches := forcedRegexp.FindStringSubmatch(sourceUrl); matches != nil && len(matches) > 2 {
+	if matches := forcedRegexp.FindStringSubmatch(sourceUrl); len(matches) > 2 {
 		return matches[1], matches[2]
 	}
 

--- a/config/cty_helpers.go
+++ b/config/cty_helpers.go
@@ -125,7 +125,7 @@ type CtyJsonOutput struct {
 // convertValuesMapToCtyVal takes a map of name - cty.Value pairs and converts to a single cty.Value object.
 func convertValuesMapToCtyVal(valMap map[string]cty.Value) (cty.Value, error) {
 	valMapAsCty := cty.NilVal
-	if valMap != nil && len(valMap) > 0 {
+	if len(valMap) > 0 {
 		var err error
 		valMapAsCty, err = gocty.ToCtyValue(valMap, generateTypeFromValuesMap(valMap))
 		if err != nil {

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -127,7 +127,7 @@ func CreateLockTable(tableName string, tags map[string]string, client *dynamodb.
 
 func tagTableIfTagsGiven(tags map[string]string, tableArn *string, client *dynamodb.DynamoDB, terragruntOptions *options.TerragruntOptions) error {
 
-	if tags == nil || len(tags) == 0 {
+	if len(tags) == 0 {
 		terragruntOptions.Logger.Printf("No tags for lock table given.")
 		return nil
 	}

--- a/util/collections.go
+++ b/util/collections.go
@@ -118,9 +118,7 @@ func CommaSeparatedStrings(list []string) string {
 // Make a copy of the given list of strings
 func CloneStringList(listToClone []string) []string {
 	out := []string{}
-	for _, item := range listToClone {
-		out = append(out, item)
-	}
+	out = append(out, listToClone...)
 	return out
 }
 


### PR DESCRIPTION
This commit makes the following improvements -
1. len() returns 0 if arg is nil, making the nil check redundant
2. multiple append() calls can be replaced with single append()

---
Find the other issues found here - [https://deepsource.io/gh/chsatyap/terragrunt/issues/?category=all](https://deepsource.io/gh/chsatyap/terragrunt/issues/?category=all)

This PR also adds `.deepsource.toml` configuration file to run DeepSource analysis on the repo with. Upon enabling DeepSource, the analysis will run on every PR and commit to detect 560+ types of issues in the changes — including bug risks, anti-patterns, security vulnerabilities, etc.

To enable DeepSource analysis after merging this PR, please follow these steps:
1. [Signup](https://deepsource.io/signup/) on DeepSource with your GitHub account and grant access to this repo.
2. Activate analysis on this repo [here](https://deepsource.io/gh/gruntwork-io/terragrunt).

You can also look at the [docs](https://deepsource.io/docs/guides/quickstart.html) for more details. Do let me know if I can be of any help!