### PR TITLE
Update Terragrunt to work with Terraform 0.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:tf13
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:tf14
 version: 2
 jobs:
   # We're running unit tests separately from integration tests - with no parallelization.

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vendor
 .terragrunt-cache
 .bundle
 .ruby-version
+.terraform.lock.hcl

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -549,6 +549,7 @@ func runTerragruntWithConfig(terragruntOptions *options.TerragruntOptions, terra
 
 	return runActionWithHooks("terraform", terragruntOptions, terragruntConfig, func() error {
 		return runTerraformWithRetry(terragruntOptions)
+		//TODO: Make sure lock file gets copied back to where you ran terragrunt from
 	})
 }
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -558,6 +558,13 @@ func runTerragruntWithConfig(originalTerragruntOptions *options.TerragruntOption
 
 		var lockFileError error
 		if util.FirstArg(terragruntOptions.TerraformCliArgs) == CMD_INIT {
+			// Copy the lock file from the Terragrunt working dir (e.g., .terragrunt-cache/xxx/<some-module>) to the
+			// user's working dir (e.g., /live/stage/vpc). That way, the lock file will end up right next to the user's
+			// terragrunt.hcl and can be checked into version control. Note that in the past, Terragrunt allowed the
+			// user's working dir to be different than the directory where the terragrunt.hcl file lived, so just in
+			// case, we are using the user's working dir here, rather than just looking at the parent dir of the
+			// terragrunt.hcl. However, the default value for the user's working dir, set in options.go, IS just the
+			// parent dir of terragrunt.hcl, so these will likely always be the same.
 			lockFileError = copyLockFile(terragruntOptions.WorkingDir, originalTerragruntOptions.WorkingDir, terragruntOptions.Logger)
 		}
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -748,8 +748,9 @@ func needsInit(terragruntOptions *options.TerragruntOptions, terragruntConfig *c
 
 // Returns true if we need to run `terraform init` to download providers
 func providersNeedInit(terragruntOptions *options.TerragruntOptions) bool {
-	providersPath := util.JoinPath(terragruntOptions.DataDir(), "plugins")
-	return !util.FileExists(providersPath)
+	providersPath013 := util.JoinPath(terragruntOptions.DataDir(), "plugins")
+	providersPath014 := util.JoinPath(terragruntOptions.DataDir(), "providers")
+	return !(util.FileExists(providersPath013) || util.FileExists(providersPath014))
 }
 
 // Runs the terraform init command to perform what is referred to as Auto-Init in the README.md.

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -518,7 +518,7 @@ func shouldRunHook(hook config.Hook, terragruntOptions *options.TerragruntOption
 // Runs terraform with the given options and CLI args.
 // This will forward all the args and extra_arguments directly to Terraform.
 
-// This function takes in the "original" terragrunt options has the unmodified 'WorkingDir' from before downloading the code from the source URL,
+// This function takes in the "original" terragrunt options which has the unmodified 'WorkingDir' from before downloading the code from the source URL,
 // and the "updated" terragrunt options that will contain the updated 'WorkingDir' into which the code has been downloaded
 func runTerragruntWithConfig(originalTerragruntOptions *options.TerragruntOptions, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig, allowSourceDownload bool) error {
 
@@ -709,7 +709,7 @@ func checkTerraformCodeDefinesBackend(terragruntOptions *options.TerragruntOptio
 }
 
 // Prepare for running any command other than 'terraform init' by running 'terraform init' if necessary
-// This function takes in the "original" terragrunt options has the unmodified 'WorkingDir' from before downloading the code from the source URL,
+// This function takes in the "original" terragrunt options which has the unmodified 'WorkingDir' from before downloading the code from the source URL,
 // and the "updated" terragrunt options that will contain the updated 'WorkingDir' into which the code has been downloaded
 func prepareNonInitCommand(originalTerragruntOptions *options.TerragruntOptions, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
 	needsInit, err := needsInit(terragruntOptions, terragruntConfig)
@@ -764,7 +764,7 @@ func providersNeedInit(terragruntOptions *options.TerragruntOptions) bool {
 //
 // This method will return an error and NOT run terraform init if the user has disabled Auto-Init
 //
-// This method takes in the "original" terragrunt options has the unmodified 'WorkingDir' from before downloading the code from the source URL,
+// This method takes in the "original" terragrunt options which has the unmodified 'WorkingDir' from before downloading the code from the source URL,
 // and the "updated" terragrunt options that will contain the updated 'WorkingDir' into which the code has been downloaded
 func runTerraformInit(originalTerragruntOptions *options.TerragruntOptions, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig, terraformSource *TerraformSource) error {
 

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -55,7 +55,7 @@ func downloadTerraformSource(source string, terragruntOptions *options.Terragrun
 	}
 
 	if err := downloadTerraformSourceIfNecessary(terraformSource, terragruntOptions, terragruntConfig); err != nil {
-		return err
+		return nil, err
 	}
 
 	terragruntOptions.Logger.Printf("Copying files from %s into %s", terragruntOptions.WorkingDir, terraformSource.WorkingDir)

--- a/cli/download_source_test.go
+++ b/cli/download_source_test.go
@@ -262,7 +262,7 @@ func TestSplitSourceUrl(t *testing.T) {
 			terragruntOptions, err := options.NewTerragruntOptionsForTest("testing")
 			require.NoError(t, err)
 
-			actualRootRepo, actualModulePath, err := splitSourceUrl(sourceUrl, terragruntOptions)
+			actualRootRepo, actualModulePath, err := splitSourceUrl(sourceUrl, terragruntOptions.Logger)
 			require.NoError(t, err)
 
 			assert.Equal(t, testCase.expectedRootRepo, actualRootRepo.String())

--- a/docs/_docs/02_features/keep-your-terraform-code-dry.md
+++ b/docs/_docs/02_features/keep-your-terraform-code-dry.md
@@ -175,8 +175,8 @@ If you’re testing changes to a local copy of the `modules` repo, you can use t
 ### Working with lock files
 
 Terraform 0.14 introduced lock files. These should mostly "just work" with Terragrunt version v0.27.0 and above: that
-is, the lock file will be generated next to your `terragrunt.hcl`, and you should check it into version control. See
-the [Lock File Handling docs]({{site.baseurl}}/docs/features/lock-file-handling/) for more details.
+is, the lock file (`.terraform.lock.hcl`) will be generated next to your `terragrunt.hcl`, and you should check it into 
+version control. See the [Lock File Handling docs]({{site.baseurl}}/docs/features/lock-file-handling/) for more details.
 
 ### Important gotcha: Terragrunt caching
 

--- a/docs/_docs/02_features/keep-your-terraform-code-dry.md
+++ b/docs/_docs/02_features/keep-your-terraform-code-dry.md
@@ -172,6 +172,12 @@ If you’re testing changes to a local copy of the `modules` repo, you can use t
 
 *(Note: the double slash (`//`) here too is intentional and required. Terragrunt downloads all the code in the folder before the double-slash into the temporary folder so that relative paths between modules work correctly. Terraform may display a "Terraform initialized in an empty directory" warning, but you can safely ignore it.)*
 
+### Working with lock files
+
+Terraform 0.14 introduced lock files. These should mostly "just work" with Terragrunt version v0.27.0 and above: that
+is, the lock file will be generated next to your `terragrunt.hcl`, and you should check it into version control. See
+the [Lock File Handling docs]({{site.baseurl}}/docs/features/lock-file-handling/) for more details.
+
 ### Important gotcha: Terragrunt caching
 
 The first time you set the `source` parameter to a remote URL, Terragrunt will download the code from that URL into a tmp folder. It will *NOT* download it again afterwords unless you change that URL. That’s because downloading code—and more importantly, reinitializing remote state, redownloading provider plugins, and redownloading modules—can take a long time. To avoid adding 10-90 seconds of overhead to every Terragrunt command, Terragrunt assumes all remote URLs are immutable, and only downloads them once.

--- a/docs/_docs/02_features/lock-file-handling.md
+++ b/docs/_docs/02_features/lock-file-handling.md
@@ -16,7 +16,7 @@ To use [Terraform lock files](https://www.terraform.io/docs/configuration/depend
 need to:
 
 1. Run Terragrunt as usual (e.g., run `terragrunt plan`, `terragrunt apply`, etc.).
-1. Check the `.terraform.lock` file, which will end up sitting next to your `terragrunt.hcl`, into version control.
+1. Check the `.terraform.lock.hcl` file, which will end up sitting next to your `terragrunt.hcl`, into version control.
 
 Everything else with Terraform and Terragrunt should work as expected. To learn the details of how this works, read on!
 
@@ -28,7 +28,7 @@ Everything else with Terraform and Terragrunt should work as expected. To learn 
 [Terraform 0.14 added support for a 
 *lock file*](https://www.hashicorp.com/blog/terraform-0-14-introduces-a-dependency-lock-file-for-providers)
 which gets created or updated every time you run `terraform init`. The file is typically generated into your working
-directory (i.e., the folder in which you ran `terraform init`) and is called `.terraform.lock`.
+directory (i.e., the folder in which you ran `terraform init`) and is called `.terraform.lock.hcl`.
 It captures the versions of all the Terraform providers you're using. Normally, you want to check this file into 
 version control so that when your team members run Terraform, they get the exact same provider versions.
 
@@ -62,18 +62,18 @@ If you ran `terragrunt apply` in the `/live/stage/vpc` folder, Terragrunt will:
    dynamically determined based on the URL.
 1. Run `terraform apply` in the `.terragrunt-cache/xxx/vpc` temp folder.
 
-As a result, the `.terraform.lock` file will be generated in the `.terragrunt-cache/xxx/vpc` temp folder, rather than in
-`/live/stage/vpc`.     
+As a result, the `.terraform.lock.hcl` file will be generated in the `.terragrunt-cache/xxx/vpc` temp folder, rather 
+than in `/live/stage/vpc`.     
 
 ### How Terragrunt solves this problem
 
 To solve this problem, since version v0.27.0, Terragrunt implements the following logic for lock files:
 
-1. If Terragrunt finds a `.terraform.lock` file in your working directory (e.g., in `/live/stage/vpc`), before running 
-   Terraform, Terragrunt will copy that lock file into the temp folder it uses when running your Terraform code 
+1. If Terragrunt finds a `.terraform.lock.hcl` file in your working directory (e.g., in `/live/stage/vpc`), before 
+   running Terraform, Terragrunt will copy that lock file into the temp folder it uses when running your Terraform code 
    (e.g., `.terragrunt-cache/xxx/vpc`). This way, if you had a lock file checked into version control, Terragrunt will 
    respect and use it with your Terraform code as you'd expect.
-1. After running Terraform, if Terragrunt finds a `.terraform.lock` in the temp folder (e.g., 
+1. After running Terraform, if Terragrunt finds a `.terraform.lock.hcl` in the temp folder (e.g., 
    `.terragrunt-cache/xxx/vpc`), it will copy that lock file back to your working directory (e.g., to `/live/stage/vpc`). 
    That way, you can commit the lock file (or the changes to the lock file) to version control as usual.
    
@@ -86,11 +86,11 @@ should end up looking something like this:
 └── live
     ├── prod
     │   └── vpc
-    │       ├── .terraform.lock
+    │       ├── .terraform.lock.hcl
     │       └── terragrunt.hcl
     └── stage
         └── vpc
-            ├── .terraform.lock
+            ├── .terraform.lock.hcl
             └── terragrunt.hcl
 ```   
 

--- a/docs/_docs/02_features/lock-file-handling.md
+++ b/docs/_docs/02_features/lock-file-handling.md
@@ -1,0 +1,98 @@
+---
+layout: collection-browser-doc
+title: Lock File Handling
+category: features
+categories_url: features
+excerpt: Learn how to Terragrunt handles the Terraform lock file
+tags: ["CLI", "DRY"]
+order: 230
+nav_title: Documentation
+nav_title_link: /docs/
+---
+
+## The short version: how to use lock files with Terragrunt
+
+To use [Terraform lock files](https://www.terraform.io/docs/configuration/dependency-lock.html) with Terragrunt, you
+need to:
+
+1. Run Terragrunt as usual (e.g., run `terragrunt plan`, `terragrunt apply`, etc.).
+1. Check the `.terraform.lock` file, which will end up sitting next to your `terragrunt.hcl`, into version control.
+
+Everything else with Terraform and Terragrunt should work as expected. To learn the details of how this works, read on!
+
+
+## The long version: details of how Terragrunt handles lock files
+
+### What's a lock file?
+
+[Terraform 0.14 added support for a 
+*lock file*](https://www.hashicorp.com/blog/terraform-0-14-introduces-a-dependency-lock-file-for-providers)
+which gets created or updated every time you run `terraform init`. The file is typically generated into your working
+directory (i.e., the folder in which you ran `terraform init`) and is called `.terraform.lock`.
+It captures the versions of all the Terraform providers you're using. Normally, you want to check this file into 
+version control so that when your team members run Terraform, they get the exact same provider versions.
+
+### The problem with mixing remote Terraform configurations in Terragrunt and lock files
+
+Let's say you are using Terragrunt with [remote Terraform 
+configurations]({{site.baseurl}}/docs/features/keep-your-terraform-code-dry/) and you have the following folder 
+structure:
+
+```
+└── live
+    ├── prod
+    │   └── vpc
+    │       └── terragrunt.hcl
+    └── stage
+        └── vpc
+            └── terragrunt.hcl
+```
+
+Imagine that in `/live/stage/vpc/terragrunt.hcl`, you have the following contents:
+
+```hcl
+terraform {
+  source = "git::git@github.com:acme/infrastructure-modules.git//networking/vpc?ref=v0.0.1"
+}
+```
+
+If you ran `terragrunt apply` in the `/live/stage/vpc` folder, Terragrunt will:
+
+1. `git clone` the VPC module in the `source` URL into a temp folder in `.terragrunt-cache/xxx/vpc`, where `xxx` is 
+   dynamically determined based on the URL.
+1. Run `terraform apply` in the `.terragrunt-cache/xxx/vpc` temp folder.
+
+As a result, the `.terraform.lock` file will be generated in the `.terragrunt-cache/xxx/vpc` temp folder, rather than in
+`/live/stage/vpc`.     
+
+### How Terragrunt solves this problem
+
+To solve this problem, since version v0.27.0, Terragrunt implements the following logic for lock files:
+
+1. If Terragrunt finds a `.terraform.lock` file in your working directory (e.g., in `/live/stage/vpc`), before running 
+   Terraform, Terragrunt will copy that lock file into the temp folder it uses when running your Terraform code 
+   (e.g., `.terragrunt-cache/xxx/vpc`). This way, if you had a lock file checked into version control, Terragrunt will 
+   respect and use it with your Terraform code as you'd expect.
+1. After running Terraform, if Terragrunt finds a `.terraform.lock` in the temp folder (e.g., 
+   `.terragrunt-cache/xxx/vpc`), it will copy that lock file back to your working directory (e.g., to `/live/stage/vpc`). 
+   That way, you can commit the lock file (or the changes to the lock file) to version control as usual.
+   
+### Check the lock file in!
+
+After running Terragrunt on each of your modules, you should check your lock files in! That means your folder structure
+should end up looking something like this:
+
+```
+└── live
+    ├── prod
+    │   └── vpc
+    │       ├── .terraform.lock
+    │       └── terragrunt.hcl
+    └── stage
+        └── vpc
+            ├── .terraform.lock
+            └── terragrunt.hcl
+```   
+
+Also, any time you change the providers you're using, and re-run `init`, the lock file will be updated, so make sure
+to check the updates into version control too. 

--- a/go.sum
+++ b/go.sum
@@ -386,9 +386,11 @@ github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/gruntwork-io/gruntwork-cli v0.5.1 h1:mVmVsFubUSLSCO8bGigI63HXzvzkC0uWXzm4dd9pXRg=
 github.com/gruntwork-io/gruntwork-cli v0.5.1/go.mod h1:IBX21bESC1/LGoV7jhXKUnTQTZgQ6dYRsoj/VqxUSZQ=
+github.com/gruntwork-io/gruntwork-cli v0.7.0 h1:YgSAmfCj9c61H+zuvHwKfYUwlMhu5arnQQLM4RH+CYs=
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
 github.com/gruntwork-io/terratest v0.26.1 h1:T+R6sxhr4hTkbhOl9EIp/xTJm6070YcM5sCG0tR4xXg=
 github.com/gruntwork-io/terratest v0.26.1/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkVC7665yRyvu3aWnk=
+github.com/gruntwork-io/terratest v0.30.26 h1:0nNTfmYl5ohvKtPot7j5jwKhG1j7EJAO3ixi0TbVmH0=
 github.com/gruntwork-io/terratest v0.30.26/go.mod h1:EEgJie28gX/4AD71IFqgMj6e99KP5mi81hEtzmDjxTo=
 github.com/hashicorp/aws-sdk-go-base v0.4.0/go.mod h1:eRhlz3c4nhqxFZJAahJEFL7gh6Jyj5rQmQc7F9eHFyQ=
 github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+sfyn/OOI=

--- a/test/fixture-download/custom-lock-file-module/main.tf
+++ b/test/fixture-download/custom-lock-file-module/main.tf
@@ -1,0 +1,10 @@
+# A dirt simple module for use with the custom-lock-file test
+
+variable "name" {
+  description = "The name to use"
+  type        = string
+}
+
+output "text" {
+  value = "Hello, ${var.name}"
+}

--- a/test/fixture-download/custom-lock-file-module/main.tf
+++ b/test/fixture-download/custom-lock-file-module/main.tf
@@ -1,5 +1,13 @@
 # A dirt simple module for use with the custom-lock-file test
 
+# This provider is not actually used in the module, but by having it here, Terraform will download the code for it
+# when we run 'init'. If the lock file copying works as expected in the custom-lock-file test, then we'll end up
+# with an older version of the provider. If there is a bug, Terraform will end up downloading the latest version of
+# the provider, as we're not pinning the version in the Terraform code (only in the lock file).
+provider "aws" {
+  region = "eu-west-1"
+}
+
 variable "name" {
   description = "The name to use"
   type        = string

--- a/test/fixture-download/custom-lock-file/.terraform.lock.hcl
+++ b/test/fixture-download/custom-lock-file/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+# THIS COMMENT IS INTENTIONALLY HERE FOR TESTING
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/test/fixture-download/custom-lock-file/.terraform.lock.hcl
+++ b/test/fixture-download/custom-lock-file/.terraform.lock.hcl
@@ -1,20 +1,20 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-# THIS COMMENT IS INTENTIONALLY HERE FOR TESTING
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.0.0"
   hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+    "h1:ULKfwySvQ4pDhy027ryRhLxDhg640wsojYc+7NHMFBU=",
+    "h1:UyKRcHE2W3io32hVQD7s9Ovb9LSyTIvhAAPS9RX5vtg=",
+    "zh:25294510ae9c250502f2e37ac32b01017439735f098f82a1728772427626a2fd",
+    "zh:3b723e7772d47bd8cc11bea6e5d3e0b5e1df8398c0e7aaf510e3a8a54e0f1874",
+    "zh:4b7b73b86f4a0705d5d2a7f1d3ad3279706bdb3957a48f4a389c36918fba838e",
+    "zh:9e26cdc3be97e3001c253c0ca28c5c8ff2d5476373ca1beb849f3f3957ce7f1a",
+    "zh:9e73cf1304bf57968d3048d70c0b766d41497430a2a9a7a718a196f3a385106a",
+    "zh:a30b5b66facfbb2b02814e4cd33ca9899f9ade5bbf478f78c41d2fe789f0582a",
+    "zh:b06fb5da094db41cb5e430c95c988b73f32695e9f90f25499e926842dbd21b21",
+    "zh:c5a4ff607e9e9edee3fcd6d6666241fb532adf88ea1fe24f2aa1eb36845b3ca3",
+    "zh:df568a69087831c1780fac4395630a2cfb3cdf67b7dffbfe16bd78c64770bb75",
+    "zh:fce1b69dd673aace19508640b0b9b7eb1ef7e746d76cb846b49e7d52e0f5fb7e",
   ]
 }

--- a/test/fixture-download/custom-lock-file/terragrunt.hcl
+++ b/test/fixture-download/custom-lock-file/terragrunt.hcl
@@ -1,0 +1,7 @@
+inputs = {
+  name = "World"
+}
+
+terraform {
+  source = "../hello-world"
+}

--- a/test/fixture-download/custom-lock-file/terragrunt.hcl
+++ b/test/fixture-download/custom-lock-file/terragrunt.hcl
@@ -3,5 +3,5 @@ inputs = {
 }
 
 terraform {
-  source = "../hello-world"
+  source = "../custom-lock-file-module"
 }

--- a/test/fixture-download/local-relative-extra-args-windows/JZwoL6Viko8bzuRvTOQFx3Jh8vs/3mU4huxMLOXOW5ZgJOFXGUFDKc8/main.tf
+++ b/test/fixture-download/local-relative-extra-args-windows/JZwoL6Viko8bzuRvTOQFx3Jh8vs/3mU4huxMLOXOW5ZgJOFXGUFDKc8/main.tf
@@ -7,7 +7,7 @@ variable "name" {
 }
 
 output "test" {
-  value = "${data.template_file.test.rendered}"
+  value = data.template_file.test.rendered
 }
 
 module "hello" {
@@ -16,5 +16,5 @@ module "hello" {
 
 module "remote" {
   source = "github.com/gruntwork-io/terragrunt.git//test/fixture-download/hello-world?ref=v0.9.9"
-  name   = "${var.name}"
+  name   = var.name
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1051,7 +1051,11 @@ func TestCustomLockFile(t *testing.T) {
 
 	readFile, err := ioutil.ReadFile(lockFilePath)
 	require.NoError(t, err)
-	assert.Contains(t, string(readFile), "THIS COMMENT IS INTENTIONALLY HERE FOR TESTING")
+
+	// In our lock file, we intentionally have hashes for an older version of the AWS provider. If the lock file
+	// copying works, then Terraform will stick with this older version. If there is a bug, Terraform will end up
+	// installing a newer version (since the version is not pinned in the .tf code, only in the lock file).
+	assert.Contains(t, string(readFile), `version = "3.0.0"`)
 }
 
 func TestLocalDownloadWithHiddenFolder(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -63,6 +63,7 @@ const (
 	TEST_FIXTURE_SKIP                                       = "fixture-skip/"
 	TEST_FIXTURE_CONFIG_SINGLE_JSON_PATH                    = "fixture-config-files/single-json-config"
 	TEST_FIXTURE_LOCAL_DOWNLOAD_PATH                        = "fixture-download/local"
+	TEST_FIXTURE_CUSTOM_LOCK_FILE                           = "fixture-download/custom-lock-file"
 	TEST_FIXTURE_REMOTE_DOWNLOAD_PATH                       = "fixture-download/remote"
 	TEST_FIXTURE_OVERRIDE_DOWNLOAD_PATH                     = "fixture-download/override"
 	TEST_FIXTURE_LOCAL_RELATIVE_DOWNLOAD_PATH               = "fixture-download/local-relative"
@@ -1029,6 +1030,18 @@ func TestLocalDownload(t *testing.T) {
 
 	// Run a second time to make sure the temporary folder can be reused without errors
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_DOWNLOAD_PATH))
+}
+
+func TestCustomLockFile(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_CUSTOM_LOCK_FILE)
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_CUSTOM_LOCK_FILE))
+
+	ioutil.ReadDir(util.JoinPath(TEST_FIXTURE_CUSTOM_LOCK_FILE, TERRAGRUNT_CACHE))
+	//As of Terraform 0.14.0 we should be copying the lock file to be in the working directory
+	//assert.FileExists(t, util.JoinPath(util.TerraformLockFile))
 }
 
 func TestLocalDownloadWithHiddenFolder(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -846,7 +846,7 @@ func TestTerragruntStdOut(t *testing.T) {
 	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt output foo --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_STDOUT), &stdout, &stderr)
 
 	output := stdout.String()
-	assert.Equal(t, `"foo"\n`, output)
+	assert.Equal(t, "\"foo\"\n", output)
 }
 
 func TestTerragruntOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1025,13 +1025,15 @@ func TestLocalDownload(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_DOWNLOAD_PATH))
 
-	//As of Terraform 0.14.0 we should be copying the lock file to be in the working directory
+	// As of Terraform 0.14.0 we should be copying the lock file from .terragrunt-cache to the working directory
 	assert.FileExists(t, util.JoinPath(TEST_FIXTURE_LOCAL_DOWNLOAD_PATH, util.TerraformLockFile))
 
 	// Run a second time to make sure the temporary folder can be reused without errors
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_DOWNLOAD_PATH))
 }
 
+// As of Terraform 0.14.0, if there's already a lock file in the working directory, we should be copying it into
+// .terragrunt-cache
 func TestCustomLockFile(t *testing.T) {
 	t.Parallel()
 
@@ -1039,7 +1041,7 @@ func TestCustomLockFile(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_CUSTOM_LOCK_FILE))
 
-	source := "../hello-world"
+	source := "../custom-lock-file-module"
 	downloadDir := util.JoinPath(TEST_FIXTURE_CUSTOM_LOCK_FILE, TERRAGRUNT_CACHE)
 	result, err := cli.ProcessTerraformSource(source, downloadDir, TEST_FIXTURE_CUSTOM_LOCK_FILE, util.CreateLogger(""))
 	require.NoError(t, err)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1024,6 +1024,9 @@ func TestLocalDownload(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_DOWNLOAD_PATH))
 
+	//As of Terraform 0.14.0 we should be copying the lock file to be in the working directory
+	assert.FileExists(t, util.JoinPath(TEST_FIXTURE_LOCAL_DOWNLOAD_PATH, util.TerraformLockFile))
+
 	// Run a second time to make sure the temporary folder can be reused without errors
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_DOWNLOAD_PATH))
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -846,7 +846,7 @@ func TestTerragruntStdOut(t *testing.T) {
 	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt output foo --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_STDOUT), &stdout, &stderr)
 
 	output := stdout.String()
-	assert.Equal(t, "foo\n", output)
+	assert.Equal(t, `"foo"\n`, output)
 }
 
 func TestTerragruntOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *testing.T) {
@@ -932,7 +932,7 @@ func testTerragruntParallelism(t *testing.T, parallelism int, numberOfModules in
 	require.NoError(t, err)
 
 	// parse output and sort the times, the regex captures a string in the format time.RFC3339 emitted by terraform's timestamp function
-	r, err := regexp.Compile(`out = ([-:\w]+)`)
+	r, err := regexp.Compile(`out = "([-:\w]+)"`)
 	require.NoError(t, err)
 
 	matches := r.FindAllStringSubmatch(output, -1)
@@ -1253,7 +1253,7 @@ func TestPriorityOrderOfArgument(t *testing.T) {
 	t.Log(out.String())
 	// And the result value for test should be the injected variable since the injected arguments are injected before the suplied parameters,
 	// so our override of extra_var should be the last argument.
-	assert.Contains(t, out.String(), fmt.Sprintf("test = %s", injectedValue))
+	assert.Contains(t, out.String(), fmt.Sprintf(`test = "%s"`, injectedValue))
 }
 
 func TestAutoRetryBasicRerun(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1039,9 +1039,17 @@ func TestCustomLockFile(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_CUSTOM_LOCK_FILE))
 
-	ioutil.ReadDir(util.JoinPath(TEST_FIXTURE_CUSTOM_LOCK_FILE, TERRAGRUNT_CACHE))
-	//As of Terraform 0.14.0 we should be copying the lock file to be in the working directory
-	//assert.FileExists(t, util.JoinPath(util.TerraformLockFile))
+	source := "../hello-world"
+	downloadDir := util.JoinPath(TEST_FIXTURE_CUSTOM_LOCK_FILE, TERRAGRUNT_CACHE)
+	result, err := cli.ProcessTerraformSource(source, downloadDir, TEST_FIXTURE_CUSTOM_LOCK_FILE, util.CreateLogger(""))
+	require.NoError(t, err)
+
+	lockFilePath := util.JoinPath(result.WorkingDir, util.TerraformLockFile)
+	require.FileExists(t, lockFilePath)
+
+	readFile, err := ioutil.ReadFile(lockFilePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(readFile), "THIS COMMENT IS INTENTIONALLY HERE FOR TESTING")
 }
 
 func TestLocalDownloadWithHiddenFolder(t *testing.T) {

--- a/util/file.go
+++ b/util/file.go
@@ -15,6 +15,8 @@ import (
 	"github.com/mattn/go-zglob"
 )
 
+const terraformLockFile = ".terraform.lock.hcl"
+
 // Return true if the given file exists
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
@@ -149,7 +151,7 @@ func ReadFileAsString(path string) (string, error) {
 // (those starting with a dot) will be skipped. Will create a specified manifest file that contains paths of all copied files.
 func CopyFolderContents(source, destination, manifestFile string) error {
 	return CopyFolderContentsWithFilter(source, destination, manifestFile, func(path string) bool {
-		return !PathContainsHiddenFileOrFolder(path)
+		return !TerragruntExcludes(path)
 	})
 }
 
@@ -229,7 +231,11 @@ func IsSymLink(path string) bool {
 	return err == nil && fileInfo.Mode()&os.ModeSymlink != 0
 }
 
-func PathContainsHiddenFileOrFolder(path string) bool {
+func TerragruntExcludes(path string) bool {
+	// Do not exclude the terraform lock file (new feature added in terraform 0.14)
+	if filepath.Base(path) == terraformLockFile {
+		return false
+	}
 	pathParts := strings.Split(path, string(filepath.Separator))
 	for _, pathPart := range pathParts {
 		if strings.HasPrefix(pathPart, ".") && pathPart != "." && pathPart != ".." {

--- a/util/file.go
+++ b/util/file.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattn/go-zglob"
 )
 
-const terraformLockFile = ".terraform.lock.hcl"
+const TerraformLockFile = ".terraform.lock.hcl"
 
 // Return true if the given file exists
 func FileExists(path string) bool {
@@ -233,7 +233,7 @@ func IsSymLink(path string) bool {
 
 func TerragruntExcludes(path string) bool {
 	// Do not exclude the terraform lock file (new feature added in terraform 0.14)
-	if filepath.Base(path) == terraformLockFile {
+	if filepath.Base(path) == TerraformLockFile {
 		return false
 	}
 	pathParts := strings.Split(path, string(filepath.Separator))

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -92,7 +92,7 @@ func TestPathContainsHiddenFileOrFolder(t *testing.T) {
 
 	for _, testCase := range testCases {
 		path := filepath.FromSlash(testCase.path)
-		actual := PathContainsHiddenFileOrFolder(path)
+		actual := TerragruntExcludes(path)
 		assert.Equal(t, testCase.expected, actual, "For path %s", path)
 	}
 }


### PR DESCRIPTION
1. Add support for copying lock files as necessary. Fixes #1454.
1. Fix issue where Terragrunt would re-init every time you ran it. Fixes #1423.