### PR TITLE
Add script to check GH release assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,9 +546,7 @@ workflows:
             - build
           filters:
             tags:
-              only: "test-asset-check"
-            branches:
-              ignore: /.*/
+              only: test-asset-check
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ jobs:
       - run:
           name: Verify that the linux amd64 asset can be downloaded
           command: |
-            CIRCLE_TAG=test-asset-check ./_ci/verify-github-release-assets.sh
+            CIRCLE_TAG=test-asset-check ./_ci/verify-release-assets.sh
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,7 +416,7 @@ jobs:
             cd bin && sha256sum * > SHA256SUMS
       - run: upload-github-release-assets --git-tag test-asset-check bin/*
       - run:
-          name: Verify that the linux amd64 asset can be downloaded
+          name: Verify that assets attached to the release
           command: |
             CIRCLE_TAG=test-asset-check ./_ci/verify-release-assets.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,7 @@ jobs:
           command: |
             brew install coreutils
             cd bin && sha256sum * > SHA256SUMS
-      - run: upload-github-release-assets bin/*
+      - run: upload-github-release-assets --git-tag test-asset-check bin/*
       - run:
           name: Verify that the linux amd64 asset can be downloaded
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,7 @@ workflows:
             - build
           filters:
             tags:
-              only: "test-sign-release"
+              only: "test-asset-check"
             branches:
               ignore: /.*/
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /^v.*/
+              only: "test-sign-release"
             branches:
               ignore: /.*/
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,7 +535,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /^v.*/
+              only: test-asset-check
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,6 +415,36 @@ jobs:
             brew install coreutils
             cd bin && sha256sum * > SHA256SUMS
       - run: upload-github-release-assets bin/*
+      - run:
+          name: Verify that the linux amd64 asset can be downloaded
+          command: |
+            # For some reason, the linux amd64 asset cannot be downloaded after it's been uploaded successfully sometimes.
+            # As a hacky workaround, we will retry the upload of that one binary if it cannot be downloaded until a better solution is found.
+
+            max_retries=10
+
+            for ((i=0; i<max_retries; i++)); do
+              if ! curl -sILf 'https://github.com/gruntwork-io/terragrunt/releases/latest/download/terragrunt_linux_amd64' > /dev/null; then
+                echo "Failed to download the linux amd64 asset. Retrying..."
+                curl -L -XDELETE \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -H "Authorization: token $GITHUB_OAUTH_TOKEN"  \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  "https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest/assets" > /dev/null
+                curl -L -XPOST \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -H "Authorization: token $GITHUB_OAUTH_TOKEN"  \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  -H "Content-Type: application/x-executable" \
+                  --data-binary "@bin/terragrunt_linux_amd64" \
+                  "https://uploads.github.com/repos/gruntwork-io/terragrunt/releases/latest/assets?name=terragrunt_linux_amd64" > /dev/null
+              else
+                exit 0
+              fi
+            done
+
+            echo "Failed to download the linux amd64 asset after $max_retries retries. Exiting..."
+            exit 1
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,33 +418,7 @@ jobs:
       - run:
           name: Verify that the linux amd64 asset can be downloaded
           command: |
-            # For some reason, the linux amd64 asset cannot be downloaded after it's been uploaded successfully sometimes.
-            # As a hacky workaround, we will retry the upload of that one binary if it cannot be downloaded until a better solution is found.
-
-            max_retries=10
-
-            for ((i=0; i<max_retries; i++)); do
-              if ! curl -sILf 'https://github.com/gruntwork-io/terragrunt/releases/latest/download/terragrunt_linux_amd64' > /dev/null; then
-                echo "Failed to download the linux amd64 asset. Retrying..."
-                curl -L -XDELETE \
-                  -H "Accept: application/vnd.github.v3+json" \
-                  -H "Authorization: token $GITHUB_OAUTH_TOKEN"  \
-                  -H "X-GitHub-Api-Version: 2022-11-28" \
-                  "https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest/assets" > /dev/null
-                curl -L -XPOST \
-                  -H "Accept: application/vnd.github.v3+json" \
-                  -H "Authorization: token $GITHUB_OAUTH_TOKEN"  \
-                  -H "X-GitHub-Api-Version: 2022-11-28" \
-                  -H "Content-Type: application/x-executable" \
-                  --data-binary "@bin/terragrunt_linux_amd64" \
-                  "https://uploads.github.com/repos/gruntwork-io/terragrunt/releases/latest/assets?name=terragrunt_linux_amd64" > /dev/null
-              else
-                exit 0
-              fi
-            done
-
-            echo "Failed to download the linux amd64 asset after $max_retries retries. Exiting..."
-            exit 1
+            CIRCLE_TAG=test-asset-check ./_ci/verify-github-release-assets.sh
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,11 +414,11 @@ jobs:
           command: |
             brew install coreutils
             cd bin && sha256sum * > SHA256SUMS
-      - run: upload-github-release-assets --git-tag test-asset-check bin/*
+      - run: upload-github-release-assets bin/*
       - run:
           name: Verify that assets attached to the release
           command: |
-            CIRCLE_TAG=test-asset-check ./_ci/verify-release-assets.sh
+            ./_ci/verify-release-assets.sh
 
 workflows:
   version: 2
@@ -509,7 +509,7 @@ workflows:
             - build
           filters:
             tags:
-              only: test-asset-check
+              only: /^v.*/
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests
@@ -520,7 +520,9 @@ workflows:
             - build
           filters:
             tags:
