### PR TITLE
Fix nested mocks

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -139,6 +139,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.AutoRetry = !parseBooleanArg(args, OPT_TERRAGRUNT_NO_AUTO_RETRY, os.Getenv("TERRAGRUNT_AUTO_RETRY") == "false")
 	opts.NonInteractive = parseBooleanArg(args, OPT_NON_INTERACTIVE, os.Getenv("TF_INPUT") == "false" || os.Getenv("TF_INPUT") == "0")
 	opts.TerraformCliArgs = filterTerragruntArgs(args)
+	opts.OriginalTerraformCommand = util.FirstArg(opts.TerraformCliArgs)
 	opts.TerraformCommand = util.FirstArg(opts.TerraformCliArgs)
 	opts.WorkingDir = filepath.ToSlash(workingDir)
 	opts.DownloadDir = filepath.ToSlash(downloadDir)

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -276,7 +276,7 @@ func shouldReturnMockOutputs(dependencyConfig Dependency, terragruntOptions *opt
 	allowedCommand :=
 		dependencyConfig.MockOutputsAllowedTerraformCommands == nil ||
 			len(*dependencyConfig.MockOutputsAllowedTerraformCommands) == 0 ||
-			util.ListContainsElement(*dependencyConfig.MockOutputsAllowedTerraformCommands, terragruntOptions.TerraformCommand)
+			util.ListContainsElement(*dependencyConfig.MockOutputsAllowedTerraformCommands, terragruntOptions.OriginalTerraformCommand)
 	return defaultOutputsSet && allowedCommand
 }
 

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -3,13 +3,13 @@ package configstack
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
-	"sort"
 )
 
 // Represents a stack of Terraform modules (i.e. folders with Terraform templates) that you can "spin up" or
