### PR TITLE
bump pre-commit gruntwork hooks to 0.1.17

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev:  v0.1.10
+    rev:  v0.1.17
     hooks:
       - id: terraform-fmt
       - id: goimports


### PR DESCRIPTION
This version fixes shebangs for me.

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Update pre-commit to fix `/bin/bash` shebangs on NixOS.


- [ ] ~~Update the docs.~~
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] ~~Include release notes. If this PR is backward incompatible, include a migration guide.~~

## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

- bump pre-commit to 0.1.17

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

