### PR TITLE
Don't copy a file if it's the same source and destination.

### DIFF
--- a/util/file.go
+++ b/util/file.go
@@ -296,6 +296,10 @@ func TerragruntExcludes(path string) bool {
 
 // Copy a file from source to destination
 func CopyFile(source string, destination string) error {
+	if source == destination {
+		return nil
+	}
+
 	contents, err := ioutil.ReadFile(source)
 	if err != nil {
 		return errors.WithStackTrace(err)


### PR DESCRIPTION
Should be safe, as the only effect of reading / writing back to the same file is to update the modified timestamp on the file.

Fixes https://github.com/gruntwork-io/terragrunt/issues/2020, because this file will no longer be modified unless necessary, meaning that multiple processes can read it safely.