### PR TITLE
add env TERRAGRUNT_EXCLUDE_DIR to docs

### DIFF
--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -989,6 +989,7 @@ terragrunt run-all plan --terragrunt-excludes-file <(terragrunt hclvalidate --te
 ### terragrunt-exclude-dir
 
 **CLI Arg**: `--terragrunt-exclude-dir`<br/>
+**Environment Variable**: `TERRAGRUNT_EXCLUDE_DIR`<br/>
 **Requires an argument**: `--terragrunt-exclude-dir /path/to/dirs/to/exclude*`<br/>
 
 Can be supplied multiple times: `--terragrunt-exclude-dir /path/to/dirs/to/exclude --terragrunt-exclude-dir /another/path/to/dirs/to/exclude`


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Add  [environment variable](https://github.com/gruntwork-io/terragrunt/blob/d56b7bbc783906f68e63f9771bf9966c561d9ed5/cli/commands/flags.go#L208)  to docs.
 
<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Specify env var in docs, that controls `terragrunt-exclude-dir` flag.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

N/A