### PR TITLE
#1815 Added conversion of module path to OS native format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: |
             # We're running this test only on Windows currently to provide a convenient 
             # means of reproducing Terragrunt issues that only occur on that platform
-            go test -v ./... -run TestTerragruntSourceMapDebug -timeout 45m
+            go test -v ./... -run TestWindowsTerragruntSourceMapDebug -timeout 45m
   # We're running unit tests separately from integration tests - with no parallelization.
   # With heavy parallelization coupled with re-use of test fixtures we've witnessed slight
   # instability with the tests. The unit tests are fast to execute, so there is negligible

--- a/config/config.go
+++ b/config/config.go
@@ -844,9 +844,9 @@ func validateDependencies(terragruntOptions *options.TerragruntOptions, dependen
 		return nil
 	}
 	for _, dependencyPath := range dependencies.Paths {
-		fullPath := dependencyPath
-		if !filepath.IsAbs(dependencyPath) {
-			fullPath = path.Join(terragruntOptions.WorkingDir, dependencyPath)
+		fullPath := filepath.FromSlash(dependencyPath)
+		if !filepath.IsAbs(fullPath) {
+			fullPath = path.Join(terragruntOptions.WorkingDir, fullPath)
 		}
 		if !util.IsDir(fullPath) {
 			missingDependencies = append(missingDependencies, fmt.Sprintf("%s (%s)", dependencyPath, fullPath))

--- a/test/integration_windows_test.go
+++ b/test/integration_windows_test.go
@@ -25,7 +25,7 @@ func TestWindowsLocalWithRelativeExtraArgsWindows(t *testing.T) {
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_RELATIVE_ARGS_WINDOWS_DOWNLOAD_PATH))
 }
 
-// TestTerragruntSourceMapDebug copies the test/fixture-source-map directory to a new Windows path
+// TestWindowsTerragruntSourceMapDebug copies the test/fixture-source-map directory to a new Windows path
 // and then ensures that the TERRAGRUNT_SOURCE_MAP env var can be used to swap out git sources for local modules
 func TestWindowsTerragruntSourceMapDebug(t *testing.T) {
 	fixtureSourceMapPath := "fixture-source-map"

--- a/test/integration_windows_test.go
+++ b/test/integration_windows_test.go
@@ -28,9 +28,15 @@ func TestWindowsLocalWithRelativeExtraArgsWindows(t *testing.T) {
 // TestWindowsTerragruntSourceMapDebug copies the test/fixture-source-map directory to a new Windows path
 // and then ensures that the TERRAGRUNT_SOURCE_MAP env var can be used to swap out git sources for local modules
 func TestWindowsTerragruntSourceMapDebug(t *testing.T) {
-	testCases := []string{
-		"multiple-match",
-		"multiple-with-dependency",
+	testCases := []struct {
+		name string
+	}{
+		{
+			name: "multiple-match",
+		},
+		{
+			name: "multiple-with-dependency",
+		},
 	}
 	for _, testCase := range testCases {
 		testCase := testCase
@@ -51,7 +57,7 @@ func TestWindowsTerragruntSourceMapDebug(t *testing.T) {
 					",",
 				),
 			)
-			tgPath := filepath.Join(rootPath, testCase)
+			tgPath := filepath.Join(rootPath, testCase.name)
 			tgArgs := fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", tgPath)
 			runTerragrunt(t, tgArgs)
 		})

--- a/test/integration_windows_test.go
+++ b/test/integration_windows_test.go
@@ -28,23 +28,32 @@ func TestWindowsLocalWithRelativeExtraArgsWindows(t *testing.T) {
 // TestWindowsTerragruntSourceMapDebug copies the test/fixture-source-map directory to a new Windows path
 // and then ensures that the TERRAGRUNT_SOURCE_MAP env var can be used to swap out git sources for local modules
 func TestWindowsTerragruntSourceMapDebug(t *testing.T) {
-	fixtureSourceMapPath := "fixture-source-map"
-	cleanupTerraformFolder(t, fixtureSourceMapPath)
-	targetPath := "C:\\test\\infrastructure-modules/"
-	copyEnvironmentToPath(t, fixtureSourceMapPath, targetPath)
-	rootPath := filepath.Join(targetPath, fixtureSourceMapPath)
+	testCases := []string{
+		"multiple-match",
+		"multiple-with-dependency",
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			fixtureSourceMapPath := "fixture-source-map"
+			cleanupTerraformFolder(t, fixtureSourceMapPath)
+			targetPath := "C:\\test\\infrastructure-modules/"
+			copyEnvironmentToPath(t, fixtureSourceMapPath, targetPath)
+			rootPath := filepath.Join(targetPath, fixtureSourceMapPath)
 
-	os.Setenv(
-		"TERRAGRUNT_SOURCE_MAP",
-		strings.Join(
-			[]string{
-				fmt.Sprintf("git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=%s", targetPath),
-				fmt.Sprintf("git::ssh://git@github.com/gruntwork-io/another-dont-exist.git=%s", targetPath),
-			},
-			",",
-		),
-	)
-	tgPath := filepath.Join(rootPath, "multiple-match")
-	tgArgs := fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", tgPath)
-	runTerragrunt(t, tgArgs)
+			os.Setenv(
+				"TERRAGRUNT_SOURCE_MAP",
+				strings.Join(
+					[]string{
+						fmt.Sprintf("git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=%s", targetPath),
+						fmt.Sprintf("git::ssh://git@github.com/gruntwork-io/another-dont-exist.git=%s", targetPath),
+					},
+					",",
+				),
+			)
+			tgPath := filepath.Join(rootPath, testCase)
+			tgArgs := fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", tgPath)
+			runTerragrunt(t, tgArgs)
+		})
+	}
 }


### PR DESCRIPTION
Added conversion of module path to OS native format
Not sure how to add a proper test for this bug since on Windows environment tests aren't executed

Tests on Windows:
Before:
```
D:\terragrunt-work\terragrunt-test-1815>terragrunt run-all plan --terragrunt-non-interactive

time=2021-09-17T20:24:13+02:00 level=error msg=2 errors occurred:
        * Cannot process module Module D:/terragrunt-work/terragrunt-test-1815/applications/gateway/app1 (excluded: false, dependencies: [D:/terragrunt-work/terragrunt-test-1815/shared/service-discovery-core]) because one of its dependencies, Module D:/terragrunt-work/terragrunt-test-1815/shared/service-discovery-core (excluded: false, dependencies: [D:/terragrunt-work/terragrunt-test-1815/shared/vpc]), finished with an error: Found paths in the 'dependencies' block that do not exist: [../vpc (vpc)]
        * Found paths in the 'dependencies' block that do not exist: [../vpc (vpc)]
```
After:
```
D:\terragrunt-work\terragrunt-test-1815>terragrunt run-all plan --terragrunt-non-interactive

Terraform has been successfully initialized!

```
Test repo: https://github.com/denis256/terragrunt-test-1815

Fix for issue https://github.com/gruntwork-io/terragrunt/issues/1815