### PR TITLE
Remove GITHUB_OAUTH_TOKEN from tflint + update docs

### DIFF
--- a/docs/_docs/02_features/hooks.md
+++ b/docs/_docs/02_features/hooks.md
@@ -75,12 +75,17 @@ terraform {
 ```
 
 The `.tflint.hcl` should exist in the same folder as `terragrunt.hcl` or one of it's parents. If Terragrunt can't find
-a `.tflint.hcl` file, it won't execute tflint and return an error.
+a `.tflint.hcl` file, it won't execute tflint and return an error. All configurations should be in a `config` block in this
+file, as per [Tflint's docs](https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md).
 ```hcl
 plugin "aws" {
     enabled = true
     version = "0.21.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+config {
+  module = true
 }
 ```
 
@@ -95,7 +100,7 @@ The `execute` parameter only accepts `tflint`, it will ignore any other paramete
 
 *Private rulesets*
 
-If you want to run a the `tflint` hook with custom rulesets defined in a private repository, you will need to export locally a valid `GITHUB_OAUTH_TOKEN` token. Terragrunt will take that and expose it to the `tflint`-recognised authentication token - `GITHUB_TOKEN`.
+If you want to run a the `tflint` hook with custom rulesets defined in a private repository, you will need to export locally a valid `GITHUB_TOKEN` token.
 
 #### Troubleshooting
 

--- a/tflint/tflint.go
+++ b/tflint/tflint.go
@@ -5,7 +5,6 @@ package tflint
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/config"
@@ -25,17 +24,6 @@ func RunTflintWithOpts(terragruntOptions *options.TerragruntOptions, terragruntC
 	variables, err := inputsToTflintVar(terragruntConfig.Inputs)
 	if err != nil {
 		return err
-	}
-
-	// Get GITHUB_OAUTH_TOKEN and set it as GITHUB_TOKEN so that tflint recognises and respects it
-	githubOauthToken := os.Getenv("GITHUB_OAUTH_TOKEN")
-	if githubOauthToken != "" {
-		err := os.Setenv("GITHUB_TOKEN", githubOauthToken)
-		if err != nil {
-			return errors.WithStackTrace(err)
-		}
-
-		terragruntOptions.Logger.Debugf("Setting GITHUB_TOKEN to the value of GITHUB_OAUTH_TOKEN")
 	}
 
 	terragruntOptions.Logger.Debugf("Initializing tflint in directory %s", terragruntOptions.WorkingDir)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Reverts #2387. The [tflint-ruleset-aws-cis](https://github.com/gruntwork-io/tflint-ruleset-aws-cis) is now opensource so we won't have issues running it in the ECS Deploy Runner.

Now, Tflint will only recognize private GitHub repos based on the token in `GITHUB_TOKEN` (as it's default behaviour).

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Removed tflint feature to export `GITHUB_OAUTH_TOKEN` as `GITHUB_TOKEN`.

### Migration Guide

For tflint private rulesets, use the environment variable `GITHUB_TOKEN` for auth.

