### PR TITLE
fix: Fixing command not found error

### DIFF
--- a/cli/commands/terraform/command.go
+++ b/cli/commands/terraform/command.go
@@ -1,6 +1,8 @@
 package terraform
 
 import (
+	"strings"
+
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/gruntwork-cli/collections"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -33,7 +35,12 @@ func action(opts *options.TerragruntOptions) cli.ActionFunc {
 		}
 
 		if !opts.DisableCommandValidation && !collections.ListContainsElement(nativeTerraformCommands, opts.TerraformCommand) {
-			return errors.WithStackTrace(WrongTerraformCommand(opts.TerraformCommand))
+			if strings.HasSuffix(opts.TerraformPath, "terraform") {
+				return errors.WithStackTrace(WrongTerraformCommand(opts.TerraformCommand))
+			} else {
+				// We default to tofu if the terraform path does not end in Terraform
+				return errors.WithStackTrace(WrongTofuCommand(opts.TerraformCommand))
+			}
 		}
 
 		return Run(ctx.Context, opts.OptionsFromContext(ctx))

--- a/cli/commands/terraform/command_test.go
+++ b/cli/commands/terraform/command_test.go
@@ -1,0 +1,53 @@
+package terraform
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/pkg/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAction(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name        string
+		opts        *options.TerragruntOptions
+		expectedErr error
+	}{
+		{
+			name: "wrong tofu command",
+			opts: &options.TerragruntOptions{
+				TerraformCommand: "foo",
+				TerraformPath:    "tofu",
+			},
+			expectedErr: WrongTofuCommand("foo"),
+		},
+		{
+			name: "wrong terraform command",
+			opts: &options.TerragruntOptions{
+				TerraformCommand: "foo",
+				TerraformPath:    "terraform",
+			},
+			expectedErr: WrongTerraformCommand("foo"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := action(tc.opts)
+
+			ctx := cli.Context{
+				Context: context.Background(),
+			}
+			err := fn(&ctx)
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cli/commands/terraform/errors.go
+++ b/cli/commands/terraform/errors.go
@@ -21,6 +21,12 @@ func (name WrongTerraformCommand) Error() string {
 	return fmt.Sprintf("Terraform has no command named %q. To see all of Terraform's top-level commands, run: terraform -help", string(name))
 }
 
+type WrongTofuCommand string
+
+func (name WrongTofuCommand) Error() string {
+	return fmt.Sprintf("OpenTofu has no command named %q. To see all of OpenTofu's top-level commands, run: tofu -help", string(name))
+}
+
 type BackendNotDefined struct {
 	Opts        *options.TerragruntOptions
 	BackendType string

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1662,7 +1662,7 @@ func TestTerraformCommandCliArgs(t *testing.T) {
 		{
 			[]string{"paln"},
 			"",
-			terraform.WrongTerraformCommand("paln"),
+			expectedWrongCommandErr("paln"),
 		},
 		{
 			[]string{"paln", "--terragrunt-disable-command-validation"},
@@ -7431,6 +7431,14 @@ func wrappedBinary() string {
 		return TERRAFORM_BINARY
 	}
 	return filepath.Base(value)
+}
+
+// expectedWrongCommandErr - return expected error message for wrong command
+func expectedWrongCommandErr(command string) error {
+	if wrappedBinary() == TOFU_BINARY {
+		return terraform.WrongTofuCommand(command)
+	}
+	return terraform.WrongTerraformCommand(command)
 }
 
 func isTerraform() bool {


### PR DESCRIPTION
## Description

Fixes bug where the error message for the wrong command always returns Terraform regardless of the actual binary being wrapped.

Was going to add a test for the happy path, but ran into side effects from [this check](https://github.com/gruntwork-io/terragrunt/blob/master/cli/commands/terraform/version_check.go#L36).

I don't think it's worth untangling that to fix this minor issue.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `terraform` package.

