### PR TITLE
update hclfmt documentation and cli command usage text

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -206,7 +206,7 @@ COMMANDS:
    terragrunt-info       Emits limited terragrunt state on stdout and exits
    validate-inputs       Checks if the terragrunt configured inputs align with the terraform defined variables.
    graph-dependencies    Prints the terragrunt dependency graph to stdout
-   hclfmt                Recursively find terragrunt.hcl files and rewrite them into a canonical format.
+   hclfmt                Recursively find hcl files and rewrite them into a canonical format.
    aws-provider-patch    Overwrite settings on nested AWS providers to work around a Terraform bug (issue #13018)
    *                     Terragrunt forwards all other commands directly to Terraform
 
@@ -230,7 +230,7 @@ GLOBAL OPTIONS:
    terragrunt-exclude-dir                       Unix-style glob of directories to exclude when running *-all commands
    terragrunt-include-dir                       Unix-style glob of directories to include when running *-all commands
    terragrunt-check                             Enable check mode in the hclfmt command.
-   terragrunt-hclfmt-file                       The path to a single terragrunt.hcl file that the hclfmt command should run on.
+   terragrunt-hclfmt-file                       The path to a single hcl file that the hclfmt command should run on.
    terragrunt-override-attr                     A key=value attribute to override in a provider block as part of the aws-provider-patch command. May be specified multiple times.
    terragrunt-debug                             Write terragrunt-debug.tfvars to working folder to help root-cause issues.
    terragrunt-log-level                         Sets the logging level for Terragrunt. Supported levels: panic, fatal, error, warn (default), info, debug, trace.

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 )
 
-// manifest for files coped from terragrunt module folder (i.e., the folder that contains the current terragrunt.hcl)
+// manifest for files copied from terragrunt module folder (i.e., the folder that contains the current terragrunt.hcl)
 const MODULE_MANIFEST_NAME = ".terragrunt-module-manifest"
 
 // 1. Download the given source URL, which should use Terraform's module source syntax, into a temporary folder

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 )
 
-// runHCLFmt recursively looks for terragrunt.hcl files in the directory tree starting at workingDir, and formats them
+// runHCLFmt recursively looks for hcl files in the directory tree starting at workingDir, and formats them
 // based on the language style guides provided by Hashicorp. This is done using the official hcl2 library.
 func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
 
@@ -29,11 +29,11 @@ func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
 		if !filepath.IsAbs(targetFile) {
 			targetFile = util.JoinPath(workingDir, targetFile)
 		}
-		terragruntOptions.Logger.Infof("Formatting terragrunt.hcl file at: %s.", targetFile)
+		terragruntOptions.Logger.Infof("Formatting hcl file at: %s.", targetFile)
 		return formatTgHCL(terragruntOptions, targetFile)
 	}
 
-	terragruntOptions.Logger.Infof("Formatting terragrunt.hcl files from the directory tree %s.", terragruntOptions.WorkingDir)
+	terragruntOptions.Logger.Infof("Formatting hcl files from the directory tree %s.", terragruntOptions.WorkingDir)
 	// zglob normalizes paths to "/"
 	tgHclFiles, err := zglob.Glob(util.JoinPath(workingDir, "**", "*.hcl"))
 	if err != nil {
@@ -50,7 +50,7 @@ func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
 		}
 	}
 
-	terragruntOptions.Logger.Debugf("Found %d terragrunt.hcl files", len(filteredTgHclFiles))
+	terragruntOptions.Logger.Debugf("Found %d hcl files", len(filteredTgHclFiles))
 
 	formatErrors := []error{}
 	for _, tgHclFile := range filteredTgHclFiles {
@@ -63,7 +63,7 @@ func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
 	return errors.NewMultiError(formatErrors...)
 }
 
-// formatTgHCL uses the hcl2 library to format the terragrunt.hcl file. This will attempt to parse the HCL file first to
+// formatTgHCL uses the hcl2 library to format the hcl file. This will attempt to parse the HCL file first to
 // ensure that there are no syntax errors, before attempting to format it.
 func formatTgHCL(terragruntOptions *options.TerragruntOptions, tgHclFile string) error {
 	terragruntOptions.Logger.Infof("Formatting %s", tgHclFile)
@@ -99,7 +99,7 @@ func formatTgHCL(terragruntOptions *options.TerragruntOptions, tgHclFile string)
 	return ioutil.WriteFile(tgHclFile, newContents, info.Mode())
 }
 
