### PR TITLE
Remove "null" values from json string (AWS policy)

### DIFF
--- a/aws_helper/policy.go
+++ b/aws_helper/policy.go
@@ -13,12 +13,13 @@ type Policy struct {
 // https://docs.aws.amazon.com/IAM//latest/UserGuide/reference_policies_elements_action.html
 // https://docs.aws.amazon.com/IAM//latest/UserGuide/reference_policies_elements_resource.html
 type Statement struct {
-	Sid       string                  `json:"Sid"`
-	Effect    string                  `json:"Effect"`
-	Principal interface{}             `json:"Principal"`
-	Action    interface{}             `json:"Action"`
-	Resource  interface{}             `json:"Resource"`
-	Condition *map[string]interface{} `json:"Condition,omitempty"`
+	Sid          string                  `json:"Sid"`
+	Effect       string                  `json:"Effect"`
+	Principal    interface{}             `json:"Principal,omitempty"`
+	NotPrincipal interface{}             `json:"NotPrincipal,omitempty"`
+	Action       interface{}             `json:"Action"`
+	Resource     interface{}             `json:"Resource"`
+	Condition    *map[string]interface{} `json:"Condition,omitempty"`
 }
 
 func UnmarshalPolicy(policy string) (Policy, error) {

--- a/aws_helper/policy_test.go
+++ b/aws_helper/policy_test.go
@@ -19,6 +19,7 @@ const simplePolicy = `
 			]
 		}
 	`
+
 const arraysPolicy = `
 		{
 			"Version": "2012-10-17",
@@ -73,6 +74,10 @@ func TestUnmarshalStringActionResource(t *testing.T) {
 	default:
 		assert.Fail(t, "Expected string type for Resource")
 	}
+
+	out, err := MarshalPolicy(bucketPolicy)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(out), "null")
 }
 
 func TestUnmarshalActionResourceList(t *testing.T) {
@@ -101,4 +106,8 @@ func TestUnmarshalActionResourceList(t *testing.T) {
 	default:
 		assert.Fail(t, "Expected []string type for Resource")
 	}
+
+	out, err := MarshalPolicy(bucketPolicy)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(out), "null")
 }


### PR DESCRIPTION
## Description

Ensure the json string (AWS policy) does not contain "null" values. 

## Related Issues

Fixes #2284



