### PR TITLE
Prevent parsing of excluded modules

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -158,6 +158,16 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		}
 		opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)
 
+		opts.ExcludeDirs, err = util.GlobCanonicalPath(opts.WorkingDir, opts.ExcludeDirs...)
+		if err != nil {
+			return err
+		}
+
+		opts.IncludeDirs, err = util.GlobCanonicalPath(opts.WorkingDir, opts.IncludeDirs...)
+		if err != nil {
+			return err
+		}
+
 		// --- Terragrunt Version
 		terragruntVersion, err := hashicorpversion.NewVersion(ctx.App.Version)
 		if err != nil {

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -314,12 +314,8 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 	opts.ExcludeDirs = []string{canonical(t, "../test/fixture-modules/module-a")}
 
 	moduleA := &TerraformModule{
-		Path:         canonical(t, "../test/fixture-modules/module-a"),
-		Dependencies: []*TerraformModule{},
-		Config: config.TerragruntConfig{
-			Terraform: &config.TerraformConfig{Source: ptr("test")},
-			IsPartial: true,
-		},
+		Path:              canonical(t, "../test/fixture-modules/module-a"),
+		Dependencies:      []*TerraformModule{},
 		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
 	}
 
@@ -353,12 +349,8 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 	opts.ExcludeDirs = []string{canonical(t, "../test/fixture-modules/module-a")}
 
 	moduleA := &TerraformModule{
-		Path:         canonical(t, "../test/fixture-modules/module-a"),
-		Dependencies: []*TerraformModule{},
-		Config: config.TerragruntConfig{
-			Terraform: &config.TerraformConfig{Source: ptr("test")},
-			IsPartial: true,
-		},
+		Path:              canonical(t, "../test/fixture-modules/module-a"),
+		Dependencies:      []*TerraformModule{},
 		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
 	}
 
@@ -400,15 +392,11 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 	t.Parallel()
 
 	opts, _ := options.NewTerragruntOptionsForTest("running_module_test")
-	opts.ExcludeDirs = []string{canonical(t, "../test/fixture-modules/module-a*")}
+	opts.ExcludeDirs = globCanonical(t, "../test/fixture-modules/module-a*")
 
 	moduleA := &TerraformModule{
-		Path:         canonical(t, "../test/fixture-modules/module-a"),
-		Dependencies: []*TerraformModule{},
-		Config: config.TerragruntConfig{
-			Terraform: &config.TerraformConfig{Source: ptr("test")},
-			IsPartial: true,
-		},
+		Path:              canonical(t, "../test/fixture-modules/module-a"),
+		Dependencies:      []*TerraformModule{},
 		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
 	}
 
@@ -424,20 +412,14 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 	}
 
 	moduleAbba := &TerraformModule{
-		Path:         canonical(t, "../test/fixture-modules/module-abba"),
-		Dependencies: []*TerraformModule{moduleA},
-		Config: config.TerragruntConfig{
-			Dependencies: &config.ModuleDependencies{Paths: []string{"../module-a"}},
-			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
-			IsPartial:    true,
-		},
+		Path:              canonical(t, "../test/fixture-modules/module-abba"),
+		Dependencies:      []*TerraformModule{},
 		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-abba/"+config.DefaultTerragruntConfigPath)),
 	}
 
 	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-abba/" + config.DefaultTerragruntConfigPath}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
-
 	// construct the expected list
 	moduleA.FlagExcluded = true
 	moduleAbba.FlagExcluded = true
@@ -464,13 +446,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithNoDepe
 	}
 
 	moduleC := &TerraformModule{
-		Path:         canonical(t, "../test/fixture-modules/module-c"),
-		Dependencies: []*TerraformModule{moduleA},
-		Config: config.TerragruntConfig{
-			Dependencies: &config.ModuleDependencies{Paths: []string{"../module-a"}},
-			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
-			IsPartial:    true,
-		},
+		Path:              canonical(t, "../test/fixture-modules/module-c"),
 		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+config.DefaultTerragruntConfigPath)),
 	}
 
