### PR TITLE
RFC for passing variables to dependencies

### DIFF
--- a/docs/_docs/05_rfc/dependency_variables.md
+++ b/docs/_docs/05_rfc/dependency_variables.md
@@ -16,35 +16,43 @@ nav_title_link: /docs/
 
 ## Background
 
-This section should describe why you need this feature in Terragrunt. This should include a description of:
+I'd like to have a function or variable enabling me to distinguish whether the current terragrunt execution was initiated by another terragrunt run. This is e.g. the scenario when you reference another directory containing a terragrunt.hcl in a dependency block. A way to handle those scenarios would be beneficial when e.g. another state would need be addressed when fetching outputs using the dependency block.
 
-- The problem you are trying to solve.
-- The reason why Terraform can't solve this problem, or data points that suggest there is a long enough time horizon for
-  implementation that it makes sense to workaround it in Terragrunt.
-- Use cases for the problem. Why is it important that we have this feature?
+We distinguish states partly by using environment variables where we would have 60+ directories (each environment) for 30+ teams. This does work quite well except when a dependency block is used and a state file should be referenced which is not addressable using the environment variables. The address tho can be inferred by running a script using run_cmd to get the components of the associated state.
 
+An example would be like that. Files can be seen [here](https://github.com/juljaeg/terragrunt/tree/feature/dependency-variables-2674/test/fixture-dependency-variables). The flow would basically be this:
+
+```bash
+cd test/fixture-dependency-variables/module-a
+
+VARIANT=a terragrunt apply
+terragrunt apply
+// Should have terraform-a.tfstate and terraform-default.tfstate now.
+
+cd ../module-b
+terragrunt apply
+// Is:     Hello World, from B: Hello World, from A: default
+// Should: Hello World, from B: Hello World, from A: a
+```
+
+Especially in large use cases where directories are not suitable anymore as single source of truth for information this is very helpful.
 
 ## Proposed solution
 
-Introduces the ability to pass environment variables to terragrunt configurations which are referenced using the dependency block. There can be general environment variables being passed to every dependency but also environment variables (merged additively) per dependency. The existing get_env function including falling to a default to retreive a value and act accordingly.
-
-This section should describe which solution you are ultimately picking for implementation. This should describe in
-detail how this solution addresses the problem. Additionally, this section should include implementation details. Be
-sure to include code samples so that it is clear how users are intended to use the solution you are proposing!
-
-Note: This section can be left blank in the initial PR, if you are unsure what the best solution is. In this case,
-include all the possible solutions you can think of as a part of the `Alternatives` section below. You can fill this
-section out once you feel confident in a potential approach after discussion on the PR.
+Introduce the ability to pass environment variables to terragrunt configurations which are referenced using the dependency block. There can be general environment variables being passed to every dependency but also environment variables (merged additively) per dependency. The existing get_env function including falling back to a default can be used to retreive a value and act accordingly.
 
 ## Alternatives
 
-This section should describe various options for resolving the problem stated in the `Background` section. Be sure to
-include various alternatives here and not just the one you are ultimately proposing. This helps communicate what
-tradeoffs you are making in picking your solution. Any reasonably complex problem that requires an RFC have multiple
-solutions that appear to be valid, so it helps to be explicit about why certain solutions were not chosen.
+### Directory structure
+
+We evaluated mirroring the state address components in the directory structure, but yielded this will become unmaintainable with growing number of teams and environments. Also it leads to a lot of duplication. Also environments come and go which would mean deleting directories across 30+ teams.
+
+### Dedicated indicator function
+
+Have a function e.g. `is_silent_run_by_terragrunt` which enables me to detect this scenario. Optionally this may be extended to also contain the operation e.g. output to further distinguish. Of course scenarios like run-all make this a bit hard to define when this function will return what value as run-all also runs terragrunt in a subdirectory.
 
 ## References
 
 - Original issue: [#2674](https://github.com/gruntwork-io/terragrunt/issues/2674)
-- RFC PR: [!2759](https://github.com/gruntwork-io/terragrunt/pull/2759)
+- RFC PR: [!2760](https://github.com/gruntwork-io/terragrunt/pull/2760)
 - Draft PR: [!2759](https://github.com/gruntwork-io/terragrunt/pull/2759)

--- a/docs/_docs/05_rfc/dependency_variables.md
+++ b/docs/_docs/05_rfc/dependency_variables.md
@@ -1,0 +1,50 @@
+---
+layout: collection-browser-doc
+title: Passing variables to dependencies
+category: RFC
+categories_url: rfc
+excerpt: Allowing more flexibility in behaviour when the directory structure is not the full source of truth.
+tags: ["rfc", "contributing", "community"]
+order: 505
+nav_title: Documentation
+nav_title_link: /docs/
+---
+
+# RFC: Passing variables to dependencies
+
+**STATUS**: In proposal
+
+## Background
+
+This section should describe why you need this feature in Terragrunt. This should include a description of:
+
+- The problem you are trying to solve.
+- The reason why Terraform can't solve this problem, or data points that suggest there is a long enough time horizon for
+  implementation that it makes sense to workaround it in Terragrunt.
+- Use cases for the problem. Why is it important that we have this feature?
+
+
+## Proposed solution
+
+Introduces the ability to pass environment variables to terragrunt configurations which are referenced using the dependency block. There can be general environment variables being passed to every dependency but also environment variables (merged additively) per dependency. The existing get_env function including falling to a default to retreive a value and act accordingly.
+
+This section should describe which solution you are ultimately picking for implementation. This should describe in
+detail how this solution addresses the problem. Additionally, this section should include implementation details. Be
+sure to include code samples so that it is clear how users are intended to use the solution you are proposing!
+
+Note: This section can be left blank in the initial PR, if you are unsure what the best solution is. In this case,
+include all the possible solutions you can think of as a part of the `Alternatives` section below. You can fill this
+section out once you feel confident in a potential approach after discussion on the PR.
+
+## Alternatives
+
+This section should describe various options for resolving the problem stated in the `Background` section. Be sure to
+include various alternatives here and not just the one you are ultimately proposing. This helps communicate what
+tradeoffs you are making in picking your solution. Any reasonably complex problem that requires an RFC have multiple
+solutions that appear to be valid, so it helps to be explicit about why certain solutions were not chosen.
+
+## References
+
+- Original issue: [#2674](https://github.com/gruntwork-io/terragrunt/issues/2674)
+- RFC PR: [!2759](https://github.com/gruntwork-io/terragrunt/pull/2759)
+- Draft PR: [!2759](https://github.com/gruntwork-io/terragrunt/pull/2759)


### PR DESCRIPTION
## Description

In relation to #2674.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added RFC for support for passing variables to terragrunt modules being included as dependencies.

### Migration Guide

No migration needed.

