### PR TITLE
Support Custom STS Endpoint For Built-In Functions

### DIFF
--- a/aws_helper/config_test.go
+++ b/aws_helper/config_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"gotest.tools/assert"
 )
 
@@ -56,15 +58,11 @@ func TestCreateCustomResolver(t *testing.T) {
 
 			// Grab the endpoint for S3 that our custom resolver is returning
 			resolvedS3Endpoint, err := resolver("s3", testCase.region)
-			if err != nil {
-				t.Fatalf("Failed to resolve endpoint for S3: %v", err)
-			}
+			require.NoError(t, err)
 
 			// Grab the endpoint for STS that our custom resolver is returning
 			resolvedStsEndpoint, err := resolver("sts", testCase.region)
-			if err != nil {
-				t.Fatalf("Failed to resolve endpoint for STS: %v", err)
-			}
+			require.NoError(t, err)
 
 			// If we defined a custom endpoint for STS, let's check it. Otherwise,
 			// check that the value is the default provided by the SDK

--- a/aws_helper/config_test.go
+++ b/aws_helper/config_test.go
@@ -1,0 +1,86 @@
+package aws_helper
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestCreateCustomResolver(t *testing.T) {
+	testCases := []struct {
+		name        string
+		region      string
+		stsEndpoint string
+		s3Endpoint  string
+	}{
+		{
+
+			"CustomSTSEndpoint",
+			"us-west-2",
+			"http://localhost",
+			"",
+		},
+		{
+			"CustomS3Endpoint",
+			"us-east-1",
+			"",
+			"http://localhost",
+		},
+		{
+			"CustomStsAndS3Endpoints",
+			"us-east-1",
+			"http://localhost:8080",
+			"http://localhost:9090",
+		},
+	}
+
+	for _, testCase := range testCases {
+		// Capture range variable so that it is brought into the scope within the for loop, so that it is stable even
+		// when subtests are run in parallel.
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			resolver := createCustomResolver(&AwsSessionConfig{
+				Region:            testCase.region,
+				CustomStsEndpoint: testCase.stsEndpoint,
+				CustomS3Endpoint:  testCase.s3Endpoint,
+			})
+
+			// Build default S3 region-specific endpoint
+			defaultS3Endpoint := fmt.Sprintf("https://s3.%s.amazonaws.com", testCase.region)
+			// STS does not have region-specific endpoints by default
+			// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
+			defaultStsEndpoint := "https://sts.amazonaws.com"
+
+			// Grab the endpoint for S3 that our custom resolver is returning
+			resolvedS3Endpoint, err := resolver("s3", testCase.region)
+			if err != nil {
+				t.Fatalf("Failed to resolve endpoint for S3: %v", err)
+			}
+
+			// Grab the endpoint for STS that our custom resolver is returning
+			resolvedStsEndpoint, err := resolver("sts", testCase.region)
+			if err != nil {
+				t.Fatalf("Failed to resolve endpoint for STS: %v", err)
+			}
+
+			// If we defined a custom endpoint for STS, let's check it. Otherwise,
+			// check that the value is the default provided by the SDK
+			if testCase.stsEndpoint != "" {
+				assert.Equal(t, testCase.stsEndpoint, resolvedStsEndpoint.URL)
+			} else {
+				assert.Equal(t, defaultStsEndpoint, resolvedStsEndpoint.URL)
+			}
+
+			// If we defined a custom endpoint for S3, let's check it. Otherwise,
+			// check that the value is the default provided by the SDK
+			if testCase.s3Endpoint != "" {
+				assert.Equal(t, testCase.s3Endpoint, resolvedS3Endpoint.URL)
+			} else {
+				assert.Equal(t, defaultS3Endpoint, resolvedS3Endpoint.URL)
+			}
+		})
+	}
+}

--- a/cli/args.go
+++ b/cli/args.go
@@ -122,6 +122,11 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 
 	strictInclude := parseBooleanArg(args, OPT_TERRAGRUNT_STRICT_INCLUDE, false)
 
