### PR TITLE
Fixes module requests routing with provider caching

### DIFF
--- a/cli/provider_cache.go
+++ b/cli/provider_cache.go
@@ -217,6 +217,8 @@ func createLocalCLIConfig(opts *options.TerragruntOptions, cliConfigFile string,
 	for i, registryName := range opts.ProviderCacheRegistryNames {
 		cfg.AddHost(registryName, map[string]any{
 			"providers.v1": fmt.Sprintf("%s/%s/", registryProviderURL, registryName),
+			// Since Terragrunt Provider Cache only caches providers, we need to route module requests to the original registry.
+			"modules.v1": fmt.Sprintf("https://%s/v1/modules", registryName),
 		})
 
 		providerInstallationIncludes[i] = fmt.Sprintf("%s/*/*", registryName)

--- a/test/fixture-provider-cache/first/app/main.tf
+++ b/test/fixture-provider-cache/first/app/main.tf
@@ -10,3 +10,8 @@ terraform {
     }
   }
 }
+
+module "naming" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+}

--- a/test/fixture-provider-cache/first/app2/main.tf
+++ b/test/fixture-provider-cache/first/app2/main.tf
@@ -13,5 +13,5 @@ terraform {
 
 
 module "naming" {
-  source  = "cloudposse/label/null"
+  source = "cloudposse/label/null"
 }

--- a/test/fixture-provider-cache/first/app2/main.tf
+++ b/test/fixture-provider-cache/first/app2/main.tf
@@ -10,3 +10,8 @@ terraform {
     }
   }
 }
+
+
+module "naming" {
+  source  = "cloudposse/label/null"
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Since Terragrunt Provider Cache only caches providers, we need to route module requests to the original registry.

Fixes #2986.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

