### PR TITLE
fix: protect sops cache from multiple parallel writes

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -643,14 +643,14 @@ func getModulePathFromSourceUrl(sourceUrl string) (string, error) {
 }
 
 //
-// A map that caches the results of a decrypt operation via sops. Each decryption
+// A cache of the results of a decrypt operation via sops. Each decryption
 // operation can take several seconds, so this cache speeds up terragrunt executions
 // where the same sops files are referenced multiple times.
 //
-// The keys are the canonical paths to the encrypted files, and the values are the
+// The cache keys are the canonical paths to the encrypted files, and the values are the
 // plain-text result of the decrypt operation.
 //
-var sopsCache = make(map[string]string)
+var sopsCache = NewStringCache()
 
 // decrypts and returns sops encrypted utf-8 yaml or json data as a string
 func sopsDecryptFile(params []string, trackInclude *TrackInclude, terragruntOptions *options.TerragruntOptions) (string, error) {
@@ -673,7 +673,7 @@ func sopsDecryptFile(params []string, trackInclude *TrackInclude, terragruntOpti
 		return "", errors.WithStackTrace(err)
 	}
 
-	if val, ok := sopsCache[canonicalSourceFile]; ok {
+	if val, ok := sopsCache.Get(canonicalSourceFile); ok {
 		return val, nil
 	}
 
@@ -684,7 +684,7 @@ func sopsDecryptFile(params []string, trackInclude *TrackInclude, terragruntOpti
 
 	if utf8.Valid(rawData) {
 		value := string(rawData)
-		sopsCache[canonicalSourceFile] = value
+		sopsCache.Put(canonicalSourceFile, value)
 		return value, nil
 	}
 


### PR DESCRIPTION

## Description

Hello,

We sometimes have this stacktrace when running terragrunt in atlantis.

While it is certainly related to how we run atlantis in parallel, protecting the cache with a mutex should lead to a very small performance hit.

Let me know if you want to implement that differently.

```
fatal error: concurrent map writes

goroutine 1870 [running]:
github.com/gruntwork-io/terragrunt/config.sopsDecryptFile({0xc0001f3540?, 0x1?, 0xc001203b40?}, 0x0?, 0xc000b12000)
	/home/runner/go/pkg/mod/github.com/gruntwork-io/terragrunt@v0.36.6/config/config_helpers.go:677 +0x1f5
github.com/gruntwork-io/terragrunt/config.wrapStringSliceToStringAsFuncImpl.func1({0xc000ac0900?, 0xc0004564b9?, 0x1076660?}, {{0xc0001f3530?, 0x3?}})
	/home/runner/go/pkg/mod/github.com/gruntwork-io/terragrunt@v0.36.6/config/cty_helpers.go:32 +0x5e
github.com/zclconf/go-cty/cty/function.Function.Call({0x1508008?}, {0xc000ac0900, 0x1, 0x1})
	/home/runner/go/pkg/mod/github.com/zclconf/go-cty@v1.8.3/cty/function/function.go:295 +0x29a
github.com/hashicorp/hcl/v2/hclsyntax.(*FunctionCallExpr).Value(0xc000262ff0, 0xc000945998)
	/home/runner/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.11.1/hclsyntax/expression.go:442 +0x1b05
github.com/hashicorp/hcl/v2/hclsyntax.(*FunctionCallExpr).Value(0xc0002630e0, 0xc000945998)
	/home/runner/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.11.1/hclsyntax/expression.go:408 +0x1327
github.com/gruntwork-io/terragrunt/config.attemptEvaluateLocals(0xc000b12000, {0xc0000cca00, 0x45}, {0xc000a0c1a0, 0x3, 0xc00066ac00?}, 0xc000acf2c0, 0xc000ace270, {0xc0008f4000, 0x3, ...}, ...)
	/home/runner/go/pkg/mod/github.com/gruntwork-io/terragrunt@v0.36.6/config/locals.go:172 +0x606
github.com/gruntwork-io/terragrunt/config.evaluateLocalsBlock(0xc000b12000, 0x0?, 0x0?, {0xc0000cca00, 0x45}, 0x3?, {0xc0008f4000, 0x3, 0x3})
	/home/runner/go/pkg/mod/github.com/gruntwork-io/terragrunt@v0.36.6/config/locals.go:86 +0x445
github.com/gruntwork-io/terragrunt/config.DecodeBaseBlocks(0x422245?, 0xc000d06000?, 0x40cd9e?, {0xc0000cca00, 0x45}, 0x4ab997?, {0xc0008f4000, 0x3, 0x3})
	/home/runner/go/pkg/mod/github.com/gruntwork-io/terragrunt@v0.36.6/config/config_partial.go:121 +0xfb
github.com/gruntwork-io/terragrunt/config.PartialParseConfigString({0xc000d06000, 0xd99}, 0x0?, 0x3?, {0xc0000cca00, 0x45}, {0xc0008f4000?, 0x3, 0x3})
	/home/runner/go/pkg/mod/github.com/gruntwork-io/terragrunt@v0.36.6/config/config_partial.go:189 +0x119
github.com/gruntwork-io/terragrunt/config.PartialParseConfigFile({0xc0000cca00, 0x45}, 0x7fd7b31e05b8?, 0x30?, {0xc0008f4000, 0x3, 0x3})
	/home/runner/go/pkg/mod/github.com/gruntwork-io/terragrunt@v0.36.6/config/config_partial.go:151 +0x7f
github.com/gruntwork-io/terragrunt/config.partialParseIncludedConfig(0xc001126600?, 0xc001126000?, {0xc0008f4000?, 0x41a026?, 0xc000d410c8?})
	/home/runner/go/pkg/mod/github.com/gruntwork-io/terragrunt@v0.36.6/config/config_partial.go:340 +0xfc
github.com/gruntwork-io/terragrunt/config.handleIncludePartial(0xc001043ad0?, 0xc0000b9960?, 0xc000b12000, {0xc0008f4000, 0x3, 0x3})
	/home/runner/go/pkg/mod/github.com/gruntwork-io/terragrunt@v0.36.6/config/include.go:167 +0x192
github.com/gruntwork-io/terragrunt/config.PartialParseConfigString({0xc0007ac000, 0x132}, 0x1d1ec00?, 0xc0008f4000?, {0xc0001b36e0, 0x5e}, {0xc0008f4000?, 0x3, 0x3})
	/home/runner/go/pkg/mod/github.com/gruntwork-io/terragrunt@v0.36.6/config/config_partial.go:318 +0xba7
github.com/gruntwork-io/terragrunt/config.PartialParseConfigFile({0xc0001b36e0, 0x5e}, 0x5f?, 0x0?, {0xc0008f4000, 0x3, 0x3})
	/home/runner/go/pkg/mod/github.com/gruntwork-io/terragrunt@v0.36.6/config/config_partial.go:151 +0x7f
github.com/transcend-io/terragrunt-atlantis-config/cmd.getDependencies.func1()
	/home/runner/work/terragrunt-atlantis-config/terragrunt-atlantis-config/cmd/generate.go:160 +0x2a7
golang.org/x/sync/singleflight.(*Group).doCall.func2(0xc000fd395e, 0xc000aa57a0, 0x60?)
	/home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/singleflight/singleflight.go:193 +0x6f
golang.org/x/sync/singleflight.(*Group).doCall(0x10e6380?, 0xc000158ff0?, {0xc0001b36e0?, 0x5e?}, 0xfc5edd?)
	/home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/singleflight/singleflight.go:195 +0xa5
golang.org/x/sync/singleflight.(*Group).Do(0x1d19cc0, {0xc0001b36e0, 0x5e}, 0x37?)
	/home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/singleflight/singleflight.go:108 +0x165
github.com/transcend-io/terragrunt-atlantis-config/cmd.getDependencies({0xc0001b36e0?, 0x5e?}, 0xc000f85ae0?)
	/home/runner/work/terragrunt-atlantis-config/terragrunt-atlantis-config/cmd/generate.go:127 +0x67
github.com/transcend-io/terragrunt-atlantis-config/cmd.createProject({0xc0001b36e0, 0x5e})
	/home/runner/work/terragrunt-atlantis-config/terragrunt-atlantis-config/cmd/generate.go:330 +0xf4
github.com/transcend-io/terragrunt-atlantis-config/cmd.main.func1()
	/home/runner/work/terragrunt-atlantis-config/terragrunt-atlantis-config/cmd/generate.go:737 +0xa5
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x67
created by golang.org/x/sync/errgroup.(*Group).Go
	/home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x8d
```

## Release Notes (draft)

Fix panic when using sops secrets in parallel.