### PR TITLE
configValuesEqual should have no side effects

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,7 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/bmatcuk/doublestar v1.1.5 h1:2bNwBOmhyFEFcoB3tGvTD5xanq+4kyOZlB8wFYbMjkk=
 github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -232,6 +233,7 @@ github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dp
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -523,6 +525,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DKN0g6uH7E=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
+github.com/pquerna/otp v1.2.0 h1:/A3+Jn+cagqayeR3iHs/L62m5ue7710D35zl1zJ1kok=
 github.com/pquerna/otp v1.2.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -77,12 +77,6 @@ func TestConfigValuesEqual(t *testing.T) {
 			true,
 		},
 		{
-			"equal-lock-table-replaced-with-dynamodb-table",
-			map[string]interface{}{"lock_table": "foo", "something": "bar"},
-			&TerraformBackend{Type: "s3", Config: map[string]interface{}{"dynamodb_table": "foo", "something": "bar"}},
-			true,
-		},
-		{
 			"unequal-wrong-backend",
 			map[string]interface{}{"foo": "bar"},
 			&TerraformBackend{Type: "wrong", Config: map[string]interface{}{"foo": "bar"}},

--- a/test/fixture-regressions/skip-versioning/.gitignore
+++ b/test/fixture-regressions/skip-versioning/.gitignore
@@ -1,0 +1,1 @@
+backend.tf

--- a/test/fixture-regressions/skip-versioning/local_terragrunt.hcl
+++ b/test/fixture-regressions/skip-versioning/local_terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixture-regressions/skip-versioning/main.tf
+++ b/test/fixture-regressions/skip-versioning/main.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "foo" {}

--- a/test/fixture-regressions/skip-versioning/remote_terragrunt.hcl
+++ b/test/fixture-regressions/skip-versioning/remote_terragrunt.hcl
@@ -1,0 +1,17 @@
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite"
+  }
+  config = {
+    encrypt = true
+    bucket = "__FILL_IN_BUCKET_NAME__"
+    key = "terraform.tfstate"
+    region = "us-west-2"
+    dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
+    enable_lock_table_ssencryption = true
+    skip_bucket_versioning = true
+  }
+}


### PR DESCRIPTION
I have no idea how this was working before, but @ina-stoyanova and @zackproser found a bug in terragrunt where we were stripping out the terragrunt only config vals before parsing out the extended s3 config object.

Digging in, I found out that this was because we were stripping that out in the `configValuesEqual` function using `delete`. I fixed this by removing the side effect from the equals function.

NOTE: I attempted to create a regression test for this, but I had difficulty reproducing the behavior in a test environment. I was able to repro this behavior, but it is not exactly clear when it happens because it relies on `.terragrunt-cache` already having been init with an s3 bucket AND it is creating a new s3 bucket.