### PR TITLE
Added --terragrunt-excludes-file flag

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -315,6 +315,12 @@ func initialSetup(cliCtx *cli.Context, opts *options.TerragruntOptions) error {
 		return err
 	}
 
+	excludeDirs, err := util.GetExcludeDirsFromFile(opts.WorkingDir, opts.ExcludesFile)
+	if err != nil {
+		return err
+	}
+	opts.ExcludeDirs = append(opts.ExcludeDirs, excludeDirs...)
+
 	// --- Terragrunt Version
 	terragruntVersion, err := hashicorpversion.NewVersion(cliCtx.App.Version)
 	if err != nil {

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -27,6 +27,7 @@ const (
 	TerragruntIgnoreDependencyOrderFlagName          = "terragrunt-ignore-dependency-order"
 	TerragruntIgnoreExternalDependenciesFlagName     = "terragrunt-ignore-external-dependencies"
 	TerragruntIncludeExternalDependenciesFlagName    = "terragrunt-include-external-dependencies"
+	TerragruntExcludesFile                           = "terragrunt-excludes-file"
 	TerragruntExcludeDirFlagName                     = "terragrunt-exclude-dir"
 	TerragruntIncludeDirFlagName                     = "terragrunt-include-dir"
 	TerragruntStrictIncludeFlagName                  = "terragrunt-strict-include"
@@ -194,6 +195,12 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 			Destination: &opts.Parallelism,
 			EnvVar:      "TERRAGRUNT_PARALLELISM",
 			Usage:       "*-all commands parallelism set to at most N modules",
+		},
+		&cli.GenericFlag[string]{
+			Name:        TerragruntExcludesFile,
+			Destination: &opts.ExcludesFile,
+			EnvVar:      "TERRAGRUNT_EXCLUDES_FILE",
+			Usage:       "Path to a file with a list of directories that need to be excluded when running *-all commands.",
 		},
 		&cli.SliceFlag[string]{
 			Name:        TerragruntExcludeDirFlagName,

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -47,6 +47,7 @@ This page documents the CLI commands and options available with Terragrunt:
   - [terragrunt-iam-role](#terragrunt-iam-role)
   - [terragrunt-iam-assume-role-duration](#terragrunt-iam-assume-role-duration)
   - [terragrunt-iam-assume-role-session-name](#terragrunt-iam-assume-role-session-name)
+  - [terragrunt-excludes-file](#terragrunt-excludes-file)
   - [terragrunt-exclude-dir](#terragrunt-exclude-dir)
   - [terragrunt-include-dir](#terragrunt-include-dir)
   - [terragrunt-strict-include](#terragrunt-strict-include)
@@ -714,6 +715,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
   - [terragrunt-iam-role](#terragrunt-iam-role)
   - [terragrunt-iam-assume-role-duration](#terragrunt-iam-assume-role-duration)
   - [terragrunt-iam-assume-role-session-name](#terragrunt-iam-assume-role-session-name)
+  - [terragrunt-excludes-file](#terragrunt-excludes-file)
   - [terragrunt-exclude-dir](#terragrunt-exclude-dir)
   - [terragrunt-include-dir](#terragrunt-include-dir)
   - [terragrunt-strict-include](#terragrunt-strict-include)
@@ -932,6 +934,16 @@ Uses the specified duration as the session duration (in seconds) for the STS ses
 **Requires an argument**: `--terragrunt-iam-assume-role-session-name "terragrunt-iam-role-session-name"`<br/>
 
 Used as the session name for the STS session which assumes the role defined in `--terragrunt-iam-role`.
+
+### terragrunt-excludes-file
+
+**CLI Arg**: `--terragrunt-excludes-file`<br/>
+**Environment Variable**: `TERRAGRUNT_EXCLUDES_FILE`<br/>
+**Requires an argument**: `--terragrunt-excludes-file /path/to/file`<br/>
+
+Path to a file with a list of directories that need to be excluded when running *-all commands, by default `.terragrunt-excludes`. Modules under these directories will be
+excluded during execution of the commands. If a relative path is specified, it should be relative from
+[--terragrunt-working-dir](#terragrunt-working-dir). This will only exclude the module, not its dependencies.
 
 ### terragrunt-exclude-dir
 

--- a/options/options.go
+++ b/options/options.go
@@ -37,6 +37,8 @@ const (
 	DefaultIAMAssumeRoleDuration = 3600
 
 	minCommandLength = 2
+
+	defaultExcludesFile = ".terragrunt-excludes"
 )
 
 var (
@@ -191,6 +193,9 @@ type TerragruntOptions struct {
 
 	// RetryableErrors is an array of regular expressions with RE2 syntax (https://github.com/google/re2/wiki/Syntax) that qualify for retrying
 	RetryableErrors []string
+
+	// Path to a file with a list of directories that need  to be excluded when running *-all commands.
+	ExcludesFile string
 
 	// Unix-style glob of directories to exclude when running *-all commands
 	ExcludeDirs []string
@@ -361,6 +366,7 @@ func MergeIAMRoleOptions(target IAMRoleOptions, source IAMRoleOptions) IAMRoleOp
 func NewTerragruntOptions() *TerragruntOptions {
 	return &TerragruntOptions{
 		TerraformPath:                  DefaultWrappedPath,
+		ExcludesFile:                   defaultExcludesFile,
 		OriginalTerraformCommand:       "",
 		TerraformCommand:               "",
 		AutoInit:                       true,
@@ -514,6 +520,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) *TerragruntOpt
 		RetryMaxAttempts:               opts.RetryMaxAttempts,
 		RetrySleepIntervalSec:          opts.RetrySleepIntervalSec,
 		RetryableErrors:                util.CloneStringList(opts.RetryableErrors),
+		ExcludesFile:                   opts.ExcludesFile,
 		ExcludeDirs:                    opts.ExcludeDirs,
 		IncludeDirs:                    opts.IncludeDirs,
 		ModulesThatInclude:             opts.ModulesThatInclude,

--- a/util/file.go
+++ b/util/file.go
@@ -658,3 +658,36 @@ func GetTempDir() (string, error) {
 
 	return tempDir, nil
 }
+
+// GetExcludeDirsFromFile returns a list of directories from the given filename, where each directory path starts on a new line.
+func GetExcludeDirsFromFile(baseDir, filename string) ([]string, error) {
+	filename, err := CanonicalPath(filename, baseDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if !FileExists(filename) || !IsFile(filename) {
+		return nil, nil
+	}
+
+	str, err := ReadFileAsString(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var dirs []string
+
+	lines := strings.Split(strings.ReplaceAll(str, "\r\n", "\n"), "\n")
+	for _, line := range lines {
+		dir := strings.TrimSpace(line)
+
+		newDirs, err := GlobCanonicalPath(baseDir, dir)
+		if err != nil {
+			return nil, err
+		}
+
+		dirs = append(dirs, newDirs...)
+	}
+
+	return dirs, nil
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

The PR is adding a new flag `--terragrunt-excludes-file`, which allows to specify a path to the file with a list of directories that need to be excluded when running *-all commands.

https://linear.app/gruntwork/issue/TG-19/improve-pre-flight-validation-tooling-in-terragrunt#comment-73a32adb

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

