### PR TITLE
Speed up repo cloning for the `catalog` command

### DIFF
--- a/cli/commands/catalog/action.go
+++ b/cli/commands/catalog/action.go
@@ -2,6 +2,9 @@ package catalog
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/module"
@@ -10,6 +13,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/util"
+)
+
+const (
+	tempDirFormat = "catalog%x"
 )
 
 func Run(ctx context.Context, opts *options.TerragruntOptions, repoURL string) error {
@@ -39,7 +46,9 @@ func Run(ctx context.Context, opts *options.TerragruntOptions, repoURL string) e
 	var modules module.Modules
 
 	for _, repoURL := range repoURLs {
-		repo, err := module.NewRepo(ctx, repoURL)
+		tempDir := filepath.Join(os.TempDir(), fmt.Sprintf(tempDirFormat, util.EncodeBase64Sha1(repoURL)))
+
+		repo, err := module.NewRepo(ctx, repoURL, tempDir)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/catalog/module/repo_test.go
+++ b/cli/commands/catalog/module/repo_test.go
@@ -60,7 +60,7 @@ func TestFindModules(t *testing.T) {
 
 			ctx := context.Background()
 
-			repo, err := NewRepo(ctx, testCase.repoPath)
+			repo, err := NewRepo(ctx, testCase.repoPath, "")
 			assert.NoError(t, err)
 
 			modules, err := repo.FindModules(ctx)

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,7 +20,10 @@ func TestScaffoldGitRepo(t *testing.T) {
 
 	ctx := context.Background()
 
-	repo, err := module.NewRepo(ctx, "github.com/gruntwork-io/terraform-fake-modules.git")
+	tempDir, err := os.MkdirTemp("", "catalog-*")
+	require.NoError(t, err)
+
+	repo, err := module.NewRepo(ctx, "github.com/gruntwork-io/terraform-fake-modules.git", tempDir)
 	require.NoError(t, err)
 
 	modules, err := repo.FindModules(ctx)
@@ -32,7 +36,10 @@ func TestScaffoldGitModule(t *testing.T) {
 
 	ctx := context.Background()
 
-	repo, err := module.NewRepo(ctx, "https://github.com/gruntwork-io/terraform-fake-modules.git")
+	tempDir, err := os.MkdirTemp("", "catalog-*")
+	require.NoError(t, err)
+
+	repo, err := module.NewRepo(ctx, "https://github.com/gruntwork-io/terraform-fake-modules.git", tempDir)
 	require.NoError(t, err)
 
 	modules, err := repo.FindModules(ctx)
@@ -68,7 +75,10 @@ func TestScaffoldGitModuleHttps(t *testing.T) {
 
 	ctx := context.Background()
 
-	repo, err := module.NewRepo(ctx, "https://github.com/gruntwork-io/terraform-fake-modules")
+	tempDir, err := os.MkdirTemp("", "catalog-*")
+	require.NoError(t, err)
+
+	repo, err := module.NewRepo(ctx, "https://github.com/gruntwork-io/terraform-fake-modules", tempDir)
 	assert.NoError(t, err)
 
 	modules, err := repo.FindModules(ctx)


### PR DESCRIPTION
## Description

Fixed the temporary folder path and repository URL that is sent to `go-getter`.

Fixes #2831.
