### PR TITLE
Share `Env` attributes with `cfgOptions`.

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -590,6 +590,7 @@ func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions,
 			terragruntOptions.Logger.Debugf("Failed to build terragrunt options from %s %v", dir, err)
 			return nil
 		}
+		cfgOptions.Env = terragruntOptions.Env
 		cfgOptions.LogLevel = terragruntOptions.LogLevel
 		if terragruntOptions.TerraformCommand == "destroy" {
 			var hook = NewForceLogLevelHook(logrus.DebugLevel)


### PR DESCRIPTION
## Description
In #1823, functionality was added to check module dependencies during destroy operations. This included creating [a fresh `TerragruntOptions` object](https://github.com/gruntwork-io/terragrunt/pull/1823/files#diff-2ce1e65bb8a23011007dae779c8bacbc45d28560b1bc4e7dc1079f52fd22cf14R504) which, by default, has [an empty map for the `Env` attribute](https://github.com/gruntwork-io/terragrunt/blob/7788a525ab61641211e3f8a127ed53b450e96bc8/options/options.go#L256). This means we're losing all environment variables when checking for dependencies.

Fixes https://github.com/gruntwork-io/terragrunt/issues/2273.

## Release Notes (draft)

Updated `FindWhereWorkingDirIsIncluded` to include `Env` in the `TerragruntOptions` object for validating module dependencies for destroy operations.