### PR TITLE
#2113 Improved parsing of AWS policy response

### DIFF
--- a/aws_helper/policy.go
+++ b/aws_helper/policy.go
@@ -2,18 +2,22 @@ package aws_helper
 
 import "encoding/json"
 
-// A representation of the polciy for AWS
+// Policy - representation of the policy for AWS
 type Policy struct {
 	Version   string      `json:"Version"`
 	Statement []Statement `json:"Statement"`
 }
 
+// Statement - AWS policy statement
+// Action and Resource - can be string OR array of strings
+// https://docs.aws.amazon.com/IAM//latest/UserGuide/reference_policies_elements_action.html
+// https://docs.aws.amazon.com/IAM//latest/UserGuide/reference_policies_elements_resource.html
 type Statement struct {
 	Sid       string                  `json:"Sid"`
 	Effect    string                  `json:"Effect"`
 	Principal interface{}             `json:"Principal"`
-	Action    string                  `json:"Action"`
-	Resource  []string                `json:"Resource"`
+	Action    interface{}             `json:"Action"`
+	Resource  interface{}             `json:"Resource"`
 	Condition *map[string]interface{} `json:"Condition,omitempty"`
 }
 

--- a/aws_helper/policy_test.go
+++ b/aws_helper/policy_test.go
@@ -6,9 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUnmarshalStringActionResource(t *testing.T) {
-	t.Parallel()
-	policy := `
+const simplePolicy = `
 		{
 			"Version": "2012-10-17",
 			"Statement": [
@@ -21,33 +19,7 @@ func TestUnmarshalStringActionResource(t *testing.T) {
 			]
 		}
 	`
-	bucketPolicy, err := UnmarshalPolicy(policy)
-	assert.NoError(t, err)
-	assert.NotNil(t, bucketPolicy)
-	assert.Equal(t, 1, len(bucketPolicy.Statement))
-	assert.NotNil(t, bucketPolicy.Statement[0].Action)
-	assert.NotNil(t, bucketPolicy.Statement[0].Resource)
-
-	switch action := bucketPolicy.Statement[0].Action.(type) {
-	case string:
-		assert.Equal(t, "s3:*", action)
-		break
-	default:
-		assert.Fail(t, "Expected string type for Action")
-	}
-
-	switch resource := bucketPolicy.Statement[0].Resource.(type) {
-	case string:
-		assert.Equal(t, "*", resource)
-		break
-	default:
-		assert.Fail(t, "Expected string type for Resource")
-	}
-}
-
-func TestUnmarshalActionResourceList(t *testing.T) {
-	t.Parallel()
-	policy := `
+const arraysPolicy = `
 		{
 			"Version": "2012-10-17",
 			"Statement": [
@@ -75,7 +47,37 @@ func TestUnmarshalActionResourceList(t *testing.T) {
 			]
 		}
 	`
-	bucketPolicy, err := UnmarshalPolicy(policy)
+
+func TestUnmarshalStringActionResource(t *testing.T) {
+	t.Parallel()
+
+	bucketPolicy, err := UnmarshalPolicy(simplePolicy)
+	assert.NoError(t, err)
+	assert.NotNil(t, bucketPolicy)
+	assert.Equal(t, 1, len(bucketPolicy.Statement))
+	assert.NotNil(t, bucketPolicy.Statement[0].Action)
+	assert.NotNil(t, bucketPolicy.Statement[0].Resource)
+
+	switch action := bucketPolicy.Statement[0].Action.(type) {
+	case string:
+		assert.Equal(t, "s3:*", action)
+		break
+	default:
+		assert.Fail(t, "Expected string type for Action")
+	}
+
+	switch resource := bucketPolicy.Statement[0].Resource.(type) {
+	case string:
+		assert.Equal(t, "*", resource)
+		break
+	default:
+		assert.Fail(t, "Expected string type for Resource")
+	}
+}
+
+func TestUnmarshalActionResourceList(t *testing.T) {
+	t.Parallel()
+	bucketPolicy, err := UnmarshalPolicy(arraysPolicy)
 	assert.NoError(t, err)
 	assert.NotNil(t, bucketPolicy)
 	assert.Equal(t, 1, len(bucketPolicy.Statement))

--- a/aws_helper/policy_test.go
+++ b/aws_helper/policy_test.go
@@ -1,0 +1,52 @@
+package aws_helper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalActionList(t *testing.T) {
+	t.Parallel()
+	policy := `
+		{
+			"Version": "2012-10-17",
+			"Statement": [
+				{
+					"Sid": "ArrayList",
+					"Effect": "Allow",
+					"Action": [
+						"s3:ListStorageLensConfigurations",
+						"s3:ListAccessPointsForObjectLambda",
+						"s3:ListBucketMultipartUploads",
+						"s3:ListAllMyBuckets",
+						"s3:DescribeJob",
+						"s3:ListAccessPoints",
+						"s3:ListJobs",
+						"s3:ListBucketVersions",
+						"s3:ListBucket",
+						"s3:ListMultiRegionAccessPoints",
+						"s3:ListMultipartUploadParts"
+					],
+					"Resource": "*"
+				}
+			]
+		}
+	`
+	bucketPolicy, err := UnmarshalPolicy(policy)
+	assert.NoError(t, err)
+	assert.NotNil(t, bucketPolicy)
+	assert.Equal(t, 1, len(bucketPolicy.Statement))
+	assert.NotNil(t, bucketPolicy.Statement[0].Action)
+
+	switch actions := bucketPolicy.Statement[0].Action.(type) {
+	case []interface{}:
+		assert.Equal(t, 11, len(actions))
+		break
+	case string:
+	default:
+		fmt.Printf("Actions: %v \n", actions)
+		assert.Fail(t, "Expected to be []string type for Action")
+	}
+}


### PR DESCRIPTION
Updated parsing of AWS policy statement to handle cases when fields "Action" and "Policy" are returned as arrays instead of strings

Closes: https://github.com/gruntwork-io/terragrunt/issues/2113

AWS reference:
https://docs.aws.amazon.com/IAM//latest/UserGuide/reference_policies_elements_action.html
https://docs.aws.amazon.com/IAM//latest/UserGuide/reference_policies_elements_resource.html