### PR TITLE
Add support for AssumeRoleWithWebIdentity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ vendor
 terragrunt
 .DS_Store
 mocks/
+.go-version

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -2,7 +2,6 @@ package aws_helper
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -123,7 +122,7 @@ func (f tokenFetcher) FetchToken(ctx credentials.Context) ([]byte, error) {
 	if _, err := os.Stat(string(f)); err != nil {
 		return []byte(f), nil
 	}
-	token, err := ioutil.ReadFile(string(f))
+	token, err := os.ReadFile(string(f))
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +237,7 @@ func AssumeIamRole(iamRoleOpts options.IAMRoleOptions) (*sts.Credentials, error)
 		if _, err := os.Stat(iamRoleOpts.WebIdentityToken); err != nil {
 			token = iamRoleOpts.WebIdentityToken
 		} else {
-			tb, err := ioutil.ReadFile(iamRoleOpts.WebIdentityToken)
+			tb, err := os.ReadFile(iamRoleOpts.WebIdentityToken)
 			if err != nil {
 				return nil, err
 			}

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -214,6 +214,10 @@ func AssumeIamRole(iamRoleOpts options.IAMRoleOptions) (*sts.Credentials, error)
 
 	sess.Handlers.Build.PushFrontNamed(addUserAgent)
 
+	if iamRoleOpts.RoleARN != "" && iamRoleOpts.WebIdentityToken != "" {
+		sess.Config.Credentials = getWebIdentityCredentialsFromIAMRoleOptions(sess, iamRoleOpts)
+	}
+
 	_, err = sess.Config.Credentials.Get()
 	if err != nil {
 		return nil, errors.WithStackTraceAndPrefix(err, "Error finding AWS credentials (did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables?)")
@@ -239,7 +243,7 @@ func AssumeIamRole(iamRoleOpts options.IAMRoleOptions) (*sts.Credentials, error)
 		} else {
 			tb, err := os.ReadFile(iamRoleOpts.WebIdentityToken)
 			if err != nil {
-				return nil, err
+				return nil, errors.WithStackTrace(err)
 			}
 			token = string(tb)
 		}

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -178,7 +178,7 @@ func CreateAwsSession(config *AwsSessionConfig, terragruntOptions *options.Terra
 		sess.Handlers.Build.PushFrontNamed(addUserAgent)
 		if terragruntOptions.IAMRoleOptions.RoleARN != "" {
 			if terragruntOptions.IAMRoleOptions.WebIdentityToken != "" {
-				terragruntOptions.Logger.Debugf("Assuming role %s with WebIdentity token %s", terragruntOptions.IAMRoleOptions.RoleARN, terragruntOptions.IAMRoleOptions.WebIdentityToken)
+				terragruntOptions.Logger.Debugf("Assuming role %s using WebIdentity token", terragruntOptions.IAMRoleOptions.RoleARN)
 				sess.Config.Credentials = getWebIdentityCredentialsFromIAMRoleOptions(sess, terragruntOptions.IAMRoleOptions)
 			} else {
 				terragruntOptions.Logger.Debugf("Assuming role %s", terragruntOptions.IAMRoleOptions.RoleARN)

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -258,20 +258,20 @@ func AssumeIamRole(iamRoleOpts options.IAMRoleOptions) (*sts.Credentials, error)
 			return nil, errors.WithStackTrace(err)
 		}
 		return resp.Credentials, nil
-	} else {
-		input := sts.AssumeRoleInput{
-			RoleArn:         aws.String(iamRoleOpts.RoleARN),
-			RoleSessionName: aws.String(sessionName),
-			DurationSeconds: aws.Int64(sessionDurationSeconds),
-		}
-
-		output, err := stsClient.AssumeRole(&input)
-		if err != nil {
-			return nil, errors.WithStackTrace(err)
-		}
-
-		return output.Credentials, nil
 	}
+
+	input := sts.AssumeRoleInput{
+		RoleArn:         aws.String(iamRoleOpts.RoleARN),
+		RoleSessionName: aws.String(sessionName),
+		DurationSeconds: aws.Int64(sessionDurationSeconds),
+	}
+
+	output, err := stsClient.AssumeRole(&input)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	return output.Credentials, nil
 }
 
 // Return the AWS caller identity associated with the current set of credentials

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -134,7 +134,7 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		},
 
 		{
-			[]string{doubleDashed(commands.FlagNameTerragruntIAMWebIdentityToken), "web-identity-token"},
+			[]string{doubleDashed(commands.TerragruntIAMWebIdentityTokenFlagName), "web-identity-token"},
 			mockOptionsWithIamWebIdentityToken(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, "web-identity-token"),
 			nil,
 		},

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -134,6 +134,12 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		},
 
 		{
+			[]string{doubleDashed(commands.FlagNameTerragruntIAMWebIdentityToken), "web-identity-token"},
+			mockOptionsWithIamWebIdentityToken(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, "web-identity-token"),
+			nil,
+		},
+
+		{
 			[]string{doubleDashed(commands.TerragruntConfigFlagName), fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), "--terragrunt-non-interactive"},
 			mockOptions(t, fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), workingDir, []string{}, true, "", false, false, defaultLogLevel, false),
 			nil,