-// checkErrors takes in the contents of a terragrunt.hcl file and looks for syntax errors.
+// checkErrors takes in the contents of a hcl file and looks for syntax errors.
 func checkErrors(contents []byte, tgHclFile string) error {
 	parser := hclparse.NewParser()
 	_, diags := parser.ParseHCL(contents, tgHclFile)

--- a/cli/hclfmt_test.go
+++ b/cli/hclfmt_test.go
@@ -36,6 +36,8 @@ func TestHCLFmt(t *testing.T) {
 			"terragrunt.hcl",
 			"a/terragrunt.hcl",
 			"a/b/c/terragrunt.hcl",
+			"a/b/c/d/services.hcl",
+			"a/b/c/d/e/terragrunt.hcl",
 		}
 		for _, dir := range dirs {
 			// Capture range variable into for block so it doesn't change while looping
@@ -128,6 +130,8 @@ func TestHCLFmtCheck(t *testing.T) {
 		"terragrunt.hcl",
 		"a/terragrunt.hcl",
 		"a/b/c/terragrunt.hcl",
+		"a/b/c/d/services.hcl",
+		"a/b/c/d/e/terragrunt.hcl",
 	}
 
 	for _, dir := range dirs {
@@ -171,6 +175,8 @@ func TestHCLFmtCheckErrors(t *testing.T) {
 		"terragrunt.hcl",
 		"a/terragrunt.hcl",
 		"a/b/c/terragrunt.hcl",
+		"a/b/c/d/services.hcl",
+		"a/b/c/d/e/terragrunt.hcl",
 	}
 
 	for _, dir := range dirs {

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -155,7 +155,7 @@ func getTerragruntDir(include *IncludeConfig, terragruntOptions *options.Terragr
 }
 
 // Return the directory where the original Terragrunt configuration file lives. This is primarily useful when one
-// Terragrunt config is being read from anothere.g., if /terraform-code/terragrunt.hcl
+// Terragrunt config is being read from another e.g., if /terraform-code/terragrunt.hcl
 // calls read_terragrunt_config("/foo/bar.hcl"), and within bar.hcl, you call get_original_terragrunt_dir(), you'll
 // get back /terraform-code.
 func getOriginalTerragruntDir(include *IncludeConfig, terragruntOptions *options.TerragruntOptions) (string, error) {

--- a/docs/_docs/01_getting-started/configuration.md
+++ b/docs/_docs/01_getting-started/configuration.md
@@ -78,11 +78,11 @@ The results of this pass are then used to build the dependency graph of the modu
 
 This allows Terragrunt to avoid resolving `dependency` on modules that haven’t been applied yet when doing a clean deployment from scratch with `run-all apply`.
 
-## Formatting terragrunt.hcl
+## Formatting hcl files
 
-You can rewrite `terragrunt.hcl` files to a canonical format using the `hclfmt` command built into `terragrunt`. Similar to `terraform fmt`, this command applies a subset of [the Terraform language style conventions](https://www.terraform.io/docs/configuration/style.html), along with other minor adjustments for readability.
+You can rewrite the hcl files to a canonical format using the `hclfmt` command built into `terragrunt`. Similar to `terraform fmt`, this command applies a subset of [the Terraform language style conventions](https://www.terraform.io/docs/configuration/style.html), along with other minor adjustments for readability.
 
-This command will recursively search for `terragrunt.hcl` files and format all of them under a given directory tree. Consider the following file structure:
+This command will recursively search for hcl files and format all of them under a given directory tree. Consider the following file structure:
 
     root
     ├── terragrunt.hcl
@@ -91,7 +91,11 @@ This command will recursively search for `terragrunt.hcl` files and format all o
     ├── dev
     │   └── terragrunt.hcl
     └── qa
-        └── terragrunt.hcl
+        ├── terragrunt.hcl
+        └── services
+            ├── services.hcl
+            └── service01
+                └── terragrunt.hcl
 
 If you run `terragrunt hclfmt` at the `root`, this will update:
 
@@ -102,5 +106,9 @@ If you run `terragrunt hclfmt` at the `root`, this will update:
   - `root/dev/terragrunt.hcl`
 
   - `root/qa/terragrunt.hcl`
+
+  - `root/qa/services/services.hcl`
+
+  - `root/qa/services/service01/terragrunt.hcl`
 
 Additionally, there’s a flag `--terragrunt-check`. `terragrunt hclfmt --terragrunt-check` will only verify if the files are correctly formatted **without rewriting** them. The command will return exit status 1 if any matching files are improperly formatted, or 0 if all matching .hcl files are correctly formatted.

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -308,7 +308,7 @@ digraph {
 
 ### hclfmt
 
-Recursively find `terragrunt.hcl` files and rewrite them into a canonical format.
+Recursively find hcl files and rewrite them into a canonical format.
 
 Example:
 
@@ -317,7 +317,7 @@ terragrunt hclfmt
 ```
 
 This will recursively search the current working directory for any folders that contain Terragrunt configuration files
-(`terragrunt.hcl`) and run the equivalent of `terraform fmt` on them.
+and run the equivalent of `terraform fmt` on them.
 
 
 ### aws-provider-patch
@@ -678,7 +678,7 @@ command to exit with exit code 1 if there are any files that are not formatted.
 **CLI Arg**: `--terragrunt-hclfmt-file`
 **Requires an argument**: `--terragrunt-hclfmt-file /path/to/terragrunt.hcl`
 
-When passed in, run `hclfmt` only on specified `*/terragrunt.hcl` file.
+When passed in, run `hclfmt` only on specified hcl file.
 
 
 ### terragrunt-override-attr

--- a/test/fixture-hclfmt-check-errors/a/b/c/d/e/terragrunt.hcl
+++ b/test/fixture-hclfmt-check-errors/a/b/c/d/e/terragrunt.hcl
@@ -1,0 +1,13 @@
+inputs = {
+# comments
+  foo =                               "bar"
+  bar="baz"
+
+  inputs = "disjoint"
+  disjoint = true
+
+  listInput = [
+"foo",
+"bar",
+]
+}

--- a/test/fixture-hclfmt-check-errors/a/b/c/d/services.hcl
+++ b/test/fixture-hclfmt-check-errors/a/b/c/d/services.hcl
@@ -1,0 +1,13 @@
+inputs = {
+# comments
+  foo =                               "bar"
+  bar="baz"
+
+  inputs = "disjoint"
+  disjoint = true
+
+  listInput = [
+"foo",
+"bar",
+]
+}

--- a/test/fixture-hclfmt-check/a/b/c/d/e/terragrunt.hcl
+++ b/test/fixture-hclfmt-check/a/b/c/d/e/terragrunt.hcl
@@ -1,0 +1,13 @@
+inputs = {
+  # comments
+  foo = "bar"
+  bar = "baz"
+
+  inputs   = "disjoint"
+  disjoint = true
+
+  listInput = [
+    "foo",
+    "bar",
+  ]
+}

--- a/test/fixture-hclfmt-check/a/b/c/d/services.hcl
+++ b/test/fixture-hclfmt-check/a/b/c/d/services.hcl
@@ -1,0 +1,13 @@
+inputs = {
+  # comments
+  foo = "bar"
+  bar = "baz"
+
+  inputs   = "disjoint"
+  disjoint = true
+
+  listInput = [
+    "foo",
+    "bar",
+  ]
+}

--- a/test/fixture-hclfmt/a/b/c/d/e/terragrunt.hcl
+++ b/test/fixture-hclfmt/a/b/c/d/e/terragrunt.hcl
@@ -1,0 +1,13 @@
+inputs = {
+# comments
+  foo =                               "bar"
+  bar="baz"
+
+  inputs = "disjoint"
+  disjoint = true
+
+  listInput = [
+"foo",
+"bar",
+]
+}

--- a/test/fixture-hclfmt/a/b/c/d/services.hcl
+++ b/test/fixture-hclfmt/a/b/c/d/services.hcl
@@ -1,0 +1,13 @@
+inputs = {
+# comments
+  foo =                               "bar"
+  bar="baz"
+
+  inputs = "disjoint"
+  disjoint = true
+
+  listInput = [
+"foo",
+"bar",
+]
+}


### PR DESCRIPTION
This PR references the #1528

As mentioned in the @brikis98 and @ChristophShyper comments:

https://github.com/gruntwork-io/terragrunt/issues/1528#issuecomment-785781103

[https://github.com/gruntwork-io/terragrunt/issues/1528#issuecomment-857641641](https://github.com/gruntwork-io/terragrunt/issues/1528#issuecomment-857641641)

The `terragrunt hclfmt` documentation is outdated.

The documented behavior says that just `terragrunt.hcl` files will be formatted/checked and this information is wrong, since that all hcl files will be formatted/checked with the `terragrunt hclfmt`

I've done the update of documentation and cli command usage text and some typo fixes and added the test scenario to format other hcl files besides the terragrunt.hcl