### PR TITLE
Use a single logger instance

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -255,7 +255,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		NonInteractive:              terragruntOptions.NonInteractive,
 		TerraformCliArgs:            util.CloneStringList(terragruntOptions.TerraformCliArgs),
 		WorkingDir:                  workingDir,
-		Logger:                      util.CreateLogEntryWithWriter(terragruntOptions.ErrWriter, workingDir, terragruntOptions.LogLevel),
+		Logger:                      terragruntOptions.Logger.WithField("prefix", workingDir),
 		LogLevel:                    terragruntOptions.LogLevel,
 		Env:                         util.CloneStringMap(terragruntOptions.Env),
 		Source:                      terragruntOptions.Source,

--- a/util/logger.go
+++ b/util/logger.go
@@ -1,8 +1,6 @@
 package util
 
 import (
-	"fmt"
-	"io"
 	"os"
 
 	"github.com/hashicorp/hcl/v2"
@@ -46,18 +44,6 @@ func CreateLogEntry(prefix string, level logrus.Level) *logrus.Entry {
 		fields = logrus.Fields{}
 	}
 	return logger.WithFields(fields)
-}
-
-// CreateLoggerWithWriter Create a logger around the given output stream and prefix
-func CreateLogEntryWithWriter(writer io.Writer, prefix string, level logrus.Level) *logrus.Entry {
-	if prefix != "" {
-		prefix = fmt.Sprintf("[%s] ", prefix)
-	} else {
-		prefix = fmt.Sprintf("[terragrunt] %s", prefix)
-	}
-	logger := CreateLogEntry(prefix, level)
-	logger.Logger.SetOutput(writer)
-	return logger
 }
 
 // GetDiagnosticsWriter returns a hcl2 parsing diagnostics emitter for the current terminal.


### PR DESCRIPTION
By using a single logger instance we avoid adding log entries to the logs written by `Stack.summarizePlanAllErrors`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated how logging context is handled, now extending the existing logger with additional information instead of creating a new instance.
  - Removed an unused logging utility function, streamlining internal logging behavior.

No user-facing features or visible changes in functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->