### PR TITLE
#299 Added confirmation before destroy with list of dependent modules

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -666,7 +666,8 @@ func runTerragruntWithConfig(originalTerragruntOptions *options.TerragruntOption
 
 	return runActionWithHooks("terraform", terragruntOptions, terragruntConfig, func() error {
 		if terragruntOptions.TerraformCommand == "destroy" {
-			modules, err := configstack.FindWhereWorkingDirIsIncluded(terragruntOptions)
+
+			modules, err := configstack.FindWhereWorkingDirIsIncluded(terragruntOptions, terragruntConfig)
 			if err != nil {
 				terragruntOptions.Logger.Warnf("Failed to detect where module is used %v", err)
 			}

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -700,17 +700,9 @@ func confirmActionWithDependentModules(terragruntOptions *options.TerragruntOpti
 		return true
 	}
 	if len(modules) != 0 {
-		err = shell.PrintErrorOutput("Detected dependent modules:\n", terragruntOptions)
-		if err != nil {
-			terragruntOptions.Logger.Error(err)
-			return false
-		}
+		terragruntOptions.ErrWriter.Write([]byte("Detected dependent modules:\n"))
 		for _, module := range modules {
-			err = shell.PrintErrorOutput(fmt.Sprintf("%s\n", module.Path), terragruntOptions)
-			if err != nil {
-				terragruntOptions.Logger.Error(err)
-				return false
-			}
+			terragruntOptions.ErrWriter.Write([]byte(fmt.Sprintf("%s\n", module.Path)))
 		}
 		prompt := "WARNING: Are you sure you want to continue?"
 		shouldRun, err := shell.PromptUserForYesNo(prompt, terragruntOptions)

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -700,9 +700,15 @@ func confirmActionWithDependentModules(terragruntOptions *options.TerragruntOpti
 		return true
 	}
 	if len(modules) != 0 {
-		terragruntOptions.ErrWriter.Write([]byte("Detected dependent modules:\n"))
+		if _, err := terragruntOptions.ErrWriter.Write([]byte("Detected dependent modules:\n")); err != nil {
+			terragruntOptions.Logger.Error(err)
+			return false
+		}
 		for _, module := range modules {
-			terragruntOptions.ErrWriter.Write([]byte(fmt.Sprintf("%s\n", module.Path)))
+			if _, err := terragruntOptions.ErrWriter.Write([]byte(fmt.Sprintf("%s\n", module.Path))); err != nil {
+				terragruntOptions.Logger.Error(err)
+				return false
+			}
 		}
 		prompt := "WARNING: Are you sure you want to continue?"
 		shouldRun, err := shell.PromptUserForYesNo(prompt, terragruntOptions)

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ type TerragruntConfig struct {
 	RetryableErrors             []string
 	RetryMaxAttempts            *int
 	RetrySleepIntervalSec       *int
-
+	ProcessedIncludes           map[string]string // Map of processed includes include_name:path
 	// Indicates whether or not this is the result of a partial evaluation
 	IsPartial bool
 }

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -120,14 +120,6 @@ func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 		output["locals"] = localsCty
 	}
 
-	processedIncludes, err := goTypeToCty(config.ProcessedIncludes)
-	if err != nil {
-		return cty.NilVal, err
-	}
-	if processedIncludes != cty.NilVal {
-		output["processedIncludes"] = processedIncludes
-	}
-
 	return convertValuesMapToCtyVal(output)
 }
 

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -120,6 +120,14 @@ func terragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 		output["locals"] = localsCty
 	}
 
+	processedIncludes, err := goTypeToCty(config.ProcessedIncludes)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	if processedIncludes != cty.NilVal {
+		output["processedIncludes"] = processedIncludes
+	}
+
 	return convertValuesMapToCtyVal(output)
 }
 

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -201,6 +201,8 @@ func terragruntConfigStructFieldToMapKey(t *testing.T, fieldName string) (string
 		return "generate", true
 	case "IsPartial":
 		return "", false
+	case "ProcessedIncludes":
+		return "", false
 	case "RetryableErrors":
 		return "retryable_errors", true
 	case "RetryMaxAttempts":

--- a/config/include.go
+++ b/config/include.go
@@ -367,8 +367,6 @@ func (targetConfig *TerragruntConfig) DeepMerge(sourceConfig *TerragruntConfig, 
 	for key, val := range sourceConfig.GenerateConfigs {
 		targetConfig.GenerateConfigs[key] = val
 	}
-
-	targetConfig.ProcessedIncludes = sourceConfig.ProcessedIncludes
 	return nil
 }
 

--- a/config/include.go
+++ b/config/include.go
@@ -264,8 +264,6 @@ func (targetConfig *TerragruntConfig) Merge(sourceConfig *TerragruntConfig, terr
 	if sourceConfig.Inputs != nil {
 		targetConfig.Inputs = mergeInputs(sourceConfig.Inputs, targetConfig.Inputs)
 	}
-
-	targetConfig.ProcessedIncludes = sourceConfig.ProcessedIncludes
 }
 
 // DeepMerge performs a deep merge of the given sourceConfig into the targetConfig. Deep merge is defined as follows:

--- a/config/include.go
+++ b/config/include.go
@@ -371,7 +371,6 @@ func (targetConfig *TerragruntConfig) DeepMerge(sourceConfig *TerragruntConfig, 
 	}
 
 	targetConfig.ProcessedIncludes = sourceConfig.ProcessedIncludes
-
 	return nil
 }
 

--- a/config/include.go
+++ b/config/include.go
@@ -69,11 +69,6 @@ func handleInclude(
 			return nil, err
 		}
 
-		if config.ProcessedIncludes == nil {
-			config.ProcessedIncludes = make(map[string]string)
-		}
-		config.ProcessedIncludes[includeConfig.Name] = includeConfig.Path
-
 		switch mergeStrategy {
 		case NoMerge:
 			terragruntOptions.Logger.Debugf("Included config %s has strategy no merge: not merging config in.", includeConfig.Path)
@@ -270,14 +265,7 @@ func (targetConfig *TerragruntConfig) Merge(sourceConfig *TerragruntConfig, terr
 		targetConfig.Inputs = mergeInputs(sourceConfig.Inputs, targetConfig.Inputs)
 	}
 
-	if sourceConfig.ProcessedIncludes != nil {
-		if targetConfig.ProcessedIncludes == nil {
-			targetConfig.ProcessedIncludes = make(map[string]string)
-		}
-		for key, val := range sourceConfig.ProcessedIncludes {
-			targetConfig.ProcessedIncludes[key] = val
-		}
-	}
+	targetConfig.ProcessedIncludes = sourceConfig.ProcessedIncludes
 }
 
 // DeepMerge performs a deep merge of the given sourceConfig into the targetConfig. Deep merge is defined as follows:
@@ -382,16 +370,7 @@ func (targetConfig *TerragruntConfig) DeepMerge(sourceConfig *TerragruntConfig, 
 		targetConfig.GenerateConfigs[key] = val
 	}
 
-	if sourceConfig.ProcessedIncludes != nil {
-
-		if targetConfig.ProcessedIncludes == nil {
-			targetConfig.ProcessedIncludes = make(map[string]string)
-		}
-
-		for key, val := range sourceConfig.ProcessedIncludes {
-			targetConfig.ProcessedIncludes[key] = val
-		}
-	}
+	targetConfig.ProcessedIncludes = sourceConfig.ProcessedIncludes
 
 	return nil
 }

--- a/config/include.go
+++ b/config/include.go
@@ -69,6 +69,11 @@ func handleInclude(
 			return nil, err
 		}
 
+		if config.ProcessedIncludes == nil {
+			config.ProcessedIncludes = make(map[string]string)
+		}
+		config.ProcessedIncludes[includeConfig.Name] = includeConfig.Path
+
 		switch mergeStrategy {
 		case NoMerge:
 			terragruntOptions.Logger.Debugf("Included config %s has strategy no merge: not merging config in.", includeConfig.Path)
@@ -264,6 +269,15 @@ func (targetConfig *TerragruntConfig) Merge(sourceConfig *TerragruntConfig, terr
 	if sourceConfig.Inputs != nil {
 		targetConfig.Inputs = mergeInputs(sourceConfig.Inputs, targetConfig.Inputs)
 	}
+
+	if sourceConfig.ProcessedIncludes != nil {
+		if targetConfig.ProcessedIncludes == nil {
+			targetConfig.ProcessedIncludes = make(map[string]string)
+		}
+		for key, val := range sourceConfig.ProcessedIncludes {
+			targetConfig.ProcessedIncludes[key] = val
+		}
+	}
 }
 
 // DeepMerge performs a deep merge of the given sourceConfig into the targetConfig. Deep merge is defined as follows:
@@ -367,6 +381,18 @@ func (targetConfig *TerragruntConfig) DeepMerge(sourceConfig *TerragruntConfig, 
 	for key, val := range sourceConfig.GenerateConfigs {
 		targetConfig.GenerateConfigs[key] = val
 	}
+
+	if sourceConfig.ProcessedIncludes != nil {
+
+		if targetConfig.ProcessedIncludes == nil {
+			targetConfig.ProcessedIncludes = make(map[string]string)
+		}
+
+		for key, val := range sourceConfig.ProcessedIncludes {
+			targetConfig.ProcessedIncludes[key] = val
+		}
+	}
+
 	return nil
 }
 

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -487,7 +487,7 @@ func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions,
 	var pathsToCheck []string
 	var matchedModulesMap = make(map[string]*TerraformModule)
 	var gitTopLevelDir = ""
-	gitTopLevelDir, err := shell.GitTopLevelDir(terragruntOptions.WorkingDir)
+	gitTopLevelDir, err := shell.GitTopLevelDir(terragruntOptions, terragruntOptions.WorkingDir)
 	if err == nil { // top level detection worked
 		pathsToCheck = append(pathsToCheck, gitTopLevelDir)
 	} else { // detection failed, trying to use include directories as source for stacks

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -479,6 +479,55 @@ func getSortedKeys(modules map[string]*TerraformModule) []string {
 	return keys
 }
 
+// FindWhereWorkingDirIsIncluded - find where working directory is included, flow:
+// 1. Find root git top level directory and build list of modules
+// 2. Iterate over includes from terragruntOptions if git top level directory detection failed
+// 3. Filter found module only items which has in dependencies working directory
+func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions) ([]*TerraformModule, error) {
+	var pathsToCheck []string
+	var matchedModulesMap = make(map[string]*TerraformModule)
+	var gitTopLevelDir = ""
+	gitTopLevelDir, err := shell.GitTopLevelDir(terragruntOptions.WorkingDir)
+	if err == nil { // top level detection worked
+		pathsToCheck = append(pathsToCheck, gitTopLevelDir)
+	} else { // detection failed, taking include directories
+		pathsToCheck = terragruntOptions.IncludeDirs
+	}
+	for _, dir := range pathsToCheck { // iterate over detected paths, build stacks and filter modules by working dir
+		dir = dir + filepath.FromSlash("/")
+		cfgOptions, err := options.NewTerragruntOptions(dir)
+		if err != nil {
+			return nil, err
+		}
+		stack, err := FindStackInSubfolders(cfgOptions)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, module := range stack.Modules {
+			for _, dep := range module.Dependencies {
+				var foundWorkingDir = false
+				if dep.Path == terragruntOptions.WorkingDir { // include in dependencies module which have in dependencies WorkingDir
+					matchedModulesMap[module.Path] = module
+					foundWorkingDir = true
+					break
+				}
+				if foundWorkingDir {
+					break
+				}
+			}
+		}
+	}
+
+	// extract modules as list
+	var matchedModules []*TerraformModule
+	for _, module := range matchedModulesMap {
+		matchedModules = append(matchedModules, module)
+	}
+
+	return matchedModules, nil
+}
+
 // Custom error types
 
 type UnrecognizedDependency struct {

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -493,7 +493,7 @@ func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions,
 	} else { // detection failed, trying to use include directories as source for stacks
 		uniquePaths := make(map[string]bool)
 		for _, includePath := range terragruntConfig.ProcessedIncludes {
-			uniquePaths[filepath.Dir(includePath)] = true
+			uniquePaths[filepath.Dir(includePath.Path)] = true
 		}
 		for path := range uniquePaths {
 			pathsToCheck = append(pathsToCheck, path)
@@ -512,13 +512,8 @@ func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions,
 
 		for _, module := range stack.Modules {
 			for _, dep := range module.Dependencies {
-				var foundWorkingDir = false
 				if dep.Path == terragruntOptions.WorkingDir { // include in dependencies module which have in dependencies WorkingDir
 					matchedModulesMap[module.Path] = module
-					foundWorkingDir = true
-					break
-				}
-				if foundWorkingDir {
 					break
 				}
 			}

--- a/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
+++ b/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
@@ -306,7 +306,7 @@ In the example above it'll generate this graph
 Note that this graph shows the dependency relationship in the direction of the arrow (top down), however terragrunt will run the action
 in reverse order (bottom up)
 
-**Note:** During execution of `destroy` command, Terragrunt will try to find all dependent modules and show a confirmation prompt with a list of all detected dependencies, because once resources will be destroyed, any commands on dependent modules will fail with missing dependencies. For example, if will be executed `destroy` on `redis`, will be asked to confirm action because `backend-app` depends on `redis`.
+**Note:** During execution of `destroy` command, Terragrunt will try to find all dependent modules and show a confirmation prompt with a list of all detected dependencies, because once resources will be destroyed, any commands on dependent modules will fail with missing dependencies. For example, if `destroy` was called on the `redis` module, you will be asked to confirm the action because `backend-app` depends on `redis`. You can avoid the prompt by using `--terragrunt-non-interactive`.
 
 ### Testing multiple modules locally
 

--- a/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
+++ b/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
@@ -306,6 +306,8 @@ In the example above it'll generate this graph
 Note that this graph shows the dependency relationship in the direction of the arrow (top down), however terragrunt will run the action
 in reverse order (bottom up)
 
+**Note:** During execution of `destroy` command, Terragrunt will try to find all dependent modules and show a confirmation prompt with a list of all detected dependencies, because once resources will be destroyed, any commands on dependent modules will fail with missing dependencies. For example, if will be executed `destroy` on `redis`, will be asked to confirm action because `backend-app` depends on `redis`.
+
 ### Testing multiple modules locally
 
 If you are using Terragrunt to configure [remote Terraform configurations]({{site.baseurl}}/docs/features/keep-your-terraform-code-dry/#remote-terraform-configurations) and all of your modules have the `source` parameter set to a Git URL, but you want to test with a local checkout of the code, you can use the `--terragrunt-source` parameter:

--- a/options/options.go
+++ b/options/options.go
@@ -175,6 +175,9 @@ type TerragruntOptions struct {
 	// Attributes to override in AWS provider nested within modules as part of the aws-provider-patch command. See that
 	// command for more info.
 	AwsProviderPatchOverrides map[string]string
+
+	// True if is required to show dependent modules and confirm action
+	CheckDependentModules bool
 }
 
 // Create a new TerragruntOptions object with reasonable defaults for real usage

--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -55,3 +55,16 @@ func PromptUserForYesNo(prompt string, terragruntOptions *options.TerragruntOpti
 		return false, nil
 	}
 }
+
+func PrintErrorOutput(prompt string, terragruntOptions *options.TerragruntOptions) error {
+	n, err := terragruntOptions.ErrWriter.Write([]byte(prompt))
+	if err != nil {
+		terragruntOptions.Logger.Error(err)
+		return errors.WithStackTrace(err)
+	}
+	if n != len(prompt) {
+		terragruntOptions.Logger.Errorln("Failed to write data")
+		return errors.WithStackTrace(err)
+	}
+	return nil
+}

--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -55,16 +55,3 @@ func PromptUserForYesNo(prompt string, terragruntOptions *options.TerragruntOpti
 		return false, nil
 	}
 }
-
-func PrintErrorOutput(prompt string, terragruntOptions *options.TerragruntOptions) error {
-	n, err := terragruntOptions.ErrWriter.Write([]byte(prompt))
-	if err != nil {
-		terragruntOptions.Logger.Error(err)
-		return errors.WithStackTrace(err)
-	}
-	if n != len(prompt) {
-		terragruntOptions.Logger.Errorln("Failed to write data")
-		return errors.WithStackTrace(err)
-	}
-	return nil
-}

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -207,9 +207,9 @@ func GitTopLevelDir(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cmd, err := RunShellCommandWithOutput(opts, path, false, false, "git", "rev-parse", "--show-toplevel")
+	cmd, err := RunShellCommandWithOutput(opts, path, true, false, "git", "rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", err
 	}
-	return cmd.Stdout, nil
+	return strings.TrimSpace(cmd.Stdout), nil
 }

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -200,3 +200,16 @@ type CmdOutput struct {
 	Stdout string
 	Stderr string
 }
+
+// GitTopLevelDir - fetch git repository path from passed directory
+func GitTopLevelDir(path string) (string, error) {
+	opts, err := options.NewTerragruntOptions(path)
+	if err != nil {
+		return "", err
+	}
+	cmd, err := RunShellCommandWithOutput(opts, path, false, false, "git", "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", err
+	}
+	return cmd.Stdout, nil
+}

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -202,12 +202,14 @@ type CmdOutput struct {
 }
 
 // GitTopLevelDir - fetch git repository path from passed directory
-func GitTopLevelDir(path string) (string, error) {
+func GitTopLevelDir(terragruntOptions *options.TerragruntOptions, path string) (string, error) {
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
 	opts, err := options.NewTerragruntOptions(path)
-	if err != nil {
-		return "", err
-	}
+	opts.Writer = &stdout
+	opts.ErrWriter = &stderr
 	cmd, err := RunShellCommandWithOutput(opts, path, true, false, "git", "rev-parse", "--show-toplevel")
+	terragruntOptions.Logger.Debugf("git show-toplevel result: \n%v\n%v\n", (string)(stdout.Bytes()), (string)(stderr.Bytes()))
 	if err != nil {
 		return "", err
 	}

--- a/test/fixture-destroy-warning/app/terragrunt.hcl
+++ b/test/fixture-destroy-warning/app/terragrunt.hcl
@@ -1,0 +1,11 @@
+dependency "vpc" {
+  config_path = "../vpc"
+
+  mock_outputs = {
+    vpc = "mock"
+  }
+}
+
+dependencies {
+  paths = ["../vpc"]
+}

--- a/test/fixture-destroy-warning/vpc/terragrunt.hcl
+++ b/test/fixture-destroy-warning/vpc/terragrunt.hcl
@@ -1,0 +1,3 @@
+include "root" {
+  path = find_in_parent_folders()
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4354,6 +4354,5 @@ func TestShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
 	assert.NoError(t, err)
 
 	output := string(stderr.Bytes())
-	fmt.Printf("stdout: %s\n", output)
 	assert.Equal(t, 1, strings.Count(output, appPath))
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -128,6 +128,7 @@ const (
 	TEST_FIXTURE_PARALLELISM                                = "fixture-parallelism"
 	TEST_FIXTURE_SOPS                                       = "fixture-sops"
 	TEST_FIXTURE_INCLUDE_NO_OUTPUT                          = "fixture-include-no-output"
+	TEST_FIXTURE_DESTROY_WARNING                            = "fixture-destroy-warning"
 	TERRAFORM_BINARY                                        = "terraform"
 	TERRAFORM_FOLDER                                        = ".terraform"
 	TERRAFORM_STATE                                         = "terraform.tfstate"
@@ -4324,4 +4325,35 @@ func TestNoFailureForModulesWithoutOutputs(t *testing.T) {
 
 	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-non-interactive --terragrunt-working-dir %s", appPath), &stdout, &stderr)
 	assert.NoError(t, err)
+}
+
+func TestShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
+
+	rootPath := copyEnvironment(t, TEST_FIXTURE_DESTROY_WARNING)
+
+	rootPath = util.JoinPath(rootPath, TEST_FIXTURE_DESTROY_WARNING)
+	vpcPath := util.JoinPath(rootPath, "vpc")
+	appPath := util.JoinPath(rootPath, "app")
+
+	cleanupTerraformFolder(t, rootPath)
+	cleanupTerraformFolder(t, vpcPath)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all init --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
+	assert.NoError(t, err)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
+	assert.NoError(t, err)
+
+	// try to destroy vpc module and check if warning is printed in output
+	stdout = bytes.Buffer{}
+	stderr = bytes.Buffer{}
+
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt destroy --terragrunt-non-interactive --terragrunt-working-dir %s", vpcPath), &stdout, &stderr)
+	assert.NoError(t, err)
+
+	output := string(stderr.Bytes())
+	fmt.Printf("stdout: %s\n", output)
+	assert.Equal(t, 1, strings.Count(output, appPath))
 }


### PR DESCRIPTION
Updated terragrunt flow to show a list of dependent modules and confirmation of action before destroy
Example (https://github.com/denis256/terragrunt-test-1815) :

app1, app2 -> service-discovery-core -> vpc
```
$ tree
.
.
├── applications
│   └── gateway
│       ├── app1
│       │   ├── main.tf
│       │   └── terragrunt.hcl
│       └── app2
│           ├── main.tf
│           └── terragrunt.hcl
├── README.md
├── shared
│   ├── service-discovery-core
│   │   ├── main.tf
│   │   └── terragrunt.hcl
│   └── vpc
│       ├── main.tf
│       ├── terragrunt.hcl
└── terragrunt.hcl

$ cd shared/service-discovery-core
$ terragrunt destroy
Detected dependent modules:
/raid1/tests/terragrunt-test-1815/applications/gateway/app1
/raid1/tests/terragrunt-test-1815/applications/gateway/app2
WARNING: Are you sure you want to continue? (y/n) y
...
Destroy complete!

...

$ cd shared/vpc
$ terragrunt destroy
Detected dependent modules:
/raid1/tests/terragrunt-test-1815/shared/service-discovery-core
WARNING: Are you sure you want to continue? (y/n)
...


$ cd applications/gateway/app2
$ terragrunt destroy
...
Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: 

```

Particularities of implementation:
* `--terragrunt-non-interactive` automatically approve the action, to be consistent with other commands
* detection of root directory from where to find dependencies is based on `git rev-parse --show-toplevel`, if it fails `include` directive is used

Fix for the issue: https://github.com/gruntwork-io/terragrunt/issues/299