### PR TITLE
[WIP] Support for passing environment variables to dependency blocks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,7 @@ const (
 	MetadataRetryMaxAttempts            = "retry_max_attempts"
 	MetadataRetrySleepIntervalSec       = "retry_sleep_interval_sec"
 	MetadataDependentModules            = "dependent_modules"
+	MetadataDependencyEnvVars           = "dependency_env_vars"
 )
 
 // Order matters, for example if none of the files are found `GetDefaultConfigPath` func returns the last element.
@@ -85,6 +86,7 @@ type TerragruntConfig struct {
 	RetryableErrors             []string
 	RetryMaxAttempts            *int
 	RetrySleepIntervalSec       *int
+	DependencyEnvVars           map[string]string
 
 	// Fields used for internal tracking
 	// Indicates whether or not this is the result of a partial evaluation
@@ -172,6 +174,8 @@ type terragruntConfigFile struct {
 	RetryableErrors       []string `hcl:"retryable_errors,optional"`
 	RetryMaxAttempts      *int     `hcl:"retry_max_attempts,optional"`
 	RetrySleepIntervalSec *int     `hcl:"retry_sleep_interval_sec,optional"`
+
+	DependencyEnvVars map[string]string `hcl:"dependency_env_vars,optional"`
 
 	// This struct is used for validating and parsing the entire terragrunt config. Since locals and include are
 	// evaluated in a completely separate cycle, it should not be evaluated here. Otherwise, we can't support self
@@ -1006,6 +1010,11 @@ func convertToTerragruntConfig(
 	if terragruntConfigFromFile.IamAssumeRoleSessionName != nil {
 		terragruntConfig.IamAssumeRoleSessionName = *terragruntConfigFromFile.IamAssumeRoleSessionName
 		terragruntConfig.SetFieldMetadata(MetadataIamAssumeRoleSessionName, defaultMetadata)
+	}
+
+	if terragruntConfigFromFile.DependencyEnvVars != nil {
+		terragruntConfig.DependencyEnvVars = terragruntConfigFromFile.DependencyEnvVars
+		terragruntConfig.SetFieldMetadata(MetadataDependencyEnvVars, defaultMetadata)
 	}
 
 	generateBlocks := []terragruntGenerateBlock{}

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -131,6 +131,14 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 		}
 	}
 
+	dependencyEnvVarsCty, err := goTypeToCty(config.DependencyEnvVars)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	if dependencyEnvVarsCty != cty.NilVal {
+		output[MetadataDependencyEnvVars] = dependencyEnvVarsCty
+	}
+
 	return convertValuesMapToCtyVal(output)
 }
 
@@ -303,6 +311,10 @@ func TerragruntConfigAsCtyWithMetadata(config *TerragruntConfig) (cty.Value, err
 			}
 			output[MetadataGenerateConfigs] = dependenciesCty
 		}
+	}
+
+	if err := wrapWithMetadata(config, config.DependencyEnvVars, MetadataDependencyEnvVars, &output); err != nil {
+		return cty.NilVal, err
 	}
 
 	return convertValuesMapToCtyVal(output)

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -60,10 +60,11 @@ type terraformConfigSourceOnly struct {
 
 // terragruntFlags is a struct that can be used to only decode the flag attributes (skip and prevent_destroy)
 type terragruntFlags struct {
-	IamRole        *string  `hcl:"iam_role,attr"`
-	PreventDestroy *bool    `hcl:"prevent_destroy,attr"`
-	Skip           *bool    `hcl:"skip,attr"`
-	Remain         hcl.Body `hcl:",remain"`
+	IamRole             *string            `hcl:"iam_role,attr"`
+	PreventDestroy      *bool              `hcl:"prevent_destroy,attr"`
+	Skip                *bool              `hcl:"skip,attr"`
+	DependenciesEnvVars *map[string]string `hcl:"dependency_env_vars,attr"`
+	Remain              hcl.Body           `hcl:",remain"`
 }
 
 // terragruntVersionConstraints is a struct that can be used to only decode the attributes related to constraining the
@@ -311,6 +312,9 @@ func PartialParseConfigString(
 			}
 			if decoded.IamRole != nil {
 				output.IamRole = *decoded.IamRole
+			}
+			if decoded.DependenciesEnvVars != nil {
+				output.DependencyEnvVars = *decoded.DependenciesEnvVars
 			}
 
 		case TerragruntVersionConstraints:

--- a/config/include.go
+++ b/config/include.go
@@ -346,6 +346,10 @@ func (targetConfig *TerragruntConfig) Merge(sourceConfig *TerragruntConfig, terr
 		targetConfig.Inputs = mergeInputs(sourceConfig.Inputs, targetConfig.Inputs)
 	}
 
+	for key, val := range sourceConfig.DependencyEnvVars {
+		targetConfig.DependencyEnvVars[key] = val
+	}
+
 	copyFieldsMetadata(sourceConfig, targetConfig)
 
 	return nil
@@ -494,6 +498,10 @@ func (targetConfig *TerragruntConfig) DeepMerge(sourceConfig *TerragruntConfig, 
 	}
 	for key, val := range sourceConfig.GenerateConfigs {
 		targetConfig.GenerateConfigs[key] = val
+	}
+
+	for key, val := range sourceConfig.DependencyEnvVars {
+		targetConfig.DependencyEnvVars[key] = val
 	}
 
 	copyFieldsMetadata(sourceConfig, targetConfig)

--- a/options/options.go
+++ b/options/options.go
@@ -246,6 +246,9 @@ type TerragruntOptions struct {
 
 	// Disalbes validation terraform command
 	DisableCommandValidation bool
+
+	// Supplies the environment variables when calling output from dependencies
+	DependencyEnvVars map[string]string
 }
 
 // IAMOptions represents options that are used by Terragrunt to assume an IAM role.
@@ -316,6 +319,7 @@ func NewTerragruntOptions() *TerragruntOptions {
 		UsePartialParseConfigCache:     false,
 		OutputPrefix:                   "",
 		IncludeModulePrefix:            false,
+		DependencyEnvVars:              map[string]string{},
 		JSONOut:                        DefaultJSONOutName,
 		TerraformImplementation:        UnknownImpl,
 		RunTerragrunt: func(opts *TerragruntOptions) error {
@@ -443,6 +447,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) *TerragruntOpt
 		FailIfBucketCreationRequired:   opts.FailIfBucketCreationRequired,
 		DisableBucketUpdate:            opts.DisableBucketUpdate,
 		TerraformImplementation:        opts.TerraformImplementation,
+		DependencyEnvVars:              util.CloneStringMap(opts.DependencyEnvVars),
 	}
 }
 

