### PR TITLE
Add OpenTofu support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,32 @@ defaults: &defaults
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.21-tf1.5-tg39.1-pck1.8-ci50.7
 
+install_tofu: &install_tofu
+  name: Install OpenTofu
+  command: |
+    pushd .
+    cd /tmp
+    curl -L "https://github.com/opentofu/opentofu/releases/download/v1.6.0-alpha1/tofu_1.6.0-alpha1_linux_amd64.zip" -o tofu.zip
+    unzip -o tofu.zip
+    sudo install -m 0755 tofu /usr/local/bin/tofu
+    rm -rf tofu
+    rm -rf tofu.zip
+    popd
+    tofu --version
+
+install_tflint: &install_tflint
+  name: Install Tflint
+  command: |
+    pushd .
+    cd /tmp
+    curl -L "https://github.com/terraform-linters/tflint/releases/download/v0.47.0/tflint_linux_amd64.zip" -o tflint.zip
+    unzip -o tflint.zip
+    sudo install -m 0755 tflint /usr/local/bin/tflint
+    rm -rf tflint
+    rm -rf tflint.zip
+    popd
+    tflint --version
+
 version: 2.1
 jobs:
   test_windows:
@@ -78,36 +104,18 @@ jobs:
           path: logs
       - store_test_results:
           path: logs
+
   integration_test:
     resource_class: large
     <<: *defaults
     steps:
       - checkout
       - run: gruntwork-install --binary-name 'terratest_log_parser' --repo 'https://github.com/gruntwork-io/terratest' --tag 'v0.30.0'
-      # install OpenTofu
       - run:
-          command: |
-            pushd .
-            cd /tmp
-            curl -L "https://github.com/opentofu/opentofu/releases/download/v1.6.0-alpha1/tofu_1.6.0-alpha1_linux_amd64.zip" -o tofu.zip
-            unzip -o tofu.zip
-            sudo install -m 0755 tofu /usr/local/bin/tofu
-            rm -rf tofu
-            rm -rf tofu.zip
-            popd
-            tofu --version
-      # install tflint
+          <<: *install_tofu
       - run:
-          command: |
-            pushd .
-            cd /tmp
-            curl -L "https://github.com/terraform-linters/tflint/releases/download/v0.47.0/tflint_linux_amd64.zip" -o tflint.zip
-            unzip -o tflint.zip
-            sudo install -m 0755 tflint /usr/local/bin/tflint
-            rm -rf tflint
-            rm -rf tflint.zip
-            popd
-            tflint --version
+          <<: *install_tflint
+
       # Make GCP Service Account creds available as a file
       - run: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
       - run: echo 'export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcloud-service-key.json' >> $BASH_ENV
@@ -121,9 +129,63 @@ jobs:
       - run:
           command: terratest_log_parser --testlog logs/integration.log --outputdir logs
           when: always
+      - store_artifacts:
+          path: logs
+      - store_test_results:
+          path: logs
+
+  integration_test_tofu:
+    resource_class: large
+    <<: *defaults
+    steps:
+      - checkout
+      - run: gruntwork-install --binary-name 'terratest_log_parser' --repo 'https://github.com/gruntwork-io/terratest' --tag 'v0.30.0'
+      - run:
+          <<: *install_tofu
+      - run:
+          <<: *install_tflint
+      # Make GCP Service Account creds available as a file
+      - run: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
+      - run: echo 'export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcloud-service-key.json' >> $BASH_ENV
+      # Import test / dev key for SOPS
+      - run:
+          command: |
+            gpg --import --no-tty --batch --yes ./test/fixture-sops/test_pgp_key.asc
+            mkdir -p logs
+            # use tofu as wrapper
+            export TERRAGRUNT_TFPATH=tofu
+            run-go-tests --packages "$(go list ./... | grep /test | tr '\n' ' ')" | tee logs/integration.log
+          no_output_timeout: 30m
+      - run:
+          command: terratest_log_parser --testlog logs/integration.log --outputdir logs
+          when: always
+      - store_artifacts:
+          path: logs
+      - store_test_results:
+          path: logs
+
+  integration_test_tflint:
+    resource_class: large
+    <<: *defaults
+    steps:
+      - checkout
+      - run: gruntwork-install --binary-name 'terratest_log_parser' --repo 'https://github.com/gruntwork-io/terratest' --tag 'v0.30.0'
+      - run:
+          <<: *install_tofu
+      - run:
+          <<: *install_tflint
+      # Make GCP Service Account creds available as a file
+      - run: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
+      - run: echo 'export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcloud-service-key.json' >> $BASH_ENV
+      # Import test / dev key for SOPS
+      - run:
+          command: |
+            gpg --import --no-tty --batch --yes ./test/fixture-sops/test_pgp_key.asc
+          no_output_timeout: 30m
       # Run TFLint tests separately as tflint during execution change working directory.
       - run:
           command: |
+            mkdir -p logs
             run-go-tests --packages "-tags tflint -run TestTflint ./test" | tee logs/integration.log
           no_output_timeout: 30m
       - run:
@@ -133,6 +195,7 @@ jobs:
           path: logs
       - store_test_results:
           path: logs
+
   build:
     resource_class: large
     <<: *defaults
@@ -201,6 +264,24 @@ workflows:
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
       - integration_test:
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GITHUB__PAT__gruntwork-ci
+            - GCP__automated-tests
+            - GITHUB__PAT__gruntwork-ci
+      - integration_test_tofu:
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GITHUB__PAT__gruntwork-ci
+            - GCP__automated-tests
+            - GITHUB__PAT__gruntwork-ci
+      - integration_test_tflint:
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,18 @@ jobs:
     steps:
       - checkout
       - run: gruntwork-install --binary-name 'terratest_log_parser' --repo 'https://github.com/gruntwork-io/terratest' --tag 'v0.30.0'
+      # install OpenTofu
+      - run:
+          command: |
+            pushd .
+            cd /tmp
+            curl -L "https://github.com/opentofu/opentofu/releases/download/v1.6.0-alpha1/tofu_1.6.0-alpha1_linux_amd64.zip" -o tofu.zip
+            unzip -o tofu.zip
+            sudo install -m 0755 tofu /usr/local/bin/tofu
+            rm -rf tofu
+            rm -rf tofu.zip
+            popd
+            tofu --version
       # install tflint
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,20 @@ jobs:
           shell: powershell.exe
           command: ./_ci/install-tflint.ps1
       - run:
-          name: Run go tests
+          name: Run go terraform tests
           shell: powershell.exe
           no_output_timeout: 45m
