### PR TITLE
Commercial support bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Please see the following for more info, including install instructions and compl
 * [Terragrunt Website](https://terragrunt.gruntwork.io)
 * [Getting started with Terragrunt](https://terragrunt.gruntwork.io/docs/getting-started/quick-start/)
 * [Terragrunt Documentation](https://terragrunt.gruntwork.io/docs)
-* [Contributing to Terragrunt](http://terragrunt.gruntwork.io/docs/community/contributing)
+* [Contributing to Terragrunt](https://terragrunt.gruntwork.io/docs/community/contributing)
+* [Commercial Support](https://terragrunt.gruntwork.io/commercial-support/)
 
 
 

--- a/docs/_includes/get-access.html
+++ b/docs/_includes/get-access.html
@@ -1,6 +1,6 @@
 <div class="get-access-cmp">
     <span>
-        Get access to over 300,000 lines of off-the-shelf, battle-tested, prodduction-grade 
+        Get access to over 300,000 lines of off-the-shelf, battle-tested, production-grade
         Terraform & Terragrunt infrastructure code.
     </span>
     <a href="https://gruntwork.io" target="_blank" class="btn btn-primary">Explore Gruntwork.io</a>

--- a/docs/_pages/commercial-support/_pricing-table.html
+++ b/docs/_pages/commercial-support/_pricing-table.html
@@ -160,7 +160,7 @@
 			</div>
 			<div class="cell-cnt col-md-2">
 				<div class="cell">
-					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/xmark.svg' />
+					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/checkmark-blue.svg' />
 				</div>
 			</div>
 			<div class="cell-cnt col-md-2">
@@ -226,7 +226,7 @@
 			</div>
 			<div class="cell-cnt col-md-2">
 				<div class="cell">
-					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/checkmark-blue.svg' />
+					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/xmark.svg' />
 				</div>
 			</div>
 			<div class="cell-cnt col-md-2">

--- a/docs/_pages/commercial-support/_pricing-table.html
+++ b/docs/_pages/commercial-support/_pricing-table.html
@@ -55,7 +55,7 @@
 			<div class="cell-cnt col-md-6">
 				<div class="description">
 					<span>Support via 
-						<a href="https://stackoverflow.com/questions/ask?tags=terragrunt" class='pricing-link' target="_blank">
+						<a href="https://stackoverflow.com/questions/tagged/terragrunt" class='pricing-link' target="_blank">
 							StackOverflow
 						</a>
 					</span>

--- a/docs/_pages/commercial-support/_pricing-table.html
+++ b/docs/_pages/commercial-support/_pricing-table.html
@@ -160,7 +160,7 @@
 			</div>
 			<div class="cell-cnt col-md-2">
 				<div class="cell">
-					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/checkmark-blue.svg' />
+					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/xmark.svg' />
 				</div>
 			</div>
 			<div class="cell-cnt col-md-2">
@@ -182,7 +182,7 @@
 			</div>
 			<div class="cell-cnt col-md-2">
 				<div class="cell">
-					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/checkmark-blue.svg' />
+					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/xmark.svg' />
 				</div>
 			</div>
 			<div class="cell-cnt col-md-2">
@@ -204,7 +204,7 @@
 			</div>
 			<div class="cell-cnt col-md-2">
 				<div class="cell">
-					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/checkmark-blue.svg' />
+					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/xmark.svg' />
 				</div>
 			</div>
 			<div class="cell-cnt col-md-2">

--- a/docs/_pages/commercial-support/index.html
+++ b/docs/_pages/commercial-support/index.html
@@ -21,7 +21,7 @@ custom_js:
         <span>
           <img src='{{site.baseurl}}/assets/img/commercial-support/access-left.svg' alt='Shape' class="shapes-left" />
           <img src='{{site.baseurl}}/assets/img/commercial-support/access-right.svg' alt='Shape' class="shapes-right" />
-          Get access to over 300,000 lines of off-the-shelf, battle-tested, prodduction-grade 
+          Get access to over 300,000 lines of off-the-shelf, battle-tested, production-grade
           Terraform & Terragrunt infrastructure code.
         </span>
         <a href="https://gruntwork.io" target="_blank" class="btn btn-primary">Explore Gruntwork.io</a>

--- a/docs/_pages/thanks/index.html
+++ b/docs/_pages/thanks/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Thank you.
-excerpt: Thank you for contacting us. A grunt will be in touch soon!
+excerpt: Thank you for contacting us. A Grunt will be in touch soon!
 permalink: /thanks/
 ---
 


### PR DESCRIPTION
1. Fix the features that are included with pro support. 
1. Capitalize the word "Grunt."
1. Fix typo in "prodduction-grade" (lol).
1. Strengthen the CTA at the bottom of the page.
1. Add link from the README to the commercial support page.
1. Remove `jekyll build` command from start script as it's redundant with the `jekyll serve` that's already there.