### PR TITLE
Fixed handling of dependency outputs when json log format is enabled

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -889,19 +889,13 @@ func runTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	// Update the stdout buffer so we can capture the output
 	var stdoutBuffer bytes.Buffer
 	stdoutBufferWriter := bufio.NewWriter(&stdoutBuffer)
-	ctx.TerragruntOptions.Writer = stdoutBufferWriter
 
-	currentTerraformLogsToJson := ctx.TerragruntOptions.TerraformLogsToJson
-	currentIncludeModulePrefix := ctx.TerragruntOptions.IncludeModulePrefix
-
-	// reset the settings after the run
-	defer func() {
-		ctx.TerragruntOptions.TerraformLogsToJson = currentTerraformLogsToJson
-		ctx.TerragruntOptions.IncludeModulePrefix = currentIncludeModulePrefix
-	}()
-	// Disable json wrapping to allow reading of outputs
-	ctx.TerragruntOptions.TerraformLogsToJson = false
-	ctx.TerragruntOptions.IncludeModulePrefix = false
+	newOpts := *ctx.TerragruntOptions
+	// explicit disable json formatting and prefixing to read json output
+	newOpts.TerraformLogsToJson = false
+	newOpts.IncludeModulePrefix = false
+	newOpts.Writer = stdoutBufferWriter
+	ctx = ctx.WithTerragruntOptions(&newOpts)
 
 	err := ctx.TerragruntOptions.RunTerragrunt(ctx, ctx.TerragruntOptions)
 	if err != nil {

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -630,7 +630,7 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	}
 
 	targetTGOptions.TerraformLogsToJson = false
-	targetTGOptions.IncludeModulePrefix = false
+	//targetTGOptions.IncludeModulePrefix = false
 
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -629,9 +629,6 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 		return nil, err
 	}
 
-	targetTGOptions.TerraformLogsToJson = false
-	targetTGOptions.IncludeModulePrefix = false
-
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 
 	// First attempt to parse the `remote_state` blocks without parsing/getting dependency outputs. If this is possible,
@@ -894,6 +891,18 @@ func runTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	var stdoutBuffer bytes.Buffer
 	stdoutBufferWriter := bufio.NewWriter(&stdoutBuffer)
 	ctx.TerragruntOptions.Writer = stdoutBufferWriter
+
+	currentTerraformLogsToJson := ctx.TerragruntOptions.TerraformLogsToJson
+	currentIncludeModulePrefix := ctx.TerragruntOptions.IncludeModulePrefix
+
+	// reset the settings after the run
+	defer func() {
+		ctx.TerragruntOptions.TerraformLogsToJson = currentTerraformLogsToJson
+		ctx.TerragruntOptions.IncludeModulePrefix = currentIncludeModulePrefix
+	}()
+	// Disable json wrapping to allow reading of outputs
+	ctx.TerragruntOptions.TerraformLogsToJson = false
+	ctx.TerragruntOptions.IncludeModulePrefix = false
 
 	err := ctx.TerragruntOptions.RunTerragrunt(ctx, ctx.TerragruntOptions)
 	if err != nil {

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -629,8 +629,8 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 		return nil, err
 	}
 
-	//targetTGOptions.TerraformLogsToJson = false
-	//targetTGOptions.IncludeModulePrefix = false
+	// targetTGOptions.TerraformLogsToJson = false
+	// targetTGOptions.IncludeModulePrefix = false
 
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -629,7 +629,7 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 		return nil, err
 	}
 
-	// targetTGOptions.TerraformLogsToJson = false
+	targetTGOptions.TerraformLogsToJson = false
 
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -890,6 +890,18 @@ func runTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	var stdoutBuffer bytes.Buffer
 	stdoutBufferWriter := bufio.NewWriter(&stdoutBuffer)
 	ctx.TerragruntOptions.Writer = stdoutBufferWriter
