### PR TITLE
Add new get_original_terragrunt_dir() helper

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -139,6 +139,8 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 		return nil, err
 	}
 
+	opts.OriginalTerragruntConfigPath = opts.TerragruntConfigPath
+
 	debug := parseBooleanArg(args, OPT_TERRAGRUNT_DEBUG, false)
 	if debug {
 		opts.Debug = true

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -380,7 +380,7 @@ func readTerragruntConfig(configPath string, defaultVal *cty.Value, terragruntOp
 	}
 
 	// We update the context of terragruntOptions to the config being read in.
-	targetOptions := terragruntOptions.Clone(targetConfig)
+	targetOptions := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
 	config, err := ParseConfigFile(targetConfig, targetOptions, nil)
 	if err != nil {
 		return cty.NilVal, err

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -111,7 +111,7 @@ func checkForDependencyBlockCycles(filename string, decodedDependency terragrunt
 	currentTraversalPaths := []string{filename}
 	for _, dependency := range decodedDependency.Dependencies {
 		dependencyPath := getCleanedTargetConfigPath(dependency.ConfigPath, filename)
-		dependencyOptions := terragruntOptions.Clone(dependencyPath)
+		dependencyOptions := cloneTerragruntOptionsForDependency(terragruntOptions, dependencyPath)
 		if err := checkForDependencyBlockCyclesUsingDFS(dependencyPath, &visitedPaths, &currentTraversalPaths, dependencyOptions); err != nil {
 			return err
 		}
@@ -144,7 +144,7 @@ func checkForDependencyBlockCyclesUsingDFS(
 	}
 	for _, dependency := range dependencyPaths {
 		nextPath := getCleanedTargetConfigPath(dependency, currentConfigPath)
-		nextOptions := terragruntOptions.Clone(nextPath)
+		nextOptions := cloneTerragruntOptionsForDependency(terragruntOptions, nextPath)
 		if err := checkForDependencyBlockCyclesUsingDFS(nextPath, visitedPaths, currentTraversalPaths, nextOptions); err != nil {
 			return err
 		}
@@ -339,9 +339,21 @@ func getOutputJsonWithCaching(targetConfig string, terragruntOptions *options.Te
 	return newJsonBytes, nil
 }
 
+// Whenever executing a dependency module, we clone the original options, and reset:
+//
+// - The config path to the dependency module's config
+// - The original config path to the dependency module's config
+//
+// That way, everything in that dependnecy happens within its own context.
+func cloneTerragruntOptionsForDependency(terragruntOptions *options.TerragruntOptions, targetConfig string) *options.TerragruntOptions {
+	targetOptions := terragruntOptions.Clone(targetConfig)
+	targetOptions.OriginalTerragruntConfigPath = targetConfig
+	return targetOptions
+}
+
 // Clone terragrunt options and update context for dependency block so that the outputs can be read correctly
 func cloneTerragruntOptionsForDependencyOutput(terragruntOptions *options.TerragruntOptions, targetConfig string) (*options.TerragruntOptions, error) {
-	targetOptions := terragruntOptions.Clone(targetConfig)
+	targetOptions := cloneTerragruntOptionsForDependency(terragruntOptions, targetConfig)
 	targetOptions.TerraformCommand = "output"
 	targetOptions.TerraformCliArgs = []string{"output", "-json"}
 
@@ -556,7 +568,7 @@ func setupTerragruntOptionsForBareTerraform(originalOptions *options.TerragruntO
 	// terraform directly.
 	// Set the terraform working dir to the tempdir, and set stdout writer to ioutil.Discard so that output content is
 	// not logged.
-	targetTGOptions := originalOptions.Clone(configPath)
+	targetTGOptions := cloneTerragruntOptionsForDependency(originalOptions, configPath)
 	targetTGOptions.WorkingDir = workingDir
 	targetTGOptions.Writer = ioutil.Discard
 
@@ -636,7 +648,7 @@ func ClearOutputCache() {
 // To help with debuggability, the errors will be printed to the console when TG_LOG=debug is set.
 func runTerraformInitForDependencyOutput(terragruntOptions *options.TerragruntOptions, workingDir string, targetConfig string) {
 	stderr := bytes.Buffer{}
-	initTGOptions := terragruntOptions.Clone(targetConfig)
+	initTGOptions := cloneTerragruntOptionsForDependency(terragruntOptions, targetConfig)
 	initTGOptions.WorkingDir = workingDir
 	initTGOptions.ErrWriter = &stderr
 	err := shell.RunTerraformCommand(initTGOptions, "init", "-get=false")

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -237,7 +237,14 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 		return nil, err
 	}
 
+	// Clone the options struct so we don't modify the original one. This is especially important as run-all operations
+	// happen concurrently.
 	opts := terragruntOptions.Clone(terragruntConfigPath)
+
+	// We need to reset the original path for each module. Otherwise, this path will be set to wherever you ran run-all
+	// from, which is not what any of the modules will want.
+	opts.OriginalTerragruntConfigPath = terragruntConfigPath
+
 	// We only partially parse the config, only using the pieces that we need in this section. This config will be fully
 	// parsed at a later stage right before the action is run. This is to delay interpolation of functions until right
 	// before we call out to terraform.

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -27,6 +27,8 @@ Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, ju
   - [get\_terragrunt\_dir()](#get_terragrunt_dir)
 
   - [get\_parent\_terragrunt\_dir()](#get_parent_terragrunt_dir)
+  
+  - [get\_original\_terragrunt\_dir()](#get_original_terragrunt_dir)
 
   - [get\_terraform\_commands\_that\_need\_vars()](#get_terraform_commands_that_need_vars)
 
@@ -376,6 +378,13 @@ terraform {
 ```
 
 The common.tfvars located in the terraform root folder will be included by all applications, whatever their relative location to the root.
+
+## get\_original\_terragrunt\_dir
+
+`get_original_terragrunt_dir()` returns the directory where the original Terragrunt configuration file (by default 
+`terragrunt.hcl`) lives. This is primarily useful when one Terragrunt config is being read from another: e.g., if 
+`/terraform-code/terragrunt.hcl` calls `read_terragrunt_config("/foo/bar.hcl")`, and within `bar.hcl`, you call 
+`get_original_terragrunt_dir()`, you'll get back `/terraform-code`.
 
 ## get\_terraform\_commands\_that\_need\_vars
 

--- a/options/options.go
+++ b/options/options.go
@@ -40,6 +40,11 @@ type TerragruntOptions struct {
 	// Location of the Terragrunt config file
 	TerragruntConfigPath string
 
+	// Location of the original Terragrunt config file. This is primarily useful when one Terragrunt config is being
+	// read from another: e.g., if /terraform-code/terragrunt.hcl calls read_terragrunt_config("/foo/bar.hcl"),
+	// and within bar.hcl, you call get_original_terragrunt_dir(), you'll get back /terraform-code.
+	OriginalTerragruntConfigPath string
+
 	// Version of terragrunt
 	TerragruntVersion *version.Version
 
@@ -245,41 +250,42 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 	// during xxx-all commands (e.g., apply-all, plan-all). See https://github.com/gruntwork-io/terragrunt/issues/367
 	// for more info.
 	return &TerragruntOptions{
-		TerragruntConfigPath:        terragruntConfigPath,
-		TerraformPath:               terragruntOptions.TerraformPath,
-		OriginalTerraformCommand:    terragruntOptions.OriginalTerraformCommand,
-		TerraformCommand:            terragruntOptions.TerraformCommand,
-		TerraformVersion:            terragruntOptions.TerraformVersion,
-		TerragruntVersion:           terragruntOptions.TerragruntVersion,
-		AutoInit:                    terragruntOptions.AutoInit,
-		NonInteractive:              terragruntOptions.NonInteractive,
-		TerraformCliArgs:            util.CloneStringList(terragruntOptions.TerraformCliArgs),
-		WorkingDir:                  workingDir,
-		Logger:                      util.CreateLogEntryWithWriter(terragruntOptions.ErrWriter, workingDir, terragruntOptions.LogLevel),
-		LogLevel:                    terragruntOptions.LogLevel,
-		Env:                         util.CloneStringMap(terragruntOptions.Env),
-		Source:                      terragruntOptions.Source,
-		SourceUpdate:                terragruntOptions.SourceUpdate,
-		DownloadDir:                 terragruntOptions.DownloadDir,
-		Debug:                       terragruntOptions.Debug,
-		IamRole:                     terragruntOptions.IamRole,
-		IgnoreDependencyErrors:      terragruntOptions.IgnoreDependencyErrors,
-		IgnoreDependencyOrder:       terragruntOptions.IgnoreDependencyOrder,
-		IgnoreExternalDependencies:  terragruntOptions.IgnoreExternalDependencies,
-		IncludeExternalDependencies: terragruntOptions.IncludeExternalDependencies,
-		Writer:                      terragruntOptions.Writer,
-		ErrWriter:                   terragruntOptions.ErrWriter,
-		MaxFoldersToCheck:           terragruntOptions.MaxFoldersToCheck,
-		AutoRetry:                   terragruntOptions.AutoRetry,
-		RetryMaxAttempts:            terragruntOptions.RetryMaxAttempts,
-		RetrySleepIntervalSec:       terragruntOptions.RetrySleepIntervalSec,
-		RetryableErrors:             util.CloneStringList(terragruntOptions.RetryableErrors),
-		ExcludeDirs:                 terragruntOptions.ExcludeDirs,
-		IncludeDirs:                 terragruntOptions.IncludeDirs,
-		Parallelism:                 terragruntOptions.Parallelism,
-		StrictInclude:               terragruntOptions.StrictInclude,
-		RunTerragrunt:               terragruntOptions.RunTerragrunt,
-		AwsProviderPatchOverrides:   terragruntOptions.AwsProviderPatchOverrides,
+		TerragruntConfigPath:         terragruntConfigPath,
+		OriginalTerragruntConfigPath: terragruntOptions.OriginalTerragruntConfigPath,
+		TerraformPath:                terragruntOptions.TerraformPath,
+		OriginalTerraformCommand:     terragruntOptions.OriginalTerraformCommand,
+		TerraformCommand:             terragruntOptions.TerraformCommand,
+		TerraformVersion:             terragruntOptions.TerraformVersion,
+		TerragruntVersion:            terragruntOptions.TerragruntVersion,
+		AutoInit:                     terragruntOptions.AutoInit,
+		NonInteractive:               terragruntOptions.NonInteractive,
+		TerraformCliArgs:             util.CloneStringList(terragruntOptions.TerraformCliArgs),
+		WorkingDir:                   workingDir,
+		Logger:                       util.CreateLogEntryWithWriter(terragruntOptions.ErrWriter, workingDir, terragruntOptions.LogLevel),
+		LogLevel:                     terragruntOptions.LogLevel,
+		Env:                          util.CloneStringMap(terragruntOptions.Env),
+		Source:                       terragruntOptions.Source,
+		SourceUpdate:                 terragruntOptions.SourceUpdate,
+		DownloadDir:                  terragruntOptions.DownloadDir,
+		Debug:                        terragruntOptions.Debug,
+		IamRole:                      terragruntOptions.IamRole,
+		IgnoreDependencyErrors:       terragruntOptions.IgnoreDependencyErrors,
+		IgnoreDependencyOrder:        terragruntOptions.IgnoreDependencyOrder,
+		IgnoreExternalDependencies:   terragruntOptions.IgnoreExternalDependencies,
+		IncludeExternalDependencies:  terragruntOptions.IncludeExternalDependencies,
+		Writer:                       terragruntOptions.Writer,
+		ErrWriter:                    terragruntOptions.ErrWriter,
+		MaxFoldersToCheck:            terragruntOptions.MaxFoldersToCheck,
+		AutoRetry:                    terragruntOptions.AutoRetry,
+		RetryMaxAttempts:             terragruntOptions.RetryMaxAttempts,
+		RetrySleepIntervalSec:        terragruntOptions.RetrySleepIntervalSec,
+		RetryableErrors:              util.CloneStringList(terragruntOptions.RetryableErrors),
+		ExcludeDirs:                  terragruntOptions.ExcludeDirs,
+		IncludeDirs:                  terragruntOptions.IncludeDirs,
+		Parallelism:                  terragruntOptions.Parallelism,
+		StrictInclude:                terragruntOptions.StrictInclude,
+		RunTerragrunt:                terragruntOptions.RunTerragrunt,
+		AwsProviderPatchOverrides:    terragruntOptions.AwsProviderPatchOverrides,
 	}
 }
 

--- a/test/fixture-read-config/with_original_terragrunt_dir/dep/main.tf
+++ b/test/fixture-read-config/with_original_terragrunt_dir/dep/main.tf
@@ -1,0 +1,31 @@
+variable "terragrunt_dir" {
+  type = string
+}
+
+variable "original_terragrunt_dir" {
+  type = string
+}
+
+variable "bar_terragrunt_dir" {
+  type = string
+}
+
+variable "bar_original_terragrunt_dir" {
+  type = string
+}
+
+output "terragrunt_dir" {
+  value = var.terragrunt_dir
+}
+
+output "original_terragrunt_dir" {
+  value = var.original_terragrunt_dir
+}
+
+output "bar_terragrunt_dir" {
+  value = var.bar_terragrunt_dir
+}
+
+output "bar_original_terragrunt_dir" {
+  value = var.bar_original_terragrunt_dir
+}

--- a/test/fixture-read-config/with_original_terragrunt_dir/dep/terragrunt.hcl
+++ b/test/fixture-read-config/with_original_terragrunt_dir/dep/terragrunt.hcl
@@ -1,0 +1,11 @@
+locals {
+  bar = read_terragrunt_config("../foo/bar.hcl")
+}
+
+inputs = {
+  terragrunt_dir          = get_terragrunt_dir()
+  original_terragrunt_dir = get_original_terragrunt_dir()
+
+  bar_terragrunt_dir          = local.bar.locals.terragrunt_dir
+  bar_original_terragrunt_dir = local.bar.locals.original_terragrunt_dir
+}

--- a/test/fixture-read-config/with_original_terragrunt_dir/foo/bar.hcl
+++ b/test/fixture-read-config/with_original_terragrunt_dir/foo/bar.hcl
@@ -1,0 +1,4 @@
+locals {
+  terragrunt_dir          = get_terragrunt_dir()
+  original_terragrunt_dir = get_original_terragrunt_dir()
+}

--- a/test/fixture-read-config/with_original_terragrunt_dir/main.tf
+++ b/test/fixture-read-config/with_original_terragrunt_dir/main.tf
@@ -1,0 +1,15 @@
+variable "terragrunt_dir" {
+  type = string
+}
+
+variable "original_terragrunt_dir" {
+  type = string
+}
+
+output "terragrunt_dir" {
+  value = var.terragrunt_dir
+}
+
+output "original_terragrunt_dir" {
+  value = var.original_terragrunt_dir
+}

--- a/test/fixture-read-config/with_original_terragrunt_dir/main.tf
+++ b/test/fixture-read-config/with_original_terragrunt_dir/main.tf
@@ -6,10 +6,42 @@ variable "original_terragrunt_dir" {
   type = string
 }
 
+variable "dep_terragrunt_dir" {
+  type = string
+}
+
+variable "dep_original_terragrunt_dir" {
+  type = string
+}
+
+variable "dep_bar_terragrunt_dir" {
+  type = string
+}
+
+variable "dep_bar_original_terragrunt_dir" {
+  type = string
+}
+
 output "terragrunt_dir" {
   value = var.terragrunt_dir
 }
 
 output "original_terragrunt_dir" {
   value = var.original_terragrunt_dir
+}
+
+output "dep_terragrunt_dir" {
+  value = var.dep_terragrunt_dir
+}
+
+output "dep_original_terragrunt_dir" {
+  value = var.dep_original_terragrunt_dir
+}
+
+output "dep_bar_terragrunt_dir" {
+  value = var.dep_bar_terragrunt_dir
+}
+
+output "dep_bar_original_terragrunt_dir" {
+  value = var.dep_bar_original_terragrunt_dir
 }

--- a/test/fixture-read-config/with_original_terragrunt_dir/terragrunt.hcl
+++ b/test/fixture-read-config/with_original_terragrunt_dir/terragrunt.hcl
@@ -2,7 +2,17 @@ locals {
   bar = read_terragrunt_config("foo/bar.hcl")
 }
 
+dependency "dep" {
+  config_path = "./dep"
+}
+
 inputs = {
   terragrunt_dir          = local.bar.locals.terragrunt_dir
   original_terragrunt_dir = local.bar.locals.original_terragrunt_dir
+
+  dep_terragrunt_dir          = dependency.dep.outputs.terragrunt_dir
+  dep_original_terragrunt_dir = dependency.dep.outputs.original_terragrunt_dir
+
+  dep_bar_terragrunt_dir          = dependency.dep.outputs.bar_terragrunt_dir
+  dep_bar_original_terragrunt_dir = dependency.dep.outputs.bar_original_terragrunt_dir
 }

--- a/test/fixture-read-config/with_original_terragrunt_dir/terragrunt.hcl
+++ b/test/fixture-read-config/with_original_terragrunt_dir/terragrunt.hcl
@@ -1,0 +1,8 @@
+locals {
+  bar = read_terragrunt_config("foo/bar.hcl")
+}
+
+inputs = {
+  terragrunt_dir          = local.bar.locals.terragrunt_dir
+  original_terragrunt_dir = local.bar.locals.original_terragrunt_dir
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3034,6 +3034,35 @@ func TestReadTerragruntConfigWithDefault(t *testing.T) {
 	assert.Equal(t, outputs["data"].Value, "default value")
 }
 
+func TestReadTerragruntConfigWithOriginalTerragruntDir(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_READ_CONFIG)
+	rootPath := util.JoinPath(TEST_FIXTURE_READ_CONFIG, "with_original_terragrunt_dir")
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+
+	// check the outputs to make sure they are as expected
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	require.NoError(
+		t,
+		runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr),
+	)
+
+	outputs := map[string]TerraformOutput{}
+	require.NoError(t, json.Unmarshal([]byte(stdout.String()), &outputs))
+
+	expectedOriginalTerragruntDir, err := filepath.Abs(rootPath)
+	require.NoError(t, err)
+
+	expectedTerragruntDir := filepath.Join(expectedOriginalTerragruntDir, "foo")
+
+	assert.Equal(t, outputs["terragrunt_dir"].Value, expectedTerragruntDir)
+	assert.Equal(t, outputs["original_terragrunt_dir"].Value, expectedOriginalTerragruntDir)
+}
+
 func TestReadTerragruntConfigFull(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`get_original_terragrunt_dir()` returns the directory where the original Terragrunt configuration file (by default 
`terragrunt.hcl`) lives. This is primarily useful when one Terragrunt config is being read from another: e.g., if 
`/terraform-code/terragrunt.hcl` calls `read_terragrunt_config("/foo/bar.hcl")`, and within `bar.hcl`, you call 
`get_original_terragrunt_dir()`, you'll get back `/terraform-code`.

@yorinasub17 This was part of my hack day project. I'll post more info on this in Slack shortly.

**Note**: this PR originally was a one-liner that changed the behavior of `get_terragrunt_dir()`, but I decided that led to some unintuitive file path behavior in files read via `read_terragrunt_config()`, and that a separate, explicit `get_original_terragrunt_dir()` function handled this requirement more clearly.