### PR TITLE
Fix debug mode

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -253,6 +253,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		Source:                      terragruntOptions.Source,
 		SourceUpdate:                terragruntOptions.SourceUpdate,
 		DownloadDir:                 terragruntOptions.DownloadDir,
+		Debug:                       terragruntOptions.Debug,
 		IamRole:                     terragruntOptions.IamRole,
 		IgnoreDependencyErrors:      terragruntOptions.IgnoreDependencyErrors,
 		IgnoreDependencyOrder:       terragruntOptions.IgnoreDependencyOrder,


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/terragrunt/issues/1502, where the `Debug` flag wasn't being propagated across the `Clone` call.