### PR TITLE
fix bug where strict validation wasn't always respected

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -324,6 +324,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		WorkingDir:                   workingDir,
 		Logger:                       util.CreateLogEntryWithWriter(terragruntOptions.ErrWriter, workingDir, terragruntOptions.LogLevel, terragruntOptions.Logger.Logger.Hooks),
 		LogLevel:                     terragruntOptions.LogLevel,
+		ValidateStrict:               terragruntOptions.ValidateStrict,
 		Env:                          util.CloneStringMap(terragruntOptions.Env),
 		Source:                       terragruntOptions.Source,
 		SourceMap:                    terragruntOptions.SourceMap,
@@ -352,6 +353,8 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		AwsProviderPatchOverrides:    terragruntOptions.AwsProviderPatchOverrides,
 		HclFile:                      terragruntOptions.HclFile,
 		JSONOut:                      terragruntOptions.JSONOut,
+		Check:                        terragruntOptions.Check,
+		CheckDependentModules:        terragruntOptions.CheckDependentModules,
 	}
 }
 

--- a/test/fixture-validate-inputs/fail-unused-inputs/terragrunt.hcl
+++ b/test/fixture-validate-inputs/fail-unused-inputs/terragrunt.hcl
@@ -2,3 +2,8 @@ inputs = {
   input = "hello world"
   unused_input = "I am unused"
 }
+
+# the existence of a `source` directive manifests the bug in https://github.com/gruntwork-io/terragrunt/issues/1793
+terraform {
+  source = "github.com/gruntwork-io/terragrunt.git//test/fixture-download/hello-world?ref=v0.9.9"
+}

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -150,8 +150,11 @@ func TestTerragruntValidateInputsWithStrictModeEnabledAndUnusedInputs(t *testing
 
 	moduleDir := filepath.Join("fixture-validate-inputs", "fail-unused-inputs")
 	cleanupTerraformFolder(t, moduleDir)
+	tmpEnvPath, _ := filepath.EvalSymlinks(copyEnvironment(t, moduleDir))
+	rootPath := util.JoinPath(tmpEnvPath, moduleDir)
+
 	args := []string{"--terragrunt-strict-validate"}
-	runTerragruntValidateInputs(t, moduleDir, args, false)
+	runTerragruntValidateInputs(t, rootPath, args, false)
 }
 
 func TestTerragruntValidateInputsWithStrictModeDisabledAndUnusedInputs(t *testing.T) {
@@ -159,8 +162,11 @@ func TestTerragruntValidateInputsWithStrictModeDisabledAndUnusedInputs(t *testin
 
 	moduleDir := filepath.Join("fixture-validate-inputs", "fail-unused-inputs")
 	cleanupTerraformFolder(t, moduleDir)
+	tmpEnvPath, _ := filepath.EvalSymlinks(copyEnvironment(t, moduleDir))
+	rootPath := util.JoinPath(tmpEnvPath, moduleDir)
+
 	args := []string{}
-	runTerragruntValidateInputs(t, moduleDir, args, true)
+	runTerragruntValidateInputs(t, rootPath, args, true)
 }
 
 func TestRenderJSONConfig(t *testing.T) {

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -149,6 +149,7 @@ func TestTerragruntValidateInputsWithStrictModeEnabledAndUnusedInputs(t *testing
 	t.Parallel()
 
 	moduleDir := filepath.Join("fixture-validate-inputs", "fail-unused-inputs")
+	cleanupTerraformFolder(t, moduleDir)
 	args := []string{"--terragrunt-strict-validate"}
 	runTerragruntValidateInputs(t, moduleDir, args, false)
 }
@@ -157,6 +158,7 @@ func TestTerragruntValidateInputsWithStrictModeDisabledAndUnusedInputs(t *testin
 	t.Parallel()
 
 	moduleDir := filepath.Join("fixture-validate-inputs", "fail-unused-inputs")
+	cleanupTerraformFolder(t, moduleDir)
 	args := []string{}
 	runTerragruntValidateInputs(t, moduleDir, args, true)
 }


### PR DESCRIPTION
Rough flow of the affected bug
1. [if the configuration has a source directive specified](https://github.com/raidancampbell/terragrunt/blob/aa552aa8eaf3a2d2ae20a2898f92ecd1a1bc0967/cli/cli_app.go#L441-L441)
2. [then a new configuration is created](http://github.com/raidancampbell/terragrunt/blob/aa552aa8eaf3a2d2ae20a2898f92ecd1a1bc0967/cli/cli_app.go#L446-L446)
3. [this new configuration is a clone of the previous](http://github.com/raidancampbell/terragrunt/blob/aa552aa8eaf3a2d2ae20a2898f92ecd1a1bc0967/cli/download_source.go#L51-L51)
4. [which changes a few key fields, while mostly copying over the others](http://github.com/raidancampbell/terragrunt/blob/aa552aa8eaf3a2d2ae20a2898f92ecd1a1bc0967/options/options.go#L324-L324)
5. The affected flag was accidentally omitted from this function when the flag was created.

This resolves #1793