### PR TITLE
Recommending pre-release as a way to mitigate the risk of failed releases

### DIFF
--- a/docs/_docs/03_community/contributing.md
+++ b/docs/_docs/03_community/contributing.md
@@ -176,7 +176,9 @@ To ensure that your changes get properly formatted, please install the git pre-c
 
 ### Releasing new versions
 
-To release a new version, just go to the [Releases Page](https://github.com/gruntwork-io/terragrunt/releases) and create a new release. The CircleCI job for this repo has been configured to:
+To release a new version, just go to the [Releases Page](https://github.com/gruntwork-io/terragrunt/releases) and create a new release. Ensure that the new release uses the **Set as a pre-release** checkbox initially.
+
+The CircleCI job for this repo has been configured to:
 
 1.  Automatically detect new tags.
 
@@ -185,3 +187,5 @@ To release a new version, just go to the [Releases Page](https://github.com/grun
 3.  Upload the binaries to the release in GitHub.
 
 See `.circleci/config.yml` for details.
+
+Follow the CircleCI job to ensure that the binaries are uploaded correctly. Once the job is successful, go back to the release, uncheck the **Set as a pre-release** checkbox and check the **Set as the latest release** checkbox.


### PR DESCRIPTION
## Description

I accidentally caused #2963 due to the fact that the release `v0.55.8` was created, but the CircleCI build failed to complete successfully.

To attempt to mitigate this, a pre-release can be recommended so that authors can ensure that builds complete successfully before the release is advertised as the latest release.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated release docs to recommend pre-releases.

