### PR TITLE
fix(provider_cache): run terraform commands without including module …

### DIFF
--- a/cli/provider_cache.go
+++ b/cli/provider_cache.go
@@ -35,7 +35,17 @@ var (
 	// The reg matches if the text contains "423 Locked", for example:
 	//
 	// - registry.terraform.io/hashicorp/template: could not query provider registry for registry.terraform.io/hashicorp/template: 423 Locked.
-	HTTPStatusCacheProviderReg = regexp.MustCompile(`(?mi)` + strconv.Itoa(controllers.HTTPStatusCacheProvider) + `[^a-z0-9]*` + http.StatusText(controllers.HTTPStatusCacheProvider))
+	//
+	// It also will match cases where terminal window is small enough so that terraform splits output in multiple lines, like following:
+	//
+	//    ╷
+	//    │ Error: Failed to install provider
+	//    │
+	//    │ Error while installing snowflake-labs/snowflake v0.89.0: could not query
+	//    │ provider registry for registry.terraform.io/snowflake-labs/snowflake: 423
+	//    │ Locked
+	//    ╵
+	HTTPStatusCacheProviderReg = regexp.MustCompile(`(?smi)` + strconv.Itoa(controllers.HTTPStatusCacheProvider) + `.*` + http.StatusText(controllers.HTTPStatusCacheProvider))
 )
 
 type ProviderCache struct {


### PR DESCRIPTION
…prefix

When 2 following conditions are met, then terragrunt can't find 423 Locked in the output:

* `--terragrunt-include-module-prefix` is enabled
* Provider name / version is long enough

The output from terraform looks like this:

```
╷
│ Error: Failed to install provider
│
│ Error while installing snowflake-labs/snowflake v0.89.0: could not query
│ provider registry for registry.terraform.io/snowflake-labs/snowflake: 423
│ Locked
╵
```

And the regex which is used right now (`(?mi)423[^a-z0-9]*Locked`) avoids non-alphanumeric characters that are prepended by the IncludeModulePrefix.

Given that the output from provider cache is not displayed to the user, there is no need to prepend module prefix.

Fixes: https://github.com/gruntwork-io/terragrunt/issues/3100