### PR TITLE
Update contributing guidelines with info about changed labels

### DIFF
--- a/docs/_docs/03_community/contributing.md
+++ b/docs/_docs/03_community/contributing.md
@@ -34,7 +34,8 @@ Before starting any work, we recommend filing a GitHub issue in this repo. This 
 get feedback from the maintainers and the community before you sink a lot of time into writing (possibly the wrong)
 code. If there is anything you're unsure about, just ask!
 
-We don't use the `help wanted` or `prs welcome` labels, because all issues are open for community contributions!
+We no longer explicitly use the `help wanted` or `prs welcome` labels, because _all_ issues are open for community
+contributions.
 
 Sometimes, the scope of the feature proposal is large enough that it requires major updates to the code base to
 implement. In these situations, a maintainer may suggest writing up an RFC that describes the feature in more details


### PR DESCRIPTION
We are removing the `help wanted` (PRs welcome) label because all issues are open to contribution. The problem is that 215 issues previously had the `help wanted` label and the issue activity on each of those says the label was removed. Optically this looks like we no longer want help. But actually we do. What's the best way to let people know this?

This PR is a suggestion. Maybe we need a script that pops a message in each of those 215 issues (detect issues that used to have that label?) and announce the label change? Is that spammy?