### PR TITLE
MacOS binary signer update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,10 @@ jobs:
           name: Compile and sign the binaries
           command: |
             sign-binary --os mac --install-macos-sign-dependencies .gon_amd64.hcl
+            wget -q https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
+            unzip gon_macos.zip -d /tmp/gon
+            ls -lahrt /tmp/gon
+            /tmp/gon --version
             sign-binary --os mac .gon_arm64.hcl
             echo "Done signing the binary"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,11 @@ jobs:
           name: Compile and sign the binaries
           command: |
             set -x
+            cleanup() {
+              echo "Cleaning up before exit..."
+              xcrun altool --list-providers -u "machine.apple@gruntwork.io" -p "${MACOS_AC_PASSWORD}"
+            }
+            trap cleanup EXIT
             sign-binary --os mac --install-macos-sign-dependencies .gon_amd64.hcl
             sign-binary --os mac .gon_arm64.hcl
             echo "Done signing the binary"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,10 +267,13 @@ jobs:
       - run:
           name: Compile and sign the binaries
           command: |
+            set -x
             sign-binary --os mac --install-macos-sign-dependencies .gon_amd64.hcl
+            pwd
+            ls -lahrt
             wget -q https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
             unzip gon_macos.zip -d /tmp/gon
-            ls -lahrt /tmp/gon
+            ls -lahrt /tmp
             /tmp/gon --version
             sign-binary --os mac .gon_arm64.hcl
             echo "Done signing the binary"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ jobs:
             sign-binary --os mac --install-macos-sign-dependencies .gon_amd64.hcl
             pwd
             ls -lahrt
-            wget -q https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
+            wget -q https://github.com/Bearer/gon/releases/download/v0.0.36/gon_macos.zip
             unzip gon_macos.zip -d /tmp/gon
             ls -lahrt /tmp
             /tmp/gon --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ workflows:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
-      - deploy:
+      - test_sign:
           requires:
             - build
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 env: &env
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.39
-    MODULE_CI_VERSION: v0.53.2
+    MODULE_CI_VERSION: v0.53.3
 
 defaults: &defaults
   docker:
@@ -247,7 +247,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths: bin
-  test_sign:
+  deploy:
     <<: *env
     macos:
       xcode: 14.2.0
@@ -263,13 +263,13 @@ jobs:
           command: |
             curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
             gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
-            gruntwork-install --module-name "sign-binary-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --branch "gon-version-update"
+            gruntwork-install --module-name "sign-binary-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
       - run:
           name: Compile and sign the binaries
           command: |
-            set -x
             export AC_PASSWORD=${MACOS_AC_PASSWORD}
             export AC_PROVIDER=${MACOS_AC_PROVIDER}
+            
             sign-binary --os mac --install-macos-sign-dependencies .gon_amd64.hcl
             sign-binary --os mac .gon_arm64.hcl
             echo "Done signing the binary"
@@ -280,6 +280,12 @@ jobs:
 
             unzip terragrunt_darwin_arm64.zip
             mv terragrunt_darwin_arm64 bin/
