### PR TITLE
Simplified run-all confirmation dialog

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -499,7 +499,7 @@ func confirmShouldApplyExternalDependency(module *TerraformModule, dependency *T
 		return false, nil
 	}
 
-	prompt := fmt.Sprintf("Module %s depends on module %s, which is an external dependency outside of the current working directory. Should Terragrunt run this external dependency? Warning, if you say 'yes', Terragrunt will make changes in %s as well!", module.Path, dependency.Path, dependency.Path)
+	prompt := fmt.Sprintf("Module: \t\t %s\nExternal dependency: \t %s\nShould Terragrunt apply the external dependency?", module.Path, dependency.Path)
 	return shell.PromptUserForYesNo(prompt, terragruntOptions)
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Included changes:
 - updated `run-all` confirmation message to be easy to read

Before:
```
$ terragrunt run-all apply
Module /home/denis/projects/gruntwork/terragrunt-tests/multiple-dependencies/app depends on module /home/denis/projects/gruntwork/terragrunt-tests/multiple-dependencies/m3, which is an external dependency outside of the current working directory. Should Terragrunt run this external dependency? Warning, if you say 'yes', Terragrunt will make changes in /home/denis/projects/gruntwork/terragrunt-tests/multiple-dependencies/m3 as well! (y/n) 

```
After:
```
$ run-all apply
Module:                  /home/denis/projects/gruntwork/terragrunt-tests/multiple-dependencies/app
External dependency:     /home/denis/projects/gruntwork/terragrunt-tests/multiple-dependencies/m1
Should Terragrunt apply the external dependency? (y/n) 

```

Fixes #78.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated run-all confirmation message to be easier to read.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

N/A

