### PR TITLE
Control --terragrunt-debug using TERRAGRUNT_DEBUG env var

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -156,7 +156,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 
 	opts.OriginalTerragruntConfigPath = opts.TerragruntConfigPath
 
-	debug := parseBooleanArg(args, OPT_TERRAGRUNT_DEBUG, false)
+	debug := parseBooleanArg(args, OPT_TERRAGRUNT_DEBUG, os.Getenv("TERRAGRUNT_DEBUG") == "true" || os.Getenv("TERRAGRUNT_DEBUG") == "1")
 	if debug {
 		opts.Debug = true
 	}

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -638,7 +638,8 @@ When passed in, limit the number of modules that are run concurrently to this nu
 
 ### terragrunt-debug
 
-**CLI Arg**: `--terragrunt-debug`
+**CLI Arg**: `--terragrunt-debug`<br/>
+**Environment Variable**: `TERRAGRUNT_DEBUG`
 
 When passed in, Terragrunt will create a tfvars file that can be used to invoke the terraform module in the same way
 that Terragrunt invokes the module, so that you can debug issues with the terragrunt config. See


### PR DESCRIPTION
This allows you to enable `--terragrunt-debug` using the `TERRAGRUNT_DEBUG` env var.