### PR TITLE
Honor the shared config in the default session

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -96,7 +96,8 @@ func CreateAwsSession(config *AwsSessionConfig, terragruntOptions *options.Terra
 	var sess *session.Session
 	var err error
 	if config == nil {
-		sess, err = session.NewSession()
+		sessionOptions := session.Options{SharedConfigState: session.SharedConfigEnable}
+		sess, err = session.NewSessionWithOptions(sessionOptions)
 		if err != nil {
 			return nil, errors.WithStackTrace(err)
 		}


### PR DESCRIPTION
The default session that we construct in terragrunt does not configure the shared config enabled bit, so it ignores `~/.aws/config`. This breaks the functions that use this path.