+      - run:
+          name: Run SHA256SUM
+          command: |
+            brew install coreutils
+            cd bin && sha256sum * > SHA256SUMS
+      - run: upload-github-release-assets bin/*
 workflows:
   version: 2
   build-and-test:
@@ -332,9 +338,14 @@ workflows:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
-      - test_sign:
+      - deploy:
           requires:
             - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,11 +268,6 @@ jobs:
           name: Compile and sign the binaries
           command: |
             set -x
-            cleanup() {
-              echo "Cleaning up before exit..."
-              xcrun altool --list-providers -u "machine.apple@gruntwork.io" -p "${MACOS_AC_PASSWORD}"
-            }
-            trap cleanup EXIT
             export AC_PASSWORD=${MACOS_AC_PASSWORD}
             sign-binary --os mac --install-macos-sign-dependencies .gon_amd64.hcl
             sign-binary --os mac .gon_arm64.hcl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,7 @@ jobs:
               xcrun altool --list-providers -u "machine.apple@gruntwork.io" -p "${MACOS_AC_PASSWORD}"
             }
             trap cleanup EXIT
+            export AC_PASSWORD=${MACOS_AC_PASSWORD}
             sign-binary --os mac --install-macos-sign-dependencies .gon_amd64.hcl
             sign-binary --os mac .gon_arm64.hcl
             echo "Done signing the binary"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,18 +263,12 @@ jobs:
           command: |
             curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
             gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
-            gruntwork-install --module-name "sign-binary-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
+            gruntwork-install --module-name "sign-binary-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --branch "gon-version-update"
       - run:
           name: Compile and sign the binaries
           command: |
             set -x
             sign-binary --os mac --install-macos-sign-dependencies .gon_amd64.hcl
-            pwd
-            ls -lahrt
-            wget -q https://github.com/Bearer/gon/releases/download/v0.0.36/gon_macos.zip
-            unzip gon_macos.zip -d /tmp/gon
-            ls -lahrt /tmp
-            /tmp/gon --version
             sign-binary --os mac .gon_arm64.hcl
             echo "Done signing the binary"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,7 @@ jobs:
           command: |
             set -x
             export AC_PASSWORD=${MACOS_AC_PASSWORD}
+            export AC_PROVIDER=${MACOS_AC_PROVIDER}
             sign-binary --os mac --install-macos-sign-dependencies .gon_amd64.hcl
             sign-binary --os mac .gon_arm64.hcl
             echo "Done signing the binary"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths: bin
-  deploy:
+  test_sign:
     <<: *env
     macos:
       xcode: 14.2.0
@@ -277,12 +277,6 @@ jobs:
 
             unzip terragrunt_darwin_arm64.zip
             mv terragrunt_darwin_arm64 bin/
-      - run:
-          name: Run SHA256SUM
-          command: |
-            brew install coreutils
-            cd bin && sha256sum * > SHA256SUMS
-      - run: upload-github-release-assets bin/*
 workflows:
   version: 2
   build-and-test:
@@ -338,11 +332,6 @@ workflows:
       - deploy:
           requires:
             - build
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests

--- a/.gon_amd64.hcl
+++ b/.gon_amd64.hcl
@@ -7,7 +7,7 @@ bundle_id = "io.gruntwork.app.terragrunt"
 
 apple_id {
   username = "machine.apple@gruntwork.io"
-  password = "@env:MACOS_AC_PASSWORD"
+  # password = "@env:MACOS_AC_PASSWORD"
 }
 
 sign {

--- a/.gon_amd64.hcl
+++ b/.gon_amd64.hcl
@@ -7,8 +7,6 @@ bundle_id = "io.gruntwork.app.terragrunt"
 
 apple_id {
   username = "machine.apple@gruntwork.io"
-  password = "@env:MACOS_AC_PASSWORD"
-  provider = "@env:MACOS_AC_PROVIDER"
 }
 
 sign {

--- a/.gon_amd64.hcl
+++ b/.gon_amd64.hcl
@@ -7,7 +7,8 @@ bundle_id = "io.gruntwork.app.terragrunt"
 
 apple_id {
   username = "machine.apple@gruntwork.io"
-  # password = "@env:MACOS_AC_PASSWORD"
+  password = "@env:MACOS_AC_PASSWORD"
+  provider = "@env:MACOS_AC_PROVIDER"
 }
 
 sign {

--- a/.gon_arm64.hcl
+++ b/.gon_arm64.hcl
@@ -7,8 +7,6 @@ bundle_id = "io.gruntwork.app.terragrunt"
 
 apple_id {
   username = "machine.apple@gruntwork.io"
-  password = "@env:MACOS_AC_PASSWORD"
-  provider = "@env:MACOS_AC_PROVIDER"
 }
 
 sign {

--- a/.gon_arm64.hcl
+++ b/.gon_arm64.hcl
@@ -7,7 +7,8 @@ bundle_id = "io.gruntwork.app.terragrunt"
 
 apple_id {
   username = "machine.apple@gruntwork.io"
-  #password = "@env:MACOS_AC_PASSWORD"
+  password = "@env:MACOS_AC_PASSWORD"
+  provider = "@env:MACOS_AC_PROVIDER"
 }
 
 sign {

--- a/.gon_arm64.hcl
+++ b/.gon_arm64.hcl
@@ -7,7 +7,7 @@ bundle_id = "io.gruntwork.app.terragrunt"
 
 apple_id {
   username = "machine.apple@gruntwork.io"
-  password = "@env:MACOS_AC_PASSWORD"
+  #password = "@env:MACOS_AC_PASSWORD"
 }
 
 sign {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated CI module used to sign Macos binaries.

Result:

![image](https://github.com/gruntwork-io/terragrunt/assets/10694338/6e03db23-41f4-448d-884c-76e29fda1399)


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

