### PR TITLE
Fix a mistake in markdown

### DIFF
--- a/docs/_docs/02_features/inputs.md
+++ b/docs/_docs/02_features/inputs.md
@@ -51,6 +51,6 @@ Variables are loaded in the following order:
 
   - `terraform.tfvars.json` file, if present.
 
-  - Any `.auto.tfvars`/`</emphasis>.auto.tfvars.json` files, processed in order of their filenames.
+  - Any `*.auto.tfvars`/`*.auto.tfvars.json` files, processed in order of their filenames.
 
   - Any `-var`/`-var-file` options on the command line, in the order they are provided.


### PR DESCRIPTION
There was a typo in the name of the variable file.

[Terraform documentation](https://www.terraform.io/docs/configuration/variables.html#variable-definition-precedence).

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

