### PR TITLE
Fixes module requests routing with provider caching

### DIFF
--- a/cli/provider_cache.go
+++ b/cli/provider_cache.go
@@ -54,8 +54,16 @@ func InitProviderCacheServer(opts *options.TerragruntOptions) (*ProviderCacheSer
 		opts.ProviderCacheDir = filepath.Join(cacheDir, "providers")
 	}
 
+	if opts.ProviderCacheDir, err = filepath.Abs(opts.ProviderCacheDir); err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
 	if opts.ProviderCacheArchiveDir == "" {
 		opts.ProviderCacheArchiveDir = filepath.Join(cacheDir, "archives")
+	}
+
+	if opts.ProviderCacheArchiveDir, err = filepath.Abs(opts.ProviderCacheArchiveDir); err != nil {
+		return nil, errors.WithStackTrace(err)
 	}
 
 	if opts.ProviderCacheToken == "" {

--- a/cli/provider_cache.go
+++ b/cli/provider_cache.go
@@ -217,6 +217,8 @@ func createLocalCLIConfig(opts *options.TerragruntOptions, cliConfigFile string,
 	for i, registryName := range opts.ProviderCacheRegistryNames {
 		cfg.AddHost(registryName, map[string]any{
 			"providers.v1": fmt.Sprintf("%s/%s/", registryProviderURL, registryName),
+			// Since Terragrunt Provider Cache only caches providers, we need to route module requests to the original registry.
+			"modules.v1": fmt.Sprintf("https://%s/v1/modules", registryName),
 		})
 
 		providerInstallationIncludes[i] = fmt.Sprintf("%s/*/*", registryName)

--- a/test/fixture-provider-cache/first/app/main.tf
+++ b/test/fixture-provider-cache/first/app/main.tf
@@ -10,3 +10,8 @@ terraform {
     }
   }
 }
+
+module "naming" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+}

--- a/test/fixture-provider-cache/first/app2/main.tf
+++ b/test/fixture-provider-cache/first/app2/main.tf
@@ -10,3 +10,8 @@ terraform {
     }
   }
 }
+
+
+module "naming" {
+  source = "cloudposse/label/null"
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6265,7 +6265,7 @@ func TestTerragruntPrintAwsErrors(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigFile, rootPath), &stdout, &stderr)
-	assert.Error(t, err)
+	require.Error(t, err)
 	message := fmt.Sprintf("%v", err.Error())
 	assert.True(t, strings.Contains(message, "AllAccessDisabled: All access to this object has been disabled") || strings.Contains(message, "BucketRegionError: incorrect region"))
 	assert.Contains(t, message, s3BucketName)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

1. Fixes module requests routing with provider caching.
2. Fixes resolving relative provider cache dir path. 

Fixes https://github.com/gruntwork-io/terragrunt/issues/2986.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

