### PR TITLE
`sops_decrypt_file()`: resolve path argument relative to `terragrunt.hcl`

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -746,7 +746,7 @@ func sopsDecryptFile(ctx *ParsingContext, params []string) (string, error) {
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
-	canonicalSourceFile, err := util.CanonicalPath(sourceFile, ctx.TerragruntOptions.WorkingDir)
+	canonicalSourceFile, err := util.CanonicalPath(sourceFile, filepath.Dir(ctx.TerragruntOptions.TerragruntConfigPath))
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
@@ -755,7 +755,7 @@ func sopsDecryptFile(ctx *ParsingContext, params []string) (string, error) {
 		return val, nil
 	}
 
-	rawData, err := decrypt.File(sourceFile, format)
+	rawData, err := decrypt.File(canonicalSourceFile, format)
 	if err != nil {
 		return "", errors.WithStackTrace(extractSopsErrors(err))
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5098,6 +5098,39 @@ func TestSopsDecryptedCorrectly(t *testing.T) {
 	assert.Contains(t, outputs["ini_value"].Value, "password = potato")
 }
 
+func TestSopsDecryptedCorrectlyRunAll(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_SOPS)
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_SOPS)
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_SOPS)
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s/.. --terragrunt-include-dir %s", rootPath, TEST_FIXTURE_SOPS))
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir %s/.. --terragrunt-include-dir %s", rootPath, TEST_FIXTURE_SOPS), &stdout, &stderr)
+	require.NoError(t, err)
+
+	outputs := map[string]TerraformOutput{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
+
+	assert.Equal(t, outputs["json_bool_array"].Value, []interface{}{true, false})
+	assert.Equal(t, outputs["json_string_array"].Value, []interface{}{"example_value1", "example_value2"})
+	assert.Equal(t, outputs["json_number"].Value, 1234.56789)
+	assert.Equal(t, outputs["json_string"].Value, "example_value")
+	assert.Equal(t, outputs["json_hello"].Value, "Welcome to SOPS! Edit this file as you please!")
+	assert.Equal(t, outputs["yaml_bool_array"].Value, []interface{}{true, false})
+	assert.Equal(t, outputs["yaml_string_array"].Value, []interface{}{"example_value1", "example_value2"})
+	assert.Equal(t, outputs["yaml_number"].Value, 1234.5679)
+	assert.Equal(t, outputs["yaml_string"].Value, "example_value")
+	assert.Equal(t, outputs["yaml_hello"].Value, "Welcome to SOPS! Edit this file as you please!")
+	assert.Equal(t, outputs["text_value"].Value, "Raw Secret Example")
+	assert.Contains(t, outputs["env_value"].Value, "DB_PASSWORD=tomato")
+	assert.Contains(t, outputs["ini_value"].Value, "password = potato")
+}
+
 func TestTerragruntRunAllCommandPrompt(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Update path resolution logic in `sops_decrypt_file()` to resolve relative path arguments relative to the file containing the call to `sops_decrypt_file()`, rather than relative to the working directory of the Terragrunt process.

This change should be invisible for the common case of running Terragrunt directly inside the directory containing `terragrunt.hcl`. However, it enables intuitive use of `terragrunt run-all` with `sops_decrypt_file()`, ensuring configurations behave the same, no matter if they're evaluated directly or under `run-all`.

An additional test case for `sops_decrypt_file()` was added that validates its behavior in combination with `run-all`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `sops_decrypt_file()` path resolution to be relative to `terragrunt.hcl` instead of Terragrunt's working directory.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

If you were relying on the behavior of `terragrunt run-all` on a set of modules using `sops_decrypt_file()` using a file in the current working directory, such as a shared secret, you can wrap the argument to `sops_decrypt_file()` in a call to `find_in_parent_folders()`, as shown in the documentation for `sops_decrypt_file()`.