### PR TITLE
#1921 Version check before creating auto-init flag file

### DIFF
--- a/cli/download_source_test.go
+++ b/cli/download_source_test.go
@@ -103,7 +103,7 @@ func TestDownloadTerraformSourceIfNecessaryLocalDirToAlreadyDownloadedDir(t *tes
 
 	copyFolder(t, "../test/fixture-download-source/hello-world-2", downloadDir)
 
-	testDownloadTerraformSourceIfNecessary(t, canonicalUrl, downloadDir, false, "# Hello, World", true)
+	testDownloadTerraformSourceIfNecessary(t, canonicalUrl, downloadDir, false, "# Hello, World", false)
 }
 
 func TestDownloadTerraformSourceIfNecessaryRemoteUrlToEmptyDir(t *testing.T) {

--- a/test/fixture-download/init-on-source-change/terragrunt.hcl
+++ b/test/fixture-download/init-on-source-change/terragrunt.hcl
@@ -1,0 +1,4 @@
+terraform {
+  // v0.35.1 v0.35.2
+  source = "github.com/gruntwork-io/terragrunt.git//test/fixture-dirs?ref=__TAG_VALUE__"
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -137,7 +137,7 @@ const (
 	TERRAFORM_STATE_BACKUP                                  = "terraform.tfstate.backup"
 	TERRAGRUNT_CACHE                                        = ".terragrunt-cache"
 
-	qaMyAppRelPath = "qa/my-app"
+	qaMyAppRelPath  = "qa/my-app"
 	fixtureDownload = "fixture-download"
 )
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4129,7 +4129,7 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	errout := string(stderr.Bytes())
 	assert.Equal(t, 1, strings.Count(errout, "Terraform has been successfully initialized!"))
 
-	updatedHcl = strings.Replace(contents, "__TAG_VALUE__", "v0.35.2 ", -1)
+	updatedHcl = strings.Replace(contents, "__TAG_VALUE__", "v0.35.2", -1)
 	require.NoError(t, ioutil.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
 
 	stdout = bytes.Buffer{}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4469,6 +4469,7 @@ func TestNoMultipleInitsWithoutSourceChange(t *testing.T) {
 	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
 	require.NoError(t, err)
 	// no initialization expected for second plan run
+	// https://github.com/gruntwork-io/terragrunt/issues/1921
 	errout = string(stderr.Bytes())
 	assert.Equal(t, 0, strings.Count(errout, "Terraform has been successfully initialized!"))
 }


### PR DESCRIPTION
Added check for source code version before creating file for auto-init, if terraform source is changed - create auto init file

Example runs:
Local dependency(https://github.com/Ic3w0lf/terragrunt-test/tree/main/auto-init-issue/accounts/prod/vpc):
```
$ terragrunt plan
Initializing the backend...

Initializing provider plugins...
- Reusing previous version of hashicorp/local from the dependency lock file
- Installing hashicorp/local v2.1.0...
- Installed hashicorp/local v2.1.0 (signed by HashiCorp)

Terraform has been successfully initialized!
...

$ terragrunt plan
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

```

Changing terraform source path(https://github.com/denis256/terragrunt-tests/tree/master/terragrunt-init)
```
$ terragrunt plan
Initializing the backend...

Initializing provider plugins...
- Reusing previous version of hashicorp/local from the dependency lock file
- Using previously-installed hashicorp/local v2.1.0

Terraform has been successfully initialized!
...
$ terragrunt plan
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
```
Change terraform source:
```
$ terragrunt plan
Initializing the backend...

Initializing provider plugins...
- Reusing previous version of hashicorp/local from the dependency lock file
- Using previously-installed hashicorp/local v2.1.0

Terraform has been successfully initialized!

$ terragrunt plan
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

```



Fixes: https://github.com/gruntwork-io/terragrunt/issues/1921