### PR TITLE
Additional known transient error handling for "Client.Timeout exceeded while awaiting headers"

### DIFF
--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -19,4 +19,5 @@ var DEFAULT_RETRYABLE_ERRORS = []string{
 	"(?s).*Error creating SSM parameter: TooManyUpdates:.*",
 	"(?s).*app.terraform.io.*: 429 Too Many Requests.*",
 	"(?s).*ssh_exchange_identification.*Connection closed by remote host.*",
+	"(?s).*Client\\.Timeout exceeded while awaiting headers.*",
 }


### PR DESCRIPTION
We've seen this a number of times on our CI servers and some developers have encountered it locally. It passes on retry, so I believe it to be a transient error communicating with terraform's registry servers.