### PR TITLE
fix: redirecting stdout to stderr in hook commands

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -703,16 +703,18 @@ func processErrorHooks(hooks []config.ErrorHook, terragruntOptions *options.Terr
 				workingDir = *curHook.WorkingDir
 			}
 
-			// creates new terragrunt options to redirect stdout to stderr of the shell command
-			opts := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
-			opts.Writer = opts.ErrWriter
+			var suppressStdout bool
+			if curHook.SuppressStdout != nil && *curHook.SuppressStdout {
+				suppressStdout = true
+			}
 
 			actionToExecute := curHook.Execute[0]
 			actionParams := curHook.Execute[1:]
+
 			_, possibleError := shell.RunShellCommandWithOutput(
-				opts,
+				terragruntOptions,
 				workingDir,
-				false,
+				suppressStdout,
 				false,
 				actionToExecute, actionParams...,
 			)

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -763,6 +763,11 @@ func runHook(terragruntOptions *options.TerragruntOptions, terragruntConfig *con
 		workingDir = *curHook.WorkingDir
 	}
 
+	var suppressStdout bool
+	if curHook.SuppressStdout != nil && *curHook.SuppressStdout {
+		suppressStdout = true
+	}
+
 	actionToExecute := curHook.Execute[0]
 	actionParams := curHook.Execute[1:]
 
