### PR TITLE
Add built-in function `get_default_retryable_errors`

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -140,6 +140,7 @@ func CreateTerragruntEvalContext(
 		"get_terraform_commands_that_need_parallelism": wrapStaticValueToStringSliceAsFuncImpl(TERRAFORM_COMMANDS_NEED_PARALLELISM),
 		"sops_decrypt_file":                            wrapStringSliceToStringAsFuncImpl(sopsDecryptFile, extensions.TrackInclude, terragruntOptions),
 		"get_terragrunt_source_cli_flag":               wrapVoidToStringAsFuncImpl(getTerragruntSourceCliFlag, extensions.TrackInclude, terragruntOptions),
+		"get_default_retryable_errors":                 wrapVoidToStringSliceAsFuncImpl(getDefaultRetryableErrors, extensions.TrackInclude, terragruntOptions),
 	}
 
 	// Map with HCL functions introduced in Terraform after v0.15.3, since upgrade to a later version is not supported
@@ -487,6 +488,11 @@ func getTerraformCommand(trackInclude *TrackInclude, terragruntOptions *options.
 // getTerraformCliArgs returns cli args for terraform
 func getTerraformCliArgs(trackInclude *TrackInclude, terragruntOptions *options.TerragruntOptions) ([]string, error) {
 	return terragruntOptions.TerraformCliArgs, nil
+}
+
+// getDefaultRetryableErrors returns default retryable errors
+func getDefaultRetryableErrors(trackInclude *TrackInclude, terragruntOptions *options.TerragruntOptions) ([]string, error) {
+	return options.DEFAULT_RETRYABLE_ERRORS, nil
 }
 
 // Return the AWS account id associated to the current set of credentials

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -46,6 +46,8 @@ Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, ju
 
   - [get\_terraform\_command()](#get_terraform_command)
 
+  - [get\_default\_retryable\_errors()](#get_default_retryable_errors)
+
   - [get\_terraform\_cli\_args()](#get_terraform_cli_args)
 
   - [get\_aws\_account\_id()](#get_aws_account_id)
@@ -594,6 +596,14 @@ inputs = {
 inputs = {
   current_cli_args = get_terraform_cli_args()
 }
+```
+
+## get\_default\_retryable\_errors
+
+`get_default_retryable_errors()` returns default retryabled errors. Example:
+
+``` hcl
+retryable_errors = concat(get_default_retryable_errors(), ["my custom error"])
 ```
 
 ## get\_aws\_caller\_identity\_user\_id

--- a/test/fixture-auto-retry/get-default-errors/main.tf
+++ b/test/fixture-auto-retry/get-default-errors/main.tf
@@ -1,0 +1,7 @@
+variable "retryable_errors" {
+  type = list
+}
+
+output "retryable_errors" {
+  value = var.retryable_errors
+}

--- a/test/fixture-auto-retry/get-default-errors/main.tf
+++ b/test/fixture-auto-retry/get-default-errors/main.tf
@@ -1,5 +1,5 @@
 variable "retryable_errors" {
-  type = list
+  type = list(any)
 }
 
 output "retryable_errors" {

--- a/test/fixture-auto-retry/get-default-errors/terragrunt.hcl
+++ b/test/fixture-auto-retry/get-default-errors/terragrunt.hcl
@@ -1,0 +1,3 @@
+inputs = {
+  retryable_errors = concat(get_default_retryable_errors(), ["my special snowflake"])
+}


### PR DESCRIPTION
## Description

The PR adds a new built-in function `get_default_retryable_errors()` that returns a list of default retryable errors.
As mentioned in [this comment](https://github.com/gruntwork-io/terragrunt/pull/1232/files#r444285628)

Fixes #1383.
