### PR TITLE
make session-name configurable for assumed-role, update related docs …

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -2,7 +2,6 @@ package aws_helper
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -125,7 +124,7 @@ func CreateAwsSession(config *AwsSessionConfig, terragruntOptions *options.Terra
 }
 
 // Make API calls to AWS to assume the IAM role specified and return the temporary AWS credentials to use that role
-func AssumeIamRole(iamRoleArn string, sessionDurationSeconds int64) (*sts.Credentials, error) {
+func AssumeIamRole(iamRoleArn, sessionName string, sessionDurationSeconds int64) (*sts.Credentials, error) {
 	sessionOptions := session.Options{SharedConfigState: session.SharedConfigEnable}
 	sess, err := session.NewSessionWithOptions(sessionOptions)
 	if err != nil {
@@ -141,7 +140,7 @@ func AssumeIamRole(iamRoleArn string, sessionDurationSeconds int64) (*sts.Creden
 
 	input := sts.AssumeRoleInput{
 		RoleArn:         aws.String(iamRoleArn),
-		RoleSessionName: aws.String(fmt.Sprintf("terragrunt-%d", time.Now().UTC().UnixNano())),
+		RoleSessionName: aws.String(sessionName),
 		DurationSeconds: aws.Int64(sessionDurationSeconds),
 	}
 
@@ -220,7 +219,7 @@ func AssumeRoleAndUpdateEnvIfNecessary(terragruntOptions *options.TerragruntOpti
 	}
 
 	terragruntOptions.Logger.Debugf("Assuming IAM role %s with a session duration of %d seconds.", terragruntOptions.IamRole, terragruntOptions.IamAssumeRoleDuration)
-	creds, err := AssumeIamRole(terragruntOptions.IamRole, terragruntOptions.IamAssumeRoleDuration)
+	creds, err := AssumeIamRole(terragruntOptions.IamRole, terragruntOptions.IamAssumeRoleSessionName, terragruntOptions.IamAssumeRoleDuration)
 	if err != nil {
 		return err
 	}

--- a/cli/args.go
+++ b/cli/args.go
@@ -125,6 +125,11 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 		return nil, err
 	}
 
+	iamAssumeRoleSessionName, err := parseStringArg(args, optTerragruntIAMAssumeRoleSessionName, os.Getenv("TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME"))
+	if err != nil {
+		return nil, err
+	}
+
 	excludeDirs, err := parseMultiStringArg(args, optTerragruntExcludeDir, []string{})
 	if err != nil {
 		return nil, err
@@ -203,6 +208,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.Env = parseEnvironmentVariables(os.Environ())
 	opts.IamRole = iamRole
 	opts.IamAssumeRoleDuration = int64(IamAssumeRoleDuration)
+	opts.IamAssumeRoleSessionName = iamAssumeRoleSessionName
 	opts.ExcludeDirs = excludeDirs
 	opts.IncludeDirs = includeDirs
 	opts.StrictInclude = strictInclude

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -38,6 +38,7 @@ const (
 	optTerragruntSourceUpdate                = "terragrunt-source-update"
 	optTerragruntIAMRole                     = "terragrunt-iam-role"
 	optTerragruntIAMAssumeRoleDuration       = "terragrunt-iam-assume-role-duration"
+	optTerragruntIAMAssumeRoleSessionName    = "terragrunt-iam-assume-role-session-name"
 	optTerragruntIgnoreDependencyErrors      = "terragrunt-ignore-dependency-errors"
 	optTerragruntIgnoreDependencyOrder       = "terragrunt-ignore-dependency-order"
 	optTerragruntIgnoreExternalDependencies  = "terragrunt-ignore-external-dependencies"
@@ -77,6 +78,7 @@ var allTerragruntStringOpts = []string{
 	optTerragruntSourceMap,
 	optTerragruntIAMRole,
 	optTerragruntIAMAssumeRoleDuration,
+	optTerragruntIAMAssumeRoleSessionName,
 	optTerragruntExcludeDir,
 	optTerragruntIncludeDir,
 	optTerragruntParallelism,
@@ -396,6 +398,10 @@ func RunTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 	// replace default sts duration if set in config
 	if terragruntOptions.IamAssumeRoleDuration == int64(options.DEFAULT_IAM_ASSUME_ROLE_DURATION) && terragruntConfig.IamAssumeRoleDuration != nil {
 		terragruntOptions.IamAssumeRoleDuration = *terragruntConfig.IamAssumeRoleDuration
+	}
+
+	if terragruntOptions.IamAssumeRoleSessionName == "" {
+		terragruntOptions.IamAssumeRoleSessionName = terragruntConfig.IamAssumeRoleSessionName
 	}
 
 	if err := aws_helper.AssumeRoleAndUpdateEnvIfNecessary(terragruntOptions); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type TerragruntConfig struct {
 	Skip                        bool
 	IamRole                     string
 	IamAssumeRoleDuration       *int64
+	IamAssumeRoleSessionName    string
 	Inputs                      map[string]interface{}
 	Locals                      map[string]interface{}
 	TerragruntDependencies      []Dependency
@@ -87,13 +88,14 @@ type terragruntConfigFile struct {
 	RemoteState     *remoteStateConfigFile `hcl:"remote_state,block"`
 	RemoteStateAttr *cty.Value             `hcl:"remote_state,optional"`
 
-	Dependencies           *ModuleDependencies `hcl:"dependencies,block"`
-	DownloadDir            *string             `hcl:"download_dir,attr"`
-	PreventDestroy         *bool               `hcl:"prevent_destroy,attr"`
-	Skip                   *bool               `hcl:"skip,attr"`
-	IamRole                *string             `hcl:"iam_role,attr"`
-	IamAssumeRoleDuration  *int64              `hcl:"iam_assume_role_duration,attr"`
-	TerragruntDependencies []Dependency        `hcl:"dependency,block"`
+	Dependencies             *ModuleDependencies `hcl:"dependencies,block"`
+	DownloadDir              *string             `hcl:"download_dir,attr"`
+	PreventDestroy           *bool               `hcl:"prevent_destroy,attr"`
+	Skip                     *bool               `hcl:"skip,attr"`
+	IamRole                  *string             `hcl:"iam_role,attr"`
+	IamAssumeRoleDuration    *int64              `hcl:"iam_assume_role_duration,attr"`
+	IamAssumeRoleSessionName *string             `hcl:"iam_assume_role_session_name,attr"`
+	TerragruntDependencies   []Dependency        `hcl:"dependency,block"`
 
 	// We allow users to configure code generation via blocks:
 	//
@@ -666,6 +668,9 @@ func setIAMRole(configString string, terragruntOptions *options.TerragruntOption
 		if iamConfig.IamAssumeRoleDuration != nil {
 			terragruntOptions.IamAssumeRoleDuration = *iamConfig.IamAssumeRoleDuration
 		}
+		if iamConfig.IamAssumeRoleSessionName != "" {
+			terragruntOptions.IamAssumeRoleSessionName = iamConfig.IamAssumeRoleSessionName
+		}
 	}
 	return nil
 }
@@ -802,6 +807,10 @@ func convertToTerragruntConfig(
 
 	if terragruntConfigFromFile.IamAssumeRoleDuration != nil {
 		terragruntConfig.IamAssumeRoleDuration = terragruntConfigFromFile.IamAssumeRoleDuration
+	}
+
+	if terragruntConfigFromFile.IamAssumeRoleSessionName != nil {
+		terragruntConfig.IamAssumeRoleSessionName = *terragruntConfigFromFile.IamAssumeRoleSessionName
 	}
 
 	generateBlocks := []terragruntGenerateBlock{}

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -26,6 +26,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 	output["download_dir"] = gostringToCty(config.DownloadDir)
 	output["iam_role"] = gostringToCty(config.IamRole)
 	output["skip"] = goboolToCty(config.Skip)
+	output["iam_assume_role_session_name"] = gostringToCty(config.IamAssumeRoleSessionName)
 
 	terraformConfigCty, err := terraformConfigAsCty(config.Terraform)
 	if err != nil {

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -191,6 +191,8 @@ func terragruntConfigStructFieldToMapKey(t *testing.T, fieldName string) (string
 		return "iam_role", true
 	case "IamAssumeRoleDuration":
 		return "iam_assume_role_duration", true
+	case "IamAssumeRoleSessionName":
+		return "iam_assume_role_session_name", true
 	case "Inputs":
 		return "inputs", true
 	case "Locals":

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -254,6 +254,24 @@ func TestParseIamAssumeRoleDuration(t *testing.T) {
 	assert.Equal(t, int64(36000), *terragruntConfig.IamAssumeRoleDuration)
 }
 
+func TestParseIamAssumeRoleSessionName(t *testing.T) {
+	t.Parallel()
+
+	config := `iam_assume_role_session_name = "terragrunt-iam-assume-role-session-name"`
+
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.Dependencies)
+	assert.Nil(t, terragruntConfig.RetryableErrors)
+
+	assert.Equal(t, "terragrunt-iam-assume-role-session-name", terragruntConfig.IamAssumeRoleSessionName)
+}
+
 func TestParseTerragruntConfigDependenciesOnePath(t *testing.T) {
 	t.Parallel()
 

--- a/docs/_docs/01_getting-started/configuration.md
+++ b/docs/_docs/01_getting-started/configuration.md
@@ -55,7 +55,7 @@ Currently terragrunt parses the config in the following order:
 
 2.  `locals` block
 
-3.  Evaluation of values for `iam_role` and `iam_assume_role_duration` attributes, if defined
+3.  Evaluation of values for `iam_role`, `iam_assume_role_duration`, and `iam_assume_role_session_name` attributes, if defined
 
 4.  `dependencies` block
 

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -619,6 +619,15 @@ and Terraform with multiple AWS accounts.
 Uses the specified duration as the session duration (in seconds) for the STS session which assumes the role defined in `--terragrunt-iam-role`.
 
 
+### terragrunt-iam-assume-role-session-name
+
+**CLI Arg**: `--terragrunt-iam-assume-role-session-name`<br/>
+**Environment Variable**: `TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME`<br/>
+**Requires an argument**: `--terragrunt-iam-assume-role-session-name "terragrunt-iam-role-session-name"`
+
+Used as the session name for the STS session which assumes the role defined in `--terragrunt-iam-role`.
+
+
 ### terragrunt-exclude-dir
 
 **CLI Arg**: `--terragrunt-exclude-dir`<br/>

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -998,6 +998,7 @@ generate = local.common.generate
 - [skip](#skip)
 - [iam_role](#iam_role)
 - [iam_assume_role_duration](#iam_assume_role_duration)
+- [iam_assume_role_session_name](#iam_assume_role_session_name)
 - [terraform_binary](#terraform_binary)
 - [terraform_version_constraint](#terraform_version_constraint)
 - [terragrunt_version_constraint](#terragrunt_version_constraint)
@@ -1145,6 +1146,14 @@ Example:
 ```hcl
 iam_assume_role_duration = 14400
 ```
+
+### iam_assume_role_session_name
+
+The `iam_assume_role_session_name` attribute can be used to specify the STS session name, for the IAM role that Terragrunt should assume prior to invoking Terraform.
+
+The precedence is as follows: `--terragrunt-iam-assume-role-session-name` command line option → `TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME` env variable →
+`iam_assume_role_session_name` attribute of the `terragrunt.hcl` file in the module directory → `iam_assume_role_session_name` attribute of the included
+`terragrunt.hcl`.
 
 
 ### terraform_binary

--- a/options/options.go
+++ b/options/options.go
@@ -109,6 +109,9 @@ type TerragruntOptions struct {
 	// Duration of the STS Session
 	IamAssumeRoleDuration int64
 
+	// STS Session name
+	IamAssumeRoleSessionName string
+
 	// If set to true, continue running *-all commands even if a dependency has errors. This is mostly useful for 'output-all <some_variable>'. See https://github.com/gruntwork-io/terragrunt/issues/193
 	IgnoreDependencyErrors bool
 
@@ -211,6 +214,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		SourceUpdate:                false,
 		DownloadDir:                 downloadDir,
 		IamAssumeRoleDuration:       DEFAULT_IAM_ASSUME_ROLE_DURATION,
+		IamAssumeRoleSessionName:    "",
 		IgnoreDependencyErrors:      false,
 		IgnoreDependencyOrder:       false,
 		IgnoreExternalDependencies:  false,


### PR DESCRIPTION
Previously, IAM Role session name is defined with `fmt.Sprintf("terragrunt-%d", time.Now().UTC().UnixNano())`. This PR try to tackle issue defined in #1027 , where user can configure IAM Role session name used by terragrunt.

This is my first contribution to open source, please let me know  if I miss something, or anything need to be check for this PR.

Thanks