### PR TITLE
fix: disable sending a second interrupt signal to `terraform`

### DIFF
--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -21,8 +21,8 @@ import (
 
 // The signal can be sent to the main process (only `terragrunt`) as well as the process group (`terragrunt` and `terraform`), for example:
 // kill -INT <pid>  # sends SIGINT only to the main process
-// kill -INT -<pid> # sends SIGINT to the process group using
-// Since we cannot know how the signal was sent, we should give `terraform` time to gracefully exit if it receives the signal directly from the shell, to avoid sending the second interrupt signal to `terraform`.
+// kill -INT -<pid> # sends SIGINT to the process group
+// Since we cannot know how the signal is sent, we should give `terraform` time to gracefully exit if it receives the signal directly from the shell, to avoid sending the second interrupt signal to `terraform`.
 const signalForwardingDelay = time.Second * 30
 
 // Commands that implement a REPL need a pseudo TTY when run as a subprocess in order for the readline properties to be

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -195,11 +195,7 @@ func NewSignalsForwarder(signals []os.Signal, c *exec.Cmd, logger *logrus.Entry,
 		for {
 			select {
 			case s := <-signalChannel:
-				logger.Debugf("Forward signal %v to terraform.", s)
-				err := c.Process.Signal(s)
-				if err != nil {
-					logger.Errorf("Error forwarding signal: %v", err)
-				}
+				logger.Debugf("%s signal received. Gracefully shutting down...", strings.Title(s.String()))
 			case <-cmdChannel:
 				return
 			}

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -17,6 +18,12 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
 )
+
+// The signal can be sent to the main process (only `terragrunt`) as well as the process group (`terragrunt` and `terraform`), for example:
+// kill -INT <pid>  # sends SIGINT only to the main process
+// kill -INT -<pid> # sends SIGINT to the process group using
+// Since we cannot know how the signal was sent, we should give `terraform` time to gracefully exit if it receives the signal directly from the shell, to avoid sending the second interrupt signal to `terraform`.
+const signalForwardingDelay = time.Second * 30
 
 // Commands that implement a REPL need a pseudo TTY when run as a subprocess in order for the readline properties to be
 // preserved. This is a list of terraform commands that have this property, which is used to determine if terragrunt
@@ -195,10 +202,22 @@ func NewSignalsForwarder(signals []os.Signal, c *exec.Cmd, logger *logrus.Entry,
 		for {
 			select {
 			case s := <-signalChannel:
-				logger.Debugf("%s signal received. Gracefully shutting down...", strings.Title(s.String()))
+				logger.Debugf("%s signal received. Gracefully shutting down... (it can take up to %v)", strings.Title(s.String()), signalForwardingDelay)
+
+				select {
+				case <-time.After(signalForwardingDelay):
+					logger.Debugf("Forward signal %v to terraform.", s)
+					err := c.Process.Signal(s)
+					if err != nil {
+						logger.Errorf("Error forwarding signal: %v", err)
+					}
+				case <-cmdChannel:
+					return
+				}
 			case <-cmdChannel:
 				return
 			}
+
 		}
 	}()
 

--- a/shell/run_shell_cmd_test.go
+++ b/shell/run_shell_cmd_test.go
@@ -2,13 +2,8 @@ package shell
 
 import (
 	"bytes"
-	"fmt"
-	"os"
-	"strconv"
 	"strings"
-	"syscall"
 	"testing"
-	"time"
 
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
@@ -57,24 +52,4 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 
 	assert.True(t, strings.Contains(stderr.String(), "Terraform"), "Output directed to stderr")
 	assert.True(t, len(stdout.String()) == 0, "No output to stdout")
-}
-
-func TestRunShellCommandWithOutputInterrupt(t *testing.T) {
-	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
-	assert.Nil(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
-
-	errCh := make(chan error)
-	expectedWait := 5
-
-	go func() {
-		_, err := RunShellCommandWithOutput(terragruntOptions, "", false, false, "../testdata/test_sigint_wait.sh", strconv.Itoa(expectedWait))
-		errCh <- err
-	}()
-
-	time.AfterFunc(3*time.Second, func() {
-		syscall.Kill(os.Getpid(), syscall.SIGINT)
-	})
-
-	expectedErr := fmt.Sprintf("exit status %d", expectedWait)
-	assert.EqualError(t, <-errCh, expectedErr)
 }

--- a/shell/run_shell_cmd_test.go
+++ b/shell/run_shell_cmd_test.go
@@ -2,8 +2,13 @@ package shell
 
 import (
 	"bytes"
+	"fmt"
+	"os"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
@@ -52,4 +57,24 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 
 	assert.True(t, strings.Contains(stderr.String(), "Terraform"), "Output directed to stderr")
 	assert.True(t, len(stdout.String()) == 0, "No output to stdout")
+}
+
+func TestRunShellCommandWithOutputInterrupt(t *testing.T) {
+	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
+	assert.Nil(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
+
+	errCh := make(chan error)
+	expectedWait := 5
+
+	go func() {
+		_, err := RunShellCommandWithOutput(terragruntOptions, "", false, false, "../testdata/test_sigint_wait.sh", strconv.Itoa(expectedWait))
+		errCh <- err
+	}()
+
+	time.AfterFunc(3*time.Second, func() {
+		syscall.Kill(os.Getpid(), syscall.SIGINT)
+	})
+
+	expectedErr := fmt.Sprintf("exit status %d", expectedWait)
+	assert.EqualError(t, <-errCh, expectedErr)
 }

--- a/shell/run_shell_cmd_unix_test.go
+++ b/shell/run_shell_cmd_unix_test.go
@@ -123,6 +123,8 @@ func TestNewSignalsForwarderMultipleUnix(t *testing.T) {
 }
 
 func TestRunShellCommandWithOutputInterrupt(t *testing.T) {
+	t.Parallel()
+
 	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
 	assert.Nil(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
 

--- a/shell/run_shell_cmd_unix_test.go
+++ b/shell/run_shell_cmd_unix_test.go
@@ -5,9 +5,11 @@ package shell
 
 import (
 	goerrors "errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -118,4 +120,24 @@ func TestNewSignalsForwarderMultipleUnix(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, retCode <= interrupts, "Subprocess received wrong number of signals")
 	assert.Equal(t, retCode, expectedInterrupts, "Subprocess didn't receive multiple signals")
+}
+
+func TestRunShellCommandWithOutputInterrupt(t *testing.T) {
+	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
+	assert.Nil(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
+
+	errCh := make(chan error)
+	expectedWait := 5
+
+	go func() {
+		_, err := RunShellCommandWithOutput(terragruntOptions, "", false, false, "../testdata/test_sigint_wait.sh", strconv.Itoa(expectedWait))
+		errCh <- err
+	}()
+
+	time.AfterFunc(3*time.Second, func() {
+		syscall.Kill(os.Getpid(), syscall.SIGINT)
+	})
+
+	expectedErr := fmt.Sprintf("exit status %d", expectedWait)
+	assert.EqualError(t, <-errCh, expectedErr)
 }

--- a/shell/run_shell_cmd_windows_test.go
+++ b/shell/run_shell_cmd_windows_test.go
@@ -79,6 +79,8 @@ func TestNewSignalsForwarderWaitWindows(t *testing.T) {
 }
 
 func TestRunShellCommandWithOutputInterrupt(t *testing.T) {
+	t.Parallel()
+
 	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
 	assert.Nil(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
 

--- a/shell/run_shell_cmd_windows_test.go
+++ b/shell/run_shell_cmd_windows_test.go
@@ -5,6 +5,7 @@ package shell
 
 import (
 	goerrors "errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -75,4 +76,27 @@ func TestNewSignalsForwarderWaitWindows(t *testing.T) {
 	// assert.Equal(t, retCode, expectedWait)
 	// assert.WithinDuration(t, start.Add(time.Duration(expectedWait)*time.Second), time.Now(), time.Second,
 	// 	"Expected to wait 5 (+/-1) seconds after SIGINT")
+}
+
+func TestRunShellCommandWithOutputInterrupt(t *testing.T) {
+	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
+	assert.Nil(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
+
+	errCh := make(chan error)
+	expectedWait := 5
+
+	go func() {
+		_, err := RunShellCommandWithOutput(terragruntOptions, "", false, false, "../testdata/test_sigint_wait.bat", strconv.Itoa(expectedWait))
+		errCh <- err
+	}()
+
+	time.AfterFunc(3*time.Second, func() {
+		process, err := os.FindProcess(os.Getpid())
+		assert.NoError(t, err)
+
+		process.Signal(os.Kill)
+	})
+
+	expectedErr := fmt.Sprintf("exit status %d", expectedWait)
+	assert.EqualError(t, <-errCh, expectedErr)
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

When `CTRL+c` keys are pressed, `terragrunt` forwards this interrupt signal to the child process `terraform`, while the shell already passes interrupt signal to the main process (in our case `terragrunt`) and its children as well (in our case `terraform`). As a result, `terraform` receives the interrupt signal twice and cancels graceful shutdown.

```
Interrupt received.
Please wait for Terraform to exit or data loss may occur.
Gracefully shutting down...


Two interrupts received. Exiting immediately. Note that data loss may have
occurred.
```

Fixes #2120.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
fix: disable sending a second interrupt signal to `terraform`

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

