### PR TITLE
Remove `init` from TERRAFORM_COMMANDS_NEED_LOCKING

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -28,7 +28,6 @@ var TERRAFORM_COMMANDS_NEED_LOCKING = []string{
 	"apply",
 	"destroy",
 	"import",
-	"init",
 	"plan",
 	"refresh",
 	"taint",


### PR DESCRIPTION
`terraform init` does not support locking
resolves https://github.com/gruntwork-io/terragrunt/issues/1641