+	stsEndpoint, err := parseStringArg(args, OPT_TERRAGRUNT_STS_ENDPOINT, os.Getenv("TERRAGRUNT_STS_ENDPOINT"))
+	if err != nil {
+		return nil, err
+	}
+
 	// Those correspond to logrus levels
 	logLevel, err := parseStringArg(args, OPT_TERRAGRUNT_LOGLEVEL, logrus.WarnLevel.String())
 	if err != nil {
@@ -184,6 +189,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.ExcludeDirs = excludeDirs
 	opts.IncludeDirs = includeDirs
 	opts.StrictInclude = strictInclude
+	opts.StsEndpoint = stsEndpoint
 	opts.Parallelism = parallelism
 	opts.Check = parseBooleanArg(args, OPT_TERRAGRUNT_CHECK, os.Getenv("TERRAGRUNT_CHECK") == "true")
 	opts.HclFile = filepath.ToSlash(terragruntHclFilePath)

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -115,6 +115,12 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		},
 
 		{
+			[]string{"--terragrunt-sts-endpoint", "http://localhost"},
+			mockOptionsWithStsEndpoint(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, "http://localhost"),
+			nil,
+		},
+
+		{
 			[]string{"--terragrunt-config", fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), "--terragrunt-non-interactive"},
 			mockOptions(t, fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), workingDir, []string{}, true, "", false, false, defaultLogLevel, false),
 			nil,
@@ -206,6 +212,13 @@ func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, t
 func mockOptionsWithIamRole(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool, iamRole string) *options.TerragruntOptions {
 	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors, false, defaultLogLevel, false)
 	opts.IamRole = iamRole
+
+	return opts
+}
+
+func mockOptionsWithStsEndpoint(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool, stsEndpoint string) *options.TerragruntOptions {
+	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors, false, false)
+	opts.StsEndpoint = stsEndpoint
 
 	return opts
 }

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -40,6 +40,7 @@ const OPT_TERRAGRUNT_INCLUDE_EXTERNAL_DEPENDENCIES = "terragrunt-include-externa
 const OPT_TERRAGRUNT_EXCLUDE_DIR = "terragrunt-exclude-dir"
 const OPT_TERRAGRUNT_INCLUDE_DIR = "terragrunt-include-dir"
 const OPT_TERRAGRUNT_STRICT_INCLUDE = "terragrunt-strict-include"
+const OPT_TERRAGRUNT_STS_ENDPOINT = "terragrunt-sts-endpoint"
 const OPT_TERRAGRUNT_PARALLELISM = "terragrunt-parallelism"
 const OPT_TERRAGRUNT_CHECK = "terragrunt-check"
 const OPT_TERRAGRUNT_HCLFMT_FILE = "terragrunt-hclfmt-file"
