### PR TITLE
Delete nightly job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,13 +101,3 @@ workflows:
               ignore: /.*/
           context:
             - Gruntwork Admin
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 6 * * *"
-          filters:
-            branches:
-              only: master
-    jobs:
-      - unit_test
-      - integration_test


### PR DESCRIPTION
Per discussions, we've decided to stop using "nightly" or triggered jobs as they are incompatible with circleci contexts.