### PR TITLE
Make Terragrunt recover from missing module and provider error

### DIFF
--- a/cli/cli_app_test.go
+++ b/cli/cli_app_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/config"
@@ -132,6 +134,162 @@ func TestTerragruntHandlesCatastrophicTerraformFailure(t *testing.T) {
 
 	// Use a path that doesn't exist to induce error
 	tgOptions.TerraformPath = "i-dont-exist"
-	err = runTerraformWithRetry(tgOptions)
+	_, err = runTerraformWithRetry(tgOptions)
 	require.Error(t, err)
+}
+
+func TestTerragruntTerraformErrorsRequiringInit(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		description string
+		output      string
+		err         error
+		options     *options.TerragruntOptions
+		matches     bool
+	}{
+		{
+			description: "Does not match as auto retry and auto init are disabled",
+			err:         errors.New("A a-test-error ocurred"),
+			options:     &options.TerragruntOptions{},
+			matches:     false,
+		},
+		{
+			description: "Does not match as auto init is disabled",
+			err:         errors.New("A a-test-error ocurred"),
+			options: &options.TerragruntOptions{
+				AutoInit:  false,
+				AutoRetry: true,
+			},
+		},
+		{
+			description: "Does not match as auto retry is disabled",
+			err:         errors.New("A a-test-error ocurred"),
+			options: &options.TerragruntOptions{
+				AutoInit:  true,
+				AutoRetry: false,
+			},
+			matches: false,
+		},
+		{
+			description: "Does not match with no error",
+			options: &options.TerragruntOptions{
+				AutoInit:  true,
+				AutoRetry: true,
+			},
+			matches: false,
+		},
+		{
+			description: "Does not match an error from an empty list",
+			output:      "This is an error message",
+			err:         errors.New("A a-test-error ocurred"),
+			options: &options.TerragruntOptions{
+				AutoInit:            true,
+				AutoRetry:           true,
+				ErrorsRequiringInit: []string{},
+			},
+			matches: false,
+		},
+		{
+			description: "Does not match an error from the provided list using regular expression",
+			output:      "This is an error message",
+			err:         errors.New("A a-test-error ocurred"),
+			options: &options.TerragruntOptions{
+				AutoInit:  true,
+				AutoRetry: true,
+				ErrorsRequiringInit: []string{
+					"(?s).*some-error.*",
+					"(?s).*a-test-error.*",
+					"(?s).*other-error.*",
+				},
+			},
+			matches: false,
+		},
+		{
+			description: "Does not match an error from the provided list using bare string",
+			output:      "This is an error message",
+			err:         errors.New("A a-test-error ocurred"),
+			options: &options.TerragruntOptions{
+				AutoInit:  true,
+				AutoRetry: true,
+				ErrorsRequiringInit: []string{
+					"some-error",
+					"a-test-error",
+					"other-error",
+				},
+			},
+			matches: false,
+		},
+		{
+			description: "Matches an error from the provided list using regular expression",
+			output:      "This is a-test-error message",
+			err:         errors.New("A a-test-error ocurred"),
+			options: &options.TerragruntOptions{
+				AutoInit:  true,
+				AutoRetry: true,
+				ErrorsRequiringInit: []string{
+					"(?s).*some-error.*",
+					"(?s).*a-test-error.*",
+					"(?s).*other-error.*",
+				},
+			},
+			matches: true,
+		},
+		{
+			description: "Matches an error from the provided list using bare string",
+			output:      "This is a-test-error message",
+			err:         errors.New("A a-test-error ocurred"),
+			options: &options.TerragruntOptions{
+				AutoInit:  true,
+				AutoRetry: true,
+				ErrorsRequiringInit: []string{
+					"some-error",
+					"a-test-error",
+					"other-error",
+				},
+			},
+			matches: true,
+		},
+		{
+			description: "Matches a multi-line error from the provided list using regular expression",
+			output:      fmt.Sprintln("This is\na-test-error\nmessage"),
+			err:         errors.New("A a-test-error ocurred"),
+			options: &options.TerragruntOptions{
+				AutoInit:  true,
+				AutoRetry: true,
+				ErrorsRequiringInit: []string{
+					"(?s).*some-error.*",
+					"(?s).*a-test-error.*",
+					"(?s).*other-error.*",
+				},
+			},
+			matches: true,
+		},
+		{
+			description: "Matches a multi-line error with ANSI colors from the provided list using regular expression",
+			output:      fmt.Sprintln("\x1b[31mThis is\x1b[0m\n\x1b[32ma-test-error\x1b[0m\n\x1b[34mmessage\x1b[0m"),
+			err:         errors.New("A a-test-error ocurred"),
+			options: &options.TerragruntOptions{
+				AutoInit:  true,
+				AutoRetry: true,
+				ErrorsRequiringInit: []string{
+					"(?s).*some-error.*",
+					"(?s).*a-test-error.*",
+					"(?s).*other-error.*",
+				},
+			},
+			matches: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		// The following is necessary to make sure testCase's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
+		testCase := testCase
+
+		t.Run(testCase.description, func(t *testing.T) {
+			actual := isErrorRequiringInit(testCase.output, testCase.err, testCase.options)
+			assert.Equal(t, testCase.matches, actual)
+		})
+	}
 }

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -93,8 +93,8 @@ func downloadTerraformSourceIfNecessary(terraformSource *TerraformSource, terrag
 	// before and after hooks (if any).
 	terragruntOptionsForDownload := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
 	terragruntOptionsForDownload.TerraformCommand = CMD_INIT_FROM_MODULE
-	downloadErr := runActionWithHooks("download source", terragruntOptionsForDownload, terragruntConfig, func() error {
-		return downloadSource(terraformSource, terragruntOptions, terragruntConfig)
+	_, downloadErr := runActionWithHooks("download source", terragruntOptionsForDownload, terragruntConfig, func() (string, error) {
+		return "", downloadSource(terraformSource, terragruntOptions, terragruntConfig)
 	})
 
 	if downloadErr != nil {

--- a/docs/_docs/02_features/auto-init.md
+++ b/docs/_docs/02_features/auto-init.md
@@ -23,7 +23,7 @@ When Auto-Init is enabled (the default), terragrunt will automatically call [`te
 
 As [mentioned]({{site.baseurl}}/docs/features/keep-your-cli-flags-dry/#extra_arguments-for-init), `extra_arguments` can be configured to allow customization of the `terraform init` command.
 
-Note that there might be cases where terragrunt does not properly detect that `terraform init` needs be called. In this case, terraform would fail. Running `terragrunt init` again corrects this situation.
+Terragrunt will attempt to detect several common errors to automatically handle the cases where `terraform init` would need to be called (for example a module version has changed and a new version has to be downloaded, etc.) and then run it as appropriate. In case where Terragrunt detected that `terraform init` has to be run it will then re-run the original command (e.g., `plan`, `apply`, etc.) once `terraform init` completes successfully. Note that even though Terragrunt will try to recover from most errors there might be cases where Terragrunt does not properly detect that `terraform init` needs be called. In this case, Terraform would fail. Running `terragrunt init` again corrects this situation.
 
 For some use cases, it might be desirable to disable Auto-Init. For example, if each user wants to specify a different `-plugin-dir` option to `terraform init` (and therefore it cannot be put in `extra_arguments`). To disable Auto-Init, use the `--terragrunt-no-auto-init` command line option or set the `TERRAGRUNT_AUTO_INIT` environment variable to `false`.
 

--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -15,7 +15,23 @@ var RETRYABLE_ERRORS = []string{
 	"(?s).*Error configuring the backend.*TLS handshake timeout.*",
 	"(?s).*Error installing provider.*tcp.*timeout.*",
 	"(?s).*Error installing provider.*tcp.*connection reset by peer.*",
-	"NoSuchBucket: The specified bucket does not exist",
+	"(?s).*NoSuchBucket: The specified bucket does not exist.*",
 	"(?s).*Error creating SSM parameter: TooManyUpdates:.*",
 	"(?s).*app.terraform.io.*: 429 Too Many Requests.*",
+	"(?s).*Get.*dial tcp.*i/o timeout.*",
+	"(?s).*Get.*dial tcp.*connect: connection refused.*",
+	"(?s).*Get.*remote error: tls: internal error.*",
+	"(?s).*Post.*net/http: TLS handshake timeout.*",
+	"(?s).*Error accessing remote module registry.*",
+	"(?s).*Registry service unreachable.*",
+}
+
+// List of recurring transient errors encountered when calling Terraform.
+// If one of these are encountered, we will re-run the init command.
+var ERRORS_REQUIRING_INIT = []string{
+	"(?s).*Please run \"terraform init\".*",
+	"(?s).*Module version requirements have changed.*",
+	"(?s).*Could not satisfy plugin requirements.*",
+	"(?s).*provider.*new or changed plugin executable.*",
+	"(?s).*Error installing provider.*error fetching checksums.*",
 }

--- a/options/options.go
+++ b/options/options.go
@@ -114,6 +114,10 @@ type TerragruntOptions struct {
 	// RetryableErrors is an array of regular expressions with RE2 syntax (https://github.com/google/re2/wiki/Syntax) that qualify for retrying
 	RetryableErrors []string
 
+	// ErrorsRequiringInit is an array of regular expressions with RE2 syntax
+	// (https://github.com/google/re2/wiki/Syntax) that qualify for re-running init.
+	ErrorsRequiringInit []string
+
 	// Unix-style glob of directories to exclude when running *-all commands
 	ExcludeDirs []string
 
@@ -181,6 +185,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		MaxRetryAttempts:            DEFAULT_MAX_RETRY_ATTEMPTS,
 		Sleep:                       DEFAULT_SLEEP,
 		RetryableErrors:             util.CloneStringList(RETRYABLE_ERRORS),
+		ErrorsRequiringInit:         util.CloneStringList(ERRORS_REQUIRING_INIT),
 		ExcludeDirs:                 []string{},
 		IncludeDirs:                 []string{},
 		StrictInclude:               false,
@@ -254,6 +259,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		MaxRetryAttempts:            terragruntOptions.MaxRetryAttempts,
 		Sleep:                       terragruntOptions.Sleep,
 		RetryableErrors:             util.CloneStringList(terragruntOptions.RetryableErrors),
+		ErrorsRequiringInit:         util.CloneStringList(terragruntOptions.ErrorsRequiringInit),
 		ExcludeDirs:                 terragruntOptions.ExcludeDirs,
 		IncludeDirs:                 terragruntOptions.IncludeDirs,
 		Parallelism:                 terragruntOptions.Parallelism,

--- a/test/fixture-auto-retry/automatic-init/module-invalid/main.tf
+++ b/test/fixture-auto-retry/automatic-init/module-invalid/main.tf
@@ -1,0 +1,3 @@
+provider "null" {
+    version = "99.99.99"
+}

--- a/test/fixture-auto-retry/automatic-init/module-invalid/terragrunt.hcl
+++ b/test/fixture-auto-retry/automatic-init/module-invalid/terragrunt.hcl
@@ -1,0 +1,13 @@
+// Used to ensure that the "terraform init" that follows a recoverable
+// error will run with colors disabled.
+terraform {
+  extra_arguments "no-color" {
+    commands = [
+      "init",
+    ]
+
+    arguments = [
+      "-no-color"
+    ]
+  }
+}

--- a/test/fixture-auto-retry/automatic-init/module-new/main.tf
+++ b/test/fixture-auto-retry/automatic-init/module-new/main.tf
@@ -1,0 +1,3 @@
+provider "null" {
+    version = "2.1.2"
+}

--- a/test/fixture-auto-retry/automatic-init/module-new/terragrunt.hcl
+++ b/test/fixture-auto-retry/automatic-init/module-new/terragrunt.hcl
@@ -1,0 +1,13 @@
+// Used to ensure that the "terraform init" that follows a recoverable
+// error will run with colors disabled.
+terraform {
+  extra_arguments "no-color" {
+    commands = [
+      "init",
+    ]
+
+    arguments = [
+      "-no-color"
+    ]
+  }
+}

--- a/test/fixture-auto-retry/automatic-init/module-old/main.tf
+++ b/test/fixture-auto-retry/automatic-init/module-old/main.tf
@@ -1,0 +1,3 @@
+provider "null" {
+    version = "2.1.1"
+}

--- a/test/fixture-auto-retry/automatic-init/module-old/terragrunt.hcl
+++ b/test/fixture-auto-retry/automatic-init/module-old/terragrunt.hcl
@@ -1,0 +1,13 @@
+// Used to ensure that the "terraform init" that follows a recoverable
+// error will run with colors disabled.
+terraform {
+  extra_arguments "no-color" {
+    commands = [
+      "init",
+    ]
+
+    arguments = [
+      "-no-color"
+    ]
+  }
+}


### PR DESCRIPTION
This change enables Terragrunt to detect errors that otherwise required the user to run "terraform init" and attempt a recovery by running Terraform automatically.

When a Terraform module or provider version changes or when a module or provider is missing and Terragrunt is invoked with an action other than "init" (e.g., plan, apply, etc.), then the Terraform run that has been started by Terragrunt will terminate with an error asking the user to run "terraform init" to reinitialize to fetch the missing runtime dependencies.

Terragrunt should detect these type of missing module and provider errors and automatically re-run "terraform init" to resolve them and retry the previous command automatically.

Signed-off-by: Krzysztof Wilczyński <kw@linux.com>