### PR TITLE
#1901 Added logic to run init when new source is downloaded

### DIFF
--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -18,6 +18,7 @@ import (
 
 // manifest for files copied from terragrunt module folder (i.e., the folder that contains the current terragrunt.hcl)
 const MODULE_MANIFEST_NAME = ".terragrunt-module-manifest"
+const MODULE_NEED_INIT = ".terragrunt-init-required"
 
 // 1. Download the given source URL, which should use Terraform's module source syntax, into a temporary folder
 // 2. Check if module directory exists in temporary folder
@@ -91,6 +92,13 @@ func downloadTerraformSourceIfNecessary(terraformSource *tfsource.TerraformSourc
 	if err := validateWorkingDir(terraformSource); err != nil {
 		return err
 	}
+
+	initFile := util.JoinPath(terraformSource.WorkingDir, MODULE_NEED_INIT)
+	f, createErr := os.Create(initFile)
+	if createErr != nil {
+		return createErr
+	}
+	defer f.Close()
 
 	return nil
 }


### PR DESCRIPTION
Updated flow to create `.terragrunt-init-required` in `WorkingDir` when a new source is downloaded, which will flag that `init` is required to be executed, if `init` is successfully executed  - `.terragrunt-init-required` is removed

```
# terragrunt.hcl
terraform {
  source = "git::git@github.com:denis256/terraform-test-module.git//modules/test-file?ref=v0.0.4"
  //source = "git::git@github.com:denis256/terraform-test-module.git//modules/test-file?ref=v0.0.1"
}
```

Before:
```
$ terragrunt apply --terragrunt-log-level debug --terragrunt-debug
...
DEBU[0001] Running command: terraform init
DEBU[0004] Running command: terraform apply 
...

# comment change commented source
$ terragrunt init --terragrunt-log-level debug --terragrunt-debug
...
DEBU[0001] Running command: terraform apply
...
```

With this change:
```
$ terragrunt init --terragrunt-log-level debug --terragrunt-debug
DEBU[0002] Running command: terraform init 
DEBU[0009] Running command: terraform apply
...
# change commented source
$ terragrunt init --terragrunt-log-level debug --terragrunt-debug
DEBU[0002] Running command: terraform init 
DEBU[0009] Running command: terraform apply
...
```

https://github.com/gruntwork-io/terragrunt/issues/1901