### PR TITLE
Improved checking of windows console errors

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/terragrunt/shell"
 	"io"
 	"os"
 	"path/filepath"
@@ -208,6 +209,9 @@ func initialSetup(opts *options.TerragruntOptions) func(ctx *cli.Context) error 
 		opts.OriginalIAMRoleOptions = opts.IAMRoleOptions
 
 		opts.RunTerragrunt = terraform.Run
+
+		shell.PrepareConsole(opts)
+
 		return nil
 	}
 }

--- a/cli/app.go
+++ b/cli/app.go
@@ -2,12 +2,13 @@ package cli
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terragrunt/shell"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/gruntwork-io/terragrunt/shell"
 
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/go-commons/version"

--- a/shell/ptty_unix.go
+++ b/shell/ptty_unix.go
@@ -85,3 +85,7 @@ func runCommandWithPTTY(terragruntOptions *options.TerragruntOptions, cmd *exec.
 
 	return nil
 }
+
+func PrepareConsole(terragruntOptions *options.TerragruntOptions) {
+	// No operation function to match windows execution
+}

--- a/shell/ptty_windows.go
+++ b/shell/ptty_windows.go
@@ -7,12 +7,15 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	"golang.org/x/sys/windows"
 
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 )
+
+const InvalidHandleErrorMessage = "The handle is invalid"
 
 // PrepareConsole enables support for escape sequences
 // https://stackoverflow.com/questions/56460651/golang-fmt-print-033c-and-fmt-print-x1bc-are-not-clearing-screenansi-es
@@ -27,13 +30,20 @@ func enableVirtualTerminalProcessing(options *options.TerragruntOptions, file *o
 	var mode uint32
 	handle := windows.Handle(file.Fd())
 	if err := windows.GetConsoleMode(handle, &mode); err != nil {
-		options.Logger.Errorf("failed to get console mode: %v\n", err)
+		if strings.Contains(err.Error(), InvalidHandleErrorMessage) {
+			options.Logger.Debugf("failed to get console mode: %v\n", err)
+		} else {
+			options.Logger.Errorf("failed to get console mode: %v\n", err)
+		}
 		return
 	}
 
 	if err := windows.SetConsoleMode(handle, mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {
 		options.Logger.Errorf("failed to set console mode: %v\n", err)
-		windows.SetConsoleMode(handle, mode)
+		if secondError := windows.SetConsoleMode(handle, mode); secondError != nil {
+			options.Logger.Errorf("failed to set console mode: %v\n", secondError)
+			return
+		}
 	}
 }
 

--- a/shell/run_shell_cmd_windows_test.go
+++ b/shell/run_shell_cmd_windows_test.go
@@ -5,8 +5,10 @@ package shell
 
 import (
 	"bytes"
+	"context"
 	goerrors "errors"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"strconv"
@@ -18,12 +20,21 @@ import (
 )
 
 func TestWindowsConsolePrepare(t *testing.T) {
-	options := options.NewTerragruntOptions()
+	t.Parallel()
 
-	options.Logger.Buffer = &bytes.Buffer{}
+	o := options.NewTerragruntOptions()
 
-	PrepareConsole(options)
-	fmt.Printf("%v", string(options.Logger.Buffer.Bytes()))
+	stdout := bytes.Buffer{}
+
+	var testLogger = logrus.New()
+	testLogger.Out = &stdout
+	testLogger.Level = logrus.DebugLevel
+
+	o.Logger = testLogger.WithContext(context.Background())
+
+	PrepareConsole(o)
+
+	assert.Contains(t, stdout.String(), " level=debug msg=\"failed to get console mode: The handle is invalid.")
 }
 
 func TestExitCodeWindows(t *testing.T) {

--- a/shell/run_shell_cmd_windows_test.go
+++ b/shell/run_shell_cmd_windows_test.go
@@ -23,7 +23,7 @@ import (
 func TestWindowsConsolePrepare(t *testing.T) {
 	t.Parallel()
 
-	o := options.NewTerragruntOptions()
+	testOptions := options.NewTerragruntOptions()
 
 	stdout := bytes.Buffer{}
 
@@ -31,11 +31,11 @@ func TestWindowsConsolePrepare(t *testing.T) {
 	testLogger.Out = &stdout
 	testLogger.Level = logrus.DebugLevel
 
-	o.Logger = testLogger.WithContext(context.Background())
+	testOptions.Logger = testLogger.WithContext(context.Background())
 
-	PrepareConsole(o)
+	PrepareConsole(testOptions)
 
-	assert.Contains(t, stdout.String(), " level=debug msg=\"failed to get console mode: The handle is invalid.")
+	assert.Contains(t, stdout.String(), "level=debug msg=\"failed to get console mode: The handle is invalid.")
 }
 
 func TestExitCodeWindows(t *testing.T) {

--- a/shell/run_shell_cmd_windows_test.go
+++ b/shell/run_shell_cmd_windows_test.go
@@ -8,12 +8,13 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"

--- a/shell/run_shell_cmd_windows_test.go
+++ b/shell/run_shell_cmd_windows_test.go
@@ -4,6 +4,7 @@
 package shell
 
 import (
+	"bytes"
 	goerrors "errors"
 	"fmt"
 	"os"
@@ -15,6 +16,15 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestWindowsConsolePrepare(t *testing.T) {
+	options := options.NewTerragruntOptions()
+
+	options.Logger.Buffer = &bytes.Buffer{}
+
+	PrepareConsole(options)
+	fmt.Printf("%v", string(options.Logger.Buffer.Bytes()))
+}
 
 func TestExitCodeWindows(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* updated console getting error check to redirect to debug log level errors with "The handle is invalid"
* added error check for the case when virtual console mode setting didn't worked
 

Fixes #1854.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Reduced noise "The handle is invalid" log noise for Windows executions.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

