### PR TITLE
fix: Fixing dynamic auth for deps

### DIFF
--- a/test/fixture-auth-provider-cmd/creds-for-dependency/dependency/creds.config
+++ b/test/fixture-auth-provider-cmd/creds-for-dependency/dependency/creds.config
@@ -1,0 +1,4 @@
+access_key_id=__FILL_AWS_ACCESS_KEY_ID__
+secret_access_key=__FILL_AWS_SECRET_ACCESS_KEY__
+session_token=
+tf_var_foo=

--- a/test/fixture-auth-provider-cmd/creds-for-dependency/dependency/main.tf
+++ b/test/fixture-auth-provider-cmd/creds-for-dependency/dependency/main.tf
@@ -1,0 +1,3 @@
+output "foo" {
+  value = "foo"
+}

--- a/test/fixture-auth-provider-cmd/creds-for-dependency/dependency/terragrunt.hcl
+++ b/test/fixture-auth-provider-cmd/creds-for-dependency/dependency/terragrunt.hcl
@@ -1,0 +1,3 @@
+locals {
+    aws_account_id = get_aws_account_id()
+}

--- a/test/fixture-auth-provider-cmd/creds-for-dependency/dependent/creds.config
+++ b/test/fixture-auth-provider-cmd/creds-for-dependency/dependent/creds.config
@@ -1,0 +1,4 @@
+access_key_id=__FILL_AWS_ACCESS_KEY_ID__
+secret_access_key=__FILL_AWS_SECRET_ACCESS_KEY__
+session_token=
+tf_var_foo=

--- a/test/fixture-auth-provider-cmd/creds-for-dependency/dependent/terragrunt.hcl
+++ b/test/fixture-auth-provider-cmd/creds-for-dependency/dependent/terragrunt.hcl
@@ -1,0 +1,3 @@
+dependency "dependency" {
+  config_path  = "../dependency"
+}

--- a/test/fixture-auth-provider-cmd/multiple-apps/app3/terragrunt.hcl
+++ b/test/fixture-auth-provider-cmd/multiple-apps/app3/terragrunt.hcl
@@ -1,9 +1,3 @@
 include {
   path = find_in_parent_folders()
 }
-
-locals {
-  // Doing this just to confirm that credentials are available
-  // while parsing a dependency.
-  aws_account_id = get_aws_account_id()
-}

--- a/test/fixture-auth-provider-cmd/multiple-apps/app3/terragrunt.hcl
+++ b/test/fixture-auth-provider-cmd/multiple-apps/app3/terragrunt.hcl
@@ -1,3 +1,9 @@
 include {
   path = find_in_parent_folders()
 }
+
+locals {
+  // Doing this just to confirm that credentials are available
+  // while parsing a dependency.
+  aws_account_id = get_aws_account_id()
+}

--- a/test/fixture-auth-provider-cmd/multiple-apps/creds.config
+++ b/test/fixture-auth-provider-cmd/multiple-apps/creds.config
@@ -1,0 +1,4 @@
+access_key_id=app1_access_key_id
+secret_access_key=app1_secret_access_key
+session_token=app1_session_token
+tf_var_foo=top-level


### PR DESCRIPTION
## Description

Closes #3296.

Fixes issue where Terragrunt isn't acquiring credentials dynamically for dependencies.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `configstack`.

