### PR TITLE
Remove InitNeededButDisabled error and instead log a warning

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -856,7 +856,8 @@ func runTerraformInit(originalTerragruntOptions *options.TerragruntOptions, terr
 
 	// Prevent Auto-Init if the user has disabled it
 	if util.FirstArg(terragruntOptions.TerraformCliArgs) != CMD_INIT && !terragruntOptions.AutoInit {
-		return errors.WithStackTrace(InitNeededButDisabled("Cannot continue because init is needed, but Auto-Init is disabled.  You must run 'terragrunt init' manually."))
+		terragruntOptions.Logger.Warnf("Detected that init is needed, but Auto-Init is disabled. Continuing with further actions, but subsequent terraform commands may fail.")
+		return nil
 	}
 
 	initOptions, err := prepareInitOptions(terragruntOptions, terraformSource)
@@ -979,12 +980,6 @@ type ArgumentNotAllowed struct {
 
 func (err ArgumentNotAllowed) Error() string {
 	return fmt.Sprintf(err.Message, err.Argument)
-}
-
-type InitNeededButDisabled string
-
-func (err InitNeededButDisabled) Error() string {
-	return string(err)
 }
 
 type BackendNotDefined struct {

--- a/test/fixture-regressions/skip-init/main.tf
+++ b/test/fixture-regressions/skip-init/main.tf
@@ -1,0 +1,7 @@
+module "mod" {
+  source = "./module"
+}
+
+output "foo" {
+  value = module.mod.foo
+}

--- a/test/fixture-regressions/skip-init/module/main.tf
+++ b/test/fixture-regressions/skip-init/module/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "foo" {}
+
+output "foo" {
+  value = null_resource.foo.id
+}

--- a/test/fixture-regressions/skip-init/terragrunt.hcl
+++ b/test/fixture-regressions/skip-init/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intenionally empty

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1731,6 +1731,22 @@ func TestDebugGeneratedInputs(t *testing.T) {
 	assert.False(t, isDefined)
 }
 
+func TestNoAutoInit(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_REGRESSIONS)
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_REGRESSIONS)
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_REGRESSIONS, "skip-init")
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-no-auto-init --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
+	logBufferContentsLineByLine(t, stdout, "no force apply stdout")
+	logBufferContentsLineByLine(t, stderr, "no force apply stderr")
+	require.Error(t, err)
+	require.Contains(t, stderr.String(), "This module is not yet installed.")
+}
+
 func TestLocalsParsing(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Alternative implementation of https://github.com/gruntwork-io/terragrunt/pull/1547, where we simply bypass the disabled init error.