### PR TITLE
Updated terragrunt-fail-on-state-bucket-creation flag wording

### DIFF
--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -938,7 +938,7 @@ When this flag is set output from Terraform sub-commands is prefixed with module
 **CLI Arg**: `--terragrunt-fail-on-state-bucket-creation`
 **Environment Variable**: `TERRAGRUNT_FAIL_ON_STATE_BUCKET_CREATION` (set to `true`)
 
-When this flag is set, Terragrunt will wait for execution if it is required to create the remote state bucket.
+When this flag is set, Terragrunt will fail and exit if it is necessary to create the remote state bucket.
 
 ### terragrunt-disable-bucket-update
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
  * updated description of `--terragrunt-fail-on-state-bucket-creation` to reflect that execution will fail if is required to create a state bucket

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated description of `--terragrunt-fail-on-state-bucket-creation` to reflect that execution will fail if is required to create a state bucket

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

N/A

