### PR TITLE
Allow parsing full included config and expose it if it has no dependency or dependencies blocks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -892,9 +892,9 @@ func configFileHasDependencyBlock(configPath string, terragruntOptions *options.
 	// We use hclwrite to parse the config instead of the normal parser because the normal parser doesn't give us an AST
 	// that we can walk and scan, and requires structured data to map against. This makes the parsing strict, so to
 	// avoid weird parsing errors due to missing dependency data, we do a structural scan here.
-	hclFile, err := hclwrite.ParseConfig(configBytes, configPath, hcl.InitialPos)
-	if err != nil {
-		return false, errors.WithStackTrace(err)
+	hclFile, diags := hclwrite.ParseConfig(configBytes, configPath, hcl.InitialPos)
+	if diags.HasErrors() {
+		return false, errors.WithStackTrace(diags)
 	}
 	for _, block := range hclFile.Body().Blocks() {
 		if block.Type() == "dependency" || block.Type() == "dependencies" {

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -876,6 +878,30 @@ func validateGenerateBlocks(blocks *[]terragruntGenerateBlock) error {
 		return DuplicatedGenerateBlocks{duplicatedGenerateBlockNames}
 	}
 	return nil
+}
+
+// configFileHasDependencyBlock statically checks the terrragrunt config file at the given path and checks if it has any
+// dependency or dependencies blocks defined. Note that this does not do any decoding of the blocks, as it is only meant
+// to check for block presence.
+func configFileHasDependencyBlock(configPath string, terragruntOptions *options.TerragruntOptions) (bool, error) {
+	configBytes, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return false, errors.WithStackTrace(err)
+	}
+
+	// We use hclwrite to parse the config instead of the normal parser because the normal parser doesn't give us an AST
+	// that we can walk and scan, and requires structured data to map against. This makes the parsing strict, so to
+	// avoid weird parsing errors due to missing dependency data, we do a structural scan here.
+	hclFile, err := hclwrite.ParseConfig(configBytes, configPath, hcl.InitialPos)
+	if err != nil {
+		return false, errors.WithStackTrace(err)
+	}
+	for _, block := range hclFile.Body().Blocks() {
+		if block.Type() == "dependency" || block.Type() == "dependencies" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // Custom error types

--- a/config/include.go
+++ b/config/include.go
@@ -575,9 +575,9 @@ func updateBareIncludeBlock(file *hcl.File, filename string) ([]byte, bool, erro
 		return updateBareIncludeBlockJSON(file.Bytes)
 	}
 
-	hclFile, err := hclwrite.ParseConfig(file.Bytes, filename, hcl.InitialPos)
-	if err != nil {
-		return nil, false, errors.WithStackTrace(err)
+	hclFile, diags := hclwrite.ParseConfig(file.Bytes, filename, hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, false, errors.WithStackTrace(diags)
 	}
 
 	codeWasUpdated := false

--- a/config/include.go
+++ b/config/include.go
@@ -84,6 +84,10 @@ func parseIncludedConfig(
 		return nil, err
 	}
 	if hasDependency && len(decodeList) > 0 {
+		terragruntOptions.Logger.Warnf(
+			"Included config %s can only be partially parsed during dependency graph formation for run-all command as it has a dependency block.",
+			includePath,
+		)
 		return PartialParseConfigFile(includePath, terragruntOptions, includedConfig, decodeList)
 	}
 	return ParseConfigFile(includePath, terragruntOptions, includedConfig, dependencyOutputs)

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -508,6 +508,32 @@ inputs = {
 }
 ```
 
+**Limitations on accessing exposed config**
+
+Note that exposed config attributes are subject to [the Terragrunt configuration parsing order]({{ site.baseurl
+}}/docs/getting-started/configuration/#configuration-parsing-order). This means that exposed attributes that are not
+available at that parsing stage are not usually available even across the `include`.
+
+For example, you can not access `inputs` from the exposed config from `include` in `dependency` blocks. The following
+config will fail:
+
+```hcl
+include "root" {
+  path   = find_in_parent_folders()
+  expose = true
+}
+
+dependency "dep" {
+  # inputs is not available when parsing this block!
+  config_path = include.root.inputs.dep_dir
+}
+```
+
+However, there is an exception to this rule. If the included config does not define any `dependency` or `dependencies`
+blocks, then Terragrunt will expose ALL the attributes from the included config regardless of the configuration parsing
+order.
+
+
 **What is deep merge?**
 
 When the `merge_strategy` for the `include` block is set to `deep`, Terragrunt will perform a deep merge of the included

--- a/test/fixture-include-expose/with-dependency-reference-input/child/main.tf
+++ b/test/fixture-include-expose/with-dependency-reference-input/child/main.tf
@@ -1,0 +1,5 @@
+variable "region" {}
+
+output "region" {
+  value = var.region
+}

--- a/test/fixture-include-expose/with-dependency-reference-input/child/terragrunt.hcl
+++ b/test/fixture-include-expose/with-dependency-reference-input/child/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path           = find_in_parent_folders()
+  expose         = true
+}
+
+dependency "dep" {
+  config_path = include.root.inputs.dep_path
+}
+
+inputs = {
+  region = "${include.root.locals.region}-${dependency.dep.outputs.env}"
+}

--- a/test/fixture-include-expose/with-dependency-reference-input/dep/main.tf
+++ b/test/fixture-include-expose/with-dependency-reference-input/dep/main.tf
@@ -1,0 +1,3 @@
+output "env" {
+  value = "test"
+}

--- a/test/fixture-include-expose/with-dependency-reference-input/dep/terragrunt.hcl
+++ b/test/fixture-include-expose/with-dependency-reference-input/dep/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixture-include-expose/with-dependency-reference-input/terragrunt.hcl
+++ b/test/fixture-include-expose/with-dependency-reference-input/terragrunt.hcl
@@ -1,0 +1,7 @@
+locals {
+  region = "us-west-1"
+}
+
+inputs = {
+  dep_path = "${get_terragrunt_dir()}/../dep"
+}


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/terragrunt/issues/1814 (with certain assumptions - see updated docs). We have regression tests for the case I described in the comment, so this fix should address both the OP and my concern.