### PR TITLE
feat: implement hclfmt diff output

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -232,6 +232,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.ModulesThatInclude = modulesThatInclude
 	opts.StrictInclude = strictInclude
 	opts.Check = parseBooleanArg(args, optTerragruntCheck, os.Getenv("TERRAGRUNT_CHECK") == "true")
+	opts.Diff = parseBooleanArg(args, optTerragruntDiff, os.Getenv("TERRAGRUNT_DIFF") == "true")
 	opts.HclFile = filepath.ToSlash(terragruntHclFilePath)
 	opts.AwsProviderPatchOverrides = awsProviderPatchOverrides
 	opts.FetchDependencyOutputFromState = parseBooleanArg(args, optTerragruntFetchDependencyOutputFromState, os.Getenv("TERRAGRUNT_FETCH_DEPENDENCY_OUTPUT_FROM_STATE") == "true")

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -53,6 +53,7 @@ const (
 	optTerragruntStrictInclude                  = "terragrunt-strict-include"
 	optTerragruntParallelism                    = "terragrunt-parallelism"
 	optTerragruntCheck                          = "terragrunt-check"
+	optTerragruntDiff                           = "terragrunt-diff"
 	optTerragruntHCLFmt                         = "terragrunt-hclfmt-file"
 	optTerragruntDebug                          = "terragrunt-debug"
 	optTerragruntOverrideAttr                   = "terragrunt-override-attr"
@@ -77,6 +78,7 @@ var allTerragruntBooleanOpts = []string{
 	optTerragruntNoAutoRetry,
 	optTerragruntNoAutoApprove,
 	optTerragruntCheck,
+	optTerragruntDiff,
 	optTerragruntStrictInclude,
 	optTerragruntDebug,
 	optTerragruntFetchDependencyOutputFromState,

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -99,7 +99,7 @@ func formatTgHCL(terragruntOptions *options.TerragruntOptions, tgHclFile string)
 		if err != nil {
 			return fmt.Errorf("Failed to generate diff for %s", tgHclFile)
 		}
-		fmt.Printf("%s\n", diff)
+		fmt.Fprintf(terragruntOptions.Writer, "%s\n", diff)
 	}
 
 	if terragruntOptions.Check && fileUpdated {
@@ -126,6 +126,7 @@ func checkErrors(logger *logrus.Entry, contents []byte, tgHclFile string) error 
 	return nil
 }
 
+// bytesDiff uses GNU diff to display the differences between the contents of HCL file before and after formatting
 func bytesDiff(b1, b2 []byte, path string) (data []byte, err error) {
 	f1, err := ioutil.TempFile("", "")
 	if err != nil {
@@ -139,9 +140,15 @@ func bytesDiff(b1, b2 []byte, path string) (data []byte, err error) {
 	}
 	defer os.Remove(f2.Name())
 	defer f2.Close()
-	f1.Write(b1)
-	f2.Write(b2)
-	data, err = exec.Command("diff", "--label=old/"+path, "--label=new/"+path, "-u", f1.Name(), f2.Name()).CombinedOutput()
+	_, err = f1.Write(b1)
+	if err != nil {
+		return
+	}
+	_, err = f2.Write(b2)
+	if err != nil {
+		return
+	}
+	data, err = exec.Command("diff", "--label="+filepath.Join("old", path), "--label="+filepath.Join("new/", path), "-u", f1.Name(), f2.Name()).CombinedOutput()
 	if len(data) > 0 {
 		// diff exits with a non-zero status when the files don't match.
 		// Ignore that failure as long as we get output.

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -93,6 +94,14 @@ func formatTgHCL(terragruntOptions *options.TerragruntOptions, tgHclFile string)
 
 	fileUpdated := !bytes.Equal(newContents, contents)
 
+	if terragruntOptions.Diff && fileUpdated {
+		diff, err := bytesDiff(contents, newContents, tgHclFile)
+		if err != nil {
+			return fmt.Errorf("Failed to generate diff for %s", tgHclFile)
+		}
+		fmt.Printf("%s\n", diff)
+	}
+
 	if terragruntOptions.Check && fileUpdated {
 		return fmt.Errorf("Invalid file format %s", tgHclFile)
 	}
@@ -115,4 +124,28 @@ func checkErrors(logger *logrus.Entry, contents []byte, tgHclFile string) error 
 		return diags
 	}
 	return nil
+}
+
+func bytesDiff(b1, b2 []byte, path string) (data []byte, err error) {
+	f1, err := ioutil.TempFile("", "")
+	if err != nil {
+		return
+	}
+	defer os.Remove(f1.Name())
+	defer f1.Close()
+	f2, err := ioutil.TempFile("", "")
+	if err != nil {
+		return
+	}
+	defer os.Remove(f2.Name())
+	defer f2.Close()
+	f1.Write(b1)
+	f2.Write(b2)
+	data, err = exec.Command("diff", "--label=old/"+path, "--label=new/"+path, "-u", f1.Name(), f2.Name()).CombinedOutput()
+	if len(data) > 0 {
+		// diff exits with a non-zero status when the files don't match.
+		// Ignore that failure as long as we get output.
+		err = nil
+	}
+	return
 }

--- a/cli/hclfmt.go
+++ b/cli/hclfmt.go
@@ -100,7 +100,11 @@ func formatTgHCL(terragruntOptions *options.TerragruntOptions, tgHclFile string)
 			terragruntOptions.Logger.Errorf("Failed to generate diff for %s", tgHclFile)
 			return err
 		}
-		fmt.Fprintf(terragruntOptions.Writer, "%s\n", diff)
+		_, err = fmt.Fprintf(terragruntOptions.Writer, "%s\n", diff)
+		if err != nil {
+			terragruntOptions.Logger.Errorf("Failed to print diff for %s", tgHclFile)
+			return err
+		}
 	}
 
 	if terragruntOptions.Check && fileUpdated {

--- a/docs/_docs/01_getting-started/configuration.md
+++ b/docs/_docs/01_getting-started/configuration.md
@@ -118,4 +118,6 @@ If you run `terragrunt hclfmt` at the `root`, this will update:
 
   - `root/qa/services/service01/terragrunt.hcl`
 
+You can set `--terragrunt-diff` option. `terragrunt hclfmt --terragrunt-check` will output diff in unified format which can be redirected to your favourite diff tool.
+
 Additionally, there’s a flag `--terragrunt-check`. `terragrunt hclfmt --terragrunt-check` will only verify if the files are correctly formatted **without rewriting** them. The command will return exit status 1 if any matching files are improperly formatted, or 0 if all matching .hcl files are correctly formatted.

--- a/docs/_docs/01_getting-started/configuration.md
+++ b/docs/_docs/01_getting-started/configuration.md
@@ -118,6 +118,6 @@ If you run `terragrunt hclfmt` at the `root`, this will update:
 
   - `root/qa/services/service01/terragrunt.hcl`
 
-You can set `--terragrunt-diff` option. `terragrunt hclfmt --terragrunt-check` will output diff in unified format which can be redirected to your favourite diff tool.
+You can set `--terragrunt-diff` option. `terragrunt hclfmt --terragrunt-check` will output diff in unified format which can be redirected to your favourite diff tool. `diff` utility must be presented in PATH.
 
 Additionally, there’s a flag `--terragrunt-check`. `terragrunt hclfmt --terragrunt-check` will only verify if the files are correctly formatted **without rewriting** them. The command will return exit status 1 if any matching files are improperly formatted, or 0 if all matching .hcl files are correctly formatted.

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -800,6 +800,16 @@ When passed in, run `hclfmt` in check only mode instead of actively overwriting 
 command to exit with exit code 1 if there are any files that are not formatted.
 
 
+### terragrunt-diff
+
+**CLI Arg**: `--terragrunt-diff`<br/>
+**Environment Variable**: `TERRAGRUNT_DIFF` (set to `true`)
+**Commands**:
+- [hclfmt](#hclfmt)
+
+When passed in, running `hclfmt` will print diff between original and modified file versions.
+
+
 ### terragrunt-hclfmt-file
 
 **CLI Arg**: `--terragrunt-hclfmt-file`

--- a/options/options.go
+++ b/options/options.go
@@ -162,6 +162,9 @@ type TerragruntOptions struct {
 	// Enable check mode, by default it's disabled.
 	Check bool
 
+	// Show diff, by default it's disabled.
+	Diff bool
+
 	// The file which hclfmt should be specifically run on
 	HclFile string
 
@@ -281,6 +284,7 @@ func NewTerragruntOptions(terragruntConfigPath string) (*TerragruntOptions, erro
 		StrictInclude:                  false,
 		Parallelism:                    DEFAULT_PARALLELISM,
 		Check:                          false,
+		Diff:                           false,
 		FetchDependencyOutputFromState: false,
 		UsePartialParseConfigCache:     false,
 		OutputPrefix:                   "",

--- a/test/fixture-hclfmt-diff/expected.diff
+++ b/test/fixture-hclfmt-diff/expected.diff
@@ -1,0 +1,19 @@
+@@ -1,11 +1,11 @@
+ inputs = {
+-# comments
+-  foo =                               "bar"
+-  bar="baz"
+-  inputs = "disjoint"
++  # comments
++  foo      = "bar"
++  bar      = "baz"
++  inputs   = "disjoint"
+   disjoint = true
+   listInput = [
+-"foo",
+-"bar",
+-]
++    "foo",
++    "bar",
++  ]
+ }

--- a/test/fixture-hclfmt-diff/terragrunt.hcl
+++ b/test/fixture-hclfmt-diff/terragrunt.hcl
@@ -1,0 +1,11 @@
+inputs = {
+# comments
+  foo =                               "bar"
+  bar="baz"
+  inputs = "disjoint"
+  disjoint = true
+  listInput = [
+"foo",
+"bar",
+]
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5445,7 +5445,7 @@ func TestHclFmtDiff(t *testing.T) {
 
 	output := stdout.String()
 
-	expectedDiff, err := ioutil.ReadFile(util.JoinPath(rootPath, "/expected.diff"))
+	expectedDiff, err := ioutil.ReadFile(util.JoinPath(rootPath, "expected.diff"))
 	assert.NoError(t, err)
 
 	logBufferContentsLineByLine(t, stdout, "output")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5445,7 +5445,7 @@ func TestHclFmtDiff(t *testing.T) {
 
 	output := stdout.String()
 
-	expectedDiff, err := ioutil.ReadFile(rootPath + "/expected.diff")
+	expectedDiff, err := ioutil.ReadFile(util.JoinPath(rootPath, "/expected.diff"))
 	assert.NoError(t, err)
 
 	logBufferContentsLineByLine(t, stdout, "output")


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #1939.

Introduce diff option for hclfmt.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added hclfmt diff output

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

