### PR TITLE
#1825 Added checking for run-all arguments

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -1008,6 +1008,9 @@ func remoteStateNeedsInit(remoteState *remote.RemoteState, terragruntOptions *op
 
 // runAll runs the provided terraform command against all the modules that are found in the directory tree.
 func runAll(terragruntOptions *options.TerragruntOptions) error {
+	if terragruntOptions.TerraformCommand == "" {
+		return MissingCommand{}
+	}
 	reason, isDisabled := runAllDisabledCommands[terragruntOptions.TerraformCommand]
 	if isDisabled {
 		return RunAllDisabledErr{
@@ -1119,4 +1122,10 @@ type RunAllDisabledErr struct {
 
 func (err RunAllDisabledErr) Error() string {
 	return fmt.Sprintf("%s with run-all is disabled: %s", err.command, err.reason)
+}
+
+type MissingCommand struct{}
+
+func (commandName MissingCommand) Error() string {
+	return fmt.Sprintf("Missing run-all command argument")
 }

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -1127,5 +1127,5 @@ func (err RunAllDisabledErr) Error() string {
 type MissingCommand struct{}
 
 func (commandName MissingCommand) Error() string {
-	return fmt.Sprintf("Missing run-all command argument")
+	return "Missing run-all command argument (Example: terragrunt run-all plan)"
 }

--- a/cli/cli_app_test.go
+++ b/cli/cli_app_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/errors"
+
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
@@ -134,4 +136,18 @@ func TestTerragruntHandlesCatastrophicTerraformFailure(t *testing.T) {
 	tgOptions.TerraformPath = "i-dont-exist"
 	err = runTerraformWithRetry(tgOptions)
 	require.Error(t, err)
+}
+
+func TestMissingRunAllArguments(t *testing.T) {
+	t.Parallel()
+
+	tgOptions, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	tgOptions.TerraformCommand = ""
+
+	err = runAll(tgOptions)
+	require.Error(t, err)
+	_, ok := errors.Unwrap(err).(MissingCommand)
+	assert.True(t, ok)
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4356,3 +4356,17 @@ func TestShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
 	output := string(stderr.Bytes())
 	assert.Equal(t, 1, strings.Count(output, appPath))
 }
+
+func TestShowErrorWhenRunAllInvokedWithoutArguments(t *testing.T) {
+
+	appPath := util.JoinPath(TEST_FIXTURE_INCLUDE_NO_OUTPUT, "app")
+
+	cleanupTerraformFolder(t, appPath)
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all --terragrunt-non-interactive --terragrunt-working-dir %s", appPath), &stdout, &stderr)
+	require.Error(t, err)
+	_, ok := errors.Unwrap(err).(cli.MissingCommand)
+	assert.True(t, ok)
+}


### PR DESCRIPTION
Added verification for an empty argument of `run-all` command and error returning if no arguments specificed

Before:
```
$ terragrunt  run-all
ERRO[0000] Module /tmp/terragrunt-test-1499/module1 has finished with an error: 1 error occurred:
        * exit status 127
  prefix=[/tmp/terragrunt-test-1499/module1] 
ERRO[0000] Dependency /tmp/terragrunt-test-1499/module1 of module /tmp/terragrunt-test-1499/app just finished with an error. Module /tmp/terragrunt-test-1499/app will have to return an error too.  prefix=[/tmp/terragrunt-test-1499/app] 
ERRO[0000] Module /tmp/terragrunt-test-1499/app has finished with an error: Cannot process module Module /tmp/terragrunt-test-1499/app (excluded: false, dependencies: [/tmp/terragrunt-test-1499/module1]) because one of its dependencies, Module /tmp/terragrunt-test-1499/module1 (excluded: false, dependencies: []), finished with an error: 1 error occurred:
        * exit status 127
  prefix=[/tmp/terragrunt-test-1499/app] 
ERRO[0000] 2 errors occurred:
        * exit status 127
        * Cannot process module Module /tmp/terragrunt-test-1499/app (excluded: false, dependencies: [/tmp/terragrunt-test-1499/module1]) because one of its dependencies, Module /tmp/terragrunt-test-1499/module1 (excluded: false, dependencies: []), finished with an error: 1 error occurred:
        * exit status 127
```

After this change:
```
$ terragrunt  run-all
ERRO[0000] Missing run-all command argument             
ERRO[0000] Unable to determine underlying exit code, so Terragrunt will exit with error code 1 

```

Fix for https://github.com/gruntwork-io/terragrunt/issues/1825