### PR TITLE
Add parameter to merge mocked outputs with the state outputs

### DIFF
--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -18,6 +18,7 @@ import (
 func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 	testSource := "./foo"
 	testTrue := true
+	testFalse := false
 	mockOutputs := cty.Zero
 	mockOutputsAllowedTerraformCommands := []string{"init"}
 	testConfig := TerragruntConfig{
@@ -75,6 +76,7 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 				SkipOutputs:                         &testTrue,
 				MockOutputs:                         &mockOutputs,
 				MockOutputsAllowedTerraformCommands: &mockOutputsAllowedTerraformCommands,
+				MockOutputsMergeWithState:           &testFalse,
 				RenderedOutputs:                     &mockOutputs,
 			},
 		},

--- a/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
+++ b/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
@@ -217,6 +217,20 @@ When `skip_outputs` is used with `mock_outputs`, mocked outputs will be returned
       skip_outputs = true
     }
 
+You can also use `mock_outputs_merge_with_state` on the `dependency` block to merge the mocked outputs and the state outputs :
+
+    dependency "vpc" {
+      config_path = "../vpc"
+      mock_outputs = {
+        vpc_id     = "temporary-dummy-id"
+        new_output = "temporary-dummy-value"
+      }
+
+      mock_outputs_merge_with_state = true
+    }
+
+If the state outputs only contains `vpc_id`, this value will be preserved. And `new_output` which is not existing, the mock value will be used.
+
 ### Dependencies between modules
 
 You can also specify dependencies explicitly. Consider the following file structure:

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -624,6 +624,7 @@ The `dependency` block supports the following arguments:
 - `mock_outputs_allowed_terraform_commands` (attribute): A list of Terraform commands for which `mock_outputs` are
   allowed. If a command is used where `mock_outputs` is not allowed, and no outputs are available in the target module,
   Terragrunt will throw an error when processing this dependency.
