### PR TITLE
Failing tests fixes

### DIFF
--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -367,8 +367,8 @@ func TestIncludeDirsDependencyConsistencyRegression(t *testing.T) {
 		"testapp/k8s",
 	}
 
-	testPath := filepath.Join(TEST_FIXTURE_REGRESSIONS, "exclude-dependency")
-	cleanupTerragruntFolder(t, testPath)
+	tmpPath, _ := filepath.EvalSymlinks(copyEnvironment(t, TEST_FIXTURE_REGRESSIONS))
+	testPath := filepath.Join(tmpPath, TEST_FIXTURE_REGRESSIONS, "exclude-dependency")
 	for _, modulePath := range modulePaths {
 		cleanupTerragruntFolder(t, filepath.Join(testPath, modulePath))
 	}
@@ -377,10 +377,10 @@ func TestIncludeDirsDependencyConsistencyRegression(t *testing.T) {
 	assert.Greater(t, len(includedModulesWithNone), 0)
 
 	includedModulesWithAmzApp := runValidateAllWithIncludeAndGetIncludedModules(t, testPath, []string{"amazing-app/k8s"}, false)
-	assert.Equal(t, includedModulesWithAmzApp, []string{"amazing-app/k8s", "clusters/eks"})
+	assert.Equal(t, []string{"amazing-app/k8s", "clusters/eks"}, includedModulesWithAmzApp)
 
 	includedModulesWithTestApp := runValidateAllWithIncludeAndGetIncludedModules(t, testPath, []string{"testapp/k8s"}, false)
-	assert.Equal(t, includedModulesWithTestApp, []string{"clusters/eks", "testapp/k8s"})
+	assert.Equal(t, []string{"clusters/eks", "testapp/k8s"}, includedModulesWithTestApp)
 }
 
 func TestIncludeDirsStrict(t *testing.T) {
@@ -392,20 +392,21 @@ func TestIncludeDirsStrict(t *testing.T) {
 		"testapp/k8s",
 	}
 
-	testPath := filepath.Join(TEST_FIXTURE_REGRESSIONS, "exclude-dependency")
+	tmpPath, _ := filepath.EvalSymlinks(copyEnvironment(t, TEST_FIXTURE_REGRESSIONS))
+	testPath := filepath.Join(tmpPath, TEST_FIXTURE_REGRESSIONS, "exclude-dependency")
 	cleanupTerragruntFolder(t, testPath)
 	for _, modulePath := range modulePaths {
 		cleanupTerragruntFolder(t, filepath.Join(testPath, modulePath))
 	}
 
 	includedModulesWithNone := runValidateAllWithIncludeAndGetIncludedModules(t, testPath, []string{}, true)
-	assert.Equal(t, includedModulesWithNone, []string{})
+	assert.Equal(t, []string{}, includedModulesWithNone)
 
 	includedModulesWithAmzApp := runValidateAllWithIncludeAndGetIncludedModules(t, testPath, []string{"amazing-app/k8s"}, true)
-	assert.Equal(t, includedModulesWithAmzApp, []string{"amazing-app/k8s"})
+	assert.Equal(t, []string{"amazing-app/k8s"}, includedModulesWithAmzApp)
 
 	includedModulesWithTestApp := runValidateAllWithIncludeAndGetIncludedModules(t, testPath, []string{"testapp/k8s"}, true)
-	assert.Equal(t, includedModulesWithTestApp, []string{"testapp/k8s"})
+	assert.Equal(t, []string{"testapp/k8s"}, includedModulesWithTestApp)
 }
 
 func TestTerragruntExternalDependencies(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2832,9 +2832,9 @@ func TestGetPathFromRepoRoot(t *testing.T) {
 func TestGetPathToRepoRoot(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, TEST_FIXTURE_GET_PATH_TO_REPO_ROOT)
 	tmpEnvPath, _ := filepath.EvalSymlinks(copyEnvironment(t, TEST_FIXTURE_GET_PATH_TO_REPO_ROOT))
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_PATH_TO_REPO_ROOT)
+	cleanupTerraformFolder(t, rootPath)
 
 	_, err := exec.Command("git", "init", tmpEnvPath+"/../").Output()
 	if err != nil {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2836,9 +2836,9 @@ func TestGetPathToRepoRoot(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_PATH_TO_REPO_ROOT)
 	cleanupTerraformFolder(t, rootPath)
 
-	_, err := exec.Command("git", "init", tmpEnvPath+"/../").Output()
+	output, err := exec.Command("git", "init", tmpEnvPath+"/../").Output()
 	if err != nil {
-		t.Fatalf("Error initializing git repo: %v", err)
+		t.Fatalf("Error initializing git repo: %v\n%s", err, string(output))
 	}
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4196,13 +4196,11 @@ func runValidateAllWithIncludeAndGetIncludedModules(t *testing.T, rootModulePath
 	logBufferContentsLineByLine(t, validateAllStderr, "validate-all stderr")
 	require.NoError(t, err)
 
-	currentDir, err := os.Getwd()
 	require.NoError(t, err)
 
 	includedModulesRegexp, err := regexp.Compile(
 		fmt.Sprintf(
-			`=> Module %s/%s/(.+) \(excluded: (true|false)`,
-			currentDir,
+			`=> Module %s/(.+) \(excluded: (true|false)`,
 			rootModulePath,
 		),
 	)


### PR DESCRIPTION
Fixes for flaky tests:
  * `TestGetPathToRepoRoot`
  * `TestIncludeDirsDependencyConsistencyRegression`
  * `TestIncludeDirsStrict`