### PR TITLE
feat: add "recurse-dependencies" option

### DIFF
--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -42,6 +42,7 @@ const (
 	TerragruntFailOnStateBucketCreationFlagName      = "terragrunt-fail-on-state-bucket-creation"
 	TerragruntDisableBucketUpdateFlagName            = "terragrunt-disable-bucket-update"
 	TerragruntDisableCommandValidationFlagName       = "terragrunt-disable-command-validation"
+	TerragruntRecurseDependenciesFlagName            = "terragrunt-recurse-dependencies"
 
 	TerragruntOutDirFlagEnvVarName = "TERRAGRUNT_OUT_DIR"
 	TerragruntOutDirFlagName       = "terragrunt-out-dir"
@@ -159,6 +160,12 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 			Destination: &opts.IAMRoleOptions.AssumeRoleSessionName,
 			EnvVar:      "TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME",
 			Usage:       "Name for the IAM Assummed Role session. Can also be set via TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME environment variable.",
+		},
+		&cli.BoolFlag{
+			Name:        TerragruntRecurseDependenciesFlagName,
+			Destination: &opts.RecurseDependencies,
+			EnvVar:      "TERRAGRUNT_RECURSE_DEPENDENCIES",
+			Usage:       "Recursively parse dependencies of dependencies. By default, disabled",
 		},
 		&cli.BoolFlag{
 			Name:        TerragruntIgnoreDependencyErrorsFlagName,

--- a/options/options.go
+++ b/options/options.go
@@ -303,6 +303,9 @@ type TerragruntOptions struct {
 
 	// Folder to store JSON representation of output files.
 	JsonOutputFolder string
+
+	// Option whether to recursively parse module dependencies.
+	RecurseDependencies bool
 }
 
 // IAMRoleOptions represents options that are used by Terragrunt to assume an IAM role.
@@ -384,6 +387,7 @@ func NewTerragruntOptions() *TerragruntOptions {
 		ProviderCacheRegistryNames: defaultProviderCacheRegistryNames,
 		OutputFolder:               "",
 		JsonOutputFolder:           "",
+		RecurseDependencies:        false,
 	}
 }
 
@@ -521,6 +525,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) *TerragruntOpt
 		DisableLogColors:                    opts.DisableLogColors,
 		OutputFolder:                        opts.OutputFolder,
 		JsonOutputFolder:                    opts.JsonOutputFolder,
+		RecurseDependencies:                 opts.RecurseDependencies,
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This change reverts to the pre 0.55.6 behavior of not recursing dependencies for all operations. In case a user desires this behavior, they can enable it with `--recurse-dependencies` or `TERRAGRUNT_RECURSE_DEPENDENCIES`.

The changes in this PR should mitigate the performance issues noticed in #2980

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `--recurse-dependencies` flag. This flag recursively parses dependencies instead of parsing only the original terragrunt module's dependencies.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

