### PR TITLE
Output run-all plan errors

### DIFF
--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -3,6 +3,7 @@ package configstack
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -61,7 +62,7 @@ func (stack *Stack) Run(terragruntOptions *options.TerragruntOptions) error {
 		// We capture the out stream for each module
 		errorStreams := make([]bytes.Buffer, len(stack.Modules))
 		for n, module := range stack.Modules {
-			module.TerragruntOptions.ErrWriter = &errorStreams[n]
+			module.TerragruntOptions.ErrWriter = io.MultiWriter(module.TerragruntOptions.ErrWriter, &errorStreams[n])
 		}
 		defer stack.summarizePlanAllErrors(terragruntOptions, errorStreams)
 	}


### PR DESCRIPTION
By using a [`io.MultiWriter`](https://golang.org/pkg/io/#MultiWriter) terraform errors and hook output is printed/output to stdErr.
This makes debugging of a hook and terraform easier because errors are no longer swallowed.
It also makes `terragrunt run-all plan` act the same in regards to output as `terragrunt plan`.

Possibly related Issue:  https://github.com/gruntwork-io/terragrunt/issues/198