@@ -142,6 +142,7 @@ func FindStackInSubfolders(terragruntOptions *options.TerragruntOptions) (*Stack
 func (stack *Stack) setTerraformCommand(command []string) {
 	for _, module := range stack.Modules {
 		module.TerragruntOptions.TerraformCliArgs = append(command, module.TerragruntOptions.TerraformCliArgs...)
+		module.TerragruntOptions.OriginalTerraformCommand = util.FirstArg(command)
 		module.TerragruntOptions.TerraformCommand = util.FirstArg(command)
 	}
 }

--- a/options/options.go
+++ b/options/options.go
@@ -51,6 +51,8 @@ type TerragruntOptions struct {
 	// TerraformCommand to `output` to run `terraform output`, which loses the context of the original command that was
 	// run to fetch the dependency. This is a problem when mock_outputs is configured and we only allow mocks to be
 	// returned on specific commands.
+	// NOTE: For `xxx-all` commands, this will be set to the Terraform command, which would be `xxx`. For example,
+	// if you run `apply-all` (which is a terragrunt command), this variable will be set to `apply`.
 	OriginalTerraformCommand string
 
 	// Version of terraform (obtained by running 'terraform version')
@@ -167,6 +169,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 	return &TerragruntOptions{
 		TerragruntConfigPath:        terragruntConfigPath,
 		TerraformPath:               TERRAFORM_DEFAULT_PATH,
+		OriginalTerraformCommand:    "",
 		TerraformCommand:            "",
 		AutoInit:                    true,
 		NonInteractive:              false,

--- a/options/options.go
+++ b/options/options.go
@@ -46,6 +46,13 @@ type TerragruntOptions struct {
 	// Current Terraform command being executed by Terragrunt
 	TerraformCommand string
 
+	// Original Terraform command being executed by Terragrunt. Used to track command evolution as terragrunt chains
+	// different commands together. For example, when retrieving dependencies, terragrunt will change the
+	// TerraformCommand to `output` to run `terraform output`, which loses the context of the original command that was
+	// run to fetch the dependency. This is a problem when mock_outputs is configured and we only allow mocks to be
+	// returned on specific commands.
+	OriginalTerraformCommand string
+
 	// Version of terraform (obtained by running 'terraform version')
 	TerraformVersion *version.Version
 
@@ -230,6 +237,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 	return &TerragruntOptions{
 		TerragruntConfigPath:        terragruntConfigPath,
 		TerraformPath:               terragruntOptions.TerraformPath,
+		OriginalTerraformCommand:    terragruntOptions.OriginalTerraformCommand,
 		TerraformCommand:            terragruntOptions.TerraformCommand,
 		TerraformVersion:            terragruntOptions.TerraformVersion,
 		TerragruntVersion:           terragruntOptions.TerragruntVersion,

--- a/test/fixture-get-output/nested-mocks/deepdep/main.tf
+++ b/test/fixture-get-output/nested-mocks/deepdep/main.tf
@@ -1,0 +1,3 @@
+output "output" {
+  value = "The answer is 42"
+}

--- a/test/fixture-get-output/nested-mocks/deepdep/terragrunt.hcl
+++ b/test/fixture-get-output/nested-mocks/deepdep/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty.

--- a/test/fixture-get-output/nested-mocks/dep/main.tf
+++ b/test/fixture-get-output/nested-mocks/dep/main.tf
@@ -1,0 +1,4 @@
+variable "input" {}
+output "output" {
+  value = "No, ${var.input}"
+}

--- a/test/fixture-get-output/nested-mocks/dep/terragrunt.hcl
+++ b/test/fixture-get-output/nested-mocks/dep/terragrunt.hcl
@@ -1,0 +1,11 @@
+dependency "deepdep" {
+  config_path = "../deepdep"
+  mock_outputs = {
+    output = "I am a mock"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate"]
+}
+
+inputs = {
+  input = dependency.deepdep.outputs.output
+}

--- a/test/fixture-get-output/nested-mocks/live/main.tf
+++ b/test/fixture-get-output/nested-mocks/live/main.tf
@@ -1,0 +1,4 @@
+variable "input" {}
+output "output" {
+  value = "They said, \"${var.input}\""
+}

--- a/test/fixture-get-output/nested-mocks/live/terragrunt.hcl
+++ b/test/fixture-get-output/nested-mocks/live/terragrunt.hcl
@@ -1,0 +1,11 @@
+dependency "dep" {
+  config_path = "../dep"
+  mock_outputs = {
+    output = "I am a shallow mock"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate"]
+}
+
+inputs = {
+  input = dependency.dep.outputs.output
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2707,6 +2707,21 @@ func TestDependencyOutputWithHooks(t *testing.T) {
 	assert.False(t, util.FileExists(mainPathFileOut))
 }
 
+func TestDeepDependencyOutputWithMock(t *testing.T) {
+	// Test that the terraform command flows through for mock output retrieval to deeper dependencies. Previously the
+	// terraform command was being overwritten, so by the time the deep dependency retrieval runs, it was replaced with
+	// "output" instead of the original one.
+
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_GET_OUTPUT)
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_GET_OUTPUT)
+	rootPath := filepath.Join(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "nested-mocks", "live")
+
+	// Since we haven't applied anything, this should only succeed if mock outputs are used.
+	runTerragrunt(t, fmt.Sprintf("terragrunt validate --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+}
+
 func TestAWSGetCallerIdentityFunctions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Problem

When retrieving dependencies, terragrunt would clone the `TerragruntOptions` object and replace the `TerraformCommand` to `output` so that we can run `terraform output` in the terragrunt context. This breaks the mock outputs feature because the mock outputs feature depended on knowing the original terraform command to decide when to return mock outputs. When you have deep dependencies (a dependency config that also has a dependency within), the nested dependency sees `output` as the terraform command, as opposed to the original one (e.g., `validate`). This makes configurations confusing because you need to add `output` to the `mock_outputs_allowed_terraform_commands`.

### Solution

We now track what the original terraform command. This will be the top level command that was run from the CLI. The PR works by only setting the `OriginalTerraformCommand` once at the beginning, and flowing that through everytime we clone the options.