### PR TITLE
JSON output prefix update

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -235,6 +235,12 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 		return nil, err
 	}
 
+	for _, arg := range args {
+		if strings.EqualFold(arg, "-json") {
+			opts.JsonFlag = true
+		}
+	}
+
 	return opts, nil
 }
 

--- a/cli/args.go
+++ b/cli/args.go
@@ -156,8 +156,16 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 		opts.Debug = true
 	}
 
+	jsonOutput := false
+	for _, arg := range args {
+		if strings.EqualFold(arg, "-json") {
+			jsonOutput = true
+			break
+		}
+	}
+
 	includeModulePrefix := parseBooleanArg(args, optTerragruntIncludeModulePrefix, os.Getenv("TERRAGRUNT_INCLUDE_MODULE_PREFIX") == "true" || os.Getenv("TERRAGRUNT_INCLUDE_MODULE_PREFIX") == "1")
-	if includeModulePrefix {
+	if includeModulePrefix && !jsonOutput {
 		opts.IncludeModulePrefix = true
 		opts.OutputPrefix = fmt.Sprintf("[%s] ", opts.WorkingDir)
 	}
@@ -233,12 +241,6 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.JSONOut, err = parseStringArg(args, optTerragruntJSONOut, "")
 	if err != nil {
 		return nil, err
-	}
-
-	for _, arg := range args {
-		if strings.EqualFold(arg, "-json") {
-			opts.JsonFlag = true
-		}
 	}
 
 	return opts, nil

--- a/options/options.go
+++ b/options/options.go
@@ -204,9 +204,6 @@ type TerragruntOptions struct {
 
 	// Controls if a module prefix will be prepended to TF outputs
 	IncludeModulePrefix bool
-
-	// Shows that was provided -json flag
-	JsonFlag bool
 }
 
 // IAMOptions represents options that are used by Terragrunt to assume an IAM role.
@@ -288,7 +285,6 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		UsePartialParseConfigCache:     false,
 		OutputPrefix:                   "",
 		IncludeModulePrefix:            false,
-		JsonFlag:                       false,
 		RunTerragrunt: func(terragruntOptions *TerragruntOptions) error {
 			return errors.WithStackTrace(RunTerragruntCommandNotSet)
 		},
@@ -387,7 +383,6 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		UsePartialParseConfigCache:     terragruntOptions.UsePartialParseConfigCache,
 		OutputPrefix:                   terragruntOptions.OutputPrefix,
 		IncludeModulePrefix:            terragruntOptions.IncludeModulePrefix,
-		JsonFlag:                       terragruntOptions.JsonFlag,
 	}
 }
 

--- a/options/options.go
+++ b/options/options.go
@@ -204,6 +204,9 @@ type TerragruntOptions struct {
 
 	// Controls if a module prefix will be prepended to TF outputs
 	IncludeModulePrefix bool
+
+	// Shows that was provided -json flag
+	JsonFlag bool
 }
 
 // IAMOptions represents options that are used by Terragrunt to assume an IAM role.
@@ -285,6 +288,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		UsePartialParseConfigCache:     false,
 		OutputPrefix:                   "",
 		IncludeModulePrefix:            false,
+		JsonFlag:                       false,
 		RunTerragrunt: func(terragruntOptions *TerragruntOptions) error {
 			return errors.WithStackTrace(RunTerragruntCommandNotSet)
 		},
@@ -383,6 +387,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		UsePartialParseConfigCache:     terragruntOptions.UsePartialParseConfigCache,
 		OutputPrefix:                   terragruntOptions.OutputPrefix,
 		IncludeModulePrefix:            terragruntOptions.IncludeModulePrefix,
+		JsonFlag:                       terragruntOptions.JsonFlag,
 	}
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5285,7 +5285,10 @@ func TestDependencyOutputModulePrefix(t *testing.T) {
 		t,
 		runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-include-module-prefix --terragrunt-non-interactive --terragrunt-working-dir %s", app3Path), &stdout, &stderr),
 	)
-	assert.Contains(t, stdout.String(), "\"value\": 42")
+	// validate that output is valid json
+	outputs := map[string]TerraformOutput{}
+	require.NoError(t, json.Unmarshal([]byte(stdout.String()), &outputs))
+	assert.Equal(t, int(outputs["z"].Value.(float64)), 42)
 }
 
 func TestErrorExplaining(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated handling of `--terragrunt-include-module-prefix` to not include module prefix in case of `-json` commands

Fixes #2538.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated handling of `--terragrunt-include-module-prefix` to not include module prefix in case of `-json` argument

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

