### PR TITLE
Scaffold command, fix unable to handle https URL

### DIFF
--- a/cli/commands/catalog/module/repo.go
+++ b/cli/commands/catalog/module/repo.go
@@ -185,11 +185,6 @@ func (repo *Repo) clone(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
-	// specify git:: scheme for the module URL
-	if strings.HasPrefix(sourceUrl.Scheme, "http") {
-		sourceUrl.Scheme = "git::" + sourceUrl.Scheme
-	}
 	repo.cloneURL = sourceUrl.String()
 
 	log.Infof("Cloning repository %q to temporary directory %q", repo.cloneURL, repo.path)

--- a/cli/commands/scaffold/action.go
+++ b/cli/commands/scaffold/action.go
@@ -35,7 +35,7 @@ const (
 	// refParam - ?ref param from url
 	refParam = "ref"
 
-	moduleUrlPattern = `git::([^:]+)://([^/]+)(/.*)`
+	moduleUrlPattern = `(?:git|hg|s3|gcs)::([^:]+)://([^/]+)(/.*)`
 	moduleUrlParts   = 4
 
 	defaultBoilerplateConfig = `

--- a/terraform/source.go
+++ b/terraform/source.go
@@ -208,6 +208,7 @@ func ToSourceUrl(source string, workingDir string) (*url.URL, error) {
 }
 
 // PrependSourceType prepends one of the "s3, gcs3, hg, git" source type to the http(s)/ssh scheme, if the user has omittied it.
+// The docs describes of this transformation https://developer.hashicorp.com/terraform/language/modules/sources
 func PrependSourceType(sourceURL *url.URL) *url.URL {
 	var (
 		prepend           string

--- a/terraform/source.go
+++ b/terraform/source.go
@@ -200,7 +200,7 @@ func ToSourceUrl(source string, workingDir string) (*url.URL, error) {
 		return nil, err
 	}
 
-	// specify git:: scheme for the module URL
+	// explicitly add prefix git:: for the http scheme to avoid further errors
 	if strings.HasPrefix(sourceUrl.Scheme, "http") {
 		sourceUrl.Scheme = "git::" + sourceUrl.Scheme
 	}

--- a/terraform/source.go
+++ b/terraform/source.go
@@ -200,8 +200,8 @@ func ToSourceUrl(source string, workingDir string) (*url.URL, error) {
 		return nil, err
 	}
 
-	// explicitly add prefix git:: for the http scheme to avoid further errors
-	if strings.HasPrefix(sourceUrl.Scheme, "http") {
+	// explicitly add prefix git:: for the http(s)/ssh schemes as a protocol by default to avoid further errors
+	if strings.HasPrefix(sourceUrl.Scheme, "http") || strings.HasPrefix(sourceUrl.Scheme, "ssh") {
 		sourceUrl.Scheme = "git::" + sourceUrl.Scheme
 	}
 	return sourceUrl, nil

--- a/terraform/source.go
+++ b/terraform/source.go
@@ -212,7 +212,7 @@ func PrependSourceType(sourceURL *url.URL) *url.URL {
 	var (
 		prepend           string
 		secondLevelDomain string
-		urlPathExt        = path.Ext(sourceURL.Path)
+		pathExt           = path.Ext(sourceURL.Path)
 		hasHTTPPrefix     = strings.HasPrefix(sourceURL.Scheme, "http")
 		hasSSHPrefix      = strings.HasPrefix(sourceURL.Scheme, "ssh")
 	)
@@ -233,7 +233,7 @@ func PrependSourceType(sourceURL *url.URL) *url.URL {
 	case "github.com", "gitlab.com", "bitbucket.org":
 		prepend = "git"
 	default:
-		switch urlPathExt {
+		switch pathExt {
 		case ".git":
 			prepend = "git"
 		case ".hg":

--- a/terraform/source.go
+++ b/terraform/source.go
@@ -195,7 +195,16 @@ func ToSourceUrl(source string, workingDir string) (*url.URL, error) {
 		return nil, errors.WithStackTrace(err)
 	}
 
-	return parseSourceUrl(rawSourceUrlWithGetter)
+	sourceUrl, err := parseSourceUrl(rawSourceUrlWithGetter)
+	if err != nil {
+		return nil, err
+	}
+
+	// specify git:: scheme for the module URL
+	if strings.HasPrefix(sourceUrl.Scheme, "http") {
+		sourceUrl.Scheme = "git::" + sourceUrl.Scheme
+	}
+	return sourceUrl, nil
 }
 
 // Parse the given source URL into a URL struct. This method can handle source URLs that include go-getter's "forced

--- a/terraform/source.go
+++ b/terraform/source.go
@@ -213,11 +213,11 @@ func PrependSourceType(sourceURL *url.URL) *url.URL {
 		prepend           string
 		secondLevelDomain string
 		urlPathExt        = path.Ext(sourceURL.Path)
-		isHTTPPrefix      = strings.HasPrefix(sourceURL.Scheme, "http")
-		isSSHPrefix       = strings.HasPrefix(sourceURL.Scheme, "ssh")
+		hasHTTPPrefix     = strings.HasPrefix(sourceURL.Scheme, "http")
+		hasSSHPrefix      = strings.HasPrefix(sourceURL.Scheme, "ssh")
 	)
 
-	if !isHTTPPrefix && !isSSHPrefix {
+	if !hasHTTPPrefix && !hasSSHPrefix {
 		return sourceURL
 	}
 
@@ -241,7 +241,7 @@ func PrependSourceType(sourceURL *url.URL) *url.URL {
 		}
 	}
 
-	if prepend == "" || (prepend != "git" && isSSHPrefix) {
+	if prepend == "" || (prepend != "git" && hasSSHPrefix) {
 		return sourceURL
 	}
 

--- a/terraform/source_test.go
+++ b/terraform/source_test.go
@@ -73,6 +73,7 @@ func TestToSourceUrl(t *testing.T) {
 		{"https://github.com/gruntwork-io/repo-name", "", "git::https://github.com/gruntwork-io/repo-name"},
 		{"git::https://github.com/gruntwork-io/repo-name", "", "git::https://github.com/gruntwork-io/repo-name"},
 		{"https://github.com/gruntwork-io/repo-name//modules/module-name", "", "git::https://github.com/gruntwork-io/repo-name//modules/module-name"},
+		{"ssh://github.com/gruntwork-io/repo-name//modules/module-name", "", "git::ssh://github.com/gruntwork-io/repo-name//modules/module-name"},
 		{"./foo//bar", "/baz", "file:///baz/foo//bar"},
 		{"git::./foo", "/baz", "git::file:///baz/foo"},
 	}

--- a/terraform/source_test.go
+++ b/terraform/source_test.go
@@ -73,6 +73,8 @@ func TestToSourceUrl(t *testing.T) {
 		{"https://github.com/gruntwork-io/repo-name", "", "git::https://github.com/gruntwork-io/repo-name"},
 		{"git::https://github.com/gruntwork-io/repo-name", "", "git::https://github.com/gruntwork-io/repo-name"},
 		{"https://github.com/gruntwork-io/repo-name//modules/module-name", "", "git::https://github.com/gruntwork-io/repo-name//modules/module-name"},
+		{"./foo//bar", "/baz", "file:///baz/foo//bar"},
+		{"git::./foo", "/baz", "git::file:///baz/foo"},
 	}
 
 	for i, testCase := range testCases {

--- a/terraform/source_test.go
+++ b/terraform/source_test.go
@@ -60,27 +60,21 @@ func TestSplitSourceUrl(t *testing.T) {
 	}
 }
 
-func TestPrependSourceType(t *testing.T) {
+func TestToSourceUrl(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		sourceURL         string
 		expectedSourceURL string
 	}{
-		{"github.com/gruntwork-io/repo-name", "github.com/gruntwork-io/repo-name"},
-		{"https://github.com/gruntwork-io/repo-name", "git::https://github.com/gruntwork-io/repo-name"},
-		{"git::https://github.com/gruntwork-io/repo-name", "git::https://github.com/gruntwork-io/repo-name"},
-		{"https://github.com/gruntwork-io/repo-name//modules/module-name", "git::https://github.com/gruntwork-io/repo-name//modules/module-name"},
-		{"ssh://github.com/gruntwork-io/repo-name//modules/module-name", "git::ssh://github.com/gruntwork-io/repo-name//modules/module-name"},
-		{"https://gitlab.com/catamphetamine/libphonenumber-js", "git::https://gitlab.com/catamphetamine/libphonenumber-js"},
-		{"https://bitbucket.org/org_name/repo_name", "git::https://bitbucket.org/org_name/repo_name"},
+		{"https://github.com/gruntwork-io/repo-name", "git::https://github.com/gruntwork-io/repo-name.git"},
+		{"git::https://github.com/gruntwork-io/repo-name", "git::https://github.com/gruntwork-io/repo-name.git"},
+		{"https://github.com/gruntwork-io/repo-name//modules/module-name", "git::https://github.com/gruntwork-io/repo-name.git//modules/module-name"},
+		{"ssh://github.com/gruntwork-io/repo-name//modules/module-name", "ssh://github.com/gruntwork-io/repo-name//modules/module-name"},
+		{"https://gitlab.com/catamphetamine/libphonenumber-js", "git::https://gitlab.com/catamphetamine/libphonenumber-js.git"},
+		{"https://bitbucket.org/atlassian/aws-ecr-push-image", "git::https://bitbucket.org/atlassian/aws-ecr-push-image.git"},
 		{"https://s3-eu-west-1.amazonaws.com/modules/vpc.zip", "s3::https://s3-eu-west-1.amazonaws.com/modules/vpc.zip"},
-		{"ssh://s3-eu-west-1.amazonaws.com/modules/vpc.zip", "ssh://s3-eu-west-1.amazonaws.com/modules/vpc.zip"},
-		{"https://example.com/vpc-module?archive=zip", "https://example.com/vpc-module?archive=zip"},
-		{"https://git.com/vpc-module.git", "git::https://git.com/vpc-module.git"},
-		{"https://www.googleapis.com/modules/foomodule.zip", "gcs::https://www.googleapis.com/modules/foomodule.zip"},
-		{"hashicorp/consul/aws//modules/consul-cluster", "hashicorp/consul/aws//modules/consul-cluster"},
-		{"http://example.com/vpc.hg?ref=v1.2.0", "hg::http://example.com/vpc.hg?ref=v1.2.0"},
+		{"https://www.googleapis.com/storage/v1/modules/foomodule.zip", "gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zip"},
 	}
 
 	for i, testCase := range testCases {
@@ -89,10 +83,8 @@ func TestPrependSourceType(t *testing.T) {
 		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
 			t.Parallel()
 
-			sourceURL, err := url.Parse(testCase.sourceURL)
+			actualSourceURL, err := ToSourceUrl(testCase.sourceURL, "")
 			require.NoError(t, err)
-
-			actualSourceURL := PrependSourceType(sourceURL)
 			assert.Equal(t, testCase.expectedSourceURL, actualSourceURL.String())
 		})
 	}

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -106,7 +106,7 @@ func TestScaffoldGitModuleHttps(t *testing.T) {
 	assert.Equal(t, 1, len(cfg.Inputs))
 	_, found := cfg.Inputs["vpc_id"]
 	assert.True(t, found)
-	assert.Contains(t, *cfg.Terraform.Source, "git::https://github.com/gruntwork-io/terraform-fake-modules//modules/aws/aurora?ref=v0.0.5")
+	assert.Contains(t, *cfg.Terraform.Source, "git::https://github.com/gruntwork-io/terraform-fake-modules.git//modules/aws/aurora?ref=v0.0.5")
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt init --terragrunt-non-interactive --terragrunt-working-dir %s", opts.WorkingDir))
 }


### PR DESCRIPTION
## Description

Fixes the issue where the `scaffold` command is unable to parse a URL with the http(s) scheme.

Fixes #2987.
