### PR TITLE
fix: Adding terragrunt-log-level to cli help

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -225,6 +225,7 @@ GLOBAL OPTIONS:
    terragrunt-hclfmt-file                       The path to a single terragrunt.hcl file that the hclfmt command should run on.
    terragrunt-override-attr                     A key=value attribute to override in a provider block as part of the aws-provider-patch command. May be specified multiple times.
    terragrunt-debug                             Write terragrunt-debug.tfvars to working folder to help root-cause issues.
+   terragrunt-log-level                         Sets the logging level for Terragrunt. Supported levels: panic, fatal, error, warn (default), info, debug, trace.
 
 VERSION:
    {{.Version}}{{if len .Authors}}


### PR DESCRIPTION
I noticed the new added [terragrunt-log-level](https://terragrunt.gruntwork.io/docs/reference/cli-options/#terragrunt-log-level) wasn't specified in the CLI help.

This tiny change adds it :)

Have a great weekend.