### PR TITLE
Docs: update to mention run-all commands not xxx-all

### DIFF
--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -123,7 +123,7 @@ func (stack *Stack) summarizePlanAllErrors(terragruntOptions *options.Terragrunt
 					dependenciesMsg = fmt.Sprintf(" contains dependencies to %v and", stack.Modules[i].Config.Dependencies.Paths)
 				}
 				terragruntOptions.Logger.Infof("%v%v refers to remote state "+
-					"you may have to apply your changes in the dependencies prior running terragrunt plan-all.\n",
+					"you may have to apply your changes in the dependencies prior running terragrunt run-all plan.\n",
 					stack.Modules[i].Path,
 					dependenciesMsg,
 				)

--- a/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
+++ b/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
@@ -86,7 +86,7 @@ Finally, if you make some changes to your project, you could evaluate the impact
 Note: It is important to realize that you could get errors running `run-all plan` if you have dependencies between your
 projects and some of those dependencies haven’t been applied yet.
 
-*Ex: If module A depends on module B and module B hasn’t been applied yet, then plan-all will show the plan for B, but exit with an error when trying to show the plan for A.*
+*Ex: If module A depends on module B and module B hasn’t been applied yet, then run-all plan will show the plan for B, but exit with an error when trying to show the plan for A.*
 
     cd root
     terragrunt run-all plan
@@ -160,11 +160,11 @@ If any of the modules failed to deploy, then Terragrunt will not attempt to depl
 
 Terragrunt will return an error indicating the dependency hasn’t been applied yet if the terraform module managed by the terragrunt config referenced in a `dependency` block has not been applied yet. This is because you cannot actually fetch outputs out of an unapplied Terraform module, even if there are no resources being created in the module.
 
-This is most problematic when running commands that do not modify state (e.g `plan-all` and `validate-all`) on a completely new setup where no infrastructure has been deployed. You won’t be able to `plan` or `validate` a module if you can’t determine the `inputs`. If the module depends on the outputs of another module that hasn’t been applied yet, you won’t be able to compute the `inputs` unless the dependencies are all applied. However, in real life usage, you would want to run `validate-all` or `plan-all` on a completely new set of infrastructure.
+This is most problematic when running commands that do not modify state (e.g `run-all plan` and `run-all validate`) on a completely new setup where no infrastructure has been deployed. You won’t be able to `plan` or `validate` a module if you can’t determine the `inputs`. If the module depends on the outputs of another module that hasn’t been applied yet, you won’t be able to compute the `inputs` unless the dependencies are all applied. However, in real life usage, you would want to run `run-all validate` or `run-all plan` on a completely new set of infrastructure.
 
 To address this, you can provide mock outputs to use when a module hasn’t been applied yet. This is configured using the `mock_outputs` attribute on the `dependency` block and it corresponds to a map that will be injected in place of the actual dependency outputs if the target config hasn’t been applied yet.
 
-For example, in the previous example with a `mysql` module and `vpc` module, suppose you wanted to place in a temporary, dummy value for the `vpc_id` during a `validate-all` for the `mysql` module. You can specify in `mysql/terragrunt.hcl`:
+For example, in the previous example with a `mysql` module and `vpc` module, suppose you wanted to place in a temporary, dummy value for the `vpc_id` during a `run-all validate` for the `mysql` module. You can specify in `mysql/terragrunt.hcl`:
 
     dependency "vpc" {
       config_path = "../vpc"
@@ -197,7 +197,7 @@ You can use the `mock_outputs_allowed_terraform_commands` attribute to indicate 
       vpc_id = dependency.vpc.outputs.vpc_id
     }
 
-Note that indicating `validate` means that the `mock_outputs` will be used either with `validate` or with `validate-all`.
+Note that indicating `validate` means that the `mock_outputs` will be used either with `validate` or with `run-all validate`.
 
 You can also use `skip_outputs` on the `dependency` block to specify the dependency without pulling in the outputs:
 
@@ -292,7 +292,7 @@ Once you’ve specified the dependencies in each `terragrunt.hcl` file, when you
 
 If any of the modules fail to deploy, then Terragrunt will not attempt to deploy the modules that depend on them. Once you’ve fixed the error, it’s usually safe to re-run the `run-all apply` or `run-all destroy` command again, since it’ll be a no-op for the modules that already deployed successfully, and should only affect the ones that had an error the last time around.
 
