### PR TITLE
doc: contributing: fix broken link to circleci

### DIFF
--- a/docs/_docs/03_community/contributing.md
+++ b/docs/_docs/03_community/contributing.md
@@ -82,10 +82,10 @@ outlined in the guide.
 to include the following:
 
 1. A description of the change, including a link to your GitHub issue.
-1. The output of your automated test run, preferably in a [GitHub Gist](https://gist.github.com/). We cannot run
-   automated tests for pull requests automatically due to [security
-   concerns](https://circleci.com/docs/fork-pr-builds/#security-implications), so we need you to manually provide this
-   test output so we can verify that everything is working.
+1. The output of your automated test run, preferably in a [GitHub Gist](https://gist.github.com/).
+   We cannot run automated tests for pull requests automatically due to
+   [security concerns](https://circleci.com/docs/2.0/oss/#pass-secrets-to-builds-from-forked-pull-requests),
+   so we need you to manually provide this test output so we can verify that everything is working.
 1. Any notes on backwards incompatibility.
 
 ### Merge and release


### PR DESCRIPTION
The only change is the circleci URL, but I also reformatted the lines to follow as much as possible the existing line length.