### PR TITLE
render-json command

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -210,6 +210,10 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.Check = parseBooleanArg(args, optTerragruntCheck, os.Getenv("TERRAGRUNT_CHECK") == "true")
 	opts.HclFile = filepath.ToSlash(terragruntHclFilePath)
 	opts.AwsProviderPatchOverrides = awsProviderPatchOverrides
+	opts.JSONOut, err = parseStringArg(args, optTerragruntJSONOut, "terragrunt_rendered.json")
+	if err != nil {
+		return nil, err
+	}
 
 	return opts, nil
 }

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -216,7 +216,7 @@ COMMANDS:
    graph-dependencies    Prints the terragrunt dependency graph to stdout
    hclfmt                Recursively find hcl files and rewrite them into a canonical format.
    aws-provider-patch    Overwrite settings on nested AWS providers to work around a Terraform bug (issue #13018)
-   render-json           Render the final interpretted terragrunt config (including running functions and merging included configs) as json. This is useful for enforcing policies using static analysis tools like Open Policy Agent, or for debugging your terragrunt config.
+   render-json           Render the final terragrunt config, with all variables, includes, and functions resolved, as json. This is useful for enforcing policies using static analysis tools like Open Policy Agent, or for debugging your terragrunt config.
    *                     Terragrunt forwards all other commands directly to Terraform
 
 GLOBAL OPTIONS:

--- a/cli/render_json.go
+++ b/cli/render_json.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+
+	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/util"
+)
+
+// runRenderJSON takes the parsed TerragruntConfig struct and renders it out as JSON so that it can be processed by
+// other tools. To make it easier to maintain, this uses the cty representation as an intermediary.
+// NOTE: An unspecified advantage of using the cty representation is that the final block outputs would be a map
+// representation, which is easier to work with than the list representation that will be returned by a naive go-struct
+// to json conversion.
+func runRenderJSON(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
+	if terragruntConfig == nil {
+		return fmt.Errorf("Terragrunt was not able to render the config as json because it received no config. This is almost certainly a bug in Terragrunt. Please open an issue on github.com/gruntwork-io/terragrunt with this message and the contents of your terragrunt.hcl.")
+	}
+
+	terragruntConfigCty, err := config.TerragruntConfigAsCty(terragruntConfig)
+	if err != nil {
+		return err
+	}
+
+	jsonBytes, err := marshalCtyValueJSONWithoutType(terragruntConfigCty)
+	if err != nil {
+		return err
+	}
+
+	jsonOutPath := terragruntOptions.JSONOut
+	if err := util.EnsureDirectory(filepath.Dir(jsonOutPath)); err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(jsonOutPath, jsonBytes, 0644); err != nil {
+		return errors.WithStackTrace(err)
+	}
+	return nil
+}
+
+// marshalCtyValueJSONWithoutType marshals the given cty.Value object into a JSON object that does not have the type.
+// Using ctyjson directly would render a json object with two attributes, "value" and "type", and this function returns
+// just the "value".
+// NOTE: We have to do two marshalling passes so that we can extract just the value.
+func marshalCtyValueJSONWithoutType(ctyVal cty.Value) ([]byte, error) {
+	jsonBytesIntermediate, err := ctyjson.Marshal(ctyVal, cty.DynamicPseudoType)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var ctyJsonOutput config.CtyJsonOutput
+	if err := json.Unmarshal(jsonBytesIntermediate, &ctyJsonOutput); err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	jsonBytes, err := json.Marshal(ctyJsonOutput.Value)
+	return jsonBytes, errors.WithStackTrace(err)
+}

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -16,7 +16,7 @@ import (
 // Specifically, we want to reference blocks by named attributes, but blocks are rendered to lists in the
 // TerragruntConfig struct, so we need to do some massaging of the data to convert the list of blocks in to a map going
 // from the block name label to the block value.
-func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
+func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 	output := map[string]cty.Value{}
 
 	// Convert attributes that are primitive types

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -92,7 +92,7 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 			},
 		},
 	}
-	ctyVal, err := terragruntConfigAsCty(&testConfig)
+	ctyVal, err := TerragruntConfigAsCty(&testConfig)
 	require.NoError(t, err)
 
 	ctyMap, err := parseCtyValueToMap(ctyVal)

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -483,7 +483,7 @@ func readTerragruntConfig(configPath string, defaultVal *cty.Value, terragruntOp
 		config.TerragruntDependencies[i].setRenderedOutputs(targetOptions)
 	}
 
-	return terragruntConfigAsCty(config)
+	return TerragruntConfigAsCty(config)
 }
 
 // Create a cty Function that can be used to for calling read_terragrunt_config.

