### PR TITLE
Bug/support running apply destroy in reverse order

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -1159,7 +1159,7 @@ func runAll(terragruntOptions *options.TerragruntOptions) error {
 	}
 
 	terragruntOptions.Logger.Debugf("%s", stack.String())
-	if err := stack.LogModuleDeployOrder(terragruntOptions.Logger, terragruntOptions.TerraformCommand); err != nil {
+	if err := stack.LogModuleDeployOrder(terragruntOptions); err != nil {
 		return err
 	}
 

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -97,6 +97,8 @@ func (stack *Stack) Run(terragruntOptions *options.TerragruntOptions) error {
 		return RunModulesIgnoreOrder(stack.Modules, terragruntOptions.Parallelism)
 	} else if stackCmd == "destroy" {
 		return RunModulesReverseOrder(stack.Modules, terragruntOptions.Parallelism)
+	} else if util.ListContainsElement(terragruntOptions.TerraformCliArgs, "-destroy") {
+		return RunModulesReverseOrder(stack.Modules, terragruntOptions.Parallelism)
 	} else {
 		return RunModules(stack.Modules, terragruntOptions.Parallelism)
 	}
@@ -162,10 +164,11 @@ func (stack *Stack) syncTerraformCliArgs(terragruntOptions *options.TerragruntOp
 func (stack *Stack) getModuleRunGraph(terragruntOptions *options.TerragruntOptions) ([][]*TerraformModule, error) {
 	var moduleRunGraph map[string]*runningModule
 	var graphErr error
-	switch terragruntOptions.TerraformCommand {
-	case "destroy":
+	if terragruntOptions.TerraformCommand == "destroy" {
 		moduleRunGraph, graphErr = toRunningModules(stack.Modules, ReverseOrder)
-	default:
+	} else if util.ListContainsElement(terragruntOptions.TerraformCliArgs, "-destroy") {
+		moduleRunGraph, graphErr = toRunningModules(stack.Modules, ReverseOrder)
+	} else {
 		moduleRunGraph, graphErr = toRunningModules(stack.Modules, NormalOrder)
 	}
 	if graphErr != nil {

--- a/configstack/stack_test.go
+++ b/configstack/stack_test.go
@@ -57,8 +57,13 @@ func TestFindStackInSubfolders(t *testing.T) {
 func TestGetModuleRunGraphApplyOrder(t *testing.T) {
 	t.Parallel()
 
+	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	terragruntOptions.TerraformCommand = "apply"
+
 	stack := createTestStack()
-	runGraph, err := stack.getModuleRunGraph("apply")
+	runGraph, err := stack.getModuleRunGraph(terragruntOptions)
 	require.NoError(t, err)
 
 	assert.Equal(
@@ -82,8 +87,13 @@ func TestGetModuleRunGraphApplyOrder(t *testing.T) {
 func TestGetModuleRunGraphDestroyOrder(t *testing.T) {
 	t.Parallel()
 
+	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	terragruntOptions.TerraformCommand = "destroy"
+
 	stack := createTestStack()
-	runGraph, err := stack.getModuleRunGraph("destroy")
+	runGraph, err := stack.getModuleRunGraph(terragruntOptions)
 	require.NoError(t, err)
 
 	assert.Equal(

--- a/configstack/stack_test.go
+++ b/configstack/stack_test.go
@@ -112,7 +112,37 @@ func TestGetModuleRunGraphDestroyOrder(t *testing.T) {
 		},
 		runGraph,
 	)
+}
 
+func TestGetModuleRunGraphApplyDestroyOrder(t *testing.T) {
+	t.Parallel()
+
+	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	terragruntOptions.TerraformCommand = "apply"
+	terragruntOptions.TerraformCliArgs = append(terragruntOptions.TerraformCliArgs, "-destroy")
+
+	stack := createTestStack()
+	runGraph, err := stack.getModuleRunGraph(terragruntOptions)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		[][]*TerraformModule{
+			{
+				stack.Modules[5],
+			},
+			{
+				stack.Modules[3],
+				stack.Modules[4],
+			},
+			{
+				stack.Modules[1],
+			},
+		},
+		runGraph,
+	)
 }
 
 func createTestStack() *Stack {


### PR DESCRIPTION
## Description

Invert module group ordering for `apply -destroy` commands, mirroring the functionality for `destroy` commands.

## Testing
This has been tested by:
- [x] `$ go test -v ./...`
- [x] Validating the group ordering is now correct with `$ go run main.go run-all apply -destroy --terragrunt-working-dir ...`

## TODOs
I'm not sure if documentation should be updated. Maybe somewhere [here](https://terragrunt.gruntwork.io/docs/features/execute-terraform-commands-on-multiple-modules-at-once/)?

## Release Notes (draft)

Added support for inverting module group ordering for `apply -destroy` commands.