### PR TITLE
fix: Set Terraform plan file as last argument in apply-all

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -276,9 +276,27 @@ func (terragruntOptions *TerragruntOptions) InsertTerraformCliArgs(argsToInsert 
 	// Options must be inserted after command but before the other args
 	// command is either 1 word or 2 words
 	var args []string
+	var lastArg string
+
 	args = append(args, terragruntOptions.TerraformCliArgs[:commandLength]...)
-	args = append(args, argsToInsert...)
+	// We need to iterate over the argsToInsert to find an arg that is a file.
+	// If we found one, we treat it as the Terraform plan file and we then set it
+	// as lastArg to append it as last argument.
+	for _, arg := range argsToInsert {
+		if util.IsFile(arg) {
+			lastArg = arg
+		} else {
+			args = append(args, arg)
+		}
+	}
+
 	args = append(args, terragruntOptions.TerraformCliArgs[commandLength:]...)
+
+	// Append lastArg which is a Terraform plan file
+	if lastArg != "" {
+		args = append(args, lastArg)
+	}
+
 	terragruntOptions.TerraformCliArgs = args
 }
 


### PR DESCRIPTION
This PR should fix #1271 (The position of the Terraform plan file in the `apply-all` command).

I'm having the same problem as @ibacalu when running Terragrunt with:

```
  extra_arguments "save_plan" {
    commands = [
      "plan"
    ]

    arguments = [
      "-out=${get_terragrunt_dir()}/${trimspace(run_cmd("basename", "${get_terragrunt_dir()}"))}.tfplan"
    ]
  }

  extra_arguments "load_plan" {
    commands = [
      "apply"
    ]

    arguments = [
      "${get_terragrunt_dir()}/${trimspace(run_cmd("basename", "${get_terragrunt_dir()}"))}.tfplan"
    ]
  }
```

And then running `plan-all` and `apply-all` (I am aware that this is an antipattern as described by @yorinasub17 but I think it needs to be fixed anyway).

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of CLI arguments so that any file argument is now always placed at the end of the command, ensuring correct argument order for Terraform commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->