### PR TITLE
Adding a policy to S3 state bucket to enforce TLS

### DIFF
--- a/docs/_docs/02_features/keep-your-remote-state-configuration-dry.md
+++ b/docs/_docs/02_features/keep-your-remote-state-configuration-dry.md
@@ -233,6 +233,7 @@ remote_state {
   skip_bucket_ssencryption       = true # use only if non-encrypted Terraform State is required and/or the object store does not support server-side encryption
   skip_bucket_accesslogging      = true # use only if the cost for the extra object space is undesirable or the object store does not support access logging
   skip_bucket_root_access        = true # use only if the AWS account root user should not have access to the remote state bucket for some reason
+  skip_bucket_enforced_tls       = true # use only if you need to access the S3 bucket without TLS being enforced
   enable_lock_table_ssencryption = true # use only if non-encrypted DynamoDB Lock Table for the Terraform State is required and/or the NoSQL database service does not support server-side encryption
 
   shared_credentials_file     = "/path/to/credentials/file"
@@ -244,7 +245,7 @@ remote_state {
 
 If you experience an error for any of these configurations, confirm you are using Terraform v0.12.2 or greater.
 
-Further, the config options `s3_bucket_tags`, `dynamodb_table_tags`, `skip_bucket_versioning`, `skip_bucket_ssencryption`, `skip_bucket_root_access`, `skip_bucket_accesslogging`, and `enable_lock_table_ssencryption` are only valid for backend `s3`. They are used by terragrunt and are **not** passed on to terraform. See section [Create remote state and locking resources automatically](#create-remote-state-and-locking-resources-automatically).
+Further, the config options `s3_bucket_tags`, `dynamodb_table_tags`, `skip_bucket_versioning`, `skip_bucket_ssencryption`, `skip_bucket_root_access`, `skip_bucket_enforced_tls`, `skip_bucket_accesslogging`, and `enable_lock_table_ssencryption` are only valid for backend `s3`. They are used by terragrunt and are **not** passed on to terraform. See section [Create remote state and locking resources automatically](#create-remote-state-and-locking-resources-automatically).
 
 ### GCS-specific remote state settings
 

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -241,6 +241,7 @@ For the `s3` backend, the following additional properties are supported in the `
 - `skip_bucket_accesslogging`: When `true`, the S3 bucket that is created to store the state will not be configured with
   access logging.
 - `skip_bucket_root_access`: When `true`, the S3 bucket that is created will not be configured with bucket policies that allow access to the root AWS user.
+- `skip_bucket_enforced_tls`: When `true`, the S3 bucket that is created will not be configured with a bucket policy that enforces access to the bucket via a TLS connection.
 - `enable_lock_table_ssencryption`: When `true`, the synchronization lock table in DynamoDB used for remote state concurrent access will not be configured with server side encryption.
 - `s3_bucket_tags`: A map of key value pairs to associate as tags on the created S3 bucket.
 - `dynamodb_table_tags`: A map of key value pairs to associate as tags on the created DynamoDB remote state lock table.

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -404,7 +404,7 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 	}
 
 	if config.SkipBucketEnforcedTLS {
-		terragruntOptions.Logger.Printf("TLS enforcement is disabled for the remote state S3 bucket %s using 'skip_bucket_enforce_tls' config.", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Printf("TLS enforcement is disabled for the remote state S3 bucket %s using 'skip_bucket_enforced_tls' config.", config.remoteStateConfigS3.Bucket)
 	} else if err := EnableEnforcedTLSAccesstoS3Bucket(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
@@ -565,7 +565,7 @@ func EnableEnforcedTLSAccesstoS3Bucket(s3Client *s3.S3, config *RemoteStateConfi
 		"Version": "2012-10-17",
 		"Statement": []map[string]interface{}{
 			{
-				"Sid":    "AllowSSLRequestsOnly",
+				"Sid":    "AllowTLSRequestsOnly",
 				"Action": "s3:*",
 				"Effect": "Deny",
 				"Resource": []string{

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -281,6 +281,7 @@ func TestGetTerraformInitArgs(t *testing.T) {
 				"skip_bucket_ssencryption":       false,
 				"skip_bucket_accesslogging":      true,
 				"skip_bucket_root_access":        false,
+				"skip_bucket_enforced_tls":       false,
 				"enable_lock_table_ssencryption": true,
 				"disable_aws_client_checksums":   false,
 			},


### PR DESCRIPTION
This policy will ensure all access to the state bucket is via
a connection secured by TLS.