### PR TITLE
feat: Adding more context on why caching partial parsing of configs can be useful

### DIFF
--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -1173,6 +1173,18 @@ Currently only AWS S3 backend is supported.
 This flag can be used to drastically decrease time required for parsing Terragrunt files. The effect will only show if a lot of similar includes are expected such as the root terragrunt.hcl include.
 NOTE: This is an experimental feature, use with caution.
 
+The reason you might want to use this flag is that Terragrunt frequently only needs to perform a partial parse of Terragrunt configurations.
+
+This is the case for scenarios like:
+
+- Building the Directed Acyclic Graph (DAG) during a `run-all` command where only the `dependency` blocks need to be evaluated to determine run order.
+- Parsing the `terraform` block to determine state configurations for fetching `dependency` outputs.
+- Determining whether Terragrunt execution behavior has to change like for `prevent_destroy` or `skip` flags in configuration.
+
+These configurations are generally safe to cache, but due to the nature of HCL being a dynamic configuration language, there are some edge cases where caching these can lead to incorrect behavior.
+
+Once this flag has been tested thoroughly, we will consider making it the default behavior.
+
 ### terragrunt-include-module-prefix
 
 **CLI Arg**: `--terragrunt-include-module-prefix`<br/>


### PR DESCRIPTION
## Description

Adding some context for why caching partial parsing of configurations is useful.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `cli-options` docs.