+	// Save original settings
+	currentTerraformLogsToJson := ctx.TerragruntOptions.TerraformLogsToJson
+	currentIncludeModulePrefix := ctx.TerragruntOptions.IncludeModulePrefix
+
+	// reset the settings after the run
+	defer func() {
+		ctx.TerragruntOptions.TerraformLogsToJson = currentTerraformLogsToJson
+		ctx.TerragruntOptions.IncludeModulePrefix = currentIncludeModulePrefix
+	}()
+	// Disable json wrapping to allow reading of outputs
+	ctx.TerragruntOptions.TerraformLogsToJson = false
+	ctx.TerragruntOptions.IncludeModulePrefix = false
 
 	err := ctx.TerragruntOptions.RunTerragrunt(ctx, ctx.TerragruntOptions)
 	if err != nil {

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -628,6 +628,10 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
+
+	targetTGOptions.TerraformLogsToJson = false
+	targetTGOptions.IncludeModulePrefix = false
+
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 
 	// First attempt to parse the `remote_state` blocks without parsing/getting dependency outputs. If this is possible,
@@ -900,8 +904,8 @@ func runTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	//	ctx.TerragruntOptions.IncludeModulePrefix = currentIncludeModulePrefix
 	//}()
 	// Disable json wrapping to allow reading of outputs
-	ctx.TerragruntOptions.TerraformLogsToJson = false
-	ctx.TerragruntOptions.IncludeModulePrefix = false
+	//ctx.TerragruntOptions.TerraformLogsToJson = false
+	//ctx.TerragruntOptions.IncludeModulePrefix = false
 
 	err := ctx.TerragruntOptions.RunTerragrunt(ctx, ctx.TerragruntOptions)
 	if err != nil {

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -629,9 +629,8 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 		return nil, err
 	}
 
-	// targetTGOptions.TerraformLogsToJson = false
-
-	// targetTGOptions.IncludeModulePrefix = false
+	targetTGOptions.TerraformLogsToJson = false
+	targetTGOptions.IncludeModulePrefix = false
 
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -629,7 +629,7 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 		return nil, err
 	}
 
-	targetTGOptions.TerraformLogsToJson = false
+	// targetTGOptions.TerraformLogsToJson = false
 
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -629,8 +629,8 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 		return nil, err
 	}
 
-	targetTGOptions.TerraformLogsToJson = false
-	targetTGOptions.IncludeModulePrefix = false
+	//targetTGOptions.TerraformLogsToJson = false
+	//targetTGOptions.IncludeModulePrefix = false
 
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -629,8 +629,8 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 		return nil, err
 	}
 
-	//targetTGOptions.TerraformLogsToJson = false
-	//targetTGOptions.IncludeModulePrefix = false
+	targetTGOptions.TerraformLogsToJson = false
+	targetTGOptions.IncludeModulePrefix = false
 
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 
@@ -894,18 +894,6 @@ func runTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	var stdoutBuffer bytes.Buffer
 	stdoutBufferWriter := bufio.NewWriter(&stdoutBuffer)
 	ctx.TerragruntOptions.Writer = stdoutBufferWriter
-	// Save original settings
-	//currentTerraformLogsToJson := ctx.TerragruntOptions.TerraformLogsToJson
-	//currentIncludeModulePrefix := ctx.TerragruntOptions.IncludeModulePrefix
-	//
-	//// reset the settings after the run
-	//defer func() {
-	//	ctx.TerragruntOptions.TerraformLogsToJson = currentTerraformLogsToJson
-	//	ctx.TerragruntOptions.IncludeModulePrefix = currentIncludeModulePrefix
-	//}()
-	// Disable json wrapping to allow reading of outputs
-	//ctx.TerragruntOptions.TerraformLogsToJson = false
-	//ctx.TerragruntOptions.IncludeModulePrefix = false
 
 	err := ctx.TerragruntOptions.RunTerragrunt(ctx, ctx.TerragruntOptions)
 	if err != nil {

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -630,6 +630,7 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	}
 
 	// targetTGOptions.TerraformLogsToJson = false
+
 	// targetTGOptions.IncludeModulePrefix = false
 
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -891,14 +891,14 @@ func runTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	stdoutBufferWriter := bufio.NewWriter(&stdoutBuffer)
 	ctx.TerragruntOptions.Writer = stdoutBufferWriter
 	// Save original settings
-	currentTerraformLogsToJson := ctx.TerragruntOptions.TerraformLogsToJson
-	currentIncludeModulePrefix := ctx.TerragruntOptions.IncludeModulePrefix
-
-	// reset the settings after the run
-	defer func() {
-		ctx.TerragruntOptions.TerraformLogsToJson = currentTerraformLogsToJson
-		ctx.TerragruntOptions.IncludeModulePrefix = currentIncludeModulePrefix
-	}()
+	//currentTerraformLogsToJson := ctx.TerragruntOptions.TerraformLogsToJson
+	//currentIncludeModulePrefix := ctx.TerragruntOptions.IncludeModulePrefix
+	//
+	//// reset the settings after the run
+	//defer func() {
+	//	ctx.TerragruntOptions.TerraformLogsToJson = currentTerraformLogsToJson
+	//	ctx.TerragruntOptions.IncludeModulePrefix = currentIncludeModulePrefix
+	//}()
 	// Disable json wrapping to allow reading of outputs
 	ctx.TerragruntOptions.TerraformLogsToJson = false
 	ctx.TerragruntOptions.IncludeModulePrefix = false

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -629,7 +629,7 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 		return nil, err
 	}
 
