### PR TITLE
fix: checking dependent modules in `destroy` command

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -606,7 +606,7 @@ func checkVersionConstraints(terragruntOptions *options.TerragruntOptions) error
 
 // Run graph dependencies prints the dependency graph to stdout
 func runGraphDependencies(terragruntOptions *options.TerragruntOptions) error {
-	stack, err := configstack.FindStackInSubfolders(terragruntOptions)
+	stack, err := configstack.FindStackInSubfolders(terragruntOptions, nil)
 	if err != nil {
 		return err
 	}
@@ -1186,7 +1186,7 @@ func runAll(terragruntOptions *options.TerragruntOptions) error {
 		}
 	}
 
-	stack, err := configstack.FindStackInSubfolders(terragruntOptions)
+	stack, err := configstack.FindStackInSubfolders(terragruntOptions, nil)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,7 @@ type TerragruntConfig struct {
 	IsPartial bool
 
 	// Map of processed includes
-	ProcessedIncludes map[string]IncludeConfig
+	ProcessedIncludes IncludeConfigs
 
 	// Map to store fields metadata
 	FieldsMetadata map[string]map[string]interface{}
@@ -239,6 +239,18 @@ type terragruntGenerateBlock struct {
 	Contents         string  `hcl:"contents,attr" mapstructure:"contents"`
 	DisableSignature *bool   `hcl:"disable_signature,attr" mapstructure:"disable_signature"`
 	Disable          *bool   `hcl:"disable,attr" mapstructure:"disable"`
+}
+
+type IncludeConfigs map[string]IncludeConfig
+
+func (cfgs IncludeConfigs) ContainsPath(path string) bool {
+	for _, cfg := range cfgs {
+		if cfg.Path == path {
+			return true
+		}
+	}
+
+	return false
 }
 
 // IncludeConfig represents the configuration settings for a parent Terragrunt configuration file that you can

--- a/config/config.go
+++ b/config/config.go
@@ -243,6 +243,7 @@ type terragruntGenerateBlock struct {
 
 type IncludeConfigs map[string]IncludeConfig
 
+// ContainsPath returns true if the given path is contained in at least one configuration.
 func (cfgs IncludeConfigs) ContainsPath(path string) bool {
 	for _, cfg := range cfgs {
 		if cfg.Path == path {

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -572,13 +572,19 @@ func readTerragruntConfigAsFuncImpl(terragruntOptions *options.TerragruntOptions
 				defaultVal = &args[1]
 			}
 
-			configPath := terragruntOptions.TerragruntConfigPath
-			if trackInclude.Original != nil {
-				configPath = trackInclude.Original.Path
-			}
-			configPath = filepath.Join(filepath.Dir(configPath), strArgs[0])
+			configPath := strArgs[0]
 
-			return readTerragruntConfig(configPath, defaultVal, terragruntOptions)
+			if !filepath.IsAbs(configPath) {
+				currentConfigPath := terragruntOptions.TerragruntConfigPath
+				if trackInclude.Original != nil {
+					currentConfigPath = trackInclude.Original.Path
+				}
+
+				configPath = filepath.Join(filepath.Dir(currentConfigPath), configPath)
+			}
+
+			relativePath, err := readTerragruntConfig(configPath, defaultVal, terragruntOptions)
+			return relativePath, err
 		},
 	})
 }

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -444,19 +444,15 @@ func pathRelativeToInclude(params []string, trackInclude *TrackInclude, terragru
 		return ".", nil
 	}
 
-	configPath := terragruntOptions.OriginalTerragruntConfigPath
-	if configPath == "" {
-		configPath = terragruntOptions.TerragruntConfigPath
-	}
-
+	currentPath := filepath.Dir(terragruntOptions.TerragruntConfigPath)
 	includePath := filepath.Dir(included.Path)
-	currentPath := filepath.Dir(configPath)
 
 	if !filepath.IsAbs(includePath) {
 		includePath = util.JoinPath(currentPath, includePath)
 	}
 
-	return util.GetPathRelativeTo(currentPath, includePath)
+	relativePath, err := util.GetPathRelativeTo(currentPath, includePath)
+	return relativePath, err
 }
 
 // Return the relative path from the current Terragrunt configuration to the included Terragrunt configuration file

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -444,8 +444,13 @@ func pathRelativeToInclude(params []string, trackInclude *TrackInclude, terragru
 		return ".", nil
 	}
 
