### PR TITLE
#2347 - add --terragrunt-global-cache support to run_cmd

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -284,16 +284,26 @@ func runCommand(args []string, trackInclude *TrackInclude, terragruntOptions *op
 	}
 
 	suppressOutput := false
-	if args[0] == "--terragrunt-quiet" {
-		suppressOutput = true
-		args = append(args[:0], args[1:]...)
-	}
-
 	currentPath := filepath.Dir(terragruntOptions.TerragruntConfigPath)
+	cachePath := currentPath
+
+	checkOptions := true
+	for checkOptions && len(args) > 0 {
+		switch args[0] {
+		case "--terragrunt-quiet":
+			suppressOutput = true
+			args = append(args[:0], args[1:]...)
+		case "--terragrunt-global-cache":
+			cachePath = "_global_"
+			args = append(args[:0], args[1:]...)
+		default:
+			checkOptions = false
+		}
+	}
 
 	// To avoid re-run of the same run_cmd command, is used in memory cache for command results, with caching key path + arguments
 	// see: https://github.com/gruntwork-io/terragrunt/issues/1427
-	cacheKey := fmt.Sprintf("%v-%v", currentPath, args)
+	cacheKey := fmt.Sprintf("%v-%v", cachePath, args)
 	cachedValue, foundInCache := runCommandCache.Get(cacheKey)
 	if foundInCache {
 		if suppressOutput {

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -189,6 +189,12 @@ func TestRunCommand(t *testing.T) {
 			nil,
 		},
 		{
+			[]string{"--terragrunt-global-cache", "/bin/bash", "-c", "echo foo"},
+			terragruntOptionsForTest(t, homeDir),
+			"foo",
+			nil,
+		},
+		{
 			nil,
 			terragruntOptionsForTest(t, homeDir),
 			"",

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -636,7 +636,7 @@ remote_state {
 }
 ```
 
-If the command you are running has the potential to output sensitive values, you may wish to redact the output from appearing in the terminal. To do so, use the special `--terragrunt-quiet` argument which must be passed as the first argument to `run_cmd()`:
+If the command you are running has the potential to output sensitive values, you may wish to redact the output from appearing in the terminal. To do so, use the special `--terragrunt-quiet` argument which must be passed as one of the first arguments to `run_cmd()`:
 
 ``` hcl
 super_secret_value = run_cmd("--terragrunt-quiet", "./decrypt_secret.sh", "foo")
@@ -684,6 +684,12 @@ carrot
   * Output contains multiple times `uuid1` and `uuid2` because during HCL evaluation each `run_cmd` in `locals` is evaluated multiple times and random argument generated from `uuid()` save cached value under different key each time
   * Output contains multiple times `uuid3`, +1 more output comparing to `uuid1` and `uuid2` - because `uuid3` is declared in locals and inputs which add one more evaluation
   * Output contains only once `uuid4` since it is declared only once in `inputs`, `inputs` is not evaluated twice
+
+You can modify this caching behavior to ignore the existing directory if you know the command you are running is not dependent on the current directory path.  To do so, use the special `--terragrunt-global-cache` argument which must be passed as one of the first arguments to `run_cmd()` (and can be combined with `--terragrunt-quiet` in any order):
+
+``` hcl
+value = run_cmd("--terragrunt-global-cache", "--terragrunt-quiet", "/usr/local/bin/get-account-map")
+```
 
 ## read\_terragrunt\_config
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #2347.

This adds a new `--terragrunt-global-cache` option to `run_cmd` that caches the command globally instead of relative to the directory it is run from.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `--terragrunt-global-cache` option for `run_cmd` to cache output globally instead of per directory.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

