### PR TITLE
Update `parseMultiStringArg` to parse multiple successive values for arg

### DIFF
--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -284,6 +284,8 @@ func TestParseMultiStringArg(t *testing.T) {
 		{[]string{"apply-all", "--test", "bar"}, "foo", []string{"default_bar"}, []string{"default_bar"}, nil},
 		{[]string{"plan-all", "--test", "--foo", "bar1", "--foo", "bar2"}, "foo", []string{"default_bar"}, []string{"bar1", "bar2"}, nil},
 		{[]string{"plan-all", "--test", "value", "--foo", "bar1", "--foo"}, "foo", []string{"default_bar"}, nil, ArgMissingValue("foo")},
+		{[]string{"plan-all", "--test", "value", "--foo"}, "foo", []string{"default_bar"}, nil, ArgMissingValue("foo")},
+		{[]string{"plan-all", "--test", "value", "--foo", "--bar"}, "foo", []string{"default_bar"}, nil, ArgMissingValue("foo")},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Needed by https://github.com/gruntwork-io/terragrunt/pull/2415

Update `parseMultiStringArg` to parse multiple successive values for an argument 
e.g. `--foo "VALUE_A" "VALUE_B" --foo "VALUE_C"`.

This is would be useful for a future PR to permit accepting multiple files for `hclfmt`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `parseMultiStringArg` to parse multiple successive values for arg