-	targetTGOptions.TerraformLogsToJson = false
+	//targetTGOptions.TerraformLogsToJson = false
 	//targetTGOptions.IncludeModulePrefix = false
 
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -628,7 +628,6 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 
 	// First attempt to parse the `remote_state` blocks without parsing/getting dependency outputs. If this is possible,

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -630,7 +630,6 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	}
 
 	targetTGOptions.TerraformLogsToJson = false
-	targetTGOptions.IncludeModulePrefix = false
 
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -630,6 +630,7 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 	}
 
 	targetTGOptions.TerraformLogsToJson = false
+	targetTGOptions.IncludeModulePrefix = false
 
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 

--- a/test/fixture-dependency-output/app/main.tf
+++ b/test/fixture-dependency-output/app/main.tf
@@ -1,0 +1,5 @@
+variable "input_value" {}
+
+output "output_value" {
+  value = var.input_value
+}

--- a/test/fixture-dependency-output/app/terragrunt.hcl
+++ b/test/fixture-dependency-output/app/terragrunt.hcl
@@ -1,0 +1,8 @@
+
+dependency "dependency" {
+  config_path = "../dependency"
+}
+
+inputs = {
+  input_value = dependency.dependency.outputs.result
+}

--- a/test/fixture-dependency-output/dependency/main.tf
+++ b/test/fixture-dependency-output/dependency/main.tf
@@ -1,0 +1,4 @@
+output result {
+
+  value = "42"
+}

--- a/test/fixture-dependency-output/dependency/main.tf
+++ b/test/fixture-dependency-output/dependency/main.tf
@@ -1,4 +1,4 @@
-output result {
+output "result" {
 
   value = "42"
 }

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -491,11 +491,12 @@ func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
 		t.Run(fmt.Sprintf("terragrunt output with %s", testCase.arg), func(t *testing.T) {
 			tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_DEPENDENCY_OUTPUT)
 			rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_DEPENDENCY_OUTPUT)
-			// apply all dependencies
-			_, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s ", rootTerragruntPath))
+			// apply dependency first
+			dependencyTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency")
+			_, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s ", dependencyTerragruntConfigPath))
 			assert.NoError(t, err)
 			appTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "app")
-			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s %s", appTerragruntConfigPath, testCase.arg))
+			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s %s", appTerragruntConfigPath, testCase.arg))
 			assert.NoError(t, err)
 			output := fmt.Sprintf("%s %s", stderr, stdout)
 			assert.NotContains(t, output, "invalid character")

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -476,31 +476,3 @@ func TestTerragruntTerraformOutputJson(t *testing.T) {
 		assert.NotNil(t, output["time"])
 	}
 }
-
-func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
-	testCases := []struct {
-		arg string
-	}{
-		{"--terragrunt-json-log"},
-		{"--terragrunt-json-log --terragrunt-tf-logs-to-json"},
-		{"--terragrunt-include-module-prefix"},
-		{"--terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-include-module-prefix"},
-	}
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(fmt.Sprintf("terragrunt output with %s", testCase.arg), func(t *testing.T) {
-			tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_DEPENDENCY_OUTPUT)
-			rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_DEPENDENCY_OUTPUT)
-			// apply dependency first
-			dependencyTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency")
-			_, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s ", dependencyTerragruntConfigPath))
-			assert.NoError(t, err)
-			appTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "app")
-			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s %s", appTerragruntConfigPath, testCase.arg))
-			assert.NoError(t, err)
-			output := fmt.Sprintf("%s %s", stderr, stdout)
-			assert.NotContains(t, output, "invalid character")
-		})
-
-	}
-}

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -476,3 +476,31 @@ func TestTerragruntTerraformOutputJson(t *testing.T) {
 		assert.NotNil(t, output["time"])
 	}
 }
