### PR TITLE
#2595 Fix for fetching reference value with slashes

### DIFF
--- a/cli/tfsource/types.go
+++ b/cli/tfsource/types.go
@@ -209,14 +209,6 @@ func parseSourceUrl(source string) (*url.URL, error) {
 		return nil, errors.WithStackTrace(err)
 	}
 
-	// Converts URL with git tag, from `git@github.com:org/bar.git?ref=feature//modules/foo` to `git@github.com:org/bar.git//modules/foo?ref=feature`
-	if ref := canonicalSourceUrl.Query().Get("ref"); ref != "" {
-		if paths := strings.SplitN(ref, "/", 2); len(paths) > 1 {
-			canonicalSourceUrl.RawQuery = fmt.Sprintf("ref=%s", paths[0])
-			canonicalSourceUrl.Path += fmt.Sprintf("/%s", paths[1])
-		}
-	}
-
 	// Reattach the "getter" prefix as part of the scheme
 	for _, forcedGetter := range forcedGetters {
 		canonicalSourceUrl.Scheme = fmt.Sprintf("%s::%s", forcedGetter, canonicalSourceUrl.Scheme)

--- a/cli/tfsource/types_test.go
+++ b/cli/tfsource/types_test.go
@@ -36,6 +36,7 @@ func TestSplitSourceUrl(t *testing.T) {
 		{"parent-url-multiple-children-no-double-slash", "ssh://git@github.com/foo/modules.git/foo/bar/baz/blah", "ssh://git@github.com/foo/modules.git/foo/bar/baz/blah", ""},
 		{"parent-url-one-child-with-double-slash", "ssh://git@github.com/foo/modules.git//foo", "ssh://git@github.com/foo/modules.git", "foo"},
 		{"parent-url-multiple-children-with-double-slash", "ssh://git@github.com/foo/modules.git//foo/bar/baz/blah", "ssh://git@github.com/foo/modules.git", "foo/bar/baz/blah"},
+		{"separate-ref-with-slash", "ssh://git@github.com/foo/modules.git//foo?ref=feature/modules", "ssh://git@github.com/foo/modules.git?ref=feature/modules", "foo"},
 	}
 
 	for _, testCase := range testCases {

--- a/config/config.go
+++ b/config/config.go
@@ -10,8 +10,6 @@ import (
 	"reflect"
 	"strings"
 
-	urlhelper "github.com/hashicorp/go-getter/helper/url"
-
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
@@ -532,20 +530,6 @@ func adjustSourceWithMap(sourceMap map[string]string, source string, modulePath 
 			return moduleSubdirFromUrl, err
 		}
 		moduleSubdir = moduleSubdirFromUrl
-	}
-	// if source path contains "?ref=", reconstruct module dir using "//"
-	if strings.Contains(sourcePath, "?ref=") && moduleSubdir != "" {
-		canonicalSourceUrl, err := urlhelper.Parse(sourcePath)
-		if err != nil {
-			return "", errors.WithStackTrace(err)
-		}
-		// append moduleSubdir to the path
-		if canonicalSourceUrl.Opaque != "" {
-			canonicalSourceUrl.Opaque += fmt.Sprintf("//%s", moduleSubdir)
-		} else {
-			canonicalSourceUrl.Path += fmt.Sprintf("//%s", moduleSubdir)
-		}
-		return canonicalSourceUrl.String(), nil
 	}
 	return util.JoinTerraformModulePath(sourcePath, moduleSubdir), nil
 

--- a/test/fixture-download/remote-ref/terragrunt.hcl
+++ b/test/fixture-download/remote-ref/terragrunt.hcl
@@ -1,0 +1,7 @@
+inputs = {
+  name = "World"
+}
+
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt.git//test/fixture-download/hello-world?ref=fixture/test"
+}

--- a/test/fixture-source-map/slashes-in-ref/terragrunt.hcl
+++ b/test/fixture-source-map/slashes-in-ref/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "git::ssh://git@github.com/gruntwork-io/i-dont-exist.git//test/fixture-download/hello-world"
+}
+
+inputs = {
+  name = "terragrunt"
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -148,6 +148,8 @@ const (
 	TEST_FIXTURE_MODULE_PATH_ERROR                                           = "fixture-module-path-in-error"
 	TEST_FIXTURE_HCLFMT_DIFF                                                 = "fixture-hclfmt-diff"
 	TEST_FIXTURE_DESTROY_DEPENDENT_MODULE                                    = "fixture-destroy-dependent-module"
+	TEST_FIXTURE_REF_SOURCE                                                  = "fixture-download/remote-ref"
+	TEST_FIXTURE_SOURCE_MAP_SLASHES                                          = "fixture-source-map/slashes-in-ref"
 	TERRAFORM_BINARY                                                         = "terraform"
 	TERRAFORM_FOLDER                                                         = ".terraform"
 	TERRAFORM_STATE                                                          = "terraform.tfstate"
@@ -5526,6 +5528,34 @@ func TestDestroyDependentModule(t *testing.T) {
 
 	assert.True(t, strings.Contains(stderr.String(), "\"value\": \"module-b.txt\""))
 	assert.True(t, strings.Contains(stderr.String(), "\"value\": \"module-a.txt\""))
+}
+
+func TestDownloadSourceWithRef(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_REF_SOURCE)
+	cleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_REF_SOURCE)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
+	require.NoError(t, err)
+}
+
+func TestSourceMapWithSlashInRef(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_SOURCE_MAP_SLASHES)
+	cleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_SOURCE_MAP_SLASHES)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-source-map git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=git::git@github.com:gruntwork-io/terragrunt.git?ref=fixture/test --terragrunt-working-dir %s", testPath), &stdout, &stderr)
+	require.NoError(t, err)
 }
 
 func validateOutput(t *testing.T, outputs map[string]TerraformOutput, key string, value interface{}) {

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -115,6 +115,12 @@ func TestJoinTerraformModulePath(t *testing.T) {
 		{"foo//", "//bar", "foo//bar"},
 		{"/foo/bar/baz", "/a/b/c", "/foo/bar/baz//a/b/c"},
 		{"/foo/bar/baz/", "//a/b/c", "/foo/bar/baz//a/b/c"},
+		{"/foo?ref=feature/1", "bar", "/foo//bar?ref=feature/1"},
+		{"/foo?ref=feature/1", "/bar", "/foo//bar?ref=feature/1"},
+		{"/foo//?ref=feature/1", "/bar", "/foo//bar?ref=feature/1"},
+		{"/foo//?ref=feature/1", "//bar", "/foo//bar?ref=feature/1"},
+		{"/foo/bar/baz?ref=feature/1", "/a/b/c", "/foo/bar/baz//a/b/c?ref=feature/1"},
+		{"/foo/bar/baz/?ref=feature/1", "//a/b/c", "/foo/bar/baz//a/b/c?ref=feature/1"},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
 * add test for handling repository sources with ref
 * source map handling by setting in url module path

Fixes #2595.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated fetching of `?ref=` value with slashes.

### Migration Guide

N/A

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

