### PR TITLE
Canonical path usage for dependencies exclusion

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -275,7 +275,11 @@ func flagModulesThatDontInclude(modules []*TerraformModule, terragruntOptions *o
 
 			dependency.FlagExcluded = true
 			for _, includeConfig := range dependency.Config.ProcessedIncludes {
-				if util.ListContainsElement(modulesThatIncludeCanonicalPath, includeConfig.Path) {
+				canonicalPath, err := util.CanonicalPath(includeConfig.Path, module.Path)
+				if err != nil {
+					return nil, err
+				}
+				if util.ListContainsElement(modulesThatIncludeCanonicalPath, canonicalPath) {
 					dependency.FlagExcluded = false
 				}
 			}

--- a/test/fixture-include-parent/common.hcl
+++ b/test/fixture-include-parent/common.hcl
@@ -1,0 +1,3 @@
+locals {
+  common = run_cmd("echo", "common_hcl")
+}

--- a/test/fixture-include-parent/dependency/terragrunt.hcl
+++ b/test/fixture-include-parent/dependency/terragrunt.hcl
@@ -1,0 +1,7 @@
+locals {
+  parent_var = run_cmd("echo", "dependency_hcl")
+}
+
+include "common" {
+  path = "../common.hcl"
+}

--- a/test/fixture-include-parent/parent.hcl
+++ b/test/fixture-include-parent/parent.hcl
@@ -1,3 +1,12 @@
 locals {
   parent_var = run_cmd("echo", "parent_hcl_file")
 }
+
+dependency "dependency" {
+  config_path = "../dependency"
+
+  mock_outputs = {
+    mock_key = "mock_value"
+  }
+
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3184,15 +3184,18 @@ func TestTerragruntIncludeParentHclFile(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_INCLUDE_PARENT)
+	tmpEnvPath = path.Join(tmpEnvPath, TEST_FIXTURE_INCLUDE_PARENT)
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-modules-that-include parent.hcl --terragrunt-non-interactive --terragrunt-working-dir %s", tmpEnvPath), &stdout, &stderr)
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-modules-that-include parent.hcl --terragrunt-modules-that-include common.hcl --terragrunt-non-interactive --terragrunt-working-dir %s", tmpEnvPath), &stdout, &stderr)
 	require.NoError(t, err)
 
 	out := stderr.String()
 	assert.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
+	assert.Equal(t, 1, strings.Count(out, "dependency_hcl"))
+	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
 }
 
 func TestTerragruntVersionConstraints(t *testing.T) {


### PR DESCRIPTION
Updated `flagModulesThatDontInclude` to get canonical path of dependencies and decide if it should be flagged as excluded

Closes: https://github.com/gruntwork-io/terragrunt/issues/1962