### PR TITLE
MacOS catalog terminal reset

### DIFF
--- a/cli/commands/catalog/tui/models/list/model.go
+++ b/cli/commands/catalog/tui/models/list/model.go
@@ -70,10 +70,7 @@ func (model Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.QuitMsg:
 		// handle quit message
-		defer func() {
-			os.Exit(0)
-		}()
-		return model, tea.Sequence(page.Cmd(tea.ClearScreen()), tea.Quit)
+		return model, tea.Sequence(page.Cmd(page.ClearScreen()), tea.Quit)
 
 	case tea.KeyMsg:
 		// Don't match any of the keys below if we're actively filtering.

--- a/cli/commands/catalog/tui/models/list/model.go
+++ b/cli/commands/catalog/tui/models/list/model.go
@@ -61,7 +61,6 @@ func (model Model) Init() tea.Cmd {
 func (model Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
-	rawMsg := fmt.Sprintf("%T", msg)
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		topPadding := 1
@@ -100,10 +99,13 @@ func (model Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 	}
-
+	rawMsg := fmt.Sprintf("%T", msg)
 	// handle special case for Exit alt screen
 	if rawMsg == "tea.execMsg" {
-		return model, tea.Sequence(page.Cmd(tea.ClearScreen()), tea.Quit)
+		defer func() {
+			os.Exit(0)
+		}()
+		return model, tea.Sequence(page.Cmd(page.ClearScreenCmd()), tea.Quit)
 	}
 
 	newModel, cmd := model.Model.Update(msg)

--- a/cli/commands/catalog/tui/models/list/model.go
+++ b/cli/commands/catalog/tui/models/list/model.go
@@ -1,8 +1,6 @@
 package list
 
 import (
-	"os"
-
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -69,8 +67,7 @@ func (model Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.QuitMsg:
 		// handle quit message
-		os.Exit(0)
-		return model, tea.Quit
+		return model, tea.Batch(page.Cmd(tea.ClearScrollArea()), page.Cmd(tea.ClearScreen()), page.Cmd(tea.ExitAltScreen()), tea.Quit, page.ClearScreenCmd())
 
 	case tea.KeyMsg:
 		// Don't match any of the keys below if we're actively filtering.

--- a/cli/commands/catalog/tui/models/page/model.go
+++ b/cli/commands/catalog/tui/models/page/model.go
@@ -217,9 +217,7 @@ func ansiTerminalReset() {
 
 // ClearScreenCmd - command to clear the screen
 func ClearScreenCmd() tea.Cmd {
-	return func() tea.Msg {
-		return ClearScreen()
-	}
+	return ClearScreen
 }
 
 // Cmd - wrap a message in a command

--- a/cli/commands/catalog/tui/models/page/model.go
+++ b/cli/commands/catalog/tui/models/page/model.go
@@ -82,7 +82,8 @@ func NewModel(module *module.Module, width, height int, previousModel tea.Model,
 					quitFn(err)
 					return cls
 				}
-				return tea.Exec(command.NewScaffold(opts, module), quitFn)
+				result := tea.Exec(command.NewScaffold(opts, module), quitFn)
+				return tea.Sequence(result, ClearScreenCmd())
 			}),
 			NewButton(ViewInBrowserButtonName, func(msg tea.Msg) tea.Cmd {
 				if err := browser.OpenURL(module.URL()); err != nil {
@@ -188,7 +189,7 @@ func ClearScreen() tea.Msg {
 		// https://www.unix.com/os-x-apple-/279401-means-clearing-scroll-buffer-osx-terminal.html
 		fmt.Print("\033[H\033[2J\033[3J")
 	}
-	return tea.Quit()
+	return tea.Sequence(Cmd(tea.ClearScreen()), Cmd(tea.ExitAltScreen()), Cmd(tea.ClearScrollArea()), tea.Quit)
 }
 
 // ClearScreenCmd - command to clear the screen

--- a/cli/commands/catalog/tui/models/page/model.go
+++ b/cli/commands/catalog/tui/models/page/model.go
@@ -78,8 +78,9 @@ func NewModel(module *module.Module, width, height int, previousModel tea.Model,
 		Buttons: NewButtons(
 			NewButton(ScaffoldButtonName, func(msg tea.Msg) tea.Cmd {
 				quitFn := func(err error) tea.Msg {
+					cls := ClearScreen()
 					quitFn(err)
-					return clearScreen()
+					return cls
 				}
 				return tea.Exec(command.NewScaffold(opts, module), quitFn)
 			}),
@@ -180,12 +181,26 @@ func (model Model) footerView() string {
 	return lipgloss.JoinVertical(lipgloss.Left, info, model.Buttons.View(), model.keys.View())
 }
 
-// clearScreen - explicit clear screen to avoid terminal hanging
-func clearScreen() tea.Msg {
+// ClearScreen - explicit clear screen to avoid terminal hanging
+func ClearScreen() tea.Msg {
 	if runtime.GOOS == "darwin" {
 		// Clear screen for macOS with ANSI commands
 		// https://www.unix.com/os-x-apple-/279401-means-clearing-scroll-buffer-osx-terminal.html
 		fmt.Print("\033[H\033[2J\033[3J")
 	}
 	return tea.Quit()
+}
+
+// ClearScreenCmd - command to clear the screen
+func ClearScreenCmd() tea.Cmd {
+	return func() tea.Msg {
+		return ClearScreen()
+	}
+}
+
+// Cmd - wrap a message in a command
+func Cmd(msg tea.Msg) tea.Cmd {
+	return func() tea.Msg {
+		return msg
+	}
 }

--- a/cli/commands/catalog/tui/tui.go
+++ b/cli/commands/catalog/tui/tui.go
@@ -2,17 +2,25 @@ package tui
 
 import (
 	"context"
-
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/module"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/tui/models/list"
 	"github.com/gruntwork-io/terragrunt/options"
+	"os/exec"
+	"runtime"
 )
 
 func Run(ctx context.Context, modules module.Modules, opts *options.TerragruntOptions) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	quitFn := func(err error) {
 		go cancel(err)
+		go func() {
+			// Reset the terminal to a sane state
+			if runtime.GOOS == "darwin" {
+				cmd := exec.Command("stty", "sane")
+				_ = cmd.Run()
+			}
+		}()
 	}
 
 	list := list.NewModel(modules, quitFn, opts)

--- a/cli/commands/catalog/tui/tui.go
+++ b/cli/commands/catalog/tui/tui.go
@@ -2,11 +2,12 @@ package tui
 
 import (
 	"context"
+	"os"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/module"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/tui/models/list"
 	"github.com/gruntwork-io/terragrunt/options"
-	"os"
 )
 
 func Run(ctx context.Context, modules module.Modules, opts *options.TerragruntOptions) error {

--- a/cli/commands/catalog/tui/tui.go
+++ b/cli/commands/catalog/tui/tui.go
@@ -2,26 +2,21 @@ package tui
 
 import (
 	"context"
-	"os/exec"
-	"runtime"
-
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/module"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/tui/models/list"
 	"github.com/gruntwork-io/terragrunt/options"
+	"os"
 )
 
 func Run(ctx context.Context, modules module.Modules, opts *options.TerragruntOptions) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	quitFn := func(err error) {
 		go cancel(err)
-		go func() {
-			// Reset the terminal to a sane state
-			if runtime.GOOS == "darwin" {
-				cmd := exec.Command("stty", "sane")
-				_ = cmd.Run()
-			}
-		}()
+		if err != nil {
+			// explicit exit from application
+			os.Exit(1)
+		}
 	}
 
 	list := list.NewModel(modules, quitFn, opts)

--- a/cli/commands/catalog/tui/tui.go
+++ b/cli/commands/catalog/tui/tui.go
@@ -2,12 +2,13 @@ package tui
 
 import (
 	"context"
+	"os/exec"
+	"runtime"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/module"
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/tui/models/list"
 	"github.com/gruntwork-io/terragrunt/options"
-	"os/exec"
-	"runtime"
 )
 
 func Run(ctx context.Context, modules module.Modules, opts *options.TerragruntOptions) error {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated exit flow to reset terminal and don't block user terminal

Fixes #2952.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

