### PR TITLE
#1944 Updated logic to resolve full path on includes

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -255,7 +255,13 @@ func flagModulesThatDontInclude(modules []*TerraformModule, terragruntOptions *o
 		// as excluded, and if it includes any path in the set, we set the exclude flag back to false.
 		module.FlagExcluded = true
 		for _, includeConfig := range module.Config.ProcessedIncludes {
-			if util.ListContainsElement(modulesThatIncludeCanonicalPath, includeConfig.Path) {
+			// resolve include config to canonical path to compare with modulesThatIncludeCanonicalPath
+			// https://github.com/gruntwork-io/terragrunt/issues/1944
+			canonicalPath, err := util.CanonicalPath(includeConfig.Path, module.Path)
+			if err != nil {
+				return nil, err
+			}
+			if util.ListContainsElement(modulesThatIncludeCanonicalPath, canonicalPath) {
 				module.FlagExcluded = false
 			}
 		}

--- a/test/fixture-include-parent/app/main.tf
+++ b/test/fixture-include-parent/app/main.tf
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixture-include-parent/app/terragrunt.hcl
+++ b/test/fixture-include-parent/app/terragrunt.hcl
@@ -1,0 +1,3 @@
+include "parent" {
+  path = "../parent.hcl"
+}

--- a/test/fixture-include-parent/parent.hcl
+++ b/test/fixture-include-parent/parent.hcl
@@ -1,0 +1,3 @@
+locals {
+  parent_var = run_cmd("echo", "parent_hcl_file")
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -117,6 +117,7 @@ const (
 	TEST_FIXTURE_PARALLELISM                                = "fixture-parallelism"
 	TEST_FIXTURE_SOPS                                       = "fixture-sops"
 	TEST_FIXTURE_DESTROY_WARNING                            = "fixture-destroy-warning"
+	TEST_FIXTURE_INCLUDE_PARENT                             = "fixture-include-parent"
 	TERRAFORM_BINARY                                        = "terraform"
 	TERRAFORM_FOLDER                                        = ".terraform"
 	TERRAFORM_STATE                                         = "terraform.tfstate"
@@ -3177,6 +3178,21 @@ func TestTerragruntValidateAllWithVersionChecks(t *testing.T) {
 	logBufferContentsLineByLine(t, stdout, "stdout")
 	logBufferContentsLineByLine(t, stderr, "stderr")
 	require.NoError(t, err)
+}
+
+func TestTerragruntIncludeParentHclFile(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_INCLUDE_PARENT)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-modules-that-include parent.hcl --terragrunt-non-interactive --terragrunt-working-dir %s", tmpEnvPath), &stdout, &stderr)
+	require.NoError(t, err)
+
+	out := stderr.String()
+	assert.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
 }
 
 func TestTerragruntVersionConstraints(t *testing.T) {


### PR DESCRIPTION
Updated module exclusion to first resolve path based on the module path, without this change, includes like bellow are ignored

```
app/terragrunt.hcl:

  include "incl" {
      path = "../parent.hcl"
  }

parent.hcl

locals {
    overwrite_var = run_cmd("echo", "parent hcl")
}

```

Fixes: https://github.com/gruntwork-io/terragrunt/issues/1944