### PR TITLE
Updating link to before-and-after-hooks

### DIFF
--- a/docs/_pages/index/_key-features.html
+++ b/docs/_pages/index/_key-features.html
@@ -80,7 +80,7 @@
       <div class="col-xs-12 col-md-5 order-md-2">
         <h3><strong>Before & After</strong> hooks</h3>
         <p class="subtitle">Execute custom code before or after running Terraform.</p>
-        <a class="btn btn-primary hidden-xs hidden-sm" href="{{site.baseurl}}/docs/features/before-and-after-hooks/#before-and-after-hooks">Learn more</a>
+        <a class="btn btn-primary hidden-xs hidden-sm" href="{{site.baseurl}}/docs/features/hooks/#before-and-after-hooks">Learn more</a>
       </div>
       <div class="col-xs-12 col-md-7 order-md-1">
         <div class="code-snippet">
@@ -97,7 +97,7 @@
   }
 }</code></pre>
         </div>
-        <a class="btn btn-primary hidden-md hidden-lg" href="{{site.baseurl}}/docs/features/before-and-after-hooks/#before-and-after-hooks">Learn more</a>
+        <a class="btn btn-primary hidden-md hidden-lg" href="{{site.baseurl}}/docs/features/hooks/#before-and-after-hooks">Learn more</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description

Just a link broken on the main page. I assume this simple change would fix it so thought I would be helpful.
Let me know if anything else needs looking at 
Fixes #2707

## Release Notes

Updated Link on Terragrunt Index Page



