### PR TITLE
Hacky attempt at AWS Provider patching to help users work around Terraform bug

### DIFF
--- a/cli/aws_provider_patch.go
+++ b/cli/aws_provider_patch.go
@@ -152,8 +152,8 @@ func patchAwsProviderInTerraformCode(terraformCode string, terraformFilePath str
 				//   - "
 				//   - aws
 				//   - "
-				if len(tokens) - index > 2 {
-					maybeAws := tokens[index + 2]
+				if len(tokens)-index > 2 {
+					maybeAws := tokens[index+2]
 
 					if maybeAws.Type == hclsyntax.TokenQuotedLit && string(maybeAws.Bytes) == "aws" {
 						for key, value := range attributesToOverride {

--- a/cli/aws_provider_patch.go
+++ b/cli/aws_provider_patch.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+	"github.com/hashicorp/hcl2/hclwrite"
+	"github.com/mattn/go-zglob"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func applyAwsProviderPatch(terragruntOptions *options.TerragruntOptions) error {
+	if len(terragruntOptions.AwsProviderPatchOverrides) == 0 {
+		return errors.WithStackTrace(MissingOverrides(OPT_TERRAGRUNT_OVERRIDE_ATTR))
+	}
+
+	terraformFilesInModules, err := findAllTerraformFilesInModules(terragruntOptions)
+	if err != nil {
+		return err
+	}
+
+	for _, terraformFile := range terraformFilesInModules {
+		originalTerraformFileContents, err := util.ReadFileAsString(terraformFile)
+		if err != nil {
+			return err
+		}
+
+		updatedTerraformFileContents, err := patchAwsProviderInTerraformCode(originalTerraformFileContents, terraformFile, terragruntOptions.AwsProviderPatchOverrides)
+		if err != nil {
+			return err
+		}
+
+		if originalTerraformFileContents != updatedTerraformFileContents {
+			terragruntOptions.Logger.Printf("Patching AWS provider in %s", terraformFile)
+			if err := util.WriteFileWithSamePermissions(terraformFile, terraformFile, []byte(updatedTerraformFileContents)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// findAllTerraformFiles returns all Terraform source files within the modules being used by this Terragrunt
+// configuration. To be more specific, it only returns the source files downloaded for module "xxx" { ... } blocks into
+// the .terraform/modules folder; it does NOT return Terraform files for the top-level (AKA "root") module.
+//
+// NOTE: this method only supports *.tf files right now. Terraform code defined in *.json files is not currently
+// supported.d
+func findAllTerraformFilesInModules(terragruntOptions *options.TerragruntOptions) ([]string, error) {
+	modulesPath := util.JoinPath(terragruntOptions.DataDir(), "modules")
+
+	if !util.FileExists(modulesPath) {
+		return nil, nil
+	}
+
+	// Ideally, we'd use a builin Go library like filepath.Glob here, but per https://github.com/golang/go/issues/11862,
+	// the current go implementation doesn't support treating ** as zero or more directories, just zero or one.
+	// So we use a third-party library.
+	matches, err := zglob.Glob(fmt.Sprintf("%s/**/*.tf", modulesPath))
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	return matches, nil
+}
+
+// patchAwsProviderInTerraformCode looks for provider "aws" { ... } blocks in the given Terraform code and overwrites
+// the attributes in those provider blocks with the given attributes.
+//
+// For example, if you passed in the following Terraform code:
+//
+// provider "aws" {
+//    region = var.aws_region
+// }
+//
+// And you set attributesToOverride to map[string]string{"region": "us-east-1"}, then this method will return:
+//
+// provider "aws" {
+//    region = "us-east-1"
+// }
+//
+// This is a temporary workaround for a Terraform bug (https://github.com/hashicorp/terraform/issues/13018) where
+// any dynamic values in nested provider blocks are not handled correctly when you call 'terraform import', so by
+// temporarily hard-coding them, we can allow 'import' to work.
+func patchAwsProviderInTerraformCode(terraformCode string, terraformFilePath string, attributesToOverride map[string]string) (string, error) {
+	hclFile, err := hclwrite.ParseConfig([]byte(terraformCode), terraformFilePath, hcl.InitialPos)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	for _, block := range hclFile.Body().Blocks() {
+		tokens := block.BuildTokens(nil)
+		if len(tokens) > 4 {
+			// The tokens should be:
+			//   - provider
+			//   - "
+			//   - aws
+			//   - "
+			maybeProvider := tokens[0]
+			maybeAws := tokens[2]
+
+			if maybeProvider.Type == hclsyntax.TokenIdent && string(maybeProvider.Bytes) == "provider" &&
+				maybeAws.Type == hclsyntax.TokenQuotedLit && string(maybeAws.Bytes) == "aws" {
+
+				for key, value := range attributesToOverride {
+					block.Body().SetAttributeValue(key, cty.StringVal(value))
+				}
+			}
+		}
+
+	}
+
+	return string(hclFile.Bytes()), nil
+}
+
+// Custom error types
+
+type MissingOverrides string
+
+func (err MissingOverrides) Error() string {
+	return fmt.Sprintf("You must specify at least one provider attribute to override via the --%s option.", string(err))
+}

--- a/cli/aws_provider_patch.go
+++ b/cli/aws_provider_patch.go
@@ -63,7 +63,7 @@ type TerraformModule struct {
 // the .terraform/modules folder; it does NOT return Terraform files for the top-level (AKA "root") module.
 //
 // NOTE: this method only supports *.tf files right now. Terraform code defined in *.json files is not currently
-// supported.d
+// supported.
 func findAllTerraformFilesInModules(terragruntOptions *options.TerragruntOptions) ([]string, error) {
 	// Terraform downloads modules into the .terraform/modules folder. Unfortunately, it downloads not only the module
 	// into that folder, but the entire repo it's in, which can contain lots of other unrelated code we probably don't
@@ -97,7 +97,7 @@ func findAllTerraformFilesInModules(terragruntOptions *options.TerragruntOptions
 				moduleAbsPath = util.JoinPath(terragruntOptions.WorkingDir, moduleAbsPath)
 			}
 
-			// Ideally, we'd use a builin Go library like filepath.Glob here, but per https://github.com/golang/go/issues/11862,
+			// Ideally, we'd use a builtin Go library like filepath.Glob here, but per https://github.com/golang/go/issues/11862,
 			// the current go implementation doesn't support treating ** as zero or more directories, just zero or one.
 			// So we use a third-party library.
 			matches, err := zglob.Glob(fmt.Sprintf("%s/**/*.tf", moduleAbsPath))

--- a/cli/aws_provider_patch.go
+++ b/cli/aws_provider_patch.go
@@ -69,7 +69,9 @@ func findAllTerraformFilesInModules(terragruntOptions *options.TerragruntOptions
 	// into that folder, but the entire repo it's in, which can contain lots of other unrelated code we probably don't
 	// want to touch. To find the paths to the actual modules, we read the modules.json file in that folder, which is
 	// a manifest file Terraform uses to track where the modules are within each repo. Note that this is an internal
-	// API, so the way we parse/read this modules.json file may break in future Terraform versions.
+	// API, so the way we parse/read this modules.json file may break in future Terraform versions. Note that we
+	// can't use the official HashiCorp code to parse this file, as it's marked internal:
+	// https://github.com/hashicorp/terraform/blob/master/internal/modsdir/manifest.go
 	modulesJsonPath := util.JoinPath(terragruntOptions.DataDir(), "modules", "modules.json")
 
 	if !util.FileExists(modulesJsonPath) {

--- a/cli/aws_provider_patch.go
+++ b/cli/aws_provider_patch.go
@@ -26,7 +26,7 @@ func applyAwsProviderPatch(terragruntOptions *options.TerragruntOptions) error {
 	}
 
 	for _, terraformFile := range terraformFilesInModules {
-		terragruntOptions.Logger.Printf("Looking at file %s...", terraformFile)
+		util.Debugf(terragruntOptions.Logger, "Looking at file %s", terraformFile)
 		originalTerraformFileContents, err := util.ReadFileAsString(terraformFile)
 		if err != nil {
 			return err

--- a/cli/aws_provider_patch.go
+++ b/cli/aws_provider_patch.go
@@ -152,7 +152,7 @@ func patchAwsProviderInTerraformCode(terraformCode string, terraformFilePath str
 			if maybeProvider.Type == hclsyntax.TokenIdent && string(maybeProvider.Bytes) == "provider" &&
 				maybeAws.Type == hclsyntax.TokenQuotedLit && string(maybeAws.Bytes) == "aws" {
 
-				codeWasUpdated = true
+				codeWasUpdated = len(attributesToOverride) > 0
 				for key, value := range attributesToOverride {
 					block.Body().SetAttributeValue(key, cty.StringVal(value))
 				}

--- a/cli/aws_provider_patch_test.go
+++ b/cli/aws_provider_patch_test.go
@@ -1,0 +1,214 @@
+package cli
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const terraformCodeExampleOutputOnly = `
+output "hello" {
+  value = "Hello, World"
+}
+`
+
+const terraformCodeExampleGcpProvider = `
+provider "google" {
+  credentials = file("account.json")
+  project     = "my-project-id"
+  region      = "us-central1"
+}
+
+output "hello" {
+  value = "Hello, World"
+}
+`
+
+const terraformCodeExampleAwsProviderEmptyOriginal = `
+provider "aws" {
+}
+
+output "hello" {
+  value = "Hello, World"
+}
+`
+
+const terraformCodeExampleAwsProviderRegionOverridenExpected = `
+provider "aws" {
+  region = "eu-west-1"
+}
+
+output "hello" {
+  value = "Hello, World"
+}
+`
+
+const terraformCodeExampleAwsProviderRegionVersionProfileOverridenExpected = `
+provider "aws" {
+  region  = "eu-west-1"
+  version = "0.3.0"
+  profile = "foo"
+}
+
+output "hello" {
+  value = "Hello, World"
+}
+`
+
+const terraformCodeExampleAwsProviderNonEmptyOriginal = `
+provider "aws" {
+  region  = var.aws_region
+  version = "0.2.0"
+}
+
+output "hello" {
+  value = "Hello, World"
+}
+`
+
+const terraformCodeExampleAwsProviderRegionOverridenVersionNotOverriddenExpected = `
+provider "aws" {
+  region  = "eu-west-1"
+  version = "0.2.0"
+}
+
+output "hello" {
+  value = "Hello, World"
+}
+`
+
+const terraformCodeExampleAwsMultipleProvidersOriginal = `
+provider "aws" {
+  region  = var.aws_region
+  version = "0.2.0"
+}
+
+provider "aws" {
+  alias   = "another"
+  region  = var.aws_region
+  version = "0.2.0"
+}
+
+resource "aws_instance" "example" {
+
+}
+
+provider "google" {
+  credentials = file("account.json")
+  project     = "my-project-id"
+  region      = "us-central1"
+}
+
+provider "aws" {
+  alias  = "yet another"
+  region = var.aws_region
+}
+
+output "hello" {
+  value = "Hello, World"
+}
+`
+
+const terraformCodeExampleAwsMultipleProvidersRegionOverridenExpected = `
+provider "aws" {
+  region  = "eu-west-1"
+  version = "0.2.0"
+}
+
+provider "aws" {
+  alias   = "another"
+  region  = "eu-west-1"
+  version = "0.2.0"
+}
+
+resource "aws_instance" "example" {
+
+}
+
+provider "google" {
+  credentials = file("account.json")
+  project     = "my-project-id"
+  region      = "us-central1"
+}
+
+provider "aws" {
+  alias  = "yet another"
+  region = "eu-west-1"
+}
+
+output "hello" {
+  value = "Hello, World"
+}
+`
+
+const terraformCodeExampleAwsMultipleProvidersRegionProfileVersionOverridenExpected = `
+provider "aws" {
+  region  = "eu-west-1"
+  version = "0.3.0"
+  profile = "foo"
+}
+
+provider "aws" {
+  alias   = "another"
+  region  = "eu-west-1"
+  version = "0.3.0"
+  profile = "foo"
+}
+
+resource "aws_instance" "example" {
+
+}
+
+provider "google" {
+  credentials = file("account.json")
+  project     = "my-project-id"
+  region      = "us-central1"
+}
+
+provider "aws" {
+  alias   = "yet another"
+  region  = "eu-west-1"
+  version = "0.3.0"
+  profile = "foo"
+}
+
+output "hello" {
+  value = "Hello, World"
+}
+`
+
+func TestPatchAwsProviderInTerraformCodeHappyPath(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testName              string
+		originalTerraformCode string
+		attributesToOverride  map[string]string
+		expectedTerraformCode string
+	}{
+		{"empty", "", nil, ""},
+		{"empty with attributes", "", map[string]string{"region": "eu-west-1"}, ""},
+		{"no provider", terraformCodeExampleOutputOnly, map[string]string{"region": "eu-west-1"}, terraformCodeExampleOutputOnly},
+		{"no aws provider", terraformCodeExampleGcpProvider, map[string]string{"region": "eu-west-1"}, terraformCodeExampleGcpProvider},
+		{"one empty aws provider, but no overrides", terraformCodeExampleAwsProviderEmptyOriginal, nil, terraformCodeExampleAwsProviderEmptyOriginal},
+		{"one empty aws provider, with region override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": "eu-west-1"}, terraformCodeExampleAwsProviderRegionOverridenExpected},
+		{"one empty aws provider, with region, version, profile override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, terraformCodeExampleAwsProviderRegionVersionProfileOverridenExpected},
+		{"one non-empty aws provider, but no overrides", terraformCodeExampleAwsProviderNonEmptyOriginal, nil, terraformCodeExampleAwsProviderNonEmptyOriginal},
+		{"one non-empty aws provider, with region override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": "eu-west-1"}, terraformCodeExampleAwsProviderRegionOverridenVersionNotOverriddenExpected},
+		{"one non-empty aws provider, with region, version, profile override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, terraformCodeExampleAwsProviderRegionVersionProfileOverridenExpected},
+		{"multiple providers, but no overrides", terraformCodeExampleAwsMultipleProvidersOriginal, nil, terraformCodeExampleAwsMultipleProvidersOriginal},
+		{"multiple providers, with region override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1"}, terraformCodeExampleAwsMultipleProvidersRegionOverridenExpected},
+		{"multiple providers, with region, version, profile override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, terraformCodeExampleAwsMultipleProvidersRegionProfileVersionOverridenExpected},
+	}
+
+	for _, testCase := range testCases {
+		// The following is necessary to make sure testCase's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
+		testCase := testCase
+		t.Run(testCase.testName, func(t *testing.T) {
+			t.Parallel()
+			actualTerraformCode, err := patchAwsProviderInTerraformCode(testCase.originalTerraformCode, "test.tf", testCase.attributesToOverride)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedTerraformCode, actualTerraformCode)
+		})
+	}
+}

--- a/cli/aws_provider_patch_test.go
+++ b/cli/aws_provider_patch_test.go
@@ -42,11 +42,10 @@ output "hello" {
 }
 `
 
-const terraformCodeExampleAwsProviderRegionVersionProfileOverridenExpected = `
+const terraformCodeExampleAwsProviderRegionVersionOverridenExpected = `
 provider "aws" {
   region  = "eu-west-1"
   version = "0.3.0"
-  profile = "foo"
 }
 
 output "hello" {
@@ -140,18 +139,16 @@ output "hello" {
 }
 `
 
-const terraformCodeExampleAwsMultipleProvidersRegionProfileVersionOverridenExpected = `
+const terraformCodeExampleAwsMultipleProvidersRegionVersionOverridenExpected = `
 provider "aws" {
   region  = "eu-west-1"
   version = "0.3.0"
-  profile = "foo"
 }
 
 provider "aws" {
   alias   = "another"
   region  = "eu-west-1"
   version = "0.3.0"
-  profile = "foo"
 }
 
 resource "aws_instance" "example" {
@@ -168,7 +165,6 @@ provider "aws" {
   alias   = "yet another"
   region  = "eu-west-1"
   version = "0.3.0"
-  profile = "foo"
 }
 
 output "hello" {
@@ -236,7 +232,7 @@ provider "aws" {
 }
 `
 
-const terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionVersionProfileOverriddenExpected = `
+const terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionVersionOverriddenExpected = `
 # Make sure comments are maintained
 # And don't interfere with parsing
 provider "aws" {
@@ -247,7 +243,6 @@ provider "aws" {
   # Make sure comments are maintained
   # And don't interfere with parsing
   version = "0.3.0"
-  profile = "foo"
 }
 
 # Make sure comments are maintained
@@ -263,8 +258,7 @@ provider "aws" {
 
   # Make sure comments are maintained
   # And don't interfere with parsing
-  alias   = "secondary"
-  profile = "foo"
+  alias = "secondary"
 }
 `
 
@@ -284,16 +278,16 @@ func TestPatchAwsProviderInTerraformCodeHappyPath(t *testing.T) {
 		{"no aws provider", terraformCodeExampleGcpProvider, map[string]string{"region": "eu-west-1"}, false, terraformCodeExampleGcpProvider},
 		{"one empty aws provider, but no overrides", terraformCodeExampleAwsProviderEmptyOriginal, nil, false, terraformCodeExampleAwsProviderEmptyOriginal},
 		{"one empty aws provider, with region override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": "eu-west-1"}, true, terraformCodeExampleAwsProviderRegionOverridenExpected},
-		{"one empty aws provider, with region, version, profile override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, true, terraformCodeExampleAwsProviderRegionVersionProfileOverridenExpected},
+		{"one empty aws provider, with region, version override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0"}, true, terraformCodeExampleAwsProviderRegionVersionOverridenExpected},
 		{"one non-empty aws provider, but no overrides", terraformCodeExampleAwsProviderNonEmptyOriginal, nil, false, terraformCodeExampleAwsProviderNonEmptyOriginal},
 		{"one non-empty aws provider, with region override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": "eu-west-1"}, true, terraformCodeExampleAwsProviderRegionOverridenVersionNotOverriddenExpected},
-		{"one non-empty aws provider, with region, version, profile override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, true, terraformCodeExampleAwsProviderRegionVersionProfileOverridenExpected},
+		{"one non-empty aws provider, with region, version override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0"}, true, terraformCodeExampleAwsProviderRegionVersionOverridenExpected},
 		{"multiple providers, but no overrides", terraformCodeExampleAwsMultipleProvidersOriginal, nil, false, terraformCodeExampleAwsMultipleProvidersOriginal},
 		{"multiple providers, with region override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1"}, true, terraformCodeExampleAwsMultipleProvidersRegionOverridenExpected},
-		{"multiple providers, with region, version, profile override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, true, terraformCodeExampleAwsMultipleProvidersRegionProfileVersionOverridenExpected},
+		{"multiple providers, with region, version override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0"}, true, terraformCodeExampleAwsMultipleProvidersRegionVersionOverridenExpected},
 		{"multiple providers with comments, but no overrides", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, nil, false, terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal},
 		{"multiple providers with comments, with region override", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, map[string]string{"region": "eu-west-1"}, true, terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionOverriddenExpected},
-		{"multiple providers with comments, with region, version, profile override", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, true, terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionVersionProfileOverriddenExpected},
+		{"multiple providers with comments, with region, version override", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0"}, true, terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionVersionOverriddenExpected},
 	}
 
 	for _, testCase := range testCases {

--- a/cli/aws_provider_patch_test.go
+++ b/cli/aws_provider_patch_test.go
@@ -176,6 +176,98 @@ output "hello" {
 }
 `
 
+const terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal = `
+# Make sure comments are maintained
+# And don't interfere with parsing
+provider "aws" {
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  region = var.aws_region
+
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  version = "0.2.0"
+}
+
+# Make sure comments are maintained
+# And don't interfere with parsing
+provider "aws" {
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  region = var.aws_region
+
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  version = "0.2.0"
+
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  alias = "secondary"
+}
+`
+
+const terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionOverriddenExpected = `
+# Make sure comments are maintained
+# And don't interfere with parsing
+provider "aws" {
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  region = "eu-west-1"
+
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  version = "0.2.0"
+}
+
+# Make sure comments are maintained
+# And don't interfere with parsing
+provider "aws" {
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  region = "eu-west-1"
+
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  version = "0.2.0"
+
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  alias = "secondary"
+}
+`
+
+const terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionVersionProfileOverriddenExpected = `
+# Make sure comments are maintained
+# And don't interfere with parsing
+provider "aws" {
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  region = "eu-west-1"
+
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  version = "0.3.0"
+  profile = "foo"
+}
+
+# Make sure comments are maintained
+# And don't interfere with parsing
+provider "aws" {
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  region = "eu-west-1"
+
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  version = "0.3.0"
+
+  # Make sure comments are maintained
+  # And don't interfere with parsing
+  alias   = "secondary"
+  profile = "foo"
+}
+`
+
 func TestPatchAwsProviderInTerraformCodeHappyPath(t *testing.T) {
 	t.Parallel()
 
@@ -199,6 +291,9 @@ func TestPatchAwsProviderInTerraformCodeHappyPath(t *testing.T) {
 		{"multiple providers, but no overrides", terraformCodeExampleAwsMultipleProvidersOriginal, nil, false, terraformCodeExampleAwsMultipleProvidersOriginal},
 		{"multiple providers, with region override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1"}, true, terraformCodeExampleAwsMultipleProvidersRegionOverridenExpected},
 		{"multiple providers, with region, version, profile override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, true, terraformCodeExampleAwsMultipleProvidersRegionProfileVersionOverridenExpected},
+		{"multiple providers with comments, but no overrides", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, nil, false, terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal},
+		{"multiple providers with comments, with region override", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, map[string]string{"region": "eu-west-1"}, true, terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionOverriddenExpected},
+		{"multiple providers with comments, with region, version, profile override", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, true, terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionVersionProfileOverriddenExpected},
 	}
 
 	for _, testCase := range testCases {
@@ -207,8 +302,9 @@ func TestPatchAwsProviderInTerraformCodeHappyPath(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.testName, func(t *testing.T) {
 			t.Parallel()
-			actualTerraformCode, codeWasUpdated, err := patchAwsProviderInTerraformCode(testCase.originalTerraformCode, "test.tf", testCase.attributesToOverride)
+			actualTerraformCode, actualCodeWasUpdated, err := patchAwsProviderInTerraformCode(testCase.originalTerraformCode, "test.tf", testCase.attributesToOverride)
 			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedCodeWasUpdated, actualCodeWasUpdated)
 			assert.Equal(t, testCase.expectedTerraformCode, actualTerraformCode)
 		})
 	}

--- a/cli/aws_provider_patch_test.go
+++ b/cli/aws_provider_patch_test.go
@@ -180,24 +180,25 @@ func TestPatchAwsProviderInTerraformCodeHappyPath(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		testName              string
-		originalTerraformCode string
-		attributesToOverride  map[string]string
-		expectedTerraformCode string
+		testName               string
+		originalTerraformCode  string
+		attributesToOverride   map[string]string
+		expectedCodeWasUpdated bool
+		expectedTerraformCode  string
 	}{
-		{"empty", "", nil, ""},
-		{"empty with attributes", "", map[string]string{"region": "eu-west-1"}, ""},
-		{"no provider", terraformCodeExampleOutputOnly, map[string]string{"region": "eu-west-1"}, terraformCodeExampleOutputOnly},
-		{"no aws provider", terraformCodeExampleGcpProvider, map[string]string{"region": "eu-west-1"}, terraformCodeExampleGcpProvider},
-		{"one empty aws provider, but no overrides", terraformCodeExampleAwsProviderEmptyOriginal, nil, terraformCodeExampleAwsProviderEmptyOriginal},
-		{"one empty aws provider, with region override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": "eu-west-1"}, terraformCodeExampleAwsProviderRegionOverridenExpected},
-		{"one empty aws provider, with region, version, profile override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, terraformCodeExampleAwsProviderRegionVersionProfileOverridenExpected},
-		{"one non-empty aws provider, but no overrides", terraformCodeExampleAwsProviderNonEmptyOriginal, nil, terraformCodeExampleAwsProviderNonEmptyOriginal},
-		{"one non-empty aws provider, with region override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": "eu-west-1"}, terraformCodeExampleAwsProviderRegionOverridenVersionNotOverriddenExpected},
-		{"one non-empty aws provider, with region, version, profile override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, terraformCodeExampleAwsProviderRegionVersionProfileOverridenExpected},
-		{"multiple providers, but no overrides", terraformCodeExampleAwsMultipleProvidersOriginal, nil, terraformCodeExampleAwsMultipleProvidersOriginal},
-		{"multiple providers, with region override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1"}, terraformCodeExampleAwsMultipleProvidersRegionOverridenExpected},
-		{"multiple providers, with region, version, profile override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, terraformCodeExampleAwsMultipleProvidersRegionProfileVersionOverridenExpected},
+		{"empty", "", nil, false, ""},
+		{"empty with attributes", "", map[string]string{"region": "eu-west-1"}, false, ""},
+		{"no provider", terraformCodeExampleOutputOnly, map[string]string{"region": "eu-west-1"}, false, terraformCodeExampleOutputOnly},
+		{"no aws provider", terraformCodeExampleGcpProvider, map[string]string{"region": "eu-west-1"}, false, terraformCodeExampleGcpProvider},
+		{"one empty aws provider, but no overrides", terraformCodeExampleAwsProviderEmptyOriginal, nil, false, terraformCodeExampleAwsProviderEmptyOriginal},
+		{"one empty aws provider, with region override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": "eu-west-1"}, true, terraformCodeExampleAwsProviderRegionOverridenExpected},
+		{"one empty aws provider, with region, version, profile override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, true, terraformCodeExampleAwsProviderRegionVersionProfileOverridenExpected},
+		{"one non-empty aws provider, but no overrides", terraformCodeExampleAwsProviderNonEmptyOriginal, nil, false, terraformCodeExampleAwsProviderNonEmptyOriginal},
+		{"one non-empty aws provider, with region override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": "eu-west-1"}, true, terraformCodeExampleAwsProviderRegionOverridenVersionNotOverriddenExpected},
+		{"one non-empty aws provider, with region, version, profile override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, true, terraformCodeExampleAwsProviderRegionVersionProfileOverridenExpected},
+		{"multiple providers, but no overrides", terraformCodeExampleAwsMultipleProvidersOriginal, nil, false, terraformCodeExampleAwsMultipleProvidersOriginal},
+		{"multiple providers, with region override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1"}, true, terraformCodeExampleAwsMultipleProvidersRegionOverridenExpected},
+		{"multiple providers, with region, version, profile override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0", "profile": "foo"}, true, terraformCodeExampleAwsMultipleProvidersRegionProfileVersionOverridenExpected},
 	}
 
 	for _, testCase := range testCases {
@@ -206,7 +207,7 @@ func TestPatchAwsProviderInTerraformCodeHappyPath(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.testName, func(t *testing.T) {
 			t.Parallel()
-			actualTerraformCode, err := patchAwsProviderInTerraformCode(testCase.originalTerraformCode, "test.tf", testCase.attributesToOverride)
+			actualTerraformCode, codeWasUpdated, err := patchAwsProviderInTerraformCode(testCase.originalTerraformCode, "test.tf", testCase.attributesToOverride)
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.expectedTerraformCode, actualTerraformCode)
 		})

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -4,14 +4,263 @@ title: CLI options
 category: reference
 categories_url: reference
 excerpt: >-
-  Terragrunt forwards all arguments and options to Terraform. Learn more about CLI options in Terragrunt.
+  Learn about all CLI arguments and options you can use with Terragrunt.
 tags: ["CLI"]
 order: 401
 nav_title: Documentation
 nav_title_link: /docs/
 ---
 
-Terragrunt forwards all arguments and options to Terraform. The only exceptions are `--version`, `terragrunt-info` and arguments that start with the prefix `--terragrunt-`. The currently available options are:
+This page documents the CLI commands and options available with Terragrunt:
+
+  - [CLI commands](#cli-commands)
+  - [CLI options](#cli-options)
+
+
+
+
+## CLI commands
+
+Terragrunt supports the following CLI commands:
+
+  - [All Terraform built-in commands](#all-terraform-built-in-commands)
+  - [plan-all](#plan-all)
+  - [apply-all](#apply-all)
+  - [output-all](#output-all)
+  - [destroy-all](#destroy-all)
+  - [validate-all](#validate-all)
+  - [terragrunt-info](#terragrunt-info)
+  - [graph-dependencies](#graph-dependencies)
+  - [hclfmt](#hclfmt)
+  - [aws-provider-patch](#aws-provider-patch)
+
+### All Terraform built-in commands
+
+Terragrunt is a thin wrapper for Terraform, so except for a few of the special commands defined in these docs, 
+Terragrunt forwards all other commands to Terraform. For example, when you run `terragrunt apply`, Terragrunt executes 
+`terraform apply`.
+
+Examples:
+
+```bash
+terragrunt plan 
+terragrunt apply 
+terragrunt output
+terragrunt destroy
+# etc 
+```
+
+Run `terraform --help` to get the full list. 
+
+### plan-all
+
+Display the plans of a 'stack' by running 'terragrunt plan' in each subfolder. Make sure to read [Execute Terraform 
+commands on multiple modules at once](/docs/features/execute-terraform-commands-on-multiple-modules-at-once/) for 
+context.
+
+Example:
+
+```bash
+terragrunt plan-all
+``` 
+
+This will recursively search the current working directory for any folders that contain Terragrunt modules and run
+`plan` in each one, concurrently, while respecting ordering defined via 
+[`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
+[`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks. 
+
+**[WARNING] `plan-all` is currently broken for certain use cases**. If you have a stack of Terragrunt modules with 
+dependencies between them—either via `dependency` blocks or `terraform_remote_state` data sources—and you've never 
+deployed them, then `plan-all` will fail as it will not be possible to resolve the `dependency` blocks or 
+`terraform_remote_state` data sources! Please [see here for more 
+information](https://github.com/gruntwork-io/terragrunt/issues/720#issuecomment-497888756).
+
+
+### apply-all
+
+Apply a 'stack' by running 'terragrunt apply' in each subfolder. Make sure to read [Execute Terraform 
+commands on multiple modules at once](/docs/features/execute-terraform-commands-on-multiple-modules-at-once/) for 
+context.
+
+Example:
+
+```bash
+terragrunt apply-all
+``` 
+
+This will recursively search the current working directory for any folders that contain Terragrunt modules and run
+`apply` in each one, concurrently, while respecting ordering defined via 
+[`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
+[`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks. 
+
+### output-all
+
+Display the outputs of a 'stack' by running 'terragrunt output' in each subfolder. Make sure to read [Execute Terraform 
+commands on multiple modules at once](/docs/features/execute-terraform-commands-on-multiple-modules-at-once/) for 
+context.
+
+Example:
+
+```bash
+terragrunt output-all
+``` 
+
+This will recursively search the current working directory for any folders that contain Terragrunt modules and run
+`output` in each one, concurrently, while respecting ordering defined via 
+[`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
+[`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks. 
+
+**[WARNING] `output-all` is currently broken for certain use cases**. If you have a stack of Terragrunt modules with 
+dependencies between them—either via `dependency` blocks or `terraform_remote_state` data sources—and you've never 
+deployed them, then `output-all` will fail as it will not be possible to resolve the `dependency` blocks or 
+`terraform_remote_state` data sources! Please [see here for more 
+information](https://github.com/gruntwork-io/terragrunt/issues/720#issuecomment-497888756).
+
+### destroy-all
+
+Destroy a 'stack' by running 'terragrunt destroy' in each subfolder. Make sure to read [Execute Terraform 
+commands on multiple modules at once](/docs/features/execute-terraform-commands-on-multiple-modules-at-once/) for 
+context.
+
+Example:
+
+```bash
+terragrunt destroy-all
+``` 
+
+This will recursively search the current working directory for any folders that contain Terragrunt modules and run
+`destroy` in each one, concurrently, while respecting ordering defined via 
+[`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
+[`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks. 
+
+### validate-all
+
+Validate 'stack' by running 'terragrunt validate' in each subfolder. Make sure to read [Execute Terraform 
+commands on multiple modules at once](/docs/features/execute-terraform-commands-on-multiple-modules-at-once/) for 
+context.
+
+Example:
+
+```bash
+terragrunt validate-all
+``` 
+
+This will recursively search the current working directory for any folders that contain Terragrunt modules and run
+`validate` in each one, concurrently, while respecting ordering defined via 
+[`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
+[`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks. 
+
+### terragrunt-info
+
+Emits limited terragrunt state on `stdout` in a JSON format and exits.
+
+Example:
+
+```bash
+terragrunt terragrunt-info
+```
+
+Might produce output such as:
+
+```json
+{
+  "ConfigPath": "/example/path/terragrunt.hcl",
+  "DownloadDir": "/example/path/.terragrunt-cache",
+  "IamRole": "",
+  "TerraformBinary": "terraform",
+  "TerraformCommand": "terragrunt-info",
+  "WorkingDir": "/example/path"
+}
+```
+
+### graph-dependencies
+
+Prints the terragrunt dependency graph, in DOT format, to `stdout`. You can generate charts from DOT format using tools
+such as [GraphViz](http://www.graphviz.org/).
+
+Example:
+
+```bash
+terragrunt graph-dependencies
+```
+
+This will recursively search the current working directory for any folders that contain Terragrunt modules and build
+the dependency graph based on [`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
+[`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks. This may produce output such as:
+
+```
+digraph {
+	"mgmt/bastion-host" ;
+	"mgmt/bastion-host" -> "mgmt/vpc";
+	"mgmt/bastion-host" -> "mgmt/kms-master-key";
+	"mgmt/kms-master-key" ;
+	"mgmt/vpc" ;
+	"stage/backend-app" ;
+	"stage/backend-app" -> "stage/vpc";
+	"stage/backend-app" -> "mgmt/bastion-host";
+	"stage/backend-app" -> "stage/mysql";
+	"stage/backend-app" -> "stage/search-app";
+	"stage/frontend-app" ;
+	"stage/frontend-app" -> "stage/vpc";
+	"stage/frontend-app" -> "mgmt/bastion-host";
+	"stage/frontend-app" -> "stage/backend-app";
+	"stage/mysql" ;
+	"stage/mysql" -> "stage/vpc";
+	"stage/redis" ;
+	"stage/redis" -> "stage/vpc";
+	"stage/search-app" ;
+	"stage/search-app" -> "stage/vpc";
+	"stage/search-app" -> "stage/redis";
+	"stage/vpc" ;
+	"stage/vpc" -> "mgmt/vpc";
+}
+```
+
+### hclfmt
+
+Recursively find `terragrunt.hcl` files and rewrite them into a canonical format.
+
+Example:
+
+```bash
+terragrunt hclfmt
+```
+
+This will recursively search the current working directory for any folders that contain Terragrunt configuration files
+(`terragrunt.hcl`) and run the equivalent of `terraform fmt` on them.
+
+
+### aws-provider-patch
+
+Overwrite settings on nested AWS providers to work around a Terraform bug. Due to 
+[issue #13018](https://github.com/hashicorp/terraform/issues/13018), the `import` command may fail if your Terraform
+code uses a module that has a `provider` block nested within it that sets any of its attributes to computed values. 
+This command is a hacky attempt at working around this problem by allowing you to temporarily hard-code those 
+attributes, based on the [terragrunt-override-attr](#terragrunt-override-attr) options you set, so that `import` 
+can work.
+
+Example:
+
+```bash
+terragrunt aws-provider-patch --terragrunt-override-attr region=eu-west-1
+```  
+
+When you run the command above, Terragrunt will:
+
+1. Run `terraform init` to download the code for all your modules into `.terraform/modules`.
+1. Scan all the Terraform code in `.terraform/modules`, find AWS `provider` blocks, and hard-code the `region` param
+   to `eu-west-1` for each one. 
+
+This should allow you to run `import` on the module and work around issue #13018.   
+
+
+
+
+
+## CLI options
+
+Terragrunt forwards all options to Terraform. The only exceptions are `--version` and arguments that start with the 
+prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available options are:
 
 - [terragrunt-config](#terragrunt-config)
 - [terragrunt-tfpath](#terragrunt-tfpath)
@@ -34,9 +283,10 @@ Terragrunt forwards all arguments and options to Terraform. The only exceptions 
 - [terragrunt-debug](#terragrunt-debug)
 - [terragrunt-check](#terragrunt-check)
 - [terragrunt-hclfmt-file](#terragrunt-hclfmt-file)
+- [terragrunt-override-attr](#terragrunt-override-attr)
 
 
-## terragrunt-config
+### terragrunt-config
 
 **CLI Arg**: `--terragrunt-config`<br/>
 **Environment Variable**: `TERRAGRUNT_CONFIG`<br/>
@@ -49,7 +299,7 @@ explanation). This argument is not used with the `apply-all`, `destroy-all`, `ou
 `plan-all` commands.
 
 
-## terragrunt-tfpath
+### terragrunt-tfpath
 
 **CLI Arg**: `--terragrunt-tfpath`<br/>
 **Environment Variable**: `TERRAGRUNT_TFPATH`<br/>
@@ -58,7 +308,7 @@ explanation). This argument is not used with the `apply-all`, `destroy-all`, `ou
 A custom path to the Terraform binary. The default is `terraform` in a directory on your PATH.
 
 
-## terragrunt-no-auto-init
+### terragrunt-no-auto-init
 
 **CLI Arg**: `--terragrunt-no-auto-init`<br/>
 **Environment Variable**: `TERRAGRUNT_AUTO_INIT` (set to `false`)
@@ -70,7 +320,7 @@ yourself in this case if needed. `terragrunt` will fail if it detects that `init
 disabled. See [Auto-Init]({{site.baseurl}}/docs/features/auto-init#auto-init)
 
 
-## terragrunt-no-auto-retry
+### terragrunt-no-auto-retry
 
 **CLI Arg**: `--terragrunt-no-auto-retry`<br/>
 **Environment Variable**: `TERRAGRUNT_AUTO_RETRY` (set to `false`)
@@ -79,7 +329,7 @@ When passed in, don't automatically retry commands which fail with transient err
 [Auto-Retry]({{site.baseurl}}/docs/features/auto-retry#auto-retry)
 
 
-## terragrunt-non-interactive
+### terragrunt-non-interactive
 
 **CLI Arg**: `--terragrunt-non-interactive`<br/>
 **Environment Variable**: `TF_INPUT` (set to `false`)
@@ -89,7 +339,7 @@ you need to run Terragrunt in an automated setting (e.g. from a script). May als
 [TF\_INPUT](https://www.terraform.io/docs/configuration/environment-variables.html#tf_input) environment variable.
 
 
-## terragrunt-working-dir
+### terragrunt-working-dir
 
 **CLI Arg**: `--terragrunt-working-dir`<br/>
 **Environment Variable**: `TERRAGRUNT_WORKING_DIR`<br/>
@@ -101,7 +351,7 @@ a different meaning: Terragrunt will apply or destroy all the Terraform modules 
 `terragrunt-working-dir`, running `terraform` in the root of each module it finds.
 
 
-## terragrunt-download-dir
+### terragrunt-download-dir
 
 **CLI Arg**: `--terragrunt-download-dir`<br/>
 **Environment Variable**: `TERRAGRUNT_DOWNLOAD`<br/>
@@ -112,7 +362,7 @@ configurations](https://blog.gruntwork.io/terragrunt-how-to-keep-your-terraform-
 Default is `.terragrunt-cache` in the working directory. We recommend adding this folder to your `.gitignore`.
 
 
-## terragrunt-source
+### terragrunt-source
 
 **CLI Arg**: `--terragrunt-source`<br/>
 **Environment Variable**: `TERRAGRUNT_SOURCE`<br/>
@@ -126,7 +376,7 @@ for all of your Terraform modules, and for each module processed by the `xxx-all
 append the path of `source` parameter in each module to the `--terragrunt-source` parameter you passed in.
 
 
-## terragrunt-source-update
+### terragrunt-source-update
 
 **CLI Arg**: `--terragrunt-source-update`<br/>
 **Environment Variable**: `TERRAGRUNT_SOURCE_UPDATE` (set to `true`)
@@ -134,14 +384,14 @@ append the path of `source` parameter in each module to the `--terragrunt-source
 When passed in, delete the contents of the temporary folder before downloading Terraform source code into it.
 
 
-## terragrunt-ignore-dependency-errors
+### terragrunt-ignore-dependency-errors
 
 **CLI Arg**: `--terragrunt-ignore-dependency-errors`
 
 When passed in, the `*-all` commands continue processing components even if a dependency fails
 
 
-## terragrunt-iam-role
+### terragrunt-iam-role
 
 **CLI Arg**: `--terragrunt-iam-role`<br/>
 **Environment Variable**: `TERRAGRUNT_IAM_ROLE`<br/>
@@ -151,7 +401,7 @@ Assume the specified IAM role ARN before running Terraform or AWS commands. This
 and Terraform with multiple AWS accounts.
 
 
-## terragrunt-exclude-dir
+### terragrunt-exclude-dir
 
 **CLI Arg**: `--terragrunt-exclude-dir`<br/>
 **Requires an argument**: `--terragrunt-exclude-dir /path/to/dirs/to/exclude*`
@@ -164,7 +414,7 @@ excluded during execution of the commands. If a relative path is specified, it s
 module, not its dependencies.
 
 
-## terragrunt-include-dir
+### terragrunt-include-dir
 
 **CLI Arg**: `--terragrunt-include-dir`<br/>
 **Requires an argument**: `--terragrunt-include-dir /path/to/dirs/to/include*`
@@ -176,7 +426,7 @@ dependent modules) will be included during execution of the commands. If a relat
 relative from `--terragrunt-working-dir`. Flag can be specified multiple times.
 
 
-## terragrunt-strict-include
+### terragrunt-strict-include
 
 **CLI Arg**: `--terragrunt-strict-include`
 
@@ -185,14 +435,14 @@ will be included. All dependencies of the included directories will be excluded 
 directories.
 
 
-## terragrunt-ignore-dependency-order
+### terragrunt-ignore-dependency-order
 
 **CLI Arg**: `--terragrunt-ignore-dependency-order`
 
 When passed in, ignore the depedencies between modules when running `*-all` commands.
 
 
-## terragrunt-ignore-external-dependencies
+### terragrunt-ignore-external-dependencies
 
 **CLI Arg**: `--terragrunt-ignore-external-dependencies`
 
@@ -201,7 +451,7 @@ dependency is a dependency that is outside the current terragrunt working direct
 included directories with `terragrunt-include-dir`.
 
 
-## terragrunt-include-external-dependencies
+### terragrunt-include-external-dependencies
 
 **CLI Arg**: `--terragrunt-include-external-dependencies`
 
@@ -210,7 +460,7 @@ dependency is a dependency that is outside the current terragrunt working direct
 included directories with `terragrunt-include-dir`.
 
 
-## terragrunt-parallelism
+### terragrunt-parallelism
 
 **CLI Arg**: `--terragrunt-parallelism`<br/>
 **Environment Variable**: `TERRAGRUNT_PARALLELISM`
@@ -219,7 +469,7 @@ When passed in, limit the number of modules that are run concurrently to this nu
 
 
 
-## terragrunt-debug
+### terragrunt-debug
 
 **CLI Arg**: `--terragrunt-debug`
 
@@ -228,7 +478,7 @@ tfvars.json file.
 
 
 
-## terragrunt-check
+### terragrunt-check
 
 **CLI Arg**: `--terragrunt-check`<br/>
 **Environment Variable**: `TERRAGRUNT_CHECK` (set to `true`)
@@ -236,9 +486,19 @@ tfvars.json file.
 When passed in, run `hclfmt` in check only mode instead of actively overwriting the files. This will cause the
 command to exit with exit code 1 if there are any files that are not formatted.
 
-## terragrunt-hclfmt-file
+
+### terragrunt-hclfmt-file
 
 **CLI Arg**: `--terragrunt-hclfmt-file`
 **Requires an argument**: `--terragrunt-hclfmt-file /path/to/terragrunt.hcl`
 
 When passed in, run `hclfmt` only on specified `*/terragrunt.hcl` file.
+
+
+### terragrunt-override-attr
+
+**CLI Arg**: `--terragrunt-override-attr`
+**Requires an argument**: `--terragrunt-override-attr KEY=VALUE`
+
+A `KEY=VALUE` attribute to override in a `provider` block as part of the [aws-provider-patch 
+command](#aws-provider-patch). May be specified multiple times.

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,7 @@ require (
 	github.com/gruntwork-io/terratest v0.26.1
 	github.com/hashicorp/go-getter v1.4.2-0.20200106182914-9813cbd4eb02
 	github.com/hashicorp/go-version v1.2.0
-	github.com/hashicorp/hcl/v2 v2.3.0
-	github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80
+	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/terraform v0.12.24
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7
 	github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/go-getter v1.4.2-0.20200106182914-9813cbd4eb02
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl/v2 v2.3.0
+	github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80
 	github.com/hashicorp/terraform v0.12.24
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7
 	github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326

--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,7 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/hashicorp/hcl/v2 v2.3.0 h1:iRly8YaMwTBAKhn1Ybk7VSdzbnopghktCD031P8ggUE=
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
+github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+o=
 github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80 h1:PFfGModn55JA0oBsvFghhj0v93me+Ctr3uHC/UmFAls=
 github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80/go.mod h1:Cxv+IJLuBiEhQ7pBYGEuORa0nr4U994pE8mYLuFd7v0=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,7 @@ github.com/bmatcuk/doublestar v1.1.5 h1:2bNwBOmhyFEFcoB3tGvTD5xanq+4kyOZlB8wFYbM
 github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
@@ -314,6 +315,7 @@ github.com/gruntwork-io/terratest v0.26.1 h1:T+R6sxhr4hTkbhOl9EIp/xTJm6070YcM5sC
 github.com/gruntwork-io/terratest v0.26.1/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkVC7665yRyvu3aWnk=
 github.com/hashicorp/aws-sdk-go-base v0.4.0/go.mod h1:eRhlz3c4nhqxFZJAahJEFL7gh6Jyj5rQmQc7F9eHFyQ=
 github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+sfyn/OOI=
+github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.10.0/go.mod h1:YuAtHxm2v74s+IjQwUG88dHBJPd5jL+cXr5BGVzSKhE=
@@ -329,6 +331,7 @@ github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-immutable-radix v0.0.0-20180129170900-7f3cd4390caa/go.mod h1:6ij3Z20p+OhOkCSrA0gImAWoHYQRGbnlcuk6XYTiaRw=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.4/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
+github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-plugin v1.0.1-0.20190610192547-a1bc61569a26/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
@@ -358,6 +361,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/hashicorp/hcl/v2 v2.3.0 h1:iRly8YaMwTBAKhn1Ybk7VSdzbnopghktCD031P8ggUE=
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
+github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80 h1:PFfGModn55JA0oBsvFghhj0v93me+Ctr3uHC/UmFAls=
+github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80/go.mod h1:Cxv+IJLuBiEhQ7pBYGEuORa0nr4U994pE8mYLuFd7v0=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc3W6JvZwjxxsE=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
@@ -379,6 +384,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -697,6 +703,7 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -915,6 +922,7 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFU
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
+github.com/apparentlymart/go-textseg/v12 v12.0.0 h1:bNEQyAGak9tojivJNkoqWErVCQbjdL7GzRt3F8NvfJ0=
+github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-versions v0.0.2-0.20180815153302-64b99f7cb171/go.mod h1:JXY95WvQrPJQtudvNARshgWajS7jNNlM90altXIPNyI=
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -135,7 +137,6 @@ github.com/bmatcuk/doublestar v1.1.5 h1:2bNwBOmhyFEFcoB3tGvTD5xanq+4kyOZlB8wFYbM
 github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
-github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
@@ -315,7 +316,6 @@ github.com/gruntwork-io/terratest v0.26.1 h1:T+R6sxhr4hTkbhOl9EIp/xTJm6070YcM5sC
 github.com/gruntwork-io/terratest v0.26.1/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkVC7665yRyvu3aWnk=
 github.com/hashicorp/aws-sdk-go-base v0.4.0/go.mod h1:eRhlz3c4nhqxFZJAahJEFL7gh6Jyj5rQmQc7F9eHFyQ=
 github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+sfyn/OOI=
-github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.10.0/go.mod h1:YuAtHxm2v74s+IjQwUG88dHBJPd5jL+cXr5BGVzSKhE=
@@ -331,7 +331,6 @@ github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-immutable-radix v0.0.0-20180129170900-7f3cd4390caa/go.mod h1:6ij3Z20p+OhOkCSrA0gImAWoHYQRGbnlcuk6XYTiaRw=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.4/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
-github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-plugin v1.0.1-0.20190610192547-a1bc61569a26/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
@@ -362,8 +361,7 @@ github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV
 github.com/hashicorp/hcl/v2 v2.3.0 h1:iRly8YaMwTBAKhn1Ybk7VSdzbnopghktCD031P8ggUE=
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
 github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+o=
-github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80 h1:PFfGModn55JA0oBsvFghhj0v93me+Ctr3uHC/UmFAls=
-github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80/go.mod h1:Cxv+IJLuBiEhQ7pBYGEuORa0nr4U994pE8mYLuFd7v0=
+github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc3W6JvZwjxxsE=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
@@ -385,7 +383,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -704,7 +701,6 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -923,7 +919,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=

--- a/options/options.go
+++ b/options/options.go
@@ -142,6 +142,10 @@ type TerragruntOptions struct {
 	// True if terragrunt should run in debug mode, writing terragrunt-debug.tfvars to working folder to help
 	// root-cause issues.
 	Debug bool
+
+	// Attributes to override in AWS provider nested within modules as part of the aws-provider-patch command. See that
+	// command for more info.
+	AwsProviderPatchOverrides map[string]string
 }
 
 // Create a new TerragruntOptions object with reasonable defaults for real usage
@@ -255,6 +259,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		Parallelism:                 terragruntOptions.Parallelism,
 		StrictInclude:               terragruntOptions.StrictInclude,
 		RunTerragrunt:               terragruntOptions.RunTerragrunt,
+		AwsProviderPatchOverrides:   terragruntOptions.AwsProviderPatchOverrides,
 	}
 }
 

--- a/test/fixture-aws-provider-patch/example-module/main.tf
+++ b/test/fixture-aws-provider-patch/example-module/main.tf
@@ -1,0 +1,25 @@
+# We intentionally have an AWS provider block nested within this module so that we can have an integration test that
+# checks if the aws-provider-patch command helps to work around https://github.com/hashicorp/terraform/issues/13018.
+provider "aws" {
+  region = var.secondary_aws_region
+  alias  = "secondary"
+}
+
+variable "secondary_aws_region" {
+  description = "The AWS region to deploy the S3 bucket into"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "The name to use for the S3 bucket"
+  type        = string
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket = var.bucket_name
+
+  provider = aws.secondary
+
+  # Set to true to make testing easier
+  force_destroy = true
+}

--- a/test/fixture-aws-provider-patch/main.tf
+++ b/test/fixture-aws-provider-patch/main.tf
@@ -1,0 +1,26 @@
+provider "aws" {
+  region = var.primary_aws_region
+}
+
+module "example_module" {
+  # TODO: replace the ref with a proper release once this is all merged!
+  source = "github.com/gruntwork-io/terragrunt.git//test/fixture-aws-provider-patch/example-module?ref=provider-overwritte"
+
+  secondary_aws_region = var.secondary_aws_region
+  bucket_name          = var.bucket_name
+}
+
+variable "primary_aws_region" {
+  description = "The primary AWS region for this module"
+  type        = string
+}
+
+variable "secondary_aws_region" {
+  description = "The secondary AWS region to deploy the S3 bucket from the module into"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "The name to use for the S3 bucket"
+  type        = string
+}

--- a/test/fixture-aws-provider-patch/terragrunt.hcl
+++ b/test/fixture-aws-provider-patch/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty. This is merely a placeholder so that Terragrunt treats this folder as a Terragrunt module.

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1223,7 +1223,7 @@ func TestAwsProviderPatch(t *testing.T) {
 	modulePath := util.JoinPath(rootPath, TEST_FIXTURE_AWS_PROVIDER_PATCH)
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt aws-provider-patch --terragrunt-override-attr region=eu-west-1 --terragrunt-working-dir %s", modulePath), os.Stdout, stderr)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Regexp(t, "Patching AWS provider in .+test/fixture-aws-provider-patch/example-module/main.tf", stderr.String())
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -98,6 +98,7 @@ const (
 	TEST_FIXTURE_AUTO_RETRY_RERUN                           = "fixture-auto-retry/re-run"
 	TEST_FIXTURE_AUTO_RETRY_EXHAUST                         = "fixture-auto-retry/exhaust"
 	TEST_FIXTURE_AUTO_RETRY_APPLY_ALL_RETRIES               = "fixture-auto-retry/apply-all"
+	TEST_FIXTURE_AWS_PROVIDER_PATCH                         = "fixture-aws-provider-patch"
 	TEST_FIXTURE_INPUTS                                     = "fixture-inputs"
 	TEST_FIXTURE_LOCALS_ERROR_UNDEFINED_LOCAL               = "fixture-locals-errors/undefined-local"
 	TEST_FIXTURE_LOCALS_ERROR_UNDEFINED_LOCAL_BUT_INPUT     = "fixture-locals-errors/undefined-local-but-input"
@@ -1212,6 +1213,18 @@ func TestAutoRetryApplyAllDependentModuleRetries(t *testing.T) {
 	assert.Contains(t, s, "app3 output")
 	assert.Contains(t, s, "Apply complete!")
 
+}
+
+func TestAwsProviderPatch(t *testing.T) {
+	t.Parallel()
+
+	stderr := new(bytes.Buffer)
+	rootPath := copyEnvironment(t, TEST_FIXTURE_AWS_PROVIDER_PATCH)
+	modulePath := util.JoinPath(rootPath, TEST_FIXTURE_AWS_PROVIDER_PATCH)
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt aws-provider-patch --terragrunt-override-attr region=eu-west-1 --terragrunt-working-dir %s", modulePath), os.Stdout, stderr)
+
+	assert.Nil(t, err)
+	assert.Regexp(t, "Patching AWS provider in .+test/fixture-aws-provider-patch/example-module/main.tf", stderr.String())
 }
 
 // This tests terragrunt properly passes through terraform commands and any number of specified args


### PR DESCRIPTION
This PR adds an `aws-provider-patch` command that can be used to override attributes in nested `provider` blocks. This is an attempt at a hacky workaround for [a Terraform bug](https://github.com/hashicorp/terraform/issues/13018) where `import` does not work if you are using any modules that have `provider` blocks nested in within them. With this PR, users could run:

```bash
terragrunt aws-provider-patch --terragrunt-override-attr region=eu-west-1
```

And Terragrunt will:

1. Run `terraform init` to download the code for all your modules into `.terraform/modules`.
1. Scan all the Terraform code in `.terraform/modules`, find AWS `provider` blocks, and hard-code the `region` param
   to `eu-west-1` for each one. 

Once you do this, you'll hopefully be able to run `import` on that module. After that, you can delete the modified `.terraform/modules` and go back to normal.

Note that I wanted to document this command somewhere, so I updated the CLI docs to include all Terragrunt commands, and not just options. Therefore, as a side effect, this PR also fixes #1306.