### PR TITLE
Improved handling of errors from AWS API

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -855,7 +855,10 @@ func isBucketAlreadyOwnedByYouError(err error) bool {
 // isBucketCreationErrorRetriable returns true if the error is temporary and bucket creation can be retried.
 func isBucketCreationErrorRetriable(err error) bool {
 	awsErr, isAwsErr := errors.Unwrap(err).(awserr.Error)
-	return isAwsErr && (awsErr.Code() == "InternalError" || awsErr.Code() == "OperationAborted")
+	if !isAwsErr {
+		return true
+	}
+	return awsErr.Code() == "InternalError" || awsErr.Code() == "OperationAborted" || awsErr.Code() == "InvalidParameter"
 }
 
 // Add a policy to allow root access to the bucket

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -399,11 +399,11 @@ func createS3BucketIfNecessary(s3Client *s3.S3, config *ExtendedRemoteStateConfi
 				if err != nil {
 					if isBucketCreationErrorRetriable(err) {
 						return err
-
 					}
+					// return FatalError so that retry loop will not continue
+					return util.FatalError{Underlying: err}
 				}
-				// return FatalError so that retry loop will not retry
-				return util.FatalError{Underlying: err}
+				return nil
 			})
 		}
 	}

--- a/test/fixture-s3-errors/main.tf
+++ b/test/fixture-s3-errors/main.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/test/fixture-s3-errors/terragrunt.hcl
+++ b/test/fixture-s3-errors/terragrunt.hcl
@@ -1,0 +1,9 @@
+remote_state {
+  backend = "s3"
+  config = {
+    region = "__FILL_IN_REGION__"
+    bucket = "__FILL_IN_BUCKET_NAME__"
+    key = "terraform.tfstate"
+    encrypt = true
+  }
+}

--- a/util/retry.go
+++ b/util/retry.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -20,9 +19,8 @@ func DoWithRetry(actionDescription string, maxRetries int, sleepBetweenRetries t
 			return nil
 		}
 
-		var fatalError FatalError
-		if errors.As(err, &fatalError) {
-			return fatalError
+		if _, isFatalErr := err.(FatalError); isFatalErr {
+			return err
 		}
 
 		logger.Errorf("%s returned an error: %s. Sleeping for %s and will try again.", actionDescription, err.Error(), sleepBetweenRetries)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* Implemented handling of error when state bucket is in a different region
* Added handling of AWS API errors in S3 bucket creation
* Added integration tests to track that AWS S3 errors are handled

Fixes #1312.
Fixes #1595.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Improved handling of AWS S3 errors:
* Handling of errors when the bucket is in a different region
* Logging of underlying S3 API errors

### Migration Guide

N/A

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

