### PR TITLE
Faster dependency outputs

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -386,7 +386,7 @@ func RunTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 	}
 
 	updatedTerragruntOptions := terragruntOptions
-	if sourceUrl := getTerraformSourceUrl(terragruntOptions, terragruntConfig); sourceUrl != "" {
+	if sourceUrl := config.GetTerraformSourceUrl(terragruntOptions, terragruntConfig); sourceUrl != "" {
 		updatedTerragruntOptions, err = downloadTerraformSource(sourceUrl, terragruntOptions, terragruntConfig)
 		if err != nil {
 			return err

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -4,12 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/mattn/go-zglob"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
 	"github.com/gruntwork-io/terragrunt/aws_helper"
+	"github.com/gruntwork-io/terragrunt/cli/tfsource"
 	"github.com/gruntwork-io/terragrunt/codegen"
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/configstack"
@@ -18,9 +22,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/remote"
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
-	"github.com/mattn/go-zglob"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 const OPT_TERRAGRUNT_CONFIG = "terragrunt-config"
@@ -850,7 +851,7 @@ func providersNeedInit(terragruntOptions *options.TerragruntOptions) bool {
 //
 // This method takes in the "original" terragrunt options which has the unmodified 'WorkingDir' from before downloading the code from the source URL,
 // and the "updated" terragrunt options that will contain the updated 'WorkingDir' into which the code has been downloaded
-func runTerraformInit(originalTerragruntOptions *options.TerragruntOptions, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig, terraformSource *TerraformSource) error {
+func runTerraformInit(originalTerragruntOptions *options.TerragruntOptions, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig, terraformSource *tfsource.TerraformSource) error {
 
 	// Prevent Auto-Init if the user has disabled it
 	if util.FirstArg(terragruntOptions.TerraformCliArgs) != CMD_INIT && !terragruntOptions.AutoInit {
@@ -866,7 +867,7 @@ func runTerraformInit(originalTerragruntOptions *options.TerragruntOptions, terr
 	return runTerragruntWithConfig(originalTerragruntOptions, initOptions, terragruntConfig, terraformSource != nil)
 }
 
-func prepareInitOptions(terragruntOptions *options.TerragruntOptions, terraformSource *TerraformSource) (*options.TerragruntOptions, error) {
+func prepareInitOptions(terragruntOptions *options.TerragruntOptions, terraformSource *tfsource.TerraformSource) (*options.TerragruntOptions, error) {
 	// Need to clone the terragruntOptions, so the TerraformCliArgs can be configured to run the init command
 	initOptions := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
 	initOptions.TerraformCliArgs = []string{CMD_INIT}

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -125,19 +125,6 @@ func readVersionFile(terraformSource *tfsource.TerraformSource) (string, error) 
 	return util.ReadFileAsString(terraformSource.VersionFile)
 }
 
-// There are two ways a user can tell Terragrunt that it needs to download Terraform configurations from a specific
-// URL: via a command-line option or via an entry in the Terragrunt configuration. If the user used one of these, this
-// method returns the source URL or an empty string if there is no source url
-func getTerraformSourceUrl(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) string {
-	if terragruntOptions.Source != "" {
-		return terragruntOptions.Source
-	} else if terragruntConfig.Terraform != nil && terragruntConfig.Terraform.Source != nil {
-		return *terragruntConfig.Terraform.Source
-	} else {
-		return ""
-	}
-}
-
 // We use this code to force go-getter to copy files instead of creating symlinks.
 var copyFiles = func(client *getter.Client) error {
 

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -2,55 +2,29 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/url"
 	"os"
-	"regexp"
-	"strings"
-
 	"path/filepath"
 
+	"github.com/hashicorp/go-getter"
+
+	"github.com/gruntwork-io/terragrunt/cli/tfsource"
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
-	"github.com/hashicorp/go-getter"
-	urlhelper "github.com/hashicorp/go-getter/helper/url"
-	"github.com/sirupsen/logrus"
 )
 
 // manifest for files coped from terragrunt module folder (i.e., the folder that contains the current terragrunt.hcl)
 const MODULE_MANIFEST_NAME = ".terragrunt-module-manifest"
 
-// This struct represents information about Terraform source code that needs to be downloaded
-type TerraformSource struct {
-	// A canonical version of RawSource, in URL format
-	CanonicalSourceURL *url.URL
-
-	// The folder where we should download the source to
-	DownloadDir string
-
-	// The folder in DownloadDir that should be used as the working directory for Terraform
-	WorkingDir string
-
-	// The path to a file in DownloadDir that stores the version number of the code
-	VersionFile string
-}
-
-func (src *TerraformSource) String() string {
-	return fmt.Sprintf("TerraformSource{CanonicalSourceURL = %v, DownloadDir = %v, WorkingDir = %v, VersionFile = %v}", src.CanonicalSourceURL, src.DownloadDir, src.WorkingDir, src.VersionFile)
-}
-
-var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
-
 // 1. Download the given source URL, which should use Terraform's module source syntax, into a temporary folder
 // 2. Copy the contents of terragruntOptions.WorkingDir into the temporary folder.
 // 3. Set terragruntOptions.WorkingDir to the temporary folder.
 //
-// See the ProcessTerraformSource method for how we determine the temporary folder so we can reuse it across multiple
+// See the NewTerraformSource method for how we determine the temporary folder so we can reuse it across multiple
 // runs of Terragrunt to avoid downloading everything from scratch every time.
 func downloadTerraformSource(source string, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) (*options.TerragruntOptions, error) {
-	terraformSource, err := ProcessTerraformSource(source, terragruntOptions.DownloadDir, terragruntOptions.WorkingDir, terragruntOptions.Logger)
+	terraformSource, err := tfsource.NewTerraformSource(source, terragruntOptions.DownloadDir, terragruntOptions.WorkingDir, terragruntOptions.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +47,7 @@ func downloadTerraformSource(source string, terragruntOptions *options.Terragrun
 }
 
 // Download the specified TerraformSource if the latest code hasn't already been downloaded.
-func downloadTerraformSourceIfNecessary(terraformSource *TerraformSource, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
+func downloadTerraformSourceIfNecessary(terraformSource *tfsource.TerraformSource, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
 	if terragruntOptions.SourceUpdate {
 		terragruntOptions.Logger.Printf("The --%s flag is set, so deleting the temporary folder %s before downloading source.", OPT_TERRAGRUNT_SOURCE_UPDATE, terraformSource.DownloadDir)
 		if err := os.RemoveAll(terraformSource.DownloadDir); err != nil {
@@ -104,7 +78,7 @@ func downloadTerraformSourceIfNecessary(terraformSource *TerraformSource, terrag
 		return downloadErr
 	}
 
-	if err := writeVersionFile(terraformSource); err != nil {
+	if err := terraformSource.WriteVersionFile(); err != nil {
 		return err
 	}
 
@@ -115,8 +89,8 @@ func downloadTerraformSourceIfNecessary(terraformSource *TerraformSource, terrag
 // DownloadFolder. This helps avoid downloading the same code multiple times. Note that if the TerraformSource points
 // to a local file path, we assume the user is doing local development and always return false to ensure the latest
 // code is downloaded (or rather, copied) every single time. See the ProcessTerraformSource method for more info.
-func alreadyHaveLatestCode(terraformSource *TerraformSource, terragruntOptions *options.TerragruntOptions) (bool, error) {
-	if isLocalSource(terraformSource.CanonicalSourceURL) ||
+func alreadyHaveLatestCode(terraformSource *tfsource.TerraformSource, terragruntOptions *options.TerragruntOptions) (bool, error) {
+	if tfsource.IsLocalSource(terraformSource.CanonicalSourceURL) ||
 		!util.FileExists(terraformSource.DownloadDir) ||
 		!util.FileExists(terraformSource.WorkingDir) ||
 		!util.FileExists(terraformSource.VersionFile) {
@@ -134,7 +108,7 @@ func alreadyHaveLatestCode(terraformSource *TerraformSource, terragruntOptions *
 		return false, nil
 	}
 
-	currentVersion := encodeSourceVersion(terraformSource.CanonicalSourceURL)
+	currentVersion := terraformSource.EncodeSourceVersion()
 	previousVersion, err := readVersionFile(terraformSource)
 
 	if err != nil {
@@ -147,185 +121,8 @@ func alreadyHaveLatestCode(terraformSource *TerraformSource, terragruntOptions *
 // Return the version number stored in the DownloadDir. This version number can be used to check if the Terraform code
 // that has already been downloaded is the same as the version the user is currently requesting. The version number is
 // calculated using the encodeSourceVersion method.
-func readVersionFile(terraformSource *TerraformSource) (string, error) {
+func readVersionFile(terraformSource *tfsource.TerraformSource) (string, error) {
 	return util.ReadFileAsString(terraformSource.VersionFile)
-}
-
-// Write a file into the DownloadDir that contains the version number of this source code. The version number is
-// calculated using the encodeSourceVersion method.
-func writeVersionFile(terraformSource *TerraformSource) error {
-	version := encodeSourceVersion(terraformSource.CanonicalSourceURL)
-	return errors.WithStackTrace(ioutil.WriteFile(terraformSource.VersionFile, []byte(version), 0640))
-}
-
-// Take the given source path and create a TerraformSource struct from it, including the folder where the source should
-// be downloaded to. Our goal is to reuse the download folder for the same source URL between Terragrunt runs.
-// Otherwise, for every Terragrunt command, you'd have to wait for Terragrunt to download your Terraform code, download
-// that code's dependencies (terraform get), and configure remote state (terraform remote config), which is very slow.
-//
-// To maximize reuse, given a working directory w and a source URL s, we download code from S into the folder /T/W/H
-// where:
-//
-// 1. S is the part of s before the double-slash (//). This typically represents the root of the repo (e.g.
-//    github.com/foo/infrastructure-modules). We download the entire repo so that relative paths to other files in that
-//    repo resolve correctly. If no double-slash is specified, all of s is used.
-// 1. T is the OS temp dir (e.g. /tmp).
-// 2. W is the base 64 encoded sha1 hash of w. This ensures that if you are running Terragrunt concurrently in
-//    multiple folders (e.g. during automated tests), then even if those folders are using the same source URL s, they
-//    do not overwrite each other.
-// 3. H is the base 64 encoded sha1 of S without its query string. For remote source URLs (e.g. Git
-//    URLs), this is based on the assumption that the scheme/host/path of the URL (e.g. git::github.com/foo/bar)
-//    identifies the repo, and we always want to download the same repo into the same folder (see the encodeSourceName
-//    method). We also assume the version of the module is stored in the query string (e.g. ref=v0.0.3), so we store
-//    the base 64 encoded sha1 of the query string in a file called .terragrunt-source-version within /T/W/H.
-//
-// The downloadTerraformSourceIfNecessary decides when we should download the Terraform code and when not to. It uses
-// the following rules:
-//
-// 1. Always download source URLs pointing to local file paths.
-// 2. Only download source URLs pointing to remote paths if /T/W/H doesn't already exist or, if it does exist, if the
-//    version number in /T/W/H/.terragrunt-source-version doesn't match the current version.
-func ProcessTerraformSource(source string, downloadDir string, workingDir string, logger *logrus.Entry) (*TerraformSource, error) {
-
-	canonicalWorkingDir, err := util.CanonicalPath(workingDir, "")
-	if err != nil {
-		return nil, err
-	}
-
-	canonicalSourceUrl, err := toSourceUrl(source, canonicalWorkingDir)
-	if err != nil {
-		return nil, err
-	}
-
-	rootSourceUrl, modulePath, err := splitSourceUrl(canonicalSourceUrl, logger)
-	if err != nil {
-		return nil, err
-	}
-
-	if isLocalSource(rootSourceUrl) {
-		// Always use canonical file paths for local source folders, rather than relative paths, to ensure
-		// that the same local folder always maps to the same download folder, no matter how the local folder
-		// path is specified
-		canonicalFilePath, err := util.CanonicalPath(rootSourceUrl.Path, "")
-		if err != nil {
-			return nil, err
-		}
-		rootSourceUrl.Path = canonicalFilePath
-	}
-
-	rootPath, err := encodeSourceName(rootSourceUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	encodedWorkingDir := util.EncodeBase64Sha1(canonicalWorkingDir)
-	updatedDownloadDir := util.JoinPath(downloadDir, encodedWorkingDir, rootPath)
-	updatedWorkingDir := util.JoinPath(updatedDownloadDir, modulePath)
-	versionFile := util.JoinPath(updatedDownloadDir, ".terragrunt-source-version")
-
-	return &TerraformSource{
-		CanonicalSourceURL: rootSourceUrl,
-		DownloadDir:        updatedDownloadDir,
-		WorkingDir:         updatedWorkingDir,
-		VersionFile:        versionFile,
-	}, nil
-}
-
-// Convert the given source into a URL struct. This method should be able to handle all source URLs that the terraform
-// init command can handle, parsing local file paths, Git paths, and HTTP URLs correctly.
-func toSourceUrl(source string, workingDir string) (*url.URL, error) {
-	// The go-getter library is what Terraform's init command uses to download source URLs. Use that library to
-	// parse the URL.
-	rawSourceUrlWithGetter, err := getter.Detect(source, workingDir, getter.Detectors)
-	if err != nil {
-		return nil, errors.WithStackTrace(err)
-	}
-
-	return parseSourceUrl(rawSourceUrlWithGetter)
-}
-
-// Parse the given source URL into a URL struct. This method can handle source URLs that include go-getter's "forced
-// getter" prefixes, such as git::.
-func parseSourceUrl(source string) (*url.URL, error) {
-	forcedGetter, rawSourceUrl := getForcedGetter(source)
-
-	// Parse the URL without the getter prefix
-	canonicalSourceUrl, err := urlhelper.Parse(rawSourceUrl)
-	if err != nil {
-		return nil, errors.WithStackTrace(err)
-	}
-
-	// Reattach the "getter" prefix as part of the scheme
-	if forcedGetter != "" {
-		canonicalSourceUrl.Scheme = fmt.Sprintf("%s::%s", forcedGetter, canonicalSourceUrl.Scheme)
-	}
-
-	return canonicalSourceUrl, nil
-}
-
-// Terraform source URLs can contain a "getter" prefix that specifies the type of protocol to use to download that URL,
-// such as "git::", which means Git should be used to download the URL. This method returns the getter prefix and the
-// rest of the URL. This code is copied from the getForcedGetter method of go-getter/get.go, as that method is not
-// exported publicly.
-func getForcedGetter(sourceUrl string) (string, string) {
-	if matches := forcedRegexp.FindStringSubmatch(sourceUrl); matches != nil && len(matches) > 2 {
-		return matches[1], matches[2]
-	}
-
-	return "", sourceUrl
-}
-
-// Splits a source URL into the root repo and the path. The root repo is the part of the URL before the double-slash
-// (//), which typically represents the root of a modules repo (e.g. github.com/foo/infrastructure-modules) and the
-// path is everything after the double slash. If there is no double-slash in the URL, the root repo is the entire
-// sourceUrl and the path is an empty string.
-func splitSourceUrl(sourceUrl *url.URL, logger *logrus.Entry) (*url.URL, string, error) {
-	pathSplitOnDoubleSlash := strings.SplitN(sourceUrl.Path, "//", 2)
-
-	if len(pathSplitOnDoubleSlash) > 1 {
-		sourceUrlModifiedPath, err := parseSourceUrl(sourceUrl.String())
-		if err != nil {
-			return nil, "", errors.WithStackTrace(err)
-		}
-
-		sourceUrlModifiedPath.Path = pathSplitOnDoubleSlash[0]
-		return sourceUrlModifiedPath, pathSplitOnDoubleSlash[1], nil
-	} else {
-		logger.Warningf("No double-slash (//) found in source URL %s. Relative paths in downloaded Terraform code may not work.", sourceUrl.Path)
-		return sourceUrl, "", nil
-	}
-}
-
-// Encode a version number for the given source URL. When calculating a version number, we simply take the query
-// string of the source URL, calculate its sha1, and base 64 encode it. For remote URLs (e.g. Git URLs), this is
-// based on the assumption that the scheme/host/path of the URL (e.g. git::github.com/foo/bar) identifies the module
-// name and the query string (e.g. ?ref=v0.0.3) identifies the version. For local file paths, there is no query string,
-// so the same file path (/foo/bar) is always considered the same version. See also the encodeSourceName and
-// ProcessTerraformSource methods.
-func encodeSourceVersion(sourceUrl *url.URL) string {
-	return util.EncodeBase64Sha1(sourceUrl.Query().Encode())
-}
-
-// Encode a the module name for the given source URL. When calculating a module name, we calculate the base 64 encoded
-// sha1 of the entire source URL without the query string. For remote URLs (e.g. Git URLs), this is based on the
-// assumption that the scheme/host/path of the URL (e.g. git::github.com/foo/bar) identifies the module name and the
-// query string (e.g. ?ref=v0.0.3) identifies the version. For local file paths, there is no query string, so the same
-// file path (/foo/bar) is always considered the same version. See also the encodeSourceVersion and
-// ProcessTerraformSource methods.
-func encodeSourceName(sourceUrl *url.URL) (string, error) {
-	sourceUrlNoQuery, err := parseSourceUrl(sourceUrl.String())
-	if err != nil {
-		return "", errors.WithStackTrace(err)
-	}
-
-	sourceUrlNoQuery.RawQuery = ""
-
-	return util.EncodeBase64Sha1(sourceUrlNoQuery.String()), nil
-}
-
-// Returns true if the given URL refers to a path on the local file system
-func isLocalSource(sourceUrl *url.URL) bool {
-	return sourceUrl.Scheme == "file"
 }
 
 // There are two ways a user can tell Terragrunt that it needs to download Terraform configurations from a specific
@@ -361,7 +158,7 @@ var copyFiles = func(client *getter.Client) error {
 }
 
 // Download the code from the Canonical Source URL into the Download Folder using the go-getter library
-func downloadSource(terraformSource *TerraformSource, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
+func downloadSource(terraformSource *tfsource.TerraformSource, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
 	terragruntOptions.Logger.Printf("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
 
 	if err := getter.GetAny(terraformSource.DownloadDir, terraformSource.CanonicalSourceURL.String(), copyFiles); err != nil {

--- a/cli/tfsource/types.go
+++ b/cli/tfsource/types.go
@@ -1,0 +1,214 @@
+package tfsource
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-getter"
+	urlhelper "github.com/hashicorp/go-getter/helper/url"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/util"
+)
+
+var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
+
+// This struct represents information about Terraform source code that needs to be downloaded
+type TerraformSource struct {
+	// A canonical version of RawSource, in URL format
+	CanonicalSourceURL *url.URL
+
+	// The folder where we should download the source to
+	DownloadDir string
+
+	// The folder in DownloadDir that should be used as the working directory for Terraform
+	WorkingDir string
+
+	// The path to a file in DownloadDir that stores the version number of the code
+	VersionFile string
+}
+
+func (src *TerraformSource) String() string {
+	return fmt.Sprintf("TerraformSource{CanonicalSourceURL = %v, DownloadDir = %v, WorkingDir = %v, VersionFile = %v}", src.CanonicalSourceURL, src.DownloadDir, src.WorkingDir, src.VersionFile)
+}
+
+// Encode a version number for the given source. When calculating a version number, we simply take the query
+// string of the source URL, calculate its sha1, and base 64 encode it. For remote URLs (e.g. Git URLs), this is
+// based on the assumption that the scheme/host/path of the URL (e.g. git::github.com/foo/bar) identifies the module
+// name and the query string (e.g. ?ref=v0.0.3) identifies the version. For local file paths, there is no query string,
+// so the same file path (/foo/bar) is always considered the same version. See also the encodeSourceName and
+// ProcessTerraformSource methods.
+func (terraformSource TerraformSource) EncodeSourceVersion() string {
+	return util.EncodeBase64Sha1(terraformSource.CanonicalSourceURL.Query().Encode())
+}
+
+// Write a file into the DownloadDir that contains the version number of this source code. The version number is
+// calculated using the EncodeSourceVersion method.
+func (terraformSource TerraformSource) WriteVersionFile() error {
+	version := terraformSource.EncodeSourceVersion()
+	return errors.WithStackTrace(ioutil.WriteFile(terraformSource.VersionFile, []byte(version), 0640))
+}
+
+// Take the given source path and create a TerraformSource struct from it, including the folder where the source should
+// be downloaded to. Our goal is to reuse the download folder for the same source URL between Terragrunt runs.
+// Otherwise, for every Terragrunt command, you'd have to wait for Terragrunt to download your Terraform code, download
+// that code's dependencies (terraform get), and configure remote state (terraform remote config), which is very slow.
+//
+// To maximize reuse, given a working directory w and a source URL s, we download code from S into the folder /T/W/H
+// where:
+//
+// 1. S is the part of s before the double-slash (//). This typically represents the root of the repo (e.g.
+//    github.com/foo/infrastructure-modules). We download the entire repo so that relative paths to other files in that
+//    repo resolve correctly. If no double-slash is specified, all of s is used.
+// 1. T is the OS temp dir (e.g. /tmp).
+// 2. W is the base 64 encoded sha1 hash of w. This ensures that if you are running Terragrunt concurrently in
+//    multiple folders (e.g. during automated tests), then even if those folders are using the same source URL s, they
+//    do not overwrite each other.
+// 3. H is the base 64 encoded sha1 of S without its query string. For remote source URLs (e.g. Git
+//    URLs), this is based on the assumption that the scheme/host/path of the URL (e.g. git::github.com/foo/bar)
+//    identifies the repo, and we always want to download the same repo into the same folder (see the encodeSourceName
+//    method). We also assume the version of the module is stored in the query string (e.g. ref=v0.0.3), so we store
+//    the base 64 encoded sha1 of the query string in a file called .terragrunt-source-version within /T/W/H.
+//
+// The downloadTerraformSourceIfNecessary decides when we should download the Terraform code and when not to. It uses
+// the following rules:
+//
+// 1. Always download source URLs pointing to local file paths.
+// 2. Only download source URLs pointing to remote paths if /T/W/H doesn't already exist or, if it does exist, if the
+//    version number in /T/W/H/.terragrunt-source-version doesn't match the current version.
+func NewTerraformSource(source string, downloadDir string, workingDir string, logger *logrus.Entry) (*TerraformSource, error) {
+
+	canonicalWorkingDir, err := util.CanonicalPath(workingDir, "")
+	if err != nil {
+		return nil, err
+	}
+
+	canonicalSourceUrl, err := toSourceUrl(source, canonicalWorkingDir)
+	if err != nil {
+		return nil, err
+	}
+
+	rootSourceUrl, modulePath, err := splitSourceUrl(canonicalSourceUrl, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if IsLocalSource(rootSourceUrl) {
+		// Always use canonical file paths for local source folders, rather than relative paths, to ensure
+		// that the same local folder always maps to the same download folder, no matter how the local folder
+		// path is specified
+		canonicalFilePath, err := util.CanonicalPath(rootSourceUrl.Path, "")
+		if err != nil {
+			return nil, err
+		}
+		rootSourceUrl.Path = canonicalFilePath
+	}
+
+	rootPath, err := encodeSourceName(rootSourceUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	encodedWorkingDir := util.EncodeBase64Sha1(canonicalWorkingDir)
+	updatedDownloadDir := util.JoinPath(downloadDir, encodedWorkingDir, rootPath)
+	updatedWorkingDir := util.JoinPath(updatedDownloadDir, modulePath)
+	versionFile := util.JoinPath(updatedDownloadDir, ".terragrunt-source-version")
+
+	return &TerraformSource{
+		CanonicalSourceURL: rootSourceUrl,
+		DownloadDir:        updatedDownloadDir,
+		WorkingDir:         updatedWorkingDir,
+		VersionFile:        versionFile,
+	}, nil
+}
+
+// Convert the given source into a URL struct. This method should be able to handle all source URLs that the terraform
+// init command can handle, parsing local file paths, Git paths, and HTTP URLs correctly.
+func toSourceUrl(source string, workingDir string) (*url.URL, error) {
+	// The go-getter library is what Terraform's init command uses to download source URLs. Use that library to
+	// parse the URL.
+	rawSourceUrlWithGetter, err := getter.Detect(source, workingDir, getter.Detectors)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	return parseSourceUrl(rawSourceUrlWithGetter)
+}
+
+// Parse the given source URL into a URL struct. This method can handle source URLs that include go-getter's "forced
+// getter" prefixes, such as git::.
+func parseSourceUrl(source string) (*url.URL, error) {
+	forcedGetter, rawSourceUrl := getForcedGetter(source)
+
+	// Parse the URL without the getter prefix
+	canonicalSourceUrl, err := urlhelper.Parse(rawSourceUrl)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	// Reattach the "getter" prefix as part of the scheme
+	if forcedGetter != "" {
+		canonicalSourceUrl.Scheme = fmt.Sprintf("%s::%s", forcedGetter, canonicalSourceUrl.Scheme)
+	}
+
+	return canonicalSourceUrl, nil
+}
+
+// Returns true if the given URL refers to a path on the local file system
+func IsLocalSource(sourceUrl *url.URL) bool {
+	return sourceUrl.Scheme == "file"
+}
+
+// Splits a source URL into the root repo and the path. The root repo is the part of the URL before the double-slash
+// (//), which typically represents the root of a modules repo (e.g. github.com/foo/infrastructure-modules) and the
+// path is everything after the double slash. If there is no double-slash in the URL, the root repo is the entire
+// sourceUrl and the path is an empty string.
+func splitSourceUrl(sourceUrl *url.URL, logger *logrus.Entry) (*url.URL, string, error) {
+	pathSplitOnDoubleSlash := strings.SplitN(sourceUrl.Path, "//", 2)
+
+	if len(pathSplitOnDoubleSlash) > 1 {
+		sourceUrlModifiedPath, err := parseSourceUrl(sourceUrl.String())
+		if err != nil {
+			return nil, "", errors.WithStackTrace(err)
+		}
+
+		sourceUrlModifiedPath.Path = pathSplitOnDoubleSlash[0]
+		return sourceUrlModifiedPath, pathSplitOnDoubleSlash[1], nil
+	} else {
+		logger.Warningf("No double-slash (//) found in source URL %s. Relative paths in downloaded Terraform code may not work.", sourceUrl.Path)
+		return sourceUrl, "", nil
+	}
+}
+
+// Encode a the module name for the given source URL. When calculating a module name, we calculate the base 64 encoded
+// sha1 of the entire source URL without the query string. For remote URLs (e.g. Git URLs), this is based on the
+// assumption that the scheme/host/path of the URL (e.g. git::github.com/foo/bar) identifies the module name and the
+// query string (e.g. ?ref=v0.0.3) identifies the version. For local file paths, there is no query string, so the same
+// file path (/foo/bar) is always considered the same version. See also the EncodeSourceVersion and
+// ProcessTerraformSource methods.
+func encodeSourceName(sourceUrl *url.URL) (string, error) {
+	sourceUrlNoQuery, err := parseSourceUrl(sourceUrl.String())
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	sourceUrlNoQuery.RawQuery = ""
+
+	return util.EncodeBase64Sha1(sourceUrlNoQuery.String()), nil
+}
+
+// Terraform source URLs can contain a "getter" prefix that specifies the type of protocol to use to download that URL,
+// such as "git::", which means Git should be used to download the URL. This method returns the getter prefix and the
+// rest of the URL. This code is copied from the getForcedGetter method of go-getter/get.go, as that method is not
+// exported publicly.
+func getForcedGetter(sourceUrl string) (string, string) {
+	if matches := forcedRegexp.FindStringSubmatch(sourceUrl); matches != nil && len(matches) > 2 {
+		return matches[1], matches[2]
+	}
+
+	return "", sourceUrl
+}

--- a/cli/tfsource/types.go
+++ b/cli/tfsource/types.go
@@ -36,7 +36,7 @@ func (src *TerraformSource) String() string {
 	return fmt.Sprintf("TerraformSource{CanonicalSourceURL = %v, DownloadDir = %v, WorkingDir = %v, VersionFile = %v}", src.CanonicalSourceURL, src.DownloadDir, src.WorkingDir, src.VersionFile)
 }
 
-// Encode a version number for the given source. When calculating a version number, we simply take the query
+// Encode a version number for the given source. When calculating a version number, we take the query
 // string of the source URL, calculate its sha1, and base 64 encode it. For remote URLs (e.g. Git URLs), this is
 // based on the assumption that the scheme/host/path of the URL (e.g. git::github.com/foo/bar) identifies the module
 // name and the query string (e.g. ?ref=v0.0.3) identifies the version. For local file paths, there is no query string,

--- a/cli/tfsource/types_test.go
+++ b/cli/tfsource/types_test.go
@@ -1,0 +1,60 @@
+package tfsource
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/options"
+)
+
+func TestSplitSourceUrl(t *testing.T) {
+
+	t.Parallel()
+
+	testCases := []struct {
+		name               string
+		sourceUrl          string
+		expectedRootRepo   string
+		expectedModulePath string
+	}{
+		{"root-path-only-no-double-slash", "/foo", "/foo", ""},
+		{"parent-path-one-child-no-double-slash", "/foo/bar", "/foo/bar", ""},
+		{"parent-path-multiple-children-no-double-slash", "/foo/bar/baz/blah", "/foo/bar/baz/blah", ""},
+		{"relative-path-no-children-no-double-slash", "../foo", "../foo", ""},
+		{"relative-path-one-child-no-double-slash", "../foo/bar", "../foo/bar", ""},
+		{"relative-path-multiple-children-no-double-slash", "../foo/bar/baz/blah", "../foo/bar/baz/blah", ""},
+		{"root-path-only-with-double-slash", "/foo//", "/foo", ""},
+		{"parent-path-one-child-with-double-slash", "/foo//bar", "/foo", "bar"},
+		{"parent-path-multiple-children-with-double-slash", "/foo/bar//baz/blah", "/foo/bar", "baz/blah"},
+		{"relative-path-no-children-with-double-slash", "..//foo", "..", "foo"},
+		{"relative-path-one-child-with-double-slash", "../foo//bar", "../foo", "bar"},
+		{"relative-path-multiple-children-with-double-slash", "../foo/bar//baz/blah", "../foo/bar", "baz/blah"},
+		{"parent-url-one-child-no-double-slash", "ssh://git@github.com/foo/modules.git/foo", "ssh://git@github.com/foo/modules.git/foo", ""},
+		{"parent-url-multiple-children-no-double-slash", "ssh://git@github.com/foo/modules.git/foo/bar/baz/blah", "ssh://git@github.com/foo/modules.git/foo/bar/baz/blah", ""},
+		{"parent-url-one-child-with-double-slash", "ssh://git@github.com/foo/modules.git//foo", "ssh://git@github.com/foo/modules.git", "foo"},
+		{"parent-url-multiple-children-with-double-slash", "ssh://git@github.com/foo/modules.git//foo/bar/baz/blah", "ssh://git@github.com/foo/modules.git", "foo/bar/baz/blah"},
+	}
+
+	for _, testCase := range testCases {
+		// Save a local copy in scope so all the tests don't run the final item in the loop
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			sourceUrl, err := url.Parse(testCase.sourceUrl)
+			require.NoError(t, err)
+
+			terragruntOptions, err := options.NewTerragruntOptionsForTest("testing")
+			require.NoError(t, err)
+
+			actualRootRepo, actualModulePath, err := splitSourceUrl(sourceUrl, terragruntOptions.Logger)
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase.expectedRootRepo, actualRootRepo.String())
+			assert.Equal(t, testCase.expectedModulePath, actualModulePath)
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -248,6 +248,19 @@ func (conf *TerraformExtraArguments) String() string {
 		conf.EnvVars)
 }
 
+// There are two ways a user can tell Terragrunt that it needs to download Terraform configurations from a specific
+// URL: via a command-line option or via an entry in the Terragrunt configuration. If the user used one of these, this
+// method returns the source URL or an empty string if there is no source url
+func GetTerraformSourceUrl(terragruntOptions *options.TerragruntOptions, terragruntConfig *TerragruntConfig) string {
+	if terragruntOptions.Source != "" {
+		return terragruntOptions.Source
+	} else if terragruntConfig.Terraform != nil && terragruntConfig.Terraform.Source != nil {
+		return *terragruntConfig.Terraform.Source
+	} else {
+		return ""
+	}
+}
+
 // Return the default hcl path to use for the Terragrunt configuration file in the given directory
 func DefaultConfigPath(workingDir string) string {
 	return util.JoinPath(workingDir, DefaultTerragruntConfigPath)

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -458,6 +458,9 @@ func terragruntAlreadyInit(terragruntOptions *options.TerragruntOptions, configP
 		workingDir = terraformSource.WorkingDir
 	}
 	// Terragrunt is already init-ed if the terraform state dir (.terraform) exists in the working dir.
+	// NOTE: if the ref changes, the workingDir would be different as the download dir includes a base64 encoded hash of
+	// the source URL with ref. This would ensure that this routine would not return true if the new ref is not already
+	// init-ed.
 	return util.FileExists(filepath.Join(workingDir, ".terraform")), workingDir, nil
 }
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -464,9 +464,10 @@ func terragruntAlreadyInit(terragruntOptions *options.TerragruntOptions, configP
 // getTerragruntOutputJsonFromInitFolder will retrieve the outputs directly from the module's working directory without
 // running init.
 func getTerragruntOutputJsonFromInitFolder(terragruntOptions *options.TerragruntOptions, terraformWorkingDir string, iamRole string) ([]byte, error) {
-	terragruntOptions.Logger.Infof("Detected module is already init-ed. Retrieving outputs directly from working directory.")
-
 	targetConfig := terragruntOptions.TerragruntConfigPath
+
+	terragruntOptions.Logger.Infof("Detected module %s is already init-ed. Retrieving outputs directly from working directory.", targetConfig)
+
 	targetTGOptions, err := setupTerragruntOptionsForBareTerraform(terragruntOptions, terraformWorkingDir, targetConfig, iamRole)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,5 @@ require (
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f
 	google.golang.org/api v0.35.0
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -1087,6 +1087,7 @@ gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2243,14 +2243,27 @@ func TestYamlDecodeRegressions(t *testing.T) {
 // If output optimization is working, we should still get the same correct output even though the state of the upmost
 // module has been destroyed.
 func TestDependencyOutputOptimization(t *testing.T) {
-	dependencyOutputOptimizationTest(t, "nested-optimization")
+	expectOutputLogs := []string{
+		`Running command: terraform init -get=false -get-plugins=false prefix=\[.*fixture-get-output/nested-optimization/dep\]`,
+	}
+	dependencyOutputOptimizationTest(t, "nested-optimization", true, expectOutputLogs)
+}
+
+func TestDependencyOutputOptimizationSkipInit(t *testing.T) {
+	expectOutputLogs := []string{
+		`Detected module .*nested-optimization/dep/terragrunt.hcl is already init-ed. Retrieving outputs directly from working directory. prefix=\[.*fixture-get-output/nested-optimization/dep\]`,
+	}
+	dependencyOutputOptimizationTest(t, "nested-optimization", false, expectOutputLogs)
 }
 
 func TestDependencyOutputOptimizationNoGenerate(t *testing.T) {
-	dependencyOutputOptimizationTest(t, "nested-optimization-nogen")
+	expectOutputLogs := []string{
+		`Running command: terraform init -get=false -get-plugins=false prefix=\[.*fixture-get-output/nested-optimization-nogen/dep\]`,
+	}
+	dependencyOutputOptimizationTest(t, "nested-optimization-nogen", true, expectOutputLogs)
 }
 
-func dependencyOutputOptimizationTest(t *testing.T, moduleName string) {
+func dependencyOutputOptimizationTest(t *testing.T, moduleName string, forceInit bool, expectedOutputLogs []string) {
 	t.Parallel()
 
 	expectedOutput := `They said, "No, The answer is 42"`
@@ -2262,6 +2275,7 @@ func dependencyOutputOptimizationTest(t *testing.T, moduleName string) {
 	rootTerragruntConfigPath := filepath.Join(rootPath, config.DefaultTerragruntConfigPath)
 	livePath := filepath.Join(rootPath, "live")
 	deepDepPath := filepath.Join(rootPath, "deepdep")
+	depPath := filepath.Join(rootPath, "dep")
 
 	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(generatedUniqueId))
 	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(generatedUniqueId))
@@ -2269,28 +2283,40 @@ func dependencyOutputOptimizationTest(t *testing.T, moduleName string) {
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply-all --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
 
 	// We need to bust the output cache that stores the dependency outputs so that the second run pulls the outputs.
 	// This is only a problem during testing, where the process is shared across terragrunt runs.
 	config.ClearOutputCache()
 
 	// verify expected output
-	stdout, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir %s", livePath))
+	stdout, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", livePath))
 	require.NoError(t, err)
 
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &outputs))
 	assert.Equal(t, expectedOutput, outputs["output"].Value)
 
+	// If we want to force reinit, delete the relevant .terraform directories
+	if forceInit {
+		cleanupTerraformFolder(t, depPath)
+	}
+
 	// Now delete the deepdep state and verify still works (note we need to bust the cache again)
 	config.ClearOutputCache()
 	require.NoError(t, os.Remove(filepath.Join(deepDepPath, "terraform.tfstate")))
-	reout, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir %s", livePath))
+	reout, reerr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", livePath))
 	require.NoError(t, err)
 
 	require.NoError(t, json.Unmarshal([]byte(reout), &outputs))
 	assert.Equal(t, expectedOutput, outputs["output"].Value)
+
+	for _, logRegexp := range expectedOutputLogs {
+		re, err := regexp.Compile(logRegexp)
+		require.NoError(t, err)
+		matches := re.FindAllString(reerr, -1)
+		assert.Greater(t, len(matches), 0)
+	}
 }
 
 func TestDependencyOutputOptimizationDisableTest(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/aws_helper"
 	"github.com/gruntwork-io/terragrunt/cli"
+	"github.com/gruntwork-io/terragrunt/cli/tfsource"
 	"github.com/gruntwork-io/terragrunt/codegen"
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/configstack"
@@ -1059,7 +1060,7 @@ func TestCustomLockFile(t *testing.T) {
 
 	source := "../custom-lock-file-module"
 	downloadDir := util.JoinPath(TEST_FIXTURE_CUSTOM_LOCK_FILE, TERRAGRUNT_CACHE)
-	result, err := cli.ProcessTerraformSource(source, downloadDir, TEST_FIXTURE_CUSTOM_LOCK_FILE, util.CreateLogEntry("", options.DEFAULT_LOG_LEVEL))
+	result, err := tfsource.NewTerraformSource(source, downloadDir, TEST_FIXTURE_CUSTOM_LOCK_FILE, util.CreateLogEntry("", options.DEFAULT_LOG_LEVEL))
 	require.NoError(t, err)
 
 	lockFilePath := util.JoinPath(result.WorkingDir, util.TerraformLockFile)


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/terragrunt/issues/1322

This implements a further optimization to dependency output fetching, where if terragrunt detects that the target module is already initialized, the dependency fetcher will directly run `terraform output` instead of running `init`. This skips a relatively long operation, where terraform needs to pull down the providers and modules.

Note that to implement this, I needed to refactor the `TerraformSource` struct so that it is available in the `config` package without a circular dependency between `config` and `cli`. Everything in `cli/tfsource` are functions that were straight copied from `cli`, with a few exceptions where the functions were converted to methods.

(I was compelled to implement this because I noticed this `init` operation is SUPER SLOW for the account-baseline module, which we have dependency links to in the ref arch)