### PR TITLE
#1891 Dependent modules detection update

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -713,11 +713,7 @@ func runTerragruntWithConfig(originalTerragruntOptions *options.TerragruntOption
 
 // confirmActionWithDependentModules - Show warning with list of dependent modules from current module before destroy
 func confirmActionWithDependentModules(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) bool {
-	modules, err := configstack.FindWhereWorkingDirIsIncluded(terragruntOptions, terragruntConfig)
-	if err != nil {
-		terragruntOptions.Logger.Warnf("Failed to detect where module is used %v", err)
-		return true
-	}
+	modules := configstack.FindWhereWorkingDirIsIncluded(terragruntOptions, terragruntConfig)
 	if len(modules) != 0 {
 		if _, err := terragruntOptions.ErrWriter.Write([]byte("Detected dependent modules:\n")); err != nil {
 			terragruntOptions.Logger.Error(err)
@@ -737,6 +733,7 @@ func confirmActionWithDependentModules(terragruntOptions *options.TerragruntOpti
 		}
 		return shouldRun
 	}
+	// request user to confirm action in any case
 	return true
 }
 

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -557,7 +557,7 @@ func getSortedKeys(modules map[string]*TerraformModule) []string {
 // 1. Find root git top level directory and build list of modules
 // 2. Iterate over includes from terragruntOptions if git top level directory detection failed
 // 3. Filter found module only items which has in dependencies working directory
-func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) ([]*TerraformModule, error) {
+func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) []*TerraformModule {
 	var pathsToCheck []string
 	var matchedModulesMap = make(map[string]*TerraformModule)
 	var gitTopLevelDir = ""
@@ -577,7 +577,8 @@ func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions,
 		dir = dir + filepath.FromSlash("/")
 		cfgOptions, err := options.NewTerragruntOptions(dir)
 		if err != nil {
-			return nil, err
+			terragruntOptions.Logger.Debugf("Failed to build terragrunt options from %s %v", dir, err)
+			return nil
 		}
 		cfgOptions.LogLevel = terragruntOptions.LogLevel
 		if terragruntOptions.TerraformCommand == "destroy" {
@@ -586,7 +587,10 @@ func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions,
 		}
 		stack, err := FindStackInSubfolders(cfgOptions)
 		if err != nil {
-			return nil, err
+			// loggign error as debug since in some cases stack building may fail because parent files can be designed
+			// to work with relative paths from downstream modules
+			terragruntOptions.Logger.Debugf("Failed to build module stack %v", err)
+			return nil
 		}
 
 		for _, module := range stack.Modules {
@@ -605,7 +609,7 @@ func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions,
 		matchedModules = append(matchedModules, module)
 	}
 
-	return matchedModules, nil
+	return matchedModules
 }
 
 // Custom error types


### PR DESCRIPTION
Updated FindWhereWorkingDirIsIncluded to return only detected dependent modules, in case of failures user will be asked to confirm the action in any case.

Fix for: https://github.com/gruntwork-io/terragrunt/issues/1891