### PR TITLE
Added retry for when module lookup fails from app.terraform.io

### DIFF
--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -17,6 +17,5 @@ var RETRYABLE_ERRORS = []string{
 	"(?s).*Error installing provider.*tcp.*connection reset by peer.*",
 	"NoSuchBucket: The specified bucket does not exist",
 	"(?s).*Error creating SSM parameter: TooManyUpdates:.*",
-	"(?s).*\"app.terraform.io/.*\": 429 Too Many Requests.*",
-	"(?s).*app.terraform.io: error looking up module versions: 429 Too Many Requests.*",
+	"(?s).*app.terraform.io.*: 429 Too Many Requests.*",
 }

--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -18,4 +18,5 @@ var RETRYABLE_ERRORS = []string{
 	"NoSuchBucket: The specified bucket does not exist",
 	"(?s).*Error creating SSM parameter: TooManyUpdates:.*",
 	"(?s).*\"app.terraform.io/.*\": 429 Too Many Requests.*",
+	"(?s).*app.terraform.io: error looking up module versions: 429 Too Many Requests.*",
 }


### PR DESCRIPTION
Similar to #1332 however, the output can also appear from terraform as

```
Error: Error accessing remote module registry

Failed to retrieve available versions for module "x" (main.tf:123) from
app.terraform.io: error looking up module versions: 429 Too Many Requests.
```

which is a subtly different message to pattern match