--- a/config/cty_helpers.go
+++ b/config/cty_helpers.go
@@ -235,7 +235,7 @@ func includeConfigAsCtyVal(
 		if err != nil {
 			return cty.NilVal, err
 		}
-		parsedIncludedCty, err := terragruntConfigAsCty(parsedIncluded)
+		parsedIncludedCty, err := TerragruntConfigAsCty(parsedIncluded)
 		if err != nil {
 			return cty.NilVal, err
 		}

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -35,6 +35,7 @@ Terragrunt supports the following CLI commands:
   - [graph-dependencies](#graph-dependencies)
   - [hclfmt](#hclfmt)
   - [aws-provider-patch](#aws-provider-patch)
+  - [render-json](#render-json)
 
 ### All Terraform built-in commands
 
@@ -395,6 +396,34 @@ This should allow you to run `import` on the module and work around those Terraf
 `import`, remember to delete your overridden code! E.g., Delete the `.terraform` or `.terragrunt-cache` folders.
 
 
+### render-json
+
+Render out the final interpretted `terragrunt.hcl` file (that is, with all the includes merged, dependencies
+resolved/interpolated, function calls executed, etc) as json.
+
+Example:
+
+_terragrunt.hcl_
+```hcl
+locals {
+  aws_region = "us-east-1"
+}
+
+inputs = {
+  aws_region = local.aws_region
+}
+```
+
+_terragrunt_rendered.json_
+```json
+{
+  "locals": {"aws_region": "us-east-1"},
+  "inputs": {"aws_region": "us-east-1"},
+  // NOTE: other attributes are omitted for brevity
+}
+```
+
+You can use the CLI option `--terragrunt-json-out` to configure where terragrunt renders out the json representation.
 
 
 ## CLI options
@@ -427,6 +456,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
 - [terragrunt-check](#terragrunt-check)
 - [terragrunt-hclfmt-file](#terragrunt-hclfmt-file)
 - [terragrunt-override-attr](#terragrunt-override-attr)
+- [terragrunt-json-out](#terragrunt-json-out)
 
 
 ### terragrunt-config
@@ -718,3 +748,10 @@ Override the attribute named `ATTR` with the value `VALUE` in a `provider` block
 command](#aws-provider-patch). May be specified multiple times. Also, `ATTR` can specify attributes within a nested
 block by specifying `<BLOCK>.<ATTR>`, where `<BLOCK>` is the block name: e.g., `assume_role.role` arn will override the
 `role_arn` attribute of the `assume_role { ... }` block.
+
+### terragrunt-json-out
+
+**CLI Arg**: `--terragrunt-json-out`
+**Requires an argument**: `--terragrunt-json-out /path/to/terragrunt_rendered.json`
+
+When passed in, render the json representation in this file.

--- a/options/options.go
+++ b/options/options.go
@@ -161,6 +161,9 @@ type TerragruntOptions struct {
 	// The file which hclfmt should be specifically run on
 	HclFile string
 
+	// The file path that terragrunt should use when rendering the terragrunt.hcl config as json.
+	JSONOut string
+
 	// A command that can be used to run Terragrunt with the given options. This is useful for running Terragrunt
 	// multiple times (e.g. when spinning up a stack of Terraform modules). The actual command is normally defined
 	// in the cli package, which depends on almost all other packages, so we declare it here so that other
@@ -304,6 +307,8 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		StrictInclude:                terragruntOptions.StrictInclude,
 		RunTerragrunt:                terragruntOptions.RunTerragrunt,
 		AwsProviderPatchOverrides:    terragruntOptions.AwsProviderPatchOverrides,
+		HclFile:                      terragruntOptions.HclFile,
+		JSONOut:                      terragruntOptions.JSONOut,
 	}
 }
 

--- a/test/fixture-render-json/common_vars.hcl
+++ b/test/fixture-render-json/common_vars.hcl
@@ -1,0 +1,8 @@
+dependency "dep" {
+  config_path = "../dep"
+}
+
+inputs = {
+  env  = "qa"
+  name = dependency.dep.outputs.name
+}

--- a/test/fixture-render-json/dep/main.tf
+++ b/test/fixture-render-json/dep/main.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = "dep"
+}

--- a/test/fixture-render-json/dep/terragrunt.hcl
+++ b/test/fixture-render-json/dep/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixture-render-json/main/module/main.tf
+++ b/test/fixture-render-json/main/module/main.tf
@@ -1,0 +1,17 @@
+variable "aws_region" {}
+variable "env" {}
+variable "name" {}
+variable "type" {}
+
+output "aws_region" {
+  value = var.aws_region
+}
+output "env" {
+  value = var.env
+}
+output "name" {
+  value = var.name
+}
+output "type" {
+  value = var.type
+}

--- a/test/fixture-render-json/main/terragrunt.hcl
+++ b/test/fixture-render-json/main/terragrunt.hcl
@@ -1,0 +1,15 @@
+terraform {
+  source = "./module"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path = find_in_parent_folders("common_vars.hcl")
+}
+
+inputs = {
+  type = "main"
+}

--- a/test/fixture-render-json/terragrunt.hcl
+++ b/test/fixture-render-json/terragrunt.hcl
@@ -1,0 +1,24 @@
+remote_state {
+  backend = "local"
+  generate = {
+    path = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    path = "foo.tfstate"
+  }
+}
+
+generate "provider" {
+  path = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents = <<EOF
+provider "aws" {
+  region = "us-east-1"
+}
+EOF
+}
+
+inputs = {
+  aws_region = "us-east-1"
+}


### PR DESCRIPTION
This introduces the `render-json` command, which will render out a json representation of the full, interpretted `terragrunt.hcl` config (that is, with all the includes merged, dependencies resolved/interpolated, function calls executed, etc).

The primary use case of this would be to run [OPA](https://github.com/open-policy-agent/opa) on the rendered json to enforce policies on `terragrunt.hcl` (since it doesn't support running against HCL inputs).

As an alternative, one could use [hcl2json](https://github.com/tmccombs/hcl2json), but this won't interpret the blocks, which makes it harder to write policies. E.g., if you want to enforce restrictions on the module source for the final example in https://terragrunt.gruntwork.io/docs/features/keep-your-terragrunt-architecture-dry/, you need to be able to see the rendered `source` that involves `include` and `local` interpolation. A naive hcl to json translation would make the `terraform.source` attribute look like:

```
{
  "terraform": {
    "source": "${include.env.locals.source_base_url}?ref=v0.2.0"
  }
}
```

which won't be possible to match against OPA rules. So a terragrunt native feature like `render-json` proposed here which outputs the fully interpreted terragrunt config to run OPA rules against is a lot more practical.

As a bonus, this tool could be a nice way to debug `terragrunt.hcl` as well, especially for those that have multiple `include` and `read_terragrunt_config` calls.