### PR TITLE
Simplified handling of tea.execMsg

### DIFF
--- a/cli/commands/catalog/tui/models/list/model.go
+++ b/cli/commands/catalog/tui/models/list/model.go
@@ -2,8 +2,6 @@ package list
 
 import (
 	"fmt"
-	"os"
-
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -99,9 +97,6 @@ func (model Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	rawMsg := fmt.Sprintf("%T", msg)
 	// handle special case for Exit alt screen
 	if rawMsg == "tea.execMsg" {
-		defer func() {
-			os.Exit(0)
-		}()
 		return model, tea.Sequence(page.Cmd(page.ClearScreenCmd()), tea.Quit)
 	}
 

--- a/cli/commands/catalog/tui/models/list/model.go
+++ b/cli/commands/catalog/tui/models/list/model.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"fmt"
+
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"

--- a/cli/commands/catalog/tui/models/page/model.go
+++ b/cli/commands/catalog/tui/models/page/model.go
@@ -5,9 +5,6 @@ package page
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -156,9 +153,6 @@ func (model Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	rawMsg := fmt.Sprintf("%T", msg)
 	// handle special case for Exit alt screen
 	if rawMsg == "tea.execMsg" {
-		defer func() {
-			os.Exit(0)
-		}()
 		return model, tea.Sequence(Cmd(ClearScreenCmd()), tea.Quit)
 	}
 
@@ -194,25 +188,7 @@ func (model Model) footerView() string {
 
 // ClearScreen - explicit clear screen to avoid terminal hanging
 func ClearScreen() tea.Msg {
-	ansiTerminalReset()
-	if runtime.GOOS == "darwin" {
-		cmd := exec.Command("stty", "sane")
-		_ = cmd.Run()
-	}
-	if runtime.GOOS == "linux" {
-		cmd := exec.Command("reset")
-		_ = cmd.Run()
-	}
 	return tea.Sequence(Cmd(tea.ExitAltScreen()), Cmd(tea.ClearScreen()), Cmd(tea.ClearScrollArea()), tea.Quit)
-}
-
-func ansiTerminalReset() {
-	// https://www.unix.com/os-x-apple-/279401-means-clearing-scroll-buffer-osx-terminal.html
-	fmt.Print("\033c")   // Reset the terminal
-	fmt.Print("\033[2J") // Clear the screen
-	fmt.Print("\033[3J") // Clear buffer
-	fmt.Print("\033[H")  // Move the cursor to the home position
-	fmt.Print("\033[0m") // Reset all terminal attributes to their defaults
 }
 
 // ClearScreenCmd - command to clear the screen


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Simplified handling of `tea.execMsg` to transform in `QuitMsg`, removed workarounds to clean terminal.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

