### PR TITLE
#1900 Updated deep merge strategy to compare modules by path

### DIFF
--- a/config/include.go
+++ b/config/include.go
@@ -391,9 +391,10 @@ func (targetConfig *TerragruntConfig) DeepMerge(sourceConfig *TerragruntConfig, 
 	if sourceConfig.Dependencies != nil {
 		resultModuleDependencies := &ModuleDependencies{}
 		if targetConfig.Dependencies != nil {
+			// take in result dependencies only paths which aren't defined in source
+			// Fix for issue: https://github.com/gruntwork-io/terragrunt/issues/1900
 			targetPathMap := fetchDependencyPaths(targetConfig)
 			sourcePathMap := fetchDependencyPaths(sourceConfig)
-			// take in result dependencies only paths which aren't defined in source
 			for key, value := range targetPathMap {
 				_, found := sourcePathMap[key]
 				if !found {

--- a/config/include.go
+++ b/config/include.go
@@ -401,6 +401,20 @@ func (targetConfig *TerragruntConfig) DeepMerge(sourceConfig *TerragruntConfig, 
 					resultModuleDependencies.Paths = append(resultModuleDependencies.Paths, value)
 				}
 			}
+			// copy target paths which are defined only in Dependencies and not in TerragruntDependencies
+			// if TerragruntDependencies will be empty, all targetConfig.Dependencies.Paths will be copied to resultModuleDependencies.Paths
+			for _, dependencyPath := range targetConfig.Dependencies.Paths {
+				var addPath = true
+				for _, targetPath := range targetPathMap {
+					if dependencyPath == targetPath { // path already defined in TerragruntDependencies, skip adding
+						addPath = false
+						break
+					}
+				}
+				if addPath {
+					resultModuleDependencies.Paths = append(resultModuleDependencies.Paths, dependencyPath)
+				}
+			}
 		}
 		resultModuleDependencies.Paths = append(resultModuleDependencies.Paths, sourceConfig.Dependencies.Paths...)
 		targetConfig.Dependencies = resultModuleDependencies
@@ -448,6 +462,9 @@ func (targetConfig *TerragruntConfig) DeepMerge(sourceConfig *TerragruntConfig, 
 // fetchDependencyMap - return from configuration map with dependency_name: path
 func fetchDependencyPaths(config *TerragruntConfig) map[string]string {
 	var m = make(map[string]string)
+	if config == nil {
+		return m
+	}
 	for _, dependency := range config.TerragruntDependencies {
 		m[dependency.Name] = dependency.ConfigPath
 	}

--- a/config/include.go
+++ b/config/include.go
@@ -445,7 +445,7 @@ func (targetConfig *TerragruntConfig) DeepMerge(sourceConfig *TerragruntConfig, 
 }
 
 // fetchDependencyMap - return from configuration map with dependency_name: path
-func fetchDependencyPaths(config *TerragruntConfig) map[string]string{
+func fetchDependencyPaths(config *TerragruntConfig) map[string]string {
 	var m = make(map[string]string)
 	for _, dependency := range config.TerragruntDependencies {
 		m[dependency.Name] = dependency.ConfigPath

--- a/config/include_test.go
+++ b/config/include_test.go
@@ -225,9 +225,28 @@ func TestDeepMergeConfigIntoIncludedConfig(t *testing.T) {
 		// Deep merge dependencies
 		{
 			"dependencies",
-			&TerragruntConfig{Dependencies: &ModuleDependencies{Paths: []string{"../vpc"}}},
-			&TerragruntConfig{Dependencies: &ModuleDependencies{Paths: []string{"../mysql"}}},
-			&TerragruntConfig{Dependencies: &ModuleDependencies{Paths: []string{"../mysql", "../vpc"}}},
+			&TerragruntConfig{Dependencies: &ModuleDependencies{Paths: []string{"../vpc"}},
+				TerragruntDependencies: []Dependency{
+				{
+					Name:       "vpc",
+					ConfigPath: "../vpc",
+				},
+			}},
+			&TerragruntConfig{Dependencies: &ModuleDependencies{Paths: []string{"../mysql"}},
+				TerragruntDependencies: []Dependency{
+					{
+						Name:       "mysql",
+						ConfigPath: "../mysql",
+					},
+				}},
+			&TerragruntConfig{Dependencies: &ModuleDependencies{Paths: []string{"../mysql", "../vpc"}},
+				TerragruntDependencies: []Dependency{
+					{
+						Name:       "mysql",
+						ConfigPath: "../mysql",
+					},
+
+				}},
 		},
 		// Deep merge retryable errors
 		{

--- a/config/include_test.go
+++ b/config/include_test.go
@@ -227,11 +227,11 @@ func TestDeepMergeConfigIntoIncludedConfig(t *testing.T) {
 			"dependencies",
 			&TerragruntConfig{Dependencies: &ModuleDependencies{Paths: []string{"../vpc"}},
 				TerragruntDependencies: []Dependency{
-				{
-					Name:       "vpc",
-					ConfigPath: "../vpc",
-				},
-			}},
+					{
+						Name:       "vpc",
+						ConfigPath: "../vpc",
+					},
+				}},
 			&TerragruntConfig{Dependencies: &ModuleDependencies{Paths: []string{"../mysql"}},
 				TerragruntDependencies: []Dependency{
 					{
@@ -245,7 +245,6 @@ func TestDeepMergeConfigIntoIncludedConfig(t *testing.T) {
 						Name:       "mysql",
 						ConfigPath: "../mysql",
 					},
-
 				}},
 		},
 		// Deep merge retryable errors

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -3,6 +3,7 @@ package configstack
 import (
 	"fmt"
 	"path/filepath"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -272,6 +273,7 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 		},
 	)
 	if err != nil {
+		debug.PrintStack()
 		return nil, errors.WithStackTrace(ErrorProcessingModule{UnderlyingError: err, HowThisModuleWasFound: howThisModuleWasFound, ModulePath: terragruntConfigPath})
 	}
 

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -3,7 +3,6 @@ package configstack
 import (
 	"fmt"
 	"path/filepath"
-	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -273,7 +272,6 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 		},
 	)
 	if err != nil {
-		debug.PrintStack()
 		return nil, errors.WithStackTrace(ErrorProcessingModule{UnderlyingError: err, HowThisModuleWasFound: howThisModuleWasFound, ModulePath: terragruntConfigPath})
 	}
 


### PR DESCRIPTION
Updated deep merge strategy to compare by module names from "TerragruntDependencies" and use paths from modules which doesn't exist in "source"

Example:
https://github.com/denis256/terragrunt-tests/tree/master/deep-merge-fix

```
.
├── accepter
│   ├── main.tf
│   └── terragrunt.hcl
├── common.hcl
├── module
│   ├── main.tf
│   └── terragrunt.hcl
└── requester
    ├── main.tf
    └── terragrunt.hcl
```
Before:
```
$ cd module
$ terragrunt  run-all init
ERRO[0000] Error processing module at '/raid1/projects-work/g/test-repos/terragrunt-tests/deep-merge-fix/module/empty/terragrunt.hcl'. How this module was found: dependency of module at '/raid1/projects-work/g/test-repos/terragrunt-tests/deep-merge-fix/module'. Underlying error: Error reading file at path /raid1/projects-work/g/test-repos/terragrunt-tests/deep-merge-fix/module/empty/terragrunt.hcl: open /raid1/projects-work/g/test-repos/terragrunt-tests/deep-merge-fix/module/empty/terragrunt.hcl: no such file or directory 
ERRO[0000] Unable to determine underlying exit code, so Terragrunt will exit with error code 1 
```

After:
```
$ cd module
$ terragrunt  run-all init
Module /raid1/projects-work/g/test-repos/terragrunt-tests/deep-merge-fix/module depends on module /raid1/projects-work/g/test-repos/terragrunt-tests/deep-merge-fix/requester, which is an external dependency outside of the current working directory. Should Terragrunt run this external dependency? Warning, if you say 'yes', Terragrunt will make changes in /raid1/projects-work/g/test-repos/terragrunt-tests/deep-merge-fix/requester as well! (y/n) 

```


Fix for: https://github.com/gruntwork-io/terragrunt/issues/1900