### PR TITLE
Fixing "dependency cycle between modules" when using `hclvalidate` command with undefined `config_path` attribute

### DIFF
--- a/cli/commands/hclvalidate/action.go
+++ b/cli/commands/hclvalidate/action.go
@@ -18,8 +18,8 @@ func Run(ctx context.Context, opts *Options) (er error) {
 	parseOptions := []hclparse.Option{
 		hclparse.WithDiagnosticsHandler(func(file *hcl.File, hclDiags hcl.Diagnostics) (hcl.Diagnostics, error) {
 			for _, hclDiag := range hclDiags {
-				if !diags.Contains(hclDiag) {
-					newDiag := diagnostic.NewDiagnostic(file, hclDiag)
+				newDiag := diagnostic.NewDiagnostic(file, hclDiag)
+				if !diags.Contains(newDiag) {
 					diags = append(diags, newDiag)
 				}
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -105,7 +105,7 @@ type TerragruntConfig struct {
 	IamWebIdentityToken         string
 	Inputs                      map[string]interface{}
 	Locals                      map[string]interface{}
-	TerragruntDependencies      []Dependency
+	TerragruntDependencies      Dependencies
 	GenerateConfigs             map[string]codegen.GenerateConfig
 	RetryableErrors             []string
 	RetryMaxAttempts            *int
@@ -179,7 +179,7 @@ type terragruntConfigFile struct {
 	IamAssumeRoleDuration    *int64              `hcl:"iam_assume_role_duration,attr"`
 	IamAssumeRoleSessionName *string             `hcl:"iam_assume_role_session_name,attr"`
 	IamWebIdentityToken      *string             `hcl:"iam_web_identity_token,attr"`
-	TerragruntDependencies   []Dependency        `hcl:"dependency,block"`
+	TerragruntDependencies   Dependencies        `hcl:"dependency,block"`
 
 	// We allow users to configure code generation via blocks:
 	//

--- a/config/config.go
+++ b/config/config.go
@@ -179,7 +179,7 @@ type terragruntConfigFile struct {
 	IamAssumeRoleDuration    *int64              `hcl:"iam_assume_role_duration,attr"`
 	IamAssumeRoleSessionName *string             `hcl:"iam_assume_role_session_name,attr"`
 	IamWebIdentityToken      *string             `hcl:"iam_web_identity_token,attr"`
-	TerragruntDependencies   Dependencies        `hcl:"dependency,block"`
+	TerragruntDependencies   []Dependency        `hcl:"dependency,block"`
 
 	// We allow users to configure code generation via blocks:
 	//

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -510,7 +510,7 @@ func remoteStateAsCty(remoteState *remote.RemoteState) (cty.Value, error) {
 }
 
 // Serialize the list of dependency blocks to a cty Value as a map that maps the block names to the cty representation.
-func dependencyBlocksAsCty(dependencyBlocks []Dependency) (cty.Value, error) {
+func dependencyBlocksAsCty(dependencyBlocks Dependencies) (cty.Value, error) {
 	out := map[string]cty.Value{}
 	for _, block := range dependencyBlocks {
 		blockCty, err := goTypeToCty(block)

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -88,7 +88,7 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 			"quote": "the answer is 42",
 		},
 		DependentModulesPath: dependentModulesPath,
-		TerragruntDependencies: []Dependency{
+		TerragruntDependencies: Dependencies{
 			{
 				Name:                                "foo",
 				ConfigPath:                          "foo",

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -79,7 +79,7 @@ type terragruntVersionConstraints struct {
 
 // terragruntDependency is a struct that can be used to only decode the dependency blocks in the terragrunt config
 type terragruntDependency struct {
-	Dependencies []Dependency `hcl:"dependency,block"`
+	Dependencies Dependencies `hcl:"dependency,block"`
 	Remain       hcl.Body     `hcl:",remain"`
 }
 
@@ -265,8 +265,9 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 			if err != nil {
 				return nil, err
 			}
-			output.TerragruntDependencies = decoded.Dependencies
+			decoded.Dependencies = decoded.Dependencies.filteredWithUndefinedPath()
 
+			output.TerragruntDependencies = decoded.Dependencies
 			// Convert dependency blocks into module depenency lists. If we already decoded some dependencies,
 			// merge them in. Otherwise, set as the new list.
 			dependencies := dependencyBlocksToModuleDependencies(decoded.Dependencies)

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -265,7 +265,8 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 			if err != nil {
 				return nil, err
 			}
-			decoded.Dependencies = decoded.Dependencies.filteredWithUndefinedPath()
+			// In normal operation, if a dependency block does not have a `config_path` attribute, decoding returns an error since this attribute is required, but the `hclvalidate` command suppresses decoding errors and this causes a cycle between modules, so we need to filter out dependencies without a defined `config_path`.
+			decoded.Dependencies = decoded.Dependencies.FilteredWithoutConfigPath()
 
 			output.TerragruntDependencies = decoded.Dependencies
 			// Convert dependency blocks into module depenency lists. If we already decoded some dependencies,

--- a/config/errors.go
+++ b/config/errors.go
@@ -241,5 +241,5 @@ func (err TerragruntOutputTargetNoOutputs) Error() string {
 type DependencyCycleError []string
 
 func (err DependencyCycleError) Error() string {
-	return fmt.Sprintf("Found a dependency cycle between modules: %s", strings.Join([]string(err), " -> "))
+	return fmt.Sprintf("Found a dependency cycle between modules----1: %s", strings.Join([]string(err), " -> "))
 }

--- a/config/include.go
+++ b/config/include.go
@@ -475,13 +475,13 @@ func fetchDependencyPaths(config *TerragruntConfig) map[string]string {
 
 // Merge dependency blocks shallowly. If the source list has the same name as the target, it will override the
 // dependency block in the target. Otherwise, the blocks are appended.
-func mergeDependencyBlocks(targetDependencies []Dependency, sourceDependencies []Dependency) []Dependency {
+func mergeDependencyBlocks(targetDependencies Dependencies, sourceDependencies Dependencies) Dependencies {
 	// We track the keys so that the dependencies are added in order, with those in target prepending those in
 	// source. This is not strictly necessary, but it makes testing easier by making the output list more
 	// predictable.
 	keys := []string{}
 
-	dependencyBlocks := make(map[string]Dependency)
+	dependencyBlocks := make(map[string]*Dependency)
 	for _, dep := range targetDependencies {
 		dependencyBlocks[dep.Name] = dep
 		keys = append(keys, dep.Name)
@@ -495,7 +495,7 @@ func mergeDependencyBlocks(targetDependencies []Dependency, sourceDependencies [
 		dependencyBlocks[dep.Name] = dep
 	}
 	// Now convert the map to list and set target
-	combinedDeps := []Dependency{}
+	combinedDeps := Dependencies{}
 	for _, key := range keys {
 		combinedDeps = append(combinedDeps, dependencyBlocks[key])
 	}
@@ -504,13 +504,13 @@ func mergeDependencyBlocks(targetDependencies []Dependency, sourceDependencies [
 
 // Merge dependency blocks deeply. This works almost the same as mergeDependencyBlocks, except it will recursively merge
 // attributes of the dependency struct if they share the same name.
-func deepMergeDependencyBlocks(targetDependencies []Dependency, sourceDependencies []Dependency) ([]Dependency, error) {
+func deepMergeDependencyBlocks(targetDependencies Dependencies, sourceDependencies Dependencies) (Dependencies, error) {
 	// We track the keys so that the dependencies are added in order, with those in target prepending those in
 	// source. This is not strictly necessary, but it makes testing easier by making the output list more
 	// predictable.
 	keys := []string{}
 
-	dependencyBlocks := make(map[string]Dependency)
+	dependencyBlocks := make(map[string]*Dependency)
 	for _, dep := range targetDependencies {
 		dependencyBlocks[dep.Name] = dep
 		keys = append(keys, dep.Name)
@@ -518,11 +518,10 @@ func deepMergeDependencyBlocks(targetDependencies []Dependency, sourceDependenci
 	for _, dep := range sourceDependencies {
 		sameKeyDep, hasSameKey := dependencyBlocks[dep.Name]
 		if hasSameKey {
-			sameKeyDepPtr := &sameKeyDep
-			if err := sameKeyDepPtr.DeepMerge(dep); err != nil {
+			if err := sameKeyDep.DeepMerge(dep); err != nil {
 				return nil, err
 			}
-			dependencyBlocks[dep.Name] = *sameKeyDepPtr
+			dependencyBlocks[dep.Name] = sameKeyDep
 		} else {
 			dependencyBlocks[dep.Name] = dep
 			keys = append(keys, dep.Name)
@@ -530,7 +529,7 @@ func deepMergeDependencyBlocks(targetDependencies []Dependency, sourceDependenci
 
 	}
 	// Now convert the map to list and set target
-	combinedDeps := []Dependency{}
+	combinedDeps := Dependencies{}
 	for _, key := range keys {
 		combinedDeps = append(combinedDeps, dependencyBlocks[key])
 	}

--- a/config/include_test.go
+++ b/config/include_test.go
@@ -147,7 +147,7 @@ func TestMergeConfigIntoIncludedConfig(t *testing.T) {
 	for _, testCase := range testCases {
 		// if nil, initialize to empty dependency list
 		if testCase.expected.TerragruntDependencies == nil {
-			testCase.expected.TerragruntDependencies = []Dependency{}
+			testCase.expected.TerragruntDependencies = Dependencies{}
 		}
 
 		err := testCase.includedConfig.Merge(testCase.config, mockOptionsForTest(t))
@@ -247,21 +247,21 @@ func TestDeepMergeConfigIntoIncludedConfig(t *testing.T) {
 		{
 			"dependencies",
 			&TerragruntConfig{Dependencies: &ModuleDependencies{Paths: []string{"../vpc"}},
-				TerragruntDependencies: []Dependency{
+				TerragruntDependencies: Dependencies{
 					{
 						Name:       "vpc",
 						ConfigPath: "../vpc",
 					},
 				}},
 			&TerragruntConfig{Dependencies: &ModuleDependencies{Paths: []string{"../mysql"}},
-				TerragruntDependencies: []Dependency{
+				TerragruntDependencies: Dependencies{
 					{
 						Name:       "mysql",
 						ConfigPath: "../mysql",
 					},
 				}},
 			&TerragruntConfig{Dependencies: &ModuleDependencies{Paths: []string{"../mysql", "../vpc"}},
-				TerragruntDependencies: []Dependency{
+				TerragruntDependencies: Dependencies{
 					{
 						Name:       "mysql",
 						ConfigPath: "../mysql",
@@ -296,7 +296,7 @@ func TestDeepMergeConfigIntoIncludedConfig(t *testing.T) {
 
 			// if nil, initialize to empty dependency list
 			if testCase.expected.TerragruntDependencies == nil {
-				testCase.expected.TerragruntDependencies = []Dependency{}
+				testCase.expected.TerragruntDependencies = Dependencies{}
 			}
 			assert.Equal(t, testCase.expected, testCase.target)
 		})

--- a/configstack/test_helpers.go
+++ b/configstack/test_helpers.go
@@ -52,10 +52,10 @@ func assertModulesEqual(t *testing.T, expected *TerraformModule, actual *Terrafo
 		// When comparing the TerragruntConfig objects, we need to normalize the dependency list to explicitly set the
 		// expected to empty list when nil, as the parsing routine will set it to empty list instead of nil.
 		if expected.Config.TerragruntDependencies == nil {
-			expected.Config.TerragruntDependencies = []config.Dependency{}
+			expected.Config.TerragruntDependencies = config.Dependencies{}
 		}
 		if actual.Config.TerragruntDependencies == nil {
-			actual.Config.TerragruntDependencies = []config.Dependency{}
+			actual.Config.TerragruntDependencies = config.Dependencies{}
 		}
 		assert.Equal(t, expected.Config, actual.Config, messageAndArgs...)
 

--- a/internal/view/diagnostic/diagnostic.go
+++ b/internal/view/diagnostic/diagnostic.go
@@ -6,9 +6,9 @@ import (
 
 type Diagnostics []*Diagnostic
 
-func (diags *Diagnostics) Contains(find *hcl.Diagnostic) bool {
+func (diags *Diagnostics) Contains(find *Diagnostic) bool {
 	for _, diag := range *diags {
-		if find.Subject != nil && find.Subject.String() == diag.Range.String() {
+		if find.Range != nil && find.Range.String() == diag.Range.String() {
 			return true
 		}
 	}

--- a/test/fixture-hclvalidate/second/c/terragrunt.hcl
+++ b/test/fixture-hclvalidate/second/c/terragrunt.hcl
@@ -11,3 +11,8 @@ locals {
 
   ddd = dependency.d
 }
+
+// should not cause a dependency cycle
+dependency iam {
+  //config_path = "../iam"
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -329,6 +329,23 @@ func TestHclvalidateDiagnostic(t *testing.T) {
 				Values:               []diagnostic.ExpressionValue{diagnostic.ExpressionValue{Traversal: "dependency.a", Statement: "is object with no attributes"}},
 			},
 		},
+		&diagnostic.Diagnostic{
+			Severity: diagnostic.DiagnosticSeverity(hcl.DiagError),
+			Summary:  "Missing required argument",
+			Detail:   "The argument \"config_path\" is required, but no definition was found.",
+			Range: &diagnostic.Range{
+				Filename: filepath.Join(rootPath, "second/c/terragrunt.hcl"),
+				Start:    diagnostic.Pos{Line: 16, Column: 16, Byte: 219},
+				End:      diagnostic.Pos{Line: 16, Column: 17, Byte: 220},
+			},
+			Snippet: &diagnostic.Snippet{
+				Context:              "dependency \"iam\"",
+				Code:                 "dependency iam {",
+				StartLine:            16,
+				HighlightStartOffset: 15,
+				HighlightEndOffset:   16,
+			},
+		},
 	}
 
 	stdout, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt hclvalidate --terragrunt-working-dir %s --terragrunt-hclvalidate-json", rootPath))


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

In normal operation, if a dependency block does not have a `config_path` attribute, decoding returns an error since this attribute is required, but the `hclvalidate` command suppresses decoding errors and this causes a cycle between modules. This PR prevents further processing of dependencies without the `config_path` attribute specified.

For more information, see ticket [111184](https://gruntwork.zendesk.com/agent/tickets/111184.)


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

