### PR TITLE
chore: Adding `performance` Lint Preset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,6 +372,35 @@ jobs:
       - store_test_results:
           path: logs
 
+  test_mocks:
+    resource_class: small
+    <<: *defaults
+    <<: *env
+    steps:
+      - checkout
+      - run:
+          <<: *install_tofu
+      - run:
+          <<: *install_tofu_engine
+      - run:
+          <<: *setup_test_environment
+      - run:
+          # Remove terraform
+          sudo rm -f $(which terraform)
+      - run:
+          name: Run mocks tests
+          command: |
+            run-go-tests --packages "-tags=mocks -run ^TestUpdateLockFile ./terraform/getproviders/lock_test.go" | tee logs/mocks.log
+          no_output_timeout: 30m
+          environment:
+            TERRAGRUNT_TFPATH: tofu
+      - run:
+          <<: *run_terratest_log_parser
+      - store_artifacts:
+          path: logs
+      - store_test_results:
+          path: logs
+
   # Run TFLint tests separately as tflint during execution change working directory.
   integration_test_tflint:
     resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,11 @@ jobs:
             pre-commit install
             pre-commit run --all-files
       - run:
+          name: generate mocks
+          command: |
+            make install-mockery
+            make generate-mocks
+      - run:
           name: run lint
           command: |
             make install-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,11 +180,6 @@ jobs:
             pre-commit install
             pre-commit run --all-files
       - run:
-          name: generate mocks
-          command: |
-            make install-mockery
-            make generate-mocks
-      - run:
           name: run lint
           command: |
             make install-lint
@@ -387,6 +382,11 @@ jobs:
       - run:
           # Remove terraform
           sudo rm -f $(which terraform)
+      - run:
+          name: generate mocks
+          command: |
+            make install-mockery
+            make generate-mocks
       - run:
           name: Run mocks tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,8 +394,6 @@ jobs:
           no_output_timeout: 30m
           environment:
             TERRAGRUNT_TFPATH: tofu
-      - run:
-          <<: *run_terratest_log_parser
       - store_artifacts:
           path: logs
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,38 +372,6 @@ jobs:
       - store_test_results:
           path: logs
 
-  test_mocks:
-    resource_class: small
-    <<: *defaults
-    <<: *env
-    steps:
-      - checkout
-      - run:
-          <<: *install_tofu
-      - run:
-          <<: *install_tofu_engine
-      - run:
-          <<: *setup_test_environment
-      - run:
-          # Remove terraform
-          sudo rm -f $(which terraform)
-      - run:
-          name: generate mocks
-          command: |
-            make install-mockery
-            make generate-mocks
-      - run:
-          name: Run mocks tests
-          command: |
-            run-go-tests --packages "-tags=mocks -run ^TestUpdateLockFile ./terraform/getproviders/." | tee logs/mocks.log
-          no_output_timeout: 30m
-          environment:
-            TERRAGRUNT_TFPATH: tofu
-      - store_artifacts:
-          path: logs
-      - store_test_results:
-          path: logs
-
   # Run TFLint tests separately as tflint during execution change working directory.
   integration_test_tflint:
     resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,7 +390,7 @@ jobs:
       - run:
           name: Run mocks tests
           command: |
-            run-go-tests --packages "-tags=mocks -run ^TestUpdateLockFile ./terraform/getproviders/lock_test.go" | tee logs/mocks.log
+            run-go-tests --packages "-tags=mocks -run ^TestUpdateLockFile ./terraform/getproviders/." | tee logs/mocks.log
           no_output_timeout: 30m
           environment:
             TERRAGRUNT_TFPATH: tofu

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,6 +75,7 @@ linters:
     ignored-functions: strconv.Format*,os.*,strconv.Parse*,strings.SplitN,bytes.SplitN
   presets:
     - bugs
+    - performance
 issues:
   exclude-dirs:
     - docs

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -3,6 +3,7 @@ package aws_helper
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -137,7 +138,7 @@ func getWebIdentityCredentialsFromIAMRoleOptions(sess *session.Session, iamRoleO
 	roleSessionName := iamRoleOptions.AssumeRoleSessionName
 	if roleSessionName == "" {
 		// Set a unique session name in the same way it is done in the SDK
-		roleSessionName = fmt.Sprintf("%d", time.Now().UTC().UnixNano())
+		roleSessionName = strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
 	}
 	svc := sts.New(sess)
 	p := stscreds.NewWebIdentityRoleProviderWithOptions(svc, iamRoleOptions.RoleARN, roleSessionName, tokenFetcher(iamRoleOptions.WebIdentityToken))

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -80,8 +79,8 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		},
 
 		{
-			[]string{doubleDashed(commands.TerragruntConfigFlagName), fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath)},
-			mockOptions(t, fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), workingDir, []string{}, false, "", false, false, defaultLogLevel, false),
+			[]string{doubleDashed(commands.TerragruntConfigFlagName), "/some/path/" + config.DefaultTerragruntConfigPath},
+			mockOptions(t, "/some/path/"+config.DefaultTerragruntConfigPath, workingDir, []string{}, false, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 
@@ -140,14 +139,14 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		},
 
 		{
-			[]string{doubleDashed(commands.TerragruntConfigFlagName), fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), "--terragrunt-non-interactive"},
-			mockOptions(t, fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), workingDir, []string{}, true, "", false, false, defaultLogLevel, false),
+			[]string{doubleDashed(commands.TerragruntConfigFlagName), "/some/path/" + config.DefaultTerragruntConfigPath, "--terragrunt-non-interactive"},
+			mockOptions(t, "/some/path/"+config.DefaultTerragruntConfigPath, workingDir, []string{}, true, "", false, false, defaultLogLevel, false),
 			nil,
 		},
 
 		{
-			[]string{"--foo", doubleDashed(commands.TerragruntConfigFlagName), fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), "bar", doubleDashed(commands.TerragruntNonInteractiveFlagName), "--baz", doubleDashed(commands.TerragruntWorkingDirFlagName), "/some/path", doubleDashed(commands.TerragruntSourceFlagName), "github.com/foo/bar//baz?ref=1.0.3"},
-			mockOptions(t, fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath), "/some/path", []string{"-foo", "bar", "-baz"}, true, "github.com/foo/bar//baz?ref=1.0.3", false, false, defaultLogLevel, false),
+			[]string{"--foo", doubleDashed(commands.TerragruntConfigFlagName), "/some/path/" + config.DefaultTerragruntConfigPath, "bar", doubleDashed(commands.TerragruntNonInteractiveFlagName), "--baz", doubleDashed(commands.TerragruntWorkingDirFlagName), "/some/path", doubleDashed(commands.TerragruntSourceFlagName), "github.com/foo/bar//baz?ref=1.0.3"},
+			mockOptions(t, "/some/path/"+config.DefaultTerragruntConfigPath, "/some/path", []string{"-foo", "bar", "-baz"}, true, "github.com/foo/bar//baz?ref=1.0.3", false, false, defaultLogLevel, false),
 			nil,
 		},
 
@@ -282,10 +281,10 @@ func TestFilterTerragruntArgs(t *testing.T) {
 	}{
 		{[]string{}, []string{}},
 		{[]string{"foo", "--bar"}, []string{"foo", "-bar"}},
-		{[]string{"foo", doubleDashed(commands.TerragruntConfigFlagName), fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath)}, []string{"foo"}},
+		{[]string{"foo", doubleDashed(commands.TerragruntConfigFlagName), "/some/path/" + config.DefaultTerragruntConfigPath}, []string{"foo"}},
 		{[]string{"foo", doubleDashed(commands.TerragruntNonInteractiveFlagName)}, []string{"foo"}},
 		{[]string{"foo", doubleDashed(commands.TerragruntDebugFlagName)}, []string{"foo"}},
-		{[]string{"foo", doubleDashed(commands.TerragruntNonInteractiveFlagName), "-bar", doubleDashed(commands.TerragruntWorkingDirFlagName), "/some/path", "--baz", doubleDashed(commands.TerragruntConfigFlagName), fmt.Sprintf("/some/path/%s", config.DefaultTerragruntConfigPath)}, []string{"foo", "-bar", "-baz"}},
+		{[]string{"foo", doubleDashed(commands.TerragruntNonInteractiveFlagName), "-bar", doubleDashed(commands.TerragruntWorkingDirFlagName), "/some/path", "--baz", doubleDashed(commands.TerragruntConfigFlagName), "/some/path/" + config.DefaultTerragruntConfigPath}, []string{"foo", "-bar", "-baz"}},
 		{[]string{CommandNameApplyAll, "foo", "bar"}, []string{terraform.CommandNameApply, "foo", "bar"}},
 		{[]string{CommandNameDestroyAll, "foo", "-foo", "--bar"}, []string{terraform.CommandNameDestroy, "foo", "-foo", "-bar"}},
 	}
