### PR TITLE
Added an retry pattern for when terraform cloud private registry returns a 429 and needs throttling

### DIFF
--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -17,4 +17,5 @@ var RETRYABLE_ERRORS = []string{
 	"(?s).*Error installing provider.*tcp.*connection reset by peer.*",
 	"NoSuchBucket: The specified bucket does not exist",
 	"(?s).*Error creating SSM parameter: TooManyUpdates:.*",
+	"(?s).*\"app.terraform.io/.*\": 429 Too Many Requests.*",
 }


### PR DESCRIPTION
Full message given when this happens, information redacted

```
Error: Error accessing remote module registry

Failed to retrieve a download URL for
app.terraform.io/company-x/module-y/provider-z 0.0.0 from app.terraform.io:
error getting download location for
"app.terraform.io/company-x/module-y/provider-z": 429 Too Many Requests
resp:{"errors":[{"status":"429","title":"Too many requests","detail":"You have
exceeded the API's rate limit of 30 requests per second."}]}
```