### PR TITLE
[WIP] Update 'trragrunt' to 'terragrunt' in TestTerragruntSkipConfirmExternalDependencies

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6468,7 +6468,7 @@ func TestTerragruntSkipConfirmExternalDependencies(t *testing.T) {
 	oldStdout := os.Stderr
 	os.Stderr = w
 
-	err = runTerragruntCommand(t, fmt.Sprintf("trragrunt destroy --terragrunt-working-dir %s", testPath), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt destroy --terragrunt-working-dir %s", testPath), &stdout, &stderr)
 	os.Stderr = oldStdout
 	assert.NoError(t, w.Close())
 


### PR DESCRIPTION
## Description

It appears that the `TestTerragruntSkipConfirmExternalDependencies` test function in `test/integration_test.go` has a typo when calling the `terragrunt` command. I'm surprised to see the test suite passes with the command as `trragrunt` instead of `terragrunt`.

This PR updates the command from `trragrunt` to `terragrunt`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Does this exposes a gap in test coverage?

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

