### PR TITLE
based on reported issue #2158, removed the trailing slash appended to get_path_to_repo_root()

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -209,7 +209,7 @@ func getPathToRepoRoot(trackInclude *TrackInclude, terragruntOptions *options.Te
 		return "", errors.WithStackTrace(err)
 	}
 
-	return filepath.ToSlash(strings.TrimSpace(repoRootPathAbs) + "/"), nil
+	return filepath.ToSlash(strings.TrimSpace(repoRootPathAbs)), nil
 }
 
 // Return the directory where the Terragrunt configuration file lives

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2927,7 +2927,7 @@ func TestGetPathToRepoRoot(t *testing.T) {
 	pathToRoot, hasPathToRoot := outputs["path_to_root"]
 
 	require.True(t, hasPathToRoot)
-	require.Equal(t, pathToRoot.Value, "../../")
+	require.Equal(t, pathToRoot.Value, "../..")
 }
 
 func TestGetPlatform(t *testing.T) {


### PR DESCRIPTION
 and updated tests to match

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #2158.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs. (Docs already show this desired state)
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes
* Removes trailing slash appended to the end of `get_path_to_repo_root()`


<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [].

### Migration Guide
* Migration:
  * `source = "${get_path_to_repo_root()}/` -> `source = "${get_path_to_repo_root()}//`
<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

