### PR TITLE
~ aws-auth docs - iam remove object level actions from the bucket resource

### DIFF
--- a/docs/_docs/02_features/aws-auth.md
+++ b/docs/_docs/02_features/aws-auth.md
@@ -63,11 +63,9 @@ For a more minimal policy, for example when using a single bucket and DynamoDB t
             "Action": [
                 "s3:ListBucket",
                 "s3:GetBucketVersioning",
-                "s3:GetObject",
                 "s3:GetBucketAcl",
                 "s3:GetBucketLogging",
                 "s3:CreateBucket",
-                "s3:PutObject",
                 "s3:PutBucketPublicAccessBlock",
                 "s3:PutBucketTagging",
                 "s3:PutBucketPolicy",


### PR DESCRIPTION
## Description

Fixes #2532.

The [AWS Auth Docs here ](https://terragrunt.gruntwork.io/docs/features/aws-auth/#aws-iam-policies) refers to a couple of s3 object level actions (SID: `AllowCreateAndListS3ActionsOnSpecifiedTerragruntBucket`) on the bucket resource which seems incorrect and is fixed in this PR.



## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)
Minor update to AWS Auth docs.

### Migration Guide
N/A

