### PR TITLE
Switch log level of terragrunt dependency fetching informational messages

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -407,8 +407,8 @@ func getTerragruntOutputJson(terragruntOptions *options.TerragruntOptions, targe
 	// directly.
 	remoteStateTGConfig, err := PartialParseConfigFile(targetConfig, targetTGOptions, nil, []PartialDecodeSectionType{RemoteStateBlock, TerragruntFlags})
 	if err != nil || !canGetRemoteState(remoteStateTGConfig.RemoteState) {
-		terragruntOptions.Logger.Warningf("Could not parse remote_state block from target config %s", targetConfig)
-		terragruntOptions.Logger.Warningf("Falling back to terragrunt output.")
+		terragruntOptions.Logger.Infof("Could not parse remote_state block from target config %s", targetConfig)
+		terragruntOptions.Logger.Infof("Falling back to terragrunt output.")
 		return runTerragruntOutputJson(targetTGOptions, targetConfig)
 	}
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -407,8 +407,8 @@ func getTerragruntOutputJson(terragruntOptions *options.TerragruntOptions, targe
 	// directly.
 	remoteStateTGConfig, err := PartialParseConfigFile(targetConfig, targetTGOptions, nil, []PartialDecodeSectionType{RemoteStateBlock, TerragruntFlags})
 	if err != nil || !canGetRemoteState(remoteStateTGConfig.RemoteState) {
-		terragruntOptions.Logger.Infof("Could not parse remote_state block from target config %s", targetConfig)
-		terragruntOptions.Logger.Infof("Falling back to terragrunt output.")
+		terragruntOptions.Logger.Debugf("Could not parse remote_state block from target config %s", targetConfig)
+		terragruntOptions.Logger.Debugf("Falling back to terragrunt output.")
 		return runTerragruntOutputJson(targetTGOptions, targetConfig)
 	}
 


### PR DESCRIPTION
Related to https://github.com/gruntwork-io/terragrunt/issues/1625

This updates the informational messages related to dependency fetching optimizations to info log level from warning. I initially made these warning to make it more visible, but in hindsight these should have been `info` level because they are purely informational.

Warning indicates that something might be amiss and the user needs to make changes. In this case, there is probably nothing wrong here because there are many valid use cases of setting up terragrunt without `remote_state` blocks (e.g., if your project uses remote state that is not backed by `s3` or `gcs`). Thus info log level seems more appropriate for these messages.