### PR TITLE
#2515 Add option to disable module output

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -116,6 +116,7 @@ const CMD_TERRAGRUNT_READ_CONFIG = "terragrunt-read-config"
 const CMD_HCLFMT = "hclfmt"
 const CMD_AWS_PROVIDER_PATCH = "aws-provider-patch"
 const CMD_RENDER_JSON = "render-json"
+const CMD_OUTPUT = "output"
 
 // START: Constants useful for multimodule command handling
 const CMD_RUN_ALL = "run-all"
@@ -199,6 +200,12 @@ var TERRAFORM_COMMANDS_THAT_DO_NOT_NEED_INIT = []string{
 	"version",
 	"terragrunt-info",
 	"graph-dependencies",
+}
+
+var TERRAGRUNT_COMMANDS_THAT_USE_OUTPUT = []string{
+	CMD_RENDER_JSON,
+	CMD_OUTPUT,
+	CMD_OUTPUT_ALL,
 }
 
 // deprecatedArguments is a map of deprecated arguments to the argument that replace them.
@@ -369,6 +376,9 @@ func checkDeprecated(command string, terragruntOptions *options.TerragruntOption
 // runCommand runs one or many terraform commands based on the type of
 // terragrunt command
 func runCommand(command string, terragruntOptions *options.TerragruntOptions) (finalEff error) {
+	//if util.ListContainsElement(TERRAGRUNT_COMMANDS_THAT_USE_OUTPUT, terragruntOptions.TerraformCommand) {
+	//	terragruntOptions.IncludeModulePrefix = false
+	//}
 	if command == CMD_RUN_ALL {
 		return runAll(terragruntOptions)
 	}

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -116,7 +116,6 @@ const CMD_TERRAGRUNT_READ_CONFIG = "terragrunt-read-config"
 const CMD_HCLFMT = "hclfmt"
 const CMD_AWS_PROVIDER_PATCH = "aws-provider-patch"
 const CMD_RENDER_JSON = "render-json"
-const CMD_OUTPUT = "output"
 
 // START: Constants useful for multimodule command handling
 const CMD_RUN_ALL = "run-all"
@@ -200,12 +199,6 @@ var TERRAFORM_COMMANDS_THAT_DO_NOT_NEED_INIT = []string{
 	"version",
 	"terragrunt-info",
 	"graph-dependencies",
-}
-
-var TERRAGRUNT_COMMANDS_THAT_USE_OUTPUT = []string{
-	CMD_RENDER_JSON,
-	CMD_OUTPUT,
-	CMD_OUTPUT_ALL,
 }
 
 // deprecatedArguments is a map of deprecated arguments to the argument that replace them.
@@ -376,9 +369,6 @@ func checkDeprecated(command string, terragruntOptions *options.TerragruntOption
 // runCommand runs one or many terraform commands based on the type of
 // terragrunt command
 func runCommand(command string, terragruntOptions *options.TerragruntOptions) (finalEff error) {
-	//if util.ListContainsElement(TERRAGRUNT_COMMANDS_THAT_USE_OUTPUT, terragruntOptions.TerraformCommand) {
-	//	terragruntOptions.IncludeModulePrefix = false
-	//}
 	if command == CMD_RUN_ALL {
 		return runAll(terragruntOptions)
 	}

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -470,7 +470,6 @@ func cloneTerragruntOptionsForDependency(terragruntOptions *options.TerragruntOp
 	if targetOptions.IAMRoleOptions != targetOptions.OriginalIAMRoleOptions {
 		targetOptions.IAMRoleOptions = options.IAMRoleOptions{}
 	}
-	targetOptions.IncludeModulePrefix = false
 	return targetOptions
 }
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -470,12 +470,14 @@ func cloneTerragruntOptionsForDependency(terragruntOptions *options.TerragruntOp
 	if targetOptions.IAMRoleOptions != targetOptions.OriginalIAMRoleOptions {
 		targetOptions.IAMRoleOptions = options.IAMRoleOptions{}
 	}
+	targetOptions.IncludeModulePrefix = false
 	return targetOptions
 }
 
 // Clone terragrunt options and update context for dependency block so that the outputs can be read correctly
 func cloneTerragruntOptionsForDependencyOutput(terragruntOptions *options.TerragruntOptions, targetConfig string) (*options.TerragruntOptions, error) {
 	targetOptions := cloneTerragruntOptionsForDependency(terragruntOptions, targetConfig)
+	targetOptions.IncludeModulePrefix = false
 	targetOptions.TerraformCommand = "output"
 	targetOptions.TerraformCliArgs = []string{"output", "-json"}
 

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -73,7 +73,10 @@ func RunShellCommandWithOutput(
 
 	var errWriter = terragruntOptions.ErrWriter
 	var outWriter = terragruntOptions.Writer
-	var prefix = terragruntOptions.OutputPrefix
+	var prefix = ""
+	if terragruntOptions.IncludeModulePrefix {
+		prefix = terragruntOptions.OutputPrefix
+	}
 	// Terragrunt can run some commands (such as terraform remote config) before running the actual terraform
 	// command requested by the user. The output of these other commands should not end up on stdout as this
 	// breaks scripts relying on terraform's output.

--- a/shell/run_shell_cmd_output_test.go
+++ b/shell/run_shell_cmd_output_test.go
@@ -45,6 +45,7 @@ func TestCommandOutputPrefix(t *testing.T) {
 		prefixedOutput = append(prefixedOutput, prefix+line)
 	}
 	testCommandOutput(t, func(terragruntOptions *options.TerragruntOptions) {
+		terragruntOptions.IncludeModulePrefix = true
 		terragruntOptions.OutputPrefix = prefix
 	}, assertOutputs(t,
 		prefixedOutput,


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Update dependency outputs fetching to not include module prefix since output is parsed as JSON

Fixes #2515.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Fixed handling of dependencies outputs to not include module prefix

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

