### PR TITLE
Add ability to disable auto-approve

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -48,6 +48,7 @@ const (
 	optTerragruntIncludeDir                  = "terragrunt-include-dir"
 	optTerragruntStrictInclude               = "terragrunt-strict-include"
 	optTerragruntParallelism                 = "terragrunt-parallelism"
+	optTerragruntNoAutoApprove               = "terragrunt-no-auto-approve"
 	optTerragruntCheck                       = "terragrunt-check"
 	optTerragruntHCLFmt                      = "terragrunt-hclfmt-file"
 	optTerragruntDebug                       = "terragrunt-debug"
@@ -67,6 +68,7 @@ var allTerragruntBooleanOpts = []string{
 	optTerragruntIncludeExternalDependencies,
 	optTerragruntNoAutoInit,
 	optTerragruntNoAutoRetry,
+	optTerragruntNoAutoApprove,
 	optTerragruntCheck,
 	optTerragruntStrictInclude,
 	optTerragruntDebug,

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -68,14 +68,16 @@ func (stack *Stack) Run(terragruntOptions *options.TerragruntOptions) error {
 		stack.syncTerraformCliArgs(terragruntOptions)
 	}
 
-	// For apply and destroy, run with auto-approve due to the co-mingling of the prompts. This is not ideal, but until
-	// we have a better way of handling interactivity with run-all, we take the evil of having a global prompt (managed
-	// in cli/cli_app.go) be the gate keeper.
+	// For apply and destroy, run with auto-approve (unless explicitly disabled) due to the co-mingling of the prompts.
+	// This is not ideal, but until we have a better way of handling interactivity with run-all, we take the evil of
+	// having a global prompt (managed in cli/cli_app.go) be the gate keeper.
 	switch stackCmd {
 	case "apply", "destroy":
 		// to support potential positional args in the args list, we append the input=false arg after the first element,
 		// which is the target command.
-		terragruntOptions.TerraformCliArgs = util.StringListInsert(terragruntOptions.TerraformCliArgs, "-auto-approve", 1)
+		if terragruntOptions.RunAllAutoApprove {
+			terragruntOptions.TerraformCliArgs = util.StringListInsert(terragruntOptions.TerraformCliArgs, "-auto-approve", 1)
+		}
 		stack.syncTerraformCliArgs(terragruntOptions)
 	}
 

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -449,6 +449,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
 - [terragrunt-tfpath](#terragrunt-tfpath)
 - [terragrunt-no-auto-init](#terragrunt-no-auto-init)
 - [terragrunt-no-auto-retry](#terragrunt-no-auto-retry)
+- [terragrunt-no-auto-approve](#terragrunt-no-auto-approve)
 - [terragrunt-non-interactive](#terragrunt-non-interactive)
 - [terragrunt-working-dir](#terragrunt-working-dir)
 - [terragrunt-download-dir](#terragrunt-download-dir)
@@ -512,6 +513,18 @@ if you want to pass custom arguments to `terraform init` that are specific to a 
 therefore cannot be specified as `extra_arguments`. For example, `-plugin-dir`. You must run `terragrunt init`
 yourself in this case if needed. `terragrunt` will fail if it detects that `init` is needed, but auto init is
 disabled. See [Auto-Init]({{site.baseurl}}/docs/features/auto-init#auto-init)
+
+
+### terragrunt-no-auto-approve
+
+**CLI Arg**: `--terragrunt-no-auto-approve`<br/>
+**Environment Variable**: `TERRAGRUNT_AUTO_APPROVE` (set to `false`)
+**Commands**:
+- [run-all](#run-all)
+
+When passed in, Terragrunt will no longer automatically append `-auto-approve` to the underlying Terraform commands run
+with `run-all`. Note that due to the interactive prompts, this flag will also **automatically assume
+`--terragrunt-parallelism 1`**.
 
 
 ### terragrunt-no-auto-retry
@@ -721,7 +734,6 @@ included directories with `terragrunt-include-dir`.
 **Environment Variable**: `TERRAGRUNT_PARALLELISM`
 
 When passed in, limit the number of modules that are run concurrently to this number during *-all commands.
-
 
 
 ### terragrunt-debug

--- a/options/options.go
+++ b/options/options.go
@@ -71,6 +71,9 @@ type TerragruntOptions struct {
 	// Whether we should automatically run terraform init if necessary when executing other commands
 	AutoInit bool
 
+	// Whether we should automatically run terraform with -auto-apply in run-all mode.
+	RunAllAutoApprove bool
+
 	// CLI args that are intended for Terraform (i.e. all the CLI args except the --terragrunt ones)
 	TerraformCliArgs []string
 
@@ -234,6 +237,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		OriginalTerraformCommand:    "",
 		TerraformCommand:            "",
 		AutoInit:                    true,
+		RunAllAutoApprove:           true,
 		NonInteractive:              false,
 		TerraformCliArgs:            []string{},
 		WorkingDir:                  workingDir,
@@ -319,6 +323,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		TerraformVersion:             terragruntOptions.TerraformVersion,
 		TerragruntVersion:            terragruntOptions.TerragruntVersion,
 		AutoInit:                     terragruntOptions.AutoInit,
+		RunAllAutoApprove:            terragruntOptions.RunAllAutoApprove,
 		NonInteractive:               terragruntOptions.NonInteractive,
 		TerraformCliArgs:             util.CloneStringList(terragruntOptions.TerraformCliArgs),
 		WorkingDir:                   workingDir,


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #2151

This implements a new flag `--terragrunt-no-auto-approve` which will prevent terragrunt from automatically including the `-auto-approve` flag to `apply` and `destroy` calls for `run-all`. In order to make the prompts work correctly, Terragrunt will also automatically set parallelism to `1`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added new flag `--terragrunt-no-auto-approve` which will prevent terragrunt from automatically including the `-auto-approve` flag to `apply` and `destroy` calls for `run-all`. In order to make the prompts work correctly, Terragrunt will also automatically set parallelism to `1`.