### PR TITLE
feat: Support assume_role in s3 backend config. Starting with TF1.6

### DIFF
--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -401,6 +401,11 @@ For the `s3` backend, the following additional properties are supported in the `
 - `accesslogging_target_prefix`: (Optional) When provided as a valid `string`, set the `TargetPrefix` for the access log objects in the S3 bucket used to store Terraform state. If set to **empty**`string`, then `TargetPrefix` will be set to **empty** `string`. If attribute is not provided at all, then `TargetPrefix` will be set to **default** value `TFStateLogs/`. This attribute won't take effect if the `accesslogging_bucket_name` attribute is not present.
 - `bucket_sse_algorithm`: (Optional) The algorithm to use for server side encryption of the state bucket. Defaults to `aws:kms`.
 - `bucket_sse_kms_key_id`: (Optional) The KMS Key to use when the encryption algorithm is `aws:kms`. Defaults to the AWS Managed `aws/s3` key.
+- `assume_role`: (Optional) A configuration `map` to use when assuming a role (starting with Terraform 1.6). Override top level arguments
+  - `role_arn` - (Optional) The role to be assumed.
+  - `external_id` - (Optional) The external ID to use when assuming the role.
+  - `session_name` - (Optional) The session name to use when assuming the role.
+
 
 For the `gcs` backend, the following additional properties are supported in the `config` attribute:
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -130,7 +130,8 @@ func (s3Config *RemoteStateConfigS3) GetLockTableName() string {
 	return s3Config.LockTable
 }
 
-// Since Terraform 1.6 assume_role is a new block but we need to keep deprecated top level arguments
+// GetSessionRoleArn returns the role defined in the AssumeRole struct
+// or fallback to the top level argument deprecated in Terraform 1.6
 func (s3Config *RemoteStateConfigS3) GetSessionRoleArn() string {
 	if s3Config.AssumeRole.RoleArn != "" {
 		return s3Config.AssumeRole.RoleArn

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -79,22 +79,29 @@ var terragruntOnlyConfigs = []string{
 	"bucket_sse_kms_key_id",
 }
 
+type RemoteStateConfigS3AssumeRole struct {
+	RoleArn     string `mapstructure:"role_arn"`
+	ExternalID  string `mapstructure:"external_id"`
+	SessionName string `mapstructure:"session_name"`
+}
+
 // A representation of the configuration options available for S3 remote state
 type RemoteStateConfigS3 struct {
-	Encrypt          bool   `mapstructure:"encrypt"`
-	Bucket           string `mapstructure:"bucket"`
-	Key              string `mapstructure:"key"`
-	Region           string `mapstructure:"region"`
-	Endpoint         string `mapstructure:"endpoint"`
-	DynamoDBEndpoint string `mapstructure:"dynamodb_endpoint"`
-	Profile          string `mapstructure:"profile"`
-	RoleArn          string `mapstructure:"role_arn"`
-	ExternalID       string `mapstructure:"external_id"`
-	SessionName      string `mapstructure:"session_name"`
-	LockTable        string `mapstructure:"lock_table"` // Deprecated in Terraform version 0.13 or newer.
-	DynamoDBTable    string `mapstructure:"dynamodb_table"`
-	CredsFilename    string `mapstructure:"shared_credentials_file"`
-	S3ForcePathStyle bool   `mapstructure:"force_path_style"`
+	Encrypt          bool                          `mapstructure:"encrypt"`
+	Bucket           string                        `mapstructure:"bucket"`
+	Key              string                        `mapstructure:"key"`
+	Region           string                        `mapstructure:"region"`
+	Endpoint         string                        `mapstructure:"endpoint"`
+	DynamoDBEndpoint string                        `mapstructure:"dynamodb_endpoint"`
+	Profile          string                        `mapstructure:"profile"`
+	RoleArn          string                        `mapstructure:"role_arn"`     // Deprecated in Terraform version 1.6 or newer.
+	ExternalID       string                        `mapstructure:"external_id"`  // Deprecated in Terraform version 1.6 or newer.
+	SessionName      string                        `mapstructure:"session_name"` // Deprecated in Terraform version 1.6 or newer.
+	LockTable        string                        `mapstructure:"lock_table"`   // Deprecated in Terraform version 0.13 or newer.
+	DynamoDBTable    string                        `mapstructure:"dynamodb_table"`
+	CredsFilename    string                        `mapstructure:"shared_credentials_file"`
+	S3ForcePathStyle bool                          `mapstructure:"force_path_style"`
+	AssumeRole       RemoteStateConfigS3AssumeRole `mapstructure:"assume_role"`
 }
 
 // Builds a session config for AWS related requests from the RemoteStateConfigS3 configuration
@@ -104,9 +111,9 @@ func (c *ExtendedRemoteStateConfigS3) GetAwsSessionConfig() *aws_helper.AwsSessi
 		CustomS3Endpoint:        c.remoteStateConfigS3.Endpoint,
 		CustomDynamoDBEndpoint:  c.remoteStateConfigS3.DynamoDBEndpoint,
 		Profile:                 c.remoteStateConfigS3.Profile,
-		RoleArn:                 c.remoteStateConfigS3.RoleArn,
-		ExternalID:              c.remoteStateConfigS3.ExternalID,
-		SessionName:             c.remoteStateConfigS3.SessionName,
+		RoleArn:                 c.remoteStateConfigS3.GetSessionRoleArn(),
+		ExternalID:              c.remoteStateConfigS3.GetExternalId(),
+		SessionName:             c.remoteStateConfigS3.GetSessionName(),
 		CredsFilename:           c.remoteStateConfigS3.CredsFilename,
 		S3ForcePathStyle:        c.remoteStateConfigS3.S3ForcePathStyle,
 		DisableComputeChecksums: c.DisableAWSClientChecksums,
@@ -121,6 +128,28 @@ func (s3Config *RemoteStateConfigS3) GetLockTableName() string {
 		return s3Config.DynamoDBTable
 	}
 	return s3Config.LockTable
+}
+
+// Since Terraform 1.6 assume_role is a new block but we need to keep deprecated top level arguments
+func (s3Config *RemoteStateConfigS3) GetSessionRoleArn() string {
+	if s3Config.AssumeRole.RoleArn != "" {
+		return s3Config.AssumeRole.RoleArn
+	}
+	return s3Config.RoleArn
+}
+
+func (s3Config *RemoteStateConfigS3) GetExternalId() string {
+	if s3Config.AssumeRole.ExternalID != "" {
+		return s3Config.AssumeRole.ExternalID
+	}
+	return s3Config.ExternalID
+}
+
+func (s3Config *RemoteStateConfigS3) GetSessionName() string {
+	if s3Config.AssumeRole.SessionName != "" {
+		return s3Config.AssumeRole.SessionName
+	}
+	return s3Config.SessionName
 }
 
 const MAX_RETRIES_WAITING_FOR_S3_BUCKET = 12

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -225,6 +225,43 @@ func TestGetAwsSessionConfig(t *testing.T) {
 	}
 }
 
+func TestGetAwsSessionConfigWithAssumeRole(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		config map[string]interface{}
+	}{
+		{
+			"all-values",
+			map[string]interface{}{"role_arn": "arn::it", "external_id": "123", "session_name": "foobar"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		// The following is necessary to make sure testCase's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			config := map[string]interface{}{"assume_role": testCase.config}
+			s3ConfigExtended, err := ParseExtendedS3Config(config)
+			require.Nil(t, err, "Unexpected error parsing config for test: %v", err)
+
+			expected := &aws_helper.AwsSessionConfig{
+				RoleArn:     s3ConfigExtended.remoteStateConfigS3.AssumeRole.RoleArn,
+				ExternalID:  s3ConfigExtended.remoteStateConfigS3.AssumeRole.ExternalID,
+				SessionName: s3ConfigExtended.remoteStateConfigS3.AssumeRole.SessionName,
+			}
+
+			actual := s3ConfigExtended.GetAwsSessionConfig()
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
 func TestGetTerraformInitArgs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Fix https://github.com/gruntwork-io/terragrunt/issues/2798

This PR adds the new assume_role block in backend s3 config.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

