### PR TITLE
Add a new `--terragrunt-iam-profile` option for the session when assuming the `--terragrunt-iam-role`.

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -372,6 +372,11 @@ func parseIAMRoleOptions(args []string) (*options.IAMRoleOptions, error) {
 		return nil, err
 	}
 
+	iamProfile, err := parseStringArg(args, optTerragruntIAMProfile, os.Getenv("TERRAGRUNT_IAM_PROFILE"))
+	if err != nil {
+		return nil, err
+	}
+
 	envValue, envProvided := os.LookupEnv("TERRAGRUNT_IAM_ASSUME_ROLE_DURATION")
 	iamAssumeRoleDuration, err := parseIntArg(args, optTerragruntIAMAssumeRoleDuration, envValue, envProvided, 0)
 	if err != nil {
@@ -386,6 +391,7 @@ func parseIAMRoleOptions(args []string) (*options.IAMRoleOptions, error) {
 
 	optsOut := &options.IAMRoleOptions{
 		RoleARN:               iamRole,
+		Profile:               iamProfile,
 		AssumeRoleDuration:    int64(iamAssumeRoleDuration),
 		AssumeRoleSessionName: iamAssumeRoleSessionName,
 	}

--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -116,6 +116,12 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		},
 
 		{
+			[]string{"--terragrunt-iam-profile", "terragrunt-profile"},
+			mockOptionsWithIamProfile(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, "terragrunt-profile"),
+			nil,
+		},
+
+		{
 			[]string{"--terragrunt-iam-assume-role-duration", "36000"},
 			mockOptionsWithIamAssumeRoleDuration(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, 36000),
 			nil,
@@ -221,6 +227,14 @@ func mockOptionsWithIamRole(t *testing.T, terragruntConfigPath string, workingDi
 	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors, false, defaultLogLevel, false)
 	opts.OriginalIAMRoleOptions.RoleARN = iamRole
 	opts.IAMRoleOptions.RoleARN = iamRole
+
+	return opts
+}
+
+func mockOptionsWithIamProfile(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool, iamProfile string) *options.TerragruntOptions {
+	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors, false, defaultLogLevel, false)
+	opts.OriginalIAMRoleOptions.Profile = iamProfile
+	opts.IAMRoleOptions.Profile = iamProfile
 
 	return opts
 }

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -42,6 +42,7 @@ const (
 	optTerragruntSourceMap                      = "terragrunt-source-map"
 	optTerragruntSourceUpdate                   = "terragrunt-source-update"
 	optTerragruntIAMRole                        = "terragrunt-iam-role"
+	optTerragruntIAMProfile                     = "terragrunt-iam-profile"
 	optTerragruntIAMAssumeRoleDuration          = "terragrunt-iam-assume-role-duration"
 	optTerragruntIAMAssumeRoleSessionName       = "terragrunt-iam-assume-role-session-name"
 	optTerragruntIgnoreDependencyErrors         = "terragrunt-ignore-dependency-errors"
@@ -92,6 +93,7 @@ var allTerragruntStringOpts = []string{
 	optTerragruntSource,
 	optTerragruntSourceMap,
 	optTerragruntIAMRole,
+	optTerragruntIAMProfile,
 	optTerragruntIAMAssumeRoleDuration,
 	optTerragruntIAMAssumeRoleSessionName,
 	optTerragruntExcludeDir,

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ const (
 	MetadataPreventDestroy              = "prevent_destroy"
 	MetadataSkip                        = "skip"
 	MetadataIamRole                     = "iam_role"
+	MetadataIamProfile                  = "iam_profile"
 	MetadataIamAssumeRoleDuration       = "iam_assume_role_duration"
 	MetadataIamAssumeRoleSessionName    = "iam_assume_role_session_name"
 	MetadataInputs                      = "inputs"
@@ -65,6 +66,7 @@ type TerragruntConfig struct {
 	PreventDestroy              *bool
 	Skip                        bool
 	IamRole                     string
+	IamProfile                  string
 	IamAssumeRoleDuration       *int64
 	IamAssumeRoleSessionName    string
 	Inputs                      map[string]interface{}
@@ -95,6 +97,7 @@ func (conf *TerragruntConfig) String() string {
 func (conf *TerragruntConfig) GetIAMRoleOptions() options.IAMRoleOptions {
 	configIAMRoleOptions := options.IAMRoleOptions{
 		RoleARN:               conf.IamRole,
+		Profile:               conf.IamProfile,
 		AssumeRoleSessionName: conf.IamAssumeRoleSessionName,
 	}
 	if conf.IamAssumeRoleDuration != nil {
@@ -133,6 +136,7 @@ type terragruntConfigFile struct {
 	PreventDestroy           *bool               `hcl:"prevent_destroy,attr"`
 	Skip                     *bool               `hcl:"skip,attr"`
 	IamRole                  *string             `hcl:"iam_role,attr"`
+	IamProfile               *string             `hcl:"iam_profile,attr"`
 	IamAssumeRoleDuration    *int64              `hcl:"iam_assume_role_duration,attr"`
 	IamAssumeRoleSessionName *string             `hcl:"iam_assume_role_session_name,attr"`
 	TerragruntDependencies   []Dependency        `hcl:"dependency,block"`
@@ -933,6 +937,11 @@ func convertToTerragruntConfig(
 	if terragruntConfigFromFile.IamRole != nil {
 		terragruntConfig.IamRole = *terragruntConfigFromFile.IamRole
 		terragruntConfig.SetFieldMetadata(MetadataIamRole, defaultMetadata)
+	}
+
+	if terragruntConfigFromFile.IamProfile != nil {
+		terragruntConfig.IamProfile = *terragruntConfigFromFile.IamProfile
+		terragruntConfig.SetFieldMetadata(MetadataIamProfile, defaultMetadata)
 	}
 
 	if terragruntConfigFromFile.IamAssumeRoleDuration != nil {

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -25,6 +25,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 	output[MetadataTerragruntVersionConstraint] = gostringToCty(config.TerragruntVersionConstraint)
 	output[MetadataDownloadDir] = gostringToCty(config.DownloadDir)
 	output[MetadataIamRole] = gostringToCty(config.IamRole)
+	output[MetadataIamProfile] = gostringToCty(config.IamProfile)
 	output[MetadataSkip] = goboolToCty(config.Skip)
 	output[MetadataIamAssumeRoleSessionName] = gostringToCty(config.IamAssumeRoleSessionName)
 
@@ -145,6 +146,10 @@ func TerragruntConfigAsCtyWithMetadata(config *TerragruntConfig) (cty.Value, err
 	}
 
 	if err := wrapWithMetadata(config, config.IamRole, MetadataIamRole, &output); err != nil {
+		return cty.NilVal, err
+	}
+
+	if err := wrapWithMetadata(config, config.IamProfile, MetadataIamProfile, &output); err != nil {
 		return cty.NilVal, err
 	}
 

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -197,6 +197,8 @@ func terragruntConfigStructFieldToMapKey(t *testing.T, fieldName string) (string
 		return "skip", true
 	case "IamRole":
 		return "iam_role", true
+	case "IamProfile":
+		return "iam_profile", true
 	case "IamAssumeRoleDuration":
 		return "iam_assume_role_duration", true
 	case "IamAssumeRoleSessionName":

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -61,6 +61,7 @@ type terraformConfigSourceOnly struct {
 // terragruntFlags is a struct that can be used to only decode the flag attributes (skip and prevent_destroy)
 type terragruntFlags struct {
 	IamRole        *string  `hcl:"iam_role,attr"`
+	IamProfile     *string  `hcl:"iam_profile,attr"`
 	PreventDestroy *bool    `hcl:"prevent_destroy,attr"`
 	Skip           *bool    `hcl:"skip,attr"`
 	Remain         hcl.Body `hcl:",remain"`
@@ -310,6 +311,9 @@ func PartialParseConfigString(
 			}
 			if decoded.IamRole != nil {
 				output.IamRole = *decoded.IamRole
+			}
+			if decoded.IamProfile != nil {
+				output.IamProfile = *decoded.IamProfile
 			}
 
 		case TerragruntVersionConstraints:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -229,10 +229,8 @@ func TestParseIamRole(t *testing.T) {
 	t.Parallel()
 
 	config := `
-{
-	"iam_role" = "terragrunt-iam-role"
-	"iam_profile" = "terragrunt-iam-profile"
-}
+iam_role = "terragrunt-iam-role"
+iam_profile = "terragrunt-iam-profile"
 `
 
 	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,7 @@ remote_state {
 	assert.Nil(t, terragruntConfig.Terraform)
 
 	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Empty(t, terragruntConfig.IamProfile)
 
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
 		assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
@@ -52,6 +53,7 @@ remote_state = {
 	assert.Nil(t, terragruntConfig.Terraform)
 
 	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Empty(t, terragruntConfig.IamProfile)
 
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
 		assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
@@ -77,6 +79,7 @@ func TestParseTerragruntJsonConfigRemoteStateMinimalConfig(t *testing.T) {
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Nil(t, terragruntConfig.RetryableErrors)
 	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Empty(t, terragruntConfig.IamProfile)
 
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
 		assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
@@ -119,6 +122,7 @@ remote_state {
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Nil(t, terragruntConfig.RetryableErrors)
 	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Empty(t, terragruntConfig.IamProfile)
 
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
 		assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
@@ -155,6 +159,7 @@ func TestParseTerragruntJsonConfigRemoteStateFullConfig(t *testing.T) {
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Nil(t, terragruntConfig.RetryableErrors)
 	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Empty(t, terragruntConfig.IamProfile)
 
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
 		assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
@@ -182,6 +187,7 @@ retryable_errors = [
 
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Empty(t, terragruntConfig.IamProfile)
 
 	assert.Equal(t, 10, *terragruntConfig.RetryMaxAttempts)
 	assert.Equal(t, 60, *terragruntConfig.RetrySleepIntervalSec)
@@ -209,6 +215,7 @@ func TestParseTerragruntJsonConfigRetryConfiguration(t *testing.T) {
 
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Empty(t, terragruntConfig.IamProfile)
 
 	assert.Equal(t, *terragruntConfig.RetryMaxAttempts, 10)
 	assert.Equal(t, *terragruntConfig.RetrySleepIntervalSec, 60)
@@ -221,7 +228,12 @@ func TestParseTerragruntJsonConfigRetryConfiguration(t *testing.T) {
 func TestParseIamRole(t *testing.T) {
 	t.Parallel()
 
-	config := `iam_role = "terragrunt-iam-role"`
+	config := `
+{
+	"iam_role" = "terragrunt-iam-role"
+	"iam_profile" = "terragrunt-iam-profile"
+}
+`
 
 	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
 	if err != nil {
@@ -234,6 +246,7 @@ func TestParseIamRole(t *testing.T) {
 	assert.Nil(t, terragruntConfig.RetryableErrors)
 
 	assert.Equal(t, "terragrunt-iam-role", terragruntConfig.IamRole)
+	assert.Equal(t, "terragrunt-iam-profile", terragruntConfig.IamProfile)
 }
 
 func TestParseIamAssumeRoleDuration(t *testing.T) {
@@ -291,6 +304,7 @@ dependencies {
 	assert.Nil(t, terragruntConfig.RetryableErrors)
 
 	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Empty(t, terragruntConfig.IamProfile)
 
 	if assert.NotNil(t, terragruntConfig.Dependencies) {
 		assert.Equal(t, []string{"../test/fixture-parent-folders/multiple-terragrunt-in-parents"}, terragruntConfig.Dependencies.Paths)
@@ -315,6 +329,7 @@ dependencies {
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Nil(t, terragruntConfig.RetryableErrors)
 	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Empty(t, terragruntConfig.IamProfile)
 
 	if assert.NotNil(t, terragruntConfig.Dependencies) {
 		assert.Equal(t, []string{"../test/fixture", "../test/fixture-dirs", "../test/fixture-inputs"}, terragruntConfig.Dependencies.Paths)
@@ -354,6 +369,7 @@ dependencies {
 	assert.Equal(t, "foo", *terragruntConfig.Terraform.Source)
 	assert.Nil(t, terragruntConfig.RetryableErrors)
 	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Empty(t, terragruntConfig.IamProfile)
 
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
 		assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
@@ -402,6 +418,7 @@ func TestParseTerragruntJsonConfigRemoteStateDynamoDbTerraformConfigAndDependenc
 	assert.Equal(t, "foo", *terragruntConfig.Terraform.Source)
 	assert.Nil(t, terragruntConfig.RetryableErrors)
 	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Empty(t, terragruntConfig.IamProfile)
 
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
 		assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
@@ -669,6 +686,7 @@ func TestParseTerragruntConfigEmptyConfig(t *testing.T) {
 	assert.Nil(t, cfg.PreventDestroy)
 	assert.False(t, cfg.Skip)
 	assert.Empty(t, cfg.IamRole)
+	assert.Empty(t, cfg.IamProfile)
 	assert.Nil(t, cfg.RetryMaxAttempts)
 	assert.Nil(t, cfg.RetrySleepIntervalSec)
 	assert.Nil(t, cfg.RetryableErrors)

--- a/config/include.go
+++ b/config/include.go
@@ -256,6 +256,10 @@ func (targetConfig *TerragruntConfig) Merge(sourceConfig *TerragruntConfig, terr
 		targetConfig.IamRole = sourceConfig.IamRole
 	}
 
+	if sourceConfig.IamProfile != "" {
+		targetConfig.IamProfile = sourceConfig.IamProfile
+	}
+
 	if sourceConfig.IamAssumeRoleDuration != nil {
 		targetConfig.IamAssumeRoleDuration = sourceConfig.IamAssumeRoleDuration
 	}
@@ -358,6 +362,10 @@ func (targetConfig *TerragruntConfig) DeepMerge(sourceConfig *TerragruntConfig, 
 
 	if sourceConfig.IamRole != "" {
 		targetConfig.IamRole = sourceConfig.IamRole
+	}
+
+	if sourceConfig.IamProfile != "" {
+		targetConfig.IamProfile = sourceConfig.IamProfile
 	}
 
 	if sourceConfig.IamAssumeRoleDuration != nil {

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -1199,6 +1199,20 @@ iam_role = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
   * Value of `iam_role` can reference local variables
   * Definitions of `iam_role` included from other HCL files through `include`
 
+### iam_profile
+
+The `iam_profile` attribute can be used to specify the IAM profile when Terragrunt assumes the IAM role prior to invoking Terraform.
+
+The precedence is as follows: `--terragrunt-iam-profile` command line option → `TERRAGRUNT_IAM_PROFILE` env variable →
+`iam_profile` attribute of the `terragrunt.hcl` file in the module directory → `iam_profile` attribute of the included
+`terragrunt.hcl`.
+
+Example:
+
+```hcl
+iam_profile = "terraform-iam-profile"
+```
+
 ### iam_assume_role_duration
 
 The `iam_assume_role_duration` attribute can be used to specify the STS session duration, in seconds, for the IAM role that Terragrunt should assume prior to invoking Terraform.

--- a/options/options.go
+++ b/options/options.go
@@ -211,6 +211,9 @@ type IAMRoleOptions struct {
 	// The ARN of an IAM Role to assume. Used when accessing AWS, both internally and through terraform.
 	RoleARN string
 
+	// The name of an IAM profile for the session when assuming the role.
+	Profile string
+
 	// Duration of the STS Session when assuming the role.
 	AssumeRoleDuration int64
 
@@ -223,6 +226,10 @@ func MergeIAMRoleOptions(target IAMRoleOptions, source IAMRoleOptions) IAMRoleOp
 
 	if source.RoleARN != "" {
 		out.RoleARN = source.RoleARN
+	}
+
+	if source.Profile != "" {
+		out.Profile = source.Profile
 	}
 
 	if source.AssumeRoleDuration != 0 {


### PR DESCRIPTION
## Description

My organization would like to make use of the `iam_role` attribute to take advantage of benefits outlined in [1]. However, we aren't able to do so because the profile we'd need to use when assuming the `iam_role` is parsed in the `terragrunt.hcl` file.

This commit adds a new option to specify an iam profile via an `iam_profile` attribute (plus `--terragrunt-iam-profile` cli and `TERRAGRUNT_IAM_PROFILE` env var options) to support this workflow.

[1] https://terragrunt.gruntwork.io/docs/features/work-with-multiple-aws-accounts/#configuring-terragrunt-to-assume-an-iam-role

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
  - I'd appreciate some help on ^. I've tried running the tests as outlined [here](https://terragrunt.gruntwork.io/docs/community/contributing/#running-tests), but I don't think my environment is set up correctly (although I could be mistaken). I have validate that this solves works by testing locally as outlined [here](--terragrunt-iam-role "arn:aws:iam::730118560661:role/RELEASE_MIGRATION_SHUTDOWN-FUTURE").
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added a `--terragrunt-iam-profile` option to specify the profile for the session when assuming the [--terragrunt-iam-role](https://terragrunt.gruntwork.io/docs/reference/cli-options/#terragrunt-iam-role).

### Migration Guide

n/a