### PR TITLE
Fix typo in DRY remote stat configuration

### DIFF
--- a/docs/_docs/02_features/keep-your-remote-state-configuration-dry.md
+++ b/docs/_docs/02_features/keep-your-remote-state-configuration-dry.md
@@ -206,7 +206,7 @@ configuration specified in the `remote_state` bucket. For example, if you requir
 block, but the underlying state bucket doesn't have versioning enabled, Terragrunt will automatically turn on versioning
 on the bucket to match the configuration.
 
-If you do not want `terragrunt` to automatically apply changes, you can configuret the following:
+If you do not want `terragrunt` to automatically apply changes, you can configure the following:
 
 ```hcl
 remote_state {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes a typo in the docs for keeping remote state configuration DRY.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated typo in docs.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

