### PR TITLE
Clarify the destroy-all operation

### DIFF
--- a/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
+++ b/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
@@ -91,6 +91,8 @@ Note: It is important to realize that you could get errors running `plan-all` if
 
 If your modules have dependencies between them—for example, you can’t deploy the backend-app until MySQL and redis are deployed—you’ll need to express those dependencies in your Terragrunt configuration as explained in the next section.
 
+Additional note: If your modules have dependencies between them, and you run a `terragrunt destroy-all` command, Terragrunt will destroy all the modules under the current working directory, *as well as each of the module dependencies*! If you wish to use exclude dependencies from being destroyed, add the `--terragrunt-ignore-external-dependencies` flag, or use the `--terragrunt-exclude-dir` once for each directory you wish to exclude.
+
 ### Passing outputs between modules
 
 Consider the following file structure:

--- a/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
+++ b/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
@@ -91,7 +91,7 @@ Note: It is important to realize that you could get errors running `plan-all` if
 
 If your modules have dependencies between them—for example, you can’t deploy the backend-app until MySQL and redis are deployed—you’ll need to express those dependencies in your Terragrunt configuration as explained in the next section.
 
-Additional note: If your modules have dependencies between them, and you run a `terragrunt destroy-all` command, Terragrunt will destroy all the modules under the current working directory, *as well as each of the module dependencies*! If you wish to use exclude dependencies from being destroyed, add the `--terragrunt-ignore-external-dependencies` flag, or use the `--terragrunt-exclude-dir` once for each directory you wish to exclude.
+Additional note: If your modules have dependencies between them, and you run a `terragrunt destroy-all` command, Terragrunt will destroy all the modules under the current working directory, *as well as each of the module dependencies* (that is, modules you depend on via `dependencies` and `dependency` blocks)! If you wish to use exclude dependencies from being destroyed, add the `--terragrunt-ignore-external-dependencies` flag, or use the `--terragrunt-exclude-dir` once for each directory you wish to exclude.
 
 ### Passing outputs between modules
 


### PR DESCRIPTION
This is inspired by a customer conversation in which there was confusion around whether the `destroy-all` command would destroy modules outside of the current directory structure.