### PR TITLE
Add terraform command validation

### DIFF
--- a/cli/commands/terraform/command.go
+++ b/cli/commands/terraform/command.go
@@ -31,7 +31,7 @@ func action(opts *options.TerragruntOptions) func(ctx *cli.Context) error {
 		}
 
 		if !collections.ListContainsElement(nativeTerraformCommands, opts.TerraformCommand) {
-			return errors.Errorf("Terraform has no command named %q. To see all of Terraform's top-level commands, run: terraform -help", opts.TerraformCommand)
+			return errors.WithStackTrace(WrongTerraformCommand(opts.TerraformCommand))
 		}
 
 		return Run(opts.OptionsFromContext(ctx))

--- a/cli/commands/terraform/command.go
+++ b/cli/commands/terraform/command.go
@@ -12,7 +12,7 @@ const (
 )
 
 var (
-	nativeTerraformCommands = []string{"apply", "console", "destroy", "env", "fmt", "get", "graph", "import", "init", "metadata", "output", "plan", "providers", "push", "refresh", "show", "taint", "test", "validate", "untaint", "workspace", "force-unlock", "state"}
+	nativeTerraformCommands = []string{"apply", "console", "destroy", "env", "fmt", "get", "graph", "import", "init", "metadata", "output", "plan", "providers", "push", "refresh", "show", "taint", "test", "version", "validate", "untaint", "workspace", "force-unlock", "state"}
 )
 
 func NewCommand(opts *options.TerragruntOptions) *cli.Command {

--- a/cli/commands/terraform/command.go
+++ b/cli/commands/terraform/command.go
@@ -1,8 +1,6 @@
 package terraform
 
 import (
-	"strings"
-
 	"github.com/gruntwork-io/gruntwork-cli/collections"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/cli"
@@ -14,7 +12,7 @@ const (
 )
 
 var (
-	nativeTerraformCommands = []string{"apply", "console", "destroy", "env", "env list", "env select", "env new", "env delete", "fmt", "get", "graph", "import", "init", "metadata", "metadata functions", "output", "plan", "providers", "providers lock", "providers mirror", "providers schema", "push", "refresh", "show", "taint", "test", "validate", "untaint", "workspace", "workspace list", "workspace select", "workspace show", "workspace new", "workspace delete", "force-unlock", "state", "state list", "state rm", "state mv", "state pull", "state push", "state show", "state replace-provider"}
+	nativeTerraformCommands = []string{"apply", "console", "destroy", "env", "fmt", "get", "graph", "import", "init", "metadata", "output", "plan", "providers", "push", "refresh", "show", "taint", "test", "validate", "untaint", "workspace", "force-unlock", "state"}
 )
 
 func NewCommand(opts *options.TerragruntOptions) *cli.Command {
@@ -32,28 +30,10 @@ func action(opts *options.TerragruntOptions) func(ctx *cli.Context) error {
 			opts.CheckDependentModules = true
 		}
 
-		if err := validateTerraformCommand(opts.TerraformCliArgs); err != nil {
-			return err
+		if !collections.ListContainsElement(nativeTerraformCommands, opts.TerraformCommand) {
+			return errors.Errorf("Terraform has no command named %q. To see all of Terraform's top-level commands, run: terraform -help", opts.TerraformCommand)
 		}
 
 		return Run(opts.OptionsFromContext(ctx))
 	}
-}
-
-func validateTerraformCommand(args []string) error {
-	var commandArgs []string
-
-	for _, arg := range args {
-		if strings.HasPrefix(arg, "-") {
-			break
-		}
-		commandArgs = append(commandArgs, arg)
-	}
-	command := strings.Join(commandArgs, " ")
-
-	if !collections.ListContainsElement(nativeTerraformCommands, command) {
-		return errors.Errorf("Terraform has no command named %q. To see all of Terraform's top-level commands, run: terraform -help", command)
-	}
-
-	return nil
 }

--- a/cli/commands/terraform/command.go
+++ b/cli/commands/terraform/command.go
@@ -1,12 +1,18 @@
 package terraform
 
 import (
+	"github.com/gruntwork-io/go-commons/collections"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/cli"
+	"github.com/gruntwork-io/terragrunt/pkg/errors"
 )
 
 const (
 	CommandName = "terraform"
+)
+
+var (
+	nativeTerraformCommands = []string{"apply", "console", "destroy", "env", "env list", "env select", "env new", "env delete", "fmt", "get", "graph", "import", "init", "metadata", "metadata functions", "output", "plan", "providers", "providers lock", "providers mirror", "providers schema", "push", "refresh", "show", "taint", "test", "validate", "untaint", "workspace", "workspace list", "workspace select", "workspace show", "workspace new", "workspace delete", "force-unlock", "state", "state list", "state rm", "state mv", "state pull", "state push", "state show", "state replace-provider"}
 )
 
 func NewCommand(opts *options.TerragruntOptions) *cli.Command {
@@ -22,6 +28,10 @@ func action(opts *options.TerragruntOptions) func(ctx *cli.Context) error {
 	return func(ctx *cli.Context) error {
 		if opts.TerraformCommand == CommandNameDestroy {
 			opts.CheckDependentModules = true
+		}
+
+		if !collections.ListContainsElement(nativeTerraformCommands, opts.TerraformCommand) {
+			return errors.Errorf("Terraform has no command named %q. To see all of Terraform's top-level commands, run: terraform -help", opts.TerraformCommand)
 		}
 
 		return Run(opts.OptionsFromContext(ctx))

--- a/cli/commands/terraform/errors.go
+++ b/cli/commands/terraform/errors.go
@@ -15,6 +15,12 @@ func (err MissingCommand) Error() string {
 	return "Missing terraform command (Example: terragrunt plan)"
 }
 
+type WrongTerraformCommand string
+
+func (name WrongTerraformCommand) Error() string {
+	return fmt.Sprintf("Terraform has no command named %q. To see all of Terraform's top-level commands, run: terraform -help", string(name))
+}
+
 type BackendNotDefined struct {
 	Opts        *options.TerragruntOptions
 	BackendType string

--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 )
@@ -63,6 +64,14 @@ func (app *App) AddCommands(cmds ...*Command) {
 
 // Run is the entry point to the cli app. Parses the arguments slice and routes to the proper flag/args combination.
 func (app *App) Run(arguments []string) error {
+	// remove empty args
+	for i := 0; i < len(arguments); i++ {
+		if len(strings.TrimSpace(arguments[i])) == 0 {
+			arguments = append(arguments[:i], arguments[i+1:]...)
+			i++
+		}
+	}
+
 	app.SkipFlagParsing = true
 	app.Authors = []*cli.Author{{Name: app.Author}}
 

--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -65,12 +65,13 @@ func (app *App) AddCommands(cmds ...*Command) {
 // Run is the entry point to the cli app. Parses the arguments slice and routes to the proper flag/args combination.
 func (app *App) Run(arguments []string) error {
 	// remove empty args
-	for i := 0; i < len(arguments); i++ {
-		if len(strings.TrimSpace(arguments[i])) == 0 {
-			arguments = append(arguments[:i], arguments[i+1:]...)
-			i++
+	filteredArguments := []string{}
+	for _, arg := range arguments {
+		if trimmedArg := strings.TrimSpace(arg); len(trimmedArg) > 0 {
+			filteredArguments = append(filteredArguments, trimmedArg)
 		}
 	}
+	arguments = filteredArguments
 
 	app.SkipFlagParsing = true
 	app.Authors = []*cli.Author{{Name: app.Author}}

--- a/pkg/cli/args.go
+++ b/pkg/cli/args.go
@@ -92,11 +92,14 @@ func (args *Args) Normalize(acts ...NormalizeActsType) *Args {
 
 // CommandName returns the first value if it starts without a dash `-`, otherwise that means the args do not consist any command and an empty string is returned.
 func (args *Args) CommandName() string {
-	name := args.First()
+	var name []string
 
-	if isFlag := strings.HasPrefix(name, "-"); !isFlag && name != "" {
-		return name
+	for _, arg := range args.Slice() {
+		if strings.HasPrefix(arg, "-") {
+			break
+		}
+		name = append(name, arg)
 	}
 
-	return ""
+	return strings.Join(name, " ")
 }

--- a/pkg/cli/args.go
+++ b/pkg/cli/args.go
@@ -92,14 +92,11 @@ func (args *Args) Normalize(acts ...NormalizeActsType) *Args {
 
 // CommandName returns the first value if it starts without a dash `-`, otherwise that means the args do not consist any command and an empty string is returned.
 func (args *Args) CommandName() string {
-	var name []string
+	name := args.First()
 
-	for _, arg := range args.Slice() {
-		if strings.HasPrefix(arg, "-") {
-			break
-		}
-		name = append(name, arg)
+	if !strings.HasPrefix(name, "-") {
+		return name
 	}
 
-	return strings.Join(name, " ")
+	return ""
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5531,7 +5531,6 @@ func TestErrorExplaining(t *testing.T) {
 	stderr := bytes.Buffer{}
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt init -no-color --terragrunt-include-module-prefix --terragrunt-non-interactive --terragrunt-working-dir %s", initTestCase), &stdout, &stderr)
-	fmt.Println(err)
 	explanation := shell.ExplainError(err)
 	assert.Contains(t, explanation, "Check your credentials and permissions")
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1356,7 +1356,6 @@ func TestTerraformSubcommandCliArgs(t *testing.T) {
 		}
 		output := stdout.String()
 		errOutput := stderr.String()
-		fmt.Println(output)
 		assert.True(t, strings.Contains(errOutput, testCase.expected) || strings.Contains(output, testCase.expected))
 	}
 }
@@ -5532,6 +5531,7 @@ func TestErrorExplaining(t *testing.T) {
 	stderr := bytes.Buffer{}
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt init -no-color --terragrunt-include-module-prefix --terragrunt-non-interactive --terragrunt-working-dir %s", initTestCase), &stdout, &stderr)
+	fmt.Println(err)
 	explanation := shell.ExplainError(err)
 	assert.Contains(t, explanation, "Check your credentials and permissions")
 }


### PR DESCRIPTION
## Description

If you specify a misspelled root command, `terragrunt` does not immediately return an error instead will perform various operations, such as `terragrunt init` or initialization of the AWS S3 bucket before returning an error.

## Related Issues

Fixes #438
