### PR TITLE
Fixed `--terragrunt-config` flag

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -8,9 +8,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gruntwork-io/go-commons/collections"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/go-commons/version"
-	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/util"
 	hashicorpversion "github.com/hashicorp/go-version"
 
@@ -152,10 +152,12 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		}
 		opts.DownloadDir = filepath.ToSlash(downloadDir)
 
-		// --- Terragrunt ConfigPath
-		if opts.TerragruntConfigPath == "" {
-			opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
+		// `run-all` command uses the `options.DefaultTerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
+		//  we need to take care that the specified `TerragruntConfigPath` is included in this slice.
+		if confPath := filepath.Base(opts.TerragruntConfigPath); !collections.ListContainsElement(options.DefaultTerragruntConfigPaths, confPath) {
+			options.DefaultTerragruntConfigPaths = append(options.DefaultTerragruntConfigPaths, filepath.Base(opts.TerragruntConfigPath))
 		}
+
 		opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)
 
 		opts.ExcludeDirs, err = util.GlobCanonicalPath(opts.WorkingDir, opts.ExcludeDirs...)

--- a/cli/app.go
+++ b/cli/app.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gruntwork-io/go-commons/collections"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/go-commons/version"
 	"github.com/gruntwork-io/terragrunt/config"
@@ -153,13 +152,15 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		}
 		opts.DownloadDir = filepath.ToSlash(downloadDir)
 
-		// `run-all` command uses the `options.DefaultTerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
-		//  we need to take care that the specified `TerragruntConfigPath` is included in this slice.
-		if confPath := filepath.Base(opts.TerragruntConfigPath); !collections.ListContainsElement(options.DefaultTerragruntConfigPaths, confPath) {
+		// --- Terragrunt ConfigPath
+		if opts.TerragruntConfigPath == options.DefaultTerragruntConfigPath {
+			opts.TerragruntConfigPath = config.GetConfigPath(opts.WorkingDir, opts.TerragruntConfigPath)
+		} else {
+			// `run-all` command uses the `options.DefaultTerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
+			//  we need to take care that the specified `TerragruntConfigPath` is included in this slice.
 			options.DefaultTerragruntConfigPaths = append(options.DefaultTerragruntConfigPaths, filepath.Base(opts.TerragruntConfigPath))
 		}
 
-		opts.TerragruntConfigPath = config.GetConfigPath(opts.WorkingDir, opts.TerragruntConfigPath)
 		opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)
 
 		opts.ExcludeDirs, err = util.GlobCanonicalPath(opts.WorkingDir, opts.ExcludeDirs...)

--- a/cli/app.go
+++ b/cli/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gruntwork-io/go-commons/collections"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/go-commons/version"
+	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/util"
 	hashicorpversion "github.com/hashicorp/go-version"
 
@@ -158,6 +159,7 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 			options.DefaultTerragruntConfigPaths = append(options.DefaultTerragruntConfigPaths, filepath.Base(opts.TerragruntConfigPath))
 		}
 
+		opts.TerragruntConfigPath = config.GetConfigPath(opts.WorkingDir, opts.TerragruntConfigPath)
 		opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)
 
 		opts.ExcludeDirs, err = util.GlobCanonicalPath(opts.WorkingDir, opts.ExcludeDirs...)

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/hclfmt"
 	runall "github.com/gruntwork-io/terragrunt/cli/commands/run-all"
 	"github.com/gruntwork-io/terragrunt/cli/commands/terraform"
-	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/cli"
 	"github.com/gruntwork-io/terragrunt/util"

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -42,110 +42,110 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 	}{
 		{
 			[]string{},
-			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, defaultLogLevel, false),
+			mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
 			[]string{"foo", "bar"},
-			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"foo", "bar"}, false, "", false, false, defaultLogLevel, false),
+			mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{"foo", "bar"}, false, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
 			[]string{"--foo", "--bar"},
-			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"-foo", "-bar"}, false, "", false, false, defaultLogLevel, false),
+			mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{"-foo", "-bar"}, false, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
 			[]string{"--foo", "apply", "--bar"},
-			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"-foo", "apply", "-bar"}, false, "", false, false, defaultLogLevel, false),
+			mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{"-foo", "apply", "-bar"}, false, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntNonInteractive)},
-			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, true, "", false, false, defaultLogLevel, false),
+			mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, true, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntIncludeExternalDependencies)},
-			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, true, defaultLogLevel, false),
+			mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, true, defaultLogLevel, false),
 			nil,
 		},
 
 		{
-			[]string{doubleDashed(commands.FlagNameTerragruntConfig), fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath)},
-			mockOptions(t, fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, defaultLogLevel, false),
+			[]string{doubleDashed(commands.FlagNameTerragruntConfig), fmt.Sprintf("/some/path/%s", options.DefaultTerragruntConfigPath)},
+			mockOptions(t, fmt.Sprintf("/some/path/%s", options.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntWorkingDir), "/some/path"},
-			mockOptions(t, util.JoinPath("/some/path", config.DefaultTerragruntConfigPath), "/some/path", []string{}, false, "", false, false, defaultLogLevel, false),
+			mockOptions(t, util.JoinPath("/some/path", options.DefaultTerragruntConfigPath), "/some/path", []string{}, false, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntSource), "/some/path"},
-			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "/some/path", false, false, defaultLogLevel, false),
+			mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, false, "/some/path", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntSourceMap), "git::git@github.com:one/gw-terraform-aws-vpc.git=git::git@github.com:two/test.git?ref=FEATURE"},
-			mockOptionsWithSourceMap(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, map[string]string{"git::git@github.com:one/gw-terraform-aws-vpc.git": "git::git@github.com:two/test.git?ref=FEATURE"}),
+			mockOptionsWithSourceMap(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, map[string]string{"git::git@github.com:one/gw-terraform-aws-vpc.git": "git::git@github.com:two/test.git?ref=FEATURE"}),
 			nil,
 		},
 
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntIgnoreDependencyErrors)},
-			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", true, false, defaultLogLevel, false),
+			mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", true, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntIgnoreExternalDependencies)},
-			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, defaultLogLevel, false),
+			mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntIAMRole), "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"},
-			mockOptionsWithIamRole(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"),
+			mockOptionsWithIamRole(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"),
 			nil,
 		},
 
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntIAMAssumeRoleDuration), "36000"},
-			mockOptionsWithIamAssumeRoleDuration(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, 36000),
+			mockOptionsWithIamAssumeRoleDuration(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, 36000),
 			nil,
 		},
 
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntIAMAssumeRoleSessionName), "terragrunt-iam-role-session-name"},
-			mockOptionsWithIamAssumeRoleSessionName(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, "terragrunt-iam-role-session-name"),
+			mockOptionsWithIamAssumeRoleSessionName(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, "terragrunt-iam-role-session-name"),
 			nil,
 		},
 
 		{
-			[]string{doubleDashed(commands.FlagNameTerragruntConfig), fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), "--terragrunt-non-interactive"},
-			mockOptions(t, fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), workingDir, []string{}, true, "", false, false, defaultLogLevel, false),
+			[]string{doubleDashed(commands.FlagNameTerragruntConfig), fmt.Sprintf("/some/path/%s", options.DefaultTerragruntConfigPath), "--terragrunt-non-interactive"},
+			mockOptions(t, fmt.Sprintf("/some/path/%s", options.DefaultTerragruntConfigPath), workingDir, []string{}, true, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
-			[]string{"--foo", doubleDashed(commands.FlagNameTerragruntConfig), fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), "bar", doubleDashed(commands.FlagNameTerragruntNonInteractive), "--baz", doubleDashed(commands.FlagNameTerragruntWorkingDir), "/some/path", doubleDashed(commands.FlagNameTerragruntSource), "github.com/foo/bar//baz?ref=1.0.3"},
-			mockOptions(t, fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), "/some/path", []string{"-foo", "bar", "-baz"}, true, "github.com/foo/bar//baz?ref=1.0.3", false, false, defaultLogLevel, false),
+			[]string{"--foo", doubleDashed(commands.FlagNameTerragruntConfig), fmt.Sprintf("/some/path/%s", options.DefaultTerragruntConfigPath), "bar", doubleDashed(commands.FlagNameTerragruntNonInteractive), "--baz", doubleDashed(commands.FlagNameTerragruntWorkingDir), "/some/path", doubleDashed(commands.FlagNameTerragruntSource), "github.com/foo/bar//baz?ref=1.0.3"},
+			mockOptions(t, fmt.Sprintf("/some/path/%s", options.DefaultTerragruntConfigPath), "/some/path", []string{"-foo", "bar", "-baz"}, true, "github.com/foo/bar//baz?ref=1.0.3", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		// Adding the --terragrunt-log-level flag should result in DebugLevel configured
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntLogLevel), "debug"},
-			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, logrus.DebugLevel, false),
+			mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, logrus.DebugLevel, false),
 			nil,
 		},
 		{
@@ -167,7 +167,7 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		},
 		{
 			[]string{doubleDashed(commands.FlagNameTerragruntDebug)},
-			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, defaultLogLevel, true),
+			mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, defaultLogLevel, true),
 			nil,
 		},
 	}
@@ -261,10 +261,10 @@ func TestFilterTerragruntArgs(t *testing.T) {
 	}{
 		{[]string{}, []string{}},
 		{[]string{"foo", "--bar"}, []string{"foo", "-bar"}},
-		{[]string{"foo", doubleDashed(commands.FlagNameTerragruntConfig), fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath)}, []string{"foo"}},
+		{[]string{"foo", doubleDashed(commands.FlagNameTerragruntConfig), fmt.Sprintf("/some/path/%s", options.DefaultTerragruntConfigPath)}, []string{"foo"}},
 		{[]string{"foo", doubleDashed(commands.FlagNameTerragruntNonInteractive)}, []string{"foo"}},
 		{[]string{"foo", doubleDashed(commands.FlagNameTerragruntDebug)}, []string{"foo"}},
