### PR TITLE
Add check for aws session before checking S3 bucket

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -217,6 +217,13 @@ func GetAWSCallerIdentity(config *AwsSessionConfig, terragruntOptions *options.T
 	return *identity, nil
 }
 
+// ValidateAwsSession - Validate if current AWS session is valid
+func ValidateAwsSession(config *AwsSessionConfig, terragruntOptions *options.TerragruntOptions) error {
+	// read the caller identity to check if the credentials are valid
+	_, err := GetAWSCallerIdentity(config, terragruntOptions)
+	return err
+}
+
 // Get the AWS Partition of the current session configuration
 func GetAWSPartition(config *AwsSessionConfig, terragruntOptions *options.TerragruntOptions) (string, error) {
 	identity, err := GetAWSCallerIdentity(config, terragruntOptions)

--- a/aws_helper/config_test.go
+++ b/aws_helper/config_test.go
@@ -33,6 +33,7 @@ func TestAwsSessionValidationFail(t *testing.T) {
 	t.Parallel()
 
 	err := ValidateAwsSession(&AwsSessionConfig{
+		Region:        "not-existing-region",
 		CredsFilename: "/tmp/not-existing-file",
 	}, options.NewTerragruntOptions())
 	assert.Error(t, err)

--- a/aws_helper/config_test.go
+++ b/aws_helper/config_test.go
@@ -28,3 +28,12 @@ func TestTerragruntIsAddedInUserAgent(t *testing.T) {
 
 	assert.Contains(t, r.HTTPRequest.Header.Get("User-Agent"), "terragrunt")
 }
+
+func TestAwsSessionValidationFail(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateAwsSession(&AwsSessionConfig{
+		CredsFilename: "/tmp/not-existing-file",
+	}, options.NewTerragruntOptions())
+	assert.Error(t, err)
+}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -165,6 +165,11 @@ func (s3Initializer S3Initializer) NeedsInitialization(remoteState *RemoteState,
 		return false, err
 	}
 
+	_, err = aws_helper.GetAWSCallerIdentity(s3ConfigExtended.GetAwsSessionConfig(), terragruntOptions)
+	if err != nil {
+		return false, err
+	}
+
 	if !DoesS3BucketExist(s3Client, &s3Config.Bucket) {
 		return true, nil
 	}

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -160,12 +160,12 @@ func (s3Initializer S3Initializer) NeedsInitialization(remoteState *RemoteState,
 
 	sessionConfig := s3ConfigExtended.GetAwsSessionConfig()
 
-	s3Client, err := CreateS3Client(sessionConfig, terragruntOptions)
-	if err != nil {
+	// Validate current AWS session before checking S3
+	if err = aws_helper.ValidateAwsSession(sessionConfig, terragruntOptions); err != nil {
 		return false, err
 	}
 
-	_, err = aws_helper.GetAWSCallerIdentity(s3ConfigExtended.GetAwsSessionConfig(), terragruntOptions)
+	s3Client, err := CreateS3Client(sessionConfig, terragruntOptions)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* added validation of AWS session status before checking S3 bucket status

Before:
```
$ terragrunt plan
Remote state S3 bucket test-s3-test-tg-123-7 does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n) y
ERRO[0006] ExpiredToken: The provided token has expired.
        status code: 400, request id: XMMD3RT92G0A44QQ, host id: CJX3KQV33ACPtdMtMZen6pSG8HI1wWuAJG1k8tyOoU5mnUTJJYDHAWofY1++Sn7OT8KOpqFru2Y= 
ERRO[0006] Unable to determine underlying exit code, so Terragrunt will exit with error code 1 
```

After:
```
$ terragrunt plan
ERRO[0001] ExpiredToken: The security token included in the request is expired
        status code: 403, request id: 4b7eee66-b61d-4be4-abdf-ab6b784b730a 
ERRO[0001] Unable to determine underlying exit code, so Terragrunt will exit with error code 1 

```

Fixes #476.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added AWS session status validation before S3 bucket status check

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

