### PR TITLE
Add page showing supported terraform versions

### DIFF
--- a/docs/_docs/01_getting-started/supported-terraform-versions.md
+++ b/docs/_docs/01_getting-started/supported-terraform-versions.md
@@ -1,8 +1,8 @@
 ---
 layout: collection-browser-doc
-title: Supported Terraform Versions
+title: Terraform Version Compatibility Table
 category: getting-started
-excerpt: Learn which Terraform versions are compatible with Terragrunt.
+excerpt: Learn which Terraform versions are compatible with which versions of Terragrunt.
 tags: ["install"]
 order: 102
 nav_title: Documentation

--- a/docs/_docs/01_getting-started/supported-terraform-versions.md
+++ b/docs/_docs/01_getting-started/supported-terraform-versions.md
@@ -1,0 +1,30 @@
+---
+layout: collection-browser-doc
+title: Supported Terraform Versions
+category: getting-started
+excerpt: Learn which Terraform versions are compatible with Terragrunt.
+tags: ["install"]
+order: 102
+nav_title: Documentation
+nav_title_link: /docs/
+---
+
+## Supported Terraform Versions
+
+The officially supported versions are:
+
+| Terraform Version | Terragrunt Version                                                                                                                                    |
+|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.13.x            | >= [0.25.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.25.0)                                                                          |
+| 0.12.x            | [0.19.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.19.0) - [0.24.4](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.24.4) |
+| 0.11.x            | [0.14.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.14.0) - [0.18.7](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.18.7) |
+
+
+However, note that these are the versions that are officially tested in the CI process. In practice, the version
+compatibility is more relaxed than documented above. For example, we've found that Terraform 0.13 works with any version
+above 0.19.0, and we've also found that terraform 0.11 works with any version above 0.19.18 as well.
+
+If you wish to use Terragrunt against an untested Terraform version, you can use the
+[terraform_version_constraint](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#terraform_version_constraint)
+(introduced in Terragrunt [v0.19.18](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.19.18)) attribute to
+relax the version constraint.

--- a/docs/assets/css/subpage.scss
+++ b/docs/assets/css/subpage.scss
@@ -129,7 +129,22 @@
       }
     }
   }
+
+  table {
+    width: 100%;
+    margin-bottom: 1em;
+
+    th {
+      padding: 5px;
+      border: 1px solid black;
+    }
+    td {
+      padding: 5px;
+      border: 1px solid black;
+    }
+  }
 }
+
 
 @media all and (max-width: 991px) {
   .subpage .subpage__header .header-bg {

--- a/docs/jekyll-serve.sh
+++ b/docs/jekyll-serve.sh
@@ -2,6 +2,5 @@
 
 set -e
 
-bundle exec jekyll build
 echo -e "\e[1;31mRun Jekyll serve to watch for changes"
 bundle exec jekyll serve --livereload --drafts --host 0.0.0.0


### PR DESCRIPTION
Addresses https://github.com/gruntwork-io/terragrunt/issues/1359

This creates a new page that shows users which terraform versions have been officially tested with our terragrunt releases. But includes a caveat to highlight that members of the community have tried and confirmed the version scope is not rigid.