### PR TITLE
Fixing behavior of `--terragrunt-strict-include` when no `--terragrunt-include-dir` flags are included

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -139,6 +139,11 @@ func flagIncludedDirs(modules []*TerraformModule, terragruntOptions *options.Ter
 
 	// If no IncludeDirs is specified return the modules list instantly
 	if len(terragruntOptions.IncludeDirs) == 0 {
+		// If we aren't given any include directories, but are given the strict include flag,
+		// return no modules.
+		if terragruntOptions.StrictInclude) {
+			return []*TerraformModule{}, nil
+		}
 		return modules, nil
 	}
 

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -141,7 +141,7 @@ func flagIncludedDirs(modules []*TerraformModule, terragruntOptions *options.Ter
 	if len(terragruntOptions.IncludeDirs) == 0 {
 		// If we aren't given any include directories, but are given the strict include flag,
 		// return no modules.
-		if terragruntOptions.StrictInclude) {
+		if terragruntOptions.StrictInclude {
 			return []*TerraformModule{}, nil
 		}
 		return modules, nil

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -557,7 +557,8 @@ relative from `--terragrunt-working-dir`. Flag can be specified multiple times.
 
 When passed in, only modules under the directories passed in with [--terragrunt-include-dir](#terragrunt-include-dir)
 will be included. All dependencies of the included directories will be excluded if they are not in the included
-directories.
+directories. If no [--terragrunt-include-dir](#terragrunt-include-dir) are included, terragrunt will not include any
+modules during the execution of the commands.
 
 
 ### terragrunt-ignore-dependency-order

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -557,8 +557,8 @@ relative from `--terragrunt-working-dir`. Flag can be specified multiple times.
 
 When passed in, only modules under the directories passed in with [--terragrunt-include-dir](#terragrunt-include-dir)
 will be included. All dependencies of the included directories will be excluded if they are not in the included
-directories. If no [--terragrunt-include-dir](#terragrunt-include-dir) are included, terragrunt will not include any
-modules during the execution of the commands.
+directories. If no [--terragrunt-include-dir](#terragrunt-include-dir) flags are included, terragrunt will not include
+any modules during the execution of the commands.
 
 
 ### terragrunt-ignore-dependency-order

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3915,22 +3915,22 @@ func fileIsInFolder(t *testing.T, name string, path string) bool {
 }
 
 func runValidateAllWithIncludeAndGetIncludedModules(t *testing.T, rootModulePath string, includeModulePaths []string, strictInclude bool) []string {
-	cmd := []string{
+	cmd_parts := []string{
 		"terragrunt", "run-all", "validate",
 		"--terragrunt-non-interactive",
 		"--terragrunt-log-level", "debug",
 		"--terragrunt-working-dir", rootModulePath,
 	}
 
-	for module := range includeModulePaths {
-		cmd = append(cmd, "--terragrunt-include-dir", module)
+	for _, module := range includeModulePaths {
+		cmd_parts = append(cmd_parts, "--terragrunt-include-dir", module)
 	}
 
 	if strictInclude {
-		cmd = append(cmd, "--terragrunt-strict-include")
+		cmd_parts = append(cmd_parts, "--terragrunt-strict-include")
 	}
 
-	cmd = strings.Join(cmd, " ")
+	cmd := strings.Join(cmd_parts, " ")
 
 	validateAllStdout := bytes.Buffer{}
 	validateAllStderr := bytes.Buffer{}


### PR DESCRIPTION
This PR is an attempt to fix the behavior of Terragrunt when the `--terragrunt-strict-include` flag is supplied without any `--terragrunt-include-dir` flags.

The expected behavior is that Terragrunt will evaluate to not run on any modules in this case, but the current behavior is that it will run over all modules of the working directory.

This is to address #1600.