### PR TITLE
Fix debug log to be printed only whe GITHUB_TOKEN is exported by tflint

### DIFF
--- a/tflint/tflint.go
+++ b/tflint/tflint.go
@@ -34,9 +34,9 @@ func RunTflintWithOpts(terragruntOptions *options.TerragruntOptions, terragruntC
 		if err != nil {
 			return errors.WithStackTrace(err)
 		}
-	}
 
-	terragruntOptions.Logger.Debugf("Setting GITHUB_TOKEN to the value of GITHUB_OAUTH_TOKEN")
+		terragruntOptions.Logger.Debugf("Setting GITHUB_TOKEN to the value of GITHUB_OAUTH_TOKEN")
+	}
 
 	terragruntOptions.Logger.Debugf("Initializing tflint in directory %s", terragruntOptions.WorkingDir)
 	cli := cmd.NewCLI(terragruntOptions.Writer, terragruntOptions.ErrWriter)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/terragrunt/pull/2387#discussion_r1047051921 for PR #https://github.com/gruntwork-io/terragrunt/pull/2387

<!-- Description of the changes introduced by this PR. -->
This PR will change:
- a debug log statement for exporting a `GITHUB_TOKEN` only if we actually export it (previously, it wasn't in the if-statement by mistake!)

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)
- Updated a DEBUG log statement for the GITHUB_TOKEN to be printed only when we actually export the token

### Migration Guide
N.A.

