### PR TITLE
Feat(#2292) add accesslogging bucket tags property to remote state s3 config block

### DIFF
--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -877,6 +877,16 @@ func TestReadTerragruntConfigRemoteState(t *testing.T) {
 		configMap["s3_bucket_tags"].(map[string]interface{}),
 		map[string]interface{}{"owner": "terragrunt integration test", "name": "Terraform state storage"},
 	)
+	assert.Equal(
+		t,
+		configMap["dynamodb_table_tags"].(map[string]interface{}),
+		map[string]interface{}{"owner": "terragrunt integration test", "name": "Terraform lock table"},
+	)
+	assert.Equal(
+		t,
+		configMap["accesslogging_bucket_tags"].(map[string]interface{}),
+		map[string]interface{}{"owner": "terragrunt integration test", "name": "Terraform access log storage"},
+	)
 }
 
 func TestReadTerragruntConfigHooks(t *testing.T) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -218,7 +218,7 @@ collections:
 5. Add `index.html` file to newly create folder:
 ```
 ---
-layout: collection-browser # DO NOT CAHNGE THIS
+layout: collection-browser # DO NOT CHANGE THIS
 title: Use cases
 subtitle: Learn how to integrate Terragrunt with Terraform.
 excerpt: Learn how to integrate Terragrunt with Terraform.
@@ -293,7 +293,7 @@ The _index_ page displays the list of collection's docs. Clicking on any of them
 
 #### config.yml
 
-Collections are registred in the `_config.yml` file like other typical Jekyll collections.
+Collections are registered in the `_config.yml` file like other typical Jekyll collections.
 Additional field used in the configuration is: `sort_by: order`. It ensures that collection's documents are displayed in the right order.
 The `order` is set then in every collection document. For large collections it's recommended to split files into several folders, and then to use 3-digit numbers. So each folder would have reserved range of numbers, like: `100 - 199`, `200-299`, etc. It makes easy to add new documents without overwriting `order` fields in other docs.
 

--- a/docs/_docs/02_features/keep-your-remote-state-configuration-dry.md
+++ b/docs/_docs/02_features/keep-your-remote-state-configuration-dry.md
@@ -249,7 +249,7 @@ remote_state {
 
 If you experience an error for any of these configurations, confirm you are using Terraform v0.12.2 or greater.
 
-Further, the config options `s3_bucket_tags`, `dynamodb_table_tags`, `skip_bucket_versioning`, `skip_bucket_ssencryption`, `skip_bucket_root_access`, `skip_bucket_enforced_tls`, `skip_bucket_public_access_blocking`, `accesslogging_bucket_name`, `accesslogging_target_prefix`, and `enable_lock_table_ssencryption` are only valid for backend `s3`. They are used by terragrunt and are **not** passed on to terraform. See section [Create remote state and locking resources automatically](#create-remote-state-and-locking-resources-automatically).
+Further, the config options `s3_bucket_tags`, `dynamodb_table_tags`, `accesslogging_bucket_tags`, `skip_bucket_versioning`, `skip_bucket_ssencryption`, `skip_bucket_root_access`, `skip_bucket_enforced_tls`, `skip_bucket_public_access_blocking`, `accesslogging_bucket_name`, `accesslogging_target_prefix`, and `enable_lock_table_ssencryption` are only valid for backend `s3`. They are used by terragrunt and are **not** passed on to terraform. See section [Create remote state and locking resources automatically](#create-remote-state-and-locking-resources-automatically).
 
 ### GCS-specific remote state settings
 

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -392,6 +392,7 @@ For the `s3` backend, the following additional properties are supported in the `
 - `enable_lock_table_ssencryption`: When `true`, the synchronization lock table in DynamoDB used for remote state concurrent access will not be configured with server side encryption.
 - `s3_bucket_tags`: A map of key value pairs to associate as tags on the created S3 bucket.
 - `dynamodb_table_tags`: A map of key value pairs to associate as tags on the created DynamoDB remote state lock table.
+- `accesslogging_bucket_tags`: A map of key value pairs to associate as tags on the created S3 bucket to store de access logs.
 - `disable_aws_client_checksums`: When `true`, disable computing and checking checksums on the request and response,
   such as the CRC32 check for DynamoDB. This can be used to workaround
   https://github.com/gruntwork-io/terragrunt/issues/1059.

--- a/docs/_docs/06_migration_guides/upgrading_to_terragrunt_0.19.x.md
+++ b/docs/_docs/06_migration_guides/upgrading_to_terragrunt_0.19.x.md
@@ -256,6 +256,12 @@ remote_state {
       owner = "terragrunt integration test"
       name = "Terraform lock table"
     }
