### PR TITLE
feat: disable terraform command validation

### DIFF
--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -39,6 +39,7 @@ const (
 	FlagNameTerragruntIncludeModulePrefix            = "terragrunt-include-module-prefix"
 	FlagNameTerragruntFailOnStateBucketCreation      = "terragrunt-fail-on-state-bucket-creation"
 	FlagNameTerragruntDisableBucketUpdate            = "terragrunt-disable-bucket-update"
+	FlagNameTerragruntDisableCommandValidation       = "terragrunt-disable-command-validation"
 
 	FlagNameHelp    = "help"
 	FlagNameVersion = "version"
@@ -230,6 +231,12 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 			Destination: &opts.DisableBucketUpdate,
 			EnvVar:      "TERRAGRUNT_DISABLE_BUCKET_UPDATE",
 			Usage:       "When this flag is set Terragrunt will not update the remote state bucket.",
+		},
+		&cli.BoolFlag{
+			Name:        FlagNameTerragruntDisableCommandValidation,
+			Destination: &opts.DisableCommandValidation,
+			EnvVar:      "TERRAGRUNT_DISABLE_COMMAND_VALIDATION",
+			Usage:       "When this flag is set, Terragrunt will not validate the terraform command.",
 		},
 	}
 

--- a/cli/commands/terraform/command.go
+++ b/cli/commands/terraform/command.go
@@ -30,7 +30,7 @@ func action(opts *options.TerragruntOptions) func(ctx *cli.Context) error {
 			opts.CheckDependentModules = true
 		}
 
-		if !collections.ListContainsElement(nativeTerraformCommands, opts.TerraformCommand) {
+		if !opts.DisableCommandValidation && !collections.ListContainsElement(nativeTerraformCommands, opts.TerraformCommand) {
 			return errors.WithStackTrace(WrongTerraformCommand(opts.TerraformCommand))
 		}
 

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -546,6 +546,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
 - [terragrunt-include-module-prefix](#terragrunt-include-module-prefix)
 - [terragrunt-fail-on-state-bucket-creation](#terragrunt-fail-on-state-bucket-creation)
 - [terragrunt-disable-bucket-update](#terragrunt-disable-bucket-update)
+- [terragrunt-disable-command-validation](#terragrunt-disable-command-validation)
 
 ### terragrunt-config
 
@@ -1000,3 +1001,10 @@ When this flag is set, Terragrunt will fail and exit if it is necessary to creat
 **Environment Variable**: `TERRAGRUNT_DISABLE_BUCKET_UPDATE` (set to `true`)
 
 When this flag is set, Terragrunt does not update the remote state bucket, which is useful to set if the state bucket is managed by a third party.
+
+### terragrunt-disable-command-validation
+
+**CLI Arg**: `--terragrunt-disable-command-validation`
+**Environment Variable**: `TERRAGRUNT_DISABLE_COMMAND_VALIDATION` (set to `true`)
+
+When this flag is set, Terragrunt will not validate the terraform command, which can be useful when need to use non-existent commands in hooks.

--- a/options/options.go
+++ b/options/options.go
@@ -227,6 +227,9 @@ type TerragruntOptions struct {
 
 	// Controls if s3 bucket should be updated or skipped
 	DisableBucketUpdate bool
+
+	// Disalbes validation terraform command
+	DisableCommandValidation bool
 }
 
 // IAMOptions represents options that are used by Terragrunt to assume an IAM role.

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1296,6 +1296,11 @@ func TestTerraformCommandCliArgs(t *testing.T) {
 			"",
 			terraform.WrongTerraformCommand("paln"),
 		},
+		{
+			[]string{"paln", "--terragrunt-disable-command-validation"},
+			"Terraform invocation failed", // error caused by running terraform with the wrong command
+			nil,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -1309,8 +1314,6 @@ func TestTerraformCommandCliArgs(t *testing.T) {
 		err := runTerragruntCommand(t, cmd, &stdout, &stderr)
 		if testCase.expectedErr != nil {
 			assert.ErrorIs(t, err, testCase.expectedErr)
-		} else {
-			assert.NoError(t, err)
 		}
 
 		output := stdout.String()


### PR DESCRIPTION
## Description

The PR adds a new flag `--terragrunt-disable-command-validation` to disable terraform command validation.

## Related issues

Fixes #2680 .
