### PR TITLE
Add regression test to confirm vars from env var in apply-all works

### DIFF
--- a/test/fixture-regressions/apply-all-envvar/module/main.tf
+++ b/test/fixture-regressions/apply-all-envvar/module/main.tf
@@ -1,0 +1,4 @@
+variable "seed" {}
+output "text" {
+  value = "Hello ${var.seed}"
+}

--- a/test/fixture-regressions/apply-all-envvar/no-require-envvar/terragrunt.hcl
+++ b/test/fixture-regressions/apply-all-envvar/no-require-envvar/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../module"
+}
+
+inputs = {
+  seed = "world"
+}

--- a/test/fixture-regressions/apply-all-envvar/require-envvar/terragrunt.hcl
+++ b/test/fixture-regressions/apply-all-envvar/require-envvar/terragrunt.hcl
@@ -1,0 +1,5 @@
+terraform {
+  source = "../module"
+}
+
+inputs = {}


### PR DESCRIPTION
There was confusion from one of our users regarding whether or not setting tf vars via env vars works with `apply-all`, so I created a regression test for it. AFAIK, none of the existing tests tests this combination.