### PR TITLE
Fixing generation of `provider_installation` block used for provider caching

### DIFF
--- a/cli/commands/terraform/creds/providers/externalcmd/provider.go
+++ b/cli/commands/terraform/creds/providers/externalcmd/provider.go
@@ -43,7 +43,6 @@ func (provider *Provider) GetCredentials(ctx context.Context) (*providers.Creden
 		args = parts[1:]
 	}
 
-	provider.terragruntOptions.Logger.Infof("Executing %s to obtain Terragrunt credentials", provider.Name())
 	output, err := shell.RunShellCommandWithOutput(ctx, provider.terragruntOptions, "", true, false, command, args...)
 	if err != nil {
 		return nil, err

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -182,7 +183,7 @@ type DeleteTableRetryer struct {
 }
 
 func (retryer DeleteTableRetryer) ShouldRetry(req *request.Request) bool {
-	if req.HTTPResponse.StatusCode == 400 {
+	if req.HTTPResponse.StatusCode == http.StatusBadRequest {
 		return true
 	}
 	return retryer.DefaultRetryer.ShouldRetry(req)

--- a/terraform/cliconfig/config.go
+++ b/terraform/cliconfig/config.go
@@ -91,11 +91,11 @@ func (cfg *Config) AddHost(name string, services map[string]string) {
 //			exclude = ["example.com/*/*"]
 //		}
 //	}
-func (cfg *Config) AddProviderInstallationMethods(methods ...ProviderInstallationMethod) {
+func (cfg *Config) AddProviderInstallationMethods(newMethods ...ProviderInstallationMethod) {
 	if cfg.ProviderInstallation == nil {
 		cfg.ProviderInstallation = &ProviderInstallation{}
 	}
-	cfg.ProviderInstallation.Methods = append(cfg.ProviderInstallation.Methods, methods...)
+	cfg.ProviderInstallation.Methods = cfg.ProviderInstallation.Methods.Merge(newMethods...)
 }
 
 // Save marshalls and saves CLI config with the given config path.

--- a/terraform/cliconfig/provider_installation.go
+++ b/terraform/cliconfig/provider_installation.go
@@ -1,8 +1,80 @@
 package cliconfig
 
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/gruntwork-io/terragrunt/util"
+)
+
 // ProviderInstallation is the structure of the "provider_installation" nested block within the CLI configuration.
 type ProviderInstallation struct {
-	Methods []ProviderInstallationMethod `hcl:",block"`
+	Methods ProviderInstallationMethods `hcl:",block"`
+}
+
+type ProviderInstallationMethods []ProviderInstallationMethod
+
+func (methods ProviderInstallationMethods) Merge(withMethods ...ProviderInstallationMethod) ProviderInstallationMethods {
+	for _, method := range methods {
+		remainedWithMethods := withMethods
+		withMethods = ProviderInstallationMethods{}
+
+		for _, withMethod := range remainedWithMethods {
+			var isMerged bool
+
+			if method, ok := method.(*ProviderInstallationFilesystemMirror); ok {
+				if withMethod, ok := withMethod.(*ProviderInstallationFilesystemMirror); ok && method.Path == withMethod.Path {
+					if withMethod.Exclude != nil {
+						method.AppendExclude(*withMethod.Exclude)
+					}
+					if withMethod.Include != nil {
+						method.AppendInclude(*withMethod.Include)
+					}
+					isMerged = true
+				}
+			}
+
+			if method, ok := method.(*ProviderInstallationNetworkMirror); ok {
+				if withMethod, ok := withMethod.(*ProviderInstallationNetworkMirror); ok && method.URL == withMethod.URL {
+					if withMethod.Exclude != nil {
+						method.AppendExclude(*withMethod.Exclude)
+					}
+					if withMethod.Include != nil {
+						method.AppendInclude(*withMethod.Include)
+					}
+					isMerged = true
+				}
+			}
+
+			if method, ok := method.(*ProviderInstallationDirect); ok {
+				if withMethod, ok := withMethod.(*ProviderInstallationDirect); ok {
+					if withMethod.Exclude != nil {
+						method.AppendExclude(*withMethod.Exclude)
+					}
+					if withMethod.Include != nil {
+						method.AppendInclude(*withMethod.Include)
+					}
+					isMerged = true
+				}
+			}
+
+			if !isMerged {
+				withMethods = append(withMethods, withMethod)
+			}
+		}
+	}
+
+	mergedMethods := append(methods, withMethods...)
+
+	sort.Slice(mergedMethods, func(i, j int) bool {
+		if _, ok := mergedMethods[j].(*ProviderInstallationDirect); ok {
+			return true
+		}
+		return false
+	})
+
+	return mergedMethods
 }
 
 // ProviderInstallationMethod is an interface type representing the different installation path types and represents an installation method block inside a provider_installation block. The concrete implementations of this interface are:
@@ -10,6 +82,8 @@ type ProviderInstallation struct {
 //	ProviderInstallationDirect:           install from the provider's origin registry
 //	ProviderInstallationFilesystemMirror: install from a local filesystem mirror
 type ProviderInstallationMethod interface {
+	fmt.Stringer
+	AppendInclude(addrs []string)
 	AppendExclude(addrs []string)
 }
 
@@ -35,11 +109,23 @@ func NewProviderInstallationDirect(include, exclude []string) *ProviderInstallat
 	return res
 }
 
+func (method *ProviderInstallationDirect) AppendInclude(addrs []string) {
+	if method.Include == nil {
+		method.Include = &[]string{}
+	}
+	*method.Include = util.RemoveDuplicatesFromList(append(*method.Include, addrs...))
+}
+
 func (method *ProviderInstallationDirect) AppendExclude(addrs []string) {
 	if method.Exclude == nil {
 		method.Exclude = &[]string{}
 	}
-	*method.Exclude = append(*method.Exclude, addrs...)
+	*method.Exclude = util.RemoveDuplicatesFromList(append(*method.Exclude, addrs...))
+}
+
+func (method *ProviderInstallationDirect) String() string {
+	b, _ := json.Marshal(method) //nolint:errcheck
+	return string(b)
 }
 
 type ProviderInstallationFilesystemMirror struct {
@@ -66,11 +152,23 @@ func NewProviderInstallationFilesystemMirror(path string, include, exclude []str
 	return res
 }
 
+func (method *ProviderInstallationFilesystemMirror) AppendInclude(addrs []string) {
+	if method.Include == nil {
+		method.Include = &[]string{}
+	}
+	*method.Include = util.RemoveDuplicatesFromList(append(*method.Include, addrs...))
+}
+
 func (method *ProviderInstallationFilesystemMirror) AppendExclude(addrs []string) {
 	if method.Exclude == nil {
 		method.Exclude = &[]string{}
 	}
-	*method.Exclude = append(*method.Exclude, addrs...)
+	*method.Exclude = util.RemoveDuplicatesFromList(append(*method.Exclude, addrs...))
+}
+
+func (method *ProviderInstallationFilesystemMirror) String() string {
+	b, _ := json.Marshal(method) //nolint:errcheck
+	return string(b)
 }
 
 type ProviderInstallationNetworkMirror struct {
@@ -97,9 +195,21 @@ func NewProviderInstallationNetworkMirror(url string, include, exclude []string)
 	return res
 }
 
+func (method *ProviderInstallationNetworkMirror) AppendInclude(addrs []string) {
+	if method.Include == nil {
+		method.Include = &[]string{}
+	}
+	*method.Include = util.RemoveDuplicatesFromList(append(*method.Include, addrs...))
+}
+
 func (method *ProviderInstallationNetworkMirror) AppendExclude(addrs []string) {
 	if method.Exclude == nil {
 		method.Exclude = &[]string{}
 	}
-	*method.Exclude = append(*method.Exclude, addrs...)
+	*method.Exclude = util.RemoveDuplicatesFromList(append(*method.Exclude, addrs...))
+}
+
+func (method *ProviderInstallationNetworkMirror) String() string {
+	b, _ := json.Marshal(method) //nolint:errcheck
+	return string(b)
 }

--- a/terraform/cliconfig/provider_installation.go
+++ b/terraform/cliconfig/provider_installation.go
@@ -85,6 +85,7 @@ type ProviderInstallationMethod interface {
 	fmt.Stringer
 	AppendInclude(addrs []string)
 	AppendExclude(addrs []string)
+	RemoveExclude(addrs []string)
 }
 
 type ProviderInstallationDirect struct {
@@ -110,6 +111,9 @@ func NewProviderInstallationDirect(include, exclude []string) *ProviderInstallat
 }
 
 func (method *ProviderInstallationDirect) AppendInclude(addrs []string) {
+	if len(addrs) == 0 {
+		return
+	}
 	if method.Include == nil {
 		method.Include = &[]string{}
 	}
@@ -117,10 +121,24 @@ func (method *ProviderInstallationDirect) AppendInclude(addrs []string) {
 }
 
 func (method *ProviderInstallationDirect) AppendExclude(addrs []string) {
+	if len(addrs) == 0 {
+		return
+	}
 	if method.Exclude == nil {
 		method.Exclude = &[]string{}
 	}
 	*method.Exclude = util.RemoveDuplicatesFromList(append(*method.Exclude, addrs...))
+}
+
+func (method *ProviderInstallationDirect) RemoveExclude(addrs []string) {
+	if len(addrs) == 0 || method.Exclude == nil {
+		return
+	}
+	*method.Exclude = util.RemoveSublistFromList(*method.Exclude, addrs)
+
+	if len(*method.Exclude) == 0 {
+		method.Exclude = nil
+	}
 }
 
 func (method *ProviderInstallationDirect) String() string {
@@ -153,6 +171,9 @@ func NewProviderInstallationFilesystemMirror(path string, include, exclude []str
 }
 
 func (method *ProviderInstallationFilesystemMirror) AppendInclude(addrs []string) {
+	if len(addrs) == 0 {
+		return
+	}
 	if method.Include == nil {
 		method.Include = &[]string{}
 	}
@@ -160,10 +181,24 @@ func (method *ProviderInstallationFilesystemMirror) AppendInclude(addrs []string
 }
 
 func (method *ProviderInstallationFilesystemMirror) AppendExclude(addrs []string) {
+	if len(addrs) == 0 {
+		return
+	}
 	if method.Exclude == nil {
 		method.Exclude = &[]string{}
 	}
 	*method.Exclude = util.RemoveDuplicatesFromList(append(*method.Exclude, addrs...))
+}
+
+func (method *ProviderInstallationFilesystemMirror) RemoveExclude(addrs []string) {
+	if len(addrs) == 0 || method.Exclude == nil {
+		return
+	}
+	*method.Exclude = util.RemoveSublistFromList(*method.Exclude, addrs)
+
+	if len(*method.Exclude) == 0 {
+		method.Exclude = nil
+	}
 }
 
 func (method *ProviderInstallationFilesystemMirror) String() string {
@@ -196,6 +231,9 @@ func NewProviderInstallationNetworkMirror(url string, include, exclude []string)
 }
 
 func (method *ProviderInstallationNetworkMirror) AppendInclude(addrs []string) {
+	if len(addrs) == 0 {
+		return
+	}
 	if method.Include == nil {
 		method.Include = &[]string{}
 	}
@@ -203,10 +241,24 @@ func (method *ProviderInstallationNetworkMirror) AppendInclude(addrs []string) {
 }
 
 func (method *ProviderInstallationNetworkMirror) AppendExclude(addrs []string) {
+	if len(addrs) == 0 {
+		return
+	}
 	if method.Exclude == nil {
 		method.Exclude = &[]string{}
 	}
 	*method.Exclude = util.RemoveDuplicatesFromList(append(*method.Exclude, addrs...))
+}
+
+func (method *ProviderInstallationNetworkMirror) RemoveExclude(addrs []string) {
+	if len(addrs) == 0 || method.Exclude == nil {
+		return
+	}
+	*method.Exclude = util.RemoveSublistFromList(*method.Exclude, addrs)
+
+	if len(*method.Exclude) == 0 {
+		method.Exclude = nil
+	}
 }
 
 func (method *ProviderInstallationNetworkMirror) String() string {

--- a/terraform/cliconfig/provider_installation.go
+++ b/terraform/cliconfig/provider_installation.go
@@ -23,8 +23,8 @@ func (methods ProviderInstallationMethods) Merge(withMethods ...ProviderInstalla
 		for _, withMethod := range remainedWithMethods {
 			var isMerged bool
 
-			if method, ok := method.(*ProviderInstallationFilesystemMirror); ok {
-				if withMethod, ok := withMethod.(*ProviderInstallationFilesystemMirror); ok && method.Path == withMethod.Path {
+			if fsMirrorMethod, ok := method.(*ProviderInstallationFilesystemMirror); ok {
+				if withMethod, ok := withMethod.(*ProviderInstallationFilesystemMirror); ok && fsMirrorMethod.Path == withMethod.Path {
 					if withMethod.Exclude != nil {
 						method.AppendExclude(*withMethod.Exclude)
 					}
@@ -35,8 +35,8 @@ func (methods ProviderInstallationMethods) Merge(withMethods ...ProviderInstalla
 				}
 			}
 
-			if method, ok := method.(*ProviderInstallationNetworkMirror); ok {
-				if withMethod, ok := withMethod.(*ProviderInstallationNetworkMirror); ok && method.URL == withMethod.URL {
+			if netMirrorMethod, ok := method.(*ProviderInstallationNetworkMirror); ok {
+				if withMethod, ok := withMethod.(*ProviderInstallationNetworkMirror); ok && netMirrorMethod.URL == withMethod.URL {
 					if withMethod.Exclude != nil {
 						method.AppendExclude(*withMethod.Exclude)
 					}
@@ -47,7 +47,7 @@ func (methods ProviderInstallationMethods) Merge(withMethods ...ProviderInstalla
 				}
 			}
 
-			if method, ok := method.(*ProviderInstallationDirect); ok {
+			if _, ok := method.(*ProviderInstallationDirect); ok {
 				if withMethod, ok := withMethod.(*ProviderInstallationDirect); ok {
 					if withMethod.Exclude != nil {
 						method.AppendExclude(*withMethod.Exclude)

--- a/test/cliconfig.go
+++ b/test/cliconfig.go
@@ -18,7 +18,7 @@ provider_installation {
 {{ if gt (len $method.Include) 0 }}
     include = [{{ range $index, $include := $method.Include }}{{ if $index }},{{ end }}"{{ $include }}"{{ end }}]
 {{ end }}{{ if gt (len $method.Exclude) 0 }}
-    include = [{{ range $index, $exclude := $method.Exclude }}{{ if $index }},{{ end }}"{{ $exclude }}"{{ end }}]
+    exclude = [{{ range $index, $exclude := $method.Exclude }}{{ if $index }},{{ end }}"{{ $exclude }}"{{ end }}]
 {{ end }}
   }
 {{ end }}{{ end }}
@@ -28,7 +28,7 @@ provider_installation {
 {{ if gt (len $method.Include) 0 }}
     include = [{{ range $index, $include := $method.Include }}{{ if $index }},{{ end }}"{{ $include }}"{{ end }}]
 {{ end }}{{ if gt (len $method.Exclude) 0 }}
-    include = [{{ range $index, $exclude := $method.Exclude }}{{ if $index }},{{ end }}"{{ $exclude }}"{{ end }}]
+    exclude = [{{ range $index, $exclude := $method.Exclude }}{{ if $index }},{{ end }}"{{ $exclude }}"{{ end }}]
 {{ end }}
   }
 {{ end }}{{ end }}
@@ -37,7 +37,7 @@ provider_installation {
 {{ if gt (len $method.Include) 0 }}
     include = [{{ range $index, $include := $method.Include }}{{ if $index }},{{ end }}"{{ $include }}"{{ end }}]
 {{ end }}{{ if gt (len $method.Exclude) 0 }}
-    include = [{{ range $index, $exclude := $method.Exclude }}{{ if $index }},{{ end }}"{{ $exclude }}"{{ end }}]
+    exclude = [{{ range $index, $exclude := $method.Exclude }}{{ if $index }},{{ end }}"{{ $exclude }}"{{ end }}]
 {{ end }}
   }
 {{ end }}{{ end }}

--- a/test/fixture-provider-cache/mirror/app/main.tf
+++ b/test/fixture-provider-cache/mirror/app/main.tf
@@ -4,11 +4,11 @@ terraform {
       source = "hashicorp/null"
     }
     network = {
-      source  = "example.com/network/null"
+      source  = "example.com/network/network"
       version = "3.2.2"
     }
     filesystem = {
-      source  = "example.com/filesystem/null"
+      source  = "example.com/filesystem/filesystem"
       version = "3.2.2"
     }
   }

--- a/test/fixture-provider-cache/mirror/app/main.tf
+++ b/test/fixture-provider-cache/mirror/app/main.tf
@@ -3,13 +3,13 @@ terraform {
     null = {
       source = "hashicorp/null"
     }
-    network = {
-      source  = "example.com/network/network"
-      version = "3.2.2"
+    aws = {
+      source  = "example.com/hashicorp/aws"
+      version = "5.59.0"
     }
-    filesystem = {
-      source  = "example.com/filesystem/filesystem"
-      version = "3.2.2"
+    azurerm = {
+      source  = "example.com/hashicorp/azurerm"
+      version = "3.113.0"
     }
   }
 }

--- a/test/fixture-provider-cache/mirror/app/main.tf
+++ b/test/fixture-provider-cache/mirror/app/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     null = {
-      source = "hashicorp/null"
+      source = "registry.opentofu.org/hashicorp/null"
     }
     aws = {
       source  = "example.com/hashicorp/aws"

--- a/test/fixture-provider-cache/mirror/app/main.tf
+++ b/test/fixture-provider-cache/mirror/app/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
-    direct = {
-      source  = "hashicorp/null"
+    null = {
+      source = "hashicorp/null"
     }
     network = {
       source  = "example.com/network/null"

--- a/test/fixture-provider-cache/mirror/app/main.tf
+++ b/test/fixture-provider-cache/mirror/app/main.tf
@@ -1,7 +1,14 @@
 terraform {
   required_providers {
-    null = {
-      source  = "example.com/hashicorp/null"
+    direct = {
+      source  = "hashicorp/null"
+    }
+    network = {
+      source  = "example.com/network/null"
+      version = "3.2.2"
+    }
+    filesystem = {
+      source  = "example.com/filesystem/null"
       version = "3.2.2"
     }
   }

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -69,13 +69,23 @@ func TestTerragruntProviderCacheWithFilesystemMirror(t *testing.T) {
 	cliConfigSettings := &CLIConfigSettings{
 		FilesystemMirrorMethods: []CLIConfigProviderInstallationFilesystemMirror{
 			{
-				Path: providersMirrorPath,
+				Path:    providersMirrorPath,
+				Include: []string{"example.com/*/*"},
 			},
 		},
 	}
 	createCLIConfig(t, cliConfigFilename, cliConfigSettings)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt run-all init --terragrunt-provider-cache --terragrunt-provider-cache-registry-names example.com --terragrunt-provider-cache-dir %s --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", providerCacheDir, appPath))
+	runTerragrunt(t, fmt.Sprintf("terragrunt run-all init --terragrunt-provider-cache --terragrunt-provider-cache-registry-names example.com --terragrunt-provider-cache-registry-names registry.terraform.io --terragrunt-provider-cache-dir %s --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", providerCacheDir, appPath))
+
+	expectedProviderInstallation := `provider_installation { "filesystem_mirror" { path = "%s" include = ["example.com/*/*"] exclude = ["example.com/*/*", "registry.terraform.io/*/*"] } "filesystem_mirror" { path = "%s" include = ["example.com/*/*", "registry.terraform.io/*/*"] } "direct" { } }`
+	expectedProviderInstallation = fmt.Sprintf(strings.Join(strings.Fields(expectedProviderInstallation), " "), providersMirrorPath, providerCacheDir)
+
+	terraformrcBytes, err := os.ReadFile(filepath.Join(appPath, ".terraformrc"))
+	require.NoError(t, err)
+	terraformrc := strings.Join(strings.Fields(string(terraformrcBytes)), " ")
+
+	assert.Contains(t, terraformrc, expectedProviderInstallation, "%s\n\n%s", terraformrc, expectedProviderInstallation)
 }
 
 func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
@@ -126,13 +136,28 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 	cliConfigSettings := &CLIConfigSettings{
 		NetworkMirrorMethods: []CLIConfigProviderInstallationNetworkMirror{
 			{
-				URL: networkMirrorURL.String(),
+				URL:     networkMirrorURL.String(),
+				Include: []string{"example.com/*/*"},
+			},
+		},
+		DirectMethods: []CLIConfigProviderInstallationDirect{
+			{
+				Exclude: []string{"example.com/*/*", "exclude.com/*/*"},
 			},
 		},
 	}
 	createCLIConfig(t, cliConfigFilename, cliConfigSettings)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt run-all init --terragrunt-provider-cache --terragrunt-provider-cache-registry-names example.com --terragrunt-provider-cache-dir %s --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", providerCacheDir, appPath))
+	runTerragrunt(t, fmt.Sprintf("terragrunt run-all init --terragrunt-provider-cache --terragrunt-provider-cache-registry-names example.com --terragrunt-provider-cache-registry-names registry.terraform.io --terragrunt-provider-cache-dir %s --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", providerCacheDir, appPath))
+
+	expectedProviderInstallation := `provider_installation { "network_mirror" { url = "%s" include = ["example.com/*/*"] exclude = ["example.com/*/*", "registry.terraform.io/*/*"] } "filesystem_mirror" { path = "%s" include = ["example.com/*/*", "registry.terraform.io/*/*"] } "direct" { exclude = ["exclude.com/*/*"] } }`
+	expectedProviderInstallation = fmt.Sprintf(strings.Join(strings.Fields(expectedProviderInstallation), " "), networkMirrorURL.String(), providerCacheDir)
+
+	terraformrcBytes, err := os.ReadFile(filepath.Join(appPath, ".terraformrc"))
+	require.NoError(t, err)
+	terraformrc := strings.Join(strings.Fields(string(terraformrcBytes)), " ")
+
+	assert.Contains(t, terraformrc, expectedProviderInstallation, "%s\n\n%s", terraformrc, expectedProviderInstallation)
 }
 
 func TestTerragruntInputsFromDependency(t *testing.T) {

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -44,8 +44,18 @@ func TestTerragruntProviderCacheWithFilesystemMirror(t *testing.T) {
 	fakeProvider := FakeProvider{
 		RegistryName: "example.com",
 		Namespace:    "hashicorp",
-		Name:         "null",
-		Version:      "3.2.2",
+		Name:         "aws",
+		Version:      "5.59.0",
+		PlatformOS:   runtime.GOOS,
+		PlatformArch: runtime.GOARCH,
+	}
+	fakeProvider.CreateMirror(t, providersMirrorPath)
+
+	fakeProvider = FakeProvider{
+		RegistryName: "example.com",
+		Namespace:    "hashicorp",
+		Name:         "azurerm",
+		Version:      "3.113.0",
 		PlatformOS:   runtime.GOOS,
 		PlatformArch: runtime.GOARCH,
 	}
@@ -88,7 +98,7 @@ func TestTerragruntProviderCacheWithFilesystemMirror(t *testing.T) {
 	assert.Contains(t, terraformrc, expectedProviderInstallation, "%s\n\n%s", terraformrc, expectedProviderInstallation)
 }
 
-func TestTerragruntProviderCacheWithMirror(t *testing.T) {
+func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 	// In this test we use os.Setenv to set the Terraform env var TF_CLI_CONFIG_FILE.
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_PROVIDER_CACHE_MIRROR)

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -105,7 +105,7 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 	netowrkProvider := FakeProvider{
 		RegistryName: "example.com",
 		Namespace:    "network",
-		Name:         "null",
+		Name:         "network",
 		Version:      "3.2.2",
 		PlatformOS:   runtime.GOOS,
 		PlatformArch: runtime.GOARCH,
@@ -115,7 +115,7 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 	filesystemProvider := FakeProvider{
 		RegistryName: "example.com",
 		Namespace:    "filesystem",
-		Name:         "null",
+		Name:         "filesystem",
 		Version:      "3.2.2",
 		PlatformOS:   runtime.GOOS,
 		PlatformArch: runtime.GOARCH,

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -88,7 +88,7 @@ func TestTerragruntProviderCacheWithFilesystemMirror(t *testing.T) {
 	assert.Contains(t, terraformrc, expectedProviderInstallation, "%s\n\n%s", terraformrc, expectedProviderInstallation)
 }
 
-func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
+func TestTerragruntProviderCacheWithMirror(t *testing.T) {
 	// In this test we use os.Setenv to set the Terraform env var TF_CLI_CONFIG_FILE.
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_PROVIDER_CACHE_MIRROR)
@@ -104,9 +104,9 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 
 	netowrkProvider := FakeProvider{
 		RegistryName: "example.com",
-		Namespace:    "network",
-		Name:         "network",
-		Version:      "3.2.2",
+		Namespace:    "hashicorp",
+		Name:         "aws",
+		Version:      "5.59.0",
 		PlatformOS:   runtime.GOOS,
 		PlatformArch: runtime.GOARCH,
 	}
@@ -114,9 +114,9 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 
 	filesystemProvider := FakeProvider{
 		RegistryName: "example.com",
-		Namespace:    "filesystem",
-		Name:         "filesystem",
-		Version:      "3.2.2",
+		Namespace:    "hashicorp",
+		Name:         "azurerm",
+		Version:      "3.113.0",
 		PlatformOS:   runtime.GOOS,
 		PlatformArch: runtime.GOARCH,
 	}
@@ -154,13 +154,13 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 		FilesystemMirrorMethods: []CLIConfigProviderInstallationFilesystemMirror{
 			{
 				Path:    providersFilesystemMirrorPath,
-				Include: []string{"example.com/filesystem/*"},
+				Include: []string{"example.com/hashicorp/azurerm"},
 			},
 		},
 		NetworkMirrorMethods: []CLIConfigProviderInstallationNetworkMirror{
 			{
 				URL:     networkMirrorURL.String(),
-				Include: []string{"example.com/network/*"},
+				Include: []string{"example.com/hashicorp/aws"},
 			},
 		},
 	}
@@ -168,7 +168,7 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 
 	runTerragrunt(t, fmt.Sprintf("terragrunt run-all init --terragrunt-provider-cache --terragrunt-provider-cache-registry-names example.com --terragrunt-provider-cache-registry-names registry.terraform.io --terragrunt-provider-cache-dir %s --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir %s", providerCacheDir, appPath))
 
-	expectedProviderInstallation := `provider_installation { "filesystem_mirror" { path = "%s" include = ["example.com/filesystem/*"] exclude = ["example.com/*/*", "registry.terraform.io/*/*"] } "network_mirror" { url = "%s" include = ["example.com/network/*"] exclude = ["example.com/*/*", "registry.terraform.io/*/*"] } "filesystem_mirror" { path = "%s" include = ["example.com/*/*", "registry.terraform.io/*/*"] } "direct" { } }`
+	expectedProviderInstallation := `provider_installation { "filesystem_mirror" { path = "%s" include = ["example.com/hashicorp/azurerm"] exclude = ["example.com/*/*", "registry.terraform.io/*/*"] } "network_mirror" { url = "%s" include = ["example.com/hashicorp/aws"] exclude = ["example.com/*/*", "registry.terraform.io/*/*"] } "filesystem_mirror" { path = "%s" include = ["example.com/*/*", "registry.terraform.io/*/*"] } "direct" { } }`
 
 	expectedProviderInstallation = fmt.Sprintf(strings.Join(strings.Fields(expectedProviderInstallation), " "), providersFilesystemMirrorPath, networkMirrorURL.String(), providerCacheDir)
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3244.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

