### PR TITLE
Fix typo for render-json CLI option

### DIFF
--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -35,7 +35,7 @@ Terragrunt supports the following CLI commands:
   - [graph-dependencies](#graph-dependencies)
   - [hclfmt](#hclfmt)
   - [aws-provider-patch](#aws-provider-patch)
-  - [crender-json](#render-json)
+  - [render-json](#render-json)
 
 ### All Terraform built-in commands
 


### PR DESCRIPTION
There was a typo on our docs for render-json. It was `crender-json`
<img width="433" alt="Screenshot 2022-07-26 at 16 42 58" src="https://user-images.githubusercontent.com/32835571/181020735-a076c4aa-4fbc-4f2d-92c9-4200f4c8bd95.png">