### PR TITLE
Add TF14 to compatibility table

### DIFF
--- a/docs/_docs/01_getting-started/supported-terraform-versions.md
+++ b/docs/_docs/01_getting-started/supported-terraform-versions.md
@@ -15,6 +15,7 @@ The officially supported versions are:
 
 | Terraform Version | Terragrunt Version                                                                                                                                    |
 |-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.14.x            | >= [0.27.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.27.0)                                                                          |
 | 0.13.x            | >= [0.25.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.25.0)                                                                          |
 | 0.12.x            | [0.19.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.19.0) - [0.24.4](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.24.4) |
 | 0.11.x            | [0.14.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.14.0) - [0.18.7](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.18.7) |


### PR DESCRIPTION
We updated Terragrunt to work with Terraform 0.14 in https://github.com/gruntwork-io/terragrunt/pull/1459, but forgot to update the version compatibility table.