### PR TITLE
Add missing IAM Permissions s3:PutBucketOwnershipControls to docs

### DIFF
--- a/docs/_docs/02_features/aws-auth.md
+++ b/docs/_docs/02_features/aws-auth.md
@@ -76,7 +76,8 @@ For a more minimal policy, for example when using a single bucket and DynamoDB t
                 "s3:GetEncryptionConfiguration",
                 "s3:GetBucketPolicy",
                 "s3:GetBucketPublicAccessBlock",
-                "s3:PutLifecycleConfiguration"
+                "s3:PutLifecycleConfiguration",
+                "s3:PutBucketOwnershipControls"
             ],
             "Resource": "arn:aws:s3:::BUCKET_NAME"
         },


### PR DESCRIPTION
Starting with terragrunt version v0.45.4 bucket ownership controls has been introduced. The IAM policies provided in in the docs does not have the required permission s3:PutBucketOwnershipControls, which is needed according to the [aws-docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-ownership-new-bucket.html). With the current policy all fresh deployments with terragrunt that use the mentioned version or a version above will fail because of not enough permissions.

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This MR will add missing permission to the IAM policy provided in the docs. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

