### PR TITLE
Fixed searching for configs with non-default names #2704.

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -152,14 +152,12 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		}
 		opts.DownloadDir = filepath.ToSlash(downloadDir)
 
+		// `run-all` command uses the `config.DefaultTerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
+		//  we need to take care that the specified `TerragruntConfigPath` is included in this slice.
+		config.DefaultTerragruntConfigPaths = append(config.DefaultTerragruntConfigPaths, opts.TerragruntConfigPath)
+
 		// --- Terragrunt ConfigPath
-		if opts.TerragruntConfigPath == "" {
-			opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
-		} else {
-			// `run-all` command uses the `config.DefaultTerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
-			//  we need to take care that the specified `TerragruntConfigPath` is included in this slice.
-			config.DefaultTerragruntConfigPaths = append(config.DefaultTerragruntConfigPaths, opts.TerragruntConfigPath)
-		}
+		opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
 
 		opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -155,6 +155,8 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		// --- Terragrunt ConfigPath
 		if opts.TerragruntConfigPath == "" {
 			opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
+		} else if ctx.Command.Name == terraform.CommandName {
+			opts.TerragruntConfigPath = util.JoinPath(opts.WorkingDir, opts.TerragruntConfigPath)
 		}
 
 		opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)

--- a/cli/app.go
+++ b/cli/app.go
@@ -155,7 +155,12 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		// --- Terragrunt ConfigPath
 		if opts.TerragruntConfigPath == "" {
 			opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
+		} else {
+			// `run-all` command uses the `options.DefaultTerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
+			//  we need to take care that the specified `TerragruntConfigPath` is included in this slice.
+			config.DefaultTerragruntConfigPaths = append(config.DefaultTerragruntConfigPaths, filepath.Base(opts.TerragruntConfigPath))
 		}
+
 		opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)
 
 		opts.ExcludeDirs, err = util.GlobCanonicalPath(opts.WorkingDir, opts.ExcludeDirs...)

--- a/cli/app.go
+++ b/cli/app.go
@@ -155,7 +155,7 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		// --- Terragrunt ConfigPath
 		if opts.TerragruntConfigPath == "" {
 			opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
-		} else if ctx.Command.Name == terraform.CommandName {
+		} else if !filepath.IsAbs(opts.TerragruntConfigPath) && ctx.Command.Name == terraform.CommandName {
 			opts.TerragruntConfigPath = util.JoinPath(opts.WorkingDir, opts.TerragruntConfigPath)
 		}
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -155,10 +155,6 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		// --- Terragrunt ConfigPath
 		if opts.TerragruntConfigPath == "" {
 			opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
-		} else {
-			// `run-all` command uses the `config.TerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
-			//  the specified `TerragruntConfigPath` needs to be included in this slice.
-			config.TerragruntConfigPaths = append([]string{opts.TerragruntConfigPath}, config.TerragruntConfigPaths...)
 		}
 
 		opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)

--- a/cli/app.go
+++ b/cli/app.go
@@ -156,9 +156,9 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		if opts.TerragruntConfigPath == "" {
 			opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
 		} else {
-			// `run-all` command uses the `config.DefaultTerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
-			//  we need to take care that the specified `TerragruntConfigPath` is included in this slice.
-			config.DefaultTerragruntConfigPaths = append([]string{opts.TerragruntConfigPath}, config.DefaultTerragruntConfigPaths...)
+			// `run-all` command uses the `config.TerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
+			//  the specified `TerragruntConfigPath` needs to be included in this slice.
+			config.TerragruntConfigPaths = append([]string{opts.TerragruntConfigPath}, config.TerragruntConfigPaths...)
 		}
 
 		opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)

--- a/cli/app.go
+++ b/cli/app.go
@@ -156,9 +156,9 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		if opts.TerragruntConfigPath == "" {
 			opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
 		} else {
-			// `run-all` command uses the `options.DefaultTerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
+			// `run-all` command uses the `config.DefaultTerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
 			//  we need to take care that the specified `TerragruntConfigPath` is included in this slice.
-			config.DefaultTerragruntConfigPaths = append(config.DefaultTerragruntConfigPaths, filepath.Base(opts.TerragruntConfigPath))
+			config.DefaultTerragruntConfigPaths = append(config.DefaultTerragruntConfigPaths, opts.TerragruntConfigPath)
 		}
 
 		opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)

--- a/cli/app.go
+++ b/cli/app.go
@@ -155,7 +155,7 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		// --- Terragrunt ConfigPath
 		if opts.TerragruntConfigPath == "" {
 			opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
-		} else if !filepath.IsAbs(opts.TerragruntConfigPath) {
+		} else if !filepath.IsAbs(opts.TerragruntConfigPath) && ctx.Command.Name == terraform.CommandName {
 			opts.TerragruntConfigPath = util.JoinPath(opts.WorkingDir, opts.TerragruntConfigPath)
 		}
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -152,12 +152,14 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		}
 		opts.DownloadDir = filepath.ToSlash(downloadDir)
 