@@ -486,13 +485,13 @@ func runAppTest(args []string, opts *options.TerragruntOptions) (*options.Terrag
 }
 
 func doubleDashed(name string) string {
-	return fmt.Sprintf("--%s", name)
+	return "--" + name
 }
 
 type argMissingValueError string
 
 func (err argMissingValueError) Error() string {
-	return fmt.Sprintf("flag needs an argument: -%s", string(err))
+	return "flag needs an argument: -" + string(err)
 }
 
 func TestAutocomplete(t *testing.T) {

--- a/cli/commands/aws-provider-patch/action.go
+++ b/cli/commands/aws-provider-patch/action.go
@@ -31,7 +31,6 @@ package awsproviderpatch
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -142,7 +141,7 @@ func findAllTerraformFilesInModules(opts *options.TerragruntOptions) ([]string, 
 			// Ideally, we'd use a builtin Go library like filepath.Glob here, but per https://github.com/golang/go/issues/11862,
 			// the current go implementation doesn't support treating ** as zero or more directories, just zero or one.
 			// So we use a third-party library.
-			matches, err := zglob.Glob(fmt.Sprintf("%s/**/*.tf", moduleAbsPath))
+			matches, err := zglob.Glob(moduleAbsPath + "/**/*.tf")
 			if err != nil {
 				return nil, errors.WithStackTrace(err)
 			}

--- a/cli/commands/catalog/tui/model.go
+++ b/cli/commands/catalog/tui/model.go
@@ -68,7 +68,7 @@ type model struct {
 
 func newModel(modules module.Modules, opts *options.TerragruntOptions) model {
 	var (
-		items        []list.Item
+		items        = make([]list.Item, 0, len(modules))
 		listKeys     = newListKeyMap()
 		delegateKeys = newDelegateKeyMap()
 		pagerKeys    = newPagerKeyMap()

--- a/cli/commands/catalog/tui/update.go
+++ b/cli/commands/catalog/tui/update.go
@@ -151,7 +151,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 
 	case rendererErrMsg:
-		m.viewport.SetContent(fmt.Sprintf("there was an error rendering markdown: %s", msg.err.Error()))
+		m.viewport.SetContent("there was an error rendering markdown: " + msg.err.Error())
 		// ensure we show the viewport
 		m.state = pagerState
 	}

--- a/cli/commands/graph/action.go
+++ b/cli/commands/graph/action.go
@@ -2,7 +2,7 @@ package graph
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	runall "github.com/gruntwork-io/terragrunt/cli/commands/run-all"
 
@@ -23,7 +23,7 @@ func Run(ctx context.Context, opts *options.TerragruntOptions) error {
 
 func graph(ctx context.Context, opts *options.TerragruntOptions, cfg *config.TerragruntConfig) error {
 	if cfg == nil {
-		return fmt.Errorf("Terragrunt was not able to render the config as json because it received no config. This is almost certainly a bug in Terragrunt. Please open an issue on github.com/gruntwork-io/terragrunt with this message and the contents of your terragrunt.hcl.")
+		return errors.New("Terragrunt was not able to render the config as json because it received no config. This is almost certainly a bug in Terragrunt. Please open an issue on github.com/gruntwork-io/terragrunt with this message and the contents of your terragrunt.hcl.")
 	}
 	// consider root for graph identification passed destroy-graph-root argument
 	rootDir := opts.GraphRoot

--- a/cli/commands/output-module-groups/command.go
+++ b/cli/commands/output-module-groups/command.go
@@ -1,8 +1,6 @@
 package outputmodulegroups
 
 import (
-	"fmt"
-
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/cli"
 )
@@ -28,7 +26,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 func subCommandFunc(cmd string, opts *options.TerragruntOptions) *cli.Command {
 	return &cli.Command{
 		Name:  cmd,
-		Usage: fmt.Sprintf("Recursively find terragrunt modules in the current directory tree and output the dependency order as a list of list in JSON for the %s", cmd),
+		Usage: "Recursively find terragrunt modules in the current directory tree and output the dependency order as a list of list in JSON for the " + cmd,
 		Action: func(ctx *cli.Context) error {
 			opts.TerraformCommand = cmd
 			return Run(ctx, opts.OptionsFromContext(ctx))

--- a/cli/commands/render-json/action.go
+++ b/cli/commands/render-json/action.go
@@ -9,7 +9,7 @@ package renderjson
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	goErrors "errors"
 	"os"
 	"path/filepath"
 
@@ -33,7 +33,7 @@ func Run(ctx context.Context, opts *options.TerragruntOptions) error {
 
 func runRenderJSON(ctx context.Context, opts *options.TerragruntOptions, cfg *config.TerragruntConfig) error {
 	if cfg == nil {
-		return fmt.Errorf("Terragrunt was not able to render the config as json because it received no config. This is almost certainly a bug in Terragrunt. Please open an issue on github.com/gruntwork-io/terragrunt with this message and the contents of your terragrunt.hcl.")
+		return goErrors.New("Terragrunt was not able to render the config as json because it received no config. This is almost certainly a bug in Terragrunt. Please open an issue on github.com/gruntwork-io/terragrunt with this message and the contents of your terragrunt.hcl.")
 	}
 
 	if !opts.JsonDisableDependentModules {

--- a/cli/commands/terraform/action.go
+++ b/cli/commands/terraform/action.go
@@ -331,7 +331,7 @@ func confirmActionWithDependentModules(ctx context.Context, terragruntOptions *o
 			return false
 		}
 		for _, module := range modules {
-			if _, err := terragruntOptions.ErrWriter.Write([]byte(fmt.Sprintf("%s\n", module.Path))); err != nil {
+			if _, err := terragruntOptions.ErrWriter.Write([]byte(module.Path + "\n")); err != nil {
 				terragruntOptions.Logger.Error(err)
 				return false
 			}
@@ -471,13 +471,13 @@ func prepareInitCommand(ctx context.Context, terragruntOptions *options.Terragru
 
 func checkFolderContainsTerraformCode(terragruntOptions *options.TerragruntOptions) error {
 	files := []string{}
-	hclFiles, err := zglob.Glob(fmt.Sprintf("%s/**/*.tf", terragruntOptions.WorkingDir))
+	hclFiles, err := zglob.Glob(terragruntOptions.WorkingDir + "/**/*.tf")
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
 	files = append(files, hclFiles...)
 
-	jsonFiles, err := zglob.Glob(fmt.Sprintf("%s/**/*.tf.json", terragruntOptions.WorkingDir))
+	jsonFiles, err := zglob.Glob(terragruntOptions.WorkingDir + "/**/*.tf.json")
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
@@ -497,7 +497,7 @@ func checkTerraformCodeDefinesBackend(terragruntOptions *options.TerragruntOptio
 		return errors.WithStackTrace(err)
 	}
 
-	definesBackend, err := util.Grep(terraformBackendRegexp, fmt.Sprintf("%s/**/*.tf", terragruntOptions.WorkingDir))
+	definesBackend, err := util.Grep(terraformBackendRegexp, terragruntOptions.WorkingDir+"/**/*.tf")
 	if err != nil {
 		return err
 	}
@@ -510,7 +510,7 @@ func checkTerraformCodeDefinesBackend(terragruntOptions *options.TerragruntOptio
 		return errors.WithStackTrace(err)
 	}
 
-	definesJSONBackend, err := util.Grep(terraformJSONBackendRegexp, fmt.Sprintf("%s/**/*.tf.json", terragruntOptions.WorkingDir))
+	definesJSONBackend, err := util.Grep(terraformJSONBackendRegexp, terragruntOptions.WorkingDir+"/**/*.tf.json")
 	if err != nil {
 		return err
 	}
@@ -661,7 +661,7 @@ func checkProtectedModule(terragruntOptions *options.TerragruntOptions, terragru
 	if util.FirstArg(terragruntOptions.TerraformCliArgs) == terraform.CommandNameDestroy {
 		destroyFlag = true
 	}
-	if util.ListContainsElement(terragruntOptions.TerraformCliArgs, fmt.Sprintf("-%s", terraform.CommandNameDestroy)) {
+	if util.ListContainsElement(terragruntOptions.TerraformCliArgs, "-"+terraform.CommandNameDestroy) {
 		destroyFlag = true
 	}
 	if !destroyFlag {
@@ -703,7 +703,7 @@ func filterTerraformExtraArgs(terragruntOptions *options.TerragruntOptions, terr
 				if !skipVars {
 					varFiles := arg.GetVarFiles(terragruntOptions.Logger)
 					for _, file := range varFiles {
-						out = append(out, fmt.Sprintf("-var-file=%s", file))
+						out = append(out, "-var-file="+file)
 					}
 				}
 			}

--- a/cli/commands/terraform/action_test.go
+++ b/cli/commands/terraform/action_test.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -344,13 +343,13 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 		{
 			mockCmdOptions(t, workingDir, []string{"apply"}),
 			mockExtraArgs([]string{"--foo", "bar"}, []string{"apply", "plan"}, []string{}, []string{temporaryFile}),
-			[]string{"--foo", "bar", fmt.Sprintf("-var-file=%s", temporaryFile)},
+			[]string{"--foo", "bar", "-var-file=" + temporaryFile},
 		},
 		// required var file + optional existing var file
 		{
 			mockCmdOptions(t, workingDir, []string{"apply"}),
 			mockExtraArgs([]string{"--foo", "bar"}, []string{"apply", "plan"}, []string{"required.tfvars"}, []string{temporaryFile}),
-			[]string{"--foo", "bar", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+			[]string{"--foo", "bar", "-var-file=required.tfvars", "-var-file=" + temporaryFile},
 		},
 		// non existing required var file + non existing optional var file
 		{
@@ -362,13 +361,13 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 		{
 			mockCmdOptions(t, workingDir, []string{"plan", workingDir}),
 			mockExtraArgs([]string{"--foo", "bar"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
-			[]string{"--foo", "bar", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+			[]string{"--foo", "bar", "-var-file=required.tfvars", "-var-file=" + temporaryFile},
 		},
 		// apply providing a folder, var files should stay included
 		{
 			mockCmdOptions(t, workingDir, []string{"apply", workingDir}),
 			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "-var='key=value'"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
-			[]string{"--foo", "-var-file=test.tfvars", "-var='key=value'", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+			[]string{"--foo", "-var-file=test.tfvars", "-var='key=value'", "-var-file=required.tfvars", "-var-file=" + temporaryFile},
 		},
 		// apply providing a file, no var files included
 		{
@@ -381,7 +380,7 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 		{
 			mockCmdOptions(t, workingDir, []string{"apply"}),
 			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
-			[]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+			[]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo", "-var-file=required.tfvars", "-var-file=" + temporaryFile},
 		},
 		// apply with some parameters, providing a file => no var files included
 		{
@@ -393,7 +392,7 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 		{
 			mockCmdOptions(t, workingDir, []string{"destroy", workingDir}),
 			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "-var='key=value'"}, []string{"plan", "destroy"}, []string{"required.tfvars"}, []string{temporaryFile}),
-			[]string{"--foo", "-var-file=test.tfvars", "-var='key=value'", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+			[]string{"--foo", "-var-file=test.tfvars", "-var='key=value'", "-var-file=required.tfvars", "-var-file=" + temporaryFile},
 		},
 		// destroy providing a file, no var files included
 		{
@@ -406,7 +405,7 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 		{
 			mockCmdOptions(t, workingDir, []string{"destroy"}),
 			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo"}, []string{"plan", "destroy"}, []string{"required.tfvars"}, []string{temporaryFile}),
-			[]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo", "-var-file=required.tfvars", fmt.Sprintf("-var-file=%s", temporaryFile)},
+			[]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo", "-var-file=required.tfvars", "-var-file=" + temporaryFile},
 		},
 		// destroy with some parameters, providing a file => no var files included
 		{

--- a/cli/commands/terraform/download_source.go
+++ b/cli/commands/terraform/download_source.go
@@ -139,7 +139,7 @@ func alreadyHaveLatestCode(terraformSource *terraform.Source, terragruntOptions 
 		return false, nil
 	}
 
-	tfFiles, err := filepath.Glob(fmt.Sprintf("%s/*.tf", terraformSource.WorkingDir))
+	tfFiles, err := filepath.Glob(terraformSource.WorkingDir + "/*.tf")
 	if err != nil {
 		return false, errors.WithStackTrace(err)
 	}

--- a/cli/commands/terraform/download_source_test.go
+++ b/cli/commands/terraform/download_source_test.go
@@ -27,7 +27,7 @@ import (
 func TestAlreadyHaveLatestCodeLocalFilePathWithNoModifiedFiles(t *testing.T) {
 	t.Parallel()
 
-	canonicalUrl := fmt.Sprintf("file://%s", absPath(t, "../../../test/fixture-download-source/hello-world-local-hash"))
+	canonicalUrl := "file://" + absPath(t, "../../../test/fixture-download-source/hello-world-local-hash")
 	downloadDir := tmpDir(t)
 	defer os.Remove(downloadDir)
 
@@ -51,7 +51,7 @@ func TestAlreadyHaveLatestCodeLocalFilePathHashingFailure(t *testing.T) {
 	t.Parallel()
 
 	fixturePath := absPath(t, "../../../test/fixture-download-source/hello-world-local-hash-failed")
-	canonicalUrl := fmt.Sprintf("file://%s", fixturePath)
+	canonicalUrl := "file://" + fixturePath
 	downloadDir := tmpDir(t)
 	defer os.Remove(downloadDir)
 
@@ -78,7 +78,7 @@ func TestAlreadyHaveLatestCodeLocalFilePathHashingFailure(t *testing.T) {
 func TestAlreadyHaveLatestCodeLocalFilePathWithHashChanged(t *testing.T) {
 	t.Parallel()
 
-	canonicalUrl := fmt.Sprintf("file://%s", absPath(t, "../../../test/fixture-download-source/hello-world-local-hash"))
+	canonicalUrl := "file://" + absPath(t, "../../../test/fixture-download-source/hello-world-local-hash")
 	downloadDir := tmpDir(t)
 	defer os.Remove(downloadDir)
 
@@ -99,7 +99,7 @@ func TestAlreadyHaveLatestCodeLocalFilePathWithHashChanged(t *testing.T) {
 func TestAlreadyHaveLatestCodeLocalFilePath(t *testing.T) {
 	t.Parallel()
 
-	canonicalUrl := fmt.Sprintf("file://%s", absPath(t, "../../../test/fixture-download-source/hello-world"))
+	canonicalUrl := "file://" + absPath(t, "../../../test/fixture-download-source/hello-world")
 	downloadDir := "does-not-exist"
 
 	testAlreadyHaveLatestCode(t, canonicalUrl, downloadDir, false)
@@ -162,7 +162,7 @@ func TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersi
 func TestDownloadTerraformSourceIfNecessaryLocalDirToEmptyDir(t *testing.T) {
 	t.Parallel()
 
-	canonicalUrl := fmt.Sprintf("file://%s", absPath(t, "../../../test/fixture-download-source/hello-world"))
+	canonicalUrl := "file://" + absPath(t, "../../../test/fixture-download-source/hello-world")
 	downloadDir := tmpDir(t)
 	defer os.Remove(downloadDir)
 
@@ -172,7 +172,7 @@ func TestDownloadTerraformSourceIfNecessaryLocalDirToEmptyDir(t *testing.T) {
 func TestDownloadTerraformSourceIfNecessaryLocalDirToAlreadyDownloadedDir(t *testing.T) {
 	t.Parallel()
 
-	canonicalUrl := fmt.Sprintf("file://%s", absPath(t, "../../../test/fixture-download-source/hello-world"))
+	canonicalUrl := "file://" + absPath(t, "../../../test/fixture-download-source/hello-world")
 	downloadDir := tmpDir(t)
 	defer os.Remove(downloadDir)
 

--- a/cli/commands/terraform/errors.go
+++ b/cli/commands/terraform/errors.go
@@ -39,7 +39,7 @@ func (err BackendNotDefined) Error() string {
 type NoTerraformFilesFound string
 
 func (path NoTerraformFilesFound) Error() string {
-	return fmt.Sprintf("Did not find any Terraform files (*.tf) in %s", string(path))
+	return "Did not find any Terraform files (*.tf) in " + string(path)
 }
 
 type ModuleIsProtected struct {

--- a/cli/commands/terraform/hook.go
+++ b/cli/commands/terraform/hook.go
@@ -100,7 +100,7 @@ func processHooks(ctx context.Context, hooks []config.Hook, terragruntOptions *o
 	for _, curHook := range hooks {
 		allPreviousErrors := multierror.Append(previousExecErrors, errorsOccured)
 		if shouldRunHook(curHook, terragruntOptions, allPreviousErrors) {
-			err := telemetry.Telemetry(ctx, terragruntOptions, fmt.Sprintf("hook_%s", curHook.Name), map[string]interface{}{
+			err := telemetry.Telemetry(ctx, terragruntOptions, "hook_"+curHook.Name, map[string]interface{}{
 				"hook": curHook.Name,
 				"dir":  curHook.WorkingDir,
 			}, func(childCtx context.Context) error {

--- a/cli/commands/terraform/version_check.go
+++ b/cli/commands/terraform/version_check.go
@@ -189,7 +189,7 @@ func parseTerraformImplementationType(versionCommandOutput string) (options.Terr
 type InvalidTerraformVersionSyntax string
 
 func (err InvalidTerraformVersionSyntax) Error() string {
-	return fmt.Sprintf("Unable to parse Terraform version output: %s", string(err))
+	return "Unable to parse Terraform version output: " + string(err)
 }
 
 type InvalidTerraformVersion struct {

--- a/cli/commands/validate-inputs/action.go
+++ b/cli/commands/validate-inputs/action.go
@@ -84,7 +84,7 @@ func runValidateInputs(ctx context.Context, opts *options.TerragruntOptions, cfg
 	// an error will only be returned if required inputs are missing. When strict mode is true, an error will be
 	// returned if required inputs are missing OR if any unused variables are passed
 	if len(missingVars) > 0 || len(unusedVars) > 0 && opts.ValidateStrict {
-		return fmt.Errorf(fmt.Sprintf("Terragrunt configuration has misaligned inputs. Strict mode enabled: %t.", opts.ValidateStrict))
+		return fmt.Errorf("Terragrunt configuration has misaligned inputs. Strict mode enabled: %t.", opts.ValidateStrict)
 	} else if len(unusedVars) > 0 {
 		opts.Logger.Warn("Terragrunt configuration has misaligned inputs, but running in relaxed mode so ignoring.")
 	}

--- a/cli/provider_cache.go
+++ b/cli/provider_cache.go
@@ -367,7 +367,9 @@ func convertToMultipleCommandsByPlatforms(args []string) [][]string {
 	var commandsArgs = make([][]string, 0, len(platformArgs))
 
 	for _, platformArg := range platformArgs {
-		commandsArgs = append(commandsArgs, append(filteredArgs, platformArg))
+		var commandArgs = make([]string, len(filteredArgs), len(filteredArgs)+1)
+		copy(commandArgs, filteredArgs)
+		commandsArgs = append(commandsArgs, append(commandArgs, platformArg))
 	}
 	return commandsArgs
 }

--- a/cli/provider_cache.go
+++ b/cli/provider_cache.go
@@ -99,13 +99,13 @@ func InitProviderCacheServer(opts *options.TerragruntOptions) (*ProviderCache, e
 	providerService := services.NewProviderService(opts.ProviderCacheDir, userProviderDir, cliCfg.CredentialsSource())
 
 	var (
-		providerHandlers []handlers.ProviderHandler
-		excludeAddrs     []string
+		providerHandlers = make([]handlers.ProviderHandler, 0, len(cliCfg.ProviderInstallation.Methods))
+		excludeAddrs     = make([]string, 0, len(cliCfg.ProviderInstallation.Methods))
 		directIsdefined  bool
 	)
 
 	for _, registryName := range opts.ProviderCacheRegistryNames {
-		excludeAddrs = append(excludeAddrs, fmt.Sprintf("%s/*/*", registryName))
+		excludeAddrs = append(excludeAddrs, registryName+"/*/*")
 	}
 
 	for _, method := range cliCfg.ProviderInstallation.Methods {
@@ -242,10 +242,10 @@ func (cache *ProviderCache) createLocalCLIConfig(ctx context.Context, opts *opti
 	cfg := cache.cliCfg.Clone()
 	cfg.PluginCacheDir = ""
 
-	var providerInstallationIncludes []string
+	var providerInstallationIncludes = make([]string, 0, len(opts.ProviderCacheRegistryNames))
 
 	for _, registryName := range opts.ProviderCacheRegistryNames {
-		providerInstallationIncludes = append(providerInstallationIncludes, fmt.Sprintf("%s/*/*", registryName))
+		providerInstallationIncludes = append(providerInstallationIncludes, registryName+"/*/*")
 
 		urls, err := DiscoveryURL(ctx, registryName)
 		if err != nil {
@@ -348,9 +348,8 @@ func providerCacheEnvironment(opts *options.TerragruntOptions, cliConfigFile str
 // `providers lock -platform=freebsd_amd64`
 func convertToMultipleCommandsByPlatforms(args []string) [][]string {
 	var (
-		filteredArgs []string
-		platformArgs []string
-		commandsArgs [][]string
+		filteredArgs = make([]string, 0, len(args))
+		platformArgs = make([]string, 0, len(args))
 	)
 
 	for _, arg := range args {
@@ -364,6 +363,8 @@ func convertToMultipleCommandsByPlatforms(args []string) [][]string {
 	if len(platformArgs) == 0 {
 		return [][]string{args}
 	}
+
+	var commandsArgs = make([][]string, 0, len(platformArgs))
 
 	for _, platformArg := range platformArgs {
 		commandsArgs = append(commandsArgs, append(filteredArgs, platformArg))

--- a/cli/registry_urls.go
+++ b/cli/registry_urls.go
@@ -72,5 +72,5 @@ type NotFoundWellKnownURL struct {
 }
 
 func (err NotFoundWellKnownURL) Error() string {
-	return fmt.Sprintf("%s not found", err.url)
+	return err.url + " not found"
 }

--- a/codegen/errors.go
+++ b/codegen/errors.go
@@ -10,7 +10,7 @@ type UnknownGenerateIfExistsVal struct {
 
 func (err UnknownGenerateIfExistsVal) Error() string {
 	if err.val != "" {
-		return fmt.Sprintf("%s is not a valid value for generate if_exists", err.val)
+		return err.val + " is not a valid value for generate if_exists"
 	}
 	return "Received unknown value for if_exists"
 }
@@ -21,7 +21,7 @@ type UnknownGenerateIfDisabledVal struct {
 
 func (err UnknownGenerateIfDisabledVal) Error() string {
 	if err.val != "" {
-		return fmt.Sprintf("%s is not a valid value for generate if_disabled", err.val)
+		return err.val + " is not a valid value for generate if_disabled"
 	}
 	return "Received unknown value for if_disabled"
 }
@@ -39,5 +39,5 @@ type GenerateFileRemoveError struct {
 }
 
 func (err GenerateFileRemoveError) Error() string {
-	return fmt.Sprintf("Can not remove terraform file: %s", err.path)
+	return "Can not remove terraform file: " + err.path
 }

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -219,7 +219,7 @@ func RemoteStateConfigToTerraformCode(backend string, config map[string]interfac
 	f := hclwrite.NewEmptyFile()
 	backendBlock := f.Body().AppendNewBlock("terraform", nil).Body().AppendNewBlock("backend", []string{backend})
 	backendBlockBody := backendBlock.Body()
-	var backendKeys []string
+	var backendKeys = make([]string, 0, len(config))
 
 	for key := range config {
 		backendKeys = append(backendKeys, key)

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
@@ -314,7 +315,7 @@ func (cfg *IncludeConfig) String() string {
 	}
 	exposeStr := "nil"
 	if cfg.Expose != nil {
-		exposeStr = fmt.Sprintf("%v", *cfg.Expose)
+		exposeStr = strconv.FormatBool(*cfg.Expose)
 	}
 	mergeStrategyStr := "nil"
 	if cfg.MergeStrategy != nil {

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	goErrors "errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -620,7 +621,7 @@ func readTerragruntConfig(ctx *ParsingContext, configPath string, defaultVal *ct
 func readTerragruntConfigAsFuncImpl(ctx *ParsingContext) function.Function {
 	return function.New(&function.Spec{
 		// Takes one required string param
-		Params: []function.Parameter{function.Parameter{Type: cty.String}},
+		Params: []function.Parameter{{Type: cty.String}},
 		// And optional param that takes anything
 		VarParam: &function.Parameter{Type: cty.DynamicPseudoType},
 		// We don't know the return type until we parse the terragrunt config, so we use a dynamic type
@@ -864,7 +865,7 @@ func endsWith(ctx *ParsingContext, args []string) (bool, error) {
 // timeCmp implements Terraform's `timecmp` function that compares two timestamps.
 func timeCmp(ctx *ParsingContext, args []string) (int64, error) {
 	if len(args) != matchedPats {
-		return 0, errors.WithStackTrace(fmt.Errorf("function can take only two parameters: timestamp_a and timestamp_b"))
+		return 0, errors.WithStackTrace(goErrors.New("function can take only two parameters: timestamp_a and timestamp_b"))
 	}
 
 	tsA, err := util.ParseTimestamp(args[0])

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -446,7 +446,7 @@ func TestResolveEnvInterpolationConfigString(t *testing.T) {
 		{
 			`iam_role = get_env("TEST_ENV_TERRAGRUNT_VAR")`,
 			nil,
-			terragruntOptionsForTestWithEnv(t, fmt.Sprintf("/root/child/%s", DefaultTerragruntConfigPath), map[string]string{"TEST_ENV_TERRAGRUNT_VAR": "SOMETHING"}),
+			terragruntOptionsForTestWithEnv(t, "/root/child/"+DefaultTerragruntConfigPath, map[string]string{"TEST_ENV_TERRAGRUNT_VAR": "SOMETHING"}),
 			"SOMETHING",
 			"",
 		},
@@ -602,7 +602,12 @@ func toStringSlice(t *testing.T, value interface{}) []string {
 	asInterfaceSlice, isInterfaceSlice := value.([]interface{})
 	require.True(t, isInterfaceSlice)
 
-	var out []string
+	// TODO: See if this logic is desired
+	if len(asInterfaceSlice) == 0 {
+		return nil
+	}
+
+	var out = make([]string, 0, len(asInterfaceSlice))
 	for _, item := range asInterfaceSlice {
 		asStr, isStr := item.(string)
 		require.True(t, isStr)
@@ -616,7 +621,7 @@ func TestGetTerragruntDirAbsPath(t *testing.T) {
 	t.Parallel()
 	workingDir, err := os.Getwd()
 	require.NoError(t, err, "Could not get current working dir: %v", err)
-	testGetTerragruntDir(t, "/foo/bar/terragrunt.hcl", fmt.Sprintf("%s/foo/bar", filepath.VolumeName(workingDir)))
+	testGetTerragruntDir(t, "/foo/bar/terragrunt.hcl", filepath.VolumeName(workingDir)+"/foo/bar")
 }
 
 func TestGetTerragruntDirRelPath(t *testing.T) {
@@ -625,7 +630,7 @@ func TestGetTerragruntDirRelPath(t *testing.T) {
 	require.NoError(t, err, "Could not get current working dir: %v", err)
 	workingDir = filepath.ToSlash(workingDir)
 
-	testGetTerragruntDir(t, "foo/bar/terragrunt.hcl", fmt.Sprintf("%s/foo/bar", workingDir))
+	testGetTerragruntDir(t, "foo/bar/terragrunt.hcl", workingDir+"/foo/bar")
 }
 
 func testGetTerragruntDir(t *testing.T, configPath string, expectedPath string) {
@@ -706,7 +711,7 @@ func TestGetParentTerragruntDir(t *testing.T) {
 			map[string]IncludeConfig{"": {Path: "../../other-child/" + DefaultTerragruntConfigPath}},
 			nil,
 			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/"+DefaultTerragruntConfigPath),
-			fmt.Sprintf("%s/other-child", filepath.VolumeName(parentDir)),
+			filepath.VolumeName(parentDir) + "/other-child",
 		},
 		{
 			map[string]IncludeConfig{"": {Path: "../../" + DefaultTerragruntConfigPath}},
@@ -721,7 +726,7 @@ func TestGetParentTerragruntDir(t *testing.T) {
 			},
 			[]string{"child"},
 			terragruntOptionsForTest(t, helpers.RootFolder+"child/sub-child/"+DefaultTerragruntConfigPath),
-			fmt.Sprintf("%s/other-child", filepath.VolumeName(parentDir)),
+			filepath.VolumeName(parentDir) + "/other-child",
 		},
 	}
 

--- a/config/cty_helpers.go
+++ b/config/cty_helpers.go
@@ -147,7 +147,7 @@ func wrapStaticValueToStringSliceAsFuncImpl(out []string) function.Function {
 // Convert the slice of cty values to a slice of strings. If any of the values in the given slice is not a string,
 // return an error.
 func ctySliceToStringSlice(args []cty.Value) ([]string, error) {
-	var out []string
+	var out = make([]string, 0, len(args))
 	for _, arg := range args {
 		if arg.Type() != cty.String {
 			return nil, errors.WithStackTrace(InvalidParameterTypeError{Expected: "string", Actual: arg.Type().FriendlyName()})

--- a/config/errors.go
+++ b/config/errors.go
@@ -32,7 +32,7 @@ func (err TooManyLevelsOfInheritanceError) Error() string {
 type CouldNotResolveTerragruntConfigInFileError string
 
 func (err CouldNotResolveTerragruntConfigInFileError) Error() string {
-	return fmt.Sprintf("Could not find Terragrunt configuration settings in %s", string(err))
+	return "Could not find Terragrunt configuration settings in " + string(err)
 }
 
 type InvalidMergeStrategyTypeError string
@@ -134,7 +134,7 @@ func (err InvalidEnvParamNameError) Error() string {
 type EmptyStringNotAllowedError string
 
 func (err EmptyStringNotAllowedError) Error() string {
-	return fmt.Sprintf("Empty string value is not allowed for %s", string(err))
+	return "Empty string value is not allowed for " + string(err)
 }
 
 type TerragruntConfigNotFoundError struct {
@@ -195,7 +195,7 @@ type DependencyConfigNotFound struct {
 }
 
 func (err DependencyConfigNotFound) Error() string {
-	return fmt.Sprintf("%s does not exist", err.Path)
+	return err.Path + " does not exist"
 }
 
 type TerragruntOutputParsingError struct {
@@ -241,5 +241,5 @@ func (err TerragruntOutputTargetNoOutputs) Error() string {
 type DependencyCycleError []string
 
 func (err DependencyCycleError) Error() string {
-	return fmt.Sprintf("Found a dependency cycle between modules: %s", strings.Join([]string(err), " -> "))
+	return "Found a dependency cycle between modules: " + strings.Join([]string(err), " -> ")
 }

--- a/config/hclparse/attributes.go
+++ b/config/hclparse/attributes.go
@@ -10,7 +10,7 @@ import (
 type Attributes []*Attribute
 
 func NewAttributes(file *File, hclAttrs hcl.Attributes) Attributes {
-	var attrs Attributes
+	var attrs = make(Attributes, 0, len(hclAttrs))
 
 	for _, hclAttr := range hclAttrs {
 		attrs = append(attrs, &Attribute{

--- a/config/include.go
+++ b/config/include.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	goErrors "errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -98,7 +99,7 @@ func parseIncludedConfig(ctx *ParsingContext, includedConfig *IncludeConfig) (*T
 // user.
 func handleInclude(ctx *ParsingContext, config *TerragruntConfig, isPartial bool) (*TerragruntConfig, error) {
 	if ctx.TrackInclude == nil {
-		return nil, fmt.Errorf("You reached an impossible condition. This is most likely a bug in terragrunt. Please open an issue at github.com/gruntwork-io/terragrunt with this error message. Code: HANDLE_INCLUDE_NIL_INCLUDE_CONFIG")
+		return nil, goErrors.New("You reached an impossible condition. This is most likely a bug in terragrunt. Please open an issue at github.com/gruntwork-io/terragrunt with this error message. Code: HANDLE_INCLUDE_NIL_INCLUDE_CONFIG")
 	}
 
 	// We merge in the include blocks in reverse order here. The expectation is that the bottom most elements override
@@ -156,7 +157,7 @@ func handleInclude(ctx *ParsingContext, config *TerragruntConfig, isPartial bool
 // child.
 func handleIncludeForDependency(ctx *ParsingContext, childDecodedDependency terragruntDependency) (*terragruntDependency, error) {
 	if ctx.TrackInclude == nil {
-		return nil, fmt.Errorf("You reached an impossible condition. This is most likely a bug in terragrunt. Please open an issue at github.com/gruntwork-io/terragrunt with this error message. Code: HANDLE_INCLUDE_DEPENDENCY_NIL_INCLUDE_CONFIG")
+		return nil, goErrors.New("You reached an impossible condition. This is most likely a bug in terragrunt. Please open an issue at github.com/gruntwork-io/terragrunt with this error message. Code: HANDLE_INCLUDE_DEPENDENCY_NIL_INCLUDE_CONFIG")
 	}
 	// We merge in the include blocks in reverse order here. The expectation is that the bottom most elements override
 	// those in earlier includes, so we need to merge bottom up instead of top down to ensure this.

--- a/configstack/errors.go
+++ b/configstack/errors.go
@@ -1,6 +1,7 @@
 package configstack
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -42,12 +43,12 @@ func (err InfiniteRecursionError) Error() string {
 	return fmt.Sprintf("Hit what seems to be an infinite recursion after going %d levels deep. Please check for a circular dependency! Modules involved: %v", err.RecursionLevel, err.Modules)
 }
 
-var NoTerraformModulesFound = fmt.Errorf("Could not find any subfolders with Terragrunt configuration files")
+var NoTerraformModulesFound = errors.New("Could not find any subfolders with Terragrunt configuration files")
 
 type DependencyCycleError []string
 
 func (err DependencyCycleError) Error() string {
-	return fmt.Sprintf("Found a dependency cycle between modules: %s", strings.Join([]string(err), " -> "))
+	return "Found a dependency cycle between modules: " + strings.Join([]string(err), " -> ")
 }
 
 type ProcessingModuleDependencyError struct {

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -254,7 +254,7 @@ func FindWhereWorkingDirIsIncluded(ctx context.Context, terragruntOptions *optio
 	}
 
 	// extract modules as list
-	var matchedModules TerraformModules
+	var matchedModules = make(TerraformModules, 0, len(matchedModulesMap))
 	for _, module := range matchedModulesMap {
 		matchedModules = append(matchedModules, module)
 	}

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -302,7 +301,7 @@ func TestRunModulesOneModuleError(t *testing.T) {
 	t.Parallel()
 
 	aRan := false
-	expectedErrA := fmt.Errorf("Expected error for module a")
+	expectedErrA := errors.New("Expected error for module a")
 	moduleA := &TerraformModule{
 		Path:              "a",
 		Dependencies:      TerraformModules{},
@@ -323,7 +322,7 @@ func TestRunModulesReverseOrderOneModuleError(t *testing.T) {
 	t.Parallel()
 
 	aRan := false
-	expectedErrA := fmt.Errorf("Expected error for module a")
+	expectedErrA := errors.New("Expected error for module a")
 	moduleA := &TerraformModule{
 		Path:              "a",
 		Dependencies:      TerraformModules{},
@@ -344,7 +343,7 @@ func TestRunModulesIgnoreOrderOneModuleError(t *testing.T) {
 	t.Parallel()
 
 	aRan := false
-	expectedErrA := fmt.Errorf("Expected error for module a")
+	expectedErrA := errors.New("Expected error for module a")
 	moduleA := &TerraformModule{
 		Path:              "a",
 		Dependencies:      TerraformModules{},
@@ -529,7 +528,7 @@ func TestRunModulesMultipleModulesNoDependenciesOneFailure(t *testing.T) {
 	}
 
 	bRan := false
-	expectedErrB := fmt.Errorf("Expected error for module b")
+	expectedErrB := errors.New("Expected error for module b")
 	moduleB := &TerraformModule{
 		Path:              "b",
 		Dependencies:      TerraformModules{},
@@ -561,7 +560,7 @@ func TestRunModulesMultipleModulesNoDependenciesMultipleFailures(t *testing.T) {
 	t.Parallel()
 
 	aRan := false
-	expectedErrA := fmt.Errorf("Expected error for module a")
+	expectedErrA := errors.New("Expected error for module a")
 	moduleA := &TerraformModule{
 		Path:              "a",
 		Dependencies:      TerraformModules{},
@@ -570,7 +569,7 @@ func TestRunModulesMultipleModulesNoDependenciesMultipleFailures(t *testing.T) {
 	}
 
 	bRan := false
-	expectedErrB := fmt.Errorf("Expected error for module b")
+	expectedErrB := errors.New("Expected error for module b")
 	moduleB := &TerraformModule{
 		Path:              "b",
 		Dependencies:      TerraformModules{},
@@ -579,7 +578,7 @@ func TestRunModulesMultipleModulesNoDependenciesMultipleFailures(t *testing.T) {
 	}
 
 	cRan := false
-	expectedErrC := fmt.Errorf("Expected error for module c")
+	expectedErrC := errors.New("Expected error for module c")
 	moduleC := &TerraformModule{
 		Path:              "c",
 		Dependencies:      TerraformModules{},
@@ -777,7 +776,7 @@ func TestRunModulesMultipleModulesWithDependenciesOneFailure(t *testing.T) {
 	}
 
 	bRan := false
-	expectedErrB := fmt.Errorf("Expected error for module b")
+	expectedErrB := errors.New("Expected error for module b")
 	moduleB := &TerraformModule{
 		Path:              "b",
 		Dependencies:      TerraformModules{moduleA},
@@ -821,7 +820,7 @@ func TestRunModulesMultipleModulesWithDependenciesOneFailureIgnoreDependencyErro
 	}
 
 	bRan := false
-	expectedErrB := fmt.Errorf("Expected error for module b")
+	expectedErrB := errors.New("Expected error for module b")
 	terragruntOptionsB := optionsWithMockTerragruntCommand(t, "b", expectedErrB, &bRan)
 	terragruntOptionsB.IgnoreDependencyErrors = true
 	moduleB := &TerraformModule{
@@ -865,7 +864,7 @@ func TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure(t *test
 	}
 
 	bRan := false
-	expectedErrB := fmt.Errorf("Expected error for module b")
+	expectedErrB := errors.New("Expected error for module b")
 	moduleB := &TerraformModule{
 		Path:              "b",
 		Dependencies:      TerraformModules{moduleA},
@@ -907,7 +906,7 @@ func TestRunModulesIgnoreOrderMultipleModulesWithDependenciesOneFailure(t *testi
 	}
 
 	bRan := false
-	expectedErrB := fmt.Errorf("Expected error for module b")
+	expectedErrB := errors.New("Expected error for module b")
 	moduleB := &TerraformModule{
 		Path:              "b",
 		Dependencies:      TerraformModules{moduleA},
@@ -939,7 +938,7 @@ func TestRunModulesMultipleModulesWithDependenciesMultipleFailures(t *testing.T)
 	t.Parallel()
 
 	aRan := false
-	expectedErrA := fmt.Errorf("Expected error for module a")
+	expectedErrA := errors.New("Expected error for module a")
 	moduleA := &TerraformModule{
 		Path:              "a",
 		Dependencies:      TerraformModules{},
@@ -982,7 +981,7 @@ func TestRunModulesIgnoreOrderMultipleModulesWithDependenciesMultipleFailures(t 
 	t.Parallel()
 
 	aRan := false
-	expectedErrA := fmt.Errorf("Expected error for module a")
+	expectedErrA := errors.New("Expected error for module a")
 	moduleA := &TerraformModule{
 		Path:              "a",
 		Dependencies:      TerraformModules{},
@@ -1104,7 +1103,7 @@ func TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure(t *te
 	}
 
 	cRan := false
-	expectedErrC := fmt.Errorf("Expected error for module large-graph-c")
+	expectedErrC := errors.New("Expected error for module large-graph-c")
 	moduleC := &TerraformModule{
 		Path:              "large-graph-c",
 		Dependencies:      TerraformModules{moduleB},
@@ -1184,7 +1183,7 @@ func TestRunModulesReverseOrderMultipleModulesWithDependenciesLargeGraphPartialF
 	}
 
 	cRan := false
-	expectedErrC := fmt.Errorf("Expected error for module c")
+	expectedErrC := errors.New("Expected error for module c")
 	moduleC := &TerraformModule{
 		Path:              "c",
 		Dependencies:      TerraformModules{moduleB},

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/gruntwork-io/go-commons/collections"
@@ -80,7 +81,7 @@ func (stack *Stack) WithOptions(opts ...Option) *Stack {
 func (stack *Stack) String() string {
 	modules := []string{}
 	for _, module := range stack.Modules {
-		modules = append(modules, fmt.Sprintf("  => %s", module.String()))
+		modules = append(modules, "  => "+module.String())
 	}
 	sort.Strings(modules)
 	return fmt.Sprintf("Stack at %s:\n%s", stack.terragruntOptions.WorkingDir, strings.Join(modules, "\n"))
@@ -117,7 +118,7 @@ func (stack *Stack) JsonModuleDeployOrder(terraformCommand string) (string, erro
 	// The index should be the group number, and the value should be an array of module paths
 	jsonGraph := make(map[string][]string)
 	for i, group := range runGraph {
-		groupNum := "Group " + fmt.Sprintf("%d", i+1)
+		groupNum := "Group " + strconv.Itoa(i+1)
 		jsonGraph[groupNum] = make([]string, len(group))
 		for j, module := range group {
 			jsonGraph[groupNum][j] = module.Path
@@ -237,7 +238,7 @@ func (stack *Stack) syncTerraformCliArgs(terragruntOptions *options.TerragruntOp
 			terragruntOptions.Logger.Debugf("Using output file %s for module %s", planFile, module.TerragruntOptions.TerragruntConfigPath)
 			if module.TerragruntOptions.TerraformCommand == terraform.CommandNamePlan {
 				// for plan command add -out=<file> to the terraform cli args
-				module.TerragruntOptions.TerraformCliArgs = util.StringListInsert(module.TerragruntOptions.TerraformCliArgs, fmt.Sprintf("-out=%s", planFile), len(module.TerragruntOptions.TerraformCliArgs))
+				module.TerragruntOptions.TerraformCliArgs = util.StringListInsert(module.TerragruntOptions.TerraformCliArgs, "-out="+planFile, len(module.TerragruntOptions.TerraformCliArgs))
 			} else {
 				module.TerragruntOptions.TerraformCliArgs = util.StringListInsert(module.TerragruntOptions.TerraformCliArgs, planFile, len(module.TerragruntOptions.TerraformCliArgs))
 			}
@@ -319,7 +320,7 @@ func (stack *Stack) ResolveTerraformModules(ctx context.Context, terragruntConfi
 	err = telemetry.Telemetry(ctx, stack.terragruntOptions, "resolve_modules", map[string]interface{}{
 		"working_dir": stack.terragruntOptions.WorkingDir,
 	}, func(childCtx context.Context) error {
-		howThesePathsWereFound := fmt.Sprintf("Terragrunt config file found in a subdirectory of %s", stack.terragruntOptions.WorkingDir)
+		howThesePathsWereFound := "Terragrunt config file found in a subdirectory of " + stack.terragruntOptions.WorkingDir
 		result, err := stack.resolveModules(ctx, canonicalTerragruntConfigPaths, howThesePathsWereFound)
 		if err != nil {
 			return err

--- a/configstack/stack_test.go
+++ b/configstack/stack_test.go
@@ -43,7 +43,7 @@ func TestFindStackInSubfolders(t *testing.T) {
 	stack, err := FindStackInSubfolders(context.Background(), terragruntOptions)
 	require.NoError(t, err)
 
-	var modulePaths []string
+	var modulePaths = make([]string, 0, len(stack.Modules))
 
 	for _, module := range stack.Modules {
 		relPath := strings.Replace(module.Path, tempFolder, "", 1)

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -145,7 +145,7 @@ func tagTableIfTagsGiven(tags map[string]string, tableArn *string, client *dynam
 	// we were able to create the table successfully, now add tags
 	terragruntOptions.Logger.Debugf("Adding tags to lock table: %s", tags)
 
-	var tagsConverted []*dynamodb.Tag
+	var tagsConverted = make([]*dynamodb.Tag, 0, len(tags))
 
 	for k, v := range tags {
 		tagsConverted = append(tagsConverted, &dynamodb.Tag{Key: aws.String(k), Value: aws.String(v)})

--- a/dynamodb/dynamo_lock_test_utils.go
+++ b/dynamodb/dynamo_lock_test_utils.go
@@ -1,7 +1,6 @@
 package dynamodb
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -34,7 +33,7 @@ func createDynamoDbClientForTest(t *testing.T) *dynamodb.DynamoDB {
 }
 
 func uniqueTableNameForTest() string {
-	return fmt.Sprintf("terragrunt_test_%s", util.UniqueId())
+	return "terragrunt_test_" + util.UniqueId()
 }
 
 func cleanupTableForTest(t *testing.T, tableName string, client *dynamodb.DynamoDB) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	goErrors "errors"
 	"fmt"
 	"io"
 	"os"
@@ -297,12 +298,12 @@ func engineChecksumName(e *options.EngineOptions) string {
 
 // engineChecksumSigName returns the file name of engine checksum file signature
 func engineChecksumSigName(e *options.EngineOptions) string {
-	return fmt.Sprintf("%s.sig", engineChecksumName(e))
+	return engineChecksumName(e) + ".sig"
 }
 
 // enginePackageName returns the package name for the engine.
 func enginePackageName(e *options.EngineOptions) string {
-	return fmt.Sprintf("%s.zip", engineFileName(e))
+	return engineFileName(e) + ".zip"
 }
 
 // isArchiveByHeader checks if a file is an archive by examining its header.
@@ -321,11 +322,11 @@ func isArchiveByHeader(filePath string) bool {
 func engineClientsFromContext(ctx context.Context) (*sync.Map, error) {
 	val := ctx.Value(TerraformCommandContextKey)
 	if val == nil {
-		return nil, errors.WithStackTrace(fmt.Errorf("failed to fetch engine clients from context"))
+		return nil, errors.WithStackTrace(goErrors.New("failed to fetch engine clients from context"))
 	}
 	result, ok := val.(*sync.Map)
 	if !ok {
-		return nil, errors.WithStackTrace(fmt.Errorf("failed to cast engine clients from context"))
+		return nil, errors.WithStackTrace(goErrors.New("failed to cast engine clients from context"))
 	}
 	return result, nil
 }
@@ -334,11 +335,11 @@ func engineClientsFromContext(ctx context.Context) (*sync.Map, error) {
 func downloadLocksFromContext(ctx context.Context) (*util.KeyLocks, error) {
 	val := ctx.Value(LocksContextKey)
 	if val == nil {
-		return nil, errors.WithStackTrace(fmt.Errorf("failed to fetch engine clients from context"))
+		return nil, errors.WithStackTrace(goErrors.New("failed to fetch engine clients from context"))
 	}
 	result, ok := val.(*util.KeyLocks)
 	if !ok {
-		return nil, errors.WithStackTrace(fmt.Errorf("failed to cast engine clients from context"))
+		return nil, errors.WithStackTrace(goErrors.New("failed to cast engine clients from context"))
 	}
 	return result, nil
 }

--- a/internal/view/diagnostic/expression_value.go
+++ b/internal/view/diagnostic/expression_value.go
@@ -67,7 +67,7 @@ Traversals:
 					if includeUnknown {
 						value.Statement = fmt.Sprintf("is a %s, known only after apply", ty.FriendlyName())
 					} else {
-						value.Statement = fmt.Sprintf("is a %s", ty.FriendlyName())
+						value.Statement = "is a " + ty.FriendlyName()
 					}
 				} else {
 					if !includeUnknown {
@@ -76,7 +76,7 @@ Traversals:
 					value.Statement = "will be known only after apply"
 				}
 			default:
-				value.Statement = fmt.Sprintf("is %s", valueStr(val))
+				value.Statement = "is " + valueStr(val)
 			}
 			values = append(values, value)
 			seen[traversalStr] = struct{}{}

--- a/internal/view/human_render.go
+++ b/internal/view/human_render.go
@@ -178,7 +178,7 @@ func (render *HumanRender) SourceSnippets(diag *diagnostic.Diagnostic) (string, 
 
 	var contextStr string
 	if snippet.Context != "" {
-		contextStr = fmt.Sprintf(", in %s", snippet.Context)
+		contextStr = ", in " + snippet.Context
 	}
 	if _, err := fmt.Fprintf(buf, "  on %s line %d%s:\n", diag.Range.Filename, diag.Range.Start.Line, contextStr); err != nil {
 		return "", errors.WithStackTrace(err)

--- a/options/options.go
+++ b/options/options.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"context"
+	goErrors "errors"
 	"fmt"
 	"io"
 	"math"
@@ -675,4 +676,4 @@ type EngineOptions struct {
 
 // Custom error types
 
-var ErrRunTerragruntCommandNotSet = fmt.Errorf("the RunTerragrunt option has not been set on this TerragruntOptions object")
+var ErrRunTerragruntCommandNotSet = goErrors.New("the RunTerragrunt option has not been set on this TerragruntOptions object")

--- a/pkg/cli/bool_flag_test.go
+++ b/pkg/cli/bool_flag_test.go
@@ -5,6 +5,7 @@ import (
 	libflag "flag"
 	"fmt"
 	"io"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -108,7 +109,7 @@ func testBoolFlagApply(t *testing.T, flag *BoolFlag, args []string, envs map[str
 		destDefined = true
 		flag.Destination = &actualValue
 	} else if val := *flag.Destination; val && !flag.Negative {
-		expectedDefaultValue = fmt.Sprintf("%t", val)
+		expectedDefaultValue = strconv.FormatBool(val)
 	}
 
 	flag.LookupEnvFunc = func(key string) (string, bool) {
@@ -141,7 +142,7 @@ func testBoolFlagApply(t *testing.T, flag *BoolFlag, args []string, envs map[str
 
 	assert.Equal(t, expectedValue, actualValue)
 	if actualValue {
-		assert.Equal(t, fmt.Sprintf("%t", expectedValue), flag.GetValue(), "GetValue()")
+		assert.Equal(t, strconv.FormatBool(expectedValue), flag.GetValue(), "GetValue()")
 	}
 
 	assert.Equal(t, len(args) > 0, flag.Value().IsSet(), "IsSet()")

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -49,7 +49,7 @@ func (commands Commands) SkipRunning() Commands {
 // VisibleCommands returns a slice of the Commands with Hidden=false.
 // Used by `urfave/cli` package to generate help.
 func (commands Commands) VisibleCommands() []*cli.Command {
-	var visible []*cli.Command
+	var visible = make([]*cli.Command, 0, len(commands))
 
 	for _, cmd := range commands {
 		if cmd.Hidden {

--- a/pkg/cli/slice_flag.go
+++ b/pkg/cli/slice_flag.go
@@ -184,7 +184,7 @@ func (flag *sliceValue[T]) String() string {
 		return ""
 	}
 
-	var vals []string
+	var vals = make([]string, 0, len(*flag.values))
 
 	for _, val := range *flag.values {
 		vals = append(vals, flag.valueType.Clone(&val).String())

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -3,6 +3,7 @@ package remote
 
 import (
 	"context"
+	goErrors "errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -190,7 +191,7 @@ func (remoteState RemoteState) ToTerraformInitArgs() []string {
 		config = initializer.GetTerraformInitArgs(remoteState.Config)
 	}
 
-	var backendConfigArgs []string = nil
+	var backendConfigArgs = make([]string, 0, len(config))
 
 	for key, value := range config {
 		arg := fmt.Sprintf("-backend-config=%s=%v", key, value)
@@ -235,8 +236,8 @@ func (remoteState *RemoteState) GenerateTerraformCode(terragruntOptions *options
 
 // Custom errors
 var (
-	ErrRemoteBackendMissing             = fmt.Errorf("the remote_state.backend field cannot be empty")
-	ErrGenerateCalledWithNoGenerateAttr = fmt.Errorf("generate code routine called when no generate attribute is configured")
+	ErrRemoteBackendMissing             = goErrors.New("the remote_state.backend field cannot be empty")
+	ErrGenerateCalledWithNoGenerateAttr = goErrors.New("generate code routine called when no generate attribute is configured")
 )
 
 type BucketCreationNotAllowed string

--- a/remote/remote_state_gcs.go
+++ b/remote/remote_state_gcs.go
@@ -302,7 +302,7 @@ func createGCSBucketIfNecessary(ctx context.Context, gcsClient *storage.Client, 
 
 		if shouldCreateBucket {
 			// To avoid any eventual consistency issues with creating a GCS bucket we use a retry loop.
-			description := fmt.Sprintf("Create GCS bucket %s", config.remoteStateConfigGCS.Bucket)
+			description := "Create GCS bucket " + config.remoteStateConfigGCS.Bucket
 
 			return util.DoWithRetry(ctx, description, gcpMaxRetries, gcpSleepBetweenRetries, logrus.DebugLevel, func(ctx context.Context) error {
 				// TODO: Remove lint suppression
@@ -525,5 +525,5 @@ func CreateGCSClient(gcsConfigRemote RemoteStateConfigGCS) (*storage.Client, err
 type MissingRequiredGCSRemoteStateConfig string
 
 func (configName MissingRequiredGCSRemoteStateConfig) Error() string {
-	return fmt.Sprintf("Missing required GCS remote state configuration %s", string(configName))
+	return "Missing required GCS remote state configuration " + string(configName)
 }

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -499,7 +499,7 @@ func createS3BucketIfNecessary(ctx context.Context, s3Client *s3.S3, config *Ext
 		// the S3 bucket, we do so in a retry loop with a sleep between retries that will hopefully work around the
 		// eventual consistency issues. Each S3 operation should be idempotent, so redoing steps that have already
 		// been performed should be a no-op.
-		description := fmt.Sprintf("Create S3 bucket with retry %s", config.remoteStateConfigS3.Bucket)
+		description := "Create S3 bucket with retry " + config.remoteStateConfigS3.Bucket
 
 		return util.DoWithRetry(ctx, description, s3MaxRetries, s3SleepBetweenRetries, logrus.DebugLevel, func(ctx context.Context) error {
 			err := CreateS3BucketWithVersioningSSEncryptionAndAccessLogging(s3Client, config, terragruntOptions)
@@ -919,8 +919,7 @@ func TagS3Bucket(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragrun
 }
 
 func convertTags(tags map[string]string) []*s3.Tag {
-
-	var tagsConverted []*s3.Tag
+	var tagsConverted = make([]*s3.Tag, 0, len(tags))
 
 	for k, v := range tags {
 		var tag = s3.Tag{
@@ -1426,7 +1425,7 @@ func validatePublicAccessBlock(output *s3.GetPublicAccessBlockOutput) (bool, err
 func configureBucketAccessLoggingAcl(s3Client *s3.S3, bucket *string, terragruntOptions *options.TerragruntOptions) error {
 	terragruntOptions.Logger.Debugf("Granting WRITE and READ_ACP permissions to S3 Log Delivery (%s) for bucket %s. This is required for access logging.", s3LogDeliveryGranteeUri, aws.StringValue(bucket))
 
-	uri := fmt.Sprintf("uri=%s", s3LogDeliveryGranteeUri)
+	uri := "uri=" + s3LogDeliveryGranteeUri
 	aclInput := s3.PutBucketAclInput{
 		Bucket:       bucket,
 		GrantWrite:   aws.String(uri),
@@ -1550,7 +1549,7 @@ func CreateS3Client(config *aws_helper.AwsSessionConfig, terragruntOptions *opti
 type MissingRequiredS3RemoteStateConfig string
 
 func (configName MissingRequiredS3RemoteStateConfig) Error() string {
-	return fmt.Sprintf("Missing required S3 remote state configuration %s", string(configName))
+	return "Missing required S3 remote state configuration " + string(configName)
 }
 
 type MultipleTagsDeclarations string

--- a/remote/terraform_config.go
+++ b/remote/terraform_config.go
@@ -8,7 +8,7 @@ import (
 
 // wrapMapToSingleLineHcl - This is a workaround to convert a map[string]interface{} to a single line HCL string.
 func wrapMapToSingleLineHcl(m map[string]interface{}) string {
-	var attributes []string
+	var attributes = make([]string, 0, len(m))
 	for key, value := range m {
 		attributes = append(attributes, fmt.Sprintf(`%s=%s`, key, formatHclValue(value)))
 	}

--- a/shell/error_explainer_test.go
+++ b/shell/error_explainer_test.go
@@ -1,7 +1,7 @@
 package shell
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/util"
@@ -43,7 +43,7 @@ func TestExplainError(t *testing.T) {
 
 		t.Run(tt.errorOutput, func(t *testing.T) {
 			err := multierror.Append(&multierror.Error{}, util.ProcessExecutionError{
-				Err:    fmt.Errorf(""),
+				Err:    errors.New(""),
 				StdOut: "",
 				Stderr: tt.errorOutput,
 			})

--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -2,7 +2,6 @@ package shell
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"strings"
 
@@ -42,7 +41,7 @@ func PromptUserForInput(prompt string, terragruntOptions *options.TerragruntOpti
 
 // Prompt the user for a yes/no response and return true if they entered yes.
 func PromptUserForYesNo(prompt string, terragruntOptions *options.TerragruntOptions) (bool, error) {
-	resp, err := PromptUserForInput(fmt.Sprintf("%s (y/n) ", prompt), terragruntOptions)
+	resp, err := PromptUserForInput(prompt+" (y/n) ", terragruntOptions)
 
 	if err != nil {
 		return false, errors.WithStackTrace(err)

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -97,7 +97,7 @@ func RunShellCommandWithOutput(
 	if workingDir == "" {
 		commandDir = terragruntOptions.WorkingDir
 	}
-	err := telemetry.Telemetry(ctx, terragruntOptions, fmt.Sprintf("run_%s", command), map[string]interface{}{
+	err := telemetry.Telemetry(ctx, terragruntOptions, "run_"+command, map[string]interface{}{
 		"command": command,
 		"args":    fmt.Sprintf("%v", args),
 		"dir":     commandDir,

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -44,7 +43,7 @@ func Time(ctx context.Context, name string, attrs map[string]interface{}, fn fun
 	}
 
 	metricAttrs := mapToAttributes(attrs)
-	histogram, err := meter.Int64Histogram(cleanMetricName(fmt.Sprintf("%s_duration", name)))
+	histogram, err := meter.Int64Histogram(cleanMetricName(name + "_duration"))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -54,9 +53,9 @@ func Time(ctx context.Context, name string, attrs map[string]interface{}, fn fun
 	if err != nil {
 		// count errors
 		Count(ctx, ErrorsCounter, 1)
-		Count(ctx, fmt.Sprintf("%s_errors", name), 1)
+		Count(ctx, name+"_errors", 1)
 	} else {
-		Count(ctx, fmt.Sprintf("%s_success", name), 1)
+		Count(ctx, name+"_success", 1)
 	}
 	return err
 }
@@ -66,7 +65,7 @@ func Count(ctx context.Context, name string, value int64) {
 	if ctx == nil || metricExporter == nil {
 		return
 	}
-	counter, err := meter.Int64Counter(cleanMetricName(fmt.Sprintf("%s_count", name)))
+	counter, err := meter.Int64Counter(cleanMetricName(name + "_count"))
 	if err != nil {
 		return
 	}

--- a/telemetry/metrics_test.go
+++ b/telemetry/metrics_test.go
@@ -2,8 +2,8 @@ package telemetry
 
 import (
 	"context"
-	"fmt"
 	"io"
+	"strconv"
 	"testing"
 
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
@@ -59,7 +59,7 @@ func TestNewMetricsExporter(t *testing.T) {
 			opts := &TelemetryOptions{
 				Vars: map[string]string{
 					"TERRAGRUNT_TELEMETRY_METRIC_EXPORTER":                   tt.exporterType,
-					"TERRAGRUNT_TELEMETRY_METRIC_EXPORTER_INSECURE_ENDPOINT": fmt.Sprintf("%v", tt.insecure),
+					"TERRAGRUNT_TELEMETRY_METRIC_EXPORTER_INSECURE_ENDPOINT": strconv.FormatBool(tt.insecure),
 				},
 				Writer: io.Discard,
 			}

--- a/terraform/cache/services/provider_cache.go
+++ b/terraform/cache/services/provider_cache.go
@@ -278,7 +278,7 @@ func (cache *ProviderCache) acquireLockFile(ctx context.Context) (*util.Lockfile
 		return nil, errors.WithStackTrace(err)
 	}
 
-	if err := util.DoWithRetry(ctx, fmt.Sprintf("Acquiring lock file %s", cache.lockfilePath), maxRetriesLockFile, retryDelayLockFile, logrus.DebugLevel, func(ctx context.Context) error {
+	if err := util.DoWithRetry(ctx, "Acquiring lock file "+cache.lockfilePath, maxRetriesLockFile, retryDelayLockFile, logrus.DebugLevel, func(ctx context.Context) error {
 		return lockfile.TryLock()
 	}); err != nil {
 		return nil, errors.Errorf("unable to acquire lock file %s (already locked?) try to remove the file manually: %w", cache.lockfilePath, err)
@@ -356,8 +356,8 @@ func (service *ProviderService) CacheProvider(ctx context.Context, requestID str
 
 		userProviderDir: filepath.Join(service.userCacheDir, provider.Address(), provider.Version, provider.Platform()),
 		packageDir:      filepath.Join(service.cacheDir, provider.Address(), provider.Version, provider.Platform()),
-		lockfilePath:    filepath.Join(service.tempDir, fmt.Sprintf("%s.lock", packageName)),
-		archivePath:     filepath.Join(service.tempDir, fmt.Sprintf("%s%s", packageName, path.Ext(provider.Filename))),
+		lockfilePath:    filepath.Join(service.tempDir, packageName+".lock"),
+		archivePath:     filepath.Join(service.tempDir, packageName+path.Ext(provider.Filename)),
 	}
 
 	select {

--- a/terraform/cliconfig/user_config.go
+++ b/terraform/cliconfig/user_config.go
@@ -50,7 +50,7 @@ func UserProviderDir() (string, error) {
 }
 
 func getUserCredentials(cfg *cliconfig.Config) []ConfigCredentials {
-	var credentials []ConfigCredentials
+	var credentials = make([]ConfigCredentials, 0, len(cfg.Credentials))
 
 	for name, credential := range cfg.Credentials {
 		var token string
@@ -90,7 +90,7 @@ func getUserCredentialsHelpers(cfg *cliconfig.Config) *ConfigCredentialsHelper {
 }
 
 func getUserHosts(cfg *cliconfig.Config) []ConfigHost {
-	var hosts []ConfigHost
+	var hosts = make([]ConfigHost, 0, len(cfg.Hosts))
 
 	for name, host := range cfg.Hosts {
 		services := make(map[string]string)

--- a/terraform/errors.go
+++ b/terraform/errors.go
@@ -8,7 +8,7 @@ type MalformedRegistryURLErr struct {
 }
 
 func (err MalformedRegistryURLErr) Error() string {
-	return fmt.Sprintf("tfr getter URL is malformed: %s", err.reason)
+	return "tfr getter URL is malformed: " + err.reason
 }
 
 // ServiceDiscoveryErr is returned if Terragrunt failed to identify the module API endpoint through the service
@@ -18,7 +18,7 @@ type ServiceDiscoveryErr struct {
 }
 
 func (err ServiceDiscoveryErr) Error() string {
-	return fmt.Sprintf("Error identifying module registry API location: %s", err.reason)
+	return "Error identifying module registry API location: " + err.reason
 }
 
 // ModuleDownloadErr is returned if Terragrunt failed to download the module.

--- a/terraform/getproviders/hash.go
+++ b/terraform/getproviders/hash.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -56,12 +55,12 @@ func PackageHashLegacyZipSHA(path string) (Hash, error) {
 	}
 
 	gotHash := hash.Sum(nil)
-	return HashSchemeZip.New(fmt.Sprintf("%x", gotHash)), nil
+	return HashSchemeZip.New(hex.EncodeToString(gotHash)), nil
 }
 
 // HashLegacyZipSHAFromSHA is a convenience method to produce the schemed-string hash format from an already-calculated hash of a provider .zip archive.
 func HashLegacyZipSHAFromSHA(sum [sha256.Size]byte) Hash {
-	return HashSchemeZip.New(fmt.Sprintf("%x", sum[:]))
+	return HashSchemeZip.New(hex.EncodeToString(sum[:]))
 }
 
 // PackageHashV1 computes a hash of the contents of the package at the given location using hash algorithm 1. The resulting Hash is guaranteed to have the scheme HashScheme1.

--- a/terraform/getproviders/package_authentication_test.go
+++ b/terraform/getproviders/package_authentication_test.go
@@ -80,25 +80,25 @@ func TestArchiveChecksumAuthentication(t *testing.T) {
 				0x5a, 0x79, 0x2a, 0xde, 0x97, 0x11, 0xf5, 0x01,
 			},
 			nil,
-			fmt.Errorf("archive has incorrect checksum zh:8610a6d93c01e05a0d3920fe66c79b3c7c3b084f1f5c70715afd919fee1d978e (expected zh:4fb39849f2e138eb16a18ba0c682635d781cb8c3b25901dd5a792ade9711f501)"),
+			errors.New("archive has incorrect checksum zh:8610a6d93c01e05a0d3920fe66c79b3c7c3b084f1f5c70715afd919fee1d978e (expected zh:4fb39849f2e138eb16a18ba0c682635d781cb8c3b25901dd5a792ade9711f501)"),
 		},
 		{
 			"testdata/no-package-here.zip",
 			[sha256.Size]byte{},
 			nil,
-			fmt.Errorf("stat testdata/no-package-here.zip: no such file or directory"),
+			errors.New("stat testdata/no-package-here.zip: no such file or directory"),
 		},
 		{
 			"testdata/filesystem-mirror/registry.terraform.io/hashicorp/null/terraform-provider-null_2.1.0_linux_amd64.zip",
 			[sha256.Size]byte{},
 			nil,
-			fmt.Errorf("archive has incorrect checksum zh:4fb39849f2e138eb16a18ba0c682635d781cb8c3b25901dd5a792ade9711f501 (expected zh:0000000000000000000000000000000000000000000000000000000000000000)"),
+			errors.New("archive has incorrect checksum zh:4fb39849f2e138eb16a18ba0c682635d781cb8c3b25901dd5a792ade9711f501 (expected zh:0000000000000000000000000000000000000000000000000000000000000000)"),
 		},
 		{
 			"testdata/filesystem-mirror/tfe.example.com/AwesomeCorp/happycloud/0.1.0-alpha.2/darwin_amd64",
 			[sha256.Size]byte{},
 			nil,
-			fmt.Errorf("cannot check archive hash for non-archive location testdata/filesystem-mirror/tfe.example.com/AwesomeCorp/happycloud/0.1.0-alpha.2/darwin_amd64"),
+			errors.New("cannot check archive hash for non-archive location testdata/filesystem-mirror/tfe.example.com/AwesomeCorp/happycloud/0.1.0-alpha.2/darwin_amd64"),
 		},
 	}
 
@@ -150,7 +150,7 @@ func TestNewMatchingChecksumAuthentication(t *testing.T) {
 				),
 			),
 			[sha256.Size]byte{0xde, 0xca, 0xde},
-			fmt.Errorf(`checksum list has no SHA-256 hash for "my-package.zip"`),
+			errors.New(`checksum list has no SHA-256 hash for "my-package.zip"`),
 		},
 		{
 			"testdata/my-package.zip",
@@ -163,7 +163,7 @@ func TestNewMatchingChecksumAuthentication(t *testing.T) {
 				),
 			),
 			[sha256.Size]byte{0xde, 0xca, 0xde},
-			fmt.Errorf(`checksum list has invalid SHA256 hash "chickens": encoding/hex: invalid byte: U+0068 'h'`),
+			errors.New(`checksum list has invalid SHA256 hash "chickens": encoding/hex: invalid byte: U+0068 'h'`),
 		},
 		{
 			"testdata/my-package.zip",
@@ -176,7 +176,7 @@ func TestNewMatchingChecksumAuthentication(t *testing.T) {
 				),
 			),
 			[sha256.Size]byte{0xde, 0xca, 0xde},
-			fmt.Errorf("checksum list has unexpected SHA-256 hash c0ffee0000000000000000000000000000000000000000000000000000000000 (expected decade0000000000000000000000000000000000000000000000000000000000)"),
+			errors.New("checksum list has unexpected SHA-256 hash c0ffee0000000000000000000000000000000000000000000000000000000000 (expected decade0000000000000000000000000000000000000000000000000000000000)"),
 		},
 	}
 

--- a/terraform/getter.go
+++ b/terraform/getter.go
@@ -4,6 +4,7 @@ package terraform
 import (
 	"context"
 	"encoding/json"
+	goErrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -172,7 +173,7 @@ func (tfrGetter *RegistryGetter) Get(dstPath string, srcURL *url.URL) error {
 // GetFile is not implemented for the Terraform module registry Getter since the terraform module registry doesn't serve
 // a single file.
 func (tfrGetter *RegistryGetter) GetFile(dst string, src *url.URL) error {
-	return errors.WithStackTrace(fmt.Errorf("GetFile is not implemented for the Terraform Registry Getter"))
+	return errors.WithStackTrace(goErrors.New("GetFile is not implemented for the Terraform Registry Getter"))
 }
 
 // getSubdir downloads the source into the destination, but with the proper subdir.
@@ -320,7 +321,7 @@ func httpGETAndGetResponse(ctx context.Context, getURL url.URL) ([]byte, *http.H
 	// the request header.
 	authToken := os.Getenv(authTokenEnvVarName)
 	if authToken != "" {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authToken))
+		req.Header.Add("Authorization", "Bearer "+authToken)
 	}
 
 	resp, err := httpClient.Do(req)

--- a/terraform/source.go
+++ b/terraform/source.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/url"
 	"os"
@@ -84,7 +85,7 @@ func (terraformSource Source) EncodeSourceVersion() (string, error) {
 		})
 
 		if err == nil {
-			hash := fmt.Sprintf("%x", sourceHash.Sum(nil))
+			hash := hex.EncodeToString(sourceHash.Sum(nil))
 
 			return hash, nil
 		}

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -107,11 +106,11 @@ func TestScaffoldGitModuleHttps(t *testing.T) {
 	require.True(t, found)
 	require.Contains(t, *cfg.Terraform.Source, "git::https://github.com/gruntwork-io/terraform-fake-modules.git//modules/aws/aurora?ref=v0.0.5")
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt init --terragrunt-non-interactive --terragrunt-working-dir %s", opts.WorkingDir))
+	runTerragrunt(t, "terragrunt init --terragrunt-non-interactive --terragrunt-working-dir "+opts.WorkingDir)
 }
 
 func readConfig(t *testing.T, opts *options.TerragruntOptions) *config.TerragruntConfig {
-	require.FileExists(t, fmt.Sprintf("%s/terragrunt.hcl", opts.WorkingDir))
+	require.FileExists(t, opts.WorkingDir+"/terragrunt.hcl")
 
 	opts, err := options.NewTerragruntOptionsForTest(filepath.Join(opts.WorkingDir, "terragrunt.hcl"))
 	require.NoError(t, err)

--- a/test/integration_common_test.go
+++ b/test/integration_common_test.go
@@ -60,7 +60,7 @@ func runNetworkMirrorServer(t *testing.T, ctx context.Context, urlPrefix, provid
 	mux.HandleFunc(urlPrefix, func(resp http.ResponseWriter, req *http.Request) {
 		if token != "" {
 			authHeaders := req.Header.Values("Authorization")
-			assert.Contains(t, authHeaders, fmt.Sprintf("Bearer %s", token))
+			assert.Contains(t, authHeaders, "Bearer "+token)
 		}
 
 		withGz.ServeHTTP(resp, req)
@@ -127,7 +127,7 @@ func (provider *FakeProvider) createVersionJSON(t *testing.T, providerDir string
 	}
 
 	version := &Version{Archives: make(map[string]VersionProvider)}
-	filename := filepath.Join(providerDir, fmt.Sprintf("%s.json", provider.Version))
+	filename := filepath.Join(providerDir, provider.Version+".json")
 	platform := fmt.Sprintf("%s_%s", provider.PlatformOS, provider.PlatformArch)
 
 	unmarshalFile(t, filename, version)

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -42,7 +42,7 @@ func TestDebugGeneratedInputs(t *testing.T) {
 
 	require.NoError(
 		t,
-		runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-debug --terragrunt-working-dir %s", rootPath), &stdout, &stderr),
+		runTerragruntCommand(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-debug --terragrunt-working-dir "+rootPath, &stdout, &stderr),
 	)
 
 	debugFile := util.JoinPath(rootPath, terragruntDebugFile)
@@ -64,7 +64,7 @@ func TestDebugGeneratedInputs(t *testing.T) {
 	stderr = bytes.Buffer{}
 	require.NoError(
 		t,
-		runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr),
+		runTerragruntCommand(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr),
 	)
 
 	outputs := map[string]TerraformOutput{}
@@ -189,7 +189,7 @@ func TestRenderJSONConfig(t *testing.T) {
 	cleanupTerraformFolder(t, fixtureRenderJSONMainModulePath)
 	cleanupTerraformFolder(t, fixtureRenderJSONDepModulePath)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", fixtureRenderJSON))
+	runTerragrunt(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+fixtureRenderJSON)
 	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-json-out %s", fixtureRenderJSONMainModulePath, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
@@ -300,9 +300,9 @@ func TestRenderJSONConfigWithIncludesDependenciesAndLocals(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, fixtureRenderJSONRegression)
 	workDir := filepath.Join(tmpEnvPath, fixtureRenderJSONRegression)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", workDir))
+	runTerragrunt(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+workDir)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-json-out %s", workDir, jsonOut))
+	runTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-json-out ", workDir)+jsonOut)
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -403,9 +403,9 @@ func TestRenderJSONConfigRunAll(t *testing.T) {
 	defer os.Remove(bazJSONOut)
 	defer os.Remove(rootChildJSONOut)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", workDir))
+	runTerragrunt(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+workDir)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt run-all render-json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", workDir))
+	runTerragrunt(t, "terragrunt run-all render-json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+workDir)
 
 	bazJSONBytes, err := os.ReadFile(bazJSONOut)
 	require.NoError(t, err)
@@ -455,7 +455,7 @@ func TestDependencyGraphWithMultiInclude(t *testing.T) {
 	stderr := bytes.Buffer{}
 	require.NoError(
 		t,
-		runTerragruntCommand(t, fmt.Sprintf("terragrunt graph-dependencies --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr),
+		runTerragruntCommand(t, "terragrunt graph-dependencies --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr),
 	)
 	stdoutStr := stdout.String()
 

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -40,13 +40,13 @@ func TestLocalDownload(t *testing.T) {
 
 	cleanupTerraformFolder(t, testFixtureLocalDownloadPath)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testFixtureLocalDownloadPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalDownloadPath)
 
 	// As of Terraform 0.14.0 we should be copying the lock file from .terragrunt-cache to the working directory
 	require.FileExists(t, util.JoinPath(testFixtureLocalDownloadPath, util.TerraformLockFile))
 
 	// Run a second time to make sure the temporary folder can be reused without errors
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testFixtureLocalDownloadPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalDownloadPath)
 }
 
 func TestLocalDownloadWithHiddenFolder(t *testing.T) {
@@ -54,10 +54,10 @@ func TestLocalDownloadWithHiddenFolder(t *testing.T) {
 
 	cleanupTerraformFolder(t, testFixtureLocalWithHiddenFolder)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testFixtureLocalWithHiddenFolder))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalWithHiddenFolder)
 
 	// Run a second time to make sure the temporary folder can be reused without errors
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testFixtureLocalWithHiddenFolder))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalWithHiddenFolder)
 }
 
 func TestLocalDownloadWithAllowedHiddenFiles(t *testing.T) {
@@ -88,17 +88,17 @@ func TestLocalDownloadWithRelativePath(t *testing.T) {
 
 	cleanupTerraformFolder(t, testFixtureLocalRelativeDownloadPath)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testFixtureLocalRelativeDownloadPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalRelativeDownloadPath)
 
 	// Run a second time to make sure the temporary folder can be reused without errors
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testFixtureLocalRelativeDownloadPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalRelativeDownloadPath)
 }
 
 func TestLocalWithBackend(t *testing.T) {
 	t.Parallel()
 
-	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
-	lockTableName := fmt.Sprintf("terragrunt-lock-table-%s", strings.ToLower(uniqueId()))
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
+	lockTableName := "terragrunt-lock-table-" + strings.ToLower(uniqueId())
 
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
@@ -109,17 +109,17 @@ func TestLocalWithBackend(t *testing.T) {
 	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, "not-used")
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	// Run a second time to make sure the temporary folder can be reused without errors
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 }
 
 func TestLocalWithMissingBackend(t *testing.T) {
 	t.Parallel()
 
-	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
-	lockTableName := fmt.Sprintf("terragrunt-lock-table-%s", strings.ToLower(uniqueId()))
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
+	lockTableName := "terragrunt-lock-table-" + strings.ToLower(uniqueId())
 
 	tmpEnvPath := copyEnvironment(t, "fixture-download")
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureLocalMissingBackend)
@@ -127,7 +127,7 @@ func TestLocalWithMissingBackend(t *testing.T) {
 	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, "not-used")
 
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), os.Stdout, os.Stderr)
+	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, os.Stdout, os.Stderr)
 	if assert.Error(t, err) {
 		underlying := errors.Unwrap(err)
 		require.IsType(t, terraform.BackendNotDefined{}, underlying)
@@ -139,10 +139,10 @@ func TestRemoteDownload(t *testing.T) {
 
 	cleanupTerraformFolder(t, testFixtureRemoteDownloadPath)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testFixtureRemoteDownloadPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureRemoteDownloadPath)
 
 	// Run a second time to make sure the temporary folder can be reused without errors
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testFixtureRemoteDownloadPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureRemoteDownloadPath)
 }
 
 func TestInvalidRemoteDownload(t *testing.T) {
@@ -152,7 +152,7 @@ func TestInvalidRemoteDownload(t *testing.T) {
 	applyStdout := bytes.Buffer{}
 	applyStderr := bytes.Buffer{}
 
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testFixtureInvalidRemoteDownloadPath), &applyStdout, &applyStderr)
+	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureInvalidRemoteDownloadPath, &applyStdout, &applyStderr)
 
 	logBufferContentsLineByLine(t, applyStdout, "apply stdout")
 	logBufferContentsLineByLine(t, applyStderr, "apply stderr")
@@ -168,10 +168,10 @@ func TestRemoteDownloadWithRelativePath(t *testing.T) {
 
 	cleanupTerraformFolder(t, testFixtureRemoteRelativeDownloadPath)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testFixtureRemoteRelativeDownloadPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureRemoteRelativeDownloadPath)
 
 	// Run a second time to make sure the temporary folder can be reused without errors
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", testFixtureRemoteRelativeDownloadPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureRemoteRelativeDownloadPath)
 }
 
 func TestRemoteDownloadOverride(t *testing.T) {
@@ -188,8 +188,8 @@ func TestRemoteDownloadOverride(t *testing.T) {
 func TestRemoteWithBackend(t *testing.T) {
 	t.Parallel()
 
-	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
-	lockTableName := fmt.Sprintf("terragrunt-lock-table-%s", strings.ToLower(uniqueId()))
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
+	lockTableName := "terragrunt-lock-table-" + strings.ToLower(uniqueId())
 
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
@@ -200,10 +200,10 @@ func TestRemoteWithBackend(t *testing.T) {
 	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
 	copyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, "not-used")
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	// Run a second time to make sure the temporary folder can be reused without errors
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 }
 
 func TestRemoteWithModuleInRoot(t *testing.T) {
@@ -212,10 +212,10 @@ func TestRemoteWithModuleInRoot(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, testFixtureRemoteModuleInRoot)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureRemoteModuleInRoot)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	// Run a second time to make sure the temporary folder can be reused without errors
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 }
 
 // As of Terraform 0.14.0, if there's already a lock file in the working directory, we should be copying it into
@@ -227,7 +227,7 @@ func TestCustomLockFile(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, filepath.Dir(testFixtureCustomLockFile))
 	rootPath := util.JoinPath(tmpEnvPath, path)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", rootPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+rootPath)
 
 	source := "../custom-lock-file-module"
 	downloadDir := util.JoinPath(rootPath, TERRAGRUNT_CACHE)
@@ -298,9 +298,9 @@ func TestExcludeDirs(t *testing.T) {
 			showStdout := bytes.Buffer{}
 			showStderr := bytes.Buffer{}
 
-			err = runTerragruntCommand(t, fmt.Sprintf("terragrunt show --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", modulePath), &showStdout, &showStderr)
-			logBufferContentsLineByLine(t, showStdout, fmt.Sprintf("show stdout for %s", modulePath))
-			logBufferContentsLineByLine(t, showStderr, fmt.Sprintf("show stderr for %s", modulePath))
+			err = runTerragruntCommand(t, "terragrunt show --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+modulePath, &showStdout, &showStderr)
+			logBufferContentsLineByLine(t, showStdout, "show stdout for "+modulePath)
+			logBufferContentsLineByLine(t, showStderr, "show stderr for "+modulePath)
 
 			require.NoError(t, err)
 			output := showStdout.String()
@@ -365,9 +365,9 @@ func TestIncludeDirs(t *testing.T) {
 			showStdout := bytes.Buffer{}
 			showStderr := bytes.Buffer{}
 
-			err = runTerragruntCommand(t, fmt.Sprintf("terragrunt show --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", modulePath), &showStdout, &showStderr)
-			logBufferContentsLineByLine(t, showStdout, fmt.Sprintf("show stdout for %s", modulePath))
-			logBufferContentsLineByLine(t, showStderr, fmt.Sprintf("show stderr for %s", modulePath))
+			err = runTerragruntCommand(t, "terragrunt show --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+modulePath, &showStdout, &showStderr)
+			logBufferContentsLineByLine(t, showStdout, "show stdout for "+modulePath)
+			logBufferContentsLineByLine(t, showStderr, "show stderr for "+modulePath)
 
 			require.NoError(t, err)
 			output := showStdout.String()
@@ -451,7 +451,7 @@ func TestTerragruntExternalDependencies(t *testing.T) {
 	rootPath := copyEnvironment(t, TEST_FIXTURE_EXTERNAL_DEPENDENCE)
 	modulePath := util.JoinPath(rootPath, TEST_FIXTURE_EXTERNAL_DEPENDENCE, "module-b")
 
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply-all --terragrunt-non-interactive --terragrunt-include-external-dependencies --terragrunt-working-dir %s", modulePath), &applyAllStdout, &applyAllStderr)
+	err := runTerragruntCommand(t, "terragrunt apply-all --terragrunt-non-interactive --terragrunt-include-external-dependencies --terragrunt-working-dir "+modulePath, &applyAllStdout, &applyAllStderr)
 	logBufferContentsLineByLine(t, applyAllStdout, "apply-all stdout")
 	logBufferContentsLineByLine(t, applyAllStderr, "apply-all stderr")
 	applyAllStdoutString := applyAllStdout.String()
@@ -461,6 +461,6 @@ func TestTerragruntExternalDependencies(t *testing.T) {
 	}
 
 	for _, module := range modules {
-		require.Contains(t, applyAllStdoutString, fmt.Sprintf("Hello World, %s", module))
+		require.Contains(t, applyAllStdoutString, "Hello World, "+module)
 	}
 }

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -46,11 +46,11 @@ func TestTerragruntWorksWithIncludeLocals(t *testing.T) {
 		t.Run(filepath.Base(testCase), func(t *testing.T) {
 			childPath := filepath.Join(includeExposeFixturePath, testCase, includeChildFixturePath)
 			cleanupTerraformFolder(t, childPath)
-			runTerragrunt(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-include-external-dependencies --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", childPath))
+			runTerragrunt(t, "terragrunt run-all apply -auto-approve --terragrunt-include-external-dependencies --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+childPath)
 
 			stdout := bytes.Buffer{}
 			stderr := bytes.Buffer{}
-			err := runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", childPath), &stdout, &stderr)
+			err := runTerragruntCommand(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+childPath, &stdout, &stderr)
 			require.NoError(t, err)
 
 			outputs := map[string]TerraformOutput{}
@@ -66,7 +66,7 @@ func TestTerragruntWorksWithIncludeShallowMerge(t *testing.T) {
 	childPath := util.JoinPath(includeFixturePath, includeShallowFixturePath)
 	cleanupTerraformFolder(t, childPath)
 
-	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 
 	tmpTerragruntConfigPath := createTmpTerragruntConfigWithParentAndChild(t, includeFixturePath, includeShallowFixturePath, s3BucketName, config.DefaultTerragruntConfigPath, config.DefaultTerragruntConfigPath)
@@ -129,10 +129,7 @@ func TestTerragruntRunAllModulesWithPrefix(t *testing.T) {
 	stderr := bytes.Buffer{}
 	err := runTerragruntCommand(
 		t,
-		fmt.Sprintf(
-			"terragrunt run-all plan --terragrunt-non-interactive --terragrunt-include-module-prefix --terragrunt-working-dir %s",
-			modulePath,
-		),
+		"terragrunt run-all plan --terragrunt-non-interactive --terragrunt-include-module-prefix --terragrunt-working-dir "+modulePath,
 		&stdout,
 		&stderr,
 	)
@@ -165,11 +162,11 @@ func TestTerragruntWorksWithIncludeDeepMerge(t *testing.T) {
 	childPath := util.JoinPath(includeDeepFixturePath, "child")
 	cleanupTerraformFolder(t, childPath)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", childPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+childPath)
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", childPath), &stdout, &stderr)
+	err := runTerragruntCommand(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+childPath, &stdout, &stderr)
 	require.NoError(t, err)
 
 	outputs := map[string]TerraformOutput{}
@@ -219,11 +216,11 @@ func TestTerragruntWorksWithMultipleInclude(t *testing.T) {
 
 			childPath := filepath.Join(includeMultipleFixturePath, testCase, includeDeepFixtureChildPath)
 			cleanupTerraformFolder(t, childPath)
-			runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", childPath))
+			runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+childPath)
 
 			stdout := bytes.Buffer{}
 			stderr := bytes.Buffer{}
-			err := runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", childPath), &stdout, &stderr)
+			err := runTerragruntCommand(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+childPath, &stdout, &stderr)
 			require.NoError(t, err)
 
 			outputs := map[string]TerraformOutput{}

--- a/test/integration_local_dev_test.go
+++ b/test/integration_local_dev_test.go
@@ -20,8 +20,8 @@ func TestTerragruntSourceMap(t *testing.T) {
 	rootPath := filepath.Join(tmpEnvPath, fixtureSourceMapPath)
 	sourceMapArgs := fmt.Sprintf(
 		"--terragrunt-source-map %s --terragrunt-source-map %s",
-		fmt.Sprintf("git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=%s", tmpEnvPath),
-		fmt.Sprintf("git::ssh://git@github.com/gruntwork-io/another-dont-exist.git=%s", tmpEnvPath),
+		"git::ssh://git@github.com/gruntwork-io/i-dont-exist.git="+tmpEnvPath,
+		"git::ssh://git@github.com/gruntwork-io/another-dont-exist.git="+tmpEnvPath,
 	)
 
 	testCases := []struct {
@@ -76,7 +76,7 @@ func TestGetTerragruntSourceHCL(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_TERRAGRUNT_SOURCE_HCL)
 	terraformSource := "" // get_terragrunt_source_cli_flag() only returns the source when it is passed in via the CLI
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -84,13 +84,13 @@ func TestGetTerragruntSourceHCL(t *testing.T) {
 
 	require.NoError(
 		t,
-		runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr),
+		runTerragruntCommand(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr),
 	)
 
 	outputs := map[string]TerraformOutput{}
 
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, fmt.Sprintf("HCL: %s", terraformSource), outputs["terragrunt_source"].Value)
+	require.Equal(t, "HCL: "+terraformSource, outputs["terragrunt_source"].Value)
 }
 
 func TestGetTerragruntSourceCLI(t *testing.T) {
@@ -115,5 +115,5 @@ func TestGetTerragruntSourceCLI(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, fmt.Sprintf("CLI: %s", terraformSource), outputs["terragrunt_source"].Value)
+	require.Equal(t, "CLI: "+terraformSource, outputs["terragrunt_source"].Value)
 }

--- a/test/integration_registry_test.go
+++ b/test/integration_registry_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/util"
@@ -42,11 +41,11 @@ func TestTerraformRegistryFetchingSubdirWithReferenceModule(t *testing.T) {
 func testTerraformRegistryFetching(t *testing.T, modPath, expectedOutputKey string) {
 	modFullPath := util.JoinPath(registryFixturePath, modPath)
 	cleanupTerraformFolder(t, modFullPath)
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", modFullPath))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+modFullPath)
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s", modFullPath), &stdout, &stderr)
+	err := runTerragruntCommand(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+modFullPath, &stdout, &stderr)
 	require.NoError(t, err)
 
 	outputs := map[string]TerraformOutput{}

--- a/test/integration_s3_encryption_test.go
+++ b/test/integration_s3_encryption_test.go
@@ -31,8 +31,8 @@ func TestTerragruntS3SSEAES(t *testing.T) {
 	cleanupTerraformFolder(t, tmpEnvPath)
 	testPath := util.JoinPath(tmpEnvPath, s3SSEAESFixturePath)
 
-	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
-	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
+	lockTableName := "terragrunt-test-locks-" + strings.ToLower(uniqueId())
 
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
@@ -58,8 +58,8 @@ func TestTerragruntS3SSECustomKey(t *testing.T) {
 	cleanupTerraformFolder(t, tmpEnvPath)
 	testPath := util.JoinPath(tmpEnvPath, s3SSECustomKeyFixturePath)
 
-	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
-	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
+	lockTableName := "terragrunt-test-locks-" + strings.ToLower(uniqueId())
 
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
@@ -84,14 +84,14 @@ func TestTerragruntS3SSEKeyNotReverted(t *testing.T) {
 
 	cleanupTerraformFolder(t, s3SSBasicEncryptionFixturePath)
 
-	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
-	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
+	lockTableName := "terragrunt-test-locks-" + strings.ToLower(uniqueId())
 
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, TERRAFORM_REMOTE_STATE_S3_REGION)
 
 	tmpTerragruntConfigPath := createTmpTerragruntConfig(t, s3SSBasicEncryptionFixturePath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
-	stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", filepath.Dir(tmpTerragruntConfigPath)))
+	stdout, stderr, err := runTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+filepath.Dir(tmpTerragruntConfigPath))
 	require.NoError(t, err)
 	output := fmt.Sprintf(stdout, stderr)
 
@@ -99,7 +99,7 @@ func TestTerragruntS3SSEKeyNotReverted(t *testing.T) {
 	assert.NotContains(t, output, "Bucket Server-Side Encryption")
 
 	tmpTerragruntConfigPath = createTmpTerragruntConfig(t, s3SSBasicEncryptionFixturePath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
-	stdout, stderr, err = runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", filepath.Dir(tmpTerragruntConfigPath)))
+	stdout, stderr, err = runTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+filepath.Dir(tmpTerragruntConfigPath))
 	require.NoError(t, err)
 	output = fmt.Sprintf(stdout, stderr)
 	assert.NotContains(t, output, "Bucket Server-Side Encryption")
@@ -122,8 +122,8 @@ func TestTerragruntS3EncryptionWarning(t *testing.T) {
 	cleanupTerraformFolder(t, tmpEnvPath)
 	testPath := util.JoinPath(tmpEnvPath, s3SSEKMSFixturePath)
 
-	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
-	lockTableName := fmt.Sprintf("terragrunt-test-locks-%s", strings.ToLower(uniqueId()))
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
+	lockTableName := "terragrunt-test-locks-" + strings.ToLower(uniqueId())
 
 	require.NoError(t, createS3BucketE(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName))
 
@@ -136,7 +136,7 @@ func TestTerragruntS3EncryptionWarning(t *testing.T) {
 	require.NoError(t, err)
 	output := fmt.Sprintf(stdout, stderr)
 	// check that warning is printed
-	assert.Contains(t, output, fmt.Sprintf("Encryption is not enabled on the S3 remote state bucket %s", s3BucketName))
+	assert.Contains(t, output, "Encryption is not enabled on the S3 remote state bucket "+s3BucketName)
 
 	// verify that encryption configuration is set
 	client := terraws.NewS3Client(t, TERRAFORM_REMOTE_STATE_S3_REGION)
@@ -151,7 +151,7 @@ func TestTerragruntS3EncryptionWarning(t *testing.T) {
 	stdout, stderr, err = runTerragruntCommandWithOutput(t, applyCommand(tmpTerragruntConfigPath, testPath))
 	require.NoError(t, err)
 	output = fmt.Sprintf(stdout, stderr)
-	assert.NotContains(t, output, fmt.Sprintf("Encryption is not enabled on the S3 remote state bucket %s", s3BucketName))
+	assert.NotContains(t, output, "Encryption is not enabled on the S3 remote state bucket "+s3BucketName)
 }
 
 func applyCommand(configPath, fixturePath string) string {

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -30,7 +30,7 @@ func TestScaffoldModule(t *testing.T) {
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_MODULE))
 	require.NoError(t, err)
 	require.Contains(t, stderr, "Scaffolding completed")
-	require.FileExists(t, fmt.Sprintf("%s/terragrunt.hcl", tmpEnvPath))
+	require.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
 }
 
 func TestScaffoldModuleShortUrl(t *testing.T) {
@@ -43,7 +43,7 @@ func TestScaffoldModuleShortUrl(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, stderr, "Scaffolding completed")
 	// check that find_in_parent_folders is generated in terragrunt.hcl
-	content, err := util.ReadFileAsString(fmt.Sprintf("%s/terragrunt.hcl", tmpEnvPath))
+	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
 	require.NoError(t, err)
 	require.Contains(t, content, "find_in_parent_folders")
 }
@@ -58,7 +58,7 @@ func TestScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, stderr, "Scaffolding completed")
 	// check that find_in_parent_folders is NOT generated in  terragrunt.hcl
-	content, err := util.ReadFileAsString(fmt.Sprintf("%s/terragrunt.hcl", tmpEnvPath))
+	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
 	require.NoError(t, err)
 	require.NotContains(t, content, "find_in_parent_folders")
 }
@@ -109,7 +109,7 @@ func TestScaffoldModuleTemplate(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, stderr, "Scaffolding completed")
 	// check that exists file from .boilerplate dir
-	require.FileExists(t, fmt.Sprintf("%s/template-file.txt", tmpEnvPath))
+	require.FileExists(t, tmpEnvPath+"/template-file.txt")
 }
 
 func TestScaffoldModuleExternalTemplate(t *testing.T) {
@@ -122,7 +122,7 @@ func TestScaffoldModuleExternalTemplate(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, stderr, "Scaffolding completed")
 	// check that exists file from external template
-	require.FileExists(t, fmt.Sprintf("%s/external-template.txt", tmpEnvPath))
+	require.FileExists(t, tmpEnvPath+"/external-template.txt")
 }
 
 func TestScaffoldErrorNoModuleUrl(t *testing.T) {
@@ -155,7 +155,7 @@ SourceUrlType: "git-ssh"
 	require.NoError(t, err)
 	require.Contains(t, stderr, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixture-inputs?ref=v0.53.1")
 	require.Contains(t, stderr, "Scaffolding completed")
-	content, err := util.ReadFileAsString(fmt.Sprintf("%s/terragrunt.hcl", tmpEnvPath))
+	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
 	require.NoError(t, err)
 	require.NotContains(t, content, "find_in_parent_folders")
 }
@@ -172,7 +172,7 @@ func TestScaffoldLocalModule(t *testing.T) {
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, fmt.Sprintf("%s//%s", workingDir, TEST_SCAFFOLD_LOCAL_MODULE)))
 	require.NoError(t, err)
 	require.Contains(t, stderr, "Scaffolding completed")
-	require.FileExists(t, fmt.Sprintf("%s/terragrunt.hcl", tmpEnvPath))
+	require.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
 }
 
 func TestScaffold3rdPartyModule(t *testing.T) {
@@ -191,7 +191,7 @@ func TestScaffold3rdPartyModule(t *testing.T) {
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_3RD_PARTY_MODULE))
 	require.NoError(t, err)
 	require.Contains(t, stderr, "Scaffolding completed")
-	require.FileExists(t, fmt.Sprintf("%s/terragrunt.hcl", tmpEnvPath))
+	require.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
 
 	// validate the generated files
 	_, _, err = runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s hclvalidate", tmpEnvPath))

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -150,7 +150,7 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 	require.NoError(t, err)
 	defer cliConfigFilename.Close()
 
-	tokenEnvName := fmt.Sprintf("TF_TOKEN_%s", strings.ReplaceAll(networkMirrorURL.Hostname(), ".", "_"))
+	tokenEnvName := "TF_TOKEN_" + strings.ReplaceAll(networkMirrorURL.Hostname(), ".", "_")
 	err = os.Setenv(tokenEnvName, token)
 	require.NoError(t, err)
 	defer os.Unsetenv(tokenEnvName)
@@ -298,14 +298,14 @@ func TestTerragruntDownloadDir(t *testing.T) {
 			"download dir set in config and as a flag",
 			util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "download-dir", "in-config"),
 			"", // env
-			fmt.Sprintf("--terragrunt-download-dir %s", util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "download-dir", "in-config", ".flag-download")),
+			"--terragrunt-download-dir " + util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "download-dir", "in-config", ".flag-download"),
 			util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "download-dir", "in-config", ".flag-download"),
 		},
 		{
 			"download dir set in config env and as a flag",
 			util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "download-dir", "in-config"),
 			util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "download-dir", "in-config", ".env-var"),
-			fmt.Sprintf("--terragrunt-download-dir %s", util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "download-dir", "in-config", ".flag-download")),
+			"--terragrunt-download-dir " + util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "download-dir", "in-config", ".flag-download"),
 			util.JoinPath(tmpEnvPath, TEST_FIXTURE_GET_OUTPUT, "download-dir", "in-config", ".flag-download"),
 		},
 	}
@@ -350,7 +350,7 @@ func TestTerragruntCorrectlyMirrorsTerraformGCPAuth(t *testing.T) {
 
 	// We need a project to create the bucket in, so we pull one from the recommended environment variable.
 	project := os.Getenv("GOOGLE_CLOUD_PROJECT")
-	gcsBucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
+	gcsBucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
 
 	defer deleteGCSBucket(t, gcsBucketName)
 
@@ -365,7 +365,7 @@ func TestTerragruntCorrectlyMirrorsTerraformGCPAuth(t *testing.T) {
 
 func TestExtraArguments(t *testing.T) {
 	out := new(bytes.Buffer)
-	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_EXTRA_ARGS_PATH), out, os.Stderr)
+	runTerragruntRedirectOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+TEST_FIXTURE_EXTRA_ARGS_PATH, out, os.Stderr)
 	t.Log(out.String())
 	require.Contains(t, out.String(), "Hello, World from dev!")
 }
@@ -373,14 +373,14 @@ func TestExtraArguments(t *testing.T) {
 func TestExtraArgumentsWithEnv(t *testing.T) {
 	out := new(bytes.Buffer)
 	t.Setenv("TF_VAR_env", "prod")
-	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_EXTRA_ARGS_PATH), out, os.Stderr)
+	runTerragruntRedirectOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+TEST_FIXTURE_EXTRA_ARGS_PATH, out, os.Stderr)
 	t.Log(out.String())
 	require.Contains(t, out.String(), "Hello, World!")
 }
 
 func TestExtraArgumentsWithEnvVarBlock(t *testing.T) {
 	out := new(bytes.Buffer)
-	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_ENV_VARS_BLOCK_PATH), out, os.Stderr)
+	runTerragruntRedirectOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+TEST_FIXTURE_ENV_VARS_BLOCK_PATH, out, os.Stderr)
 	t.Log(out.String())
 	require.Contains(t, out.String(), "I'm set in extra_arguments env_vars")
 }
@@ -388,7 +388,7 @@ func TestExtraArgumentsWithEnvVarBlock(t *testing.T) {
 func TestExtraArgumentsWithRegion(t *testing.T) {
 	out := new(bytes.Buffer)
 	t.Setenv("TF_VAR_region", "us-west-2")
-	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_EXTRA_ARGS_PATH), out, os.Stderr)
+	runTerragruntRedirectOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+TEST_FIXTURE_EXTRA_ARGS_PATH, out, os.Stderr)
 	t.Log(out.String())
 	require.Contains(t, out.String(), "Hello, World from Oregon!")
 }
@@ -401,7 +401,7 @@ func TestPreserveEnvVarApplyAll(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_REGRESSIONS, "apply-all-envvar")
 
 	stdout := bytes.Buffer{}
-	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt apply-all -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, os.Stderr)
+	runTerragruntRedirectOutput(t, "terragrunt apply-all -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, os.Stderr)
 	t.Log(stdout.String())
 
 	// Check the output of each child module to make sure the inputs were overridden by the env var
@@ -409,7 +409,7 @@ func TestPreserveEnvVarApplyAll(t *testing.T) {
 	noRequireEnvVarModule := util.JoinPath(rootPath, "no-require-envvar")
 	for _, mod := range []string{requireEnvVarModule, noRequireEnvVarModule} {
 		stdout := bytes.Buffer{}
-		err := runTerragruntCommand(t, fmt.Sprintf("terragrunt output text -no-color --terragrunt-non-interactive --terragrunt-working-dir %s", mod), &stdout, os.Stderr)
+		err := runTerragruntCommand(t, "terragrunt output text -no-color --terragrunt-non-interactive --terragrunt-working-dir "+mod, &stdout, os.Stderr)
 		require.NoError(t, err)
 		require.Contains(t, stdout.String(), "Hello from the env")
 	}
@@ -450,14 +450,14 @@ func TestTerragruntSourceMapEnvArg(t *testing.T) {
 		"TERRAGRUNT_SOURCE_MAP",
 		strings.Join(
 			[]string{
-				fmt.Sprintf("git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=%s", tmpEnvPath),
-				fmt.Sprintf("git::ssh://git@github.com/gruntwork-io/another-dont-exist.git=%s", tmpEnvPath),
+				"git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=" + tmpEnvPath,
+				"git::ssh://git@github.com/gruntwork-io/another-dont-exist.git=" + tmpEnvPath,
 			},
 			",",
 		),
 	)
 	tgPath := filepath.Join(rootPath, "multiple-match")
-	tgArgs := fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir %s", tgPath)
+	tgArgs := "terragrunt run-all apply -auto-approve --terragrunt-log-level debug --terragrunt-non-interactive --terragrunt-working-dir " + tgPath
 	runTerragrunt(t, tgArgs)
 }
 
@@ -476,7 +476,7 @@ func TestTerragruntLogLevelEnvVarOverridesDefault(t *testing.T) {
 
 	require.NoError(
 		t,
-		runTerragruntCommand(t, fmt.Sprintf("terragrunt validate --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, &stderr),
+		runTerragruntCommand(t, "terragrunt validate --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr),
 	)
 	output := stderr.String()
 	require.Contains(t, output, "level=debug")
@@ -493,7 +493,7 @@ func TestTerragruntLogLevelEnvVarUnparsableLogsErrorButContinues(t *testing.T) {
 	// Ideally, we would check stderr to introspect the error message, but the global fallback logger only logs to real
 	// stderr and we can't capture the output, so in this case we only make sure that the command runs successfully to
 	// completion.
-	runTerragrunt(t, fmt.Sprintf("terragrunt validate --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	runTerragrunt(t, "terragrunt validate --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 }
 
 // NOTE: the following test requires precise timing for determining parallelism. As such, it can not be run in parallel
@@ -511,7 +511,7 @@ func testTerragruntParallelism(t *testing.T, parallelism int, numberOfModules in
 	matches := regex.FindAllStringSubmatch(output, -1)
 	require.Len(t, matches, numberOfModules)
 
-	var deploymentTimes []int
+	var deploymentTimes = make([]int, 0, len(matches))
 	for _, match := range matches {
 		parsedTime, err := time.Parse(time.RFC3339, match[1])
 		require.NoError(t, err)
@@ -572,7 +572,7 @@ func TestTerragruntWorksWithImpersonateGCSBackend(t *testing.T) {
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", tmpImpersonatorCreds)
 
 	project := os.Getenv("GOOGLE_CLOUD_PROJECT")
-	gcsBucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
+	gcsBucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
 
 	// run with impersonation
 	tmpTerragruntImpersonateGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_IMPERSONATE_PATH, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, config.DefaultTerragruntConfigPath)
@@ -602,7 +602,7 @@ func TestTerragruntProduceTelemetryTraces(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_HOOKS_BEFORE_AND_AFTER_PATH)
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_HOOKS_BEFORE_AND_AFTER_PATH)
 
-	output, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	output, _, err := runTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 	require.NoError(t, err)
 
 	// check that output have Telemetry json output
@@ -619,7 +619,7 @@ func TestTerragruntProduceTelemetryMetrics(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_HOOKS_BEFORE_AND_AFTER_PATH)
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_HOOKS_BEFORE_AND_AFTER_PATH)
 
-	output, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -no-color -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	output, _, err := runTerragruntCommandWithOutput(t, "terragrunt apply -no-color -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 	require.NoError(t, err)
 
 	// sleep for a bit to allow the metrics to be flushed
@@ -641,15 +641,16 @@ func TestTerragruntOutputJson(t *testing.T) {
 	cleanupTerraformFolder(t, tmpEnvPath)
 	testPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_NOT_EXISTING_SOURCE)
 
-	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply --terragrunt-json-log --terragrunt-non-interactive --terragrunt-working-dir %s", testPath))
+	_, stderr, err := runTerragruntCommandWithOutput(t, "terragrunt apply --terragrunt-json-log --terragrunt-non-interactive --terragrunt-working-dir "+testPath)
 	require.Error(t, err)
-
-	var msgs []string
 
 	// for windows OS
 	output := bytes.ReplaceAll([]byte(stderr), []byte("\r\n"), []byte("\n"))
 
 	multipeJSONs := bytes.Split(output, []byte("\n"))
+
+	var msgs = make([]string, 0, len(multipeJSONs))
+
 	for _, jsonBytes := range multipeJSONs {
 		if len(jsonBytes) == 0 {
 			continue
@@ -678,7 +679,7 @@ func TestTerragruntTerraformOutputJson(t *testing.T) {
 	cleanupTerraformFolder(t, tmpEnvPath)
 	testPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_INIT_ERROR)
 
-	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply --no-color --terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-non-interactive --terragrunt-working-dir %s", testPath))
+	_, stderr, err := runTerragruntCommandWithOutput(t, "terragrunt apply --no-color --terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-non-interactive --terragrunt-working-dir "+testPath)
 	require.Error(t, err)
 
 	require.Contains(t, stderr, "\"level\":\"info\",\"msg\":\"Initializing the backend...")
@@ -709,7 +710,7 @@ func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		testCase := testCase
-		t.Run(fmt.Sprintf("terragrunt output with %s", testCase.arg), func(t *testing.T) {
+		t.Run("terragrunt output with "+testCase.arg, func(t *testing.T) {
 			defer func() {
 				util.DisableJsonFormat()
 			}()
@@ -741,7 +742,7 @@ func TestTerragruntJsonPlanJsonOutput(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		testCase := testCase
-		t.Run(fmt.Sprintf("terragrunt with %s", testCase.arg), func(t *testing.T) {
+		t.Run("terragrunt with "+testCase.arg, func(t *testing.T) {
 			defer func() {
 				util.DisableJsonFormat()
 			}()
@@ -777,7 +778,7 @@ func TestTerragruntProduceTelemetryTracesWithRootSpanAndTraceID(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_HOOKS_BEFORE_AND_AFTER_PATH)
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_HOOKS_BEFORE_AND_AFTER_PATH)
 
-	output, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	output, _, err := runTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 	require.NoError(t, err)
 
 	// check that output have Telemetry json output
@@ -797,7 +798,7 @@ func TestTerragruntProduceTelemetryInCasOfError(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_HOOKS_BEFORE_AND_AFTER_PATH)
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_HOOKS_BEFORE_AND_AFTER_PATH)
 
-	output, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt no-existing-command -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
+	output, _, err := runTerragruntCommandWithOutput(t, "terragrunt no-existing-command -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 	require.Error(t, err)
 
 	require.Contains(t, output, "\"SpanContext\":{\"TraceID\":\"b2ff2d54551433d53dd807a6c94e81d1\"")
@@ -902,7 +903,7 @@ func TestReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_AUTH_PROVIDER_CMD, "remote-state")
 	mockAuthCmd := filepath.Join(tmpEnvPath, TEST_FIXTURE_AUTH_PROVIDER_CMD, "mock-auth-cmd.sh")
 
-	s3BucketName := fmt.Sprintf("terragrunt-test-bucket-%s", strings.ToLower(uniqueId()))
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
 	defer deleteS3Bucket(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 
 	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -388,9 +388,7 @@ func TestTerragruntProviderCacheMultiplePlatforms(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_PROVIDER_CACHE_MULTIPLE_PLATFORMS)
 	rootPath := util.JoinPath(tmpEnvPath, TEST_FIXTURE_PROVIDER_CACHE_MULTIPLE_PLATFORMS)
 
-	cacheDir, err := util.GetCacheDir()
-	require.NoError(t, err)
-	providerCacheDir := filepath.Join(cacheDir, "provider-cache-multiple-platforms")
+	providerCacheDir := t.TempDir()
 
 	var (
 		platforms     = []string{"linux_amd64", "darwin_arm64"}

--- a/test/integration_unix_test.go
+++ b/test/integration_unix_test.go
@@ -4,7 +4,6 @@
 package test
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -17,8 +16,8 @@ func TestLocalWithRelativeExtraArgsUnix(t *testing.T) {
 
 	cleanupTerraformFolder(t, TEST_FIXTURE_LOCAL_RELATIVE_ARGS_UNIX_DOWNLOAD_PATH)
 
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_RELATIVE_ARGS_UNIX_DOWNLOAD_PATH))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+TEST_FIXTURE_LOCAL_RELATIVE_ARGS_UNIX_DOWNLOAD_PATH)
 
 	// Run a second time to make sure the temporary folder can be reused without errors
-	runTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", TEST_FIXTURE_LOCAL_RELATIVE_ARGS_UNIX_DOWNLOAD_PATH))
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+TEST_FIXTURE_LOCAL_RELATIVE_ARGS_UNIX_DOWNLOAD_PATH)
 }

--- a/tflint/tflint.go
+++ b/tflint/tflint.go
@@ -191,7 +191,7 @@ func tfArgumentsToTflintVar(terragruntOptions *options.TerragruntOptions, hook c
 
 				if strings.HasPrefix(value, argVarFilePrefix) {
 					varName := strings.TrimPrefix(value, argVarFilePrefix)
-					newVar := fmt.Sprintf("--var-file=%s", varName)
+					newVar := "--var-file=" + varName
 					variables = append(variables, newVar)
 				}
 			}
@@ -200,7 +200,7 @@ func tfArgumentsToTflintVar(terragruntOptions *options.TerragruntOptions, hook c
 		if arg.RequiredVarFiles != nil {
 			// extract required variables
 			for _, file := range *arg.RequiredVarFiles {
-				newVar := fmt.Sprintf("--var-file=%s", file)
+				newVar := "--var-file=" + file
 				variables = append(variables, newVar)
 			}
 		}
@@ -209,7 +209,7 @@ func tfArgumentsToTflintVar(terragruntOptions *options.TerragruntOptions, hook c
 			// extract optional variables
 			for _, file := range util.RemoveDuplicatesFromListKeepLast(*arg.OptionalVarFiles) {
 				if util.FileExists(file) {
-					newVar := fmt.Sprintf("--var-file=%s", file)
+					newVar := "--var-file=" + file
 					variables = append(variables, newVar)
 				} else {
 					terragruntOptions.Logger.Debugf("Skipping tflint var-file %s as it does not exist", file)
@@ -279,5 +279,5 @@ type ConfigNotFound struct {
 }
 
 func (err ConfigNotFound) Error() string {
-	return fmt.Sprintf("Could not find .tflint.hcl config file in the parent folders: %s", err.cause)
+	return "Could not find .tflint.hcl config file in the parent folders: " + err.cause
 }

--- a/util/datetime.go
+++ b/util/datetime.go
@@ -2,6 +2,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -44,7 +45,7 @@ func ParseTimestamp(ts string) (time.Time, error) {
 			case "Z07:00":
 				what = "UTC offset"
 			case "T":
-				return time.Time{}, fmt.Errorf("not a valid RFC3339 timestamp: missing required time introducer 'T'")
+				return time.Time{}, errors.New("not a valid RFC3339 timestamp: missing required time introducer 'T'")
 			case ":", "-":
 				if err.ValueElem == "" {
 					return time.Time{}, fmt.Errorf("not a valid RFC3339 timestamp: end of string where %q is expected", err.LayoutElem)

--- a/util/file.go
+++ b/util/file.go
@@ -249,7 +249,7 @@ func expandGlobPath(source, absoluteGlobPath string) ([]string, error) {
 		includeExpandedGlobs = append(includeExpandedGlobs, relativeExpandGlobPath)
 
 		if IsDir(absoluteExpandGlobPath) {
-			dirExpandGlob, err := expandGlobPath(source, fmt.Sprintf("%s/*", absoluteExpandGlobPath))
+			dirExpandGlob, err := expandGlobPath(source, absoluteExpandGlobPath+"/*")
 			if err != nil {
 				return nil, errors.WithStackTrace(err)
 			}
@@ -308,7 +308,7 @@ func CopyFolderContentsWithFilter(source, destination, manifestFile string, filt
 	// Why use filepath.Glob here? The original implementation used os.ReadDir, but that method calls lstat on all
 	// the files/folders in the directory, including files/folders you may want to explicitly skip. The next attempt
 	// was to use filepath.Walk, but that doesn't work because it ignores symlinks. So, now we turn to filepath.Glob.
-	files, err := filepath.Glob(fmt.Sprintf("%s/*", source))
+	files, err := filepath.Glob(source + "/*")
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
@@ -577,7 +577,7 @@ type PathIsNotDirectory struct {
 }
 
 func (err PathIsNotDirectory) Error() string {
-	return fmt.Sprintf("%s is not a directory", err.path)
+	return err.path + " is not a directory"
 }
 
 // PathIsNotFile is returned when the given path is unexpectedly not a file.
@@ -586,7 +586,7 @@ type PathIsNotFile struct {
 }
 
 func (err PathIsNotFile) Error() string {
-	return fmt.Sprintf("%s is not a file", err.path)
+	return err.path + " is not a file"
 }
 
 // Terraform 0.14 now generates a lock file when you run `terraform init`.

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -172,12 +172,13 @@ func TestJoinTerraformModulePath(t *testing.T) {
 func TestFileManifest(t *testing.T) {
 	t.Parallel()
 
-	var testfiles []string
+	files := []string{"file1", "file2"}
+	var testfiles = make([]string, 0, len(files))
 
 	// create temp dir
 	dir, err := os.MkdirTemp("", ".terragrunt-test-dir")
 	require.NoError(t, err)
-	for _, file := range []string{"file1", "file2"} {
+	for _, file := range files {
 		// create temp files in the dir
 		f, err := os.CreateTemp(dir, file)
 		require.NoError(t, err)

--- a/util/logger.go
+++ b/util/logger.go
@@ -87,7 +87,7 @@ func CreateLogEntryWithWriter(writer io.Writer, prefix string, level logrus.Leve
 	if prefix != "" {
 		prefix = fmt.Sprintf("[%s] ", prefix)
 	} else {
-		prefix = fmt.Sprintf("[terragrunt] %s", prefix)
+		prefix = "[terragrunt] " + prefix
 	}
 	logger := CreateLogEntry(prefix, level)
 	logger.Logger.SetOutput(writer)


### PR DESCRIPTION
## Description

Adds the `performance` preset to the linting rules.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated package `aws_helper`
Updated package `awsproviderpatch`
Updated package `cache`
Updated package `cli`
Updated package `cliconfig`
Updated package `codegen`
Updated package `config`
Updated package `configstack`
Updated package `diagnostic`
Updated package `dynamodb`
Updated package `engine`
Updated package `getproviders`
Updated package `graph`
Updated package `hclparse`
Updated package `options`
Updated package `outputmodulegroups`
Updated package `remote`
Updated package `renderjson`
Updated package `services`
Updated package `shell`
Updated package `telemetry`
Updated package `terraform`
Updated package `test`
Updated package `tflint`
Updated package `tui`
Updated package `util`
Updated package `validateinputs`
Updated package `view`

