### PR TITLE
feat: add built-in function to `get_aws_account_alias`

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -107,6 +107,7 @@ func CreateTerragruntEvalContext(
 		"get_terraform_command":                        wrapVoidToStringAsFuncImpl(getTerraformCommand, extensions.Include, terragruntOptions),
 		"get_terraform_cli_args":                       wrapVoidToStringSliceAsFuncImpl(getTerraformCliArgs, extensions.Include, terragruntOptions),
 		"get_parent_terragrunt_dir":                    wrapVoidToStringAsFuncImpl(getParentTerragruntDir, extensions.Include, terragruntOptions),
+		"get_aws_account_alias":                        wrapVoidToStringAsFuncImpl(GetAWSAccountAlias, extensions.Include, terragruntOptions),
 		"get_aws_account_id":                           wrapVoidToStringAsFuncImpl(getAWSAccountID, extensions.Include, terragruntOptions),
 		"get_aws_caller_identity_arn":                  wrapVoidToStringAsFuncImpl(getAWSCallerIdentityARN, extensions.Include, terragruntOptions),
 		"get_aws_caller_identity_user_id":              wrapVoidToStringAsFuncImpl(getAWSCallerIdentityUserID, extensions.Include, terragruntOptions),
@@ -336,6 +337,15 @@ func getTerraformCommand(include *IncludeConfig, terragruntOptions *options.Terr
 // getTerraformCliArgs returns cli args for terraform
 func getTerraformCliArgs(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) ([]string, error) {
 	return terragruntOptions.TerraformCliArgs, nil
+}
+
+// Return the AWS account id associated to the current set of credentials
+func GetAWSAccountAlias(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
+	accountID, err := aws_helper.GetAWSAccountAlias(terragruntOptions)
+	if err == nil {
+		return accountID, nil
+	}
+	return "", err
 }
 
 // Return the AWS account id associated to the current set of credentials

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -413,6 +413,19 @@ terraform {
 }
 ```
 
+## get\_aws\_account\_alias
+
+`get_aws_account_alias()` returns the AWS account alias associated with the current set of credentials. Example:
+
+``` hcl
+remote_state {
+  backend = "s3"
+  config = {
+    bucket = "mycompany-${get_aws_account_alias()}"
+  }
+}
+```
+
 ## get\_aws\_account\_id
 
 `get_aws_account_id()` returns the AWS account id associated with the current set of credentials. Example:

--- a/test/fixture-get-aws-caller-identity/main.tf
+++ b/test/fixture-get-aws-caller-identity/main.tf
@@ -2,6 +2,10 @@ variable "account" {
   type = string
 }
 
+variable "account_alias" {
+  type = string
+}
+
 variable "arn" {
   type = string
 }
@@ -12,6 +16,10 @@ variable "user_id" {
 
 output "account" {
   value = var.account
+}
+
+output "account_alias" {
+  value = var.account_alias
 }
 
 output "arn" {

--- a/test/fixture-get-aws-caller-identity/terragrunt.hcl
+++ b/test/fixture-get-aws-caller-identity/terragrunt.hcl
@@ -1,5 +1,6 @@
 inputs = {
   account = get_aws_account_id()
+  account_alias = get_aws_account_alias()
   arn = get_aws_caller_identity_arn()
   user_id = get_aws_caller_identity_user_id()
 }


### PR DESCRIPTION
This is the PR for issue #1615 to add support for looking up the current account alias for AWS. I did not see any other unit tests for the other AWS built-in functions, but would be glad to figure out how to add some in for this if that would help.