### PR TITLE
Usage of locks when copy metadata fields

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,13 +3,14 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/gruntwork-io/terragrunt/telemetry"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/gruntwork-io/terragrunt/telemetry"
 
 	"github.com/mitchellh/mapstructure"
 

--- a/config/config.go
+++ b/config/config.go
@@ -3,14 +3,12 @@ package config
 import (
 	"context"
 	"fmt"
+	"github.com/gruntwork-io/terragrunt/telemetry"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
-	"sync"
-
-	"github.com/gruntwork-io/terragrunt/telemetry"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -111,8 +109,7 @@ type TerragruntConfig struct {
 	ProcessedIncludes IncludeConfigs
 
 	// Map to store fields metadata
-	FieldsMetadata      map[string]map[string]interface{}
-	FieldsMetadataMutex sync.Mutex
+	FieldsMetadata map[string]map[string]interface{}
 
 	// List of dependent modules
 	DependentModulesPath []*string
@@ -949,8 +946,7 @@ func convertToTerragruntConfig(ctx *ParsingContext, configPath string, terragrun
 	terragruntConfig := &TerragruntConfig{
 		IsPartial: false,
 		// Initialize GenerateConfigs so we can append to it
-		GenerateConfigs:     map[string]codegen.GenerateConfig{},
-		FieldsMetadataMutex: sync.Mutex{},
+		GenerateConfigs: map[string]codegen.GenerateConfig{},
 	}
 
 	defaultMetadata := map[string]interface{}{FoundInFile: configPath}

--- a/config/config.go
+++ b/config/config.go
@@ -3,13 +3,13 @@ package config
 import (
 	"context"
 	"fmt"
+	"github.com/gruntwork-io/terragrunt/telemetry"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
-
-	"github.com/gruntwork-io/terragrunt/telemetry"
+	"sync"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -110,7 +110,8 @@ type TerragruntConfig struct {
 	ProcessedIncludes IncludeConfigs
 
 	// Map to store fields metadata
-	FieldsMetadata map[string]map[string]interface{}
+	FieldsMetadata      map[string]map[string]interface{}
+	FieldsMetadataMutex sync.Mutex
 
 	// List of dependent modules
 	DependentModulesPath []*string
@@ -947,7 +948,8 @@ func convertToTerragruntConfig(ctx *ParsingContext, configPath string, terragrun
 	terragruntConfig := &TerragruntConfig{
 		IsPartial: false,
 		// Initialize GenerateConfigs so we can append to it
-		GenerateConfigs: map[string]codegen.GenerateConfig{},
+		GenerateConfigs:     map[string]codegen.GenerateConfig{},
+		FieldsMetadataMutex: sync.Mutex{},
 	}
 
 	defaultMetadata := map[string]interface{}{FoundInFile: configPath}

--- a/config/config.go
+++ b/config/config.go
@@ -3,12 +3,13 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/gruntwork-io/terragrunt/telemetry"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/gruntwork-io/terragrunt/telemetry"
 
 	"github.com/mitchellh/mapstructure"
 

--- a/config/include.go
+++ b/config/include.go
@@ -20,6 +20,8 @@ import (
 
 const bareIncludeKey = ""
 
+var fieldsCopyLocks = util.NewKeyLocks()
+
 // Parse the config of the given include, if one is specified
 func parseIncludedConfig(ctx *ParsingContext, includedConfig *IncludeConfig) (*TerragruntConfig, error) {
 	if includedConfig.Path == "" {
@@ -824,8 +826,6 @@ func jsonIsIncludeBlock(jsonData interface{}) bool {
 	}
 	return false
 }
-
-var fieldsCopyLocks = util.NewKeyLocks()
 
 // copyFieldsMetadata Copy fields metadata between TerragruntConfig instances.
 func copyFieldsMetadata(sourceConfig *TerragruntConfig, targetConfig *TerragruntConfig) {

--- a/config/include.go
+++ b/config/include.go
@@ -3,10 +3,11 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gruntwork-io/terragrunt/codegen"
-	"github.com/gruntwork-io/terragrunt/config/hclparse"
 	"path/filepath"
 	"strings"
+
+	"github.com/gruntwork-io/terragrunt/codegen"
+	"github.com/gruntwork-io/terragrunt/config/hclparse"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"

--- a/config/include.go
+++ b/config/include.go
@@ -825,11 +825,13 @@ func jsonIsIncludeBlock(jsonData interface{}) bool {
 	return false
 }
 
+var fieldsCopyLocks = util.NewKeyLocks()
+
 // copyFieldsMetadata Copy fields metadata between TerragruntConfig instances.
 func copyFieldsMetadata(sourceConfig *TerragruntConfig, targetConfig *TerragruntConfig) {
 
-	defer targetConfig.FieldsMetadataMutex.Unlock()
-	targetConfig.FieldsMetadataMutex.Lock()
+	fieldsCopyLocks.Lock(targetConfig.String())
+	defer fieldsCopyLocks.Unlock(targetConfig.String())
 
 	if sourceConfig.FieldsMetadata != nil {
 		if targetConfig.FieldsMetadata == nil {

--- a/config/include.go
+++ b/config/include.go
@@ -3,11 +3,10 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
-	"strings"
-
 	"github.com/gruntwork-io/terragrunt/codegen"
 	"github.com/gruntwork-io/terragrunt/config/hclparse"
+	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -827,6 +826,10 @@ func jsonIsIncludeBlock(jsonData interface{}) bool {
 
 // copyFieldsMetadata Copy fields metadata between TerragruntConfig instances.
 func copyFieldsMetadata(sourceConfig *TerragruntConfig, targetConfig *TerragruntConfig) {
+
+	defer targetConfig.FieldsMetadataMutex.Unlock()
+	targetConfig.FieldsMetadataMutex.Lock()
+
 	if sourceConfig.FieldsMetadata != nil {
 		if targetConfig.FieldsMetadata == nil {
 			targetConfig.FieldsMetadata = map[string]map[string]interface{}{}

--- a/config/include_test.go
+++ b/config/include_test.go
@@ -299,7 +299,7 @@ func TestConcurrentCopyFieldsMetadata(t *testing.T) {
 	targetConfig := &TerragruntConfig{}
 
 	var wg sync.WaitGroup
-	numGoroutines := 100
+	numGoroutines := 666
 
 	wg.Add(numGoroutines)
 	for i := 0; i < numGoroutines; i++ {

--- a/util/locks.go
+++ b/util/locks.go
@@ -1,0 +1,39 @@
+package util
+
+import "sync"
+
+// KeyLocks manages a map of locks, each associated with a string key.
+type KeyLocks struct {
+	masterLock sync.Mutex
+	locks      map[string]*sync.Mutex
+}
+
+// NewKeyLocks creates a new instance of KeyLocks.
+func NewKeyLocks() *KeyLocks {
+	return &KeyLocks{
+		locks: make(map[string]*sync.Mutex),
+	}
+}
+
+// Lock acquires the lock for the given key.
+func (kl *KeyLocks) Lock(key string) {
+	kl.ensureLock(key)
+	kl.locks[key].Lock()
+}
+
+// Unlock releases the lock for the given key.
+func (kl *KeyLocks) Unlock(key string) {
+	if lock, ok := kl.locks[key]; ok {
+		lock.Unlock()
+	}
+}
+
+// ensureLock checks if a lock exists for the key, and if not, creates one.
+func (kl *KeyLocks) ensureLock(key string) {
+	kl.masterLock.Lock()
+	defer kl.masterLock.Unlock()
+
+	if _, ok := kl.locks[key]; !ok {
+		kl.locks[key] = new(sync.Mutex)
+	}
+}

--- a/util/locks_test.go
+++ b/util/locks_test.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewKeyLocks(t *testing.T) {
+	t.Parallel()
+	kl := NewKeyLocks()
+	require.NotNil(t, kl, "NewKeyLocks() should not return nil")
+	require.Empty(t, kl.locks, "NewKeyLocks() should create an empty map")
+}
+
+func TestLockUnlock(t *testing.T) {
+	t.Parallel()
+	kl := NewKeyLocks()
+	key := "testkey"
+
+	kl.Lock(key)
+	require.Contains(t, kl.locks, key, "Lock should create a lock for key: %s", key)
+
+	kl.Unlock(key)
+
+	kl.Lock(key)
+	kl.Unlock(key)
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	kl := NewKeyLocks()
+	key := "concurrentKey"
+	wg := sync.WaitGroup{}
+	sharedResource := 0
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			kl.Lock(key)
+			defer kl.Unlock(key)
+			time.Sleep(10 * time.Millisecond)
+			sharedResource++
+		}()
+	}
+
+	wg.Wait()
+
+	require.Equal(t, 100, sharedResource, "Concurrent access to shared resource managed incorrectly")
+}
+
+func TestMultipleKeys(t *testing.T) {
+	t.Parallel()
+	kl := NewKeyLocks()
+	keys := []string{"key1", "key2", "key3"}
+	wg := sync.WaitGroup{}
+	lockState := make(map[string]bool)
+
+	for _, key := range keys {
+		wg.Add(1)
+		go func(k string) {
+			defer wg.Done()
+			kl.Lock(k)
+			defer kl.Unlock(k)
+			lockState[k] = true
+		}(key)
+	}
+
+	wg.Wait()
+	require.Len(t, lockState, len(keys), "Locks for multiple keys did not function independently")
+}

--- a/util/locks_test.go
+++ b/util/locks_test.go
@@ -1,10 +1,11 @@
 package util
 
 import (
-	"github.com/stretchr/testify/require"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewKeyLocks(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* added struct to keep locks by key
* added lock before copy of metadata fields
* added tests to track copy errors

Fixes #3112.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated metadata copy flow to use locks and avoid concurrent modification exceptions.


### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