@@ -774,7 +779,7 @@ func runHook(terragruntOptions *options.TerragruntOptions, terragruntConfig *con
 		_, possibleError := shell.RunShellCommandWithOutput(
 			terragruntOptions,
 			workingDir,
-			false,
+			suppressStdout,
 			false,
 			actionToExecute, actionParams...,
 		)

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -703,10 +703,14 @@ func processErrorHooks(hooks []config.ErrorHook, terragruntOptions *options.Terr
 				workingDir = *curHook.WorkingDir
 			}
 
+			// creates new terragrunt options to redirect stdout to stderr of the shell command
+			opts := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
+			opts.Writer = opts.ErrWriter
+
 			actionToExecute := curHook.Execute[0]
 			actionParams := curHook.Execute[1:]
 			_, possibleError := shell.RunShellCommandWithOutput(
-				terragruntOptions,
+				opts,
 				workingDir,
 				false,
 				false,

--- a/config/config.go
+++ b/config/config.go
@@ -337,11 +337,12 @@ type Hook struct {
 }
 
 type ErrorHook struct {
-	Name       string   `hcl:"name,label" cty:"name"`
-	Commands   []string `hcl:"commands,attr" cty:"commands"`
-	Execute    []string `hcl:"execute,attr" cty:"execute"`
-	OnErrors   []string `hcl:"on_errors,attr" cty:"on_errors"`
-	WorkingDir *string  `hcl:"working_dir,attr" cty:"working_dir"`
+	Name           string   `hcl:"name,label" cty:"name"`
+	Commands       []string `hcl:"commands,attr" cty:"commands"`
+	Execute        []string `hcl:"execute,attr" cty:"execute"`
+	OnErrors       []string `hcl:"on_errors,attr" cty:"on_errors"`
+	SuppressStdout *bool    `hcl:"suppress_stdout,attr" cty:"suppress_stdout"`
+	WorkingDir     *string  `hcl:"working_dir,attr" cty:"working_dir"`
 }
 
 func (conf *Hook) String() string {

--- a/config/config.go
+++ b/config/config.go
@@ -328,11 +328,12 @@ func (deps *ModuleDependencies) String() string {
 
 // Hook specifies terraform commands (apply/plan) and array of os commands to execute
 type Hook struct {
-	Name       string   `hcl:"name,label" cty:"name"`
-	Commands   []string `hcl:"commands,attr" cty:"commands"`
-	Execute    []string `hcl:"execute,attr" cty:"execute"`
-	RunOnError *bool    `hcl:"run_on_error,attr" cty:"run_on_error"`
-	WorkingDir *string  `hcl:"working_dir,attr" cty:"working_dir"`
+	Name           string   `hcl:"name,label" cty:"name"`
+	Commands       []string `hcl:"commands,attr" cty:"commands"`
+	Execute        []string `hcl:"execute,attr" cty:"execute"`
+	RunOnError     *bool    `hcl:"run_on_error,attr" cty:"run_on_error"`
+	SuppressStdout *bool    `hcl:"suppress_stdout,attr" cty:"suppress_stdout"`
+	WorkingDir     *string  `hcl:"working_dir,attr" cty:"working_dir"`
 }
 
 type ErrorHook struct {

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -100,6 +100,7 @@ The `terraform` block supports the following arguments:
       `terragrunt-read-config` and `init-from-module` hooks, and the terraform module directory for other command hooks.
     - `run_on_error` (optional) : If set to true, this hook will run even if a previous hook hit an error, or in the
       case of "after" hooks, if the Terraform command hit an error. Default is false.
+    - `suppress_stdout` (optional) : If set to true, the stdout output of the executed commands will be suppressed. This can be useful when there are scripts relying on terraform's output and any other output would break their parsing.
 
 - `after_hook` (block): Nested blocks used to specify command hooks that should be run after `terraform` is called.
   Hooks run from the terragrunt configuration directory (the directory where `terragrunt.hcl` lives). Supports the same

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -83,12 +83,6 @@ func RunShellCommandWithOutput(
 	if terragruntOptions.IncludeModulePrefix {
 		prefix = terragruntOptions.OutputPrefix
 	}
-	// Terragrunt can run some commands (such as terraform remote config) before running the actual terraform
-	// command requested by the user. The output of these other commands should not end up on stdout as this
-	// breaks scripts relying on terraform's output.
-	// if !reflect.DeepEqual(terragruntOptions.TerraformCliArgs, args) {
-	// 	outWriter = terragruntOptions.ErrWriter
-	// }
 
 	if workingDir == "" {
 		cmd.Dir = terragruntOptions.WorkingDir

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"reflect"
 	"strings"
 	"syscall"
 	"time"
@@ -87,9 +86,9 @@ func RunShellCommandWithOutput(
 	// Terragrunt can run some commands (such as terraform remote config) before running the actual terraform
 	// command requested by the user. The output of these other commands should not end up on stdout as this
 	// breaks scripts relying on terraform's output.
-	if !reflect.DeepEqual(terragruntOptions.TerraformCliArgs, args) {
-		outWriter = terragruntOptions.ErrWriter
-	}
+	// if !reflect.DeepEqual(terragruntOptions.TerraformCliArgs, args) {
+	// 	outWriter = terragruntOptions.ErrWriter
+	// }
 
 	if workingDir == "" {
 		cmd.Dir = terragruntOptions.WorkingDir

--- a/shell/run_shell_cmd_test.go
+++ b/shell/run_shell_cmd_test.go
@@ -44,7 +44,7 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 	stderr = new(bytes.Buffer)
 
 	terragruntOptions.TerraformCliArgs = []string{}
-	terragruntOptions.Writer = stdout
+	terragruntOptions.Writer = stderr
 	terragruntOptions.ErrWriter = stderr
 
 	cmd = RunShellCommand(terragruntOptions, "terraform", "--version")

--- a/test/fixture-hooks/init-once/with-source-no-backend-suppress-hook-stdout/terragrunt.hcl
+++ b/test/fixture-hooks/init-once/with-source-no-backend-suppress-hook-stdout/terragrunt.hcl
@@ -6,6 +6,7 @@ terraform {
   after_hook "after_init_from_module" {
     commands = ["init-from-module"]
     execute = ["echo","AFTER_INIT_FROM_MODULE_ONLY_ONCE"]
+    suppress_stdout = true
   }
 
   # SHOULD execute.
@@ -13,5 +14,6 @@ terraform {
   after_hook "after_init" {
     commands = ["init"]
     execute = ["echo","AFTER_INIT_ONLY_ONCE"]
+    suppress_stdout = true
   }
 }

--- a/test/fixture-hooks/init-once/with-source-no-backend/terragrunt.hcl
+++ b/test/fixture-hooks/init-once/with-source-no-backend/terragrunt.hcl
@@ -6,6 +6,7 @@ terraform {
   after_hook "after_init_from_module" {
     commands = ["init-from-module"]
     execute = ["echo","AFTER_INIT_FROM_MODULE_ONLY_ONCE"]
+    suppress_stdout = true
   }
 
   # SHOULD execute.
@@ -13,5 +14,6 @@ terraform {
   after_hook "after_init" {
     commands = ["init"]
     execute = ["echo","AFTER_INIT_ONLY_ONCE"]
+    suppress_stdout = true
   }
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -49,108 +49,109 @@ import (
 
 // hard-code this to match the test fixture for now
 const (
-	TERRAFORM_REMOTE_STATE_S3_REGION                        = "us-west-2"
-	TERRAFORM_REMOTE_STATE_GCP_REGION                       = "eu"
-	TEST_FIXTURE_PATH                                       = "fixture/"
-	TEST_FIXTURE_CODEGEN_PATH                               = "fixture-codegen"
-	TEST_FIXTURE_GCS_PATH                                   = "fixture-gcs/"
-	TEST_FIXTURE_GCS_BYO_BUCKET_PATH                        = "fixture-gcs-byo-bucket/"
-	TEST_FIXTURE_STACK                                      = "fixture-stack/"
-	TEST_FIXTURE_GRAPH_DEPENDENCIES                         = "fixture-graph-dependencies"
-	TEST_FIXTURE_OUTPUT_ALL                                 = "fixture-output-all"
-	TEST_FIXTURE_OUTPUT_FROM_REMOTE_STATE                   = "fixture-output-from-remote-state"
-	TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY                     = "fixture-output-from-dependency"
-	TEST_FIXTURE_STDOUT                                     = "fixture-download/stdout-test"
-	TEST_FIXTURE_EXTRA_ARGS_PATH                            = "fixture-extra-args/"
-	TEST_FIXTURE_ENV_VARS_BLOCK_PATH                        = "fixture-env-vars-block/"
-	TEST_FIXTURE_SKIP                                       = "fixture-skip/"
-	TEST_FIXTURE_CONFIG_SINGLE_JSON_PATH                    = "fixture-config-files/single-json-config"
-	TEST_FIXTURE_PREVENT_DESTROY_OVERRIDE                   = "fixture-prevent-destroy-override/child"
-	TEST_FIXTURE_PREVENT_DESTROY_NOT_SET                    = "fixture-prevent-destroy-not-set/child"
-	TEST_FIXTURE_LOCAL_PREVENT_DESTROY                      = "fixture-download/local-with-prevent-destroy"
-	TEST_FIXTURE_LOCAL_PREVENT_DESTROY_DEPENDENCIES         = "fixture-download/local-with-prevent-destroy-dependencies"
-	TEST_FIXTURE_LOCAL_INCLUDE_PREVENT_DESTROY_DEPENDENCIES = "fixture-download/local-include-with-prevent-destroy-dependencies"
-	TEST_FIXTURE_NOT_EXISTING_SOURCE                        = "fixture-download/invalid-path"
-	TEST_FIXTURE_EXTERNAL_DEPENDENCIE                       = "fixture-external-dependencies"
-	TEST_FIXTURE_MISSING_DEPENDENCIE                        = "fixture-missing-dependencies/main"
-	TEST_FIXTURE_GET_OUTPUT                                 = "fixture-get-output"
-	TEST_FIXTURE_HOOKS_BEFORE_ONLY_PATH                     = "fixture-hooks/before-only"
-	TEST_FIXTURE_HOOKS_ALL_PATH                             = "fixture-hooks/all"
-	TEST_FIXTURE_HOOKS_AFTER_ONLY_PATH                      = "fixture-hooks/after-only"
-	TEST_FIXTURE_HOOKS_BEFORE_AND_AFTER_PATH                = "fixture-hooks/before-and-after"
-	TEST_FIXTURE_HOOKS_BEFORE_AFTER_AND_ERROR_MERGE_PATH    = "fixture-hooks/before-after-and-error-merge"
-	TEST_FIXTURE_HOOKS_SKIP_ON_ERROR_PATH                   = "fixture-hooks/skip-on-error"
-	TEST_FIXTURE_ERROR_HOOKS_PATH                           = "fixture-hooks/error-hooks"
-	TEST_FIXTURE_HOOKS_ONE_ARG_ACTION_PATH                  = "fixture-hooks/one-arg-action"
-	TEST_FIXTURE_HOOKS_EMPTY_STRING_COMMAND_PATH            = "fixture-hooks/bad-arg-action/empty-string-command"
-	TEST_FIXTURE_HOOKS_EMPTY_COMMAND_LIST_PATH              = "fixture-hooks/bad-arg-action/empty-command-list"
-	TEST_FIXTURE_HOOKS_INTERPOLATIONS_PATH                  = "fixture-hooks/interpolations"
-	TEST_FIXTURE_HOOKS_INIT_ONCE_NO_SOURCE_NO_BACKEND       = "fixture-hooks/init-once/no-source-no-backend"
-	TEST_FIXTURE_HOOKS_INIT_ONCE_NO_SOURCE_WITH_BACKEND     = "fixture-hooks/init-once/no-source-with-backend"
-	TEST_FIXTURE_HOOKS_INIT_ONCE_WITH_SOURCE_NO_BACKEND     = "fixture-hooks/init-once/with-source-no-backend"
-	TEST_FIXTURE_HOOKS_INIT_ONCE_WITH_SOURCE_WITH_BACKEND   = "fixture-hooks/init-once/with-source-with-backend"
-	TEST_FIXTURE_HOOKS_WORKING_DIR                          = "fixture-hooks/working_dir"
-	TEST_FIXTURE_FAILED_TERRAFORM                           = "fixture-failure"
-	TEST_FIXTURE_EXIT_CODE                                  = "fixture-exit-code"
-	TEST_FIXTURE_AUTO_RETRY_RERUN                           = "fixture-auto-retry/re-run"
-	TEST_FIXTURE_AUTO_RETRY_EXHAUST                         = "fixture-auto-retry/exhaust"
-	TEST_FIXTURE_AUTO_RETRY_CUSTOM_ERRORS                   = "fixture-auto-retry/custom-errors"
-	TEST_FIXTURE_AUTO_RETRY_CUSTOM_ERRORS_NOT_SET           = "fixture-auto-retry/custom-errors-not-set"
-	TEST_FIXTURE_AUTO_RETRY_APPLY_ALL_RETRIES               = "fixture-auto-retry/apply-all"
-	TEST_FIXTURE_AUTO_RETRY_CONFIGURABLE_RETRIES            = "fixture-auto-retry/configurable-retries"
-	TEST_FIXTURE_AUTO_RETRY_CONFIGURABLE_RETRIES_ERROR_1    = "fixture-auto-retry/configurable-retries-incorrect-retry-attempts"
-	TEST_FIXTURE_AUTO_RETRY_CONFIGURABLE_RETRIES_ERROR_2    = "fixture-auto-retry/configurable-retries-incorrect-sleep-interval"
-	TEST_FIXTURE_AWS_PROVIDER_PATCH                         = "fixture-aws-provider-patch"
-	TEST_FIXTURE_INPUTS                                     = "fixture-inputs"
-	TEST_FIXTURE_LOCALS_ERROR_UNDEFINED_LOCAL               = "fixture-locals-errors/undefined-local"
-	TEST_FIXTURE_LOCALS_ERROR_UNDEFINED_LOCAL_BUT_INPUT     = "fixture-locals-errors/undefined-local-but-input"
-	TEST_FIXTURE_LOCALS_CANONICAL                           = "fixture-locals/canonical"
-	TEST_FIXTURE_LOCALS_IN_INCLUDE                          = "fixture-locals/local-in-include"
-	TEST_FIXTURE_LOCAL_RUN_ONCE                             = "fixture-locals/run-once"
-	TEST_FIXTURE_LOCAL_RUN_MULTIPLE                         = "fixture-locals/run-multiple"
-	TEST_FIXTURE_LOCALS_IN_INCLUDE_CHILD_REL_PATH           = "qa/my-app"
-	TEST_FIXTURE_READ_CONFIG                                = "fixture-read-config"
-	TEST_FIXTURE_READ_IAM_ROLE                              = "fixture-read-config/iam_role_in_file"
-	TEST_FIXTURE_IAM_ROLES_MULTIPLE_MODULES                 = "fixture-read-config/iam_roles_multiple_modules"
-	TEST_FIXTURE_RELATIVE_INCLUDE_CMD                       = "fixture-relative-include-cmd"
-	TEST_FIXTURE_AWS_GET_CALLER_IDENTITY                    = "fixture-get-aws-caller-identity"
-	TEST_FIXTURE_GET_REPO_ROOT                              = "fixture-get-repo-root"
-	TEST_FIXTURE_PATH_RELATIVE_FROM_INCLUDE                 = "fixture-get-path/fixture-path_relative_from_include"
-	TEST_FIXTURE_GET_PATH_FROM_REPO_ROOT                    = "fixture-get-path/fixture-get-path-from-repo-root"
-	TEST_FIXTURE_GET_PATH_TO_REPO_ROOT                      = "fixture-get-path/fixture-get-path-to-repo-root"
-	TEST_FIXTURE_GET_PLATFORM                               = "fixture-get-platform"
-	TEST_FIXTURE_GET_TERRAGRUNT_SOURCE_HCL                  = "fixture-get-terragrunt-source-hcl"
-	TEST_FIXTURE_GET_TERRAGRUNT_SOURCE_CLI                  = "fixture-get-terragrunt-source-cli"
-	TEST_FIXTURE_REGRESSIONS                                = "fixture-regressions"
-	TEST_FIXTURE_PLANFILE_ORDER                             = "fixture-planfile-order-test"
-	TEST_FIXTURE_DIRS_PATH                                  = "fixture-dirs"
-	TEST_FIXTURE_PARALLELISM                                = "fixture-parallelism"
-	TEST_FIXTURE_SOPS                                       = "fixture-sops"
-	TEST_FIXTURE_DESTROY_WARNING                            = "fixture-destroy-warning"
-	TEST_FIXTURE_INCLUDE_PARENT                             = "fixture-include-parent"
-	TEST_FIXTURE_AUTO_INIT                                  = "fixture-download/init-on-source-change"
-	TEST_FIXTURE_DISJOINT                                   = "fixture-stack/disjoint"
-	TEST_FIXTURE_BROKEN_LOCALS                              = "fixture-broken-locals"
-	TEST_FIXTURE_BROKEN_DEPENDENCY                          = "fixture-broken-dependency"
-	TEST_FIXTURE_RENDER_JSON_METADATA                       = "fixture-render-json-metadata"
-	TEST_FIXTURE_RENDER_JSON_MOCK_OUTPUTS                   = "fixture-render-json-mock-outputs"
-	TEST_FIXTURE_STARTSWITH                                 = "fixture-startswith"
-	TEST_FIXTURE_TIMECMP                                    = "fixture-timecmp"
-	TEST_FIXTURE_TIMECMP_INVALID_TIMESTAMP                  = "fixture-timecmp-errors/invalid-timestamp"
-	TEST_FIXTURE_ENDSWITH                                   = "fixture-endswith"
-	TEST_FIXTURE_TFLINT_NO_ISSUES_FOUND                     = "fixture-tflint/no-issues-found"
-	TEST_FIXTURE_TFLINT_ISSUES_FOUND                        = "fixture-tflint/issues-found"
-	TEST_FIXTURE_TFLINT_NO_CONFIG_FILE                      = "fixture-tflint/no-config-file"
-	TEST_FIXTURE_TFLINT_MODULE_FOUND                        = "fixture-tflint/module-found"
-	TEST_FIXTURE_TFLINT_NO_TF_SOURCE_PATH                   = "fixture-tflint/no-tf-source"
-	TEST_FIXTURE_PARALLEL_RUN                               = "fixture-parallel-run"
-	TEST_FIXTURE_INIT_ERROR                                 = "fixture-init-error"
-	TEST_FIXTURE_MODULE_PATH_ERROR                          = "fixture-module-path-in-error"
-	TERRAFORM_BINARY                                        = "terraform"
-	TERRAFORM_FOLDER                                        = ".terraform"
-	TERRAFORM_STATE                                         = "terraform.tfstate"
-	TERRAFORM_STATE_BACKUP                                  = "terraform.tfstate.backup"
-	TERRAGRUNT_CACHE                                        = ".terragrunt-cache"
+	TERRAFORM_REMOTE_STATE_S3_REGION                                         = "us-west-2"
+	TERRAFORM_REMOTE_STATE_GCP_REGION                                        = "eu"
+	TEST_FIXTURE_PATH                                                        = "fixture/"
+	TEST_FIXTURE_CODEGEN_PATH                                                = "fixture-codegen"
+	TEST_FIXTURE_GCS_PATH                                                    = "fixture-gcs/"
+	TEST_FIXTURE_GCS_BYO_BUCKET_PATH                                         = "fixture-gcs-byo-bucket/"
+	TEST_FIXTURE_STACK                                                       = "fixture-stack/"
+	TEST_FIXTURE_GRAPH_DEPENDENCIES                                          = "fixture-graph-dependencies"
+	TEST_FIXTURE_OUTPUT_ALL                                                  = "fixture-output-all"
+	TEST_FIXTURE_OUTPUT_FROM_REMOTE_STATE                                    = "fixture-output-from-remote-state"
+	TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY                                      = "fixture-output-from-dependency"
+	TEST_FIXTURE_STDOUT                                                      = "fixture-download/stdout-test"
+	TEST_FIXTURE_EXTRA_ARGS_PATH                                             = "fixture-extra-args/"
+	TEST_FIXTURE_ENV_VARS_BLOCK_PATH                                         = "fixture-env-vars-block/"
+	TEST_FIXTURE_SKIP                                                        = "fixture-skip/"
+	TEST_FIXTURE_CONFIG_SINGLE_JSON_PATH                                     = "fixture-config-files/single-json-config"
+	TEST_FIXTURE_PREVENT_DESTROY_OVERRIDE                                    = "fixture-prevent-destroy-override/child"
+	TEST_FIXTURE_PREVENT_DESTROY_NOT_SET                                     = "fixture-prevent-destroy-not-set/child"
+	TEST_FIXTURE_LOCAL_PREVENT_DESTROY                                       = "fixture-download/local-with-prevent-destroy"
+	TEST_FIXTURE_LOCAL_PREVENT_DESTROY_DEPENDENCIES                          = "fixture-download/local-with-prevent-destroy-dependencies"
+	TEST_FIXTURE_LOCAL_INCLUDE_PREVENT_DESTROY_DEPENDENCIES                  = "fixture-download/local-include-with-prevent-destroy-dependencies"
+	TEST_FIXTURE_NOT_EXISTING_SOURCE                                         = "fixture-download/invalid-path"
+	TEST_FIXTURE_EXTERNAL_DEPENDENCIE                                        = "fixture-external-dependencies"
+	TEST_FIXTURE_MISSING_DEPENDENCIE                                         = "fixture-missing-dependencies/main"
+	TEST_FIXTURE_GET_OUTPUT                                                  = "fixture-get-output"
+	TEST_FIXTURE_HOOKS_BEFORE_ONLY_PATH                                      = "fixture-hooks/before-only"
+	TEST_FIXTURE_HOOKS_ALL_PATH                                              = "fixture-hooks/all"
+	TEST_FIXTURE_HOOKS_AFTER_ONLY_PATH                                       = "fixture-hooks/after-only"
+	TEST_FIXTURE_HOOKS_BEFORE_AND_AFTER_PATH                                 = "fixture-hooks/before-and-after"
+	TEST_FIXTURE_HOOKS_BEFORE_AFTER_AND_ERROR_MERGE_PATH                     = "fixture-hooks/before-after-and-error-merge"
+	TEST_FIXTURE_HOOKS_SKIP_ON_ERROR_PATH                                    = "fixture-hooks/skip-on-error"
+	TEST_FIXTURE_ERROR_HOOKS_PATH                                            = "fixture-hooks/error-hooks"
+	TEST_FIXTURE_HOOKS_ONE_ARG_ACTION_PATH                                   = "fixture-hooks/one-arg-action"
+	TEST_FIXTURE_HOOKS_EMPTY_STRING_COMMAND_PATH                             = "fixture-hooks/bad-arg-action/empty-string-command"
+	TEST_FIXTURE_HOOKS_EMPTY_COMMAND_LIST_PATH                               = "fixture-hooks/bad-arg-action/empty-command-list"
+	TEST_FIXTURE_HOOKS_INTERPOLATIONS_PATH                                   = "fixture-hooks/interpolations"
+	TEST_FIXTURE_HOOKS_INIT_ONCE_NO_SOURCE_NO_BACKEND                        = "fixture-hooks/init-once/no-source-no-backend"
+	TEST_FIXTURE_HOOKS_INIT_ONCE_NO_SOURCE_WITH_BACKEND                      = "fixture-hooks/init-once/no-source-with-backend"
+	TEST_FIXTURE_HOOKS_INIT_ONCE_WITH_SOURCE_NO_BACKEND                      = "fixture-hooks/init-once/with-source-no-backend"
+	TEST_FIXTURE_HOOKS_INIT_ONCE_WITH_SOURCE_NO_BACKEND_SUPPRESS_HOOK_STDOUT = "fixture-hooks/init-once/with-source-no-backend-suppress-hook-stdout"
+	TEST_FIXTURE_HOOKS_INIT_ONCE_WITH_SOURCE_WITH_BACKEND                    = "fixture-hooks/init-once/with-source-with-backend"
+	TEST_FIXTURE_HOOKS_WORKING_DIR                                           = "fixture-hooks/working_dir"
+	TEST_FIXTURE_FAILED_TERRAFORM                                            = "fixture-failure"
+	TEST_FIXTURE_EXIT_CODE                                                   = "fixture-exit-code"
+	TEST_FIXTURE_AUTO_RETRY_RERUN                                            = "fixture-auto-retry/re-run"
+	TEST_FIXTURE_AUTO_RETRY_EXHAUST                                          = "fixture-auto-retry/exhaust"
+	TEST_FIXTURE_AUTO_RETRY_CUSTOM_ERRORS                                    = "fixture-auto-retry/custom-errors"
+	TEST_FIXTURE_AUTO_RETRY_CUSTOM_ERRORS_NOT_SET                            = "fixture-auto-retry/custom-errors-not-set"
+	TEST_FIXTURE_AUTO_RETRY_APPLY_ALL_RETRIES                                = "fixture-auto-retry/apply-all"
+	TEST_FIXTURE_AUTO_RETRY_CONFIGURABLE_RETRIES                             = "fixture-auto-retry/configurable-retries"
+	TEST_FIXTURE_AUTO_RETRY_CONFIGURABLE_RETRIES_ERROR_1                     = "fixture-auto-retry/configurable-retries-incorrect-retry-attempts"
+	TEST_FIXTURE_AUTO_RETRY_CONFIGURABLE_RETRIES_ERROR_2                     = "fixture-auto-retry/configurable-retries-incorrect-sleep-interval"
+	TEST_FIXTURE_AWS_PROVIDER_PATCH                                          = "fixture-aws-provider-patch"
+	TEST_FIXTURE_INPUTS                                                      = "fixture-inputs"
+	TEST_FIXTURE_LOCALS_ERROR_UNDEFINED_LOCAL                                = "fixture-locals-errors/undefined-local"
+	TEST_FIXTURE_LOCALS_ERROR_UNDEFINED_LOCAL_BUT_INPUT                      = "fixture-locals-errors/undefined-local-but-input"
+	TEST_FIXTURE_LOCALS_CANONICAL                                            = "fixture-locals/canonical"
+	TEST_FIXTURE_LOCALS_IN_INCLUDE                                           = "fixture-locals/local-in-include"
+	TEST_FIXTURE_LOCAL_RUN_ONCE                                              = "fixture-locals/run-once"
+	TEST_FIXTURE_LOCAL_RUN_MULTIPLE                                          = "fixture-locals/run-multiple"
+	TEST_FIXTURE_LOCALS_IN_INCLUDE_CHILD_REL_PATH                            = "qa/my-app"
+	TEST_FIXTURE_READ_CONFIG                                                 = "fixture-read-config"
+	TEST_FIXTURE_READ_IAM_ROLE                                               = "fixture-read-config/iam_role_in_file"
+	TEST_FIXTURE_IAM_ROLES_MULTIPLE_MODULES                                  = "fixture-read-config/iam_roles_multiple_modules"
+	TEST_FIXTURE_RELATIVE_INCLUDE_CMD                                        = "fixture-relative-include-cmd"
+	TEST_FIXTURE_AWS_GET_CALLER_IDENTITY                                     = "fixture-get-aws-caller-identity"
+	TEST_FIXTURE_GET_REPO_ROOT                                               = "fixture-get-repo-root"
+	TEST_FIXTURE_PATH_RELATIVE_FROM_INCLUDE                                  = "fixture-get-path/fixture-path_relative_from_include"
+	TEST_FIXTURE_GET_PATH_FROM_REPO_ROOT                                     = "fixture-get-path/fixture-get-path-from-repo-root"
+	TEST_FIXTURE_GET_PATH_TO_REPO_ROOT                                       = "fixture-get-path/fixture-get-path-to-repo-root"
+	TEST_FIXTURE_GET_PLATFORM                                                = "fixture-get-platform"
+	TEST_FIXTURE_GET_TERRAGRUNT_SOURCE_HCL                                   = "fixture-get-terragrunt-source-hcl"
+	TEST_FIXTURE_GET_TERRAGRUNT_SOURCE_CLI                                   = "fixture-get-terragrunt-source-cli"
+	TEST_FIXTURE_REGRESSIONS                                                 = "fixture-regressions"
+	TEST_FIXTURE_PLANFILE_ORDER                                              = "fixture-planfile-order-test"
+	TEST_FIXTURE_DIRS_PATH                                                   = "fixture-dirs"
+	TEST_FIXTURE_PARALLELISM                                                 = "fixture-parallelism"
+	TEST_FIXTURE_SOPS                                                        = "fixture-sops"
+	TEST_FIXTURE_DESTROY_WARNING                                             = "fixture-destroy-warning"
+	TEST_FIXTURE_INCLUDE_PARENT                                              = "fixture-include-parent"
+	TEST_FIXTURE_AUTO_INIT                                                   = "fixture-download/init-on-source-change"
+	TEST_FIXTURE_DISJOINT                                                    = "fixture-stack/disjoint"
+	TEST_FIXTURE_BROKEN_LOCALS                                               = "fixture-broken-locals"
+	TEST_FIXTURE_BROKEN_DEPENDENCY                                           = "fixture-broken-dependency"
+	TEST_FIXTURE_RENDER_JSON_METADATA                                        = "fixture-render-json-metadata"
+	TEST_FIXTURE_RENDER_JSON_MOCK_OUTPUTS                                    = "fixture-render-json-mock-outputs"
+	TEST_FIXTURE_STARTSWITH                                                  = "fixture-startswith"
+	TEST_FIXTURE_TIMECMP                                                     = "fixture-timecmp"
+	TEST_FIXTURE_TIMECMP_INVALID_TIMESTAMP                                   = "fixture-timecmp-errors/invalid-timestamp"
+	TEST_FIXTURE_ENDSWITH                                                    = "fixture-endswith"
+	TEST_FIXTURE_TFLINT_NO_ISSUES_FOUND                                      = "fixture-tflint/no-issues-found"
+	TEST_FIXTURE_TFLINT_ISSUES_FOUND                                         = "fixture-tflint/issues-found"
+	TEST_FIXTURE_TFLINT_NO_CONFIG_FILE                                       = "fixture-tflint/no-config-file"
+	TEST_FIXTURE_TFLINT_MODULE_FOUND                                         = "fixture-tflint/module-found"
+	TEST_FIXTURE_TFLINT_NO_TF_SOURCE_PATH                                    = "fixture-tflint/no-tf-source"
+	TEST_FIXTURE_PARALLEL_RUN                                                = "fixture-parallel-run"
+	TEST_FIXTURE_INIT_ERROR                                                  = "fixture-init-error"
+	TEST_FIXTURE_MODULE_PATH_ERROR                                           = "fixture-module-path-in-error"
+	TERRAFORM_BINARY                                                         = "terraform"
+	TERRAFORM_FOLDER                                                         = ".terraform"
+	TERRAFORM_STATE                                                          = "terraform.tfstate"
+	TERRAFORM_STATE_BACKUP                                                   = "terraform.tfstate.backup"
+	TERRAGRUNT_CACHE                                                         = ".terragrunt-cache"
 
 	qaMyAppRelPath  = "qa/my-app"
 	fixtureDownload = "fixture-download"
@@ -229,7 +230,7 @@ func TestTerragruntInitHookWithSourceNoBackend(t *testing.T) {
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-log-level debug", rootPath), &stdout, &stderr)
 	logBufferContentsLineByLine(t, stdout, "apply stdout")
 	logBufferContentsLineByLine(t, stderr, "apply stderr")
-	output := stderr.String()
+	output := stdout.String()
 
 	if err != nil {
 		t.Errorf("Did not expect to get error: %s", err.Error())
@@ -387,7 +388,8 @@ func TestTerragruntBeforeAfterAndErrorMergeHook(t *testing.T) {
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
-	runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, childPath), &stdout, &stderr)
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, childPath), &stdout, &stderr)
+	assert.ErrorContains(t, err, "executable file not found in $PATH")
 
 	_, beforeException := ioutil.ReadFile(childPath + "/before.out")
 	_, beforeChildException := ioutil.ReadFile(childPath + "/before-child.out")
@@ -427,7 +429,6 @@ func TestTerragruntSkipOnError(t *testing.T) {
 	assert.Error(t, err)
 
 	output := stdout.String()
-	errOutput := stderr.String()
 
 	assert.Contains(t, output, "BEFORE_SHOULD_DISPLAY")
 	assert.NotContains(t, output, "BEFORE_NODISPLAY")
@@ -435,9 +436,9 @@ func TestTerragruntSkipOnError(t *testing.T) {
 	assert.Contains(t, output, "AFTER_SHOULD_DISPLAY")
 	assert.NotContains(t, output, "AFTER_NODISPLAY")
 
-	assert.Contains(t, errOutput, "ERROR_HOOK_EXECUTED")
-	assert.NotContains(t, errOutput, "NOT_MATCHING_ERROR_HOOK")
-	assert.Contains(t, errOutput, "PATTERN_MATCHING_ERROR_HOOK")
+	assert.Contains(t, output, "ERROR_HOOK_EXECUTED")
+	assert.NotContains(t, output, "NOT_MATCHING_ERROR_HOOK")
+	assert.Contains(t, output, "PATTERN_MATCHING_ERROR_HOOK")
 }
 
 func TestTerragruntCatchErrorsInTerraformExecution(t *testing.T) {
@@ -1846,9 +1847,9 @@ func TestApplyAllSkipFalse(t *testing.T) {
 func TestTerragruntInfo(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, TEST_FIXTURE_HOOKS_INIT_ONCE_WITH_SOURCE_NO_BACKEND)
+	cleanupTerraformFolder(t, TEST_FIXTURE_HOOKS_INIT_ONCE_WITH_SOURCE_NO_BACKEND_SUPPRESS_HOOK_STDOUT)
 	tmpEnvPath := copyEnvironment(t, "fixture-hooks/init-once")
-	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_HOOKS_INIT_ONCE_WITH_SOURCE_NO_BACKEND)
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_HOOKS_INIT_ONCE_WITH_SOURCE_NO_BACKEND_SUPPRESS_HOOK_STDOUT)
 
 	showStdout := bytes.Buffer{}
 	showStderr := bytes.Buffer{}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -173,7 +173,7 @@ func TestTerragruntInitHookNoSourceNoBackend(t *testing.T) {
 	)
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
-	output := stderr.String()
+	output := stdout.String()
 
 	if err != nil {
 		t.Errorf("Did not expect to get error: %s", err.Error())
@@ -204,8 +204,7 @@ func TestTerragruntInitHookNoSourceWithBackend(t *testing.T) {
 	)
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
-	output := stderr.String()
-
+	output := stdout.String()
 	if err != nil {
 		t.Errorf("Did not expect to get error: %s", err.Error())
 	}
@@ -260,7 +259,7 @@ func TestTerragruntInitHookWithSourceWithBackend(t *testing.T) {
 	)
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
-	output := stderr.String()
+	output := stdout.String()
 
 	if err != nil {
 		t.Errorf("Did not expect to get error: %s", err.Error())
@@ -359,7 +358,7 @@ func TestTerragruntBeforeAndAfterHook(t *testing.T) {
 	_, beforeException := ioutil.ReadFile(rootPath + "/before.out")
 	_, afterException := ioutil.ReadFile(rootPath + "/after.out")
 
-	output := stderr.String()
+	output := stdout.String()
 
 	if err != nil {
 		t.Errorf("Did not expect to get error: %s", err.Error())
@@ -427,7 +426,8 @@ func TestTerragruntSkipOnError(t *testing.T) {
 
 	assert.Error(t, err)
 
-	output := stderr.String()
+	output := stdout.String()
+	errOutput := stderr.String()
 
 	assert.Contains(t, output, "BEFORE_SHOULD_DISPLAY")
 	assert.NotContains(t, output, "BEFORE_NODISPLAY")
@@ -435,9 +435,9 @@ func TestTerragruntSkipOnError(t *testing.T) {
 	assert.Contains(t, output, "AFTER_SHOULD_DISPLAY")
 	assert.NotContains(t, output, "AFTER_NODISPLAY")
 
-	assert.Contains(t, output, "ERROR_HOOK_EXECUTED")
-	assert.NotContains(t, output, "NOT_MATCHING_ERROR_HOOK")
-	assert.Contains(t, output, "PATTERN_MATCHING_ERROR_HOOK")
+	assert.Contains(t, errOutput, "ERROR_HOOK_EXECUTED")
+	assert.NotContains(t, errOutput, "NOT_MATCHING_ERROR_HOOK")
+	assert.Contains(t, errOutput, "PATTERN_MATCHING_ERROR_HOOK")
 }
 
 func TestTerragruntCatchErrorsInTerraformExecution(t *testing.T) {
@@ -541,7 +541,7 @@ func TestTerragruntHookInterpolation(t *testing.T) {
 	)
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
-	erroutput := stderr.String()
+	output := stdout.String()
 
 	homePath := os.Getenv("HOME")
 	if homePath == "" {
@@ -552,7 +552,7 @@ func TestTerragruntHookInterpolation(t *testing.T) {
 		t.Errorf("Did not expect to get error: %s", err.Error())
 	}
 
-	assert.Contains(t, erroutput, homePath)
+	assert.Contains(t, output, homePath)
 
 }
 
@@ -3398,20 +3398,22 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 			},
 			"before_hook": map[string]interface{}{
 				"before_hook_1": map[string]interface{}{
-					"name":         "before_hook_1",
-					"commands":     []interface{}{"apply", "plan"},
-					"execute":      []interface{}{"touch", "before.out"},
-					"working_dir":  nil,
-					"run_on_error": true,
+					"name":            "before_hook_1",
+					"commands":        []interface{}{"apply", "plan"},
+					"execute":         []interface{}{"touch", "before.out"},
+					"working_dir":     nil,
+					"run_on_error":    true,
+					"suppress_stdout": nil,
 				},
 			},
 			"after_hook": map[string]interface{}{
 				"after_hook_1": map[string]interface{}{
-					"name":         "after_hook_1",
-					"commands":     []interface{}{"apply", "plan"},
-					"execute":      []interface{}{"touch", "after.out"},
-					"working_dir":  nil,
-					"run_on_error": true,
+					"name":            "after_hook_1",
+					"commands":        []interface{}{"apply", "plan"},
+					"execute":         []interface{}{"touch", "after.out"},
+					"working_dir":     nil,
+					"run_on_error":    true,
+					"suppress_stdout": nil,
 				},
 			},
 			"error_hook": map[string]interface{}{},
@@ -3709,7 +3711,7 @@ func TestTerragruntIncludeParentHclFile(t *testing.T) {
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-modules-that-include parent.hcl --terragrunt-modules-that-include common.hcl --terragrunt-non-interactive --terragrunt-working-dir %s", tmpEnvPath), &stdout, &stderr)
 	require.NoError(t, err)
 
-	out := stderr.String()
+	out := stdout.String()
 	assert.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
 	assert.Equal(t, 1, strings.Count(out, "dependency_hcl"))
 	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
@@ -4580,7 +4582,7 @@ func TestTerragruntInitOnce(t *testing.T) {
 
 	runTerragruntCommand(t, fmt.Sprintf("terragrunt init --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_RUN_ONCE), &stdout, &stderr)
 
-	errout := string(stderr.Bytes())
+	errout := string(stdout.Bytes())
 
 	assert.Equal(t, 1, strings.Count(errout, "foo"))
 }
@@ -4594,7 +4596,7 @@ func TestTerragruntInitRunCmd(t *testing.T) {
 
 	runTerragruntCommand(t, fmt.Sprintf("terragrunt init --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_RUN_MULTIPLE), &stdout, &stderr)
 
-	errout := string(stderr.Bytes())
+	errout := string(stdout.Bytes())
 
 	// Check for cached values between locals and inputs sections
 	assert.Equal(t, 1, strings.Count(errout, "potato"))
@@ -4662,9 +4664,9 @@ func TestPathRelativeToIncludeInvokedInCorrectPathFromChild(t *testing.T) {
 	stderr := bytes.Buffer{}
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt version --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", appPath), &stdout, &stderr)
 	require.NoError(t, err)
-	errout := string(stderr.Bytes())
-	assert.Equal(t, 1, strings.Count(errout, "\npath_relative_to_inclue: app\n"))
-	assert.Equal(t, 0, strings.Count(errout, "\npath_relative_to_inclue: .\n"))
+	output := string(stdout.Bytes())
+	assert.Equal(t, 1, strings.Count(output, "path_relative_to_inclue: app\n"))
+	assert.Equal(t, 0, strings.Count(output, "path_relative_to_inclue: .\n"))
 }
 
 func TestTerragruntInitConfirmation(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixed redirecting stdout to stderr in hook commands. Also added a new option `suppress_stdout` to the hook configuration when it needs to avoid displaying the stdout of the hook command.

Fixes #2561 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Fixed redirecting stdout to stderr in hook commands

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

Before these changes, the output of commands from all hooks was displayed from stdout to `terragrunt` stderr, and after the changes, the output displays respectively stdout to stdout and stderr to stderr. Related to this, if `terragrunt` stdout output is used for later parsing,  it might be worth considering suspending the output of hook commands with the new `suppress_stdout` hook attribute.