### PR TITLE
Deprecate "lock_table" attribute from use in the remote S3 backend configuration

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -193,7 +193,7 @@ func configValuesEqual(config map[string]interface{}, existingBackend *Terraform
 
 	// Nowadays it only makes sense to set the "dynamodb_table" attribute as it has
 	// been supported in Terraform since the release of version 0.10. The deprecated
-	// "lock_table" attribute it's either set to NULL in the state file or missing
+	// "lock_table" attribute is either set to NULL in the state file or missing
 	// from it altogether. Display a deprecation warning when the "lock_table"
 	// attribute is being used.
 	if util.KindOf(config["lock_table"]) == reflect.String && config["lock_table"] != "" {

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -88,7 +88,7 @@ func (c *ExtendedRemoteStateConfigS3) GetAwsSessionConfig() *aws_helper.AwsSessi
 
 // The DynamoDB lock table attribute used to be called "lock_table", but has since been renamed to "dynamodb_table", and
 // the old attribute name deprecated. The old attribute name has been eventually removed from Terraform starting with
-// release 0.13. To maintain a backwards compatibility, we support both names.
+// release 0.13. To maintain backwards compatibility, we support both names.
 func (s3Config *RemoteStateConfigS3) GetLockTableName() string {
 	if s3Config.DynamoDBTable != "" {
 		return s3Config.DynamoDBTable

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -77,6 +77,12 @@ func TestConfigValuesEqual(t *testing.T) {
 			true,
 		},
 		{
+			"equal-lock-table-replaced-with-dynamodb-table",
+			map[string]interface{}{"lock_table": "foo", "something": "bar"},
+			&TerraformBackend{Type: "s3", Config: map[string]interface{}{"dynamodb_table": "foo", "something": "bar"}},
+			true,
+		},
+		{
 			"unequal-wrong-backend",
 			map[string]interface{}{"foo": "bar"},
 			&TerraformBackend{Type: "wrong", Config: map[string]interface{}{"foo": "bar"}},
@@ -212,6 +218,126 @@ func TestGetAwsSessionConfig(t *testing.T) {
 
 			actual := s3ConfigExtended.GetAwsSessionConfig()
 			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestGetTerraformInitArgs(t *testing.T) {
+	t.Parallel()
+
+	initializer := S3Initializer{}
+
+	testCases := []struct {
+		name          string
+		config        map[string]interface{}
+		expected      map[string]interface{}
+		shouldBeEqual bool
+	}{
+		{
+			"empty-no-values",
+			map[string]interface{}{},
+			map[string]interface{}{},
+			true,
+		},
+		{
+			"valid-s3-configuration-keys",
+			map[string]interface{}{
+				"bucket":  "foo",
+				"encrypt": "bar",
+				"key":     "baz",
+				"region":  "quux",
+			},
+			map[string]interface{}{
+				"bucket":  "foo",
+				"encrypt": "bar",
+				"key":     "baz",
+				"region":  "quux",
+			},
+			true,
+		},
+		{
+			"terragrunt-keys-filtered",
+			map[string]interface{}{
+				"bucket":         "foo",
+				"encrypt":        "bar",
+				"key":            "baz",
+				"region":         "quux",
+				"s3_bucket_tags": map[string]string{},
+			},
+			map[string]interface{}{
+				"bucket":  "foo",
+				"encrypt": "bar",
+				"key":     "baz",
+				"region":  "quux",
+			},
+			true,
+		},
+		{
+			"empty-no-values-all-terragrunt-keys-filtered",
+			map[string]interface{}{
+				"s3_bucket_tags":                 map[string]string{},
+				"dynamodb_table_tags":            map[string]string{},
+				"skip_bucket_versioning":         true,
+				"skip_bucket_ssencryption":       false,
+				"skip_bucket_accesslogging":      true,
+				"skip_bucket_root_access":        false,
+				"enable_lock_table_ssencryption": true,
+				"disable_aws_client_checksums":   false,
+			},
+			map[string]interface{}{},
+			true,
+		},
+		{
+			"lock-table-replaced-with-dynamodb-table",
+			map[string]interface{}{
+				"bucket":     "foo",
+				"encrypt":    "bar",
+				"key":        "baz",
+				"region":     "quux",
+				"lock_table": "xyzzy",
+			},
+			map[string]interface{}{
+				"bucket":         "foo",
+				"encrypt":        "bar",
+				"key":            "baz",
+				"region":         "quux",
+				"dynamodb_table": "xyzzy",
+			},
+			true,
+		},
+		{
+			"dynamodb-table-not-replaced-with-lock-table",
+			map[string]interface{}{
+				"bucket":         "foo",
+				"encrypt":        "bar",
+				"key":            "baz",
+				"region":         "quux",
+				"dynamodb_table": "xyzzy",
+			},
+			map[string]interface{}{
+				"bucket":     "foo",
+				"encrypt":    "bar",
+				"key":        "baz",
+				"region":     "quux",
+				"lock_table": "xyzzy",
+			},
+			false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		// Save the testCase in local scope so all the t.Run calls don't end up with the last item in the list
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			actual := initializer.GetTerraformInitArgs(testCase.config)
+
+			if !testCase.shouldBeEqual {
+				assert.NotEqual(t, testCase.expected, actual)
+				return
+			}
+			assert.Equal(t, testCase.expected, actual)
 		})
 	}
 }

--- a/test/fixture-download/remote-with-backend/terragrunt.hcl
+++ b/test/fixture-download/remote-with-backend/terragrunt.hcl
@@ -14,7 +14,7 @@ remote_state {
     bucket = "__FILL_IN_BUCKET_NAME__"
     key = "terraform.tfstate"
     region = "us-west-2"
-    # Intentionally keeping this at the old (deprecated) name of "lock_table" instead of dynamodb_table to test for
+    # Intentionally keeping this at the old (deprecated) name of "lock_table" instead of "dynamodb_table" to test for
     # backwards compatibility
     lock_table = "__FILL_IN_LOCK_TABLE_NAME__"
   }

--- a/test/fixture-stack/terragrunt.hcl
+++ b/test/fixture-stack/terragrunt.hcl
@@ -6,7 +6,7 @@ remote_state {
     bucket = "__FILL_IN_BUCKET_NAME__"
     key = "${path_relative_to_include()}/terraform.tfstate"
     region = "us-west-2"
-    # Intentionally keeping this at the old (deprecated) name of "lock_table" instead of dynamodb_table to test for
+    # Intentionally keeping this at the old (deprecated) name of "lock_table" instead of "dynamodb_table" to test for
     # backwards compatibility
     lock_table = "__FILL_IN_LOCK_TABLE_NAME__"
   }


### PR DESCRIPTION
The "lock_table" attribute of the remote S3 backend configuration has been deprecated in Terraform before release 0.13 where it has been retired. The current name of the attribute is "dynamodb_table".

Terragrunt currently supports both of the attributes, but should the "lock_table" one be used, then it would be passed as-is either when generating a remote S3 backend block when templating Terraform or as a command-line argument. Using older attribute would not be a problem with Terraform before release 0.13, where the old attribute is still present albeit deprecated, but for anyone who uses the latest release, this would now become a problem as Terraform would terminate with an error.

This change deprecates the use of the "lock_table" in Terragrunt for remote S3 backend configuration and adds facilities to notify the user about the attribute being deprecated. Additionally, the use of "lock_table" will be normalised so that the "dynamodb_table" will be used instead in the resulting remote S3 backend block or as a command-line argument.