--- a/test/fixture-dependency-variables/module-a/main.tf
+++ b/test/fixture-dependency-variables/module-a/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "local" {}
+}
+
+variable "content" {
+  type = string
+}
+
+output "result" {
+  value = "Hello World, from A: ${var.content}"
+}

--- a/test/fixture-dependency-variables/module-a/terragrunt.hcl
+++ b/test/fixture-dependency-variables/module-a/terragrunt.hcl
@@ -1,0 +1,23 @@
+locals {
+  env_value = get_env("VARIANT", "")
+  variant = local.env_value == "" ? "default" : local.env_value
+}
+
+terraform {
+  extra_arguments "data_directory" {
+    commands  = [get_terraform_command()]
+    arguments = []
+    env_vars = {
+      "TF_DATA_DIR" = ".terraform/${local.variant}"
+    }
+  }
+
+  extra_arguments "state_backend" {
+    commands  = ["init"]
+    arguments = ["-backend-config=path=terraform-${local.variant}.tfstate"]
+  }
+}
+
+inputs = {
+  content = local.variant
+}

--- a/test/fixture-dependency-variables/module-b/main.tf
+++ b/test/fixture-dependency-variables/module-b/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "local" {}
+}
+
+variable "content" {
+  type = string
+}
+
+output "result" {
+  value = "Hello World, from B: ${var.content}"
+}

--- a/test/fixture-dependency-variables/module-b/terragrunt.hcl
+++ b/test/fixture-dependency-variables/module-b/terragrunt.hcl
@@ -1,0 +1,13 @@
+dependency "a" {
+  config_path = "../module-a"
+
+  env_vars = {}
+}
+
+dependency_env_vars = {
+  "VARIANT" = "a"
+}
+
+inputs = {
+  content = dependency.a.outputs.result
+}

--- a/util/hash.go
+++ b/util/hash.go
@@ -23,3 +23,13 @@ func GenerateRandomSha256() (string, error) {
 
 	return fmt.Sprintf("%x", sha256.Sum256(randomBytes)), nil
 }
+
+func EncodeStringMap(stringMap *map[string]string, seed string) string {
+	rollingHash := sha1.Sum([]byte(seed))
+
+	for k, v := range *stringMap {
+		rollingHash = sha1.Sum([]byte(fmt.Sprintf("%s:%s:%s", rollingHash, k, v)))
+	}
+
+	return string(rollingHash[:])
+}


### PR DESCRIPTION
## Description

Fixes #2674.

Introduces the ability to pass environment variables to terragrunt configurations which are referenced using the `dependency` block. There can be general environment variables being passed to every dependency but also environment variables (merged additively) per dependency. The existing `get_env` function including falling to a default to retreive a value and act accordingly.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Add some tests.

## Known Issues

- [ ] The top-level attribute `dependency_env_vars` currently is not respected (help appreciated).
- [ ] The attribute on the `dependency` block is required even tho it can be empty (help appreciated).

## Target situation

Fixture `test/fixture-dependency-variables` can be used as an example.

```bash
cd test/fixture-dependency-variables/module-a

VARIANT=a terragrunt apply
terragrunt apply
// Should have terraform-a.tfstate and terraform-default.tfstate now.

cd ../module-b
terragrunt apply
// Is:     Hello World, from B: Hello World, from A: default
// Should: Hello World, from B: Hello World, from A: a
```

Currently it works when the file is changed to be (see known issues):

```
# File: module-b/terragrunt.hcl
dependency "a" {
  config_path = "../module-a"

  # Can be optional.
  env_vars = {
    "VARIANT" = "a"
  }
}

[...]
```


## Release Notes (draft)

Added support for passing variables to terragrunt modules being included as dependencies.

### Migration Guide

No migration needed.

