### PR TITLE
#1788 Verification if module source point to existing directory

### DIFF
--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -184,7 +184,7 @@ type WorkingDirNotFound struct {
 }
 
 func (err WorkingDirNotFound) Error() string {
-	return fmt.Sprintf("Not found directory: %s", err.Dir)
+	return fmt.Sprintf("Directory not found: %s", err.Dir)
 }
 
 type WorkingDirNotDir struct {
@@ -192,5 +192,5 @@ type WorkingDirNotDir struct {
 }
 
 func (err WorkingDirNotDir) Error() string {
-	return fmt.Sprintf("Not a directory: %s", err.Dir)
+	return fmt.Sprintf("Invalid directory: %s", err.Dir)
 }

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -2,10 +2,11 @@ package cli
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-getter"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/hashicorp/go-getter"
 
 	"github.com/gruntwork-io/terragrunt/cli/tfsource"
 	"github.com/gruntwork-io/terragrunt/config"

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -173,9 +173,7 @@ type WorkingDirNotFound struct {
 }
 
 func (err WorkingDirNotFound) Error() string {
-	return fmt.Sprintf(
-		"Not found directory: %s", err.Dir,
-	)
+	return fmt.Sprintf("Not found directory: %s", err.Dir)
 }
 
 type WorkingDirNotDir struct {
@@ -183,7 +181,5 @@ type WorkingDirNotDir struct {
 }
 
 func (err WorkingDirNotDir) Error() string {
-	return fmt.Sprintf(
-		"Not a directory: %s", err.Dir,
-	)
+	return fmt.Sprintf("Not a directory: %s", err.Dir)
 }

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -63,7 +63,7 @@ func downloadTerraformSourceIfNecessary(terraformSource *tfsource.TerraformSourc
 	}
 
 	if alreadyLatest {
-		if err := validateWorkingDir(terraformSource, terragruntOptions); err != nil {
+		if err := validateWorkingDir(terraformSource); err != nil {
 			return err
 		}
 		terragruntOptions.Logger.Debugf("Terraform files in %s are up to date. Will not download again.", terraformSource.WorkingDir)
@@ -87,7 +87,7 @@ func downloadTerraformSourceIfNecessary(terraformSource *tfsource.TerraformSourc
 		return err
 	}
 
-	if err := validateWorkingDir(terraformSource, terragruntOptions); err != nil {
+	if err := validateWorkingDir(terraformSource); err != nil {
 		return err
 	}
 
@@ -168,8 +168,8 @@ func downloadSource(terraformSource *tfsource.TerraformSource, terragruntOptions
 }
 
 // Check if working terraformSource.WorkingDir exists and is directory
-func validateWorkingDir(terraformSource *tfsource.TerraformSource, terragruntOptions *options.TerragruntOptions) error {
-	workingLocalDir := strings.Replace(terraformSource.WorkingDir, terraformSource.DownloadDir+"/", "", -1)
+func validateWorkingDir(terraformSource *tfsource.TerraformSource) error {
+	workingLocalDir := strings.Replace(terraformSource.WorkingDir, terraformSource.DownloadDir+filepath.FromSlash("/"), "", -1)
 	if util.IsFile(terraformSource.WorkingDir) {
 		return WorkingDirNotDir{Dir: workingLocalDir, Source: terraformSource.CanonicalSourceURL.String()}
 	}

--- a/cli/download_source_test.go
+++ b/cli/download_source_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terragrunt/errors"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -10,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gruntwork-io/terragrunt/errors"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/test/fixture-download/invalid-path/terragrunt.hcl
+++ b/test/fixture-download/invalid-path/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "github.com/gruntwork-io/terragrunt.git//test/fixture-download/not-existing-path?ref=v0.9.9"
+}


### PR DESCRIPTION
Updated source downloading logic to verify if module directory actually exists

Example:
```

$ cat terragrunt.hcl
terraform {
  source = "git::ssh://git@github.com/denis256/internal-terragrunt-test-cases.git//module-666/invalid-path?ref=main"
}

$ terragrunt init
ERRO[0001] Working dir module-666/invalid-path from source git::ssh://git@github.com/denis256/internal-terragrunt-test-cases.git?ref=main does not exist 
ERRO[0001] Unable to determine underlying exit code, so Terragrunt will exit with error code 1 


```

Included changes:
 * Added verification of terraformSource.WorkingDir after downloading of sources
 * Added test cases

Fix for issue: #1788