### PR TITLE
feat(configstack): start and finish module logs on run-all execution

### DIFF
--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -103,10 +103,10 @@ func toRunningModules(modules []*TerraformModule, dependencyOrder DependencyOrde
 
 // Loop through the map of runningModules and for each module M:
 //
-// * If dependencyOrder is NormalOrder, plug in all the modules M depends on into the Dependencies field and all the
-//   modules that depend on M into the NotifyWhenDone field.
-// * If dependencyOrder is ReverseOrder, do the reverse.
-// * If dependencyOrder is IgnoreOrder, do nothing.
+//   - If dependencyOrder is NormalOrder, plug in all the modules M depends on into the Dependencies field and all the
+//     modules that depend on M into the NotifyWhenDone field.
+//   - If dependencyOrder is ReverseOrder, do the reverse.
+//   - If dependencyOrder is IgnoreOrder, do nothing.
 func crossLinkDependencies(modules map[string]*runningModule, dependencyOrder DependencyOrder) (map[string]*runningModule, error) {
 	for _, module := range modules {
 		for _, dependency := range module.Module.Dependencies {
@@ -235,7 +235,7 @@ func (module *runningModule) runNow() error {
 		module.Module.TerragruntOptions.Logger.Debugf("Assuming module %s has already been applied and skipping it", module.Module.Path)
 		return nil
 	} else {
-		module.Module.TerragruntOptions.Logger.Debugf("Running module %s now", module.Module.Path)
+		module.Module.TerragruntOptions.Logger.Infof("Running module %s now", module.Module.Path)
 		return module.Module.TerragruntOptions.RunTerragrunt(module.Module.TerragruntOptions)
 	}
 }
@@ -243,7 +243,7 @@ func (module *runningModule) runNow() error {
 // Record that a module has finished executing and notify all of this module's dependencies
 func (module *runningModule) moduleFinished(moduleErr error) {
 	if moduleErr == nil {
-		module.Module.TerragruntOptions.Logger.Debugf("Module %s has finished successfully!", module.Module.Path)
+		module.Module.TerragruntOptions.Logger.Infof("Module %s has finished successfully!", module.Module.Path)
 	} else {
 		module.Module.TerragruntOptions.Logger.Errorf("Module %s has finished with an error: %v", module.Module.Path, moduleErr)
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Log when a module start/finish on multi-modules execution for an easier visualization of the terraform commands and their results

Fixes #2216.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