-		{[]string{"foo", doubleDashed(commands.FlagNameTerragruntNonInteractive), "-bar", doubleDashed(commands.FlagNameTerragruntWorkingDir), "/some/path", "--baz", doubleDashed(commands.FlagNameTerragruntConfig), fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath)}, []string{"foo", "-bar", "-baz"}},
+		{[]string{"foo", doubleDashed(commands.FlagNameTerragruntNonInteractive), "-bar", doubleDashed(commands.FlagNameTerragruntWorkingDir), "/some/path", "--baz", doubleDashed(commands.FlagNameTerragruntConfig), fmt.Sprintf("/some/path/%s", options.DefaultTerragruntConfigPath)}, []string{"foo", "-bar", "-baz"}},
 		{[]string{CommandNameApplyAll, "foo", "bar"}, []string{terraform.CommandNameApply, "foo", "bar"}},
 		{[]string{CommandNameDestroyAll, "foo", "-foo", "--bar"}, []string{terraform.CommandNameDestroy, "foo", "-foo", "-bar"}},
 	}

--- a/cli/commands/terraform/action_test.go
+++ b/cli/commands/terraform/action_test.go
@@ -436,7 +436,7 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 var defaultLogLevel = util.GetDefaultLogLevel()
 
 func mockCmdOptions(t *testing.T, workingDir string, terraformCliArgs []string) *options.TerragruntOptions {
-	o := mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, terraformCliArgs, true, "", false, false, defaultLogLevel, false)
+	o := mockOptions(t, util.JoinPath(workingDir, options.DefaultTerragruntConfigPath), workingDir, terraformCliArgs, true, "", false, false, defaultLogLevel, false)
 	return o
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -539,10 +539,8 @@ func GetConfigPath(workingDir string, configPaths ...string) string {
 	var configPath string
 
 	for _, configPath = range configPaths {
-		if !filepath.IsAbs(configPath) {
-			configPath = util.JoinPath(workingDir, configPath)
-		}
-		if !util.FileNotExists(configPath) {
+		configPath = util.JoinPath(workingDir, configPath)
+		if util.FileExists(configPath) {
 			break
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -537,7 +537,9 @@ func adjustSourceWithMap(sourceMap map[string]string, source string, modulePath 
 // GetConfigPath returns the path to use for the Terragrunt configuration that exists within the path giving preference to `terragrunt.hcl`
 func GetConfigPath(workingDir string, configPaths ...string) string {
 	for _, configPath := range configPaths {
-		configPath = util.JoinPath(workingDir, configPath)
+		if !filepath.IsAbs(configPath) {
+			configPath = util.JoinPath(workingDir, configPath)
+		}
 		if !util.FileNotExists(configPath) {
 			return configPath
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -536,16 +536,18 @@ func adjustSourceWithMap(sourceMap map[string]string, source string, modulePath 
 
 // GetConfigPath returns the path to use for the Terragrunt configuration that exists within the path giving preference to `terragrunt.hcl`
 func GetConfigPath(workingDir string, configPaths ...string) string {
-	for _, configPath := range configPaths {
+	var configPath string
+
+	for _, configPath = range configPaths {
 		if !filepath.IsAbs(configPath) {
 			configPath = util.JoinPath(workingDir, configPath)
 		}
 		if !util.FileNotExists(configPath) {
-			return configPath
+			break
 		}
 	}
 
-	return ""
+	return configPath
 }
 
 // Returns a list of all Terragrunt config files in the given path or any subfolder of the path. A file is a Terragrunt

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -392,7 +392,7 @@ func findInParentFolders(
 
 	previousDir = filepath.ToSlash(previousDir)
 
-	fileToFindStr := DefaultTerragruntConfigPath
+	fileToFindStr := options.DefaultTerragruntConfigPath
 	if fileToFindParam != "" {
 		fileToFindStr = fileToFindParam
 	}
@@ -408,7 +408,7 @@ func findInParentFolders(
 			return "", errors.WithStackTrace(ParentFileNotFound{Path: terragruntOptions.TerragruntConfigPath, File: fileToFindStr, Cause: "Traversed all the way to the root"})
 		}
 
-		fileToFind := GetDefaultConfigPath(currentDir)
+		fileToFind := GetConfigPath(currentDir, options.DefaultTerragruntConfigPaths...)
 		if fileToFindParam != "" {
 			fileToFind = util.JoinPath(currentDir, fileToFindParam)
 		}
@@ -591,7 +591,7 @@ func getCleanedTargetConfigPath(configPath string, workingPath string) string {
 		targetConfig = util.JoinPath(cwd, targetConfig)
 	}
 	if util.IsDir(targetConfig) {
-		targetConfig = GetDefaultConfigPath(targetConfig)
+		targetConfig = GetConfigPath(targetConfig, options.DefaultTerragruntConfigPaths...)
 	}
 	return util.CleanPath(targetConfig)
 }

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -26,52 +26,52 @@ func TestPathRelativeToInclude(t *testing.T) {
 		{
 			nil,
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+options.DefaultTerragruntConfigPath),
 			".",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+options.DefaultTerragruntConfigPath),
 			"child",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+options.DefaultTerragruntConfigPath),
 			"child",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../../../" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../../../" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+options.DefaultTerragruntConfigPath),
 			"child/sub-child/sub-sub-child",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+options.DefaultTerragruntConfigPath),
 			"child/sub-child/sub-sub-child",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../../other-child/" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../../other-child/" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/"+options.DefaultTerragruntConfigPath),
 			"../child/sub-child",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../../" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../../" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, "../child/sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../child/sub-child/"+options.DefaultTerragruntConfigPath),
 			"child/sub-child",
 		},
 		{
 			map[string]IncludeConfig{
-				"root":  IncludeConfig{Path: "../../" + DefaultTerragruntConfigPath},
-				"child": IncludeConfig{Path: "../../other-child/" + DefaultTerragruntConfigPath},
+				"root":  IncludeConfig{Path: "../../" + options.DefaultTerragruntConfigPath},
+				"child": IncludeConfig{Path: "../../other-child/" + options.DefaultTerragruntConfigPath},
 			},
 			[]string{"child"},
-			terragruntOptionsForTest(t, "../child/sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../child/sub-child/"+options.DefaultTerragruntConfigPath),
 			"../child/sub-child",
 		},
 	}
@@ -96,52 +96,52 @@ func TestPathRelativeFromInclude(t *testing.T) {
 		{
 			nil,
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+options.DefaultTerragruntConfigPath),
 			".",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+options.DefaultTerragruntConfigPath),
 			"..",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+options.DefaultTerragruntConfigPath),
 			"..",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../../../" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../../../" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+options.DefaultTerragruntConfigPath),
 			"../../..",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+options.DefaultTerragruntConfigPath),
 			"../../..",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../../other-child/" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../../other-child/" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/"+options.DefaultTerragruntConfigPath),
 			"../../other-child",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../../" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../../" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, "../child/sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../child/sub-child/"+options.DefaultTerragruntConfigPath),
 			"../..",
 		},
 		{
 			map[string]IncludeConfig{
-				"root":  IncludeConfig{Path: "../../" + DefaultTerragruntConfigPath},
-				"child": IncludeConfig{Path: "../../other-child/" + DefaultTerragruntConfigPath},
+				"root":  IncludeConfig{Path: "../../" + options.DefaultTerragruntConfigPath},
+				"child": IncludeConfig{Path: "../../other-child/" + options.DefaultTerragruntConfigPath},
 			},
 			[]string{"child"},
-			terragruntOptionsForTest(t, "../child/sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../child/sub-child/"+options.DefaultTerragruntConfigPath),
 			"../../other-child",
 		},
 	}
@@ -245,43 +245,43 @@ func TestFindInParentFolders(t *testing.T) {
 	}{
 		{
 			nil,
-			terragruntOptionsForTest(t, "../test/fixture-parent-folders/terragrunt-in-root/child/"+DefaultTerragruntConfigPath),
-			absPath(t, "../test/fixture-parent-folders/terragrunt-in-root/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../test/fixture-parent-folders/terragrunt-in-root/child/"+options.DefaultTerragruntConfigPath),
+			absPath(t, "../test/fixture-parent-folders/terragrunt-in-root/"+options.DefaultTerragruntConfigPath),
 			nil,
 		},
 		{
 			nil,
-			terragruntOptionsForTest(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath),
-			absPath(t, "../test/fixture-parent-folders/terragrunt-in-root/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/"+options.DefaultTerragruntConfigPath),
+			absPath(t, "../test/fixture-parent-folders/terragrunt-in-root/"+options.DefaultTerragruntConfigPath),
 			nil,
 		},
 		{
 			nil,
-			terragruntOptionsForTestWithMaxFolders(t, "../test/fixture-parent-folders/no-terragrunt-in-root/child/sub-child/"+DefaultTerragruntConfigPath, 3),
+			terragruntOptionsForTestWithMaxFolders(t, "../test/fixture-parent-folders/no-terragrunt-in-root/child/sub-child/"+options.DefaultTerragruntConfigPath, 3),
 			"",
 			ParentFileNotFound{},
 		},
 		{
 			nil,
-			terragruntOptionsForTest(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+DefaultTerragruntConfigPath),
-			absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+options.DefaultTerragruntConfigPath),
+			absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/"+options.DefaultTerragruntConfigPath),
 			nil,
 		},
 		{
 			nil,
-			terragruntOptionsForTest(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+DefaultTerragruntConfigPath),
-			absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+options.DefaultTerragruntConfigPath),
+			absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+options.DefaultTerragruntConfigPath),
 			nil,
 		},
 		{
 			nil,
-			terragruntOptionsForTest(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath),
-			absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/sub-sub-child/"+options.DefaultTerragruntConfigPath),
+			absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+options.DefaultTerragruntConfigPath),
 			nil,
 		},
 		{
 			[]string{"foo.txt"},
-			terragruntOptionsForTest(t, "../test/fixture-parent-folders/other-file-names/child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../test/fixture-parent-folders/other-file-names/child/"+options.DefaultTerragruntConfigPath),
 			absPath(t, "../test/fixture-parent-folders/other-file-names/foo.txt"),
 			nil,
 		},