-              only: test-asset-check
+              only: /^v.*/
+            branches:
+              ignore: /.*/
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests

--- a/_ci/verify-github-release-assets.sh
+++ b/_ci/verify-github-release-assets.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Ensure CIRCLE_TAG and GITHUB_OAUTH_TOKEN are set
+
+if [ -z "$CIRCLE_TAG" ]; then
+  echo "CIRCLE_TAG environment variable is not set. Exiting..."
+  exit 1
+fi
+
+if [ -z "$GITHUB_OAUTH_TOKEN" ]; then
+  echo "GITHUB_OAUTH_TOKEN environment variable is not set. Exiting..."
+  exit 1
+fi
+
+export RELEASE_TAG=$CIRCLE_TAG
+
+REPO_OWNER="gruntwork-io"
+REPO_NAME="terragrunt"
+MAX_RETRIES=10
+
+RELEASE_RESPONSE=$(curl -s \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Authorization: token $GITHUB_OAUTH_TOKEN" \
+  "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/tags/$RELEASE_TAG")
+
+# Check if the release exists
+if echo "$RELEASE_RESPONSE" | jq -e '.message == "Not Found"' > /dev/null; then
+  echo "Release $RELEASE_TAG not found. Exiting..."
+  exit 1
+fi
+
+# Get the release id
+RELEASE_ID=$(echo "$RELEASE_RESPONSE" | jq -r '.id')
+ASSET_URLS=$(echo "$RELEASE_RESPONSE" | jq -r '.assets[].browser_download_url')
+
+# Loop through each asset URL and attempt to download
+for ASSET_URL in $ASSET_URLS; do
+  ASSET_NAME=$(basename "$ASSET_URL")
+
+  for ((i=0; i<MAX_RETRIES; i++)); do
+    if ! curl -sILf "$ASSET_URL" > /dev/null; then
+      echo "Failed to download the asset $ASSET_NAME. Retrying..."
+
+      # Delete the asset
+      ASSET_ID=$(echo "$RELEASE_RESPONSE" | jq -r ".assets[] | select(.name==\"$ASSET_NAME\") | .id")
+      curl -s -L -XDELETE \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token $GITHUB_OAUTH_TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/assets/$ASSET_ID" > /dev/null
+
+      # Re-upload the asset
+      curl -s -L -XPOST \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token $GITHUB_OAUTH_TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Content-Type: application/octet-stream" \
+        --data-binary "@bin/$ASSET_NAME" \
+        "https://uploads.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/$RELEASE_ID/assets?name=$ASSET_NAME" > /dev/null
+    else
+      echo "Successfully checked the asset $ASSET_NAME"
+      break
+    fi
+  done
+
+  if (( i == MAX_RETRIES )); then
+    echo "Failed to download the asset $ASSET_NAME after $MAX_RETRIES retries. Exiting..."
+    exit 1
+  fi
+done
+
+echo "All assets checks passed."

--- a/_ci/verify-release-assets.sh
+++ b/_ci/verify-release-assets.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
+# Script to verify the release assets by downloading them from the GitHub release
+# and checking if they are accessible. If the asset is not accessible, the script
+# will try to delete asset and re-upload it to the release.
+# https://github.com/gruntwork-io/terragrunt/issues/3220
 
 # Ensure CIRCLE_TAG and GITHUB_OAUTH_TOKEN are set
-
 if [ -z "$CIRCLE_TAG" ]; then
   echo "CIRCLE_TAG environment variable is not set. Exiting..."
   exit 1

--- a/_ci/verify-release-assets.sh
+++ b/_ci/verify-release-assets.sh
@@ -12,8 +12,7 @@ if [ -z "$GITHUB_OAUTH_TOKEN" ]; then
   exit 1
 fi
 
-export RELEASE_TAG=$CIRCLE_TAG
-
+RELEASE_TAG=$CIRCLE_TAG
 REPO_OWNER="gruntwork-io"
 REPO_NAME="terragrunt"
 MAX_RETRIES=10


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* Added script which verifies GitHub release assets
* If the asset is not available - it is removed and re-uploaded
* added call to release check script in Circle CI

Example run:

![image](https://github.com/gruntwork-io/terragrunt/assets/10694338/1f37f5ff-2b52-4b3e-9c4b-a5b421e4a613)


Fixes #3220.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

N/A

### Migration Guide

N/A

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

