### PR TITLE
#1778 Added url encoding of branch name in TestAwsProviderPatch

### DIFF
--- a/_ci/install-golang.ps1
+++ b/_ci/install-golang.ps1
@@ -1,8 +1,8 @@
 # remove the old go installation
 Remove-Item "C:\Go" -Recurse
 # Download golang, unpack it, and then update the PATH to include gobin
-$golangURI = "https://golang.org/dl/go1.14.7.windows-amd64.zip"
-$output = "go1.14.7.zip"
+$golangURI = "https://golang.org/dl/go1.16.7.windows-amd64.zip"
+$output = "go1.16.7.zip"
 # The SilentlyContinue is needed to handle access denied error. See
 # https://discuss.circleci.com/t/access-denied-error-while-trying-to-download-software-on-windows-cirlcleci-environment/32809/2
 $ProgressPreference = "SilentlyContinue"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -1248,7 +1249,11 @@ func TestAwsProviderPatch(t *testing.T) {
 	// fill in branch so we can test against updates to the test case file
 	mainContents, err := util.ReadFileAsString(mainTFFile)
 	require.NoError(t, err)
-	mainContents = strings.Replace(mainContents, "__BRANCH_NAME__", git.GetCurrentBranchName(t), -1)
+	branchName := git.GetCurrentBranchName(t)
+	// https://www.terraform.io/docs/language/modules/sources.html#modules-in-package-sub-directories
+	// https://github.com/gruntwork-io/terragrunt/issues/1778
+	branchName = url.QueryEscape(branchName)
+	mainContents = strings.Replace(mainContents, "__BRANCH_NAME__", branchName, -1)
 	require.NoError(t, ioutil.WriteFile(mainTFFile, []byte(mainContents), 0444))
 
 	assert.NoError(


### PR DESCRIPTION
Updated TestAwsProviderPatch to do URL encode of current branch name

Before:
```
      │ Error: Failed to download module
      │ 
      │ Could not download module "example_module" (main.tf:6) source code from
      │ "github.com/gruntwork-io/terragrunt.git?ref=bugfix/issue-1415": error
      │ downloading
      │ 'https://github.com/gruntwork-io/terragrunt.git?ref=bugfix':
      │ /usr/bin/git exited with 1: error: pathspec 'bugfix' did not
      │ match any file(s) known to git.
      │ 

```
After:
```
        Initializing modules...
        Downloading github.com/gruntwork-io/terragrunt.git?ref=bugfix%2Fissue-1415 for example_module...
        - example_module in .terraform/modules/example_module/test/fixture-aws-provider-patch/example-module
       Terraform has been successfully initialized!

```

![followup-emal1](https://user-images.githubusercontent.com/10694338/132299000-938a158e-3c3b-438f-9da5-40575ee99489.png)


Fix for #1778