### PR TITLE
RDD: Introduce import blocks to support multiple includes

### DIFF
--- a/docs/_docs/02_features/auto-init.md
+++ b/docs/_docs/02_features/auto-init.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Auto-Init is a feature of Terragrunt that makes it so that terragrunt init does not need to be called explicitly before other terragrunt commands.
 tags: ["CLI"]
-order: 209
+order: 245
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/auto-retry.md
+++ b/docs/_docs/02_features/auto-retry.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Auto-Retry is a feature of terragrunt that will automatically address situations where a terraform command needs to be re-run.
 tags: ["CLI"]
-order: 210
+order: 250
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/aws-auth.md
+++ b/docs/_docs/02_features/aws-auth.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Learn how the Terragrunt works with AWS Credentials and AWS IAM policies.
 tags: ["AWS"]
-order: 213
+order: 260
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/before-and-after-hooks.md
+++ b/docs/_docs/02_features/before-and-after-hooks.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Learn how to execute custom code before or after running Terraform.
 tags: ["hooks"]
-order: 208
+order: 240
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/caching.md
+++ b/docs/_docs/02_features/caching.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Learn more about caching in Terragrunt.
 tags: ["caching"]
-order: 211
+order: 255
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/debugging.md
+++ b/docs/_docs/02_features/debugging.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Learn how to debug issues with terragrunt and terraform.
 tags: ["DRY", "Use cases", "CLI"]
-order: 220
+order: 265
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
+++ b/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Learn how to avoid tedious tasks of running commands on each module separately.
 tags: ["DRY", "Modules", "Use cases", "CLI"]
-order: 203
+order: 220
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/inputs.md
+++ b/docs/_docs/02_features/inputs.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Learn how to use inputs.
 tags: ["inputs"]
-order: 205
+order: 230
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/keep-your-cli-flags-dry.md
+++ b/docs/_docs/02_features/keep-your-cli-flags-dry.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Learn how to keep CLI flags DRY with "extra_arguments" block in your "terragrunt.hcl".
 tags: ["DRY", "Use cases", "CLI"]
-order: 202
+order: 215
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/keep-your-remote-state-configuration-dry.md
+++ b/docs/_docs/02_features/keep-your-remote-state-configuration-dry.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Learn how to create and manage remote state configuration.
 tags: ["DRY", "remote", "Use cases", "CLI"]
