### PR TITLE
fix: set noisy Window console log entry to debug

### DIFF
--- a/shell/ptty_windows.go
+++ b/shell/ptty_windows.go
@@ -27,7 +27,7 @@ func enableVirtualTerminalProcessing(options *options.TerragruntOptions, file *o
 	var mode uint32
 	handle := windows.Handle(file.Fd())
 	if err := windows.GetConsoleMode(handle, &mode); err != nil {
-		options.Logger.Errorf("failed to get console mode: %v\n", err)
+		options.Logger.Debugf("failed to get console mode: %v\n", err)
 		return
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

When running on Windows, Terragrunt output is extremely noisy due to an error calling `GetConsoleMode`. The following "error" message is output multiple times for each Terragrunt command run:

```
time=0000-00-00T00:00:00Z level=error msg=failed to get console mode: The handle is invalid.
```

This result in very noisy output and when run in a pipeline, cluttered build logs. 

This has no impact on functionality or the result of the run. Since it has no impact and would only be useful for debugging purposes, I propose setting its log level to debug. This would keep the output clean for the average user while allowing it to be output when setting the Terragrunt log level to debug. 

Although it does not technically fix the underlying issue with the `GetConsoleMode` call, it does keep the output clean and that's what users are complaining about in the issue linked below. 

Fixes #1854.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Log `GetConsoleMode` errors on Windows as `debug` rather than `error`

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

