### PR TITLE
Add ability to force skip auto-init

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -152,6 +152,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 
 	opts.TerraformPath = filepath.ToSlash(terraformPath)
 	opts.AutoInit = !parseBooleanArg(args, OPT_TERRAGRUNT_NO_AUTO_INIT, os.Getenv("TERRAGRUNT_AUTO_INIT") == "false")
+	opts.ForceSkipInit = parseBooleanArg(args, OPT_TERRAGRUNT_FORCE_SKIP_INIT, os.Getenv("TERRAGRUNT_FORCE_SKIP_INIT") == "true")
 	opts.AutoRetry = !parseBooleanArg(args, OPT_TERRAGRUNT_NO_AUTO_RETRY, os.Getenv("TERRAGRUNT_AUTO_RETRY") == "false")
 	opts.NonInteractive = parseBooleanArg(args, OPT_NON_INTERACTIVE, os.Getenv("TF_INPUT") == "false" || os.Getenv("TF_INPUT") == "0")
 	opts.TerraformCliArgs = filterTerragruntArgs(args)

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -27,6 +27,7 @@ import (
 const OPT_TERRAGRUNT_CONFIG = "terragrunt-config"
 const OPT_TERRAGRUNT_TFPATH = "terragrunt-tfpath"
 const OPT_TERRAGRUNT_NO_AUTO_INIT = "terragrunt-no-auto-init"
+const OPT_TERRAGRUNT_FORCE_SKIP_INIT = "terragrunt-force-skip-init"
 const OPT_TERRAGRUNT_NO_AUTO_RETRY = "terragrunt-no-auto-retry"
 const OPT_NON_INTERACTIVE = "terragrunt-non-interactive"
 const OPT_WORKING_DIR = "terragrunt-working-dir"
@@ -56,6 +57,7 @@ var ALL_TERRAGRUNT_BOOLEAN_OPTS = []string{
 	OPT_TERRAGRUNT_IGNORE_EXTERNAL_DEPENDENCIES,
 	OPT_TERRAGRUNT_INCLUDE_EXTERNAL_DEPENDENCIES,
 	OPT_TERRAGRUNT_NO_AUTO_INIT,
+	OPT_TERRAGRUNT_FORCE_SKIP_INIT,
 	OPT_TERRAGRUNT_NO_AUTO_RETRY,
 	OPT_TERRAGRUNT_CHECK,
 	OPT_TERRAGRUNT_STRICT_INCLUDE,
@@ -856,6 +858,10 @@ func runTerraformInit(originalTerragruntOptions *options.TerragruntOptions, terr
 
 	// Prevent Auto-Init if the user has disabled it
 	if util.FirstArg(terragruntOptions.TerraformCliArgs) != CMD_INIT && !terragruntOptions.AutoInit {
+		if terragruntOptions.ForceSkipInit {
+			terragruntOptions.Logger.Warnf("Detected that init is needed, but Auto-Init is disabled and --terragrunt-force-skip-init flag is passed in. Continuing with further actuions, but subsequent terraform commands may fail.")
+			return nil
+		}
 		return errors.WithStackTrace(InitNeededButDisabled("Cannot continue because init is needed, but Auto-Init is disabled.  You must run 'terragrunt init' manually."))
 	}
 

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -339,6 +339,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
 - [terragrunt-tfpath](#terragrunt-tfpath)
 - [terragrunt-no-auto-init](#terragrunt-no-auto-init)
 - [terragrunt-no-auto-retry](#terragrunt-no-auto-retry)
+- [terragrunt-force-skip-init](#terragrunt-force-skip-init)
 - [terragrunt-non-interactive](#terragrunt-non-interactive)
 - [terragrunt-working-dir](#terragrunt-working-dir)
 - [terragrunt-download-dir](#terragrunt-download-dir)
@@ -390,7 +391,8 @@ When passed in, don't automatically run `terraform init` when other commands are
 if you want to pass custom arguments to `terraform init` that are specific to a user or execution environment, and
 therefore cannot be specified as `extra_arguments`. For example, `-plugin-dir`. You must run `terragrunt init`
 yourself in this case if needed. `terragrunt` will fail if it detects that `init` is needed, but auto init is
-disabled. See [Auto-Init]({{site.baseurl}}/docs/features/auto-init#auto-init)
+disabled, unless [terragrunt-force-skip-init](#terragrunt-force-skip-init) is also passed in. See
+[Auto-Init]({{site.baseurl}}/docs/features/auto-init#auto-init)
 
 
 ### terragrunt-no-auto-retry
@@ -400,6 +402,19 @@ disabled. See [Auto-Init]({{site.baseurl}}/docs/features/auto-init#auto-init)
 
 When passed in, don't automatically retry commands which fail with transient errors. See
 [Auto-Retry]({{site.baseurl}}/docs/features/auto-retry#auto-retry)
+
+
+### terragrunt-force-skip-init
+
+**CLI Arg**: `--terragrunt-force-skip-init`<br/>
+**Environment Variable**: `TERRAGRUNT_FORCE_SKIP_INIT` (set to `true`)
+
+When passed in, force skipping `terraform init` when other commands are run
+even if terragrunt detects that `init` is needed. This is useful when you want
+to skip configuring modules and providers with `init` to fix issues with the
+state file during a terraform upgrade.
+
+See [Auto-Init]({{site.baseurl}}/docs/features/auto-init#auto-init) for additional information.
 
 
 ### terragrunt-non-interactive

--- a/options/options.go
+++ b/options/options.go
@@ -67,6 +67,9 @@ type TerragruntOptions struct {
 	// Whether we should automatically run terraform init if necessary when executing other commands
 	AutoInit bool
 
+	// Whether we should force skipping init.
+	ForceSkipInit bool
+
 	// CLI args that are intended for Terraform (i.e. all the CLI args except the --terragrunt ones)
 	TerraformCliArgs []string
 
@@ -178,6 +181,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		OriginalTerraformCommand:    "",
 		TerraformCommand:            "",
 		AutoInit:                    true,
+		ForceSkipInit:               false,
 		NonInteractive:              false,
 		TerraformCliArgs:            []string{},
 		WorkingDir:                  workingDir,
@@ -252,6 +256,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		TerraformVersion:            terragruntOptions.TerraformVersion,
 		TerragruntVersion:           terragruntOptions.TerragruntVersion,
 		AutoInit:                    terragruntOptions.AutoInit,
+		ForceSkipInit:               terragruntOptions.ForceSkipInit,
 		NonInteractive:              terragruntOptions.NonInteractive,
 		TerraformCliArgs:            util.CloneStringList(terragruntOptions.TerraformCliArgs),
 		WorkingDir:                  workingDir,

--- a/test/fixture-regressions/skip-init/main.tf
+++ b/test/fixture-regressions/skip-init/main.tf
@@ -1,0 +1,7 @@
+module "mod" {
+  source = "./module"
+}
+
+output "foo" {
+  value = module.mod.foo
+}

--- a/test/fixture-regressions/skip-init/module/main.tf
+++ b/test/fixture-regressions/skip-init/module/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "foo" {}
+
+output "foo" {
+  value = null_resource.foo.id
+}

--- a/test/fixture-regressions/skip-init/terragrunt.hcl
+++ b/test/fixture-regressions/skip-init/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intenionally empty

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1731,6 +1731,30 @@ func TestDebugGeneratedInputs(t *testing.T) {
 	assert.False(t, isDefined)
 }
 
+func TestForceSkipInit(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_REGRESSIONS)
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_REGRESSIONS)
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_REGRESSIONS, "skip-init")
+
+	noForceStdout := bytes.Buffer{}
+	noForceStderr := bytes.Buffer{}
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-no-auto-init --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &noForceStdout, &noForceStderr)
+	logBufferContentsLineByLine(t, noForceStdout, "no force apply stdout")
+	logBufferContentsLineByLine(t, noForceStderr, "no force apply stderr")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Cannot continue because init is needed, but Auto-Init is disabled.")
+
+	forceStdout := bytes.Buffer{}
+	forceStderr := bytes.Buffer{}
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-force-skip-init --terragrunt-no-auto-init --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &forceStdout, &forceStderr)
+	logBufferContentsLineByLine(t, forceStdout, "no force apply stdout")
+	logBufferContentsLineByLine(t, forceStderr, "no force apply stderr")
+	require.Error(t, err)
+	require.Contains(t, forceStderr.String(), "This module is not yet installed.")
+}
+
 func TestLocalsParsing(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This is a workaround for https://github.com/gruntwork-io/terragrunt/issues/1545

Sometimes, we need to be able to run a terraform command with partial initialization (in this case, only the state needs to be initialized and nothing else). However, terragrunt attempts to detect full initialization of modules and refuse to run terraform commands even when the `--terragrunt-no-auto-init` flag is passed in. This is problematic for the issue linked above as now there is no way to run the required upgrade command to finish initialization.

To workaround this, this PR introduces another flag `--terragrunt-force-skip-init` that will bypass the error message.