### PR TITLE
fix: Adjusting language for `--terragrunt-non-interactive` in the docs so that it's clearer what it does for users

### DIFF
--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -814,7 +814,7 @@ When passed in, don't automatically retry commands which fail with transient err
 **Environment Variable**: `TERRAGRUNT_NON_INTERACTIVE` (set to `true`)<br/>
 _(Prior to Terragrunt v0.48.6, this environment variable was called `TF_INPUT` (set to `false`), and is still available for backwards compatibility. NOTE: [TF_INPUT](https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_input) is native to Terraform!)_
 
-When passed in, don't show interactive user prompts. This will default the answer for all Terragrunt prompts to `yes` except for
+When passed in, don't show interactive user prompts. This will default the answer for all Terragrunt (not OpenTofu/Terraform) prompts to `yes` except for
 the listed cases below. This is useful if you need to run Terragrunt in an automated setting (e.g. from a script). May
 also be specified with the [TF_INPUT](https://www.terraform.io/docs/configuration/environment-variables.html#tf_input) environment variable.
 
@@ -822,6 +822,16 @@ This setting will default to `no` for the following cases:
 
 - Prompts related to pulling in external dependencies. You can force include external dependencies using the
   [--terragrunt-include-external-dependencies](#terragrunt-include-external-dependencies) option.
+
+Note that this does not impact the behavior of OpenTofu/Terraform commands invoked by Terragrunt.
+
+e.g.
+
+```bash
+terragrunt --terragrunt-non-interactive apply -auto-approve
+```
+
+Is how you would make Terragrunt apply without any user prompts from Terragrunt or OpenTofu/Terraform.
 
 ### terragrunt-working-dir
 

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -814,7 +814,7 @@ When passed in, don't automatically retry commands which fail with transient err
 **Environment Variable**: `TERRAGRUNT_NON_INTERACTIVE` (set to `true`)<br/>
 _(Prior to Terragrunt v0.48.6, this environment variable was called `TF_INPUT` (set to `false`), and is still available for backwards compatibility. NOTE: [TF_INPUT](https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_input) is native to Terraform!)_
 
-When passed in, don't show interactive user prompts. This will default the answer for all prompts to `yes` except for
+When passed in, don't show interactive user prompts. This will default the answer for all Terragrunt prompts to `yes` except for
 the listed cases below. This is useful if you need to run Terragrunt in an automated setting (e.g. from a script). May
 also be specified with the [TF_INPUT](https://www.terraform.io/docs/configuration/environment-variables.html#tf_input) environment variable.
 


### PR DESCRIPTION
## Description

Should help avoid confusion like what created #3215.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `--terragrunt-non-interactive` docs.