### PR TITLE
Skip the cache dir entirely when finding configs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -277,6 +277,11 @@ func FindConfigFilesInPath(rootPath string, terragruntOptions *options.Terragrun
 			return err
 		}
 
+		// Skip the Terragrunt cache dir entirely
+		if info.IsDir() && info.Name() == options.TerragruntCacheDir {
+			return filepath.SkipDir
+		}
+
 		isTerragruntModule, err := containsTerragruntModule(path, info, terragruntOptions)
 		if err != nil {
 			return err


### PR DESCRIPTION
Rather than searching each path that might exist below the
`.terragrunt-cache` directory, skip it entirely speeding up the process.