### PR TITLE
Improved handling of disabled modules

### DIFF
--- a/test/fixture-skip-dependencies/first/terragrunt.hcl
+++ b/test/fixture-skip-dependencies/first/terragrunt.hcl
@@ -1,0 +1,9 @@
+skip = true
+
+terraform {
+  source = "../module"
+}
+
+inputs = {
+  input = "first"
+}

--- a/test/fixture-skip-dependencies/module/main.tf
+++ b/test/fixture-skip-dependencies/module/main.tf
@@ -1,0 +1,5 @@
+resource "local_file" "test_file" {
+  content  = "test_file_content"
+  filename = "${path.module}/test_file.txt"
+}
+

--- a/test/fixture-skip-dependencies/second/terragrunt.hcl
+++ b/test/fixture-skip-dependencies/second/terragrunt.hcl
@@ -1,0 +1,19 @@
+skip = true
+
+terraform {
+  source = "../module"
+}
+
+dependency "first" {
+  config_path = "../first"
+
+  mock_outputs_allowed_terraform_commands = ["init", "destroy", "validate"]
+  mock_outputs_merge_strategy_with_state  = "deep_map_only"
+  mock_outputs = {
+    random_output = ""
+  }
+}
+
+inputs = {
+  input = dependency.first.outputs.random_output
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6681,6 +6681,11 @@ func TestTerragruntSkipDependenciesWithSkipFlag(t *testing.T) {
 
 	assert.Contains(t, output, "first/terragrunt.hcl due to skip = true")
 	assert.Contains(t, output, "second/terragrunt.hcl due to skip = true")
+	// check that no test_file.txt was created in module directory
+	_, err = os.Stat(util.JoinPath(tmpEnvPath, TEST_FIXTURE_SKIP_DEPENDENCIES, "first", "test_file.txt"))
+	assert.Error(t, err)
+	_, err = os.Stat(util.JoinPath(tmpEnvPath, TEST_FIXTURE_SKIP_DEPENDENCIES, "second", "test_file.txt"))
+	assert.Error(t, err)
 }
 
 func prepareGraphFixture(t *testing.T) string {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -183,6 +183,7 @@ const (
 	TEST_FIXTURE_GCS_PARALLEL_STATE_INIT                                     = "fixture-gcs-parallel-state-init"
 	TEST_FIXTURE_ASSUME_ROLE                                                 = "fixture-assume-role"
 	TEST_FIXTURE_GRAPH                                                       = "fixture-graph"
+	TEST_FIXTURE_SKIP_DEPENDENCIES                                           = "fixture-skip-dependencies"
 	TERRAFORM_BINARY                                                         = "terraform"
 	TOFU_BINARY                                                              = "tofu"
 	TERRAFORM_FOLDER                                                         = ".terraform"
@@ -6661,6 +6662,25 @@ func TestTerragruntGraphNonTerraformCommandExecution(t *testing.T) {
 		_, err = os.Stat(util.JoinPath(tmpEnvPath, TEST_FIXTURE_GRAPH, module, "terragrunt_rendered.json"))
 		assert.NoError(t, err)
 	}
+}
+
+func TestTerragruntSkipDependenciesWithSkipFlag(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_SKIP_DEPENDENCIES)
+	cleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_SKIP_DEPENDENCIES)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --no-color --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
+	assert.NoError(t, err)
+
+	output := fmt.Sprintf("%s %s", stderr.String(), stdout.String())
+
+	assert.Contains(t, output, "first/terragrunt.hcl due to skip = true")
+	assert.Contains(t, output, "second/terragrunt.hcl due to skip = true")
 }
 
 func prepareGraphFixture(t *testing.T) string {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* added check for `skip` value when processing dependencies to disable dependencies with `skip=true` flag
* disabled modules will use mock values
* added warning message in case if parsing fails to keep backward compatibility and for cases when disabled modules is "broken" and can't be parsed as HCL


Fixes #2935.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Improved dependency management by ensuring 'skip' flag properly excludes evaluation of skipped dependencies.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

