### PR TITLE
chore: Bumping OpenTofu to `v1.8.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ install_tofu: &install_tofu
   command: |
     pushd .
     cd /tmp
-    curl -L "https://github.com/opentofu/opentofu/releases/download/v1.7.0/tofu_1.7.0_linux_amd64.zip" -o tofu.zip
+    curl -L "https://github.com/opentofu/opentofu/releases/download/v1.8.0/tofu_1.8.0_linux_amd64.zip" -o tofu.zip
     unzip -o tofu.zip
     sudo install -m 0755 tofu /usr/local/bin/tofu
     rm -rf tofu

--- a/_ci/install-opentofu.ps1
+++ b/_ci/install-opentofu.ps1
@@ -8,8 +8,8 @@ if (Test-Path -Path $OpenTofuInstallPath)
 	Remove-Item $OpenTofuInstallPath -Recurse
 }
 # Download OpenTofu and unpack it
-$OpenTofuURI = "https://github.com/opentofu/opentofu/releases/download/v1.7.0/tofu_1.7.0_windows_amd64.zip"
-$output = "tofu_1.7.0_windows_amd64.zip"
+$OpenTofuURI = "https://github.com/opentofu/opentofu/releases/download/v1.8.0/tofu_1.8.0_windows_amd64.zip"
+$output = "tofu_1.8.0_windows_amd64.zip"
 $ProgressPreference = "SilentlyContinue"
 Invoke-WebRequest -Uri $OpenTofuURI -OutFile $output
 New-Item -ItemType "directory" -Path $OpenTofuTmpPath

--- a/docs/_docs/01_getting-started/supported-versions.md
+++ b/docs/_docs/01_getting-started/supported-versions.md
@@ -15,6 +15,7 @@ The officially supported versions are:
 
 | OpenTofu Version | Terragrunt Version                                                           |
 |------------------|------------------------------------------------------------------------------|
+| 1.8.x            | >= [0.66.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.66.0) |
 | 1.7.x            | >= [0.58.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.58.0) |
 | 1.6.x            | >= [0.52.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.52.0) |
 


### PR DESCRIPTION
## Description

Closes #3314.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated OpenTofu support to `v1.8.0`.