### PR TITLE
Don't link build->deploy with test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           shell: powershell.exe
           no_output_timeout: 45m
           command: |
-            # We're running this test only on Windows currently to provide a convenient 
+            # We're running this test only on Windows currently to provide a convenient
             # means of reproducing Terragrunt issues that only occur on that platform
             go test -v ./... -run TestWindowsTerragruntSourceMapDebug -timeout 45m
   # We're running unit tests separately from integration tests - with no parallelization.
@@ -120,9 +120,6 @@ workflows:
             - Gruntwork Admin
             - Gruntwork GCP
       - build:
-          requires:
-            - unit_test
-            - integration_test
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
We have a few flaky tests that fail occasionally. This isn't much of a concern during PR stage, but it causes issues during releases where it stops the binary from being built + uploaded.

This PR updates the workflow so that the `build` and `deploy` steps happen regardless of test failure.

Permanent fix for https://github.com/gruntwork-io/terragrunt/issues/1829