### PR TITLE
add repo path functions

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -122,6 +122,8 @@ func CreateTerragruntEvalContext(
 		"run_cmd":                                      wrapStringSliceToStringAsFuncImpl(runCommand, extensions.TrackInclude, terragruntOptions),
 		"read_terragrunt_config":                       readTerragruntConfigAsFuncImpl(terragruntOptions),
 		"get_platform":                                 wrapVoidToStringAsFuncImpl(getPlatform, extensions.TrackInclude, terragruntOptions),
+		"get_path_from_repo_root":                      wrapVoidToStringAsFuncImpl(getPathFromRepoRoot, extensions.TrackInclude, terragruntOptions),
+		"get_path_to_repo_root":                        wrapVoidToStringAsFuncImpl(getPathToRepoRoot, extensions.TrackInclude, terragruntOptions),
 		"get_terragrunt_dir":                           wrapVoidToStringAsFuncImpl(getTerragruntDir, extensions.TrackInclude, terragruntOptions),
 		"get_original_terragrunt_dir":                  wrapVoidToStringAsFuncImpl(getOriginalTerragruntDir, extensions.TrackInclude, terragruntOptions),
 		"get_terraform_command":                        wrapVoidToStringAsFuncImpl(getTerraformCommand, extensions.TrackInclude, terragruntOptions),
@@ -171,6 +173,37 @@ func CreateTerragruntEvalContext(
 // Return the OS platform
 func getPlatform(trackInclude *TrackInclude, terragruntOptions *options.TerragruntOptions) (string, error) {
 	return runtime.GOOS, nil
+}
+
+// Return the path from the repository root
+func getPathFromRepoRoot(trackInclude *TrackInclude, terragruntOptions *options.TerragruntOptions) (string, error) {
+	repoAbsPath, err := shell.GitTopLevelDir(terragruntOptions, terragruntOptions.WorkingDir)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	pathFromRoot := strings.TrimSpace(strings.Replace(
+		strings.TrimSpace(terragruntOptions.WorkingDir),
+		strings.TrimSpace(string(repoAbsPath))+"/",
+		"", -1,
+	))
+
+	return pathFromRoot, nil
+}
+
+// Return the path to the repository root
+func getPathToRepoRoot(trackInclude *TrackInclude, terragruntOptions *options.TerragruntOptions) (string, error) {
+	repoAbsPath, err := shell.GitTopLevelDir(terragruntOptions, terragruntOptions.WorkingDir)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	repoRootPathAbs, err := filepath.Rel(terragruntOptions.WorkingDir, string(repoAbsPath))
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	return strings.TrimSpace(repoRootPathAbs) + "/", nil
 }
 
 // Return the directory where the Terragrunt configuration file lives

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -182,13 +182,7 @@ func getPathFromRepoRoot(trackInclude *TrackInclude, terragruntOptions *options.
 		return "", errors.WithStackTrace(err)
 	}
 
-	pathFromRoot := strings.TrimSpace(strings.Replace(
-		strings.TrimSpace(terragruntOptions.WorkingDir),
-		strings.TrimSpace(string(repoAbsPath))+"/",
-		"", -1,
-	))
-
-	return pathFromRoot, nil
+	return filepath.Rel(repoAbsPath, terragruntOptions.WorkingDir)
 }
 
 // Return the path to the repository root

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -24,6 +24,10 @@ Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, ju
 
   - [get\_platform()](#get_platform)
 
+  - [get\_path\_from\_repo\_root()](#get_path_from_repo_root)
+
+  - [get\_path\_to\_repo\_root()](#get_path_to_repo_root)
+
   - [get\_terragrunt\_dir()](#get_terragrunt_dir)
 
   - [get\_parent\_terragrunt\_dir()](#get_parent_terragrunt_dir)
@@ -317,6 +321,35 @@ darwin
 freebsd
 linux
 windows
+```
+
+## get\_path\_from\_repo\_root
+
+`get_path_from_repo_root()` returns the path from the current directory to the root of the repository:
+
+```hcl
+remote_state {
+  backend = "s3"
+
+  config = {
+    bucket         = "terraform"
+    dynamodb_table = "terraform"
+    encrypt        = true
+    key            = "${get_path_from_repo_root()}/terraform.tfstate"
+    session_name   = "terraform"
+    region         = "us-east-1"
+  }
+}
+```
+
+## get\_path\_to\_repo\_root
+
+`get_path_to_repo_root()` returns the relative path to the root of the git repository:
+
+```hcl
+terraform {
+  source = "${get_path_to_repo_root()}//modules/example"
+}
 ```
 
 ## get\_terragrunt\_dir

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -342,6 +342,9 @@ remote_state {
 }
 ```
 
+This function will error if the file is not located in a git repository.
+
+
 ## get\_path\_to\_repo\_root
 
 `get_path_to_repo_root()` returns the relative path to the root of the git repository:
@@ -351,6 +354,8 @@ terraform {
   source = "${get_path_to_repo_root()}//modules/example"
 }
 ```
+
+This function will error if the file is not located in a git repository.
 
 ## get\_terragrunt\_dir
 

--- a/test/fixture-get-path-from-repo-root/main.tf
+++ b/test/fixture-get-path-from-repo-root/main.tf
@@ -1,0 +1,7 @@
+variable "path_from_root" {
+  type = string
+}
+
+output "path_from_root" {
+  value = var.path_from_root
+}

--- a/test/fixture-get-path-from-repo-root/terragrunt.hcl
+++ b/test/fixture-get-path-from-repo-root/terragrunt.hcl
@@ -1,0 +1,3 @@
+inputs = {
+  path_from_root  = get_path_from_repo_root()
+}

--- a/test/fixture-get-path-to-repo-root/main.tf
+++ b/test/fixture-get-path-to-repo-root/main.tf
@@ -1,0 +1,7 @@
+variable "path_to_root" {
+  type = string
+}
+
+output "path_to_root" {
+  value = var.path_to_root
+}

--- a/test/fixture-get-path-to-repo-root/terragrunt.hcl
+++ b/test/fixture-get-path-to-repo-root/terragrunt.hcl
@@ -1,0 +1,3 @@
+inputs = {
+  path_to_root = get_path_to_repo_root()
+}


### PR DESCRIPTION
This PR adds two functions, `get_path_to_repo_root()` and `get_path_from_repo_root()`, loosely linked to https://github.com/gruntwork-io/terragrunt/issues/305

Tests:
```shell
terragrunt/test on  add-repo-path-functions via 🐹 v1.17
❯ go test -v -run TestGetPathToRepoRoot
=== RUN   TestGetPathToRepoRoot
=== PAUSE TestGetPathToRepoRoot
=== CONT  TestGetPathToRepoRoot
    integration_test.go:3467: Copying fixture-get-path-to-repo-root to /var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test1054949920
runTerragruntVersionCommand after split
[terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir /private/var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test1054949920/fixture-get-path-to-repo-root]
WARN[0000] 'apply-all' is deprecated. Running 'terragrunt run-all apply' instead. Please update your workflows to use 'terragrunt run-all apply', as 'apply-all' may be removed in the future!
INFO[0000] The stack at /private/var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test1054949920/fixture-get-path-to-repo-root will be processed in the following order for command apply:
Group 1
- Module /private/var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test1054949920/fixture-get-path-to-repo-root
  prefix=[/private/var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test1054949920/fixture-get-path-to-repo-root]

Initializing the backend...

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

Changes to Outputs:
  + path_to_root = "../../"

You can apply this plan to save these new output values to the Terraform
state, without changing any real infrastructure.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

path_to_root = "../../"
runTerragruntVersionCommand after split
[terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir /private/var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test1054949920/fixture-get-path-to-repo-root]
--- PASS: TestGetPathToRepoRoot (15.09s)
PASS
ok  	github.com/gruntwork-io/terragrunt/test	16.128s
terragrunt/test on  add-repo-path-functions via 🐹 v1.17 took 22s
❯ go test -v -run TestGetPathFromRepoRoot
=== RUN   TestGetPathFromRepoRoot
=== PAUSE TestGetPathFromRepoRoot
=== CONT  TestGetPathFromRepoRoot
    integration_test.go:3467: Copying fixture-get-path-from-repo-root to /var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test2705825776
runTerragruntVersionCommand after split
[terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir /private/var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test2705825776/fixture-get-path-from-repo-root]
WARN[0000] 'apply-all' is deprecated. Running 'terragrunt run-all apply' instead. Please update your workflows to use 'terragrunt run-all apply', as 'apply-all' may be removed in the future!
INFO[0000] The stack at /private/var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test2705825776/fixture-get-path-from-repo-root will be processed in the following order for command apply:
Group 1
- Module /private/var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test2705825776/fixture-get-path-from-repo-root
  prefix=[/private/var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test2705825776/fixture-get-path-from-repo-root]

Initializing the backend...

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

Changes to Outputs:
  + path_from_root = "terragrunt-test2705825776/fixture-get-path-from-repo-root"

You can apply this plan to save these new output values to the Terraform
state, without changing any real infrastructure.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

path_from_root = "terragrunt-test2705825776/fixture-get-path-from-repo-root"
runTerragruntVersionCommand after split
[terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir /private/var/folders/mg/dlfyyxbj4s32mwd8599bh3200000gq/T/terragrunt-test2705825776/fixture-get-path-from-repo-root]
--- PASS: TestGetPathFromRepoRoot (12.21s)
PASS
ok  	github.com/gruntwork-io/terragrunt/test	12.826s
```