### PR TITLE
fix(docs): use correct link

### DIFF
--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -293,7 +293,7 @@ instead of the module repository.**
 
 The `remote_state` block is used to configure how Terragrunt will set up the remote state configuration of your
 Terraform code. You can read more about Terragrunt's remote state functionality in [Keep your remote state configuration
-DRY](/use-cases/keep-your-remote-state-configuration-dry) use case overview.
+DRY](/docs/features/keep-your-remote-state-configuration-dry/) use case overview.
 
 The `remote_state` block supports the following arguments:
 


### PR DESCRIPTION
[Here](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#remote_state) was incorrect link to [Keep your remote state configuration DRY](https://terragrunt.gruntwork.io/docs/features/keep-your-remote-state-configuration-dry/)