### PR TITLE
Circleci resource_class update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,7 @@ jobs:
       - store_test_results:
           path: logs
   integration_test:
-    executor:
-      size: "large"
+    resource_class: large
     <<: *defaults
     steps:
       - checkout
@@ -100,15 +99,13 @@ jobs:
       - store_test_results:
           path: logs
   build:
-    executor:
-      size: "large"
+    resource_class: large
     <<: *defaults
     steps:
       - checkout
       - run: build-go-binaries --app-name terragrunt --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
   deploy:
-    executor:
-      size: "large"
+    resource_class: large
     <<: *defaults
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,9 +68,9 @@ jobs:
       - store_test_results:
           path: logs
   integration_test:
-    <<: *defaults
     executor:
       size: "large"
+    <<: *defaults
     steps:
       - checkout
       - run: gruntwork-install --binary-name 'terratest_log_parser' --repo 'https://github.com/gruntwork-io/terratest' --tag 'v0.30.0'
@@ -100,16 +100,16 @@ jobs:
       - store_test_results:
           path: logs
   build:
-    <<: *defaults
     executor:
       size: "large"
+    <<: *defaults
     steps:
       - checkout
       - run: build-go-binaries --app-name terragrunt --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
   deploy:
-    <<: *defaults
     executor:
       size: "large"
+    <<: *defaults
     steps:
       - checkout
       - run: build-go-binaries --app-name terragrunt --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,8 @@ jobs:
           path: logs
   integration_test:
     <<: *defaults
+    executor:
+      size: "large"
     steps:
       - checkout
       - run: gruntwork-install --binary-name 'terratest_log_parser' --repo 'https://github.com/gruntwork-io/terratest' --tag 'v0.30.0'
@@ -99,11 +101,15 @@ jobs:
           path: logs
   build:
     <<: *defaults
+    executor:
+      size: "large"
     steps:
       - checkout
       - run: build-go-binaries --app-name terragrunt --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
   deploy:
     <<: *defaults
+    executor:
+      size: "large"
     steps:
       - checkout
       - run: build-go-binaries --app-name terragrunt --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated `resource_class` for for CircleCI jobs to reduce cases when builds are killed or fail with timeout on test execution

Execution after changes:
build step ~3 min (was ~5 min)
integration tests ~11 min (was 25-35 min)

![image](https://github.com/gruntwork-io/terragrunt/assets/10694338/cfe282fb-9ab4-4e2a-9073-4c021d23dfef)


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
N/A
### Migration Guide
N/A

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

