### PR TITLE
CI Build fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
             gpg --import --no-tty --batch --yes ./test/fixture-sops/test_pgp_key.asc
             mkdir -p logs
             run-go-tests --packages "$(go list ./... | grep /test | tr '\n' ' ')" | tee logs/integration.log
-          no_output_timeout: 30m
+          no_output_timeout: 11m
       - run:
           command: terratest_log_parser --testlog logs/integration.log --outputdir logs
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
             gpg --import --no-tty --batch --yes ./test/fixture-sops/test_pgp_key.asc
             mkdir -p logs
             run-go-tests --packages "$(go list ./... | grep /test | tr '\n' ' ')" | tee logs/integration.log
+          no_output_timeout: 30m
       - run:
           command: terratest_log_parser --testlog logs/integration.log --outputdir logs
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
             gpg --import --no-tty --batch --yes ./test/fixture-sops/test_pgp_key.asc
             mkdir -p logs
             run-go-tests --packages "$(go list ./... | grep /test | tr '\n' ' ')" | tee logs/integration.log
-          no_output_timeout: 11m
+          no_output_timeout: 30m
       - run:
           command: terratest_log_parser --testlog logs/integration.log --outputdir logs
           when: always


### PR DESCRIPTION
Fix for Too long with no output (exceeded 10m0s): context deadline exceeded in circleci

Fix for errors like:
https://app.circleci.com/pipelines/github/gruntwork-io/terragrunt/1248/workflows/c75fd373-b1c2-4074-8a49-81b3954dbf59/jobs/8399

https://app.circleci.com/pipelines/github/gruntwork-io/terragrunt/1246/workflows/952023d5-f81c-4870-8fd1-df981720d7de/jobs/8393