### PR TITLE
Update cli-options.md to mention silent auto-approve on run-all.

### DIFF
--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -85,6 +85,8 @@ deployed them, then `plan-all` will fail as it will not be possible to resolve t
 `terraform_remote_state` data sources! Please [see here for more
 information](https://github.com/gruntwork-io/terragrunt/issues/720#issuecomment-497888756).
 
+**[NOTE]** Using `run-all` with `apply` or `destroy` silently adds the `-auto-approve` flag to the command line arguments passed to Terraform due to issues with shared `stdin` making individual approvals impossible. Please [see here for more information](https://github.com/gruntwork-io/terragrunt/issues/386#issuecomment-358306268)
+
 
 
 
@@ -133,6 +135,9 @@ This will recursively search the current working directory for any folders that 
 [`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
 [`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks.
 
+**[NOTE]** Using `apply-all` silently adds the `-auto-approve` flag to the command line arguments passed to Terraform due to issues with shared `stdin` making individual approvals impossible. Please [see here for more information](https://github.com/gruntwork-io/terragrunt/issues/386#issuecomment-358306268)
+
+
 ### output-all (DEPRECATED: use run-all)
 
 **DEPRECATED: Use `run-all output` instead.**
@@ -176,6 +181,9 @@ This will recursively search the current working directory for any folders that 
 `destroy` in each one, concurrently, while respecting ordering defined via
 [`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
 [`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks.
+
+**[NOTE]** Using `destroy-all` silently adds the `-auto-approve` flag to the command line arguments passed to Terraform due to issues with shared `stdin` making individual approvals impossible. Please [see here for more information](https://github.com/gruntwork-io/terragrunt/issues/386#issuecomment-358306268)
+
 
 ### validate-all (DEPRECATED: use run-all)
 

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -85,7 +85,9 @@ deployed them, then `plan-all` will fail as it will not be possible to resolve t
 `terraform_remote_state` data sources! Please [see here for more
 information](https://github.com/gruntwork-io/terragrunt/issues/720#issuecomment-497888756).
 
-**[NOTE]** Using `run-all` with `apply` or `destroy` silently adds the `-auto-approve` flag to the command line arguments passed to Terraform due to issues with shared `stdin` making individual approvals impossible. Please [see here for more information](https://github.com/gruntwork-io/terragrunt/issues/386#issuecomment-358306268)
+**[NOTE]** Using `run-all` with `apply` or `destroy` silently adds the `-auto-approve` flag to the command line
+arguments passed to Terraform due to issues with shared `stdin` making individual approvals impossible. Please
+[see here for more information](https://github.com/gruntwork-io/terragrunt/issues/386#issuecomment-358306268)
 
 
 
@@ -135,7 +137,9 @@ This will recursively search the current working directory for any folders that 
 [`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
 [`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks.
 
-**[NOTE]** Using `apply-all` silently adds the `-auto-approve` flag to the command line arguments passed to Terraform due to issues with shared `stdin` making individual approvals impossible. Please [see here for more information](https://github.com/gruntwork-io/terragrunt/issues/386#issuecomment-358306268)
+**[NOTE]** Using `apply-all` silently adds the `-auto-approve` flag to the command line arguments passed to Terraform
+due to issues with shared `stdin` making individual approvals impossible. Please [see here for more
+information](https://github.com/gruntwork-io/terragrunt/issues/386#issuecomment-358306268)
 
 
 ### output-all (DEPRECATED: use run-all)
@@ -182,7 +186,9 @@ This will recursively search the current working directory for any folders that 
 [`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
 [`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks.
 
-**[NOTE]** Using `destroy-all` silently adds the `-auto-approve` flag to the command line arguments passed to Terraform due to issues with shared `stdin` making individual approvals impossible. Please [see here for more information](https://github.com/gruntwork-io/terragrunt/issues/386#issuecomment-358306268)
+**[NOTE]** Using `destroy-all` silently adds the `-auto-approve` flag to the command line arguments passed to Terraform
+due to issues with shared `stdin` making individual approvals impossible. Please [see here for more
+information](https://github.com/gruntwork-io/terragrunt/issues/386#issuecomment-358306268)
 
 
 ### validate-all (DEPRECATED: use run-all)


### PR DESCRIPTION
Added a note explaining that due to the shared `stdin` and `stdout` meaning you can't approve any given individual apply, the use of `run-all apply` or `apply-all` will silently add `-auto-approve`.

This appears to have been true for several years, but I saw no mention of it on this documentation page or anywhere outside of finding the original GitHub issue, so when I changed a workflow from `run-all apply` to just `apply` today it broke in a non-obvious way that I couldn't diagnose with the documentation...