+
+func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
+	testCases := []struct {
+		arg string
+	}{
+		{"--terragrunt-json-log"},
+		{"--terragrunt-json-log --terragrunt-tf-logs-to-json"},
+		{"--terragrunt-include-module-prefix"},
+		{"--terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-include-module-prefix"},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(fmt.Sprintf("terragrunt output with %s", testCase.arg), func(t *testing.T) {
+			tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_DEPENDENCY_OUTPUT)
+			rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_DEPENDENCY_OUTPUT)
+			// apply dependency first
+			dependencyTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency")
+			_, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s ", dependencyTerragruntConfigPath))
+			assert.NoError(t, err)
+			appTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "app")
+			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s %s", appTerragruntConfigPath, testCase.arg))
+			assert.NoError(t, err)
+			output := fmt.Sprintf("%s %s", stderr, stdout)
+			assert.NotContains(t, output, "invalid character")
+		})
+
+	}
+}

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -487,24 +487,21 @@ func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
 		{"--terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-include-module-prefix"},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(fmt.Sprintf("terragrunt output with %s", testCase.arg), func(t *testing.T) {
+		key := fmt.Sprintf("terragrunt output with %s", testCase.arg)
+		s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
+		defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 
-			s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
-			defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
+		tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY)
 
-			tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY)
+		rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY)
+		depTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency", config.DefaultTerragruntConfigPath)
 
-			rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY)
-			depTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency", config.DefaultTerragruntConfigPath)
+		copyTerragruntConfigAndFillPlaceholders(t, depTerragruntConfigPath, depTerragruntConfigPath, s3BucketName, "not-used", TERRAFORM_REMOTE_STATE_S3_REGION)
 
-			copyTerragruntConfigAndFillPlaceholders(t, depTerragruntConfigPath, depTerragruntConfigPath, s3BucketName, "not-used", TERRAFORM_REMOTE_STATE_S3_REGION)
+		stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s %s", rootTerragruntPath, testCase.arg))
+		assert.NoError(t, err, key)
 
-			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s %s", rootTerragruntPath, testCase.arg))
-			assert.NoError(t, err)
-
-			output := fmt.Sprintf("%s %s", stderr, stdout)
-			assert.NotContains(t, output, "invalid character")
-		})
+		output := fmt.Sprintf("%s %s", stderr, stdout)
+		assert.NotContains(t, output, "invalid character", key)
 	}
 }

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -477,31 +477,30 @@ func TestTerragruntTerraformOutputJson(t *testing.T) {
 	}
 }
 
-//
-//func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
-//	testCases := []struct {
-//		arg string
-//	}{
-//		{"--terragrunt-json-log"},
-//		{"--terragrunt-json-log --terragrunt-tf-logs-to-json"},
-//		{"--terragrunt-include-module-prefix"},
-//		{"--terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-include-module-prefix"},
-//	}
-//	for _, testCase := range testCases {
-//		testCase := testCase
-//		t.Run(fmt.Sprintf("terragrunt output with %s", testCase.arg), func(t *testing.T) {
-//			tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_DEPENDENCY_OUTPUT)
-//			rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_DEPENDENCY_OUTPUT)
-//			// apply dependency first
-//			dependencyTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency")
-//			_, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s ", dependencyTerragruntConfigPath))
-//			assert.NoError(t, err)
-//			appTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "app")
-//			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s %s", appTerragruntConfigPath, testCase.arg))
-//			assert.NoError(t, err)
-//			output := fmt.Sprintf("%s %s", stderr, stdout)
-//			assert.NotContains(t, output, "invalid character")
-//		})
-//
-//	}
-//}
+func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
+	testCases := []struct {
+		arg string
+	}{
+		{"--terragrunt-json-log"},
+		{"--terragrunt-json-log --terragrunt-tf-logs-to-json"},
+		{"--terragrunt-include-module-prefix"},
+		{"--terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-include-module-prefix"},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(fmt.Sprintf("terragrunt output with %s", testCase.arg), func(t *testing.T) {
+			tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_DEPENDENCY_OUTPUT)
+			rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_DEPENDENCY_OUTPUT)
+			// apply dependency first
+			dependencyTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency")
+			_, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s ", dependencyTerragruntConfigPath))
+			assert.NoError(t, err)
+			appTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "app")
+			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s %s", appTerragruntConfigPath, testCase.arg))
+			assert.NoError(t, err)
+			output := fmt.Sprintf("%s %s", stderr, stdout)
+			assert.NotContains(t, output, "invalid character")
+		})
+
+	}
+}

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -478,6 +478,10 @@ func TestTerragruntTerraformOutputJson(t *testing.T) {
 }
 
 func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
