### PR TITLE
Fixed passing assume_role generation

### DIFF
--- a/test/fixture-assume-role/terragrunt.hcl
+++ b/test/fixture-assume-role/terragrunt.hcl
@@ -1,0 +1,19 @@
+remote_state {
+  backend  = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket         = "__FILL_IN_BUCKET_NAME__"
+    dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
+    key            = "${path_relative_to_include()}/terraform.tfstate"
+    region         = "us-west-2"
+    encrypt        = true
+    assume_role    = {
+      role_arn     = get_aws_caller_identity_arn()
+      external_id  = "external_id_123"
+      session_name = "session_name_example"
+    }
+  }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6445,6 +6445,7 @@ func TestTerragruntAssumeRole(t *testing.T) {
 	assert.NoError(t, err)
 
 	identityARN, err := aws_helper.GetAWSIdentityArn(nil, opts)
+	assert.NoError(t, err)
 
 	assert.Contains(t, content, "role_arn     = \""+identityARN+"\"")
 	assert.Contains(t, content, "external_id  = \"external_id_123\"")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6432,7 +6432,7 @@ func TestTerragruntAssumeRole(t *testing.T) {
 	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
 	copyTerragruntConfigAndFillPlaceholders(t, originalTerragruntConfigPath, tmpTerragruntConfigFile, s3BucketName, lockTableName, "us-east-2")
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt init -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testPath))
+	runTerragrunt(t, fmt.Sprintf("terragrunt validate-inputs -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testPath))
 
 	// validate generated backend.tf
 	backendFile := filepath.Join(testPath, "backend.tf")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gruntwork-io/go-commons/files"
+
 	"cloud.google.com/go/storage"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -179,6 +181,7 @@ const (
 	TEST_COMMANDS_THAT_NEED_INPUT                                            = "fixture-commands-that-need-input"
 	TEST_FIXTURE_PARALLEL_STATE_INIT                                         = "fixture-parallel-state-init"
 	TEST_FIXTURE_GCS_PARALLEL_STATE_INIT                                     = "fixture-gcs-parallel-state-init"
+	TEST_FIXTURE_ASSUME_ROLE                                                 = "fixture-assume-role"
 	TERRAFORM_BINARY                                                         = "terraform"
 	TOFU_BINARY                                                              = "tofu"
 	TERRAFORM_FOLDER                                                         = ".terraform"
@@ -6414,6 +6417,38 @@ func TestTerragruntGCSParallelStateInit(t *testing.T) {
 	assert.NoError(t, err)
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", tmpEnvPath))
+}
+
+func TestTerragruntAssumeRole(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_ASSUME_ROLE)
+	cleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_ASSUME_ROLE)
+
+	originalTerragruntConfigPath := util.JoinPath(TEST_FIXTURE_ASSUME_ROLE, "terragrunt.hcl")
+	tmpTerragruntConfigFile := util.JoinPath(testPath, "terragrunt.hcl")
+	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
+	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
+	copyTerragruntConfigAndFillPlaceholders(t, originalTerragruntConfigPath, tmpTerragruntConfigFile, s3BucketName, lockTableName, "us-east-2")
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt init -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testPath))
+
+	// validate generated backend.tf
+	backendFile := filepath.Join(testPath, "backend.tf")
+	assert.FileExists(t, backendFile)
+
+	content, err := files.ReadFileAsString(backendFile)
+	assert.NoError(t, err)
+
+	opts, err := options.NewTerragruntOptionsForTest(testPath)
+	assert.NoError(t, err)
+
+	identityARN, err := aws_helper.GetAWSIdentityArn(nil, opts)
+
+	assert.Contains(t, content, "role_arn     = \""+identityARN+"\"")
+	assert.Contains(t, content, "external_id  = \"external_id_123\"")
+	assert.Contains(t, content, "session_name = \"session_name_example\"")
 }
 
 func validateOutput(t *testing.T, outputs map[string]TerraformOutput, key string, value interface{}) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* Fixed generation of `assume_role` field
* Added tests to track that `assume_role` contains right values


Before this PR:
```
# backend.tf
terraform {
  backend "s3" {
    assume_role = "{external_id=\"xxx\",role_arn=\"yyy\",session_name=\"zzz\"}"
...
```

With changes from this PR:
```
# backend.tf
terraform {
  backend "s3" {
    assume_role = {
      external_id  = "xxx"
      role_arn     = "yyy"
      session_name = "zzz"
    }
...
```

Fixes #2813.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated remote state `assume_role` generation to not be a single-line HCL string.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

