### PR TITLE
Update inputs.md typo

### DIFF
--- a/docs/_docs/02_features/inputs.md
+++ b/docs/_docs/02_features/inputs.md
@@ -35,7 +35,7 @@ Whenever you run a Terragrunt command, Terragrunt will set any inputs you pass i
     TF_VAR_tags='{"Name":"example-app"}' \
     terraform apply
 
-Note that Terragrunt will respect any `TF_VAR_xxx` variables you’ve manually set in your environment, ensuring that anything in `inputs` will NOT be override anything you’ve already set in your environment.
+Note that Terragrunt will respect any `TF_VAR_xxx` variables you’ve manually set in your environment, ensuring that anything in `inputs` will NOT override anything you’ve already set in your environment.
 
 ### Variable precedence
 


### PR DESCRIPTION
Can someone please check that the language is correct here? Is it true that `TF_VAR_xxx` will override `inputs`, or is it true that `TF_VAR_xxx` will be overridden by `inputs`? The original language could have implied either one, and I want to fix this precisely because it's confusing.