### PR TITLE
feat: support git tag in `--terragrunt-source-map` option

### DIFF
--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -175,9 +175,10 @@ func readVersionFile(terraformSource *tfsource.TerraformSource) (string, error) 
 }
 
 // updateGetters returns the customized go-getter interfaces that Terragrunt relies on. Specifically:
-// - Local file path getter is updated to copy the files instead of creating symlinks, which is what go-getter defaults
-//   to.
-// - Include the customized getter for fetching sources from the Terraform Registry.
+//   - Local file path getter is updated to copy the files instead of creating symlinks, which is what go-getter defaults
+//     to.
+//   - Include the customized getter for fetching sources from the Terraform Registry.
+//
 // This creates a closure that returns a function so that we have access to the terragrunt configuration, which is
 // necessary for customizing the behavior of the file getter.
 func updateGetters(terragruntConfig *config.TerragruntConfig) func(*getter.Client) error {

--- a/cli/tfsource/types.go
+++ b/cli/tfsource/types.go
@@ -111,25 +111,25 @@ func (terraformSource TerraformSource) WriteVersionFile() error {
 // To maximize reuse, given a working directory w and a source URL s, we download code from S into the folder /T/W/H
 // where:
 //
-// 1. S is the part of s before the double-slash (//). This typically represents the root of the repo (e.g.
-//    github.com/foo/infrastructure-modules). We download the entire repo so that relative paths to other files in that
-//    repo resolve correctly. If no double-slash is specified, all of s is used.
-// 1. T is the OS temp dir (e.g. /tmp).
-// 2. W is the base 64 encoded sha1 hash of w. This ensures that if you are running Terragrunt concurrently in
-//    multiple folders (e.g. during automated tests), then even if those folders are using the same source URL s, they
-//    do not overwrite each other.
-// 3. H is the base 64 encoded sha1 of S without its query string. For remote source URLs (e.g. Git
-//    URLs), this is based on the assumption that the scheme/host/path of the URL (e.g. git::github.com/foo/bar)
-//    identifies the repo, and we always want to download the same repo into the same folder (see the encodeSourceName
-//    method). We also assume the version of the module is stored in the query string (e.g. ref=v0.0.3), so we store
-//    the base 64 encoded sha1 of the query string in a file called .terragrunt-source-version within /T/W/H.
+//  1. S is the part of s before the double-slash (//). This typically represents the root of the repo (e.g.
+//     github.com/foo/infrastructure-modules). We download the entire repo so that relative paths to other files in that
+//     repo resolve correctly. If no double-slash is specified, all of s is used.
+//  1. T is the OS temp dir (e.g. /tmp).
+//  2. W is the base 64 encoded sha1 hash of w. This ensures that if you are running Terragrunt concurrently in
+//     multiple folders (e.g. during automated tests), then even if those folders are using the same source URL s, they
+//     do not overwrite each other.
+//  3. H is the base 64 encoded sha1 of S without its query string. For remote source URLs (e.g. Git
+//     URLs), this is based on the assumption that the scheme/host/path of the URL (e.g. git::github.com/foo/bar)
+//     identifies the repo, and we always want to download the same repo into the same folder (see the encodeSourceName
+//     method). We also assume the version of the module is stored in the query string (e.g. ref=v0.0.3), so we store
+//     the base 64 encoded sha1 of the query string in a file called .terragrunt-source-version within /T/W/H.
 //
 // The downloadTerraformSourceIfNecessary decides when we should download the Terraform code and when not to. It uses
 // the following rules:
 //
-// 1. Always download source URLs pointing to local file paths.
-// 2. Only download source URLs pointing to remote paths if /T/W/H doesn't already exist or, if it does exist, if the
-//    version number in /T/W/H/.terragrunt-source-version doesn't match the current version.
+//  1. Always download source URLs pointing to local file paths.
+//  2. Only download source URLs pointing to remote paths if /T/W/H doesn't already exist or, if it does exist, if the
+//     version number in /T/W/H/.terragrunt-source-version doesn't match the current version.
 func NewTerraformSource(source string, downloadDir string, workingDir string, logger *logrus.Entry) (*TerraformSource, error) {
 
 	canonicalWorkingDir, err := util.CanonicalPath(workingDir, "")
@@ -207,6 +207,14 @@ func parseSourceUrl(source string) (*url.URL, error) {
 	canonicalSourceUrl, err := urlhelper.Parse(rawSourceUrl)
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
+	}
+
+	// Converts URL with git tag, from `git@github.com:org/bar.git?ref=feature//modules/foo` to `git@github.com:org/bar.git//modules/foo?ref=feature`
+	if ref := canonicalSourceUrl.Query().Get("ref"); ref != "" {
+		if paths := strings.SplitN(ref, "/", 2); len(paths) > 1 {
+			canonicalSourceUrl.RawQuery = fmt.Sprintf("ref=%s", paths[0])
+			canonicalSourceUrl.Path += fmt.Sprintf("/%s", paths[1])
+		}
 	}
 
 	// Reattach the "getter" prefix as part of the scheme

--- a/util/collections.go
+++ b/util/collections.go
@@ -172,8 +172,27 @@ func StringListInsert(list []string, element string, index int) []string {
 // KeyValuePairListToMap converts a list of key value pair encoded as `key=value` strings into a map.
 func KeyValuePairStringListToMap(asList []string) (map[string]string, error) {
 	asMap := map[string]string{}
+
 	for _, arg := range asList {
-		parts := strings.Split(arg, "=")
+		var parts []string
+
+		// splits the string to the slice `parts`, using `=` sign as delimiter, but taking into account that the `=` sign can also be used as a git tag, e.g. `git@github.com/test.git?ref=feature`
+		for i, l := 0, 0; i <= len(arg); i++ {
+			if i == len(arg) {
+				parts = append(parts, arg[l:])
+				break
+			}
+
+			if arg[i] == '=' {
+				if i >= 4 && arg[i-4:i] == "?ref" {
+					continue
+				}
+
+				parts = append(parts, arg[l:i])
+				l = i + 1
+			}
+		}
+
 		if len(parts) != 2 {
 			return nil, errors.WithStackTrace(InvalidKeyValue(arg))
 		}

--- a/util/collections_test.go
+++ b/util/collections_test.go
@@ -258,6 +258,11 @@ func TestKeyValuePairStringListToMap(t *testing.T) {
 			map[string]string{"ssh://git@github.com": "/path/to/local"},
 		},
 		{
+			"with_tags",
+			[]string{"ssh://git@github.com=ssh://git@github.com/test.git?ref=feature"},
+			map[string]string{"ssh://git@github.com": "ssh://git@github.com/test.git?ref=feature"},
+		},
+		{
 			"empty",
 			[]string{},
 			map[string]string{},


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Added support git tag in URL for `--terragrunt-source-map` option. For example:
```
--terragrunt-source-map github.com/old-org/modules.git=git::github.com/new-org/modules.git?ref=feature
```

Fixes #2460.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added support git tag in URL for `--terragrunt-source-map` option.