-		// `run-all` command uses the `config.DefaultTerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
-		//  we need to take care that the specified `TerragruntConfigPath` is included in this slice.
-		config.DefaultTerragruntConfigPaths = append(config.DefaultTerragruntConfigPaths, opts.TerragruntConfigPath)
-
 		// --- Terragrunt ConfigPath
-		opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
+		if opts.TerragruntConfigPath == "" {
+			opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
+		} else {
+			// `run-all` command uses the `config.DefaultTerragruntConfigPaths` slice when looking for terragrunt configuration in subfolders,
+			//  we need to take care that the specified `TerragruntConfigPath` is included in this slice.
+			config.DefaultTerragruntConfigPaths = append([]string{opts.TerragruntConfigPath}, config.DefaultTerragruntConfigPaths...)
+		}
 
 		opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -155,7 +155,7 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		// --- Terragrunt ConfigPath
 		if opts.TerragruntConfigPath == "" {
 			opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
-		} else if !filepath.IsAbs(opts.TerragruntConfigPath) && ctx.Command.Name == terraform.CommandName {
+		} else if !filepath.IsAbs(opts.TerragruntConfigPath) {
 			opts.TerragruntConfigPath = util.JoinPath(opts.WorkingDir, opts.TerragruntConfigPath)
 		}
 

