### PR TITLE
Fix #1113: Makefile: add convenience 'build' target w/ dynamic version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,17 @@ install-pre-commit-hook:
 	@ln -s scripts/pre-commit .git/hooks/pre-commit
 	@echo "pre-commit hook installed."
 
-.PHONY: help fmtcheck fmt install-fmt-hook
+
+# This build target just for convenience for those building directly from
+# source. See also: .circleci/config.yml
+build: terragrunt
+terragrunt: $(shell find . \( -type d -name 'vendor' -prune \) \
+                        -o \( -type f -name '*.go'   -print \) )
+	set -xe ;\
+	vtag_maybe_extra=$$(git describe --tags --abbrev=12 --dirty --broken) ;\
+	go build -o $@ -ldflags "-X main.VERSION=$${vtag_maybe_extra}" .
+
+clean:
+	rm -f terragrunt
+
+.PHONY: help fmtcheck fmt install-fmt-hook clean


### PR DESCRIPTION
New `Makefile` targets include: 'build', 'terragrunt', and 'clean', along with a comment pointing out that 'build' is merely a convenience for those building from source. It is not intended to compete with or interfere in any way with the existing tagging and CI building approach.

Similar to how `.circleci/config.yml` works, the `main.VERSION` value is obtained dynamically, only here from `git-describe(1)`. This avoids committing the version number to any static file, and should also avoid interfering with the existing commit/tagging/CI building approach.

However, for end-users building from source out of the git repo, it allows the `terragrunt` binary to be easily built with correct version information without the user having to specify it manually (or even knowing how to do so). When built in this way, the `terragrunt --version` output will reflect the git tag (and possibly additional commit info).

If building from a checked-out tag (detached state), then the version number will reflect the tag:

```
    $ git checkout v1.2.3

    $ make build

    $ ./terragrunt --version
    terragrunt version v1.2.3
```

If building from `master` (with commits beyond a given tag), then the version string will reflect that, too:

```
    $ git checkout master

    $ make build

    $ ./terragrunt --version
    terragrunt version v0.23.33-7-g2c8c2d3fbfbe
```

That says that the `master` build is seven commits beyond the `v0.23.33` tag, and that the binary was built from a clean working directory at commit `2c8c2d3fbfbe`.

If the user has made any changes to the working directory, then the fact that the build was made from a "dirty" working directory will be reflected in the version output, as well:

```
    $ ./terragrunt --version
    terragrunt version v0.23.33-7-g2c8c2d3fbfbe-dirty
```
