### PR TITLE
do not pass null value variables

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -390,14 +390,17 @@ func toTerraformEnvVars(vars map[string]interface{}) (map[string]string, error) 
 	out := map[string]string{}
 
 	for varName, varValue := range vars {
-		envVarName := fmt.Sprintf("TF_VAR_%s", varName)
+		// Do not set null value variables
+		// null assigned variables in terraform are "unset" (do not exist)
+		if varValue != nil {
+			envVarName := fmt.Sprintf("TF_VAR_%s", varName)
+			envVarValue, err := asTerraformEnvVarJsonValue(varValue)
+			if err != nil {
+				return nil, err
+			}
 
-		envVarValue, err := asTerraformEnvVarJsonValue(varValue)
-		if err != nil {
-			return nil, err
+			out[envVarName] = string(envVarValue)
 		}
-
-		out[envVarName] = string(envVarValue)
 	}
 
 	return out, nil


### PR DESCRIPTION
Hello Terragrunt team,
Thanks for this wonderfull tool!
Currently I'm facing a blocker issue using null values. A null value variables are "unset" variables, which means that terraform does not recognize it. Said that, when a null value is assigned to a variable it should not be exported to terraform (same behavior as terraform) 

Here is a thread talking about the issue: https://github.com/gruntwork-io/terragrunt/issues/892

One example is when a dependency dynamically offers an output and it becomes optional to the children inputs:

`inputs ={
  optional_input = try(dependency.foo.outputs.optional_output, null)
}`

In the below example, when in terraform dependency's code the output was set to "null", the output actually will not be exported and will be not available, hence we will be defaulting to a null value by the try function (because has failed to find it)
That means that the input will not be set and terraform will use the default input value defined on its own "variables.tf" module's file, example:

`variable optional_input {
   type = number
   default = -1
}`

In this case, "-1" will be used because there was no input/dependency information about this value.