### PR TITLE
Add support for env vars and Pseudo TTY in hooks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -330,21 +330,25 @@ func (deps *ModuleDependencies) String() string {
 
 // Hook specifies terraform commands (apply/plan) and array of os commands to execute
 type Hook struct {
-	Name           string   `hcl:"name,label" cty:"name"`
-	Commands       []string `hcl:"commands,attr" cty:"commands"`
-	Execute        []string `hcl:"execute,attr" cty:"execute"`
-	RunOnError     *bool    `hcl:"run_on_error,attr" cty:"run_on_error"`
-	SuppressStdout *bool    `hcl:"suppress_stdout,attr" cty:"suppress_stdout"`
-	WorkingDir     *string  `hcl:"working_dir,attr" cty:"working_dir"`
+	Name           string             `hcl:"name,label" cty:"name"`
+	Commands       []string           `hcl:"commands,attr" cty:"commands"`
+	Execute        []string           `hcl:"execute,attr" cty:"execute"`
+	EnvVars        *map[string]string `hcl:"env_vars,attr" cty:"env_vars"`
+	TTY            *bool              `hcl:"tty,attr" cty:"tty"`
+	RunOnError     *bool              `hcl:"run_on_error,attr" cty:"run_on_error"`
+	SuppressStdout *bool              `hcl:"suppress_stdout,attr" cty:"suppress_stdout"`
+	WorkingDir     *string            `hcl:"working_dir,attr" cty:"working_dir"`
 }
 
 type ErrorHook struct {
-	Name           string   `hcl:"name,label" cty:"name"`
-	Commands       []string `hcl:"commands,attr" cty:"commands"`
-	Execute        []string `hcl:"execute,attr" cty:"execute"`
-	OnErrors       []string `hcl:"on_errors,attr" cty:"on_errors"`
-	SuppressStdout *bool    `hcl:"suppress_stdout,attr" cty:"suppress_stdout"`
-	WorkingDir     *string  `hcl:"working_dir,attr" cty:"working_dir"`
+	Name           string             `hcl:"name,label" cty:"name"`
+	Commands       []string           `hcl:"commands,attr" cty:"commands"`
+	Execute        []string           `hcl:"execute,attr" cty:"execute"`
+	EnvVars        *map[string]string `hcl:"env_vars,attr" cty:"env_vars"`
+	TTY            *bool              `hcl:"tty,attr" cty:"tty"`
+	OnErrors       []string           `hcl:"on_errors,attr" cty:"on_errors"`
+	SuppressStdout *bool              `hcl:"suppress_stdout,attr" cty:"suppress_stdout"`
+	WorkingDir     *string            `hcl:"working_dir,attr" cty:"working_dir"`
 }
 
 func (conf *Hook) String() string {

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -95,9 +95,11 @@ The `terraform` block supports the following arguments:
     - `commands` (required) : A list of `terraform` sub commands for which the hook should run before.
     - `execute` (required) : A list of command and arguments that should be run as the hook. For example, if `execute` is set as
       `["echo", "Foo"]`, the command `echo Foo` will be run.
+    - `env_vars` (optional) : A map of key value pairs to set as environment variables when calling `execute`.
     - `working_dir` (optional) : The path to set as the working directory of the hook. Terragrunt will switch directory
       to this path prior to running the hook command. Defaults to the terragrunt configuration directory for
       `terragrunt-read-config` and `init-from-module` hooks, and the terraform module directory for other command hooks.
+    - `tty` (optional) : If set to true, this hook will pass a TTY to `execute`.  Helpful if colorized output is desired.
     - `run_on_error` (optional) : If set to true, this hook will run even if a previous hook hit an error, or in the
       case of "after" hooks, if the Terraform command hit an error. Default is false.
     - `suppress_stdout` (optional) : If set to true, the stdout output of the executed commands will be suppressed. This can be useful when there are scripts relying on terraform's output and any other output would break their parsing.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Add support for env vars and Pseudo TTY in hooks.  TTY allows me to have colorized output from hook output for a tool such as `helm-diff`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

