### PR TITLE
Fixing typo in the log message when using catalog

### DIFF
--- a/cli/commands/catalog/module/repo.go
+++ b/cli/commands/catalog/module/repo.go
@@ -192,7 +192,7 @@ func (repo *Repo) clone(ctx context.Context) error {
 	}
 	repo.cloneURL = sourceUrl.String()
 
-	log.Infof("Cloning repository %q to temprory directory %q", repo.cloneURL, repo.path)
+	log.Infof("Cloning repository %q to temporary directory %q", repo.cloneURL, repo.path)
 
 	if err := getter.Get(repo.path, strings.Trim(sourceUrl.String(), "/"), getter.WithContext(ctx)); err != nil {
 		return errors.WithStackTrace(err)


### PR DESCRIPTION
## Description

Fixes typo in log message when using `terragrunt catalog`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated log message for catalog.

