### PR TITLE
Adding supply credentials for a third-party registry when using Terragrunt Provider Cache

### DIFF
--- a/cli/provider_cache_test.go
+++ b/cli/provider_cache_test.go
@@ -110,8 +110,8 @@ func TestProviderCache(t *testing.T) {
 
 			errGroup, ctx := errgroup.WithContext(ctx)
 
-			providerService := services.NewProviderService(providerCacheDir, pluginCacheDir)
-			providerHandler := handlers.NewProviderDirectHandler(providerService, cacheProviderHTTPStatusCode, new(cliconfig.ProviderInstallationDirect))
+			providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil)
+			providerHandler := handlers.NewProviderDirectHandler(providerService, cacheProviderHTTPStatusCode, new(cliconfig.ProviderInstallationDirect), nil)
 
 			testCase.opts = append(testCase.opts, cache.WithServices(providerService), cache.WithProviderHandlers(providerHandler))
 
@@ -155,5 +155,4 @@ func TestProviderCache(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-
 }

--- a/terraform/cache/handlers/provider_direct.go
+++ b/terraform/cache/handlers/provider_direct.go
@@ -44,10 +44,10 @@ type ProviderDirectHandler struct {
 	cacheProviderHTTPStatusCode int
 }
 
-func NewProviderDirectHandler(providerService *services.ProviderService, cacheProviderHTTPStatusCode int, method *cliconfig.ProviderInstallationDirect) *ProviderDirectHandler {
+func NewProviderDirectHandler(providerService *services.ProviderService, cacheProviderHTTPStatusCode int, method *cliconfig.ProviderInstallationDirect, credsSource *cliconfig.CredentialsSource) *ProviderDirectHandler {
 	return &ProviderDirectHandler{
 		CommonProviderHandler:       NewCommonProviderHandler(method.Include, method.Exclude),
-		ReverseProxy:                &ReverseProxy{},
+		ReverseProxy:                &ReverseProxy{CredsSource: credsSource},
 		providerService:             providerService,
 		cacheProviderHTTPStatusCode: cacheProviderHTTPStatusCode,
 	}

--- a/terraform/cache/handlers/provider_network_mirror.go
+++ b/terraform/cache/handlers/provider_network_mirror.go
@@ -122,9 +122,7 @@ func (handler *ProviderNetworkMirrorHandler) do(ctx echo.Context, method, reqPat
 
 	if handler.credsSource != nil {
 		hostname := svchost.Hostname(req.URL.Hostname())
-		if creds, err := handler.credsSource.ForHost(hostname); err != nil {
-			return err
-		} else if creds != nil {
+		if creds := handler.credsSource.ForHost(hostname); creds != nil {
 			creds.PrepareRequest(req)
 		}
 	}

--- a/terraform/cache/handlers/provider_network_mirror.go
+++ b/terraform/cache/handlers/provider_network_mirror.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/terraform/cache/router"
 	"github.com/gruntwork-io/terragrunt/terraform/cache/services"
 	"github.com/gruntwork-io/terragrunt/terraform/cliconfig"
+	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/labstack/echo/v4"
 )
 
@@ -23,15 +24,17 @@ type ProviderNetworkMirrorHandler struct {
 	providerService             *services.ProviderService
 	cacheProviderHTTPStatusCode int
 	networkMirrorURL            string
+	credsSource                 *cliconfig.CredentialsSource
 }
 
-func NewProviderNetworkMirrorHandler(providerService *services.ProviderService, cacheProviderHTTPStatusCode int, networkMirror *cliconfig.ProviderInstallationNetworkMirror) ProviderHandler {
+func NewProviderNetworkMirrorHandler(providerService *services.ProviderService, cacheProviderHTTPStatusCode int, networkMirror *cliconfig.ProviderInstallationNetworkMirror, credsSource *cliconfig.CredentialsSource) ProviderHandler {
 	return &ProviderNetworkMirrorHandler{
 		CommonProviderHandler:       NewCommonProviderHandler(networkMirror.Include, networkMirror.Exclude),
 		Client:                      &http.Client{},
 		providerService:             providerService,
 		cacheProviderHTTPStatusCode: cacheProviderHTTPStatusCode,
 		networkMirrorURL:            networkMirror.URL,
+		credsSource:                 credsSource,
 	}
 }
 
@@ -46,7 +49,7 @@ func (handler *ProviderNetworkMirrorHandler) GetVersions(ctx echo.Context, provi
 	}
 
 	reqPath := path.Join(provider.RegistryName, provider.Namespace, provider.Name, "index.json")
-	if err := handler.request(ctx, http.MethodGet, reqPath, &mirrorData); err != nil {
+	if err := handler.do(ctx, http.MethodGet, reqPath, &mirrorData); err != nil {
 		return err
 	}
 
@@ -82,7 +85,7 @@ func (handler *ProviderNetworkMirrorHandler) GetPlatform(ctx echo.Context, provi
 	}
 
 	reqPath := path.Join(provider.RegistryName, provider.Namespace, provider.Name, provider.Version+".json")
-	if err := handler.request(ctx, http.MethodGet, reqPath, &mirrorData); err != nil {
+	if err := handler.do(ctx, http.MethodGet, reqPath, &mirrorData); err != nil {
 		return err
 	}
 
@@ -109,12 +112,21 @@ func (handler *ProviderNetworkMirrorHandler) Download(ctx echo.Context, provider
 	return ctx.NoContent(http.StatusNotImplemented)
 }
 
-func (handler *ProviderNetworkMirrorHandler) request(ctx echo.Context, method, reqPath string, value any) error {
+func (handler *ProviderNetworkMirrorHandler) do(ctx echo.Context, method, reqPath string, value any) error {
 	reqURL := fmt.Sprintf("%s/%s", strings.TrimRight(handler.networkMirrorURL, "/"), reqPath)
 
 	req, err := http.NewRequestWithContext(ctx.Request().Context(), method, reqURL, nil)
 	if err != nil {
 		return errors.WithStackTrace(err)
+	}
+
+	if handler.credsSource != nil {
+		hostname := svchost.Hostname(req.URL.Hostname())
+		if creds, err := handler.credsSource.ForHost(hostname); err != nil {
+			return err
+		} else if creds != nil {
+			creds.PrepareRequest(req)
+		}
 	}
 
 	resp, err := handler.Client.Do(req)

--- a/terraform/cache/handlers/reverse_proxy.go
+++ b/terraform/cache/handlers/reverse_proxy.go
@@ -6,11 +6,14 @@ import (
 	"net/url"
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/terraform/cliconfig"
+	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/labstack/echo/v4"
 )
 
 type ReverseProxy struct {
-	ServerURL *url.URL
+	ServerURL   *url.URL
+	CredsSource *cliconfig.CredentialsSource
 
 	Rewrite        func(*httputil.ProxyRequest)
 	ModifyResponse func(resp *http.Response) error
@@ -32,6 +35,13 @@ func (reverseProxy *ReverseProxy) NewRequest(ctx echo.Context, targetURL *url.UR
 		Rewrite: func(req *httputil.ProxyRequest) {
 			req.Out.Host = targetURL.Host
 			req.Out.URL = targetURL
+
+			if reverseProxy.CredsSource != nil {
+				hostname := svchost.Hostname(req.Out.URL.Hostname())
+				if creds, err := reverseProxy.CredsSource.ForHost(hostname); err == nil && creds != nil {
+					creds.PrepareRequest(req.Out)
+				}
+			}
 
 			if reverseProxy.Rewrite != nil {
 				reverseProxy.Rewrite(req)

--- a/terraform/cache/handlers/reverse_proxy.go
+++ b/terraform/cache/handlers/reverse_proxy.go
@@ -38,7 +38,7 @@ func (reverseProxy *ReverseProxy) NewRequest(ctx echo.Context, targetURL *url.UR
 
 			if reverseProxy.CredsSource != nil {
 				hostname := svchost.Hostname(req.Out.URL.Hostname())
-				if creds, err := reverseProxy.CredsSource.ForHost(hostname); err == nil && creds != nil {
+				if creds := reverseProxy.CredsSource.ForHost(hostname); creds != nil {
 					creds.PrepareRequest(req.Out)
 				}
 			}

--- a/terraform/cache/helpers/http.go
+++ b/terraform/cache/helpers/http.go
@@ -15,11 +15,7 @@ import (
 	"github.com/hashicorp/go-getter/v2"
 )
 
-func Fetch(ctx context.Context, url string, dst io.Writer) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return errors.WithStackTrace(err)
-	}
+func Fetch(ctx context.Context, req *http.Request, dst io.Writer) error {
 	req.Header.Add("Accept-Encoding", "gzip")
 
 	resp, err := (&http.Client{}).Do(req)
@@ -29,7 +25,7 @@ func Fetch(ctx context.Context, url string, dst io.Writer) error {
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%s returned from %s", resp.Status, url)
+		return fmt.Errorf("%s returned from %s", resp.Status, req.URL)
 	}
 
 	reader, err := ResponseReader(resp)
@@ -47,14 +43,14 @@ func Fetch(ctx context.Context, url string, dst io.Writer) error {
 }
 
 // FetchToFile downloads the file from the given `url` into the specified `dst` file.
-func FetchToFile(ctx context.Context, url, dst string) error {
+func FetchToFile(ctx context.Context, req *http.Request, dst string) error {
 	file, err := os.Create(dst)
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
 	defer file.Close() //nolint:errcheck
 
-	if err := Fetch(ctx, url, file); err != nil {
+	if err := Fetch(ctx, req, file); err != nil {
 		return err
 	}
 

--- a/terraform/cache/services/provider_cache.go
+++ b/terraform/cache/services/provider_cache.go
@@ -254,9 +254,11 @@ func (cache *ProviderCache) newRequest(ctx context.Context, url string) (*http.R
 	}
 
 	hostname := svchost.Hostname(req.URL.Hostname())
-	if creds, err := cache.credsSource.ForHost(hostname); err != nil {
+	creds, err := cache.credsSource.ForHost(hostname)
+	if err != nil {
 		return nil, err
-	} else if creds != nil {
+	}
+	if creds != nil {
 		creds.PrepareRequest(req)
 	}
 

--- a/terraform/cache/services/provider_cache.go
+++ b/terraform/cache/services/provider_cache.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -16,10 +17,12 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/terraform/cache/helpers"
 	"github.com/gruntwork-io/terragrunt/terraform/cache/models"
+	"github.com/gruntwork-io/terragrunt/terraform/cliconfig"
 	"github.com/gruntwork-io/terragrunt/terraform/getproviders"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/hashicorp/go-getter/v2"
 	"github.com/hashicorp/go-multierror"
+	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
@@ -85,6 +88,8 @@ type ProviderCache struct {
 	packageDir      string
 	lockfilePath    string
 	archivePath     string
+
+	credsSource *cliconfig.CredentialsSource
 }
 
 func (cache *ProviderCache) DocumentSHA256Sums(ctx context.Context) ([]byte, error) {
@@ -94,7 +99,11 @@ func (cache *ProviderCache) DocumentSHA256Sums(ctx context.Context) ([]byte, err
 
 	var documentSHA256Sums = new(bytes.Buffer)
 
-	if err := helpers.Fetch(ctx, cache.SHA256SumsURL, documentSHA256Sums); err != nil {
+	req, err := cache.newRequest(ctx, cache.SHA256SumsURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := helpers.Fetch(ctx, req, documentSHA256Sums); err != nil {
 		return nil, fmt.Errorf("failed to retrieve authentication checksums for provider %q: %w", cache.Provider, err)
 	}
 
@@ -109,7 +118,11 @@ func (cache *ProviderCache) Signature(ctx context.Context) ([]byte, error) {
 
 	var signature = new(bytes.Buffer)
 
-	if err := helpers.Fetch(ctx, cache.SHA256SumsSignatureURL, signature); err != nil {
+	req, err := cache.newRequest(ctx, cache.SHA256SumsSignatureURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := helpers.Fetch(ctx, req, signature); err != nil {
 		return nil, fmt.Errorf("failed to retrieve authentication signature for provider %q: %w", cache.Provider, err)
 	}
 
@@ -204,7 +217,11 @@ func (cache *ProviderCache) warmUp(ctx context.Context) error {
 		cache.archivePath = cache.DownloadURL
 	} else {
 		if err := util.DoWithRetry(ctx, fmt.Sprintf("Fetching provider %s", cache.Provider), maxRetriesFetchFile, retryDelayFetchFile, logrus.DebugLevel, func(ctx context.Context) error {
-			return helpers.FetchToFile(ctx, cache.DownloadURL, cache.archivePath)
+			req, err := cache.newRequest(ctx, cache.DownloadURL)
+			if err != nil {
+				return err
+			}
+			return helpers.FetchToFile(ctx, req, cache.archivePath)
 		}); err != nil {
 			return err
 		}
@@ -224,6 +241,26 @@ func (cache *ProviderCache) warmUp(ctx context.Context) error {
 	log.Infof("Cached %s (%s)", cache.Provider, auth)
 
 	return nil
+}
+
+func (cache *ProviderCache) newRequest(ctx context.Context, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	if cache.credsSource == nil {
+		return req, nil
+	}
+
+	hostname := svchost.Hostname(req.URL.Hostname())
+	if creds, err := cache.credsSource.ForHost(hostname); err != nil {
+		return nil, err
+	} else if creds != nil {
+		creds.PrepareRequest(req)
+	}
+
+	return req, nil
 }
 
 func (cache *ProviderCache) removeArchive() error {
@@ -267,13 +304,16 @@ type ProviderService struct {
 
 	cacheMu      sync.RWMutex
 	cacheReadyMu sync.RWMutex
+
+	credsSource *cliconfig.CredentialsSource
 }
 
-func NewProviderService(cacheDir, userCacheDir string) *ProviderService {
+func NewProviderService(cacheDir, userCacheDir string, credsSource *cliconfig.CredentialsSource) *ProviderService {
 	return &ProviderService{
 		cacheDir:              cacheDir,
 		userCacheDir:          userCacheDir,
 		providerCacheWarmUpCh: make(chan *ProviderCache),
+		credsSource:           credsSource,
 	}
 }
 
@@ -312,8 +352,9 @@ func (service *ProviderService) CacheProvider(ctx context.Context, requestID str
 	packageName := fmt.Sprintf("%s-%s-%s-%s-%s", provider.RegistryName, provider.Namespace, provider.Name, provider.Version, provider.Platform())
 
 	cache := &ProviderCache{
-		Provider: provider,
-		started:  make(chan struct{}, 1),
+		Provider:    provider,
+		credsSource: service.credsSource,
+		started:     make(chan struct{}, 1),
 
 		userProviderDir: filepath.Join(service.userCacheDir, provider.Address(), provider.Version, provider.Platform()),
 		packageDir:      filepath.Join(service.cacheDir, provider.Address(), provider.Version, provider.Platform()),

--- a/terraform/cache/services/provider_cache.go
+++ b/terraform/cache/services/provider_cache.go
@@ -254,11 +254,7 @@ func (cache *ProviderCache) newRequest(ctx context.Context, url string) (*http.R
 	}
 
 	hostname := svchost.Hostname(req.URL.Hostname())
-	creds, err := cache.credsSource.ForHost(hostname)
-	if err != nil {
-		return nil, err
-	}
-	if creds != nil {
+	if creds := cache.credsSource.ForHost(hostname); creds != nil {
 		creds.PrepareRequest(req)
 	}
 

--- a/terraform/cliconfig/credentials.go
+++ b/terraform/cliconfig/credentials.go
@@ -1,0 +1,76 @@
+package cliconfig
+
+import (
+	"os"
+	"strings"
+
+	svchost "github.com/hashicorp/terraform-svchost"
+	svcauth "github.com/hashicorp/terraform-svchost/auth"
+)
+
+type CredentialsSource struct {
+	// configured describes the credentials explicitly configured in the CLI config via "credentials" blocks.
+	configured map[svchost.Hostname]string
+}
+
+func (s *CredentialsSource) ForHost(host svchost.Hostname) (svcauth.HostCredentials, error) {
+	// The first order of precedence for credentials is a host-specific environment variable
+	if envCreds := hostCredentialsFromEnv(host); envCreds != nil {
+		return envCreds, nil
+	}
+
+	// Then, any credentials block present in the CLI config
+	if token, ok := s.configured[host]; ok {
+		return svcauth.HostCredentialsToken(token), nil
+	}
+
+	return nil, nil
+}
+
+// hostCredentialsFromEnv returns a token credential by searching for a hostname-specific environment variable. The host parameter is expected to be in the "comparison" form, for example, hostnames containing non-ASCII characters like "café.fr" should be expressed as "xn--caf-dma.fr". If the variable based on the hostname is not defined, nil is returned.
+//
+// Hyphen and period characters are allowed in environment variable names, but are not valid POSIX variable names. However, it's still possible to set variable names with these characters using utilities like env or docker. Variable names may have periods translated to underscores and hyphens translated to double underscores in the variable name. For the example "café.fr", you may use the variable names "TF_TOKEN_xn____caf__dma_fr", "TF_TOKEN_xn--caf-dma_fr", or "TF_TOKEN_xn--caf-dma.fr"
+func hostCredentialsFromEnv(host svchost.Hostname) svcauth.HostCredentials {
+	token, ok := collectCredentialsFromEnv()[host]
+	if !ok {
+		return nil
+	}
+	return svcauth.HostCredentialsToken(token)
+}
+
+func collectCredentialsFromEnv() map[svchost.Hostname]string {
+	const prefix = "TF_TOKEN_"
+
+	ret := make(map[svchost.Hostname]string)
+	for _, ev := range os.Environ() {
+		eqIdx := strings.Index(ev, "=")
+		if eqIdx < 0 {
+			continue
+		}
+		name := ev[:eqIdx]
+		value := ev[eqIdx+1:]
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		rawHost := name[len(prefix):]
+
+		// We accept double underscores in place of hyphens because hyphens are not valid identifiers in most shells and are therefore hard to set.
+		rawHost = strings.ReplaceAll(rawHost, "__", "-")
+
+		// We accept underscores in place of dots because dots are not valid identifiers in most shells and are therefore hard to set.
+		// Underscores are not valid in hostnames, so this is unambiguous for valid hostnames.
+		rawHost = strings.ReplaceAll(rawHost, "_", ".")
+
+		// Because environment variables are often set indirectly by OS libraries that might interfere with how they are encoded, we'll be tolerant of them being given either directly as UTF-8 IDNs or in Punycode form, normalizing to Punycode form here because that is what the OpenTofu credentials helper protocol will use in its requests.
+		dispHost := svchost.ForDisplay(rawHost)
+		hostname, err := svchost.ForComparison(dispHost)
+		if err != nil {
+			// Ignore invalid hostnames
+			continue
+		}
+
+		ret[hostname] = value
+	}
+
+	return ret
+}

--- a/terraform/cliconfig/credentials.go
+++ b/terraform/cliconfig/credentials.go
@@ -13,18 +13,18 @@ type CredentialsSource struct {
 	configured map[svchost.Hostname]string
 }
 
-func (s *CredentialsSource) ForHost(host svchost.Hostname) (svcauth.HostCredentials, error) {
+func (s *CredentialsSource) ForHost(host svchost.Hostname) svcauth.HostCredentials {
 	// The first order of precedence for credentials is a host-specific environment variable
 	if envCreds := hostCredentialsFromEnv(host); envCreds != nil {
-		return envCreds, nil
+		return envCreds
 	}
 
 	// Then, any credentials block present in the CLI config
 	if token, ok := s.configured[host]; ok {
-		return svcauth.HostCredentialsToken(token), nil
+		return svcauth.HostCredentialsToken(token)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // hostCredentialsFromEnv returns a token credential by searching for a hostname-specific environment variable. The host parameter is expected to be in the "comparison" form, for example, hostnames containing non-ASCII characters like "café.fr" should be expressed as "xn--caf-dma.fr". If the variable based on the hostname is not defined, nil is returned.

--- a/test/integration_common_test.go
+++ b/test/integration_common_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/NYTimes/gziphandler"
@@ -43,7 +44,7 @@ func testRunAllPlan(t *testing.T, args string) (string, string, string, error) {
 	return tmpEnvPath, stdout, stderr, err
 }
 
-func runNetworkMirrorServer(t *testing.T, ctx context.Context, urlPrefix, providerDir string) *url.URL {
+func runNetworkMirrorServer(t *testing.T, ctx context.Context, urlPrefix, providerDir, token string) *url.URL {
 	serverTLSConf, clientTLSConf := certSetup(t)
 
 	http.DefaultTransport = &http.Transport{
@@ -56,7 +57,14 @@ func runNetworkMirrorServer(t *testing.T, ctx context.Context, urlPrefix, provid
 
 	withGz := gziphandler.GzipHandler(http.StripPrefix(urlPrefix, fs))
 
-	mux.Handle(urlPrefix, withGz)
+	mux.HandleFunc(urlPrefix, func(resp http.ResponseWriter, req *http.Request) {
+		if token != "" {
+			authHeaders := req.Header.Values("Authorization")
+			assert.Contains(t, authHeaders, fmt.Sprintf("Bearer %s", token))
+		}
+
+		withGz.ServeHTTP(resp, req)
+	})
 
 	ln, err := tls.Listen("tcp", "localhost:8888", serverTLSConf)
 	require.NoError(t, err)

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -138,7 +138,9 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 		http.DefaultTransport = defaultTransport
 	}()
 
-	networkMirrorURL := runNetworkMirrorServer(t, ctx, "/providers/", providersNetkworMirrorPath)
+	token := "123456790"
+
+	networkMirrorURL := runNetworkMirrorServer(t, ctx, "/providers/", providersNetkworMirrorPath, token)
 	t.Logf("Network mirror URL: %s", networkMirrorURL)
 	t.Logf("Provdiers network mirror path: %s", providersNetkworMirrorPath)
 	t.Logf("Provdiers filesysmte mirror path: %s", providersFilesystemMirrorPath)
@@ -148,6 +150,11 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 	cliConfigFilename, err := os.CreateTemp("", "*")
 	require.NoError(t, err)
 	defer cliConfigFilename.Close()
+
+	tokenEnvName := fmt.Sprintf("TF_TOKEN_%s", strings.ReplaceAll(networkMirrorURL.Hostname(), ".", "_"))
+	err = os.Setenv(tokenEnvName, token)
+	require.NoError(t, err)
+	defer os.Unsetenv(tokenEnvName)
 
 	err = os.Setenv(terraform.EnvNameTFCLIConfigFile, cliConfigFilename.Name())
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3298.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

