### PR TITLE
Add support for Terraform 1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 
 defaults: &defaults
   docker:
-    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.17-tf1.2-tg37.4-pck1.8
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.17-tf1.3-tg39.1-pck1.8-ci50.7
 
 version: 2.1
 jobs:

--- a/_ci/install-terraform.ps1
+++ b/_ci/install-terraform.ps1
@@ -8,8 +8,8 @@ if (Test-Path -Path $TerraformInstallPath)
 	Remove-Item $TerraformInstallPath -Recurse
 }
 # Download terraform and unpack it
-$terraformURI = "https://releases.hashicorp.com/terraform/1.0.4/terraform_1.0.4_windows_amd64.zip"
-$output = "terraform.1.0.4.zip"
+$terraformURI = "https://releases.hashicorp.com/terraform/1.3.2/terraform_1.3.2_windows_amd64.zip"
+$output = "terraform.1.3.2.zip"
 $ProgressPreference = "SilentlyContinue"
 Invoke-WebRequest -Uri $terraformURI -OutFile $output
 New-Item -ItemType "directory" -Path $TerraformTmpPath

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -142,6 +142,8 @@ func CreateTerragruntEvalContext(
 		"get_terragrunt_source_cli_flag":               wrapVoidToStringAsFuncImpl(getTerragruntSourceCliFlag, extensions.TrackInclude, terragruntOptions),
 	}
 
+	// Map with HCL functions introduced in Terraform after v0.15.3, since upgrade to a later version is not supported
+	// https://github.com/gruntwork-io/terragrunt/blob/master/go.mod#L22
 	terraformCompatibilityFunctions := map[string]function.Function{
 		"startswith": wrapStringSliceToBoolAsFuncImpl(startsWith, extensions.TrackInclude, terragruntOptions),
 		"endswith":   wrapStringSliceToBoolAsFuncImpl(endsWith, extensions.TrackInclude, terragruntOptions),

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -969,6 +969,64 @@ func TestGetTerragruntSourceForModuleHappyPath(t *testing.T) {
 	}
 }
 
+func TestStartsWith(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		config *options.TerragruntOptions
+		args   []string
+		value  bool
+	}{
+		{terragruntOptionsForTest(t, ""), []string{"hello world", "hello"}, true},
+		{terragruntOptionsForTest(t, ""), []string{"hello world", "world"}, false},
+		{terragruntOptionsForTest(t, ""), []string{"hello world", ""}, true},
+		{terragruntOptionsForTest(t, ""), []string{"hello world", " "}, false},
+		{terragruntOptionsForTest(t, ""), []string{"", ""}, true},
+		{terragruntOptionsForTest(t, ""), []string{"", " "}, false},
+		{terragruntOptionsForTest(t, ""), []string{" ", ""}, true},
+		{terragruntOptionsForTest(t, ""), []string{"", "hello"}, false},
+		{terragruntOptionsForTest(t, ""), []string{" ", "hello"}, false},
+	}
+
+	for id, testCase := range testCases {
+		testCase := testCase
+		t.Run(fmt.Sprintf("%v %v", id, testCase.args), func(t *testing.T) {
+			actual, err := startsWith(testCase.args, nil, testCase.config)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.value, actual)
+		})
+	}
+}
+
+func TestEndsWith(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		config *options.TerragruntOptions
+		args   []string
+		value  bool
+	}{
+		{terragruntOptionsForTest(t, ""), []string{"hello world", "world"}, true},
+		{terragruntOptionsForTest(t, ""), []string{"hello world", "hello"}, false},
+		{terragruntOptionsForTest(t, ""), []string{"hello world", ""}, true},
+		{terragruntOptionsForTest(t, ""), []string{"hello world", " "}, false},
+		{terragruntOptionsForTest(t, ""), []string{"", ""}, true},
+		{terragruntOptionsForTest(t, ""), []string{"", " "}, false},
+		{terragruntOptionsForTest(t, ""), []string{" ", ""}, true},
+		{terragruntOptionsForTest(t, ""), []string{"", "hello"}, false},
+		{terragruntOptionsForTest(t, ""), []string{" ", "hello"}, false},
+	}
+
+	for id, testCase := range testCases {
+		testCase := testCase
+		t.Run(fmt.Sprintf("%v %v", id, testCase.args), func(t *testing.T) {
+			actual, err := endsWith(testCase.args, nil, testCase.config)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.value, actual)
+		})
+	}
+}
+
 func mockConfigWithSource(sourceUrl string) *TerragruntConfig {
 	cfg := TerragruntConfig{IsPartial: true}
 	cfg.Terraform = &TerraformConfig{Source: &sourceUrl}

--- a/config/cty_helpers.go
+++ b/config/cty_helpers.go
@@ -38,6 +38,28 @@ func wrapStringSliceToStringAsFuncImpl(
 	})
 }
 
