### PR TITLE
refactor: fix usage of deprecated calls to io/ioutil package

### DIFF
--- a/cli/commands/aws-provider-patch/action.go
+++ b/cli/commands/aws-provider-patch/action.go
@@ -31,7 +31,7 @@ package awsproviderpatch
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -117,7 +117,7 @@ func findAllTerraformFilesInModules(opts *options.TerragruntOptions) ([]string, 
 		return nil, nil
 	}
 
-	modulesJsonContents, err := ioutil.ReadFile(modulesJsonPath)
+	modulesJsonContents, err := os.ReadFile(modulesJsonPath)
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}

--- a/cli/commands/hclfmt/action.go
+++ b/cli/commands/hclfmt/action.go
@@ -6,7 +6,6 @@ package hclfmt
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -115,7 +114,7 @@ func formatTgHCL(opts *options.TerragruntOptions, tgHclFile string) error {
 
 	if fileUpdated {
 		opts.Logger.Infof("%s was updated", tgHclFile)
-		return ioutil.WriteFile(tgHclFile, newContents, info.Mode())
+		return os.WriteFile(tgHclFile, newContents, info.Mode())
 	}
 
 	return nil
@@ -135,7 +134,7 @@ func checkErrors(logger *logrus.Entry, contents []byte, tgHclFile string) error 
 
 // bytesDiff uses GNU diff to display the differences between the contents of HCL file before and after formatting
 func bytesDiff(b1, b2 []byte, path string) ([]byte, error) {
-	f1, err := ioutil.TempFile("", "")
+	f1, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +143,7 @@ func bytesDiff(b1, b2 []byte, path string) ([]byte, error) {
 		os.Remove(f1.Name())
 	}()
 
-	f2, err := ioutil.TempFile("", "")
+	f2, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/cli/commands/hclfmt/action_test.go
+++ b/cli/commands/hclfmt/action_test.go
@@ -1,7 +1,6 @@
 package hclfmt
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -117,7 +116,7 @@ func TestHCLFmtCheck(t *testing.T) {
 	defer os.RemoveAll(tmpPath)
 	require.NoError(t, err)
 
-	expected, err := ioutil.ReadFile("../../../test/fixture-hclfmt-check/expected.hcl")
+	expected, err := os.ReadFile("../../../test/fixture-hclfmt-check/expected.hcl")
 	require.NoError(t, err)
 
 	tgOptions, err := options.NewTerragruntOptionsForTest("")
@@ -148,7 +147,7 @@ func TestHCLFmtCheck(t *testing.T) {
 				t.Parallel()
 
 				tgHclPath := filepath.Join(tmpPath, dir)
-				actual, err := ioutil.ReadFile(tgHclPath)
+				actual, err := os.ReadFile(tgHclPath)
 				require.NoError(t, err)
 				assert.Equal(t, expected, actual)
 			})
@@ -163,7 +162,7 @@ func TestHCLFmtCheckErrors(t *testing.T) {
 	defer os.RemoveAll(tmpPath)
 	require.NoError(t, err)
 
-	expected, err := ioutil.ReadFile("../../../test/fixture-hclfmt-check-errors/expected.hcl")
+	expected, err := os.ReadFile("../../../test/fixture-hclfmt-check-errors/expected.hcl")
 	require.NoError(t, err)
 
 	tgOptions, err := options.NewTerragruntOptionsForTest("")
@@ -194,7 +193,7 @@ func TestHCLFmtCheckErrors(t *testing.T) {
 				t.Parallel()
 
 				tgHclPath := filepath.Join(tmpPath, dir)
-				actual, err := ioutil.ReadFile(tgHclPath)
+				actual, err := os.ReadFile(tgHclPath)
 				require.NoError(t, err)
 				assert.Equal(t, expected, actual)
 			})
@@ -209,7 +208,7 @@ func TestHCLFmtFile(t *testing.T) {
 	defer os.RemoveAll(tmpPath)
 	require.NoError(t, err)
 
-	expected, err := ioutil.ReadFile("../../../test/fixture-hclfmt/expected.hcl")
+	expected, err := os.ReadFile("../../../test/fixture-hclfmt/expected.hcl")
 	require.NoError(t, err)
 
 	tgOptions, err := options.NewTerragruntOptionsForTest("")
@@ -226,7 +225,7 @@ func TestHCLFmtFile(t *testing.T) {
 		t.Run(tgOptions.HclFile, func(t *testing.T) {
 			t.Parallel()
 			tgHclPath := filepath.Join(tmpPath, tgOptions.HclFile)
-			formatted, err := ioutil.ReadFile(tgHclPath)
+			formatted, err := os.ReadFile(tgHclPath)
 			require.NoError(t, err)
 			assert.Equal(t, expected, formatted)
 		})
@@ -237,7 +236,7 @@ func TestHCLFmtFile(t *testing.T) {
 		"a/b/c/terragrunt.hcl",
 	}
 
-	original, err := ioutil.ReadFile("../../../test/fixture-hclfmt/terragrunt.hcl")
+	original, err := os.ReadFile("../../../test/fixture-hclfmt/terragrunt.hcl")
 	require.NoError(t, err)
 
 	// test that none of the other files were formatted
@@ -251,7 +250,7 @@ func TestHCLFmtFile(t *testing.T) {
 			t.Run(dir, func(t *testing.T) {
 				t.Parallel()
 				testingPath := filepath.Join(tmpPath, dir)
-				actual, err := ioutil.ReadFile(testingPath)
+				actual, err := os.ReadFile(testingPath)
 				require.NoError(t, err)
 				assert.Equal(t, original, actual)
 			})
@@ -266,7 +265,7 @@ func TestHCLFmtHeredoc(t *testing.T) {
 	defer os.RemoveAll(tmpPath)
 	require.NoError(t, err)
 
-	expected, err := ioutil.ReadFile("../../../test/fixture-hclfmt-heredoc/expected.hcl")
+	expected, err := os.ReadFile("../../../test/fixture-hclfmt-heredoc/expected.hcl")
 	require.NoError(t, err)
 
 	tgOptions, err := options.NewTerragruntOptionsForTest("")
@@ -278,7 +277,7 @@ func TestHCLFmtHeredoc(t *testing.T) {
 	require.NoError(t, err)
 
 	tgHclPath := filepath.Join(tmpPath, "terragrunt.hcl")
-	actual, err := ioutil.ReadFile(tgHclPath)
+	actual, err := os.ReadFile(tgHclPath)
 	require.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }

--- a/cli/commands/render-json/action.go
+++ b/cli/commands/render-json/action.go
@@ -9,7 +9,7 @@ package renderjson
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/zclconf/go-cty/cty"
@@ -64,7 +64,7 @@ func runRenderJSON(opts *options.TerragruntOptions, cfg *config.TerragruntConfig
 	}
 	opts.Logger.Debugf("Rendering config %s to JSON %s", opts.TerragruntConfigPath, jsonOutPath)
 
-	if err := ioutil.WriteFile(jsonOutPath, jsonBytes, 0644); err != nil {
+	if err := os.WriteFile(jsonOutPath, jsonBytes, 0644); err != nil {
 		return errors.WithStackTrace(err)
 	}
 	return nil

--- a/cli/commands/terraform/action_test.go
+++ b/cli/commands/terraform/action_test.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -471,7 +470,7 @@ func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, t
 }
 
 func createTempFile(t *testing.T) string {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %s\n", err.Error())
 	}

--- a/cli/commands/terraform/debug.go
+++ b/cli/commands/terraform/debug.go
@@ -3,7 +3,6 @@ package terraform
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,7 +41,7 @@ func WriteTerragruntDebugFile(terragruntOptions *options.TerragruntOptions, terr
 
 	configFolder := filepath.Dir(terragruntOptions.TerragruntConfigPath)
 	fileName := filepath.Join(configFolder, TerragruntTFVarsFile)
-	if err := ioutil.WriteFile(fileName, fileContents, os.FileMode(int(0600))); err != nil {
+	if err := os.WriteFile(fileName, fileContents, os.FileMode(int(0600))); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/cli/commands/terraform/download_source_test.go
+++ b/cli/commands/terraform/download_source_test.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"path"
@@ -360,7 +360,7 @@ func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, d
 
 func createConfig(t *testing.T, canonicalUrl string, downloadDir string, sourceUpdate bool) (*terraform.Source, *options.TerragruntOptions, *config.TerragruntConfig, error) {
 	logger := logrus.New()
-	logger.Out = ioutil.Discard
+	logger.Out = io.Discard
 	terraformSource := &terraform.Source{
 		CanonicalSourceURL: parseUrl(t, canonicalUrl),
 		DownloadDir:        downloadDir,
@@ -389,7 +389,7 @@ func createConfig(t *testing.T, canonicalUrl string, downloadDir string, sourceU
 
 func testAlreadyHaveLatestCode(t *testing.T, canonicalUrl string, downloadDir string, expected bool) {
 	logger := logrus.New()
-	logger.Out = ioutil.Discard
+	logger.Out = io.Discard
 	terraformSource := &terraform.Source{
 		CanonicalSourceURL: parseUrl(t, canonicalUrl),
 		DownloadDir:        downloadDir,
@@ -407,7 +407,7 @@ func testAlreadyHaveLatestCode(t *testing.T, canonicalUrl string, downloadDir st
 }
 
 func tmpDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "download-source-test")
+	dir, err := os.MkdirTemp("", "download-source-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/commands/terraform/version_check.go
+++ b/cli/commands/terraform/version_check.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"regexp"
 	"strings"
 
@@ -69,8 +69,8 @@ func checkVersionConstraints(terragruntOptions *options.TerragruntOptions) error
 func PopulateTerraformVersion(terragruntOptions *options.TerragruntOptions) error {
 	// Discard all log output to make sure we don't pollute stdout or stderr with this extra call to '--version'
 	terragruntOptionsCopy := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
-	terragruntOptionsCopy.Writer = ioutil.Discard
-	terragruntOptionsCopy.ErrWriter = ioutil.Discard
+	terragruntOptionsCopy.Writer = io.Discard
+	terragruntOptionsCopy.ErrWriter = io.Discard
 
 	// Remove any TF_CLI_ARGS before version checking. These are appended to
 	// the arguments supplied on the command line and cause issues when running

--- a/cli/commands/validate-inputs/action.go
+++ b/cli/commands/validate-inputs/action.go
@@ -7,7 +7,7 @@ package validateinputs
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -266,7 +266,7 @@ func getVarNamesFromVarFiles(varFiles []string) ([]string, error) {
 // getVarNamesFromVarFile will parse the given terraform var file and return a list of names of variables that are
 // configured in that var file.
 func getVarNamesFromVarFile(varFile string) ([]string, error) {
-	fileContents, err := ioutil.ReadFile(varFile)
+	fileContents, err := os.ReadFile(varFile)
 	if err != nil {
 		return nil, err
 	}

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -91,7 +90,7 @@ func WriteToFile(terragruntOptions *options.TerragruntOptions, basePath string, 
 	}
 	contentsToWrite := fmt.Sprintf("%s%s", prefix, config.Contents)
 
-	if err := ioutil.WriteFile(targetPath, []byte(contentsToWrite), 0644); err != nil {
+	if err := os.WriteFile(targetPath, []byte(contentsToWrite), 0644); err != nil {
 		return errors.WithStackTrace(err)
 	}
 	terragruntOptions.Logger.Debugf("Generated file %s.", targetPath)

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -1123,7 +1122,7 @@ func validateGenerateBlocks(blocks *[]terragruntGenerateBlock) error {
 // dependency or dependencies blocks defined. Note that this does not do any decoding of the blocks, as it is only meant
 // to check for block presence.
 func configFileHasDependencyBlock(configPath string, terragruntOptions *options.TerragruntOptions) (bool, error) {
-	configBytes, err := ioutil.ReadFile(configPath)
+	configBytes, err := os.ReadFile(configPath)
 	if err != nil {
 		return false, errors.WithStackTrace(err)
 	}

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -702,7 +702,7 @@ func getTerragruntOutputJsonFromRemoteState(
 	if err := util.EnsureDirectory(terragruntOptions.DownloadDir); err != nil {
 		return nil, err
 	}
-	tempWorkDir, err := ioutil.TempDir(terragruntOptions.DownloadDir, "")
+	tempWorkDir, err := os.MkdirTemp(terragruntOptions.DownloadDir, "")
 	if err != nil {
 		return nil, err
 	}
@@ -798,7 +798,7 @@ func getTerragruntOutputJsonFromRemoteStateS3(
 	}
 
 	defer result.Body.Close()
-	steateBody, err := ioutil.ReadAll(result.Body)
+	steateBody, err := io.ReadAll(result.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -820,11 +820,11 @@ func getTerragruntOutputJsonFromRemoteStateS3(
 func setupTerragruntOptionsForBareTerraform(originalOptions *options.TerragruntOptions, workingDir string, configPath string, iamRoleOpts options.IAMRoleOptions) (*options.TerragruntOptions, error) {
 	// Here we clone the terragrunt options again since we need to make further modifications to it to allow running
 	// terraform directly.
-	// Set the terraform working dir to the tempdir, and set stdout writer to ioutil.Discard so that output content is
+	// Set the terraform working dir to the tempdir, and set stdout writer to io.Discard so that output content is
 	// not logged.
 	targetTGOptions := cloneTerragruntOptionsForDependency(originalOptions, configPath)
 	targetTGOptions.WorkingDir = workingDir
-	targetTGOptions.Writer = ioutil.Discard
+	targetTGOptions.Writer = io.Discard
 
 	// If the target config has an IAM role directive and it was not set on the command line, set it to
 	// the one we retrieved from the config.

--- a/configstack/stack_test.go
+++ b/configstack/stack_test.go
@@ -1,7 +1,6 @@
 package configstack
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -153,7 +152,7 @@ func createTestStack() *Stack {
 }
 
 func createTempFolder(t *testing.T) string {
-	tmpFolder, err := ioutil.TempDir("", "")
+	tmpFolder, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %s\n", err.Error())
 	}
@@ -170,7 +169,7 @@ func writeDummyTerragruntConfigs(t *testing.T, tmpFolder string, paths []string)
 		containingDir := filepath.Dir(absPath)
 		createDirIfNotExist(t, containingDir)
 
-		err := ioutil.WriteFile(absPath, contents, os.ModePerm)
+		err := os.WriteFile(absPath, contents, os.ModePerm)
 		if err != nil {
 			t.Fatalf("Failed to write file at path %s: %s\n", path, err.Error())
 		}

--- a/terraform/getter.go
+++ b/terraform/getter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -283,7 +283,7 @@ func httpGETAndGetResponse(ctx context.Context, getURL url.URL) ([]byte, *http.H
 		return nil, nil, errors.WithStackTrace(RegistryAPIErr{url: getURL.String(), statusCode: resp.StatusCode})
 	}
 
-	bodyData, err := ioutil.ReadAll(resp.Body)
+	bodyData, err := io.ReadAll(resp.Body)
 	return bodyData, &resp.Header, errors.WithStackTrace(err)
 }
 

--- a/terraform/getter_test.go
+++ b/terraform/getter_test.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"context"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -105,7 +104,7 @@ func TestTFRGetterRootDir(t *testing.T) {
 	testModuleURL, err := url.Parse("tfr://registry.terraform.io/terraform-aws-modules/vpc/aws?version=3.3.0")
 	require.NoError(t, err)
 
-	dstPath, err := ioutil.TempDir("", "")
+	dstPath, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(dstPath)
 
@@ -124,7 +123,7 @@ func TestTFRGetterSubModule(t *testing.T) {
 	testModuleURL, err := url.Parse("tfr://registry.terraform.io/terraform-aws-modules/vpc/aws//modules/vpc-endpoints?version=3.3.0")
 	require.NoError(t, err)
 
-	dstPath, err := ioutil.TempDir("", "")
+	dstPath, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(dstPath)
 

--- a/terraform/source.go
+++ b/terraform/source.go
@@ -3,7 +3,6 @@ package terraform
 import (
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -107,7 +106,7 @@ func (terraformSource Source) WriteVersionFile() error {
 		}
 	}
 
-	return errors.WithStackTrace(ioutil.WriteFile(terraformSource.VersionFile, []byte(version), 0640))
+	return errors.WithStackTrace(os.WriteFile(terraformSource.VersionFile, []byte(version), 0640))
 }
 
 // Take the given source path and create a Source struct from it, including the folder where the source should

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,7 +71,7 @@ func TestDebugGeneratedInputs(t *testing.T) {
 	validateInputs(t, outputs)
 
 	// Also make sure the undefined variable is not included in the json file
-	debugJsonContents, err := ioutil.ReadFile(debugFile)
+	debugJsonContents, err := os.ReadFile(debugFile)
 	require.NoError(t, err)
 	var data map[string]interface{}
 	require.NoError(t, json.Unmarshal(debugJsonContents, &data))
@@ -181,7 +180,7 @@ func TestTerragruntValidateInputsWithStrictModeDisabledAndUnusedInputs(t *testin
 func TestRenderJSONConfig(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", "terragrunt-render-json-*")
+	tmpDir, err := os.MkdirTemp("", "terragrunt-render-json-*")
 	require.NoError(t, err)
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
 	defer os.RemoveAll(tmpDir)
@@ -192,7 +191,7 @@ func TestRenderJSONConfig(t *testing.T) {
 	runTerragrunt(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", fixtureRenderJSON))
 	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-json-out %s", fixtureRenderJSONMainModulePath, jsonOut))
 
-	jsonBytes, err := ioutil.ReadFile(jsonOut)
+	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
 
 	var rendered map[string]interface{}
@@ -290,7 +289,7 @@ func TestRenderJSONConfig(t *testing.T) {
 func TestRenderJSONConfigWithIncludesDependenciesAndLocals(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", "terragrunt-render-json-*")
+	tmpDir, err := os.MkdirTemp("", "terragrunt-render-json-*")
 	require.NoError(t, err)
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
 	defer os.RemoveAll(tmpDir)
@@ -302,7 +301,7 @@ func TestRenderJSONConfigWithIncludesDependenciesAndLocals(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-json-out %s", workDir, jsonOut))
 
-	jsonBytes, err := ioutil.ReadFile(jsonOut)
+	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
 
 	var rendered map[string]interface{}
@@ -403,7 +402,7 @@ func TestRenderJSONConfigRunAll(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt run-all render-json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", workDir))
 
-	bazJSONBytes, err := ioutil.ReadFile(bazJSONOut)
+	bazJSONBytes, err := os.ReadFile(bazJSONOut)
 	require.NoError(t, err)
 
 	var bazRendered map[string]interface{}
@@ -421,7 +420,7 @@ func TestRenderJSONConfigRunAll(t *testing.T) {
 		)
 	}
 
-	rootChildJSONBytes, err := ioutil.ReadFile(rootChildJSONOut)
+	rootChildJSONBytes, err := os.ReadFile(rootChildJSONOut)
 	require.NoError(t, err)
 
 	var rootChildRendered map[string]interface{}

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -217,7 +216,7 @@ func TestCustomLockFile(t *testing.T) {
 	lockFilePath := util.JoinPath(result.WorkingDir, util.TerraformLockFile)
 	require.FileExists(t, lockFilePath)
 
-	readFile, err := ioutil.ReadFile(lockFilePath)
+	readFile, err := os.ReadFile(lockFilePath)
 	require.NoError(t, err)
 
 	// In our lock file, we intentionally have hashes for an older version of the AWS provider. If the lock file

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -30,7 +30,7 @@ const (
 func TestTerragruntWorksWithIncludeLocals(t *testing.T) {
 	t.Parallel()
 
-	files, err := ioutil.ReadDir(includeExposeFixturePath)
+	files, err := os.ReadDir(includeExposeFixturePath)
 	require.NoError(t, err)
 
 	testCases := []string{}
@@ -193,7 +193,7 @@ func TestTerragruntWorksWithIncludeDeepMerge(t *testing.T) {
 func TestTerragruntWorksWithMultipleInclude(t *testing.T) {
 	t.Parallel()
 
-	files, err := ioutil.ReadDir(includeMultipleFixturePath)
+	files, err := os.ReadDir(includeMultipleFixturePath)
 	require.NoError(t, err)
 
 	testCases := []string{}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"os"
@@ -310,9 +309,9 @@ func TestTerragruntHookRunAllApply(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
 
-	_, beforeErr := ioutil.ReadFile(beforeOnlyPath + "/file.out")
+	_, beforeErr := os.ReadFile(beforeOnlyPath + "/file.out")
 	assert.NoError(t, beforeErr)
-	_, afterErr := ioutil.ReadFile(afterOnlyPath + "/file.out")
+	_, afterErr := os.ReadFile(afterOnlyPath + "/file.out")
 	assert.NoError(t, afterErr)
 }
 
@@ -327,9 +326,9 @@ func TestTerragruntHookApplyAll(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply-all -auto-approve --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
 
-	_, beforeErr := ioutil.ReadFile(beforeOnlyPath + "/file.out")
+	_, beforeErr := os.ReadFile(beforeOnlyPath + "/file.out")
 	assert.NoError(t, beforeErr)
-	_, afterErr := ioutil.ReadFile(afterOnlyPath + "/file.out")
+	_, afterErr := os.ReadFile(afterOnlyPath + "/file.out")
 	assert.NoError(t, afterErr)
 }
 
@@ -342,7 +341,7 @@ func TestTerragruntBeforeHook(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
 
-	_, exception := ioutil.ReadFile(rootPath + "/file.out")
+	_, exception := os.ReadFile(rootPath + "/file.out")
 
 	assert.NoError(t, exception)
 }
@@ -367,7 +366,7 @@ func TestTerragruntAfterHook(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
 
-	_, exception := ioutil.ReadFile(rootPath + "/file.out")
+	_, exception := os.ReadFile(rootPath + "/file.out")
 
 	assert.NoError(t, exception)
 }
@@ -383,8 +382,8 @@ func TestTerragruntBeforeAndAfterHook(t *testing.T) {
 	stderr := bytes.Buffer{}
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr)
 
-	_, beforeException := ioutil.ReadFile(rootPath + "/before.out")
-	_, afterException := ioutil.ReadFile(rootPath + "/after.out")
+	_, beforeException := os.ReadFile(rootPath + "/before.out")
+	_, afterException := os.ReadFile(rootPath + "/after.out")
 
 	output := stdout.String()
 
@@ -418,14 +417,14 @@ func TestTerragruntBeforeAfterAndErrorMergeHook(t *testing.T) {
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, childPath), &stdout, &stderr)
 	assert.ErrorContains(t, err, "executable file not found in $PATH")
 
-	_, beforeException := ioutil.ReadFile(childPath + "/before.out")
-	_, beforeChildException := ioutil.ReadFile(childPath + "/before-child.out")
-	_, beforeOverriddenParentException := ioutil.ReadFile(childPath + "/before-parent.out")
-	_, afterException := ioutil.ReadFile(childPath + "/after.out")
-	_, afterParentException := ioutil.ReadFile(childPath + "/after-parent.out")
-	_, errorHookParentException := ioutil.ReadFile(childPath + "/error-hook-parent.out")
-	_, errorHookChildException := ioutil.ReadFile(childPath + "/error-hook-child.out")
-	_, errorHookOverridenParentException := ioutil.ReadFile(childPath + "/error-hook-merge-parent.out")
+	_, beforeException := os.ReadFile(childPath + "/before.out")
+	_, beforeChildException := os.ReadFile(childPath + "/before-child.out")
+	_, beforeOverriddenParentException := os.ReadFile(childPath + "/before-parent.out")
+	_, afterException := os.ReadFile(childPath + "/after.out")
+	_, afterParentException := os.ReadFile(childPath + "/after-parent.out")
+	_, errorHookParentException := os.ReadFile(childPath + "/error-hook-parent.out")
+	_, errorHookChildException := os.ReadFile(childPath + "/error-hook-child.out")
+	_, errorHookOverridenParentException := os.ReadFile(childPath + "/error-hook-merge-parent.out")
 
 	assert.NoError(t, beforeException)
 	assert.NoError(t, beforeChildException)
@@ -1004,7 +1003,7 @@ func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules
 	//fixtureApp := path.Join(TEST_FIXTURE_PARALLELISM, "app")
 
 	// copy the template `numberOfModules` times into the app
-	tmpEnvPath, err := ioutil.TempDir("", "terragrunt-test")
+	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir due to error: %v", err)
 	}
@@ -1310,7 +1309,7 @@ func TestAwsProviderPatch(t *testing.T) {
 	// https://github.com/gruntwork-io/terragrunt/issues/1778
 	branchName = url.QueryEscape(branchName)
 	mainContents = strings.Replace(mainContents, "__BRANCH_NAME__", branchName, -1)
-	require.NoError(t, ioutil.WriteFile(mainTFFile, []byte(mainContents), 0444))
+	require.NoError(t, os.WriteFile(mainTFFile, []byte(mainContents), 0444))
 
 	assert.NoError(
 		t,
@@ -2744,7 +2743,7 @@ func TestOrderedMapOutputRegressions1102(t *testing.T) {
 		t,
 		runTerragruntCommand(t, command, &stdout, &stderr),
 	)
-	expected, _ := ioutil.ReadFile(path)
+	expected, _ := os.ReadFile(path)
 	require.Contains(t, string(expected), "local")
 
 	// runs terragrunt again. All the outputs must be
@@ -2754,7 +2753,7 @@ func TestOrderedMapOutputRegressions1102(t *testing.T) {
 			t,
 			runTerragruntCommand(t, command, &stdout, &stderr),
 		)
-		actual, _ := ioutil.ReadFile(path)
+		actual, _ := os.ReadFile(path)
 		require.Equal(t, expected, actual)
 	}
 }
@@ -4049,7 +4048,7 @@ func runTerragruntRedirectOutput(t *testing.T, command string, writer io.Writer,
 }
 
 func copyEnvironment(t *testing.T, environmentPath string) string {
-	tmpDir, err := ioutil.TempDir("", "terragrunt-test")
+	tmpDir, err := os.MkdirTemp("", "terragrunt-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir due to error: %v", err)
 	}
@@ -4062,7 +4061,7 @@ func copyEnvironment(t *testing.T, environmentPath string) string {
 }
 
 func copyEnvironmentWithTflint(t *testing.T, environmentPath string) string {
-	tmpDir, err := ioutil.TempDir("", "terragrunt-test")
+	tmpDir, err := os.MkdirTemp("", "terragrunt-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir due to error: %v", err)
 	}
@@ -4084,7 +4083,7 @@ func copyEnvironmentToPath(t *testing.T, environmentPath, targetPath string) {
 }
 
 func createTmpTerragruntConfigWithParentAndChild(t *testing.T, parentPath string, childRelPath string, s3BucketName string, parentConfigFileName string, childConfigFileName string) string {
-	tmpDir, err := ioutil.TempDir("", "terragrunt-parent-child-test")
+	tmpDir, err := os.MkdirTemp("", "terragrunt-parent-child-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir due to error: %v", err)
 	}
@@ -4107,7 +4106,7 @@ func createTmpTerragruntConfigWithParentAndChild(t *testing.T, parentPath string
 }
 
 func createTmpTerragruntConfig(t *testing.T, templatesPath string, s3BucketName string, lockTableName string, configFileName string) string {
-	tmpFolder, err := ioutil.TempDir("", "terragrunt-test")
+	tmpFolder, err := os.MkdirTemp("", "terragrunt-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp folder due to error: %v", err)
 	}
@@ -4120,14 +4119,14 @@ func createTmpTerragruntConfig(t *testing.T, templatesPath string, s3BucketName 
 }
 
 func createTmpTerragruntConfigContent(t *testing.T, contents string, configFileName string) string {
-	tmpFolder, err := ioutil.TempDir("", "terragrunt-test")
+	tmpFolder, err := os.MkdirTemp("", "terragrunt-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp folder due to error: %v", err)
 	}
 
 	tmpTerragruntConfigFile := util.JoinPath(tmpFolder, configFileName)
 
-	if err := ioutil.WriteFile(tmpTerragruntConfigFile, []byte(contents), 0444); err != nil {
+	if err := os.WriteFile(tmpTerragruntConfigFile, []byte(contents), 0444); err != nil {
 		t.Fatalf("Error writing temp Terragrunt config to %s: %v", tmpTerragruntConfigFile, err)
 	}
 
@@ -4135,7 +4134,7 @@ func createTmpTerragruntConfigContent(t *testing.T, contents string, configFileN
 }
 
 func createTmpTerragruntGCSConfig(t *testing.T, templatesPath string, project string, location string, gcsBucketName string, configFileName string) string {
-	tmpFolder, err := ioutil.TempDir("", "terragrunt-test")
+	tmpFolder, err := os.MkdirTemp("", "terragrunt-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp folder due to error: %v", err)
 	}
@@ -4158,7 +4157,7 @@ func copyTerragruntConfigAndFillPlaceholders(t *testing.T, configSrcPath string,
 	contents = strings.Replace(contents, "__FILL_IN_REGION__", region, -1)
 	contents = strings.Replace(contents, "__FILL_IN_LOGS_BUCKET_NAME__", s3BucketName+"-tf-state-logs", -1)
 
-	if err := ioutil.WriteFile(configDestPath, []byte(contents), 0444); err != nil {
+	if err := os.WriteFile(configDestPath, []byte(contents), 0444); err != nil {
 		t.Fatalf("Error writing temp Terragrunt config to %s: %v", configDestPath, err)
 	}
 }
@@ -4176,7 +4175,7 @@ func copyTerragruntGCSConfigAndFillPlaceholders(t *testing.T, configSrcPath stri
 	email := os.Getenv("GOOGLE_IDENTITY_EMAIL")
 	contents = strings.Replace(contents, "__FILL_IN_GCP_EMAIL__", email, -1)
 
-	if err := ioutil.WriteFile(configDestPath, []byte(contents), 0444); err != nil {
+	if err := os.WriteFile(configDestPath, []byte(contents), 0444); err != nil {
 		t.Fatalf("Error writing temp Terragrunt config to %s: %v", configDestPath, err)
 	}
 }
@@ -4906,7 +4905,7 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 		require.NoError(t, err)
 	}
 	updatedHcl := strings.Replace(contents, "__TAG_VALUE__", "v0.35.1", -1)
-	require.NoError(t, ioutil.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
+	require.NoError(t, os.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
@@ -4917,7 +4916,7 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(stdout.String(), "Terraform has been successfully initialized!"))
 
 	updatedHcl = strings.Replace(contents, "__TAG_VALUE__", "v0.35.2", -1)
-	require.NoError(t, ioutil.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
+	require.NoError(t, os.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
 
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
@@ -4963,7 +4962,7 @@ func TestRenderJsonAttributesMetadata(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
 
-	jsonBytes, err := ioutil.ReadFile(jsonOut)
+	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
 
 	var renderedJson = map[string]interface{}{}
@@ -5101,7 +5100,7 @@ func TestRenderJsonMetadataDependency(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
 
-	jsonBytes, err := ioutil.ReadFile(jsonOut)
+	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
 
 	var renderedJson = map[string]interface{}{}
@@ -5145,7 +5144,7 @@ func TestRenderJsonWithMockOutputs(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
 
-	jsonBytes, err := ioutil.ReadFile(jsonOut)
+	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
 
 	var renderedJson = map[string]interface{}{}
@@ -5213,7 +5212,7 @@ func TestRenderJsonMetadataIncludes(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
 
-	jsonBytes, err := ioutil.ReadFile(jsonOut)
+	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
 
 	var renderedJson = map[string]interface{}{}
@@ -5308,7 +5307,7 @@ func TestRenderJsonMetadataDepenency(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
 
-	jsonBytes, err := ioutil.ReadFile(jsonOut)
+	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
 
 	var renderedJson = map[string]interface{}{}
@@ -5381,7 +5380,7 @@ func TestRenderJsonMetadataTerraform(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
 
-	jsonBytes, err := ioutil.ReadFile(jsonOut)
+	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
 
 	var renderedJson = map[string]interface{}{}
@@ -5720,7 +5719,7 @@ func TestHclFmtDiff(t *testing.T) {
 
 	output := stdout.String()
 
-	expectedDiff, err := ioutil.ReadFile(util.JoinPath(rootPath, "expected.diff"))
+	expectedDiff, err := os.ReadFile(util.JoinPath(rootPath, "expected.diff"))
 	assert.NoError(t, err)
 
 	logBufferContentsLineByLine(t, stdout, "output")
@@ -5846,7 +5845,7 @@ func TestInitSkipCache(t *testing.T) {
 
 	// verify that after adding new file, init is executed
 	tfFile := util.JoinPath(tmpEnvPath, TEST_FIXTURE_INIT_CACHE, "app", "project.tf")
-	if err := ioutil.WriteFile(tfFile, []byte(""), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(""), 0644); err != nil {
 		t.Fatalf("Error writing new Terraform file to %s: %v", tfFile, err)
 	}
 
@@ -5876,7 +5875,7 @@ func TestRenderJsonWithInputsNotExistingOutput(t *testing.T) {
 
 	jsonOut := filepath.Join(appPath, "terragrunt_rendered.json")
 
-	jsonBytes, err := ioutil.ReadFile(jsonOut)
+	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
 
 	var renderedJson = map[string]interface{}{}

--- a/test/integration_tflint_test.go
+++ b/test/integration_tflint_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"testing"
@@ -93,7 +92,7 @@ func TestTflintFindsNoIssuesWithValidCodeDifferentDownloadDir(t *testing.T) {
 	out := new(bytes.Buffer)
 	errOut := new(bytes.Buffer)
 
-	downloadDir, err := ioutil.TempDir("", "download-dir")
+	downloadDir, err := os.MkdirTemp("", "download-dir")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir due to error: %v", err)
 	}

--- a/util/file.go
+++ b/util/file.go
@@ -3,7 +3,6 @@ package util
 import (
 	"encoding/gob"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -34,7 +33,7 @@ func FileOrData(maybePath string) (string, error) {
 	}
 
 	if IsFile(expandedMaybePath) {
-		contents, err := ioutil.ReadFile(expandedMaybePath)
+		contents, err := os.ReadFile(expandedMaybePath)
 		if err != nil {
 			return "", errors.WithStackTrace(err)
 		}
@@ -152,7 +151,7 @@ func Grep(regex *regexp.Regexp, glob string) (bool, error) {
 		if IsDir(match) {
 			continue
 		}
-		bytes, err := ioutil.ReadFile(match)
+		bytes, err := os.ReadFile(match)
 		if err != nil {
 			return false, errors.WithStackTrace(err)
 		}
@@ -206,7 +205,7 @@ func GetPathRelativeTo(path string, basePath string) (string, error) {
 
 // Return the contents of the file at the given path as a string
 func ReadFileAsString(path string) (string, error) {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return "", errors.WithStackTraceAndPrefix(err, "Error reading file at path %s", path)
 	}
@@ -292,7 +291,7 @@ func CopyFolderContentsWithFilter(source, destination, manifestFile string, filt
 	}
 	defer manifest.Close()
 
-	// Why use filepath.Glob here? The original implementation used ioutil.ReadDir, but that method calls lstat on all
+	// Why use filepath.Glob here? The original implementation used os.ReadDir, but that method calls lstat on all
 	// the files/folders in the directory, including files/folders you may want to explicitly skip. The next attempt
 	// was to use filepath.Walk, but that doesn't work because it ignores symlinks. So, now we turn to filepath.Glob.
 	files, err := filepath.Glob(fmt.Sprintf("%s/*", source))
@@ -368,7 +367,7 @@ func TerragruntExcludes(path string) bool {
 
 // Copy a file from source to destination
 func CopyFile(source string, destination string) error {
-	contents, err := ioutil.ReadFile(source)
+	contents, err := os.ReadFile(source)
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
@@ -383,7 +382,7 @@ func WriteFileWithSamePermissions(source string, destination string, contents []
 		return errors.WithStackTrace(err)
 	}
 
-	return ioutil.WriteFile(destination, contents, fileInfo.Mode())
+	return os.WriteFile(destination, contents, fileInfo.Mode())
 }
 
 // Windows systems use \ as the path separator *nix uses /

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -176,11 +175,11 @@ func TestFileManifest(t *testing.T) {
 	var testfiles []string
 
 	// create temp dir
-	dir, err := ioutil.TempDir("", ".terragrunt-test-dir")
+	dir, err := os.MkdirTemp("", ".terragrunt-test-dir")
 	require.NoError(t, err)
 	for _, file := range []string{"file1", "file2"} {
 		// create temp files in the dir
-		f, err := ioutil.TempFile(dir, file)
+		f, err := os.CreateTemp(dir, file)
 		assert.NoError(t, err, f.Close())
 		testfiles = append(testfiles, f.Name())
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Replaces all calls to the `io/ioutils` package with the recommended function calls by the package documentation. Those have been wrapper as of go 1.16.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Not required.

### Migration Guide

Not required.
