### PR TITLE
Add skip evaluation of locals for strict included modules

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -333,6 +333,20 @@ func resolveTerraformModule(terragruntConfigPath string, moduleMap map[string]*T
 		return nil, nil
 	}
 
+	// in case of strict include, allow only modules that are included in the terragruntOptions.ModulesThatInclude
+	if terragruntOptions.StrictInclude {
+		var found = false
+		for _, includePath := range terragruntOptions.IncludeDirs {
+			if modulePath == includePath {
+				found = true
+				break
+			}
+		}
+		if !found {
+			terragruntOptions.Logger.Debugf("Module %s is not included in the --terragrunt-include-dir and will be skipped.", modulePath)
+			return nil, nil
+		}
+	}
 	// Clone the options struct so we don't modify the original one. This is especially important as run-all operations
 	// happen concurrently.
 	opts := terragruntOptions.Clone(terragruntConfigPath)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* add skip of locals evaluation  for all modules in case of strict includes, evaluate only matched modules

Fixes #2860.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

