### PR TITLE
feat: Adding binary signing test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,11 +372,12 @@ jobs:
 
             unzip terragrunt_darwin_arm64.zip
             mv terragrunt_darwin_arm64 bin/
-      - run:
-          name: Run SHA256SUM
-          command: |
-            brew install coreutils
-            cd bin && sha256sum * > SHA256SUMS
+
+            ./bin/terragrunt_darwin_amd64 --version
+            ./bin/terragrunt_darwin_arm64 --version
+
+            codesign -dv --verbose=4 ./bin/terragrunt_darwin_amd64
+            codesign -dv --verbose=4 ./bin/terragrunt_darwin_arm64
 
   deploy:
     <<: *env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,9 +373,6 @@ jobs:
             unzip terragrunt_darwin_arm64.zip
             mv terragrunt_darwin_arm64 bin/
 
-            ./bin/terragrunt_darwin_amd64 --version
-            ./bin/terragrunt_darwin_arm64 --version
-
             codesign -dv --verbose=4 ./bin/terragrunt_darwin_amd64
             codesign -dv --verbose=4 ./bin/terragrunt_darwin_arm64
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,45 @@ jobs:
           root: .
           paths: [bin]
 
+  test_signing:
+    <<: *env
+    macos:
+      xcode: 15.3.0
+    resource_class: macos.x86.medium.gen2
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - go/install:
+          version: "1.20.5"
+      - run:
+          name: Install sign-binary-helpers
+          command: |
+            curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
+            gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
+            gruntwork-install --module-name "sign-binary-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
+      - run:
+          name: Compile and sign the binaries
+          command: |
+            export AC_PASSWORD=${MACOS_AC_PASSWORD}
+            export AC_PROVIDER=${MACOS_AC_PROVIDER}
+
+            sign-binary --os mac --install-macos-sign-dependencies .gon_amd64.hcl
+            sign-binary --os mac .gon_arm64.hcl
+            echo "Done signing the binary"
+
+            # Replace the files in bin. These are the same file names generated from .gon_amd64.hcl and .gon_arm64.hcl
+            unzip terragrunt_darwin_amd64.zip
+            mv terragrunt_darwin_amd64 bin/
+
+            unzip terragrunt_darwin_arm64.zip
+            mv terragrunt_darwin_arm64 bin/
+      - run:
+          name: Run SHA256SUM
+          command: |
+            brew install coreutils
+            cd bin && sha256sum * > SHA256SUMS
+
   deploy:
     <<: *env
     macos:
@@ -463,6 +502,17 @@ workflows:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
+      - test_signing:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GCP__automated-tests
+            - GITHUB__PAT__gruntwork-ci
+            - APPLE__OSX__code-signing
       - deploy:
           requires:
             - build


### PR DESCRIPTION
## Description

Tests signing pre-merge so that errors with signing can be caught earlier.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated CircleCI configs

