### PR TITLE
fix: Check planfile and put it in the end of an arguments list

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -631,7 +631,8 @@ func runTerragruntWithConfig(originalTerragruntOptions *options.TerragruntOption
 
 	// Add extra_arguments to the command
 	if terragruntConfig.Terraform != nil && terragruntConfig.Terraform.ExtraArgs != nil && len(terragruntConfig.Terraform.ExtraArgs) > 0 {
-		terragruntOptions.InsertTerraformCliArgs(filterTerraformExtraArgs(terragruntOptions, terragruntConfig)...)
+		args := filterTerraformExtraArgs(terragruntOptions, terragruntConfig)
+		terragruntOptions.InsertTerraformCliArgs(args...)
 		for k, v := range filterTerraformEnvVarsFromExtraArgs(terragruntOptions, terragruntConfig) {
 			terragruntOptions.Env[k] = v
 		}

--- a/options/options.go
+++ b/options/options.go
@@ -304,7 +304,14 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 
 // Check if argument is planfile TODO check file format
 func checkIfPlanFile(arg string) bool {
-	return util.IsFile(arg)
+	isFile := util.IsFile(arg)
+
+	if isFile {
+		ext := filepath.Ext(arg)
+		return ext == ".tfplan"
+	}
+
+	return false
 }
 
 // Extract planfile from arguments list

--- a/options/options.go
+++ b/options/options.go
@@ -315,19 +315,19 @@ func checkIfPlanfile(arg string) bool {
 
 // Extract planfile from arguments list
 func extractPlanFile(argsToInsert []string) (*string, []string) {
-	planfile := ""
-	filteredArgs := []string{}
+	planFile := ""
+	var filteredArgs []string
 
 	for _, arg := range argsToInsert {
 		if checkIfPlanfile(arg) {
-			planfile = arg
+			planFile = arg
 		} else {
 			filteredArgs = append(filteredArgs, arg)
 		}
 	}
 
-	if planfile != "" {
-		return &planfile, filteredArgs
+	if planFile != "" {
+		return &planFile, filteredArgs
 	}
 
 	return nil, filteredArgs

--- a/options/options.go
+++ b/options/options.go
@@ -304,14 +304,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 
 // Check if argument is planfile TODO check file format
 func checkIfPlanFile(arg string) bool {
-	isFile := util.IsFile(arg)
-
-	if isFile {
-		ext := filepath.Ext(arg)
-		return ext == ".tfplan"
-	}
-
-	return false
+	return util.IsFile(arg) && filepath.Ext(arg) == ".tfplan"
 }
 
 // Extract planfile from arguments list

--- a/options/options.go
+++ b/options/options.go
@@ -303,7 +303,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 }
 
 // Check if argument is planfile TODO check file format
-func checkIfPlanfile(arg string) bool {
+func checkIfPlanFile(arg string) bool {
 	return util.IsFile(arg)
 }
 
@@ -313,7 +313,7 @@ func extractPlanFile(argsToInsert []string) (*string, []string) {
 	var filteredArgs []string
 
 	for _, arg := range argsToInsert {
-		if checkIfPlanfile(arg) {
+		if checkIfPlanFile(arg) {
 			planFile = arg
 		} else {
 			filteredArgs = append(filteredArgs, arg)

--- a/options/options.go
+++ b/options/options.go
@@ -304,13 +304,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 
 // Check if argument is planfile TODO check file format
 func checkIfPlanfile(arg string) bool {
-	stat, err := os.Stat(arg)
-
-	if err != nil {
-		return false
-	}
-
-	return !stat.IsDir()
+	return util.IsFile(arg)
 }
 
 // Extract planfile from arguments list

--- a/options/options.go
+++ b/options/options.go
@@ -302,8 +302,40 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 	}
 }
 
+// Check if argument is planfile TODO check file format
+func checkIfPlanfile(arg string) bool {
+	stat, err := os.Stat(arg)
+
+	if err != nil {
+		return false
+	}
+
+	return !stat.IsDir()
+}
+
+// Extract planfile from arguments list
+func extractPlanFile(argsToInsert []string) (*string, []string) {
+	planfile := ""
+	filteredArgs := []string{}
+
+	for _, arg := range argsToInsert {
+		if checkIfPlanfile(arg) {
+			planfile = arg
+		} else {
+			filteredArgs = append(filteredArgs, arg)
+		}
+	}
+
+	if planfile != "" {
+		return &planfile, filteredArgs
+	}
+
+	return nil, filteredArgs
+}
+
 // Inserts the given argsToInsert after the terraform command argument, but before the remaining args
 func (terragruntOptions *TerragruntOptions) InsertTerraformCliArgs(argsToInsert ...string) {
+	planFile, restArgs := extractPlanFile(argsToInsert)
 
 	commandLength := 1
 	if util.ListContainsElement(TERRAFORM_COMMANDS_WITH_SUBCOMMAND, terragruntOptions.TerraformCliArgs[0]) {
@@ -316,8 +348,14 @@ func (terragruntOptions *TerragruntOptions) InsertTerraformCliArgs(argsToInsert 
 	// command is either 1 word or 2 words
 	var args []string
 	args = append(args, terragruntOptions.TerraformCliArgs[:commandLength]...)
-	args = append(args, argsToInsert...)
+	args = append(args, restArgs...)
 	args = append(args, terragruntOptions.TerraformCliArgs[commandLength:]...)
+
+	// check if planfile was extracted
+	if planFile != nil {
+		args = append(args, *planFile)
+	}
+
 	terragruntOptions.TerraformCliArgs = args
 }
 

--- a/test/fixture-planfile-order-test/.gitignore
+++ b/test/fixture-planfile-order-test/.gitignore
@@ -1,0 +1,1 @@
+test-provider.tf

--- a/test/fixture-planfile-order-test/inputs.tf
+++ b/test/fixture-planfile-order-test/inputs.tf
@@ -1,0 +1,3 @@
+variable "resource_count" {
+  type = number
+}

--- a/test/fixture-planfile-order-test/resource.tf
+++ b/test/fixture-planfile-order-test/resource.tf
@@ -1,0 +1,3 @@
+resource "null_resource" "test-resources" {
+  count = var.resource_count
+}

--- a/test/fixture-planfile-order-test/terragrunt.hcl
+++ b/test/fixture-planfile-order-test/terragrunt.hcl
@@ -17,7 +17,8 @@ terraform {
 
     arguments = [
       "-out=${get_terragrunt_dir()}/default.tfplan",
-      "-var-file=${get_terragrunt_dir()}/vars/variables.tfvars",
+      "-var-file",
+      "${get_terragrunt_dir()}/vars/variables.tfvars",
       "-no-color",
     ]
   }

--- a/test/fixture-planfile-order-test/terragrunt.hcl
+++ b/test/fixture-planfile-order-test/terragrunt.hcl
@@ -1,0 +1,39 @@
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remote_state {
+  backend = "local"
+  config = {}
+}
+
+generate "test-null-provider" {
+  path      = "test-provider.tf"
+  if_exists = "overwrite_terragrunt"
+
+  contents = <<EOF
+provider "null" {
+}
+EOF
+}
+
+terraform {
+  extra_arguments "plan_vars" {
+    commands = [
+      "plan",
+    ]
+
+    arguments = [
+      "-out=${get_terragrunt_dir()}/default.tfplan",
+      "-var-file=${get_terragrunt_dir()}/vars/variables.tfvars",
+    ]
+  }
+
+  extra_arguments "apply_vars" {
+    commands = [
+      "apply",
+    ]
+
+    arguments = [
+      "${get_terragrunt_dir()}/default.tfplan",
+      "-var-file=${get_terragrunt_dir()}/vars/variables.tfvars",
+    ]
+  }
+}

--- a/test/fixture-planfile-order-test/terragrunt.hcl
+++ b/test/fixture-planfile-order-test/terragrunt.hcl
@@ -1,9 +1,4 @@
 # Configure Terragrunt to automatically store tfstate files in an S3 bucket
-remote_state {
-  backend = "local"
-  config = {}
-}
-
 generate "test-null-provider" {
   path      = "test-provider.tf"
   if_exists = "overwrite_terragrunt"
@@ -23,6 +18,7 @@ terraform {
     arguments = [
       "-out=${get_terragrunt_dir()}/default.tfplan",
       "-var-file=${get_terragrunt_dir()}/vars/variables.tfvars",
+      "-no-color",
     ]
   }
 
@@ -33,7 +29,7 @@ terraform {
 
     arguments = [
       "${get_terragrunt_dir()}/default.tfplan",
-      "-var-file=${get_terragrunt_dir()}/vars/variables.tfvars",
+      "-no-color",
     ]
   }
 }

--- a/test/fixture-planfile-order-test/vars/variables.tfvars
+++ b/test/fixture-planfile-order-test/vars/variables.tfvars
@@ -1,0 +1,1 @@
+resource_count = 3

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -121,6 +121,7 @@ const (
 	TEST_FIXTURE_GET_TERRAGRUNT_SOURCE_HCL                  = "fixture-get-terragrunt-source-hcl"
 	TEST_FIXTURE_GET_TERRAGRUNT_SOURCE_CLI                  = "fixture-get-terragrunt-source-cli"
 	TEST_FIXTURE_REGRESSIONS                                = "fixture-regressions"
+	TEST_FIXTURE_PLANFILE_ORDER                             = "fixture-planfile-order-test"
 	TEST_FIXTURE_DIRS_PATH                                  = "fixture-dirs"
 	TEST_FIXTURE_PARALLELISM                                = "fixture-parallelism"
 	TEST_FIXTURE_SOPS                                       = "fixture-sops"
@@ -1219,6 +1220,19 @@ func TestAutoRetrySkip(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.NotContains(t, out.String(), "Apply complete!")
+}
+
+func TestPlanfileOrder(t *testing.T) {
+	t.Parallel()
+
+	rootPath := copyEnvironment(t, TEST_FIXTURE_PLANFILE_ORDER)
+	modulePath := util.JoinPath(rootPath, TEST_FIXTURE_PLANFILE_ORDER)
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-working-dir %s", modulePath), os.Stdout, os.Stderr)
+	assert.NotNil(t, err)
+
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-working-dir %s", modulePath), os.Stdout, os.Stderr)
+	assert.NotNil(t, err)
 }
 
 func TestAutoRetryExhaustRetries(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1229,10 +1229,10 @@ func TestPlanfileOrder(t *testing.T) {
 	modulePath := util.JoinPath(rootPath, TEST_FIXTURE_PLANFILE_ORDER)
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-working-dir %s", modulePath), os.Stdout, os.Stderr)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 
 	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-working-dir %s", modulePath), os.Stdout, os.Stderr)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 }
 
 func TestAutoRetryExhaustRetries(t *testing.T) {


### PR DESCRIPTION
This issue should fix #1271

This MR fixes args order when planfile is specified in extra_args for apply