--- a/cli/commands/terraform/command.go
+++ b/cli/commands/terraform/command.go
@@ -1,10 +1,13 @@
 package terraform
 
 import (
+	"path/filepath"
+
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/gruntwork-cli/collections"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/cli"
+	"github.com/gruntwork-io/terragrunt/util"
 )
 
 const (
@@ -32,6 +35,10 @@ func action(opts *options.TerragruntOptions) func(ctx *cli.Context) error {
 
 		if !opts.DisableCommandValidation && !collections.ListContainsElement(nativeTerraformCommands, opts.TerraformCommand) {
 			return errors.WithStackTrace(WrongTerraformCommand(opts.TerraformCommand))
+		}
+
+		if !filepath.IsAbs(opts.TerragruntConfigPath) {
+			opts.TerragruntConfigPath = util.JoinPath(opts.WorkingDir, opts.TerragruntConfigPath)
 		}
 
 		return Run(opts.OptionsFromContext(ctx))

--- a/cli/commands/terraform/command.go
+++ b/cli/commands/terraform/command.go
@@ -1,13 +1,10 @@
 package terraform
 
 import (
-	"path/filepath"
-
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/gruntwork-cli/collections"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/cli"
-	"github.com/gruntwork-io/terragrunt/util"
 )
 
 const (
@@ -35,10 +32,6 @@ func action(opts *options.TerragruntOptions) func(ctx *cli.Context) error {
 
 		if !opts.DisableCommandValidation && !collections.ListContainsElement(nativeTerraformCommands, opts.TerraformCommand) {
 			return errors.WithStackTrace(WrongTerraformCommand(opts.TerraformCommand))
-		}
-
-		if !filepath.IsAbs(opts.TerragruntConfigPath) {
-			opts.TerragruntConfigPath = util.JoinPath(opts.WorkingDir, opts.TerragruntConfigPath)
 		}
 
 		return Run(opts.OptionsFromContext(ctx))

--- a/config/config.go
+++ b/config/config.go
@@ -589,8 +589,11 @@ func FindConfigFilesInPath(rootPath string, terragruntOptions *options.Terragrun
 			return nil
 		}
 
-		if strings.HasSuffix(path, ".hcl") || strings.HasSuffix(path, ".hcl.json") {
-			configFiles = append(configFiles, path)
+		for _, configFile := range append(DefaultTerragruntConfigPaths, terragruntOptions.TerragruntConfigPath) {
+			if strings.HasSuffix(path, configFile) {
+				configFiles = append(configFiles, path)
+				break
+			}
 		}
 
 		return nil

--- a/config/config.go
+++ b/config/config.go
@@ -56,7 +56,7 @@ const (
 	MetadataRetrySleepIntervalSec       = "retry_sleep_interval_sec"
 )
 
-var DefaultTerragruntConfigPaths = []string{
+var TerragruntConfigPaths = []string{
 	DefaultTerragruntJsonConfigPath,
 	DefaultTerragruntConfigPath,
 }
@@ -548,7 +548,7 @@ func adjustSourceWithMap(sourceMap map[string]string, source string, modulePath 
 func GetDefaultConfigPath(workingDir string) string {
 	var configPath string
 
-	for _, configPath = range DefaultTerragruntConfigPaths {
+	for _, configPath = range TerragruntConfigPaths {
 		configPath = util.JoinPath(workingDir, configPath)
 		if util.FileExists(configPath) {
 			break

--- a/config/config.go
+++ b/config/config.go
@@ -544,23 +544,13 @@ func adjustSourceWithMap(sourceMap map[string]string, source string, modulePath 
 
 }
 
-// Return the default hcl path to use for the Terragrunt configuration file in the given directory
-func DefaultConfigPath(workingDir string) string {
-	return util.JoinPath(workingDir, DefaultTerragruntConfigPath)
-}
-
-// Return the default path to use for the Terragrunt Json configuration file in the given directory
-func DefaultJsonConfigPath(workingDir string) string {
-	return util.JoinPath(workingDir, DefaultTerragruntJsonConfigPath)
-}
-
 // Return the default path to use for the Terragrunt configuration that exists within the path giving preference to `terragrunt.hcl`
 func GetDefaultConfigPath(workingDir string) string {
 	var configPath string
 
 	for _, configPath = range DefaultTerragruntConfigPaths {
 		configPath = util.JoinPath(workingDir, configPath)
-		if util.FileExists(DefaultJsonConfigPath(workingDir)) {
+		if util.FileExists(configPath) {
 			break
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -577,23 +577,22 @@ func FindConfigFilesInPath(rootPath string, terragruntOptions *options.Terragrun
 			return err
 		}
 
-		if !info.IsDir() {
+		if info.IsDir() {
+			if ok, err := isTerragruntModuleDir(path, terragruntOptions); err != nil {
+				return err
+			} else if !ok {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 
-		if ok, err := isTerragruntModuleDir(path, terragruntOptions); err != nil {
-			return err
-		} else if !ok {
-			return filepath.SkipDir
+		if strings.HasSuffix(path, util.TerraformLockFile) {
+			return nil
 		}
 
 		for _, configFile := range append(DefaultTerragruntConfigPaths, terragruntOptions.TerragruntConfigPath) {
-			if !filepath.IsAbs(configFile) {
-				configFile = util.JoinPath(path, configFile)
-			}
-
-			if !util.IsDir(configFile) && util.FileExists(configFile) {
-				configFiles = append(configFiles, configFile)
+			if strings.HasSuffix(path, configFile) {
+				configFiles = append(configFiles, path)
 				break
 			}
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -59,8 +59,8 @@ const (
 
 // Order matters, for example if none of the files are found `GetDefaultConfigPath` func returns the last element.
 var DefaultTerragruntConfigPaths = []string{
-	DefaultTerragruntConfigPath,
 	DefaultTerragruntJsonConfigPath,
+	DefaultTerragruntConfigPath,
 }
 
 // TerragruntConfig represents a parsed and expanded configuration

--- a/config/config.go
+++ b/config/config.go
@@ -587,7 +587,7 @@ func FindConfigFilesInPath(rootPath string, terragruntOptions *options.Terragrun
 			return filepath.SkipDir
 		}
 
-		for _, configFile := range append(DefaultTerragruntConfigPaths, terragruntOptions.TerragruntConfigPath) {
+		for _, configFile := range append(DefaultTerragruntConfigPaths, filepath.Base(terragruntOptions.TerragruntConfigPath)) {
 			if !filepath.IsAbs(configFile) {
 				configFile = util.JoinPath(path, configFile)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -577,22 +577,23 @@ func FindConfigFilesInPath(rootPath string, terragruntOptions *options.Terragrun
 			return err
 		}
 
-		if info.IsDir() {
-			if ok, err := isTerragruntModuleDir(path, terragruntOptions); err != nil {
-				return err
-			} else if !ok {
-				return filepath.SkipDir
-			}
+		if !info.IsDir() {
 			return nil
 		}
 
-		if strings.HasSuffix(path, util.TerraformLockFile) {
-			return nil
+		if ok, err := isTerragruntModuleDir(path, terragruntOptions); err != nil {
+			return err
+		} else if !ok {
+			return filepath.SkipDir
 		}
 
 		for _, configFile := range append(DefaultTerragruntConfigPaths, terragruntOptions.TerragruntConfigPath) {
-			if strings.HasSuffix(path, configFile) {
-				configFiles = append(configFiles, path)
+			if !filepath.IsAbs(configFile) {
+				configFile = util.JoinPath(path, configFile)
+			}
+
+			if !util.IsDir(configFile) && util.FileExists(configFile) {
+				configFiles = append(configFiles, configFile)
 				break
 			}
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,7 @@ const (
 	MetadataRetrySleepIntervalSec       = "retry_sleep_interval_sec"
 )
 
-// The order matters, if none of the files are found the first element will be returned.
+// Order matters, for example if none of the files are found `GetDefaultConfigPath` func returns the last element.
 var DefaultTerragruntConfigPaths = []string{
 	DefaultTerragruntConfigPath,
 	DefaultTerragruntJsonConfigPath,
@@ -553,16 +553,18 @@ func GetDefaultConfigPath(workingDir string) string {
 		return workingDir
 	}
 
-	for _, configPath := range DefaultTerragruntConfigPaths {
+	var configPath string
+
+	for _, configPath = range DefaultTerragruntConfigPaths {
 		if !filepath.IsAbs(configPath) {
 			configPath = util.JoinPath(workingDir, configPath)
 		}
 		if files.FileExists(configPath) {
-			return configPath
+			break
 		}
 	}
 
-	return DefaultTerragruntConfigPaths[0]
+	return configPath
 }
 
 // Returns a list of all Terragrunt config files in the given path or any subfolder of the path. A file is a Terragrunt

--- a/config/config.go
+++ b/config/config.go
@@ -27,8 +27,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 )
 
-const DefaultTerragruntConfigPath = "terragrunt.hcl"
-const DefaultTerragruntJsonConfigPath = "terragrunt.hcl.json"
+const (
+	DefaultTerragruntConfigPath     = "terragrunt.hcl"
+	DefaultTerragruntJsonConfigPath = "terragrunt.hcl.json"
+)
 
 const foundInFile = "found_in_file"
 
@@ -53,6 +55,11 @@ const (
 	MetadataRetryMaxAttempts            = "retry_max_attempts"
 	MetadataRetrySleepIntervalSec       = "retry_sleep_interval_sec"
 )
+
+var DefaultTerragruntConfigPaths = []string{
+	DefaultTerragruntJsonConfigPath,
+	DefaultTerragruntConfigPath,
+}
 
 // TerragruntConfig represents a parsed and expanded configuration
 // NOTE: if any attributes are added, make sure to update terragruntConfigAsCty in config_as_cty.go
@@ -549,11 +556,16 @@ func DefaultJsonConfigPath(workingDir string) string {
 
 // Return the default path to use for the Terragrunt configuration that exists within the path giving preference to `terragrunt.hcl`
 func GetDefaultConfigPath(workingDir string) string {
-	if util.FileNotExists(DefaultConfigPath(workingDir)) && util.FileExists(DefaultJsonConfigPath(workingDir)) {
-		return DefaultJsonConfigPath(workingDir)
+	var configPath string
+
+	for _, configPath = range DefaultTerragruntConfigPaths {
+		configPath = util.JoinPath(workingDir, configPath)
+		if util.FileExists(DefaultJsonConfigPath(workingDir)) {
+			break
+		}
 	}
 
-	return DefaultConfigPath(workingDir)
+	return configPath
 }
 
 // Returns a list of all Terragrunt config files in the given path or any subfolder of the path. A file is a Terragrunt

--- a/config/config.go
+++ b/config/config.go
@@ -588,11 +588,11 @@ func FindConfigFilesInPath(rootPath string, terragruntOptions *options.Terragrun
 		}
 
 		for _, configFile := range append(DefaultTerragruntConfigPaths, terragruntOptions.TerragruntConfigPath) {
-			configFile, err := util.CanonicalPath(configFile, path)
-			if err != nil {
-				return err
+			if !filepath.IsAbs(configFile) {
+				configFile = util.JoinPath(path, configFile)
 			}
-			if util.FileExists(configFile) {
+
+			if !util.IsDir(configFile) && util.FileExists(configFile) {
 				configFiles = append(configFiles, configFile)
 				break
 			}

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -290,7 +290,7 @@ func PartialParseConfigString(
 
 			// Convert dependency blocks into module depenency lists. If we already decoded some dependencies,
 			// merge them in. Otherwise, set as the new list.
-			dependencies := dependencyBlocksToModuleDependencies(decoded.Dependencies)
+			dependencies := dependencyBlocksToModuleDependencies(terragruntOptions.WorkingDir, decoded.Dependencies)
 			if output.Dependencies != nil {
 				output.Dependencies.Merge(dependencies)
 			} else {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -936,7 +936,7 @@ func TestFindConfigFilesInPathMultipleConfigs(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/multiple-configs", terragruntOptions)
 
 	assert.Nil(t, err, "Unexpected error: %v", err)
-	assert.Equal(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesInPathMultipleJsonConfigs(t *testing.T) {
@@ -953,7 +953,7 @@ func TestFindConfigFilesInPathMultipleJsonConfigs(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/multiple-json-configs", terragruntOptions)
 
 	assert.Nil(t, err, "Unexpected error: %v", err)
-	assert.Equal(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesInPathMultipleMixedConfigs(t *testing.T) {
@@ -970,7 +970,7 @@ func TestFindConfigFilesInPathMultipleMixedConfigs(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/multiple-mixed-configs", terragruntOptions)
 
 	assert.Nil(t, err, "Unexpected error: %v", err)
-	assert.Equal(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesIgnoresTerragruntCache(t *testing.T) {
@@ -1003,7 +1003,7 @@ func TestFindConfigFilesIgnoresTerraformDataDir(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/ignore-terraform-data-dir", terragruntOptions)
 
 	assert.Nil(t, err, "Unexpected error: %v", err)
-	assert.Equal(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesIgnoresTerraformDataDirEnv(t *testing.T) {
@@ -1021,7 +1021,7 @@ func TestFindConfigFilesIgnoresTerraformDataDirEnv(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/ignore-terraform-data-dir", terragruntOptions)
 
 	assert.Nil(t, err, "Unexpected error: %v", err)
-	assert.Equal(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesIgnoresTerraformDataDirEnvPath(t *testing.T) {
@@ -1040,7 +1040,7 @@ func TestFindConfigFilesIgnoresTerraformDataDirEnvPath(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/ignore-terraform-data-dir", terragruntOptions)
 
 	assert.Nil(t, err, "Unexpected error: %v", err)
-	assert.Equal(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesIgnoresTerraformDataDirEnvRoot(t *testing.T) {
@@ -1063,7 +1063,7 @@ func TestFindConfigFilesIgnoresTerraformDataDirEnvRoot(t *testing.T) {
 	actual, err := FindConfigFilesInPath(workingDir, terragruntOptions)
 
 	assert.Nil(t, err, "Unexpected error: %v", err)
-	assert.Equal(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesIgnoresDownloadDir(t *testing.T) {
@@ -1080,7 +1080,7 @@ func TestFindConfigFilesIgnoresDownloadDir(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/multiple-configs", terragruntOptions)
 
 	assert.Nil(t, err, "Unexpected error: %v", err)
-	assert.Equal(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func mockOptionsForTestWithConfigPath(t *testing.T, configPath string) *options.TerragruntOptions {

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -177,7 +177,7 @@ func decodeAndRetrieveOutputs(
 
 // Convert the list of parsed Dependency blocks into a list of module dependencies. Each output block should
 // become a dependency of the current config, since that module has to be applied before we can read the output.
-func dependencyBlocksToModuleDependencies(decodedDependencyBlocks []Dependency) *ModuleDependencies {
+func dependencyBlocksToModuleDependencies(workingDir string, decodedDependencyBlocks []Dependency) *ModuleDependencies {
 	if len(decodedDependencyBlocks) == 0 {
 		return nil
 	}
@@ -185,12 +185,19 @@ func dependencyBlocksToModuleDependencies(decodedDependencyBlocks []Dependency) 
 	paths := []string{}
 	for _, decodedDependencyBlock := range decodedDependencyBlocks {
 		configPath := decodedDependencyBlock.ConfigPath
-		if util.IsFile(configPath) && filepath.Base(configPath) == DefaultTerragruntConfigPath {
-			// dependencies system expects the directory containing the terragrunt.hcl file
-			configPath = filepath.Dir(configPath)
-		}
+
+		// absolutePath := configPath
+		// if !filepath.IsAbs(absolutePath) {
+		// 	absolutePath = util.JoinPath(workingDir, absolutePath)
+		// }
+		// if !files.IsDir(absolutePath) && files.FileExists(absolutePath) {
+		// 	// dependencies system expects the directory containing the terragrunt.hcl file
+		// 	configPath = filepath.Dir(configPath)
+		// }
+
 		paths = append(paths, configPath)
 	}
+
 	return &ModuleDependencies{Paths: paths}
 }
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -184,18 +184,7 @@ func dependencyBlocksToModuleDependencies(workingDir string, decodedDependencyBl
 
 	paths := []string{}
 	for _, decodedDependencyBlock := range decodedDependencyBlocks {
-		configPath := decodedDependencyBlock.ConfigPath
-
-		// absolutePath := configPath
-		// if !filepath.IsAbs(absolutePath) {
-		// 	absolutePath = util.JoinPath(workingDir, absolutePath)
-		// }
-		// if !files.IsDir(absolutePath) && files.FileExists(absolutePath) {
-		// 	// dependencies system expects the directory containing the terragrunt.hcl file
-		// 	configPath = filepath.Dir(configPath)
-		// }
-
-		paths = append(paths, configPath)
+		paths = append(paths, decodedDependencyBlock.ConfigPath)
 	}
 
 	return &ModuleDependencies{Paths: paths}

--- a/configstack/errors.go
+++ b/configstack/errors.go
@@ -1,0 +1,34 @@
+package configstack
+
+import "fmt"
+
+// Custom error types
+
+type UnrecognizedDependency struct {
+	ModulePath            string
+	DependencyPath        string
+	TerragruntConfigPaths []string
+}
+
+func (err UnrecognizedDependency) Error() string {
+	return fmt.Sprintf("Module %s specifies %s as a dependency, but that dependency was not one of the ones found while scanning subfolders: %v", err.ModulePath, err.DependencyPath, err.TerragruntConfigPaths)
+}
+
+type ErrorProcessingModule struct {
+	UnderlyingError       error
+	ModulePath            string
+	HowThisModuleWasFound string
+}
+
+func (err ErrorProcessingModule) Error() string {
+	return fmt.Sprintf("Error processing module at '%s'. How this module was found: %s. Underlying error: %v", err.ModulePath, err.HowThisModuleWasFound, err.UnderlyingError)
+}
+
+type InfiniteRecursion struct {
+	RecursionLevel int
+	Modules        map[string]*TerraformModule
+}
+
+func (err InfiniteRecursion) Error() string {
+	return fmt.Sprintf("Hit what seems to be an infinite recursion after going %d levels deep. Please check for a circular dependency! Modules involved: %v", err.RecursionLevel, err.Modules)
+}

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -230,13 +230,13 @@ func resolveModules(canonicalTerragruntConfigPaths []string, terragruntOptions *
 		}
 		if module != nil {
 			moduleMap[module.Path] = module
-		}
 
-		dependencies, err := resolveDependenciesForModule(module, moduleMap, terragruntOptions, childTerragruntConfig, true)
-		if err != nil {
-			return moduleMap, err
+			dependencies, err := resolveDependenciesForModule(module, moduleMap, terragruntOptions, childTerragruntConfig, true)
+			if err != nil {
+				return moduleMap, err
+			}
+			moduleMap = collections.MergeMaps(moduleMap, dependencies)
 		}
-		moduleMap = collections.MergeMaps(moduleMap, dependencies)
 	}
 
 	return moduleMap, nil

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -395,7 +395,12 @@ func resolveExternalDependenciesForModule(module *TerraformModule, moduleMap map
 			return map[string]*TerraformModule{}, err
 		}
 
+		if files.FileExists(dependencyPath) && !files.IsDir(dependencyPath) {
+			dependencyPath = filepath.Dir(dependencyPath)
+		}
+
 		terragruntConfigPath := config.GetDefaultConfigPath(dependencyPath)
+
 		if _, alreadyContainsModule := moduleMap[dependencyPath]; !alreadyContainsModule {
 			externalTerragruntConfigPaths = append(externalTerragruntConfigPaths, terragruntConfigPath)
 		}

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -224,10 +224,11 @@ func resolveModules(canonicalTerragruntConfigPaths []string, terragruntOptions *
 	moduleMap := map[string]*TerraformModule{}
 
 	for _, terragruntConfigPath := range canonicalTerragruntConfigPaths {
-		module, err := resolveTerraformModule(terragruntConfigPath, terragruntOptions, childTerragruntConfig, howTheseModulesWereFound)
+		module, err := resolveTerraformModule(terragruntConfigPath, moduleMap, terragruntOptions, childTerragruntConfig, howTheseModulesWereFound)
 		if err != nil {
 			return moduleMap, err
 		}
+
 		if module != nil {
 			moduleMap[module.Path] = module
 
@@ -245,10 +246,14 @@ func resolveModules(canonicalTerragruntConfigPaths []string, terragruntOptions *
 // Create a TerraformModule struct for the Terraform module specified by the given Terragrunt configuration file path.
 // Note that this method will NOT fill in the Dependencies field of the TerraformModule struct (see the
 // crosslinkDependencies method for that).
-func resolveTerraformModule(terragruntConfigPath string, terragruntOptions *options.TerragruntOptions, childTerragruntConfig *config.TerragruntConfig, howThisModuleWasFound string) (*TerraformModule, error) {
+func resolveTerraformModule(terragruntConfigPath string, moduleMap map[string]*TerraformModule, terragruntOptions *options.TerragruntOptions, childTerragruntConfig *config.TerragruntConfig, howThisModuleWasFound string) (*TerraformModule, error) {
 	modulePath, err := util.CanonicalPath(filepath.Dir(terragruntConfigPath), ".")
 	if err != nil {
 		return nil, err
+	}
+
+	if _, ok := moduleMap[modulePath]; ok {
+		return nil, nil
 	}
 
 	// Clone the options struct so we don't modify the original one. This is especially important as run-all operations

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -389,11 +389,9 @@ func resolveExternalDependenciesForModules(moduleMap map[string]*TerraformModule
 	return allExternalDependencies, nil
 }
 
-// Look through the dependencies of the given module and resolve the "external" dependency paths listed in the module's
-// config (i.e. those dependencies not in the given list of Terragrunt config canonical file paths). These external
-// dependencies are outside of the current working directory, which means they may not be part of the environment the
-// user is trying to apply-all or destroy-all. Note that this method will NOT fill in the Dependencies field of the
-// TerraformModule struct (see the crosslinkDependencies method for that).
+// resolveDependenciesForModule looks through the dependencies of the given module and resolve the dependency paths listed in the module's config.
+// If `skipExternal` is true, the func returns only dependencies that are inside of the current working directory, which means they are part of the environment the
+// user is trying to apply-all or destroy-all. Note that this method will NOT fill in the Dependencies field of the TerraformModule struct (see the crosslinkDependencies method for that).
 func resolveDependenciesForModule(module *TerraformModule, moduleMap map[string]*TerraformModule, terragruntOptions *options.TerragruntOptions, chilTerragruntConfig *config.TerragruntConfig, skipExternal bool) (map[string]*TerraformModule, error) {
 	if module.Config.Dependencies == nil || len(module.Config.Dependencies.Paths) == 0 {
 		return map[string]*TerraformModule{}, nil

--- a/pkg/cli/command.go
+++ b/pkg/cli/command.go
@@ -118,6 +118,11 @@ func (cmd *Command) Run(ctx *Context, args ...string) (err error) {
 		return err
 	}
 
+	if cmd.IsRoot && ctx.App.DefaultCommand != nil {
+		err = ctx.App.DefaultCommand.Run(ctx, args...)
+		return err
+	}
+
 	if ctx.App.CommonBefore != nil {
 		if err = ctx.App.CommonBefore(ctx); err != nil {
 			return ctx.App.handleExitCoder(err)
@@ -128,11 +133,6 @@ func (cmd *Command) Run(ctx *Context, args ...string) (err error) {
 		if err = cmd.Action(ctx); err != nil {
 			return ctx.App.handleExitCoder(err)
 		}
-	}
-
-	if cmd.IsRoot && ctx.App.DefaultCommand != nil {
-		err = ctx.App.DefaultCommand.Run(ctx, args...)
-		return err
 	}
 
 	return nil

--- a/test/fixture-config-files/with-non-default-names/app/main.hcl
+++ b/test/fixture-config-files/with-non-default-names/app/main.hcl
@@ -1,0 +1,3 @@
+include "parent" {
+  path = "../parent.hcl"
+}

--- a/test/fixture-config-files/with-non-default-names/app/main.tf
+++ b/test/fixture-config-files/with-non-default-names/app/main.tf
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixture-config-files/with-non-default-names/common.hcl
+++ b/test/fixture-config-files/with-non-default-names/common.hcl
@@ -1,0 +1,3 @@
+locals {
+  common = run_cmd("echo", "common_hcl")
+}

--- a/test/fixture-config-files/with-non-default-names/dependency/another-name.hcl
+++ b/test/fixture-config-files/with-non-default-names/dependency/another-name.hcl
@@ -1,0 +1,7 @@
+locals {
+  parent_var = run_cmd("echo", "dependency_hcl")
+}
+
+include "common" {
+  path = "../common.hcl"
+}

--- a/test/fixture-config-files/with-non-default-names/parent.hcl
+++ b/test/fixture-config-files/with-non-default-names/parent.hcl
@@ -1,0 +1,12 @@
+locals {
+  parent_var = run_cmd("echo", "parent_hcl_file")
+}
+
+dependency "dependency" {
+  config_path = "../dependency/another-name.hcl"
+
+  mock_outputs = {
+    mock_key = "mock_value"
+  }
+
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -69,6 +69,7 @@ const (
 	TEST_FIXTURE_ENV_VARS_BLOCK_PATH                                         = "fixture-env-vars-block/"
 	TEST_FIXTURE_SKIP                                                        = "fixture-skip/"
 	TEST_FIXTURE_CONFIG_SINGLE_JSON_PATH                                     = "fixture-config-files/single-json-config"
+	TEST_FIXTURE_CONFIG_WITH_NON_DEFAULT_NAMES                               = "fixture-config-files/with-non-default-names"
 	TEST_FIXTURE_PREVENT_DESTROY_OVERRIDE                                    = "fixture-prevent-destroy-override/child"
 	TEST_FIXTURE_PREVENT_DESTROY_NOT_SET                                     = "fixture-prevent-destroy-not-set/child"
 	TEST_FIXTURE_LOCAL_PREVENT_DESTROY                                       = "fixture-download/local-with-prevent-destroy"
@@ -759,6 +760,24 @@ func TestTerragruntWorksWithSingleJsonConfig(t *testing.T) {
 	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_CONFIG_SINGLE_JSON_PATH)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", rootTerragruntConfigPath))
+}
+
+func TestTerragruntWorksWithNonDefaultConfigNames(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_CONFIG_WITH_NON_DEFAULT_NAMES)
+	tmpEnvPath = path.Join(tmpEnvPath, TEST_FIXTURE_CONFIG_WITH_NON_DEFAULT_NAMES)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-config main.hcl --terragrunt-non-interactive --terragrunt-working-dir %s", tmpEnvPath), &stdout, &stderr)
+	require.NoError(t, err)
+
+	out := stdout.String()
+	assert.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
+	assert.Equal(t, 1, strings.Count(out, "dependency_hcl"))
+	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
 }
 
 func TestTerragruntReportsTerraformErrorsWithPlanAll(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -780,6 +780,24 @@ func TestTerragruntWorksWithNonDefaultConfigNamesAndRunAllCommand(t *testing.T) 
 	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
 }
 
+func TestTerragruntWorksWithNonDefaultConfigNames(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_CONFIG_WITH_NON_DEFAULT_NAMES)
+	tmpEnvPath = path.Join(tmpEnvPath, TEST_FIXTURE_CONFIG_WITH_NON_DEFAULT_NAMES)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-config main.hcl --terragrunt-non-interactive --terragrunt-working-dir %s", filepath.Join(tmpEnvPath, "app")), &stdout, &stderr)
+	require.NoError(t, err)
+
+	out := stdout.String()
+	assert.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
+	assert.Equal(t, 1, strings.Count(out, "dependency_hcl"))
+	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
+}
+
 func TestTerragruntReportsTerraformErrorsWithPlanAll(t *testing.T) {
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_FAILED_TERRAFORM)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -762,7 +762,7 @@ func TestTerragruntWorksWithSingleJsonConfig(t *testing.T) {
 	runTerragrunt(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", rootTerragruntConfigPath))
 }
 
-func TestTerragruntWorksWithNonDefaultConfigNames(t *testing.T) {
+func TestTerragruntWorksWithNonDefaultConfigNamesAndRunAllCommand(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_CONFIG_WITH_NON_DEFAULT_NAMES)
@@ -772,6 +772,24 @@ func TestTerragruntWorksWithNonDefaultConfigNames(t *testing.T) {
 	stderr := bytes.Buffer{}
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-config main.hcl --terragrunt-non-interactive --terragrunt-working-dir %s", tmpEnvPath), &stdout, &stderr)
+	require.NoError(t, err)
+
+	out := stdout.String()
+	assert.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
+	assert.Equal(t, 1, strings.Count(out, "dependency_hcl"))
+	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
+}
+
+func TestTerragruntWorksWithNonDefaultConfigNames(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_CONFIG_WITH_NON_DEFAULT_NAMES)
+	tmpEnvPath = path.Join(tmpEnvPath, TEST_FIXTURE_CONFIG_WITH_NON_DEFAULT_NAMES)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-config main.hcl --terragrunt-non-interactive --terragrunt-working-dir %s", filepath.Join(tmpEnvPath, "app")), &stdout, &stderr)
 	require.NoError(t, err)
 
 	out := stdout.String()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -780,24 +780,6 @@ func TestTerragruntWorksWithNonDefaultConfigNamesAndRunAllCommand(t *testing.T) 
 	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
 }
 
-func TestTerragruntWorksWithNonDefaultConfigNames(t *testing.T) {
-	t.Parallel()
-
-	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_CONFIG_WITH_NON_DEFAULT_NAMES)
-	tmpEnvPath = path.Join(tmpEnvPath, TEST_FIXTURE_CONFIG_WITH_NON_DEFAULT_NAMES)
-
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-config main.hcl --terragrunt-non-interactive --terragrunt-working-dir %s", filepath.Join(tmpEnvPath, "app")), &stdout, &stderr)
-	require.NoError(t, err)
-
-	out := stdout.String()
-	assert.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
-	assert.Equal(t, 1, strings.Count(out, "dependency_hcl"))
-	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
-}
-
 func TestTerragruntReportsTerraformErrorsWithPlanAll(t *testing.T) {
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_FAILED_TERRAFORM)


### PR DESCRIPTION
## Description

* Fixed searching for config with explicitly specified `--terragrunt-config` and `run-all` command.
* Added the ability to explicitly specify the name of dependency configuration files, which may differ from the default name `terragrunt.conf`.

Fixes #2031 .