### PR TITLE
fix: Correcting docs on default binary used by Terragrunt

### DIFF
--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -770,7 +770,7 @@ explanation). This argument is not used with the `run-all` commands.
 **Environment Variable**: `TERRAGRUNT_TFPATH`<br/>
 **Requires an argument**: `--terragrunt-tfpath /path/to/terraform-binary`<br/>
 
-A custom path to the Terraform binary. The default is `terraform` in a directory on your PATH.
+A custom path to the Terraform binary. The default is `tofu` in a directory on your PATH.
 
 **NOTE**: This will override the `terraform` binary that is used by `terragrunt` in all instances, including
 `dependency` lookups. This setting will also override any [terraform_binary]({{site.baseurl}}/docs/reference/config-blocks-and-attributes/#terraform_binary)

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -1331,7 +1331,7 @@ The precedence is as follows: `--terragrunt-iam-assume-role-session-name` comman
 ### terraform_binary
 
 The terragrunt `terraform_binary` string option can be used to override the default terraform binary path (which is
-`terraform`).
+`tofu`).
 
 The precedence is as follows: `--terragrunt-tfpath` command line option → `TERRAGRUNT_TFPATH` env variable →
 `terragrunt.hcl` in the module directory → included `terragrunt.hcl`


### PR DESCRIPTION
## Description

Fixes #3172.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated docs on `TERRAGRUNT_TFPATH`.

