### PR TITLE
Revert #1811 to restore useful error message when dependency output is missing

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -345,12 +345,9 @@ func getTerragruntOutputIfAppliedElseConfiguredDefault(dependencyConfig Dependen
 		return dependencyConfig.MockOutputs, nil
 	}
 
-	// In case of init, and empty output, skip generating error about missing outputs
-	// https://github.com/gruntwork-io/terragrunt/issues/1499
-	if dependencyConfig.shouldGetOutputs() && terragruntOptions.AutoInit {
-		return nil, nil
-	}
-
+	// At this point, we expect outputs to exist because there is a `dependency` block without skip_outputs = true, and
+	// returning mocks is not allowed. So return a useful error message indicating that we expected outputs, but they
+	// did not exist.
 	err := TerragruntOutputTargetNoOutputs{
 		targetConfig:  targetConfig,
 		currentConfig: currentConfig,

--- a/test/fixture-include-no-output/app/main.tf
+++ b/test/fixture-include-no-output/app/main.tf
@@ -1,9 +1,0 @@
-resource "local_file" "main_file" {
-  content  = "main_file"
-  filename = "${path.module}/test_file.tfstate"
-}
-
-output "main_file" {
-  value = local_file.main_file.filename
-}
-

--- a/test/fixture-include-no-output/app/terragrunt.hcl
+++ b/test/fixture-include-no-output/app/terragrunt.hcl
@@ -1,3 +1,0 @@
-dependency "no_output_module" {
-  config_path = "../no_output_module"
-}

--- a/test/fixture-include-no-output/no_output_module/main.tf
+++ b/test/fixture-include-no-output/no_output_module/main.tf
@@ -1,4 +1,0 @@
-resource "local_file" "module_main_file" {
-  content  = "module_main_file"
-  filename = "${path.module}/module_main_file.txt"
-}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -127,7 +127,6 @@ const (
 	TEST_FIXTURE_DIRS_PATH                                  = "fixture-dirs"
 	TEST_FIXTURE_PARALLELISM                                = "fixture-parallelism"
 	TEST_FIXTURE_SOPS                                       = "fixture-sops"
-	TEST_FIXTURE_INCLUDE_NO_OUTPUT                          = "fixture-include-no-output"
 	TEST_FIXTURE_DESTROY_WARNING                            = "fixture-destroy-warning"
 	TERRAFORM_BINARY                                        = "terraform"
 	TERRAFORM_FOLDER                                        = ".terraform"
@@ -2266,7 +2265,7 @@ func TestDependencyOutputErrorBeforeApply(t *testing.T) {
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", app3Path), &showStdout, &showStderr)
 	assert.Error(t, err)
 	// Verify that we fail because the dependency is not applied yet
-	assert.Contains(t, err.Error(), "object does not have an attribute named \"outputs\"")
+	assert.Contains(t, err.Error(), "has not been applied yet")
 
 	logBufferContentsLineByLine(t, showStdout, "show stdout")
 	logBufferContentsLineByLine(t, showStderr, "show stderr")
@@ -2595,7 +2594,7 @@ func TestDependencyMockOutputRestricted(t *testing.T) {
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", dependent2Path), &showStdout, &showStderr)
 	assert.Error(t, err)
 	// Verify that we fail because the dependency is not applied yet
-	assert.Contains(t, err.Error(), "object does not have an attribute named \"outputs\"")
+	assert.Contains(t, err.Error(), "has not been applied yet")
 
 	logBufferContentsLineByLine(t, showStdout, "show stdout")
 	logBufferContentsLineByLine(t, showStderr, "show stderr")
@@ -4307,24 +4306,6 @@ func TestTerragruntInitRunCmd(t *testing.T) {
 	assert.Equal(t, 3, strings.Count(errout, "uuid"))
 	assert.Equal(t, 4, strings.Count(errout, "random_arg"))
 	assert.Equal(t, 3, strings.Count(errout, "another_arg"))
-}
-
-func TestNoFailureForModulesWithoutOutputs(t *testing.T) {
-
-	appPath := util.JoinPath(TEST_FIXTURE_INCLUDE_NO_OUTPUT, "app")
-
-	cleanupTerraformFolder(t, appPath)
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all init --terragrunt-non-interactive --terragrunt-working-dir %s", appPath), &stdout, &stderr)
-	assert.NoError(t, err)
-
-	stdout = bytes.Buffer{}
-	stderr = bytes.Buffer{}
-
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-non-interactive --terragrunt-working-dir %s", appPath), &stdout, &stderr)
-	assert.NoError(t, err)
 }
 
 func TestShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {


### PR DESCRIPTION
#1811 implements logic where we always allow empty outputs unless `auto-init` is disabled. Auto-init shouldn't matter for whether or not empty outputs are allowed. I think the original intention of the PR was to only allow empty outputs when `terragrunt init` is run.

While I can fix this `if` logic to implement the original intention, I don't think that logic is correct either. This is because the intention of the `dependency` block is to allow direct references to the dependency output. Consider the following simplified example:

```
dependency "dep" {
  config_path = "../dep"
}

inputs = {
  input = dependency.dep.outputs.id
}
```

With the logic in #1811, this returns a confusing error message because terragrunt can't resolve `dependency.dep.outputs.id`. The original error message before #1811, was more helpful (specifically, the part about if this is intended, they should set `skip_outputs = true` on the `dependency` block):

```
xxxxxxx/terragrunt.hcl is a dependency of  yyyyy/terragrunt.hcl but detected no outputs. Either the target
module has not been applied yet, or the module has no outputs. If this is expected, set the skip_outputs
flag to true on the dependency block.
```

If one wants to conditionally skip outputs based on the command, then the solution is to use `mock_outputs` and include those commands in the `mock_outputs_allowed_terraform_commands`. So for example, if the intention is to skip outputs just for `init` (which is what #1811 tried to implement), they can do:

```
dependency "dep" {
  config_path = "../dep"
  mock_outputs = {
    id = "foo"
  }
  mock_outputs_allowed_terraform_commands = ["init"]
}

inputs = {
  input = dependency.dep.outputs.id
}
```

as covered in https://terragrunt.gruntwork.io/docs/features/execute-terraform-commands-on-multiple-modules-at-once/#unapplied-dependency-and-mock-outputs.

So this PR reverts #1811.

---

In regards to the issue about timing brought up in #1499, please read https://github.com/gruntwork-io/terragrunt/issues/1499#issuecomment-930414538