### PR TITLE
Added `--terragrunt-excludes-file` flag

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -317,6 +317,12 @@ func initialSetup(cliCtx *cli.Context, opts *options.TerragruntOptions) error {
 		return err
 	}
 
+	excludeDirs, err := util.GetExcludeDirsFromFile(opts.WorkingDir, opts.ExcludesFile)
+	if err != nil {
+		return err
+	}
+	opts.ExcludeDirs = append(opts.ExcludeDirs, excludeDirs...)
+
 	opts.IncludeDirs, err = util.GlobCanonicalPath(opts.WorkingDir, opts.IncludeDirs...)
 	if err != nil {
 		return err

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -27,6 +27,7 @@ const (
 	TerragruntIgnoreDependencyOrderFlagName          = "terragrunt-ignore-dependency-order"
 	TerragruntIgnoreExternalDependenciesFlagName     = "terragrunt-ignore-external-dependencies"
 	TerragruntIncludeExternalDependenciesFlagName    = "terragrunt-include-external-dependencies"
+	TerragruntExcludesFile                           = "terragrunt-excludes-file"
 	TerragruntExcludeDirFlagName                     = "terragrunt-exclude-dir"
 	TerragruntIncludeDirFlagName                     = "terragrunt-include-dir"
 	TerragruntStrictIncludeFlagName                  = "terragrunt-strict-include"
@@ -194,6 +195,12 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 			Destination: &opts.Parallelism,
 			EnvVar:      "TERRAGRUNT_PARALLELISM",
 			Usage:       "*-all commands parallelism set to at most N modules",
+		},
+		&cli.GenericFlag[string]{
+			Name:        TerragruntExcludesFile,
+			Destination: &opts.ExcludesFile,
+			EnvVar:      "TERRAGRUNT_EXCLUDES_FILE",
+			Usage:       "Path to a file with a list of directories that need to be excluded when running *-all commands.",
 		},
 		&cli.SliceFlag[string]{
 			Name:        TerragruntExcludeDirFlagName,

--- a/cli/commands/hclvalidate/action.go
+++ b/cli/commands/hclvalidate/action.go
@@ -39,18 +39,18 @@ func Run(ctx context.Context, opts *Options) (er error) {
 		return err
 	}
 
-	stackErr := stack.Run(ctx, opts.TerragruntOptions)
-
-	if len(diags) > 0 {
-		if err := writeDiagnostics(opts, diags); err != nil {
-			return err
-		}
+	if err := stack.Run(ctx, opts.TerragruntOptions); err != nil {
+		return nil
 	}
 
-	return stackErr
+	return writeDiagnostics(opts, diags)
 }
 
 func writeDiagnostics(opts *Options, diags diagnostic.Diagnostics) error {
+	if len(diags) == 0 {
+		return nil
+	}
+
 	render := view.NewHumanRender(opts.DisableLogColors)
 	if opts.JSONOutput {
 		render = view.NewJSONRender()

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -48,6 +48,7 @@ This page documents the CLI commands and options available with Terragrunt:
   - [terragrunt-iam-role](#terragrunt-iam-role)
   - [terragrunt-iam-assume-role-duration](#terragrunt-iam-assume-role-duration)
   - [terragrunt-iam-assume-role-session-name](#terragrunt-iam-assume-role-session-name)
+  - [terragrunt-excludes-file](#terragrunt-excludes-file)
   - [terragrunt-exclude-dir](#terragrunt-exclude-dir)
   - [terragrunt-include-dir](#terragrunt-include-dir)
   - [terragrunt-strict-include](#terragrunt-strict-include)
@@ -731,6 +732,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
   - [terragrunt-iam-role](#terragrunt-iam-role)
   - [terragrunt-iam-assume-role-duration](#terragrunt-iam-assume-role-duration)
   - [terragrunt-iam-assume-role-session-name](#terragrunt-iam-assume-role-session-name)
+  - [terragrunt-excludes-file](#terragrunt-excludes-file)
   - [terragrunt-exclude-dir](#terragrunt-exclude-dir)
   - [terragrunt-include-dir](#terragrunt-include-dir)
   - [terragrunt-strict-include](#terragrunt-strict-include)
@@ -951,6 +953,16 @@ Uses the specified duration as the session duration (in seconds) for the STS ses
 **Requires an argument**: `--terragrunt-iam-assume-role-session-name "terragrunt-iam-role-session-name"`<br/>
 
 Used as the session name for the STS session which assumes the role defined in `--terragrunt-iam-role`.
+
+### terragrunt-excludes-file
+
+**CLI Arg**: `--terragrunt-excludes-file`<br/>
+**Environment Variable**: `TERRAGRUNT_EXCLUDES_FILE`<br/>
+**Requires an argument**: `--terragrunt-excludes-file /path/to/file`<br/>
+
+Path to a file with a list of directories that need to be excluded when running *-all commands, by default `.terragrunt-excludes`. Modules under these directories will be
+excluded during execution of the commands. If a relative path is specified, it should be relative from
+[--terragrunt-working-dir](#terragrunt-working-dir). This will only exclude the module, not its dependencies.
 
 ### terragrunt-exclude-dir
 

--- a/options/options.go
+++ b/options/options.go
@@ -37,6 +37,8 @@ const (
 	DefaultIAMAssumeRoleDuration = 3600
 
 	minCommandLength = 2
+
+	DefaultExcludesFile = ".terragrunt-excludes"
 )
 
 var (
@@ -191,6 +193,9 @@ type TerragruntOptions struct {
 
 	// RetryableErrors is an array of regular expressions with RE2 syntax (https://github.com/google/re2/wiki/Syntax) that qualify for retrying
 	RetryableErrors []string
+
+	// Path to a file with a list of directories that need  to be excluded when running *-all commands.
+	ExcludesFile string
 
 	// Unix-style glob of directories to exclude when running *-all commands
 	ExcludeDirs []string
@@ -364,6 +369,7 @@ func MergeIAMRoleOptions(target IAMRoleOptions, source IAMRoleOptions) IAMRoleOp
 func NewTerragruntOptions() *TerragruntOptions {
 	return &TerragruntOptions{
 		TerraformPath:                  DefaultWrappedPath,
+		ExcludesFile:                   DefaultExcludesFile,
 		OriginalTerraformCommand:       "",
 		TerraformCommand:               "",
 		AutoInit:                       true,
@@ -550,6 +556,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) *TerragruntOpt
 		JsonOutputFolder:               opts.JsonOutputFolder,
 		AuthProviderCmd:                opts.AuthProviderCmd,
 		SkipOutput:                     opts.SkipOutput,
+		ExcludesFile:                   opts.ExcludesFile,
 	}
 }
 

--- a/util/file.go
+++ b/util/file.go
@@ -658,3 +658,36 @@ func GetTempDir() (string, error) {
 
 	return tempDir, nil
 }
+
+// GetExcludeDirsFromFile returns a list of directories from the given filename, where each directory path starts on a new line.
+func GetExcludeDirsFromFile(baseDir, filename string) ([]string, error) {
+	filename, err := CanonicalPath(filename, baseDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if !FileExists(filename) || !IsFile(filename) {
+		return nil, nil
+	}
+
+	str, err := ReadFileAsString(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var dirs []string
+
+	lines := strings.Split(strings.ReplaceAll(str, "\r\n", "\n"), "\n")
+	for _, line := range lines {
+		dir := strings.TrimSpace(line)
+
+		newDirs, err := GlobCanonicalPath(baseDir, dir)
+		if err != nil {
+			return nil, err
+		}
+
+		dirs = append(dirs, newDirs...)
+	}
+
+	return dirs, nil
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

The PR is adding a new flag `--terragrunt-excludes-file`, which allows to specify a path to the file with a list of directories that need to be excluded when running *-all commands.

https://linear.app/gruntwork/issue/TG-19/improve-pre-flight-validation-tooling-in-terragrunt#comment-73a32adb

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

