### PR TITLE
chore: Bumping `gruntwork-io/pre-commit` to `v0.1.23`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev:  v0.1.10
+    rev:  v0.1.23
     hooks:
       - id: terraform-fmt
       - id: goimports


### PR DESCRIPTION
## Description

Closes #2211.

That stale PR tried to get us to bump pre-commit. This bumps it to the latest.

I tested this locally, and it ran without issue.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated pre-commit to the latest version.

