### PR TITLE
Follow up to dependency optimization

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,10 +80,11 @@ type terragruntLocal struct {
 
 // Configuration for Terraform remote state as parsed from a terragrunt.hcl config file
 type remoteStateConfigFile struct {
-	Backend     string                     `hcl:"backend,attr"`
-	DisableInit *bool                      `hcl:"disable_init,attr"`
-	Generate    *remoteStateConfigGenerate `hcl:"generate,attr"`
-	Config      cty.Value                  `hcl:"config,attr"`
+	Backend                       string                     `hcl:"backend,attr"`
+	DisableInit                   *bool                      `hcl:"disable_init,attr"`
+	DisableDependencyOptimization *bool                      `hcl:"disable_dependency_optimization,attr"`
+	Generate                      *remoteStateConfigGenerate `hcl:"generate,attr"`
+	Config                        cty.Value                  `hcl:"config,attr"`
 }
 
 func (remoteState *remoteStateConfigFile) String() string {
@@ -110,6 +111,9 @@ func (remoteState *remoteStateConfigFile) toConfig() (*remote.RemoteState, error
 
 	if remoteState.DisableInit != nil {
 		config.DisableInit = *remoteState.DisableInit
+	}
+	if remoteState.DisableDependencyOptimization != nil {
+		config.DisableDependencyOptimization = *remoteState.DisableDependencyOptimization
 	}
 
 	config.FillDefaults()

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -50,7 +50,7 @@ func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 	if dependenciesCty != cty.NilVal {
 		output["dependencies"] = dependenciesCty
 	}
-	
+
 	if config.PreventDestroy != nil {
 		output["prevent_destroy"] = goboolToCty(*config.PreventDestroy)
 	}
@@ -135,6 +135,7 @@ func remoteStateAsCty(remoteState *remote.RemoteState) (cty.Value, error) {
 	output := map[string]cty.Value{}
 	output["backend"] = gostringToCty(remoteState.Backend)
 	output["disable_init"] = goboolToCty(remoteState.DisableInit)
+	output["disable_dependency_optimization"] = goboolToCty(remoteState.DisableDependencyOptimization)
 
 	generateCty, err := gostructToCty(remoteState.Generate)
 	if err != nil {

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -48,8 +48,9 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 		TerraformVersionConstraint:  "= 0.12.20",
 		TerragruntVersionConstraint: "= 0.23.18",
 		RemoteState: &remote.RemoteState{
-			Backend:     "foo",
-			DisableInit: true,
+			Backend:                       "foo",
+			DisableInit:                   true,
+			DisableDependencyOptimization: true,
 			Config: map[string]interface{}{
 				"bar": "baz",
 			},
@@ -116,8 +117,9 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 // This test makes sure that all the fields in RemoteState are converted to cty
 func TestRemoteStateAsCtyDrift(t *testing.T) {
 	testConfig := remote.RemoteState{
-		Backend:     "foo",
-		DisableInit: true,
+		Backend:                       "foo",
+		DisableInit:                   true,
+		DisableDependencyOptimization: true,
 		Generate: &remote.RemoteStateGenerate{
 			Path:     "foo",
 			IfExists: "overwrite_terragrunt",
@@ -208,6 +210,8 @@ func remoteStateStructFieldToMapKey(t *testing.T, fieldName string) (string, boo
 		return "backend", true
 	case "DisableInit":
 		return "disable_init", true
+	case "DisableDependencyOptimization":
+		return "disable_dependency_optimization", true
 	case "Generate":
 		return "generate", true
 	case "Config":

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -415,9 +415,9 @@ func getTerragruntOutputJson(terragruntOptions *options.TerragruntOptions, targe
 	return getTerragruntOutputJsonFromRemoteState(targetTGOptions, targetConfig, remoteStateTGConfig.RemoteState, remoteStateTGConfig.IamRole)
 }
 
-// canGetRemoteState returns true if the remote state block is not nil
+// canGetRemoteState returns true if the remote state block is not nil and dependency optimization is not disabled
 func canGetRemoteState(remoteState *remote.RemoteState) bool {
-	return remoteState != nil
+	return remoteState != nil && !remoteState.DisableDependencyOptimization
 }
 
 // getTerragruntOutputJsonFromRemoteState will retrieve the outputs directly by using just the remote state block. This

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -451,7 +451,6 @@ However, terragrunt includes an optimization to only fetch the lowest level outp
 example) provided that the following conditions are met in the immediate dependencies:
 
 - The remote state is managed using `remote_state` blocks.
-- The `remote_state` block is in generate mode (the `generate` attribute is set).
 - The `remote_state` block itself does not depend on any `dependency` outputs (`locals` and `include` are ok).
 
 If these conditions are met, terragrunt will only parse out the `remote_state` blocks and use that to pull down the

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -184,6 +184,9 @@ The `remote_state` block supports the following arguments:
   have support in Terragrunt to be automatically created if the storage does not exist. Currently `s3` and `gcs` are the
   two backends with support for automatic creation. Defaults to `false`.
 
+- `disable_dependency_optimization` (attribute): When `true`, disable optimized dependency fetching for terragrunt
+  modules using this `remote_state` block. See the documentation for [dependency block](#dependency) for more details.
+
 - `generate` (attribute): Configure Terragrunt to automatically generate a `.tf` file that configures the remote state
   backend. This is a map that expects two properties:
     - `path`: The path where the generated file should be written. If a relative path, it'll be relative to the Terragrunt
@@ -451,7 +454,11 @@ However, terragrunt includes an optimization to only fetch the lowest level outp
 example) provided that the following conditions are met in the immediate dependencies:
 
 - The remote state is managed using `remote_state` blocks.
+- The dependency optimization feature flag is enabled (`disable_dependency_optimization = false`, which is the default).
 - The `remote_state` block itself does not depend on any `dependency` outputs (`locals` and `include` are ok).
+- You are not relying on `before_hook`, `after_hook`, or `extra_arguments` to the `terraform init` call. NOTE:
+  terragrunt will not automatically detect this and you will need to explicitly opt out of the dependency optimization
+  flag.
 
 If these conditions are met, terragrunt will only parse out the `remote_state` blocks and use that to pull down the
 state for the target module without parsing the `dependency` blocks, avoiding the recursive dependency retrieval.

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -10,16 +10,17 @@ import (
 )
 
 // Configuration for Terraform remote state
-// NOTE: If any attributes are added here, be sure to add it to ctyRemoteState in config/config_as_cty.go
+// NOTE: If any attributes are added here, be sure to add it to remoteStateAsCty in config/config_as_cty.go
 type RemoteState struct {
-	Backend     string
-	DisableInit bool
-	Generate    *RemoteStateGenerate
-	Config      map[string]interface{}
+	Backend                       string
+	DisableInit                   bool
+	DisableDependencyOptimization bool
+	Generate                      *RemoteStateGenerate
+	Config                        map[string]interface{}
 }
 
 func (remoteState *RemoteState) String() string {
-	return fmt.Sprintf("RemoteState{Backend = %v, DisableInit = %v, Generate = %v, Config = %v}", remoteState.Backend, remoteState.DisableInit, remoteState.Generate, remoteState.Config)
+	return fmt.Sprintf("RemoteState{Backend = %v, DisableInit = %v, DisableDependencyOptimization = %v, Generate = %v, Config = %v}", remoteState.Backend, remoteState.DisableInit, remoteState.DisableDependencyOptimization, remoteState.Generate, remoteState.Config)
 }
 
 // Code gen configuration for Terraform remote state

--- a/test/fixture-get-output/localstate/live/terragrunt.hcl
+++ b/test/fixture-get-output/localstate/live/terragrunt.hcl
@@ -1,6 +1,6 @@
 remote_state {
   backend = "local"
   config = {
-    path = "${path_relative_to_include()}/terraform.tfstate"
+    path = "${get_terragrunt_dir()}/${path_relative_to_include()}/terraform.tfstate"
   }
 }

--- a/test/fixture-get-output/nested-optimization-disable/.gitignore
+++ b/test/fixture-get-output/nested-optimization-disable/.gitignore
@@ -1,0 +1,1 @@
+backend.tf

--- a/test/fixture-get-output/nested-optimization-disable/deepdep/main.tf
+++ b/test/fixture-get-output/nested-optimization-disable/deepdep/main.tf
@@ -1,0 +1,3 @@
+output "output" {
+  value = "The answer is 42"
+}

--- a/test/fixture-get-output/nested-optimization-disable/deepdep/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization-disable/deepdep/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty.

--- a/test/fixture-get-output/nested-optimization-disable/dep/main.tf
+++ b/test/fixture-get-output/nested-optimization-disable/dep/main.tf
@@ -1,0 +1,4 @@
+variable "input" {}
+output "output" {
+  value = "No, ${var.input}"
+}

--- a/test/fixture-get-output/nested-optimization-disable/dep/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization-disable/dep/terragrunt.hcl
@@ -1,0 +1,12 @@
+include {
+  path = find_in_parent_folders()
+}
+
+# Retrieve a dependency. In the test, we will destroy this state and verify we can still get the output.
+dependency "deepdep" {
+  config_path = "../deepdep"
+}
+
+inputs = {
+  input = dependency.deepdep.outputs.output
+}

--- a/test/fixture-get-output/nested-optimization-disable/live/main.tf
+++ b/test/fixture-get-output/nested-optimization-disable/live/main.tf
@@ -1,0 +1,4 @@
+variable "input" {}
+output "output" {
+  value = "They said, \"${var.input}\""
+}

--- a/test/fixture-get-output/nested-optimization-disable/live/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization-disable/live/terragrunt.hcl
@@ -1,0 +1,8 @@
+# Retrieve a dependency. In the test, we will destroy this state and verify we can still get the output.
+dependency "dep" {
+  config_path = "../dep"
+}
+
+inputs = {
+  input = dependency.dep.outputs.output
+}

--- a/test/fixture-get-output/nested-optimization-disable/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization-disable/terragrunt.hcl
@@ -1,0 +1,17 @@
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remote_state {
+  disable_dependency_optimization = true
+  backend = "s3"
+  config = {
+    encrypt = true
+    bucket = "__FILL_IN_BUCKET_NAME__"
+    key = "${path_relative_to_include()}/terraform.tfstate"
+    region = "us-west-2"
+    dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
+    enable_lock_table_ssencryption = true
+  }
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite"
+  }
+}

--- a/test/fixture-get-output/nested-optimization-nogen/.gitignore
+++ b/test/fixture-get-output/nested-optimization-nogen/.gitignore
@@ -1,0 +1,1 @@
+backend.tf

--- a/test/fixture-get-output/nested-optimization-nogen/deepdep/main.tf
+++ b/test/fixture-get-output/nested-optimization-nogen/deepdep/main.tf
@@ -1,0 +1,3 @@
+output "output" {
+  value = "The answer is 42"
+}

--- a/test/fixture-get-output/nested-optimization-nogen/deepdep/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization-nogen/deepdep/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty.

--- a/test/fixture-get-output/nested-optimization-nogen/dep/main.tf
+++ b/test/fixture-get-output/nested-optimization-nogen/dep/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {}
+}
+
+variable "input" {}
+output "output" {
+  value = "No, ${var.input}"
+}

--- a/test/fixture-get-output/nested-optimization-nogen/dep/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization-nogen/dep/terragrunt.hcl
@@ -1,0 +1,12 @@
+include {
+  path = find_in_parent_folders()
+}
+
+# Retrieve a dependency. In the test, we will destroy this state and verify we can still get the output.
+dependency "deepdep" {
+  config_path = "../deepdep"
+}
+
+inputs = {
+  input = dependency.deepdep.outputs.output
+}

--- a/test/fixture-get-output/nested-optimization-nogen/live/main.tf
+++ b/test/fixture-get-output/nested-optimization-nogen/live/main.tf
@@ -1,0 +1,4 @@
+variable "input" {}
+output "output" {
+  value = "They said, \"${var.input}\""
+}

--- a/test/fixture-get-output/nested-optimization-nogen/live/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization-nogen/live/terragrunt.hcl
@@ -1,0 +1,8 @@
+# Retrieve a dependency. In the test, we will destroy this state and verify we can still get the output.
+dependency "dep" {
+  config_path = "../dep"
+}
+
+inputs = {
+  input = dependency.dep.outputs.output
+}

--- a/test/fixture-get-output/nested-optimization-nogen/terragrunt.hcl
+++ b/test/fixture-get-output/nested-optimization-nogen/terragrunt.hcl
@@ -1,0 +1,12 @@
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remote_state {
+  backend = "s3"
+  config = {
+    encrypt = true
+    bucket = "__FILL_IN_BUCKET_NAME__"
+    key = "${path_relative_to_include()}/terraform.tfstate"
+    region = "us-west-2"
+    dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
+    enable_lock_table_ssencryption = true
+  }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2495,7 +2495,11 @@ func TestDependencyOutputSameOutputConcurrencyRegression(t *testing.T) {
 // Regression testing for bug where terragrunt output runs on dependency blocks are done in the terragrunt-cache for the
 // child, not the parent.
 func TestDependencyOutputCachePathBug(t *testing.T) {
-	t.Parallel()
+	// NOTE: this test can't be run in parallel, as it is sensitive to the dependency output cache, and we can't have
+	// all the different tests busting it at random points in time.
+	// We need to bust the output cache that stores the dependency outputs so that the second run pulls the outputs.
+	// This is only a problem during testing, where the process is shared across terragrunt runs.
+	config.ClearOutputCache()
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_GET_OUTPUT)
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_GET_OUTPUT)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2495,11 +2495,7 @@ func TestDependencyOutputSameOutputConcurrencyRegression(t *testing.T) {
 // Regression testing for bug where terragrunt output runs on dependency blocks are done in the terragrunt-cache for the
 // child, not the parent.
 func TestDependencyOutputCachePathBug(t *testing.T) {
-	// NOTE: this test can't be run in parallel, as it is sensitive to the dependency output cache, and we can't have
-	// all the different tests busting it at random points in time.
-	// We need to bust the output cache that stores the dependency outputs so that the second run pulls the outputs.
-	// This is only a problem during testing, where the process is shared across terragrunt runs.
-	config.ClearOutputCache()
+	t.Parallel()
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_GET_OUTPUT)
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_GET_OUTPUT)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2037,6 +2037,14 @@ func TestYamlDecodeRegressions(t *testing.T) {
 // If output optimization is working, we should still get the same correct output even though the state of the upmost
 // module has been destroyed.
 func TestDependencyOutputOptimization(t *testing.T) {
+	dependencyOutputOptimizationTest(t, "nested-optimization")
+}
+
+func TestDependencyOutputOptimizationNoGenerate(t *testing.T) {
+	dependencyOutputOptimizationTest(t, "nested-optimization-nogen")
+}
+
+func dependencyOutputOptimizationTest(t *testing.T, moduleName string) {
 	t.Parallel()
 
 	expectedOutput := `They said, "No, The answer is 42"`
@@ -2044,7 +2052,7 @@ func TestDependencyOutputOptimization(t *testing.T) {
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_GET_OUTPUT)
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_GET_OUTPUT)
-	rootPath := filepath.Join(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "nested-optimization")
+	rootPath := filepath.Join(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, moduleName)
 	rootTerragruntConfigPath := filepath.Join(rootPath, config.DefaultTerragruntConfigPath)
 	livePath := filepath.Join(rootPath, "live")
 	deepDepPath := filepath.Join(rootPath, "deepdep")


### PR DESCRIPTION
- Allow `remote_state` blocks without `generate` set by dynamically configuring `generate` just for the purpose of output fetching.

- Reclone terragrunt options in inner function to avoid global patching issues.