### PR TITLE
#1842 Redirect and cache modules output in case of plan command

### DIFF
--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -62,7 +62,7 @@ func (stack *Stack) Run(terragruntOptions *options.TerragruntOptions) error {
 		errorStreams := make([]RedirectBuffer, len(stack.Modules))
 		for n, module := range stack.Modules {
 			if !terragruntOptions.NonInteractive { // redirect output to ErrWriter in case of not NonInteractive mode
-				errorStreams[n].Writer = &module.TerragruntOptions.ErrWriter
+				errorStreams[n].Writer = module.TerragruntOptions.ErrWriter
 			}
 			errorStreams[n].CachedData = []byte{}
 			module.TerragruntOptions.ErrWriter = &errorStreams[n]
@@ -154,7 +154,7 @@ func createStackForTerragruntConfigPaths(path string, terragruntConfigPaths []st
 // RedirectBuffer - structure used as io.Writer which cache written data and redirect to configured writer
 type RedirectBuffer struct {
 	CachedData []byte
-	Writer     *io.Writer
+	Writer     io.Writer
 }
 
 // Write - implementation which cache data and redirect to provided Writer
@@ -163,8 +163,7 @@ func (buffer *RedirectBuffer) Write(b []byte) (int, error) {
 	if buffer.Writer == nil {
 		return len(b), nil
 	}
-	writer := buffer.Writer
-	return (*writer).Write(b)
+	return buffer.Writer.Write(b)
 }
 
 // String - fetch cached data as string

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -149,7 +149,7 @@ func createStackForTerragruntConfigPaths(path string, terragruntConfigPaths []st
 	return stack, nil
 }
 
-// RedirectBuffer - structure used as io.Writer which cache written data and redirect to another writer
+// RedirectBuffer - structure used as io.Writer which cache written data and redirect to configured writer
 type RedirectBuffer struct {
 	CachedData []byte
 	Writer     io.Writer

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -59,7 +59,7 @@ func (stack *Stack) Run(terragruntOptions *options.TerragruntOptions) error {
 
 	if stackCmd == "plan" {
 		// We capture the out stream for each module
-		errorStreams := make([]CachingRedirectBuffer, len(stack.Modules))
+		errorStreams := make([]RedirectBuffer, len(stack.Modules))
 		for n, module := range stack.Modules {
 			errorStreams[n].Writer = module.TerragruntOptions.ErrWriter
 			errorStreams[n].CachedData = []byte{}
@@ -79,7 +79,7 @@ func (stack *Stack) Run(terragruntOptions *options.TerragruntOptions) error {
 // We inspect the error streams to give an explicit message if the plan failed because there were references to
 // remote states. `terraform plan` will fail if it tries to access remote state from dependencies and the plan
 // has never been applied on the dependency.
-func (stack *Stack) summarizePlanAllErrors(terragruntOptions *options.TerragruntOptions, errorStreams []CachingRedirectBuffer) {
+func (stack *Stack) summarizePlanAllErrors(terragruntOptions *options.TerragruntOptions, errorStreams []RedirectBuffer) {
 	for i, errorStream := range errorStreams {
 		output := errorStream.String()
 
@@ -149,20 +149,20 @@ func createStackForTerragruntConfigPaths(path string, terragruntConfigPaths []st
 	return stack, nil
 }
 
-// CachingRedirectBuffer - structure used as io.Writer which cache written data and redirect to another writer
-type CachingRedirectBuffer struct {
+// RedirectBuffer - structure used as io.Writer which cache written data and redirect to another writer
+type RedirectBuffer struct {
 	CachedData []byte
-	Writer io.Writer
+	Writer     io.Writer
 }
 
 // Write - implementation which cache data and redirect to provided Writer
-func (buffer *CachingRedirectBuffer) Write(b []byte)(int, error)  {
+func (buffer *RedirectBuffer) Write(b []byte) (int, error) {
 	buffer.CachedData = append(buffer.CachedData, b...)
 	return buffer.Writer.Write(b)
 }
 
 // String - fetch cached data as string
-func (buffer *CachingRedirectBuffer) String() string {
+func (buffer *RedirectBuffer) String() string {
 	return string(buffer.CachedData)
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4350,3 +4350,21 @@ func TestShowErrorWhenRunAllInvokedWithoutArguments(t *testing.T) {
 	_, ok := errors.Unwrap(err).(cli.MissingCommand)
 	assert.True(t, ok)
 }
+
+func TestTerragruntInitConfirmation(t *testing.T) {
+	t.Parallel()
+
+	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
+
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_ALL)
+
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, config.DefaultTerragruntConfigPath)
+	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", "not-used")
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all init --terragrunt-working-dir %s", tmpEnvPath), &stdout, &stderr)
+	require.Error(t, err)
+	errout := string(stderr.Bytes())
+	assert.Equal(t, 1, strings.Count(errout, "does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n)"))
+}


### PR DESCRIPTION
Updated handling of "plan" to pass error stream that cache output inside and redirects to console(for interactive mode), cached data later is used to print plan summary

Example usage on https://github.com/dkossako/infra-ref :
```
$ cd prod
$ terragrunt run-all plan

ERRO[0000] Module /tmp/infra-ref/prod/_global/_global/monitoring/budget has finished with an error: 1 error occurred:
        * stat /mnt/panda/cloudpanda.io/terraform-aws-budget: no such file or directory
  prefix=[/tmp/infra-ref/prod/_global/_global/monitoring/budget] 
Remote state S3 bucket terraform-state-cpanda does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) 

```

Fix for the issue: https://github.com/gruntwork-io/terragrunt/issues/1842