### PR TITLE
Fix bug where terragrunt run-all render-json overwrites all files

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -224,7 +224,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.FetchDependencyOutputFromState = parseBooleanArg(args, optTerragruntFetchDependencyOutputFromState, os.Getenv("TERRAGRUNT_FETCH_DEPENDENCY_OUTPUT_FROM_STATE") == "true")
 	opts.RenderJsonWithMetadata = parseBooleanArg(args, optTerragruntOutputWithMetadata, false)
 
-	opts.JSONOut, err = parseStringArg(args, optTerragruntJSONOut, "terragrunt_rendered.json")
+	opts.JSONOut, err = parseStringArg(args, optTerragruntJSONOut, "")
 	if err != nil {
 		return nil, err
 	}

--- a/cli/render_json.go
+++ b/cli/render_json.go
@@ -15,6 +15,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 )
 
+const defaultJSONOutName = "terragrunt_rendered.json"
+
 // runRenderJSON takes the parsed TerragruntConfig struct and renders it out as JSON so that it can be processed by
 // other tools. To make it easier to maintain, this uses the cty representation as an intermediary.
 // NOTE: An unspecified advantage of using the cty representation is that the final block outputs would be a map
@@ -47,6 +49,11 @@ func runRenderJSON(terragruntOptions *options.TerragruntOptions, terragruntConfi
 	}
 
 	jsonOutPath := terragruntOptions.JSONOut
+	if jsonOutPath == "" {
+		// Default to naming it `terragrunt_rendered.json` in the terragrunt config directory.
+		terragruntConfigDir := filepath.Dir(terragruntOptions.TerragruntConfigPath)
+		jsonOutPath = filepath.Join(terragruntConfigDir, defaultJSONOutName)
+	}
 	if err := util.EnsureDirectory(filepath.Dir(jsonOutPath)); err != nil {
 		return err
 	}

--- a/cli/render_json.go
+++ b/cli/render_json.go
@@ -57,6 +57,7 @@ func runRenderJSON(terragruntOptions *options.TerragruntOptions, terragruntConfi
 	if err := util.EnsureDirectory(filepath.Dir(jsonOutPath)); err != nil {
 		return err
 	}
+	terragruntOptions.Logger.Debugf("Rendering config %s to JSON %s", terragruntOptions.TerragruntConfigPath, jsonOutPath)
 
 	if err := ioutil.WriteFile(jsonOutPath, jsonBytes, 0644); err != nil {
 		return errors.WithStackTrace(err)

--- a/test/fixture-render-json-regression/baz/terragrunt.hcl
+++ b/test/fixture-render-json-regression/baz/terragrunt.hcl
@@ -1,1 +1,4 @@
-# empty
+locals {
+  # This is intentionally unused, and is used to check the validity of the json output from render-json.
+  self = "baz"
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/terragrunt/issues/1973

This updates the `run-all render-json` command to output the rendered json for each `terragrunt.hcl` file adjacent to the config file (in the same directory).

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
- Fixed a bug in `render-json` where when running with `run-all`, it reuses the same rendered json file for all runs, causing a race condition where the last module to run always wins. Now the rendered json output is created adjacent to each `terragrunt.hcl` config `terragrunt` finds.