+	// no parallel test execution since JSON output is global
+	defer func() {
+		util.DisableJsonFormat()
+	}()
 	testCases := []struct {
 		arg string
 	}{

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -477,30 +477,31 @@ func TestTerragruntTerraformOutputJson(t *testing.T) {
 	}
 }
 
-func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
-	testCases := []struct {
-		arg string
-	}{
-		{"--terragrunt-json-log"},
-		{"--terragrunt-json-log --terragrunt-tf-logs-to-json"},
-		{"--terragrunt-include-module-prefix"},
-		{"--terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-include-module-prefix"},
-	}
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(fmt.Sprintf("terragrunt output with %s", testCase.arg), func(t *testing.T) {
-			tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_DEPENDENCY_OUTPUT)
-			rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_DEPENDENCY_OUTPUT)
-			// apply dependency first
-			dependencyTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency")
-			_, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s ", dependencyTerragruntConfigPath))
-			assert.NoError(t, err)
-			appTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "app")
-			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s %s", appTerragruntConfigPath, testCase.arg))
-			assert.NoError(t, err)
-			output := fmt.Sprintf("%s %s", stderr, stdout)
-			assert.NotContains(t, output, "invalid character")
-		})
-
-	}
-}
+//
+//func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
+//	testCases := []struct {
+//		arg string
+//	}{
+//		{"--terragrunt-json-log"},
+//		{"--terragrunt-json-log --terragrunt-tf-logs-to-json"},
+//		{"--terragrunt-include-module-prefix"},
+//		{"--terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-include-module-prefix"},
+//	}
+//	for _, testCase := range testCases {
+//		testCase := testCase
+//		t.Run(fmt.Sprintf("terragrunt output with %s", testCase.arg), func(t *testing.T) {
+//			tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_DEPENDENCY_OUTPUT)
+//			rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_DEPENDENCY_OUTPUT)
+//			// apply dependency first
+//			dependencyTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency")
+//			_, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s ", dependencyTerragruntConfigPath))
+//			assert.NoError(t, err)
+//			appTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "app")
+//			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s %s", appTerragruntConfigPath, testCase.arg))
+//			assert.NoError(t, err)
+//			output := fmt.Sprintf("%s %s", stderr, stdout)
+//			assert.NotContains(t, output, "invalid character")
+//		})
+//
+//	}
+//}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -190,6 +190,7 @@ const (
 	TEST_FIXTURE_GRAPH                                                       = "fixture-graph"
 	TEST_FIXTURE_SKIP_DEPENDENCIES                                           = "fixture-skip-dependencies"
 	TEST_FIXTURE_INFO_ERROR                                                  = "fixture-terragrunt-info-error"
