### PR TITLE
terragrunt issue 3017: expand docs for find_in_parent_folder()

### DIFF
--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -114,11 +114,17 @@ include "root" {
 }
 ```
 
-The function takes an optional `name` parameter that allows you to specify a different filename to search for:
+The function takes an optional `name` parameter that allows you to specify a different path to search for:
 
 ``` hcl
 include "root" {
   path = find_in_parent_folders("some-other-file-name.hcl")
+}
+```
+
+``` hcl
+include "root" {
+  path = find_in_parent_folders("some-folder")
 }
 ```
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3017.

<!-- Description of the changes introduced by this PR. -->

## TODOs

- [x] Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).
- [x] Update the docs.
- [n/a] Run the relevant tests successfully, including pre-commit checks.
- [n/a] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated find_in_parent_folders() docs to describe folder-finding functionality

