### PR TITLE
Hclfmt multiple files

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -229,7 +229,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.ModulesThatInclude = modulesThatInclude
 	opts.StrictInclude = strictInclude
 	opts.Check = parseBooleanArg(args, optTerragruntCheck, os.Getenv("TERRAGRUNT_CHECK") == "true")
-	opts.HclFiles = terragruntHclFilesPaths
+	opts.HclFiles = util.CleanPaths(terragruntHclFilesPaths)
 	opts.AwsProviderPatchOverrides = awsProviderPatchOverrides
 	opts.FetchDependencyOutputFromState = parseBooleanArg(args, optTerragruntFetchDependencyOutputFromState, os.Getenv("TERRAGRUNT_FETCH_DEPENDENCY_OUTPUT_FROM_STATE") == "true")
 	opts.UsePartialParseConfigCache = parseBooleanArg(args, optTerragruntUsePartialParseConfigCache, os.Getenv("TERRAGRUNT_USE_PARTIAL_PARSE_CONFIG_CACHE") == "true")

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -284,6 +284,8 @@ func TestParseMultiStringArg(t *testing.T) {
 		{[]string{"apply-all", "--test", "bar"}, "foo", []string{"default_bar"}, []string{"default_bar"}, nil},
 		{[]string{"plan-all", "--test", "--foo", "bar1", "--foo", "bar2"}, "foo", []string{"default_bar"}, []string{"bar1", "bar2"}, nil},
 		{[]string{"plan-all", "--test", "value", "--foo", "bar1", "--foo"}, "foo", []string{"default_bar"}, nil, ArgMissingValue("foo")},
+		{[]string{"plan-all", "--test", "value", "--foo"}, "foo", []string{"default_bar"}, nil, ArgMissingValue("foo")},
+		{[]string{"plan-all", "--test", "value", "--foo", "--bar"}, "foo", []string{"default_bar"}, nil, ArgMissingValue("foo")},
 	}
 
 	for _, testCase := range testCases {

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -52,7 +52,8 @@ const (
 	optTerragruntStrictInclude                  = "terragrunt-strict-include"
 	optTerragruntParallelism                    = "terragrunt-parallelism"
 	optTerragruntCheck                          = "terragrunt-check"
-	optTerragruntHCLFmt                         = "terragrunt-hclfmt-file"
+	optTerragruntHCLFmtDeprecated               = "terragrunt-hclfmt-file"
+	optTerragruntHCLFmt                         = "terragrunt-hclfmt-files"
 	optTerragruntDebug                          = "terragrunt-debug"
 	optTerragruntOverrideAttr                   = "terragrunt-override-attr"
 	optTerragruntLogLevel                       = "terragrunt-log-level"
@@ -81,6 +82,7 @@ var allTerragruntBooleanOpts = []string{
 	optTerragruntUsePartialParseConfigCache,
 	optTerragruntOutputWithMetadata,
 }
+
 var allTerragruntStringOpts = []string{
 	optTerragruntConfig,
 	optTerragruntTFPath,
@@ -94,6 +96,7 @@ var allTerragruntStringOpts = []string{
 	optTerragruntExcludeDir,
 	optTerragruntIncludeDir,
 	optTerragruntParallelism,
+	optTerragruntHCLFmtDeprecated,
 	optTerragruntHCLFmt,
 	optTerragruntOverrideAttr,
 	optTerragruntLogLevel,
@@ -199,7 +202,9 @@ var TERRAFORM_COMMANDS_THAT_DO_NOT_NEED_INIT = []string{
 }
 
 // deprecatedArguments is a map of deprecated arguments to the argument that replace them.
-var deprecatedArguments = map[string]string{}
+var deprecatedArguments = map[string]string{
+	optTerragruntHCLFmtDeprecated: optTerragruntHCLFmt,
+}
 
 // Struct is output as JSON by 'terragrunt-info':
 type TerragruntInfoGroup struct {
@@ -255,7 +260,8 @@ GLOBAL OPTIONS:
    terragrunt-exclude-dir                       Unix-style glob of directories to exclude when running *-all commands
    terragrunt-include-dir                       Unix-style glob of directories to include when running *-all commands
    terragrunt-check                             Enable check mode in the hclfmt command.
-   terragrunt-hclfmt-file                       The path to a single hcl file that the hclfmt command should run on.
+   terragrunt-hclfmt-file                       The path to one or more hcl files that the hclfmt command should run on. Could be specified multiple times.
+   terragrunt-hclfmt-files                      The path to one or more hcl files that the hclfmt command should run on. Could be specified multiple times.
    terragrunt-override-attr                     A key=value attribute to override in a provider block as part of the aws-provider-patch command. May be specified multiple times.
    terragrunt-debug                             Write terragrunt-debug.tfvars to working folder to help root-cause issues.
    terragrunt-log-level                         Sets the logging level for Terragrunt. Supported levels: panic, fatal, error, warn (default), info, debug, trace.

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -22,24 +22,26 @@ import (
 // runHCLFmt recursively looks for hcl files in the directory tree starting at workingDir, and formats them
 // based on the language style guides provided by Hashicorp. This is done using the official hcl2 library.
 func runHCLFmt(terragruntOptions *options.TerragruntOptions) error {
+	terragruntOptions.Logger.Debugf("Formatting hcl files...")
 
-	workingDir := terragruntOptions.WorkingDir
-	targetFile := terragruntOptions.HclFile
-
-	// handle when option specifies a particular file
-	if targetFile != "" {
-		if !filepath.IsAbs(targetFile) {
-			targetFile = util.JoinPath(workingDir, targetFile)
+	tgHclFiles := []string{}
+	for _, fname := range terragruntOptions.HclFiles {
+		if !filepath.IsAbs(fname) {
+			fname = util.JoinPath(terragruntOptions.WorkingDir, fname)
 		}
-		terragruntOptions.Logger.Debugf("Formatting hcl file at: %s.", targetFile)
-		return formatTgHCL(terragruntOptions, targetFile)
+		tgHclFiles = append(tgHclFiles, fname)
 	}
 
-	terragruntOptions.Logger.Debugf("Formatting hcl files from the directory tree %s.", terragruntOptions.WorkingDir)
-	// zglob normalizes paths to "/"
-	tgHclFiles, err := zglob.Glob(util.JoinPath(workingDir, "**", "*.hcl"))
-	if err != nil {
-		return err
+	if len(tgHclFiles) == 0 {
+		var err error
+		// zglob normalizes paths to "/"
+		tgHclFiles, err = zglob.Glob(util.JoinPath(
+			terragruntOptions.WorkingDir,
+			"**", "*.hcl",
+		))
+		if err != nil {
+			return err
+		}
 	}
 
 	filteredTgHclFiles := []string{}

--- a/cli/hclfmt_test.go
+++ b/cli/hclfmt_test.go
@@ -211,17 +211,17 @@ func TestHCLFmtFile(t *testing.T) {
 	tgOptions, err := options.NewTerragruntOptionsForTest("")
 	require.NoError(t, err)
 
-	// format only the hcl file contained within the a subdirectory of the fixture
-	tgOptions.HclFile = "a/terragrunt.hcl"
+	// format only the specified terragrunt files
+	tgOptions.HclFiles = []string{"a/terragrunt.hcl", "terragrunt.hcl"}
 	tgOptions.WorkingDir = tmpPath
 	err = runHCLFmt(tgOptions)
 	require.NoError(t, err)
 
 	// test that the formatting worked on the specified file
 	t.Run("formatted", func(t *testing.T) {
-		t.Run(tgOptions.HclFile, func(t *testing.T) {
+		t.Run("specified files", func(t *testing.T) {
 			t.Parallel()
-			tgHclPath := filepath.Join(tmpPath, tgOptions.HclFile)
+			tgHclPath := filepath.Join(tmpPath, tgOptions.HclFiles[0])
 			formatted, err := ioutil.ReadFile(tgHclPath)
 			require.NoError(t, err)
 			assert.Equal(t, expected, formatted)
@@ -229,17 +229,17 @@ func TestHCLFmtFile(t *testing.T) {
 	})
 
 	dirs := []string{
-		"terragrunt.hcl",
 		"a/b/c/terragrunt.hcl",
+		"a/b/c/d/services.hcl",
 	}
-
-	original, err := ioutil.ReadFile("../test/fixture-hclfmt/terragrunt.hcl")
-	require.NoError(t, err)
 
 	// test that none of the other files were formatted
 	for _, dir := range dirs {
 		// Capture range variable into for block so it doesn't change while looping
 		dir := dir
+
+		original, err := ioutil.ReadFile(filepath.Join("../test/fixture-hclfmt/", dir))
+		require.NoError(t, err)
 
 		// Create a synchronous subtest to group the child tests so that they can run in parallel while honoring cleanup
 		// routines in the main test.

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -777,7 +777,7 @@ that Terragrunt invokes the module, so that you can debug issues with the terrag
 **Environment Variable**: `TERRAGRUNT_LOG_LEVEL`
 **Requires an argument**: `--terragrunt-log-level <LOG_LEVEL>`
 
-When passed it, sets logging level for terragrunt. All supported levels are:
+When passed in, sets logging level for terragrunt. All supported levels are:
 
 * panic
 * fatal

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -496,6 +496,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
 - [terragrunt-log-level](#terragrunt-log-level)
 - [terragrunt-check](#terragrunt-check)
 - [terragrunt-hclfmt-file](#terragrunt-hclfmt-file)
+- [terragrunt-hclfmt-files](#terragrunt-hclfmt-files)
 - [terragrunt-override-attr](#terragrunt-override-attr)
 - [terragrunt-json-out](#terragrunt-json-out)
 - [terragrunt-modules-that-include](#terragrunt-modules-that-include)
@@ -798,15 +799,18 @@ When passed it, sets logging level for terragrunt. All supported levels are:
 When passed in, run `hclfmt` in check only mode instead of actively overwriting the files. This will cause the
 command to exit with exit code 1 if there are any files that are not formatted.
 
-
 ### terragrunt-hclfmt-file
 
-**CLI Arg**: `--terragrunt-hclfmt-file`
-**Requires an argument**: `--terragrunt-hclfmt-file /path/to/terragrunt.hcl`
+**DEPRECATED: Please see [--terragrunt-hclfmt-files](#terragrunt-hclfmt-files)**
+
+### terragrunt-hclfmt-files
+
+**CLI Arg**: `--terragrunt-hclfmt-files`<br/>
+**Requires an argument**: `--terragrunt-hclfmt-files /path/to/terragrunt.hcl /another/path/terragrunt.hcl`<br/>
 **Commands**:
 - [hclfmt](#hclfmt)
 
-When passed in, run `hclfmt` only on specified hcl file.
+When passed in, run `hclfmt` on the specified files.
 
 
 ### terragrunt-override-attr

--- a/options/options.go
+++ b/options/options.go
@@ -163,7 +163,7 @@ type TerragruntOptions struct {
 	Check bool
 
 	// The file which hclfmt should be specifically run on
-	HclFile string
+	HclFiles []string
 
 	// The file path that terragrunt should use when rendering the terragrunt.hcl config as json.
 	JSONOut string
@@ -367,7 +367,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		StrictInclude:                  terragruntOptions.StrictInclude,
 		RunTerragrunt:                  terragruntOptions.RunTerragrunt,
 		AwsProviderPatchOverrides:      terragruntOptions.AwsProviderPatchOverrides,
-		HclFile:                        terragruntOptions.HclFile,
+		HclFiles:                       terragruntOptions.HclFiles,
 		JSONOut:                        terragruntOptions.JSONOut,
 		Check:                          terragruntOptions.Check,
 		CheckDependentModules:          terragruntOptions.CheckDependentModules,

--- a/util/file.go
+++ b/util/file.go
@@ -362,6 +362,14 @@ func CleanPath(path string) string {
 	return filepath.ToSlash(filepath.Clean(path))
 }
 
+func CleanPaths(paths []string) []string {
+	var result []string
+	for _, path := range paths {
+		result = append(result, CleanPath(path))
+	}
+	return result
+}
+
 // ContainsPath returns true if path contains the given subpath
 // E.g. path="foo/bar/bee", subpath="bar/bee" -> true
 // E.g. path="foo/bar/bee", subpath="bar/be" -> false (becuase be is not a directory)

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -158,7 +158,6 @@ func TestFileManifest(t *testing.T) {
 	for _, file := range testfiles {
 		assert.Equal(t, FileExists(file), false)
 	}
-
 }
 
 func TestSplitPath(t *testing.T) {
@@ -276,4 +275,16 @@ func TestIncludeInCopy(t *testing.T) {
 				!testCase.copyExpected && errors.Is(err, os.ErrNotExist),
 			"Unexpected copy result for file '%s' (should be copied: '%t') - got error: %s", testCase.path, testCase.copyExpected, err)
 	}
+}
+
+func TestCleanPaths(t *testing.T) {
+	paths := []string{".", "/", "/a/b", "a//b"}
+	expected := []string{
+		".",
+		string(filepath.Separator),
+		string([]byte{filepath.Separator, 'a', filepath.Separator, 'b'}),
+		string([]byte{'a', filepath.Separator, 'b'}),
+	}
+	actual := CleanPaths(paths)
+	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Depends on https://github.com/gruntwork-io/terragrunt/pull/2414

Allow passing multiple files to `hclfmt`  e.g. 
- `--terragrunt-hclfmt-files file_1.hcl file_2.hcl`
- `--terragrunt-hclfmt-files file_1.hcl --terragrunt-hclfmt-files file_2.hcl` 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `hclfmt` to accept multiple files through `--terragrunt-hclfmt-files`

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
If you are using `hclfmt` with `--terragrunt-hclfmt-file`, make sure to update it to `--terragrunt-hclfmt-files`.