+          command: |
+            # We're running this test only on Windows currently to provide a convenient
+            # means of reproducing Terragrunt issues that only occur on that platform
+            go test -v ./... -run TestWindowsTerragruntSourceMapDebug -timeout 45m
+            go test -v ./... -run TestWindowsTflintIsInvoked -timeout 45m
+      - run:
+          name: Run go tofu tests
+          shell: powershell.exe
+          no_output_timeout: 45m
+          environment:
+            TERRAGRUNT_TFPATH: tofu
           command: |
             # We're running this test only on Windows currently to provide a convenient
             # means of reproducing Terragrunt issues that only occur on that platform
@@ -105,7 +116,7 @@ jobs:
       - store_test_results:
           path: logs
 
-  integration_test:
+  integration_test_terraform:
     resource_class: large
     <<: *defaults
     steps:
@@ -151,11 +162,14 @@ jobs:
       - run:
           command: |
             gpg --import --no-tty --batch --yes ./test/fixture-sops/test_pgp_key.asc
+            # remove terraform 
+            sudo rm -f $(which terraform)
             mkdir -p logs
-            # use tofu as wrapper
-            export TERRAGRUNT_TFPATH=tofu
             run-go-tests --packages "$(go list ./... | grep /test | tr '\n' ' ')" | tee logs/integration.log
           no_output_timeout: 30m
+          environment:
+            # use tofu as wrapper
+            TERRAGRUNT_TFPATH: tofu
       - run:
           command: terratest_log_parser --testlog logs/integration.log --outputdir logs
           when: always
@@ -263,7 +277,7 @@ workflows:
             - GITHUB__PAT__gruntwork-ci
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
-      - integration_test:
+      - integration_test_terraform:
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,8 +123,6 @@ jobs:
       - checkout
       - run: gruntwork-install --binary-name 'terratest_log_parser' --repo 'https://github.com/gruntwork-io/terratest' --tag 'v0.30.0'
       - run:
-          <<: *install_tofu
-      - run:
           <<: *install_tflint
 
       # Make GCP Service Account creds available as a file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,10 @@ jobs:
           shell: powershell.exe
           command: ./_ci/install-terraform.ps1
       - run:
+          name: Install Opentofu
+          shell: powershell.exe
+          command: ./_ci/install-opentofu.ps1
+      - run:
           name: Install TFLint
           shell: powershell.exe
           command: ./_ci/install-tflint.ps1

--- a/_ci/install-opentofu.ps1
+++ b/_ci/install-opentofu.ps1
@@ -1,7 +1,7 @@
-OpenTofuInstallPath = "C:\Program Files\OpenTofu\tofu.exe"
+OpenTofuInstallPath = "C:\Program Files\tofu\tofu.exe"
 $OpenTofuTmpPath = "C:\OpenTofutmp"
