### PR TITLE
Allow v0.36 to define disable_bucket_update to make it easier to transition to v0.37

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -42,6 +42,7 @@ type ExtendedRemoteStateConfigS3 struct {
 	SkipBucketEnforcedTLS       bool              `mapstructure:"skip_bucket_enforced_tls"`
 	EnableLockTableSSEncryption bool              `mapstructure:"enable_lock_table_ssencryption"`
 	DisableAWSClientChecksums   bool              `mapstructure:"disable_aws_client_checksums"`
+	DisableBucketUpdate         bool              `mapstructure:"disable_bucket_update"`
 	AccessLoggingBucketName     string            `mapstructure:"accesslogging_bucket_name"`
 	AccessLoggingTargetPrefix   string            `mapstructure:"accesslogging_target_prefix"`
 }
@@ -58,6 +59,7 @@ var terragruntOnlyConfigs = []string{
 	"skip_bucket_enforced_tls",
 	"enable_lock_table_ssencryption",
 	"disable_aws_client_checksums",
+	"disable_bucket_update",
 	"accesslogging_bucket_name",
 	"accesslogging_target_prefix",
 }

--- a/test/fixture-s3-update-backward-compatibility/main.tf
+++ b/test/fixture-s3-update-backward-compatibility/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  backend "s3" {}
+}
+
+# Create an arbitrary local resource
+data "template_file" "test" {
+  template = "Hello, I am a template. My sample_var value = $${sample_var}"
+
+  vars = {
+    sample_var = var.sample_var
+  }
+}

--- a/test/fixture-s3-update-backward-compatibility/outputs.tf
+++ b/test/fixture-s3-update-backward-compatibility/outputs.tf
@@ -1,0 +1,3 @@
+output "rendered_template" {
+  value = data.template_file.test.rendered
+}

--- a/test/fixture-s3-update-backward-compatibility/terragrunt.hcl
+++ b/test/fixture-s3-update-backward-compatibility/terragrunt.hcl
@@ -1,0 +1,23 @@
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remote_state {
+  backend = "s3"
+  config = {
+    encrypt                        = true
+    bucket                         = "__FILL_IN_BUCKET_NAME__"
+    key                            = "terraform.tfstate"
+    region                         = "us-west-2"
+    dynamodb_table                 = "__FILL_IN_LOCK_TABLE_NAME__"
+    enable_lock_table_ssencryption = true
+    disable_bucket_update          = true
+
+    s3_bucket_tags = {
+      owner = "terragrunt integration test"
+      name  = "Terraform state storage"
+    }
+
+    dynamodb_table_tags = {
+      owner = "terragrunt integration test"
+      name  = "Terraform lock table"
+    }
+  }
+}

--- a/test/fixture-s3-update-backward-compatibility/vars.tf
+++ b/test/fixture-s3-update-backward-compatibility/vars.tf
@@ -1,0 +1,5 @@
+# Configure these variables
+variable "sample_var" {
+  description = "A sample_var to pass to the template."
+  default     = "hello"
+}


### PR DESCRIPTION
__IMPORTANT: Merges into v036-dev, which is a snapshot of v0.36.11__

This PR is intended to be a patch release for `v0.36.x` that is intended to smooth the upgrade process from v0.36 to v0.37. Right now, users can't prepare for the v0.37 update by preconfiguring their terragrunt project with `disable_bucket_update = true`, because `terragrunt` 0.36.11 doesn't support this config (terragrunt crashes if that is set).

In this PR, we add the config variable but do nothing with it so that users can setup for the v0.37 update.

When this is merged to `v036-dev`, I'll go ahead and cut a patch release `v0.36.12` pointing to that branch, and then will delete the branches.