### PR TITLE
Fixed using dynamic AWS credentials for `remote_state`

### DIFF
--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -161,7 +161,6 @@ func getSTSCredentialsFromIAMRoleOptions(sess *session.Session, iamRoleOptions o
 }
 
 func getCredentialsFromEnvs(opts *options.TerragruntOptions) *credentials.Credentials {
-	return nil
 	var (
 		accessKeyID     = opts.Env["AWS_ACCESS_KEY_ID"]
 		secretAccessKey = opts.Env["AWS_SECRET_ACCESS_KEY"]

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -109,9 +109,7 @@ func CreateAwsSessionFromConfig(config *AwsSessionConfig, terragruntOptions *opt
 
 	if iamRoleOptions.RoleARN != "" {
 		sess.Config.Credentials = getSTSCredentialsFromIAMRoleOptions(sess, iamRoleOptions, credentialOptFn)
-	}
-
-	if sess.Config.Credentials == nil {
+	} else {
 		sess.Config.Credentials = getCredentialsFromEnvs(terragruntOptions)
 	}
 

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -161,11 +161,16 @@ func getSTSCredentialsFromIAMRoleOptions(sess *session.Session, iamRoleOptions o
 }
 
 func getCredentialsFromEnvs(opts *options.TerragruntOptions) *credentials.Credentials {
+	return nil
 	var (
 		accessKeyID     = opts.Env["AWS_ACCESS_KEY_ID"]
 		secretAccessKey = opts.Env["AWS_SECRET_ACCESS_KEY"]
 		sessionToken    = opts.Env["AWS_SESSION_TOKEN"]
 	)
+
+	if accessKeyID == "" || secretAccessKey == "" {
+		return nil
+	}
 	return credentials.NewStaticCredentials(accessKeyID, secretAccessKey, sessionToken)
 }
 

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -65,6 +65,7 @@ func CreateAwsSessionFromConfig(config *AwsSessionConfig, terragruntOptions *opt
 		EndpointResolver:        endpoints.ResolverFunc(s3CustResolverFn),
 		S3ForcePathStyle:        aws.Bool(config.S3ForcePathStyle),
 		DisableComputeChecksums: aws.Bool(config.DisableComputeChecksums),
+		Credentials:             getCredentialsFromEnvs(terragruntOptions),
 	}
 
 	var sessionOptions = session.Options{
@@ -157,6 +158,15 @@ func getSTSCredentialsFromIAMRoleOptions(sess *session.Session, iamRoleOptions o
 		}
 	})
 	return stscreds.NewCredentials(sess, iamRoleOptions.RoleARN, optFns...)
+}
+
+func getCredentialsFromEnvs(opts *options.TerragruntOptions) *credentials.Credentials {
+	var (
+		accessKeyID     = opts.Env["AWS_ACCESS_KEY_ID"]
+		secretAccessKey = opts.Env["AWS_SECRET_ACCESS_KEY"]
+		sessionToken    = opts.Env["AWS_SESSION_TOKEN"]
+	)
+	return credentials.NewStaticCredentials(accessKeyID, secretAccessKey, sessionToken)
 }
 
 // Returns an AWS session object. The session is configured by either:

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -65,7 +65,6 @@ func CreateAwsSessionFromConfig(config *AwsSessionConfig, terragruntOptions *opt
 		EndpointResolver:        endpoints.ResolverFunc(s3CustResolverFn),
 		S3ForcePathStyle:        aws.Bool(config.S3ForcePathStyle),
 		DisableComputeChecksums: aws.Bool(config.DisableComputeChecksums),
-		Credentials:             getCredentialsFromEnvs(terragruntOptions),
 	}
 
 	var sessionOptions = session.Options{
@@ -111,6 +110,11 @@ func CreateAwsSessionFromConfig(config *AwsSessionConfig, terragruntOptions *opt
 	if iamRoleOptions.RoleARN != "" {
 		sess.Config.Credentials = getSTSCredentialsFromIAMRoleOptions(sess, iamRoleOptions, credentialOptFn)
 	}
+
+	if sess.Config.Credentials == nil {
+		sess.Config.Credentials = getCredentialsFromEnvs(terragruntOptions)
+	}
+
 	return sess, nil
 }
 

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -109,8 +109,8 @@ func CreateAwsSessionFromConfig(config *AwsSessionConfig, terragruntOptions *opt
 
 	if iamRoleOptions.RoleARN != "" {
 		sess.Config.Credentials = getSTSCredentialsFromIAMRoleOptions(sess, iamRoleOptions, credentialOptFn)
-	} else {
-		sess.Config.Credentials = getCredentialsFromEnvs(terragruntOptions)
+	} else if creds := getCredentialsFromEnvs(terragruntOptions); creds != nil {
+		sess.Config.Credentials = creds
 	}
 
 	return sess, nil

--- a/cli/commands/terraform/creds/providers/externalcmd/provider.go
+++ b/cli/commands/terraform/creds/providers/externalcmd/provider.go
@@ -65,6 +65,7 @@ func (provider *Provider) GetCredentials(ctx context.Context) (*providers.Creden
 
 	if resp.AWSCredentials != nil {
 		if envs := resp.AWSCredentials.Envs(provider.terragruntOptions); envs != nil {
+			provider.terragruntOptions.Logger.Debugf("Obtaining AWS credentials from the %s.", provider.Name())
 			maps.Copy(creds.Envs, envs)
 		}
 	}

--- a/test/fixture-auth-provider-cmd-remote-state/mock-auth-cmd.sh
+++ b/test/fixture-auth-provider-cmd-remote-state/mock-auth-cmd.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+json_string=$( jq -n \
+                  --arg access_key_id "__FILL_AWS_ACCESS_KEY_ID__" \
+                  --arg secret_access_key "__FILL_AWS_SECRET_ACCESS_KEY__" \
+                  --arg session_token "" \
+                  --arg tf_var_foo "$tf_var_foo" \
+                  '{awsCredentials: {ACCESS_KEY_ID: $access_key_id, SECRET_ACCESS_KEY: $secret_access_key, SESSION_TOKEN: $session_token}, envs: {TF_VAR_foo: $tf_var_foo}}' )
+echo $json_string

--- a/test/fixture-auth-provider-cmd-remote-state/terragrunt.hcl
+++ b/test/fixture-auth-provider-cmd-remote-state/terragrunt.hcl
@@ -1,0 +1,13 @@
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket  = "__FILL_IN_BUCKET_NAME__"
+    key     = "${path_relative_to_include()}/terraform.tfstate"
+    region  = "__FILL_IN_REGION__"
+    encrypt = true
+  }
+}

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -839,4 +839,37 @@ func TestTerragruntProviderCache(t *testing.T) {
 	}
 }
 
+func TestReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, TEST_FIXTURE_AUTH_PROVIDER_CMD_REMOTE_STATE)
+	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_AUTH_PROVIDER_CMD_REMOTE_STATE)
+	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_AUTH_PROVIDER_CMD_REMOTE_STATE)
+
+	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
+	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
+
+	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
+	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", TERRAFORM_REMOTE_STATE_S3_REGION)
+
+	mockAuthCmd := filepath.Join(rootPath, "mock-auth-cmd.sh")
+
+	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
+	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	os.Setenv("AWS_ACCESS_KEY_ID", "")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	defer func() {
+		os.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey)
+	}()
+
+	copyAndFillMapPlaceholders(t, mockAuthCmd, mockAuthCmd, map[string]string{
+		"__FILL_AWS_ACCESS_KEY_ID__":     accessKeyID,
+		"__FILL_AWS_SECRET_ACCESS_KEY__": secretAccessKey,
+	})
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-auth-provider-cmd %s", rootPath, mockAuthCmd))
+}
+
 // @SONAR_START@

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -840,8 +840,6 @@ func TestTerragruntProviderCache(t *testing.T) {
 }
 
 func TestReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
-	t.Parallel()
-
 	cleanupTerraformFolder(t, TEST_FIXTURE_AUTH_PROVIDER_CMD_REMOTE_STATE)
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_AUTH_PROVIDER_CMD_REMOTE_STATE)
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_AUTH_PROVIDER_CMD_REMOTE_STATE)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

https://linear.app/gruntwork/issue/SME-1066/auth-provider-command-does-not-get-used-during-remote-state

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