-To check all of your dependencies and validate the code in them, you can use the `validate-all` command.
+To check all of your dependencies and validate the code in them, you can use the `run-all validate` command.
 
 To check the dependency graph you can use the `graph-dependencies` command (similar to the `terraform graph` command),
 the graph is output in DOT format The typical program that can read this format is GraphViz, but many web services are also available to read this format.

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -79,10 +79,10 @@ This will recursively search the current working directory for any folders that 
 [`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
 [`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks.
 
-**[WARNING] Using `run-all` with `plan` is currently broken for certain use cases**. If you have a stack of Terragrunt modules with
-dependencies between them—either via `dependency` blocks or `terraform_remote_state` data sources—and you've never
-deployed them, then `plan-all` will fail as it will not be possible to resolve the `dependency` blocks or
-`terraform_remote_state` data sources! Please [see here for more
+**[WARNING] Using `run-all` with `plan` is currently broken for certain use cases**. If you have a stack of Terragrunt 
+modules with dependencies between them—either via `dependency` blocks or `terraform_remote_state` data sources—and 
+you've never deployed them, then `run-all plan` will fail as it will not be possible to resolve the `dependency` blocks 
+or `terraform_remote_state` data sources! Please [see here for more 
 information](https://github.com/gruntwork-io/terragrunt/issues/720#issuecomment-497888756).
 
 **[NOTE]** Using `run-all` with `apply` or `destroy` silently adds the `-auto-approve` flag to the command line
@@ -103,7 +103,7 @@ context.
 Example:
 
 ```bash
-terragrunt plan-all
+terragrunt run-all plan
 ```
 
 This will recursively search the current working directory for any folders that contain Terragrunt modules and run
@@ -111,9 +111,9 @@ This will recursively search the current working directory for any folders that 
 [`dependency`](/docs/reference/config-blocks-and-attributes/#dependency) and
 [`dependencies`](/docs/reference/config-blocks-and-attributes/#dependencies) blocks.
 
-**[WARNING] `plan-all` is currently broken for certain use cases**. If you have a stack of Terragrunt modules with
+**[WARNING] `run-all plan` is currently broken for certain use cases**. If you have a stack of Terragrunt modules with
 dependencies between them—either via `dependency` blocks or `terraform_remote_state` data sources—and you've never
-deployed them, then `plan-all` will fail as it will not be possible to resolve the `dependency` blocks or
+deployed them, then `run-all plan` will fail as it will not be possible to resolve the `dependency` blocks or
 `terraform_remote_state` data sources! Please [see here for more
 information](https://github.com/gruntwork-io/terragrunt/issues/720#issuecomment-497888756).
 
@@ -511,8 +511,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
 A custom path to the `terragrunt.hcl` or `terragrunt.hcl.json` file. The
 default path is `terragrunt.hcl` (preferred) or `terragrunt.hcl.json` in the current directory (see
 [Configuration]({{site.baseurl}}/docs/getting-started/configuration/#configuration) for a slightly more nuanced
-explanation). This argument is not used with the `apply-all`, `destroy-all`, `output-all`, `validate-all`, and
-`plan-all` commands.
+explanation). This argument is not used with the `run-all` commands.
 
 
 ### terragrunt-tfpath
@@ -584,9 +583,9 @@ This setting will default to `no` for the following cases:
 **Requires an argument**: `--terragrunt-working-dir /path/to/working-directory`
 
 Set the directory where Terragrunt should execute the `terraform` command. Default is the current working directory.
-Note that for the `apply-all`, `destroy-all`, `output-all`, `validate-all`, and `plan-all` commands, this parameter has
-a different meaning: Terragrunt will apply or destroy all the Terraform modules in the subfolders of the
-`terragrunt-working-dir`, running `terraform` in the root of each module it finds.
+Note that for the `run-all` commands, this parameter has a different meaning: Terragrunt will apply or destroy all the 
+Terraform modules in the subfolders of the `terragrunt-working-dir`, running `terraform` in the root of each module it
+finds.
 
 
 ### terragrunt-download-dir
@@ -608,10 +607,10 @@ Default is `.terragrunt-cache` in the working directory. We recommend adding thi
 
 Download Terraform configurations from the specified source into a temporary folder, and run Terraform in that temporary
 folder. The source should use the same syntax as the [Terraform module
-source](https://www.terraform.io/docs/modules/sources.html) parameter. If you specify this argument for the `apply-all`,
-`destroy-all`, `output-all`, `validate-all`, or `plan-all` commands, Terragrunt will assume this is the local file path
-for all of your Terraform modules, and for each module processed by the `xxx-all` command, Terragrunt will automatically
-append the path of `source` parameter in each module to the `--terragrunt-source` parameter you passed in.
+source](https://www.terraform.io/docs/modules/sources.html) parameter. If you specify this argument for the `run-all`
+commands, Terragrunt will assume this is the local file path for all of your Terraform modules, and for each module 
+processed by the `run-all` command, Terragrunt will automatically append the path of `source` parameter in each module 
+to the `--terragrunt-source` parameter you passed in.
 
 
 ### terragrunt-source-map


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updates docs to mention run-all command rather than xxx-all.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated docs to reflect run-all syntax.