### PR TITLE
hclfmt: accept multiple files

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -72,7 +72,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 		terragruntConfigPath = config.GetDefaultConfigPath(workingDir)
 	}
 
-	terragruntHclFilePath, err := parseStringArg(args, optTerragruntHCLFmt, "")
+	terragruntHclFilePaths, err := parseMultiStringArg(args, optTerragruntHCLFmt, []string{})
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +219,9 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.ModulesThatInclude = modulesThatInclude
 	opts.StrictInclude = strictInclude
 	opts.Check = parseBooleanArg(args, optTerragruntCheck, os.Getenv("TERRAGRUNT_CHECK") == "true")
-	opts.HclFile = filepath.ToSlash(terragruntHclFilePath)
+	for _, p := range terragruntHclFilePaths {
+		opts.HclFiles = append(opts.HclFiles, filepath.ToSlash(p))
+	}
 	opts.AwsProviderPatchOverrides = awsProviderPatchOverrides
 	opts.FetchDependencyOutputFromState = parseBooleanArg(args, optTerragruntFetchDependencyOutputFromState, os.Getenv("TERRAGRUNT_FETCH_DEPENDENCY_OUTPUT_FROM_STATE") == "true")
 	opts.RenderJsonWithMetadata = parseBooleanArg(args, optTerragruntOutputWithMetadata, false)

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -251,7 +251,7 @@ GLOBAL OPTIONS:
    terragrunt-exclude-dir                       Unix-style glob of directories to exclude when running *-all commands
    terragrunt-include-dir                       Unix-style glob of directories to include when running *-all commands
    terragrunt-check                             Enable check mode in the hclfmt command.
-   terragrunt-hclfmt-file                       The path to a single hcl file that the hclfmt command should run on.
+   terragrunt-hclfmt-file                       The path to a single hcl file that the hclfmt command should run on. May be specified multiple times.
    terragrunt-override-attr                     A key=value attribute to override in a provider block as part of the aws-provider-patch command. May be specified multiple times.
    terragrunt-debug                             Write terragrunt-debug.tfvars to working folder to help root-cause issues.
    terragrunt-log-level                         Sets the logging level for Terragrunt. Supported levels: panic, fatal, error, warn (default), info, debug, trace.

--- a/cli/hclfmt_test.go
+++ b/cli/hclfmt_test.go
@@ -212,7 +212,7 @@ func TestHCLFmtFile(t *testing.T) {
 	require.NoError(t, err)
 
 	// format only the hcl file contained within the a subdirectory of the fixture
-	tgOptions.HclFile = "a/terragrunt.hcl"
+	tgOptions.HclFiles = []string{"a/terragrunt.hcl"}
 	tgOptions.WorkingDir = tmpPath
 	err = runHCLFmt(tgOptions)
 	require.NoError(t, err)
@@ -221,7 +221,7 @@ func TestHCLFmtFile(t *testing.T) {
 	t.Run("formatted", func(t *testing.T) {
 		t.Run(tgOptions.HclFile, func(t *testing.T) {
 			t.Parallel()
-			tgHclPath := filepath.Join(tmpPath, tgOptions.HclFile)
+			tgHclPath := filepath.Join(tmpPath, tgOptions.HclFiles[0])
 			formatted, err := ioutil.ReadFile(tgHclPath)
 			require.NoError(t, err)
 			assert.Equal(t, expected, formatted)

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -806,7 +806,7 @@ command to exit with exit code 1 if there are any files that are not formatted.
 **Commands**:
 - [hclfmt](#hclfmt)
 
-When passed in, run `hclfmt` only on specified hcl file.
+When passed in, run `hclfmt` only on specified hcl file. May be specified multiple times to include multiple files.
 
 
 ### terragrunt-override-attr

--- a/options/options.go
+++ b/options/options.go
@@ -163,7 +163,7 @@ type TerragruntOptions struct {
 	Check bool
 
 	// The file which hclfmt should be specifically run on
-	HclFile string
+	HclFiles []string
 
 	// The file path that terragrunt should use when rendering the terragrunt.hcl config as json.
 	JSONOut string
@@ -363,7 +363,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		StrictInclude:                  terragruntOptions.StrictInclude,
 		RunTerragrunt:                  terragruntOptions.RunTerragrunt,
 		AwsProviderPatchOverrides:      terragruntOptions.AwsProviderPatchOverrides,
-		HclFile:                        terragruntOptions.HclFile,
+		HclFiles:                       util.CloneStringList(terragruntOptions.HclFiles),
 		JSONOut:                        terragruntOptions.JSONOut,
 		Check:                          terragruntOptions.Check,
 		CheckDependentModules:          terragruntOptions.CheckDependentModules,


### PR DESCRIPTION


<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

hclfmt: accept multiple files when using the `--terragrunt-hclfmt-file` option.
This is useful when used in combination with https://github.com/numtide/treefmt

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

- The `--terragrunt-hclfmt-file` option in `hclfmt` now supports multiple files.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

