### PR TITLE
Update regex for version check

### DIFF
--- a/cli/commands/terraform/version_check.go
+++ b/cli/commands/terraform/version_check.go
@@ -18,11 +18,12 @@ import (
 const DefaultTerraformVersionConstraint = ">= v0.12.0"
 
 // TerraformVersionRegex verifies that terraform --version output is in one of the following formats:
+// - OpenTofu v1.6.0-dev
 // - Terraform v0.9.5-dev (cad024a5fe131a546936674ef85445215bbc4226+CHANGES)
 // - Terraform v0.13.0-beta2
 // - Terraform v0.12.27
 // We only make sure the "v#.#.#" part is present in the output.
-var TerraformVersionRegex = regexp.MustCompile(`^(.*?)\s(v?\d+\.\d+\.\d+).*`)
+var TerraformVersionRegex = regexp.MustCompile(`^(\S+)\s(v?\d+\.\d+\.\d+)`)
 
 const versionParts = 3
 

--- a/cli/commands/terraform/version_check_test.go
+++ b/cli/commands/terraform/version_check_test.go
@@ -35,6 +35,16 @@ func TestCheckTerraformVersionMeetsConstraintLessMajor(t *testing.T) {
 	testCheckTerraformVersionMeetsConstraint(t, "v0.8.8", ">= v0.9.3", false)
 }
 
+func TestParseOpenTofuVersionNormal(t *testing.T) {
+	t.Parallel()
+	testParseTerraformVersion(t, "OpenTofu v1.6.0", "v1.6.0", nil)
+}
+
+func TestParseOpenTofuVersionDev(t *testing.T) {
+	t.Parallel()
+	testParseTerraformVersion(t, "OpenTofu v1.6.0-dev", "v1.6.0", nil)
+}
+
 func TestParseTerraformVersionNormal(t *testing.T) {
 	t.Parallel()
 	testParseTerraformVersion(t, "Terraform v0.9.3", "v0.9.3", nil)


### PR DESCRIPTION
## Description
Fixes #2818
This follows up on some changes in #2745 

- Simplify regex for version check
  * use `\S+` instead of `.*` for main package name (note: this could be just `Terraform|OpenTofu` since it was `Terraform` before; not sure if this would break `UnknownImpl` so left it a bit looser).
  * remove trailing `.*`, which should be redundant
- Add minimal unit test cases for OpenTofu

Note: this _would_ break if there was a name with spaces in it before the version string. IMO, `InvalidTerraformVersionSyntax()` or a similar error should still get thrown, and I don't think there's a real use case with a multi word string here in the version?

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)
Updated version check regular expression.

### Migration Guide
IMO, this should be backwards compatible under normal circumstances.