### PR TITLE
Scaffold template blank lines fix

### DIFF
--- a/cli/commands/scaffold/action.go
+++ b/cli/commands/scaffold/action.go
@@ -50,14 +50,11 @@ variables:
 terraform {
   source = "{{ .sourceUrl }}"
 }
-
-{{if .EnableRootInclude}}
+{{ if .EnableRootInclude }}
 include "root" {
   path = find_in_parent_folders()
 }
-{{end}}
-
-
+{{ end }}
 inputs = {
   # --------------------------------------------------------------------------------------------------------------------
   # Required input variables

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -13,12 +13,11 @@ import (
 )
 
 const (
-	// TODO: change ref values to master once the feature is merged
-	TEST_SCAFOLD_MODULE                   = "https://github.com/gruntwork-io/terragrunt.git//test/fixture-scaffold/scaffold-module?ref=feature/scaffold"
-	TEST_SCAFOLD_MODULE_GIT               = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/scaffold-module?ref=feature/scaffold"
+	TEST_SCAFOLD_MODULE                   = "https://github.com/gruntwork-io/terragrunt.git//test/fixture-scaffold/scaffold-module"
+	TEST_SCAFOLD_MODULE_GIT               = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/scaffold-module"
 	TEST_SCAFOLD_MODULE_SHORT             = "github.com/gruntwork-io/terragrunt.git//test/fixture-inputs"
-	TEST_SCAFOLD_TEMPLATE_MODULE          = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/module-with-template?ref=feature/scaffold"
-	TEST_SCAFOLD_EXTERNAL_TEMPLATE_MODULE = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/external-template?ref=feature/scaffold"
+	TEST_SCAFOLD_TEMPLATE_MODULE          = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/module-with-template"
+	TEST_SCAFOLD_EXTERNAL_TEMPLATE_MODULE = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/external-template"
 )
 
 func TestTerragruntScaffoldModule(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* removed blank lines adding in scaffold template
* updated integration tests to use release branch

scaffold template after changes:

```
# --var=EnableRootInclude=false

terraform {
  source = "git::https://github.com/gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.7.0"
}

inputs = {
```

```
# --var=EnableRootInclude=true

terraform {
  source = "git::https://github.com/gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.7.0"
}

include "root" {
  path = find_in_parent_folders()
}

inputs = {
```

Fixes #2837.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Removed blank lines from generated HCL code by `scaffold` command.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

