### PR TITLE
update for least priv minimal iam access to create an s3 backend

### DIFF
--- a/docs/_docs/02_features/aws-auth.md
+++ b/docs/_docs/02_features/aws-auth.md
@@ -63,7 +63,18 @@ For a more minimal policy, for example when using a single bucket and DynamoDB t
             "Action": [
                 "s3:ListBucket",
                 "s3:GetBucketVersioning",
-                "s3:CreateBucket"
+                "s3:GetObject",
+                "s3:GetBucketAcl",
+                "s3:GetBucketLogging",
+                "s3:CreateBucket",
+                "s3:PutObject",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:PutBucketTagging",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketVersioning",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutBucketAcl",
+                "s3:PutBucketLogging"
             ],
             "Resource": "arn:aws:s3:::BUCKET_NAME"
         },


### PR DESCRIPTION
The docs for IAM access required for creating the S3 backend were missing a few permissions
Updated the minimal policy to include what was needed to successfully create the backend