+	TEST_FIXTURE_DEPENDENCY_OUTPUT                                           = "fixture-dependency-output"
 	TERRAFORM_BINARY                                                         = "terraform"
 	TOFU_BINARY                                                              = "tofu"
 	TERRAFORM_FOLDER                                                         = ".terraform"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6897,40 +6897,6 @@ func TestTerragruntInfoError(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
-	t.Parallel()
-	testCases := []struct {
-		arg string
-	}{
-		{"--terragrunt-json-log"},
-		{"--terragrunt-json-log --terragrunt-tf-logs-to-json"},
-		{"--terragrunt-include-module-prefix"},
-		{"--terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-include-module-prefix"},
-	}
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(fmt.Sprintf("terragrunt output with %s", testCase.arg), func(t *testing.T) {
-			t.Parallel()
-
-			s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
-			defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
-
-			tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY)
-
-			rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY)
-			depTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency", config.DefaultTerragruntConfigPath)
-
-			copyTerragruntConfigAndFillPlaceholders(t, depTerragruntConfigPath, depTerragruntConfigPath, s3BucketName, "not-used", TERRAFORM_REMOTE_STATE_S3_REGION)
-
-			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s %s", rootTerragruntPath, testCase.arg))
-			assert.NoError(t, err)
-
-			output := fmt.Sprintf("%s %s", stderr, stdout)
-			assert.NotContains(t, output, "invalid character")
-		})
-	}
-}
-
 func validateOutput(t *testing.T, outputs map[string]TerraformOutput, key string, value interface{}) {
 	t.Helper()
 	output, hasPlatform := outputs[key]

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6897,6 +6897,41 @@ func TestTerragruntInfoError(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		arg string
+	}{
+		{"--terragrunt-json-log"},
+		{"--terragrunt-json-log --terragrunt-tf-logs-to-json"},
+		{"--terragrunt-include-module-prefix"},
+		{"--terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-include-module-prefix"},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(fmt.Sprintf("terragrunt output with %s", testCase.arg), func(t *testing.T) {
+			t.Parallel()
+
+			s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
+			defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
+
+			tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY)
+
+			rootTerragruntPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUTPUT_FROM_DEPENDENCY)
+			depTerragruntConfigPath := util.JoinPath(rootTerragruntPath, "dependency", config.DefaultTerragruntConfigPath)
+
+			copyTerragruntConfigAndFillPlaceholders(t, depTerragruntConfigPath, depTerragruntConfigPath, s3BucketName, "not-used", TERRAFORM_REMOTE_STATE_S3_REGION)
+
+			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s %s", rootTerragruntPath, testCase.arg))
+			assert.NoError(t, err)
+
+			output := fmt.Sprintf("%s %s", stderr, stdout)
+			assert.NotContains(t, output, "invalid character")
+		})
+	}
+
+}
+
 func validateOutput(t *testing.T, outputs map[string]TerraformOutput, key string, value interface{}) {
 	t.Helper()
 	output, hasPlatform := outputs[key]

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6263,11 +6263,9 @@ func TestTerragruntPrintAwsErrors(t *testing.T) {
 	originalTerragruntConfigPath := util.JoinPath(rootPath, "terragrunt.hcl")
 	copyTerragruntConfigAndFillPlaceholders(t, originalTerragruntConfigPath, tmpTerragruntConfigFile, s3BucketName, lockTableName, "us-east-2")
 
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigFile, rootPath), &stdout, &stderr)
+	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigFile, rootPath))
 	assert.Error(t, err)
-	message := fmt.Sprintf("%v", err.Error())
+	message := fmt.Sprintf("%v", stderr)
 	assert.True(t, strings.Contains(message, "AllAccessDisabled: All access to this object has been disabled") || strings.Contains(message, "BucketRegionError: incorrect region"))
 	assert.Contains(t, message, s3BucketName)
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6929,7 +6929,6 @@ func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
 			assert.NotContains(t, output, "invalid character")
 		})
 	}
-
 }
 
 func validateOutput(t *testing.T, outputs map[string]TerraformOutput, key string, value interface{}) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6543,12 +6543,9 @@ func TestTerragruntCommandsThatNeedInput(t *testing.T) {
 	cleanupTerraformFolder(t, tmpEnvPath)
 	testPath := util.JoinPath(tmpEnvPath, TEST_COMMANDS_THAT_NEED_INPUT)
 
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", testPath), &stdout, &stderr)
+	stdout, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir %s", testPath))
 	require.NoError(t, err)
-	require.Contains(t, stdout.String(), "Apply complete")
+	require.Contains(t, stdout, "Apply complete")
 }
 
 func TestTerragruntParallelStateInit(t *testing.T) {
@@ -6701,12 +6698,9 @@ func TestTerragruntDestroyGraph(t *testing.T) {
 			tmpEnvPath := prepareGraphFixture(t)
 			tmpModulePath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_GRAPH, testCase.path)
 
-			stdout := bytes.Buffer{}
-			stderr := bytes.Buffer{}
-
-			err := runTerragruntCommand(t, fmt.Sprintf("terragrunt graph destroy --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-graph-root %s", tmpModulePath, tmpEnvPath), &stdout, &stderr)
+			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt graph destroy --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-graph-root %s", tmpModulePath, tmpEnvPath))
 			assert.NoError(t, err)
-			output := fmt.Sprintf("%v\n%v\n", stdout.String(), stderr.String())
+			output := fmt.Sprintf("%v\n%v\n", stdout, stderr)
 
 			for _, module := range testCase.expectedModules {
 				assert.Containsf(t, output, "/"+module+"\n", "Expected module %s to be in output", module)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* disabled json wrapping when reading outputs
* added matrix test to track changes
* added usage of `runTerragruntCommandWithOutput` on some failing tests - will raise a separated issue to switch all remaining tests

Fixes #3043.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

