### PR TITLE
fix: sync Terraform CLI args for 'show' command

### DIFF
--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -126,6 +126,8 @@ func (stack *Stack) Run(ctx context.Context, terragruntOptions *options.Terragru
 			terragruntOptions.TerraformCliArgs = util.StringListInsert(terragruntOptions.TerraformCliArgs, "-auto-approve", 1)
 		}
 		stack.syncTerraformCliArgs(terragruntOptions)
+	case terraform.CommandNameShow:
+		stack.syncTerraformCliArgs(terragruntOptions)
 	case terraform.CommandNamePlan:
 		// We capture the out stream for each module
 		errorStreams := make([]bytes.Buffer, len(stack.Modules))

--- a/test/fixture-out-dir/app/terragrunt.hcl
+++ b/test/fixture-out-dir/app/terragrunt.hcl
@@ -5,7 +5,7 @@ dependency "dependency" {
   mock_outputs = {
     result = "46521694"
   }
-  mock_outputs_allowed_terraform_commands = ["plan", "apply"]
+  mock_outputs_allowed_terraform_commands = ["plan", "apply", "show"]
 }
 
 inputs = {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6991,6 +6991,33 @@ func TestPlanJsonPlanBinaryRunAll(t *testing.T) {
 
 }
 
+func TestTerragruntRunAllPlanAndShow(t *testing.T) {
+	t.Parallel()
+
+	// create temporary directory for plan files
+	tmpDir := t.TempDir()
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_OUT_DIR)
+	cleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_OUT_DIR)
+
+	// run plan and apply
+	_, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terraform run-all plan --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-out-dir %s", testPath, tmpDir))
+	require.NoError(t, err)
+
+	_, _, err = runTerragruntCommandWithOutput(t, fmt.Sprintf("terraform run-all apply --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-out-dir %s", testPath, tmpDir))
+	require.NoError(t, err)
+
+	// run new plan and show
+	_, _, err = runTerragruntCommandWithOutput(t, fmt.Sprintf("terraform run-all plan --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-out-dir %s", testPath, tmpDir))
+	require.NoError(t, err)
+
+	stdout, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terraform run-all show --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-out-dir %s -no-color", testPath, tmpDir))
+	require.NoError(t, err)
+
+	// Verify that output contains the plan and not just the actual state output
+	assert.Contains(t, stdout, "No changes. Your infrastructure matches the configuration.")
+}
+
 func validateOutput(t *testing.T, outputs map[string]TerraformOutput, key string, value interface{}) {
 	t.Helper()
 	output, hasPlatform := outputs[key]


### PR DESCRIPTION
## Description

Pass the tfplan path when `show` command is requested with --terragrunt-output-folder.

Fixes 0ecffe01e63b831593a8259d6560bd8e9fc9fa61

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] ~~Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.~~
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

