### PR TITLE
Remove all usage of get-plugins=false which is removed in 0.15.0

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -639,7 +639,7 @@ func runTerraformInitForDependencyOutput(terragruntOptions *options.TerragruntOp
 	initTGOptions := terragruntOptions.Clone(targetConfig)
 	initTGOptions.WorkingDir = workingDir
 	initTGOptions.ErrWriter = &stderr
-	err := shell.RunTerraformCommand(initTGOptions, "init", "-get=false", "-get-plugins=false")
+	err := shell.RunTerraformCommand(initTGOptions, "init", "-get=false")
 	if err != nil {
 		terragruntOptions.Logger.Debugf("Ignoring expected error from dependency init call")
 		terragruntOptions.Logger.Debugf("Init call stderr:")

--- a/docs/_docs/02_features/keep-your-cli-flags-dry.md
+++ b/docs/_docs/02_features/keep-your-cli-flags-dry.md
@@ -129,7 +129,6 @@ terraform {
     ]
 
     arguments = [
-      "-get-plugins=false",
       "-plugin-dir=/my/terraform/plugin/dir",
     ]
   }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2136,7 +2136,7 @@ func TestYamlDecodeRegressions(t *testing.T) {
 // module has been destroyed.
 func TestDependencyOutputOptimization(t *testing.T) {
 	expectOutputLogs := []string{
-		`Running command: terraform init -get=false -get-plugins=false prefix=\[.*fixture-get-output/nested-optimization/dep\]`,
+		`Running command: terraform init -get=false prefix=\[.*fixture-get-output/nested-optimization/dep\]`,
 	}
 	dependencyOutputOptimizationTest(t, "nested-optimization", true, expectOutputLogs)
 }
@@ -2150,7 +2150,7 @@ func TestDependencyOutputOptimizationSkipInit(t *testing.T) {
 
 func TestDependencyOutputOptimizationNoGenerate(t *testing.T) {
 	expectOutputLogs := []string{
-		`Running command: terraform init -get=false -get-plugins=false prefix=\[.*fixture-get-output/nested-optimization-nogen/dep\]`,
+		`Running command: terraform init -get=false prefix=\[.*fixture-get-output/nested-optimization-nogen/dep\]`,
 	}
 	dependencyOutputOptimizationTest(t, "nested-optimization-nogen", true, expectOutputLogs)
 }


### PR DESCRIPTION
The optimization from #1321 added use of `-get-plugins` flag when calling `terraform init`. This flag is removed in Terraform 0.15.0-beta1, and has been a no-op since 0.13.0:

From the changelog for Terraform v014.3:

>    terraform init: setting -get-plugins to false will now cause a warning, as this flag has been a no-op since 0.13.0 and usage is better served through using provider_installation blocks (#27092)

From the changelog for Terraform v0.15.0-beta1:

>    The -get-plugins=false option is no longer available on terraform init. (Terraform now always installs plugins.) (#27463)


Due to the use of this, when running Terraform 0.15.0-beta1 or later, Terragrunt will fail with a rather uninformative error from Terraform bubbling up:

```
davidalger@silver-bullet:~/work/algerdev (master) $ find . -type d -name .terragrunt-cache -exec rm -rf {} +
davidalger@silver-bullet:~/work/algerdev (master) $ (cd live/traefik; terragrunt init)
╷
│ Error: Initialization required. Please see the error message above.
│ 
│ 
╵
╷
│ Error: Initialization required. Please see the error message above.
│ 
│ 
╵
ERRO[0002] exit status 1                                
```

A trace reveals the error, silelently ignored by Terragrunt:

```
DEBU[0000] Running command: terraform init -get=false -get-plugins=false  prefix=[/Users/davidalger/Work/algerdev/live/project] 
DEBU[0001] Ignoring expected error from dependency init call  prefix=[/Users/davidalger/Work/algerdev/live/project] 
DEBU[0001] Init call stderr:                             prefix=[/Users/davidalger/Work/algerdev/live/project] 
DEBU[0001] Usage: terraform [global options] init [options]

  Initialize a new or existing Terraform working directory by creating
  initial files, loading any remote state, downloading modules, etc.

  This is the first command that should be run for any new or existing
  Terraform configuration per machine. This sets up all the local data
  necessary to run Terraform that is typically not committed to version
  control.

  This command is always safe to run multiple times. Though subsequent runs
  may give errors, this command will never delete your configuration or
  state. Even so, if you have important information, please back it up prior
  to running this command, just in case.

Options:

  -backend=true        Configure the backend for this configuration.

  -backend-config=path This can be either a path to an HCL file with key/value
                       assignments (same format as terraform.tfvars) or a
                       'key=value' format. This is merged with what is in the
                       configuration file. This can be specified multiple
                       times. The backend type must be in the configuration
                       itself.

  -force-copy          Suppress prompts about copying state data. This is
                       equivalent to providing a "yes" to all confirmation
                       prompts.

  -from-module=SOURCE  Copy the contents of the given module into the target
                       directory before initialization.

  -get=true            Download any modules for this configuration.

  -input=true          Ask for input if necessary. If false, will error if
                       input was required.

  -no-color            If specified, output won't contain any color.

  -plugin-dir          Directory containing plugin binaries. This overrides all
                       default search paths for plugins, and prevents the
                       automatic installation of plugins. This flag can be used
                       multiple times.

  -reconfigure         Reconfigure the backend, ignoring any saved
                       configuration.

  -upgrade=false       If installing modules (-get) or plugins, ignore
                       previously-downloaded objects and install the
                       latest version allowed within configured constraints.

  -lockfile=MODE       Set a dependency lockfile mode.
```
Full trace can be found here: https://github.com/gruntwork-io/terragrunt/issues/1577#issuecomment-808297028

Setting `disable_dependency_optimization` to `true` workaround the problem as it disables the optimization which introduced use of the deprecated argument to `terraform init`.

The changes here have resolved the underlying for me in local tests and in our CI where I was testing the use of 0.15.0 betas, and the tests changed continue to pass:

```
davidalger@silver-bullet:.../terragrunt/remote (develop) $ go test -v -run TestDependencyOutputOptimization
testing: warning: no tests to run
PASS
ok  	github.com/gruntwork-io/terragrunt/remote	0.254s
davidalger@silver-bullet:.../terragrunt/remote (develop) $ go test -v -run TestDependencyOutputOptimizationNoGenerate
testing: warning: no tests to run
PASS
ok  	github.com/gruntwork-io/terragrunt/remote	0.217s
```


