### PR TITLE
Add CLI flags to set handling state buckets

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -238,6 +238,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.FetchDependencyOutputFromState = parseBooleanArg(args, optTerragruntFetchDependencyOutputFromState, os.Getenv("TERRAGRUNT_FETCH_DEPENDENCY_OUTPUT_FROM_STATE") == "true")
 	opts.UsePartialParseConfigCache = parseBooleanArg(args, optTerragruntUsePartialParseConfigCache, os.Getenv("TERRAGRUNT_USE_PARTIAL_PARSE_CONFIG_CACHE") == "true")
 	opts.DisableBucketUpdate = parseBooleanArg(args, optTerragruntDisableBucketUpdate, os.Getenv("TERRAGRUNT_DISABLE_BUCKET_UPDATE") == "true")
+	opts.FailIfBucketCreationRequired = parseBooleanArg(args, optTerragruntFailIfBucketCreationRequired, os.Getenv("TERRAGRUNT_FAIL_IF_BUCKET-creation-required") == "true")
 	opts.RenderJsonWithMetadata = parseBooleanArg(args, optTerragruntOutputWithMetadata, false)
 
 	opts.JSONOut, err = parseStringArg(args, optTerragruntJSONOut, "")

--- a/cli/args.go
+++ b/cli/args.go
@@ -237,6 +237,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.AwsProviderPatchOverrides = awsProviderPatchOverrides
 	opts.FetchDependencyOutputFromState = parseBooleanArg(args, optTerragruntFetchDependencyOutputFromState, os.Getenv("TERRAGRUNT_FETCH_DEPENDENCY_OUTPUT_FROM_STATE") == "true")
 	opts.UsePartialParseConfigCache = parseBooleanArg(args, optTerragruntUsePartialParseConfigCache, os.Getenv("TERRAGRUNT_USE_PARTIAL_PARSE_CONFIG_CACHE") == "true")
+	opts.DisableBucketUpdate = parseBooleanArg(args, optTerragruntDisableBucketUpdate, os.Getenv("TERRAGRUNT_DISABLE_BUCKET_UPDATE") == "true")
 	opts.RenderJsonWithMetadata = parseBooleanArg(args, optTerragruntOutputWithMetadata, false)
 
 	opts.JSONOut, err = parseStringArg(args, optTerragruntJSONOut, "")

