### PR TITLE
Add TF 1.1.x to version compatibility table

### DIFF
--- a/docs/_docs/01_getting-started/supported-terraform-versions.md
+++ b/docs/_docs/01_getting-started/supported-terraform-versions.md
@@ -15,6 +15,7 @@ The officially supported versions are:
 
 | Terraform Version | Terragrunt Version                                                                                                                                    |
 |-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.x             | >= [0.36.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.36.0)                                                                          |
 | 1.0.x             | >= [0.31.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.31.0)                                                                          |
 | 0.15.x            | >= [0.29.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.29.0)                                                                          |
 | 0.14.x            | >= [0.27.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.27.0)                                                                          |


### PR DESCRIPTION
Forgot to include this in https://github.com/gruntwork-io/terragrunt/pull/1990