### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -107,9 +107,9 @@ func TestTerragruntCorrectlyMirrorsTerraformGCPAuth(t *testing.T) {
 	// There is no true way to properly unset env vars from the environment, but we still try
 	// to unset the CI credentials during this test.
 	defaultCreds := os.Getenv("GCLOUD_SERVICE_KEY")
-	defer t.Setenv("GCLOUD_SERVICE_KEY", defaultCreds)
+	defer os.Setenv("GCLOUD_SERVICE_KEY", defaultCreds)
 	os.Unsetenv("GCLOUD_SERVICE_KEY")
-	t.Setenv("GOOGLE_CREDENTIALS", defaultCreds)
+	os.Setenv("GOOGLE_CREDENTIALS", defaultCreds)
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_GCS_PATH)
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1218,8 +1218,7 @@ func TestAutoRetryFlagWithRecoverableError(t *testing.T) {
 }
 
 func TestAutoRetryEnvVarWithRecoverableError(t *testing.T) {
-	os.Setenv("TERRAGRUNT_NO_AUTO_RETRY", "true")
-	defer os.Unsetenv("TERRAGRUNT_NO_AUTO_RETRY")
+	t.Setenv("TERRAGRUNT_NO_AUTO_RETRY", "true")
 	out := new(bytes.Buffer)
 	rootPath := copyEnvironment(t, TEST_FIXTURE_AUTO_RETRY_RERUN)
 	modulePath := util.JoinPath(rootPath, TEST_FIXTURE_AUTO_RETRY_RERUN)
@@ -3154,8 +3153,7 @@ func TestDataDir(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_DIRS_PATH)
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_DIRS_PATH)
 
-	os.Setenv("TF_DATA_DIR", util.JoinPath(tmpEnvPath, "data_dir"))
-	defer os.Unsetenv("TF_DATA_DIR")
+	t.Setenv("TF_DATA_DIR", util.JoinPath(tmpEnvPath, "data_dir"))
 
 	var (
 		stdout bytes.Buffer

--- a/test/integration_windows_test.go
+++ b/test/integration_windows_test.go
@@ -6,6 +6,7 @@ package test
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"

--- a/test/integration_windows_test.go
+++ b/test/integration_windows_test.go
@@ -6,7 +6,6 @@ package test
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -54,7 +53,7 @@ func TestWindowsTerragruntSourceMapDebug(t *testing.T) {
 			copyEnvironmentToPath(t, fixtureSourceMapPath, targetPath)
 			rootPath := filepath.Join(targetPath, fixtureSourceMapPath)
 
-			os.Setenv(
+			t.Setenv(
 				"TERRAGRUNT_SOURCE_MAP",
 				strings.Join(
 					[]string{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

Reference: https://pkg.go.dev/testing#T.Setenv

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Use `T.Setenv` to set env vars in tests

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

