### PR TITLE
fix(aws_helper): make sure AWS SSO shared profiles are considered by default

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -125,7 +125,8 @@ func CreateAwsSession(config *AwsSessionConfig, terragruntOptions *options.Terra
 
 // Make API calls to AWS to assume the IAM role specified and return the temporary AWS credentials to use that role
 func AssumeIamRole(iamRoleArn string, sessionDurationSeconds int64) (*sts.Credentials, error) {
-	sess, err := session.NewSession()
+	sessionOptions := session.Options{SharedConfigState: session.SharedConfigEnable}
+	sess, err := session.NewSessionWithOptions(sessionOptions)
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}


### PR DESCRIPTION
This fixes https://github.com/gruntwork-io/terragrunt/issues/1669 

Corresponding  docs https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ 

```txt
Sessions options from Shared Config

By default NewSession will only load credentials from the shared credentials file (~/.aws/credentials). If the AWS_SDK_LOAD_CONFIG environment variable is set to a truthy value the Session will be created from the configuration values from the shared config (~/.aws/config) and shared credentials (~/.aws/credentials) files. Using the NewSessionWithOptions with SharedConfigState set to SharedConfigEnable will create the session as if the AWS_SDK_LOAD_CONFIG environment variable was set.
```