### PR TITLE
Add configurable retries

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -391,6 +391,24 @@ func RunTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		terragruntOptions.RetryableErrors = terragruntConfig.RetryableErrors
 	}
 
+	// Override the default value of the max retry attempts using the value set in the config file
+	if val := terragruntConfig.RetryMaxAttempts; val != nil {
+		if *val < 1 {
+			terragruntOptions.Logger.Warnf("%s", "Cannot have less than 1 max retry, so we're using 1.")
+			*val = 1
+		}
+		terragruntOptions.MaxRetryAttempts = *val
+	}
+
+	// Override the default value of the max retry attempts using the value set in the config file
+	if val := terragruntConfig.RetrySleepInterval; val != nil {
+		if *val < 0 {
+			terragruntOptions.Logger.Warnf("%s", "Cannot sleep for less than 0 seconds, so we're using 0.")
+			*val = 0
+		}
+		terragruntOptions.Sleep = time.Duration(*terragruntConfig.RetrySleepInterval) * time.Second
+	}
+
 	updatedTerragruntOptions := terragruntOptions
 	if sourceUrl := config.GetTerraformSourceUrl(terragruntOptions, terragruntConfig); sourceUrl != "" {
 		updatedTerragruntOptions, err = downloadTerraformSource(sourceUrl, terragruntOptions, terragruntConfig)

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,8 @@ type TerragruntConfig struct {
 	TerragruntDependencies      []Dependency
 	GenerateConfigs             map[string]codegen.GenerateConfig
 	RetryableErrors             []string
+	RetryMaxAttempts            *int
+	RetrySleepInterval          *int
 
 	// Indicates whether or not this is the result of a partial evaluation
 	IsPartial bool
@@ -67,6 +69,8 @@ type terragruntConfigFile struct {
 	TerragruntDependencies      []Dependency              `hcl:"dependency,block"`
 	GenerateBlocks              []terragruntGenerateBlock `hcl:"generate,block"`
 	RetryableErrors             []string                  `hcl:"retryable_errors,optional"`
+	RetryMaxAttempts            *int                      `hcl:"retry_max_attempts,optional"`
+	RetrySleepInterval          *int                      `hcl:"retry_sleep_interval,optional"`
 
 	// This struct is used for validating and parsing the entire terragrunt config. Since locals are evaluated in a
 	// completely separate cycle, it should not be evaluated here. Otherwise, we can't support self referencing other
@@ -566,6 +570,14 @@ func mergeConfigWithIncludedConfig(config *TerragruntConfig, includedConfig *Ter
 		includedConfig.RetryableErrors = config.RetryableErrors
 	}
 
+	if config.RetryMaxAttempts != nil {
+		includedConfig.RetryMaxAttempts = config.RetryMaxAttempts
+	}
+
+	if config.RetrySleepInterval != nil {
+		includedConfig.RetrySleepInterval = config.RetrySleepInterval
+	}
+
 	if config.TerragruntVersionConstraint != "" {
 		includedConfig.TerragruntVersionConstraint = config.TerragruntVersionConstraint
 	}
@@ -731,6 +743,14 @@ func convertToTerragruntConfig(
 
 	if terragruntConfigFromFile.RetryableErrors != nil {
 		terragruntConfig.RetryableErrors = terragruntConfigFromFile.RetryableErrors
+	}
+
+	if terragruntConfigFromFile.RetryMaxAttempts != nil {
+		terragruntConfig.RetryMaxAttempts = terragruntConfigFromFile.RetryMaxAttempts
+	}
+
+	if terragruntConfigFromFile.RetrySleepInterval != nil {
+		terragruntConfig.RetrySleepInterval = terragruntConfigFromFile.RetrySleepInterval
 	}
 
 	if terragruntConfigFromFile.DownloadDir != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ type TerragruntConfig struct {
 	GenerateConfigs             map[string]codegen.GenerateConfig
 	RetryableErrors             []string
 	RetryMaxAttempts            *int
-	RetrySleepInterval          *int
+	RetrySleepIntervalSec       *int
 
 	// Indicates whether or not this is the result of a partial evaluation
 	IsPartial bool
@@ -70,7 +70,7 @@ type terragruntConfigFile struct {
 	GenerateBlocks              []terragruntGenerateBlock `hcl:"generate,block"`
 	RetryableErrors             []string                  `hcl:"retryable_errors,optional"`
 	RetryMaxAttempts            *int                      `hcl:"retry_max_attempts,optional"`
-	RetrySleepInterval          *int                      `hcl:"retry_sleep_interval,optional"`
+	RetrySleepIntervalSec       *int                      `hcl:"retry_sleep_interval_sec,optional"`
 
 	// This struct is used for validating and parsing the entire terragrunt config. Since locals are evaluated in a
 	// completely separate cycle, it should not be evaluated here. Otherwise, we can't support self referencing other
@@ -574,8 +574,8 @@ func mergeConfigWithIncludedConfig(config *TerragruntConfig, includedConfig *Ter
 		includedConfig.RetryMaxAttempts = config.RetryMaxAttempts
 	}
 
-	if config.RetrySleepInterval != nil {
-		includedConfig.RetrySleepInterval = config.RetrySleepInterval
+	if config.RetrySleepIntervalSec != nil {
+		includedConfig.RetrySleepIntervalSec = config.RetrySleepIntervalSec
 	}
 
 	if config.TerragruntVersionConstraint != "" {
@@ -749,8 +749,8 @@ func convertToTerragruntConfig(
 		terragruntConfig.RetryMaxAttempts = terragruntConfigFromFile.RetryMaxAttempts
 	}
 
-	if terragruntConfigFromFile.RetrySleepInterval != nil {
-		terragruntConfig.RetrySleepInterval = terragruntConfigFromFile.RetrySleepInterval
+	if terragruntConfigFromFile.RetrySleepIntervalSec != nil {
+		terragruntConfig.RetrySleepIntervalSec = terragruntConfigFromFile.RetrySleepIntervalSec
 	}
 
 	if terragruntConfigFromFile.DownloadDir != nil {

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -79,6 +79,22 @@ func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 		output["retryable_errors"] = retryableCty
 	}
 
+	retryMaxAttemptsCty, err := goTypeToCty(config.RetryMaxAttempts)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	if retryMaxAttemptsCty != cty.NilVal {
+		output["retry_max_attempts"] = retryMaxAttemptsCty
+	}
+
+	retrySleepIntervalCty, err := goTypeToCty(config.RetrySleepInterval)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	if retrySleepIntervalCty != cty.NilVal {
+		output["retry_sleep_interval"] = retrySleepIntervalCty
+	}
+
 	inputsCty, err := convertToCtyWithJson(config.Inputs)
 	if err != nil {
 		return cty.NilVal, err

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -87,12 +87,12 @@ func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 		output["retry_max_attempts"] = retryMaxAttemptsCty
 	}
 
-	retrySleepIntervalCty, err := goTypeToCty(config.RetrySleepInterval)
+	retrySleepIntervalSecCty, err := goTypeToCty(config.RetrySleepIntervalSec)
 	if err != nil {
 		return cty.NilVal, err
 	}
-	if retrySleepIntervalCty != cty.NilVal {
-		output["retry_sleep_interval"] = retrySleepIntervalCty
+	if retrySleepIntervalSecCty != cty.NilVal {
+		output["retry_sleep_interval_sec"] = retrySleepIntervalSecCty
 	}
 
 	inputsCty, err := convertToCtyWithJson(config.Inputs)

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -201,8 +201,8 @@ func terragruntConfigStructFieldToMapKey(t *testing.T, fieldName string) (string
 		return "retryable_errors", true
 	case "RetryMaxAttempts":
 		return "retry_max_attempts", true
-	case "RetrySleepInterval":
-		return "retry_sleep_interval", true
+	case "RetrySleepIntervalSec":
+		return "retry_sleep_interval_sec", true
 	default:
 		t.Fatalf("Unknown struct property: %s", fieldName)
 		// This should not execute

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -199,6 +199,10 @@ func terragruntConfigStructFieldToMapKey(t *testing.T, fieldName string) (string
 		return "", false
 	case "RetryableErrors":
 		return "retryable_errors", true
+	case "RetryMaxAttempts":
+		return "retry_max_attempts", true
+	case "RetrySleepInterval":
+		return "retry_sleep_interval", true
 	default:
 		t.Fatalf("Unknown struct property: %s", fieldName)
 		// This should not execute

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -163,7 +163,7 @@ func TestParseTerragruntHclConfigRetryConfiguration(t *testing.T) {
 
 	config := `
 retry_max_attempts = 10
-retry_sleep_interval = 60
+retry_sleep_interval_sec = 60
 retryable_errors = [
     "My own little error",
     "Another one of my errors"
@@ -176,7 +176,7 @@ retryable_errors = [
 	assert.Empty(t, terragruntConfig.IamRole)
 
 	assert.Equal(t, 10, *terragruntConfig.RetryMaxAttempts)
-	assert.Equal(t, 60, *terragruntConfig.RetrySleepInterval)
+	assert.Equal(t, 60, *terragruntConfig.RetrySleepIntervalSec)
 
 	if assert.NotNil(t, terragruntConfig.RetryableErrors) {
 		assert.Equal(t, []string{"My own little error", "Another one of my errors"}, terragruntConfig.RetryableErrors)
@@ -189,7 +189,7 @@ func TestParseTerragruntJsonConfigRetryConfiguration(t *testing.T) {
 	config := `
 {
 	"retry_max_attempts": 10,
-	"retry_sleep_interval": 60,
+	"retry_sleep_interval_sec": 60,
 	"retryable_errors": [
         "My own little error"
 	]
@@ -203,7 +203,7 @@ func TestParseTerragruntJsonConfigRetryConfiguration(t *testing.T) {
 	assert.Empty(t, terragruntConfig.IamRole)
 
 	assert.Equal(t, *terragruntConfig.RetryMaxAttempts, 10)
-	assert.Equal(t, *terragruntConfig.RetrySleepInterval, 60)
+	assert.Equal(t, *terragruntConfig.RetrySleepIntervalSec, 60)
 
 	if assert.NotNil(t, terragruntConfig.RetryableErrors) {
 		assert.Equal(t, []string{"My own little error"}, terragruntConfig.RetryableErrors)
@@ -626,7 +626,7 @@ func TestParseTerragruntConfigEmptyConfig(t *testing.T) {
 	assert.False(t, cfg.Skip)
 	assert.Empty(t, cfg.IamRole)
 	assert.Nil(t, cfg.RetryMaxAttempts)
-	assert.Nil(t, cfg.RetrySleepInterval)
+	assert.Nil(t, cfg.RetrySleepIntervalSec)
 	assert.Nil(t, cfg.RetryableErrors)
 }
 

--- a/docs/_docs/02_features/auto-retry.md
+++ b/docs/_docs/02_features/auto-retry.md
@@ -45,11 +45,11 @@ retryable_errors = [
 ```
 
 By default, `auto-retry` tries a maximum of three times to re-run a command, pausing for five seconds between each retry, at which point it will deem the error as not transient, and accept the `terraform` failure.
-However, we can override these defaults too. For example, the following retries up to five times, with 60 seconds in between each retry:
+However, you can override these defaults. For example, the following retries up to five times, with 60 seconds in between each retry:
 
 ```hcl
 retry_max_attempts = 5
-retry_sleep_interval = 60
+retry_sleep_interval_sec = 60
 ```
 
 To disable `auto-retry`, use the `--terragrunt-no-auto-retry` command line option or set the `TERRAGRUNT_AUTO_RETRY` environment variable to `false`.

--- a/docs/_docs/02_features/auto-retry.md
+++ b/docs/_docs/02_features/auto-retry.md
@@ -28,8 +28,6 @@ Error installing provider "template": error fetching checksums: Get https://rele
 
 Terragrunt sees this error, and knows it is a transient error that can be addressed by re-running the `apply` command.
 
-`auto-retry` will try a maximum of three times to re-run the command, at which point it will deem the error as not transient, and accept the terraform failure. Retries will occur when the error is encountered, pausing for 5 seconds between retries.
-
 Terragrunt has a small list of default known errors built-in. You can override these defaults with your own custom retryable errors in your `terragrunt.hcl` configuration:
 ```hcl
 retryable_errors = [
@@ -46,6 +44,12 @@ retryable_errors = [
 ]
 ```
 
-Future upgrades to `terragrunt` may include the ability to configure max retries and retry intervals in the `terragrunt` config (PRs welcome\!).
+By default, `auto-retry` tries a maximum of three times to re-run a command, pausing for five seconds between each retry, at which point it will deem the error as not transient, and accept the `terraform` failure.
+However, we can override these defaults too. For example, the following retries up to five times, with 60 seconds in between each retry:
+
+```hcl
+retry_max_attempts = 5
+retry_sleep_interval = 60
+```
 
 To disable `auto-retry`, use the `--terragrunt-no-auto-retry` command line option or set the `TERRAGRUNT_AUTO_RETRY` environment variable to `false`.

--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -3,7 +3,7 @@ package options
 import "time"
 
 const DEFAULT_RETRY_MAX_ATTEMPTS = 3
-const DEFAULT_RETRY_SLEEP_INTERVAL = 5 * time.Second
+const DEFAULT_RETRY_SLEEP_INTERVAL_SEC = 5 * time.Second
 
 // List of recurring transient errors encountered when calling terraform
 // If any of these match, we'll retry the command

--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -2,8 +2,8 @@ package options
 
 import "time"
 
-const DEFAULT_MAX_RETRY_ATTEMPTS = 3
-const DEFAULT_SLEEP = 5 * time.Second
+const DEFAULT_RETRY_MAX_ATTEMPTS = 3
+const DEFAULT_RETRY_SLEEP_INTERVAL = 5 * time.Second
 
 // List of recurring transient errors encountered when calling terraform
 // If any of these match, we'll retry the command

--- a/options/options.go
+++ b/options/options.go
@@ -124,7 +124,7 @@ type TerragruntOptions struct {
 	RetryMaxAttempts int
 
 	// The duration in seconds to wait before retrying
-	RetrySleepInterval time.Duration
+	RetrySleepIntervalSec time.Duration
 
 	// RetryableErrors is an array of regular expressions with RE2 syntax (https://github.com/google/re2/wiki/Syntax) that qualify for retrying
 	RetryableErrors []string
@@ -196,7 +196,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		MaxFoldersToCheck:           DEFAULT_MAX_FOLDERS_TO_CHECK,
 		AutoRetry:                   true,
 		RetryMaxAttempts:            DEFAULT_RETRY_MAX_ATTEMPTS,
-		RetrySleepInterval:          DEFAULT_RETRY_SLEEP_INTERVAL,
+		RetrySleepIntervalSec:       DEFAULT_RETRY_SLEEP_INTERVAL_SEC,
 		RetryableErrors:             util.CloneStringList(DEFAULT_RETRYABLE_ERRORS),
 		ExcludeDirs:                 []string{},
 		IncludeDirs:                 []string{},
@@ -272,7 +272,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		MaxFoldersToCheck:           terragruntOptions.MaxFoldersToCheck,
 		AutoRetry:                   terragruntOptions.AutoRetry,
 		RetryMaxAttempts:            terragruntOptions.RetryMaxAttempts,
-		RetrySleepInterval:          terragruntOptions.RetrySleepInterval,
+		RetrySleepIntervalSec:       terragruntOptions.RetrySleepIntervalSec,
 		RetryableErrors:             util.CloneStringList(terragruntOptions.RetryableErrors),
 		ExcludeDirs:                 terragruntOptions.ExcludeDirs,
 		IncludeDirs:                 terragruntOptions.IncludeDirs,

--- a/options/options.go
+++ b/options/options.go
@@ -117,14 +117,14 @@ type TerragruntOptions struct {
 	// exposed here primarily so we can set it to a low value at test time.
 	MaxFoldersToCheck int
 
-	// Whether we should automatically retry errored Terraform command
+	// Whether we should automatically retry errored Terraform commands
 	AutoRetry bool
 
 	// Maximum number of times to retry errors matching RetryableErrors
-	MaxRetryAttempts int
+	RetryMaxAttempts int
 
-	// Sleep is the duration in seconds to wait before retrying
-	Sleep time.Duration
+	// The duration in seconds to wait before retrying
+	RetrySleepInterval time.Duration
 
 	// RetryableErrors is an array of regular expressions with RE2 syntax (https://github.com/google/re2/wiki/Syntax) that qualify for retrying
 	RetryableErrors []string
@@ -195,8 +195,8 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		ErrWriter:                   os.Stderr,
 		MaxFoldersToCheck:           DEFAULT_MAX_FOLDERS_TO_CHECK,
 		AutoRetry:                   true,
-		MaxRetryAttempts:            DEFAULT_MAX_RETRY_ATTEMPTS,
-		Sleep:                       DEFAULT_SLEEP,
+		RetryMaxAttempts:            DEFAULT_RETRY_MAX_ATTEMPTS,
+		RetrySleepInterval:          DEFAULT_RETRY_SLEEP_INTERVAL,
 		RetryableErrors:             util.CloneStringList(DEFAULT_RETRYABLE_ERRORS),
 		ExcludeDirs:                 []string{},
 		IncludeDirs:                 []string{},
@@ -271,8 +271,8 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		ErrWriter:                   terragruntOptions.ErrWriter,
 		MaxFoldersToCheck:           terragruntOptions.MaxFoldersToCheck,
 		AutoRetry:                   terragruntOptions.AutoRetry,
-		MaxRetryAttempts:            terragruntOptions.MaxRetryAttempts,
-		Sleep:                       terragruntOptions.Sleep,
+		RetryMaxAttempts:            terragruntOptions.RetryMaxAttempts,
+		RetrySleepInterval:          terragruntOptions.RetrySleepInterval,
 		RetryableErrors:             util.CloneStringList(terragruntOptions.RetryableErrors),
 		ExcludeDirs:                 terragruntOptions.ExcludeDirs,
 		IncludeDirs:                 terragruntOptions.IncludeDirs,

--- a/options/options.go
+++ b/options/options.go
@@ -117,7 +117,7 @@ type TerragruntOptions struct {
 	// exposed here primarily so we can set it to a low value at test time.
 	MaxFoldersToCheck int
 
-	// Whether we should automatically run terraform init if necessary when executing other commands
+	// Whether we should automatically retry errored Terraform command
 	AutoRetry bool
 
 	// Maximum number of times to retry errors matching RetryableErrors

--- a/test/fixture-auto-retry/configurable-retries-incorrect-retry-attempts/main.tf
+++ b/test/fixture-auto-retry/configurable-retries-incorrect-retry-attempts/main.tf
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixture-auto-retry/configurable-retries-incorrect-retry-attempts/terragrunt.hcl
+++ b/test/fixture-auto-retry/configurable-retries-incorrect-retry-attempts/terragrunt.hcl
@@ -1,0 +1,1 @@
+retry_max_attempts = 0

--- a/test/fixture-auto-retry/configurable-retries-incorrect-sleep-interval/main.tf
+++ b/test/fixture-auto-retry/configurable-retries-incorrect-sleep-interval/main.tf
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixture-auto-retry/configurable-retries-incorrect-sleep-interval/terragrunt.hcl
+++ b/test/fixture-auto-retry/configurable-retries-incorrect-sleep-interval/terragrunt.hcl
@@ -1,0 +1,1 @@
+retry_sleep_interval_sec = -1

--- a/test/fixture-auto-retry/configurable-retries/main.tf
+++ b/test/fixture-auto-retry/configurable-retries/main.tf
@@ -1,0 +1,29 @@
+resource "null_resource" "tf_success_on_fifth_retry" {
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+
+    // The command will fail with 'TLS handshake timeout' error on the first
+    // run, and on the fifth will succeed. We use a 'count' file to keep track
+    // of the run number.
+    command = <<EOF
+if ! [ -f count ]; then i=1; else i="$((1 + $(cat count)))"; fi
+echo "$i" > count
+    
+if [ "$i" -lt 5 ]; then
+    echo 'Failed to load backend: Error configuring the backend 's3': RequestError: send request failed caused by: Post https://sts.amazonaws.com/: net/http: TLS handshake timeout'
+    exit 1
+else
+    exit 0
+fi
+EOF
+  }
+}
+
+variable "some_var" {
+  description = "Just to get some output"
+  default     = "Some value"
+}
+
+output "test" {
+  value = var.some_var
+}

--- a/test/fixture-auto-retry/configurable-retries/terragrunt.hcl
+++ b/test/fixture-auto-retry/configurable-retries/terragrunt.hcl
@@ -1,0 +1,2 @@
+retry_max_attempts       = 5
+retry_sleep_interval_sec = 0

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -106,6 +106,8 @@ const (
 	TEST_FIXTURE_AUTO_RETRY_CUSTOM_ERRORS_NOT_SET           = "fixture-auto-retry/custom-errors-not-set"
 	TEST_FIXTURE_AUTO_RETRY_APPLY_ALL_RETRIES               = "fixture-auto-retry/apply-all"
 	TEST_FIXTURE_AUTO_RETRY_CONFIGURABLE_RETRIES            = "fixture-auto-retry/configurable-retries"
+	TEST_FIXTURE_AUTO_RETRY_CONFIGURABLE_RETRIES_ERROR_1    = "fixture-auto-retry/configurable-retries-incorrect-retry-attempts"
+	TEST_FIXTURE_AUTO_RETRY_CONFIGURABLE_RETRIES_ERROR_2    = "fixture-auto-retry/configurable-retries-incorrect-sleep-interval"
 	TEST_FIXTURE_AWS_PROVIDER_PATCH                         = "fixture-aws-provider-patch"
 	TEST_FIXTURE_INPUTS                                     = "fixture-inputs"
 	TEST_FIXTURE_LOCALS_ERROR_UNDEFINED_LOCAL               = "fixture-locals-errors/undefined-local"
@@ -1322,6 +1324,34 @@ func TestAutoRetryConfigurableRetries(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(sleeps)) // 5 retries, so 4 sleeps
 	assert.Contains(t, stdout.String(), "Apply complete!")
+}
+
+func TestAutoRetryConfigurableRetriesErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		fixture      string
+		errorMessage string
+	}{
+		{TEST_FIXTURE_AUTO_RETRY_CONFIGURABLE_RETRIES_ERROR_1, "Cannot have less than 1 max retry"},
+		{TEST_FIXTURE_AUTO_RETRY_CONFIGURABLE_RETRIES_ERROR_2, "Cannot sleep for less than 0 seconds"},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.fixture, func(t *testing.T) {
+			t.Parallel()
+
+			stdout := new(bytes.Buffer)
+			stderr := new(bytes.Buffer)
+			rootPath := copyEnvironment(t, tc.fixture)
+			modulePath := util.JoinPath(rootPath, tc.fixture)
+
+			err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", modulePath), stdout, stderr)
+			assert.NotNil(t, err)
+			assert.NotContains(t, stdout.String(), "Apply complete!")
+			assert.Contains(t, err.Error(), tc.errorMessage)
+		})
+	}
 }
 
 func TestAwsProviderPatch(t *testing.T) {


### PR DESCRIPTION
Addresses https://github.com/gruntwork-io/terragrunt/issues/1630. Please lemme know what y'all think!

This PR adds two new options to configure our retries. For example, the following will try up to 10 times with 60 seconds in between each retry:

```hcl
retry_max_attempts = 10
retry_sleep_interval_sec = 60
retryable_errors = [
  "My own little error",
  "Another one of my errors",
]
```