### PR TITLE
Fixed 'inputs' field typo in docs

### DIFF
--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -605,7 +605,7 @@ dependency "alb" {
   )
 }
 
-input = {
+inputs = {
   alb_id = dependency.alb.outputs.id
 }
 ```
@@ -662,7 +662,7 @@ dependency "alb" {
   )
 }
 
-input = {
+inputs = {
   vpc_name = dependency.vpc.outputs.name
   alb_id   = dependency.alb.outputs.id
 }


### PR DESCRIPTION
Fixed 'inputs' field typo in 'Configuration Blocks and Attributes' docs