### PR TITLE
Resolves #1369

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -2,6 +2,7 @@ package aws_helper
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -165,6 +166,17 @@ func GetAWSCallerIdentity(config *AwsSessionConfig, terragruntOptions *options.T
 	}
 
 	return *identity, nil
+}
+
+// Get the AWS Partition of the current session configuration
+func GetAWSPartition(config *AwsSessionConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
+	identity, err := GetAWSCallerIdentity(config, terragruntOptions)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	arn_slice := strings.Split(*identity.Arn, ":")
+	return arn_slice[1], nil
 }
 
 // Get the AWS account ID of the current session configuration

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -2,10 +2,10 @@ package aws_helper
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -175,8 +175,11 @@ func GetAWSPartition(config *AwsSessionConfig, terragruntOptions *options.Terrag
 		return "", errors.WithStackTrace(err)
 	}
 
-	arn_slice := strings.Split(*identity.Arn, ":")
-	return arn_slice[1], nil
+	arn, err := arn.Parse(*identity.Arn)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+	return arn.Partition, nil
 }
 
 // Get the AWS account ID of the current session configuration

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -600,7 +600,6 @@ func EnableRootAccesstoS3Bucket(s3Client *s3.S3, config *ExtendedRemoteStateConf
 	}
 
 	_, err = s3Client.PutBucketPolicy(&s3.PutBucketPolicyInput{
-
 		Bucket: aws.String(bucket),
 		Policy: aws.String(string(policy)),
 	})


### PR DESCRIPTION
making the AWS ARN partition value a dynamic lookup and removing hard-coding of ":aws:" to support GovCloud and other paritions. Resolves #1369