### PR TITLE
Fix data type issue with aws-provider-patch

### DIFF
--- a/cli/aws_provider_patch_test.go
+++ b/cli/aws_provider_patch_test.go
@@ -1,8 +1,9 @@
 package cli
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const terraformCodeExampleOutputOnly = `
@@ -301,23 +302,23 @@ func TestPatchAwsProviderInTerraformCodeHappyPath(t *testing.T) {
 		expectedTerraformCode  []string
 	}{
 		{"empty", "", nil, false, []string{""}},
-		{"empty with attributes", "", map[string]string{"region": "eu-west-1"}, false, []string{""}},
-		{"no provider", terraformCodeExampleOutputOnly, map[string]string{"region": "eu-west-1"}, false, []string{terraformCodeExampleOutputOnly}},
-		{"no aws provider", terraformCodeExampleGcpProvider, map[string]string{"region": "eu-west-1"}, false, []string{terraformCodeExampleGcpProvider}},
+		{"empty with attributes", "", map[string]string{"region": `"eu-west-1"`}, false, []string{""}},
+		{"no provider", terraformCodeExampleOutputOnly, map[string]string{"region": `"eu-west-1"`}, false, []string{terraformCodeExampleOutputOnly}},
+		{"no aws provider", terraformCodeExampleGcpProvider, map[string]string{"region": `"eu-west-1"`}, false, []string{terraformCodeExampleGcpProvider}},
 		{"one empty aws provider, but no overrides", terraformCodeExampleAwsProviderEmptyOriginal, nil, false, []string{terraformCodeExampleAwsProviderEmptyOriginal}},
-		{"one empty aws provider, with region override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": "eu-west-1"}, false, []string{terraformCodeExampleAwsProviderEmptyOriginal}},
-		{"one empty aws provider, with region, version override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0"}, false, []string{terraformCodeExampleAwsProviderEmptyOriginal}},
+		{"one empty aws provider, with region override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": `"eu-west-1"`}, false, []string{terraformCodeExampleAwsProviderEmptyOriginal}},
+		{"one empty aws provider, with region, version override", terraformCodeExampleAwsProviderEmptyOriginal, map[string]string{"region": `"eu-west-1"`, "version": `"0.3.0"`}, false, []string{terraformCodeExampleAwsProviderEmptyOriginal}},
 		{"one non-empty aws provider, but no overrides", terraformCodeExampleAwsProviderNonEmptyOriginal, nil, false, []string{terraformCodeExampleAwsProviderNonEmptyOriginal}},
-		{"one non-empty aws provider, with region override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": "eu-west-1"}, true, []string{terraformCodeExampleAwsProviderRegionOverridenVersionNotOverriddenExpected}},
-		{"one non-empty aws provider, with region, version override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0"}, true, []string{terraformCodeExampleAwsProviderRegionVersionOverridenExpected, terraformCodeExampleAwsProviderRegionVersionOverridenReverseOrderExpected}},
+		{"one non-empty aws provider, with region override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": `"eu-west-1"`}, true, []string{terraformCodeExampleAwsProviderRegionOverridenVersionNotOverriddenExpected}},
+		{"one non-empty aws provider, with region, version override", terraformCodeExampleAwsProviderNonEmptyOriginal, map[string]string{"region": `"eu-west-1"`, "version": `"0.3.0"`}, true, []string{terraformCodeExampleAwsProviderRegionVersionOverridenExpected, terraformCodeExampleAwsProviderRegionVersionOverridenReverseOrderExpected}},
 		{"multiple providers, but no overrides", terraformCodeExampleAwsMultipleProvidersOriginal, nil, false, []string{terraformCodeExampleAwsMultipleProvidersOriginal}},
-		{"multiple providers, with region override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1"}, true, []string{terraformCodeExampleAwsMultipleProvidersRegionOverridenExpected}},
-		{"multiple providers, with region, version override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0"}, true, []string{terraformCodeExampleAwsMultipleProvidersRegionVersionOverridenExpected}},
+		{"multiple providers, with region override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": `"eu-west-1"`}, true, []string{terraformCodeExampleAwsMultipleProvidersRegionOverridenExpected}},
+		{"multiple providers, with region, version override", terraformCodeExampleAwsMultipleProvidersOriginal, map[string]string{"region": `"eu-west-1"`, "version": `"0.3.0"`}, true, []string{terraformCodeExampleAwsMultipleProvidersRegionVersionOverridenExpected}},
 		{"multiple providers with comments, but no overrides", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, nil, false, []string{terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal}},
-		{"multiple providers with comments, with region override", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, map[string]string{"region": "eu-west-1"}, true, []string{terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionOverriddenExpected}},
-		{"multiple providers with comments, with region, version override", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, map[string]string{"region": "eu-west-1", "version": "0.3.0"}, true, []string{terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionVersionOverriddenExpected}},
-		{"one provider with nested blocks, with region and role_arn override", terraformCodeExampleAwsOneProviderNestedBlocks, map[string]string{"region": "eu-west-1", "assume_role.role_arn": "nested-override"}, true, []string{terraformCodeExampleAwsOneProviderNestedBlocksRegionRoleArnExpected}},
-		{"one provider with nested blocks, with region and role_arn override, plus non-matching overrides", terraformCodeExampleAwsOneProviderNestedBlocks, map[string]string{"region": "eu-west-1", "assume_role.role_arn": "nested-override", "should-be": "ignored", "assume_role.should-be": "ignored"}, true, []string{terraformCodeExampleAwsOneProviderNestedBlocksRegionRoleArnExpected}},
+		{"multiple providers with comments, with region override", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, map[string]string{"region": `"eu-west-1"`}, true, []string{terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionOverriddenExpected}},
+		{"multiple providers with comments, with region, version override", terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsOriginal, map[string]string{"region": `"eu-west-1"`, "version": `"0.3.0"`}, true, []string{terraformCodeExampleAwsMultipleProvidersNonEmptyWithCommentsRegionVersionOverriddenExpected}},
+		{"one provider with nested blocks, with region and role_arn override", terraformCodeExampleAwsOneProviderNestedBlocks, map[string]string{"region": `"eu-west-1"`, "assume_role.role_arn": `"nested-override"`}, true, []string{terraformCodeExampleAwsOneProviderNestedBlocksRegionRoleArnExpected}},
+		{"one provider with nested blocks, with region and role_arn override, plus non-matching overrides", terraformCodeExampleAwsOneProviderNestedBlocks, map[string]string{"region": `"eu-west-1"`, "assume_role.role_arn": `"nested-override"`, "should-be": `"ignored"`, "assume_role.should-be": `"ignored"`}, true, []string{terraformCodeExampleAwsOneProviderNestedBlocksRegionRoleArnExpected}},
 	}
 
 	for _, testCase := range testCases {

--- a/test/fixture-aws-provider-patch/example-module/main.tf
+++ b/test/fixture-aws-provider-patch/example-module/main.tf
@@ -1,8 +1,9 @@
 # We intentionally have an AWS provider block nested within this module so that we can have an integration test that
 # checks if the aws-provider-patch command helps to work around https://github.com/hashicorp/terraform/issues/13018.
 provider "aws" {
-  region = var.secondary_aws_region
-  alias  = "secondary"
+  region              = var.secondary_aws_region
+  allowed_account_ids = var.allowed_account_ids
+  alias               = "secondary"
 }
 
 variable "secondary_aws_region" {
@@ -13,6 +14,11 @@ variable "secondary_aws_region" {
 variable "bucket_name" {
   description = "The name to use for the S3 bucket"
   type        = string
+}
+
+variable "allowed_account_ids" {
+  description = "The list of IDs of AWS accounts that are allowed to run this module."
+  type        = list(string)
 }
 
 resource "aws_s3_bucket" "example" {

--- a/test/fixture-aws-provider-patch/main.tf
+++ b/test/fixture-aws-provider-patch/main.tf
@@ -1,10 +1,12 @@
 provider "aws" {
-  region = var.primary_aws_region
+  region              = var.primary_aws_region
+  allowed_account_ids = var.allowed_account_ids
 }
 
 module "example_module" {
   source = "github.com/gruntwork-io/terragrunt.git//test/fixture-aws-provider-patch/example-module?ref=__BRANCH_NAME__"
 
+  allowed_account_ids  = var.allowed_account_ids
   secondary_aws_region = var.secondary_aws_region
   bucket_name          = var.bucket_name
 }
@@ -17,6 +19,11 @@ variable "primary_aws_region" {
 variable "secondary_aws_region" {
   description = "The secondary AWS region to deploy the S3 bucket from the module into"
   type        = string
+}
+
+variable "allowed_account_ids" {
+  description = "The list of IDs of AWS accounts that are allowed to run this module."
+  type        = list(string)
 }
 
 variable "bucket_name" {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1316,7 +1316,7 @@ func TestAwsProviderPatch(t *testing.T) {
 
 	assert.NoError(
 		t,
-		runTerragruntCommand(t, fmt.Sprintf("terragrunt aws-provider-patch --terragrunt-override-attr region=eu-west-1 --terragrunt-override-attr allowed_account_ids=[\"00000000000\"] --terragrunt-working-dir %s --terragrunt-log-level debug", modulePath), os.Stdout, stderr),
+		runTerragruntCommand(t, fmt.Sprintf("terragrunt aws-provider-patch --terragrunt-override-attr region=\"eu-west-1\" --terragrunt-override-attr allowed_account_ids=[\"00000000000\"] --terragrunt-working-dir %s --terragrunt-log-level debug", modulePath), os.Stdout, stderr),
 	)
 	t.Log(stderr.String())
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1316,7 +1316,7 @@ func TestAwsProviderPatch(t *testing.T) {
 
 	assert.NoError(
 		t,
-		runTerragruntCommand(t, fmt.Sprintf("terragrunt aws-provider-patch --terragrunt-override-attr region=eu-west-1 --terragrunt-working-dir %s --terragrunt-log-level debug", modulePath), os.Stdout, stderr),
+		runTerragruntCommand(t, fmt.Sprintf("terragrunt aws-provider-patch --terragrunt-override-attr region=eu-west-1 --terragrunt-override-attr allowed_account_ids=[\"00000000000\"] --terragrunt-working-dir %s --terragrunt-log-level debug", modulePath), os.Stdout, stderr),
 	)
 	t.Log(stderr.String())
 


### PR DESCRIPTION
Fixes #1709 

`aws-provider-patch` blindly patches the provider attributes to string type, but the underlying type for the provider might be different (as is the case with `allowed_account_ids`). To support this, I updated the `aws-provider-patch` to use json inputs instead.

Note that this does result in a backward incompatible API as you now need to provide `"` for the json to resolve correctly. I updated the docs accordingly to highlight this.