### PR TITLE
Hiding diagnostic error when first parsing `remote_state`

### DIFF
--- a/cli/commands/hclfmt/action.go
+++ b/cli/commands/hclfmt/action.go
@@ -131,7 +131,9 @@ func formatTgHCL(opts *options.TerragruntOptions, tgHclFile string) error {
 func checkErrors(logger *logrus.Entry, disableColor bool, contents []byte, tgHclFile string) error {
 	parser := hclparse.NewParser()
 	_, diags := parser.ParseHCL(contents, tgHclFile)
-	diagWriter := util.GetDiagnosticsWriter(logger, parser, disableColor)
+
+	writer := &util.LogWriter{Logger: logger, Level: logrus.ErrorLevel}
+	diagWriter := util.GetDiagnosticsWriter(writer, parser, disableColor)
 	err := diagWriter.WriteDiagnostics(diags)
 	if err != nil {
 		return errors.WithStackTrace(err)

--- a/config/config.go
+++ b/config/config.go
@@ -73,8 +73,10 @@ var (
 	}
 
 	DefaultParserOptions = func(opts *options.TerragruntOptions) []hclparse.Option {
+		writer := &util.LogWriter{Logger: opts.Logger, Level: logrus.ErrorLevel}
+
 		return []hclparse.Option{
-			hclparse.WithLogger(opts.Logger, opts.DisableLogColors),
+			hclparse.WithDiagnosticsWriter(writer, opts.DisableLogColors),
 			hclparse.WithFileUpdate(updateBareIncludeBlock),
 		}
 	}

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -642,8 +642,9 @@ func getTerragruntOutputJson(ctx *ParsingContext, targetConfig string) ([]byte, 
 
 	// First attempt to parse the `remote_state` blocks without parsing/getting dependency outputs. If this is possible,
 	// proceed to routine that fetches remote state directly. Otherwise, fallback to calling `terragrunt output`
-	// directly.
-	remoteStateTGConfig, err := PartialParseConfigFile(ctx.WithDecodeList(RemoteStateBlock, TerragruntFlags), targetConfig, nil)
+	// directly. We need to suspend logging diagnostic errors on this attempt.
+	parseOptions := append(ctx.ParserOptions, hclparse.WithDiagnosticsWriter(io.Discard, true))
+	remoteStateTGConfig, err := PartialParseConfigFile(ctx.WithParseOption(parseOptions).WithDecodeList(RemoteStateBlock, TerragruntFlags), targetConfig, nil)
 	if err != nil || !canGetRemoteState(remoteStateTGConfig.RemoteState) {
 		ctx.TerragruntOptions.Logger.Debugf("Could not parse remote_state block from target config %s", targetConfig)
 		ctx.TerragruntOptions.Logger.Debugf("Falling back to terragrunt output.")

--- a/config/hclparse/options.go
+++ b/config/hclparse/options.go
@@ -1,19 +1,20 @@
 package hclparse
 
 import (
+	"io"
+
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/sirupsen/logrus"
 )
 
 type Option func(*Parser) *Parser
 
-func WithLogger(logger *logrus.Entry, disableColor bool) Option {
+func WithDiagnosticsWriter(writer io.Writer, disableColor bool) Option {
 	return func(parser *Parser) *Parser {
-		diagsWriter := util.GetDiagnosticsWriter(logger, parser.Parser, disableColor)
+		diagsWriter := util.GetDiagnosticsWriter(writer, parser.Parser, disableColor)
 
-		parser.loggerFunc = func(diags hcl.Diagnostics) error {
+		parser.diagsWriterFunc = func(diags hcl.Diagnostics) error {
 			if !diags.HasErrors() {
 				return nil
 			}

--- a/config/hclparse/parser.go
+++ b/config/hclparse/parser.go
@@ -15,7 +15,7 @@ import (
 
 type Parser struct {
 	*hclparse.Parser
-	loggerFunc            func(hcl.Diagnostics) error
+	diagsWriterFunc       func(hcl.Diagnostics) error
 	handleDiagnosticsFunc func(*File, hcl.Diagnostics) (hcl.Diagnostics, error)
 	fileUpdateHandlerFunc func(*File) error
 }
@@ -95,7 +95,7 @@ func (parser *Parser) handleDiagnostics(file *File, diags hcl.Diagnostics) error
 		}
 	}
 
-	if fn := parser.loggerFunc; fn != nil {
+	if fn := parser.diagsWriterFunc; fn != nil {
 		if err := fn(diags); err != nil {
 			return err
 		}

--- a/util/logger.go
+++ b/util/logger.go
@@ -96,14 +96,13 @@ func CreateLogEntryWithWriter(writer io.Writer, prefix string, level logrus.Leve
 }
 
 // GetDiagnosticsWriter returns a hcl2 parsing diagnostics emitter for the current terminal.
-func GetDiagnosticsWriter(logger *logrus.Entry, parser *hclparse.Parser, disableColor bool) hcl.DiagnosticWriter {
+func GetDiagnosticsWriter(writer io.Writer, parser *hclparse.Parser, disableColor bool) hcl.DiagnosticWriter {
 	termColor := !disableColor && term.IsTerminal(int(os.Stderr.Fd()))
 	termWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
 		termWidth = 80
 	}
-	var writer = LogWriter{Logger: logger, Level: logrus.ErrorLevel}
-	return hcl.NewDiagnosticTextWriter(&writer, parser.Files(), uint(termWidth), termColor)
+	return hcl.NewDiagnosticTextWriter(writer, parser.Files(), uint(termWidth), termColor)
 }
 
 // GetDefaultLogLevel returns the default log level to use. The log level is resolved based on the environment variable


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

After refactoring the code in version v0.54.16, and moving the diags logger writer to inside of the `hclparse` package, it began to display a diags parse error during a first parsing of the `remote_state` block, when it should not. In fact, the fix hides the diag errors.

https://github.com/gruntwork-io/terragrunt/blob/95f356ec87e295d1a300c3e2acda904e865828f7/config/dependency.go#L646

Fixes #3036.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