+
+    # accesslogging_bucket_tags is an attribute, so an equals sign is REQUIRED
+    accesslogging_bucket_tags = {
+      owner = "terragrunt integration test"
+      name  = "Terraform access log storage"
+    }
   }
 }
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -27,15 +27,17 @@ const (
 )
 
 /*
- * We use this construct to separate the two config keys 's3_bucket_tags' and 'dynamodb_table_tags'
- * from the others, as they are specific to the s3 backend, but only used by terragrunt to tag
- * the s3 bucket and the dynamo db, in case it has to create them.
+ * We use this construct to separate the three config keys 's3_bucket_tags', 'dynamodb_table_tags'
+ * and 'accesslogging_bucket_tags' from the others, as they are specific to the s3 backend,
+ * but only used by terragrunt to tag the s3 bucket, the dynamo db and the s3 bucket used to the
+ * access logs, in case it has to create them.
  */
 type ExtendedRemoteStateConfigS3 struct {
 	remoteStateConfigS3 RemoteStateConfigS3
 
 	S3BucketTags                   map[string]string `mapstructure:"s3_bucket_tags"`
 	DynamotableTags                map[string]string `mapstructure:"dynamodb_table_tags"`
+	AccessLoggingBucketTags        map[string]string `mapstructure:"accesslogging_bucket_tags"`
 	SkipBucketVersioning           bool              `mapstructure:"skip_bucket_versioning"`
 	SkipBucketSSEncryption         bool              `mapstructure:"skip_bucket_ssencryption"`
 	SkipBucketAccessLogging        bool              `mapstructure:"skip_bucket_accesslogging"`
@@ -56,6 +58,7 @@ type ExtendedRemoteStateConfigS3 struct {
 var terragruntOnlyConfigs = []string{
 	"s3_bucket_tags",
 	"dynamodb_table_tags",
+	"accesslogging_bucket_tags",
 	"skip_bucket_versioning",
 	"skip_bucket_ssencryption",
 	"skip_bucket_accesslogging",
@@ -677,6 +680,10 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 		terragruntOptions.Logger.Debugf("Access Logging is disabled for the remote state AWS S3 bucket %s", config.remoteStateConfigS3.Bucket)
 	}
 
+	if err := TagS3BucketAccessLogging(s3Client, config, terragruntOptions); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -692,6 +699,34 @@ func CreateLogsS3BucketIfNecessary(s3Client *s3.S3, logsBucketName *string, terr
 			return CreateS3Bucket(s3Client, logsBucketName, terragruntOptions)
 		}
 	}
+	return nil
+}
+
+func TagS3BucketAccessLogging(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
+
+	if config.AccessLoggingBucketTags == nil || len(config.AccessLoggingBucketTags) == 0 {
+		terragruntOptions.Logger.Debugf("No tags specified for bucket %s.", config.AccessLoggingBucketName)
+		return nil
+	}
+
+	// There must be one entry in the list
+	var tagsConverted = convertTags(config.AccessLoggingBucketTags)
+
+	terragruntOptions.Logger.Debugf("Tagging S3 bucket with %s", config.AccessLoggingBucketTags)
+
+	putBucketTaggingInput := s3.PutBucketTaggingInput{
+		Bucket: aws.String(config.AccessLoggingBucketName),
+		Tagging: &s3.Tagging{
+			TagSet: tagsConverted,
+		},
+	}
+
+	_, err := s3Client.PutBucketTagging(&putBucketTaggingInput)
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	terragruntOptions.Logger.Debugf("Tagged S3 bucket with %s", config.AccessLoggingBucketTags)
 	return nil
 }
 

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -79,6 +79,12 @@ func TestConfigValuesEqual(t *testing.T) {
 			true,
 		},
 		{
+			"equal-ignore-accesslogging-bucket-tags",
+			map[string]interface{}{"accesslogging_bucket_tags": []map[string]string{{"foo": "bar"}}},
+			&TerraformBackend{Type: "s3", Config: map[string]interface{}{}},
+			true,
+		},
+		{
 			"unequal-wrong-backend",
 			map[string]interface{}{"foo": "bar"},
 			&TerraformBackend{Type: "wrong", Config: map[string]interface{}{"foo": "bar"}},
@@ -274,6 +280,7 @@ func TestGetTerraformInitArgs(t *testing.T) {
 			map[string]interface{}{
 				"s3_bucket_tags":                     map[string]string{},
 				"dynamodb_table_tags":                map[string]string{},
+				"accesslogging_bucket_tags":          map[string]string{},
 				"skip_bucket_versioning":             true,
 				"skip_bucket_ssencryption":           false,
 				"skip_bucket_root_access":            false,

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -29,7 +29,12 @@ func TestToTerraformInitArgs(t *testing.T) {
 
 			"dynamodb_table_tags": map[string]interface{}{
 				"team":    "team name",
-				"name":    "Terraform state storage",
+				"name":    "Terraform lock table",
+				"service": "Terraform"},
+
+			"accesslogging_bucket_tags": map[string]interface{}{
+				"team":    "team name",
+				"name":    "Terraform access log storage",
 				"service": "Terraform"},
 
 			"skip_bucket_versioning": true,
@@ -40,7 +45,7 @@ func TestToTerraformInitArgs(t *testing.T) {
 	}
 	args := remoteState.ToTerraformInitArgs()
 
-	// must not contain s3_bucket_tags or dynamodb_table_tags or skip_bucket_versioning
+	// must not contain s3_bucket_tags or dynamodb_table_tags or accesslogging_bucket_tags or skip_bucket_versioning
 	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1 -backend-config=force_path_style=true -backend-config=shared_credentials_file=my-file")
 }
 

--- a/test/fixture-codegen/remote-state/s3/terragrunt.hcl
+++ b/test/fixture-codegen/remote-state/s3/terragrunt.hcl
@@ -23,6 +23,11 @@ remote_state {
       owner = "terragrunt integration test"
       name  = "Terraform lock table"
     }
+
+    accesslogging_bucket_tags = {
+      owner = "terragrunt integration test"
+      name  = "Terraform access log storage"
+    }
   }
 }
 

--- a/test/fixture/terragrunt.hcl
+++ b/test/fixture/terragrunt.hcl
@@ -18,5 +18,10 @@ remote_state {
       owner = "terragrunt integration test"
       name = "Terraform lock table"
     }
+
+    accesslogging_bucket_tags = {
+      owner = "terragrunt integration test"
+      name  = "Terraform access log storage"
+    }
   }
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #2292.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `accesslogging_bucket_tags` property to remote_state s3 config block 

