### PR TITLE
Add handling of multi line variables description

### DIFF
--- a/cli/commands/scaffold/action.go
+++ b/cli/commands/scaffold/action.go
@@ -61,7 +61,14 @@ inputs = {
   # Required input variables
   # --------------------------------------------------------------------------------------------------------------------
   {{ range .requiredVariables }}
+  {{- if eq 1 (regexSplit "\n" .Description -1 | len ) }}
   # Description: {{ .Description }}
+  {{- else }}
+  # Description:
+    {{- range $line := regexSplit "\n" .Description -1 }}
+    # {{ $line | indent 4 }}
+    {{- end }}
+  {{- end }}
   # Type: {{ .Type }}
   {{ .Name }} = {{ .DefaultValuePlaceholder }}  # TODO: fill in value
   {{ end }}
@@ -71,7 +78,14 @@ inputs = {
   # Uncomment the ones you wish to set
   # --------------------------------------------------------------------------------------------------------------------
   {{ range .optionalVariables }}
+  {{- if eq 1 (regexSplit "\n" .Description -1 | len ) }}
   # Description: {{ .Description }}
+  {{- else }}
+  # Description:
+    {{- range $line := regexSplit "\n" .Description -1 }}
+    # {{ $line | indent 4 }}
+    {{- end }}
+  {{- end }}
   # Type: {{ .Type }}
   # {{ .Name }} = {{ .DefaultValue }}
   {{ end }}

--- a/cli/commands/scaffold/action.go
+++ b/cli/commands/scaffold/action.go
@@ -66,7 +66,7 @@ inputs = {
   {{- else }}
   # Description:
     {{- range $line := regexSplit "\n" .Description -1 }}
-    # {{ $line | indent 4 }}
+    # {{ $line | indent 2 }}
     {{- end }}
   {{- end }}
   # Type: {{ .Type }}
@@ -83,7 +83,7 @@ inputs = {
   {{- else }}
   # Description:
     {{- range $line := regexSplit "\n" .Description -1 }}
-    # {{ $line | indent 4 }}
+    # {{ $line | indent 2 }}
     {{- end }}
   {{- end }}
   # Type: {{ .Type }}

--- a/test/fixture-scaffold/scaffold-module/variables.tf
+++ b/test/fixture-scaffold/scaffold-module/variables.tf
@@ -22,7 +22,10 @@ variable "enabled" {
 
 variable "open_port" {
   type        = number
-  description = "Port to open"
+  description = <<-EOF
+    Port to be opened in the security group
+    Can be a single port or a range
+  EOF
 }
 
 variable "enable_backups" {

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -199,7 +199,11 @@ func TestScaffoldLocalModule(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_LOCAL_MODULE), &stdout, &stderr)
+	// get working directory
+	workingDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, workingDir+"//"+TEST_SCAFFOLD_LOCAL_MODULE), &stdout, &stderr)
 	require.NoError(t, err)
 	require.Contains(t, stderr.String(), "Scaffolding completed")
 	require.FileExists(t, fmt.Sprintf("%s/terragrunt.hcl", tmpEnvPath))

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -13,14 +13,15 @@ import (
 )
 
 const (
-	TEST_SCAFOLD_MODULE                   = "https://github.com/gruntwork-io/terragrunt.git//test/fixture-scaffold/scaffold-module"
-	TEST_SCAFOLD_MODULE_GIT               = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/scaffold-module"
-	TEST_SCAFOLD_MODULE_SHORT             = "github.com/gruntwork-io/terragrunt.git//test/fixture-inputs"
-	TEST_SCAFOLD_TEMPLATE_MODULE          = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/module-with-template"
-	TEST_SCAFOLD_EXTERNAL_TEMPLATE_MODULE = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/external-template"
+	TEST_SCAFFOLD_MODULE                   = "https://github.com/gruntwork-io/terragrunt.git//test/fixture-scaffold/scaffold-module"
+	TEST_SCAFFOLD_MODULE_GIT               = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/scaffold-module"
+	TEST_SCAFFOLD_MODULE_SHORT             = "github.com/gruntwork-io/terragrunt.git//test/fixture-inputs"
+	TEST_SCAFFOLD_TEMPLATE_MODULE          = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/module-with-template"
+	TEST_SCAFFOLD_EXTERNAL_TEMPLATE_MODULE = "git@github.com:gruntwork-io/terragrunt.git//test/fixture-scaffold/external-template"
+	TEST_SCAFFOLD_LOCAL_MODULE             = "fixture-scaffold/scaffold-module"
 )
 
-func TestTerragruntScaffoldModule(t *testing.T) {
+func TestScaffoldModule(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
@@ -29,13 +30,13 @@ func TestTerragruntScaffoldModule(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFOLD_MODULE), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_MODULE), &stdout, &stderr)
 	require.NoError(t, err)
 	require.Contains(t, stderr.String(), "Scaffolding completed")
 	require.FileExists(t, fmt.Sprintf("%s/terragrunt.hcl", tmpEnvPath))
 }
 
-func TestTerragruntScaffoldModuleShortUrl(t *testing.T) {
+func TestScaffoldModuleShortUrl(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
@@ -44,7 +45,7 @@ func TestTerragruntScaffoldModuleShortUrl(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFOLD_MODULE_SHORT), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_MODULE_SHORT), &stdout, &stderr)
 	require.NoError(t, err)
 	require.Contains(t, stderr.String(), "Scaffolding completed")
 	// check that find_in_parent_folders is generated in terragrunt.hcl
@@ -53,7 +54,7 @@ func TestTerragruntScaffoldModuleShortUrl(t *testing.T) {
 	require.Contains(t, content, "find_in_parent_folders")
 }
 
-func TestTerragruntScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
+func TestScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
@@ -62,7 +63,7 @@ func TestTerragruntScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=EnableRootInclude=false", tmpEnvPath, TEST_SCAFOLD_MODULE_SHORT), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=EnableRootInclude=false", tmpEnvPath, TEST_SCAFFOLD_MODULE_SHORT), &stdout, &stderr)
 	require.NoError(t, err)
 	require.Contains(t, stderr.String(), "Scaffolding completed")
 	// check that find_in_parent_folders is NOT generated in  terragrunt.hcl
