### PR TITLE
Conditionally set log level of s3 bucket encryption warning

### DIFF
--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -377,7 +377,7 @@ For the `s3` backend, the following additional properties are supported in the `
 - `region` - (Optional) The region of the S3 bucket.
 - `profile` - (Optional) This is the AWS profile name as set in the shared credentials file.
 - `endpoint` - (Optional) A custom endpoint for the S3 API.
-- `encrypt` - (Optional) Whether to enable server side encryption of the state file.
+- `encrypt` - (Optional) Whether to enable server side encryption of the state file. If disabled, a log warning will be issued in the console output to notify the user. If `skip_bucket_ssencryption` is enabled, the log will be written as a debug log.
 - `role_arn` - (Optional) The role to be assumed.
 - `shared_credentials_file` - (Optional) This is the path to the shared credentials file. If this is not set and a profile is specified, `~/.aws/credentials` will be used.
 - `external_id` - (Optional) The external ID to use when assuming the role.

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -416,7 +416,12 @@ func validateS3Config(extendedConfig *ExtendedRemoteStateConfigS3, terragruntOpt
 	}
 
 	if !config.Encrypt {
-		terragruntOptions.Logger.Warnf("Encryption is not enabled on the S3 remote state bucket %s. Terraform state files may contain secrets, so we STRONGLY recommend enabling encryption!", config.Bucket)
+		msg := fmt.Sprintf("Encryption is not enabled on the S3 remote state bucket %s. Terraform state files may contain secrets, so we STRONGLY recommend enabling encryption!", config.Bucket)
+		if extendedConfig.SkipBucketSSEncryption {
+			terragruntOptions.Logger.Debug(msg)
+		} else {
+			terragruntOptions.Logger.Warn(msg)
+		}
 	}
 
 	return nil

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -520,8 +520,8 @@ func TestValidateS3Config(t *testing.T) {
 			logger := logrus.New()
 			logger.SetLevel(logrus.DebugLevel)
 			logger.SetOutput(buf)
-			options := &options.TerragruntOptions{Logger: logrus.NewEntry(logger)}
-			err := validateS3Config(testCase.extendedConfig, options)
+			opts := &options.TerragruntOptions{Logger: logrus.NewEntry(logger)}
+			err := validateS3Config(testCase.extendedConfig, opts)
 			if err != nil {
 				assert.ErrorIs(t, err, testCase.expectedErr)
 			}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

As described in the issue, Terragrunt will log a message warning the user if encryption is disabled. This message is still logged even if the user has disabled S3 SSE encryption. This PR adds a conditional statement to log the warning at the debug level if S3 SSE encryption is explicitly disabled by the user.

Fixes https://github.com/gruntwork-io/terragrunt/issues/2227.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->

Conditionally set log level of s3 bucket encryption warning

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

N/A