@@ -69,6 +70,7 @@ var ALL_TERRAGRUNT_STRING_OPTS = []string{
 	OPT_TERRAGRUNT_IAM_ROLE,
 	OPT_TERRAGRUNT_EXCLUDE_DIR,
 	OPT_TERRAGRUNT_INCLUDE_DIR,
+	OPT_TERRAGRUNT_STS_ENDPOINT,
 	OPT_TERRAGRUNT_PARALLELISM,
 	OPT_TERRAGRUNT_HCLFMT_FILE,
 	OPT_TERRAGRUNT_OVERRIDE_ATTR,
@@ -214,6 +216,7 @@ GLOBAL OPTIONS:
    terragrunt-source                            Download Terraform configurations from the specified source into a temporary folder, and run Terraform in that temporary folder.
    terragrunt-source-update                     Delete the contents of the temporary folder to clear out any old, cached source code before downloading new source code into it.
    terragrunt-iam-role                          Assume the specified IAM role before executing Terraform. Can also be set via the TERRAGRUNT_IAM_ROLE environment variable.
+   terragrunt-sts-endpoint                  	Use a custom endpoint for Terragrunt calls to STS for built-in helper functions. Can also be set by TERRAGRUNT_STS_ENDPOINT environment variable.
    terragrunt-ignore-dependency-errors          *-all commands continue processing components even if a dependency fails.
    terragrunt-ignore-dependency-order           *-all commands will be run disregarding the dependencies
    terragrunt-ignore-external-dependencies      *-all commands will not attempt to include external dependencies

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -216,7 +216,7 @@ GLOBAL OPTIONS:
    terragrunt-source                            Download Terraform configurations from the specified source into a temporary folder, and run Terraform in that temporary folder.
    terragrunt-source-update                     Delete the contents of the temporary folder to clear out any old, cached source code before downloading new source code into it.
    terragrunt-iam-role                          Assume the specified IAM role before executing Terraform. Can also be set via the TERRAGRUNT_IAM_ROLE environment variable.
-   terragrunt-sts-endpoint                  	Use a custom endpoint for Terragrunt calls to STS for built-in helper functions. Can also be set by TERRAGRUNT_STS_ENDPOINT environment variable.
+   terragrunt-sts-endpoint                      Use a custom endpoint for Terragrunt calls to STS for built-in helper functions. Can also be set by TERRAGRUNT_STS_ENDPOINT environment variable.
    terragrunt-ignore-dependency-errors          *-all commands continue processing components even if a dependency fails.
    terragrunt-ignore-dependency-order           *-all commands will be run disregarding the dependencies
    terragrunt-ignore-external-dependencies      *-all commands will not attempt to include external dependencies

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type TerragruntConfig struct {
 	DownloadDir                 string
 	PreventDestroy              *bool
 	Skip                        bool
+	StsEndpoint                 string
 	IamRole                     string
 	Inputs                      map[string]interface{}
 	Locals                      map[string]interface{}
@@ -591,6 +592,10 @@ func mergeConfigWithIncludedConfig(config *TerragruntConfig, includedConfig *Ter
 
 	if config.Inputs != nil {
 		includedConfig.Inputs = mergeInputs(config.Inputs, includedConfig.Inputs)
+	}
+
+	if config.StsEndpoint != "" {
+		includedConfig.StsEndpoint = config.StsEndpoint
 	}
 
 	return includedConfig, nil

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -349,6 +349,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
 - [terragrunt-exclude-dir](#terragrunt-exclude-dir)
 - [terragrunt-include-dir](#terragrunt-include-dir)
 - [terragrunt-strict-include](#terragrunt-strict-include)
+- [terragrunt-sts-endpoint](#terragrunt-sts-enpoint)
 - [terragrunt-ignore-dependency-order](#terragrunt-ignore-dependency-order)
 - [terragrunt-ignore-external-dependencies](#terragrunt-ignore-external-dependencies)
 - [terragrunt-include-external-dependencies](#terragrunt-include-external-dependencies)
@@ -507,6 +508,15 @@ When passed in, only modules under the directories passed in with [--terragrunt-
 will be included. All dependencies of the included directories will be excluded if they are not in the included
 directories.
 
+### terragrunt-sts-endpoint
+
+**CLI Arg**: `--terragrunt-sts-endpoint http://custom-endpoint`
+
+An option for defining a custom endpoint to use for Terragrunt calls to the AWS STS service. The endpoint is only used
+by Terragrunt when executing the AWS specific built-in functions `get_aws_account_id`, `get_aws_caller_identity_arn`,
+and `get_aws_caller_identity_user_id`. 
+
+This option is useful when working with Terragrunt locally and using tools that mock the STS endpoint (such as Localstack).
 
 ### terragrunt-ignore-dependency-order
 

--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,5 @@ require (
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f
 	google.golang.org/api v0.35.0
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -1087,6 +1087,7 @@ gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/options/options.go
+++ b/options/options.go
@@ -161,6 +161,9 @@ type TerragruntOptions struct {
 	// Attributes to override in AWS provider nested within modules as part of the aws-provider-patch command. See that
 	// command for more info.
 	AwsProviderPatchOverrides map[string]string
+
+	// The endpoint to use for Terragrunt calls to STS (get_aws_account_id, get_aws_caller_identity_arn, get_aws_caller_identity_user_id)
+	StsEndpoint string
 }
 
 // Create a new TerragruntOptions object with reasonable defaults for real usage
@@ -280,6 +283,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		StrictInclude:               terragruntOptions.StrictInclude,
 		RunTerragrunt:               terragruntOptions.RunTerragrunt,
 		AwsProviderPatchOverrides:   terragruntOptions.AwsProviderPatchOverrides,
+		StsEndpoint:                 terragruntOptions.StsEndpoint,
 	}
 }
 


### PR DESCRIPTION
Aiming to fix https://github.com/gruntwork-io/terragrunt/issues/1485

Terragrunt can't pull a custom STS endpoint from Terraform configuration because the built-in helper functions (like `get_aws_account_id`) run before the Terraform code is parsed. Since the AWS Go SDK doesn't provide a way to override endpoints with any environment variables, we have to define a custom endpoint when creating a session.

This PR adds a config flag (`--terragrunt-sts-endpoint`) that is passed to the call to STS for the helper functions. I wasn't quite sure what to name the flag, so I went with something similar to `--terragrunt-iam-role`. Happy to update/change anything as necessary.

Thanks!