### PR TITLE
Add get_repo_root() built-in

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -123,6 +123,7 @@ func CreateTerragruntEvalContext(
 		"run_cmd":                                      wrapStringSliceToStringAsFuncImpl(runCommand, extensions.TrackInclude, terragruntOptions),
 		"read_terragrunt_config":                       readTerragruntConfigAsFuncImpl(terragruntOptions),
 		"get_platform":                                 wrapVoidToStringAsFuncImpl(getPlatform, extensions.TrackInclude, terragruntOptions),
+		"get_repo_root":                                wrapVoidToStringAsFuncImpl(getRepoRoot, extensions.TrackInclude, terragruntOptions),
 		"get_path_from_repo_root":                      wrapVoidToStringAsFuncImpl(getPathFromRepoRoot, extensions.TrackInclude, terragruntOptions),
 		"get_path_to_repo_root":                        wrapVoidToStringAsFuncImpl(getPathToRepoRoot, extensions.TrackInclude, terragruntOptions),
 		"get_terragrunt_dir":                           wrapVoidToStringAsFuncImpl(getTerragruntDir, extensions.TrackInclude, terragruntOptions),
@@ -174,6 +175,11 @@ func CreateTerragruntEvalContext(
 // Return the OS platform
 func getPlatform(trackInclude *TrackInclude, terragruntOptions *options.TerragruntOptions) (string, error) {
 	return runtime.GOOS, nil
+}
+
+// Return the repository root as an absolute path
+func getRepoRoot(trackInclude *TrackInclude, terragruntOptions *options.TerragruntOptions) (string, error) {
+	return shell.GitTopLevelDir(terragruntOptions, terragruntOptions.WorkingDir)
 }
 
 // Return the path from the repository root

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -24,6 +24,8 @@ Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, ju
 
   - [get\_platform()](#get_platform)
 
+  - [get\_repo\_root()](#get_repo_root)
+  -
   - [get\_path\_from\_repo\_root()](#get_path_from_repo_root)
 
   - [get\_path\_to\_repo\_root()](#get_path_to_repo_root)
@@ -323,9 +325,22 @@ linux
 windows
 ```
 
+## get\_repo\_root
+
+`get_repo_root()` returns the absolute path to the root of the Git repository:
+
+```hcl
+inputs {
+  very_important_config = "${get_repo_root()}/config/strawberries.conf"
+}
+```
+
+This function will error if the file is not located in a Git repository.
+
+
 ## get\_path\_from\_repo\_root
 
-`get_path_from_repo_root()` returns the path from the current directory to the root of the repository:
+`get_path_from_repo_root()` returns the path from the current directory to the root of the Git repository:
 
 ```hcl
 remote_state {
@@ -342,12 +357,12 @@ remote_state {
 }
 ```
 
-This function will error if the file is not located in a git repository.
+This function will error if the file is not located in a Git repository.
 
 
 ## get\_path\_to\_repo\_root
 
-`get_path_to_repo_root()` returns the relative path to the root of the git repository:
+`get_path_to_repo_root()` returns the relative path to the root of the Git repository:
 
 ```hcl
 terraform {
@@ -355,7 +370,7 @@ terraform {
 }
 ```
 
-This function will error if the file is not located in a git repository.
+This function will error if the file is not located in a Git repository.
 
 ## get\_terragrunt\_dir
 

--- a/test/fixture-get-repo-root/main.tf
+++ b/test/fixture-get-repo-root/main.tf
@@ -1,0 +1,7 @@
+variable "repo_root" {
+  type = string
+}
+
+output "repo_root" {
+  value = var.repo_root
+}

--- a/test/fixture-get-repo-root/terragrunt.hcl
+++ b/test/fixture-get-repo-root/terragrunt.hcl
@@ -1,0 +1,3 @@
+inputs = {
+  repo_root = get_repo_root()
+}


### PR DESCRIPTION
A common pattern I've found myself repeating across our Terragrunt modules is referring to the repo root instead of boggling my head around relative paths.

For example, in the parent:
```hcl
locals {
  root = run_cmd("--terragrunt-quiet", "git", "rev-parse", "--show-toplevel")
}
```

In the child:
```hcl
include "root" {
  expose = true
  path   = find_in_parent_folders()
}

locals {
  something = "${include.root.locals.root}/some/config.yml"
}
```

While `get_parent_terragrunt_dir()` might be enough if our parent `terragrunt.hcl` is also at the root of the repo, as soon as one wants to nest their Terragrunt configuration inside of an `infra` directory or similar, it won't be enough.

I saw https://github.com/gruntwork-io/terragrunt/pull/1954 was merged in but it was only for relative paths (plus it has a few limitations documented in https://github.com/gruntwork-io/terragrunt/issues/2026). Having a built-in function to get the absolute path equivalent would be a nice to have. The above example would now look like:

In the parent:
```hcl
locals {}
```

In the child:
```hcl
include "root" {
  path   = find_in_parent_folders()
}

locals {
  something = "${get_repo_root()}/some/config.yml"
}
```

Please lemme know if y'all are open to this change! Thanks.