### PR TITLE
fix: use normalized separator

### DIFF
--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -34,6 +34,7 @@ func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
 	}
 
 	terragruntOptions.Logger.Printf("Formatting terragrunt.hcl files from the directory tree %s.", terragruntOptions.WorkingDir)
+	// zglob normalizes paths to "/"
 	tgHclFiles, err := zglob.Glob(util.JoinPath(workingDir, "**", "*.hcl"))
 	if err != nil {
 		return err
@@ -42,7 +43,7 @@ func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
 	filteredTgHclFiles := []string{}
 	for _, fname := range tgHclFiles {
 		// Ignore any files that are in the .terragrunt-cache
-		if !util.ListContainsElement(strings.Split(fname, string(os.PathSeparator)), ".terragrunt-cache") {
+		if !util.ListContainsElement(strings.Split(fname, "/"), ".terragrunt-cache") {
 			filteredTgHclFiles = append(filteredTgHclFiles, fname)
 		} else {
 			util.Debugf(terragruntOptions.Logger, "%s was ignored due to being in the terragrunt cache", fname)


### PR DESCRIPTION
# Description

in #1366, we see that terragrunt does not correctly run xxx-all commands on windows due to an unaccounted .terragrunt-cache directory. This is because terragrunt is confusing slash separators in file paths. 

[There is exactly one failing unit test when run on windows in the cli module](https://github.com/gruntwork-io/terragrunt/blob/master/cli/hclfmt_test.go#L57). Debugging the tests reveals that the library[ `zglob` automatically normalizes paths to "/" (unix slashes)](https://github.com/mattn/go-zglob/blob/master/zglob.go#L30). The test works as expected on linux and mac because it has the same os.PathSeparator. This fails on windows though because os.PathSeparator is "\". In the debugger, one can see that the list contains exactly 1 element (exactly one result that matches entire path).

![image](https://user-images.githubusercontent.com/1364747/100158339-dded8100-2e60-11eb-95b5-de9bbb433f84.png)

# Change

This PR updates the call to `util.ListContainsElement` to the hard-coded "/" separator. This resolves the issue in #1366 for windows users. It can be verified by running tests in the `cli` module locally on a windows host. 