### PR TITLE
Fixed subcommand actions wrapping

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -77,9 +77,9 @@ func NewApp(writer io.Writer, errWriter io.Writer) *App {
 		commands.NewHelpVersionFlags(opts)...)
 	app.Commands = append(
 		deprecatedCommands(opts),
-		terragruntCommands(opts)...)
+		terragruntCommands(opts)...).WrapAction(wrapWithTelemetry(opts))
 	app.Before = beforeAction(opts)
-	app.DefaultCommand = telemetryCommand(opts, terraformCmd.NewCommand(opts)) // by default, if no terragrunt command is specified, run the Terraform command
+	app.DefaultCommand = terraformCmd.NewCommand(opts).WrapAction(wrapWithTelemetry(opts)) // by default, if no terragrunt command is specified, run the Terraform command
 	app.OsExiter = osExiter
 
 	return &App{app}
@@ -128,31 +128,30 @@ func (app *App) RunContext(ctx context.Context, args []string) error {
 // This set of commands is also used in unit tests
 func terragruntCommands(opts *options.TerragruntOptions) cli.Commands {
 	cmds := cli.Commands{
-		telemetryCommand(opts, runall.NewCommand(opts)),             // runAction-all
-		telemetryCommand(opts, terragruntinfo.NewCommand(opts)),     // terragrunt-info
-		telemetryCommand(opts, validateinputs.NewCommand(opts)),     // validate-inputs
-		telemetryCommand(opts, graphdependencies.NewCommand(opts)),  // graph-dependencies
-		telemetryCommand(opts, hclfmt.NewCommand(opts)),             // hclfmt
-		telemetryCommand(opts, renderjson.NewCommand(opts)),         // render-json
-		telemetryCommand(opts, awsproviderpatch.NewCommand(opts)),   // aws-provider-patch
-		telemetryCommand(opts, outputmodulegroups.NewCommand(opts)), // output-module-groups
-		telemetryCommand(opts, catalog.NewCommand(opts)),            // catalog
-		telemetryCommand(opts, scaffold.NewCommand(opts)),           // scaffold
-		telemetryCommand(opts, graph.NewCommand(opts)),              // graph
+		runall.NewCommand(opts),             // runAction-all
+		terragruntinfo.NewCommand(opts),     // terragrunt-info
+		validateinputs.NewCommand(opts),     // validate-inputs
+		graphdependencies.NewCommand(opts),  // graph-dependencies
+		hclfmt.NewCommand(opts),             // hclfmt
+		renderjson.NewCommand(opts),         // render-json
+		awsproviderpatch.NewCommand(opts),   // aws-provider-patch
+		outputmodulegroups.NewCommand(opts), // output-module-groups
+		catalog.NewCommand(opts),            // catalog
+		scaffold.NewCommand(opts),           // scaffold
+		graph.NewCommand(opts),              // graph
 	}
 
 	sort.Sort(cmds)
 
 	// add terraform command `*` after sorting to put the command at the end of the list in the help.
-	cmds.Add(telemetryCommand(opts, terraformCmd.NewCommand(opts)))
+	cmds.Add(terraformCmd.NewCommand(opts))
 
 	return cmds
 }
 
 // Wrap CLI command execution with setting of telemetry context and labels, if telemetry is disabled, just runAction the command.
-func telemetryCommand(opts *options.TerragruntOptions, cmd *cli.Command) *cli.Command {
-	action := cmd.Action
-	cmd.Action = func(ctx *cli.Context) error {
+func wrapWithTelemetry(opts *options.TerragruntOptions) func(ctx *cli.Context, action cli.ActionFunc) error {
+	return func(ctx *cli.Context, action cli.ActionFunc) error {
 		return telemetry.Telemetry(ctx.Context, opts, fmt.Sprintf("%s %s", ctx.Command.Name, opts.TerraformCommand), map[string]interface{}{
 			"terraformCommand": opts.TerraformCommand,
 			"args":             opts.TerraformCliArgs,
@@ -166,7 +165,6 @@ func telemetryCommand(opts *options.TerragruntOptions, cmd *cli.Command) *cli.Co
 			return runAction(ctx, opts, action)
 		})
 	}
-	return cmd
 }
 
 func beforeAction(opts *options.TerragruntOptions) cli.ActionFunc {

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands"
 	awsproviderpatch "github.com/gruntwork-io/terragrunt/cli/commands/aws-provider-patch"
 	"github.com/gruntwork-io/terragrunt/cli/commands/hclfmt"
+	outputmodulegroups "github.com/gruntwork-io/terragrunt/cli/commands/output-module-groups"
 	runall "github.com/gruntwork-io/terragrunt/cli/commands/run-all"
 	terraformcmd "github.com/gruntwork-io/terragrunt/cli/commands/terraform"
 	"github.com/gruntwork-io/terragrunt/config"
@@ -170,6 +171,11 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		{
 			[]string{doubleDashed(commands.TerragruntDebugFlagName)},
 			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, defaultLogLevel, true),
+			nil,
+		},
+		{
+			[]string{outputmodulegroups.CommandName, outputmodulegroups.SubCommandApply},
+			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{outputmodulegroups.SubCommandApply}, false, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 	}
@@ -435,14 +441,18 @@ func TestTerraformHelp_wrongHelpFlag(t *testing.T) {
 }
 
 func runAppTest(args []string, opts *options.TerragruntOptions) (*options.TerragruntOptions, error) {
-	testAction := func(cliCtx *cli.Context) error {
-		return initialSetup(cliCtx, opts)
-	}
+	emptyAction := func(ctx *cli.Context) error { return nil }
 
 	terragruntCommands := terragruntCommands(opts)
 	for _, command := range terragruntCommands {
-		command.Action = testAction
+		command.Action = emptyAction
+		for _, cmd := range command.Subcommands {
+			cmd.Action = emptyAction
+		}
 	}
+
+	defaultCommand := terraformcmd.NewCommand(opts)
+	defaultCommand.Action = emptyAction
 
 	app := cli.NewApp()
 	app.Writer = &bytes.Buffer{}
@@ -452,9 +462,8 @@ func runAppTest(args []string, opts *options.TerragruntOptions) (*options.Terrag
 		commands.NewHelpVersionFlags(opts)...)
 	app.Commands = append(
 		deprecatedCommands(opts),
-		terragruntCommands...)
-	app.DefaultCommand = terraformcmd.NewCommand(opts)
-	app.DefaultCommand.Action = testAction
+		terragruntCommands...).WrapAction(wrapWithTelemetry(opts))
+	app.DefaultCommand = defaultCommand.WrapAction(wrapWithTelemetry(opts))
 	app.OsExiter = osExiter
 
 	err := app.Run(append([]string{"--"}, args...))

--- a/cli/commands/output-module-groups/command.go
+++ b/cli/commands/output-module-groups/command.go
@@ -15,20 +15,14 @@ const (
 
 func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 	return &cli.Command{
-		Name:        CommandName,
-		Usage:       "Output groups of modules ordered by command (apply or destroy) as a list of list in JSON (useful for CI use cases).",
-		Subcommands: subCommands(opts),
-		Action:      func(ctx *cli.Context) error { return Run(ctx, opts.OptionsFromContext(ctx)) },
+		Name:  CommandName,
+		Usage: "Output groups of modules ordered by command (apply or destroy) as a list of list in JSON (useful for CI use cases).",
+		Subcommands: cli.Commands{
+			subCommandFunc(SubCommandApply, opts),
+			subCommandFunc(SubCommandDestroy, opts),
+		},
+		Action: func(ctx *cli.Context) error { return Run(ctx, opts.OptionsFromContext(ctx)) },
 	}
-}
-
-func subCommands(opts *options.TerragruntOptions) cli.Commands {
-	cmds := cli.Commands{
-		subCommandFunc(SubCommandApply, opts),
-		subCommandFunc(SubCommandDestroy, opts),
-	}
-
-	return cmds
 }
 
 func subCommandFunc(cmd string, opts *options.TerragruntOptions) *cli.Command {

--- a/cli/deprecated_commands.go
+++ b/cli/deprecated_commands.go
@@ -72,7 +72,7 @@ func deprecatedCommands(opts *options.TerragruntOptions) cli.Commands {
 			Hidden: true,
 			Action: runFunc(opts),
 		}
-		commands = append(commands, telemetryCommand(opts, command))
+		commands = append(commands, command)
 	}
 
 	return commands

--- a/pkg/cli/command.go
+++ b/pkg/cli/command.go
@@ -238,3 +238,13 @@ func (cmd *Command) flagSetParse(flagSet *libflag.FlagSet, args []string) ([]str
 	undefArgs = append(undefArgs, flagSet.Args()...)
 	return undefArgs, nil
 }
+
+func (cmd Command) WrapAction(fn func(ctx *Context, action ActionFunc) error) *Command {
+	action := cmd.Action
+	cmd.Action = func(ctx *Context) error {
+		return fn(ctx, action)
+	}
+	cmd.Subcommands = cmd.Subcommands.WrapAction(fn)
+
+	return &cmd
+}

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -85,3 +85,13 @@ func (commands Commands) Less(i, j int) bool {
 func (commands Commands) Swap(i, j int) {
 	commands[i], commands[j] = commands[j], commands[i]
 }
+
+func (commands Commands) WrapAction(fn func(ctx *Context, action ActionFunc) error) Commands {
+	var wrapped Commands
+
+	for _, cmd := range commands {
+		wrapped.Add(cmd.WrapAction(fn))
+	}
+
+	return wrapped
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

PR fixes the issue with wrapping the action of subcommands that normalizes terragrunt options and invokes telemetry. For example:
```
terragrunt output-module-groups apply
```

where `apply` is a subcommand and the `telemetryCommand` function has never been called
 https://github.com/gruntwork-io/terragrunt/blob/7e283d73c328c594f711b256a6113bb309c90dde/cli/app.go#L153

Fixes #3063.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

