### PR TITLE
#2435 Improved handling of default value for sse_algorithm

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -1135,7 +1135,7 @@ func checkIfSSEForS3Enabled(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3
 	for _, rule := range output.ServerSideEncryptionConfiguration.Rules {
 		if rule.ApplyServerSideEncryptionByDefault != nil {
 			if rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm != nil {
-				if *rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm == config.BucketSSEAlgorithm {
+				if *rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm == fetchEncryptionAlgorithm(config) {
 					return true, nil
 				}
 

--- a/test/fixture-s3-encryption/basic-encryption/terragrunt.hcl
+++ b/test/fixture-s3-encryption/basic-encryption/terragrunt.hcl
@@ -1,0 +1,17 @@
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite"
+  }
+  config = {
+    encrypt                        = true
+    bucket                         = "__FILL_IN_BUCKET_NAME__"
+    key                            = "terraform.tfstate"
+    region                         = "us-west-2"
+    dynamodb_table                 = "__FILL_IN_LOCK_TABLE_NAME__"
+    enable_lock_table_ssencryption = true
+    bucket_sse_kms_key_id          = "alias/dedicated-test-key"
+
+  }
+}

--- a/test/integration_s3_encryption_test.go
+++ b/test/integration_s3_encryption_test.go
@@ -1,7 +1,9 @@
 package test
 
 import (
+	"bytes"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -15,8 +17,9 @@ import (
 )
 
 const (
-	s3SSEAESFixturePath       = "fixture-s3-encryption/sse-aes"
-	s3SSECustomKeyFixturePath = "fixture-s3-encryption/custom-key"
+	s3SSEAESFixturePath            = "fixture-s3-encryption/sse-aes"
+	s3SSECustomKeyFixturePath      = "fixture-s3-encryption/custom-key"
+	s3SSBasicEncryptionFixturePath = "fixture-s3-encryption/basic-encryption"
 )
 
 func TestTerragruntS3SSEAES(t *testing.T) {
@@ -68,4 +71,43 @@ func TestTerragruntS3SSECustomKey(t *testing.T) {
 	assert.Equal(t, s3.ServerSideEncryptionAwsKms, aws.StringValue(sseRule.SSEAlgorithm))
 	assert.True(t, strings.HasSuffix(aws.StringValue(sseRule.KMSMasterKeyID), "alias/dedicated-test-key"))
 
+}
+
+func TestTerragruntS3SSEKeyNotReverted(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, s3SSBasicEncryptionFixturePath)
+
+	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
+	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
+
+	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
+	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, s3SSBasicEncryptionFixturePath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", filepath.Dir(tmpTerragruntConfigPath)), &stdout, &stderr)
+	output := stderr.String()
+
+	// verify that bucket encryption message is not printed
+	assert.NotContains(t, output, "Bucket Server-Side Encryption")
+
+	stdout = bytes.Buffer{}
+	stderr = bytes.Buffer{}
+	tmpTerragruntConfigPath = createTmpTerragruntConfig(t, s3SSBasicEncryptionFixturePath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", filepath.Dir(tmpTerragruntConfigPath)), &stdout, &stderr)
+	output = stderr.String()
+	assert.NotContains(t, output, "Bucket Server-Side Encryption")
+
+	// verify that encryption key is not reverted
+	client := terraws.NewS3Client(t, TERRAFORM_REMOTE_STATE_S3_REGION)
+	resp, err := client.GetBucketEncryption(&s3.GetBucketEncryptionInput{Bucket: aws.String(s3BucketName)})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(resp.ServerSideEncryptionConfiguration.Rules))
+	sseRule := resp.ServerSideEncryptionConfiguration.Rules[0].ApplyServerSideEncryptionByDefault
+	require.NotNil(t, sseRule)
+	assert.Equal(t, s3.ServerSideEncryptionAwsKms, aws.StringValue(sseRule.SSEAlgorithm))
+	assert.True(t, strings.HasSuffix(aws.StringValue(sseRule.KMSMasterKeyID), "alias/dedicated-test-key"))
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated handling of default value for `bucket_sse_algorithm` to not print false positive  "S3 bucket is out of date" messages.

Fixes #2435.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated handling of default value for `bucket_sse_algorithm`

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

