### PR TITLE
Fix empty outputs

### DIFF
--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -81,6 +81,12 @@ func (stack *Stack) Run(terragruntOptions *options.TerragruntOptions) error {
 func (stack *Stack) summarizePlanAllErrors(terragruntOptions *options.TerragruntOptions, errorStreams []bytes.Buffer) {
 	for i, errorStream := range errorStreams {
 		output := errorStream.String()
+
+		if len(output) == 0 {
+			// We get empty buffer if stack execution completed without errors, so skip that to avoid logging too much
+			continue
+		}
+
 		terragruntOptions.Logger.Infoln(output)
 		if strings.Contains(output, "Error running plan:") {
 			if strings.Contains(output, ": Resource 'data.terraform_remote_state.") {


### PR DESCRIPTION
If stack run finished without errors, `summarizePlanAllErrors()`
receives empty buffer and outputs empty line. This change ensures that
only non-empty outputs are getting logged.

Related: #1541