### PR TITLE
Make include_in_copy work for patterns containing parent folders

### DIFF
--- a/util/file.go
+++ b/util/file.go
@@ -170,6 +170,15 @@ func ReadFileAsString(path string) (string, error) {
 	return string(bytes), nil
 }
 
+func listContainsElementStartingWith(list []string, elementPrefix string) bool {
+	for _, element := range list {
+		if strings.HasPrefix(element, elementPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // Takes apbsolute glob path and returns an array of expanded relative paths
 func expandGlobPath(source, absoluteGlobPath string) ([]string, error) {
 	includeExpandedGlobs := []string{}
@@ -216,7 +225,7 @@ func CopyFolderContents(source, destination, manifestFile string, includeInCopy 
 
 	return CopyFolderContentsWithFilter(source, destination, manifestFile, func(absolutePath string) bool {
 		relativePath, err := GetPathRelativeTo(absolutePath, source)
-		if err == nil && ListContainsElement(includeExpandedGlobs, relativePath) {
+		if err == nil && listContainsElementStartingWith(includeExpandedGlobs, relativePath) {
 			return true
 		}
 		return !TerragruntExcludes(relativePath)

--- a/util/file.go
+++ b/util/file.go
@@ -170,7 +170,7 @@ func ReadFileAsString(path string) (string, error) {
 	return string(bytes), nil
 }
 
-func listContainsElementStartingWith(list []string, elementPrefix string) bool {
+func listContainsElementWithPrefix(list []string, elementPrefix string) bool {
 	for _, element := range list {
 		if strings.HasPrefix(element, elementPrefix) {
 			return true
@@ -225,7 +225,7 @@ func CopyFolderContents(source, destination, manifestFile string, includeInCopy 
 
 	return CopyFolderContentsWithFilter(source, destination, manifestFile, func(absolutePath string) bool {
 		relativePath, err := GetPathRelativeTo(absolutePath, source)
-		if err == nil && listContainsElementStartingWith(includeExpandedGlobs, relativePath) {
+		if err == nil && listContainsElementWithPrefix(includeExpandedGlobs, relativePath) {
 			return true
 		}
 		return !TerragruntExcludes(relativePath)

--- a/util/file.go
+++ b/util/file.go
@@ -228,7 +228,7 @@ func CopyFolderContents(source, destination, manifestFile string, includeInCopy 
 		if err == nil && listContainsElementWithPrefix(includeExpandedGlobs, relativePath) {
 			return true
 		}
-		return !TerragruntExcludes(relativePath)
+		return !TerragruntExcludes(filepath.FromSlash(relativePath))
 	})
 }
 

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -256,26 +256,18 @@ func TestIncludeInCopy(t *testing.T) {
 		{"/_module/.region2/project2-2/f2-dot-f0.txt", true},
 	}
 
-	check := func(err error) {
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	tempDir, err := os.MkdirTemp("", "TerragruntIncludeInCopyTest")
-	check(err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	source := filepath.Join(tempDir, "source")
 	destination := filepath.Join(tempDir, "destination")
 
 	fileContent := []byte("source file")
 	for _, testCase := range testCases {
 		path := filepath.Join(source, testCase.path)
-		check(os.MkdirAll(filepath.Dir(path), os.ModePerm))
-		check(os.WriteFile(path, fileContent, 0644))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), os.ModePerm))
+		require.NoError(t, os.WriteFile(path, fileContent, 0644))
 	}
 
-	check(CopyFolderContents(source, destination, ".terragrunt-test", includeInCopy))
+	require.NoError(t, CopyFolderContents(source, destination, ".terragrunt-test", includeInCopy))
 
 	for _, testCase := range testCases {
 		_, err := os.Stat(filepath.Join(destination, testCase.path))

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"errors"
 	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -206,6 +208,7 @@ func TestContainsPath(t *testing.T) {
 		assert.Equal(t, testCase.expected, actual, "For path %s and subpath %s", testCase.path, testCase.subpath)
 	}
 }
+
 func TestHasPathPrefix(t *testing.T) {
 	t.Parallel()
 
@@ -232,5 +235,53 @@ func TestHasPathPrefix(t *testing.T) {
 	for _, testCase := range testCases {
 		actual := HasPathPrefix(testCase.path, testCase.prefix)
 		assert.Equal(t, testCase.expected, actual, "For path %s and prefix %s", testCase.path, testCase.prefix)
+	}
+}
+
+func TestIncludeInCopy(t *testing.T) {
+	includeInCopy := []string{"_module/.region2", "**/app2", "**/.include-me-too"}
+
+	testCases := []struct {
+		path         string
+		copyExpected bool
+	}{
+		{"/app/terragrunt.hcl", true},
+		{"/_module/main.tf", true},
+		{"/_module/.region1/info.txt", false},
+		{"/_module/.region3/project3-1/f1-2-levels.txt", false},
+		{"/_module/.region3/project3-1/app1/.include-me-too/file.txt", true},
+		{"/_module/.region3/project3-2/.f0/f0-3-levels.txt", false},
+		{"/_module/.region2/.project2-1/app2/f2-dot-f2.txt", true},
+		{"/_module/.region2/.project2-1/readme.txt", true},
+		{"/_module/.region2/project2-2/f2-dot-f0.txt", true},
+	}
+
+	check := func(err error) {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tempDir, err := os.MkdirTemp("", "TerragruntIncludeInCopyTest")
+	check(err)
+	defer os.RemoveAll(tempDir)
+	source := filepath.Join(tempDir, "source")
+	destination := filepath.Join(tempDir, "destination")
+
+	fileContent := []byte("source file")
+	for _, testCase := range testCases {
+		path := filepath.Join(source, testCase.path)
+		check(os.MkdirAll(filepath.Dir(path), os.ModePerm))
+		check(os.WriteFile(path, fileContent, 0644))
+	}
+
+	check(CopyFolderContents(source, destination, ".terragrunt-test", includeInCopy))
+
+	for _, testCase := range testCases {
+		_, err := os.Stat(filepath.Join(destination, testCase.path))
+		assert.True(t,
+			testCase.copyExpected && err == nil ||
+				!testCase.copyExpected && errors.Is(err, os.ErrNotExist),
+			"Unexpected copy result for file '%s' (should be copied: '%t') - got error: %s", testCase.path, testCase.copyExpected, err)
 	}
 }


### PR DESCRIPTION
The current implementation does not allow to copy files specified with `include_in_copy` which are not at the root of the repository.

I have the following repository structure:
```
├── config
│   └── app
│       └── dev
│           ├── .terraform.lock.hcl
│           └── terragrunt.hcl
└── modules
    └── app
        ├── chart
        │   ├── .helmignore
        │   ├── Chart.yaml
        │   ├── charts
        │   ├── templates
        │   │   ├── NOTES.txt
        │   │   ├── _helpers.tpl
        │   │   ├── deployment.yaml
        │   │   ├── hpa.yaml
        │   │   ├── ingress.yaml
        │   │   ├── service.yaml
        │   │   ├── serviceaccount.yaml
        │   │   └── tests
        │   │       └── test-connection.yaml
        │   └── values.yaml
        └── main.tf
```

My `terragrunt.hcl` looks as follows:
```
terraform {
  source = "../../..//modules/app"
  include_in_copy = [
    "**/.helmignore"
  ]
}
```

Doing `terragrunt init` does NOT copy `.helmignore`. I explained what I believe the issue in [this comment](https://github.com/gruntwork-io/terragrunt/issues/2067#issuecomment-1128131056).

This PR changes the semantic and invocation of the `filter` function. The function parameter is now an absolute path, which allows proper lookup in `includeExpandedGlobs` list.

Changing the semantic of the `filter` function also changes slightly the behavior of `CopyFolderContentsWithFilter`. I noticed that this function is also used in `internal/tfr/getter.go` but the actual filter function implementation used there always returns `true` so the introduced change should have no negative impact there.

Finally, note that this implementation may not be completely correct yet. Based on the [documentation](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#terraform) for the `include_in_copy` attribute, *"The path should be specified relative to the source directory"*. If my source directory is `modules/app`, the value of `include_in_copy` should be `chart/.helmignore`. Unfortunately this does not work either even with my proposed changes. I see that in the code the "source" is my repository root - that's why `include_in_copy=["modules/app/chart/.helmignore"]` also works for me.