--- a/cli/args.go
+++ b/cli/args.go
@@ -238,7 +238,7 @@ func parseTerragruntOptionsFromArgs(terragruntVersion string, args []string, wri
 	opts.FetchDependencyOutputFromState = parseBooleanArg(args, optTerragruntFetchDependencyOutputFromState, os.Getenv("TERRAGRUNT_FETCH_DEPENDENCY_OUTPUT_FROM_STATE") == "true")
 	opts.UsePartialParseConfigCache = parseBooleanArg(args, optTerragruntUsePartialParseConfigCache, os.Getenv("TERRAGRUNT_USE_PARTIAL_PARSE_CONFIG_CACHE") == "true")
 	opts.DisableBucketUpdate = parseBooleanArg(args, optTerragruntDisableBucketUpdate, os.Getenv("TERRAGRUNT_DISABLE_BUCKET_UPDATE") == "true")
-	opts.FailIfBucketCreationRequired = parseBooleanArg(args, optTerragruntFailIfBucketCreationRequired, os.Getenv("TERRAGRUNT_FAIL_IF_BUCKET-creation-required") == "true")
+	opts.FailIfBucketCreationRequired = parseBooleanArg(args, optTerragruntFailOnStateBucketCreation, os.Getenv("TERRAGRUNT_FAIL_ON_STATE_BUCKET_CREATION") == "true")
 	opts.RenderJsonWithMetadata = parseBooleanArg(args, optTerragruntOutputWithMetadata, false)
 
 	opts.JSONOut, err = parseStringArg(args, optTerragruntJSONOut, "")

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -64,7 +64,7 @@ const (
 	optTerragruntFetchDependencyOutputFromState = "terragrunt-fetch-dependency-output-from-state"
 	optTerragruntUsePartialParseConfigCache     = "terragrunt-use-partial-parse-config-cache"
 	optTerragruntIncludeModulePrefix            = "terragrunt-include-module-prefix"
-	optTerragruntFailIfBucketCreationRequired   = "terragrunt-fail-if-bucket-creation-required"
+	optTerragruntFailOnStateBucketCreation      = "terragrunt-fail-on-state-bucket-creation"
 	optTerragruntDisableBucketUpdate            = "terragrunt-disable-bucket-update"
 	optTerragruntOutputWithMetadata             = "with-metadata"
 )
@@ -87,7 +87,7 @@ var allTerragruntBooleanOpts = []string{
 	optTerragruntUsePartialParseConfigCache,
 	optTerragruntOutputWithMetadata,
 	optTerragruntIncludeModulePrefix,
-	optTerragruntFailIfBucketCreationRequired,
+	optTerragruntFailOnStateBucketCreation,
 	optTerragruntDisableBucketUpdate,
 }
 var allTerragruntStringOpts = []string{
@@ -276,7 +276,7 @@ GLOBAL OPTIONS:
    terragrunt-json-out                          The file path that terragrunt should use when rendering the terragrunt.hcl config as json. Only used in the render-json command. Defaults to terragrunt_rendered.json.
    terragrunt-use-partial-parse-config-cache    Enables caching of includes during partial parsing operations. Will also be used for the --terragrunt-iam-role option if provided.
    terragrunt-include-module-prefix             When this flag is set output from Terraform sub-commands is prefixed with module path.
-   terragrunt-fail-if-bucket-creation-required  When this flag is set Terragrunt will fail if the remote state bucket needs to be created.
+   terragrunt-fail-on-state-bucket-creation     When this flag is set Terragrunt will fail if the remote state bucket needs to be created.
    terragrunt-disable-bucket-update             When this flag is set Terragrunt will not update the remote state bucket.
 
 VERSION:

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -64,6 +64,7 @@ const (
 	optTerragruntFetchDependencyOutputFromState = "terragrunt-fetch-dependency-output-from-state"
 	optTerragruntUsePartialParseConfigCache     = "terragrunt-use-partial-parse-config-cache"
 	optTerragruntIncludeModulePrefix            = "terragrunt-include-module-prefix"
+	optTerragruntDisableBucketUpdate            = "terragrunt-disable-bucket-update"
 	optTerragruntOutputWithMetadata             = "with-metadata"
 )
 
@@ -272,6 +273,7 @@ GLOBAL OPTIONS:
    terragrunt-json-out                          The file path that terragrunt should use when rendering the terragrunt.hcl config as json. Only used in the render-json command. Defaults to terragrunt_rendered.json.
    terragrunt-use-partial-parse-config-cache    Enables caching of includes during partial parsing operations. Will also be used for the --terragrunt-iam-role option if provided.
    terragrunt-include-module-prefix             When this flag is set output from Terraform sub-commands is prefixed with module path.
+   terragrunt-disable-bucket-update             When this flag is set Terragrunt will not update the remote state bucket.
 
 VERSION:
    {{.Version}}{{if len .Authors}}

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -64,6 +64,7 @@ const (
 	optTerragruntFetchDependencyOutputFromState = "terragrunt-fetch-dependency-output-from-state"
 	optTerragruntUsePartialParseConfigCache     = "terragrunt-use-partial-parse-config-cache"
 	optTerragruntIncludeModulePrefix            = "terragrunt-include-module-prefix"
+	optTerragruntFailIfBucketCreationRequired   = "terragrunt-fail-if-bucket-creation-required"
 	optTerragruntDisableBucketUpdate            = "terragrunt-disable-bucket-update"
 	optTerragruntOutputWithMetadata             = "with-metadata"
 )
@@ -86,6 +87,8 @@ var allTerragruntBooleanOpts = []string{
 	optTerragruntUsePartialParseConfigCache,
 	optTerragruntOutputWithMetadata,
 	optTerragruntIncludeModulePrefix,
+	optTerragruntFailIfBucketCreationRequired,
+	optTerragruntDisableBucketUpdate,
 }
 var allTerragruntStringOpts = []string{
 	optTerragruntConfig,
@@ -273,6 +276,7 @@ GLOBAL OPTIONS:
    terragrunt-json-out                          The file path that terragrunt should use when rendering the terragrunt.hcl config as json. Only used in the render-json command. Defaults to terragrunt_rendered.json.
    terragrunt-use-partial-parse-config-cache    Enables caching of includes during partial parsing operations. Will also be used for the --terragrunt-iam-role option if provided.
    terragrunt-include-module-prefix             When this flag is set output from Terraform sub-commands is prefixed with module path.
+   terragrunt-fail-if-bucket-creation-required  When this flag is set Terragrunt will fail if the remote state bucket needs to be created.
    terragrunt-disable-bucket-update             When this flag is set Terragrunt will not update the remote state bucket.
 
 VERSION:

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -502,6 +502,8 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
 - [terragrunt-fetch-dependency-output-from-state](#terragrunt-fetch-dependency-output-from-state)
 - [terragrunt-use-partial-parse-config-cache](#terragrunt-use-partial-parse-config-cache)
 - [terragrunt-include-module-prefix](#terragrunt-include-module-prefix)
+- [terragrunt-fail-on-state-bucket-creation](#terragrunt-fail-on-state-bucket-creation)
+- [terragrunt-disable-bucket-update](#terragrunt-disable-bucket-update)
 
 ### terragrunt-config
 
@@ -930,3 +932,17 @@ NOTE: This is an experimental feature, use with caution.
 **Environment Variable**: `TERRAGRUNT_INCLUDE_MODULE_PREFIX` (set to `true`)
 
 When this flag is set output from Terraform sub-commands is prefixed with module path.
+
+### terragrunt-fail-on-state-bucket-creation
+
+**CLI Arg**: `--terragrunt-fail-on-state-bucket-creation`
+**Environment Variable**: `TERRAGRUNT_FAIL_ON_STATE_BUCKET_CREATION` (set to `true`)
+
+When this flag is set, Terragrunt will wait for execution if it is required to create the remote state bucket.
+
+### terragrunt-disable-bucket-update
+
+**CLI Arg**: `--terragrunt-disable-bucket-update`
+**Environment Variable**: `TERRAGRUNT_DISABLE_BUCKET_UPDATE` (set to `true`)
+
+When this flag is set, Terragrunt does not update the remote state bucket, which is useful to set if the state bucket is managed by a third party.

--- a/options/options.go
+++ b/options/options.go
@@ -205,6 +205,9 @@ type TerragruntOptions struct {
 
 	// Controls if a module prefix will be prepended to TF outputs
 	IncludeModulePrefix bool
+
+	// Controls if s3 bucket should be updated or skipped
+	DisableBucketUpdate bool
 }
 
 // IAMOptions represents options that are used by Terragrunt to assume an IAM role.
@@ -385,6 +388,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		UsePartialParseConfigCache:     terragruntOptions.UsePartialParseConfigCache,
 		OutputPrefix:                   terragruntOptions.OutputPrefix,
 		IncludeModulePrefix:            terragruntOptions.IncludeModulePrefix,
+		DisableBucketUpdate:            terragruntOptions.DisableBucketUpdate,
 	}
 }
 

--- a/options/options.go
+++ b/options/options.go
@@ -206,6 +206,9 @@ type TerragruntOptions struct {
 	// Controls if a module prefix will be prepended to TF outputs
 	IncludeModulePrefix bool
 
+	// Fail execution if is required to create S3 bucket
+	FailIfBucketCreationRequired bool
+
 	// Controls if s3 bucket should be updated or skipped
 	DisableBucketUpdate bool
 }
@@ -388,6 +391,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		UsePartialParseConfigCache:     terragruntOptions.UsePartialParseConfigCache,
 		OutputPrefix:                   terragruntOptions.OutputPrefix,
 		IncludeModulePrefix:            terragruntOptions.IncludeModulePrefix,
+		FailIfBucketCreationRequired:   terragruntOptions.FailIfBucketCreationRequired,
 		DisableBucketUpdate:            terragruntOptions.DisableBucketUpdate,
 	}
 }

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -209,8 +209,8 @@ var (
 	ErrGenerateCalledWithNoGenerateAttr = fmt.Errorf("generate code routine called when no generate attribute is configured")
 )
 
-type RemoteStateBucketCreationNotAllowed string
+type BucketCreationNotAllowed string
 
-func (bucketName RemoteStateBucketCreationNotAllowed) Error() string {
-	return fmt.Sprintf("Creation of remote state bucket is not allowed %s", string(bucketName))
+func (bucketName BucketCreationNotAllowed) Error() string {
+	return fmt.Sprintf("Creation of remote state bucket %s is not allowed", string(bucketName))
 }

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -208,3 +208,9 @@ var (
 	ErrRemoteBackendMissing             = fmt.Errorf("the remote_state.backend field cannot be empty")
 	ErrGenerateCalledWithNoGenerateAttr = fmt.Errorf("generate code routine called when no generate attribute is configured")
 )
+
+type RemoteStateBucketCreationNotAllowed string
+
+func (bucketName RemoteStateBucketCreationNotAllowed) Error() string {
+	return fmt.Sprintf("Creation of remote state bucket is not allowed %s", string(bucketName))
+}

--- a/remote/remote_state_gcs.go
+++ b/remote/remote_state_gcs.go
@@ -259,7 +259,7 @@ func createGCSBucketIfNecessary(gcsClient *storage.Client, config *ExtendedRemot
 		}
 
 		if terragruntOptions.FailIfBucketCreationRequired {
-			return RemoteStateBucketCreationNotAllowed(config.remoteStateConfigGCS.Bucket)
+			return BucketCreationNotAllowed(config.remoteStateConfigGCS.Bucket)
 		}
 
 		prompt := fmt.Sprintf("Remote state GCS bucket %s does not exist or you don't have permissions to access it. Would you like Terragrunt to create it?", config.remoteStateConfigGCS.Bucket)

--- a/remote/remote_state_gcs.go
+++ b/remote/remote_state_gcs.go
@@ -258,6 +258,10 @@ func createGCSBucketIfNecessary(gcsClient *storage.Client, config *ExtendedRemot
 			return errors.WithStackTrace(MissingRequiredGCSRemoteStateConfig("location"))
 		}
 
+		if terragruntOptions.FailIfBucketCreationRequired {
+			return RemoteStateBucketCreationNotAllowed(config.remoteStateConfigGCS.Bucket)
+		}
+
 		prompt := fmt.Sprintf("Remote state GCS bucket %s does not exist or you don't have permissions to access it. Would you like Terragrunt to create it?", config.remoteStateConfigGCS.Bucket)
 		shouldCreateBucket, err := shell.PromptUserForYesNo(prompt, terragruntOptions)
 		if err != nil {

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -373,6 +373,11 @@ func validateS3Config(extendedConfig *ExtendedRemoteStateConfigS3, terragruntOpt
 // confirms, create the bucket and enable versioning for it.
 func createS3BucketIfNecessary(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
 	if !DoesS3BucketExist(s3Client, &config.remoteStateConfigS3.Bucket) {
+
+		if terragruntOptions.FailIfBucketCreationRequired {
+			return RemoteStateBucketCreationNotAllowed(config.remoteStateConfigS3.Bucket)
+		}
+
 		prompt := fmt.Sprintf("Remote state S3 bucket %s does not exist or you don't have permissions to access it. Would you like Terragrunt to create it?", config.remoteStateConfigS3.Bucket)
 		shouldCreateBucket, err := shell.PromptUserForYesNo(prompt, terragruntOptions)
 		if err != nil {
@@ -401,6 +406,9 @@ func createS3BucketIfNecessary(s3Client *s3.S3, config *ExtendedRemoteStateConfi
 
 func updateS3BucketIfNecessary(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
 	if !DoesS3BucketExist(s3Client, &config.remoteStateConfigS3.Bucket) {
+		if terragruntOptions.FailIfBucketCreationRequired {
+			return RemoteStateBucketCreationNotAllowed(config.remoteStateConfigS3.Bucket)
+		}
 		return errors.WithStackTrace(fmt.Errorf("remote state S3 bucket %s does not exist or you don't have permissions to access it", config.remoteStateConfigS3.Bucket))
 	}
 
@@ -710,6 +718,9 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 
 func CreateLogsS3BucketIfNecessary(s3Client *s3.S3, logsBucketName *string, terragruntOptions *options.TerragruntOptions) error {
 	if !DoesS3BucketExist(s3Client, logsBucketName) {
+		if terragruntOptions.FailIfBucketCreationRequired {
+			return RemoteStateBucketCreationNotAllowed(*logsBucketName)
+		}
 		prompt := fmt.Sprintf("Logs S3 bucket %s for the remote state does not exist or you don't have permissions to access it. Would you like Terragrunt to create it?", *logsBucketName)
 		shouldCreateBucket, err := shell.PromptUserForYesNo(prompt, terragruntOptions)
 		if err != nil {

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -374,7 +374,7 @@ func validateS3Config(extendedConfig *ExtendedRemoteStateConfigS3, terragruntOpt
 func createS3BucketIfNecessary(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
 	if !DoesS3BucketExist(s3Client, &config.remoteStateConfigS3.Bucket) {
 		if terragruntOptions.FailIfBucketCreationRequired {
-			return RemoteStateBucketCreationNotAllowed(config.remoteStateConfigS3.Bucket)
+			return BucketCreationNotAllowed(config.remoteStateConfigS3.Bucket)
 		}
 
 		prompt := fmt.Sprintf("Remote state S3 bucket %s does not exist or you don't have permissions to access it. Would you like Terragrunt to create it?", config.remoteStateConfigS3.Bucket)
@@ -406,7 +406,7 @@ func createS3BucketIfNecessary(s3Client *s3.S3, config *ExtendedRemoteStateConfi
 func updateS3BucketIfNecessary(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
 	if !DoesS3BucketExist(s3Client, &config.remoteStateConfigS3.Bucket) {
 		if terragruntOptions.FailIfBucketCreationRequired {
-			return RemoteStateBucketCreationNotAllowed(config.remoteStateConfigS3.Bucket)
+			return BucketCreationNotAllowed(config.remoteStateConfigS3.Bucket)
 		}
 		return errors.WithStackTrace(fmt.Errorf("remote state S3 bucket %s does not exist or you don't have permissions to access it", config.remoteStateConfigS3.Bucket))
 	}
@@ -718,7 +718,7 @@ func CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client *s3.S3, c
 func CreateLogsS3BucketIfNecessary(s3Client *s3.S3, logsBucketName *string, terragruntOptions *options.TerragruntOptions) error {
 	if !DoesS3BucketExist(s3Client, logsBucketName) {
 		if terragruntOptions.FailIfBucketCreationRequired {
-			return RemoteStateBucketCreationNotAllowed(*logsBucketName)
+			return BucketCreationNotAllowed(*logsBucketName)
 		}
 		prompt := fmt.Sprintf("Logs S3 bucket %s for the remote state does not exist or you don't have permissions to access it. Would you like Terragrunt to create it?", *logsBucketName)
 		shouldCreateBucket, err := shell.PromptUserForYesNo(prompt, terragruntOptions)

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -373,7 +373,6 @@ func validateS3Config(extendedConfig *ExtendedRemoteStateConfigS3, terragruntOpt
 // confirms, create the bucket and enable versioning for it.
 func createS3BucketIfNecessary(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) error {
 	if !DoesS3BucketExist(s3Client, &config.remoteStateConfigS3.Bucket) {
-
 		if terragruntOptions.FailIfBucketCreationRequired {
 			return RemoteStateBucketCreationNotAllowed(config.remoteStateConfigS3.Bucket)
 		}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -270,7 +270,7 @@ func (s3Initializer S3Initializer) Initialize(remoteState *RemoteState, terragru
 		return err
 	}
 
-	if !s3ConfigExtended.DisableBucketUpdate {
+	if !terragruntOptions.DisableBucketUpdate && !s3ConfigExtended.DisableBucketUpdate {
 		if err := updateS3BucketIfNecessary(s3Client, s3ConfigExtended, terragruntOptions); err != nil {
 			return err
 		}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5708,15 +5708,17 @@ func TestTerragruntFailIfBucketCreationIsRequired(t *testing.T) {
 	t.Parallel()
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_PATH)
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_PATH)
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_PATH)
 
 	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
 	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, TEST_FIXTURE_PATH, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, rootPath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-fail-on-state-bucket-creation --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, TEST_FIXTURE_PATH), &stdout, &stderr)
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-fail-on-state-bucket-creation --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, rootPath), &stdout, &stderr)
 	assert.Error(t, err)
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5707,9 +5707,9 @@ func TestRenderJsonWithInputsNotExistingOutput(t *testing.T) {
 func TestTerragruntFailIfBucketCreationIsRequired(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, TEST_FIXTURE_PATH)
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_PATH)
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_PATH)
+	cleanupTerraformFolder(t, rootPath)
 
 	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
 	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
@@ -5725,7 +5725,9 @@ func TestTerragruntFailIfBucketCreationIsRequired(t *testing.T) {
 func TestTerragruntDisableBucketUpdate(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, TEST_FIXTURE_PATH)
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_PATH)
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_PATH)
+	cleanupTerraformFolder(t, rootPath)
 
 	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
 	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
@@ -5736,9 +5738,9 @@ func TestTerragruntDisableBucketUpdate(t *testing.T) {
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, TEST_FIXTURE_PATH, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, rootPath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-disable-bucket-update --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, TEST_FIXTURE_PATH))
+	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-disable-bucket-update --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, rootPath))
 
 	_, err = bucketPolicy(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	// validate that bucket policy is not updated, because of --terragrunt-disable-bucket-update


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Added CLI flags to handle state buckets:
 * `--terragrunt-fail-on-state-bucket-creation` fail Terragrunt execution if is required creation of state buckets #2633
 * `--terragrunt-disable-bucket-update` when set, it will disable updating of state buckets  #2121

Fixes #2121.
Fixes #2633.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added `--terragrunt-fail-on-state-bucket-creation` which will fail Terragrunt execution if state bucket creation is required.

Added `--terragrunt-disable-bucket-update` which will disable updating of state bucket.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

