### PR TITLE
follow symlinks for path_relative_to_include

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -301,6 +301,7 @@ func pathRelativeToInclude(include *IncludeConfig, terragruntOptions *options.Te
 
 	includePath := filepath.Dir(include.Path)
 	currentPath := filepath.Dir(terragruntOptions.TerragruntConfigPath)
+	currentPath = filepath.EvalSymlinks(currentPath)
 
 	if !filepath.IsAbs(includePath) {
 		includePath = util.JoinPath(currentPath, includePath)


### PR DESCRIPTION
Closes #543

My use case involves wanting to prefix terragrunt dirs with numbers to make the stage order obvious, generate state keys based on path to ensure uniqueness, and use a fair number of `terraform_remote_state` objects.

Reordering or inserting stages is a time-consuming process involving moving many different state files, adjusting `terraform_remote_state` objects, and renaming folders.

Also, `cd`ing isn't as frictionless as it could be; with the extra often 0-padded prefixes.

Creating numbered symlinks to the terragrunt dirs (but having terragrunt ignore those symlinks) would be an ideal solution.

Things to consider:
- I think `path_relative_to_include` should take a boolean argument if possible; defaulting to the old behavior but allowing the use of this behavior.
- Should this be done for `path_relative_from_include` too?
- Haven't yet tested. Especially if not implementing the bool toggle; need to see how this behaves when a relative include path is valid from one but not both of the real and symlinked directories.
- Is it alright that this runs `filepath.Clean` on the path too?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of symbolic links in configuration paths to ensure more accurate path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->