### PR TITLE
fix config remote state s3 and update if needs

### DIFF
--- a/aws_helper/policy.go
+++ b/aws_helper/policy.go
@@ -1,0 +1,37 @@
+package aws_helper
+
+import "encoding/json"
+
+// A representation of the polciy for AWS
+type Policy struct {
+	Version   string      `json:"Version"`
+	Statement []Statement `json:"Statement"`
+}
+
+type Statement struct {
+	Sid       string                  `json:"Sid"`
+	Effect    string                  `json:"Effect"`
+	Principal interface{}             `json:"Principal"`
+	Action    string                  `json:"Action"`
+	Resource  []string                `json:"Resource"`
+	Condition *map[string]interface{} `json:"Condition,omitempty"`
+}
+
+func UnmarshalPolicy(policy string) (Policy, error) {
+	var p Policy
+	err := json.Unmarshal([]byte(policy), &p)
+	if err != nil {
+		return p, err
+	}
+
+	return p, nil
+}
+
+func MarshalPolicy(policy Policy) ([]byte, error) {
+	policyJson, err := json.Marshal(policy)
+	if err != nil {
+		return nil, err
+	}
+
+	return policyJson, nil
+}

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -387,6 +387,7 @@ For the `s3` backend, the following additional properties are supported in the `
 - `skip_bucket_accesslogging`: _DEPRECATED_ If provided, will be ignored. A log warning will be issued in the console output to notify the user.
 - `skip_bucket_root_access`: When `true`, the S3 bucket that is created will not be configured with bucket policies that allow access to the root AWS user.
 - `skip_bucket_enforced_tls`: When `true`, the S3 bucket that is created will not be configured with a bucket policy that enforces access to the bucket via a TLS connection.
+- `disable_bucket_update`: When `true`, disable update S3 bucket if not equal configured in config block 
 - `enable_lock_table_ssencryption`: When `true`, the synchronization lock table in DynamoDB used for remote state concurrent access will not be configured with server side encryption.
 - `s3_bucket_tags`: A map of key value pairs to associate as tags on the created S3 bucket.
 - `dynamodb_table_tags`: A map of key value pairs to associate as tags on the created DynamoDB remote state lock table.

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -55,7 +55,7 @@ func (remoteState *RemoteState) FillDefaults() {
 // Validate that the remote state is configured correctly
 func (remoteState *RemoteState) Validate() error {
 	if remoteState.Backend == "" {
-		return errors.WithStackTrace(RemoteBackendMissing)
+		return errors.WithStackTrace(ErrRemoteBackendMissing)
 	}
 
 	return nil
@@ -173,7 +173,7 @@ func (remoteState RemoteState) ToTerraformInitArgs() []string {
 // Generate the terraform code for configuring remote state backend.
 func (remoteState *RemoteState) GenerateTerraformCode(terragruntOptions *options.TerragruntOptions) error {
 	if remoteState.Generate == nil {
-		return errors.WithStackTrace(GenerateCalledWithNoGenerateAttr)
+		return errors.WithStackTrace(ErrGenerateCalledWithNoGenerateAttr)
 	}
 
 	// Make sure to strip out terragrunt specific configurations from the config.
@@ -205,6 +205,6 @@ func (remoteState *RemoteState) GenerateTerraformCode(terragruntOptions *options
 
 // Custom errors
 var (
-	RemoteBackendMissing             = fmt.Errorf("The remote_state.backend field cannot be empty")
-	GenerateCalledWithNoGenerateAttr = fmt.Errorf("Generate code routine called when no generate attribute is configured.")
+	ErrRemoteBackendMissing             = fmt.Errorf("the remote_state.backend field cannot be empty")
+	ErrGenerateCalledWithNoGenerateAttr = fmt.Errorf("generate code routine called when no generate attribute is configured")
 )

--- a/remote/remote_state_gcs.go
+++ b/remote/remote_state_gcs.go
@@ -289,7 +289,7 @@ func checkIfGCSVersioningEnabled(gcsClient *storage.Client, config *RemoteStateC
 		return errors.WithStackTrace(err)
 	}
 
-	if attrs.VersioningEnabled == false {
+	if !attrs.VersioningEnabled {
 		terragruntOptions.Logger.Warnf("Versioning is not enabled for the remote state GCS bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", config.Bucket)
 	}
 
@@ -326,7 +326,7 @@ func AddLabelsToGCSBucket(gcsClient *storage.Client, config *ExtendedRemoteState
 	ctx := context.Background()
 	bucket := gcsClient.Bucket(config.remoteStateConfigGCS.Bucket)
 
-	bucketAttrs := *&storage.BucketAttrsToUpdate{}
+	bucketAttrs := storage.BucketAttrsToUpdate{}
 
 	for key, value := range config.GCSBucketLabels {
 		bucketAttrs.SetLabel(key, value)

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -411,68 +411,70 @@ func updateS3BucketIfNecessary(s3Client *s3.S3, config *ExtendedRemoteStateConfi
 		return err
 	}
 
-	if shouldUpdateBucket {
-		if configBucket.Versioning != "" {
-			if config.SkipBucketVersioning {
-				terragruntOptions.Logger.Debugf("Versioning is disabled for the remote state S3 bucket %s using 'skip_bucket_versioning' config.", config.remoteStateConfigS3.Bucket)
-			} else if err := EnableVersioningForS3Bucket(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
-				return err
-			}
+	if !shouldUpdateBucket {
+		return nil
+	}
+
+	if configBucket.Versioning != "" {
+		if config.SkipBucketVersioning {
+			terragruntOptions.Logger.Debugf("Versioning is disabled for the remote state S3 bucket %s using 'skip_bucket_versioning' config.", config.remoteStateConfigS3.Bucket)
+		} else if err := EnableVersioningForS3Bucket(s3Client, &config.remoteStateConfigS3, terragruntOptions); err != nil {
+			return err
 		}
+	}
 
-		if configBucket.SSEEncryption != "" {
-			if config.SkipBucketSSEncryption {
-				terragruntOptions.Logger.Debugf("Server-Side Encryption is disabled for the remote state AWS S3 bucket %s using 'skip_bucket_ssencryption' config.", config.remoteStateConfigS3.Bucket)
-			} else if err := EnableSSEForS3BucketWide(s3Client, config, terragruntOptions); err != nil {
-				return err
-			}
+	if configBucket.SSEEncryption != "" {
+		if config.SkipBucketSSEncryption {
+			terragruntOptions.Logger.Debugf("Server-Side Encryption is disabled for the remote state AWS S3 bucket %s using 'skip_bucket_ssencryption' config.", config.remoteStateConfigS3.Bucket)
+		} else if err := EnableSSEForS3BucketWide(s3Client, config, terragruntOptions); err != nil {
+			return err
 		}
+	}
 
-		if configBucket.RootAccess != "" {
-			if config.SkipBucketRootAccess {
-				terragruntOptions.Logger.Debugf("Root access is disabled for the remote state S3 bucket %s using 'skip_bucket_root_access' config.", config.remoteStateConfigS3.Bucket)
-			} else if err := EnableRootAccesstoS3Bucket(s3Client, config, terragruntOptions); err != nil {
-				return err
-			}
+	if configBucket.RootAccess != "" {
+		if config.SkipBucketRootAccess {
+			terragruntOptions.Logger.Debugf("Root access is disabled for the remote state S3 bucket %s using 'skip_bucket_root_access' config.", config.remoteStateConfigS3.Bucket)
+		} else if err := EnableRootAccesstoS3Bucket(s3Client, config, terragruntOptions); err != nil {
+			return err
 		}
+	}
 
-		if configBucket.EnforcedTLS != "" {
-			if config.SkipBucketEnforcedTLS {
-				terragruntOptions.Logger.Debugf("Enforced TLS is disabled for the remote state AWS S3 bucket %s using 'skip_bucket_enforced_tls' config.", config.remoteStateConfigS3.Bucket)
-			} else if err := EnableEnforcedTLSAccesstoS3Bucket(s3Client, config, terragruntOptions); err != nil {
-				return err
-			}
+	if configBucket.EnforcedTLS != "" {
+		if config.SkipBucketEnforcedTLS {
+			terragruntOptions.Logger.Debugf("Enforced TLS is disabled for the remote state AWS S3 bucket %s using 'skip_bucket_enforced_tls' config.", config.remoteStateConfigS3.Bucket)
+		} else if err := EnableEnforcedTLSAccesstoS3Bucket(s3Client, config, terragruntOptions); err != nil {
+			return err
 		}
+	}
 
-		if configBucket.AccessLogging != "" {
-			if config.SkipBucketAccessLogging {
-				terragruntOptions.Logger.Debugf("Access logging is disabled for the remote state AWS S3 bucket %s using 'skip_bucket_access_logging' config.", config.remoteStateConfigS3.Bucket)
-			} else {
-				if config.AccessLoggingBucketName != "" {
-					terragruntOptions.Logger.Debugf("Enabling bucket-wide Access Logging on AWS S3 bucket %s - using as TargetBucket %s", config.remoteStateConfigS3.Bucket, config.AccessLoggingBucketName)
+	if configBucket.AccessLogging != "" {
+		if config.SkipBucketAccessLogging {
+			terragruntOptions.Logger.Debugf("Access logging is disabled for the remote state AWS S3 bucket %s using 'skip_bucket_access_logging' config.", config.remoteStateConfigS3.Bucket)
+		} else {
+			if config.AccessLoggingBucketName != "" {
+				terragruntOptions.Logger.Debugf("Enabling bucket-wide Access Logging on AWS S3 bucket %s - using as TargetBucket %s", config.remoteStateConfigS3.Bucket, config.AccessLoggingBucketName)
 
-					if err := CreateLogsS3BucketIfNecessary(s3Client, aws.String(config.AccessLoggingBucketName), terragruntOptions); err != nil {
-						terragruntOptions.Logger.Errorf("Could not create logs bucket %s for AWS S3 bucket %s", config.AccessLoggingBucketName, config.remoteStateConfigS3.Bucket)
-						return err
-					}
-
-					if err := EnablePublicAccessBlockingForS3Bucket(s3Client, config.AccessLoggingBucketName, terragruntOptions); err != nil {
-						return err
-					}
-
-					if err := EnableAccessLoggingForS3BucketWide(s3Client, &config.remoteStateConfigS3, terragruntOptions, config.AccessLoggingBucketName, config.AccessLoggingTargetPrefix); err != nil {
-						return err
-					}
-				} else {
-					terragruntOptions.Logger.Debugf("Access Logging is disabled for the remote state AWS S3 bucket %s", config.remoteStateConfigS3.Bucket)
+				if err := CreateLogsS3BucketIfNecessary(s3Client, aws.String(config.AccessLoggingBucketName), terragruntOptions); err != nil {
+					terragruntOptions.Logger.Errorf("Could not create logs bucket %s for AWS S3 bucket %s", config.AccessLoggingBucketName, config.remoteStateConfigS3.Bucket)
+					return err
 				}
+
+				if err := EnablePublicAccessBlockingForS3Bucket(s3Client, config.AccessLoggingBucketName, terragruntOptions); err != nil {
+					return err
+				}
+
+				if err := EnableAccessLoggingForS3BucketWide(s3Client, &config.remoteStateConfigS3, terragruntOptions, config.AccessLoggingBucketName, config.AccessLoggingTargetPrefix); err != nil {
+					return err
+				}
+			} else {
+				terragruntOptions.Logger.Debugf("Access Logging is disabled for the remote state AWS S3 bucket %s", config.remoteStateConfigS3.Bucket)
 			}
 		}
+	}
 
-		if configBucket.PublicAccess != "" {
-			if err := EnablePublicAccessBlockingForS3Bucket(s3Client, config.remoteStateConfigS3.Bucket, terragruntOptions); err != nil {
-				return err
-			}
+	if configBucket.PublicAccess != "" {
+		if err := EnablePublicAccessBlockingForS3Bucket(s3Client, config.remoteStateConfigS3.Bucket, terragruntOptions); err != nil {
+			return err
 		}
 	}
 
@@ -952,11 +954,19 @@ func checkIfBucketEnforcedTLS(s3Client *s3.S3, config *RemoteStateConfigS3, terr
 		Bucket: aws.String(config.Bucket),
 	})
 	if err != nil {
-		terragruntOptions.Logger.Debugf("Could not get policy for bucket %s", config.Bucket)
-		return false, nil
+		// S3 API error codes:
+		// http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+		if aerr, ok := err.(awserr.Error); ok {
+			// Enforced TLS policy if is not found bucket policy
+			if aerr.Code() == "NoSuchBucketPolicy" {
+				terragruntOptions.Logger.Debugf("Could not get policy for bucket %s", config.Bucket)
+				return false, nil
+			}
+		}
+
+		return false, errors.WithStackTrace(err)
 	}
 
-	// If the bucket has no policy, it is not enforced
 	if policyOutput.Policy == nil {
 		return true, nil
 	}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -590,7 +590,7 @@ func EnableRootAccesstoS3Bucket(s3Client *s3.S3, config *ExtendedRemoteStateConf
 					"arn:" + partition + ":s3:::" + bucket + "/*",
 				},
 				"Principal": map[string][]string{
-					"AWS": []string{
+					"AWS": {
 						"arn:" + partition + ":iam::" + accountID + ":root",
 					},
 				},

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -276,7 +276,7 @@ func TestGetTerraformInitArgs(t *testing.T) {
 				"skip_bucket_ssencryption":       false,
 				"skip_bucket_root_access":        false,
 				"skip_bucket_enforced_tls":       false,
-				"disable_bucket_update":          false,
+				"disable_bucket_update":          true,
 				"enable_lock_table_ssencryption": true,
 				"disable_aws_client_checksums":   false,
 				"accesslogging_bucket_name":      "test",

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -276,6 +276,7 @@ func TestGetTerraformInitArgs(t *testing.T) {
 				"skip_bucket_ssencryption":       false,
 				"skip_bucket_root_access":        false,
 				"skip_bucket_enforced_tls":       false,
+				"disable_bucket_update":          false,
 				"enable_lock_table_ssencryption": true,
 				"disable_aws_client_checksums":   false,
 				"accesslogging_bucket_name":      "test",

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -109,8 +109,8 @@ func TestToTerraformInitArgsNoBackendConfigs(t *testing.T) {
 	t.Parallel()
 
 	remoteStates := []RemoteState{
-		RemoteState{Backend: "s3"},
-		RemoteState{Backend: "gcs"},
+		{Backend: "s3"},
+		{Backend: "gcs"},
 	}
 
 	for _, state := range remoteStates {

--- a/remote/terraform_state_file_test.go
+++ b/remote/terraform_state_file_test.go
@@ -33,7 +33,7 @@ func TestParseTerraformStateLocal(t *testing.T) {
 		Serial:  0,
 		Backend: nil,
 		Modules: []TerraformStateModule{
-			TerraformStateModule{
+			{
 				Path:      []string{"root"},
 				Outputs:   map[string]interface{}{},
 				Resources: map[string]interface{}{},
@@ -90,7 +90,7 @@ func TestParseTerraformStateRemote(t *testing.T) {
 			},
 		},
 		Modules: []TerraformStateModule{
-			TerraformStateModule{
+			{
 				Path:      []string{"root"},
 				Outputs:   map[string]interface{}{},
 				Resources: map[string]interface{}{},
@@ -220,7 +220,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 			},
 		},
 		Modules: []TerraformStateModule{
-			TerraformStateModule{
+			{
 				Path: []string{"root"},
 				Outputs: map[string]interface{}{
 					"key1": "value1",
@@ -229,7 +229,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 				},
 				Resources: map[string]interface{}{},
 			},
-			TerraformStateModule{
+			{
 				Path: []string{"root", "module_with_outputs_no_resources"},
 				Outputs: map[string]interface{}{
 					"key1": "",
@@ -237,7 +237,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 				},
 				Resources: map[string]interface{}{},
 			},
-			TerraformStateModule{
+			{
 				Path:    []string{"root", "module_with_resources_no_outputs"},
 				Outputs: map[string]interface{}{},
 				Resources: map[string]interface{}{
@@ -277,7 +277,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 					},
 				},
 			},
-			TerraformStateModule{
+			{
 				Path:      []string{"root", "module_level_1", "module_level_2"},
 				Outputs:   map[string]interface{}{},
 				Resources: map[string]interface{}{},


### PR DESCRIPTION
Hi, this PR is a suggestion to resolve the KMS config when the bucket is created, as the default key KMS ID is not being informed, the bucket has encryption enabled but without the KMS:

<img width="986" alt="image" src="https://user-images.githubusercontent.com/20444705/162739997-8739eb3e-9e5e-4690-9ea2-197eb2131e45.png">

I am also suggesting an important change so that buckets that do not comply with the default encryption settings, public access blocking, bucket policy (enforce SSL only), access logging, versioning enabled are updated according to what is defined in the block of config. The `disable_bucket_update` attribute disable this behavior for anyone managing the bucket outside of terragrunt. This change causes the buckets to be updated when running terragrunt to conform to the config that are already made when the bucket is created.

Another fix is for the bucket policy, where currently only EnforcedTLS is being defined, the first policy configured for RootAccess is overwritten.
What I changed is to check the policy already configured and be attached to the existing one, as shown in the image below

<img width="1053" alt="image" src="https://user-images.githubusercontent.com/20444705/162741464-77e9f58f-74e6-4966-b2ab-6a2ff2f8d106.png">


Closes #1770 
Closes #1143 
Closes #1106 