### PR TITLE
fix: Fixing cookie policy link

### DIFF
--- a/docs/_pages/cookie-policy/index.md
+++ b/docs/_pages/cookie-policy/index.md
@@ -3,5 +3,5 @@ layout: subpage
 permalink: /cookie-policy/
 slug: cookie-policy
 redirect_to:
-  - https://gruntwork.io/cookie-policy/
+  - https://gruntwork.io/legal/cookie-policy/
 ---


### PR DESCRIPTION
## Description

Fixes #3209.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `/cookie-policy` redirect to appropriate https://gruntwork.io URL.

