### PR TITLE
TFLint configuration loading from hook parameters

### DIFF
--- a/docs/_docs/02_features/hooks.md
+++ b/docs/_docs/02_features/hooks.md
@@ -93,6 +93,7 @@ config {
 
 By default, is executed internal `tflint` which evaluate passed parameters. Any desired extra configuration should be added in the `.tflint.hcl` file. 
 It will work with a `.tflint.hcl` file in the current folder or any parent folder.
+To utilize an alternative configuration file, use the `--config` flag with the path to the configuration file.
 
 If there is a need to run `tflint` from the operating system directly, should be use the extra parameter `--terragrunt-external-tflint`.
 Example:
@@ -100,7 +101,7 @@ Example:
 terraform {
     before_hook "tflint" {
     commands = ["apply", "plan"]
-    execute = ["tflint" , "--terragrunt-external-tflint", "--minimum-failure-severity=error"]
+    execute = ["tflint" , "--terragrunt-external-tflint", "--minimum-failure-severity=error", "--config", "custom.tflint.hcl"]
   }
 }
 ```

--- a/test/fixture-tflint/custom-tflint-config/custom.tflint.hcl
+++ b/test/fixture-tflint/custom-tflint-config/custom.tflint.hcl
@@ -1,0 +1,21 @@
+plugin "terraform" {
+  enabled = true
+  version = "0.2.1"
+  source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.25.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+config {
+  module = true
+}
+
+rule "aws_s3_bucket_name" {
+  enabled = true
+  regex = "my-prefix-.*"
+  prefix = "my-prefix-"
+}

--- a/test/fixture-tflint/custom-tflint-config/main.tf
+++ b/test/fixture-tflint/custom-tflint-config/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.11.0"
+    }
+  }
+  required_version = ">= 1.2.7"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = var.bucket_name
+
+}

--- a/test/fixture-tflint/custom-tflint-config/outputs.tf
+++ b/test/fixture-tflint/custom-tflint-config/outputs.tf
@@ -1,0 +1,4 @@
+output "bucket_name" {
+  description = "bucket name"
+  value       = var.bucket_name
+}

--- a/test/fixture-tflint/custom-tflint-config/terragrunt.hcl
+++ b/test/fixture-tflint/custom-tflint-config/terragrunt.hcl
@@ -1,0 +1,10 @@
+terraform {
+  before_hook "tflint" {
+    commands = ["plan"]
+    execute  = ["tflint", "--terragrunt-external-tflint", "--config", "custom.tflint.hcl"]
+  }
+}
+
+inputs = {
+  bucket_name = "my-prefix-qwe"
+}

--- a/test/fixture-tflint/custom-tflint-config/variables.tf
+++ b/test/fixture-tflint/custom-tflint-config/variables.tf
@@ -1,0 +1,5 @@
+variable "bucket_name" {
+  description = "bucket name"
+  type        = string
+}
+

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -152,6 +152,7 @@ const (
 	TEST_FIXTURE_TFLINT_EXTERNAL_TFLINT                                      = "fixture-tflint/external-tflint"
 	TEST_FIXTURE_TFLINT_TFVAR_PASSING                                        = "fixture-tflint/tfvar-passing"
 	TEST_FIXTURE_TFLINT_ARGS                                                 = "fixture-tflint/tflint-args"
+	TEST_FIXTURE_TFLINT_CUSTOM_CONFIG                                        = "fixture-tflint/custom-tflint-config"
 	TEST_FIXTURE_PARALLEL_RUN                                                = "fixture-parallel-run"
 	TEST_FIXTURE_INIT_ERROR                                                  = "fixture-init-error"
 	TEST_FIXTURE_MODULE_PATH_ERROR                                           = "fixture-module-path-in-error"

--- a/test/integration_tflint_test.go
+++ b/test/integration_tflint_test.go
@@ -157,3 +157,19 @@ func TestTflintArgumentsPassedIn(t *testing.T) {
 	assert.Contains(t, errOut.String(), "--minimum-failure-severity=error")
 	assert.Contains(t, errOut.String(), "Tflint has run successfully. No issues found")
 }
+
+func TestTflintCustomConfig(t *testing.T) {
+	out := new(bytes.Buffer)
+	errOut := new(bytes.Buffer)
+
+	rootPath := copyEnvironmentWithTflint(t, TEST_FIXTURE_TFLINT_CUSTOM_CONFIG)
+	t.Cleanup(func() {
+		removeFolder(t, rootPath)
+	})
+	runPath := util.JoinPath(rootPath, TEST_FIXTURE_TFLINT_CUSTOM_CONFIG)
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-log-level debug --terragrunt-working-dir %s", runPath), out, errOut)
+	assert.NoError(t, err)
+
+	assert.Contains(t, errOut.String(), "--config custom.tflint.hcl")
+	assert.Contains(t, errOut.String(), "Tflint has run successfully. No issues found")
+}

--- a/tflint/tflint.go
+++ b/tflint/tflint.go
@@ -29,11 +29,17 @@ const (
 
 // RunTflintWithOpts runs tflint with the given options and returns an error if there are any issues.
 func RunTflintWithOpts(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig, hook config.Hook) error {
-	configFile, err := findTflintConfigInProject(terragruntOptions)
-	if err != nil {
-		return err
+	// try to fetch configuration file from hook parameters
+	configFile := tflintConfigFilePath(hook.Execute)
+	if configFile == "" {
+		// find .tflint.hcl configuration in project files if it is not provided in arguments
+		projectConfigFile, err := findTflintConfigInProject(terragruntOptions)
+		if err != nil {
+			return err
+		}
+		configFile = projectConfigFile
 	}
-	terragruntOptions.Logger.Debugf("Found .tflint.hcl file in %s", configFile)
+	terragruntOptions.Logger.Debugf("Using .tflint.hcl file in %s", configFile)
 
 	variables, err := inputsToTflintVar(terragruntConfig.Inputs)
 	if err != nil {
@@ -115,6 +121,16 @@ func tflintArguments(arguments []string) ([]string, bool) {
 		filteredArguments = append(filteredArguments, arg)
 	}
 	return filteredArguments, externalTfLint
+}
+
+// configFilePathArgument return configuration file specified in --config argument
+func tflintConfigFilePath(arguments []string) string {
+	for i, arg := range arguments {
+		if arg == "--config" && len(arguments) > i+1 {
+			return arguments[i+1]
+		}
+	}
+	return ""
 }
 
 // inputsToTflintVar converts the inputs map to a list of tflint variables.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Included changes:
* added extraction of the configuration file from "--config" argument in hook
* added test to validate fetching of custom configuration file

Fixes #2678.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated `tflint` hook to handle the passing of custom configuration file through `--config` argument.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

