### PR TITLE
#1457 Detection of duplicated "generate" blocks in HCL files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -828,6 +828,7 @@ func convertToTerragruntConfig(
 	return terragruntConfig, nil
 }
 
+// Iterate over generate blocks and detect duplicate names, return error with list of duplicated names
 func validateGenerateBlocks(blocks *[]terragruntGenerateBlock) error {
 	var blockNames = map[string]bool{}
 	var duplicatedGenerateBlockNames []string

--- a/test/fixture-codegen/generate-block/same_name_error/terragrunt.hcl
+++ b/test/fixture-codegen/generate-block/same_name_error/terragrunt.hcl
@@ -1,0 +1,16 @@
+generate "backend" {
+  path = "data.txt"
+  if_exists = "overwrite"
+  contents = "test data1"
+}
+
+generate "backend" {
+  path = "data.txt"
+  if_exists = "overwrite"
+  contents = "test data2"
+}
+
+
+terraform {
+  source = "../../module"
+}

--- a/test/fixture-codegen/generate-block/same_name_pair_error/terragrunt.hcl
+++ b/test/fixture-codegen/generate-block/same_name_pair_error/terragrunt.hcl
@@ -1,0 +1,28 @@
+generate "backend" {
+  path = "data.txt"
+  if_exists = "overwrite"
+  contents = "test data1"
+}
+
+generate "backend2" {
+  path = "data2.txt"
+  if_exists = "overwrite"
+  contents = "test data2"
+}
+
+generate "backend" {
+  path = "data.txt"
+  if_exists = "overwrite"
+  contents = "test data1"
+}
+
+generate "backend2" {
+  path = "data2.txt"
+  if_exists = "overwrite"
+  contents = "test data2"
+}
+
+
+terraform {
+  source = "../../module"
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3363,6 +3363,41 @@ func TestTerragruntGenerateBlockDisableSignature(t *testing.T) {
 	assert.Equal(t, outputs["text"].Value, "Hello, World!")
 }
 
+func TestTerragruntGenerateBlockSameNameFail(t *testing.T) {
+	t.Parallel()
+
+	generateTestCase := filepath.Join(TEST_FIXTURE_CODEGEN_PATH, "generate-block", "same_name_error")
+	cleanupTerraformFolder(t, generateTestCase)
+	cleanupTerragruntFolder(t, generateTestCase)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt init --terragrunt-working-dir %s", generateTestCase), &stdout, &stderr)
+	require.Error(t, err)
+	parsedError, ok := errors.Unwrap(err).(config.DuplicatedGenerateBlocks)
+	assert.True(t, ok)
+	assert.True(t, len(parsedError.BlockName) == 1)
+	assert.Contains(t, parsedError.BlockName, "backend")
+}
+
+func TestTerragruntGenerateBlockMultipleSameNameFail(t *testing.T) {
+	t.Parallel()
+
+	generateTestCase := filepath.Join(TEST_FIXTURE_CODEGEN_PATH, "generate-block", "same_name_pair_error")
+	cleanupTerraformFolder(t, generateTestCase)
+	cleanupTerragruntFolder(t, generateTestCase)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt init --terragrunt-working-dir %s", generateTestCase), &stdout, &stderr)
+	require.Error(t, err)
+	parsedError, ok := errors.Unwrap(err).(config.DuplicatedGenerateBlocks)
+	assert.True(t, ok)
+	assert.True(t, len(parsedError.BlockName) == 2)
+	assert.Contains(t, parsedError.BlockName, "backend")
+	assert.Contains(t, parsedError.BlockName, "backend2")
+}
+
 func TestTerragruntRemoteStateCodegenGeneratesBackendBlock(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Updated `Terragrunt` to detect generate blocks with duplicate name, fix for issue https://github.com/gruntwork-io/terragrunt/issues/1457

Example:
```
$ cat terragrunt.hcl
generate "backend" {
  path = "data.txt"
  if_exists = "overwrite"
  contents = "test data1"
}
generate "backend2" {
  path = "data2.txt"
  if_exists = "overwrite"
  contents = "test data2"
}
generate "backend" {
  path = "data.txt"
  if_exists = "overwrite"
  contents = "test data11"
}
generate "backend2" {
  path = "data2.txt"
  if_exists = "overwrite"
  contents = "test data22"
}

generate "backend3" {
  path = "data3.txt"
  if_exists = "overwrite"
  contents = "test data3"
}

$ terragrunt init
ERRO[0000] Detected generate blocks with the same name: [backend backend2] 
ERRO[0000] Unable to determine underlying exit code, so Terragrunt will exit with error code 1 

```
Included changes:
 * configuration loading updates
 * integration tests to cover this case