-order: 201
+order: 205
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/keep-your-terragrunt-architecture-dry.md
+++ b/docs/_docs/02_features/keep-your-terragrunt-architecture-dry.md
@@ -1,0 +1,347 @@
+---
+layout: collection-browser-doc
+title: Keep your Terragrunt Architecture DRY
+category: features
+categories_url: features
+excerpt: Learn how to use multiple terragrunt configurations to DRY up your architecture.
+tags: ["DRY", "Use cases", "backend"]
+order: 210
+nav_title: Documentation
+nav_title_link: /docs/
+---
+
+## Keep your Terragrunt Architecture DRY
+
+  - [Motivation](#motivation)
+
+  - [Using import to DRY common Terragrunt config](#using-import-to-dry-common-terragrunt-config)
+
+  - [Using read\_terragrunt\_config to DRY parent configurations](#using-read_terragrunt_config-to-dry-parent-configurations)
+
+
+### Motivation
+
+As covered in [Keep your Terraform code DRY]({{site.baseurl}}/docs/features/keep-your-terraform-code-dry) and [Keep your
+remote state configuration DRY]({{site.baseurl}}/docs/features/keep-your-remote-state-configuration-dry), it becomes
+important to define base Terragrunt configuration files that are included in the child config. For example, you might
+have a **root** Terragrunt configuration that defines the remote state and provider configurations:
+
+```hcl
+remote_state {
+  backend = "s3"
+  config = {
+    bucket         = "my-terraform-state"
+    key            = "${path_relative_to_include()}/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "my-lock-table"
+  }
+}
+
+generate "provider" {
+  path = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents = <<EOF
+provider "aws" {
+  assume_role {
+    role_arn = "arn:aws:iam::0123456789:role/terragrunt"
+  }
+}
+EOF
+}
+```
+
+You can then include this in each of your **child** `terragrunt.hcl` files using the `include` block for each
+infrastructure module you need to deploy:
+
+```hcl
+include {
+  path = find_in_parent_folders()
+}
+```
+
+This pattern is useful for global configuration blocks that need to be imported in all of your modules, but what if you
+have Terragrunt configurations that are only relevant to subsets of your module? For example, consider the following
+terragrunt file structure, which defines three environments (`prod`, `qa`, and `stage`) with the same infrastructure in
+each one (an app, a MySQL database, and a VPC):
+
+    └── live
+        ├── terragrunt.hcl
+        ├── prod
+        │   ├── app
+        │   │   └── terragrunt.hcl
+        │   ├── mysql
+        │   │   └── terragrunt.hcl
+        │   └── vpc
+        │       └── terragrunt.hcl
+        ├── qa
+        │   ├── app
+        │   │   └── terragrunt.hcl
+        │   ├── mysql
+        │   │   └── terragrunt.hcl
+        │   └── vpc
+        │       └── terragrunt.hcl
+        └── stage
+            ├── app
+            │   └── terragrunt.hcl
+            ├── mysql
+            │   └── terragrunt.hcl
+            └── vpc
+                └── terragrunt.hcl
+
+More often than not, each of the services will look similar across the different environments, only requiring small
+tweaks. For example, the `app/terragrunt.hcl` files may be identical across all three environments except for an
+adjustment to the `instance_type` parameter for each environment. These identical settings don't belong in the root
+`terragrunt.hcl` configuration because they are only relevant to the `app` configurations, and not `mysql` or `vpc`.
+However, it is cumbersome to copy paste these settings across all three environments.
+
+To solve this, you can use [import instead of
+include]({{site.baseurl}}/docs/reference/config-blocks-and-attributes#import-include), which supports merging multiple
+included configurations unlike `include` blocks.
+
+### Using import to DRY common Terragrunt config
+
+Suppose your `qa/app/terragrunt.hcl` configuration looks like the following:
+
+```hcl
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "github.com/<org>/modules.git//app?ref=v0.1.0"
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+dependency "mysql" {
+  config_path = "../mysql"
+}
+
+inputs = {
+  env            = "qa"
+  basename       = "example-app"
+  vpc_id         = dependency.vpc.outputs.vpc_id
+  subnet_ids     = dependency.vpc.outputs.subnet_ids
+  mysql_endpoint = dependency.mysql.outputs.endpoint
+}
+```
+
+In this example, the only thing that is different between the environments is the `env` input variable. This means that
+except for one line, everything in the config is duplicated across `prod`, `qa`, and `stage`.
+
+To DRY this up, we will introduce a new folder called `_env` which will contain the common configurations across the
+three environments (we prefix with `_` to indicate that this folder doesn't contain deployable configurations):
+
+    └── live
+        ├── terragrunt.hcl
+        ├── _env
+        │   ├── app.hcl
+        │   ├── mysql.hcl
+        │   └── vpc.hcl
+        ├── prod
+        │   ├── app
+        │   │   └── terragrunt.hcl
+        │   ├── mysql
+        │   │   └── terragrunt.hcl
+        │   └── vpc
+        │       └── terragrunt.hcl
+        ├── qa
+        │   ├── app
+        │   │   └── terragrunt.hcl
+        │   ├── mysql
+        │   │   └── terragrunt.hcl
+        │   └── vpc
+        │       └── terragrunt.hcl
+        └── stage
+            ├── app
+            │   └── terragrunt.hcl
+            ├── mysql
+            │   └── terragrunt.hcl
+            └── vpc
+                └── terragrunt.hcl
+
+In our example, the contents of `_env/app.hcl` would look like the following:
+
+```hcl
+terraform {
+  source = "github.com/<org>/modules.git//app?ref=v0.1.0"
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+dependency "mysql" {
+  config_path = "../mysql"
+}
+
+inputs = {
+  basename       = "example-app"
+  vpc_id         = dependency.vpc.outputs.vpc_id
+  subnet_ids     = dependency.vpc.outputs.subnet_ids
+  mysql_endpoint = dependency.mysql.outputs.endpoint
+}
+```
+
+Note that everything is defined except for the `env` input variable. We now modify `qa/app/terragrunt.hcl` to import
+this alongside the root configuration by using `import` blocks instead of `include`, significantly reducing our per
+environment configuration:
+
+```hcl
+import "root" {
+  path = find_in_parent_folders()
+}
+
+import "env" {
+  path = "${get_terragrunt_dir()}/../../_env/app.hcl"
+}
+
+inputs = {
+  env = "qa"
+}
+```
+
+### Using read\_terragrunt\_config to DRY parent configurations
+
+In the previous section, we covered using `import` to DRY common component configurations. While powerful, `import` has
+a limitation where the imported configuration is statically merged into the child configuration.
+
+In our example, note that the `_env/app.hcl` file hardcodes the `app `module version to `v0.1.0` (relevant section
+pasted below for convenience):
+
+```hcl
+terraform {
+  source = "github.com/<org>/modules.git//app?ref=v0.1.0"
+}
+
+# ... other blocks omitted for brevity ...
+```
+
+What if we want to deploy a different version for each environment? One way you can do this is by redefining the
+`terraform` block in the child config. For example, if you want to deploy `v0.2.0` in the `qa` environment, you can do
+the following:
+
+```hcl
+import "root" {
+  path = find_in_parent_folders()
+}
+
+import "env" {
+  path = "${get_terragrunt_dir()}/../../_env/app.hcl"
+}
+
+# Override the terraform.source attribute to v0.2.0
+terraform {
+  source = "github.com/<org>/modules.git//app?ref=v0.2.0"
+}
+
+inputs = {
+  env = "qa"
+}
+```
+
+While this works, we now have duplicated the source URL. To avoid repeating the source URL, we can use
+`read_terragrunt_config` to load additional context into the the parent configuration by taking advantage of the folder
+structure.
+
+To do this, we will introduce a new `env.hcl` configuration in each environment:
+
+    └── live
+        ├── terragrunt.hcl
+        ├── _env
+        │   ├── app.hcl
+        │   ├── mysql.hcl
+        │   └── vpc.hcl
+        ├── prod
+        │   ├── env.hcl
+        │   ├── app
+        │   │   └── terragrunt.hcl
+        │   ├── mysql
+        │   │   └── terragrunt.hcl
+        │   └── vpc
+        │       └── terragrunt.hcl
+        ├── qa
+        │   ├── env.hcl
+        │   ├── app
+        │   │   └── terragrunt.hcl
+        │   ├── mysql
+        │   │   └── terragrunt.hcl
+        │   └── vpc
+        │       └── terragrunt.hcl
+        └── stage
+            ├── env.hcl
+            ├── app
+            │   └── terragrunt.hcl
+            ├── mysql
+            │   └── terragrunt.hcl
+            └── vpc
+                └── terragrunt.hcl
+
+
+The `env.hcl` configuration will look like the following:
+
+```hcl
+locals {
+  env = "qa" # this will be prod in the prod folder, and stage in the stage folder.
+}
+```
+
+We can then load the `env.hcl` file in the `_env/app.hcl` file to change the version based on which environment is
+loaded:
+
+```hcl
+locals {
+  # Load the relevant env.hcl file based on where terragrunt was invoked. This works because find_in_parent_folders
+  # always works at the context of the child configuration.
+  env_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  env_name = local.env_vars.locals.env
+
+  # Centrally manage what version of the app module is used in each environment. This makes it easier to promote
+  # a version from dev -> stage -> prod.
+  module_version = {
+    qa    = "v0.2.0"
+    stage = "v0.1.0"
+    prod  = "v0.1.0"
+  }
+}
+
+terraform {
+  source = "github.com/<org>/modules.git//app?ref=${local.module_version[local.env_name]}"
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+dependency "mysql" {
+  config_path = "../mysql"
+}
+
+inputs = {
+  env            = local.env_name
+  basename       = "example-app"
+  vpc_id         = dependency.vpc.outputs.vpc_id
+  subnet_ids     = dependency.vpc.outputs.subnet_ids
+  mysql_endpoint = dependency.mysql.outputs.endpoint
+}
+```
+
+With this configuration, `env_vars` is loaded based on which folder is being invoked. For example, when Terragrunt is
+invoked in the `prod/app/terragrunt.hcl` folder, `prod/env.hcl` is loaded, while `qa/env.hcl` is loaded when
+Terragrunt is invoked in the `qa/app/terragrunt.hcl` folder.
+
+Now we can keep the same child config even if we have different versions to deploy per environment. As a bonus, we can
+further reduce our child config to eliminate the `env` input variable since that is loaded in the `env.hcl` context:
+
+```hcl
+import "root" {
+  path = find_in_parent_folders()
+}
+
+import "env" {
+  path = "${get_terragrunt_dir()}/../../_env/app.hcl"
+}
+```

--- a/docs/_docs/02_features/keep-your-terragrunt-architecture-dry.md
+++ b/docs/_docs/02_features/keep-your-terragrunt-architecture-dry.md
@@ -14,7 +14,7 @@ nav_title_link: /docs/
 
   - [Motivation](#motivation)
 
-  - [Using import to DRY common Terragrunt config](#using-import-to-dry-common-terragrunt-config)
+  - [Using include to DRY common Terragrunt config](#using-include-to-dry-common-terragrunt-config)
 
   - [Using read\_terragrunt\_config to DRY parent configurations](#using-read_terragrunt_config-to-dry-parent-configurations)
 
@@ -60,7 +60,7 @@ include {
 }
 ```
 
-This pattern is useful for global configuration blocks that need to be imported in all of your modules, but what if you
+This pattern is useful for global configuration blocks that need to be included in all of your modules, but what if you
 have Terragrunt configurations that are only relevant to subsets of your module? For example, consider the following
 terragrunt file structure, which defines three environments (`prod`, `qa`, and `stage`) with the same infrastructure in
 each one (an app, a MySQL database, and a VPC):
@@ -95,11 +95,9 @@ adjustment to the `instance_type` parameter for each environment. These identica
 `terragrunt.hcl` configuration because they are only relevant to the `app` configurations, and not `mysql` or `vpc`.
 However, it is cumbersome to copy paste these settings across all three environments.
 
-To solve this, you can use [import instead of
-include]({{site.baseurl}}/docs/reference/config-blocks-and-attributes#import-include), which supports merging multiple
-included configurations unlike `include` blocks.
+To solve this, you can use [multiple include blocks]({{site.baseurl}}/docs/reference/config-blocks-and-attributes#include).
 
-### Using import to DRY common Terragrunt config
+### Using include to DRY common Terragrunt config
 
 Suppose your `qa/app/terragrunt.hcl` configuration looks like the following:
 
@@ -186,16 +184,16 @@ inputs = {
 }
 ```
 
-Note that everything is defined except for the `env` input variable. We now modify `qa/app/terragrunt.hcl` to import
-this alongside the root configuration by using `import` blocks instead of `include`, significantly reducing our per
+Note that everything is defined except for the `env` input variable. We now modify `qa/app/terragrunt.hcl` to include
+this alongside the root configuration by using multiple `include` blocks, significantly reducing our per
 environment configuration:
 
 ```hcl
-import "root" {
+include "root" {
   path = find_in_parent_folders()
 }
 
-import "env" {
+include "env" {
   path = "${get_terragrunt_dir()}/../../_env/app.hcl"
 }
 
@@ -206,8 +204,8 @@ inputs = {
 
 ### Using read\_terragrunt\_config to DRY parent configurations
 
-In the previous section, we covered using `import` to DRY common component configurations. While powerful, `import` has
-a limitation where the imported configuration is statically merged into the child configuration.
+In the previous section, we covered using `include` to DRY common component configurations. While powerful, `include` has
+a limitation where the included configuration is statically merged into the child configuration.
 
 In our example, note that the `_env/app.hcl` file hardcodes the `app `module version to `v0.1.0` (relevant section
 pasted below for convenience):
@@ -225,11 +223,11 @@ What if we want to deploy a different version for each environment? One way you 
 the following:
 
 ```hcl
-import "root" {
+include "root" {
   path = find_in_parent_folders()
 }
 
-import "env" {
+include "env" {
   path = "${get_terragrunt_dir()}/../../_env/app.hcl"
 }
 
@@ -337,11 +335,11 @@ Now we can keep the same child config even if we have different versions to depl
 further reduce our child config to eliminate the `env` input variable since that is loaded in the `env.hcl` context:
 
 ```hcl
-import "root" {
+include "root" {
   path = find_in_parent_folders()
 }
 
-import "env" {
+include "env" {
   path = "${get_terragrunt_dir()}/../../_env/app.hcl"
 }
 ```

--- a/docs/_docs/02_features/locals.md
+++ b/docs/_docs/02_features/locals.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Learn how to use locals.
 tags: ["locals"]
-order: 206
+order: 235
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/lock-file-handling.md
+++ b/docs/_docs/02_features/lock-file-handling.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Learn how to Terragrunt handles the Terraform lock file
 tags: ["CLI", "DRY"]
-order: 230
+order: 270
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/02_features/work-with-multiple-aws-accounts.md
+++ b/docs/_docs/02_features/work-with-multiple-aws-accounts.md
@@ -5,7 +5,7 @@ category: features
 categories_url: features
 excerpt: Learn how the Terragrunt may help you to work with mulitple AWS accounts.
 tags: ["AWS", "Use cases", "CLI", "AWS IAM"]
-order: 204
+order: 225
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -172,6 +172,24 @@ remote_state {
 
 The resulting `key` will be `prod/mysql/terraform.tfstate` for the prod `mysql` module and `stage/mysql/terraform.tfstate` for the stage `mysql` module.
 
+If you have `import` blocks, this function requires a `name` parameter when used in the child config to specify which
+`import` block to base the relative path on.
+
+Example:
+
+```hcl
+import "root" {
+  path = find_in_parent_folders()
+}
+import "region" {
+  path = find_in_parent_folders("region.hcl")
+}
+
+terraform {
+  source = "../modules/${path_relative_to_include("root")}"
+}
+```
+
 ## path\_relative\_from\_include
 
 `path_relative_from_include()` returns the relative path between the `path` specified in its `include` block and the current `terragrunt.hcl` file (it is the counterpart of `path_relative_to_include()`). For example, consider the following folder structure:
@@ -230,6 +248,25 @@ Another use case would be to add extra argument to include the `common.tfvars` f
 ```
 
 This allows proper retrieval of the `common.tfvars` from whatever the level of subdirectories we have.
+
+If you have `import` blocks, this function requires a `name` parameter when used in the child config to specify which
+`import` block to base the relative path on.
+
+Example:
+
+```hcl
+import "root" {
+  path = find_in_parent_folders()
+}
+import "region" {
+  path = find_in_parent_folders("region.hcl")
+}
+
+terraform {
+  source = "../modules/${path_relative_from_include("root")}"
+}
+```
+
 
 ## get\_env
 

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -172,16 +172,16 @@ remote_state {
 
 The resulting `key` will be `prod/mysql/terraform.tfstate` for the prod `mysql` module and `stage/mysql/terraform.tfstate` for the stage `mysql` module.
 
-If you have `import` blocks, this function requires a `name` parameter when used in the child config to specify which
-`import` block to base the relative path on.
+If you have `include` blocks, this function requires a `name` parameter when used in the child config to specify which
+`include` block to base the relative path on.
 
 Example:
 
 ```hcl
-import "root" {
+include "root" {
   path = find_in_parent_folders()
 }
-import "region" {
+include "region" {
   path = find_in_parent_folders("region.hcl")
 }
 
@@ -249,16 +249,16 @@ Another use case would be to add extra argument to include the `common.tfvars` f
 
 This allows proper retrieval of the `common.tfvars` from whatever the level of subdirectories we have.
 
-If you have `import` blocks, this function requires a `name` parameter when used in the child config to specify which
-`import` block to base the relative path on.
+If you have `include` blocks, this function requires a `name` parameter when used in the child config to specify which
+`include` block to base the relative path on.
 
 Example:
 
 ```hcl
-import "root" {
+include "root" {
   path = find_in_parent_folders()
 }
-import "region" {
+include "region" {
   path = find_in_parent_folders("region.hcl")
 }
 

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -21,7 +21,7 @@ The following is a reference of all the supported blocks and attributes in the c
 
 - [terraform](#terraform)
 - [remote_state](#remote_state)
-- [import/include](#import-include)
+- [include](#include)
 - [locals](#locals)
 - [dependency](#dependency)
 - [dependencies](#dependencies)
@@ -369,38 +369,36 @@ remote_state {
 
 
 
-### import/include
+### include
 
-The `import` and `include` blocks are used to specify inheritance of Terragrunt configuration files. The included config (also called
+The `include` block is used to specify inheritance of Terragrunt configuration files. The included config (also called
 the `parent`) will be merged with the current configuration (also called the `child`) before processing. You can learn
 more about the inheritance properties of Terragrunt in the [Filling in remote state settings with Terragrunt
 section](/docs/features/keep-your-remote-state-configuration-dry/#filling-in-remote-state-settings-with-terragrunt) of the
 "Keep your remote state configuration DRY" use case overview.
 
-`include` blocks are a special case of the `import` block, where there is no label associated with it (equivalent to
-`import "" {}`). This is a special shorthand you can use if you only have a single import. While you can have multiple
-`import` blocks in a single config, you can only have one `include` block per config.
+You can have more than one `include` block, but each one must have a unique label. Note that a bare `include` block with
+no label (`include {}`) is a short hand for an `include` block that uses the label `""` (equivalent to `include "" {}`).
 
-Both `import` and `include` blocks supports the following arguments:
+`include` blocks support the following arguments:
 
-- `name` (label; only for `import`): You can define multiple `import` blocks in a single terragrunt config. Each import
-  must be labeled with a unique name to differentiate it from the other imports. E.g., if you had a block `import
-  "remote" {}`, you can reference the relevant exposed data with the expression `include.remote`. Defaults to `""` for
-  `include` blocks.
+- `name` (label): You can define multiple `include` blocks in a single terragrunt config. Each include block
+  must be labeled with a unique name to differentiate it from the other includes. E.g., if you had a block `include
+  "remote" {}`, you can reference the relevant exposed data with the expression `include.remote`.
 - `path` (attribute): Specifies the path to a Terragrunt configuration file (the `parent` config) that should be merged
   with this configuration (the `child` config).
-- `expose` (attribute, optional): Specifies whether or not the imported config should be parsed and exposed as a
-  variable. When `true`, you can reference the data of the imported config under the variable `include`. Defaults to
-  `false`. Note that the `include` variable is a map of `import` labels to the parsed configuration value when there are
-  multiple `import` blocks, while it will be the actual parsed configuration value when there is only one
-  `import`/`include` block.
+- `expose` (attribute, optional): Specifies whether or not the included config should be parsed and exposed as a
+  variable. When `true`, you can reference the data of the included config under the variable `include`. Defaults to
+  `false`. Note that the `include` variable is a map of `include` labels to the parsed configuration value when there are
+  multiple `include` blocks, while it will be the actual parsed configuration value when there is only one
+  `include` block.
 - `merge_strategy` (attribute, optional): Specifies how the included config should be merged. Valid values are:
   `no_merge` (do not merge the included config), `shallow` (do a shallow merge - default), `deep` (do a deep merge of
   the included config).
 
 Examples:
 
-_Single import_
+_Single include_
 ```hcl
 # If you have the following folder structure, and the following contents for ./child/terragrunt.hcl, this will include
 # and merge the items in the terragrunt.hcl file at the root.
@@ -419,9 +417,9 @@ inputs = {
 }
 ```
 
-_Multiple imports_
+_Multiple includes_
 ```hcl
-# If you have the following folder structure, and the following contents for ./child/terragrunt.hcl, this will import
+# If you have the following folder structure, and the following contents for ./child/terragrunt.hcl, this will include
 # and merge the items in the terragrunt.hcl file at the root, while only loading the data in the region.hcl
 # configuration.
 #
@@ -430,12 +428,12 @@ _Multiple imports_
 # ├── region.hcl
 # └── child
 #     └── terragrunt.hcl
-import "remote_state" {
+include "remote_state" {
   path   = find_in_parent_folders()
   expose = true
 }
 
-import "region" {
+include "region" {
   path           = find_in_parent_folders("region.hcl")
   expose         = true
   merge_strategy = "no_merge"

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -21,7 +21,7 @@ The following is a reference of all the supported blocks and attributes in the c
 
 - [terraform](#terraform)
 - [remote_state](#remote_state)
-- [include](#include)
+- [import/include](#import-include)
 - [locals](#locals)
 - [dependency](#dependency)
 - [dependencies](#dependencies)
@@ -369,27 +369,38 @@ remote_state {
 
 
 
-### include
+### import/include
 
-The `include` block is used to specify inheritance of Terragrunt configuration files. The included config (also called
+The `import` and `include` blocks are used to specify inheritance of Terragrunt configuration files. The included config (also called
 the `parent`) will be merged with the current configuration (also called the `child`) before processing. You can learn
 more about the inheritance properties of Terragrunt in the [Filling in remote state settings with Terragrunt
 section](/docs/features/keep-your-remote-state-configuration-dry/#filling-in-remote-state-settings-with-terragrunt) of the
 "Keep your remote state configuration DRY" use case overview.
 
-The `include` block supports the following arguments:
+`include` blocks are a special case of the `import` block, where there is no label associated with it (equivalent to
+`import "" {}`). This is a special shorthand you can use if you only have a single import. While you can have multiple
+`import` blocks in a single config, you can only have one `include` block per config.
 
+Both `import` and `include` blocks supports the following arguments:
+
+- `name` (label; only for `import`): You can define multiple `import` blocks in a single terragrunt config. Each import
+  must be labeled with a unique name to differentiate it from the other imports. E.g., if you had a block `import
+  "remote" {}`, you can reference the relevant exposed data with the expression `include.remote`. Defaults to `""` for
+  `include` blocks.
 - `path` (attribute): Specifies the path to a Terragrunt configuration file (the `parent` config) that should be merged
   with this configuration (the `child` config).
-- `expose` (attribute, optional): Specifies whether or not the included config should be parsed and exposed as a
-  variable. When `true`, you can reference the data of the included config under the variable `include`. Defaults to
-  `false`.
+- `expose` (attribute, optional): Specifies whether or not the imported config should be parsed and exposed as a
+  variable. When `true`, you can reference the data of the imported config under the variable `include`. Defaults to
+  `false`. Note that the `include` variable is a map of `import` labels to the parsed configuration value when there are
+  multiple `import` blocks, while it will be the actual parsed configuration value when there is only one
+  `import`/`include` block.
 - `merge_strategy` (attribute, optional): Specifies how the included config should be merged. Valid values are:
   `no_merge` (do not merge the included config), `shallow` (do a shallow merge - default), `deep` (do a deep merge of
   the included config).
 
-Example:
+Examples:
 
+_Single import_
 ```hcl
 # If you have the following folder structure, and the following contents for ./child/terragrunt.hcl, this will include
 # and merge the items in the terragrunt.hcl file at the root.
@@ -405,6 +416,34 @@ include {
 
 inputs = {
   remote_state_config = include.remote_state
+}
+```
+
+_Multiple imports_
+```hcl
+# If you have the following folder structure, and the following contents for ./child/terragrunt.hcl, this will import
+# and merge the items in the terragrunt.hcl file at the root, while only loading the data in the region.hcl
+# configuration.
+#
+# .
+# ├── terragrunt.hcl
+# ├── region.hcl
+# └── child
+#     └── terragrunt.hcl
+import "remote_state" {
+  path   = find_in_parent_folders()
+  expose = true
+}
+
+import "region" {
+  path           = find_in_parent_folders("region.hcl")
+  expose         = true
+  merge_strategy = "no_merge"
+}
+
+inputs = {
+  remote_state_config = include.remote_state.remote_state
+  region              = include.region.region
 }
 ```
 


### PR DESCRIPTION
__This is a README Driven Development PR, and only contains the docs. Note that some of the design decisions are based on an in-progress implementation (see section down below)__

This PR is the README updates for the upcoming changes to support including multiple terragrunt configurations in a child. Note that this is different from nested `include`, which is more complicated to implement due to the implications to the relevant `include` functions like `get_parent_terragrunt_dir` and `path_relative_to_include`.

## IMPORTANT NOTE

If we wish to maintain backward compatibility with the existing `include` functionality, this implementation requires defining a new `import` block to replace `include`. The main reason for this is due to a design choice in the HCL parser where it does not support optional labels on blocks. That is, you can not parse the following two blocks into the same go struct:

```hcl
include {}
include "root" {}
```

Once you require a label on the internal struct, the corresponding hcl block MUST have one label - otherwise, the hcl parser errors out saying as such. I found this out in the WIP implementation being done in the branch https://github.com/gruntwork-io/terragrunt/tree/yori-multiple-include-blocks.