### PR TITLE
#2109  Updated reading of AWS response using BoolValue function

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -1152,16 +1152,16 @@ func checkIfS3PublicAccessBlockingEnabled(s3Client *s3.S3, config *RemoteStateCo
 		return false, nil
 	}
 
-	if !*output.PublicAccessBlockConfiguration.BlockPublicAcls {
+	if !aws.BoolValue(output.PublicAccessBlockConfiguration.BlockPublicAcls) {
 		return false, nil
 	}
-	if !*output.PublicAccessBlockConfiguration.BlockPublicPolicy {
+	if !aws.BoolValue(output.PublicAccessBlockConfiguration.BlockPublicAcls) {
 		return false, nil
 	}
-	if !*output.PublicAccessBlockConfiguration.IgnorePublicAcls {
+	if !aws.BoolValue(output.PublicAccessBlockConfiguration.BlockPublicAcls) {
 		return false, nil
 	}
-	if !*output.PublicAccessBlockConfiguration.RestrictPublicBuckets {
+	if !aws.BoolValue(output.PublicAccessBlockConfiguration.BlockPublicAcls) {
 		return false, nil
 	}
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -1148,6 +1148,10 @@ func checkIfS3PublicAccessBlockingEnabled(s3Client *s3.S3, config *RemoteStateCo
 		return false, errors.WithStackTrace(err)
 	}
 
+	return validatePublicAccessBlock(output)
+}
+
+func validatePublicAccessBlock(output *s3.GetPublicAccessBlockOutput) (bool, error) {
 	if output.PublicAccessBlockConfiguration == nil {
 		return false, nil
 	}

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -342,9 +342,10 @@ func TestGetTerraformInitArgs(t *testing.T) {
 	}
 }
 
+// Test to validate cases when is not possible to read all S3 configurations
+//https://github.com/gruntwork-io/terragrunt/issues/2109
 func TestNegativePublicAccessResponse(t *testing.T) {
 	t.Parallel()
-	// https://github.com/gruntwork-io/terragrunt/issues/2109
 	testCases := []struct {
 		name     string
 		response *s3.GetPublicAccessBlockOutput


### PR DESCRIPTION
Included changes:
  * added usage of aws.BoolValue for fetching AWS responses
  * extracted validation logic as separated function and set unit tests for s3 responses


Closes: [#2109](https://github.com/gruntwork-io/terragrunt/issues/2109)