### PR TITLE
Terragrunt version in AWS API Calls

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -34,7 +34,7 @@ type AwsSessionConfig struct {
 
 // addUserAgent - Add terragrunt version to the user agent for AWS API calls.
 var addUserAgent = request.NamedHandler{
-	Name: "TerragruntUserAgentHandler",
+	Name: "terragrunt.UserAgentHandler",
 	Fn: request.MakeAddToUserAgentHandler(
 		"terragrunt", version.GetVersion()),
 }

--- a/aws_helper/config_test.go
+++ b/aws_helper/config_test.go
@@ -1,0 +1,30 @@
+package aws_helper
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerragruntIsAddedInUserAgent(t *testing.T) {
+	t.Parallel()
+
+	sess, err := CreateAwsSession(nil, options.NewTerragruntOptions())
+	assert.NoError(t, err)
+
+	op := &request.Operation{
+		Name:       "",
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+	input := &sts.GetCallerIdentityInput{}
+	output := &sts.GetCallerIdentityOutput{}
+
+	r := sts.New(sess).NewRequest(op, input, output)
+	sess.Handlers.Build.Run(r)
+
+	assert.Contains(t, r.HTTPRequest.Header.Get("User-Agent"), "terragrunt")
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* Added session handler which injects Terragrunt version to user agent in AWS API calls
* Added tests to track that user agent is included in requests

Result in AWS Cloud Trail:

![image](https://github.com/gruntwork-io/terragrunt/assets/10694338/b50ad598-193d-4035-9aa6-a7f3bb138ddf)


Fixes #255.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added passing of Terragrunt version in user agent for AWS API calls.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

