### PR TITLE
[WIP] Increase config package test coverage for free

### DIFF
--- a/config/config_partial_test.go
+++ b/config/config_partial_test.go
@@ -7,6 +7,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// func TestDecodeBaseBlocks(t *testing.T) {
+// 	ctrl := gomock.NewController(t)
+// 	defer ctrl.Finish()
+
+// 	mockBody := NewMockBody(ctrl)
+// 	mockBody.
+// 		EXPECT().
+// 		PartialContent().
+// 		Return(gomock.Any(), gomock.Any(), gomock.Any())
+
+// 	testTerragruntOptions := options.TerragruntOptions{}
+// 	testParser := hclparse.NewParser()
+// 	testHclFile := hcl.File{
+// 		Body: mockBody,
+// 	}
+// 	testFilename := "IAmAFile.hcl"
+// 	testIncludeFromChild := IncludeConfig{}
+// 	testDecodeList := make([]PartialDecodeSectionType, 0)
+
+// 	actualCtyValue, actualTrackInclude, _ := DecodeBaseBlocks(&testTerragruntOptions, testParser, &testHclFile, testFilename, &testIncludeFromChild, testDecodeList)
+
+// 	assert.Equal(t, "Lol", actualCtyValue)
+// 	assert.Equal(t, "Lol", actualTrackInclude)
+// }
+
 func TestPartialParseResolvesLocals(t *testing.T) {
 	t.Parallel()
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -490,11 +490,55 @@ func TestTerraformExtraArgumentsGetVarFilesOptionalVarFiles(t *testing.T) {
 
 	actualResult := testTerraformExtraArguments.GetVarFiles(testLogger)
 
-	expectedOutput := []string{}
-
 	// Note: False positive
 	// Because util.FileExists currently not working in test
+	// Monkey patching is currently not possible
+	expectedOutput := []string{dummyFile}
+
 	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestGetTerraformSourceUrlReturnsConfigSource(t *testing.T) {
+	t.Parallel()
+
+	dummySource := "some-path"
+	testTerragruntOptions := options.TerragruntOptions{
+		Source: dummySource,
+	}
+	testTerragruntConfig := TerragruntConfig{}
+
+	actualResult, _ := GetTerraformSourceUrl(&testTerragruntOptions, &testTerragruntConfig)
+
+	assert.Equal(t, dummySource, actualResult)
+}
+
+func TestGetTerraformSourceUrlReturnsTerraformSource(t *testing.T) {
+	t.Parallel()
+
+	dummySource := "some-path"
+	dummyConfig := TerraformConfig{
+		Source: &dummySource,
+	}
+
+	testTerragruntOptions := options.TerragruntOptions{}
+	testTerragruntConfig := TerragruntConfig{
+		Terraform: &dummyConfig,
+	}
+
+	actualResult, _ := GetTerraformSourceUrl(&testTerragruntOptions, &testTerragruntConfig)
+
+	assert.Equal(t, dummySource, actualResult)
+}
+
+func TestGetTerraformSourceUrlNoSourceIsEmptyl(t *testing.T) {
+	t.Parallel()
+
+	testTerragruntOptions := options.TerragruntOptions{}
+	testTerragruntConfig := TerragruntConfig{}
+
+	actualResult, _ := GetTerraformSourceUrl(&testTerragruntOptions, &testTerragruntConfig)
+
+	assert.Equal(t, "", actualResult)
 }
 
 func TestParseTerragruntConfigRemoteStateMinimalConfig(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/remote"
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -427,6 +428,73 @@ func TestTerraformConfigValidateHooksErrorHooksError(t *testing.T) {
 	actualResult := testTerraformConfig.ValidateHooks()
 
 	assert.Error(t, actualResult)
+}
+
+func TestTerraformExtraArgumentsStringIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	testTerraformExtraArguments := TerraformExtraArguments{}
+
+	actualResult := testTerraformExtraArguments.String()
+
+	expectedOutput := "TerraformArguments{Name = , Arguments = <nil>, Commands = [], EnvVars = <nil>}"
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestTerraformExtraArgumentsGetVarFilesIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	mockLogger := logrus.StandardLogger()
+
+	testTerraformExtraArguments := TerraformExtraArguments{}
+	testLogger := logrus.NewEntry(mockLogger)
+
+	actualResult := testTerraformExtraArguments.GetVarFiles(testLogger)
+
+	expectedOutput := make([]string, 0)
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestTerraformExtraArgumentsGetVarFilesRequiredVarFiles(t *testing.T) {
+	t.Parallel()
+
+	dummyFile := "someFile.hcl"
+	dummyRequiredVarFiles := []string{dummyFile, dummyFile}
+	mockLogger := logrus.StandardLogger()
+
+	testTerraformExtraArguments := TerraformExtraArguments{
+		RequiredVarFiles: &dummyRequiredVarFiles,
+	}
+	testLogger := logrus.NewEntry(mockLogger)
+
+	actualResult := testTerraformExtraArguments.GetVarFiles(testLogger)
+
+	expectedOutput := []string{dummyFile}
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestTerraformExtraArgumentsGetVarFilesOptionalVarFiles(t *testing.T) {
+	t.Parallel()
+
+	dummyFile := "someFile.hcl"
+	dummyOptionalVarFiles := []string{dummyFile, dummyFile}
+	mockLogger := logrus.StandardLogger()
+
+	testTerraformExtraArguments := TerraformExtraArguments{
+		OptionalVarFiles: &dummyOptionalVarFiles,
+	}
+	testLogger := logrus.NewEntry(mockLogger)
+
+	actualResult := testTerraformExtraArguments.GetVarFiles(testLogger)
+
+	expectedOutput := []string{}
+
+	// Note: False positive
+	// Because util.FileExists currently not working in test
+	assert.Equal(t, expectedOutput, actualResult)
 }
 
 func TestParseTerragruntConfigRemoteStateMinimalConfig(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -208,6 +208,124 @@ func TestRemoteStateConfigFileToConfigUsesDisableDependencyOptimization(t *testi
 	assert.Equal(t, expectedOutput, actualResult)
 }
 
+func TestIncludeConfigStringIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	testIncludeConfig := IncludeConfig{}
+
+	actualResult := testIncludeConfig.String()
+
+	expectedOutput := "IncludeConfig{Path = , Expose = <nil>, MergeStrategy = <nil>}"
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestGetExposeIsFalseIfExposeIsNil(t *testing.T) {
+	t.Parallel()
+
+	testIncludeConfig := IncludeConfig{
+		Expose: nil,
+	}
+
+	actualResult := testIncludeConfig.GetExpose()
+
+	expectedOutput := false
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestGetExpose(t *testing.T) {
+	t.Parallel()
+
+	testExpose := true
+	testIncludeConfig := IncludeConfig{
+		Expose: &testExpose,
+	}
+
+	actualResult := testIncludeConfig.GetExpose()
+
+	expectedOutput := testExpose
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestGetMergeStrategyNilDefaultsToShallow(t *testing.T) {
+	t.Parallel()
+
+	testIncludeConfig := IncludeConfig{
+		MergeStrategy: nil,
+	}
+
+	actualResult, _ := testIncludeConfig.GetMergeStrategy()
+
+	expectedOutput := ShallowMerge
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestGetMergeStrategyDefaultsToNoMerge(t *testing.T) {
+	t.Parallel()
+
+	testMergeStrategy := ""
+	testIncludeConfig := IncludeConfig{
+		MergeStrategy: &testMergeStrategy,
+	}
+
+	actualResult, _ := testIncludeConfig.GetMergeStrategy()
+
+	expectedOutput := NoMerge
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestModuleDependenciesStringIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	testModuleDependencies := ModuleDependencies{}
+
+	actualResult := testModuleDependencies.String()
+
+	expectedOutput := "ModuleDependencies{Paths = []}"
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestHookStringIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	testHook := Hook{}
+
+	actualResult := testHook.String()
+
+	expectedOutput := "Hook{Name = , Commands = 0}"
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestErrorHookStringIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	testErrorHook := ErrorHook{}
+
+	actualResult := testErrorHook.String()
+
+	expectedOutput := "Hook{Name = , Commands = 0}"
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestTerraformConfigStringIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	testTerraformConfig := TerraformConfig{}
+
+	actualResult := testTerraformConfig.String()
+
+	expectedOutput := "TerraformConfig{Source = <nil>}"
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
 func TestParseTerragruntConfigRemoteStateMinimalConfig(t *testing.T) {
 	t.Parallel()
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -326,6 +326,109 @@ func TestTerraformConfigStringIsEmpty(t *testing.T) {
 	assert.Equal(t, expectedOutput, actualResult)
 }
 
+func TestTerraformConfigGetBeforeHooks(t *testing.T) {
+	t.Parallel()
+
+	testBeforeHooks := make([]Hook, 0)
+	testTerraformConfig := TerraformConfig{
+		BeforeHooks: testBeforeHooks,
+	}
+
+	actualResult := testTerraformConfig.GetBeforeHooks()
+
+	expectedOutput := testBeforeHooks
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestTerraformConfigGetAfterHooks(t *testing.T) {
+	t.Parallel()
+
+	testAfterHooks := make([]Hook, 0)
+	testTerraformConfig := TerraformConfig{
+		AfterHooks: testAfterHooks,
+	}
+
+	actualResult := testTerraformConfig.GetAfterHooks()
+
+	expectedOutput := testAfterHooks
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestTerraformConfigGetErrorHooks(t *testing.T) {
+	t.Parallel()
+
+	testErrorHooks := make([]ErrorHook, 0)
+	testTerraformConfig := TerraformConfig{
+		ErrorHooks: testErrorHooks,
+	}
+
+	actualResult := testTerraformConfig.GetErrorHooks()
+
+	expectedOutput := testErrorHooks
+
+	assert.Equal(t, expectedOutput, actualResult)
+}
+
+func TestTerraformConfigValidateHooksNoHooksNoError(t *testing.T) {
+	t.Parallel()
+
+	testTerraformConfig := TerraformConfig{}
+
+	actualResult := testTerraformConfig.ValidateHooks()
+
+	assert.Nil(t, actualResult)
+}
+
+func TestTerraformConfigValidateHooksBeforeHooksError(t *testing.T) {
+	t.Parallel()
+
+	stubHook := Hook{}
+
+	testBeforeHooks := make([]Hook, 1)
+	testBeforeHooks = append(testBeforeHooks, stubHook)
+	testTerraformConfig := TerraformConfig{
+		BeforeHooks: testBeforeHooks,
+	}
+
+	actualResult := testTerraformConfig.ValidateHooks()
+
+	assert.Error(t, actualResult)
+}
+
+func TestTerraformConfigValidateHooksAftereHooksError(t *testing.T) {
+	t.Parallel()
+
+	stubHook := Hook{}
+
+	testAfterHooks := make([]Hook, 1)
+	testAfterHooks = append(testAfterHooks, stubHook)
+	testTerraformConfig := TerraformConfig{
+		AfterHooks: testAfterHooks,
+	}
+
+	actualResult := testTerraformConfig.ValidateHooks()
+
+	assert.Error(t, actualResult)
+}
+
+func TestTerraformConfigValidateHooksErrorHooksError(t *testing.T) {
+	t.Parallel()
+
+	stubHook := ErrorHook{}
+
+	testErrorHooks := make([]ErrorHook, 1)
+	testErrorHooks = append(testErrorHooks, stubHook)
+	testTerraformConfig := TerraformConfig{
+		ErrorHooks: testErrorHooks,
+	}
+
+	actualResult := testTerraformConfig.ValidateHooks()
+
+	assert.Error(t, actualResult)
+}
+
 func TestParseTerragruntConfigRemoteStateMinimalConfig(t *testing.T) {
 	t.Parallel()
 

--- a/config/config_test_mocks.go
+++ b/config/config_test_mocks.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"os"
+	"time"
+)
+
+type MockFileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	isDir   bool
+	sys     interface{}
+}
+
+func (mock MockFileInfo) Name() string {
+	return mock.name
+}
+
+func (mock MockFileInfo) Size() int64 {
+	return mock.size
+}
+
+func (mock MockFileInfo) Mode() os.FileMode {
+	return mock.mode
+}
+
+func (mock MockFileInfo) ModTime() time.Time {
+	return mock.modTime
+}
+
+func (mock MockFileInfo) IsDir() bool {
+	return mock.isDir
+}
+
+func (mock MockFileInfo) Sys() interface{} {
+	return mock.sys
+}

--- a/config/config_test_mocks.go
+++ b/config/config_test_mocks.go
@@ -3,9 +3,11 @@ package config
 import (
 	"os"
 	"time"
+
+	"github.com/hashicorp/hcl/v2"
 )
 
-type MockFileInfo struct {
+type MockOsFileInfo struct {
 	name    string
 	size    int64
 	mode    os.FileMode
@@ -14,26 +16,51 @@ type MockFileInfo struct {
 	sys     interface{}
 }
 
-func (mock MockFileInfo) Name() string {
+func (mock MockOsFileInfo) Name() string {
 	return mock.name
 }
 
-func (mock MockFileInfo) Size() int64 {
+func (mock MockOsFileInfo) Size() int64 {
 	return mock.size
 }
 
-func (mock MockFileInfo) Mode() os.FileMode {
+func (mock MockOsFileInfo) Mode() os.FileMode {
 	return mock.mode
 }
 
-func (mock MockFileInfo) ModTime() time.Time {
+func (mock MockOsFileInfo) ModTime() time.Time {
 	return mock.modTime
 }
 
-func (mock MockFileInfo) IsDir() bool {
+func (mock MockOsFileInfo) IsDir() bool {
 	return mock.isDir
 }
 
-func (mock MockFileInfo) Sys() interface{} {
+func (mock MockOsFileInfo) Sys() interface{} {
 	return mock.sys
+}
+
+type MockHclBody struct {
+	bodyContent *hcl.BodyContent
+	diagnostics hcl.Diagnostics
+	attributes hcl.Attributes
+	itemRange hcl.Range
+}
+
+func (mock MockHclBody) Content(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Diagnostics) {
+	return mock.bodyContent, mock.diagnostics
+}
+
+func (mock MockHclBody) PartialContent(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Body, hcl.Diagnostics) {
+	inlineBody := MockHclBody{}
+
+	return mock.bodyContent, inlineBody, mock.diagnostics
+}
+
+func (mock MockHclBody) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
+	return mock.attributes, mock.diagnostics
+}
+
+func (mock MockHclBody) MissingItemRange() hcl.Range {
+	return mock.itemRange
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

> This is a Draft for an upcoming "change"

This basically fixes nothing function-wise but adds a bunch of unit tests to increase the coverage and secure the currently implemented logic. My believe is that Clean Code can improve software in a good way but first we need to write tests covering the logic before doing any changes to structure, names or algorithms.

Understand this as a giveaway to the project.

Small side note to the term "test coverage":
I know that the current status i am working on has a nice coverage around 55%. However, this is the coverage for all tests executed. One single test may run code from more than one unit. So basically those tests do more than a simple unit test. This will make the coverage fuzzy because it captures coverage of implicitly tested units but you'd rather want to go for explicit tests.

I'll take the opportunity to open a PR early so that you can tell me if you don't like to get free tests or have requirements to make this work for you.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->