### PR TITLE
Removed example with destroy execution

### DIFF
--- a/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
+++ b/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
@@ -348,7 +348,6 @@ To save the plan, use the `--terragrunt-out-dir` flag (or `TERRAGRUNT_OUT_DIR` e
 ```sh
 terragrunt run-all plan --terragrunt-out-dir /tmp/tfplan
 terragrunt run-all apply --terragrunt-out-dir /tmp/tfplan
-terragrunt run-all destroy --terragrunt-out-dir /tmp/tfplan
 ```
 
 For planning a destroy operation, use the following commands:


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Removed from documentation usage of `destroy` command with plan for `apply`, it is working only when there is a special destroy plan explained in the same document.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

