### PR TITLE
Account for iam role configurations when fetching remote state in dependency optimization

### DIFF
--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -60,6 +60,7 @@ type terraformConfigSourceOnly struct {
 
 // terragruntFlags is a struct that can be used to only decode the flag attributes (skip and prevent_destroy)
 type terragruntFlags struct {
+	IamRole        *string  `hcl:"iam_role,attr"`
 	PreventDestroy *bool    `hcl:"prevent_destroy,attr"`
 	Skip           *bool    `hcl:"skip,attr"`
 	Remain         hcl.Body `hcl:",remain"`
@@ -253,6 +254,9 @@ func PartialParseConfigString(
 			}
 			if decoded.Skip != nil {
 				output.Skip = *decoded.Skip
+			}
+			if decoded.IamRole != nil {
+				output.IamRole = *decoded.IamRole
 			}
 
 		case TerragruntVersionConstraints:


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/terragrunt/issues/1314

This fixes a bug that was introduced in the recent dependency retrieval optimization, where it was not accounting for IAM role assume configurations.

NOTE: I didn't add tests because it doesn't look like we have tests for this functionality, but we should figure out a way to have a test. In the meantime, I am going to cut an alpha testing release so that the reporter can test this.