@@ -333,35 +333,35 @@ func TestResolveTerragruntInterpolation(t *testing.T) {
 		{
 			"terraform { source = path_relative_to_include() }",
 			nil,
-			terragruntOptionsForTest(t, "/root/child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "/root/child/"+options.DefaultTerragruntConfigPath),
 			".",
 			"",
 		},
 		{
 			"terraform { source = path_relative_to_include() }",
-			&IncludeConfig{Path: "../" + DefaultTerragruntConfigPath},
-			terragruntOptionsForTest(t, "/root/child/"+DefaultTerragruntConfigPath),
+			&IncludeConfig{Path: "../" + options.DefaultTerragruntConfigPath},
+			terragruntOptionsForTest(t, "/root/child/"+options.DefaultTerragruntConfigPath),
 			"child",
 			"",
 		},
 		{
 			"terraform { source = find_in_parent_folders() }",
 			nil,
-			terragruntOptionsForTest(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/"+DefaultTerragruntConfigPath),
-			absPath(t, "../test/fixture-parent-folders/terragrunt-in-root/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/"+options.DefaultTerragruntConfigPath),
+			absPath(t, "../test/fixture-parent-folders/terragrunt-in-root/"+options.DefaultTerragruntConfigPath),
 			"",
 		},
 		{
 			"terraform { source = find_in_parent_folders() }",
 			nil,
-			terragruntOptionsForTestWithMaxFolders(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/"+DefaultTerragruntConfigPath, 1),
+			terragruntOptionsForTestWithMaxFolders(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/"+options.DefaultTerragruntConfigPath, 1),
 			"",
 			"ParentFileNotFound",
 		},
 		{
 			"terraform { source = find_in_parent_folders() }",
 			nil,
-			terragruntOptionsForTestWithMaxFolders(t, "../test/fixture-parent-folders/no-terragrunt-in-root/child/sub-child/"+DefaultTerragruntConfigPath, 3),
+			terragruntOptionsForTestWithMaxFolders(t, "../test/fixture-parent-folders/no-terragrunt-in-root/child/sub-child/"+options.DefaultTerragruntConfigPath, 3),
 			"",
 			"ParentFileNotFound",
 		},
@@ -400,63 +400,63 @@ func TestResolveEnvInterpolationConfigString(t *testing.T) {
 		{
 			`iam_role = "foo/${get_env()}/bar"`,
 			nil,
-			terragruntOptionsForTest(t, "/root/child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "/root/child/"+options.DefaultTerragruntConfigPath),
 			"",
 			"InvalidGetEnvParams",
 		},
 		{
 			`iam_role = "foo/${get_env("","")}/bar"`,
 			nil,
-			terragruntOptionsForTest(t, "/root/child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "/root/child/"+options.DefaultTerragruntConfigPath),
 			"",
 			"InvalidEnvParamName",
 		},
 		{
 			`iam_role = get_env()`,
 			nil,
-			terragruntOptionsForTest(t, "/root/child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "/root/child/"+options.DefaultTerragruntConfigPath),
 			"",
 			"InvalidGetEnvParams",
 		},
 		{
 			`iam_role = get_env("TEST_VAR_1", "TEST_VAR_2", "TEST_VAR_3")`,
 			nil,
-			terragruntOptionsForTest(t, "/root/child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "/root/child/"+options.DefaultTerragruntConfigPath),
 			"",
 			"InvalidGetEnvParams",
 		},
 		{
 			`iam_role = get_env("TEST_ENV_TERRAGRUNT_VAR")`,
 			nil,
-			terragruntOptionsForTestWithEnv(t, "/root/child/"+DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_VAR": "SOMETHING"}),
+			terragruntOptionsForTestWithEnv(t, "/root/child/"+options.DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_VAR": "SOMETHING"}),
 			"SOMETHING",
 			"",
 		},
 		{
 			`iam_role = get_env("SOME_VAR", "SOME_VALUE")`,
 			nil,
-			terragruntOptionsForTest(t, "/root/child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "/root/child/"+options.DefaultTerragruntConfigPath),
 			"SOME_VALUE",
 			"",
 		},
 		{
 			`iam_role = "foo/${get_env("TEST_ENV_TERRAGRUNT_HIT","")}/bar"`,
 			nil,
-			terragruntOptionsForTestWithEnv(t, "/root/child/"+DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_OTHER": "SOMETHING"}),
+			terragruntOptionsForTestWithEnv(t, "/root/child/"+options.DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_OTHER": "SOMETHING"}),
 			"foo//bar",
 			"",
 		},
 		{
 			`iam_role = "foo/${get_env("TEST_ENV_TERRAGRUNT_HIT","DEFAULT")}/bar"`,
 			nil,
-			terragruntOptionsForTestWithEnv(t, "/root/child/"+DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_OTHER": "SOMETHING"}),
+			terragruntOptionsForTestWithEnv(t, "/root/child/"+options.DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_OTHER": "SOMETHING"}),
 			"foo/DEFAULT/bar",
 			"",
 		},
 		{
 			`iam_role = "foo/${get_env("TEST_ENV_TERRAGRUNT_VAR")}/bar"`,
 			nil,
-			terragruntOptionsForTestWithEnv(t, "/root/child/"+DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_VAR": "SOMETHING"}),
+			terragruntOptionsForTestWithEnv(t, "/root/child/"+options.DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_VAR": "SOMETHING"}),
 			"foo/SOMETHING/bar",
 			"",
 		},
@@ -491,19 +491,19 @@ func TestResolveCommandsInterpolationConfigString(t *testing.T) {
 		{
 			"inputs = { foo = get_terraform_commands_that_need_locking() }",
 			nil,
-			terragruntOptionsForTest(t, DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, options.DefaultTerragruntConfigPath),
 			TERRAFORM_COMMANDS_NEED_LOCKING,
 		},
 		{
 			`inputs = { foo = get_terraform_commands_that_need_vars() }`,
 			nil,
-			terragruntOptionsForTest(t, DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, options.DefaultTerragruntConfigPath),
 			TERRAFORM_COMMANDS_NEED_VARS,
 		},
 		{
 			"inputs = { foo = get_terraform_commands_that_need_parallelism() }",
 			nil,
-			terragruntOptionsForTest(t, DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, options.DefaultTerragruntConfigPath),
 			TERRAFORM_COMMANDS_NEED_PARALLELISM,
 		},
 	}
@@ -536,7 +536,7 @@ func TestResolveCliArgsInterpolationConfigString(t *testing.T) {
 	t.Parallel()
 
 	for _, cliArgs := range [][]string{nil, {}, {"apply"}, {"plan", "-out=planfile"}} {
-		opts := terragruntOptionsForTest(t, DefaultTerragruntConfigPath)
+		opts := terragruntOptionsForTest(t, options.DefaultTerragruntConfigPath)
 		opts.TerraformCliArgs = cliArgs
 		expectedFooInput := cliArgs
 		// Expecting nil to be returned for get_terraform_cli_args() call for
@@ -650,52 +650,52 @@ func TestGetParentTerragruntDir(t *testing.T) {
 		{
 			nil,
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+options.DefaultTerragruntConfigPath),
 			helpers.RootFolder + "child",
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+options.DefaultTerragruntConfigPath),
 			helpers.RootFolder,
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/"+options.DefaultTerragruntConfigPath),
 			helpers.RootFolder,
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../../../" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../../../" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+options.DefaultTerragruntConfigPath),
 			helpers.RootFolder,
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: helpers.RootFolder + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/sub-sub-child/"+options.DefaultTerragruntConfigPath),
 			helpers.RootFolder,
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../../other-child/" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../../other-child/" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/"+options.DefaultTerragruntConfigPath),
 			fmt.Sprintf("%s/other-child", filepath.VolumeName(parentDir)),
 		},
 		{
-			map[string]IncludeConfig{"": IncludeConfig{Path: "../../" + DefaultTerragruntConfigPath}},
+			map[string]IncludeConfig{"": IncludeConfig{Path: "../../" + options.DefaultTerragruntConfigPath}},
 			nil,
-			terragruntOptionsForTest(t, "../child/sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, "../child/sub-child/"+options.DefaultTerragruntConfigPath),
 			parentDir,
 		},
 		{
 			map[string]IncludeConfig{
-				"root":  IncludeConfig{Path: "../../" + DefaultTerragruntConfigPath},
-				"child": IncludeConfig{Path: "../../other-child/" + DefaultTerragruntConfigPath},
+				"root":  IncludeConfig{Path: "../../" + options.DefaultTerragruntConfigPath},
+				"child": IncludeConfig{Path: "../../other-child/" + options.DefaultTerragruntConfigPath},
 			},
 			[]string{"child"},
-			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/"+DefaultTerragruntConfigPath),
+			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/"+options.DefaultTerragruntConfigPath),
 			fmt.Sprintf("%s/other-child", filepath.VolumeName(parentDir)),
 		},
 	}
@@ -752,7 +752,7 @@ func TestTerraformBuiltInFunctions(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.input, func(t *testing.T) {
 
-			terragruntOptions := terragruntOptionsForTest(t, "../test/fixture-config-terraform-functions/"+DefaultTerragruntConfigPath)
+			terragruntOptions := terragruntOptionsForTest(t, "../test/fixture-config-terraform-functions/"+options.DefaultTerragruntConfigPath)
 			actual, err := ParseConfigString(fmt.Sprintf("inputs = { test = %s }", testCase.input), terragruntOptions, nil, terragruntOptions.TerragruntConfigPath, nil)
 			require.NoError(t, err, "For hcl '%s' include %v and options %v, unexpected error: %v", testCase.input, nil, terragruntOptions, err)
 
@@ -823,7 +823,7 @@ func TestTerraformOutputJsonToCtyValueMap(t *testing.T) {
 		},
 	}
 
-	mockTargetConfig := DefaultTerragruntConfigPath
+	mockTargetConfig := options.DefaultTerragruntConfigPath
 	for _, testCase := range testCases {
 		converted, err := terraformOutputJsonToCtyValueMap(mockTargetConfig, []byte(testCase.input))
 		assert.NoError(t, err)
@@ -837,7 +837,7 @@ func TestTerraformOutputJsonToCtyValueMap(t *testing.T) {
 func TestReadTerragruntConfigInputs(t *testing.T) {
 	t.Parallel()
 
-	options := terragruntOptionsForTest(t, DefaultTerragruntConfigPath)
+	options := terragruntOptionsForTest(t, options.DefaultTerragruntConfigPath)
 	tgConfigCty, err := readTerragruntConfig("../test/fixture-inputs/terragrunt.hcl", nil, options)
 	require.NoError(t, err)
 
@@ -878,7 +878,7 @@ func TestReadTerragruntConfigInputs(t *testing.T) {
 func TestReadTerragruntConfigRemoteState(t *testing.T) {
 	t.Parallel()
 
-	options := terragruntOptionsForTest(t, DefaultTerragruntConfigPath)
+	options := terragruntOptionsForTest(t, options.DefaultTerragruntConfigPath)
 	tgConfigCty, err := readTerragruntConfig("../test/fixture/terragrunt.hcl", nil, options)
 	require.NoError(t, err)
 
@@ -910,7 +910,7 @@ func TestReadTerragruntConfigRemoteState(t *testing.T) {
 func TestReadTerragruntConfigHooks(t *testing.T) {
 	t.Parallel()
 
-	options := terragruntOptionsForTest(t, DefaultTerragruntConfigPath)
+	options := terragruntOptionsForTest(t, options.DefaultTerragruntConfigPath)
 	tgConfigCty, err := readTerragruntConfig("../test/fixture-hooks/before-after-and-on-error/terragrunt.hcl", nil, options)
 	require.NoError(t, err)
 
@@ -952,7 +952,7 @@ func TestReadTerragruntConfigHooks(t *testing.T) {
 func TestReadTerragruntConfigLocals(t *testing.T) {
 	t.Parallel()
 
-	options := terragruntOptionsForTest(t, DefaultTerragruntConfigPath)
+	options := terragruntOptionsForTest(t, options.DefaultTerragruntConfigPath)
 	tgConfigCty, err := readTerragruntConfig("../test/fixture-locals/canonical/terragrunt.hcl", nil, options)
 	require.NoError(t, err)
 

--- a/config/config_partial_test.go
+++ b/config/config_partial_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +21,7 @@ dependencies {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -48,10 +49,10 @@ dependencies {
 prevent_destroy = false
 `
 
-	_, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{TerragruntFlags})
+	_, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{TerragruntFlags})
 	assert.NoError(t, err)
 
-	_, err = PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock})
+	_, err = PartialParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock})
 	assert.Error(t, err)
 }
 
@@ -67,7 +68,7 @@ prevent_destroy = true
 skip = true
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, TerragruntFlags})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, TerragruntFlags})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -87,7 +88,7 @@ skip = true
 func TestPartialParseOmittedItems(t *testing.T) {
 	t.Parallel()
 
-	terragruntConfig, err := PartialParseConfigString("", mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, TerragruntFlags})
+	terragruntConfig, err := PartialParseConfigString("", mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, TerragruntFlags})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 	assert.Nil(t, terragruntConfig.Dependencies)
@@ -102,7 +103,7 @@ func TestPartialParseOmittedItems(t *testing.T) {
 func TestPartialParseDoesNotResolveIgnoredBlockEvenInParent(t *testing.T) {
 	t.Parallel()
 
-	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-partial-parse/ignore-bad-block-in-parent/child/"+DefaultTerragruntConfigPath)
+	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-partial-parse/ignore-bad-block-in-parent/child/"+options.DefaultTerragruntConfigPath)
 	_, err := PartialParseConfigFile(opts.TerragruntConfigPath, opts, nil, []PartialDecodeSectionType{TerragruntFlags})
 	assert.NoError(t, err)
 
@@ -113,7 +114,7 @@ func TestPartialParseDoesNotResolveIgnoredBlockEvenInParent(t *testing.T) {
 func TestPartialParseOnlyInheritsSelectedBlocksFlags(t *testing.T) {
 	t.Parallel()
 
-	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-partial-parse/partial-inheritance/child/"+DefaultTerragruntConfigPath)
+	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-partial-parse/partial-inheritance/child/"+options.DefaultTerragruntConfigPath)
 	terragruntConfig, err := PartialParseConfigFile(opts.TerragruntConfigPath, opts, nil, []PartialDecodeSectionType{TerragruntFlags})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
@@ -129,7 +130,7 @@ func TestPartialParseOnlyInheritsSelectedBlocksFlags(t *testing.T) {
 func TestPartialParseOnlyInheritsSelectedBlocksDependencies(t *testing.T) {
 	t.Parallel()
 
-	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-partial-parse/partial-inheritance/child/"+DefaultTerragruntConfigPath)
+	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-partial-parse/partial-inheritance/child/"+options.DefaultTerragruntConfigPath)
 	terragruntConfig, err := PartialParseConfigFile(opts.TerragruntConfigPath, opts, nil, []PartialDecodeSectionType{DependenciesBlock})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
@@ -155,7 +156,7 @@ dependency "vpc" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -178,7 +179,7 @@ dependency "sql" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -203,7 +204,7 @@ dependency "sql" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -229,7 +230,7 @@ dependency "sql" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, DependencyBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependenciesBlock, DependencyBlock})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -255,7 +256,7 @@ dependency "sql" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock, DependenciesBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock, DependenciesBlock})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -281,7 +282,7 @@ dependency "sql" {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock, DependenciesBlock})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{DependencyBlock, DependenciesBlock})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -307,7 +308,7 @@ terraform {
 }
 `
 
-	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, []PartialDecodeSectionType{TerraformSource})
+	terragruntConfig, err := PartialParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, []PartialDecodeSectionType{TerraformSource})
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ remote_state {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.Terraform)
@@ -46,7 +46,7 @@ remote_state = {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.Terraform)
@@ -71,7 +71,7 @@ func TestParseTerragruntJsonConfigRemoteStateMinimalConfig(t *testing.T) {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntJsonConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntJsonConfigPath, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.Terraform)
@@ -91,7 +91,7 @@ func TestParseTerragruntHclConfigRemoteStateMissingBackend(t *testing.T) {
 remote_state {}
 `
 
-	_, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	_, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Missing required argument; The argument \"backend\" is required")
 }
@@ -111,7 +111,7 @@ remote_state {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +147,7 @@ func TestParseTerragruntJsonConfigRemoteStateFullConfig(t *testing.T) {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntJsonConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntJsonConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ retryable_errors = [
     "Another one of my errors"
 ]
 `
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.Terraform)
@@ -204,7 +204,7 @@ func TestParseTerragruntJsonConfigRetryConfiguration(t *testing.T) {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntJsonConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntJsonConfigPath, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.Terraform)
@@ -223,7 +223,7 @@ func TestParseIamRole(t *testing.T) {
 
 	config := `iam_role = "terragrunt-iam-role"`
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +241,7 @@ func TestParseIamAssumeRoleDuration(t *testing.T) {
 
 	config := `iam_assume_role_duration = 36000`
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +259,7 @@ func TestParseIamAssumeRoleSessionName(t *testing.T) {
 
 	config := `iam_assume_role_session_name = "terragrunt-iam-assume-role-session-name"`
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +281,7 @@ dependencies {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -306,7 +306,7 @@ dependencies {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -344,7 +344,7 @@ dependencies {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestParseTerragruntJsonConfigRemoteStateDynamoDbTerraformConfigAndDependenc
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntJsonConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntJsonConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,10 +425,10 @@ func TestParseTerragruntConfigInclude(t *testing.T) {
 include {
 	path = "../../../%s"
 }
-`, DefaultTerragruntConfigPath)
+`, options.DefaultTerragruntConfigPath)
 
 	opts := options.TerragruntOptions{
-		TerragruntConfigPath: "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/" + DefaultTerragruntConfigPath,
+		TerragruntConfigPath: "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/" + options.DefaultTerragruntConfigPath,
 		NonInteractive:       true,
 		Logger:               util.CreateLogEntry("", util.GetDefaultLogLevel()),
 	}
@@ -458,7 +458,7 @@ include {
 }
 `
 
-	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath)
+	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/"+options.DefaultTerragruntConfigPath)
 
 	terragruntConfig, err := ParseConfigString(config, opts, nil, opts.TerragruntConfigPath, nil)
 	if assert.Nil(t, err, "Unexpected error: %v", errors.PrintErrorWithStackTrace(err)) {
@@ -495,9 +495,9 @@ remote_state {
 		region = "override"
 	}
 }
-`, DefaultTerragruntConfigPath)
+`, options.DefaultTerragruntConfigPath)
 
-	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath)
+	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/"+options.DefaultTerragruntConfigPath)
 
 	terragruntConfig, err := ParseConfigString(config, opts, nil, opts.TerragruntConfigPath, nil)
 	if assert.Nil(t, err, "Unexpected error: %v", errors.PrintErrorWithStackTrace(err)) {
@@ -542,9 +542,9 @@ remote_state {
 dependencies {
 	paths = ["override"]
 }
-`, DefaultTerragruntConfigPath)
+`, options.DefaultTerragruntConfigPath)
 
-	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/"+DefaultTerragruntConfigPath)
+	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/"+options.DefaultTerragruntConfigPath)
 
 	terragruntConfig, err := ParseConfigString(config, opts, nil, opts.TerragruntConfigPath, nil)
 	require.NoError(t, err, "Unexpected error: %v", errors.PrintErrorWithStackTrace(err))
@@ -590,9 +590,9 @@ func TestParseTerragruntJsonConfigIncludeOverrideAll(t *testing.T) {
 		"paths": ["override"]
 	}
 }
-`, DefaultTerragruntConfigPath)
+`, options.DefaultTerragruntConfigPath)
 
-	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/"+DefaultTerragruntJsonConfigPath)
+	opts := mockOptionsForTestWithConfigPath(t, "../test/fixture-parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/"+options.DefaultTerragruntJsonConfigPath)
 
 	terragruntConfig, err := ParseConfigString(config, opts, nil, opts.TerragruntConfigPath, nil)
 	require.NoError(t, err, "Unexpected error: %v", errors.PrintErrorWithStackTrace(err))
@@ -616,7 +616,7 @@ func TestParseTerragruntJsonConfigIncludeOverrideAll(t *testing.T) {
 func TestParseTerragruntConfigTwoLevels(t *testing.T) {
 	t.Parallel()
 
-	configPath := "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/" + DefaultTerragruntConfigPath
+	configPath := "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/" + options.DefaultTerragruntConfigPath
 
 	config, err := util.ReadFileAsString(configPath)
 	if err != nil {
@@ -628,8 +628,8 @@ func TestParseTerragruntConfigTwoLevels(t *testing.T) {
 	_, actualErr := ParseConfigString(config, opts, nil, configPath, nil)
 	expectedErr := TooManyLevelsOfInheritance{
 		ConfigPath:             configPath,
-		FirstLevelIncludePath:  absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+DefaultTerragruntConfigPath),
-		SecondLevelIncludePath: absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+DefaultTerragruntConfigPath),
+		FirstLevelIncludePath:  absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+options.DefaultTerragruntConfigPath),
+		SecondLevelIncludePath: absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/"+options.DefaultTerragruntConfigPath),
 	}
 	assert.True(t, errors.IsError(actualErr, expectedErr), "Expected error %v but got %v", expectedErr, actualErr)
 }
@@ -637,7 +637,7 @@ func TestParseTerragruntConfigTwoLevels(t *testing.T) {
 func TestParseTerragruntConfigThreeLevels(t *testing.T) {
 	t.Parallel()
 
-	configPath := "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/sub-sub-child/" + DefaultTerragruntConfigPath
+	configPath := "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/sub-sub-child/" + options.DefaultTerragruntConfigPath
 
 	config, err := util.ReadFileAsString(configPath)
 	if err != nil {
@@ -649,8 +649,8 @@ func TestParseTerragruntConfigThreeLevels(t *testing.T) {
 	_, actualErr := ParseConfigString(config, opts, nil, configPath, nil)
 	expectedErr := TooManyLevelsOfInheritance{
 		ConfigPath:             configPath,
-		FirstLevelIncludePath:  absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+DefaultTerragruntConfigPath),
-		SecondLevelIncludePath: absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+DefaultTerragruntConfigPath),
+		FirstLevelIncludePath:  absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+options.DefaultTerragruntConfigPath),
+		SecondLevelIncludePath: absPath(t, "../test/fixture-parent-folders/multiple-terragrunt-in-parents/child/sub-child/"+options.DefaultTerragruntConfigPath),
 	}
 	assert.True(t, errors.IsError(actualErr, expectedErr), "Expected error %v but got %v", expectedErr, actualErr)
 }
@@ -660,7 +660,7 @@ func TestParseTerragruntConfigEmptyConfig(t *testing.T) {
 
 	config := ``
 
-	cfg, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	cfg, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	assert.NoError(t, err)
 
 	assert.Nil(t, cfg.Terraform)
@@ -679,7 +679,7 @@ func TestParseTerragruntConfigEmptyConfigOldConfig(t *testing.T) {
 
 	config := ``
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -694,7 +694,7 @@ func TestParseTerragruntConfigTerraformNoSource(t *testing.T) {
 terraform {}
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -715,7 +715,7 @@ terraform {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -746,7 +746,7 @@ terraform {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -805,7 +805,7 @@ terraform {
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.RemoteState)
@@ -861,7 +861,7 @@ func TestParseTerragruntJsonConfigTerraformWithMultipleExtraArguments(t *testing
 }
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntJsonConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntJsonConfigPath, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.RemoteState)
@@ -1102,7 +1102,7 @@ func TestParseTerragruntConfigPreventDestroyTrue(t *testing.T) {
 prevent_destroy = true
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1120,7 +1120,7 @@ func TestParseTerragruntConfigPreventDestroyFalse(t *testing.T) {
 prevent_destroy = false
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1138,7 +1138,7 @@ func TestParseTerragruntConfigSkipTrue(t *testing.T) {
 skip = true
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1156,7 +1156,7 @@ func TestParseTerragruntConfigSkipFalse(t *testing.T) {
 skip = false
 `
 
-	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, mockOptionsForTest(t), nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1177,13 +1177,13 @@ terraform {
 }
 `
 	opts := options.TerragruntOptions{
-		TerragruntConfigPath: "../test/fixture-parent-folders/terragrunt-in-root/child/" + DefaultTerragruntConfigPath,
+		TerragruntConfigPath: "../test/fixture-parent-folders/terragrunt-in-root/child/" + options.DefaultTerragruntConfigPath,
 		NonInteractive:       true,
 		MaxFoldersToCheck:    5,
 		Logger:               util.CreateLogEntry("", util.GetDefaultLogLevel()),
 	}
 
-	terragruntConfig, err := ParseConfigString(config, &opts, nil, DefaultTerragruntConfigPath, nil)
+	terragruntConfig, err := ParseConfigString(config, &opts, nil, options.DefaultTerragruntConfigPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -185,7 +185,7 @@ func dependencyBlocksToModuleDependencies(decodedDependencyBlocks []Dependency) 
 	paths := []string{}
 	for _, decodedDependencyBlock := range decodedDependencyBlocks {
 		configPath := decodedDependencyBlock.ConfigPath
-		if util.IsFile(configPath) && filepath.Base(configPath) == DefaultTerragruntConfigPath {
+		if util.IsFile(configPath) && filepath.Base(configPath) == options.DefaultTerragruntConfigPath {
 			// dependencies system expects the directory containing the terragrunt.hcl file
 			configPath = filepath.Dir(configPath)
 		}

--- a/config/dependency_test.go
+++ b/config/dependency_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ dependency "sql" {
   config_path = "../sql"
 }
 `
-	filename := DefaultTerragruntConfigPath
+	filename := options.DefaultTerragruntConfigPath
 	parser := hclparse.NewParser()
 	file, err := parseHcl(parser, config, filename)
 	require.NoError(t, err)
@@ -44,7 +45,7 @@ locals {
   path = "../vpc"
 }
 `
-	filename := DefaultTerragruntConfigPath
+	filename := options.DefaultTerragruntConfigPath
 	parser := hclparse.NewParser()
 	file, err := parseHcl(parser, config, filename)
 	require.NoError(t, err)
@@ -62,7 +63,7 @@ dependency {
   config_path = "../vpc"
 }
 `
-	filename := DefaultTerragruntConfigPath
+	filename := options.DefaultTerragruntConfigPath
 	parser := hclparse.NewParser()
 	file, err := parseHcl(parser, config, filename)
 	require.NoError(t, err)
@@ -83,7 +84,7 @@ dependency "hitchhiker" {
   mock_outputs_allowed_terraform_commands = ["validate", "apply"]
 }
 `
-	filename := DefaultTerragruntConfigPath
+	filename := options.DefaultTerragruntConfigPath
 	parser := hclparse.NewParser()
 	file, err := parseHcl(parser, config, filename)
 	require.NoError(t, err)

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -394,7 +394,7 @@ func resolveExternalDependenciesForModule(module *TerraformModule, moduleMap map
 			return map[string]*TerraformModule{}, err
 		}
 
-		terragruntConfigPath := config.GetDefaultConfigPath(dependencyPath)
+		terragruntConfigPath := config.GetConfigPath(dependencyPath, options.DefaultTerragruntConfigPaths...)
 		if _, alreadyContainsModule := moduleMap[dependencyPath]; !alreadyContainsModule {
 			externalTerragruntConfigPaths = append(externalTerragruntConfigPaths, terragruntConfigPath)
 		}

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -36,10 +36,10 @@ func TestResolveTerraformModulesOneModuleNoDependencies(t *testing.T) {
 		Path:              canonical(t, "../test/fixture-modules/module-a"),
 		Dependencies:      []*TerraformModule{},
 		Config:            config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: ptr("test")}, IsPartial: true},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleA}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -54,10 +54,10 @@ func TestResolveTerraformModulesOneJsonModuleNoDependencies(t *testing.T) {
 		Path:              canonical(t, "../test/fixture-modules/json-module-a"),
 		Dependencies:      []*TerraformModule{},
 		Config:            config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: ptr("test")}, IsPartial: true},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-a/"+config.DefaultTerragruntJsonConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-a/"+options.DefaultTerragruntJsonConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/json-module-a/" + config.DefaultTerragruntJsonConfigPath}
+	configPaths := []string{"../test/fixture-modules/json-module-a/" + options.DefaultTerragruntJsonConfigPath}
 	expected := []*TerraformModule{moduleA}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -78,10 +78,10 @@ func TestResolveTerraformModulesOneModuleWithIncludesNoDependencies(t *testing.T
 				"": {Path: canonical(t, "../test/fixture-modules/module-b/terragrunt.hcl")},
 			},
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-b/module-b-child/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-b/module-b-child/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-b/module-b-child/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-b/module-b-child/" + options.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleB}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -93,10 +93,10 @@ func TestResolveTerraformModulesReadConfigFromParentConfig(t *testing.T) {
 	t.Parallel()
 
 	childDir := "../test/fixture-modules/module-m/module-m-child"
-	childConfigPath := filepath.Join(childDir, config.DefaultTerragruntConfigPath)
+	childConfigPath := filepath.Join(childDir, options.DefaultTerragruntConfigPath)
 
 	parentDir := "../test/fixture-modules/module-m"
-	parentCofnigPath := filepath.Join(parentDir, config.DefaultTerragruntConfigPath)
+	parentCofnigPath := filepath.Join(parentDir, options.DefaultTerragruntConfigPath)
 
 	localsConfigPaths := map[string]string{
 		"env_vars":  "../test/fixture-modules/module-m/env.hcl",
@@ -176,10 +176,10 @@ func TestResolveTerraformModulesOneJsonModuleWithIncludesNoDependencies(t *testi
 				"": {Path: canonical(t, "../test/fixture-modules/json-module-b/terragrunt.hcl")},
 			},
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-b/module-b-child/"+config.DefaultTerragruntJsonConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-b/module-b-child/"+options.DefaultTerragruntJsonConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/json-module-b/module-b-child/" + config.DefaultTerragruntJsonConfigPath}
+	configPaths := []string{"../test/fixture-modules/json-module-b/module-b-child/" + options.DefaultTerragruntJsonConfigPath}
 	expected := []*TerraformModule{moduleB}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -200,10 +200,10 @@ func TestResolveTerraformModulesOneHclModuleWithIncludesNoDependencies(t *testin
 				"": {Path: canonical(t, "../test/fixture-modules/hcl-module-b/terragrunt.hcl.json")},
 			},
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/hcl-module-b/module-b-child/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/hcl-module-b/module-b-child/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/hcl-module-b/module-b-child/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/hcl-module-b/module-b-child/" + options.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleB}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -221,7 +221,7 @@ func TestResolveTerraformModulesTwoModulesWithDependencies(t *testing.T) {
 			Terraform: &config.TerraformConfig{Source: ptr("test")},
 			IsPartial: true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
@@ -232,10 +232,10 @@ func TestResolveTerraformModulesTwoModulesWithDependencies(t *testing.T) {
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-c/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-c/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + options.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleA, moduleC}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -253,7 +253,7 @@ func TestResolveTerraformModulesJsonModulesWithHclDependencies(t *testing.T) {
 			Terraform: &config.TerraformConfig{Source: ptr("test")},
 			IsPartial: true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
@@ -264,10 +264,10 @@ func TestResolveTerraformModulesJsonModulesWithHclDependencies(t *testing.T) {
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-c/"+config.DefaultTerragruntJsonConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-c/"+options.DefaultTerragruntJsonConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/json-module-c/" + config.DefaultTerragruntJsonConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/json-module-c/" + options.DefaultTerragruntJsonConfigPath}
 	expected := []*TerraformModule{moduleA, moduleC}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -285,7 +285,7 @@ func TestResolveTerraformModulesHclModulesWithJsonDependencies(t *testing.T) {
 			Terraform: &config.TerraformConfig{Source: ptr("test")},
 			IsPartial: true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-a/"+config.DefaultTerragruntJsonConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-a/"+options.DefaultTerragruntJsonConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
@@ -296,10 +296,10 @@ func TestResolveTerraformModulesHclModulesWithJsonDependencies(t *testing.T) {
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/hcl-module-c/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/hcl-module-c/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/json-module-a/" + config.DefaultTerragruntJsonConfigPath, "../test/fixture-modules/hcl-module-c/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/json-module-a/" + options.DefaultTerragruntJsonConfigPath, "../test/fixture-modules/hcl-module-c/" + options.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleA, moduleC}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -316,7 +316,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 	moduleA := &TerraformModule{
 		Path:              canonical(t, "../test/fixture-modules/module-a"),
 		Dependencies:      []*TerraformModule{},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
@@ -327,10 +327,10 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + options.DefaultTerragruntConfigPath}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
@@ -351,7 +351,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 	moduleA := &TerraformModule{
 		Path:              canonical(t, "../test/fixture-modules/module-a"),
 		Dependencies:      []*TerraformModule{},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
@@ -362,7 +362,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleAbba := &TerraformModule{
@@ -373,10 +373,10 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-abba/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-abba/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-abba/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-abba/" + options.DefaultTerragruntConfigPath}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
@@ -397,7 +397,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 	moduleA := &TerraformModule{
 		Path:              canonical(t, "../test/fixture-modules/module-a"),
 		Dependencies:      []*TerraformModule{},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
@@ -408,16 +408,16 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithDepend
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleAbba := &TerraformModule{
 		Path:              canonical(t, "../test/fixture-modules/module-abba"),
 		Dependencies:      []*TerraformModule{},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-abba/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-abba/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-abba/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-abba/" + options.DefaultTerragruntConfigPath}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 	// construct the expected list
@@ -442,15 +442,15 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesExcludedDirsWithNoDepe
 			Terraform: &config.TerraformConfig{Source: ptr("test")},
 			IsPartial: true,
 		},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
 		Path:              canonical(t, "../test/fixture-modules/module-c"),
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + options.DefaultTerragruntConfigPath}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
@@ -475,7 +475,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithDepend
 			Terraform: &config.TerraformConfig{Source: ptr("test")},
 			IsPartial: true,
 		},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
@@ -486,10 +486,10 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithDepend
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + options.DefaultTerragruntConfigPath}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
@@ -514,7 +514,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithNoDepe
 			Terraform: &config.TerraformConfig{Source: ptr("test")},
 			IsPartial: true,
 		},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
@@ -525,10 +525,10 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithNoDepe
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + options.DefaultTerragruntConfigPath}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
@@ -554,7 +554,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithDepend
 			Terraform: &config.TerraformConfig{Source: ptr("test")},
 			IsPartial: true,
 		},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
@@ -565,17 +565,17 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithDepend
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: opts.Clone(canonical(t, "../test/fixture-modules/module-c/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleF := &TerraformModule{
 		Path:                 canonical(t, "../test/fixture-modules/module-f"),
 		Dependencies:         []*TerraformModule{},
-		TerragruntOptions:    mockOptions.Clone(canonical(t, "../test/fixture-modules/module-f/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions:    mockOptions.Clone(canonical(t, "../test/fixture-modules/module-f/"+options.DefaultTerragruntConfigPath)),
 		AssumeAlreadyApplied: false,
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-f/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-f/" + options.DefaultTerragruntConfigPath}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, opts, nil, mockHowThesePathsWereFound)
 
@@ -594,7 +594,7 @@ func TestResolveTerraformModulesMultipleModulesWithDependencies(t *testing.T) {
 		Path:              canonical(t, "../test/fixture-modules/module-a"),
 		Dependencies:      []*TerraformModule{},
 		Config:            config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: ptr("test")}, IsPartial: true},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleB := &TerraformModule{
@@ -607,7 +607,7 @@ func TestResolveTerraformModulesMultipleModulesWithDependencies(t *testing.T) {
 				"": {Path: canonical(t, "../test/fixture-modules/module-b/terragrunt.hcl")},
 			},
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-b/module-b-child/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-b/module-b-child/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
@@ -618,7 +618,7 @@ func TestResolveTerraformModulesMultipleModulesWithDependencies(t *testing.T) {
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-c/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-c/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleD := &TerraformModule{
@@ -628,10 +628,10 @@ func TestResolveTerraformModulesMultipleModulesWithDependencies(t *testing.T) {
 			Dependencies: &config.ModuleDependencies{Paths: []string{"../module-a", "../module-b/module-b-child", "../module-c"}},
 			IsPartial:    true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-d/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-d/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-b/module-b-child/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-d/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-b/module-b-child/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-c/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-d/" + options.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleA, moduleB, moduleC, moduleD}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -646,7 +646,7 @@ func TestResolveTerraformModulesMultipleModulesWithMixedDependencies(t *testing.
 		Path:              canonical(t, "../test/fixture-modules/module-a"),
 		Dependencies:      []*TerraformModule{},
 		Config:            config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: ptr("test")}, IsPartial: true},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleB := &TerraformModule{
@@ -659,7 +659,7 @@ func TestResolveTerraformModulesMultipleModulesWithMixedDependencies(t *testing.
 				"": {Path: canonical(t, "../test/fixture-modules/json-module-b/terragrunt.hcl")},
 			},
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-b/module-b-child/"+config.DefaultTerragruntJsonConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-b/module-b-child/"+options.DefaultTerragruntJsonConfigPath)),
 	}
 
 	moduleC := &TerraformModule{
@@ -670,7 +670,7 @@ func TestResolveTerraformModulesMultipleModulesWithMixedDependencies(t *testing.
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-c/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-c/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleD := &TerraformModule{
@@ -680,10 +680,10 @@ func TestResolveTerraformModulesMultipleModulesWithMixedDependencies(t *testing.
 			Dependencies: &config.ModuleDependencies{Paths: []string{"../module-a", "../json-module-b/module-b-child", "../module-c"}},
 			IsPartial:    true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-d/"+config.DefaultTerragruntJsonConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/json-module-d/"+options.DefaultTerragruntJsonConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/json-module-b/module-b-child/" + config.DefaultTerragruntJsonConfigPath, "../test/fixture-modules/module-c/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/json-module-d/" + config.DefaultTerragruntJsonConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/json-module-b/module-b-child/" + options.DefaultTerragruntJsonConfigPath, "../test/fixture-modules/module-c/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/json-module-d/" + options.DefaultTerragruntJsonConfigPath}
 	expected := []*TerraformModule{moduleA, moduleB, moduleC, moduleD}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -698,7 +698,7 @@ func TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes(t *t
 		Path:              canonical(t, "../test/fixture-modules/module-a"),
 		Dependencies:      []*TerraformModule{},
 		Config:            config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: ptr("test")}, IsPartial: true},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-a/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleB := &TerraformModule{
@@ -711,7 +711,7 @@ func TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes(t *t
 				"": {Path: canonical(t, "../test/fixture-modules/module-b/terragrunt.hcl")},
 			},
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-b/module-b-child/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-b/module-b-child/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleE := &TerraformModule{
@@ -725,10 +725,10 @@ func TestResolveTerraformModulesMultipleModulesWithDependenciesWithIncludes(t *t
 				"": {Path: canonical(t, "../test/fixture-modules/module-e/terragrunt.hcl")},
 			},
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-e/module-e-child/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-e/module-e-child/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-a/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-b/module-b-child/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-e/module-e-child/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-a/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-b/module-b-child/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-e/module-e-child/" + options.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleA, moduleB, moduleE}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -743,7 +743,7 @@ func TestResolveTerraformModulesMultipleModulesWithExternalDependencies(t *testi
 		Path:                 canonical(t, "../test/fixture-modules/module-f"),
 		Dependencies:         []*TerraformModule{},
 		Config:               config.TerragruntConfig{IsPartial: true},
-		TerragruntOptions:    mockOptions.Clone(canonical(t, "../test/fixture-modules/module-f/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions:    mockOptions.Clone(canonical(t, "../test/fixture-modules/module-f/"+options.DefaultTerragruntConfigPath)),
 		AssumeAlreadyApplied: true,
 	}
 
@@ -755,10 +755,10 @@ func TestResolveTerraformModulesMultipleModulesWithExternalDependencies(t *testi
 			Terraform:    &config.TerraformConfig{Source: ptr("test")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-g/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-g/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-g/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-g/" + options.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleF, moduleG}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -773,7 +773,7 @@ func TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies(t 
 		Path:                 canonical(t, "../test/fixture-modules/module-h"),
 		Dependencies:         []*TerraformModule{},
 		Config:               config.TerragruntConfig{IsPartial: true},
-		TerragruntOptions:    mockOptions.Clone(canonical(t, "../test/fixture-modules/module-h/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions:    mockOptions.Clone(canonical(t, "../test/fixture-modules/module-h/"+options.DefaultTerragruntConfigPath)),
 		AssumeAlreadyApplied: true,
 	}
 
@@ -784,7 +784,7 @@ func TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies(t 
 			Dependencies: &config.ModuleDependencies{Paths: []string{"../module-h"}},
 			IsPartial:    true,
 		},
-		TerragruntOptions:    mockOptions.Clone(canonical(t, "../test/fixture-modules/module-i/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions:    mockOptions.Clone(canonical(t, "../test/fixture-modules/module-i/"+options.DefaultTerragruntConfigPath)),
 		AssumeAlreadyApplied: true,
 	}
 
@@ -796,7 +796,7 @@ func TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies(t 
 			Terraform:    &config.TerraformConfig{Source: ptr("temp")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-j/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-j/"+options.DefaultTerragruntConfigPath)),
 	}
 
 	moduleK := &TerraformModule{
@@ -807,10 +807,10 @@ func TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies(t 
 			Terraform:    &config.TerraformConfig{Source: ptr("fire")},
 			IsPartial:    true,
 		},
-		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-k/"+config.DefaultTerragruntConfigPath)),
+		TerragruntOptions: mockOptions.Clone(canonical(t, "../test/fixture-modules/module-k/"+options.DefaultTerragruntConfigPath)),
 	}
 
-	configPaths := []string{"../test/fixture-modules/module-j/" + config.DefaultTerragruntConfigPath, "../test/fixture-modules/module-k/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-j/" + options.DefaultTerragruntConfigPath, "../test/fixture-modules/module-k/" + options.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{moduleH, moduleI, moduleJ, moduleK}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
@@ -821,7 +821,7 @@ func TestResolveTerraformModulesMultipleModulesWithNestedExternalDependencies(t 
 func TestResolveTerraformModulesInvalidPaths(t *testing.T) {
 	t.Parallel()
 
-	configPaths := []string{"../test/fixture-modules/module-missing-dependency/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-missing-dependency/" + options.DefaultTerragruntConfigPath}
 
 	_, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)
 	require.Error(t, actualErr)
@@ -836,7 +836,7 @@ func TestResolveTerraformModulesInvalidPaths(t *testing.T) {
 func TestResolveTerraformModuleNoTerraformConfig(t *testing.T) {
 	t.Parallel()
 
-	configPaths := []string{"../test/fixture-modules/module-l/" + config.DefaultTerragruntConfigPath}
+	configPaths := []string{"../test/fixture-modules/module-l/" + options.DefaultTerragruntConfigPath}
 	expected := []*TerraformModule{}
 
 	actualModules, actualErr := ResolveTerraformModules(configPaths, mockOptions, nil, mockHowThesePathsWereFound)

--- a/configstack/stack_test.go
+++ b/configstack/stack_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/stretchr/testify/assert"
@@ -18,11 +17,11 @@ func TestFindStackInSubfolders(t *testing.T) {
 	t.Parallel()
 
 	filePaths := []string{
-		"/stage/data-stores/redis/" + config.DefaultTerragruntConfigPath,
-		"/stage/data-stores/postgres/" + config.DefaultTerragruntConfigPath,
-		"/stage/ecs-cluster/" + config.DefaultTerragruntConfigPath,
-		"/stage/kms-master-key/" + config.DefaultTerragruntConfigPath,
-		"/stage/vpc/" + config.DefaultTerragruntConfigPath,
+		"/stage/data-stores/redis/" + options.DefaultTerragruntConfigPath,
+		"/stage/data-stores/postgres/" + options.DefaultTerragruntConfigPath,
+		"/stage/ecs-cluster/" + options.DefaultTerragruntConfigPath,
+		"/stage/kms-master-key/" + options.DefaultTerragruntConfigPath,
+		"/stage/vpc/" + options.DefaultTerragruntConfigPath,
 	}
 
 	tempFolder := createTempFolder(t)
@@ -43,7 +42,7 @@ func TestFindStackInSubfolders(t *testing.T) {
 
 	for _, module := range stack.Modules {
 		relPath := strings.Replace(module.Path, tempFolder, "", 1)
-		relPath = filepath.ToSlash(util.JoinPath(relPath, config.DefaultTerragruntConfigPath))
+		relPath = filepath.ToSlash(util.JoinPath(relPath, options.DefaultTerragruntConfigPath))
 
 		modulePaths = append(modulePaths, relPath)
 	}

--- a/options/options.go
+++ b/options/options.go
@@ -15,13 +15,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var TERRAFORM_COMMANDS_WITH_SUBCOMMAND = []string{
-	"debug",
-	"force-unlock",
-	"state",
-}
-
 const (
+	ContextKey ctxKey = iota
+
 	DefaultMaxFoldersToCheck = 100
 
 	// no limits on parallelism by default (limited by GOPROCS)
@@ -36,9 +32,23 @@ const (
 	DefaultTFDataDir = ".terraform"
 
 	DefaultIAMAssumeRoleDuration = 3600
+
+	DefaultTerragruntConfigPath     = "terragrunt.hcl"
+	DefaultTerragruntJsonConfigPath = "terragrunt.hcl.json"
 )
 
-const ContextKey ctxKey = iota
+var (
+	TERRAFORM_COMMANDS_WITH_SUBCOMMAND = []string{
+		"debug",
+		"force-unlock",
+		"state",
+	}
+
+	DefaultTerragruntConfigPaths = []string{
+		DefaultTerragruntConfigPath,
+		DefaultTerragruntJsonConfigPath,
+	}
+)
 
 type ctxKey byte
 
@@ -265,6 +275,7 @@ func MergeIAMRoleOptions(target IAMRoleOptions, source IAMRoleOptions) IAMRoleOp
 // Create a new TerragruntOptions object with reasonable defaults for real usage
 func NewTerragruntOptions() *TerragruntOptions {
 	return &TerragruntOptions{
+		TerragruntConfigPath:           DefaultTerragruntConfigPath,
 		TerraformPath:                  TerraformDefaultPath,
 		OriginalTerraformCommand:       "",
 		TerraformCommand:               "",

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/terragrunt/cli/commands/terraform"
-	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/options"
 	tfsource "github.com/gruntwork-io/terragrunt/terraform"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/stretchr/testify/assert"

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -106,7 +106,7 @@ func TestLocalWithBackend(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, "fixture-download")
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureLocalWithBackend)
 
-	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(rootPath, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, "not-used")
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
@@ -124,7 +124,7 @@ func TestLocalWithMissingBackend(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, "fixture-download")
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureLocalMissingBackend)
 
-	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(rootPath, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, "not-used")
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), os.Stdout, os.Stderr)
@@ -179,7 +179,7 @@ func TestRemoteWithBackend(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, testFixtureRemoteWithBackend)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureRemoteWithBackend)
 
-	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(rootPath, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, "not-used")
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -70,7 +70,7 @@ func TestTerragruntWorksWithIncludeShallowMerge(t *testing.T) {
 	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfigWithParentAndChild(t, includeFixturePath, includeShallowFixturePath, s3BucketName, config.DefaultTerragruntConfigPath, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfigWithParentAndChild(t, includeFixturePath, includeShallowFixturePath, s3BucketName, options.DefaultTerragruntConfigPath, options.DefaultTerragruntConfigPath)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, childPath))
 	validateIncludeRemoteStateReflection(t, s3BucketName, includeShallowFixturePath, tmpTerragruntConfigPath, childPath)
@@ -85,7 +85,7 @@ func TestTerragruntWorksWithIncludeNoMerge(t *testing.T) {
 	// We deliberately pick an s3 bucket name that is invalid, as we don't expect to create this s3 bucket.
 	s3BucketName := "__INVALID_NAME__"
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfigWithParentAndChild(t, includeFixturePath, includeNoMergeFixturePath, s3BucketName, config.DefaultTerragruntConfigPath, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfigWithParentAndChild(t, includeFixturePath, includeNoMergeFixturePath, s3BucketName, options.DefaultTerragruntConfigPath, options.DefaultTerragruntConfigPath)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, childPath))
 	validateIncludeRemoteStateReflection(t, s3BucketName, includeNoMergeFixturePath, tmpTerragruntConfigPath, childPath)

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/test/integration_s3_encryption_test.go
+++ b/test/integration_s3_encryption_test.go
@@ -9,11 +9,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/gruntwork-io/terragrunt/options"
 	terraws "github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/gruntwork-io/terragrunt/config"
 )
 
 const (

--- a/test/integration_s3_encryption_test.go
+++ b/test/integration_s3_encryption_test.go
@@ -33,7 +33,7 @@ func TestTerragruntS3SSEAES(t *testing.T) {
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, s3SSEAESFixturePath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, s3SSEAESFixturePath, s3BucketName, lockTableName, options.DefaultTerragruntConfigPath)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, s3SSEAESFixturePath))
 
@@ -58,7 +58,7 @@ func TestTerragruntS3SSECustomKey(t *testing.T) {
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, s3SSECustomKeyFixturePath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, s3SSECustomKeyFixturePath, s3BucketName, lockTableName, options.DefaultTerragruntConfigPath)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, s3SSECustomKeyFixturePath))
 
@@ -87,7 +87,7 @@ func TestTerragruntS3SSEKeyNotReverted(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, s3SSBasicEncryptionFixturePath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, s3SSBasicEncryptionFixturePath, s3BucketName, lockTableName, options.DefaultTerragruntConfigPath)
 	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", filepath.Dir(tmpTerragruntConfigPath)), &stdout, &stderr)
 	output := stderr.String()
 
@@ -96,7 +96,7 @@ func TestTerragruntS3SSEKeyNotReverted(t *testing.T) {
 
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
-	tmpTerragruntConfigPath = createTmpTerragruntConfig(t, s3SSBasicEncryptionFixturePath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath = createTmpTerragruntConfig(t, s3SSBasicEncryptionFixturePath, s3BucketName, lockTableName, options.DefaultTerragruntConfigPath)
 	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", filepath.Dir(tmpTerragruntConfigPath)), &stdout, &stderr)
 	output = stderr.String()
 	assert.NotContains(t, output, "Bucket Server-Side Encryption")

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -122,7 +122,7 @@ func TestTerragruntCorrectlyMirrorsTerraformGCPAuth(t *testing.T) {
 
 	defer deleteGCSBucket(t, gcsBucketName)
 
-	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_PATH, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_PATH, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, options.DefaultTerragruntConfigPath)
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntGCSConfigPath, TEST_FIXTURE_GCS_PATH))
 
 	var expectedGCSLabels = map[string]string{
@@ -369,7 +369,7 @@ func TestTerragruntWorksWithImpersonateGCSBackend(t *testing.T) {
 	gcsBucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
 
 	// run with impersonation
-	tmpTerragruntImpersonateGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_IMPERSONATE_PATH, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntImpersonateGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_IMPERSONATE_PATH, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, options.DefaultTerragruntConfigPath)
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntImpersonateGCSConfigPath, TEST_FIXTURE_GCS_IMPERSONATE_PATH))
 
 	var expectedGCSLabels = map[string]string{

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	terragruntinfo "github.com/gruntwork-io/terragrunt/cli/commands/terragrunt-info"
-	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
 )
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -218,7 +218,7 @@ func TestTerragruntInitHookNoSourceWithBackend(t *testing.T) {
 
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 
-	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(rootPath, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", TERRAFORM_REMOTE_STATE_S3_REGION)
 
 	var (
@@ -273,7 +273,7 @@ func TestTerragruntInitHookWithSourceWithBackend(t *testing.T) {
 
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 
-	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(rootPath, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", TERRAFORM_REMOTE_STATE_S3_REGION)
 
 	var (
@@ -406,7 +406,7 @@ func TestTerragruntBeforeAfterAndErrorMergeHook(t *testing.T) {
 	t.Logf("bucketName: %s", s3BucketName)
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfigWithParentAndChild(t, TEST_FIXTURE_HOOKS_BEFORE_AFTER_AND_ERROR_MERGE_PATH, qaMyAppRelPath, s3BucketName, config.DefaultTerragruntConfigPath, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfigWithParentAndChild(t, TEST_FIXTURE_HOOKS_BEFORE_AFTER_AND_ERROR_MERGE_PATH, qaMyAppRelPath, s3BucketName, options.DefaultTerragruntConfigPath, options.DefaultTerragruntConfigPath)
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
@@ -590,7 +590,7 @@ func TestTerragruntWorksWithLocalTerraformVersion(t *testing.T) {
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, TEST_FIXTURE_PATH, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, TEST_FIXTURE_PATH, s3BucketName, lockTableName, options.DefaultTerragruntConfigPath)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, TEST_FIXTURE_PATH))
 
@@ -720,7 +720,7 @@ func TestTerragruntWorksWithGCSBackend(t *testing.T) {
 
 	defer deleteGCSBucket(t, gcsBucketName)
 
-	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_PATH, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_PATH, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, options.DefaultTerragruntConfigPath)
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntGCSConfigPath, TEST_FIXTURE_GCS_PATH))
 
 	var expectedGCSLabels = map[string]string{
@@ -744,7 +744,7 @@ func TestTerragruntWorksWithExistingGCSBucket(t *testing.T) {
 	location := TERRAFORM_REMOTE_STATE_GCP_REGION
 	createGCSBucket(t, project, location, gcsBucketName)
 
-	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_BYO_BUCKET_PATH, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_BYO_BUCKET_PATH, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, options.DefaultTerragruntConfigPath)
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntGCSConfigPath, TEST_FIXTURE_GCS_BYO_BUCKET_PATH))
 
 	validateGCSBucketExistsAndIsLabeled(t, location, gcsBucketName, nil)
@@ -792,7 +792,7 @@ func TestTerragruntGraphDependenciesCommand(t *testing.T) {
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_GRAPH_DEPENDENCIES)
 
-	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_GRAPH_DEPENDENCIES, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_GRAPH_DEPENDENCIES, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", "not-used")
 
 	environmentPath := fmt.Sprintf("%s/%s/root", tmpEnvPath, TEST_FIXTURE_GRAPH_DEPENDENCIES)
@@ -829,7 +829,7 @@ func TestTerragruntRunAllCommand(t *testing.T) {
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_ALL)
 
-	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", "not-used")
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL)
@@ -845,7 +845,7 @@ func TestTerragruntOutputAllCommand(t *testing.T) {
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_ALL)
 
-	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", "not-used")
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL)
@@ -875,7 +875,7 @@ func TestTerragruntOutputFromDependency(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY)
 
 	rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY)
-	depTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency", config.DefaultTerragruntConfigPath)
+	depTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency", options.DefaultTerragruntConfigPath)
 
 	copyTerragruntConfigAndFillPlaceholders(t, depTerragruntConfigPath, depTerragruntConfigPath, s3BucketName, "not-used", TERRAFORM_REMOTE_STATE_S3_REGION)
 
@@ -901,7 +901,7 @@ func TestTerragruntValidateAllCommand(t *testing.T) {
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_ALL)
 
-	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", "not-used")
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL)
@@ -933,7 +933,7 @@ func TestTerragruntOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *tes
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_ALL)
 
-	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", "not-used")
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL)
@@ -980,7 +980,7 @@ func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules
 		}
 	}
 
-	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", "not-used")
 
 	environmentPath := fmt.Sprintf("%s", tmpEnvPath)
@@ -1017,7 +1017,7 @@ func TestTerragruntStackCommands(t *testing.T) {
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_STACK)
 
-	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, "fixture-stack", config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, "fixture-stack", options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, "not-used")
 
 	mgmtEnvironmentPath := fmt.Sprintf("%s/fixture-stack/mgmt", tmpEnvPath)
@@ -1935,7 +1935,7 @@ func dependencyOutputOptimizationTest(t *testing.T, moduleName string, forceInit
 	cleanupTerraformFolder(t, TEST_FIXTURE_GET_OUTPUT)
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_GET_OUTPUT)
 	rootPath := filepath.Join(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, moduleName)
-	rootTerragruntConfigPath := filepath.Join(rootPath, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := filepath.Join(rootPath, options.DefaultTerragruntConfigPath)
 	livePath := filepath.Join(rootPath, "live")
 	deepDepPath := filepath.Join(rootPath, "deepdep")
 	depPath := filepath.Join(rootPath, "dep")
@@ -1991,7 +1991,7 @@ func TestDependencyOutputOptimizationDisableTest(t *testing.T) {
 	cleanupTerraformFolder(t, TEST_FIXTURE_GET_OUTPUT)
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_GET_OUTPUT)
 	rootPath := filepath.Join(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "nested-optimization-disable")
-	rootTerragruntConfigPath := filepath.Join(rootPath, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := filepath.Join(rootPath, options.DefaultTerragruntConfigPath)
 	livePath := filepath.Join(rootPath, "live")
 	deepDepPath := filepath.Join(rootPath, "deepdep")
 
@@ -3659,7 +3659,7 @@ func TestTerragruntRemoteStateCodegenGeneratesBackendBlockS3(t *testing.T) {
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, generateTestCase, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, generateTestCase, s3BucketName, lockTableName, options.DefaultTerragruntConfigPath)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, generateTestCase))
 }
@@ -3770,7 +3770,7 @@ func TestTerragruntVersionConstraints(t *testing.T) {
 			tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_READ_CONFIG)
 			rootPath := filepath.Join(tmpEnvPath, TEST_FIXTURE_READ_CONFIG, "with_constraints")
 
-			tmpTerragruntConfigPath := createTmpTerragruntConfigContent(t, testCase.terragruntConstraint, config.DefaultTerragruntConfigPath)
+			tmpTerragruntConfigPath := createTmpTerragruntConfigContent(t, testCase.terragruntConstraint, options.DefaultTerragruntConfigPath)
 
 			stdout := bytes.Buffer{}
 			stderr := bytes.Buffer{}
@@ -4613,7 +4613,7 @@ func TestTerragruntRunAllCommandPrompt(t *testing.T) {
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_ALL)
 
-	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", "not-used")
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL)
@@ -4706,7 +4706,7 @@ func TestTerragruntOutputFromRemoteState(t *testing.T) {
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_FROM_REMOTE_STATE)
 
-	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_FROM_REMOTE_STATE, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_FROM_REMOTE_STATE, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", "not-used")
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, TEST_FIXTURE_OUTPUT_FROM_REMOTE_STATE)
@@ -4771,7 +4771,7 @@ func TestTerragruntInitConfirmation(t *testing.T) {
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_ALL)
 
-	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, config.DefaultTerragruntConfigPath)
+	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_ALL, options.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", "not-used")
 
 	stdout := bytes.Buffer{}
@@ -5807,7 +5807,7 @@ func TestTerragruntFailIfBucketCreationIsRequired(t *testing.T) {
 	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
 	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, rootPath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, rootPath, s3BucketName, lockTableName, options.DefaultTerragruntConfigPath)
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
@@ -5831,7 +5831,7 @@ func TestTerragruntDisableBucketUpdate(t *testing.T) {
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
 
-	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, rootPath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, rootPath, s3BucketName, lockTableName, options.DefaultTerragruntConfigPath)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-disable-bucket-update --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, rootPath))
 
@@ -5942,7 +5942,7 @@ func TestTerragruntCheckMissingGCSBucket(t *testing.T) {
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
-	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_NO_BUCKET, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_NO_BUCKET, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, options.DefaultTerragruntConfigPath)
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntGCSConfigPath, TEST_FIXTURE_GCS_NO_BUCKET), &stdout, &stderr)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Missing required GCS remote state configuration bucket")
@@ -5961,7 +5961,7 @@ func TestTerragruntNoPrefixGCSBucket(t *testing.T) {
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
-	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_NO_PREFIX, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_NO_PREFIX, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, options.DefaultTerragruntConfigPath)
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntGCSConfigPath, TEST_FIXTURE_GCS_NO_PREFIX), &stdout, &stderr)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Description

Fixed identifying path to Terragrunt configuration file with `--terragrunt-config` (`TERRAGRUNT_CONFIG`) flag.

Fixes #2031 .
