### PR TITLE
Fixed ignoring `TERRAGRUNT_DOWNLOAD` for dependent modules

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -298,6 +298,11 @@ func initialSetup(cliCtx *cli.Context, opts *options.TerragruntOptions) error {
 		opts.TerragruntConfigPath = util.JoinPath(opts.WorkingDir, opts.TerragruntConfigPath)
 	}
 
+	opts.TerragruntConfigPath, err = filepath.Abs(opts.TerragruntConfigPath)
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
 	opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)
 
 	opts.ExcludeDirs, err = util.GlobCanonicalPath(opts.WorkingDir, opts.ExcludeDirs...)

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -541,7 +541,13 @@ func getOutputJsonWithCaching(ctx *ParsingContext, targetConfig string) ([]byte,
 func cloneTerragruntOptionsForDependency(ctx *ParsingContext, targetConfigPath string) *options.TerragruntOptions {
 	targetOptions := ctx.TerragruntOptions.Clone(targetConfigPath)
 	targetOptions.OriginalTerragruntConfigPath = targetConfigPath
-	targetOptions.DownloadDir = filepath.Join(filepath.Dir(targetConfigPath), util.TerragruntCacheDir)
+
+	// `needUpdateDownloadDir` is true if `DownloadDir` was not explicitly specified by the user and we need to assign the default download dir, otherwise leave as is.
+	needUpdateDownloadDir := filepath.Join(filepath.Dir(ctx.TerragruntOptions.TerragruntConfigPath), util.TerragruntCacheDir) == ctx.TerragruntOptions.DownloadDir
+	if needUpdateDownloadDir {
+		targetOptions.DownloadDir = filepath.Join(filepath.Dir(targetConfigPath), util.TerragruntCacheDir)
+	}
+
 	// Clear IAMRoleOptions in case if it is different from one passed through CLI to allow dependencies to define own iam roles
 	// https://github.com/gruntwork-io/terragrunt/issues/1853#issuecomment-940102676
 	if targetOptions.IAMRoleOptions != targetOptions.OriginalIAMRoleOptions {

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -143,13 +143,22 @@ func TestTerragruntInputsFromDependency(t *testing.T) {
 			stderr bytes.Buffer
 		)
 
-		var appDir string
+		var (
+			appDir  string
+			appDirs = []string{"c", "b", "a"}
+		)
 
-		for _, app := range []string{"c", "b", "a"} {
+		for _, app := range appDirs {
 			appDir = filepath.Join(testCase.rootPath, app)
 
 			runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-download-dir=%s", appDir, testCase.downloadDir))
 			config.ClearOutputCache()
+		}
+
+		if testCase.downloadDir != "" {
+			entries, err := os.ReadDir(testCase.downloadDir)
+			require.NoError(t, err)
+			assert.Equal(t, len(appDirs), len(entries))
 		}
 
 		runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt output --terragrunt-non-interactive --terragrunt-working-dir %s  --terragrunt-download-dir=%s", appDir, testCase.downloadDir), &stdout, &stderr)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4189,10 +4189,13 @@ func TestLogFailedLocalsEvaluation(t *testing.T) {
 	)
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-log-level debug", TEST_FIXTURE_BROKEN_LOCALS), &stdout, &stderr)
-	output := stderr.String()
-
 	assert.Error(t, err)
-	assert.Contains(t, output, "Encountered error while evaluating locals in file fixture-broken-locals/terragrunt.hcl")
+
+	testdataDir, err := filepath.Abs(TEST_FIXTURE_BROKEN_LOCALS)
+	require.NoError(t, err)
+
+	output := stderr.String()
+	assert.Contains(t, output, fmt.Sprintf("Encountered error while evaluating locals in file %s", filepath.Join(testdataDir, "terragrunt.hcl")))
 }
 
 func TestLogFailingDependencies(t *testing.T) {
@@ -4204,10 +4207,13 @@ func TestLogFailingDependencies(t *testing.T) {
 	path := filepath.Join(TEST_FIXTURE_BROKEN_DEPENDENCY, "app")
 
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-log-level debug", path), &stdout, &stderr)
-	output := stderr.String()
-
 	assert.Error(t, err)
-	assert.Contains(t, output, wrappedBinary()+" invocation failed in fixture-broken-dependency/dependency")
+
+	testdataDir, err := filepath.Abs(TEST_FIXTURE_BROKEN_DEPENDENCY)
+	require.NoError(t, err)
+
+	output := stderr.String()
+	assert.Contains(t, output, fmt.Sprintf("%s invocation failed in %s", wrappedBinary(), testdataDir))
 }
 
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3156.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

