### PR TITLE
feat: Adding initialization check caching

### DIFF
--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/terragrunt/codegen"
+	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -29,6 +30,10 @@ type stateAccess struct {
 }
 
 var stateAccessLock = newStateAccess()
+
+// initializedRemoteStateCache is a cache to store the result of a remote state initialization check.
+// This is used to avoid checking to see if remote state needs to be initialized multiple times.
+var initializedRemoteStateCache = cache.NewCache[bool]()
 
 func (remoteState *RemoteState) String() string {
 	return fmt.Sprintf("RemoteState{Backend = %v, DisableInit = %v, DisableDependencyOptimization = %v, Generate = %v, Config = %v}", remoteState.Backend, remoteState.DisableInit, remoteState.DisableDependencyOptimization, remoteState.Generate, remoteState.Config)

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -287,7 +287,6 @@ func configValuesEqual(config map[string]interface{}, existingBackend *Terraform
 // Initialize the remote state S3 bucket specified in the given config. This function will validate the config
 // parameters, create the S3 bucket if it doesn't already exist, and check that versioning is enabled.
 func (s3Initializer S3Initializer) Initialize(ctx context.Context, remoteState *RemoteState, terragruntOptions *options.TerragruntOptions) error {
-
 	s3ConfigExtended, err := ParseExtendedS3Config(remoteState.Config)
 	if err != nil {
 		return errors.WithStackTrace(err)
@@ -299,8 +298,19 @@ func (s3Initializer S3Initializer) Initialize(ctx context.Context, remoteState *
 
 	var s3Config = s3ConfigExtended.remoteStateConfigS3
 
+	if initialized, hit := initializedRemoteStateCache.Get(s3Config.Bucket); initialized && hit {
+		terragruntOptions.Logger.Debugf("S3 bucket %s has already been confirmed to be initialized, skipping initialization checks", s3Config.Bucket)
+		return nil
+	}
+
 	// ensure that only one goroutine can initialize bucket
 	return stateAccessLock.StateBucketUpdate(s3Config.Bucket, func() error {
+		// Check if another goroutine has already initialized the bucket
+		if initialized, hit := initializedRemoteStateCache.Get(s3Config.Bucket); initialized && hit {
+			terragruntOptions.Logger.Debugf("S3 bucket %s has already been confirmed to be initialized, skipping initialization checks", s3Config.Bucket)
+			return nil
+		}
+
 		// Display a deprecation warning when the "lock_table" attribute is being used
 		// during initialization.
 		if s3Config.LockTable != "" {
@@ -335,6 +345,9 @@ func (s3Initializer S3Initializer) Initialize(ctx context.Context, remoteState *
 		if err := UpdateLockTableSetSSEncryptionOnIfNecessary(&s3Config, s3ConfigExtended, terragruntOptions); err != nil {
 			return errors.WithStackTrace(err)
 		}
+
+		initializedRemoteStateCache.Put(s3Config.Bucket, true)
+
 		return nil
 	})
 }

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -284,6 +284,11 @@ func configValuesEqual(config map[string]interface{}, existingBackend *Terraform
 	return true
 }
 
+// buildInitializerCacheKey returns a unique key for the given S3 config that can be used to cache the initialization
+func (s3Initializer S3Initializer) buildInitializerCacheKey(s3Config *RemoteStateConfigS3) string {
+	return fmt.Sprintf("%s-%s-%s-%s", s3Config.Bucket, s3Config.Region, s3Config.LockTable, s3Config.DynamoDBTable)
+}
+
 // Initialize the remote state S3 bucket specified in the given config. This function will validate the config
 // parameters, create the S3 bucket if it doesn't already exist, and check that versioning is enabled.
 func (s3Initializer S3Initializer) Initialize(ctx context.Context, remoteState *RemoteState, terragruntOptions *options.TerragruntOptions) error {
@@ -298,7 +303,8 @@ func (s3Initializer S3Initializer) Initialize(ctx context.Context, remoteState *
 
 	var s3Config = s3ConfigExtended.remoteStateConfigS3
 
-	if initialized, hit := initializedRemoteStateCache.Get(s3Config.Bucket); initialized && hit {
+	cacheKey := s3Initializer.buildInitializerCacheKey(&s3Config)
+	if initialized, hit := initializedRemoteStateCache.Get(cacheKey); initialized && hit {
 		terragruntOptions.Logger.Debugf("S3 bucket %s has already been confirmed to be initialized, skipping initialization checks", s3Config.Bucket)
 		return nil
 	}
@@ -306,7 +312,7 @@ func (s3Initializer S3Initializer) Initialize(ctx context.Context, remoteState *
 	// ensure that only one goroutine can initialize bucket
 	return stateAccessLock.StateBucketUpdate(s3Config.Bucket, func() error {
 		// Check if another goroutine has already initialized the bucket
-		if initialized, hit := initializedRemoteStateCache.Get(s3Config.Bucket); initialized && hit {
+		if initialized, hit := initializedRemoteStateCache.Get(cacheKey); initialized && hit {
 			terragruntOptions.Logger.Debugf("S3 bucket %s has already been confirmed to be initialized, skipping initialization checks", s3Config.Bucket)
 			return nil
 		}
@@ -346,7 +352,7 @@ func (s3Initializer S3Initializer) Initialize(ctx context.Context, remoteState *
 			return errors.WithStackTrace(err)
 		}
 
-		initializedRemoteStateCache.Put(s3Config.Bucket, true)
+		initializedRemoteStateCache.Put(cacheKey, true)
 
 		return nil
 	})


### PR DESCRIPTION
## Description

Adds initialization check caching so that remote state checks only have to be done once for a given bucket if the bucket can be initialized successfully.

Mitigates the need to have any network traffic to inspect the initialization status of a bucket after it's been initialized once.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `remote` package to include a cache for initialization checks.

