### PR TITLE
Dependency optimization

### DIFF
--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -428,6 +428,35 @@ inputs = {
 }
 ```
 
+##### Can I speed up dependency fetching?
+
+`dependency` blocks are fetched in parallel at each source level, but will serially parse each recursive dependency. For
+example, consider the following chain of dependencies:
+
+```
+account --> vpc --> securitygroup --> ecs
+                                      ^
+                                     /
+                              ecr --
+```
+
+In this chain, the `ecr` and `securitygroup` module outputs will be fetched concurrently when applying the `ecs` module,
+but the outputs for `account` and `vpc` will be fetched serially as terragrunt needs to recursively walk through the
+tree to retrieve the outputs at each level.
+
+This recursive parsing happens due to the necessity to parse the entire `terragrunt.hcl` configuration (including
+`dependency` blocks) in full before being able to call `terraform output`.
+
+However, terragrunt includes an optimization to only fetch the lowest level outputs (`securitygroup` and `ecr` in this
+example) provided that the following conditions are met in the immediate dependencies:
+
+- The remote state is managed using `remote_state` blocks.
+- The `remote_state` block is in generate mode (the `generate` attribute is set).
+- The `remote_state` block itself does not depend on any `dependency` outputs (`locals` and `include` are ok).
+
+If these conditions are met, terragrunt will only parse out the `remote_state` blocks and use that to pull down the
+state for the target module without parsing the `dependency` blocks, avoiding the recursive dependency retrieval.
+
 
 ### dependencies
 

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -428,7 +428,7 @@ inputs = {
 }
 ```
 
-##### Can I speed up dependency fetching?
+**Can I speed up dependency fetching?**
 
 `dependency` blocks are fetched in parallel at each source level, but will serially parse each recursive dependency. For
 example, consider the following chain of dependencies:

--- a/test/fixture-get-output/nested-optimization/.gitignore
+++ b/test/fixture-get-output/nested-optimization/.gitignore
@@ -1,0 +1,1 @@
+backend.tf

--- a/test/fixture-get-output/nested-optimization/deepdep/main.tf
+++ b/test/fixture-get-output/nested-optimization/deepdep/main.tf
@@ -1,0 +1,3 @@
+output "output" {
+  value = "The answer is 42"
+}

--- a/test/fixture-get-output/nested-optimization/deepdep/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization/deepdep/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty.

--- a/test/fixture-get-output/nested-optimization/dep/main.tf
+++ b/test/fixture-get-output/nested-optimization/dep/main.tf
@@ -1,0 +1,4 @@
+variable "input" {}
+output "output" {
+  value = "No, ${var.input}"
+}

--- a/test/fixture-get-output/nested-optimization/dep/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization/dep/terragrunt.hcl
@@ -1,0 +1,12 @@
+include {
+  path = find_in_parent_folders()
+}
+
+# Retrieve a dependency. In the test, we will destroy this state and verify we can still get the output.
+dependency "deepdep" {
+  config_path = "../deepdep"
+}
+
+inputs = {
+  input = dependency.deepdep.outputs.output
+}

--- a/test/fixture-get-output/nested-optimization/live/main.tf
+++ b/test/fixture-get-output/nested-optimization/live/main.tf
@@ -1,0 +1,4 @@
+variable "input" {}
+output "output" {
+  value = "They said, \"${var.input}\""
+}

--- a/test/fixture-get-output/nested-optimization/live/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization/live/terragrunt.hcl
@@ -1,0 +1,8 @@
+# Retrieve a dependency. In the test, we will destroy this state and verify we can still get the output.
+dependency "dep" {
+  config_path = "../dep"
+}
+
+inputs = {
+  input = dependency.dep.outputs.output
+}

--- a/test/fixture-get-output/nested-optimization/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization/terragrunt.hcl
@@ -1,0 +1,16 @@
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remote_state {
+  backend = "s3"
+  config = {
+    encrypt = true
+    bucket = "__FILL_IN_BUCKET_NAME__"
+    key = "${path_relative_to_include()}/terraform.tfstate"
+    region = "us-west-2"
+    dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
+    enable_lock_table_ssencryption = true
+  }
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite"
+  }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2040,6 +2040,7 @@ func TestDependencyOutputOptimization(t *testing.T) {
 	t.Parallel()
 
 	expectedOutput := `They said, "No, The answer is 42"`
+	generatedUniqueId := uniqueId()
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_GET_OUTPUT)
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_GET_OUTPUT)
@@ -2048,8 +2049,8 @@ func TestDependencyOutputOptimization(t *testing.T) {
 	livePath := filepath.Join(rootPath, "live")
 	deepDepPath := filepath.Join(rootPath, "deepdep")
 
-	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
-	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
+	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(generatedUniqueId))
+	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(generatedUniqueId))
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)


### PR DESCRIPTION
This is an attempt at partially resolving https://github.com/gruntwork-io/terragrunt/issues/1103 

I thought if there was a way we can optimize the remote state fetching to avoid recursively parsing all the dependencies, and realized that if the config follows a few conventions, this is possible.

- The remote state is managed using `remote_state` blocks.
- The `remote_state` block is in generate mode (the `generate` attribute is set).
- The `remote_state` block itself does not depend on any `dependency` outputs (`locals` and `include` are ok).

When these conditions are met, we are able to generate a terraform module that only contains the remote state backend configuration, which we can use to run `terraform output` to get the recorded outputs from the state without retrieving dependencies. You don't even need the full module source to do this!

Note that supporting arbitrary terragrunt configuration (e.g. those managing backends with `generate`) is difficult as there won't be a stable API we could define to account for all the cases. For these configurations, we will have to fall back to the old method until we are ready to relax these constraints further.