### PR TITLE
Fix config_dir support on Windows

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -197,7 +197,7 @@ func DefaultWorkingAndDownloadDirs(terragruntConfigPath string) (string, string,
 		return "", "", errors.WithStackTrace(err)
 	}
 
-	return workingDir, downloadDir, nil
+	return filepath.ToSlash(workingDir), filepath.ToSlash(downloadDir), nil
 }
 
 // Create a new TerragruntOptions object with reasonable defaults for test usage


### PR DESCRIPTION
Using the `config_dir` attribute on a `terragrunt.hcl` when running
it on Windows didn't load the appropriate configuration as expected.

[This line](https://github.com/gruntwork-io/terragrunt/blob/c395cdfdf1dd71a7cab0e4b6e07305d1d188e0d4/cli/cli_app.go#L320)
seems to be the culprit.



On Windows, the file path comparison was using a forward-slash on one
variable, and a backward-slash file separator on the other, never
entering the conditional branch and loading the information from
`terragrunt.hcl`.

This commit introduces a call to change change the file-separator as
other parts of the codebase does, so the default folder uses forward-slash
 and the comparison passes.