### PR TITLE
RDD: introduce ability to call terragrunt commands in before or after hooks

### DIFF
--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -52,12 +52,16 @@ The `terraform` block supports the following arguments:
 
 - `before_hook` (block): Nested blocks used to specify command hooks that should be run before `terraform` is called.
   Hooks run from the directory with the terraform module, except for hooks related to `terragrunt-read-config` and
-  `init-from-module`. These hooks run in the terragrunt configuration directory (the directory where `terragrunt.hcl`
-  lives).
+  `init-from-module`, and if `execute_terragrunt` is set. These hooks run in the terragrunt configuration directory (the
+  directory where `terragrunt.hcl` lives).
   Supports the following arguments:
     - `commands` (required) : A list of `terraform` sub commands for which the hook should run before.
     - `execute` (required) : A list of command and arguments that should be run as the hook. For example, if `execute` is set as
-      `["echo", "Foo"]`, the command `echo Foo` will be run.
+      `["echo", "Foo"]`, the command `echo Foo` will be run. Mutually exclusive with `execute_terragrunt`.
+    - `execute_terragrunt` (required) : A list of terragrunt command and arguments that should be run as the hook. Only
+      supports terragrunt specific commands other than `run-all` (e.g., `aws-provider-patch`). For example, if
+      `execute_terragrunt` is set as `["aws-provider-patch", "--terragrunt-override-attr", "region=us-east-2"]`,
+      terragrunt will run the `aws-provider-patch` command. Mutually exclusive with `execute`.
     - `run_on_error` (optional) : If set to true, this hook will run even if a previous hook hit an error, or in the
       case of "after" hooks, if the Terraform command hit an error. Default is false.
 


### PR DESCRIPTION
This is a README proposal of a feature to allow terragrunt to run terragrunt commands in a before or after hook. Opened early to get feedback.

## Use case

Our multiregion modules almost always require you to run `aws-provider-patch` prior to any `destroy` call, making the `destroy` experience very unfriendly. With this feature, we can work around this issue by registering the `aws-provider-patch` call as a `destroy` before hook so that it always runs anytime someone wants to destroy the multi region module.

This feature is necessary because, as the README update indicates, before hooks run in the terraform working directory, which means `terragrunt` commands fail. So you can't set `execute = ["terragrunt", "aws-provider-patch"]` to address this.