### PR TITLE
Add Default Retryable Error List to Docs

### DIFF
--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -1264,19 +1264,19 @@ Default List:
 
 ```hcl
 retryable_errors = [
-	"(?s).*Failed to load state.*tcp.*timeout.*",
-	"(?s).*Failed to load backend.*TLS handshake timeout.*",
-	"(?s).*Creating metric alarm failed.*request to update this alarm is in progress.*",
-	"(?s).*Error installing provider.*TLS handshake timeout.*",
-	"(?s).*Error configuring the backend.*TLS handshake timeout.*",
-	"(?s).*Error installing provider.*tcp.*timeout.*",
-	"(?s).*Error installing provider.*tcp.*connection reset by peer.*",
-	"NoSuchBucket: The specified bucket does not exist",
-	"(?s).*Error creating SSM parameter: TooManyUpdates:.*",
-	"(?s).*app.terraform.io.*: 429 Too Many Requests.*",
-	"(?s).*ssh_exchange_identification.*Connection closed by remote host.*",
-	"(?s).*Client\\.Timeout exceeded while awaiting headers.*",
-	"(?s).*Could not download module.*The requested URL returned error: 429.*",
+  "(?s).*Failed to load state.*tcp.*timeout.*",
+  "(?s).*Failed to load backend.*TLS handshake timeout.*",
+  "(?s).*Creating metric alarm failed.*request to update this alarm is in progress.*",
+  "(?s).*Error installing provider.*TLS handshake timeout.*",
+  "(?s).*Error configuring the backend.*TLS handshake timeout.*",
+  "(?s).*Error installing provider.*tcp.*timeout.*",
+  "(?s).*Error installing provider.*tcp.*connection reset by peer.*",
+  "NoSuchBucket: The specified bucket does not exist",
+  "(?s).*Error creating SSM parameter: TooManyUpdates:.*",
+  "(?s).*app.terraform.io.*: 429 Too Many Requests.*",
+  "(?s).*ssh_exchange_identification.*Connection closed by remote host.*",
+  "(?s).*Client\\.Timeout exceeded while awaiting headers.*",
+  "(?s).*Could not download module.*The requested URL returned error: 429.*",
 ]
 ```
 

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -1260,6 +1260,26 @@ terragrunt_version_constraint = ">= 0.23"
 The terragrunt `retryable_errors` list can be used to override the default list of retryable errors with your own custom list.
 To learn more about the `retryable_errors` attribute, see the [auto-retry feature overview](/docs/features/auto-retry).
 
+Default List:
+
+```hcl
+retryable_errors = [
+	"(?s).*Failed to load state.*tcp.*timeout.*",
+	"(?s).*Failed to load backend.*TLS handshake timeout.*",
+	"(?s).*Creating metric alarm failed.*request to update this alarm is in progress.*",
+	"(?s).*Error installing provider.*TLS handshake timeout.*",
+	"(?s).*Error configuring the backend.*TLS handshake timeout.*",
+	"(?s).*Error installing provider.*tcp.*timeout.*",
+	"(?s).*Error installing provider.*tcp.*connection reset by peer.*",
+	"NoSuchBucket: The specified bucket does not exist",
+	"(?s).*Error creating SSM parameter: TooManyUpdates:.*",
+	"(?s).*app.terraform.io.*: 429 Too Many Requests.*",
+	"(?s).*ssh_exchange_identification.*Connection closed by remote host.*",
+	"(?s).*Client\\.Timeout exceeded while awaiting headers.*",
+	"(?s).*Could not download module.*The requested URL returned error: 429.*",
+]
+```
+
 Example:
 
 ```hcl


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds the list of default retryable errors to the Terragrunt docs. This list is needed if you want to add new retryable errors without losing the defaults. Referenced from https://github.com/gruntwork-io/terragrunt/blob/master/options/auto_retry_options.go.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added default retryable error list to docs

### Migration Guide

None
