### PR TITLE
Handle relative paths correctly when fetching tfr

### DIFF
--- a/internal/tfr/getter.go
+++ b/internal/tfr/getter.go
@@ -125,7 +125,7 @@ func (tfrGetter *TerraformRegistryGetter) Get(dstPath string, srcURL *url.URL) e
 		return err
 	}
 
-	downloadURL, err := getDownloadURLFromHeader(ctx, *moduleURL, terraformGet)
+	downloadURL, err := getDownloadURLFromHeader(*moduleURL, terraformGet)
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func getTerraformGetHeader(ctx context.Context, url url.URL) (string, error) {
 
 // getDownloadURLFromHeader checks if the content of the X-Terraform-GET header contains the base url
 // and prepends it if not
-func getDownloadURLFromHeader(ctx context.Context, moduleURL url.URL, terraformGet string) (string, error) {
+func getDownloadURLFromHeader(moduleURL url.URL, terraformGet string) (string, error) {
 	// If url from X-Terrafrom-Get Header seems to be a relative url,
 	// append scheme and host from url used for getting the download url
 	// because third-party registry implementations may not "know" their own absolute URLs if

--- a/internal/tfr/getter.go
+++ b/internal/tfr/getter.go
@@ -242,13 +242,18 @@ func getTerraformGetHeader(ctx context.Context, url url.URL) (string, error) {
 
 // getDownloadURLFromHeader checks if the content of the X-Terraform-GET header contains the base url
 // and prepends it if not
-func getDownloadURLFromHeader(ctx context.Context, url url.URL, terraformGet string) (string, error) {
+func getDownloadURLFromHeader(ctx context.Context, moduleURL url.URL, terraformGet string) (string, error) {
 	// If url from X-Terrafrom-Get Header seems to be a relative url,
 	// append scheme and host from url used for getting the download url
 	// because third-party registry implementations may not "know" their own absolute URLs if
 	// e.g. they are running behind a reverse proxy frontend, or such.
 	if strings.HasPrefix(terraformGet, "/") || strings.HasPrefix(terraformGet, "./") || strings.HasPrefix(terraformGet, "../") {
-		terraformGet = fmt.Sprintf("%v://%v%v", url.Scheme, url.Host, terraformGet)
+		relativePathURL, err := url.Parse(terraformGet)
+		if err != nil {
+			return "", errors.WithStackTrace(err)
+		}
+		terraformGetURL := moduleURL.ResolveReference(relativePathURL)
+		terraformGet = terraformGetURL.String()
 	}
 	return terraformGet, nil
 }

--- a/internal/tfr/getter_test.go
+++ b/internal/tfr/getter_test.go
@@ -34,17 +34,7 @@ func TestGetTerraformHeader(t *testing.T) {
 	assert.Contains(t, terraformGetHeader, "github.com/terraform-aws-modules/terraform-aws-vpc")
 }
 
-func TestGetDownloadURLFromHeaderWithPrefixedURL(t *testing.T) {
-	t.Parallel()
-
-	testTerraformGet := "github.com/terraform-aws-modules/terraform-aws-vpc"
-
-	downloadURL, err := getDownloadURLFromHeader(context.Background(), url.URL{}, testTerraformGet)
-	require.NoError(t, err)
-	assert.Equal(t, "github.com/terraform-aws-modules/terraform-aws-vpc", downloadURL)
-}
-
-func TestGetDownloadURLFromHeaderWithoutPrefixedURL(t *testing.T) {
+func TestGetDownloadURLFromHeader(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -61,6 +51,12 @@ func TestGetDownloadURLFromHeaderWithoutPrefixedURL(t *testing.T) {
 			},
 			terraformGet:   "/terraform-aws-modules/terraform-aws-vpc",
 			expectedResult: "https://registry.terraform.io/terraform-aws-modules/terraform-aws-vpc",
+		},
+		{
+			name:           "PrefixedURL",
+			moduleURL:      url.URL{},
+			terraformGet:   "github.com/terraform-aws-modules/terraform-aws-vpc",
+			expectedResult: "github.com/terraform-aws-modules/terraform-aws-vpc",
 		},
 		{
 			name: "PathWithRoot",
@@ -96,7 +92,7 @@ func TestGetDownloadURLFromHeaderWithoutPrefixedURL(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			downloadURL, err := getDownloadURLFromHeader(context.Background(), testCase.moduleURL, testCase.terraformGet)
+			downloadURL, err := getDownloadURLFromHeader(testCase.moduleURL, testCase.terraformGet)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.expectedResult, downloadURL)
 		})


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/terragrunt/issues/2003

This updates the relative path handling to use the same approach that terraform uses internally by relying on the `URL` struct to combine reference paths, instead of manually doing it. 