### PR TITLE
Null vars file cleanup

### DIFF
--- a/cli/commands/terraform/action.go
+++ b/cli/commands/terraform/action.go
@@ -254,10 +254,6 @@ func runTerragruntWithConfig(originalTerragruntOptions *options.TerragruntOption
 		return err
 	}
 
-	if err := setTerragruntNullValues(terragruntOptions, terragruntConfig); err != nil {
-		return err
-	}
-
 	if util.FirstArg(terragruntOptions.TerraformCliArgs) == CommandNameInit {
 		if err := prepareInitCommand(terragruntOptions, terragruntConfig, allowSourceDownload); err != nil {
 			return err
@@ -267,6 +263,18 @@ func runTerragruntWithConfig(originalTerragruntOptions *options.TerragruntOption
 			return err
 		}
 	}
+
+	fileName, err := setTerragruntNullValues(terragruntOptions, terragruntConfig)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if fileName != "" {
+			if err := os.Remove(fileName); err != nil {
+				terragruntOptions.Logger.Debugf("Failed to remove null values file %s: %v", fileName, err)
+			}
+		}
+	}()
 
 	// Now that we've run 'init' and have all the source code locally, we can finally run the patch command
 	if target.isPoint(TargetPointInitCommand) {
@@ -725,7 +733,7 @@ func toTerraformEnvVars(vars map[string]interface{}) (map[string]string, error) 
 }
 
 // setTerragruntNullValues - Generate a .auto.tfvars.json file with variables which have null values.
-func setTerragruntNullValues(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
+func setTerragruntNullValues(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) (string, error) {
 	jsonEmptyVars := make(map[string]interface{})
 	for varName, varValue := range terragruntConfig.Inputs {
 		if varValue == nil {
@@ -734,16 +742,16 @@ func setTerragruntNullValues(terragruntOptions *options.TerragruntOptions, terra
 	}
 	// skip generation on empty file
 	if len(jsonEmptyVars) == 0 {
-		return nil
+		return "", nil
 	}
 	jsonContents, err := json.MarshalIndent(jsonEmptyVars, "", "  ")
 	if err != nil {
-		return errors.WithStackTrace(err)
+		return "", errors.WithStackTrace(err)
 	}
 	varFile := filepath.Join(terragruntOptions.WorkingDir, NullTFVarsFile)
 	if err := os.WriteFile(varFile, jsonContents, os.FileMode(0600)); err != nil {
-		return errors.WithStackTrace(err)
+		return "", errors.WithStackTrace(err)
 	}
 
-	return nil
+	return varFile, nil
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5815,6 +5815,22 @@ func TestTerragruntPassNullValues(t *testing.T) {
 	// check that the null values are passed correctly
 	assert.Equal(t, outputs["output1"].Value, nil)
 	assert.Equal(t, outputs["output2"].Value, "variable 2")
+
+	// check that file with null values is removed
+	cachePath := filepath.Join(TEST_FIXTURE_NULL_VALUE, TERRAGRUNT_CACHE)
+	foundNullValuesFile := false
+	err := filepath.Walk(cachePath,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if strings.HasPrefix(path, terraform.NullTFVarsFile) {
+				foundNullValuesFile = true
+			}
+			return nil
+		})
+	assert.Falsef(t, foundNullValuesFile, "Found %s file in cache directory", terraform.NullTFVarsFile)
+	assert.NoError(t, err)
 }
 
 func validateOutput(t *testing.T, outputs map[string]TerraformOutput, key string, value interface{}) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* skip generation of .terragrunt-null-vars.auto.tfvars.json if there are no null values
* removal of .terragrunt-null-vars.auto.tfvars.json after terraform execution


Fixes #2669.
Fixes #2670

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated Terragrunt to not generate `.terragrunt-null-vars.auto.tfvars.json` if is not required.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

