### PR TITLE
chore: Hiding Mocks Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,11 @@ jobs:
             pre-commit install
             pre-commit run --all-files
       - run:
+          name: generate mocks
+          command: |
+            make install-mockery
+            make generate-mocks
+      - run:
           name: run lint
           command: |
             make install-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,8 +350,6 @@ jobs:
       - run:
           <<: *install_tofu
       - run:
-          <<: *install_tofu_engine
-      - run:
           <<: *setup_test_environment
       - run:
           # Remove terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,6 +341,35 @@ jobs:
       - store_test_results:
           path: logs
 
+  test_mocks:
+    resource_class: small
+    <<: *defaults
+    <<: *env
+    steps:
+      - checkout
+      - run:
+          <<: *install_tofu
+      - run:
+          <<: *install_tofu_engine
+      - run:
+          <<: *setup_test_environment
+      - run:
+          # Remove terraform
+          sudo rm -f $(which terraform)
+      - run:
+          name: Run mocks tests
+          command: |
+            run-go-tests --packages "-tags=mocks -run ^TestUpdateLockFile ./terraform/getproviders/lock_test.go" | tee logs/mocks.log
+          no_output_timeout: 30m
+          environment:
+            TERRAGRUNT_TFPATH: tofu
+      - run:
+          <<: *run_terratest_log_parser
+      - store_artifacts:
+          path: logs
+      - store_test_results:
+          path: logs
+
   # Run TFLint tests separately as tflint during execution change working directory.
   integration_test_tflint:
     resource_class: large
@@ -521,6 +550,14 @@ workflows:
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
       - integration_test_tflint:
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GCP__automated-tests
+            - GITHUB__PAT__gruntwork-ci
+      - test_mocks:
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,7 @@ jobs:
       - run:
           name: Run mocks tests
           command: |
-            run-go-tests --packages "-tags=mocks -run ^TestUpdateLockFile ./terraform/getproviders/lock_test.go" | tee logs/mocks.log
+            run-go-tests --packages "-tags=mocks -run ^TestUpdateLockFile ./terraform/getproviders/." | tee logs/mocks.log
           no_output_timeout: 30m
           environment:
             TERRAGRUNT_TFPATH: tofu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,8 +363,6 @@ jobs:
           no_output_timeout: 30m
           environment:
             TERRAGRUNT_TFPATH: tofu
-      - run:
-          <<: *run_terratest_log_parser
       - store_artifacts:
           path: logs
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,11 +180,6 @@ jobs:
             pre-commit install
             pre-commit run --all-files
       - run:
-          name: generate mocks
-          command: |
-            make install-mockery
-            make generate-mocks
-      - run:
           name: run lint
           command: |
             make install-lint
@@ -356,6 +351,11 @@ jobs:
       - run:
           # Remove terraform
           sudo rm -f $(which terraform)
+      - run:
+          name: generate mocks
+          command: |
+            make install-mockery
+            make generate-mocks
       - run:
           name: Run mocks tests
           command: |

--- a/terraform/getproviders/lock_test.go
+++ b/terraform/getproviders/lock_test.go
@@ -1,3 +1,5 @@
+//go:build mocks
+
 package getproviders
 
 import (


### PR DESCRIPTION
## Description

Hides tests requiring mockery behind a build flag.

This makes it easier to lint and test locally without having to install additional tooling.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `getproviders`.

