### PR TITLE
fix: debug terraform command output

### DIFF
--- a/cli/debug.go
+++ b/cli/debug.go
@@ -50,10 +50,10 @@ func writeTerragruntDebugFile(terragruntOptions *options.TerragruntOptions, terr
 	terragruntOptions.Logger.Debugf("Variables passed to terraform are located in \"%s\"", fileName)
 	terragruntOptions.Logger.Debugf("Run this command to replicate how terraform was invoked:")
 	terragruntOptions.Logger.Debugf(
-		"\tterraform %s -var-file=\"%s\" \"%s\"",
+		"\tterraform -chdir=\"%s\" %s -var-file=\"%s\" ",
+		terragruntOptions.WorkingDir,
 		strings.Join(terragruntOptions.TerraformCliArgs, " "),
 		fileName,
-		terragruntOptions.WorkingDir,
 	)
 	return nil
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes (part of) #2014  
This corrects the debug logging output to log a valid `terraform` command that can be used for testing. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Fix `terraform` command logging to output commands that can be copied and ran.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

N/A