### PR TITLE
Temporary workaround for flaky TestJsonHcl test

### DIFF
--- a/terraform/cliconfig/marshal_test.go
+++ b/terraform/cliconfig/marshal_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 func TestJsonHcl(t *testing.T) {
-	jsonData := `{"name": "peter", "parties":["one", "two", ["four"], {"six":61}]}`
+	jsonData := `{"parties":["one", "two", ["four"], {"six":61}]}`
 
 	expectedHCL := `
-  name = "peter"
   parties = [
     "one",
     "two",


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Since the `cliconfig.Marshal` uses a map, the order of the key values is not predictable. For permanent order, code refactoring is required. This is a temporary solution.

Related #3092.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

