### PR TITLE
Only check if versioning is enabled on GCS bucket when skip_bucket_versioning is false

### DIFF
--- a/remote/remote_state_gcs.go
+++ b/remote/remote_state_gcs.go
@@ -179,8 +179,8 @@ func (gcsInitializer GCSInitializer) Initialize(remoteState *RemoteState, terrag
 		}
 	}
 
-	// Check versioning on the bucket only if the bucket is specified
-	if gcsConfig.Bucket != "" {
+	// If bucket is specified and skip_bucket_versioning is false then warn user if versioning is disabled on bucket
+	if !gcsConfigExtended.SkipBucketVersioning && gcsConfig.Bucket != "" {
 		if err := checkIfGCSVersioningEnabled(gcsClient, &gcsConfig, terragruntOptions); err != nil {
 			return err
 		}


### PR DESCRIPTION
Have a use-case where I am running everything in CI pipelines executed on a GKE cluster which is using workload identity to ascribe the runners a service account which has access to state files and the ability to impersonate service accounts required to plan and apply each of the modules in a given pipeline.

The main service account on the runner has `roles/storage.objectAdmin` on the GCS bucket where state is located. This has been working very will when Terraform is used directly, but failing when attempting to introduce Terragrunt to these pipelines with the following error message:

```
$ ${TF_COMMAND} init -backend=false
time=2021-03-26T03:13:18Z level=error msg=googleapi: Error 403: my-terraform-sa@my-terraform-project.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket., forbidden
time=2021-03-26T03:13:18Z level=error msg=Unable to determine underlying exit code, so Terragrunt will exit with error code 1
```

Granting `roles/storage.admin` on the bucket isn't really an option, and I'd rather not create a custom role simply to allow the versioning check (which is what triggers the error) to pass. In our case, buckets are created by Terraform with versioning enabled and this is no need to have Terragrunt verifying it's enabled on every run.

What I'm proposing here, since the check is indeed valuable, is to simply skip the check when `skip_bucket_versioning` is `true` allowing Terragrunt to operate with nothing more than is required for Terraform itself to operate. If a different option for the behavior would be preferred, lmk and I can update the PR.

When compiled with the changes in this PR, the following configuration resolves the permissions by avoiding the need for `storage.buckets.get` as the versioning check is no longer performed:

```
remote_state {
  backend = "gcs"
  config = {
    bucket                 = local.common_vars.gcp_tfstate_bucket
    prefix                 = path_relative_to_include()
    skip_bucket_creation   = true
    skip_bucket_versioning = true
  }
}
```
