### PR TITLE
Fix `terraform init` output from being displayed triggered by `auto-init`

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -1138,7 +1138,7 @@ func prepareInitOptions(terragruntOptions *options.TerragruntOptions, terraformS
 	initOptions.TerraformCommand = CMD_INIT
 
 	// Don't pollute stdout with the stdout from Auto Init
-	initOptions.Writer = initOptions.ErrWriter
+	initOptions.Writer = &util.EmptyWriter{}
 
 	return initOptions, nil
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3049,28 +3049,16 @@ func TestDataDir(t *testing.T) {
 		stderr bytes.Buffer
 	)
 
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
-	erroutput := stderr.String()
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
+	require.NoError(t, err)
+	assert.Contains(t, stderr.String(), "terraform init")
 
-	if err != nil {
-		t.Errorf("Did not expect to get an error: %s", err.Error())
-	}
+	stdout = bytes.Buffer{}
+	stderr = bytes.Buffer{}
 
-	assert.Contains(t, erroutput, "Initializing provider plugins")
-
-	var (
-		stdout2 bytes.Buffer
-		stderr2 bytes.Buffer
-	)
-
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout2, &stderr2)
-	erroutput2 := stderr2.String()
-
-	if err != nil {
-		t.Errorf("Did not expect to get an error: %s", err.Error())
-	}
-
-	assert.NotContains(t, erroutput2, "Initializing provider plugins")
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
+	require.NoError(t, err)
+	assert.NotContains(t, stderr.String(), "terraform init")
 }
 
 func TestReadTerragruntConfigWithDependency(t *testing.T) {
@@ -4634,21 +4622,19 @@ func TestNoMultipleInitsWithoutSourceChange(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
 	require.NoError(t, err)
 	// providers initialization during first plan
-	errout := string(stderr.Bytes())
-	assert.Equal(t, 1, strings.Count(errout, "Terraform has been successfully initialized!"))
+	assert.Equal(t, 1, strings.Count(stderr.String(), "terraform init"))
 
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
 	require.NoError(t, err)
 	// no initialization expected for second plan run
 	// https://github.com/gruntwork-io/terragrunt/issues/1921
-	errout = string(stderr.Bytes())
-	assert.Equal(t, 0, strings.Count(errout, "Terraform has been successfully initialized!"))
+	assert.Equal(t, 0, strings.Count(stderr.String(), "terraform init"))
 }
 
 func TestAutoInitWhenSourceIsChanged(t *testing.T) {
@@ -4669,11 +4655,10 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
 	require.NoError(t, err)
 	// providers initialization during first plan
-	errout := string(stderr.Bytes())
-	assert.Equal(t, 1, strings.Count(errout, "Terraform has been successfully initialized!"))
+	assert.Equal(t, 1, strings.Count(stderr.String(), "terraform init"))
 
 	updatedHcl = strings.Replace(contents, "__TAG_VALUE__", "v0.35.2", -1)
 	require.NoError(t, ioutil.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
@@ -4681,11 +4666,10 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
 	require.NoError(t, err)
 	// auto initialization when source is changed
-	errout = string(stderr.Bytes())
-	assert.Equal(t, 1, strings.Count(errout, "Terraform has been successfully initialized!"))
+	assert.Equal(t, 1, strings.Count(stderr.String(), "terraform init"))
 }
 
 func TestRenderJsonAttributesMetadata(t *testing.T) {

--- a/util/collections.go
+++ b/util/collections.go
@@ -194,3 +194,10 @@ type InvalidKeyValue string
 func (err InvalidKeyValue) Error() string {
 	return fmt.Sprintf("Invalid key-value pair. Expected format KEY=VALUE, got %s.", string(err))
 }
+
+// EmptyWriter implements interface io.Writer
+type EmptyWriter struct{}
+
+func (*EmptyWriter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

**Issue:** The `terraform init` output is displayed twice in `stderr` when it's triggered by `auto-init` (doc: https://terragrunt.gruntwork.io/docs/features/auto-init/).

The output looks like this:
```
... omitted
time=2023-05-05T13:23:46+03:00 level=debug msg=Running command: terraform init prefix=[/live/stage/data-stores/mysql]
Initializing the backend...
... omitted
time=2023-05-05T13:23:55+03:00 level=debug msg=Running command: terraform init prefix=[/live/stage/app]
Initializing the backend...
... omitted
time=2023-05-05T13:23:55+03:00 level=debug msg=Running command: terraform init prefix=[/live/stage/app]
Initializing the backend...
... omitted
time=2023-05-05T13:23:46+03:00 level=debug msg=Running command: terraform init prefix=[/live/stage/data-stores/mysql]
Initializing the backend...
```
This _terragrunt output_ gives the impression that `terraform init` is being run twice.

**Fixed:** On successful auto-initialization, the output of `terraform init` is not displayed at all.

Fixes #2519.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Fix `terraform init` output from being displayed triggered by `auto-init`
### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

