### PR TITLE
Implement a mechanism for providing macro placeholders and substitutions

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -176,6 +176,10 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	if err != nil {
 		return nil, err
 	}
+
+	terragruntSubstituteMacrosEnvvar := "TERRAGRUNT_SUBSTITUTE_MACROS"
+	substituteMacros := parseBooleanArg(args, optTerragruntSubstituteMacros, os.Getenv(terragruntSubstituteMacrosEnvvar) == "true" || os.Getenv(terragruntSubstituteMacrosEnvvar) == "1")
+
 	// We don't need to check for nil, because parseIAMRoleOptions always returns a valid pointer when no error is
 	// returned.
 	opts.OriginalIAMRoleOptions = *iamRoleOpts
@@ -223,6 +227,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.FetchDependencyOutputFromState = parseBooleanArg(args, optTerragruntFetchDependencyOutputFromState, os.Getenv("TERRAGRUNT_FETCH_DEPENDENCY_OUTPUT_FROM_STATE") == "true")
 	opts.UsePartialParseConfigCache = parseBooleanArg(args, optTerragruntUsePartialParseConfigCache, os.Getenv("TERRAGRUNT_USE_PARTIAL_PARSE_CONFIG_CACHE") == "true")
 	opts.RenderJsonWithMetadata = parseBooleanArg(args, optTerragruntOutputWithMetadata, false)
+	opts.SubstituteMacros = substituteMacros
 
 	opts.JSONOut, err = parseStringArg(args, optTerragruntJSONOut, "")
 	if err != nil {

--- a/cli/cli_app_test.go
+++ b/cli/cli_app_test.go
@@ -307,3 +307,23 @@ func BenchmarkRunGraphDependencies(b *testing.B) {
 		})
 	}
 }
+
+func TestTerragruntSubstituteMacros(t *testing.T) {
+	t.Parallel()
+
+	tgOptions, err := options.NewTerragruntOptionsForTest("/not/a/real/path.hcl")
+	require.NoError(t, err)
+	tgOptions.SubstituteMacros = true
+	tgOptions.TerraformCliArgs = []string{"plan", "-out=::TERRAGRUNT_DIR::/test.plan"}
+	err = performMacroSubstitutions(tgOptions)
+	require.NoError(t, err)
+	assert.EqualValues(t, tgOptions.TerraformCliArgs, []string{"plan", "-out=/not/a/real/test.plan"})
+
+	tgOptions, err = options.NewTerragruntOptionsForTest("/still/not/a/real/path.hcl")
+	require.NoError(t, err)
+	tgOptions.SubstituteMacros = false
+	tgOptions.TerraformCliArgs = []string{"plan", "-out=::TERRAGRUNT_DIR::/test.plan"}
+	err = performMacroSubstitutions(tgOptions)
+	require.NoError(t, err)
+	assert.EqualValues(t, tgOptions.TerraformCliArgs, []string{"plan", "-out=::TERRAGRUNT_DIR::/test.plan"})
+}

--- a/cli/cli_app_test.go
+++ b/cli/cli_app_test.go
@@ -315,15 +315,13 @@ func TestTerragruntSubstituteMacros(t *testing.T) {
 	require.NoError(t, err)
 	tgOptions.SubstituteMacros = true
 	tgOptions.TerraformCliArgs = []string{"plan", "-out=::TERRAGRUNT_DIR::/test.plan"}
-	err = performMacroSubstitutions(tgOptions)
-	require.NoError(t, err)
+	performMacroSubstitutions(tgOptions)
 	assert.EqualValues(t, tgOptions.TerraformCliArgs, []string{"plan", "-out=/not/a/real/test.plan"})
 
 	tgOptions, err = options.NewTerragruntOptionsForTest("/still/not/a/real/path.hcl")
 	require.NoError(t, err)
 	tgOptions.SubstituteMacros = false
 	tgOptions.TerraformCliArgs = []string{"plan", "-out=::TERRAGRUNT_DIR::/test.plan"}
-	err = performMacroSubstitutions(tgOptions)
-	require.NoError(t, err)
+	performMacroSubstitutions(tgOptions)
 	assert.EqualValues(t, tgOptions.TerraformCliArgs, []string{"plan", "-out=::TERRAGRUNT_DIR::/test.plan"})
 }

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -501,6 +501,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
 - [terragrunt-modules-that-include](#terragrunt-modules-that-include)
 - [terragrunt-fetch-dependency-output-from-state](#terragrunt-fetch-dependency-output-from-state)
 - [terragrunt-use-partial-parse-config-cache](#terragrunt-use-partial-parse-config-cache)
+- [terragrunt-substitute-macros](#terragrunt-substitute-macros)
 
 ### terragrunt-config
 
@@ -912,3 +913,24 @@ Currently only AWS S3 backend is supported.
 
 This flag can be used to drastically decrease time required for parsing Terragrunt files. The effect will only show if a lot of similar includes are expected such as the root terragrunt.hcl include.
 NOTE: This is an experimental feature, use with caution.
+
+### terragrunt-substitute-macros
+
+**CLI Arg**: `terragrunt-substitute-macros`
+**Environment Variable**: `TERRAGRUNT_SUBSTITUTE_MACROS`
+
+When passed in, Terragrunt will replace particular macro placeholders in the Terraform command line
+with a value specific to that instantiation of Terraform.
+
+The following placeholders are currently recognized:
+
+* `::TERRAGRUNT_DIR::`: the directory in which the Terragrunt file resides
+
+The substitution operates with `run-all` as expected. If you run the command
+
+```
+terragrunt run-all --terragrunt-substitute-macros plan -out=::TERRAGRUNT_DIR::/plan.cache
+```
+
+in a directory which contains multiple subdirectories with `terragrunt.hcl` files, Terraform would write
+each `plan.cache` to the same directory as the associated `terragrunt.hcl` file.

--- a/options/options.go
+++ b/options/options.go
@@ -198,6 +198,9 @@ type TerragruntOptions struct {
 
 	// Include fields metadata in render-json
 	RenderJsonWithMetadata bool
+
+	// True if Terragrunt should replace all instances of macro placeholders
+	SubstituteMacros bool
 }
 
 // IAMOptions represents options that are used by Terragrunt to assume an IAM role.
@@ -373,6 +376,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		CheckDependentModules:          terragruntOptions.CheckDependentModules,
 		FetchDependencyOutputFromState: terragruntOptions.FetchDependencyOutputFromState,
 		UsePartialParseConfigCache:     terragruntOptions.UsePartialParseConfigCache,
+		SubstituteMacros:               terragruntOptions.SubstituteMacros,
 	}
 }
 


### PR DESCRIPTION
This implements a mechanism to allow Terragrunt to recognize and replace
specific macro placeholders in the Terraform command line with a
value specific to that instantiation of Terraform. The only implemented
macro in this commit is `::TERRAGRUNT_DIR::`, which is replaced with
the directory of the Terragrunt file.

The use case here is to allow Terragrunt to interact smoothly with our GitLab CI
processes and artifact archival by being able to control exactly where our generated
plans are created, instead of them being created deep inside `.terragrunt-cache`
somewhere.