### PR TITLE
#1499 Added logic to skip outputs verification in case of module initialization

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -309,7 +309,11 @@ func getTerragruntOutputIfAppliedElseConfiguredDefault(dependencyConfig Dependen
 		if err != nil {
 			return nil, err
 		}
-
+		// Skip output variables verification in case of initialization
+		// https://github.com/gruntwork-io/terragrunt/issues/1499
+		if terragruntOptions.AutoInit && isEmpty {
+			return outputVal, err
+		}
 		if !isEmpty && dependencyConfig.shouldMergeMockOutputsWithState(terragruntOptions) {
 			stateOutputsMap, err := parseCtyValueToMap(*outputVal)
 			if err != nil {

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -346,7 +346,7 @@ func getTerragruntOutputIfAppliedElseConfiguredDefault(dependencyConfig Dependen
 
 	// In case of init, and empty output, skip generating error about missing outputs
 	// https://github.com/gruntwork-io/terragrunt/issues/1499
-	if dependencyConfig.shouldGetOutputs() && terragruntOptions.TerraformCommand == "init" {
+	if dependencyConfig.shouldGetOutputs() && terragruntOptions.AutoInit {
 		return nil, nil
 	}
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -309,6 +309,7 @@ func getTerragruntOutputIfAppliedElseConfiguredDefault(dependencyConfig Dependen
 		if err != nil {
 			return nil, err
 		}
+
 		if !isEmpty && dependencyConfig.shouldMergeMockOutputsWithState(terragruntOptions) {
 			stateOutputsMap, err := parseCtyValueToMap(*outputVal)
 			if err != nil {

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -309,11 +309,6 @@ func getTerragruntOutputIfAppliedElseConfiguredDefault(dependencyConfig Dependen
 		if err != nil {
 			return nil, err
 		}
-		// Skip output variables verification in case of initialization
-		// https://github.com/gruntwork-io/terragrunt/issues/1499
-		if terragruntOptions.AutoInit && isEmpty {
-			return outputVal, err
-		}
 		if !isEmpty && dependencyConfig.shouldMergeMockOutputsWithState(terragruntOptions) {
 			stateOutputsMap, err := parseCtyValueToMap(*outputVal)
 			if err != nil {
@@ -347,6 +342,12 @@ func getTerragruntOutputIfAppliedElseConfiguredDefault(dependencyConfig Dependen
 			currentConfig,
 		)
 		return dependencyConfig.MockOutputs, nil
+	}
+
+	// In case of init, and empty output, skip generating error about missing outputs
+	// https://github.com/gruntwork-io/terragrunt/issues/1499
+	if dependencyConfig.shouldGetOutputs() && terragruntOptions.TerraformCommand == "init" {
+		return nil, nil
 	}
 
 	err := TerragruntOutputTargetNoOutputs{

--- a/test/fixture-include-no-output/app/main.tf
+++ b/test/fixture-include-no-output/app/main.tf
@@ -1,7 +1,7 @@
 
 resource "local_file" "main_file" {
   content     = "main_file"
-  filename = "${path.module}/main_file.txt"
+  filename = "${path.module}/test_file.tfstate"
 }
 
 output "main_file" {

--- a/test/fixture-include-no-output/app/main.tf
+++ b/test/fixture-include-no-output/app/main.tf
@@ -1,6 +1,5 @@
-
 resource "local_file" "main_file" {
-  content     = "main_file"
+  content = "main_file"
   filename = "${path.module}/test_file.tfstate"
 }
 

--- a/test/fixture-include-no-output/app/main.tf
+++ b/test/fixture-include-no-output/app/main.tf
@@ -1,0 +1,10 @@
+
+resource "local_file" "main_file" {
+  content     = "main_file"
+  filename = "${path.module}/main_file.txt"
+}
+
+output "main_file" {
+  value = local_file.main_file.filename
+}
+

--- a/test/fixture-include-no-output/app/main.tf
+++ b/test/fixture-include-no-output/app/main.tf
@@ -1,5 +1,5 @@
 resource "local_file" "main_file" {
-  content = "main_file"
+  content  = "main_file"
   filename = "${path.module}/test_file.tfstate"
 }
 

--- a/test/fixture-include-no-output/app/terragrunt.hcl
+++ b/test/fixture-include-no-output/app/terragrunt.hcl
@@ -1,3 +1,3 @@
 dependency "no_output_module" {
-    config_path = "../no_output_module"
+  config_path = "../no_output_module"
 }

--- a/test/fixture-include-no-output/app/terragrunt.hcl
+++ b/test/fixture-include-no-output/app/terragrunt.hcl
@@ -1,0 +1,3 @@
+dependency "no_output_module" {
+    config_path = "../no_output_module"
+}

--- a/test/fixture-include-no-output/no_output_module/main.tf
+++ b/test/fixture-include-no-output/no_output_module/main.tf
@@ -1,0 +1,4 @@
+resource "local_file" "module_main_file" {
+  content     = "module_main_file"
+  filename = "${path.module}/module_main_file.txt"
+}

--- a/test/fixture-include-no-output/no_output_module/main.tf
+++ b/test/fixture-include-no-output/no_output_module/main.tf
@@ -1,4 +1,4 @@
 resource "local_file" "module_main_file" {
-  content     = "module_main_file"
+  content = "module_main_file"
   filename = "${path.module}/module_main_file.txt"
 }

--- a/test/fixture-include-no-output/no_output_module/main.tf
+++ b/test/fixture-include-no-output/no_output_module/main.tf
@@ -1,4 +1,4 @@
 resource "local_file" "module_main_file" {
-  content = "module_main_file"
+  content  = "module_main_file"
   filename = "${path.module}/module_main_file.txt"
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2265,7 +2265,7 @@ func TestDependencyOutputErrorBeforeApply(t *testing.T) {
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", app3Path), &showStdout, &showStderr)
 	assert.Error(t, err)
 	// Verify that we fail because the dependency is not applied yet
-	assert.Contains(t, err.Error(), "has not been applied yet")
+	assert.Contains(t, err.Error(), "object does not have an attribute named \"outputs\"")
 
 	logBufferContentsLineByLine(t, showStdout, "show stdout")
 	logBufferContentsLineByLine(t, showStderr, "show stderr")
@@ -2594,7 +2594,7 @@ func TestDependencyMockOutputRestricted(t *testing.T) {
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", dependent2Path), &showStdout, &showStderr)
 	assert.Error(t, err)
 	// Verify that we fail because the dependency is not applied yet
-	assert.Contains(t, err.Error(), "has not been applied yet")
+	assert.Contains(t, err.Error(), "object does not have an attribute named \"outputs\"")
 
 	logBufferContentsLineByLine(t, showStdout, "show stdout")
 	logBufferContentsLineByLine(t, showStderr, "show stderr")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -127,6 +127,7 @@ const (
 	TEST_FIXTURE_DIRS_PATH                                  = "fixture-dirs"
 	TEST_FIXTURE_PARALLELISM                                = "fixture-parallelism"
 	TEST_FIXTURE_SOPS                                       = "fixture-sops"
+	TEST_FIXTURE_INCLUDE_NO_OUTPUT                          = "fixture-include-no-output"
 	TERRAFORM_BINARY                                        = "terraform"
 	TERRAFORM_FOLDER                                        = ".terraform"
 	TERRAFORM_STATE                                         = "terraform.tfstate"
@@ -4305,4 +4306,22 @@ func TestTerragruntInitRunCmd(t *testing.T) {
 	assert.Equal(t, 3, strings.Count(errout, "uuid"))
 	assert.Equal(t, 4, strings.Count(errout, "random_arg"))
 	assert.Equal(t, 3, strings.Count(errout, "another_arg"))
+}
+
+func TestNoFailureForModulesWithoutOutputs(t *testing.T) {
+
+	appPath := util.JoinPath(TEST_FIXTURE_INCLUDE_NO_OUTPUT, "app")
+
+	cleanupTerraformFolder(t, appPath)
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all init --terragrunt-non-interactive --terragrunt-working-dir %s", appPath), &stdout, &stderr)
+	assert.NoError(t, err)
+
+	stdout = bytes.Buffer{}
+	stderr = bytes.Buffer{}
+
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-non-interactive --terragrunt-working-dir %s", appPath), &stdout, &stderr)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Added logic to skip outputs verification in case of module initialization, if the dependency fail to generate outputs it is handled as error code from terraform invocation

Example: https://github.com/denis256/terragrunt-test-1499

Before this change:
```
$ terragrunt run-all init

ERRO[0011] Module /work/app has finished with an error: /work/module1/terragrunt.hcl is a dependency of /work/app/terragrunt.hcl but detected no outputs. Either the target module has not been applied yet, or the module has no outputs. If this is expected, set the skip_outputs flag to true on the dependency block.  prefix=[/work/app] 
ERRO[0011] 1 error occurred:
        * /work/module1/terragrunt.hcl is a dependency of /work/app/terragrunt.hcl but detected no outputs. Either the target module has not been applied yet, or the module has no outputs. If this is expected, set the skip_outputs flag to true on the dependency block.
 
ERRO[0011] Unable to determine underlying exit code, so Terragrunt will exit with error code 1 
```

After this change:
```
$ terragrunt run-all init
...
Terraform has been successfully initialized!
...
$ terragrunt run-all apply
Apply complete!
```

Fix for missing outputs from https://github.com/gruntwork-io/terragrunt/issues/1499
