### PR TITLE
Adds regex to retry errors when backend initialization fails

### DIFF
--- a/options/auto_retry_options.go
+++ b/options/auto_retry_options.go
@@ -21,4 +21,5 @@ var DEFAULT_RETRYABLE_ERRORS = []string{
 	"(?s).*ssh_exchange_identification.*Connection closed by remote host.*",
 	"(?s).*Client\\.Timeout exceeded while awaiting headers.*",
 	"(?s).*Could not download module.*The requested URL returned error: 429.*",
+	"(?s).*Error: NoCredentialProviders: no valid providers in chain.*",
 }


### PR DESCRIPTION
<!-- Description of the changes introduced by this PR. -->

Adds regex to retry errors when backend initialization fails

Fixes #2305

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added regex to retry errors when backend initialization fails.
