### PR TITLE
Add config of CircleCI to sign MacOS binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,12 @@ orbs:
   # The Windows orb gives us everything we need to start using the Windows executor.
   win: circleci/windows@2.4.0
 
+# The "sign binary" rubs in a MacOS environment, so it's necessary to download GW's binaries
+env: &env
+  environment:
+    GRUNTWORK_INSTALLER_VERSION: v0.0.39
+    MODULE_CI_VERSION: v0.52.6
+
 defaults: &defaults
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.20-tf1.5-tg39.1-pck1.8-ci50.7
@@ -105,12 +111,40 @@ jobs:
       - checkout
       - run: build-go-binaries --app-name terragrunt --dest-path bin --ld-flags "-X github.com/gruntwork-io/go-commons/version.Version=$CIRCLE_TAG -extldflags '-static'"
   deploy:
-    resource_class: large
-    <<: *defaults
+    <<: *env
+    macos:
+      xcode: 14.2.0
+    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
-      - run: build-go-binaries --app-name terragrunt --dest-path bin --ld-flags "-X github.com/gruntwork-io/go-commons/version.Version=$CIRCLE_TAG -extldflags '-static'"
-      - run: cd bin && sha256sum * > SHA256SUMS
+      - attach_workspace:
+          at: .
+      - go/install:
+          version: "1.20.5"
+      - run:
+          name: Install sign-binary-helpers
+          command: |
+            curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
+            gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
+            gruntwork-install --module-name "sign-binary-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
+      - run:
+          name: Compile and sign the binaries
+          command: |
+            sign-binary --install-macos-sign-dependencies --os mac .gon_amd64.hcl
+            sign-binary --os mac .gon_arm64.hcl
+            echo "Done signing the binary"
+
+            # Replace the files in bin. These are the same file names generated from .gon_amd64.hcl and .gon_arm64.hcl
+            unzip terragrunt_darwin_amd64.zip
+            mv terragrunt_darwin_amd64 bin/
+
+            unzip terragrunt_darwin_arm64.zip
+            mv terragrunt_darwin_arm64 bin/
+      - run:
+          name: Run SHA256SUM
+          command: |
+            brew install coreutils
+            cd bin && sha256sum * > SHA256SUMS
       - run: upload-github-release-assets bin/*
 workflows:
   version: 2
@@ -165,3 +199,4 @@ workflows:
             - GITHUB__PAT__gruntwork-ci
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
+            - APPLE__OSX__code-signing

--- a/.gon_amd64.hcl
+++ b/.gon_amd64.hcl
@@ -1,0 +1,19 @@
+# See https://github.com/gruntwork-io/terraform-aws-ci/blob/main/modules/sign-binary-helpers/
+# for further instructions on how to sign the binary + submitting for notarization.
+
+source = ["./bin/terragrunt_darwin_amd64"]
+
+bundle_id = "io.gruntwork.app.terragrunt"
+
+apple_id {
+  username = "machine.apple@gruntwork.io"
+  password = "@env:MACOS_AC_PASSWORD"
+}
+
+sign {
+  application_identity = "Developer ID Application: Gruntwork, Inc."
+}
+
+zip {
+  output_path = "terragrunt_darwin_amd64.zip"
+}

--- a/.gon_arm64.hcl
+++ b/.gon_arm64.hcl
@@ -1,0 +1,19 @@
+# See https://github.com/gruntwork-io/terraform-aws-ci/blob/main/modules/sign-binary-helpers/
+# for further instructions on how to sign the binary + submitting for notarization.
+
+source = ["./bin/terragrunt_darwin_arm64"]
+
+bundle_id = "io.gruntwork.app.terragrunt"
+
+apple_id {
+  username = "machine.apple@gruntwork.io"
+  password = "@env:MACOS_AC_PASSWORD"
+}
+
+sign {
+  application_identity = "Developer ID Application: Gruntwork, Inc."
+}
+
+zip {
+  output_path = "terragrunt_darwin_arm64.zip"
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

We are already able to sign the binaries of internal project, like [patcher-cli](https://github.com/gruntwork-io/patcher-cli/releases).

I am replicating the same process in Terragrunt, the MacOS binaries will be signed and notarized before generating the `sha256sum`. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Signing MacOS binaries from now on! 🎉 



