### PR TITLE
#2045 Fixed pattern matching for error hooks 

### DIFF
--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -124,6 +124,14 @@ func RunShellCommandWithOutput(
 		Stderr: stderrBuf.String(),
 	}
 
+	if err != nil {
+		err = ProcessExecutionError{
+			Err:    err,
+			StdOut: stdoutBuf.String(),
+			Stderr: stderrBuf.String(),
+		}
+	}
+
 	return &cmdOutput, errors.WithStackTrace(err)
 }
 
@@ -215,4 +223,15 @@ func GitTopLevelDir(terragruntOptions *options.TerragruntOptions, path string) (
 		return "", err
 	}
 	return strings.TrimSpace(cmd.Stdout), nil
+}
+
+// ProcessExecutionError - error returned when a command fails, contains StdOut and StdErr
+type ProcessExecutionError struct {
+	Err    error
+	StdOut string
+	Stderr string
+}
+
+func (err ProcessExecutionError) Error() string {
+	return err.Err.Error()
 }

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -235,3 +235,7 @@ type ProcessExecutionError struct {
 func (err ProcessExecutionError) Error() string {
 	return err.Err.Error()
 }
+
+func (err ProcessExecutionError) ExitStatus() (int, error) {
+	return GetExitCode(err.Err)
+}

--- a/test/fixture-hooks/error-hooks/main.tf
+++ b/test/fixture-hooks/error-hooks/main.tf
@@ -1,0 +1,4 @@
+
+data "local_file" "read_not_existing_file" {
+  filename = "${path.module}/not-existing-file.txt"
+}

--- a/test/fixture-hooks/error-hooks/terragrunt.hcl
+++ b/test/fixture-hooks/error-hooks/terragrunt.hcl
@@ -1,0 +1,29 @@
+terraform {
+  source = "."
+
+  error_hook "pattern_matching_hook" {
+    commands = ["apply"]
+    execute  = ["echo", "pattern_matching_hook"]
+    on_errors = [
+      "not-existing-file.txt"
+    ]
+  }
+
+  error_hook "catch_all_matching_hook" {
+    commands = ["apply"]
+    execute  = ["echo", "catch_all_matching_hook"]
+    on_errors = [
+      ".*"
+    ]
+  }
+
+  error_hook "not_matching_hook" {
+    commands = ["apply"]
+    execute  = ["echo", "not_matching_hook"]
+    on_errors = [
+      ".*random-not-matching-pattern.*"
+    ]
+  }
+
+}
+

--- a/test/fixture-hooks/skip-on-error/terragrunt.hcl
+++ b/test/fixture-hooks/skip-on-error/terragrunt.hcl
@@ -34,4 +34,17 @@ terraform {
     execute   = ["echo", "ERROR_HOOK_EXECUTED"]
     on_errors = [".*"]
   }
+
+  error_hook "not_matching_error_hook" {
+    commands  = ["apply", "plan"]
+    execute   = ["echo", "NOT_MATCHING_ERROR_HOOK"]
+    on_errors = [".*custom-matcher.*"]
+  }
+
+  # hook to match error "executable file not found in $PATH"
+  error_hook "e" {
+    commands  = ["apply", "plan"]
+    execute   = ["echo", "PATTERN_MATCHING_ERROR_HOOK"]
+    on_errors = [".*executable file not found.*"]
+  }
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -402,19 +402,19 @@ func TestTerragruntSkipOnError(t *testing.T) {
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
 
+	assert.Error(t, err)
+
 	output := stderr.String()
-	if err != nil {
-		assert.Contains(t, output, "BEFORE_SHOULD_DISPLAY")
-		assert.NotContains(t, output, "BEFORE_NODISPLAY")
 
-		assert.Contains(t, output, "AFTER_SHOULD_DISPLAY")
-		assert.NotContains(t, output, "AFTER_NODISPLAY")
+	assert.Contains(t, output, "BEFORE_SHOULD_DISPLAY")
+	assert.NotContains(t, output, "BEFORE_NODISPLAY")
 
-		assert.Contains(t, output, "ERROR_HOOK_EXECUTED")
+	assert.Contains(t, output, "AFTER_SHOULD_DISPLAY")
+	assert.NotContains(t, output, "AFTER_NODISPLAY")
 
-	} else {
-		t.Error("Expected NO terragrunt execution due to previous errors but it did run.")
-	}
+	assert.Contains(t, output, "ERROR_HOOK_EXECUTED")
+	assert.NotContains(t, output, "NOT_MATCHING_ERROR_HOOK")
+	assert.Contains(t, output, "PATTERN_MATCHING_ERROR_HOOK")
 }
 
 func TestTerragruntBeforeOneArgAction(t *testing.T) {


### PR DESCRIPTION
Included changes:
 * Updated handling of terraform execution to return error with execution outputs which later is used in pattern matching for error hooks
 * Updated integration tests to track that errors generated during the execution of terraform are handled by error hooks

Closes: https://github.com/gruntwork-io/terragrunt/issues/2045