### PR TITLE
chore: Bumping CircleCI configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 orbs:
   # The Windows orb gives us everything we need to start using the Windows executor.
-  win: circleci/windows@2.4.0
-  go: circleci/go@1.7.3
+  win: circleci/windows@5.0
+  go: circleci/go@1.11
 
 # The "sign binary" rubs in a MacOS environment, so it's necessary to download GW's binaries
 env: &env
@@ -342,8 +342,8 @@ jobs:
   deploy:
     <<: *env
     macos:
-      xcode: 14.2.0
-    resource_class: macos.x86.medium.gen2
+      xcode: 15.3.0
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
## Description

Updates some out of date dependencies in our CircleCI configs.

Let's not merge this in on a Friday if approved, though.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated CircleCI Configs.