-$OpenTofuTmpBinaryPath = "C:\OpenTofutmp\OpenTofu.exe"
-$OpenTofuPath = "C:\Program Files\OpenTofu"
+$OpenTofuTmpBinaryPath = "C:\OpenTofutmp\tofu.exe"
+$OpenTofuPath = "C:\Program Files\tofu"
 # Remove any old OpenTofu installation, if present
 if (Test-Path -Path $OpenTofuInstallPath)
 {

--- a/_ci/install-opentofu.ps1
+++ b/_ci/install-opentofu.ps1
@@ -1,0 +1,29 @@
+OpenTofuInstallPath = "C:\Program Files\OpenTofu\tofu.exe"
+$OpenTofuTmpPath = "C:\OpenTofutmp"
+$OpenTofuTmpBinaryPath = "C:\OpenTofutmp\OpenTofu.exe"
+$OpenTofuPath = "C:\Program Files\OpenTofu"
+# Remove any old OpenTofu installation, if present
+if (Test-Path -Path $OpenTofuInstallPath)
+{
+	Remove-Item $OpenTofuInstallPath -Recurse
+}
+# Download OpenTofu and unpack it
+$OpenTofuURI = "https://github.com/opentofu/opentofu/releases/download/v1.6.0-alpha1/tofu_1.6.0-alpha1_windows_amd64.zip"
+$output = "tofu_1.6.0-alpha1_windows_amd64.zip"
+$ProgressPreference = "SilentlyContinue"
+Invoke-WebRequest -Uri $OpenTofuURI -OutFile $output
+New-Item -ItemType "directory" -Path $OpenTofuTmpPath
+# Unpack OpenTofu to temp directory
+Expand-Archive -LiteralPath $output -DestinationPath $OpenTofuTmpPath
+# Make new OpenTofu directory to hold binary
+New-Item -ItemType "directory" -Path $OpenTofuPath
+Move-Item $OpenTofuTmpBinaryPath $OpenTofuPath
+# Add new OpenTofu path to system
+$OldPath = [System.Environment]::GetEnvironmentVariable('PATH', "Machine")
+$NewPath = "$OldPath;$OpenTofuPath"
+[Environment]::SetEnvironmentVariable("PATH", "$NewPath", "Machine")
+# Load System and User PATHs into latest $env:Path, which has the effect of "refreshing" the latest path
+# in the current PowerShell session
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+# Verify installation
+tofu version

--- a/cli/commands/terraform/action.go
+++ b/cli/commands/terraform/action.go
@@ -407,7 +407,7 @@ func runTerraformWithRetry(terragruntOptions *options.TerragruntOptions) error {
 				terragruntOptions.Logger.Infof("Encountered an error eligible for retrying. Sleeping %v before retrying.\n", terragruntOptions.RetrySleepIntervalSec)
 				time.Sleep(terragruntOptions.RetrySleepIntervalSec)
 			} else {
-				terragruntOptions.Logger.Errorf("Terraform invocation failed in %s", terragruntOptions.WorkingDir)
+				terragruntOptions.Logger.Errorf("%s invocation failed in %s", terragruntOptions.TerraformImplementation, terragruntOptions.WorkingDir)
 				return tferr
 			}
 		} else {

--- a/cli/commands/terraform/download_source.go
+++ b/cli/commands/terraform/download_source.go
@@ -78,7 +78,7 @@ func downloadTerraformSourceIfNecessary(terraformSource *terraform.Source, terra
 		if err := validateWorkingDir(terraformSource); err != nil {
 			return err
 		}
-		terragruntOptions.Logger.Debugf("Terraform files in %s are up to date. Will not download again.", terraformSource.WorkingDir)
+		terragruntOptions.Logger.Debugf("%s files in %s are up to date. Will not download again.", terragruntOptions.TerraformImplementation, terraformSource.WorkingDir)
 		return nil
 	}
 

--- a/cli/commands/terraform/version_check.go
+++ b/cli/commands/terraform/version_check.go
@@ -42,7 +42,7 @@ func checkVersionConstraints(terragruntOptions *options.TerragruntOptions) error
 
 	// Change the terraform binary path before checking the version
 	// if the path is not changed from default and set in the config.
-	if terragruntOptions.TerraformPath == options.TerraformDefaultPath && partialTerragruntConfig.TerraformBinary != "" {
+	if terragruntOptions.TerraformPath == options.TofuPath && partialTerragruntConfig.TerraformBinary != "" {
 		terragruntOptions.TerraformPath = partialTerragruntConfig.TerraformBinary
 	}
 	if err := PopulateTerraformVersion(terragruntOptions); err != nil {

--- a/cli/commands/terraform/version_check.go
+++ b/cli/commands/terraform/version_check.go
@@ -170,6 +170,7 @@ func parseTerraformVersion(versionCommandOutput string) (*version.Version, error
 	return version.NewVersion(matches[2])
 }
 
+// parseTerraformImplementationType - Parse terraform implementation from --version command output
 func parseTerraformImplementationType(versionCommandOutput string) (options.TerraformImplementationType, error) {
 	matches := TerraformVersionRegex.FindStringSubmatch(versionCommandOutput)
 

--- a/cli/commands/terraform/version_check.go
+++ b/cli/commands/terraform/version_check.go
@@ -17,8 +17,6 @@ import (
 // This version of Terragrunt was tested to work with Terraform 0.12.0 and above only
 const DefaultTerraformVersionConstraint = ">= v0.12.0"
 
-const OpensourceTerraformVersionConstraint = "<= 1.5.7"
-
 // TerraformVersionRegex verifies that terraform --version output is in one of the following formats:
 // - Terraform v0.9.5-dev (cad024a5fe131a546936674ef85445215bbc4226+CHANGES)
 // - Terraform v0.13.0-beta2
@@ -44,19 +42,11 @@ func checkVersionConstraints(terragruntOptions *options.TerragruntOptions) error
 
 	// Change the terraform binary path before checking the version
 	// if the path is not changed from default and set in the config.
-	if terragruntOptions.TerraformPath == options.TofuPath && partialTerragruntConfig.TerraformBinary != "" {
+	if terragruntOptions.TerraformPath == options.DefaultWrappedPath && partialTerragruntConfig.TerraformBinary != "" {
 		terragruntOptions.TerraformPath = partialTerragruntConfig.TerraformBinary
 	}
 	if err := PopulateTerraformVersion(terragruntOptions); err != nil {
 		return err
-	}
-
-	// Check if terraform version is supported
-	if terragruntOptions.TerraformImplementation == options.TerraformImpl {
-		if err := CheckTerraformVersion(OpensourceTerraformVersionConstraint, terragruntOptions); err != nil {
-			terragruntOptions.Logger.Errorf("Terragrunt don't support %s version of terraform, please use OpenTofu", terragruntOptions.TerraformVersion)
-			return err
-		}
 	}
 
 	terraformVersionConstraint := DefaultTerraformVersionConstraint

--- a/cli/commands/terraform/version_check.go
+++ b/cli/commands/terraform/version_check.go
@@ -22,7 +22,7 @@ const DefaultTerraformVersionConstraint = ">= v0.12.0"
 // - Terraform v0.13.0-beta2
 // - Terraform v0.12.27
 // We only make sure the "v#.#.#" part is present in the output.
-var TerraformVersionRegex = regexp.MustCompile(`Terraform (v?\d+\.\d+\.\d+).*`)
+var TerraformVersionRegex = regexp.MustCompile(`(?:Terraform|OpenTofu) (v?\d+\.\d+\.\d+).*`)
 
 // Check the version constraints of both terragrunt and terraform. Note that as a side effect this will set the
 // following settings on terragruntOptions:

--- a/cli/commands/terraform/version_check.go
+++ b/cli/commands/terraform/version_check.go
@@ -17,6 +17,8 @@ import (
 // This version of Terragrunt was tested to work with Terraform 0.12.0 and above only
 const DefaultTerraformVersionConstraint = ">= v0.12.0"
 
+const OpensourceTerraformVersionConstraint = "<= 1.5.7"
+
 // TerraformVersionRegex verifies that terraform --version output is in one of the following formats:
 // - Terraform v0.9.5-dev (cad024a5fe131a546936674ef85445215bbc4226+CHANGES)
 // - Terraform v0.13.0-beta2
@@ -47,6 +49,14 @@ func checkVersionConstraints(terragruntOptions *options.TerragruntOptions) error
 	}
 	if err := PopulateTerraformVersion(terragruntOptions); err != nil {
 		return err
+	}
+
+	// Check if terraform version is supported
+	if terragruntOptions.TerraformImplementation == options.TerraformImpl {
+		if err := CheckTerraformVersion(OpensourceTerraformVersionConstraint, terragruntOptions); err != nil {
+			terragruntOptions.Logger.Errorf("Terragrunt don't support %s version of terraform, please use OpenTofu", terragruntOptions.TerraformVersion)
+			return err
+		}
 	}
 
 	terraformVersionConstraint := DefaultTerraformVersionConstraint

--- a/cli/commands/terraform/version_check.go
+++ b/cli/commands/terraform/version_check.go
@@ -22,7 +22,7 @@ const DefaultTerraformVersionConstraint = ">= v0.12.0"
 // - Terraform v0.13.0-beta2
 // - Terraform v0.12.27
 // We only make sure the "v#.#.#" part is present in the output.
-var TerraformVersionRegex = regexp.MustCompile(`(?:Terraform|OpenTofu) (v?\d+\.\d+\.\d+).*`)
+var TerraformVersionRegex = regexp.MustCompile(`^(.*?)\s(v?\d+\.\d+\.\d+).*`)
 
 // Check the version constraints of both terragrunt and terraform. Note that as a side effect this will set the
 // following settings on terragruntOptions:
@@ -92,8 +92,20 @@ func PopulateTerraformVersion(terragruntOptions *options.TerragruntOptions) erro
 		return err
 	}
 
+	tfImplementation, err := parseTerraformImplementationType(output.Stdout)
+	if err != nil {
+		return err
+	}
+
 	terragruntOptions.TerraformVersion = terraformVersion
-	terragruntOptions.Logger.Debugf("Terraform version: %s", terraformVersion)
+	terragruntOptions.TerraformImplementation = tfImplementation
+
+	if tfImplementation == options.UnknownImpl {
+		terragruntOptions.TerraformImplementation = options.TerraformImpl
+		terragruntOptions.Logger.Warnf("Failed to identify Terraform implementation, fallback to terraform version: %s", terraformVersion)
+	} else {
+		terragruntOptions.Logger.Debugf("%s version: %s", tfImplementation, terraformVersion)
+	}
 	return nil
 }
 
@@ -141,11 +153,28 @@ func checkTerraformVersionMeetsConstraint(currentVersion *version.Version, const
 func parseTerraformVersion(versionCommandOutput string) (*version.Version, error) {
 	matches := TerraformVersionRegex.FindStringSubmatch(versionCommandOutput)
 
-	if len(matches) != 2 {
+	if len(matches) != 3 {
 		return nil, errors.WithStackTrace(InvalidTerraformVersionSyntax(versionCommandOutput))
 	}
 
-	return version.NewVersion(matches[1])
+	return version.NewVersion(matches[2])
+}
+
+func parseTerraformImplementationType(versionCommandOutput string) (options.TerraformImplementationType, error) {
+	matches := TerraformVersionRegex.FindStringSubmatch(versionCommandOutput)
+
+	if len(matches) != 3 {
+		return options.UnknownImpl, errors.WithStackTrace(InvalidTerraformVersionSyntax(versionCommandOutput))
+	}
+	rawType := strings.ToLower(matches[1])
+	switch rawType {
+	case "terraform":
+		return options.TerraformImpl, nil
+	case "opentofu":
+		return options.OpenTofuImpl, nil
+	default:
+		return options.UnknownImpl, nil
+	}
 }
 
 // Custom error types

--- a/docs/_docs/01_getting-started/supported-versions.md
+++ b/docs/_docs/01_getting-started/supported-versions.md
@@ -35,7 +35,9 @@ The officially supported versions are:
 | 0.12.x            | [0.19.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.19.0) - [0.24.4](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.24.4) |
 | 0.11.x            | [0.14.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.14.0) - [0.18.7](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.18.7) |
 
-With the HashiCorp Terraform BSL license change, will be supported Terraform versions `<= 1.5.7`, for newer features, please use OpenTofu.
+Due to the HashiCorp BSL license change, we are restricting Terraform to the latest open source version (`1.5.7`).
+Going forward we will be adding support for OpenTofu. To learn more, see the official [OpenTofu website](https://opentofu.org/)
+and [project status](https://github.com/opentofu/opentofu/blob/main/WEEKLY_UPDATES.md).
 
 However, note that these are the versions that are officially tested in the CI process. In practice, the version
 compatibility is more relaxed than documented above. For example, we've found that Terraform 0.13 works with any version

--- a/docs/_docs/01_getting-started/supported-versions.md
+++ b/docs/_docs/01_getting-started/supported-versions.md
@@ -35,10 +35,6 @@ The officially supported versions are:
 | 0.12.x            | [0.19.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.19.0) - [0.24.4](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.24.4) |
 | 0.11.x            | [0.14.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.14.0) - [0.18.7](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.18.7) |
 
-Due to the HashiCorp BSL license change, we are restricting Terraform to the latest open source version (`1.5.7`).
-Going forward we will be adding support for OpenTofu. To learn more, see the official [OpenTofu website](https://opentofu.org/)
-and [project status](https://github.com/opentofu/opentofu/blob/main/WEEKLY_UPDATES.md).
-
 However, note that these are the versions that are officially tested in the CI process. In practice, the version
 compatibility is more relaxed than documented above. For example, we've found that Terraform 0.13 works with any version
 above 0.19.0, and we've also found that terraform 0.11 works with any version above 0.19.18 as well.

--- a/docs/_docs/01_getting-started/supported-versions.md
+++ b/docs/_docs/01_getting-started/supported-versions.md
@@ -1,13 +1,21 @@
 ---
 layout: collection-browser-doc
-title: Terraform Version Compatibility Table
+title: Terraform and OpenTofu Version Compatibility Table
 category: getting-started
-excerpt: Learn which Terraform versions are compatible with which versions of Terragrunt.
+excerpt: Learn which Terraform and OpenTofu versions are compatible with which versions of Terragrunt.
 tags: ["install"]
 order: 102
 nav_title: Documentation
 nav_title_link: /docs/
 ---
+
+## Supported OpenTofu Versions
+
+The officially supported versions are:
+
+| OpenTofu Version | Terragrunt Version                                                           |
+|------------------|------------------------------------------------------------------------------|
+| 1.6.x            | >= [0.52.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.52.0) |
 
 ## Supported Terraform Versions
 
@@ -27,6 +35,7 @@ The officially supported versions are:
 | 0.12.x            | [0.19.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.19.0) - [0.24.4](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.24.4) |
 | 0.11.x            | [0.14.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.14.0) - [0.18.7](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.18.7) |
 
+With the HashiCorp Terraform BSL license change, will be supported Terraform versions `<= 1.5.7`, for newer features, please use OpenTofu.
 
 However, note that these are the versions that are officially tested in the CI process. In practice, the version
 compatibility is more relaxed than documented above. For example, we've found that Terraform 0.13 works with any version

--- a/options/options.go
+++ b/options/options.go
@@ -47,6 +47,14 @@ var TofuPath = identifyDefaultTofuPath()
 
 type ctxKey byte
 
+type TerraformImplementationType string
+
+const (
+	TerraformImpl TerraformImplementationType = "terraform"
+	OpenTofuImpl  TerraformImplementationType = "tofu"
+	UnknownImpl   TerraformImplementationType = "unknown"
+)
+
 // TerragruntOptions represents options that configure the behavior of the Terragrunt program
 type TerragruntOptions struct {
 	// Location of the Terragrunt config file
@@ -74,6 +82,9 @@ type TerragruntOptions struct {
 	// NOTE: For `xxx-all` commands, this will be set to the Terraform command, which would be `xxx`. For example,
 	// if you run `apply-all` (which is a terragrunt command), this variable will be set to `apply`.
 	OriginalTerraformCommand string
+
+	// Terraform implementation tool (e.g. terraform, tofu) that terragrunt is wrapping
+	TerraformImplementation TerraformImplementationType
 
 	// Version of terraform (obtained by running 'terraform version')
 	TerraformVersion *version.Version
@@ -306,6 +317,7 @@ func NewTerragruntOptions() *TerragruntOptions {
 		OutputPrefix:                   "",
 		IncludeModulePrefix:            false,
 		JSONOut:                        DefaultJSONOutName,
+		TerraformImplementation:        UnknownImpl,
 		RunTerragrunt: func(opts *TerragruntOptions) error {
 			return errors.WithStackTrace(RunTerragruntCommandNotSet)
 		},
@@ -430,6 +442,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) *TerragruntOpt
 		IncludeModulePrefix:            opts.IncludeModulePrefix,
 		FailIfBucketCreationRequired:   opts.FailIfBucketCreationRequired,
 		DisableBucketUpdate:            opts.DisableBucketUpdate,
+		TerraformImplementation:        opts.TerraformImplementation,
 	}
 }
 

--- a/options/options.go
+++ b/options/options.go
@@ -43,7 +43,7 @@ const (
 
 const ContextKey ctxKey = iota
 
-var TofuPath = identifyDefaultTofuPath()
+var DefaultWrappedPath = identifyDefaultWrappedExecutable()
 
 type ctxKey byte
 
@@ -281,7 +281,7 @@ func MergeIAMRoleOptions(target IAMRoleOptions, source IAMRoleOptions) IAMRoleOp
 // Create a new TerragruntOptions object with reasonable defaults for real usage
 func NewTerragruntOptions() *TerragruntOptions {
 	return &TerragruntOptions{
-		TerraformPath:                  TofuPath,
+		TerraformPath:                  TerraformDefaultPath,
 		OriginalTerraformCommand:       "",
 		TerraformCommand:               "",
 		AutoInit:                       true,
@@ -520,13 +520,13 @@ func (opts *TerragruntOptions) DataDir() string {
 	return util.JoinPath(opts.WorkingDir, tfDataDir)
 }
 
-// identifyDefaultTofuPath - return default path used for tofu invocation
-func identifyDefaultTofuPath() string {
-	if util.IsCommandExecutable(TofuDefaultPath, "-version") {
-		return TofuDefaultPath
+// identifyDefaultWrappedExecutable - return default path used for wrapped executable
+func identifyDefaultWrappedExecutable() string {
+	if util.IsCommandExecutable(TerraformDefaultPath, "-version") {
+		return TerraformDefaultPath
 	}
-	// fallback to terraform
-	return TerraformDefaultPath
+	// fallback to Tofu if terraform is not available
+	return TofuDefaultPath
 }
 
 // Custom error types

--- a/options/options.go
+++ b/options/options.go
@@ -27,6 +27,9 @@ const (
 	// no limits on parallelism by default (limited by GOPROCS)
 	DefaultParallelism = math.MaxInt32
 
+	// TofuDefaultPath command to run tofu
+	TofuDefaultPath = "tofu"
+
 	// TerraformDefaultPath just takes terraform from the path
 	TerraformDefaultPath = "terraform"
 
@@ -39,6 +42,8 @@ const (
 )
 
 const ContextKey ctxKey = iota
+
+var TofuPath = identifyDefaultTofuPath()
 
 type ctxKey byte
 
@@ -265,7 +270,7 @@ func MergeIAMRoleOptions(target IAMRoleOptions, source IAMRoleOptions) IAMRoleOp
 // Create a new TerragruntOptions object with reasonable defaults for real usage
 func NewTerragruntOptions() *TerragruntOptions {
 	return &TerragruntOptions{
-		TerraformPath:                  TerraformDefaultPath,
+		TerraformPath:                  TofuPath,
 		OriginalTerraformCommand:       "",
 		TerraformCommand:               "",
 		AutoInit:                       true,
@@ -500,6 +505,15 @@ func (opts *TerragruntOptions) DataDir() string {
 		return tfDataDir
 	}
 	return util.JoinPath(opts.WorkingDir, tfDataDir)
+}
+
+// identifyDefaultTofuPath - return default path used for tofu invocation
+func identifyDefaultTofuPath() string {
+	if util.IsCommandExecutable(TofuDefaultPath, "-version") {
+		return TofuDefaultPath
+	}
+	// fallback to terraform
+	return TerraformDefaultPath
 }
 
 // Custom error types

--- a/options/options.go
+++ b/options/options.go
@@ -281,7 +281,7 @@ func MergeIAMRoleOptions(target IAMRoleOptions, source IAMRoleOptions) IAMRoleOp
 // Create a new TerragruntOptions object with reasonable defaults for real usage
 func NewTerragruntOptions() *TerragruntOptions {
 	return &TerragruntOptions{
-		TerraformPath:                  TerraformDefaultPath,
+		TerraformPath:                  DefaultWrappedPath,
 		OriginalTerraformCommand:       "",
 		TerraformCommand:               "",
 		AutoInit:                       true,

--- a/test/fixture-download/custom-lock-file-module/main.tf
+++ b/test/fixture-download/custom-lock-file-module/main.tf
@@ -4,6 +4,15 @@
 # when we run 'init'. If the lock file copying works as expected in the custom-lock-file test, then we'll end up
 # with an older version of the provider. If there is a bug, Terraform will end up downloading the latest version of
 # the provider, as we're not pinning the version in the Terraform code (only in the lock file).
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.19.0"
+    }
+  }
+}
+
 provider "aws" {
   region = "eu-west-1"
 }

--- a/test/fixture-download/custom-lock-file/.terraform.lock.hcl
+++ b/test/fixture-download/custom-lock-file/.terraform.lock.hcl
@@ -1,20 +1,20 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.0.0"
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.19.0"
+  constraints = "5.19.0"
   hashes = [
-    "h1:ULKfwySvQ4pDhy027ryRhLxDhg640wsojYc+7NHMFBU=",
-    "h1:UyKRcHE2W3io32hVQD7s9Ovb9LSyTIvhAAPS9RX5vtg=",
-    "zh:25294510ae9c250502f2e37ac32b01017439735f098f82a1728772427626a2fd",
-    "zh:3b723e7772d47bd8cc11bea6e5d3e0b5e1df8398c0e7aaf510e3a8a54e0f1874",
-    "zh:4b7b73b86f4a0705d5d2a7f1d3ad3279706bdb3957a48f4a389c36918fba838e",
-    "zh:9e26cdc3be97e3001c253c0ca28c5c8ff2d5476373ca1beb849f3f3957ce7f1a",
-    "zh:9e73cf1304bf57968d3048d70c0b766d41497430a2a9a7a718a196f3a385106a",
-    "zh:a30b5b66facfbb2b02814e4cd33ca9899f9ade5bbf478f78c41d2fe789f0582a",
-    "zh:b06fb5da094db41cb5e430c95c988b73f32695e9f90f25499e926842dbd21b21",
-    "zh:c5a4ff607e9e9edee3fcd6d6666241fb532adf88ea1fe24f2aa1eb36845b3ca3",
-    "zh:df568a69087831c1780fac4395630a2cfb3cdf67b7dffbfe16bd78c64770bb75",
-    "zh:fce1b69dd673aace19508640b0b9b7eb1ef7e746d76cb846b49e7d52e0f5fb7e",
+    "h1:xoQFH3TCqCvdaBuqxChcPaooKWOuz3mHI3VKdgxnxEk=",
+    "zh:0c1887bd8efd1da9458ad6d8c59f33de21041d06db3a1d3fa8eae53404051943",
+    "zh:1c3604f15481eff8ccbbeb31b47acf11454a391c1247c7b23d4e3636f1ce4547",
+    "zh:3363e23fe87cb7b0fbbb5e6fc4ef58d2aff05ef5fdf17605e5fbd7e4ee91a312",
+    "zh:3cba361ff181877cb261762a8225a42c5d1053503cb53796b6277bfedeb1baf9",
+    "zh:7a9d7dfaa5878ab51c45d8b5b6bec74a42e12d755753efaee6b2075875d3afd0",
+    "zh:b160fd637ebf3ffb8ee3f4f17e8d51f50e176e26f7889464fd019d20dd045159",
+    "zh:b32b9da9dba98e5be8b9b110c5306e99f49e6608eb434e93211db5bc3a78412e",
+    "zh:b5b60196dd0ce47111fbe2792670a0aca4d8814d15c291d23f1cb29224fbd9a7",
+    "zh:bd349062b14435a8d8924b37208e51caa197617b7a5f2c26e488007c7c6f3298",
+    "zh:f574b9f4652b3d4209fe41f360868e2a90aebebff5f9000f94c507b520490f74",
   ]
 }

--- a/test/fixture-no-submodules/terragrunt.hcl
+++ b/test/fixture-no-submodules/terragrunt.hcl
@@ -1,3 +1,3 @@
 terraform {
-  source = "git::git@github.com:terraform-google-modules/terraform-google-folders.git?ref=v3.0.0"
+  source = "git::git@github.com:terraform-google-modules/terraform-google-folders.git?ref=v4.0.0"
 }

--- a/test/fixture-render-json-metadata/attributes/terragrunt.hcl
+++ b/test/fixture-render-json-metadata/attributes/terragrunt.hcl
@@ -15,7 +15,7 @@ skip = true
 iam_role = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
 iam_assume_role_duration = 666
 
-terraform_binary = "terraform"
+terraform_binary = get_env("TERRAGRUNT_TFPATH", "terraform")
 terraform_version_constraint = ">= 0.11"
 
 retryable_errors = [

--- a/test/fixture-tf-1-6/tf-1-6.sh
+++ b/test/fixture-tf-1-6/tf-1-6.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "Terraform v1.6.0"
+echo "on linux_amd64"

--- a/test/fixture-tf-1-6/tf-1-6.sh
+++ b/test/fixture-tf-1-6/tf-1-6.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-echo "Terraform v1.6.0"
-echo "on linux_amd64"

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -222,7 +222,7 @@ func TestCustomLockFile(t *testing.T) {
 	// In our lock file, we intentionally have hashes for an older version of the AWS provider. If the lock file
 	// copying works, then Terraform will stick with this older version. If there is a bug, Terraform will end up
 	// installing a newer version (since the version is not pinned in the .tf code, only in the lock file).
-	assert.Contains(t, string(readFile), `version = "3.0.0"`)
+	assert.Contains(t, string(readFile), `version     = "5.19.0"`)
 }
 
 func TestExcludeDirs(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1920,30 +1920,18 @@ func TestTerragruntInfo(t *testing.T) {
 	showStdout := bytes.Buffer{}
 	showStderr := bytes.Buffer{}
 
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt terragrunt-info --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-tfpath tofu", rootPath), &showStdout, &showStderr)
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt terragrunt-info --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &showStdout, &showStderr)
 	assert.Nil(t, err)
 
 	logBufferContentsLineByLine(t, showStdout, "show stdout")
 
 	var dat terragruntinfo.TerragruntInfoGroup
-	err_unmarshal := json.Unmarshal(showStdout.Bytes(), &dat)
-	assert.Nil(t, err_unmarshal)
+	errUnmarshal := json.Unmarshal(showStdout.Bytes(), &dat)
+	assert.Nil(t, errUnmarshal)
 
 	assert.Equal(t, dat.DownloadDir, fmt.Sprintf("%s/%s", rootPath, TERRAGRUNT_CACHE))
-	assert.Equal(t, dat.TerraformBinary, TOFU_BINARY)
+	assert.Equal(t, dat.TerraformBinary, wrappedBinary())
 	assert.Equal(t, dat.IamRole, "")
-
-	showStdout = bytes.Buffer{}
-	showStderr = bytes.Buffer{}
-
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt terragrunt-info --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-tfpath terraform", rootPath), &showStdout, &showStderr)
-	assert.Nil(t, err)
-
-	logBufferContentsLineByLine(t, showStdout, "show stdout")
-
-	err_unmarshal = json.Unmarshal(showStdout.Bytes(), &dat)
-	assert.Nil(t, err_unmarshal)
-	assert.Equal(t, dat.TerraformBinary, TERRAFORM_BINARY)
 }
 
 // Test case for yamldecode bug: https://github.com/gruntwork-io/terragrunt/issues/834

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1398,19 +1398,19 @@ func TestTerraformSubcommandCliArgs(t *testing.T) {
 	}{
 		{
 			[]string{"force-unlock"},
-			"terraform force-unlock",
+			"tofu force-unlock",
 		},
 		{
 			[]string{"force-unlock", "foo"},
-			"terraform force-unlock foo",
+			"tofu force-unlock foo",
 		},
 		{
 			[]string{"force-unlock", "foo", "bar", "baz"},
-			"terraform force-unlock foo bar baz",
+			"tofu force-unlock foo bar baz",
 		},
 		{
 			[]string{"force-unlock", "foo", "bar", "baz", "foobar"},
-			"terraform force-unlock foo bar baz foobar",
+			"tofu force-unlock foo bar baz foobar",
 		},
 	}
 
@@ -1994,7 +1994,7 @@ func TestDependencyOutputOptimizationSkipInit(t *testing.T) {
 
 func TestDependencyOutputOptimizationNoGenerate(t *testing.T) {
 	expectOutputLogs := []string{
-		`Running command: terraform init -get=false prefix=\[.*fixture-get-output/nested-optimization-nogen/dep\]`,
+		`Running command: tofu init -get=false prefix=\[.*fixture-get-output/nested-optimization-nogen/dep\]`,
 	}
 	dependencyOutputOptimizationTest(t, "nested-optimization-nogen", true, expectOutputLogs)
 }
@@ -4895,7 +4895,7 @@ func TestNoMultipleInitsWithoutSourceChange(t *testing.T) {
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
 	require.NoError(t, err)
 	// providers initialization during first plan
-	assert.Equal(t, 1, strings.Count(stdout.String(), "Terraform has been successfully initialized!"))
+	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
 
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
@@ -4904,7 +4904,7 @@ func TestNoMultipleInitsWithoutSourceChange(t *testing.T) {
 	require.NoError(t, err)
 	// no initialization expected for second plan run
 	// https://github.com/gruntwork-io/terragrunt/issues/1921
-	assert.Equal(t, 0, strings.Count(stdout.String(), "Terraform has been successfully initialized!"))
+	assert.Equal(t, 0, strings.Count(stdout.String(), "has been successfully initialized!"))
 }
 
 func TestAutoInitWhenSourceIsChanged(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5038,7 +5038,7 @@ func TestRenderJsonAttributesMetadata(t *testing.T) {
 	var terraformBinary = renderedJson[config.MetadataTerraformBinary]
 	expectedTerraformBinary := map[string]interface{}{
 		"metadata": expectedMetadata,
-		"value":    "terraform",
+		"value":    wrappedBinary(),
 	}
 	assert.True(t, reflect.DeepEqual(expectedTerraformBinary, terraformBinary))
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -173,7 +173,6 @@ const (
 	TEST_FIXTURE_NO_SUBMODULES                                               = "fixture-no-submodules/"
 	TEST_FIXTURE_DISABLED_MODULE                                             = "fixture-disabled/"
 	TEST_FIXTURE_EMPTY_STATE                                                 = "fixture-empty-state/"
-	TEST_FIXTURE_TF_1_6                                                      = "fixture-tf-1-6/"
 	TERRAFORM_BINARY                                                         = "terraform"
 	TOFU_BINARY                                                              = "tofu"
 	TERRAFORM_FOLDER                                                         = ".terraform"
@@ -6195,25 +6194,6 @@ func TestRenderJsonDependentModulesMetadataTerraform(t *testing.T) {
 	// check if value list contains app-v1 and app-v2
 	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, TEST_FIXTURE_DESTROY_WARNING, "app-v1"))
 	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, TEST_FIXTURE_DESTROY_WARNING, "app-v2"))
-}
-
-func TestTerragruntFailUnsupportedTerraform(t *testing.T) {
-	t.Parallel()
-
-	generateTestCase := TEST_FIXTURE_TF_1_6
-	cleanupTerraformFolder(t, generateTestCase)
-	cleanupTerragruntFolder(t, generateTestCase)
-
-	// generating path to custom script which return 1.6.0 version of terraform
-	curdir, err := os.Getwd()
-	require.NoError(t, err)
-	tfBinary := filepath.Join(curdir, generateTestCase, "tf-1-6.sh")
-
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-working-dir %s --terragrunt-tfpath %s", generateTestCase, tfBinary), &stdout, &stderr)
-	require.Error(t, err)
-	require.Contains(t, stderr.String(), "Terragrunt don't support 1.6.0 version of terraform, please use OpenTofu")
 }
 
 func validateOutput(t *testing.T, outputs map[string]TerraformOutput, key string, value interface{}) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6148,7 +6148,7 @@ func TestRenderJsonDependentModulesTerraform(t *testing.T) {
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
 	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
 
-	jsonBytes, err := ioutil.ReadFile(jsonOut)
+	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
 
 	var renderedJson = map[string]interface{}{}
@@ -6170,7 +6170,7 @@ func TestRenderJsonDependentModulesMetadataTerraform(t *testing.T) {
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
 	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
 
-	jsonBytes, err := ioutil.ReadFile(jsonOut)
+	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
 
 	var renderedJson = map[string]map[string]interface{}{}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1338,22 +1338,22 @@ func TestTerraformCommandCliArgs(t *testing.T) {
 	}{
 		{
 			[]string{"version"},
-			"tofu version",
+			wrappedBinary() + " version",
 			nil,
 		},
 		{
 			[]string{"version", "foo"},
-			"tofu version foo",
+			wrappedBinary() + " version foo",
 			nil,
 		},
 		{
 			[]string{"version", "foo", "bar", "baz"},
-			"tofu version foo bar baz",
+			wrappedBinary() + " version foo bar baz",
 			nil,
 		},
 		{
 			[]string{"version", "foo", "bar", "baz", "foobar"},
-			"tofu version foo bar baz foobar",
+			wrappedBinary() + " version foo bar baz foobar",
 			nil,
 		},
 		{
@@ -6203,6 +6203,7 @@ func validateOutput(t *testing.T, outputs map[string]TerraformOutput, key string
 	require.Equalf(t, output.Value, value, "Expected output %s to be %t", key, value)
 }
 
+// wrappedBinary - return which binary will be wrapped by Terragrunt, useful in CICD to run same tests against tofu and terraform
 func wrappedBinary() string {
 	value, found := os.LookupEnv("TERRAGRUNT_TFPATH")
 	if !found {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1363,7 +1363,7 @@ func TestTerraformCommandCliArgs(t *testing.T) {
 		},
 		{
 			[]string{"paln", "--terragrunt-disable-command-validation"},
-			"Terraform invocation failed", // error caused by running terraform with the wrong command
+			"tofu invocation failed", // error caused by running terraform with the wrong command
 			nil,
 		},
 	}
@@ -1980,7 +1980,7 @@ func TestYamlDecodeRegressions(t *testing.T) {
 // module has been destroyed.
 func TestDependencyOutputOptimization(t *testing.T) {
 	expectOutputLogs := []string{
-		`Running command: terraform init -get=false prefix=\[.*fixture-get-output/nested-optimization/dep\]`,
+		`Running command: tofu init -get=false prefix=\[.*fixture-get-output/nested-optimization/dep\]`,
 	}
 	dependencyOutputOptimizationTest(t, "nested-optimization", true, expectOutputLogs)
 }
@@ -3988,7 +3988,7 @@ func TestLogFailingDependencies(t *testing.T) {
 	output := stderr.String()
 
 	assert.Error(t, err)
-	assert.Contains(t, output, "Terraform invocation failed in fixture-broken-dependency/dependency")
+	assert.Contains(t, output, "tofu invocation failed in fixture-broken-dependency/dependency")
 }
 
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {
@@ -4928,7 +4928,7 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
 	require.NoError(t, err)
 	// providers initialization during first plan
-	assert.Equal(t, 1, strings.Count(stdout.String(), "Terraform has been successfully initialized!"))
+	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
 
 	updatedHcl = strings.Replace(contents, "__TAG_VALUE__", "v0.35.2", -1)
 	require.NoError(t, os.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
@@ -4939,7 +4939,7 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
 	require.NoError(t, err)
 	// auto initialization when source is changed
-	assert.Equal(t, 1, strings.Count(stdout.String(), "Terraform has been successfully initialized!"))
+	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
 }
 
 func TestNoColor(t *testing.T) {
@@ -4955,7 +4955,7 @@ func TestNoColor(t *testing.T) {
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan -no-color --terragrunt-working-dir %s", testPath), &stdout, &stderr)
 	require.NoError(t, err)
 	// providers initialization during first plan
-	assert.Equal(t, 1, strings.Count(stdout.String(), "Terraform has been successfully initialized!"))
+	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
 
 	assert.NotContains(t, stdout.String(), "[")
 }
@@ -5843,8 +5843,8 @@ func TestInitSkipCache(t *testing.T) {
 	)
 
 	// verify that init was invoked
-	assert.Contains(t, stdout.String(), "Terraform has been successfully initialized!")
-	assert.Contains(t, stderr.String(), "Running command: terraform init")
+	assert.Contains(t, stdout.String(), "has been successfully initialized!")
+	assert.Contains(t, stderr.String(), "Running command: tofu init")
 
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
@@ -5855,8 +5855,8 @@ func TestInitSkipCache(t *testing.T) {
 	)
 
 	// verify that init wasn't invoked second time since cache directories are ignored
-	assert.NotContains(t, stdout.String(), "Terraform has been successfully initialized!")
-	assert.NotContains(t, stderr.String(), "Running command: terraform init")
+	assert.NotContains(t, stdout.String(), "has been successfully initialized!")
+	assert.NotContains(t, stderr.String(), "Running command: tofu init")
 
 	// verify that after adding new file, init is executed
 	tfFile := util.JoinPath(tmpEnvPath, TEST_FIXTURE_INIT_CACHE, "app", "project.tf")
@@ -5873,8 +5873,8 @@ func TestInitSkipCache(t *testing.T) {
 	)
 
 	// verify that init was invoked
-	assert.Contains(t, stdout.String(), "Terraform has been successfully initialized!")
-	assert.Contains(t, stderr.String(), "Running command: terraform init")
+	assert.Contains(t, stdout.String(), "has been successfully initialized!")
+	assert.Contains(t, stderr.String(), "Running command: tofu init")
 }
 
 func TestRenderJsonWithInputsNotExistingOutput(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -174,6 +174,7 @@ const (
 	TEST_FIXTURE_DISABLED_MODULE                                             = "fixture-disabled/"
 	TEST_FIXTURE_EMPTY_STATE                                                 = "fixture-empty-state/"
 	TERRAFORM_BINARY                                                         = "terraform"
+	TOFU_BINARY                                                              = "tofu"
 	TERRAFORM_FOLDER                                                         = ".terraform"
 	TERRAFORM_STATE                                                          = "terraform.tfstate"
 	TERRAFORM_STATE_BACKUP                                                   = "terraform.tfstate.backup"
@@ -1337,22 +1338,22 @@ func TestTerraformCommandCliArgs(t *testing.T) {
 	}{
 		{
 			[]string{"version"},
-			"terraform version",
+			"tofu version",
 			nil,
 		},
 		{
 			[]string{"version", "foo"},
-			"terraform version foo",
+			"tofu version foo",
 			nil,
 		},
 		{
 			[]string{"version", "foo", "bar", "baz"},
-			"terraform version foo bar baz",
+			"tofu version foo bar baz",
 			nil,
 		},
 		{
 			[]string{"version", "foo", "bar", "baz", "foobar"},
-			"terraform version foo bar baz foobar",
+			"tofu version foo bar baz foobar",
 			nil,
 		},
 		{
@@ -1929,8 +1930,20 @@ func TestTerragruntInfo(t *testing.T) {
 	assert.Nil(t, err_unmarshal)
 
 	assert.Equal(t, dat.DownloadDir, fmt.Sprintf("%s/%s", rootPath, TERRAGRUNT_CACHE))
-	assert.Equal(t, dat.TerraformBinary, TERRAFORM_BINARY)
+	assert.Equal(t, dat.TerraformBinary, TOFU_BINARY)
 	assert.Equal(t, dat.IamRole, "")
+
+	showStdout = bytes.Buffer{}
+	showStderr = bytes.Buffer{}
+
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt terragrunt-info --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-tfpath terraform", rootPath), &showStdout, &showStderr)
+	assert.Nil(t, err)
+
+	logBufferContentsLineByLine(t, showStdout, "show stdout")
+
+	err_unmarshal = json.Unmarshal(showStdout.Bytes(), &dat)
+	assert.Nil(t, err_unmarshal)
+	assert.Equal(t, dat.TerraformBinary, TERRAFORM_BINARY)
 }
 
 // Test case for yamldecode bug: https://github.com/gruntwork-io/terragrunt/issues/834

--- a/util/shell.go
+++ b/util/shell.go
@@ -1,0 +1,19 @@
+package util
+
+import "os/exec"
+
+// IsCommandExecutable - returns true if a command can be executed without errors.
+func IsCommandExecutable(command string, args ...string) bool {
+	cmd := exec.Command(command, args...)
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode() == 0
+		}
+		return false
+	}
+	return true
+}

--- a/util/shell_test.go
+++ b/util/shell_test.go
@@ -9,7 +9,7 @@ import (
 func TestExistingCommand(t *testing.T) {
 	t.Parallel()
 
-	assert.True(t, IsCommandExecutable("tofu", "--version"))
+	assert.True(t, IsCommandExecutable("pwd"))
 }
 
 func TestNotExistingCommand(t *testing.T) {

--- a/util/shell_test.go
+++ b/util/shell_test.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExistingCommand(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsCommandExecutable("tofu", "--version"))
+}
+
+func TestNotExistingCommand(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, IsCommandExecutable("not-existing-command", "--version"))
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* added support for wrapping `tofu` command: if `terraform` command is not available, will be used `tofu`
* updated version parsing to handle OpenTofu output
* separated integration tests to run separated the same test suits against `terraform` and `tofu`(terraform binary is removed before starting tofu tests)
* added field in `TerragruntOptions` to track used Terraform implementation
* updated logs to reflect used implementation
* usage of OpenTofu in Windows tests


![image](https://github.com/gruntwork-io/terragrunt/assets/10694338/5d6a67d8-f1e3-4272-87e6-e81d0c48ade8)



Fixes #2690.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added support for OpenTofu in Terragrunt, by default, will be wrapped `terraform` command with a fallback to `tofu`.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
Install OpenTofu cli tool https://github.com/opentofu/opentofu