+- `mock_outputs_merge_with_state` (attribute): When `true`, `mock_outputs` and the state outputs will be merged.
 
 Example:
 

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/live/child/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/live/child/terragrunt.hcl
@@ -1,0 +1,22 @@
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "x" {
+  config_path = "../parent"
+
+  mock_outputs_allowed_terraform_commands = ["validate", "init", "destroy", "plan", "apply", "terragrunt-info"]
+  mock_outputs = {
+    test_output1 = "fake-data"
+    test_output2 = "fake-data2"
+  }
+}
+
+inputs = {
+  test_input1 = dependency.x.outputs.test_output1
+  test_input2 = dependency.x.outputs.test_output2
+}
+
+terraform {
+  source = "../..//modules/child"
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/live/parent/parent/terraform.tfstate
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/live/parent/parent/terraform.tfstate
@@ -1,0 +1,13 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.3",
+  "serial": 1,
+  "lineage": "bd1cefab-16fb-fd93-db39-7e272ecc60df",
+  "outputs": {
+    "test_output1": {
+      "value": "value1",
+      "type": "string"
+    }
+  },
+  "resources": []
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/live/parent/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/live/parent/terragrunt.hcl
@@ -1,0 +1,7 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../..//modules/parent"
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/live/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/live/terragrunt.hcl
@@ -1,0 +1,12 @@
+remote_state {
+  backend = "local"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+
+  config = {
+    path = "${get_terragrunt_dir()}/${path_relative_to_include()}/terraform.tfstate"
+  }
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/modules/child/main.tf
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/modules/child/main.tf
@@ -1,0 +1,15 @@
+variable "test_input1" {
+  type = string
+}
+
+output "test_output1_from_parent" {
+  value = var.test_input1
+}
+
+variable "test_input2" {
+  type = string
+}
+
+output "test_output2_from_parent" {
+  value = var.test_input2
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/modules/parent/main.tf
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-default/modules/parent/main.tf
@@ -1,0 +1,7 @@
+output "test_output1" {
+  value = "value1"
+}
+
+output "test_output2" {
+  value = "value2"
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/live/child/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/live/child/terragrunt.hcl
@@ -1,0 +1,23 @@
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "x" {
+  config_path = "../parent"
+
+  mock_outputs_allowed_terraform_commands = ["validate", "init", "destroy", "plan", "apply", "terragrunt-info"]
+  mock_outputs_merge_with_state = false
+  mock_outputs = {
+    test_output1 = "fake-data"
+    test_output2 = "fake-data2"
+  }
+}
+
+inputs = {
+  test_input1 = dependency.x.outputs.test_output1
+  test_input2 = dependency.x.outputs.test_output2
+}
+
+terraform {
+  source = "../..//modules/child"
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/live/parent/parent/terraform.tfstate
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/live/parent/parent/terraform.tfstate
@@ -1,0 +1,13 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.3",
+  "serial": 1,
+  "lineage": "bd1cefab-16fb-fd93-db39-7e272ecc60df",
+  "outputs": {
+    "test_output1": {
+      "value": "value1",
+      "type": "string"
+    }
+  },
+  "resources": []
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/live/parent/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/live/parent/terragrunt.hcl
@@ -1,0 +1,7 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../..//modules/parent"
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/live/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/live/terragrunt.hcl
@@ -1,0 +1,12 @@
+remote_state {
+  backend = "local"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+
+  config = {
+    path = "${get_terragrunt_dir()}/${path_relative_to_include()}/terraform.tfstate"
+  }
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/modules/child/main.tf
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/modules/child/main.tf
@@ -1,0 +1,15 @@
+variable "test_input1" {
+  type = string
+}
+
+output "test_output1_from_parent" {
+  value = var.test_input1
+}
+
+variable "test_input2" {
+  type = string
+}
+
+output "test_output2_from_parent" {
+  value = var.test_input2
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/modules/parent/main.tf
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-false/modules/parent/main.tf
@@ -1,0 +1,7 @@
+output "test_output1" {
+  value = "value1"
+}
+
+output "test_output2" {
+  value = "value2"
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/live/child/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/live/child/terragrunt.hcl
@@ -1,0 +1,23 @@
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "x" {
+  config_path = "../parent"
+
+  mock_outputs_allowed_terraform_commands = ["validate", "init", "destroy", "plan", "apply", "terragrunt-info"]
+  mock_outputs_merge_with_state = true
+  mock_outputs = {
+    test_output1 = "fake-data"
+    test_output2 = "fake-data2"
+  }
+}
+
+inputs = {
+  test_input1 = dependency.x.outputs.test_output1
+  test_input2 = dependency.x.outputs.test_output2
+}
+
+terraform {
+  source = "../..//modules/child"
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/live/parent/parent/terraform.tfstate
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/live/parent/parent/terraform.tfstate
@@ -1,0 +1,17 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.3",
+  "serial": 1,
+  "lineage": "bd1cefab-16fb-fd93-db39-7e272ecc60df",
+  "outputs": {
+    "test_output1": {
+      "value": "value1",
+      "type": "string"
+    },
+    "test_output2": {
+      "value": "value2",
+      "type": "string"
+    }
+  },
+  "resources": []
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/live/parent/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/live/parent/terragrunt.hcl
@@ -1,0 +1,7 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../..//modules/parent"
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/live/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/live/terragrunt.hcl
@@ -1,0 +1,12 @@
+remote_state {
+  backend = "local"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+
+  config = {
+    path = "${get_terragrunt_dir()}/${path_relative_to_include()}/terraform.tfstate"
+  }
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/modules/child/main.tf
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/modules/child/main.tf
@@ -1,0 +1,15 @@
+variable "test_input1" {
+  type = string
+}
+
+output "test_output1_from_parent" {
+  value = var.test_input1
+}
+
+variable "test_input2" {
+  type = string
+}
+
+output "test_output2_from_parent" {
+  value = var.test_input2
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/modules/parent/main.tf
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-no-override/modules/parent/main.tf
@@ -1,0 +1,7 @@
+output "test_output1" {
+  value = "value1"
+}
+
+output "test_output2" {
+  value = "value2"
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/live/child/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/live/child/terragrunt.hcl
@@ -1,0 +1,23 @@
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "x" {
+  config_path = "../parent"
+
+  mock_outputs_allowed_terraform_commands = ["validate", "init", "destroy", "plan", "apply", "terragrunt-info"]
+  mock_outputs_merge_with_state = true
+  mock_outputs = {
+    test_output1 = "fake-data"
+    test_output2 = "fake-data2"
+  }
+}
+
+inputs = {
+  test_input1 = dependency.x.outputs.test_output1
+  test_input2 = dependency.x.outputs.test_output2
+}
+
+terraform {
+  source = "../..//modules/child"
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/live/parent/parent/terraform.tfstate
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/live/parent/parent/terraform.tfstate
@@ -1,0 +1,13 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.3",
+  "serial": 1,
+  "lineage": "bd1cefab-16fb-fd93-db39-7e272ecc60df",
+  "outputs": {
+    "test_output1": {
+      "value": "value1",
+      "type": "string"
+    }
+  },
+  "resources": []
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/live/parent/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/live/parent/terragrunt.hcl
@@ -1,0 +1,7 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../..//modules/parent"
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/live/terragrunt.hcl
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/live/terragrunt.hcl
@@ -1,0 +1,12 @@
+remote_state {
+  backend = "local"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+
+  config = {
+    path = "${get_terragrunt_dir()}/${path_relative_to_include()}/terraform.tfstate"
+  }
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/modules/child/main.tf
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/modules/child/main.tf
@@ -1,0 +1,15 @@
+variable "test_input1" {
+  type = string
+}
+
+output "test_output1_from_parent" {
+  value = var.test_input1
+}
+
+variable "test_input2" {
+  type = string
+}
+
+output "test_output2_from_parent" {
+  value = var.test_input2
+}

--- a/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/modules/parent/main.tf
+++ b/test/fixture-get-output/mock-outputs-merge-with-state/merge-with-state-true/modules/parent/main.tf
@@ -1,0 +1,7 @@
+output "test_output1" {
+  value = "value1"
+}
+
+output "test_output2" {
+  value = "value2"
+}


### PR DESCRIPTION
Add parameter to merge mocked outputs with the state outputs

- Adding a parameter, with explicit name => merge_state_and_mocks_outputs
- As default is should be set to false
- If true, terragrunt will add missing mocks, in the state outputs

In order to fix
#940 
#1756