### PR TITLE
Go upgrade to 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 
 defaults: &defaults
   docker:
-    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.18-tf1.4-tg39.1-pck1.8-ci50.7
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.20-tf1.4-tg39.1-pck1.8-ci50.7
 
 version: 2.1
 jobs:

--- a/_ci/install-golang.ps1
+++ b/_ci/install-golang.ps1
@@ -1,5 +1,5 @@
 # Install golang using Chocolatey
-choco install golang --version 1.18.5 -y
+choco install golang --version 1.20.0 -y
 # Verify installation
 Get-Command go
 go version

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -110,9 +110,10 @@ func getSTSCredentialsFromIAMRoleOptions(sess *session.Session, iamRoleOptions o
 }
 
 // Returns an AWS session object. The session is configured by either:
-// - The provided AwsSessionConfig struct, which specifies region (required), profile name (optional), and IAM role to
-//   assume (optional).
-// - The provided TerragruntOptions struct, which specifies any IAM role to assume (optional).
+//   - The provided AwsSessionConfig struct, which specifies region (required), profile name (optional), and IAM role to
+//     assume (optional).
+//   - The provided TerragruntOptions struct, which specifies any IAM role to assume (optional).
+//
 // Note that if the AwsSessionConfig object is null, this will return default session credentials using the default
 // credentials chain of the AWS SDK.
 func CreateAwsSession(config *AwsSessionConfig, terragruntOptions *options.TerragruntOptions) (*session.Session, error) {

--- a/cli/aws_provider_patch.go
+++ b/cli/aws_provider_patch.go
@@ -33,23 +33,23 @@ const awsProviderPatchHelp = `
 //
 // For example, if were running Terragrunt against code that contained a module:
 //
-// module "example" {
-//   source = "<URL>"
-// }
+//	module "example" {
+//	  source = "<URL>"
+//	}
 //
 // When you run 'init', Terraform would download the code for that module into .terraform/modules. This function would
 // scan that module code for provider blocks:
 //
-// provider "aws" {
-//    region = var.aws_region
-// }
+//	provider "aws" {
+//	   region = var.aws_region
+//	}
 //
 // And if AwsProviderPatchOverrides in terragruntOptions was set to map[string]string{"region": "us-east-1"}, then this
 // method would update the module code to:
 //
-// provider "aws" {
-//    region = "us-east-1"
-// }
+//	provider "aws" {
+//	   region = "us-east-1"
+//	}
 //
 // This is a temporary workaround for a Terraform bug (https://github.com/hashicorp/terraform/issues/13018) where
 // any dynamic values in nested provider blocks are not handled correctly when you call 'terraform import', so by
@@ -158,15 +158,15 @@ func findAllTerraformFilesInModules(terragruntOptions *options.TerragruntOptions
 //
 // For example, if you passed in the following Terraform code:
 //
-// provider "aws" {
-//    region = var.aws_region
-// }
+//	provider "aws" {
+//	   region = var.aws_region
+//	}
 //
 // And you set attributesToOverride to map[string]string{"region": "us-east-1"}, then this method will return:
 //
-// provider "aws" {
-//    region = "us-east-1"
-// }
+//	provider "aws" {
+//	   region = "us-east-1"
+//	}
 //
 // This is a temporary workaround for a Terraform bug (https://github.com/hashicorp/terraform/issues/13018) where
 // any dynamic values in nested provider blocks are not handled correctly when you call 'terraform import', so by
@@ -209,12 +209,12 @@ func patchAwsProviderInTerraformCode(terraformCode string, terraformFilePath str
 //
 // Assume that block1 is:
 //
-// provider "aws" {
-//   region = var.aws_region
-//   assume_role {
-//     role_arn = var.role_arn
-//   }
-// }
+//	provider "aws" {
+//	  region = var.aws_region
+//	  assume_role {
+//	    role_arn = var.role_arn
+//	  }
+//	}
 //
 // If you call:
 //
@@ -223,12 +223,12 @@ func patchAwsProviderInTerraformCode(terraformCode string, terraformFilePath str
 //
 // The result would be:
 //
-// provider "aws" {
-//   region = "eu-west-1"
-//   assume_role {
-//     role_arn = "foo"
-//   }
-// }
+//	provider "aws" {
+//	  region = "eu-west-1"
+//	  assume_role {
+//	    role_arn = "foo"
+//	  }
+//	}
 //
 // Assume block2 is:
 //
@@ -238,7 +238,6 @@ func patchAwsProviderInTerraformCode(terraformCode string, terraformFilePath str
 //
 // overrideAttributeInBlock(block2, "region", "eu-west-1")
 // overrideAttributeInBlock(block2, "assume_role.role_arn", "foo")
-//
 //
 // The result would be:
 //
@@ -285,24 +284,28 @@ func overrideAttributeInBlock(block *hclwrite.Block, key string, value string) (
 //
 // Assume block is:
 //
-// provider "aws" {
-//   region = var.aws_region
-//   assume_role {
-//     role_arn = var.role_arn
-//   }
-// }
+//	provider "aws" {
+//	  region = var.aws_region
+//	  assume_role {
+//	    role_arn = var.role_arn
+//	  }
+//	}
 //
 // traverseBlock(block, []string{"region"})
-//   => returns (<body of the current block>, "region")
+//
+//	=> returns (<body of the current block>, "region")
 //
 // traverseBlock(block, []string{"assume_role", "role_arn"})
-//   => returns (<body of the nested assume_role block>, "role_arn")
+//
+//	=> returns (<body of the nested assume_role block>, "role_arn")
 //
 // traverseBlock(block, []string{"foo"})
-//   => returns (nil, "")
+//
+//	=> returns (nil, "")
 //
 // traverseBlock(block, []string{"assume_role", "foo"})
-//   => returns (nil, "")
+//
+//	=> returns (nil, "")
 func traverseBlock(block *hclwrite.Block, keyParts []string) (*hclwrite.Body, string) {
 	if block == nil {
 		return nil, ""

--- a/config/include.go
+++ b/config/include.go
@@ -242,7 +242,8 @@ func handleIncludeForDependency(
 // attributes defined in the targetConfig. Note that this will modify the targetConfig.
 // NOTE: the following attributes are deliberately omitted from the merge operation, as they are handled differently in
 // the parser:
-//     - locals [These blocks are not merged by design]
+//   - locals [These blocks are not merged by design]
+//
 // NOTE: dependencies block is a special case and is merged deeply. This is necessary to ensure the configstack system
 // works correctly, as it uses the `Dependencies` list to track the dependencies of modules for graph building purposes.
 // This list includes the dependencies added from dependency blocks, which is handled in a different stage.
@@ -337,19 +338,19 @@ func (targetConfig *TerragruntConfig) Merge(sourceConfig *TerragruntConfig, terr
 }
 
 // DeepMerge performs a deep merge of the given sourceConfig into the targetConfig. Deep merge is defined as follows:
-// - For simple types, the source overrides the target.
-// - For lists, the two attribute lists are combined together in concatenation.
-// - For maps, the two maps are combined together recursively. That is, if the map keys overlap, then a deep merge is
-//   performed on the map value.
-// - Note that some structs are not deep mergeable due to an implementation detail. This will change in the future. The
-//   following structs have this limitation:
-//     - remote_state
-//     - generate
-// - Note that the following attributes are deliberately omitted from the merge operation, as they are handled
-//   differently in the parser:
-//     - dependency blocks (TerragruntDependencies) [These blocks need to retrieve outputs, so we need to merge during
-//       the parsing step, not after the full config is decoded]
-//     - locals [These blocks are not merged by design]
+//   - For simple types, the source overrides the target.
+//   - For lists, the two attribute lists are combined together in concatenation.
+//   - For maps, the two maps are combined together recursively. That is, if the map keys overlap, then a deep merge is
+//     performed on the map value.
+//   - Note that some structs are not deep mergeable due to an implementation detail. This will change in the future. The
+//     following structs have this limitation:
+//   - remote_state
+//   - generate
+//   - Note that the following attributes are deliberately omitted from the merge operation, as they are handled
+//     differently in the parser:
+//   - dependency blocks (TerragruntDependencies) [These blocks need to retrieve outputs, so we need to merge during
+//     the parsing step, not after the full config is decoded]
+//   - locals [These blocks are not merged by design]
 func (targetConfig *TerragruntConfig) DeepMerge(sourceConfig *TerragruntConfig, terragruntOptions *options.TerragruntOptions) error {
 	// Merge simple attributes first
 	if sourceConfig.DownloadDir != "" {
@@ -738,37 +739,42 @@ func updateBareIncludeBlock(file *hcl.File, filename string) ([]byte, bool, erro
 // block:
 //
 // Case 1: a single include block as top level:
-// {
-//   "include": {
-//     "path": "foo"
-//   }
-// }
+//
+//	{
+//	  "include": {
+//	    "path": "foo"
+//	  }
+//	}
 //
 // Case 2: a single include block in list:
-// {
-//   "include": [
-//     {"path": "foo"}
-//   ]
-// }
+//
+//	{
+//	  "include": [
+//	    {"path": "foo"}
+//	  ]
+//	}
 //
 // Case 3: mixed bare and labeled include block as list:
-// {
-//   "include": [
-//     {"path": "foo"},
-//     {
-//       "labeled": {"path": "bar"}
-//     }
-//   ]
-// }
+//
+//	{
+//	  "include": [
+//	    {"path": "foo"},
+//	    {
+//	      "labeled": {"path": "bar"}
+//	    }
+//	  ]
+//	}
 //
 // For simplicity of implementation, we focus on handling Case 1 and 2, and ignore Case 3. If we see Case 3, we will
 // error out. Instead, the user should handle this case explicitly using the object encoding instead of list encoding:
-// {
-//   "include": {
-//     "": {"path": "foo"},
-//     "labeled": {"path": "bar"}
-//   }
-// }
+//
+//	{
+//	  "include": {
+//	    "": {"path": "foo"},
+//	    "labeled": {"path": "bar"}
+//	  }
+//	}
+//
 // If the multiple include blocks are encoded in this way in the json configuration, nothing needs to be done by this
 // function.
 func updateBareIncludeBlockJSON(fileBytes []byte) ([]byte, bool, error) {

--- a/config/locals.go
+++ b/config/locals.go
@@ -36,9 +36,10 @@ type Local struct {
 
 // evaluateLocalsBlock is a routine to evaluate the locals block in a way to allow references to other locals. This
 // will:
-// - Extract a reference to the locals block from the parsed file
-// - Continuously evaluate the block until all references are evaluated, defering evaluation of anything that references
-//   other locals until those references are evaluated.
+//   - Extract a reference to the locals block from the parsed file
+//   - Continuously evaluate the block until all references are evaluated, defering evaluation of anything that references
+//     other locals until those references are evaluated.
+//
 // This returns a map of the local names to the evaluated expressions (represented as `cty.Value` objects). This will
 // error if there are remaining unevaluated locals after all references that can be evaluated has been evaluated.
 func evaluateLocalsBlock(

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -103,10 +103,10 @@ func toRunningModules(modules []*TerraformModule, dependencyOrder DependencyOrde
 
 // Loop through the map of runningModules and for each module M:
 //
-// * If dependencyOrder is NormalOrder, plug in all the modules M depends on into the Dependencies field and all the
-//   modules that depend on M into the NotifyWhenDone field.
-// * If dependencyOrder is ReverseOrder, do the reverse.
-// * If dependencyOrder is IgnoreOrder, do nothing.
+//   - If dependencyOrder is NormalOrder, plug in all the modules M depends on into the Dependencies field and all the
+//     modules that depend on M into the NotifyWhenDone field.
+//   - If dependencyOrder is ReverseOrder, do the reverse.
+//   - If dependencyOrder is IgnoreOrder, do nothing.
 func crossLinkDependencies(modules map[string]*runningModule, dependencyOrder DependencyOrder) (map[string]*runningModule, error) {
 	for _, module := range modules {
 		for _, dependency := range module.Module.Dependencies {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gruntwork-io/terragrunt
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go/storage v1.27.0

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -351,7 +351,7 @@ func TestGetTerraformInitArgs(t *testing.T) {
 }
 
 // Test to validate cases when is not possible to read all S3 configurations
-//https://github.com/gruntwork-io/terragrunt/issues/2109
+// https://github.com/gruntwork-io/terragrunt/issues/2109
 func TestNegativePublicAccessResponse(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -15,22 +15,23 @@ func KindOf(value interface{}) reflect.Kind {
 }
 
 // MustWalkTerraformOutput is a helper utility to deeply return a value from a terraform output.
-//   nil will be returned if the path is invalid
 //
-//   Using an example terraform output:
-//     a = {
-//       b = {
-//         c = "foo"
-//       }
-//       "d" = [
-//         1,
-//         2
-//       ]
-//     }
+//	nil will be returned if the path is invalid
 //
-//   path ["a", "b", "c"] will return "foo"
-//   path ["a", "d", "1"] will return 2
-//   path ["a", "foo"] will return nil
+//	Using an example terraform output:
+//	  a = {
+//	    b = {
+//	      c = "foo"
+//	    }
+//	    "d" = [
+//	      1,
+//	      2
+//	    ]
+//	  }
+//
+//	path ["a", "b", "c"] will return "foo"
+//	path ["a", "d", "1"] will return 2
+//	path ["a", "foo"] will return nil
 func MustWalkTerraformOutput(value interface{}, path ...string) interface{} {
 	if value == nil {
 		return nil


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated Go version to last supported release

Included changes:
 * updated used docker image with go 1.20
 * updated go version used in windows tests
 * updated formatting on files to match go 1.20


![image](https://github.com/gruntwork-io/terragrunt/assets/10694338/ee36a8d6-962e-4550-863c-49e10b996cb3)


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated used Go version to 1.20

### Migration Guide

N/A
<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

