### PR TITLE
Bump sops from v3.7.0 to v3.7.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/urfave/cli v1.22.3
 	github.com/zclconf/go-cty v1.8.3
-	go.mozilla.org/sops/v3 v3.7.0
+	go.mozilla.org/sops/v3 v3.7.2
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f

--- a/go.sum
+++ b/go.sum
@@ -901,6 +901,8 @@ go.mozilla.org/gopgagent v0.0.0-20170926210634-4d7ea76ff71a h1:N7VD+PwpJME2ZfQT8
 go.mozilla.org/gopgagent v0.0.0-20170926210634-4d7ea76ff71a/go.mod h1:YDKUvO0b//78PaaEro6CAPH6NqohCmL2Cwju5XI2HoE=
 go.mozilla.org/sops/v3 v3.7.0 h1:JuurncZrzjzirMNiQLm5WZLPyB5vcWhgre9YAWlTusA=
 go.mozilla.org/sops/v3 v3.7.0/go.mod h1:CJzeerUlKPLyVr8FxEGgEmc7LgUq4hwzqGxJqs8b+1c=
+go.mozilla.org/sops/v3 v3.7.2 h1:LNThLKe/pb80eGyAOFiWKP1Znqp1GQO2hqvuQOCmy5o=
+go.mozilla.org/sops/v3 v3.7.2/go.mod h1:OUNXNSkIrbr2wq3+RbK8s/ZCG+GaUnh8EY8IhXHI+wc=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
Hi!

After hitting this error `Call to function "sops_decrypt_file" failed: Error getting data key: 0 successful groups required, got 0.` coming from the sops package. I have tried to upgrade the sops dependency and build the project and  It solves the issue. 

Fix the issue : #1486 