### PR TITLE
#1895 Updated tfr handling to support full paths

### DIFF
--- a/internal/tfr/getter.go
+++ b/internal/tfr/getter.go
@@ -115,7 +115,8 @@ func (tfrGetter *TerraformRegistryGetter) Get(dstPath string, srcURL *url.URL) e
 		return err
 	}
 
-	moduleFullPath := path.Join(moduleRegistryBasePath, modulePath, version, "download")
+	moduleFullPath := fmt.Sprintf("%s/%s/%s/download", moduleRegistryBasePath, modulePath, version)
+		//path.Join(moduleRegistryBasePath, modulePath, version, "download")
 	moduleURL := url.URL{
 		Scheme: "https",
 		Host:   registryDomain,

--- a/internal/tfr/getter.go
+++ b/internal/tfr/getter.go
@@ -115,20 +115,32 @@ func (tfrGetter *TerraformRegistryGetter) Get(dstPath string, srcURL *url.URL) e
 		return err
 	}
 
+	moduleRegistryBasePath = strings.TrimSuffix(moduleRegistryBasePath, "/")
+	modulePath = strings.TrimSuffix(modulePath, "/")
+	modulePath = strings.TrimPrefix(modulePath, "/")
+
 	moduleFullPath := fmt.Sprintf("%s/%s/%s/download", moduleRegistryBasePath, modulePath, version)
-		//path.Join(moduleRegistryBasePath, modulePath, version, "download")
-	moduleURL := url.URL{
-		Scheme: "https",
-		Host:   registryDomain,
-		Path:   moduleFullPath,
+
+	var moduleURL *url.URL
+	if strings.HasPrefix(moduleFullPath, "https") {
+		moduleURL, err = url.Parse(modulePath)
+		if err != nil {
+			return err
+		}
+	} else {
+		moduleURL = &url.URL{
+			Scheme: "https",
+			Host:   registryDomain,
+			Path:   moduleFullPath,
+		}
 	}
 
-	terraformGet, err := getTerraformGetHeader(ctx, moduleURL)
+	terraformGet, err := getTerraformGetHeader(ctx, *moduleURL)
 	if err != nil {
 		return err
 	}
 
-	downloadURL, err := getDownloadURLFromHeader(ctx, moduleURL, terraformGet)
+	downloadURL, err := getDownloadURLFromHeader(ctx, *moduleURL, terraformGet)
 	if err != nil {
 		return err
 	}

--- a/internal/tfr/getter.go
+++ b/internal/tfr/getter.go
@@ -99,11 +99,6 @@ func (tfrGetter *TerraformRegistryGetter) Get(dstPath string, srcURL *url.URL) e
 		registryDomain = defaultRegistryDomain
 	}
 
-	moduleRegistryBasePath, err := getModuleRegistryURLBasePath(ctx, registryDomain)
-	if err != nil {
-		return err
-	}
-
 	queryValues := srcURL.Query()
 	modulePath, moduleSubDir := getter.SourceDirSubdir(srcURL.Path)
 
@@ -115,6 +110,11 @@ func (tfrGetter *TerraformRegistryGetter) Get(dstPath string, srcURL *url.URL) e
 		return errors.WithStackTrace(MalformedRegistryURLErr{reason: "more than one version query"})
 	}
 	version := versionList[0]
+
+	moduleRegistryBasePath, err := getModuleRegistryURLBasePath(ctx, registryDomain)
+	if err != nil {
+		return err
+	}
 
 	moduleURL, err := buildRequestUrl(registryDomain, moduleRegistryBasePath, modulePath, version)
 	if err != nil {

--- a/internal/tfr/getter_test.go
+++ b/internal/tfr/getter_test.go
@@ -104,7 +104,6 @@ func TestBuildRequestUrlFullPath(t *testing.T) {
 	assert.Equal(t, "https://gruntwork.io/registry/modules/v1/tfr-project/terraform-aws-tfr/6.6.6/download", requestUrl.String())
 }
 
-
 func TestBuildRequestUrlRelativePath(t *testing.T) {
 	t.Parallel()
 	requestUrl, err := buildRequestUrl("gruntwork.io", "/registry/modules/v1", "/tfr-project/terraform-aws-tfr", "6.6.6")

--- a/internal/tfr/getter_test.go
+++ b/internal/tfr/getter_test.go
@@ -97,9 +97,17 @@ func TestTFRGetterSubModule(t *testing.T) {
 	assert.True(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 }
 
-func TestBuildRequestUrl(t *testing.T) {
+func TestBuildRequestUrlFullPath(t *testing.T) {
 	t.Parallel()
 	requestUrl, err := buildRequestUrl("gruntwork.io", "https://gruntwork.io/registry/modules/v1/", "/tfr-project/terraform-aws-tfr", "6.6.6")
+	assert.Nil(t, err)
+	assert.Equal(t, "https://gruntwork.io/registry/modules/v1/tfr-project/terraform-aws-tfr/6.6.6/download", requestUrl.String())
+}
+
+
+func TestBuildRequestUrlRelativePath(t *testing.T) {
+	t.Parallel()
+	requestUrl, err := buildRequestUrl("gruntwork.io", "/registry/modules/v1", "/tfr-project/terraform-aws-tfr", "6.6.6")
 	assert.Nil(t, err)
 	assert.Equal(t, "https://gruntwork.io/registry/modules/v1/tfr-project/terraform-aws-tfr/6.6.6/download", requestUrl.String())
 

--- a/internal/tfr/getter_test.go
+++ b/internal/tfr/getter_test.go
@@ -96,3 +96,11 @@ func TestTFRGetterSubModule(t *testing.T) {
 	require.NoError(t, tfrGetter.Get(moduleDestPath, testModuleURL))
 	assert.True(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 }
+
+func TestBuildRequestUrl(t *testing.T) {
+	t.Parallel()
+	requestUrl, err := buildRequestUrl("gruntwork.io", "https://gruntwork.io/registry/modules/v1/", "/tfr-project/terraform-aws-tfr", "6.6.6")
+	assert.Nil(t, err)
+	assert.Equal(t, "https://gruntwork.io/registry/modules/v1/tfr-project/terraform-aws-tfr/6.6.6/download", requestUrl.String())
+
+}


### PR DESCRIPTION
Updated handling of TFR paths to concatenate strings and avoid using `path.Join` which for urls generate broken paths like:
```
path.Join("http://foo", "bar") => http:/foo/bar
```

https://github.com/gruntwork-io/terragrunt/issues/1895