### PR TITLE
--terragrunt-modules-that-include filter for run-all

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -126,6 +126,11 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 
 	strictInclude := parseBooleanArg(args, optTerragruntStrictInclude, false)
 
+	modulesThatInclude, err := parseMultiStringArg(args, optTerragruntModulesThatInclude, []string{})
+	if err != nil {
+		return nil, err
+	}
+
 	// Those correspond to logrus levels
 	logLevel, err := parseStringArg(args, optTerragruntLogLevel, util.GetDefaultLogLevel().String())
 	if err != nil {
@@ -201,6 +206,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.Env = parseEnvironmentVariables(os.Environ())
 	opts.ExcludeDirs = excludeDirs
 	opts.IncludeDirs = includeDirs
+	opts.ModulesThatInclude = modulesThatInclude
 	opts.StrictInclude = strictInclude
 	opts.Parallelism = parallelism
 	opts.Check = parseBooleanArg(args, optTerragruntCheck, os.Getenv("TERRAGRUNT_CHECK") == "true")

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -54,6 +54,7 @@ const (
 	optTerragruntLogLevel                    = "terragrunt-log-level"
 	optTerragruntStrictValidate              = "terragrunt-strict-validate"
 	optTerragruntJSONOut                     = "terragrunt-json-out"
+	optTerragruntModulesThatInclude          = "terragrunt-modules-that-include"
 )
 
 var allTerragruntBooleanOpts = []string{
@@ -87,6 +88,7 @@ var allTerragruntStringOpts = []string{
 	optTerragruntLogLevel,
 	optTerragruntStrictValidate,
 	optTerragruntJSONOut,
+	optTerragruntModulesThatInclude,
 }
 
 const CMD_INIT = "init"

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -315,7 +315,13 @@ func PartialParseConfigString(
 
 	// If this file includes another, parse and merge the partial blocks.  Otherwise just return this config.
 	if len(trackInclude.CurrentList) > 0 {
-		return handleIncludePartial(&output, trackInclude, terragruntOptions, decodeList)
+		config, err := handleIncludePartial(&output, trackInclude, terragruntOptions, decodeList)
+		if err != nil {
+			return nil, err
+		}
+		// Saving processed includes into configuration, direct assignment since nested includes aren't supported
+		config.ProcessedIncludes = trackInclude.CurrentMap
+		return config, nil
 	}
 	return &output, nil
 }

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -70,6 +70,9 @@ func TestResolveTerraformModulesOneModuleWithIncludesNoDependencies(t *testing.T
 		Config: config.TerragruntConfig{
 			Terraform: &config.TerraformConfig{Source: ptr("...")},
 			IsPartial: true,
+			ProcessedIncludes: map[string]config.IncludeConfig{
+				"": {Path: canonical(t, "../test/fixture-modules/module-b/terragrunt.hcl")},
+			},
 		},
 		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-b/module-b-child/"+config.DefaultTerragruntConfigPath)),
 	}
@@ -91,6 +94,9 @@ func TestResolveTerraformModulesOneJsonModuleWithIncludesNoDependencies(t *testi
 		Config: config.TerragruntConfig{
 			Terraform: &config.TerraformConfig{Source: ptr("...")},
 			IsPartial: true,
+			ProcessedIncludes: map[string]config.IncludeConfig{
+				"": {Path: canonical(t, "../test/fixture-modules/json-module-b/terragrunt.hcl")},
+			},
 		},
 		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-b/module-b-child/"+config.DefaultTerragruntJsonConfigPath)),
 	}
@@ -112,6 +118,9 @@ func TestResolveTerraformModulesOneHclModuleWithIncludesNoDependencies(t *testin
 		Config: config.TerragruntConfig{
 			Terraform: &config.TerraformConfig{Source: ptr("...")},
 			IsPartial: true,
+			ProcessedIncludes: map[string]config.IncludeConfig{
+				"": {Path: canonical(t, "../test/fixture-modules/hcl-module-b/terragrunt.hcl.json")},
+			},
 		},
 		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/hcl-module-b/module-b-child/"+config.DefaultTerragruntConfigPath)),
 	}
@@ -541,6 +550,9 @@ func TestResolveTerraformModulesMultipleModulesWithDependencies(t *testing.T) {
 		Config: config.TerragruntConfig{
 			Terraform: &config.TerraformConfig{Source: ptr("...")},
 			IsPartial: true,
+			ProcessedIncludes: map[string]config.IncludeConfig{
+				"": {Path: canonical(t, "../test/fixture-modules/module-b/terragrunt.hcl")},
+			},
 		},
 		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-b/module-b-child/"+config.DefaultTerragruntConfigPath)),
 	}
@@ -590,6 +602,9 @@ func TestResolveTerraformModulesMultipleModulesWithMixedDependencies(t *testing.
 		Config: config.TerragruntConfig{
 			Terraform: &config.TerraformConfig{Source: ptr("...")},
 			IsPartial: true,
+			ProcessedIncludes: map[string]config.IncludeConfig{
+				"": {Path: canonical(t, "../test/fixture-modules/json-module-b/terragrunt.hcl")},
+			},
 		},
 		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-b/module-b-child/"+config.DefaultTerragruntJsonConfigPath)),
 	}
@@ -639,6 +654,9 @@ func TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes(t *t
 		Config: config.TerragruntConfig{
 			Terraform: &config.TerraformConfig{Source: ptr("...")},
 			IsPartial: true,
+			ProcessedIncludes: map[string]config.IncludeConfig{
+				"": {Path: canonical(t, "../test/fixture-modules/module-b/terragrunt.hcl")},
+			},
 		},
 		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-b/module-b-child/"+config.DefaultTerragruntConfigPath)),
 	}
@@ -650,6 +668,9 @@ func TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes(t *t
 			Dependencies: &config.ModuleDependencies{Paths: []string{"../../module-a", "../../module-b/module-b-child"}},
 			Terraform:    &config.TerraformConfig{Source: ptr("test")},
 			IsPartial:    true,
+			ProcessedIncludes: map[string]config.IncludeConfig{
+				"": {Path: canonical(t, "../test/fixture-modules/module-e/terragrunt.hcl")},
+			},
 		},
 		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-e/module-e-child/"+config.DefaultTerragruntConfigPath)),
 	}

--- a/docs/_docs/02_features/keep-your-terragrunt-architecture-dry.md
+++ b/docs/_docs/02_features/keep-your-terragrunt-architecture-dry.md
@@ -442,3 +442,23 @@ _env/app.hcl`. This will:
   `_env/app.hcl`).
 
 Thereby allowing you to only touch those modules that need to be updated by the code change.
+
+Alternatively, you can implement a promotion workflow if you have multiple environments that depend on the
+`_env/app.hcl` configuration. In the above example, suppose you wanted to progressively roll out the changes through the
+environments, `qa`, `stage`, and `prod` in order. In this case, you can use `--terragrunt-working-dir` to scope down the
+updates from the common file:
+
+```
+# Roll out the change to the qa environment first
+terragrunt run-all plan --terragrunt-modules-that-include _env/app.hcl --terragrunt-working-dir qa
+terragrunt run-all apply --terragrunt-modules-that-include _env/app.hcl --terragrunt-working-dir qa
+# If the apply succeeds to qa, move on to the stage environment
+terragrunt run-all plan --terragrunt-modules-that-include _env/app.hcl --terragrunt-working-dir stage
+terragrunt run-all apply --terragrunt-modules-that-include _env/app.hcl --terragrunt-working-dir stage
+# And finally, prod.
+terragrunt run-all plan --terragrunt-modules-that-include _env/app.hcl --terragrunt-working-dir prod
+terragrunt run-all apply --terragrunt-modules-that-include _env/app.hcl --terragrunt-working-dir prod
+```
+
+This allows you to have flexibility in how changes are rolled out. For example, you can add extra validation stages
+inbetween the roll out to each environment, or add in manual approval between the stages.

--- a/docs/_docs/02_features/keep-your-terragrunt-architecture-dry.md
+++ b/docs/_docs/02_features/keep-your-terragrunt-architecture-dry.md
@@ -462,3 +462,9 @@ terragrunt run-all apply --terragrunt-modules-that-include _env/app.hcl --terrag
 
 This allows you to have flexibility in how changes are rolled out. For example, you can add extra validation stages
 inbetween the roll out to each environment, or add in manual approval between the stages.
+
+**NOTE**: If you identify an issue with rolling out the change in a downstream environment, and want to abort, you will
+need to make sure that that environment uses the older version of the common configuration. This is because the common
+configuration is now partially rolled out, where some environments need to use the new updated common configuration,
+while other environments need the old one. The best way to handle this situation is to create a new copy of the common
+configuration at the old version and have the environments that depend on the older version point to that version.

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -826,3 +826,6 @@ and then will apply this filter on the set of modules that it found.
 
 You can pass this argument in multiple times to provide a list of include files to consider. When multiple files are
 passed in, the set will be the union of modules that includes at least one of the files in the list.
+
+NOTE: When using relative paths, the paths are relative to the working directory. This is either the current working
+directory, or any path passed in to [terragrunt-working-dir](#terragrunt-working-dir).

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -815,6 +815,15 @@ include. For example, consider the following folder structure:
                     └── terragrunt.hcl
 ```
 
+Suppose that both `dev/us-west-2/dev/data-stores/aurora/terragrunt.hcl` and
+`stage/us-west-2/stage/data-stores/aurora/terragrunt.hcl` had the following contents:
+
+```
+include "envcommon" {
+  path = "../../../../../_envcommon/data-stores/aurora.hcl"
+}
+```
+
 If you run the command `run-all init --terragrunt-modules-that-include ../_envcommon/data-stores/aurora.hcl` from the
 `dev` folder, only `dev/us-west-2/dev/data-stores/aurora` will be run; not `stage/us-west-2/stage/data-stores/aurora`.
 This is because `run-all` by default restricts the modules to only those that are direct descendents of the current

--- a/options/options.go
+++ b/options/options.go
@@ -165,6 +165,10 @@ type TerragruntOptions struct {
 	// The file path that terragrunt should use when rendering the terragrunt.hcl config as json.
 	JSONOut string
 
+	// When used with `run-all`, restrict the modules in the stack to only those that include at least one of the files
+	// in this list.
+	ModulesThatInclude []string
+
 	// A command that can be used to run Terragrunt with the given options. This is useful for running Terragrunt
 	// multiple times (e.g. when spinning up a stack of Terraform modules). The actual command is normally defined
 	// in the cli package, which depends on almost all other packages, so we declare it here so that other
@@ -254,6 +258,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		RetryableErrors:             util.CloneStringList(DEFAULT_RETRYABLE_ERRORS),
 		ExcludeDirs:                 []string{},
 		IncludeDirs:                 []string{},
+		ModulesThatInclude:          []string{},
 		StrictInclude:               false,
 		Parallelism:                 DEFAULT_PARALLELISM,
 		Check:                       false,
@@ -340,6 +345,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		RetryableErrors:              util.CloneStringList(terragruntOptions.RetryableErrors),
 		ExcludeDirs:                  terragruntOptions.ExcludeDirs,
 		IncludeDirs:                  terragruntOptions.IncludeDirs,
+		ModulesThatInclude:           terragruntOptions.ModulesThatInclude,
 		Parallelism:                  terragruntOptions.Parallelism,
 		StrictInclude:                terragruntOptions.StrictInclude,
 		RunTerragrunt:                terragruntOptions.RunTerragrunt,

--- a/test/fixture-include-runall/a/main.tf
+++ b/test/fixture-include-runall/a/main.tf
@@ -1,0 +1,3 @@
+output "text" {
+  value = "alpha"
+}

--- a/test/fixture-include-runall/a/terragrunt.hcl
+++ b/test/fixture-include-runall/a/terragrunt.hcl
@@ -1,0 +1,3 @@
+include "alpha" {
+  path = find_in_parent_folders("alpha.hcl")
+}

--- a/test/fixture-include-runall/alpha.hcl
+++ b/test/fixture-include-runall/alpha.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixture-include-runall/b/main.tf
+++ b/test/fixture-include-runall/b/main.tf
@@ -1,0 +1,3 @@
+output "text" {
+  value = "beta"
+}

--- a/test/fixture-include-runall/b/terragrunt.hcl
+++ b/test/fixture-include-runall/b/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixture-include-runall/c/main.tf
+++ b/test/fixture-include-runall/c/main.tf
@@ -1,0 +1,3 @@
+output "text" {
+  value = "charlie"
+}

--- a/test/fixture-include-runall/c/terragrunt.hcl
+++ b/test/fixture-include-runall/c/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty


### PR DESCRIPTION
## Motivation

With the introduction of multiple include blocks, it is becoming increasingly common to setup terragrunt projects that have shared configurations for specific components. However, this introduces a problem for infrastructure CI/CD pipelines, where you want to only run against the modules that changed.

Consider our example in [terragrunt-infrastructure-live-example](https://github.com/gruntwork-io/terragrunt-infrastructure-live-example). The common configurations related to `mysql` are extracted in the file `_envcommon/mysql.hcl`. If we were bumping the module version for the `qa` environment by editing the source reference in [non-prod/us-east-1/qa/mysql/terragrunt.hcl](https://github.com/gruntwork-io/terragrunt-infrastructure-live-example/blob/master/non-prod/us-east-1/qa/mysql/terragrunt.hcl#L10), the pipeline is straightforward - we just run `terragrunt plan` and `terragrunt apply` in the folder of the file that changed.

However, what should we do if the common configuration gets updated? E.g., bumping the instance type: https://github.com/gruntwork-io/terragrunt-infrastructure-live-example/blob/master/_envcommon/mysql.hcl#L40

It isn't immediately obvious what the desired behavior is in this case. For example, for something like changing the instance type of the database, the desired behavior is probably to run `terragrunt plan` and `terragrunt apply` progressively across the environments. That is, start with `qa`, then `stage`, and then `prod`. On the other hand, for a change like updating the environment variables for an application, you can get away with running `terragrunt plan` and `terragrunt apply` in parallel across all environments.

This PR seeks to provide a basic building block that can be used for designing a pipeline for both use cases.

## Solution

In this PR, we introduce a flag for `run-all` (`--terragrunt-modules-that-include`) which will filter out all modules in a stack that does not include at least one of the files listed in the arg.

With such a filter, you can implement the two flows:

For the promotion flow, you can have your pipeline run each environment in succession:
```
terragrunt run-all plan --terragrunt-modules-that-include ../_envcommon/mysql.hcl --terragrunt-working-dir non-prod/qa
# if that succeeds
terragrunt run-all plan --terragrunt-modules-that-include ../_envcommon/mysql.hcl --terragrunt-working-dir non-prod/stage
# ... and so on ...
```

For the parallel flow, you can call `run-all` from the root once:
```
terragrunt run-all plan --terragrunt-modules-that-include _envcommon/mysql.hcl
```

Refer to the docs update in this PR for more details on the use case and how this feature can help implement the pipeline.