+func wrapStringSliceToBoolAsFuncImpl(
+	toWrap func(params []string, trackInclude *TrackInclude, terragruntOptions *options.TerragruntOptions) (bool, error),
+	trackInclude *TrackInclude,
+	terragruntOptions *options.TerragruntOptions,
+) function.Function {
+	return function.New(&function.Spec{
+		VarParam: &function.Parameter{Type: cty.String},
+		Type:     function.StaticReturnType(cty.Bool),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			params, err := ctySliceToStringSlice(args)
+			if err != nil {
+				return cty.BoolVal(false), err
+			}
+			out, err := toWrap(params, trackInclude, terragruntOptions)
+			if err != nil {
+				return cty.BoolVal(false), err
+			}
+			return cty.BoolVal(out), nil
+		},
+	})
+}
+
 // Create a cty Function that takes no input parameters and returns as output a string. The implementation of the
 // function calls the given toWrap function, passing it the given include and terragruntOptions.
 func wrapVoidToStringAsFuncImpl(

--- a/docs/_docs/01_getting-started/supported-terraform-versions.md
+++ b/docs/_docs/01_getting-started/supported-terraform-versions.md
@@ -15,6 +15,7 @@ The officially supported versions are:
 
 | Terraform Version | Terragrunt Version                                                                                                                                    |
 |-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.3.x             | >= [0.40.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.40.0)                                                                          |
 | 1.2.x             | >= [0.38.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.38.0)                                                                          |
 | 1.1.x             | >= [0.36.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.36.0)                                                                          |
 | 1.0.x             | >= [0.31.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.31.0)                                                                          |

--- a/test/fixture-endswith/main.tf
+++ b/test/fixture-endswith/main.tf
@@ -1,0 +1,73 @@
+variable "endswith1" {
+  type = bool
+}
+
+variable "endswith2" {
+  type = bool
+}
+
+variable "endswith3" {
+  type = bool
+}
+
+variable "endswith4" {
+  type = bool
+}
+
+variable "endswith5" {
+  type = bool
+}
+
+variable "endswith6" {
+  type = bool
+}
+
+variable "endswith7" {
+  type = bool
+}
+
+variable "endswith8" {
+  type = bool
+}
+
+variable "endswith9" {
+  type = bool
+}
+
+output "endswith1" {
+  value = var.endswith1
+}
+
+output "endswith2" {
+  value = var.endswith2
+}
+
+output "endswith3" {
+  value = var.endswith3
+}
+
+output "endswith4" {
+  value = var.endswith4
+}
+
+output "endswith5" {
+  value = var.endswith5
+}
+
+output "endswith6" {
+  value = var.endswith6
+}
+
+output "endswith7" {
+  value = var.endswith7
+}
+
+output "endswith8" {
+  value = var.endswith8
+}
+
+output "endswith9" {
+  value = var.endswith9
+}
+
+

--- a/test/fixture-endswith/terragrunt.hcl
+++ b/test/fixture-endswith/terragrunt.hcl
@@ -1,0 +1,11 @@
+inputs = {
+  endswith1 = endswith("hello world", "world")
+  endswith2 = endswith("hello world", "hello")
+  endswith3 = endswith("hello world", "")
+  endswith4 = endswith("hello world", " ")
+  endswith5 = endswith("", "")
+  endswith6 = endswith("", " ")
+  endswith7 = endswith(" ", "")
+  endswith8 = endswith("", "hello")
+  endswith9 = endswith(" ", "hello")
+}

--- a/test/fixture-startswith/main.tf
+++ b/test/fixture-startswith/main.tf
@@ -1,0 +1,73 @@
+variable "startswith1" {
+  type = bool
+}
+
+variable "startswith2" {
+  type = bool
+}
+
+variable "startswith3" {
+  type = bool
+}
+
+variable "startswith4" {
+  type = bool
+}
+
+variable "startswith5" {
+  type = bool
+}
+
+variable "startswith6" {
+  type = bool
+}
+
+variable "startswith7" {
+  type = bool
+}
+
+variable "startswith8" {
+  type = bool
+}
+
+variable "startswith9" {
+  type = bool
+}
+
+output "startswith1" {
+  value = var.startswith1
+}
+
+output "startswith2" {
+  value = var.startswith2
+}
+
+output "startswith3" {
+  value = var.startswith3
+}
+
+output "startswith4" {
+  value = var.startswith4
+}
+
+output "startswith5" {
+  value = var.startswith5
+}
+
+output "startswith6" {
+  value = var.startswith6
+}
+
+output "startswith7" {
+  value = var.startswith7
+}
+
+output "startswith8" {
+  value = var.startswith8
+}
+
+output "startswith9" {
+  value = var.startswith9
+}
+
+

--- a/test/fixture-startswith/terragrunt.hcl
+++ b/test/fixture-startswith/terragrunt.hcl
@@ -1,0 +1,11 @@
+inputs = {
+  startswith1 = startswith("hello world", "hello")
+  startswith2 = startswith("hello world", "world")
+  startswith3 = startswith("hello world", "")
+  startswith4 = startswith("hello world", " ")
+  startswith5 = startswith("", "")
+  startswith6 = startswith("", " ")
+  startswith7 = startswith(" ", "")
+  startswith8 = startswith("", "hello")
+  startswith9 = startswith(" ", "hello")
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
  * upgraded circle ci image to run with Terraform 1.3
  * updated Windows tests to download and install Terraform 1.3
  * updated documentation to reflect usage of Terraform 1.3


Fixes #2309.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated supported Terraform version to 1.3

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

