### PR TITLE
Change default logging level to Info

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -123,7 +123,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	strictInclude := parseBooleanArg(args, OPT_TERRAGRUNT_STRICT_INCLUDE, false)
 
 	// Those correspond to logrus levels
-	logLevel, err := parseStringArg(args, OPT_TERRAGRUNT_LOGLEVEL, logrus.WarnLevel.String())
+	logLevel, err := parseStringArg(args, OPT_TERRAGRUNT_LOGLEVEL, util.DEFAULT_LOG_LEVEL.String())
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -534,18 +534,18 @@ func processHooks(hooks []config.Hook, terragruntOptions *options.TerragruntOpti
 
 	errorsOccurred := []error{}
 
-	terragruntOptions.Logger.Printf("Detected %d Hooks", len(hooks))
+	terragruntOptions.Logger.Infof("Detected %d Hooks", len(hooks))
 
 	for _, curHook := range hooks {
 		allPreviousErrors := append(previousExecError, errorsOccurred...)
 		if shouldRunHook(curHook, terragruntOptions, allPreviousErrors...) {
-			terragruntOptions.Logger.Printf("Executing hook: %s", curHook.Name)
+			terragruntOptions.Logger.Infof("Executing hook: %s", curHook.Name)
 			actionToExecute := curHook.Execute[0]
 			actionParams := curHook.Execute[1:]
 			possibleError := shell.RunShellCommand(terragruntOptions, actionToExecute, actionParams...)
 
 			if possibleError != nil {
-				terragruntOptions.Logger.Printf("Error running hook %s with message: %s", curHook.Name, possibleError.Error())
+				terragruntOptions.Logger.Infof("Error running hook %s with message: %s", curHook.Name, possibleError.Error())
 				errorsOccurred = append(errorsOccurred, possibleError)
 			}
 
@@ -674,7 +674,7 @@ func runActionWithHooks(description string, terragruntOptions *options.Terragrun
 	if beforeHookErrors == nil {
 		actionErrors = action()
 	} else {
-		terragruntOptions.Logger.Printf("Errors encountered running before_hooks. Not running '%s'.", description)
+		terragruntOptions.Logger.Infof("Errors encountered running before_hooks. Not running '%s'.", description)
 	}
 
 	postHookErrors := processHooks(terragruntConfig.Terraform.GetAfterHooks(), terragruntOptions, beforeHookErrors, actionErrors)
@@ -708,7 +708,7 @@ func runTerraformWithRetry(terragruntOptions *options.TerragruntOptions) error {
 	for i := 0; i < terragruntOptions.MaxRetryAttempts; i++ {
 		if out, tferr := shell.RunTerraformCommandWithOutput(terragruntOptions, terragruntOptions.TerraformCliArgs...); tferr != nil {
 			if out != nil && isRetryable(out.Stderr, tferr, terragruntOptions) {
-				terragruntOptions.Logger.Printf("Encountered an error eligible for retrying. Sleeping %v before retrying.\n", terragruntOptions.Sleep)
+				terragruntOptions.Logger.Infof("Encountered an error eligible for retrying. Sleeping %v before retrying.\n", terragruntOptions.Sleep)
 				time.Sleep(terragruntOptions.Sleep)
 			} else {
 				return tferr

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -534,7 +534,7 @@ func processHooks(hooks []config.Hook, terragruntOptions *options.TerragruntOpti
 
 	errorsOccurred := []error{}
 
-	terragruntOptions.Logger.Infof("Detected %d Hooks", len(hooks))
+	terragruntOptions.Logger.Debugf("Detected %d Hooks", len(hooks))
 
 	for _, curHook := range hooks {
 		allPreviousErrors := append(previousExecError, errorsOccurred...)
@@ -545,7 +545,7 @@ func processHooks(hooks []config.Hook, terragruntOptions *options.TerragruntOpti
 			possibleError := shell.RunShellCommand(terragruntOptions, actionToExecute, actionParams...)
 
 			if possibleError != nil {
-				terragruntOptions.Logger.Infof("Error running hook %s with message: %s", curHook.Name, possibleError.Error())
+				terragruntOptions.Logger.Errorf("Error running hook %s with message: %s", curHook.Name, possibleError.Error())
 				errorsOccurred = append(errorsOccurred, possibleError)
 			}
 
@@ -674,7 +674,7 @@ func runActionWithHooks(description string, terragruntOptions *options.Terragrun
 	if beforeHookErrors == nil {
 		actionErrors = action()
 	} else {
-		terragruntOptions.Logger.Infof("Errors encountered running before_hooks. Not running '%s'.", description)
+		terragruntOptions.Logger.Errorf("Errors encountered running before_hooks. Not running '%s'.", description)
 	}
 
 	postHookErrors := processHooks(terragruntConfig.Terraform.GetAfterHooks(), terragruntOptions, beforeHookErrors, actionErrors)

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -33,14 +33,14 @@ func downloadTerraformSource(source string, terragruntOptions *options.Terragrun
 		return nil, err
 	}
 
-	terragruntOptions.Logger.Infof("Copying files from %s into %s", terragruntOptions.WorkingDir, terraformSource.WorkingDir)
+	terragruntOptions.Logger.Debugf("Copying files from %s into %s", terragruntOptions.WorkingDir, terraformSource.WorkingDir)
 	if err := util.CopyFolderContents(terragruntOptions.WorkingDir, terraformSource.WorkingDir, MODULE_MANIFEST_NAME); err != nil {
 		return nil, err
 	}
 
 	updatedTerragruntOptions := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
 
-	terragruntOptions.Logger.Infof("Setting working directory to %s", terraformSource.WorkingDir)
+	terragruntOptions.Logger.Debugf("Setting working directory to %s", terraformSource.WorkingDir)
 	updatedTerragruntOptions.WorkingDir = terraformSource.WorkingDir
 
 	return updatedTerragruntOptions, nil
@@ -49,7 +49,7 @@ func downloadTerraformSource(source string, terragruntOptions *options.Terragrun
 // Download the specified TerraformSource if the latest code hasn't already been downloaded.
 func downloadTerraformSourceIfNecessary(terraformSource *tfsource.TerraformSource, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
 	if terragruntOptions.SourceUpdate {
-		terragruntOptions.Logger.Infof("The --%s flag is set, so deleting the temporary folder %s before downloading source.", OPT_TERRAGRUNT_SOURCE_UPDATE, terraformSource.DownloadDir)
+		terragruntOptions.Logger.Debugf("The --%s flag is set, so deleting the temporary folder %s before downloading source.", OPT_TERRAGRUNT_SOURCE_UPDATE, terraformSource.DownloadDir)
 		if err := os.RemoveAll(terraformSource.DownloadDir); err != nil {
 			return errors.WithStackTrace(err)
 		}
@@ -61,7 +61,7 @@ func downloadTerraformSourceIfNecessary(terraformSource *tfsource.TerraformSourc
 	}
 
 	if alreadyLatest {
-		terragruntOptions.Logger.Infof("Terraform files in %s are up to date. Will not download again.", terraformSource.WorkingDir)
+		terragruntOptions.Logger.Debugf("Terraform files in %s are up to date. Will not download again.", terraformSource.WorkingDir)
 		return nil
 	}
 
@@ -104,7 +104,7 @@ func alreadyHaveLatestCode(terraformSource *tfsource.TerraformSource, terragrunt
 	}
 
 	if len(tfFiles) == 0 {
-		terragruntOptions.Logger.Infof("Working dir %s exists but contains no Terraform files, so assuming code needs to be downloaded again.", terraformSource.WorkingDir)
+		terragruntOptions.Logger.Debugf("Working dir %s exists but contains no Terraform files, so assuming code needs to be downloaded again.", terraformSource.WorkingDir)
 		return false, nil
 	}
 
@@ -146,7 +146,7 @@ var copyFiles = func(client *getter.Client) error {
 
 // Download the code from the Canonical Source URL into the Download Folder using the go-getter library
 func downloadSource(terraformSource *tfsource.TerraformSource, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
-	terragruntOptions.Logger.Infof("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
+	terragruntOptions.Logger.Debugf("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
 
 	if err := getter.GetAny(terraformSource.DownloadDir, terraformSource.CanonicalSourceURL.String(), copyFiles); err != nil {
 		return errors.WithStackTrace(err)

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -33,14 +33,14 @@ func downloadTerraformSource(source string, terragruntOptions *options.Terragrun
 		return nil, err
 	}
 
-	terragruntOptions.Logger.Printf("Copying files from %s into %s", terragruntOptions.WorkingDir, terraformSource.WorkingDir)
+	terragruntOptions.Logger.Infof("Copying files from %s into %s", terragruntOptions.WorkingDir, terraformSource.WorkingDir)
 	if err := util.CopyFolderContents(terragruntOptions.WorkingDir, terraformSource.WorkingDir, MODULE_MANIFEST_NAME); err != nil {
 		return nil, err
 	}
 
 	updatedTerragruntOptions := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
 
-	terragruntOptions.Logger.Printf("Setting working directory to %s", terraformSource.WorkingDir)
+	terragruntOptions.Logger.Infof("Setting working directory to %s", terraformSource.WorkingDir)
 	updatedTerragruntOptions.WorkingDir = terraformSource.WorkingDir
 
 	return updatedTerragruntOptions, nil
@@ -49,7 +49,7 @@ func downloadTerraformSource(source string, terragruntOptions *options.Terragrun
 // Download the specified TerraformSource if the latest code hasn't already been downloaded.
 func downloadTerraformSourceIfNecessary(terraformSource *tfsource.TerraformSource, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
 	if terragruntOptions.SourceUpdate {
-		terragruntOptions.Logger.Printf("The --%s flag is set, so deleting the temporary folder %s before downloading source.", OPT_TERRAGRUNT_SOURCE_UPDATE, terraformSource.DownloadDir)
+		terragruntOptions.Logger.Infof("The --%s flag is set, so deleting the temporary folder %s before downloading source.", OPT_TERRAGRUNT_SOURCE_UPDATE, terraformSource.DownloadDir)
 		if err := os.RemoveAll(terraformSource.DownloadDir); err != nil {
 			return errors.WithStackTrace(err)
 		}
@@ -61,7 +61,7 @@ func downloadTerraformSourceIfNecessary(terraformSource *tfsource.TerraformSourc
 	}
 
 	if alreadyLatest {
-		terragruntOptions.Logger.Printf("Terraform files in %s are up to date. Will not download again.", terraformSource.WorkingDir)
+		terragruntOptions.Logger.Infof("Terraform files in %s are up to date. Will not download again.", terraformSource.WorkingDir)
 		return nil
 	}
 
@@ -104,7 +104,7 @@ func alreadyHaveLatestCode(terraformSource *tfsource.TerraformSource, terragrunt
 	}
 
 	if len(tfFiles) == 0 {
-		terragruntOptions.Logger.Printf("Working dir %s exists but contains no Terraform files, so assuming code needs to be downloaded again.", terraformSource.WorkingDir)
+		terragruntOptions.Logger.Infof("Working dir %s exists but contains no Terraform files, so assuming code needs to be downloaded again.", terraformSource.WorkingDir)
 		return false, nil
 	}
 
@@ -146,7 +146,7 @@ var copyFiles = func(client *getter.Client) error {
 
 // Download the code from the Canonical Source URL into the Download Folder using the go-getter library
 func downloadSource(terraformSource *tfsource.TerraformSource, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
-	terragruntOptions.Logger.Printf("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
+	terragruntOptions.Logger.Infof("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
 
 	if err := getter.GetAny(terraformSource.DownloadDir, terraformSource.CanonicalSourceURL.String(), copyFiles); err != nil {
 		return errors.WithStackTrace(err)

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -29,11 +29,11 @@ func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
 		if !filepath.IsAbs(targetFile) {
 			targetFile = util.JoinPath(workingDir, targetFile)
 		}
-		terragruntOptions.Logger.Printf("Formatting terragrunt.hcl file at: %s.", targetFile)
+		terragruntOptions.Logger.Infof("Formatting terragrunt.hcl file at: %s.", targetFile)
 		return formatTgHCL(terragruntOptions, targetFile)
 	}
 
-	terragruntOptions.Logger.Printf("Formatting terragrunt.hcl files from the directory tree %s.", terragruntOptions.WorkingDir)
+	terragruntOptions.Logger.Infof("Formatting terragrunt.hcl files from the directory tree %s.", terragruntOptions.WorkingDir)
 	// zglob normalizes paths to "/"
 	tgHclFiles, err := zglob.Glob(util.JoinPath(workingDir, "**", "*.hcl"))
 	if err != nil {
@@ -66,24 +66,24 @@ func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
 // formatTgHCL uses the hcl2 library to format the terragrunt.hcl file. This will attempt to parse the HCL file first to
 // ensure that there are no syntax errors, before attempting to format it.
 func formatTgHCL(terragruntOptions *options.TerragruntOptions, tgHclFile string) error {
-	terragruntOptions.Logger.Printf("Formatting %s", tgHclFile)
+	terragruntOptions.Logger.Infof("Formatting %s", tgHclFile)
 
 	info, err := os.Stat(tgHclFile)
 	if err != nil {
-		terragruntOptions.Logger.Printf("Error retrieving file info of %s", tgHclFile)
+		terragruntOptions.Logger.Infof("Error retrieving file info of %s", tgHclFile)
 		return err
 	}
 
 	contentsStr, err := util.ReadFileAsString(tgHclFile)
 	if err != nil {
-		terragruntOptions.Logger.Printf("Error reading %s", tgHclFile)
+		terragruntOptions.Logger.Infof("Error reading %s", tgHclFile)
 		return err
 	}
 	contents := []byte(contentsStr)
 
 	err = checkErrors(contents, tgHclFile)
 	if err != nil {
-		terragruntOptions.Logger.Printf("Error parsing %s", tgHclFile)
+		terragruntOptions.Logger.Infof("Error parsing %s", tgHclFile)
 		return err
 	}
 

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -70,20 +70,20 @@ func formatTgHCL(terragruntOptions *options.TerragruntOptions, tgHclFile string)
 
 	info, err := os.Stat(tgHclFile)
 	if err != nil {
-		terragruntOptions.Logger.Infof("Error retrieving file info of %s", tgHclFile)
+		terragruntOptions.Logger.Errorf("Error retrieving file info of %s", tgHclFile)
 		return err
 	}
 
 	contentsStr, err := util.ReadFileAsString(tgHclFile)
 	if err != nil {
-		terragruntOptions.Logger.Infof("Error reading %s", tgHclFile)
+		terragruntOptions.Logger.Errorf("Error reading %s", tgHclFile)
 		return err
 	}
 	contents := []byte(contentsStr)
 
 	err = checkErrors(contents, tgHclFile)
 	if err != nil {
-		terragruntOptions.Logger.Infof("Error parsing %s", tgHclFile)
+		terragruntOptions.Logger.Errorf("Error parsing %s", tgHclFile)
 		return err
 	}
 

--- a/cli/version_check.go
+++ b/cli/version_check.go
@@ -47,7 +47,7 @@ func PopulateTerraformVersion(terragruntOptions *options.TerragruntOptions) erro
 	}
 
 	terragruntOptions.TerraformVersion = terraformVersion
-	terragruntOptions.Logger.Printf("Terraform version: %s", terraformVersion)
+	terragruntOptions.Logger.Infof("Terraform version: %s", terraformVersion)
 	return nil
 }
 

--- a/cli/version_check.go
+++ b/cli/version_check.go
@@ -47,7 +47,7 @@ func PopulateTerraformVersion(terragruntOptions *options.TerragruntOptions) erro
 	}
 
 	terragruntOptions.TerraformVersion = terraformVersion
-	terragruntOptions.Logger.Infof("Terraform version: %s", terraformVersion)
+	terragruntOptions.Logger.Debugf("Terraform version: %s", terraformVersion)
 	return nil
 }
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -469,7 +469,7 @@ func terragruntAlreadyInit(terragruntOptions *options.TerragruntOptions, configP
 func getTerragruntOutputJsonFromInitFolder(terragruntOptions *options.TerragruntOptions, terraformWorkingDir string, iamRole string) ([]byte, error) {
 	targetConfig := terragruntOptions.TerragruntConfigPath
 
-	terragruntOptions.Logger.Infof("Detected module %s is already init-ed. Retrieving outputs directly from working directory.", targetConfig)
+	terragruntOptions.Logger.Debugf("Detected module %s is already init-ed. Retrieving outputs directly from working directory.", targetConfig)
 
 	targetTGOptions, err := setupTerragruntOptionsForBareTerraform(terragruntOptions, terraformWorkingDir, targetConfig, iamRole)
 	if err != nil {

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -249,7 +249,7 @@ func (module *runningModule) moduleFinished(moduleErr error) {
 	if moduleErr == nil {
 		module.Module.TerragruntOptions.Logger.Debugf("Module %s has finished successfully!", module.Module.Path)
 	} else {
-		module.Module.TerragruntOptions.Logger.Infof("Module %s has finished with an error: %v", module.Module.Path, moduleErr)
+		module.Module.TerragruntOptions.Logger.Errorf("Module %s has finished with an error: %v", module.Module.Path, moduleErr)
 	}
 
 	module.Status = Finished

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -249,7 +249,7 @@ func (module *runningModule) moduleFinished(moduleErr error) {
 	if moduleErr == nil {
 		module.Module.TerragruntOptions.Logger.Debugf("Module %s has finished successfully!", module.Module.Path)
 	} else {
-		module.Module.TerragruntOptions.Logger.Printf("Module %s has finished with an error: %v", module.Module.Path, moduleErr)
+		module.Module.TerragruntOptions.Logger.Infof("Module %s has finished with an error: %v", module.Module.Path, moduleErr)
 	}
 
 	module.Status = Finished

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -77,14 +77,14 @@ func (stack *Stack) Run(terragruntOptions *options.TerragruntOptions) error {
 func (stack *Stack) summarizePlanAllErrors(terragruntOptions *options.TerragruntOptions, errorStreams []bytes.Buffer) {
 	for i, errorStream := range errorStreams {
 		output := errorStream.String()
-		terragruntOptions.Logger.Println(output)
+		terragruntOptions.Logger.Infoln(output)
 		if strings.Contains(output, "Error running plan:") {
 			if strings.Contains(output, ": Resource 'data.terraform_remote_state.") {
 				var dependenciesMsg string
 				if len(stack.Modules[i].Dependencies) > 0 {
 					dependenciesMsg = fmt.Sprintf(" contains dependencies to %v and", stack.Modules[i].Config.Dependencies.Paths)
 				}
-				terragruntOptions.Logger.Printf("%v%v refers to remote state "+
+				terragruntOptions.Logger.Infof("%v%v refers to remote state "+
 					"you may have to apply your changes in the dependencies prior running terragrunt plan-all.\n",
 					stack.Modules[i].Path,
 					dependenciesMsg,

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -561,8 +561,8 @@ When passed it, sets logging level for terragrunt. All supported levels are:
 * panic
 * fatal
 * error
-* warn (this is the default)
-* info
+* warn
+* info (this is the default)
 * debug
 * trace
 

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -44,7 +44,7 @@ func CreateLockTableIfNecessary(tableName string, tags map[string]string, client
 	}
 
 	if !tableExists {
-		terragruntOptions.Logger.Printf("Lock table %s does not exist in DynamoDB. Will need to create it just this first time.", tableName)
+		terragruntOptions.Logger.Infof("Lock table %s does not exist in DynamoDB. Will need to create it just this first time.", tableName)
 		return CreateLockTable(tableName, tags, client, terragruntOptions)
 	}
 
@@ -81,7 +81,7 @@ func CreateLockTable(tableName string, tags map[string]string, client *dynamodb.
 	tableCreateDeleteSemaphore.Acquire()
 	defer tableCreateDeleteSemaphore.Release()
 
-	terragruntOptions.Logger.Printf("Creating table %s in DynamoDB", tableName)
+	terragruntOptions.Logger.Infof("Creating table %s in DynamoDB", tableName)
 
 	attributeDefinitions := []*dynamodb.AttributeDefinition{
 		{AttributeName: aws.String(ATTR_LOCK_ID), AttributeType: aws.String(dynamodb.ScalarAttributeTypeS)},
@@ -100,7 +100,7 @@ func CreateLockTable(tableName string, tags map[string]string, client *dynamodb.
 
 	if err != nil {
 		if isTableAlreadyBeingCreatedOrUpdatedError(err) {
-			terragruntOptions.Logger.Printf("Looks like someone created table %s at the same time. Will wait for it to be in active state.", tableName)
+			terragruntOptions.Logger.Infof("Looks like someone created table %s at the same time. Will wait for it to be in active state.", tableName)
 		} else {
 			return errors.WithStackTrace(err)
 		}
@@ -128,12 +128,12 @@ func CreateLockTable(tableName string, tags map[string]string, client *dynamodb.
 func tagTableIfTagsGiven(tags map[string]string, tableArn *string, client *dynamodb.DynamoDB, terragruntOptions *options.TerragruntOptions) error {
 
 	if tags == nil || len(tags) == 0 {
-		terragruntOptions.Logger.Printf("No tags for lock table given.")
+		terragruntOptions.Logger.Infof("No tags for lock table given.")
 		return nil
 	}
 
 	// we were able to create the table successfully, now add tags
-	terragruntOptions.Logger.Printf("Adding tags to lock table: %s", tags)
+	terragruntOptions.Logger.Infof("Adding tags to lock table: %s", tags)
 
 	var tagsConverted []*dynamodb.Tag
 
@@ -183,12 +183,12 @@ func waitForTableToBeActiveWithRandomSleep(tableName string, client *dynamodb.Dy
 		}
 
 		if tableReady {
-			terragruntOptions.Logger.Printf("Success! Table %s is now in active state.", tableName)
+			terragruntOptions.Logger.Infof("Success! Table %s is now in active state.", tableName)
 			return nil
 		}
 
 		sleepBetweenRetries := util.GetRandomTime(sleepBetweenRetriesMin, sleepBetweenRetriesMax)
-		terragruntOptions.Logger.Printf("Table %s is not yet in active state. Will check again after %s.", tableName, sleepBetweenRetries)
+		terragruntOptions.Logger.Infof("Table %s is not yet in active state. Will check again after %s.", tableName, sleepBetweenRetries)
 		time.Sleep(sleepBetweenRetries)
 	}
 
@@ -203,14 +203,14 @@ func UpdateLockTableSetSSEncryptionOnIfNecessary(tableName string, client *dynam
 	}
 
 	if tableSSEncrypted {
-		terragruntOptions.Logger.Printf("Table %s already has encryption enabled", tableName)
+		terragruntOptions.Logger.Infof("Table %s already has encryption enabled", tableName)
 		return nil
 	}
 
 	tableCreateDeleteSemaphore.Acquire()
 	defer tableCreateDeleteSemaphore.Release()
 
-	terragruntOptions.Logger.Printf("Enabling server-side encryption on table %s in AWS DynamoDB", tableName)
+	terragruntOptions.Logger.Infof("Enabling server-side encryption on table %s in AWS DynamoDB", tableName)
 
 	input := &dynamodb.UpdateTableInput{
 		SSESpecification: &dynamodb.SSESpecification{
@@ -222,7 +222,7 @@ func UpdateLockTableSetSSEncryptionOnIfNecessary(tableName string, client *dynam
 
 	if _, err := client.UpdateTable(input); err != nil {
 		if isTableAlreadyBeingCreatedOrUpdatedError(err) {
-			terragruntOptions.Logger.Printf("Looks like someone is already updating table %s at the same time. Will wait for that update to complete.", tableName)
+			terragruntOptions.Logger.Infof("Looks like someone is already updating table %s at the same time. Will wait for that update to complete.", tableName)
 		} else {
 			return errors.WithStackTrace(err)
 		}
@@ -240,7 +240,7 @@ func waitForEncryptionToBeEnabled(tableName string, client *dynamodb.DynamoDB, t
 	maxRetries := 15
 	sleepBetweenRetries := 20 * time.Second
 
-	terragruntOptions.Logger.Printf("Waiting for encryption to be enabled on table %s", tableName)
+	terragruntOptions.Logger.Infof("Waiting for encryption to be enabled on table %s", tableName)
 
 	for i := 0; i < maxRetries; i++ {
 		tableSSEncrypted, err := LockTableCheckSSEncryptionIsOn(tableName, client)
@@ -249,11 +249,11 @@ func waitForEncryptionToBeEnabled(tableName string, client *dynamodb.DynamoDB, t
 		}
 
 		if tableSSEncrypted {
-			terragruntOptions.Logger.Printf("Encryption is now enabled for table %s!", tableName)
+			terragruntOptions.Logger.Infof("Encryption is now enabled for table %s!", tableName)
 			return nil
 		}
 
-		terragruntOptions.Logger.Printf("Encryption is still not enabled for table %s. Will sleep for %v and try again.", tableName, sleepBetweenRetries)
+		terragruntOptions.Logger.Infof("Encryption is still not enabled for table %s. Will sleep for %v and try again.", tableName, sleepBetweenRetries)
 		time.Sleep(sleepBetweenRetries)
 	}
 

--- a/options/options.go
+++ b/options/options.go
@@ -227,7 +227,7 @@ func NewTerragruntOptionsForTest(terragruntConfigPath string) (*TerragruntOption
 
 	if err != nil {
 		logger := util.CreateLogEntry("", DEFAULT_LOG_LEVEL)
-		logger.Errorf("error: %v\n", errors.WithStackTrace(err))
+		logger.Errorf("%v\n", errors.WithStackTrace(err))
 		return nil, err
 	}
 

--- a/options/options.go
+++ b/options/options.go
@@ -227,7 +227,7 @@ func NewTerragruntOptionsForTest(terragruntConfigPath string) (*TerragruntOption
 
 	if err != nil {
 		logger := util.CreateLogEntry("", DEFAULT_LOG_LEVEL)
-		logger.Infof("error: %v\n", errors.WithStackTrace(err))
+		logger.Errorf("error: %v\n", errors.WithStackTrace(err))
 		return nil, err
 	}
 

--- a/options/options.go
+++ b/options/options.go
@@ -227,7 +227,7 @@ func NewTerragruntOptionsForTest(terragruntConfigPath string) (*TerragruntOption
 
 	if err != nil {
 		logger := util.CreateLogEntry("", DEFAULT_LOG_LEVEL)
-		logger.Printf("error: %v\n", errors.WithStackTrace(err))
+		logger.Infof("error: %v\n", errors.WithStackTrace(err))
 		return nil, err
 	}
 

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -64,7 +64,7 @@ func (remoteState *RemoteState) Validate() error {
 // Perform any actions necessary to initialize the remote state before it's used for storage. For example, if you're
 // using S3 or GCS for remote state storage, this may create the bucket if it doesn't exist already.
 func (remoteState *RemoteState) Initialize(terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Initializing remote state for the %s backend", remoteState.Backend)
+	terragruntOptions.Logger.Infof("Initializing remote state for the %s backend", remoteState.Backend)
 	initializer, hasInitializer := remoteStateInitializers[remoteState.Backend]
 	if hasInitializer {
 		return initializer.Initialize(remoteState, terragruntOptions)
@@ -116,7 +116,7 @@ func (remoteState *RemoteState) differsFrom(existingBackend *TerraformBackend, t
 		return true
 	}
 
-	terragruntOptions.Logger.Printf("Backend %s has not changed.", existingBackend.Type)
+	terragruntOptions.Logger.Infof("Backend %s has not changed.", existingBackend.Type)
 	return false
 }
 

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -64,7 +64,7 @@ func (remoteState *RemoteState) Validate() error {
 // Perform any actions necessary to initialize the remote state before it's used for storage. For example, if you're
 // using S3 or GCS for remote state storage, this may create the bucket if it doesn't exist already.
 func (remoteState *RemoteState) Initialize(terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Infof("Initializing remote state for the %s backend", remoteState.Backend)
+	terragruntOptions.Logger.Debugf("Initializing remote state for the %s backend", remoteState.Backend)
 	initializer, hasInitializer := remoteStateInitializers[remoteState.Backend]
 	if hasInitializer {
 		return initializer.Initialize(remoteState, terragruntOptions)
@@ -116,7 +116,7 @@ func (remoteState *RemoteState) differsFrom(existingBackend *TerraformBackend, t
 		return true
 	}
 
-	terragruntOptions.Logger.Infof("Backend %s has not changed.", existingBackend.Type)
+	terragruntOptions.Logger.Debugf("Backend %s has not changed.", existingBackend.Type)
 	return false
 }
 

--- a/remote/remote_state_gcs.go
+++ b/remote/remote_state_gcs.go
@@ -117,7 +117,7 @@ func gcsConfigValuesEqual(config map[string]interface{}, existingBackend *Terraf
 	}
 
 	if existingBackend.Type != "gcs" {
-		terragruntOptions.Logger.Printf("Backend type has changed from gcs to %s", existingBackend.Type)
+		terragruntOptions.Logger.Infof("Backend type has changed from gcs to %s", existingBackend.Type)
 		return false
 	}
 
@@ -245,7 +245,7 @@ func validateGCSConfig(extendedConfig *ExtendedRemoteStateConfigGCS, terragruntO
 // confirms, create the bucket and enable versioning for it.
 func createGCSBucketIfNecessary(gcsClient *storage.Client, config *ExtendedRemoteStateConfigGCS, terragruntOptions *options.TerragruntOptions) error {
 	if !DoesGCSBucketExist(gcsClient, &config.remoteStateConfigGCS) {
-		terragruntOptions.Logger.Printf("Remote state GCS bucket %s does not exist. Attempting to create it", config.remoteStateConfigGCS.Bucket)
+		terragruntOptions.Logger.Infof("Remote state GCS bucket %s does not exist. Attempting to create it", config.remoteStateConfigGCS.Bucket)
 
 		// A project must be specified in order for terragrunt to automatically create a storage bucket.
 		if config.Project == "" {
@@ -290,7 +290,7 @@ func checkIfGCSVersioningEnabled(gcsClient *storage.Client, config *RemoteStateC
 	}
 
 	if attrs.VersioningEnabled == false {
-		terragruntOptions.Logger.Printf("WARNING: Versioning is not enabled for the remote state GCS bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
+		terragruntOptions.Logger.Infof("WARNING: Versioning is not enabled for the remote state GCS bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
 	}
 
 	return nil
@@ -317,11 +317,11 @@ func CreateGCSBucketWithVersioning(gcsClient *storage.Client, config *ExtendedRe
 
 func AddLabelsToGCSBucket(gcsClient *storage.Client, config *ExtendedRemoteStateConfigGCS, terragruntOptions *options.TerragruntOptions) error {
 	if config.GCSBucketLabels == nil || len(config.GCSBucketLabels) == 0 {
-		terragruntOptions.Logger.Printf("No labels specified for bucket %s.", config.remoteStateConfigGCS.Bucket)
+		terragruntOptions.Logger.Infof("No labels specified for bucket %s.", config.remoteStateConfigGCS.Bucket)
 		return nil
 	}
 
-	terragruntOptions.Logger.Printf("Adding labels to GCS bucket with %s", config.GCSBucketLabels)
+	terragruntOptions.Logger.Infof("Adding labels to GCS bucket with %s", config.GCSBucketLabels)
 
 	ctx := context.Background()
 	bucket := gcsClient.Bucket(config.remoteStateConfigGCS.Bucket)
@@ -344,7 +344,7 @@ func AddLabelsToGCSBucket(gcsClient *storage.Client, config *ExtendedRemoteState
 
 // Create the GCS bucket specified in the given config
 func CreateGCSBucket(gcsClient *storage.Client, config *ExtendedRemoteStateConfigGCS, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Creating GCS bucket %s in project %s", config.remoteStateConfigGCS.Bucket, config.Project)
+	terragruntOptions.Logger.Infof("Creating GCS bucket %s in project %s", config.remoteStateConfigGCS.Bucket, config.Project)
 
 	// The project ID to which the bucket belongs. This is only used when creating a new bucket during initialization.
 	// Since buckets have globally unique names, the project ID is not required to access the bucket during normal
@@ -357,19 +357,19 @@ func CreateGCSBucket(gcsClient *storage.Client, config *ExtendedRemoteStateConfi
 	bucketAttrs := &storage.BucketAttrs{}
 
 	if config.Location != "" {
-		terragruntOptions.Logger.Printf("Creating GCS bucket in location %s.", config.Location)
+		terragruntOptions.Logger.Infof("Creating GCS bucket in location %s.", config.Location)
 		bucketAttrs.Location = config.Location
 	}
 
 	if config.SkipBucketVersioning {
-		terragruntOptions.Logger.Printf("Versioning is disabled for the remote state GCS bucket %s using 'skip_bucket_versioning' config.", config.remoteStateConfigGCS.Bucket)
+		terragruntOptions.Logger.Infof("Versioning is disabled for the remote state GCS bucket %s using 'skip_bucket_versioning' config.", config.remoteStateConfigGCS.Bucket)
 	} else {
-		terragruntOptions.Logger.Printf("Enabling versioning on GCS bucket %s", config.remoteStateConfigGCS.Bucket)
+		terragruntOptions.Logger.Infof("Enabling versioning on GCS bucket %s", config.remoteStateConfigGCS.Bucket)
 		bucketAttrs.VersioningEnabled = true
 	}
 
 	if config.EnableBucketPolicyOnly {
-		terragruntOptions.Logger.Printf("Enabling uniform bucket-level access on GCS bucket %s", config.remoteStateConfigGCS.Bucket)
+		terragruntOptions.Logger.Infof("Enabling uniform bucket-level access on GCS bucket %s", config.remoteStateConfigGCS.Bucket)
 		bucketAttrs.BucketPolicyOnly = storage.BucketPolicyOnly{Enabled: true}
 	}
 
@@ -380,13 +380,13 @@ func CreateGCSBucket(gcsClient *storage.Client, config *ExtendedRemoteStateConfi
 // GCP is eventually consistent, so after creating a GCS bucket, this method can be used to wait until the information
 // about that GCS bucket has propagated everywhere.
 func WaitUntilGCSBucketExists(gcsClient *storage.Client, config *RemoteStateConfigGCS, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Waiting for bucket %s to be created", config.Bucket)
+	terragruntOptions.Logger.Infof("Waiting for bucket %s to be created", config.Bucket)
 	for retries := 0; retries < MAX_RETRIES_WAITING_FOR_GCS_BUCKET; retries++ {
 		if DoesGCSBucketExist(gcsClient, config) {
-			terragruntOptions.Logger.Printf("GCS bucket %s created.", config.Bucket)
+			terragruntOptions.Logger.Infof("GCS bucket %s created.", config.Bucket)
 			return nil
 		} else if retries < MAX_RETRIES_WAITING_FOR_GCS_BUCKET-1 {
-			terragruntOptions.Logger.Printf("GCS bucket %s has not been created yet. Sleeping for %s and will check again.", config.Bucket, SLEEP_BETWEEN_RETRIES_WAITING_FOR_GCS_BUCKET)
+			terragruntOptions.Logger.Infof("GCS bucket %s has not been created yet. Sleeping for %s and will check again.", config.Bucket, SLEEP_BETWEEN_RETRIES_WAITING_FOR_GCS_BUCKET)
 			time.Sleep(SLEEP_BETWEEN_RETRIES_WAITING_FOR_GCS_BUCKET)
 		}
 	}

--- a/remote/remote_state_gcs.go
+++ b/remote/remote_state_gcs.go
@@ -118,7 +118,7 @@ func gcsConfigValuesEqual(config map[string]interface{}, existingBackend *Terraf
 	}
 
 	if existingBackend.Type != "gcs" {
-		terragruntOptions.Logger.Infof("Backend type has changed from gcs to %s", existingBackend.Type)
+		terragruntOptions.Logger.Debugf("Backend type has changed from gcs to %s", existingBackend.Type)
 		return false
 	}
 
@@ -291,7 +291,7 @@ func checkIfGCSVersioningEnabled(gcsClient *storage.Client, config *RemoteStateC
 	}
 
 	if attrs.VersioningEnabled == false {
-		terragruntOptions.Logger.Warnf("WARNING: Versioning is not enabled for the remote state GCS bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
+		terragruntOptions.Logger.Warnf("Versioning is not enabled for the remote state GCS bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
 	}
 
 	return nil

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -125,7 +125,7 @@ func (s3Initializer S3Initializer) NeedsInitialization(remoteState *RemoteState,
 	// from it altogether. Display a deprecation warning when the "lock_table"
 	// attribute is being used.
 	if util.KindOf(remoteState.Config["lock_table"]) == reflect.String && remoteState.Config["lock_table"] != "" {
-		terragruntOptions.Logger.Printf("%s\n", lockTableDeprecationMessage)
+		terragruntOptions.Logger.Infof("%s\n", lockTableDeprecationMessage)
 		remoteState.Config["dynamodb_table"] = remoteState.Config["lock_table"]
 		delete(remoteState.Config, "lock_table")
 	}
@@ -176,7 +176,7 @@ func configValuesEqual(config map[string]interface{}, existingBackend *Terraform
 	}
 
 	if existingBackend.Type != "s3" {
-		terragruntOptions.Logger.Printf("Backend type has changed from s3 to %s", existingBackend.Type)
+		terragruntOptions.Logger.Infof("Backend type has changed from s3 to %s", existingBackend.Type)
 		return false
 	}
 
@@ -193,7 +193,7 @@ func configValuesEqual(config map[string]interface{}, existingBackend *Terraform
 		if value, err := strconv.ParseBool(existingBackend.Config["encrypt"].(string)); err == nil {
 			existingBackend.Config["encrypt"] = value
 		} else {
-			terragruntOptions.Logger.Printf("Remote state configuration encrypt contains invalid value %v, should be boolean.", existingBackend.Config["encrypt"])
+			terragruntOptions.Logger.Infof("Remote state configuration encrypt contains invalid value %v, should be boolean.", existingBackend.Config["encrypt"])
 		}
 	}
 
@@ -240,7 +240,7 @@ func (s3Initializer S3Initializer) Initialize(remoteState *RemoteState, terragru
 	// Display a deprecation warning when the "lock_table" attribute is being used
 	// during initialization.
 	if s3Config.LockTable != "" {
-		terragruntOptions.Logger.Printf("%s\n", lockTableDeprecationMessage)
+		terragruntOptions.Logger.Infof("%s\n", lockTableDeprecationMessage)
 	}
 
 	s3Client, err := CreateS3Client(s3ConfigExtended.GetAwsSessionConfig(), terragruntOptions)
@@ -334,7 +334,7 @@ func validateS3Config(extendedConfig *ExtendedRemoteStateConfigS3, terragruntOpt
 	}
 
 	if !config.Encrypt {
-		terragruntOptions.Logger.Printf("WARNING: encryption is not enabled on the S3 remote state bucket %s. Terraform state files may contain secrets, so we STRONGLY recommend enabling encryption!", config.Bucket)
+		terragruntOptions.Logger.Infof("WARNING: encryption is not enabled on the S3 remote state bucket %s. Terraform state files may contain secrets, so we STRONGLY recommend enabling encryption!", config.Bucket)
 	}
 
 	return nil
@@ -380,7 +380,7 @@ func checkIfVersioningEnabled(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 	// NOTE: There must be a bug in the AWS SDK since out == nil when versioning is not enabled. In the future,
 	// check the AWS SDK for updates to see if we can remove "out == nil ||".
 	if out == nil || out.Status == nil || *out.Status != s3.BucketVersioningStatusEnabled {
-		terragruntOptions.Logger.Printf("WARNING: Versioning is not enabled for the remote state S3 bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
+		terragruntOptions.Logger.Infof("WARNING: Versioning is not enabled for the remote state S3 bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
 	}
 
 	return nil
@@ -392,7 +392,7 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 
 	if err != nil {
 		if isBucketAlreadyOwnedByYouError(err) {
-			terragruntOptions.Logger.Printf("Looks like you're already creating bucket %s at the same time. Will not attempt to create it again.", config.remoteStateConfigS3.Bucket)
+			terragruntOptions.Logger.Infof("Looks like you're already creating bucket %s at the same time. Will not attempt to create it again.", config.remoteStateConfigS3.Bucket)
 			return WaitUntilS3BucketExists(s3Client, &config.remoteStateConfigS3, terragruntOptions)
 		}
 
@@ -404,13 +404,13 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 	}
 
 	if config.SkipBucketRootAccess {
-		terragruntOptions.Logger.Printf("Root access is disabled for the remote state S3 bucket %s using 'skip_bucket_root_access' config.", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Infof("Root access is disabled for the remote state S3 bucket %s using 'skip_bucket_root_access' config.", config.remoteStateConfigS3.Bucket)
 	} else if err := EnableRootAccesstoS3Bucket(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
 
 	if config.SkipBucketEnforcedTLS {
-		terragruntOptions.Logger.Printf("TLS enforcement is disabled for the remote state S3 bucket %s using 'skip_bucket_enforced_tls' config.", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Infof("TLS enforcement is disabled for the remote state S3 bucket %s using 'skip_bucket_enforced_tls' config.", config.remoteStateConfigS3.Bucket)
 	} else if err := EnableEnforcedTLSAccesstoS3Bucket(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
@@ -424,26 +424,26 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 	}
 
 	if config.SkipBucketVersioning {
-		terragruntOptions.Logger.Printf("Versioning is disabled for the remote state S3 bucket %s using 'skip_bucket_versioning' config.", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Infof("Versioning is disabled for the remote state S3 bucket %s using 'skip_bucket_versioning' config.", config.remoteStateConfigS3.Bucket)
 	} else if err := EnableVersioningForS3Bucket(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
 
 	if config.SkipBucketSSEncryption {
-		terragruntOptions.Logger.Printf("Server-Side Encryption is disabled for the remote state AWS S3 bucket %s using 'skip_bucket_ssencryption' config.", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Infof("Server-Side Encryption is disabled for the remote state AWS S3 bucket %s using 'skip_bucket_ssencryption' config.", config.remoteStateConfigS3.Bucket)
 	} else if err := EnableSSEForS3BucketWide(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
 
 	if config.SkipBucketAccessLogging {
-		terragruntOptions.Logger.Printf("___WARNING___: The terragrunt configuration option 'skip_bucket_accesslogging' is now deprecated. Access logging for the state bucket %s is disabled by default. To enable access logging for bucket %s, please provide property `accesslogging_bucket_name` in the terragrunt config file. For more details, please refer to the Terragrunt documentation.", config.remoteStateConfigS3.Bucket, config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Infof("___WARNING___: The terragrunt configuration option 'skip_bucket_accesslogging' is now deprecated. Access logging for the state bucket %s is disabled by default. To enable access logging for bucket %s, please provide property `accesslogging_bucket_name` in the terragrunt config file. For more details, please refer to the Terragrunt documentation.", config.remoteStateConfigS3.Bucket, config.remoteStateConfigS3.Bucket)
 	}
 
 	if config.AccessLoggingBucketName != "" {
-		terragruntOptions.Logger.Printf("Enabling bucket-wide Access Logging on AWS S3 bucket %s - using as TargetBucket %s", config.remoteStateConfigS3.Bucket, config.AccessLoggingBucketName)
+		terragruntOptions.Logger.Infof("Enabling bucket-wide Access Logging on AWS S3 bucket %s - using as TargetBucket %s", config.remoteStateConfigS3.Bucket, config.AccessLoggingBucketName)
 
 		if err := CreateLogsS3BucketIfNecessary(s3Client, aws.String(config.AccessLoggingBucketName), terragruntOptions); err != nil {
-			terragruntOptions.Logger.Printf("Error: Could not create logs bucket %s for AWS S3 bucket %s", config.AccessLoggingBucketName, config.remoteStateConfigS3.Bucket)
+			terragruntOptions.Logger.Infof("Error: Could not create logs bucket %s for AWS S3 bucket %s", config.AccessLoggingBucketName, config.remoteStateConfigS3.Bucket)
 			return err
 		}
 
@@ -451,7 +451,7 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 			return err
 		}
 	} else {
-		terragruntOptions.Logger.Printf("Access Logging is disabled for the remote state AWS S3 bucket %s", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Infof("Access Logging is disabled for the remote state AWS S3 bucket %s", config.remoteStateConfigS3.Bucket)
 	}
 
 	return nil
@@ -475,14 +475,14 @@ func CreateLogsS3BucketIfNecessary(s3Client *s3.S3, logsBucketName *string, terr
 func TagS3Bucket(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
 
 	if config.S3BucketTags == nil || len(config.S3BucketTags) == 0 {
-		terragruntOptions.Logger.Printf("No tags specified for bucket %s.", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Infof("No tags specified for bucket %s.", config.remoteStateConfigS3.Bucket)
 		return nil
 	}
 
 	// There must be one entry in the list
 	var tagsConverted = convertTags(config.S3BucketTags)
 
-	terragruntOptions.Logger.Printf("Tagging S3 bucket with %s", config.S3BucketTags)
+	terragruntOptions.Logger.Infof("Tagging S3 bucket with %s", config.S3BucketTags)
 
 	putBucketTaggingInput := s3.PutBucketTaggingInput{
 		Bucket: aws.String(config.remoteStateConfigS3.Bucket),
@@ -494,7 +494,7 @@ func TagS3Bucket(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragrun
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Printf("Tagged S3 bucket with %s", config.S3BucketTags)
+	terragruntOptions.Logger.Infof("Tagged S3 bucket with %s", config.S3BucketTags)
 	return nil
 }
 
@@ -516,13 +516,13 @@ func convertTags(tags map[string]string) []*s3.Tag {
 // AWS is eventually consistent, so after creating an S3 bucket, this method can be used to wait until the information
 // about that S3 bucket has propagated everywhere
 func WaitUntilS3BucketExists(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Waiting for bucket %s to be created", config.Bucket)
+	terragruntOptions.Logger.Infof("Waiting for bucket %s to be created", config.Bucket)
 	for retries := 0; retries < MAX_RETRIES_WAITING_FOR_S3_BUCKET; retries++ {
 		if DoesS3BucketExist(s3Client, aws.String(config.Bucket)) {
-			terragruntOptions.Logger.Printf("S3 bucket %s created.", config.Bucket)
+			terragruntOptions.Logger.Infof("S3 bucket %s created.", config.Bucket)
 			return nil
 		} else if retries < MAX_RETRIES_WAITING_FOR_S3_BUCKET-1 {
-			terragruntOptions.Logger.Printf("S3 bucket %s has not been created yet. Sleeping for %s and will check again.", config.Bucket, SLEEP_BETWEEN_RETRIES_WAITING_FOR_S3_BUCKET)
+			terragruntOptions.Logger.Infof("S3 bucket %s has not been created yet. Sleeping for %s and will check again.", config.Bucket, SLEEP_BETWEEN_RETRIES_WAITING_FOR_S3_BUCKET)
 			time.Sleep(SLEEP_BETWEEN_RETRIES_WAITING_FOR_S3_BUCKET)
 		}
 	}
@@ -532,12 +532,12 @@ func WaitUntilS3BucketExists(s3Client *s3.S3, config *RemoteStateConfigS3, terra
 
 // Create the S3 bucket specified in the given config
 func CreateS3Bucket(s3Client *s3.S3, bucket *string, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Creating S3 bucket %s", aws.StringValue(bucket))
+	terragruntOptions.Logger.Infof("Creating S3 bucket %s", aws.StringValue(bucket))
 	_, err := s3Client.CreateBucket(&s3.CreateBucketInput{Bucket: bucket})
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
-	terragruntOptions.Logger.Printf("Created S3 bucket %s", aws.StringValue(bucket))
+	terragruntOptions.Logger.Infof("Created S3 bucket %s", aws.StringValue(bucket))
 	return nil
 }
 
@@ -550,7 +550,7 @@ func isBucketAlreadyOwnedByYouError(err error) bool {
 
 // Add a policy to allow root access to the bucket
 func EnableRootAccesstoS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Enabling root access to S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Infof("Enabling root access to S3 bucket %s", config.Bucket)
 
 	accountID, err := aws_helper.GetAWSAccountID(terragruntOptions)
 	if err != nil {
@@ -590,13 +590,13 @@ func EnableRootAccesstoS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, te
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Printf("Enabled root access to bucket %s", config.Bucket)
+	terragruntOptions.Logger.Infof("Enabled root access to bucket %s", config.Bucket)
 	return nil
 }
 
 // Add a policy to enforce TLS based access to the bucket
 func EnableEnforcedTLSAccesstoS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Enabling enforced TLS access for S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Infof("Enabling enforced TLS access for S3 bucket %s", config.Bucket)
 
 	tlsS3Policy := map[string]interface{}{
 		"Version": "2012-10-17",
@@ -632,13 +632,13 @@ func EnableEnforcedTLSAccesstoS3Bucket(s3Client *s3.S3, config *RemoteStateConfi
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Printf("Enabled enforced TLS access for bucket %s", config.Bucket)
+	terragruntOptions.Logger.Infof("Enabled enforced TLS access for bucket %s", config.Bucket)
 	return nil
 }
 
 // Enable versioning for the S3 bucket specified in the given config
 func EnableVersioningForS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Enabling versioning on S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Infof("Enabling versioning on S3 bucket %s", config.Bucket)
 	input := s3.PutBucketVersioningInput{
 		Bucket:                  aws.String(config.Bucket),
 		VersioningConfiguration: &s3.VersioningConfiguration{Status: aws.String(s3.BucketVersioningStatusEnabled)},
@@ -649,13 +649,13 @@ func EnableVersioningForS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, t
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Printf("Enabled versioning on S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Infof("Enabled versioning on S3 bucket %s", config.Bucket)
 	return nil
 }
 
 // Enable bucket-wide Server-Side Encryption for the AWS S3 bucket specified in the given config
 func EnableSSEForS3BucketWide(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Enabling bucket-wide SSE on AWS S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Infof("Enabling bucket-wide SSE on AWS S3 bucket %s", config.Bucket)
 	// Encrypt with KMS by default
 	defEnc := &s3.ServerSideEncryptionByDefault{SSEAlgorithm: aws.String(s3.ServerSideEncryptionAwsKms)}
 	rule := &s3.ServerSideEncryptionRule{ApplyServerSideEncryptionByDefault: defEnc}
@@ -668,7 +668,7 @@ func EnableSSEForS3BucketWide(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Printf("Enabled bucket-wide SSE on AWS S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Infof("Enabled bucket-wide SSE on AWS S3 bucket %s", config.Bucket)
 	return nil
 }
 
@@ -679,7 +679,7 @@ func EnableAccessLoggingForS3BucketWide(s3Client *s3.S3, config *RemoteStateConf
 	}
 
 	targetPrefix := "TFStateLogs/"
-	terragruntOptions.Logger.Printf("Putting bucket logging on S3 bucket %s with TargetBucket %s and TargetPrefix %s", config.Bucket, logsBucket, targetPrefix)
+	terragruntOptions.Logger.Infof("Putting bucket logging on S3 bucket %s with TargetBucket %s and TargetPrefix %s", config.Bucket, logsBucket, targetPrefix)
 
 	loggingInput := s3.PutBucketLoggingInput{
 		Bucket: aws.String(config.Bucket),
@@ -695,7 +695,7 @@ func EnableAccessLoggingForS3BucketWide(s3Client *s3.S3, config *RemoteStateConf
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Printf("Enabled bucket-wide Access Logging on AWS S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Infof("Enabled bucket-wide Access Logging on AWS S3 bucket %s", config.Bucket)
 	return nil
 }
 
@@ -703,7 +703,7 @@ func EnableAccessLoggingForS3BucketWide(s3Client *s3.S3, config *RemoteStateConf
 // bucket or objects will not accidentally enable public access to those items. See
 // https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html for more information.
 func EnablePublicAccessBlockingForS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Blocking all public access to S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Infof("Blocking all public access to S3 bucket %s", config.Bucket)
 	_, err := s3Client.PutPublicAccessBlock(
 		&s3.PutPublicAccessBlockInput{
 			Bucket: aws.String(config.Bucket),
@@ -720,7 +720,7 @@ func EnablePublicAccessBlockingForS3Bucket(s3Client *s3.S3, config *RemoteStateC
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Printf("Blocked all public access to S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Infof("Blocked all public access to S3 bucket %s", config.Bucket)
 	return nil
 }
 
@@ -728,7 +728,7 @@ func EnablePublicAccessBlockingForS3Bucket(s3Client *s3.S3, config *RemoteStateC
 // Group. For more info, see:
 // https://docs.aws.amazon.com/AmazonS3/latest/dev/enable-logging-programming.html
 func configureBucketAccessLoggingAcl(s3Client *s3.S3, bucket *string, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Granting WRITE and READ_ACP permissions to S3 Log Delivery (%s) for bucket %s. This is required for access logging.", s3LogDeliveryGranteeUri, aws.StringValue(bucket))
+	terragruntOptions.Logger.Infof("Granting WRITE and READ_ACP permissions to S3 Log Delivery (%s) for bucket %s. This is required for access logging.", s3LogDeliveryGranteeUri, aws.StringValue(bucket))
 
 	uri := fmt.Sprintf("uri=%s", s3LogDeliveryGranteeUri)
 	aclInput := s3.PutBucketAclInput{
@@ -745,7 +745,7 @@ func configureBucketAccessLoggingAcl(s3Client *s3.S3, bucket *string, terragrunt
 }
 
 func waitUntilBucketHasAccessLoggingAcl(s3Client *s3.S3, bucket *string, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Printf("Waiting for ACL bucket %s to have the updated ACL for access logging.", aws.StringValue(bucket))
+	terragruntOptions.Logger.Infof("Waiting for ACL bucket %s to have the updated ACL for access logging.", aws.StringValue(bucket))
 
 	maxRetries := 10
 	timeBetweenRetries := 5 * time.Second
@@ -771,11 +771,11 @@ func waitUntilBucketHasAccessLoggingAcl(s3Client *s3.S3, bucket *string, terragr
 		}
 
 		if hasReadAcp && hasWrite {
-			terragruntOptions.Logger.Printf("Bucket %s now has the proper ACL permissions for access logging!", aws.StringValue(bucket))
+			terragruntOptions.Logger.Infof("Bucket %s now has the proper ACL permissions for access logging!", aws.StringValue(bucket))
 			return nil
 		}
 
-		terragruntOptions.Logger.Printf("Bucket %s still does not have the ACL permissions for access logging. Will sleep for %v and check again.", aws.StringValue(bucket), timeBetweenRetries)
+		terragruntOptions.Logger.Infof("Bucket %s still does not have the ACL permissions for access logging. Will sleep for %v and check again.", aws.StringValue(bucket), timeBetweenRetries)
 		time.Sleep(timeBetweenRetries)
 	}
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -125,7 +126,7 @@ func (s3Initializer S3Initializer) NeedsInitialization(remoteState *RemoteState,
 	// from it altogether. Display a deprecation warning when the "lock_table"
 	// attribute is being used.
 	if util.KindOf(remoteState.Config["lock_table"]) == reflect.String && remoteState.Config["lock_table"] != "" {
-		terragruntOptions.Logger.Infof("%s\n", lockTableDeprecationMessage)
+		terragruntOptions.Logger.Warnf("%s\n", lockTableDeprecationMessage)
 		remoteState.Config["dynamodb_table"] = remoteState.Config["lock_table"]
 		delete(remoteState.Config, "lock_table")
 	}
@@ -176,7 +177,7 @@ func configValuesEqual(config map[string]interface{}, existingBackend *Terraform
 	}
 
 	if existingBackend.Type != "s3" {
-		terragruntOptions.Logger.Infof("Backend type has changed from s3 to %s", existingBackend.Type)
+		terragruntOptions.Logger.Debugf("Backend type has changed from s3 to %s", existingBackend.Type)
 		return false
 	}
 
@@ -193,7 +194,7 @@ func configValuesEqual(config map[string]interface{}, existingBackend *Terraform
 		if value, err := strconv.ParseBool(existingBackend.Config["encrypt"].(string)); err == nil {
 			existingBackend.Config["encrypt"] = value
 		} else {
-			terragruntOptions.Logger.Infof("Remote state configuration encrypt contains invalid value %v, should be boolean.", existingBackend.Config["encrypt"])
+			terragruntOptions.Logger.Warnf("Remote state configuration encrypt contains invalid value %v, should be boolean.", existingBackend.Config["encrypt"])
 		}
 	}
 
@@ -240,7 +241,7 @@ func (s3Initializer S3Initializer) Initialize(remoteState *RemoteState, terragru
 	// Display a deprecation warning when the "lock_table" attribute is being used
 	// during initialization.
 	if s3Config.LockTable != "" {
-		terragruntOptions.Logger.Infof("%s\n", lockTableDeprecationMessage)
+		terragruntOptions.Logger.Warnf("%s\n", lockTableDeprecationMessage)
 	}
 
 	s3Client, err := CreateS3Client(s3ConfigExtended.GetAwsSessionConfig(), terragruntOptions)
@@ -334,7 +335,7 @@ func validateS3Config(extendedConfig *ExtendedRemoteStateConfigS3, terragruntOpt
 	}
 
 	if !config.Encrypt {
-		terragruntOptions.Logger.Infof("WARNING: encryption is not enabled on the S3 remote state bucket %s. Terraform state files may contain secrets, so we STRONGLY recommend enabling encryption!", config.Bucket)
+		terragruntOptions.Logger.Warnf("WARNING: encryption is not enabled on the S3 remote state bucket %s. Terraform state files may contain secrets, so we STRONGLY recommend enabling encryption!", config.Bucket)
 	}
 
 	return nil
@@ -361,7 +362,7 @@ func createS3BucketIfNecessary(s3Client *s3.S3, config *ExtendedRemoteStateConfi
 			maxRetries := 3
 			sleepBetweenRetries := 10 * time.Second
 
-			return util.DoWithRetry(description, maxRetries, sleepBetweenRetries, terragruntOptions.Logger, func() error {
+			return util.DoWithRetry(description, maxRetries, sleepBetweenRetries, terragruntOptions.Logger, logrus.DebugLevel, func() error {
 				return CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client, config, terragruntOptions)
 			})
 		}
@@ -380,7 +381,7 @@ func checkIfVersioningEnabled(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 	// NOTE: There must be a bug in the AWS SDK since out == nil when versioning is not enabled. In the future,
 	// check the AWS SDK for updates to see if we can remove "out == nil ||".
 	if out == nil || out.Status == nil || *out.Status != s3.BucketVersioningStatusEnabled {
-		terragruntOptions.Logger.Infof("WARNING: Versioning is not enabled for the remote state S3 bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
+		terragruntOptions.Logger.Warnf("WARNING: Versioning is not enabled for the remote state S3 bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
 	}
 
 	return nil
@@ -392,7 +393,7 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 
 	if err != nil {
 		if isBucketAlreadyOwnedByYouError(err) {
-			terragruntOptions.Logger.Infof("Looks like you're already creating bucket %s at the same time. Will not attempt to create it again.", config.remoteStateConfigS3.Bucket)
+			terragruntOptions.Logger.Debugf("Looks like you're already creating bucket %s at the same time. Will not attempt to create it again.", config.remoteStateConfigS3.Bucket)
 			return WaitUntilS3BucketExists(s3Client, &config.remoteStateConfigS3, terragruntOptions)
 		}
 
@@ -404,13 +405,13 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 	}
 
 	if config.SkipBucketRootAccess {
-		terragruntOptions.Logger.Infof("Root access is disabled for the remote state S3 bucket %s using 'skip_bucket_root_access' config.", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Debugf("Root access is disabled for the remote state S3 bucket %s using 'skip_bucket_root_access' config.", config.remoteStateConfigS3.Bucket)
 	} else if err := EnableRootAccesstoS3Bucket(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
 
 	if config.SkipBucketEnforcedTLS {
-		terragruntOptions.Logger.Infof("TLS enforcement is disabled for the remote state S3 bucket %s using 'skip_bucket_enforced_tls' config.", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Debugf("TLS enforcement is disabled for the remote state S3 bucket %s using 'skip_bucket_enforced_tls' config.", config.remoteStateConfigS3.Bucket)
 	} else if err := EnableEnforcedTLSAccesstoS3Bucket(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
@@ -424,26 +425,26 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 	}
 
 	if config.SkipBucketVersioning {
-		terragruntOptions.Logger.Infof("Versioning is disabled for the remote state S3 bucket %s using 'skip_bucket_versioning' config.", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Debugf("Versioning is disabled for the remote state S3 bucket %s using 'skip_bucket_versioning' config.", config.remoteStateConfigS3.Bucket)
 	} else if err := EnableVersioningForS3Bucket(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
 
 	if config.SkipBucketSSEncryption {
-		terragruntOptions.Logger.Infof("Server-Side Encryption is disabled for the remote state AWS S3 bucket %s using 'skip_bucket_ssencryption' config.", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Debugf("Server-Side Encryption is disabled for the remote state AWS S3 bucket %s using 'skip_bucket_ssencryption' config.", config.remoteStateConfigS3.Bucket)
 	} else if err := EnableSSEForS3BucketWide(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
 		return err
 	}
 
 	if config.SkipBucketAccessLogging {
-		terragruntOptions.Logger.Infof("___WARNING___: The terragrunt configuration option 'skip_bucket_accesslogging' is now deprecated. Access logging for the state bucket %s is disabled by default. To enable access logging for bucket %s, please provide property `accesslogging_bucket_name` in the terragrunt config file. For more details, please refer to the Terragrunt documentation.", config.remoteStateConfigS3.Bucket, config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Warnf("___WARNING___: The terragrunt configuration option 'skip_bucket_accesslogging' is now deprecated. Access logging for the state bucket %s is disabled by default. To enable access logging for bucket %s, please provide property `accesslogging_bucket_name` in the terragrunt config file. For more details, please refer to the Terragrunt documentation.", config.remoteStateConfigS3.Bucket, config.remoteStateConfigS3.Bucket)
 	}
 
 	if config.AccessLoggingBucketName != "" {
-		terragruntOptions.Logger.Infof("Enabling bucket-wide Access Logging on AWS S3 bucket %s - using as TargetBucket %s", config.remoteStateConfigS3.Bucket, config.AccessLoggingBucketName)
+		terragruntOptions.Logger.Debugf("Enabling bucket-wide Access Logging on AWS S3 bucket %s - using as TargetBucket %s", config.remoteStateConfigS3.Bucket, config.AccessLoggingBucketName)
 
 		if err := CreateLogsS3BucketIfNecessary(s3Client, aws.String(config.AccessLoggingBucketName), terragruntOptions); err != nil {
-			terragruntOptions.Logger.Infof("Error: Could not create logs bucket %s for AWS S3 bucket %s", config.AccessLoggingBucketName, config.remoteStateConfigS3.Bucket)
+			terragruntOptions.Logger.Errorf("Error: Could not create logs bucket %s for AWS S3 bucket %s", config.AccessLoggingBucketName, config.remoteStateConfigS3.Bucket)
 			return err
 		}
 
@@ -451,7 +452,7 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 			return err
 		}
 	} else {
-		terragruntOptions.Logger.Infof("Access Logging is disabled for the remote state AWS S3 bucket %s", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Debugf("Access Logging is disabled for the remote state AWS S3 bucket %s", config.remoteStateConfigS3.Bucket)
 	}
 
 	return nil
@@ -475,14 +476,14 @@ func CreateLogsS3BucketIfNecessary(s3Client *s3.S3, logsBucketName *string, terr
 func TagS3Bucket(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
 
 	if config.S3BucketTags == nil || len(config.S3BucketTags) == 0 {
-		terragruntOptions.Logger.Infof("No tags specified for bucket %s.", config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Debugf("No tags specified for bucket %s.", config.remoteStateConfigS3.Bucket)
 		return nil
 	}
 
 	// There must be one entry in the list
 	var tagsConverted = convertTags(config.S3BucketTags)
 
-	terragruntOptions.Logger.Infof("Tagging S3 bucket with %s", config.S3BucketTags)
+	terragruntOptions.Logger.Debugf("Tagging S3 bucket with %s", config.S3BucketTags)
 
 	putBucketTaggingInput := s3.PutBucketTaggingInput{
 		Bucket: aws.String(config.remoteStateConfigS3.Bucket),
@@ -494,7 +495,7 @@ func TagS3Bucket(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragrun
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Infof("Tagged S3 bucket with %s", config.S3BucketTags)
+	terragruntOptions.Logger.Debugf("Tagged S3 bucket with %s", config.S3BucketTags)
 	return nil
 }
 
@@ -516,13 +517,13 @@ func convertTags(tags map[string]string) []*s3.Tag {
 // AWS is eventually consistent, so after creating an S3 bucket, this method can be used to wait until the information
 // about that S3 bucket has propagated everywhere
 func WaitUntilS3BucketExists(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Infof("Waiting for bucket %s to be created", config.Bucket)
+	terragruntOptions.Logger.Debugf("Waiting for bucket %s to be created", config.Bucket)
 	for retries := 0; retries < MAX_RETRIES_WAITING_FOR_S3_BUCKET; retries++ {
 		if DoesS3BucketExist(s3Client, aws.String(config.Bucket)) {
-			terragruntOptions.Logger.Infof("S3 bucket %s created.", config.Bucket)
+			terragruntOptions.Logger.Debugf("S3 bucket %s created.", config.Bucket)
 			return nil
 		} else if retries < MAX_RETRIES_WAITING_FOR_S3_BUCKET-1 {
-			terragruntOptions.Logger.Infof("S3 bucket %s has not been created yet. Sleeping for %s and will check again.", config.Bucket, SLEEP_BETWEEN_RETRIES_WAITING_FOR_S3_BUCKET)
+			terragruntOptions.Logger.Debugf("S3 bucket %s has not been created yet. Sleeping for %s and will check again.", config.Bucket, SLEEP_BETWEEN_RETRIES_WAITING_FOR_S3_BUCKET)
 			time.Sleep(SLEEP_BETWEEN_RETRIES_WAITING_FOR_S3_BUCKET)
 		}
 	}
@@ -532,12 +533,12 @@ func WaitUntilS3BucketExists(s3Client *s3.S3, config *RemoteStateConfigS3, terra
 
 // Create the S3 bucket specified in the given config
 func CreateS3Bucket(s3Client *s3.S3, bucket *string, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Infof("Creating S3 bucket %s", aws.StringValue(bucket))
+	terragruntOptions.Logger.Debugf("Creating S3 bucket %s", aws.StringValue(bucket))
 	_, err := s3Client.CreateBucket(&s3.CreateBucketInput{Bucket: bucket})
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
-	terragruntOptions.Logger.Infof("Created S3 bucket %s", aws.StringValue(bucket))
+	terragruntOptions.Logger.Debugf("Created S3 bucket %s", aws.StringValue(bucket))
 	return nil
 }
 
@@ -550,7 +551,7 @@ func isBucketAlreadyOwnedByYouError(err error) bool {
 
 // Add a policy to allow root access to the bucket
 func EnableRootAccesstoS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Infof("Enabling root access to S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Debugf("Enabling root access to S3 bucket %s", config.Bucket)
 
 	accountID, err := aws_helper.GetAWSAccountID(terragruntOptions)
 	if err != nil {
@@ -590,13 +591,13 @@ func EnableRootAccesstoS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, te
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Infof("Enabled root access to bucket %s", config.Bucket)
+	terragruntOptions.Logger.Debugf("Enabled root access to bucket %s", config.Bucket)
 	return nil
 }
 
 // Add a policy to enforce TLS based access to the bucket
 func EnableEnforcedTLSAccesstoS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Infof("Enabling enforced TLS access for S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Debugf("Enabling enforced TLS access for S3 bucket %s", config.Bucket)
 
 	tlsS3Policy := map[string]interface{}{
 		"Version": "2012-10-17",
@@ -632,13 +633,13 @@ func EnableEnforcedTLSAccesstoS3Bucket(s3Client *s3.S3, config *RemoteStateConfi
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Infof("Enabled enforced TLS access for bucket %s", config.Bucket)
+	terragruntOptions.Logger.Debugf("Enabled enforced TLS access for bucket %s", config.Bucket)
 	return nil
 }
 
 // Enable versioning for the S3 bucket specified in the given config
 func EnableVersioningForS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Infof("Enabling versioning on S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Debugf("Enabling versioning on S3 bucket %s", config.Bucket)
 	input := s3.PutBucketVersioningInput{
 		Bucket:                  aws.String(config.Bucket),
 		VersioningConfiguration: &s3.VersioningConfiguration{Status: aws.String(s3.BucketVersioningStatusEnabled)},
@@ -649,13 +650,13 @@ func EnableVersioningForS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, t
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Infof("Enabled versioning on S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Debugf("Enabled versioning on S3 bucket %s", config.Bucket)
 	return nil
 }
 
 // Enable bucket-wide Server-Side Encryption for the AWS S3 bucket specified in the given config
 func EnableSSEForS3BucketWide(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Infof("Enabling bucket-wide SSE on AWS S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Debugf("Enabling bucket-wide SSE on AWS S3 bucket %s", config.Bucket)
 	// Encrypt with KMS by default
 	defEnc := &s3.ServerSideEncryptionByDefault{SSEAlgorithm: aws.String(s3.ServerSideEncryptionAwsKms)}
 	rule := &s3.ServerSideEncryptionRule{ApplyServerSideEncryptionByDefault: defEnc}
@@ -668,7 +669,7 @@ func EnableSSEForS3BucketWide(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Infof("Enabled bucket-wide SSE on AWS S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Debugf("Enabled bucket-wide SSE on AWS S3 bucket %s", config.Bucket)
 	return nil
 }
 
@@ -679,7 +680,7 @@ func EnableAccessLoggingForS3BucketWide(s3Client *s3.S3, config *RemoteStateConf
 	}
 
 	targetPrefix := "TFStateLogs/"
-	terragruntOptions.Logger.Infof("Putting bucket logging on S3 bucket %s with TargetBucket %s and TargetPrefix %s", config.Bucket, logsBucket, targetPrefix)
+	terragruntOptions.Logger.Debugf("Putting bucket logging on S3 bucket %s with TargetBucket %s and TargetPrefix %s", config.Bucket, logsBucket, targetPrefix)
 
 	loggingInput := s3.PutBucketLoggingInput{
 		Bucket: aws.String(config.Bucket),
@@ -695,7 +696,7 @@ func EnableAccessLoggingForS3BucketWide(s3Client *s3.S3, config *RemoteStateConf
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Infof("Enabled bucket-wide Access Logging on AWS S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Debugf("Enabled bucket-wide Access Logging on AWS S3 bucket %s", config.Bucket)
 	return nil
 }
 
@@ -703,7 +704,7 @@ func EnableAccessLoggingForS3BucketWide(s3Client *s3.S3, config *RemoteStateConf
 // bucket or objects will not accidentally enable public access to those items. See
 // https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html for more information.
 func EnablePublicAccessBlockingForS3Bucket(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Infof("Blocking all public access to S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Debugf("Blocking all public access to S3 bucket %s", config.Bucket)
 	_, err := s3Client.PutPublicAccessBlock(
 		&s3.PutPublicAccessBlockInput{
 			Bucket: aws.String(config.Bucket),
@@ -720,7 +721,7 @@ func EnablePublicAccessBlockingForS3Bucket(s3Client *s3.S3, config *RemoteStateC
 		return errors.WithStackTrace(err)
 	}
 
-	terragruntOptions.Logger.Infof("Blocked all public access to S3 bucket %s", config.Bucket)
+	terragruntOptions.Logger.Debugf("Blocked all public access to S3 bucket %s", config.Bucket)
 	return nil
 }
 
@@ -728,7 +729,7 @@ func EnablePublicAccessBlockingForS3Bucket(s3Client *s3.S3, config *RemoteStateC
 // Group. For more info, see:
 // https://docs.aws.amazon.com/AmazonS3/latest/dev/enable-logging-programming.html
 func configureBucketAccessLoggingAcl(s3Client *s3.S3, bucket *string, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Infof("Granting WRITE and READ_ACP permissions to S3 Log Delivery (%s) for bucket %s. This is required for access logging.", s3LogDeliveryGranteeUri, aws.StringValue(bucket))
+	terragruntOptions.Logger.Debugf("Granting WRITE and READ_ACP permissions to S3 Log Delivery (%s) for bucket %s. This is required for access logging.", s3LogDeliveryGranteeUri, aws.StringValue(bucket))
 
 	uri := fmt.Sprintf("uri=%s", s3LogDeliveryGranteeUri)
 	aclInput := s3.PutBucketAclInput{
@@ -745,7 +746,7 @@ func configureBucketAccessLoggingAcl(s3Client *s3.S3, bucket *string, terragrunt
 }
 
 func waitUntilBucketHasAccessLoggingAcl(s3Client *s3.S3, bucket *string, terragruntOptions *options.TerragruntOptions) error {
-	terragruntOptions.Logger.Infof("Waiting for ACL bucket %s to have the updated ACL for access logging.", aws.StringValue(bucket))
+	terragruntOptions.Logger.Debugf("Waiting for ACL bucket %s to have the updated ACL for access logging.", aws.StringValue(bucket))
 
 	maxRetries := 10
 	timeBetweenRetries := 5 * time.Second
@@ -771,11 +772,11 @@ func waitUntilBucketHasAccessLoggingAcl(s3Client *s3.S3, bucket *string, terragr
 		}
 
 		if hasReadAcp && hasWrite {
-			terragruntOptions.Logger.Infof("Bucket %s now has the proper ACL permissions for access logging!", aws.StringValue(bucket))
+			terragruntOptions.Logger.Debugf("Bucket %s now has the proper ACL permissions for access logging!", aws.StringValue(bucket))
 			return nil
 		}
 
-		terragruntOptions.Logger.Infof("Bucket %s still does not have the ACL permissions for access logging. Will sleep for %v and check again.", aws.StringValue(bucket), timeBetweenRetries)
+		terragruntOptions.Logger.Debugf("Bucket %s still does not have the ACL permissions for access logging. Will sleep for %v and check again.", aws.StringValue(bucket), timeBetweenRetries)
 		time.Sleep(timeBetweenRetries)
 	}
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -335,7 +335,7 @@ func validateS3Config(extendedConfig *ExtendedRemoteStateConfigS3, terragruntOpt
 	}
 
 	if !config.Encrypt {
-		terragruntOptions.Logger.Warnf("WARNING: encryption is not enabled on the S3 remote state bucket %s. Terraform state files may contain secrets, so we STRONGLY recommend enabling encryption!", config.Bucket)
+		terragruntOptions.Logger.Warnf("Encryption is not enabled on the S3 remote state bucket %s. Terraform state files may contain secrets, so we STRONGLY recommend enabling encryption!", config.Bucket)
 	}
 
 	return nil
@@ -381,7 +381,7 @@ func checkIfVersioningEnabled(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 	// NOTE: There must be a bug in the AWS SDK since out == nil when versioning is not enabled. In the future,
 	// check the AWS SDK for updates to see if we can remove "out == nil ||".
 	if out == nil || out.Status == nil || *out.Status != s3.BucketVersioningStatusEnabled {
-		terragruntOptions.Logger.Warnf("WARNING: Versioning is not enabled for the remote state S3 bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
+		terragruntOptions.Logger.Warnf("Versioning is not enabled for the remote state S3 bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
 	}
 
 	return nil
@@ -437,14 +437,14 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 	}
 
 	if config.SkipBucketAccessLogging {
-		terragruntOptions.Logger.Warnf("___WARNING___: The terragrunt configuration option 'skip_bucket_accesslogging' is now deprecated. Access logging for the state bucket %s is disabled by default. To enable access logging for bucket %s, please provide property `accesslogging_bucket_name` in the terragrunt config file. For more details, please refer to the Terragrunt documentation.", config.remoteStateConfigS3.Bucket, config.remoteStateConfigS3.Bucket)
+		terragruntOptions.Logger.Warnf("Terragrunt configuration option 'skip_bucket_accesslogging' is now deprecated. Access logging for the state bucket %s is disabled by default. To enable access logging for bucket %s, please provide property `accesslogging_bucket_name` in the terragrunt config file. For more details, please refer to the Terragrunt documentation.", config.remoteStateConfigS3.Bucket, config.remoteStateConfigS3.Bucket)
 	}
 
 	if config.AccessLoggingBucketName != "" {
 		terragruntOptions.Logger.Debugf("Enabling bucket-wide Access Logging on AWS S3 bucket %s - using as TargetBucket %s", config.remoteStateConfigS3.Bucket, config.AccessLoggingBucketName)
 
 		if err := CreateLogsS3BucketIfNecessary(s3Client, aws.String(config.AccessLoggingBucketName), terragruntOptions); err != nil {
-			terragruntOptions.Logger.Errorf("Error: Could not create logs bucket %s for AWS S3 bucket %s", config.AccessLoggingBucketName, config.remoteStateConfigS3.Bucket)
+			terragruntOptions.Logger.Errorf("Could not create logs bucket %s for AWS S3 bucket %s", config.AccessLoggingBucketName, config.remoteStateConfigS3.Bucket)
 			return err
 		}
 

--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -12,9 +12,14 @@ import (
 // Prompt the user for text in the CLI. Returns the text entered by the user.
 func PromptUserForInput(prompt string, terragruntOptions *options.TerragruntOptions) (string, error) {
 	// We are writing directly to ErrWriter so the prompt is always visible
-	// no matter what logLevel is configured.
+	// no matter what logLevel is configured. If `--non-interactive` is set, we return "yes" early,
+	// so that prompt is not shown
 	//
 	// See https://github.com/gruntwork-io/terragrunt/issues/1524 for additional context
+	if terragruntOptions.NonInteractive {
+		terragruntOptions.Logger.Infof("The non-interactive flag is set to true, so assuming 'yes' for all prompts")
+		return "yes", nil
+	}
 	n, err := terragruntOptions.ErrWriter.Write([]byte(prompt))
 	if err != nil {
 		terragruntOptions.Logger.Error(err)
@@ -23,10 +28,6 @@ func PromptUserForInput(prompt string, terragruntOptions *options.TerragruntOpti
 	if n != len(prompt) {
 		terragruntOptions.Logger.Errorln("Failed to write data")
 		return "", errors.WithStackTrace(err)
-	}
-	if terragruntOptions.NonInteractive {
-		terragruntOptions.Logger.Infof("The non-interactive flag is set to true, so assuming 'yes' for all prompts")
-		return "yes", nil
 	}
 
 	reader := bufio.NewReader(os.Stdin)

--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -12,12 +12,11 @@ import (
 // Prompt the user for text in the CLI. Returns the text entered by the user.
 func PromptUserForInput(prompt string, terragruntOptions *options.TerragruntOptions) (string, error) {
 	// We are writing directly to ErrWriter so the prompt is always visible
-	// no matter what logLevel is configured. If `--non-interactive` is set, we return "yes" early,
-	// so that prompt is not shown
-	//
-	// See https://github.com/gruntwork-io/terragrunt/issues/1524 for additional context
+	// no matter what logLevel is configured. If `--non-interactive` is set, we log both prompt and
+	// a message about assuming `yes` to Debug, so
 	if terragruntOptions.NonInteractive {
-		terragruntOptions.Logger.Infof("The non-interactive flag is set to true, so assuming 'yes' for all prompts")
+		terragruntOptions.Logger.Debugf(prompt)
+		terragruntOptions.Logger.Debugf("The non-interactive flag is set to true, so assuming 'yes' for all prompts")
 		return "yes", nil
 	}
 	n, err := terragruntOptions.ErrWriter.Write([]byte(prompt))

--- a/shell/ptty_unix.go
+++ b/shell/ptty_unix.go
@@ -27,7 +27,7 @@ func runCommandWithPTTY(terragruntOptions *options.TerragruntOptions, cmd *exec.
 	pseudoTerminal, startErr := pty.Start(cmd)
 	defer func() {
 		if closeErr := pseudoTerminal.Close(); closeErr != nil {
-			terragruntOptions.Logger.Infof("Error closing pty: %s", closeErr)
+			terragruntOptions.Logger.Errorf("Error closing pty: %s", closeErr)
 			// Only overwrite the previous error if there was no error since this error has lower priority than any
 			// errors in the main routine
 			if err == nil {
@@ -45,7 +45,7 @@ func runCommandWithPTTY(terragruntOptions *options.TerragruntOptions, cmd *exec.
 	go func() {
 		for range ch {
 			if inheritSizeErr := pty.InheritSize(os.Stdin, pseudoTerminal); inheritSizeErr != nil {
-				terragruntOptions.Logger.Infof("error resizing pty: %s", inheritSizeErr)
+				terragruntOptions.Logger.Errorf("error resizing pty: %s", inheritSizeErr)
 				// We don't propagate this error upstream because it does not affect normal operation of the command
 			}
 		}
@@ -59,7 +59,7 @@ func runCommandWithPTTY(terragruntOptions *options.TerragruntOptions, cmd *exec.
 	}
 	defer func() {
 		if restoreErr := terminal.Restore(int(os.Stdin.Fd()), oldState); restoreErr != nil {
-			terragruntOptions.Logger.Infof("Error restoring terminal state: %s", restoreErr)
+			terragruntOptions.Logger.Errorf("Error restoring terminal state: %s", restoreErr)
 			// Only overwrite the previous error if there was no error since this error has lower priority than any
 			// errors in the main routine
 			if err == nil {
@@ -71,7 +71,7 @@ func runCommandWithPTTY(terragruntOptions *options.TerragruntOptions, cmd *exec.
 	// Copy stdin to the pty
 	go func() {
 		_, copyStdinErr := io.Copy(pseudoTerminal, os.Stdin)
-		terragruntOptions.Logger.Infof("Error forwarding stdin: %s", copyStdinErr)
+		terragruntOptions.Logger.Errorf("Error forwarding stdin: %s", copyStdinErr)
 		// We don't propagate this error upstream because it does not affect normal operation of the command. A repeat
 		// of the same stdin in this case should resolve the issue.
 	}()

--- a/shell/ptty_unix.go
+++ b/shell/ptty_unix.go
@@ -27,7 +27,7 @@ func runCommandWithPTTY(terragruntOptions *options.TerragruntOptions, cmd *exec.
 	pseudoTerminal, startErr := pty.Start(cmd)
 	defer func() {
 		if closeErr := pseudoTerminal.Close(); closeErr != nil {
-			terragruntOptions.Logger.Printf("Error closing pty: %s", closeErr)
+			terragruntOptions.Logger.Infof("Error closing pty: %s", closeErr)
 			// Only overwrite the previous error if there was no error since this error has lower priority than any
 			// errors in the main routine
 			if err == nil {
@@ -45,7 +45,7 @@ func runCommandWithPTTY(terragruntOptions *options.TerragruntOptions, cmd *exec.
 	go func() {
 		for range ch {
 			if inheritSizeErr := pty.InheritSize(os.Stdin, pseudoTerminal); inheritSizeErr != nil {
-				terragruntOptions.Logger.Printf("error resizing pty: %s", inheritSizeErr)
+				terragruntOptions.Logger.Infof("error resizing pty: %s", inheritSizeErr)
 				// We don't propagate this error upstream because it does not affect normal operation of the command
 			}
 		}
@@ -59,7 +59,7 @@ func runCommandWithPTTY(terragruntOptions *options.TerragruntOptions, cmd *exec.
 	}
 	defer func() {
 		if restoreErr := terminal.Restore(int(os.Stdin.Fd()), oldState); restoreErr != nil {
-			terragruntOptions.Logger.Printf("Error restoring terminal state: %s", restoreErr)
+			terragruntOptions.Logger.Infof("Error restoring terminal state: %s", restoreErr)
 			// Only overwrite the previous error if there was no error since this error has lower priority than any
 			// errors in the main routine
 			if err == nil {
@@ -71,7 +71,7 @@ func runCommandWithPTTY(terragruntOptions *options.TerragruntOptions, cmd *exec.
 	// Copy stdin to the pty
 	go func() {
 		_, copyStdinErr := io.Copy(pseudoTerminal, os.Stdin)
-		terragruntOptions.Logger.Printf("Error forwarding stdin: %s", copyStdinErr)
+		terragruntOptions.Logger.Infof("Error forwarding stdin: %s", copyStdinErr)
 		// We don't propagate this error upstream because it does not affect normal operation of the command. A repeat
 		// of the same stdin in this case should resolve the issue.
 	}()

--- a/shell/ptty_windows.go
+++ b/shell/ptty_windows.go
@@ -26,12 +26,12 @@ func enableVirtualTerminalProcessing(options *options.TerragruntOptions, file *o
 	var mode uint32
 	handle := windows.Handle(file.Fd())
 	if err := windows.GetConsoleMode(handle, &mode); err != nil {
-		options.Logger.Printf("failed to get console mode: %v\n", err)
+		options.Logger.Infof("failed to get console mode: %v\n", err)
 		return
 	}
 
 	if err := windows.SetConsoleMode(handle, mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {
-		options.Logger.Printf("failed to set console mode: %v\n", err)
+		options.Logger.Infof("failed to set console mode: %v\n", err)
 		windows.SetConsoleMode(handle, mode)
 	}
 }

--- a/shell/ptty_windows.go
+++ b/shell/ptty_windows.go
@@ -26,12 +26,12 @@ func enableVirtualTerminalProcessing(options *options.TerragruntOptions, file *o
 	var mode uint32
 	handle := windows.Handle(file.Fd())
 	if err := windows.GetConsoleMode(handle, &mode); err != nil {
-		options.Logger.Infof("failed to get console mode: %v\n", err)
+		options.Logger.Errorf("failed to get console mode: %v\n", err)
 		return
 	}
 
 	if err := windows.SetConsoleMode(handle, mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {
-		options.Logger.Infof("failed to set console mode: %v\n", err)
+		options.Logger.Errorf("failed to set console mode: %v\n", err)
 		windows.SetConsoleMode(handle, mode)
 	}
 }

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -57,7 +57,7 @@ func RunShellCommandWithOutput(
 	command string,
 	args ...string,
 ) (*CmdOutput, error) {
-	terragruntOptions.Logger.Infof("Running command: %s %s", command, strings.Join(args, " "))
+	terragruntOptions.Logger.Debugf("Running command: %s %s", command, strings.Join(args, " "))
 	if suppressStdout {
 		terragruntOptions.Logger.Debugf("Command output will be suppressed.")
 	}
@@ -174,10 +174,10 @@ func NewSignalsForwarder(signals []os.Signal, c *exec.Cmd, logger *logrus.Entry,
 		for {
 			select {
 			case s := <-signalChannel:
-				logger.Infof("Forward signal %v to terraform.", s)
+				logger.Debugf("Forward signal %v to terraform.", s)
 				err := c.Process.Signal(s)
 				if err != nil {
-					logger.Infof("Error forwarding signal: %v", err)
+					logger.Errorf("Error forwarding signal: %v", err)
 				}
 			case <-cmdChannel:
 				return

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -174,10 +174,10 @@ func NewSignalsForwarder(signals []os.Signal, c *exec.Cmd, logger *logrus.Entry,
 		for {
 			select {
 			case s := <-signalChannel:
-				logger.Printf("Forward signal %v to terraform.", s)
+				logger.Infof("Forward signal %v to terraform.", s)
 				err := c.Process.Signal(s)
 				if err != nil {
-					logger.Printf("Error forwarding signal: %v", err)
+					logger.Infof("Error forwarding signal: %v", err)
 				}
 			case <-cmdChannel:
 				return

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -768,7 +768,7 @@ func TestTerragruntReportsTerraformErrorsWithPlanAll(t *testing.T) {
 
 	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, "fixture-failure")
 
-	cmd := fmt.Sprintf("terragrunt plan-all --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-log-level debug", rootTerragruntConfigPath)
+	cmd := fmt.Sprintf("terragrunt plan-all --terragrunt-non-interactive --terragrunt-working-dir %s", rootTerragruntConfigPath)
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer

--- a/util/logger.go
+++ b/util/logger.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-const DEFAULT_LOG_LEVEL = logrus.WarnLevel
+const DEFAULT_LOG_LEVEL = logrus.InfoLevel
 
 // GlobalFallbackLogEntry is a global fallback logentry for the application
 // Should be used in cases when more specific logger can't be created (like in the very beginning, when we have not yet

--- a/util/retry.go
+++ b/util/retry.go
@@ -9,9 +9,9 @@ import (
 // DoWithRetry runs the specified action. If it returns a value, return that value. If it returns an error, sleep for
 // sleepBetweenRetries and try again, up to a maximum of maxRetries retries. If maxRetries is exceeded, return a
 // MaxRetriesExceeded error.
-func DoWithRetry(actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, logger *logrus.Entry, action func() error) error {
+func DoWithRetry(actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, logger *logrus.Entry, logLevel logrus.Level, action func() error) error {
 	for i := 0; i <= maxRetries; i++ {
-		logger.Infof(actionDescription)
+		logger.Logf(logLevel, actionDescription)
 
 		err := action()
 		if err == nil {

--- a/util/retry.go
+++ b/util/retry.go
@@ -11,7 +11,7 @@ import (
 // MaxRetriesExceeded error.
 func DoWithRetry(actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, logger *logrus.Entry, action func() error) error {
 	for i := 0; i <= maxRetries; i++ {
-		logger.Printf(actionDescription)
+		logger.Infof(actionDescription)
 
 		err := action()
 		if err == nil {


### PR DESCRIPTION
Recent PR (#1510) changed logging, and also introduced default logging
level. While it seemed like a good idea, it also introduced a lot of
confusion, because in logrus `Println()` is an alias to `Info()`
loglevel - so lots of messages were lost.

This change restores previous behavior in logging output.

Related: gruntwork-io/terragrunt#1529
Related: gruntwork-io/terragrunt#1530
Related: gruntwork-io/terragrunt#1531
Related: gruntwork-io/terragrunt#1532