### PR TITLE
feat: add read_tfvars_file function

### DIFF
--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -1128,6 +1128,24 @@ func TestStrContains(t *testing.T) {
 	}
 }
 
+func TestReadTFVarFiles(t *testing.T) {
+	t.Parallel()
+
+	options := terragruntOptionsForTest(t, DefaultTerragruntConfigPath)
+	tgConfigCty, err := readTerragruntConfig("../test/fixture-read-tf-vars/terragrunt.hcl", nil, options)
+	require.NoError(t, err)
+
+	tgConfigMap, err := parseCtyValueToMap(tgConfigCty)
+	require.NoError(t, err)
+
+	locals := tgConfigMap["locals"].(map[string]interface{})
+
+	assert.Equal(t, locals["string_var"].(string), "string")
+	assert.Equal(t, locals["number_var"].(float64), float64(42))
+	assert.Equal(t, locals["bool_var"].(bool), true)
+	assert.Equal(t, locals["list_var"].([]interface{}), []interface{}{"hello", "world"})
+}
+
 func mockConfigWithSource(sourceUrl string) *TerragruntConfig {
 	cfg := TerragruntConfig{IsPartial: true}
 	cfg.Terraform = &TerraformConfig{Source: &sourceUrl}

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -1128,7 +1128,7 @@ func TestStrContains(t *testing.T) {
 	}
 }
 
-func TestReadTFVarFiles(t *testing.T) {
+func TestReadTFVarsFiles(t *testing.T) {
 	t.Parallel()
 
 	options := terragruntOptionsForTest(t, DefaultTerragruntConfigPath)

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -1144,6 +1144,10 @@ func TestReadTFVarsFiles(t *testing.T) {
 	assert.Equal(t, locals["number_var"].(float64), float64(42))
 	assert.Equal(t, locals["bool_var"].(bool), true)
 	assert.Equal(t, locals["list_var"].([]interface{}), []interface{}{"hello", "world"})
+
+	assert.Equal(t, locals["json_number_var"].(float64), float64(24))
+	assert.Equal(t, locals["json_string_var"].(string), "another string")
+	assert.Equal(t, locals["json_bool_var"].(bool), false)
 }
 
 func mockConfigWithSource(sourceUrl string) *TerragruntConfig {

--- a/test/fixture-read-tf-vars/my.tfvars
+++ b/test/fixture-read-tf-vars/my.tfvars
@@ -1,0 +1,4 @@
+string_var = "string"
+number_var = 42
+bool_var = true
+list_var = ["hello", "world"]

--- a/test/fixture-read-tf-vars/my.tfvars.json
+++ b/test/fixture-read-tf-vars/my.tfvars.json
@@ -1,0 +1,5 @@
+{
+    "string_var": "another string",
+    "number_var": 24,
+    "bool_var": false
+}

--- a/test/fixture-read-tf-vars/terragrunt.hcl
+++ b/test/fixture-read-tf-vars/terragrunt.hcl
@@ -1,7 +1,12 @@
 locals {
   vars       = jsondecode(read_tfvars_file("my.tfvars"))
+  json_vars = jsondecode(read_tfvars_file("my.tfvars.json"))
   string_var = local.vars.string_var
   bool_var   = local.vars.bool_var
   number_var = local.vars.number_var
   list_var   = local.vars.list_var
+
+  json_string_var = local.json_vars.string_var
+  json_bool_var   = local.json_vars.bool_var
+  json_number_var = local.json_vars.number_var
 }

--- a/test/fixture-read-tf-vars/terragrunt.hcl
+++ b/test/fixture-read-tf-vars/terragrunt.hcl
@@ -1,0 +1,7 @@
+locals {
+  vars       = jsondecode(read_tfvars_file("my.tfvars"))
+  string_var = local.vars.string_var
+  bool_var   = local.vars.bool_var
+  number_var = local.vars.number_var
+  list_var   = local.vars.list_var
+}


### PR DESCRIPTION


## Description

Hi! 

I implemented `read_tfvars_file` function which had been discussed in #1621. Since most the built-in functions return results of a type string I have done the same for this one.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `read_tfvars_file` function which accepts the path to tfvar.tf or tfvar.json file and returns JSON string

### Migration Guide

No need for migration
<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