+	configPath := terragruntOptions.OriginalTerragruntConfigPath
+	if configPath == "" {
+		configPath = terragruntOptions.TerragruntConfigPath
+	}
+
 	includePath := filepath.Dir(included.Path)
-	currentPath := filepath.Dir(terragruntOptions.OriginalTerragruntConfigPath)
+	currentPath := filepath.Dir(configPath)
 
 	if !filepath.IsAbs(includePath) {
 		includePath = util.JoinPath(currentPath, includePath)

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -193,13 +193,14 @@ func TerragruntConfigFromPartialConfigString(
 // PartialParseConfigString partially parses and decodes the provided string. Which blocks/attributes to decode is
 // controlled by the function parameter decodeList. These blocks/attributes are parsed and set on the output
 // TerragruntConfig. Valid values are:
-// - DependenciesBlock: Parses the `dependencies` block in the config
-// - DependencyBlock: Parses the `dependency` block in the config
-// - TerraformBlock: Parses the `terraform` block in the config
-// - TerragruntFlags: Parses the boolean flags `prevent_destroy` and `skip` in the config
-// - TerragruntVersionConstraints: Parses the attributes related to constraining terragrunt and terraform versions in
-//                                 the config.
-// - RemoteStateBlock: Parses the `remote_state` block in the config
+//   - DependenciesBlock: Parses the `dependencies` block in the config
+//   - DependencyBlock: Parses the `dependency` block in the config
+//   - TerraformBlock: Parses the `terraform` block in the config
+//   - TerragruntFlags: Parses the boolean flags `prevent_destroy` and `skip` in the config
+//   - TerragruntVersionConstraints: Parses the attributes related to constraining terragrunt and terraform versions in
+//     the config.
+//   - RemoteStateBlock: Parses the `remote_state` block in the config
+//
 // Note that the following blocks are always decoded:
 // - locals
 // - include

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -583,9 +583,8 @@ func getSortedKeys(modules map[string]*TerraformModule) []string {
 func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) []*TerraformModule {
 	var pathsToCheck []string
 	var matchedModulesMap = make(map[string]*TerraformModule)
-	var gitTopLevelDir = ""
-	gitTopLevelDir, err := shell.GitTopLevelDir(terragruntOptions, terragruntOptions.WorkingDir)
 
+	gitTopLevelDir, err := shell.GitTopLevelDir(terragruntOptions, terragruntOptions.WorkingDir)
 	if err == nil { // top level detection worked
 		pathsToCheck = append(pathsToCheck, gitTopLevelDir)
 	} else { // detection failed, trying to use include directories as source for stacks
@@ -608,7 +607,7 @@ func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions,
 
 		cfgOptions.Env = terragruntOptions.Env
 		cfgOptions.LogLevel = terragruntOptions.LogLevel
-		cfgOptions.OriginalTerragruntConfigPath = terragruntOptions.TerragruntConfigPath
+		cfgOptions.OriginalTerragruntConfigPath = terragruntOptions.OriginalTerragruntConfigPath
 
 		if terragruntOptions.TerraformCommand == "destroy" {
 			var hook = NewForceLogLevelHook(logrus.DebugLevel)

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -321,10 +321,16 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 	// happen concurrently.
 	opts := terragruntOptions.Clone(terragruntConfigPath)
 
+	var includeConfig *config.IncludeConfig
+
 	// We need to reset the original path for each module. Otherwise, this path will be set to wherever you ran run-all
 	// from, which is not what any of the modules will want.
 	if opts.OriginalTerragruntConfigPath == "" {
 		opts.OriginalTerragruntConfigPath = terragruntConfigPath
+	}
+
+	if opts.OriginalTerragruntConfigPath != terragruntConfigPath {
+		includeConfig = &config.IncludeConfig{Path: terragruntConfigPath}
 	}
 
 	// We only partially parse the config, only using the pieces that we need in this section. This config will be fully
@@ -333,7 +339,7 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 	terragruntConfig, err := config.PartialParseConfigFile(
 		terragruntConfigPath,
 		opts,
-		&config.IncludeConfig{Path: terragruntConfigPath},
+		includeConfig,
 		[]config.PartialDecodeSectionType{
 			// Need for initializing the modules
 			config.TerraformSource,

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -325,9 +325,10 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 	// from, which is not what any of the modules will want.
 	opts.OriginalTerragruntConfigPath = terragruntConfigPath
 
-	// If `childTerragruntConfig.ProcessedIncludes`  contains the path `terragruntConfigPath`, then this is a parent config
+	// If `childTerragruntConfig.ProcessedIncludes` contains the path `terragruntConfigPath`, then this is a parent config
 	// which implies that `TerragruntConfigPath` must have the child configuration path and defined `IncludeConfig`
-	// in order to configuration functions such as `path_relative_from_include` works correctly.
+	// in order to the base directory for the `read-terragrunt-config()` function is the child directory,
+	// and the `path_relative_to_include()` function returns the relative path to the child configuration.
 	var includeConfig *config.IncludeConfig
 	if childTerragruntConfig != nil && childTerragruntConfig.ProcessedIncludes.ContainsPath(terragruntConfigPath) {
 		includeConfig = &config.IncludeConfig{Path: terragruntConfigPath}

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -325,6 +325,9 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 	// from, which is not what any of the modules will want.
 	opts.OriginalTerragruntConfigPath = terragruntConfigPath
 
+	// If `childTerragruntConfig.ProcessedIncludes`  contains the path `terragruntConfigPath`, then this is a parent config
+	// which implies that `TerragruntConfigPath` must have the child configuration path and defined `IncludeConfig`
+	// in order to configuration functions such as `path_relative_from_include` works correctly.
 	var includeConfig *config.IncludeConfig
 	if childTerragruntConfig != nil && childTerragruntConfig.ProcessedIncludes.ContainsPath(terragruntConfigPath) {
 		includeConfig = &config.IncludeConfig{Path: terragruntConfigPath}
@@ -594,6 +597,7 @@ func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions,
 			pathsToCheck = append(pathsToCheck, path)
 		}
 	}
+
 	for _, dir := range pathsToCheck { // iterate over detected paths, build stacks and filter modules by working dir
 		dir = dir + filepath.FromSlash("/")
 		cfgOptions, err := options.NewTerragruntOptions(dir)

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -82,7 +82,7 @@ func ResolveTerraformModules(terragruntConfigPaths []string, terragruntOptions *
 	return finalModules, nil
 }
 
-//flagExcludedDirs iterates over a module slice and flags all entries as excluded, which should be ignored via the terragrunt-exclude-dir CLI flag.
+// flagExcludedDirs iterates over a module slice and flags all entries as excluded, which should be ignored via the terragrunt-exclude-dir CLI flag.
 func flagExcludedDirs(modules []*TerraformModule, terragruntOptions *options.TerragruntOptions) ([]*TerraformModule, error) {
 
 	// If no ExcludeDirs is specified return the modules list instantly
@@ -144,7 +144,7 @@ func flagExcludedDirs(modules []*TerraformModule, terragruntOptions *options.Ter
 	return modules, nil
 }
 
-//flagIncludedDirs iterates over a module slice and flags all entries not in the list specified via the terragrunt-include-dir CLI flag  as excluded.
+// flagIncludedDirs iterates over a module slice and flags all entries not in the list specified via the terragrunt-include-dir CLI flag  as excluded.
 func flagIncludedDirs(modules []*TerraformModule, terragruntOptions *options.TerragruntOptions) ([]*TerraformModule, error) {
 
 	// If no IncludeDirs is specified return the modules list instantly
@@ -323,7 +323,9 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 
 	// We need to reset the original path for each module. Otherwise, this path will be set to wherever you ran run-all
 	// from, which is not what any of the modules will want.
-	opts.OriginalTerragruntConfigPath = terragruntConfigPath
+	if opts.OriginalTerragruntConfigPath == "" {
+		opts.OriginalTerragruntConfigPath = terragruntConfigPath
+	}
 
 	// We only partially parse the config, only using the pieces that we need in this section. This config will be fully
 	// parsed at a later stage right before the action is run. This is to delay interpolation of functions until right
@@ -331,7 +333,7 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 	terragruntConfig, err := config.PartialParseConfigFile(
 		terragruntConfigPath,
 		opts,
-		nil,
+		&config.IncludeConfig{Path: terragruntConfigPath},
 		[]config.PartialDecodeSectionType{
 			// Need for initializing the modules
 			config.TerraformSource,
@@ -595,7 +597,9 @@ func FindWhereWorkingDirIsIncluded(terragruntOptions *options.TerragruntOptions,
 			return nil
 		}
 		cfgOptions.Env = terragruntOptions.Env
+		cfgOptions.OriginalTerragruntConfigPath = terragruntOptions.OriginalTerragruntConfigPath
 		cfgOptions.LogLevel = terragruntOptions.LogLevel
+
 		if terragruntOptions.TerraformCommand == "destroy" {
 			var hook = NewForceLogLevelHook(logrus.DebugLevel)
 			cfgOptions.Logger.Logger.AddHook(hook)

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -326,9 +326,8 @@ func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *opti
 	opts.OriginalTerragruntConfigPath = terragruntConfigPath
 
 	// If `childTerragruntConfig.ProcessedIncludes` contains the path `terragruntConfigPath`, then this is a parent config
-	// which implies that `TerragruntConfigPath` must have the child configuration path and defined `IncludeConfig`
-	// in order to the base directory for the `read-terragrunt-config()` function is the child directory,
-	// and the `path_relative_to_include()` function returns the relative path to the child configuration.
+	// which implies that `TerragruntConfigPath` must refer to a child configuration file, and the defined `IncludeConfig` must contain the path to the file itself
+	// for the built-in functions `read-terragrunt-config()`, `path_relative_to_include()` to work correctly.
 	var includeConfig *config.IncludeConfig
 	if childTerragruntConfig != nil && childTerragruntConfig.ProcessedIncludes.ContainsPath(terragruntConfigPath) {
 		includeConfig = &config.IncludeConfig{Path: terragruntConfigPath}

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -23,7 +23,7 @@ func TestResolveTerraformModulesNoPaths(t *testing.T) {
 	configPaths := []string{}
 	expected := []*TerraformModule{}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -41,7 +41,7 @@ func TestResolveTerraformModulesOneModuleNoDependencies(t *testing.T) {
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleA}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -59,7 +59,7 @@ func TestResolveTerraformModulesOneJsonModuleNoDependencies(t *testing.T) {
 	configPaths := []string{"../test/fixture-modules/json-module-a/" + config.DefaultTerragruntJsonConfigPath}
 	expected := []*TerraformModule{moduleA}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -83,7 +83,7 @@ func TestResolveTerraformModulesOneModuleWithIncludesNoDependencies(t *testing.T
 	configPaths := []string{"../test/fixture-modules/module-b/module-b-child/" + config.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleB}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -107,7 +107,7 @@ func TestResolveTerraformModulesOneJsonModuleWithIncludesNoDependencies(t *testi
 	configPaths := []string{"../test/fixture-modules/json-module-b/module-b-child/" + config.DefaultTerragruntJsonConfigPath}
 	expected := []*TerraformModule{moduleB}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -131,7 +131,7 @@ func TestResolveTerraformModulesOneHclModuleWithIncludesNoDependencies(t *testin
 	configPaths := []string{"../test/fixture-modules/hcl-module-b/module-b-child/" + config.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleB}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -163,7 +163,7 @@ func TestResolveTerraformModulesTwoModulesWithDependencies(t *testing.T) {
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleA, moduleC}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -195,7 +195,7 @@ func TestResolveTerraformModulesJsonModulesWithHclDependencies(t *testing.T) {
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/json-module-c/" + config.DefaultTerragruntJsonConfigPath}
 	expected := []*TerraformModule{moduleA, moduleC}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -227,7 +227,7 @@ func TestResolveTerraformModulesHclModulesWithJsonDependencies(t *testing.T) {
 	configPaths := []string{"../test/fixture-modules/json-module-a/" + config.DefaultTerragruntJsonConfigPath, "../test/fixture-modules/hcl-module-c/" + config.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleA, moduleC}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -261,7 +261,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
 	// construct the expected list
 	moduleA.FlagExcluded = true
@@ -311,7 +311,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-abba/" + config.DefaultTerragruntConfigPath}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
 	// construct the expected list
 	moduleA.FlagExcluded = true
@@ -361,7 +361,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-abba/" + config.DefaultTerragruntConfigPath}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
 	// construct the expected list
 	moduleA.FlagExcluded = true
@@ -401,7 +401,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithNoDepe
 
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
 	// construct the expected list
 	moduleC.FlagExcluded = true
@@ -440,7 +440,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithDepend
 
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
 	// construct the expected list
 	moduleA.FlagExcluded = false
@@ -479,7 +479,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithNoDepe
 
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
 	// construct the expected list
 	moduleC.FlagExcluded = true
@@ -527,7 +527,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithDepend
 
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-f/" + config.DefaultTerragruntConfigPath}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
 	// construct the expected list
 	moduleF.FlagExcluded = true
@@ -584,7 +584,7 @@ func TestResolveTerraformModulesMultipleModulesWithDependencies(t *testing.T) {
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-b/module-b-child/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-d/" + config.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleA, moduleB, moduleC, moduleD}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -636,7 +636,7 @@ func TestResolveTerraformModulesMultipleModulesWithMixedDependencies(t *testing.
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/json-module-b/module-b-child/" + config.DefaultTerragruntJsonConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/json-module-d/" + config.DefaultTerragruntJsonConfigPath}
 	expected := []*TerraformModule{moduleA, moduleB, moduleC, moduleD}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -681,7 +681,7 @@ func TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes(t *t
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-b/module-b-child/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-e/module-e-child/" + config.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleA, moduleB, moduleE}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -711,7 +711,7 @@ func TestResolveTerraformModulesMultipleModulesWithExternalDependencies(t *testi
 	configPaths := []string{"../test/fixture-modules/module-g/" + config.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleF, moduleG}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -763,7 +763,7 @@ func TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies(t 
 	configPaths := []string{"../test/fixture-modules/module-j/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-k/" + config.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleH, moduleI, moduleJ, moduleK}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	require.NoError(t, actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }
@@ -773,7 +773,7 @@ func TestResolveTerraformModulesInvalidPaths(t *testing.T) {
 
 	configPaths := []string{"../test/fixture-modules/module-missing-dependency/" + config.DefaultTerragruntConfigPath}
 
-	_, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	_, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	require.Error(t, actualErr)
 
 	underlying, ok := errors.Unwrap(actualErr).(ErrorProcessingModule)
@@ -789,7 +789,7 @@ func TestResolveTerraformModuleNoTerraformConfig(t *testing.T) {
 	configPaths := []string{"../test/fixture-modules/module-l/" + config.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{}
 
-	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, mockHowThesePathsWereFound)
+	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	assert.Nil(t, actualErr, "Unexpected error: %v", actualErr)
 	assertModuleListsEqual(t, expected, actualModules)
 }

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -139,14 +139,14 @@ func (stack *Stack) CheckForCycles() error {
 
 // Find all the Terraform modules in the subfolders of the working directory of the given TerragruntOptions and
 // assemble them into a Stack object that can be applied or destroyed in a single command
-func FindStackInSubfolders(terragruntOptions *options.TerragruntOptions) (*Stack, error) {
+func FindStackInSubfolders(terragruntOptions *options.TerragruntOptions, childTerragruntConfig *config.TerragruntConfig) (*Stack, error) {
 	terragruntConfigFiles, err := config.FindConfigFilesInPath(terragruntOptions.WorkingDir, terragruntOptions)
 	if err != nil {
 		return nil, err
 	}
 
 	howThesePathsWereFound := fmt.Sprintf("Terragrunt config file found in a subdirectory of %s", terragruntOptions.WorkingDir)
-	return createStackForTerragruntConfigPaths(terragruntOptions.WorkingDir, terragruntConfigFiles, terragruntOptions, howThesePathsWereFound)
+	return createStackForTerragruntConfigPaths(terragruntOptions.WorkingDir, terragruntConfigFiles, terragruntOptions, childTerragruntConfig, howThesePathsWereFound)
 }
 
 // Sync the TerraformCliArgs for each module in the stack to match the provided terragruntOptions struct.
@@ -233,12 +233,12 @@ func (stack *Stack) getModuleRunGraph(terraformCommand string) ([][]*TerraformMo
 
 // Find all the Terraform modules in the folders that contain the given Terragrunt config files and assemble those
 // modules into a Stack object that can be applied or destroyed in a single command
-func createStackForTerragruntConfigPaths(path string, terragruntConfigPaths []string, terragruntOptions *options.TerragruntOptions, howThesePathsWereFound string) (*Stack, error) {
+func createStackForTerragruntConfigPaths(path string, terragruntConfigPaths []string, terragruntOptions *options.TerragruntOptions, childTerragruntConfig *config.TerragruntConfig, howThesePathsWereFound string) (*Stack, error) {
 	if len(terragruntConfigPaths) == 0 {
 		return nil, errors.WithStackTrace(NoTerraformModulesFound)
 	}
 
-	modules, err := ResolveTerraformModules(terragruntConfigPaths, terragruntOptions, howThesePathsWereFound)
+	modules, err := ResolveTerraformModules(terragruntConfigPaths, terragruntOptions, childTerragruntConfig, howThesePathsWereFound)
 	if err != nil {
 		return nil, err
 	}

--- a/configstack/stack_test.go
+++ b/configstack/stack_test.go
@@ -36,7 +36,7 @@ func TestFindStackInSubfolders(t *testing.T) {
 
 	terragruntOptions.WorkingDir = envFolder
 
-	stack, err := FindStackInSubfolders(terragruntOptions)
+	stack, err := FindStackInSubfolders(terragruntOptions, nil)
 	require.NoError(t, err)
 
 	var modulePaths []string

--- a/test/fixture-get-path/fixture-path_relative_from_include/lives/dev/base/terragrunt.hcl
+++ b/test/fixture-get-path/fixture-path_relative_from_include/lives/dev/base/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../../../modules//base"
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/test/fixture-get-path/fixture-path_relative_from_include/lives/dev/base/tier.hcl
+++ b/test/fixture-get-path/fixture-path_relative_from_include/lives/dev/base/tier.hcl
@@ -1,0 +1,3 @@
+locals {
+  tier = "base"
+}

--- a/test/fixture-get-path/fixture-path_relative_from_include/lives/dev/cluster/terragrunt.hcl
+++ b/test/fixture-get-path/fixture-path_relative_from_include/lives/dev/cluster/terragrunt.hcl
@@ -1,0 +1,15 @@
+terraform {
+  source = "../../../modules//cluster"
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "base" {
+  config_path = "../base"
+}
+
+inputs = {
+  some_input = dependency.base.outputs.some_output
+}

--- a/test/fixture-get-path/fixture-path_relative_from_include/lives/dev/cluster/tier.hcl
+++ b/test/fixture-get-path/fixture-path_relative_from_include/lives/dev/cluster/tier.hcl
@@ -1,0 +1,3 @@
+locals {
+  tier = "cluster"
+}

--- a/test/fixture-get-path/fixture-path_relative_from_include/lives/dev/env.hcl
+++ b/test/fixture-get-path/fixture-path_relative_from_include/lives/dev/env.hcl
@@ -1,0 +1,3 @@
+locals {
+  environment = "dev"
+}

--- a/test/fixture-get-path/fixture-path_relative_from_include/lives/org.hcl
+++ b/test/fixture-get-path/fixture-path_relative_from_include/lives/org.hcl
@@ -1,0 +1,3 @@
+locals {
+  organization_unit = "test"
+}

--- a/test/fixture-get-path/fixture-path_relative_from_include/lives/terragrunt.hcl
+++ b/test/fixture-get-path/fixture-path_relative_from_include/lives/terragrunt.hcl
@@ -1,0 +1,27 @@
+locals {
+  org_vars = read_terragrunt_config("${get_parent_terragrunt_dir()}/org.hcl")
+  env_vars = read_terragrunt_config("${get_parent_terragrunt_dir()}/dev/env.hcl")
+  tier_vars = read_terragrunt_config("tier.hcl")
+
+  organization_unit = local.org_vars.locals.organization_unit
+  environment       = local.env_vars.locals.environment
+  tier              = local.tier_vars.locals.tier
+}
+
+generate "provider" {
+  path      = "terraform.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-EOF
+    terraform {
+      backend "local" {
+        path = "${local.environment}-${local.tier}.state"
+      }
+    }
+    EOF
+}
+
+inputs = merge(
+  local.org_vars.locals,
+  local.env_vars.locals,
+  local.tier_vars.locals,
+  )

--- a/test/fixture-get-path/fixture-path_relative_from_include/modules/base/main.tf
+++ b/test/fixture-get-path/fixture-path_relative_from_include/modules/base/main.tf
@@ -1,0 +1,3 @@
+output "some_output" {
+  value = "something"
+}

--- a/test/fixture-get-path/fixture-path_relative_from_include/modules/cluster/main.tf
+++ b/test/fixture-get-path/fixture-path_relative_from_include/modules/cluster/main.tf
@@ -1,0 +1,5 @@
+variable "some_input" {}
+
+output "some_output" {
+  value = "${var.some_input} else"
+}

--- a/test/fixture-modules/module-m/env.hcl
+++ b/test/fixture-modules/module-m/env.hcl
@@ -1,0 +1,3 @@
+locals {
+  environment = "dev"
+}

--- a/test/fixture-modules/module-m/module-m-child/terragrunt.hcl
+++ b/test/fixture-modules/module-m/module-m-child/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}

--- a/test/fixture-modules/module-m/module-m-child/tier.hcl
+++ b/test/fixture-modules/module-m/module-m-child/tier.hcl
@@ -1,0 +1,3 @@
+locals {
+  tier = "base"
+}

--- a/test/fixture-modules/module-m/terragrunt.hcl
+++ b/test/fixture-modules/module-m/terragrunt.hcl
@@ -1,0 +1,15 @@
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remote_state {
+  backend = "s3"
+  config = {
+    bucket = "bucket"
+    key = "${path_relative_to_include()}/terraform.tfstate"
+  }
+}
+terraform {
+  source = "..."
+}
+locals {
+  env_vars = read_terragrunt_config("${get_parent_terragrunt_dir()}/env.hcl")
+  tier_vars = read_terragrunt_config("tier.hcl")
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2977,7 +2977,7 @@ func TestPathRelativeFromInclude(t *testing.T) {
 	require.True(t, hasVal)
 	require.Equal(t, "something else", val.Value)
 
-	// try to destroy vpc module and check if warning is printed in output
+	// try to destroy module and check if warning is printed in output, also test `get_parent_terragrunt_dir()` func in the parent terragrunt config.
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
 


### PR DESCRIPTION
## Description

This PR fixes: The `destroy` process checks dependent modules, 
https://github.com/gruntwork-io/terragrunt/blob/e5b394060e8eb5009b99d15195e64688614a768f/cli/cli_app.go#L533
which does not take into account that the configuration can be a parent and contain built-in functions for determining the paths to the child configuration.

Fixes #2508.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)
fix: checking dependent modules in `destroy` command



