### PR TITLE
Speed up git clones and catalog command

### DIFF
--- a/cli/commands/catalog/action.go
+++ b/cli/commands/catalog/action.go
@@ -3,6 +3,9 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/module"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/tui"
@@ -11,8 +14,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/util"
 	"golang.org/x/sync/errgroup"
-	"os"
-	"path/filepath"
 )
 
 const (

--- a/cli/commands/catalog/action.go
+++ b/cli/commands/catalog/action.go
@@ -3,9 +3,6 @@ package catalog
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/module"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/tui"
@@ -13,6 +10,9 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/util"
+	"golang.org/x/sync/errgroup"
+	"os"
+	"path/filepath"
 )
 
 const (
@@ -37,24 +37,43 @@ func Run(ctx context.Context, opts *options.TerragruntOptions, repoURL string) e
 
 	repoURLs = util.RemoveDuplicatesFromList(repoURLs)
 
+	// Create one goroutine to listen on a channel, receive parsed module data, and add it to the modules slice
+	modulesChan := make(chan module.Modules)
 	var modules module.Modules
+	go func() {
+		for repoModules := range modulesChan {
+			modules = append(modules, repoModules...)
+		}
+	}()
 
+	// Create a bunch more goroutines that concurrently 'git clone' repos, parse module data from them, and send that
+	// data to the channel created above
+	errGroup := new(errgroup.Group)
 	for _, repoURL := range repoURLs {
-		tempDir := filepath.Join(os.TempDir(), fmt.Sprintf(tempDirFormat, util.EncodeBase64Sha1(repoURL)))
+		// Copy the value so each goroutine gets the right one: https://golang.org/doc/faq#closures_and_goroutines
+		repoURL := repoURL
+		errGroup.Go(func() error {
+			tempDir := filepath.Join(os.TempDir(), fmt.Sprintf(tempDirFormat, util.EncodeBase64Sha1(repoURL)))
 
-		repo, err := module.NewRepo(ctx, repoURL, tempDir)
-		if err != nil {
-			return err
-		}
+			repo, err := module.NewRepo(ctx, repoURL, tempDir)
+			if err != nil {
+				return err
+			}
 
-		repoModules, err := repo.FindModules(ctx)
-		if err != nil {
-			return err
-		}
+			repoModules, err := repo.FindModules(ctx)
+			if err != nil {
+				return err
+			}
 
-		log.Infof("Found %d modules in repository %q", len(repoModules), repoURL)
+			log.Infof("Found %d modules in repository %q", len(repoModules), repoURL)
 
-		modules = append(modules, repoModules...)
+			modulesChan <- repoModules
+			return nil
+		})
+	}
+
+	if err := errGroup.Wait(); err != nil {
+		return err
 	}
 
 	if len(modules) == 0 {

--- a/cli/commands/catalog/module/repo.go
+++ b/cli/commands/catalog/module/repo.go
@@ -192,7 +192,7 @@ func (repo *Repo) clone(ctx context.Context) error {
 	}
 	repo.cloneURL = sourceUrl.String()
 
-	log.Infof("Cloning repository %q to temprory directory %q", repo.cloneURL, repo.path)
+	log.Infof("Cloning repository %q to temporary directory %q", repo.cloneURL, repo.path)
 
 	if err := getter.Get(repo.path, strings.Trim(sourceUrl.String(), "/"), getter.WithContext(ctx)); err != nil {
 		return errors.WithStackTrace(err)

--- a/terraform/source.go
+++ b/terraform/source.go
@@ -222,6 +222,13 @@ func parseSourceUrl(source string) (*url.URL, error) {
 		canonicalSourceUrl.Scheme = fmt.Sprintf("%s::%s", forcedGetter, canonicalSourceUrl.Scheme)
 	}
 
+	// Set the "depth" parameter to 1 so that go-getter does a shallow clone. This will speed up the clone operation
+	// significantly, and as we aren't making any changes in these repos (these are read-only clones), a shallow clone
+	// should be fine
+	query := canonicalSourceUrl.Query()
+	query.Set("depth", "1")
+	canonicalSourceUrl.RawQuery = query.Encode()
+
 	return canonicalSourceUrl, nil
 }
 

--- a/terraform/source_test.go
+++ b/terraform/source_test.go
@@ -4,6 +4,9 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/hashicorp/go-getter"
+	urlhelper "github.com/hashicorp/go-getter/helper/url"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -34,9 +37,9 @@ func TestSplitSourceUrl(t *testing.T) {
 		{"relative-path-multiple-children-with-double-slash", "../foo/bar//baz/blah", "../foo/bar", "baz/blah"},
 		{"parent-url-one-child-no-double-slash", "ssh://git@github.com/foo/modules.git/foo", "ssh://git@github.com/foo/modules.git/foo", ""},
 		{"parent-url-multiple-children-no-double-slash", "ssh://git@github.com/foo/modules.git/foo/bar/baz/blah", "ssh://git@github.com/foo/modules.git/foo/bar/baz/blah", ""},
-		{"parent-url-one-child-with-double-slash", "ssh://git@github.com/foo/modules.git//foo", "ssh://git@github.com/foo/modules.git", "foo"},
-		{"parent-url-multiple-children-with-double-slash", "ssh://git@github.com/foo/modules.git//foo/bar/baz/blah", "ssh://git@github.com/foo/modules.git", "foo/bar/baz/blah"},
-		{"separate-ref-with-slash", "ssh://git@github.com/foo/modules.git//foo?ref=feature/modules", "ssh://git@github.com/foo/modules.git?ref=feature/modules", "foo"},
+		{"parent-url-one-child-with-double-slash", "ssh://git@github.com/foo/modules.git//foo", "ssh://git@github.com/foo/modules.git?depth=1", "foo"},
+		{"parent-url-multiple-children-with-double-slash", "ssh://git@github.com/foo/modules.git//foo/bar/baz/blah", "ssh://git@github.com/foo/modules.git?depth=1", "foo/bar/baz/blah"},
+		{"separate-ref-with-slash", "ssh://git@github.com/foo/modules.git//foo?ref=feature/modules", "ssh://git@github.com/foo/modules.git?depth=1&ref=feature%2Fmodules", "foo"},
 	}
 
 	for _, testCase := range testCases {
@@ -60,6 +63,50 @@ func TestSplitSourceUrl(t *testing.T) {
 	}
 }
 
+func TestIsGitUrl(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		sourceUrl     string
+		forcedGetters []string
+		expected      bool
+	}{
+		{"git scheme", "git://example.com/owner/repo", nil, true},
+		{"git+ssh scheme", "git+ssh://example.com/owner/repo", nil, true},
+		{"ssh scheme", "ssh://example.com/owner/repo", nil, true},
+		{"git/ssh URL", "git@example.com:owner/repo", nil, true},
+		{"https scheme, github", "https://github.com/owner/repo", nil, true},
+		{"https scheme, gitlab", "https://gitlab.com/owner/repo", nil, true},
+		{"https scheme, bitbucket", "https://bitbucket.org/owner/repo", nil, true},
+		{"https scheme, path contains .git", "https://example.com/owner/repo.git", nil, true},
+		{"https scheme unknown host / pattern", "https://example.com/owner/repo", nil, false},
+		{"https scheme with git forcedGetter", "https://example.com/owner/repo", []string{"git"}, true},
+		{"https scheme with other forcedGetter", "https://example.com/owner/repo", []string{"scp"}, false},
+		{"realistic GitHub HTTPS URL", "https://github.com/owner/repo.git", nil, true},
+		{"realistic GitHub SSH URL", "git@github.com:owner/repo.git", nil, true},
+		{"realistic GitHub HTTPS URL with module", "https://github.com/owner/repo.git//modules/vpc", nil, true},
+		{"realistic GitHub SSH URL with module", "git@github.com:owner/repo.git//modules/vpc", nil, true},
+	}
+
+	for _, testCase := range testCases {
+		// Save a local copy in scope so all the tests don't run the final item in the loop
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			sourceUrlWithGetter, err := getter.Detect(testCase.sourceUrl, ".", getter.Detectors)
+			require.NoError(t, err)
+
+			sourceUrl, err := urlhelper.Parse(sourceUrlWithGetter)
+			require.NoError(t, err)
+
+			actual := isGitUrl(sourceUrl, testCase.forcedGetters)
+			assert.Equal(t, testCase.expected, actual, "For source URL %s and forcedGetters %v", testCase.sourceUrl, testCase.forcedGetters)
+		})
+	}
+}
+
 func TestRegressionSupportForGitRemoteCodecommit(t *testing.T) {
 	t.Parallel()
 
@@ -74,6 +121,6 @@ func TestRegressionSupportForGitRemoteCodecommit(t *testing.T) {
 	actualRootRepo, actualModulePath, err := SplitSourceUrl(sourceURL, terragruntOptions.Logger)
 	require.NoError(t, err)
 
-	require.Equal(t, "git::codecommit::ap-northeast-1://my_app_modules", actualRootRepo.String())
+	require.Equal(t, "git::codecommit::ap-northeast-1://my_app_modules?depth=1", actualRootRepo.String())
 	require.Equal(t, "my-app/modules/main-module", actualModulePath)
 }

--- a/util/collections.go
+++ b/util/collections.go
@@ -39,6 +39,17 @@ func ListContainsElement(list []string, element string) bool {
 	return false
 }
 
+// ListContainsAnyElement returns true if the given list contains any of the elements from the second list
+func ListContainsAnyElement(list []string, elements []string) bool {
+	for _, element := range elements {
+		if ListContainsElement(list, element) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ListContainsSublist returns true if an instance of the sublist can be found in the given list
 func ListContainsSublist(list, sublist []string) bool {
 	// A list cannot contain an empty sublist

--- a/util/collections_test.go
+++ b/util/collections_test.go
@@ -59,6 +59,30 @@ func TestListContainsElement(t *testing.T) {
 	}
 }
 
+func TestListContainsAnyElement(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		list     []string
+		elements []string
+		expected bool
+	}{
+		{[]string{}, []string{}, false},
+		{[]string{}, []string{"foo"}, false},
+		{[]string{"foo"}, []string{"foo"}, true},
+		{[]string{"bar", "foo", "baz"}, []string{"foo"}, true},
+		{[]string{"bar", "foo", "baz"}, []string{"foo", "bar", "other"}, true},
+		{[]string{"bar", "foo", "baz"}, []string{"nope"}, false},
+		{[]string{"bar", "foo", "baz"}, []string{"nope", "also nope", "uh uh"}, false},
+		{[]string{"bar", "foo", "baz"}, []string{""}, false},
+	}
+
+	for _, testCase := range testCases {
+		actual := ListContainsAnyElement(testCase.list, testCase.elements)
+		assert.Equal(t, testCase.expected, actual, "For list %v and elements %v", testCase.list, testCase.elements)
+	}
+}
+
 func TestListEquals(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This PR started as a way to improve the speed of the `terragrunt catalog` command. However, I believe the improvements here may also speed up Terragrunt in general. Here's a summary of the changes:

1. Add `depth=1` parameter to `source` URLs. This will have `go-getter` do a shallow `git clone`. Whenever we clone a repo, it is for read-only usage on a single branch/ref anyway, so a shallow clone should work fine, and should be much faster, especially for larger/older repos.
2. Run the `git clone` steps of the `catalog` command concurrently using goroutines. So instead of cloning and parsing one repo at a time, we do them all in parallel (up to number of CPU cores), which speeds things up quite a bit as well.

I tested the `catalog` command with 4 URLs in my `terragrunt.hcl` config and the average time for first run when from ~20 seconds to ~5 seconds.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

