### PR TITLE
Expose a token for tflint 

### DIFF
--- a/docs/_docs/02_features/hooks.md
+++ b/docs/_docs/02_features/hooks.md
@@ -88,7 +88,16 @@ plugin "aws" {
 
 The `execute` parameter only accepts `tflint`, it will ignore any other parameter. Any desired extra configuration should be added in the `.tflint.hcl` file. It will work with a `.tflint.hcl` file in the current folder or any parent folder.
 
-### Troubleshooting
+#### Authentication for tflint rulesets 
+*Public rulesets*
+
+`tflint` works without any authentication for public rulesets (hosted on public repositories).
+
+*Private rulesets*
+
+If you want to run a the `tflint` hook with custom rulesets defined in a private repository, you will need to export locally a valid `GITHUB_OAUTH_TOKEN` token. Terragrunt will take that and expose it to the `tflint`-recognised authentication token - `GITHUB_TOKEN`.
+
+#### Troubleshooting
 
 **`flag provided but not defined: -act-as-bundled-plugin` error**
 

--- a/tflint/tflint.go
+++ b/tflint/tflint.go
@@ -5,6 +5,7 @@ package tflint
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/config"
@@ -25,6 +26,17 @@ func RunTflintWithOpts(terragruntOptions *options.TerragruntOptions, terragruntC
 	if err != nil {
 		return err
 	}
+
+	// Get GITHUB_OAUTH_TOKEN and set it as GITHUB_TOKEN so that tflint recognises and respects it
+	githubOauthToken := os.Getenv("GITHUB_OAUTH_TOKEN")
+	if githubOauthToken != "" {
+		err := os.Setenv("GITHUB_TOKEN", githubOauthToken)
+		if err != nil {
+			return errors.WithStackTrace(err)
+		}
+	}
+
+	terragruntOptions.Logger.Debugf("Setting GITHUB_TOKEN to the value of GITHUB_OAUTH_TOKEN")
 
 	terragruntOptions.Logger.Debugf("Initializing tflint in directory %s", terragruntOptions.WorkingDir)
 	cli := cmd.NewCLI(terragruntOptions.Writer, terragruntOptions.ErrWriter)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This fixes https://github.com/gruntwork-io/terragrunt/issues/2386

## Notes:
~I feel uncomfortable with this change, although it will probably achieve what we need for tflint. I would prefer if we could handle this on the tflint rule side somehow. I'll work on that option too.~

It seems like as we [discussed](https://gruntwork-io.slack.com/archives/C01LR3Q5LJH/p1670609104509099?thread_ts=1670608510.418979&cid=C01LR3Q5LJH) internally, this may be the only way we've got for now. 

<!-- Description of the changes introduced by this PR. -->

## Testing:
- watch after 15sec.
- Video recorded shows how running the tflint hook works without the fix from this branch, and how it works after calling a custom TG build with the code from this branch:
 https://asciinema.org/a/5y73haP23k781tmcj8KxBHq7o
 
 ### To replicate this locally:
 1. Pull latest `terragrunt` from the `master` branch and build it.
 2. Pull code from https://github.com/gruntwork-patcher-dev/terragrunt-tflint-example/tree/main/dev/eu-central-1/data-stores
 3. In the place where you pulled the example code - e.g. `gruntwork-io/terragrunt-tflint-example/dev/eu-central-1/data-stores`, run `aws-vault exec sbox -- terragrunt (master branch) plan`
 4. You will see an error from `tflint` that shows basically the lack of authentication for downloading the ruleset for `tflint`
 ```
 INFO[0000] Executing hook: tflint                        prefix=[/Users/in4o/repositories/gruntwork-io/terragrunt-tflint-example/dev/eu-central-1/data-stores]
Installing `aws-cis` plugin...
No signing key configured. Set `signing_key` to verify that the release is signed by the plugin developer
Failed to install a plugin; Failed to fetch GitHub releases: GET https://api.github.com/repos/gruntwork-io/terraform-aws-cis-service-catalog/releases/tags/v0.42.2: 404 Not Found []
ERRO[0000] Error running hook tflint with message: Error while running tflint with args: [tflint --init --config /Users/in4o/repositories/gruntwork-io/terragrunt-tflint-example/.tflint.hcl /Users/in4o/repositories/gruntwork-io/terragrunt-tflint-example/dev/eu-central-1/data-stores/.terragrunt-cache/aEojylF2H6RhmCuAbY0rX77YIqY/yosiWh_5Lq4oIBkZb5_Iiwo6A38/modules/redshift]  prefix=[/Users/in4o/repositories/gruntwork-io/terragrunt-tflint-example/dev/eu-central-1/data-stores]
.....
 ```
5. Now, in the same folder expose your `GITHUB_OAUTH_TOKEN` and run the same `terragrunt` command again 
6. This won't work either, since we're still exporting a token that `tflint` doesn't recognise
7. Now, build locally the code from this branch 
```
git checkout expose-tflint-token
cd terragrunt 
go build . 
mv terragrunt /usr/local/bin/terragrunt-with-token-fix
```
8. In the same example folder, without changing anything, run
```
aws-vault exec sbox -- terragrunt-with-token-fix plan
```
9. This should work

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

- Expose `GITHUB_OAUTH_TOKEN` to the `tflint` hook as `GITHUB_TOKEN`. This allows users to run `tflint` with rulesets for `tflint` hosted in private repositories.
