### PR TITLE
#1912 Go 1.16 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gruntwork-io/terragrunt
 
-go 1.13
+go 1.16
 
 require (
 	cloud.google.com/go v0.93.3 // indirect


### PR DESCRIPTION
Updated `go.mod` to declare version go 1.16, same go version used in CI/CD

#1912