### PR TITLE
fix(init): do not require re-init after explicit init on clean directory

### DIFF
--- a/cli/commands/terraform/download_source.go
+++ b/cli/commands/terraform/download_source.go
@@ -130,9 +130,9 @@ func DownloadTerraformSourceIfNecessary(ctx context.Context, terraformSource *te
 	currentVersion, err := terraformSource.EncodeSourceVersion()
 	// if source versions are different or calculating version failed, create file to run init
 	// https://github.com/gruntwork-io/terragrunt/issues/1921
-	if previousVersion != currentVersion || err != nil {
+	if (previousVersion != "" && previousVersion != currentVersion) || err != nil {
+		terragruntOptions.Logger.Debugf("Requesting re-init, source version has changed from %s to %s recently.", previousVersion, currentVersion)
 		initFile := util.JoinPath(terraformSource.WorkingDir, ModuleInitRequiredFile)
-
 		f, createErr := os.Create(initFile)
 		if createErr != nil {
 			return createErr

--- a/cli/commands/terraform/download_source.go
+++ b/cli/commands/terraform/download_source.go
@@ -132,7 +132,9 @@ func DownloadTerraformSourceIfNecessary(ctx context.Context, terraformSource *te
 	// https://github.com/gruntwork-io/terragrunt/issues/1921
 	if (previousVersion != "" && previousVersion != currentVersion) || err != nil {
 		terragruntOptions.Logger.Debugf("Requesting re-init, source version has changed from %s to %s recently.", previousVersion, currentVersion)
+
 		initFile := util.JoinPath(terraformSource.WorkingDir, ModuleInitRequiredFile)
+
 		f, createErr := os.Create(initFile)
 		if createErr != nil {
 			return createErr

--- a/cli/commands/terraform/download_source_test.go
+++ b/cli/commands/terraform/download_source_test.go
@@ -168,7 +168,7 @@ func TestDownloadTerraformSourceIfNecessaryLocalDirToEmptyDir(t *testing.T) {
 	downloadDir := tmpDir(t)
 	defer os.Remove(downloadDir)
 
-	testDownloadTerraformSourceIfNecessary(t, canonicalURL, downloadDir, false, "# Hello, World", true)
+	testDownloadTerraformSourceIfNecessary(t, canonicalURL, downloadDir, false, "# Hello, World", false)
 }
 
 func TestDownloadTerraformSourceIfNecessaryLocalDirToAlreadyDownloadedDir(t *testing.T) {
@@ -190,7 +190,7 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlToEmptyDir(t *testing.T) {
 	downloadDir := tmpDir(t)
 	defer os.Remove(downloadDir)
 
-	testDownloadTerraformSourceIfNecessary(t, canonicalURL, downloadDir, false, "# Hello, World", true)
+	testDownloadTerraformSourceIfNecessary(t, canonicalURL, downloadDir, false, "# Hello, World", false)
 }
 
 func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDir(t *testing.T) {

--- a/cli/commands/terraform/download_source_test.go
+++ b/cli/commands/terraform/download_source_test.go
@@ -238,7 +238,7 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlOverrideSource(t *testing.T)
 
 	copyFolder(t, "../../../test/fixtures/download-source/hello-world-version-remote", downloadDir)
 
-	testDownloadTerraformSourceIfNecessary(t, canonicalURL, downloadDir, true, "# Hello, World", true)
+	testDownloadTerraformSourceIfNecessary(t, canonicalURL, downloadDir, true, "# Hello, World", false)
 }
 
 func TestDownloadTerraformSourceIfNecessaryInvalidTerraformSource(t *testing.T) {


### PR DESCRIPTION
## Description

**UPD:** added file content and adjusted commands sequence

Running `terragrunt plan --terragrunt-no-auto-init` on clean directory just after `terragrunt init`, raises confusing warning: 

> WARN   Detected that init is needed, but Auto-Init is disabled. Continuing with further actions, but subsequent terraform commands may fail.

On 1st clean init `previousVersion` is always empty, therefore no need to mark it as init required again and this warning is misleading.

**How-to reproduce:**

Files content:

```hlc
### file: terragrunt.hcl

terraform {
  source = "."
}

### file: main.tf

resource "null_resource" "test" {
  triggers = {
    number = "test"
  }
}

output "null_resource_id" {
  value = null_resource.test.id
}

```
Commands sequence:

```shell
$ rm -rf .terragrunt-cache/

$ terragrunt init
16:49:08.179 INFO   Downloading Terraform configurations from . into ./.terragrunt-cache/xsGgncPlv531bgEjaMU89xHqM8w/7u8g8e1lJs7NSLAk1_AaGslrY_I
16:49:08.211 STDOUT terraform: Initializing the backend...
16:49:08.211 STDOUT terraform: Initializing provider plugins...
16:49:08.211 STDOUT terraform: - Reusing previous version of hashicorp/null from the dependency lock file
16:49:08.568 STDOUT terraform: - Installing hashicorp/null v3.2.3...
16:49:08.961 STDOUT terraform: - Installed hashicorp/null v3.2.3 (signed by HashiCorp)
16:49:08.961 STDOUT terraform: Terraform has been successfully initialized!


$ find . -type f -name .terragrunt-init-required
./.terragrunt-cache/xsGgncPlv531bgEjaMU89xHqM8w/7u8g8e1lJs7NSLAk1_AaGslrY_I/.terragrunt-init-required


$ terragrunt plan --terragrunt-no-auto-init
16:49:49.988 WARN   Detected that init is needed, but Auto-Init is disabled. Continuing with further actions, but subsequent terraform commands may fail.
16:49:50.501 STDOUT terraform: Terraform used the selected providers to generate the following execution
16:49:50.501 STDOUT terraform: plan. Resource actions are indicated with the following symbols:
16:49:50.501 STDOUT terraform:   + create
16:49:50.501 STDOUT terraform: Terraform will perform the following actions:
16:49:50.501 STDOUT terraform:   # null_resource.test will be created
16:49:50.501 STDOUT terraform:   + resource "null_resource" "test" {
...
```

**Workaround:**
drop `.terragrunt-init-required` file after init using `after_hook`:

```hcl
terraform {
  after_hook "cleanup_init_required_file" {
    commands = ["init"]
    execute  = ["sh", "-ec", "find . -type f -name .terragrunt-init-required -delete"]
  }
}
```



## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Removed warning when using `no-auto-init` flag after explicit `init` on clean directory.