### PR TITLE
automatically chomp newlines when using run_cmd

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -209,13 +209,15 @@ func runCommand(args []string, include *IncludeConfig, terragruntOptions *option
 		return "", errors.WithStackTrace(err)
 	}
 
+	value := strings.TrimSuffix(cmdOutput.Stdout, "\n")
+
 	if suppressOutput {
 		terragruntOptions.Logger.Debugf("run_cmd output: [REDACTED]")
 	} else {
-		terragruntOptions.Logger.Debugf("run_cmd output: [%s]", cmdOutput.Stdout)
+		terragruntOptions.Logger.Debugf("run_cmd output: [%s]", value)
 	}
 
-	return cmdOutput.Stdout, nil
+	return value, nil
 }
 
 func getEnvironmentVariable(parameters []string, include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -135,7 +135,19 @@ func TestRunCommand(t *testing.T) {
 			nil,
 		},
 		{
+			[]string{"/bin/bash", "-c", "echo foo"},
+			terragruntOptionsForTest(t, homeDir),
+			"foo",
+			nil,
+		},
+		{
 			[]string{"--terragrunt-quiet", "/bin/bash", "-c", "echo -n foo"},
+			terragruntOptionsForTest(t, homeDir),
+			"foo",
+			nil,
+		},
+		{
+			[]string{"--terragrunt-quiet", "/bin/bash", "-c", "echo foo"},
 			terragruntOptionsForTest(t, homeDir),
 			"foo",
 			nil,


### PR DESCRIPTION
This is just a `gofmt` ed copy of https://github.com/gruntwork-io/terragrunt/pull/728 which appears to have gone inactive.