### PR TITLE
fix: use correct slashes for repo root functions

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -189,7 +189,12 @@ func getPathFromRepoRoot(trackInclude *TrackInclude, terragruntOptions *options.
 		return "", errors.WithStackTrace(err)
 	}
 
-	return filepath.Rel(repoAbsPath, terragruntOptions.WorkingDir)
+	repoRelPath, err := filepath.Rel(repoAbsPath, terragruntOptions.WorkingDir)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	return filepath.ToSlash(repoRelPath), nil
 }
 
 // Return the path to the repository root
@@ -204,7 +209,7 @@ func getPathToRepoRoot(trackInclude *TrackInclude, terragruntOptions *options.Te
 		return "", errors.WithStackTrace(err)
 	}
 
-	return strings.TrimSpace(repoRootPathAbs) + "/", nil
+	return filepath.ToSlash(strings.TrimSpace(repoRootPathAbs) + "/"), nil
 }
 
 // Return the directory where the Terragrunt configuration file lives


### PR DESCRIPTION
This ensures the functions `get_path_to_repo_root()` and `get_path_from_repo_root()` always return forward slashes. 

Currently on Windows platforms these functions will return back slashes, this can cause issues with multi-platform usage. In my use-case we use `get_path_from_repo_root()` to build the `remote_state` path, and this caused the created S3 files to have the incorrect slashes thereby causing clashes between platforms.

Test outputs:

```
❯ go test -v -run TestGetPathFromRepoRoot
go: downloading github.com/go-sql-driver/mysql v1.5.0
go: downloading github.com/gruntwork-io/gruntwork-cli v0.7.0
go: downloading github.com/pquerna/otp v1.2.1-0.20191009055518-468c2dd2b58d
go: downloading github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc
=== RUN   TestGetPathFromRepoRoot
=== PAUSE TestGetPathFromRepoRoot
=== CONT  TestGetPathFromRepoRoot
    integration_test.go:3726: Copying fixture-get-path-from-repo-root to /var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3230247470
runTerragruntVersionCommand after split
[terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir /private/var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3230247470/fixture-get-path-from-repo-root]
WARN[0000] 'apply-all' is deprecated. Running 'terragrunt run-all apply' instead. Please update your workflows to use 'terragrunt run-all apply', as 'apply-all' may be removed in the future!
INFO[0000] The stack at /private/var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3230247470/fixture-get-path-from-repo-root will be processed in the following order for command apply:
Group 1
- Module /private/var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3230247470/fixture-get-path-from-repo-root
  prefix=[/private/var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3230247470/fixture-get-path-from-repo-root]

Initializing the backend...

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

Changes to Outputs:
  + path_from_root = "terragrunt-test3230247470/fixture-get-path-from-repo-root"

You can apply this plan to save these new output values to the Terraform
state, without changing any real infrastructure.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

path_from_root = "terragrunt-test3230247470/fixture-get-path-from-repo-root"
runTerragruntVersionCommand after split
[terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir /private/var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3230247470/fixture-get-path-from-repo-root]
--- PASS: TestGetPathFromRepoRoot (11.02s)
PASS
ok  	github.com/gruntwork-io/terragrunt/test	11.852s

❯ go test -v -run TestGetPathToRepoRoot
=== RUN   TestGetPathToRepoRoot
=== PAUSE TestGetPathToRepoRoot
=== CONT  TestGetPathToRepoRoot
    integration_test.go:3726: Copying fixture-get-path-to-repo-root to /var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3651881574
runTerragruntVersionCommand after split
[terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir /private/var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3651881574/fixture-get-path-to-repo-root]
WARN[0000] 'apply-all' is deprecated. Running 'terragrunt run-all apply' instead. Please update your workflows to use 'terragrunt run-all apply', as 'apply-all' may be removed in the future!
INFO[0000] The stack at /private/var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3651881574/fixture-get-path-to-repo-root will be processed in the following order for command apply:
Group 1
- Module /private/var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3651881574/fixture-get-path-to-repo-root
  prefix=[/private/var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3651881574/fixture-get-path-to-repo-root]

Initializing the backend...

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
fix: use correct slashes for repo root functions

Changes to Outputs:
  + path_to_root = "../../"

You can apply this plan to save these new output values to the Terraform
state, without changing any real infrastructure.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

path_to_root = "../../"
runTerragruntVersionCommand after split
[terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir /private/var/folders/y6/33bzrkt12qz4jw_n07mfsdyc0000gn/T/terragrunt-test3651881574/fixture-get-path-to-repo-root]
--- PASS: TestGetPathToRepoRoot (10.02s)
PASS
ok  	github.com/gruntwork-io/terragrunt/test	10.411s 
```