@@ -595,7 +571,6 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithDepend
 	moduleF := &TerraformModule{
 		Path:                 canonical(t, "../test/fixture-modules/module-f"),
 		Dependencies:         []*TerraformModule{},
-		Config:               config.TerragruntConfig{IsPartial: true},
 		TerragruntOptions:    mockOptions.Clone(canonical(t, "../test/fixture-modules/module-f/"+config.DefaultTerragruntConfigPath)),
 		AssumeAlreadyApplied: false,
 	}

--- a/configstack/test_helpers.go
+++ b/configstack/test_helpers.go
@@ -155,6 +155,14 @@ func canonical(t *testing.T, path string) string {
 	return out
 }
 
+func globCanonical(t *testing.T, path string) []string {
+	out, err := util.GlobCanonicalPath(path, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
 // Create a mock TerragruntOptions object and configure its RunTerragrunt command to return the given error object. If
 // the RunTerragrunt command is called, this method will also set the executed boolean to true.
 func optionsWithMockTerragruntCommand(t *testing.T, terragruntConfigPath string, toReturnFromTerragruntCommand error, executed *bool) *options.TerragruntOptions {

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"fmt"
@@ -66,6 +67,44 @@ func TestCanonicalPath(t *testing.T) {
 		actual, err := CanonicalPath(testCase.path, testCase.basePath)
 		assert.Nil(t, err, "Unexpected error for path %s and basePath %s: %v", testCase.path, testCase.basePath, err)
 		assert.Equal(t, testCase.expected, actual, "For path %s and basePath %s", testCase.path, testCase.basePath)
+	}
+}
+
+func TestGlobCanonicalPath(t *testing.T) {
+	t.Parallel()
+
+	basePath := "testdata/fixture-glob-canonical"
+
+	expectedHelper := func(path string) string {
+		basePath, err := filepath.Abs(basePath)
+		assert.NoError(t, err)
+		return filepath.Join(basePath, path)
+	}
+
+	testCases := []struct {
+		paths    []string
+		expected []string
+	}{
+		{[]string{"module-a", "module-b/module-b-child/.."}, []string{expectedHelper("module-a"), expectedHelper("module-b")}},
+		{[]string{"*-a", "*-b"}, []string{expectedHelper("module-a"), expectedHelper("module-b")}},
+		{[]string{"module-*"}, []string{expectedHelper("module-a"), expectedHelper("module-b")}},
+		{[]string{"module-*/*.hcl"}, []string{expectedHelper("module-a/terragrunt.hcl"), expectedHelper("module-b/terragrunt.hcl")}},
+		{[]string{"module-*/**/*.hcl"}, []string{expectedHelper("module-a/terragrunt.hcl"), expectedHelper("module-b/terragrunt.hcl"), expectedHelper("module-b/module-b-child/terragrunt.hcl")}},
+	}
+
+	for _, testCase := range testCases {
+		actual, err := GlobCanonicalPath(basePath, testCase.paths...)
+
+		sort.Slice(actual, func(i, j int) bool {
+			return actual[i] < actual[j]
+		})
+
+		sort.Slice(testCase.expected, func(i, j int) bool {
+			return testCase.expected[i] < testCase.expected[j]
+		})
+
+		assert.Nil(t, err, "Unexpected error for paths %s and basePath %s: %v", testCase.paths, basePath, err)
+		assert.Equal(t, testCase.expected, actual, "For path %s and basePath %s", testCase.paths, basePath)
 	}
 }
 

--- a/util/testdata/fixture-glob-canonical/module-a/terragrunt.hcl
+++ b/util/testdata/fixture-glob-canonical/module-a/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "test"
+}

--- a/util/testdata/fixture-glob-canonical/module-b/module-b-child/terragrunt.hcl
+++ b/util/testdata/fixture-glob-canonical/module-b/module-b-child/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}

--- a/util/testdata/fixture-glob-canonical/module-b/terragrunt.hcl
+++ b/util/testdata/fixture-glob-canonical/module-b/terragrunt.hcl
@@ -1,0 +1,11 @@
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remote_state {
+  backend = "s3"
+  config = {
+    bucket = "bucket"
+    key = "${path_relative_to_include()}/terraform.tfstate"
+  }
+}
+terraform {
+  source = "..."
+}


### PR DESCRIPTION
## Description

Prevent parsing of excluded modules. For example, these modules may have invalid syntax or incomplete configuration, causing terragrunt to fail when parsed.

## Related Issues

Fixes #2167 



