### PR TITLE
feat: Prefer remote tfstate over local tfstate, if present

### DIFF
--- a/remote/terraform_state_file.go
+++ b/remote/terraform_state_file.go
@@ -53,10 +53,10 @@ func ParseTerraformStateFileFromLocation(backend string, config map[string]inter
 	stateFile, ok := config["path"].(string)
 	if backend == "local" && ok && util.FileExists(stateFile) {
 		return ParseTerraformStateFile(stateFile)
-	} else if util.FileExists(util.JoinPath(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE)) {
-		return ParseTerraformStateFile(util.JoinPath(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE))
 	} else if util.FileExists(util.JoinPath(dataDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE)) {
 		return ParseTerraformStateFile(util.JoinPath(dataDir, DEFAULT_PATH_TO_REMOTE_STATE_FILE))
+	} else if util.FileExists(util.JoinPath(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE)) {
+		return ParseTerraformStateFile(util.JoinPath(workingDir, DEFAULT_PATH_TO_LOCAL_STATE_FILE))
 	} else {
 		return nil, nil
 	}


### PR DESCRIPTION
This addresses issue #514:

Upon a local to remote tfstate migration, Terraform will leave an empty
`terraform.tfstate` file in the working directory. Subsequent
invocations on the state should then refer to the `terraform.tfstate`
file in the data directory (`.terraform`) which points to the remote
state. By prefering the data directory when parsing the tfstate,
Terragrunt behaves similarly to Terraform, and no longer errors out on
the empty `terraform.tfstate` file.

---

Reproduction of issue #514:

```console
❯ echo 'resource "null_resource" "blah" {}' > main.tf
❯ terraform init
❯ terraform apply -auto-approve
```

Now we must generate and migrate to a remote backend with Terragrunt. I use an HTTP backend:

```hcl
remote_state {
  generate = {
    path      = "backend.tf"
    if_exists = "overwrite"
  }

  backend = "http"

  config = {
    username = get_env("TF_BACKEND_USERNAME")
    password = get_env("TF_BACKEND_PASSWORD")
    address  = "https://tf.kaipov.com/demo/terragrunt.bug.test"
  }
}
```

Upon a `terragrunt init`, a yes to the prompt to migrate state, and a `terragrunt plan`, we'll get that `unexpected end of JSON input` error because of the empty `terraform.tfstate` file.

---

I don't expect this change to break anything since the new behavior is in line with how Terraform behaves, i.e. completely igoring any local `terraform.tfstate` files if a `.terraform/terraform.tfstate` is present. Even if we were to replace the empty `terraform.tfstate` file with a valid state, Terraform would pay no attention it, so it too prefers remote states over local!