### PR TITLE
Fix for assume_role generation during backend creation

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -341,6 +341,7 @@ func (s3Initializer S3Initializer) GetTerraformInitArgs(config map[string]interf
 	const (
 		lockTableKey     = "lock_table"
 		dynamoDBTableKey = "dynamodb_table"
+		assumeRoleKey    = "assume_role"
 	)
 
 	for key, val := range config {
@@ -357,6 +358,12 @@ func (s3Initializer S3Initializer) GetTerraformInitArgs(config map[string]interf
 		if key == lockTableKey {
 			filteredConfig[dynamoDBTableKey] = val
 			continue
+		}
+		if key == assumeRoleKey {
+			if mapVal, ok := val.(map[string]interface{}); ok {
+				filteredConfig[key] = wrapMapToSingleLineHcl(mapVal)
+				continue
+			}
 		}
 
 		filteredConfig[key] = val

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -370,6 +370,22 @@ func TestGetTerraformInitArgs(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"assume-role",
+			map[string]interface{}{
+				"bucket": "foo",
+				"assume_role": map[string]interface{}{
+					"role_arn":     "arn:aws:iam::123:role/role",
+					"external_id":  "123",
+					"session_name": "qwe",
+				},
+			},
+			map[string]interface{}{
+				"bucket":      "foo",
+				"assume_role": "{external_id=\"123\",role_arn=\"arn:aws:iam::123:role/role\",session_name=\"qwe\"}",
+			},
+			true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/remote/terraform_config.go
+++ b/remote/terraform_config.go
@@ -1,0 +1,30 @@
+package remote
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// wrapMapToSingleLineHcl - This is a workaround to convert a map[string]interface{} to a single line HCL string.
+func wrapMapToSingleLineHcl(m map[string]interface{}) string {
+	var attributes []string
+	for key, value := range m {
+		attributes = append(attributes, fmt.Sprintf(`%s=%s`, key, formatHclValue(value)))
+	}
+	sort.Strings(attributes)
+	return fmt.Sprintf("{%s}", strings.Join(attributes, ","))
+}
+
+// formatHclValue - Wrap single line HCL values in quotes.
+func formatHclValue(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		escapedValue := strings.ReplaceAll(v, `"`, `\"`)
+		return fmt.Sprintf(`"%s"`, escapedValue)
+	case map[string]interface{}:
+		return wrapMapToSingleLineHcl(v)
+	default:
+		return fmt.Sprintf(`%v`, v)
+	}
+}

--- a/remote/terraform_config_test.go
+++ b/remote/terraform_config_test.go
@@ -1,0 +1,31 @@
+package remote
+
+import "testing"
+
+func TestWrapMapToSingleLineHcl(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "SimpleMap",
+			input:    map[string]interface{}{"key1": "value1", "key2": 46521694, "key3": true},
+			expected: `{key1="value1",key2=46521694,key3=true}`,
+		},
+		{
+			name:     "NestedMap",
+			input:    map[string]interface{}{"key1": "value1", "key2": map[string]interface{}{"nestedKey": "nestedValue"}},
+			expected: `{key1="value1",key2={nestedKey="nestedValue"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := wrapMapToSingleLineHcl(tt.input)
+			if result != tt.expected {
+				t.Errorf("Expected %s, but got %s", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Include changes:
* fixed generation of `assume_role` values
* added test to track conversion of passed values

Fixes #2803.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Fixed passing of assume_role values to Terraform.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

