### PR TITLE
Added caching of  IAM roles parsed from HCL files

### DIFF
--- a/config/cache.go
+++ b/config/cache.go
@@ -4,6 +4,8 @@ import (
 	"crypto/md5"
 	"fmt"
 	"sync"
+
+	"github.com/gruntwork-io/terragrunt/options"
 )
 
 // StringCache - structure to store cached values
@@ -32,6 +34,39 @@ func (cache *StringCache) Get(key string) (string, bool) {
 
 // Put - put value in cache, md5 hash is used as key to have fixed length keys and avoid duplicates
 func (cache *StringCache) Put(key string, value string) {
+	cache.Mutex.Lock()
+	defer cache.Mutex.Unlock()
+	md5Sum := md5.Sum([]byte(key))
+	cacheKey := fmt.Sprintf("%x", md5Sum)
+	cache.Cache[cacheKey] = value
+}
+
+// IAMRoleOptionsCache - cache for IAMRole options
+type IAMRoleOptionsCache struct {
+	Cache map[string]options.IAMRoleOptions
+	Mutex *sync.Mutex
+}
+
+// NewIAMRoleOptionsCache - create new cache for IAM roles
+func NewIAMRoleOptionsCache() *IAMRoleOptionsCache {
+	return &IAMRoleOptionsCache{
+		Cache: map[string]options.IAMRoleOptions{},
+		Mutex: &sync.Mutex{},
+	}
+}
+
+// Get - get cached value, md5 hash is used as key to have fixed length keys and avoid duplicates
+func (cache *IAMRoleOptionsCache) Get(key string) (options.IAMRoleOptions, bool) {
+	cache.Mutex.Lock()
+	defer cache.Mutex.Unlock()
+	md5Sum := md5.Sum([]byte(key))
+	cacheKey := fmt.Sprintf("%x", md5Sum)
+	value, found := cache.Cache[cacheKey]
+	return value, found
+}
+
+// Put - put value in cache, md5 hash is used as key to have fixed length keys and avoid duplicates
+func (cache *IAMRoleOptionsCache) Put(key string, value options.IAMRoleOptions) {
 	cache.Mutex.Lock()
 	defer cache.Mutex.Unlock()
 	md5Sum := md5.Sum([]byte(key))

--- a/config/config.go
+++ b/config/config.go
@@ -706,6 +706,7 @@ var iamRoleCache = NewIAMRoleOptionsCache()
 
 // setIAMRole - extract IAM role details from Terragrunt flags block
 func setIAMRole(configString string, terragruntOptions *options.TerragruntOptions, includeFromChild *IncludeConfig, filename string) error {
+	// as key is considered HCL code and include configuration
 	var key = fmt.Sprintf("%v-%v", configString, includeFromChild)
 	var config, found = iamRoleCache.Get(key)
 	if !found {

--- a/config/config.go
+++ b/config/config.go
@@ -701,16 +701,25 @@ func ParseConfigString(
 	return config, nil
 }
 
+// iamRoleCache - store for cached values of IAM roles
+var iamRoleCache = NewIAMRoleOptionsCache()
+
 // setIAMRole - extract IAM role details from Terragrunt flags block
 func setIAMRole(configString string, terragruntOptions *options.TerragruntOptions, includeFromChild *IncludeConfig, filename string) error {
-	iamConfig, err := PartialParseConfigString(configString, terragruntOptions, includeFromChild, filename, []PartialDecodeSectionType{TerragruntFlags})
-	if err != nil {
-		return err
+	var key = fmt.Sprintf("%v-%v", configString, includeFromChild)
+	var config, found = iamRoleCache.Get(key)
+	if !found {
+		iamConfig, err := PartialParseConfigString(configString, terragruntOptions, includeFromChild, filename, []PartialDecodeSectionType{TerragruntFlags})
+		if err != nil {
+			return err
+		}
+		config = iamConfig.GetIAMRoleOptions()
+		iamRoleCache.Put(key, config)
 	}
 	// We merge the OriginalIAMRoleOptions into the one from the config, because the CLI passed IAMRoleOptions has
 	// precedence.
 	terragruntOptions.IAMRoleOptions = options.MergeIAMRoleOptions(
-		iamConfig.GetIAMRoleOptions(),
+		config,
 		terragruntOptions.OriginalIAMRoleOptions,
 	)
 	return nil


### PR DESCRIPTION
Updated `setIAMRole` to cache IAM role parsed from HCL files by file contents and include configuration

Before this change, `time terragrunt apply` execution:
```
real    0m6.941s
user    0m15.873s
sys     0m0.562s
```

With changes from this PR:
```
real    0m4.103s
user    0m8.019s
sys     0m0.352s
```

Closes:

https://github.com/gruntwork-io/terragrunt/issues/1971