### PR TITLE
Updated terragrunt command execution in parallel tests

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1180,8 +1180,10 @@ func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules
 	t.Logf("apply-all start time = %d, %s", testStart, time.Now().Format(time.RFC3339))
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply-all --terragrunt-parallelism %d --terragrunt-non-interactive --terragrunt-working-dir %s -var sleep_seconds=%d", parallelism, environmentPath, timeToDeployEachModule/time.Second))
 
-	// Call runTerragruntCommand directly because this command contains failures (which causes runTerragruntRedirectOutput to abort) but we don't care.
-	stdout, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output-all --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-parallelism %d", environmentPath, parallelism))
+	// read the output of all modules 1 by 1 sequence, parallel reads mix outputs and make output complicated to parse
+	outputParallelism := 1
+	// Call runTerragruntCommandWithOutput directly because this command contains failures (which causes runTerragruntRedirectOutput to abort) but we don't care.
+	stdout, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output-all -no-color --terragrunt-include-module-prefix --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-parallelism %d", environmentPath, outputParallelism))
 	if err != nil {
 		return "", 0, err
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1180,17 +1180,13 @@ func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules
 	t.Logf("apply-all start time = %d, %s", testStart, time.Now().Format(time.RFC3339))
 	runTerragrunt(t, fmt.Sprintf("terragrunt apply-all --terragrunt-parallelism %d --terragrunt-non-interactive --terragrunt-working-dir %s -var sleep_seconds=%d", parallelism, environmentPath, timeToDeployEachModule/time.Second))
 
-	var (
-		stdout bytes.Buffer
-		stderr bytes.Buffer
-	)
 	// Call runTerragruntCommand directly because this command contains failures (which causes runTerragruntRedirectOutput to abort) but we don't care.
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt output-all --terragrunt-non-interactive --terragrunt-working-dir %s", environmentPath), &stdout, &stderr)
+	stdout, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output-all --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-parallelism %d", environmentPath, parallelism))
 	if err != nil {
 		return "", 0, err
 	}
 
-	return stdout.String(), testStart, nil
+	return stdout, testStart, nil
 }
 
 func TestTerragruntStackCommands(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated terragrunt command execution in parallel tests

![image](https://github.com/gruntwork-io/terragrunt/assets/10694338/a56442ef-b96b-45e6-abc2-bc3b66593c4d)


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