@@ -71,7 +72,7 @@ func TestTerragruntScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
 	require.NotContains(t, content, "find_in_parent_folders")
 }
 
-func TestTerragruntScaffoldModuleDifferentRevision(t *testing.T) {
+func TestScaffoldModuleDifferentRevision(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
@@ -80,14 +81,14 @@ func TestTerragruntScaffoldModuleDifferentRevision(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=Ref=v0.53.1", tmpEnvPath, TEST_SCAFOLD_MODULE_SHORT), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=Ref=v0.53.1", tmpEnvPath, TEST_SCAFFOLD_MODULE_SHORT), &stdout, &stderr)
 
 	require.NoError(t, err)
 	require.Contains(t, stderr.String(), "git::https://github.com/gruntwork-io/terragrunt.git//test/fixture-inputs?ref=v0.53.1")
 	require.Contains(t, stderr.String(), "Scaffolding completed")
 }
 
-func TestTerragruntScaffoldModuleDifferentRevisionAndSsh(t *testing.T) {
+func TestScaffoldModuleDifferentRevisionAndSsh(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
@@ -96,13 +97,13 @@ func TestTerragruntScaffoldModuleDifferentRevisionAndSsh(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=Ref=v0.53.1 --var=SourceUrlType=git-ssh", tmpEnvPath, TEST_SCAFOLD_MODULE_SHORT), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=Ref=v0.53.1 --var=SourceUrlType=git-ssh", tmpEnvPath, TEST_SCAFFOLD_MODULE_SHORT), &stdout, &stderr)
 	require.NoError(t, err)
 	require.Contains(t, stderr.String(), "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixture-inputs?ref=v0.53.1")
 	require.Contains(t, stderr.String(), "Scaffolding completed")
 }
 
