### PR TITLE
Adds retryable error regex to match rate limit message from CodeCommit

### DIFF
--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -20,4 +20,5 @@ var DEFAULT_RETRYABLE_ERRORS = []string{
 	"(?s).*app.terraform.io.*: 429 Too Many Requests.*",
 	"(?s).*ssh_exchange_identification.*Connection closed by remote host.*",
 	"(?s).*Client\\.Timeout exceeded while awaiting headers.*",
+	"(?s).*Error: Failed to download module.*The requested URL returned error: 429.*",
 }

--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -20,5 +20,5 @@ var DEFAULT_RETRYABLE_ERRORS = []string{
 	"(?s).*app.terraform.io.*: 429 Too Many Requests.*",
 	"(?s).*ssh_exchange_identification.*Connection closed by remote host.*",
 	"(?s).*Client\\.Timeout exceeded while awaiting headers.*",
-	"(?s).*Error: Failed to download module.*The requested URL returned error: 429.*",
+	"(?s).*Could not download module.*The requested URL returned error: 429.*",
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #2275

<!-- Description of the changes introduced by this PR. -->

Adds a regex pattern to the list of retryable errors that matches the rate limit message from CodeCommit.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added a regex pattern to the list of retryable errors that matches the rate limit message from CodeCommit..
