### PR TITLE
Fix TestTerragruntParallelism

### DIFF
--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -301,8 +301,7 @@ func testTerragruntParallelism(t *testing.T, parallelism int, numberOfModules in
 	}
 
 	t.Logf("Parallelism test numberOfModules=%d p=%d expectedTimes=%v deploymentTimes=%v scaledTimes=%v scaleFactor=%f", numberOfModules, parallelism, expectedTimings, deploymentTimes, scaledTimes, scalingFactor)
-
-	maxDiffInSeconds := 5.0
+	maxDiffInSeconds := 5.0 * scalingFactor
 	for i, scaledTime := range scaledTimes {
 		difference := math.Abs(scaledTime - float64(expectedTimings[i]))
 		require.True(t, difference <= maxDiffInSeconds, "Expected timing %d but got %f", expectedTimings[i], scaledTime)

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -304,7 +304,7 @@ func testTerragruntParallelism(t *testing.T, parallelism int, numberOfModules in
 	for i := 0; i < len(times); i++ {
 		// it's impossible to know when will the first test finish however once a test finishes
 		// we know that all the other times are relative to the first one
-		assert.True(t, isEqual(scaledTimes[i], float64(expectedTimings[i])))
+		assert.True(t, isEqual(scaledTimes[i], float64(expectedTimings[i])), "Expected %d but got %f", expectedTimings[i], scaledTimes[i])
 	}
 }
 

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -270,41 +270,42 @@ func testTerragruntParallelism(t *testing.T, parallelism int, numberOfModules in
 	require.NoError(t, err)
 
 	// parse output and sort the times, the regex captures a string in the format time.RFC3339 emitted by terraform's timestamp function
-	r, err := regexp.Compile(`out = "([-:\w]+)"`)
+	regex, err := regexp.Compile(`out = "([-:\w]+)"`)
 	require.NoError(t, err)
 
-	matches := r.FindAllStringSubmatch(output, -1)
-	assert.Equal(t, numberOfModules, len(matches))
-	var times []int
-	for _, v := range matches {
-		// timestamp() is parsed
-		parsed, err := time.Parse(time.RFC3339, v[1])
+	matches := regex.FindAllStringSubmatch(output, -1)
+	require.Equal(t, numberOfModules, len(matches))
+
+	var deploymentTimes []int
+	for _, match := range matches {
+		parsedTime, err := time.Parse(time.RFC3339, match[1])
 		require.NoError(t, err)
-		times = append(times, int(parsed.Unix())-testStart)
+		deploymentTime := int(parsedTime.Unix()) - testStart
+		deploymentTimes = append(deploymentTimes, deploymentTime)
 	}
-	sort.Slice(times, func(i, j int) bool {
-		return times[i] < times[j]
-	})
+	sort.Ints(deploymentTimes)
 
 	// the reported times are skewed (running terragrunt/terraform apply adds a little bit of overhead)
 	// we apply a simple scaling algorithm on the times based on the last expected time and the last actual time
-	k := float64(times[len(times)-1]) / float64(expectedTimings[len(expectedTimings)-1])
-
-	scaledTimes := make([]float64, len(times))
-	for i := 0; i < len(times); i++ {
-		scaledTimes[i] = float64(times[i]) / k
+	scalingFactor := float64(deploymentTimes[0]) / float64(expectedTimings[0])
+	// find max skew time deploymentTimes vs expectedTimings
+	for i := 1; i < len(deploymentTimes); i++ {
+		factor := float64(deploymentTimes[i]) / float64(expectedTimings[i])
+		if factor > scalingFactor {
+			scalingFactor = factor
+		}
+	}
+	scaledTimes := make([]float64, len(deploymentTimes))
+	for i, deploymentTime := range deploymentTimes {
+		scaledTimes[i] = float64(deploymentTime) / scalingFactor
 	}
 
-	t.Logf("Parallelism test numberOfModules=%d p=%d expectedTimes=%v times=%v scaledTimes=%v scaleFactor=%f", numberOfModules, parallelism, expectedTimings, times, scaledTimes, k)
+	t.Logf("Parallelism test numberOfModules=%d p=%d expectedTimes=%v deploymentTimes=%v scaledTimes=%v scaleFactor=%f", numberOfModules, parallelism, expectedTimings, deploymentTimes, scaledTimes, scalingFactor)
 
 	maxDiffInSeconds := 5.0
-	isEqual := func(x, y float64) bool {
-		return math.Abs(x-y) <= maxDiffInSeconds
-	}
-	for i := 0; i < len(times); i++ {
-		// it's impossible to know when will the first test finish however once a test finishes
-		// we know that all the other times are relative to the first one
-		assert.True(t, isEqual(scaledTimes[i], float64(expectedTimings[i])), "Expected %d but got %f", expectedTimings[i], scaledTimes[i])
+	for i, scaledTime := range scaledTimes {
+		difference := math.Abs(scaledTime - float64(expectedTimings[i]))
+		require.True(t, difference <= maxDiffInSeconds, "Expected timing %d but got %f", expectedTimings[i], scaledTime)
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated TestTerragruntParallelism to use scaling factor for drift time calculation.

![image](https://github.com/gruntwork-io/terragrunt/assets/10694338/9980ea3a-be8b-459d-9bbf-5db5223bc2d7)


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

