### PR TITLE
3274 - fix: Include nothing when value for `terragrunt-include-dir` doesn't exist on the filesystem

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -329,6 +329,11 @@ func initialSetup(cliCtx *cli.Context, opts *options.TerragruntOptions) error {
 		return err
 	}
 
+	if len(opts.IncludeDirs) > 0 {
+		opts.Logger.Debugf("Included directories set. Excluding by default.")
+		opts.ExcludeByDefault = true
+	}
+
 	opts.IncludeDirs, err = util.GlobCanonicalPath(opts.WorkingDir, opts.IncludeDirs...)
 	if err != nil {
 		return err

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -394,8 +394,9 @@ func (modules TerraformModules) flagExcludedDirs(terragruntOptions *options.Terr
 
 // flagIncludedDirs iterates over a module slice and flags all entries not in the list specified via the terragrunt-include-dir CLI flag as excluded.
 func (modules TerraformModules) flagIncludedDirs(terragruntOptions *options.TerragruntOptions) TerraformModules {
-	// If no IncludeDirs is specified return the modules list instantly
-	if len(terragruntOptions.IncludeDirs) == 0 {
+	// If we're not excluding by default, we should include everything by default.
+	// This can happen when a user doesn't set include flags.
+	if !terragruntOptions.ExcludeByDefault {
 		// If we aren't given any include directories, but are given the strict include flag,
 		// return no modules.
 		if terragruntOptions.StrictInclude {

--- a/configstack/stack_test.go
+++ b/configstack/stack_test.go
@@ -728,6 +728,7 @@ func TestResolveTerraformModulesTwoModulesWithDependenciesIncludedDirsWithNoDepe
 
 	opts, _ := options.NewTerragruntOptionsForTest("running_module_test")
 	opts.IncludeDirs = []string{canonical(t, "../test/fixture-modules/module-a")}
+	opts.ExcludeByDefault = true
 
 	moduleA := &TerraformModule{
 		Path:         canonical(t, "../test/fixture-modules/module-a"),

--- a/options/options.go
+++ b/options/options.go
@@ -203,6 +203,10 @@ type TerragruntOptions struct {
 	// Unix-style glob of directories to include when running *-all commands
 	IncludeDirs []string
 
+	// If set to true, exclude all directories by default when running *-all commands
+	// Is set automatically if IncludeDirs is set
+	ExcludeByDefault bool
+
 	// If set to true, do not include dependencies when processing IncludeDirs (unless they are in the included dirs)
 	StrictInclude bool
 

--- a/options/options.go
+++ b/options/options.go
@@ -533,6 +533,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) *TerragruntOpt
 		ExcludesFile:                   opts.ExcludesFile,
 		ExcludeDirs:                    opts.ExcludeDirs,
 		IncludeDirs:                    opts.IncludeDirs,
+		ExcludeByDefault:               opts.ExcludeByDefault,
 		ModulesThatInclude:             opts.ModulesThatInclude,
 		Parallelism:                    opts.Parallelism,
 		StrictInclude:                  opts.StrictInclude,

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -329,6 +329,7 @@ func TestIncludeDirs(t *testing.T) {
 		includeArgs           string
 		includedModuleOutputs []string
 	}{
+		{testFixtureLocalWithIncludeDir, "--terragrunt-include-dir xyz", []string{}},
 		{testFixtureLocalWithIncludeDir, "--terragrunt-include-dir */aws", []string{"Module GCE B", "Module GCE C", "Module GCE E"}},
 		{testFixtureLocalWithIncludeDir, "--terragrunt-include-dir production-env --terragrunt-include-dir **/module-gce-c", []string{"Module GCE B", "Module AWS A"}},
 		{testFixtureLocalWithIncludeDir, "--terragrunt-include-dir integration-env/gce/module-gce-b --terragrunt-include-dir integration-env/gce/module-gce-c --terragrunt-include-dir **/module-aws*", []string{"Module GCE E"}},


### PR DESCRIPTION
## Description

Fixes #3274.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `--terragrunt-include-dir` to properly exclude by default when set, even if the value is not found.

