### PR TITLE
Handle provider lock file when fetching dependency outputs

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gruntwork-io/gruntwork-cli/collections"
 	"github.com/hashicorp/go-multierror"
 	"github.com/mattn/go-zglob"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 
 	"github.com/gruntwork-io/terragrunt/aws_helper"
@@ -845,7 +844,7 @@ func runTerragruntWithConfig(originalTerragruntOptions *options.TerragruntOption
 			// case, we are using the user's working dir here, rather than just looking at the parent dir of the
 			// terragrunt.hcl. However, the default value for the user's working dir, set in options.go, IS just the
 			// parent dir of terragrunt.hcl, so these will likely always be the same.
-			lockFileError = copyLockFile(terragruntOptions.WorkingDir, originalTerragruntOptions.WorkingDir, terragruntOptions.Logger)
+			lockFileError = util.CopyLockFile(terragruntOptions.WorkingDir, originalTerragruntOptions.WorkingDir, terragruntOptions.Logger)
 		}
 
 		return multierror.Append(runTerraformError, lockFileError).ErrorOrNil()
@@ -901,20 +900,6 @@ func shouldCopyLockFile(args []string) bool {
 		return true
 	}
 	return false
-}
-
-// Terraform 0.14 now generates a lock file when you run `terraform init`.
-// If any such file exists, this function will copy the lock file to the destination folder
-func copyLockFile(sourceFolder string, destinationFolder string, logger *logrus.Entry) error {
-	sourceLockFilePath := util.JoinPath(sourceFolder, util.TerraformLockFile)
-	destinationLockFilePath := util.JoinPath(destinationFolder, util.TerraformLockFile)
-
-	if util.FileExists(sourceLockFilePath) {
-		logger.Debugf("Copying lock file from %s to %s", sourceLockFilePath, destinationFolder)
-		return util.CopyFile(sourceLockFilePath, destinationLockFilePath)
-	}
-
-	return nil
 }
 
 // Run the given action function surrounded by hooks. That is, run the before hooks first, then, if there were no

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -716,14 +715,9 @@ func getTerragruntOutputJsonFromRemoteState(
 	terragruntOptions.Logger.Debugf("Generated remote state configuration in working dir %s", tempWorkDir)
 
 	// Check for a provider lock file and copy it to the working dir if it exists.
-	lockFileSrc := util.JoinPath(path.Dir(terragruntOptions.TerragruntConfigPath), util.TerraformLockFile)
-	if util.IsFile(lockFileSrc) {
-		lockFileDst := util.JoinPath(tempWorkDir, util.TerraformLockFile)
-		err = util.CopyFile(lockFileSrc, lockFileDst)
-		if err != nil {
-			return nil, err
-		}
-		terragruntOptions.Logger.Debugf("Copied %s from %s to %s", util.TerraformLockFile, path.Dir(terragruntOptions.TerragruntConfigPath), tempWorkDir)
+	terragruntDir := filepath.Dir(terragruntOptions.TerragruntConfigPath)
+	if err := util.CopyLockFile(terragruntDir, tempWorkDir, terragruntOptions.Logger); err != nil {
+		return nil, err
 	}
 
 	// The working directory is now set up to interact with the state, so pull it down to get the json output.

--- a/util/file.go
+++ b/util/file.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/mattn/go-zglob"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/sirupsen/logrus"
 )
 
 const TerraformLockFile = ".terraform.lock.hcl"
@@ -510,4 +511,18 @@ type PathIsNotFile struct {
 
 func (err PathIsNotFile) Error() string {
 	return fmt.Sprintf("%s is not a file", err.path)
+}
+
+// Terraform 0.14 now generates a lock file when you run `terraform init`.
+// If any such file exists, this function will copy the lock file to the destination folder
+func CopyLockFile(sourceFolder string, destinationFolder string, logger *logrus.Entry) error {
+	sourceLockFilePath := JoinPath(sourceFolder, TerraformLockFile)
+	destinationLockFilePath := JoinPath(destinationFolder, TerraformLockFile)
+
+	if FileExists(sourceLockFilePath) {
+		logger.Debugf("Copying lock file from %s to %s", sourceLockFilePath, destinationFolder)
+		return CopyFile(sourceLockFilePath, destinationLockFilePath)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fixes errors when using the plugin cache caused by new cache behavior in Terraform 1.4+.

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #2542.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Fixed provider lock file handling when retrieving outputs from dependencies via remote state.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

