### PR TITLE
Fix backend generation when access and secret keys are supplied

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -67,20 +67,22 @@ var terragruntOnlyConfigs = []string{
 
 // A representation of the configuration options available for S3 remote state
 type RemoteStateConfigS3 struct {
-	Encrypt          bool   `mapstructure:"encrypt"`
-	Bucket           string `mapstructure:"bucket"`
-	Key              string `mapstructure:"key"`
-	Region           string `mapstructure:"region"`
-	Endpoint         string `mapstructure:"endpoint"`
-	DynamoDBEndpoint string `mapstructure:"dynamodb_endpoint"`
-	Profile          string `mapstructure:"profile"`
-	RoleArn          string `mapstructure:"role_arn"`
-	ExternalID       string `mapstructure:"external_id"`
-	SessionName      string `mapstructure:"session_name"`
-	LockTable        string `mapstructure:"lock_table"` // Deprecated in Terraform version 0.13 or newer.
-	DynamoDBTable    string `mapstructure:"dynamodb_table"`
-	CredsFilename    string `mapstructure:"shared_credentials_file"`
-	S3ForcePathStyle bool   `mapstructure:"force_path_style"`
+	Encrypt          bool    `mapstructure:"encrypt"`
+	Bucket           string  `mapstructure:"bucket"`
+	Key              string  `mapstructure:"key"`
+	Region           string  `mapstructure:"region"`
+	Endpoint         string  `mapstructure:"endpoint"`
+	DynamoDBEndpoint string  `mapstructure:"dynamodb_endpoint"`
+	Profile          string  `mapstructure:"profile"`
+	RoleArn          string  `mapstructure:"role_arn"`
+	ExternalID       string  `mapstructure:"external_id"`
+	SessionName      string  `mapstructure:"session_name"`
+	LockTable        string  `mapstructure:"lock_table"` // Deprecated in Terraform version 0.13 or newer.
+	DynamoDBTable    string  `mapstructure:"dynamodb_table"`
+	CredsFilename    string  `mapstructure:"shared_credentials_file"`
+	S3ForcePathStyle bool    `mapstructure:"force_path_style"`
+	AccessKey        *string `mapstructure:"access_key"`
+	SecretKey        *string `mapstructure:"secret_key"`
 }
 
 // Builds a session config for AWS related requests from the RemoteStateConfigS3 configuration
@@ -96,6 +98,8 @@ func (c *ExtendedRemoteStateConfigS3) GetAwsSessionConfig() *aws_helper.AwsSessi
 		CredsFilename:           c.remoteStateConfigS3.CredsFilename,
 		S3ForcePathStyle:        c.remoteStateConfigS3.S3ForcePathStyle,
 		DisableComputeChecksums: c.DisableAWSClientChecksums,
+		AccessKey:               c.remoteStateConfigS3.AccessKey,
+		SecretKey:               c.remoteStateConfigS3.SecretKey,
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This should fix a bug that happens when you provide only access and secret keys and terragrunt tries to initialize the bucket, and it fails because it always fallbacks to env/config file from ~/.aws

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs. (nothing changes)
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Allow terragrunt to be initialized with s3 backend using access and secret keys.


### Migration Guide

It should be backwards compatible
<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

