### PR TITLE
Expose include config attributes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -188,11 +188,19 @@ type terragruntGenerateBlock struct {
 // IncludeConfig represents the configuration settings for a parent Terragrunt configuration file that you can
 // "include" in a child Terragrunt configuration file
 type IncludeConfig struct {
-	Path string `hcl:"path,attr"`
+	Path   string `hcl:"path,attr"`
+	Expose *bool  `hcl:"expose,attr"`
 }
 
 func (cfg *IncludeConfig) String() string {
-	return fmt.Sprintf("IncludeConfig{Path = %s}", cfg.Path)
+	return fmt.Sprintf("IncludeConfig{Path = %s, Expose = %v}", cfg.Path, cfg.Expose)
+}
+
+func (cfg *IncludeConfig) GetExpose() bool {
+	if cfg == nil || cfg.Expose == nil {
+		return false
+	}
+	return *cfg.Expose
 }
 
 // ModuleDependencies represents the paths to other Terraform modules that must be applied before the current module

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -147,7 +147,7 @@ func CreateTerragruntEvalContext(
 	if extensions.DecodedDependencies != nil {
 		ctx.Variables["dependency"] = *extensions.DecodedDependencies
 	}
-	if extensions.TrackInclude.Current != nil {
+	if extensions.TrackInclude.Current != nil && extensions.TrackInclude.Current.GetExpose() {
 		includedConfig, err := parseIncludedConfig(extensions.TrackInclude.Current, terragruntOptions)
 		if err != nil {
 			return ctx, err

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -67,11 +67,22 @@ type EnvVar struct {
 	IsRequired   bool
 }
 
+// TrackInclude is used to differentiate between an included config in the current parsing context, and an included
+// config that was passed through from a previous parsing context.
+type TrackInclude struct {
+	// Current is used to specify another config that should be imported and merged before the final
+	// TerragruntConfig is returned.
+	Current *IncludeConfig
+
+	// Original is used to track the original included config, and is used for resolving the include related
+	// functions.
+	Original *IncludeConfig
+}
+
 // EvalContextExtensions provides various extensions to the evaluation context to enhance the parsing capabilities.
 type EvalContextExtensions struct {
-	// Include is used to specify another config that should be imported and merged before the final TerragruntConfig is
-	// returned.
-	Include *IncludeConfig
+	// TrackInclude represents contexts of included configurations.
+	TrackInclude TrackInclude
 
 	// Locals are preevaluated variable bindings that can be used by reference in the code.
 	Locals *cty.Value
@@ -89,33 +100,33 @@ func CreateTerragruntEvalContext(
 	filename string,
 	terragruntOptions *options.TerragruntOptions,
 	extensions EvalContextExtensions,
-) *hcl.EvalContext {
+) (*hcl.EvalContext, error) {
 	tfscope := tflang.Scope{
 		BaseDir: filepath.Dir(filename),
 	}
 
 	terragruntFunctions := map[string]function.Function{
-		"find_in_parent_folders":                       wrapStringSliceToStringAsFuncImpl(findInParentFolders, extensions.Include, terragruntOptions),
-		"path_relative_to_include":                     wrapVoidToStringAsFuncImpl(pathRelativeToInclude, extensions.Include, terragruntOptions),
-		"path_relative_from_include":                   wrapVoidToStringAsFuncImpl(pathRelativeFromInclude, extensions.Include, terragruntOptions),
-		"get_env":                                      wrapStringSliceToStringAsFuncImpl(getEnvironmentVariable, extensions.Include, terragruntOptions),
-		"run_cmd":                                      wrapStringSliceToStringAsFuncImpl(runCommand, extensions.Include, terragruntOptions),
+		"find_in_parent_folders":                       wrapStringSliceToStringAsFuncImpl(findInParentFolders, extensions.TrackInclude.Original, terragruntOptions),
+		"path_relative_to_include":                     wrapVoidToStringAsFuncImpl(pathRelativeToInclude, extensions.TrackInclude.Original, terragruntOptions),
+		"path_relative_from_include":                   wrapVoidToStringAsFuncImpl(pathRelativeFromInclude, extensions.TrackInclude.Original, terragruntOptions),
+		"get_env":                                      wrapStringSliceToStringAsFuncImpl(getEnvironmentVariable, extensions.TrackInclude.Original, terragruntOptions),
+		"run_cmd":                                      wrapStringSliceToStringAsFuncImpl(runCommand, extensions.TrackInclude.Original, terragruntOptions),
 		"read_terragrunt_config":                       readTerragruntConfigAsFuncImpl(terragruntOptions),
-		"get_platform":                                 wrapVoidToStringAsFuncImpl(getPlatform, extensions.Include, terragruntOptions),
-		"get_terragrunt_dir":                           wrapVoidToStringAsFuncImpl(getTerragruntDir, extensions.Include, terragruntOptions),
-		"get_original_terragrunt_dir":                  wrapVoidToStringAsFuncImpl(getOriginalTerragruntDir, extensions.Include, terragruntOptions),
-		"get_terraform_command":                        wrapVoidToStringAsFuncImpl(getTerraformCommand, extensions.Include, terragruntOptions),
-		"get_terraform_cli_args":                       wrapVoidToStringSliceAsFuncImpl(getTerraformCliArgs, extensions.Include, terragruntOptions),
-		"get_parent_terragrunt_dir":                    wrapVoidToStringAsFuncImpl(getParentTerragruntDir, extensions.Include, terragruntOptions),
-		"get_aws_account_id":                           wrapVoidToStringAsFuncImpl(getAWSAccountID, extensions.Include, terragruntOptions),
-		"get_aws_caller_identity_arn":                  wrapVoidToStringAsFuncImpl(getAWSCallerIdentityARN, extensions.Include, terragruntOptions),
-		"get_aws_caller_identity_user_id":              wrapVoidToStringAsFuncImpl(getAWSCallerIdentityUserID, extensions.Include, terragruntOptions),
+		"get_platform":                                 wrapVoidToStringAsFuncImpl(getPlatform, extensions.TrackInclude.Original, terragruntOptions),
+		"get_terragrunt_dir":                           wrapVoidToStringAsFuncImpl(getTerragruntDir, extensions.TrackInclude.Original, terragruntOptions),
+		"get_original_terragrunt_dir":                  wrapVoidToStringAsFuncImpl(getOriginalTerragruntDir, extensions.TrackInclude.Original, terragruntOptions),
+		"get_terraform_command":                        wrapVoidToStringAsFuncImpl(getTerraformCommand, extensions.TrackInclude.Original, terragruntOptions),
+		"get_terraform_cli_args":                       wrapVoidToStringSliceAsFuncImpl(getTerraformCliArgs, extensions.TrackInclude.Original, terragruntOptions),
+		"get_parent_terragrunt_dir":                    wrapVoidToStringAsFuncImpl(getParentTerragruntDir, extensions.TrackInclude.Original, terragruntOptions),
+		"get_aws_account_id":                           wrapVoidToStringAsFuncImpl(getAWSAccountID, extensions.TrackInclude.Original, terragruntOptions),
+		"get_aws_caller_identity_arn":                  wrapVoidToStringAsFuncImpl(getAWSCallerIdentityARN, extensions.TrackInclude.Original, terragruntOptions),
+		"get_aws_caller_identity_user_id":              wrapVoidToStringAsFuncImpl(getAWSCallerIdentityUserID, extensions.TrackInclude.Original, terragruntOptions),
 		"get_terraform_commands_that_need_vars":        wrapStaticValueToStringSliceAsFuncImpl(TERRAFORM_COMMANDS_NEED_VARS),
 		"get_terraform_commands_that_need_locking":     wrapStaticValueToStringSliceAsFuncImpl(TERRAFORM_COMMANDS_NEED_LOCKING),
 		"get_terraform_commands_that_need_input":       wrapStaticValueToStringSliceAsFuncImpl(TERRAFORM_COMMANDS_NEED_INPUT),
 		"get_terraform_commands_that_need_parallelism": wrapStaticValueToStringSliceAsFuncImpl(TERRAFORM_COMMANDS_NEED_PARALLELISM),
-		"sops_decrypt_file":                            wrapStringSliceToStringAsFuncImpl(sopsDecryptFile, extensions.Include, terragruntOptions),
-		"get_terragrunt_source_cli_flag":               wrapVoidToStringAsFuncImpl(getTerragruntSourceCliFlag, extensions.Include, terragruntOptions),
+		"sops_decrypt_file":                            wrapStringSliceToStringAsFuncImpl(sopsDecryptFile, extensions.TrackInclude.Original, terragruntOptions),
+		"get_terragrunt_source_cli_flag":               wrapVoidToStringAsFuncImpl(getTerragruntSourceCliFlag, extensions.TrackInclude.Original, terragruntOptions),
 	}
 
 	functions := map[string]function.Function{}
@@ -136,7 +147,20 @@ func CreateTerragruntEvalContext(
 	if extensions.DecodedDependencies != nil {
 		ctx.Variables["dependency"] = *extensions.DecodedDependencies
 	}
-	return ctx
+	if extensions.TrackInclude.Current != nil {
+		includedConfig, err := parseIncludedConfig(extensions.TrackInclude.Current, terragruntOptions)
+		if err != nil {
+			return ctx, err
+		}
+
+		// MAINTAINER'S NOTE: For now, we don't support multiple include blocks in a terragrunt config. In the future,
+		// when we support multiple include blocks, expose each included config indexed by the label.
+		ctx.Variables["include"], err = terragruntConfigAsCty(includedConfig)
+		if err != nil {
+			return ctx, err
+		}
+	}
+	return ctx, nil
 }
 
 // Return the OS platform

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -98,7 +98,7 @@ func DecodeBaseBlocks(
 	hclFile *hcl.File,
 	filename string,
 	includeFromChild *IncludeConfig,
-) (*cty.Value, *terragruntInclude, *IncludeConfig, error) {
+) (*cty.Value, *terragruntInclude, TrackInclude, error) {
 	// Decode just the `include` block, and verify that it's allowed here
 	terragruntInclude, err := decodeAsTerragruntInclude(
 		hclFile,
@@ -107,25 +107,40 @@ func DecodeBaseBlocks(
 		EvalContextExtensions{},
 	)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, TrackInclude{}, err
 	}
-	includeForDecode, err := getIncludedConfigForDecode(terragruntInclude, terragruntOptions, includeFromChild)
-	if err != nil {
-		return nil, nil, nil, err
+
+	// Assert that only single level is inherited
+	if terragruntInclude.Include != nil && includeFromChild != nil {
+		return nil, nil, TrackInclude{}, errors.WithStackTrace(TooManyLevelsOfInheritance{
+			ConfigPath:             terragruntOptions.TerragruntConfigPath,
+			FirstLevelIncludePath:  includeFromChild.Path,
+			SecondLevelIncludePath: terragruntInclude.Include.Path,
+		})
+	}
+	trackInclude := TrackInclude{
+		Current:  terragruntInclude.Include,
+		Original: includeFromChild,
 	}
 
 	// Evaluate all the expressions in the locals block separately and generate the variables list to use in the
 	// evaluation context.
-	locals, err := evaluateLocalsBlock(terragruntOptions, parser, hclFile, filename, includeForDecode)
+	locals, err := evaluateLocalsBlock(
+		terragruntOptions,
+		parser,
+		hclFile,
+		filename,
+		trackInclude,
+	)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, trackInclude, err
 	}
 	localsAsCty, err := convertValuesMapToCtyVal(locals)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, trackInclude, err
 	}
 
-	return &localsAsCty, terragruntInclude, includeForDecode, nil
+	return &localsAsCty, terragruntInclude, trackInclude, nil
 }
 
 func PartialParseConfigFile(
@@ -177,15 +192,15 @@ func PartialParseConfigString(
 	}
 
 	// Decode just the Base blocks. See the function docs for DecodeBaseBlocks for more info on what base blocks are.
-	localsAsCty, terragruntInclude, includeForDecode, err := DecodeBaseBlocks(terragruntOptions, parser, file, filename, includeFromChild)
+	localsAsCty, terragruntInclude, trackInclude, err := DecodeBaseBlocks(terragruntOptions, parser, file, filename, includeFromChild)
 	if err != nil {
 		return nil, err
 	}
 
 	// Initialize evaluation context extensions from base blocks.
 	contextExtensions := EvalContextExtensions{
-		Locals:  localsAsCty,
-		Include: includeForDecode,
+		Locals:       localsAsCty,
+		TrackInclude: trackInclude,
 	}
 
 	output := TerragruntConfig{IsPartial: true}

--- a/config/hcl_parser.go
+++ b/config/hcl_parser.go
@@ -55,7 +55,10 @@ func decodeHcl(
 		}
 	}()
 
-	evalContext := CreateTerragruntEvalContext(filename, terragruntOptions, extensions)
+	evalContext, err := CreateTerragruntEvalContext(filename, terragruntOptions, extensions)
+	if err != nil {
+		return err
+	}
 
 	decodeDiagnostics := gohcl.DecodeBody(file.Body, evalContext, out)
 	if decodeDiagnostics != nil && decodeDiagnostics.HasErrors() {

--- a/config/locals_test.go
+++ b/config/locals_test.go
@@ -22,7 +22,7 @@ func TestEvaluateLocalsBlock(t *testing.T) {
 	file, err := parseHcl(parser, LocalsTestConfig, mockFilename)
 	require.NoError(t, err)
 
-	evaluatedLocals, err := evaluateLocalsBlock(terragruntOptions, parser, file, mockFilename, nil)
+	evaluatedLocals, err := evaluateLocalsBlock(terragruntOptions, parser, file, mockFilename, TrackInclude{})
 	require.NoError(t, err)
 
 	var actualRegion string
@@ -67,7 +67,7 @@ func TestEvaluateLocalsBlockMultiDeepReference(t *testing.T) {
 	file, err := parseHcl(parser, LocalsTestMultiDeepReferenceConfig, mockFilename)
 	require.NoError(t, err)
 
-	evaluatedLocals, err := evaluateLocalsBlock(terragruntOptions, parser, file, mockFilename, nil)
+	evaluatedLocals, err := evaluateLocalsBlock(terragruntOptions, parser, file, mockFilename, TrackInclude{})
 	require.NoError(t, err)
 
 	expected := "a"
@@ -106,7 +106,7 @@ func TestEvaluateLocalsBlockImpossibleWillFail(t *testing.T) {
 	file, err := parseHcl(parser, LocalsTestImpossibleConfig, mockFilename)
 	require.NoError(t, err)
 
-	_, err = evaluateLocalsBlock(terragruntOptions, parser, file, mockFilename, nil)
+	_, err = evaluateLocalsBlock(terragruntOptions, parser, file, mockFilename, TrackInclude{})
 	require.Error(t, err)
 
 	switch errors.Unwrap(err).(type) {
@@ -126,7 +126,7 @@ func TestEvaluateLocalsBlockMultipleLocalsBlocksWillFail(t *testing.T) {
 	file, err := parseHcl(parser, MultipleLocalsBlockConfig, mockFilename)
 	require.NoError(t, err)
 
-	_, err = evaluateLocalsBlock(terragruntOptions, parser, file, mockFilename, nil)
+	_, err = evaluateLocalsBlock(terragruntOptions, parser, file, mockFilename, TrackInclude{})
 	require.Error(t, err)
 }
 

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -367,6 +367,9 @@ The `include` block supports the following arguments:
 
 - `path` (attribute): Specifies the path to a Terragrunt configuration file (the `parent` config) that should be merged
   with this configuration (the `child` config).
+- `expose` (attribute, optional): Specifies whether or not the included config should be parsed and exposed as a
+  variable. When `true`, you can reference the data of the included config under the variable `include`. Defaults to
+  `false`.
 
 Example:
 
@@ -379,7 +382,12 @@ Example:
 # └── child
 #     └── terragrunt.hcl
 include {
-  path = find_in_parent_folders()
+  path   = find_in_parent_folders()
+  expose = true
+}
+
+inputs = {
+  remote_state_config = include.remote_state
 }
 ```
 

--- a/test/fixture-include/qa/my-app/main.tf
+++ b/test/fixture-include/qa/my-app/main.tf
@@ -6,3 +6,8 @@ terraform {
 data "template_file" "test" {
   template = "Hello, I am a template."
 }
+
+variable "reflect" {}
+output "reflect" {
+  value = var.reflect
+}

--- a/test/fixture-include/qa/my-app/terragrunt.hcl
+++ b/test/fixture-include/qa/my-app/terragrunt.hcl
@@ -1,5 +1,6 @@
 include {
-  path = "${find_in_parent_folders()}"
+  path   = "${find_in_parent_folders()}"
+  expose = true
 }
 
 inputs = {

--- a/test/fixture-include/qa/my-app/terragrunt.hcl
+++ b/test/fixture-include/qa/my-app/terragrunt.hcl
@@ -1,3 +1,7 @@
 include {
   path = "${find_in_parent_folders()}"
 }
+
+inputs = {
+  reflect = include.remote_state
+}


### PR DESCRIPTION
This is the first of several PRs for implementing the Imports RFC, as described in https://github.com/gruntwork-io/terragrunt/issues/1566

This PR is a minimal, backward compatible change that exposes included config attributes in the current config if the special `expose` attribute is toggled to `true`. When `expose` is set to `true`, users can reference the values from a parent included config using `include`, e.g. `include.locals.foo`.

Some caveats:
- In the interest of backward compatibility, the `expose` toggle defaults to `false` - in the future, once the full feature set is implemented, we can decide if we should default to `true` instead.
- Dependencies are not automatically fetched at the moment. This is a future feature (the ticket has been updated accordingly).
- Currently only one include block can exist per terragrunt config (this is why the include vars are available directly under `include` and not `include.LABEL`). This will change in the future.