### PR TITLE
improve s3 error handling (#2267)

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -588,6 +588,7 @@ func checkIfS3BucketNeedsUpdate(s3Client *s3.S3, config *ExtendedRemoteStateConf
 
 // Check if versioning is enabled for the S3 bucket specified in the given config and warn the user if it is not
 func checkIfVersioningEnabled(s3Client *s3.S3, config *RemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) (bool, error) {
+	terragruntOptions.Logger.Debugf("Checking if Versioning is enabled for AWS S3 bucket %s", config.Bucket)
 	out, err := s3Client.GetBucketVersioning(&s3.GetBucketVersioningInput{Bucket: aws.String(config.Bucket)})
 	if err != nil {
 		return false, errors.WithStackTrace(err)
@@ -860,7 +861,7 @@ func checkIfBucketRootAccess(s3Client *s3.S3, config *RemoteStateConfigS3, terra
 	})
 	if err != nil {
 		terragruntOptions.Logger.Debugf("Could not get policy for bucket %s", config.Bucket)
-		return false, nil
+		return false, err
 	}
 
 	// If the bucket has no policy, it is not enforced
@@ -1062,7 +1063,7 @@ func checkIfSSEForS3Enabled(s3Client *s3.S3, config *RemoteStateConfigS3, terrag
 	output, err := s3Client.GetBucketEncryption(input)
 	if err != nil {
 		terragruntOptions.Logger.Debugf("Error checking if SSE is enabled for AWS S3 bucket %s: %s", config.Bucket, err.Error())
-		return false, nil
+		return false, err
 	}
 
 	if output.ServerSideEncryptionConfiguration == nil {
@@ -1117,7 +1118,7 @@ func checkIfAccessLoggingForS3Enabled(s3Client *s3.S3, config *RemoteStateConfig
 	output, err := s3Client.GetBucketLogging(input)
 	if err != nil {
 		terragruntOptions.Logger.Debugf("Error checking if Access Logging is enabled for AWS S3 bucket %s: %s", config.Bucket, err.Error())
-		return false, nil
+		return false, err
 	}
 
 	if output.LoggingEnabled == nil {


### PR DESCRIPTION
* add missing Logger.Debugf() in checkIfVersioningEnabled()

* in check*(), don't return nil when the AWS API call returned an error
