### PR TITLE
Built-in functions list cleanup

### DIFF
--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -25,7 +25,7 @@ Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, ju
   - [get\_platform()](#get_platform)
 
   - [get\_repo\_root()](#get_repo_root)
-  -
+
   - [get\_path\_from\_repo\_root()](#get_path_from_repo_root)
 
   - [get\_path\_to\_repo\_root()](#get_path_to_repo_root)


### PR DESCRIPTION
Removed empty list item in "Built-in functions list cleanup" that break spacing:

![image](https://user-images.githubusercontent.com/10694338/156532616-05e483b8-a810-4ee7-87c0-8c4749ac8677.png)
