### PR TITLE
#2222 Terragrunt sub-commands help output

### DIFF
--- a/cli/aws_provider_patch.go
+++ b/cli/aws_provider_patch.go
@@ -17,6 +17,16 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 )
 
+const awsProviderPatchHelp = `
+   Usage: terragrunt aws-provider-patch [OPTIONS]
+
+   Description:
+   Overwrite settings on nested AWS providers to work around a Terraform bug (issue #13018)
+   
+   Options:
+   --terragrunt-override-attr	A key=value attribute to override in a provider block as part of the aws-provider-patch command. May be specified multiple times.
+`
+
 // applyAwsProviderPatch finds all Terraform modules nested in the current code (i.e., in the .terraform/modules
 // folder), looks for provider "aws" { ... } blocks in those modules, and overwrites the attributes in those provider
 // blocks with the attributes specified in terragrntOptions.

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -289,7 +289,9 @@ var TERRAFORM_HELP_FLAGS = []string{
 
 // map of help functions for each terragrunt command
 var terragruntHelp = map[string]string{
-	CMD_RENDER_JSON: renderJsonHelp,
+	CMD_RENDER_JSON:                renderJsonHelp,
+	CMD_AWS_PROVIDER_PATCH:         awsProviderPatchHelp,
+	CMD_TERRAGRUNT_VALIDATE_INPUTS: validateInputsHelp,
 }
 
 // Create the Terragrunt CLI App

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -289,7 +289,7 @@ var TERRAFORM_HELP_FLAGS = []string{
 
 // map of help functions for each terragrunt command
 var terragruntHelp = map[string]string{
-	CMD_RENDER_JSON: RenderJsonHelp,
+	CMD_RENDER_JSON: renderJsonHelp,
 }
 
 // Create the Terragrunt CLI App

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -288,8 +288,8 @@ var TERRAFORM_HELP_FLAGS = []string{
 }
 
 // map of help functions for each terragrunt command
-var terraguntHelp = map[string]func(terragruntOptions *options.TerragruntOptions) error{
-	CMD_RENDER_JSON: helpRenderJson,
+var terragruntHelp = map[string]string{
+	CMD_RENDER_JSON: RenderJsonHelp,
 }
 
 // Create the Terragrunt CLI App
@@ -370,8 +370,9 @@ func runCommand(command string, terragruntOptions *options.TerragruntOptions) (f
 // This will forward all the args and extra_arguments directly to Terraform.
 func RunTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 	if shouldPrintTerragruntHelp(terragruntOptions) {
-		helpFunction, _ := terraguntHelp[terragruntOptions.TerraformCommand]
-		return helpFunction(terragruntOptions)
+		helpMessage, _ := terragruntHelp[terragruntOptions.TerraformCommand]
+		_, err := fmt.Fprintf(terragruntOptions.Writer, "%s\n", helpMessage)
+		return err
 	}
 	if shouldPrintTerraformHelp(terragruntOptions) {
 		return shell.RunTerraformCommand(terragruntOptions, terragruntOptions.TerraformCliArgs...)
@@ -597,7 +598,8 @@ func shouldPrintTerraformHelp(terragruntOptions *options.TerragruntOptions) bool
 }
 
 func shouldPrintTerragruntHelp(terragruntOptions *options.TerragruntOptions) bool {
-	_, found := terraguntHelp[terragruntOptions.TerraformCommand]
+	// check if command is in help map
+	_, found := terragruntHelp[terragruntOptions.TerraformCommand]
 	if !found {
 		return false
 	}

--- a/cli/render_json.go
+++ b/cli/render_json.go
@@ -27,6 +27,7 @@ const renderJsonHelp = `
    --with-metadata 		Add metadata to the rendered JSON file.
    --terragrunt-json-out 	The file path that terragrunt should use when rendering the terragrunt.hcl config as json.
 `
+
 // runRenderJSON takes the parsed TerragruntConfig struct and renders it out as JSON so that it can be processed by
 // other tools. To make it easier to maintain, this uses the cty representation as an intermediary.
 // NOTE: An unspecified advantage of using the cty representation is that the final block outputs would be a map

--- a/cli/render_json.go
+++ b/cli/render_json.go
@@ -27,14 +27,6 @@ const renderJsonHelp = `
    --with-metadata 		Add metadata to the rendered JSON file.
    --terragrunt-json-out 	The file path that terragrunt should use when rendering the terragrunt.hcl config as json.
 `
-
-//func helpRenderJson(terragruntOptions *options.TerragruntOptions) error {
-//
-//	fmt.Fprintf(terragruntOptions.Writer, "%s\n", renderJsonHelp)
-//
-//	return nil
-//}
-
 // runRenderJSON takes the parsed TerragruntConfig struct and renders it out as JSON so that it can be processed by
 // other tools. To make it easier to maintain, this uses the cty representation as an intermediary.
 // NOTE: An unspecified advantage of using the cty representation is that the final block outputs would be a map

--- a/cli/render_json.go
+++ b/cli/render_json.go
@@ -17,7 +17,7 @@ import (
 
 const defaultJSONOutName = "terragrunt_rendered.json"
 
-const RenderJsonHelp = `
+const renderJsonHelp = `
    Usage: terragrunt render-json [OPTIONS]
 
    Description:

--- a/cli/render_json.go
+++ b/cli/render_json.go
@@ -17,6 +17,16 @@ import (
 
 const defaultJSONOutName = "terragrunt_rendered.json"
 
+func helpRenderJson(terragruntOptions *options.TerragruntOptions) error {
+
+	terragruntOptions.Logger.Printf("Usage: terragrunt render-json [OPTIONS]")
+	terragruntOptions.Logger.Printf("")
+	terragruntOptions.Logger.Printf("Options:")
+	terragruntOptions.Logger.Printf("--with-metadata Add metadata to the rendered JSON output.")
+
+	return nil
+}
+
 // runRenderJSON takes the parsed TerragruntConfig struct and renders it out as JSON so that it can be processed by
 // other tools. To make it easier to maintain, this uses the cty representation as an intermediary.
 // NOTE: An unspecified advantage of using the cty representation is that the final block outputs would be a map

--- a/cli/render_json.go
+++ b/cli/render_json.go
@@ -17,15 +17,23 @@ import (
 
 const defaultJSONOutName = "terragrunt_rendered.json"
 
-func helpRenderJson(terragruntOptions *options.TerragruntOptions) error {
+const RenderJsonHelp = `
+   Usage: terragrunt render-json [OPTIONS]
 
-	terragruntOptions.Logger.Printf("Usage: terragrunt render-json [OPTIONS]")
-	terragruntOptions.Logger.Printf("")
-	terragruntOptions.Logger.Printf("Options:")
-	terragruntOptions.Logger.Printf("--with-metadata Add metadata to the rendered JSON output.")
+   Description:
+   Render the final terragrunt config, with all variables, includes, and functions resolved, as json.
+   
+   Options:
+   --with-metadata 		Add metadata to the rendered JSON file.
+   --terragrunt-json-out 	The file path that terragrunt should use when rendering the terragrunt.hcl config as json.
+`
 
-	return nil
-}
+//func helpRenderJson(terragruntOptions *options.TerragruntOptions) error {
+//
+//	fmt.Fprintf(terragruntOptions.Writer, "%s\n", renderJsonHelp)
+//
+//	return nil
+//}
 
 // runRenderJSON takes the parsed TerragruntConfig struct and renders it out as JSON so that it can be processed by
 // other tools. To make it easier to maintain, this uses the cty representation as an intermediary.

--- a/cli/validate_inputs.go
+++ b/cli/validate_inputs.go
@@ -14,6 +14,16 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 )
 
+const validateInputsHelp = `
+   Usage: terragrunt validate-inputs [OPTIONS]
+
+   Description:
+   Checks if the terragrunt configured inputs align with the terraform defined variables.
+   
+   Options:
+   --terragrunt-strict-validate		Enable strict mode for validation. When strict mode is turned on, an error will be returned if required inputs are missing OR if unused variables are passed to Terragrunt.
+`
+
 // validateTerragruntInputs will collect all the terraform variables defined in the target module, and the terragrunt
 // inputs that are configured, and compare the two to determine if there are any unused inputs or undefined required
 // inputs.

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4950,3 +4950,24 @@ func TestRenderJsonMetadataTerraform(t *testing.T) {
 
 	assert.Equal(t, string(serializedExpectedRemoteState), string(serializedRemoteState))
 }
+
+func TestTerragruntRenderJsonHelp(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_HOOKS_INIT_ONCE_WITH_SOURCE_NO_BACKEND)
+	tmpEnvPath := copyEnvironment(t, "fixture-hooks/init-once")
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_HOOKS_INIT_ONCE_WITH_SOURCE_NO_BACKEND)
+
+	showStdout := bytes.Buffer{}
+	showStderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt render-json --help --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &showStdout, &showStderr)
+	assert.Nil(t, err)
+
+	logBufferContentsLineByLine(t, showStdout, "show stdout")
+
+	output := showStdout.String()
+
+	assert.Contains(t, output, "Usage: terragrunt render-json [OPTIONS]")
+	assert.Contains(t, output, "--with-metadata")
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Update Terragrunt to support `--help` option for Terragrunt commands that have parameters:
* render-json
* aws-provider-patch
* validate-inputs

Fixes #2222.

Example output:

![image](https://user-images.githubusercontent.com/10694338/193422613-710c010f-8496-43d3-9a0a-e280c76a5092.png)


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