-func TestTerragruntScaffoldModuleSsh(t *testing.T) {
+func TestScaffoldModuleSsh(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
@@ -111,12 +112,12 @@ func TestTerragruntScaffoldModuleSsh(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFOLD_MODULE_GIT), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_MODULE_GIT), &stdout, &stderr)
 	require.NoError(t, err)
 	require.Contains(t, stderr.String(), "Scaffolding completed")
 }
 
-func TestTerragruntScaffoldModuleTemplate(t *testing.T) {
+func TestScaffoldModuleTemplate(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
@@ -125,14 +126,14 @@ func TestTerragruntScaffoldModuleTemplate(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFOLD_TEMPLATE_MODULE), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_TEMPLATE_MODULE), &stdout, &stderr)
 	require.NoError(t, err)
 	require.Contains(t, stderr.String(), "Scaffolding completed")
 	// check that exists file from .boilerplate dir
 	require.FileExists(t, fmt.Sprintf("%s/template-file.txt", tmpEnvPath))
 }
 
-func TestTerragruntScaffoldModuleExternalTemplate(t *testing.T) {
+func TestScaffoldModuleExternalTemplate(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
@@ -141,14 +142,14 @@ func TestTerragruntScaffoldModuleExternalTemplate(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s %s", tmpEnvPath, TEST_SCAFOLD_MODULE_GIT, TEST_SCAFOLD_EXTERNAL_TEMPLATE_MODULE), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s %s", tmpEnvPath, TEST_SCAFFOLD_MODULE_GIT, TEST_SCAFFOLD_EXTERNAL_TEMPLATE_MODULE), &stdout, &stderr)
 	require.NoError(t, err)
 	require.Contains(t, stderr.String(), "Scaffolding completed")
 	// check that exists file from external template
 	require.FileExists(t, fmt.Sprintf("%s/external-template.txt", tmpEnvPath))
 }
 
-func TestTerragruntScaffoldErrorNoModuleUrl(t *testing.T) {
+func TestScaffoldErrorNoModuleUrl(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
@@ -162,7 +163,7 @@ func TestTerragruntScaffoldErrorNoModuleUrl(t *testing.T) {
 	require.Contains(t, err.Error(), "No module URL passed")
 }
 
-func TestTerragruntScaffoldModuleVarFile(t *testing.T) {
+func TestScaffoldModuleVarFile(t *testing.T) {
 	t.Parallel()
 	// generate var file with specific version, without root include and use GIT/SSH to clone module.
 	varFileContent := `
@@ -180,11 +181,26 @@ SourceUrlType: "git-ssh"
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var-file=%s", tmpEnvPath, TEST_SCAFOLD_MODULE_SHORT, varFile), &stdout, &stderr)
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var-file=%s", tmpEnvPath, TEST_SCAFFOLD_MODULE_SHORT, varFile), &stdout, &stderr)
 	require.NoError(t, err)
 	require.Contains(t, stderr.String(), "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixture-inputs?ref=v0.53.1")
 	require.Contains(t, stderr.String(), "Scaffolding completed")
 	content, err := util.ReadFileAsString(fmt.Sprintf("%s/terragrunt.hcl", tmpEnvPath))
 	require.NoError(t, err)
 	require.NotContains(t, content, "find_in_parent_folders")
+}
+
+func TestScaffoldLocalModule(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
+	require.NoError(t, err)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_LOCAL_MODULE), &stdout, &stderr)
+	require.NoError(t, err)
+	require.Contains(t, stderr.String(), "Scaffolding completed")
+	require.FileExists(t, fmt.Sprintf("%s/terragrunt.hcl", tmpEnvPath))
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Add handling of multi-line variables description
Included changes:
* updated go template to handle multi-line description
* updated tests to validate local and remote repositories for handling multi-line description
* simplified naming convention for tests
* simplified tests to use `runTerragruntCommandWithOutput` without creation of buffers for outputs


Fixes #3264.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated `scaffold` to support multi-line variables description.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

