### PR TITLE
Allow setting log level with env var

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -138,7 +138,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	strictInclude := parseBooleanArg(args, OPT_TERRAGRUNT_STRICT_INCLUDE, false)
 
 	// Those correspond to logrus levels
-	logLevel, err := parseStringArg(args, OPT_TERRAGRUNT_LOGLEVEL, util.DEFAULT_LOG_LEVEL.String())
+	logLevel, err := parseStringArg(args, OPT_TERRAGRUNT_LOGLEVEL, util.GetDefaultLogLevel().String())
 	if err != nil {
 		return nil, err
 	}

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const defaultLogLevel = options.DEFAULT_LOG_LEVEL
+var defaultLogLevel = util.GetDefaultLogLevel()
 
 func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 	t.Parallel()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -412,7 +412,7 @@ include {
 	opts := options.TerragruntOptions{
 		TerragruntConfigPath: "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/" + DefaultTerragruntConfigPath,
 		NonInteractive:       true,
-		Logger:               util.CreateLogEntry("", util.DEFAULT_LOG_LEVEL),
+		Logger:               util.CreateLogEntry("", util.GetDefaultLogLevel()),
 	}
 
 	terragruntConfig, err := ParseConfigString(config, &opts, nil, opts.TerragruntConfigPath, nil)
@@ -1162,7 +1162,7 @@ terraform {
 		TerragruntConfigPath: "../test/fixture-parent-folders/terragrunt-in-root/child/" + DefaultTerragruntConfigPath,
 		NonInteractive:       true,
 		MaxFoldersToCheck:    5,
-		Logger:               util.CreateLogEntry("", util.DEFAULT_LOG_LEVEL),
+		Logger:               util.CreateLogEntry("", util.GetDefaultLogLevel()),
 	}
 
 	terragruntConfig, err := ParseConfigString(config, &opts, nil, DefaultTerragruntConfigPath, nil)

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -677,6 +677,7 @@ that Terragrunt invokes the module, so that you can debug issues with the terrag
 ### terragrunt-log-level
 
 **CLI Arg**: `--terragrunt-log-level`<br/>
+**Environment Variable**: `TERRAGRUNT_LOG_LEVEL`
 **Requires an argument**: `--terragrunt-log-level <LOG_LEVEL>`
 
 When passed it, sets logging level for terragrunt. All supported levels are:

--- a/options/options.go
+++ b/options/options.go
@@ -28,9 +28,6 @@ const DEFAULT_PARALLELISM = math.MaxInt32
 // TERRAFORM_DEFAULT_PATH just takes terraform from the path
 const TERRAFORM_DEFAULT_PATH = "terraform"
 
-// DEFAULT_LOG_LEVEL defines default log level for Terragrunt
-const DEFAULT_LOG_LEVEL = util.DEFAULT_LOG_LEVEL
-
 const TerragruntCacheDir = ".terragrunt-cache"
 
 const DefaultTFDataDir = ".terraform"
@@ -182,7 +179,8 @@ type TerragruntOptions struct {
 
 // Create a new TerragruntOptions object with reasonable defaults for real usage
 func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, error) {
-	logger := util.CreateLogEntry("", DEFAULT_LOG_LEVEL)
+	defaultLogLevel := util.GetDefaultLogLevel()
+	logger := util.CreateLogEntry("", defaultLogLevel)
 
 	workingDir, downloadDir, err := DefaultWorkingAndDownloadDirs(terragruntConfigPath)
 	if err != nil {
@@ -199,7 +197,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		TerraformCliArgs:            []string{},
 		WorkingDir:                  workingDir,
 		Logger:                      logger,
-		LogLevel:                    DEFAULT_LOG_LEVEL,
+		LogLevel:                    defaultLogLevel,
 		ValidateStrict:              false,
 		Env:                         map[string]string{},
 		Source:                      "",
@@ -246,7 +244,7 @@ func NewTerragruntOptionsForTest(terragruntConfigPath string) (*TerragruntOption
 	opts, err := NewTerragruntOptions(terragruntConfigPath)
 
 	if err != nil {
-		logger := util.CreateLogEntry("", DEFAULT_LOG_LEVEL)
+		logger := util.CreateLogEntry("", util.GetDefaultLogLevel())
 		logger.Errorf("%v\n", errors.WithStackTrace(err))
 		return nil, err
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -939,7 +939,7 @@ func TestCustomLockFile(t *testing.T) {
 
 	source := "../custom-lock-file-module"
 	downloadDir := util.JoinPath(TEST_FIXTURE_CUSTOM_LOCK_FILE, TERRAGRUNT_CACHE)
-	result, err := tfsource.NewTerraformSource(source, downloadDir, TEST_FIXTURE_CUSTOM_LOCK_FILE, util.CreateLogEntry("", options.DEFAULT_LOG_LEVEL))
+	result, err := tfsource.NewTerraformSource(source, downloadDir, TEST_FIXTURE_CUSTOM_LOCK_FILE, util.CreateLogEntry("", util.GetDefaultLogLevel()))
 	require.NoError(t, err)
 
 	lockFilePath := util.JoinPath(result.WorkingDir, util.TerraformLockFile)

--- a/util/logger.go
+++ b/util/logger.go
@@ -11,7 +11,8 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-const DEFAULT_LOG_LEVEL = logrus.InfoLevel
+const defaultLogLevel = logrus.InfoLevel
+const logLevelEnvVar = "TERRAGRUNT_LOG_LEVEL"
 
 // GlobalFallbackLogEntry is a global fallback logentry for the application
 // Should be used in cases when more specific logger can't be created (like in the very beginning, when we have not yet
@@ -22,7 +23,8 @@ const DEFAULT_LOG_LEVEL = logrus.InfoLevel
 var GlobalFallbackLogEntry *logrus.Entry
 
 func init() {
-	GlobalFallbackLogEntry = CreateLogEntry("", DEFAULT_LOG_LEVEL)
+	defaultLogLevel := GetDefaultLogLevel()
+	GlobalFallbackLogEntry = CreateLogEntry("", defaultLogLevel)
 }
 
 // CreateLogger creates a logger. If debug is set, we use ErrorLevel to enable verbose output, otherwise - only errors are shown
@@ -68,4 +70,25 @@ func GetDiagnosticsWriter(parser *hclparse.Parser) hcl.DiagnosticWriter {
 		termWidth = 80
 	}
 	return hcl.NewDiagnosticTextWriter(os.Stderr, parser.Files(), uint(termWidth), termColor)
+}
+
+// GetDefaultLogLevel returns the default log level to use. The log level is resolved based on the environment variable
+// with name from LogLevelEnvVar, falling back to info if unspecified or there is an error parsing the given log level.
+func GetDefaultLogLevel() logrus.Level {
+	defaultLogLevelStr := os.Getenv(logLevelEnvVar)
+	if defaultLogLevelStr == "" {
+		return defaultLogLevel
+	}
+
+	parsedLogLevel, err := logrus.ParseLevel(defaultLogLevelStr)
+	if err != nil {
+		CreateLogEntry("", defaultLogLevel).Errorf(
+			"Could not parse log level from environment variable %s (%s) - falling back to default %s",
+			logLevelEnvVar,
+			defaultLogLevelStr,
+			defaultLogLevel,
+		)
+		return defaultLogLevel
+	}
+	return parsedLogLevel
 }


### PR DESCRIPTION
This PR updates the log level routine to allow configuring the terragrunt log level using the env var `TERRAGRUNT_LOG_LEVEL`.

Note that the env var configured log level has special properties beyond the `--terragrunt-log-level` CLI arg, where it allows configuring the terragrunt log level for the global fallback (because it doesn't depend on parsing the CLI args). This is very useful for debugging panic errors where we need the stack trace, because the stack trace is only available in debug mode on the global logger.