### PR TITLE
Allow skipping parsing of locals

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -460,6 +460,7 @@ func checkVersionConstraints(terragruntOptions *options.TerragruntOptions) error
 		terragruntOptions,
 		nil,
 		[]config.PartialDecodeSectionType{config.TerragruntVersionConstraints},
+		false,
 	)
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -408,7 +408,7 @@ func ParseConfigString(configString string, terragruntOptions *options.Terragrun
 	}
 
 	// Decode just the Base blocks. See the function docs for DecodeBaseBlocks for more info on what base blocks are.
-	localsAsCty, terragruntInclude, includeForDecode, err := DecodeBaseBlocks(terragruntOptions, parser, file, filename, includeFromChild)
+	localsAsCty, terragruntInclude, includeForDecode, err := DecodeBaseBlocks(terragruntOptions, parser, file, filename, includeFromChild, true)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config_partial_test.go
+++ b/config/config_partial_test.go
@@ -20,7 +20,7 @@ dependencies {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -48,10 +48,10 @@ dependencies {
 prevent_destroy = false
 `
 
-	_, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{TerragruntFlags})
+	_, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{TerragruntFlags}, true)
 	assert.NoError(t, err)
 
-	_, err = PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock})
+	_, err = PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock}, true)
 	assert.Error(t, err)
 }
 
@@ -67,7 +67,7 @@ prevent_destroy = true
 skip = true
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, TerragruntFlags})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, TerragruntFlags}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -87,7 +87,7 @@ skip = true
 func TestPartialParseOmittedItems(t *testing.T) {
 	t.Parallel()
 
-	terragruntConfig, err := PartialParseConfigString("", mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, TerragruntFlags})
+	terragruntConfig, err := PartialParseConfigString("", mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, TerragruntFlags}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 	assert.Nil(t, terragruntConfig.Dependencies)
@@ -103,10 +103,10 @@ func TestPartialParseDoesNotResolveIgnoredBlockEvenInParent(t *testing.T) {
 	t.Parallel()
 
 	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-partial-parse/ignore-bad-block-in-parent/child/"+DefaultTerragruntConfigPath)
-	_, err := PartialParseConfigFile(opts.TerragruntConfigPath, opts, nil, []PartialDecodeSectionType{TerragruntFlags})
+	_, err := PartialParseConfigFile(opts.TerragruntConfigPath, opts, nil, []PartialDecodeSectionType{TerragruntFlags}, true)
 	assert.NoError(t, err)
 
-	_, err = PartialParseConfigFile(opts.TerragruntConfigPath, opts, nil, []PartialDecodeSectionType{DependenciesBlock})
+	_, err = PartialParseConfigFile(opts.TerragruntConfigPath, opts, nil, []PartialDecodeSectionType{DependenciesBlock}, true)
 	assert.Error(t, err)
 }
 
@@ -114,7 +114,7 @@ func TestPartialParseOnlyInheritsSelectedBlocksFlags(t *testing.T) {
 	t.Parallel()
 
 	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-partial-parse/partial-inheritance/child/"+DefaultTerragruntConfigPath)
-	terragruntConfig, err := PartialParseConfigFile(opts.TerragruntConfigPath, opts, nil, []PartialDecodeSectionType{TerragruntFlags})
+	terragruntConfig, err := PartialParseConfigFile(opts.TerragruntConfigPath, opts, nil, []PartialDecodeSectionType{TerragruntFlags}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 	assert.Nil(t, terragruntConfig.Dependencies)
@@ -130,7 +130,7 @@ func TestPartialParseOnlyInheritsSelectedBlocksDependencies(t *testing.T) {
 	t.Parallel()
 
 	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-partial-parse/partial-inheritance/child/"+DefaultTerragruntConfigPath)
-	terragruntConfig, err := PartialParseConfigFile(opts.TerragruntConfigPath, opts, nil, []PartialDecodeSectionType{DependenciesBlock})
+	terragruntConfig, err := PartialParseConfigFile(opts.TerragruntConfigPath, opts, nil, []PartialDecodeSectionType{DependenciesBlock}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -155,7 +155,7 @@ dependency "vpc" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -178,7 +178,7 @@ dependency "sql" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -203,7 +203,7 @@ dependency "sql" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -229,7 +229,7 @@ dependency "sql" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, DependencyBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, DependencyBlock}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -255,7 +255,7 @@ dependency "sql" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock, DependenciesBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock, DependenciesBlock}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -281,7 +281,7 @@ dependency "sql" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock, DependenciesBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock, DependenciesBlock}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -307,7 +307,7 @@ terraform {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{TerraformSource})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{TerraformSource}, true)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -162,7 +162,7 @@ func getDependencyBlockConfigPathsByFilepath(configPath string, terragruntOption
 	// TerragruntConfig.Dependencies. Note that since we aren't passing in `DependenciesBlock` to the
 	// PartialDecodeSectionType list, the Dependencies attribute will not include any dependencies specified via the
 	// dependencies block.
-	tgConfig, err := PartialParseConfigFile(configPath, terragruntOptions, nil, []PartialDecodeSectionType{DependencyBlock})
+	tgConfig, err := PartialParseConfigFile(configPath, terragruntOptions, nil, []PartialDecodeSectionType{DependencyBlock}, true)
 	if err != nil {
 		return nil, err
 	}
@@ -368,6 +368,7 @@ func cloneTerragruntOptionsForDependencyOutput(terragruntOptions *options.Terrag
 			targetOptions,
 			nil,
 			[]PartialDecodeSectionType{TerraformBlock},
+			true,
 		)
 		if err != nil {
 			return nil, err
@@ -402,10 +403,10 @@ func getTerragruntOutputJson(terragruntOptions *options.TerragruntOptions, targe
 		return nil, err
 	}
 
-	// First attempt to parse the `remote_state` blocks without parsing/getting dependency outputs. If this is possible,
-	// proceed to routine that fetches remote state directly. Otherwise, fallback to calling `terragrunt output`
-	// directly.
-	remoteStateTGConfig, err := PartialParseConfigFile(targetConfig, targetTGOptions, nil, []PartialDecodeSectionType{RemoteStateBlock, TerragruntFlags})
+	// First, attempt to parse the `remote_state` blocks without parsing/getting dependency outputs. If this is
+	// possible, proceed to routine that fetches remote state directly. Otherwise, fallback to calling
+	// `terragrunt output` directly.
+	remoteStateTGConfig, err := PartialParseConfigFile(targetConfig, targetTGOptions, nil, []PartialDecodeSectionType{RemoteStateBlock, TerragruntFlags}, true)
 	if err != nil || !canGetRemoteState(remoteStateTGConfig.RemoteState) {
 		terragruntOptions.Logger.Warningf("Could not parse remote_state block from target config %s", targetConfig)
 		terragruntOptions.Logger.Warningf("Falling back to terragrunt output.")
@@ -435,7 +436,7 @@ func canGetRemoteState(remoteState *remote.RemoteState) bool {
 func terragruntAlreadyInit(terragruntOptions *options.TerragruntOptions, configPath string) (bool, string, error) {
 	// We need to first determine the working directory where the terraform source should be located. This is dependent
 	// on the source field of the terraform block in the config.
-	terraformBlockTGConfig, err := PartialParseConfigFile(configPath, terragruntOptions, nil, []PartialDecodeSectionType{TerraformSource})
+	terraformBlockTGConfig, err := PartialParseConfigFile(configPath, terragruntOptions, nil, []PartialDecodeSectionType{TerraformSource}, true)
 	if err != nil {
 		return false, "", err
 	}

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -253,6 +253,7 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 			config.DependenciesBlock,
 			config.DependencyBlock,
 		},
+		true,
 	)
 	if err != nil {
 		return nil, errors.WithStackTrace(ErrorProcessingModule{UnderlyingError: err, HowThisModuleWasFound: howThisModuleWasFound, ModulePath: terragruntConfigPath})

--- a/test/fixture-locals/run-once/terragrunt.hcl
+++ b/test/fixture-locals/run-once/terragrunt.hcl
@@ -1,0 +1,3 @@
+locals {
+  foo = run_cmd("echo", "aaa")
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -125,6 +125,7 @@ const (
 	TERRAFORM_STATE_BACKUP                                  = "terraform.tfstate.backup"
 	TERRAGRUNT_CACHE                                        = ".terragrunt-cache"
 	TERRAGRUNT_DEBUG_FILE                                   = "terragrunt-debug.tfvars.json"
+	TEST_FIXTURE_LOCAL_RUN_ONCE                             = "fixture-locals/run-once"
 )
 
 func init() {
@@ -4117,4 +4118,19 @@ func TestTerragruntRunAllCommandPrompt(t *testing.T) {
 	logBufferContentsLineByLine(t, stderr, "stderr")
 	assert.Contains(t, stderr.String(), "Are you sure you want to run 'terragrunt apply' in each folder of the stack described above? (y/n)")
 	assert.Error(t, err)
+}
+
+// See https://github.com/gruntwork-io/terragrunt/issues/1427
+func TestTerragruntInitRunOnce(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_LOCAL_RUN_ONCE)
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	runTerragruntCommand(t, fmt.Sprintf("terragrunt init --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_RUN_ONCE), &stdout, &stderr)
+
+	errout := string(stderr.Bytes())
+
+	assert.Equal(t, 1, strings.Count(errout, "aaa"))
 }

--- a/util/logger.go
+++ b/util/logger.go
@@ -17,7 +17,7 @@ const DEFAULT_LOG_LEVEL = logrus.InfoLevel
 // Should be used in cases when more specific logger can't be created (like in the very beginning, when we have not yet
 // parsed command line arguments).
 //
-// This might go away once we migrate toproper cli library
+// This might go away once we migrate to proper cli library
 // (see https://github.com/gruntwork-io/terragrunt/blob/master/cli/args.go#L29)
 var GlobalFallbackLogEntry *logrus.Entry
 


### PR DESCRIPTION
Allow skipping parsing of locals

Since `locals` can have side effects, we might run into cases when we don't need to pasre them. One example is `checkVersionConstraints()`, which is executed early on and relies on parsing HCL.

Fixes #1427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for conditional parsing of local variables in configuration files.
  - Introduced a new test fixture and integration test to ensure that local variables defined with external commands are processed only once during initialization.

- **Bug Fixes**
  - Ensured that local variables using commands are not evaluated multiple times during configuration parsing.

- **Tests**
  - Updated and expanded test coverage to validate the new parsing behavior and prevent regressions.

- **Documentation**
  - Corrected a comment typo for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->