@@ -251,6 +257,13 @@ func mockOptionsWithIamAssumeRoleSessionName(t *testing.T, terragruntConfigPath 
 	opts.OriginalIAMRoleOptions.AssumeRoleSessionName = iamAssumeRoleSessionName
 	opts.IAMRoleOptions.AssumeRoleSessionName = iamAssumeRoleSessionName
 
+	return opts
+}
+
+func mockOptionsWithIamWebIdentityToken(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool, webIdentityToken string) *options.TerragruntOptions {
+	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors, false, defaultLogLevel, false)
+	opts.OriginalIAMRoleOptions.WebIdentityToken = webIdentityToken
+	opts.IAMRoleOptions.WebIdentityToken = webIdentityToken
 	return opts
 }
 

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -22,6 +22,7 @@ const (
 	TerragruntIAMRoleFlagName                        = "terragrunt-iam-role"
 	TerragruntIAMAssumeRoleDurationFlagName          = "terragrunt-iam-assume-role-duration"
 	TerragruntIAMAssumeRoleSessionNameFlagName       = "terragrunt-iam-assume-role-session-name"
+	FlagNameTerragruntIAMWebIdentityToken            = "terragrunt-iam-web-identity-token"
 	TerragruntIgnoreDependencyErrorsFlagName         = "terragrunt-ignore-dependency-errors"
 	TerragruntIgnoreDependencyOrderFlagName          = "terragrunt-ignore-dependency-order"
 	TerragruntIgnoreExternalDependenciesFlagName     = "terragrunt-ignore-external-dependencies"
@@ -157,6 +158,12 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 			Destination: &opts.IAMRoleOptions.AssumeRoleSessionName,
 			EnvVar:      "TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME",
 			Usage:       "Name for the IAM Assummed Role session. Can also be set via TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME environment variable.",
+		},
+		&cli.GenericFlag[string]{
+			Name:        FlagNameTerragruntIAMWebIdentityToken,
+			Destination: &opts.IAMRoleOptions.WebIdentityToken,
+			EnvVar:      "TERRRAGRUNT_IAM_ASSUME_ROLE_WEB_IDENTITY_TOKEN",
+			Usage:       "For AssumeRoleWithWebIdentity, the WebIdentity token. Can also be set via TERRRAGRUNT_IAM_ASSUME_ROLE_WEB_IDENTITY_TOKEN environment variable",
 		},
 		&cli.BoolFlag{
 			Name:        TerragruntIgnoreDependencyErrorsFlagName,

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -22,7 +22,7 @@ const (
 	TerragruntIAMRoleFlagName                        = "terragrunt-iam-role"
 	TerragruntIAMAssumeRoleDurationFlagName          = "terragrunt-iam-assume-role-duration"
 	TerragruntIAMAssumeRoleSessionNameFlagName       = "terragrunt-iam-assume-role-session-name"
-	FlagNameTerragruntIAMWebIdentityToken            = "terragrunt-iam-web-identity-token"
+	TerragruntIAMWebIdentityTokenFlagName            = "terragrunt-iam-web-identity-token"
 	TerragruntIgnoreDependencyErrorsFlagName         = "terragrunt-ignore-dependency-errors"
 	TerragruntIgnoreDependencyOrderFlagName          = "terragrunt-ignore-dependency-order"
 	TerragruntIgnoreExternalDependenciesFlagName     = "terragrunt-ignore-external-dependencies"
@@ -160,7 +160,7 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 			Usage:       "Name for the IAM Assummed Role session. Can also be set via TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME environment variable.",
 		},
 		&cli.GenericFlag[string]{
-			Name:        FlagNameTerragruntIAMWebIdentityToken,
+			Name:        TerragruntIAMWebIdentityTokenFlagName,
 			Destination: &opts.IAMRoleOptions.WebIdentityToken,
 			EnvVar:      "TERRRAGRUNT_IAM_ASSUME_ROLE_WEB_IDENTITY_TOKEN",
 			Usage:       "For AssumeRoleWithWebIdentity, the WebIdentity token. Can also be set via TERRRAGRUNT_IAM_ASSUME_ROLE_WEB_IDENTITY_TOKEN environment variable",

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ const (
 	MetadataIamRole                     = "iam_role"
 	MetadataIamAssumeRoleDuration       = "iam_assume_role_duration"
 	MetadataIamAssumeRoleSessionName    = "iam_assume_role_session_name"
+	MetadataIamWebIdentityToken         = "iam_web_identity_token"
 	MetadataInputs                      = "inputs"
 	MetadataLocals                      = "locals"
 	MetadataLocal                       = "local"
@@ -94,6 +95,7 @@ type TerragruntConfig struct {
 	IamRole                     string
 	IamAssumeRoleDuration       *int64
 	IamAssumeRoleSessionName    string
+	IamWebIdentityToken         string
 	Inputs                      map[string]interface{}
 	Locals                      map[string]interface{}
 	TerragruntDependencies      []Dependency
@@ -126,6 +128,7 @@ func (conf *TerragruntConfig) GetIAMRoleOptions() options.IAMRoleOptions {
 	configIAMRoleOptions := options.IAMRoleOptions{
 		RoleARN:               conf.IamRole,
 		AssumeRoleSessionName: conf.IamAssumeRoleSessionName,
+		WebIdentityToken:      conf.IamWebIdentityToken,
 	}
 	if conf.IamAssumeRoleDuration != nil {
 		configIAMRoleOptions.AssumeRoleDuration = *conf.IamAssumeRoleDuration
@@ -166,6 +169,7 @@ type terragruntConfigFile struct {
 	IamRole                  *string             `hcl:"iam_role,attr"`
 	IamAssumeRoleDuration    *int64              `hcl:"iam_assume_role_duration,attr"`
 	IamAssumeRoleSessionName *string             `hcl:"iam_assume_role_session_name,attr"`
+	IamWebIdentityToken      *string             `hcl:"iam_web_identity_token,attr"`
 	TerragruntDependencies   []Dependency        `hcl:"dependency,block"`
 
 	// We allow users to configure code generation via blocks:
@@ -1057,6 +1061,11 @@ func convertToTerragruntConfig(ctx *ParsingContext, configPath string, terragrun
 	if terragruntConfigFromFile.IamAssumeRoleSessionName != nil {
 		terragruntConfig.IamAssumeRoleSessionName = *terragruntConfigFromFile.IamAssumeRoleSessionName
 		terragruntConfig.SetFieldMetadata(MetadataIamAssumeRoleSessionName, defaultMetadata)
+	}
+
+	if terragruntConfigFromFile.IamWebIdentityToken != nil {
+		terragruntConfig.IamWebIdentityToken = *terragruntConfigFromFile.IamWebIdentityToken
+		terragruntConfig.SetFieldMetadata(MetadataIamWebIdentityToken, defaultMetadata)
 	}
 
 	generateBlocks := []terragruntGenerateBlock{}

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -27,6 +27,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 	output[MetadataIamRole] = gostringToCty(config.IamRole)
 	output[MetadataSkip] = goboolToCty(config.Skip)
 	output[MetadataIamAssumeRoleSessionName] = gostringToCty(config.IamAssumeRoleSessionName)
+	output[MetadataIamWebIdentityToken] = gostringToCty(config.IamWebIdentityToken)
 
 	catalogConfigCty, err := catalogConfigAsCty(config.Catalog)
 	if err != nil {

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -210,6 +210,8 @@ func terragruntConfigStructFieldToMapKey(t *testing.T, fieldName string) (string
 		return "iam_assume_role_duration", true
 	case "IamAssumeRoleSessionName":
 		return "iam_assume_role_session_name", true
+	case "IamWebIdentityToken":
+		return "iam_web_identity_token", true
 	case "Inputs":
 		return "inputs", true
 	case "Locals":

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -60,10 +60,11 @@ type terraformConfigSourceOnly struct {
 
 // terragruntFlags is a struct that can be used to only decode the flag attributes (skip and prevent_destroy)
 type terragruntFlags struct {
-	IamRole        *string  `hcl:"iam_role,attr"`
-	PreventDestroy *bool    `hcl:"prevent_destroy,attr"`
-	Skip           *bool    `hcl:"skip,attr"`
-	Remain         hcl.Body `hcl:",remain"`
+	IamRole             *string  `hcl:"iam_role,attr"`
+	IamWebIdentityToken *string  `hcl:"iam_web_identity_token,attr"`
+	PreventDestroy      *bool    `hcl:"prevent_destroy,attr"`
+	Skip                *bool    `hcl:"skip,attr"`
+	Remain              hcl.Body `hcl:",remain"`
 }
 
 // terragruntVersionConstraints is a struct that can be used to only decode the attributes related to constraining the
@@ -289,7 +290,9 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 			if decoded.IamRole != nil {
 				output.IamRole = *decoded.IamRole
 			}
-
+			if decoded.IamWebIdentityToken != nil {
+				output.IamWebIdentityToken = *decoded.IamWebIdentityToken
+			}
 		case TerragruntInputs:
 			decoded := terragruntInputs{}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -283,6 +283,25 @@ func TestParseIamAssumeRoleSessionName(t *testing.T) {
 	assert.Equal(t, "terragrunt-iam-assume-role-session-name", terragruntConfig.IamAssumeRoleSessionName)
 }
 
+func TestParseIamWebIdentity(t *testing.T) {
+	t.Parallel()
+	token := "test-token"
+
+	config := fmt.Sprintf(`iam_web_identity_token = "%s"`, token)
+
+	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t))
+	terragruntConfig, err := ParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.Dependencies)
+	assert.Nil(t, terragruntConfig.RetryableErrors)
+	assert.Empty(t, terragruntConfig.IamRole)
+	assert.Equal(t, token, terragruntConfig.IamWebIdentityToken)
+}
+
 func TestParseTerragruntConfigDependenciesOnePath(t *testing.T) {
 	t.Parallel()
 
@@ -692,6 +711,7 @@ func TestParseTerragruntConfigEmptyConfig(t *testing.T) {
 	assert.Nil(t, cfg.PreventDestroy)
 	assert.False(t, cfg.Skip)
 	assert.Empty(t, cfg.IamRole)
+	assert.Empty(t, cfg.IamWebIdentityToken)
 	assert.Nil(t, cfg.RetryMaxAttempts)
 	assert.Nil(t, cfg.RetrySleepIntervalSec)
 	assert.Nil(t, cfg.RetryableErrors)

--- a/config/include_test.go
+++ b/config/include_test.go
@@ -127,6 +127,21 @@ func TestMergeConfigIntoIncludedConfig(t *testing.T) {
 			&TerragruntConfig{IamRole: "role1"},
 			&TerragruntConfig{IamRole: "role2"},
 		},
+		{
+			&TerragruntConfig{IamWebIdentityToken: "token"},
+			&TerragruntConfig{IamWebIdentityToken: "token"},
+			&TerragruntConfig{IamWebIdentityToken: "token"},
+		},
+		{
+			&TerragruntConfig{IamWebIdentityToken: "token"},
+			&TerragruntConfig{IamWebIdentityToken: "token2"},
+			&TerragruntConfig{IamWebIdentityToken: "token2"},
+		},
+		{
+			&TerragruntConfig{},
+			&TerragruntConfig{IamWebIdentityToken: "token"},
+			&TerragruntConfig{IamWebIdentityToken: "token"},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -132,6 +132,7 @@ func TestResolveTerraformModulesReadConfigFromParentConfig(t *testing.T) {
 			"iam_assume_role_duration":      interface{}(nil),
 			"iam_assume_role_session_name":  "",
 			"iam_role":                      "",
+			"iam_web_identity_token":        "",
 			"inputs":                        interface{}(nil),
 			"locals":                        cfg.Locals,
 			"retry_max_attempts":            interface{}(nil),

--- a/docs/_docs/01_getting-started/configuration.md
+++ b/docs/_docs/01_getting-started/configuration.md
@@ -55,7 +55,7 @@ Currently terragrunt parses the config in the following order:
 
 2. `locals` block
 
-3. Evaluation of values for `iam_role`, `iam_assume_role_duration`, and `iam_assume_role_session_name` attributes, if defined
+3. Evaluation of values for `iam_role`, `iam_assume_role_duration`, `iam_assume_role_session_name`, and `iam_web_identity_token` attributes, if defined
 
 4. `dependencies` block
 

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -1172,6 +1172,7 @@ generate = local.common.generate
   - [iam\_role](#iam_role)
   - [iam\_assume\_role\_duration](#iam_assume_role_duration)
   - [iam\_assume\_role\_session\_name](#iam_assume_role_session_name)
+  - [iam\_web\_identity\_token(#iam_web_identity_token)
   - [terraform\_binary](#terraform_binary)
   - [terraform\_version\_constraint](#terraform_version_constraint)
   - [terragrunt\_version\_constraint](#terragrunt_version_constraint)
@@ -1326,6 +1327,14 @@ The `iam_assume_role_session_name` attribute can be used to specify the STS sess
 
 The precedence is as follows: `--terragrunt-iam-assume-role-session-name` command line option → `TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME` env variable →
 `iam_assume_role_session_name` attribute of the `terragrunt.hcl` file in the module directory → `iam_assume_role_session_name` attribute of the included
+`terragrunt.hcl`.
+
+### iam_web_identity_token
+
+The `iam_web_identity_token` attribute can be used along with `iam_role` to assume a role using AssumeRoleWithWebIdentity. `iam_web_identity_token` can be set to either the token value (typically using `get_env()`), or the path to a file on disk.
+
+The precedence is as follows: `--terragrunt-iam-web-identity-token` command line option → `TERRRAGRUNT_IAM_ASSUME_ROLE_WEB_IDENTITY_TOKEN` env variable →
+`iam_web_identity_token` attribute of the `terragrunt.hcl` file in the module directory → `iam_web_identity_token` attribute of the included
 `terragrunt.hcl`.
 
 ### terraform_binary

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -1347,6 +1347,7 @@ provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_cr
 provided by your git provider.
 
 Follow the instructions below for whichever Git provider you use:
+
 - GitLab: [Configure OpenID Connect in AWS to retrieve temporary credentials](https://docs.gitlab.com/ee/ci/cloud_services/aws/)
 - GitHub: [Configuring OpenID Connect in Amazon Web Services](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
 - CircleCI: [Using OpenID Connect tokens in jobs](https://circleci.com/docs/openid-connect-tokens/)

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -1337,6 +1337,13 @@ The precedence is as follows: `--terragrunt-iam-web-identity-token` command line
 `iam_web_identity_token` attribute of the `terragrunt.hcl` file in the module directory → `iam_web_identity_token` attribute of the included
 `terragrunt.hcl`.
 
+The primary benefit of using AssumeRoleWithWebIdentity over regular AssumeRole is that it enables you to run terragrunt in your CI/CD pipelines wihthout static AWS credentials.
+
+For instructions on how to set this up, see the appropriate documentation for your git provider
+- GitLab: [Configure OpenID Connect in AWS to retrieve temporary credentials](https://docs.gitlab.com/ee/ci/cloud_services/aws/)
+- GitHub: [Configuring OpenID Connect in Amazon Web Services](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+- CircleCI: [Using OpenID Connect tokens in jobs](https://circleci.com/docs/openid-connect-tokens/)
+
 ### terraform_binary
 
 The terragrunt `terraform_binary` string option can be used to override the default terraform binary path (which is

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -37,6 +37,7 @@ The following is a reference of all the supported blocks and attributes in the c
   - [iam\_role](#iam_role)
   - [iam\_assume\_role\_duration](#iam_assume_role_duration)
   - [iam\_assume\_role\_session\_name](#iam_assume_role_session_name)
+  - [iam\_web\_identity\_token](#iam_web_identity_token)
   - [terraform\_binary](#terraform_binary)
   - [terraform\_version\_constraint](#terraform_version_constraint)
   - [terragrunt\_version\_constraint](#terragrunt_version_constraint)
@@ -1172,7 +1173,7 @@ generate = local.common.generate
   - [iam\_role](#iam_role)
   - [iam\_assume\_role\_duration](#iam_assume_role_duration)
   - [iam\_assume\_role\_session\_name](#iam_assume_role_session_name)
-  - [iam\_web\_identity\_token(#iam_web_identity_token)
+  - [iam\_web\_identity\_token](#iam_web_identity_token)
   - [terraform\_binary](#terraform_binary)
   - [terraform\_version\_constraint](#terraform_version_constraint)
   - [terragrunt\_version\_constraint](#terragrunt_version_constraint)
@@ -1339,10 +1340,35 @@ The precedence is as follows: `--terragrunt-iam-web-identity-token` command line
 
 The primary benefit of using AssumeRoleWithWebIdentity over regular AssumeRole is that it enables you to run terragrunt in your CI/CD pipelines wihthout static AWS credentials.
 
-For instructions on how to set this up, see the appropriate documentation for your git provider
+#### Git Provider Configuration
+
+To use AssumeRoleWithWebIdentity in your CI/CD environment, you must first configure an AWS [OpenID Connect
+provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html) to trust the OIDC service
+provided by your git provider.
+
+Follow the instructions below for whichever Git provider you use:
 - GitLab: [Configure OpenID Connect in AWS to retrieve temporary credentials](https://docs.gitlab.com/ee/ci/cloud_services/aws/)
 - GitHub: [Configuring OpenID Connect in Amazon Web Services](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
 - CircleCI: [Using OpenID Connect tokens in jobs](https://circleci.com/docs/openid-connect-tokens/)
+
+Once you have configured your OpenID Connect Provider and configured the trust policy of your IAM role according to the above instructions, you
+can configure Terragrunt to use the Web Identity Token in the following manner.
+
+If your Git provider provides the OIDC token as an environment variable, pass it in to the `iam_web_identity_token` as follows
+
+```terragrunt
+iam_role = "arn:aws:iam::<AWS account number>:role/<IAM role name>"
+
+iam_web_identity_token = get_env("<variable name>")
+```
+
+If your Git provider provides the OIDC token as a file, simply pass the file path to `iam_web_identity_token`
+
+```terragrunt
+iam_role = "arn:aws:iam::<AWS account number>:role/<IAM role name>"
+
+iam_web_identity_token = "/path/to/token/file" 
+```
 
 ### terraform_binary
 

--- a/options/options.go
+++ b/options/options.go
@@ -304,6 +304,9 @@ type IAMRoleOptions struct {
 	// The ARN of an IAM Role to assume. Used when accessing AWS, both internally and through terraform.
 	RoleARN string
 
+	// The Web identity token. Used when RoleArn is also set to use AssumeRoleWithWebIdentity instead of AssumeRole.
+	WebIdentityToken string
+
 	// Duration of the STS Session when assuming the role.
 	AssumeRoleDuration int64
 
@@ -324,6 +327,10 @@ func MergeIAMRoleOptions(target IAMRoleOptions, source IAMRoleOptions) IAMRoleOp
 
 	if source.AssumeRoleSessionName != "" {
 		out.AssumeRoleSessionName = source.AssumeRoleSessionName
+	}
+
+	if source.WebIdentityToken != "" {
+		out.WebIdentityToken = source.WebIdentityToken
 	}
 
 	return out

--- a/options/options.go
+++ b/options/options.go
@@ -302,7 +302,7 @@ type TerragruntOptions struct {
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests
 type TerragruntOptionsFunc func(*TerragruntOptions)
 
-// WithRoleARN adds the provided role ARN to IamRoleOptions. Used to configure IAM role in
+// WithRoleARN adds the provided role ARN to IamRoleOptions
 func WithIAMRoleARN(arn string) TerragruntOptionsFunc {
 	return func(t *TerragruntOptions) {
 		t.IAMRoleOptions.RoleARN = arn

--- a/options/options.go
+++ b/options/options.go
@@ -299,6 +299,23 @@ type TerragruntOptions struct {
 	JsonOutputFolder string
 }
 
+// TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests
+type TerragruntOptionsFunc func(*TerragruntOptions)
+
+// WithRoleARN adds the provided role ARN to IamRoleOptions. Used to configure IAM role in
+func WithIAMRoleARN(arn string) TerragruntOptionsFunc {
+	return func(t *TerragruntOptions) {
+		t.IAMRoleOptions.RoleARN = arn
+	}
+}
+
+// WithIAMWebIdentityToken adds the provided WebIdentity token to IamRoleOptions
+func WithIAMWebIdentityToken(token string) TerragruntOptionsFunc {
+	return func(t *TerragruntOptions) {
+		t.IAMRoleOptions.WebIdentityToken = token
+	}
+}
+
 // IAMRoleOptions represents options that are used by Terragrunt to assume an IAM role.
 type IAMRoleOptions struct {
 	// The ARN of an IAM Role to assume. Used when accessing AWS, both internally and through terraform.
@@ -420,7 +437,7 @@ func GetDefaultIAMAssumeRoleSessionName() string {
 }
 
 // Create a new TerragruntOptions object with reasonable defaults for test usage
-func NewTerragruntOptionsForTest(terragruntConfigPath string) (*TerragruntOptions, error) {
+func NewTerragruntOptionsForTest(terragruntConfigPath string, options ...TerragruntOptionsFunc) (*TerragruntOptions, error) {
 	opts, err := NewTerragruntOptionsWithConfigPath(terragruntConfigPath)
 	if err != nil {
 		logger := util.CreateLogEntry("", util.GetDefaultLogLevel())
@@ -431,6 +448,10 @@ func NewTerragruntOptionsForTest(terragruntConfigPath string) (*TerragruntOption
 	opts.NonInteractive = true
 	opts.Logger = util.CreateLogEntry("", logrus.DebugLevel)
 	opts.LogLevel = logrus.DebugLevel
+
+	for _, opt := range options {
+		opt(opts)
+	}
 
 	return opts, nil
 }

--- a/test/fixture-assume-role-web-identity/env-var/main.tf
+++ b/test/fixture-assume-role-web-identity/env-var/main.tf
@@ -1,0 +1,4 @@
+resource "local_file" "test_file" {
+  content  = "test_file"
+  filename = "${path.module}/test_file.txt"
+}

--- a/test/fixture-assume-role-web-identity/env-var/terragrunt.hcl
+++ b/test/fixture-assume-role-web-identity/env-var/terragrunt.hcl
@@ -1,0 +1,16 @@
+iam_role = "__FILL_IN_ASSUME_ROLE__"
+iam_web_identity_token = get_env("__FILL_IN_IDENTITY_TOKEN_ENV_VAR__", "")
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket         = "__FILL_IN_BUCKET_NAME__"
+    key            = "${path_relative_to_include()}/terraform.tfstate"
+    region         = "__FILL_IN_REGION__"
+    encrypt        = true
+  }
+}

--- a/test/fixture-assume-role-web-identity/file-path/main.tf
+++ b/test/fixture-assume-role-web-identity/file-path/main.tf
@@ -1,0 +1,4 @@
+resource "local_file" "test_file" {
+  content  = "test_file"
+  filename = "${path.module}/test_file.txt"
+}

--- a/test/fixture-assume-role-web-identity/file-path/terragrunt.hcl
+++ b/test/fixture-assume-role-web-identity/file-path/terragrunt.hcl
@@ -1,0 +1,16 @@
+iam_role = "__FILL_IN_ASSUME_ROLE__"
+iam_web_identity_token = "__FILL_IN_IDENTITY_TOKEN_FILE_PATH__"
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket         = "__FILL_IN_BUCKET_NAME__"
+    key            = "${path_relative_to_include()}/terraform.tfstate"
+    region         = "__FILL_IN_REGION__"
+    encrypt        = true
+  }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6907,7 +6907,7 @@ func TestTerragruntAssumeRoleWebIdentityEnv(t *testing.T) {
 	tmpTerragruntConfigFile := util.JoinPath(testPath, "terragrunt.hcl")
 	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
 
-	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName, options.WithIAMRoleARN(os.Getenv(assumeRole)), options.WithIAMWebIdentityToken(os.Getenv(tokenEnvVar)))
+	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName, options.WithIAMRoleARN(assumeRole), options.WithIAMWebIdentityToken(os.Getenv(tokenEnvVar)))
 
 	copyTerragruntConfigAndFillMapPlaceholders(t, originalTerragruntConfigPath, tmpTerragruntConfigFile, map[string]string{
 		"__FILL_IN_BUCKET_NAME__":            s3BucketName,


### PR DESCRIPTION

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Add support for STS [AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html).

Includes new config option `iam_web_identity_token` which takes either a WebIdentity token (designed to be passed in with `get_env()`), or a path to a file containing a WebIdentity token.

Fixes #2585.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added attribute `iam_web_identity_token` to support AssumeRoleWithWebIdentity 

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

