### PR TITLE
fix: Reverting to asserts for non error checking assertions

### DIFF
--- a/aws_helper/policy_test.go
+++ b/aws_helper/policy_test.go
@@ -84,13 +84,13 @@ func TestUnmarshalActionResourceList(t *testing.T) {
 	bucketPolicy, err := UnmarshalPolicy(arraysPolicy)
 	require.NoError(t, err)
 	assert.NotNil(t, bucketPolicy)
-	require.Len(t, bucketPolicy.Statement, 1)
+	assert.Len(t, bucketPolicy.Statement, 1)
 	assert.NotNil(t, bucketPolicy.Statement[0].Action)
 	assert.NotNil(t, bucketPolicy.Statement[0].Resource)
 
 	switch actions := bucketPolicy.Statement[0].Action.(type) {
 	case []interface{}:
-		require.Len(t, actions, 11)
+		assert.Len(t, actions, 11)
 		assert.Contains(t, actions, "s3:ListJobs")
 	default:
 		assert.Fail(t, "Expected []string type for Action")
@@ -98,7 +98,7 @@ func TestUnmarshalActionResourceList(t *testing.T) {
 
 	switch resource := bucketPolicy.Statement[0].Resource.(type) {
 	case []interface{}:
-		require.Len(t, resource, 2)
+		assert.Len(t, resource, 2)
 		assert.Contains(t, resource, "arn:aws:s3:*:666:job/*")
 	default:
 		assert.Fail(t, "Expected []string type for Resource")

--- a/cli/commands/scaffold/action_test.go
+++ b/cli/commands/scaffold/action_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,7 +86,7 @@ func TestDefaultTemplateVariables(t *testing.T) {
 	cfg, err := config.ReadTerragruntConfig(context.Background(), opts, config.DefaultParserOptions(opts))
 	require.NoError(t, err)
 	require.NotEmpty(t, cfg.Inputs)
-	require.Len(t, cfg.Inputs, 1)
+	assert.Len(t, cfg.Inputs, 1)
 	_, found := cfg.Inputs["required_var_1"]
 	require.True(t, found)
 	require.Equal(t, "git::https://github.com/gruntwork-io/terragrunt.git//test/fixture-inputs?ref=v0.53.8", *cfg.Terraform.Source)

--- a/cli/commands/terraform/download_source_test.go
+++ b/cli/commands/terraform/download_source_test.go
@@ -256,7 +256,7 @@ func TestDownloadTerraformSourceIfNecessaryInvalidTerraformSource(t *testing.T) 
 	require.Error(t, err)
 	var downloadingTerraformSourceErr DownloadingTerraformSourceErr
 	ok := errors.As(err, &downloadingTerraformSourceErr)
-	require.True(t, ok)
+	assert.True(t, ok)
 }
 
 func TestInvalidModulePath(t *testing.T) {
@@ -276,7 +276,7 @@ func TestInvalidModulePath(t *testing.T) {
 	require.Error(t, err)
 	var workingDirNotFound WorkingDirNotFound
 	ok := errors.As(err, &workingDirNotFound)
-	require.True(t, ok)
+	assert.True(t, ok)
 }
 
 func TestDownloadInvalidPathToFilePath(t *testing.T) {
@@ -296,7 +296,7 @@ func TestDownloadInvalidPathToFilePath(t *testing.T) {
 	require.Error(t, err)
 	var workingDirNotDir WorkingDirNotDir
 	ok := errors.As(err, &workingDirNotDir)
-	require.True(t, ok)
+	assert.True(t, ok)
 }
 
 func TestDownloadTerraformSourceFromLocalFolderWithManifest(t *testing.T) {
@@ -356,14 +356,14 @@ func TestDownloadTerraformSourceFromLocalFolderWithManifest(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			copyFolder(t, testCase.sourceURL, downloadDir)
-			require.Condition(t, testCase.comp)
+			assert.Condition(t, testCase.comp)
 		})
 
 	}
 
 }
 
-func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, downloadDir string, sourceUpdate bool, expectedFileContents string, requireInitFile bool) {
+func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, downloadDir string, sourceUpdate bool, expectedFileContents string, assertInitFile bool) {
 	terraformSource, terragruntOptions, terragruntConfig, err := createConfig(t, canonicalUrl, downloadDir, sourceUpdate)
 
 	require.NoError(t, err)
@@ -374,12 +374,12 @@ func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, d
 	expectedFilePath := util.JoinPath(downloadDir, "main.tf")
 	if assert.True(t, util.FileExists(expectedFilePath), "For terraform source %v", terraformSource) {
 		actualFileContents := readFile(t, expectedFilePath)
-		require.Equal(t, expectedFileContents, actualFileContents, "For terraform source %v", terraformSource)
+		assert.Equal(t, expectedFileContents, actualFileContents, "For terraform source %v", terraformSource)
 	}
 
-	if requireInitFile {
+	if assertInitFile {
 		existsInitFile := util.FileExists(util.JoinPath(terraformSource.WorkingDir, moduleInitRequiredFile))
-		require.True(t, existsInitFile)
+		assert.True(t, existsInitFile)
 	}
 }
 
@@ -428,7 +428,7 @@ func testAlreadyHaveLatestCode(t *testing.T, canonicalUrl string, downloadDir st
 
 	actual, err := alreadyHaveLatestCode(terraformSource, opts)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual, "For terraform source %v", terraformSource)
+	assert.Equal(t, expected, actual, "For terraform source %v", terraformSource)
 }
 
 func tmpDir(t *testing.T) string {

--- a/cli/commands/terraform/version_check_test.go
+++ b/cli/commands/terraform/version_check_test.go
@@ -94,9 +94,9 @@ func testCheckTerraformVersionMeetsConstraint(t *testing.T, currentVersion strin
 
 	err = checkTerraformVersionMeetsConstraint(current, versionConstraint)
 	if versionMeetsConstraint && err != nil {
-		require.NoError(t, err, "Expected Terraform version %s to meet constraint %s, but got error: %v", currentVersion, versionConstraint, err)
+		assert.NoError(t, err, "Expected Terraform version %s to meet constraint %s, but got error: %v", currentVersion, versionConstraint, err)
 	} else if !versionMeetsConstraint && err == nil {
-		require.Error(t, err, "Expected Terraform version %s to NOT meet constraint %s, but got back a nil error", currentVersion, versionConstraint)
+		assert.Error(t, err, "Expected Terraform version %s to NOT meet constraint %s, but got back a nil error", currentVersion, versionConstraint)
 	}
 }
 

--- a/codegen/generate_test.go
+++ b/codegen/generate_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,15 +54,15 @@ func TestRemoteStateConfigToTerraformCode(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			output, err := RemoteStateConfigToTerraformCode(testCase.backend, testCase.config)
 			// validates the first output.
-			require.True(t, bytes.Contains(output, []byte(testCase.backend)))
-			require.Equal(t, testCase.expected, output)
+			assert.True(t, bytes.Contains(output, []byte(testCase.backend)))
+			assert.Equal(t, testCase.expected, output)
 			require.NoError(t, err)
 
 			// runs the function a few of times again. All the outputs must be
 			// equal to the first output.
 			for i := 0; i < 20; i++ {
 				actual, _ := RemoteStateConfigToTerraformCode(testCase.backend, testCase.config)
-				require.Equal(t, output, actual)
+				assert.Equal(t, output, actual)
 			}
 		})
 	}
@@ -106,15 +107,15 @@ func TestGenerateDisabling(t *testing.T) {
 
 			opts, err := options.NewTerragruntOptionsForTest("mock-path-for-test.hcl")
 			require.NoError(t, err)
-			require.NotNil(t, opts)
+			assert.NotNil(t, opts)
 
 			err = WriteToFile(opts, "", config)
 			require.NoError(t, err)
 
 			if testCase.disabled {
-				require.True(t, util.FileNotExists(testCase.path))
+				assert.True(t, util.FileNotExists(testCase.path))
 			} else {
-				require.True(t, util.FileExists(testCase.path))
+				assert.True(t, util.FileExists(testCase.path))
 			}
 		})
 	}

--- a/config/cache_test.go
+++ b/config/cache_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 const testCacheName = "TerragruntConfig"
@@ -15,10 +15,10 @@ func TestTerragruntConfigCacheCreation(t *testing.T) {
 
 	cache := cache.NewCache[TerragruntConfig](testCacheName)
 
-	require.NotNil(t, cache.Mutex)
-	require.NotNil(t, cache.Cache)
+	assert.NotNil(t, cache.Mutex)
+	assert.NotNil(t, cache.Cache)
 
-	require.Empty(t, cache.Cache)
+	assert.Empty(t, cache.Cache)
 }
 
 func TestTerragruntConfigCacheOperation(t *testing.T) {
@@ -31,8 +31,8 @@ func TestTerragruntConfigCacheOperation(t *testing.T) {
 
 	actualResult, found := cache.Get(ctx, testCacheKey)
 
-	require.False(t, found)
-	require.Empty(t, actualResult)
+	assert.False(t, found)
+	assert.Empty(t, actualResult)
 
 	stubTerragruntConfig := TerragruntConfig{
 		IsPartial: true, // Any random property will be sufficient
@@ -41,7 +41,7 @@ func TestTerragruntConfigCacheOperation(t *testing.T) {
 	cache.Put(ctx, testCacheKey, stubTerragruntConfig)
 	actualResult, found = cache.Get(ctx, testCacheKey)
 
-	require.True(t, found)
-	require.NotEmpty(t, actualResult)
-	require.Equal(t, stubTerragruntConfig, actualResult)
+	assert.True(t, found)
+	assert.NotEmpty(t, actualResult)
+	assert.Equal(t, stubTerragruntConfig, actualResult)
 }

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -82,7 +82,7 @@ func TestPathRelativeToInclude(t *testing.T) {
 		ctx := NewParsingContext(context.Background(), testCase.terragruntOptions).WithTrackInclude(trackInclude)
 		actualPath, actualErr := pathRelativeToInclude(ctx, testCase.params)
 		require.NoError(t, actualErr, "For include %v and options %v, unexpected error: %v", testCase.include, testCase.terragruntOptions, actualErr)
-		require.Equal(t, testCase.expectedPath, actualPath, "For include %v and options %v", testCase.include, testCase.terragruntOptions)
+		assert.Equal(t, testCase.expectedPath, actualPath, "For include %v and options %v", testCase.include, testCase.terragruntOptions)
 	}
 }
 
@@ -153,7 +153,7 @@ func TestPathRelativeFromInclude(t *testing.T) {
 		ctx := NewParsingContext(context.Background(), testCase.terragruntOptions).WithTrackInclude(trackInclude)
 		actualPath, actualErr := pathRelativeFromInclude(ctx, testCase.params)
 		require.NoError(t, actualErr, "For include %v and options %v, unexpected error: %v", testCase.include, testCase.terragruntOptions, actualErr)
-		require.Equal(t, testCase.expectedPath, actualPath, "For include %v and options %v", testCase.include, testCase.terragruntOptions)
+		assert.Equal(t, testCase.expectedPath, actualPath, "For include %v and options %v", testCase.include, testCase.terragruntOptions)
 	}
 }
 
@@ -226,7 +226,7 @@ func TestRunCommand(t *testing.T) {
 				}
 			} else {
 				require.NoError(t, actualErr)
-				require.Equal(t, testCase.expectedOutput, actualOutput)
+				assert.Equal(t, testCase.expectedOutput, actualOutput)
 			}
 		})
 	}
@@ -331,7 +331,7 @@ func TestFindInParentFolders(t *testing.T) {
 				}
 			} else {
 				require.NoError(t, actualErr)
-				require.Equal(t, testCase.expectedPath, actualPath)
+				assert.Equal(t, testCase.expectedPath, actualPath)
 			}
 		})
 	}
@@ -396,9 +396,9 @@ func TestResolveTerragruntInterpolation(t *testing.T) {
 				assert.Contains(t, actualErr.Error(), testCase.expectedErr)
 			} else {
 				require.NoError(t, actualErr)
-				require.NotNil(t, actualOut)
-				require.NotNil(t, actualOut.Terraform)
-				require.NotNil(t, actualOut.Terraform.Source)
+				assert.NotNil(t, actualOut)
+				assert.NotNil(t, actualOut.Terraform)
+				assert.NotNil(t, actualOut.Terraform.Source)
 				assert.Equal(t, testCase.expectedOut, *actualOut.Terraform.Source)
 			}
 		})
@@ -537,10 +537,10 @@ func TestResolveCommandsInterpolationConfigString(t *testing.T) {
 			actualOut, actualErr := ParseConfigString(ctx, "mock-path-for-test.hcl", testCase.str, testCase.include)
 			require.NoError(t, actualErr, "For string '%s' include %v and options %v, unexpected error: %v", testCase.str, testCase.include, testCase.terragruntOptions, actualErr)
 
-			require.NotNil(t, actualOut)
+			assert.NotNil(t, actualOut)
 
 			inputs := actualOut.Inputs
-			require.NotNil(t, inputs)
+			assert.NotNil(t, inputs)
 
 			foo, containsFoo := inputs["foo"]
 			assert.True(t, containsFoo)
@@ -580,10 +580,10 @@ func TestResolveCliArgsInterpolationConfigString(t *testing.T) {
 			actualOut, actualErr := ParseConfigString(ctx, "mock-path-for-test.hcl", testCase.str, testCase.include)
 			require.NoError(t, actualErr, "For string '%s' include %v and options %v, unexpected error: %v", testCase.str, testCase.include, testCase.terragruntOptions, actualErr)
 
-			require.NotNil(t, actualOut)
+			assert.NotNil(t, actualOut)
 
 			inputs := actualOut.Inputs
-			require.NotNil(t, inputs)
+			assert.NotNil(t, inputs)
 
 			foo, containsFoo := inputs["foo"]
 			assert.True(t, containsFoo)
@@ -600,7 +600,7 @@ func toStringSlice(t *testing.T, value interface{}) []string {
 	}
 
 	asInterfaceSlice, isInterfaceSlice := value.([]interface{})
-	require.True(t, isInterfaceSlice)
+	assert.True(t, isInterfaceSlice)
 
 	// TODO: See if this logic is desired
 	if len(asInterfaceSlice) == 0 {
@@ -610,7 +610,7 @@ func toStringSlice(t *testing.T, value interface{}) []string {
 	var out = make([]string, 0, len(asInterfaceSlice))
 	for _, item := range asInterfaceSlice {
 		asStr, isStr := item.(string)
-		require.True(t, isStr)
+		assert.True(t, isStr)
 		out = append(out, asStr)
 	}
 
@@ -735,7 +735,7 @@ func TestGetParentTerragruntDir(t *testing.T) {
 		ctx := NewParsingContext(context.Background(), testCase.terragruntOptions).WithTrackInclude(trackInclude)
 		actualPath, actualErr := getParentTerragruntDir(ctx, testCase.params)
 		require.NoError(t, actualErr, "For include %v and options %v, unexpected error: %v", testCase.include, testCase.terragruntOptions, actualErr)
-		require.Equal(t, testCase.expectedPath, actualPath, "For include %v and options %v", testCase.include, testCase.terragruntOptions)
+		assert.Equal(t, testCase.expectedPath, actualPath, "For include %v and options %v", testCase.include, testCase.terragruntOptions)
 	}
 }
 
@@ -789,10 +789,10 @@ func TestTerraformBuiltInFunctions(t *testing.T) {
 			actual, err := ParseConfigString(ctx, terragruntOptions.TerragruntConfigPath, configString, nil)
 			require.NoError(t, err, "For hcl '%s' include %v and options %v, unexpected error: %v", testCase.input, nil, terragruntOptions, err)
 
-			require.NotNil(t, actual)
+			assert.NotNil(t, actual)
 
 			inputs := actual.Inputs
-			require.NotNil(t, inputs)
+			assert.NotNil(t, inputs)
 
 			test, containsTest := inputs["test"]
 			assert.True(t, containsTest)
@@ -860,7 +860,7 @@ func TestTerraformOutputJsonToCtyValueMap(t *testing.T) {
 	for _, testCase := range testCases {
 		converted, err := terraformOutputJsonToCtyValueMap(mockTargetConfig, []byte(testCase.input))
 		require.NoError(t, err)
-		require.Equal(t, getKeys(converted), getKeys(testCase.expected))
+		assert.Equal(t, getKeys(converted), getKeys(testCase.expected))
 		for k, v := range converted {
 			assert.True(t, v.Equals(testCase.expected[k]).True())
 		}
@@ -881,17 +881,17 @@ func TestReadTerragruntConfigInputs(t *testing.T) {
 
 	inputsMap := tgConfigMap["inputs"].(map[string]interface{})
 
-	require.Equal(t, "string", inputsMap["string"].(string))
-	require.InEpsilon(t, float64(42), inputsMap["number"].(float64), 0.0000000001)
-	require.True(t, inputsMap["bool"].(bool))
-	require.Equal(t, []interface{}{"a", "b", "c"}, inputsMap["list_string"].([]interface{}))
-	require.Equal(t, []interface{}{float64(1), float64(2), float64(3)}, inputsMap["list_number"].([]interface{}))
-	require.Equal(t, []interface{}{true, false}, inputsMap["list_bool"].([]interface{}))
-	require.Equal(t, map[string]interface{}{"foo": "bar"}, inputsMap["map_string"].(map[string]interface{}))
-	require.Equal(t, map[string]interface{}{"foo": float64(42), "bar": float64(12345)}, inputsMap["map_number"].(map[string]interface{}))
-	require.Equal(t, map[string]interface{}{"foo": true, "bar": false, "baz": true}, inputsMap["map_bool"].(map[string]interface{}))
+	assert.Equal(t, "string", inputsMap["string"].(string))
+	assert.InEpsilon(t, float64(42), inputsMap["number"].(float64), 0.0000000001)
+	assert.True(t, inputsMap["bool"].(bool))
+	assert.Equal(t, []interface{}{"a", "b", "c"}, inputsMap["list_string"].([]interface{}))
+	assert.Equal(t, []interface{}{float64(1), float64(2), float64(3)}, inputsMap["list_number"].([]interface{}))
+	assert.Equal(t, []interface{}{true, false}, inputsMap["list_bool"].([]interface{}))
+	assert.Equal(t, map[string]interface{}{"foo": "bar"}, inputsMap["map_string"].(map[string]interface{}))
+	assert.Equal(t, map[string]interface{}{"foo": float64(42), "bar": float64(12345)}, inputsMap["map_number"].(map[string]interface{}))
+	assert.Equal(t, map[string]interface{}{"foo": true, "bar": false, "baz": true}, inputsMap["map_bool"].(map[string]interface{}))
 
-	require.Equal(
+	assert.Equal(
 		t,
 		map[string]interface{}{
 			"str":  "string",
@@ -902,7 +902,7 @@ func TestReadTerragruntConfigInputs(t *testing.T) {
 		inputsMap["object"].(map[string]interface{}),
 	)
 
-	require.Equal(t, "default", inputsMap["from_env"].(string))
+	assert.Equal(t, "default", inputsMap["from_env"].(string))
 }
 
 func TestReadTerragruntConfigRemoteState(t *testing.T) {
@@ -917,21 +917,21 @@ func TestReadTerragruntConfigRemoteState(t *testing.T) {
 	require.NoError(t, err)
 
 	remoteStateMap := tgConfigMap["remote_state"].(map[string]interface{})
-	require.Equal(t, "s3", remoteStateMap["backend"].(string))
+	assert.Equal(t, "s3", remoteStateMap["backend"].(string))
 	configMap := remoteStateMap["config"].(map[string]interface{})
-	require.True(t, configMap["encrypt"].(bool))
-	require.Equal(t, "terraform.tfstate", configMap["key"].(string))
-	require.Equal(
+	assert.True(t, configMap["encrypt"].(bool))
+	assert.Equal(t, "terraform.tfstate", configMap["key"].(string))
+	assert.Equal(
 		t,
 		map[string]interface{}{"owner": "terragrunt integration test", "name": "Terraform state storage"},
 		configMap["s3_bucket_tags"].(map[string]interface{}),
 	)
-	require.Equal(
+	assert.Equal(
 		t,
 		map[string]interface{}{"owner": "terragrunt integration test", "name": "Terraform lock table"},
 		configMap["dynamodb_table_tags"].(map[string]interface{}),
 	)
-	require.Equal(
+	assert.Equal(
 		t,
 		map[string]interface{}{"owner": "terragrunt integration test", "name": "Terraform access log storage"},
 		configMap["accesslogging_bucket_tags"].(map[string]interface{}),
@@ -951,30 +951,30 @@ func TestReadTerragruntConfigHooks(t *testing.T) {
 
 	terraformMap := tgConfigMap["terraform"].(map[string]interface{})
 	beforeHooksMap := terraformMap["before_hook"].(map[string]interface{})
-	require.Equal(
+	assert.Equal(
 		t,
 		[]interface{}{"touch", "before.out"},
 		beforeHooksMap["before_hook_1"].(map[string]interface{})["execute"].([]interface{}),
 	)
-	require.Equal(
+	assert.Equal(
 		t,
 		[]interface{}{"echo", "BEFORE_TERRAGRUNT_READ_CONFIG"},
 		beforeHooksMap["before_hook_2"].(map[string]interface{})["execute"].([]interface{}),
 	)
 
 	afterHooksMap := terraformMap["after_hook"].(map[string]interface{})
-	require.Equal(
+	assert.Equal(
 		t,
 		[]interface{}{"touch", "after.out"},
 		afterHooksMap["after_hook_1"].(map[string]interface{})["execute"].([]interface{}),
 	)
-	require.Equal(
+	assert.Equal(
 		t,
 		[]interface{}{"echo", "AFTER_TERRAGRUNT_READ_CONFIG"},
 		afterHooksMap["after_hook_2"].(map[string]interface{})["execute"].([]interface{}),
 	)
 	errorHooksMap := terraformMap["error_hook"].(map[string]interface{})
-	require.Equal(
+	assert.Equal(
 		t,
 		[]interface{}{"echo", "ON_APPLY_ERROR"},
 		errorHooksMap["error_hook_1"].(map[string]interface{})["execute"].([]interface{}),
@@ -993,9 +993,9 @@ func TestReadTerragruntConfigLocals(t *testing.T) {
 	require.NoError(t, err)
 
 	localsMap := tgConfigMap["locals"].(map[string]interface{})
-	require.InEpsilon(t, float64(2), localsMap["x"].(float64), 0.0000000001)
-	require.Equal(t, "Hello world\n", localsMap["file_contents"].(string))
-	require.InEpsilon(t, float64(42), localsMap["number_expression"].(float64), 0.0000000001)
+	assert.InEpsilon(t, float64(2), localsMap["x"].(float64), 0.0000000001)
+	assert.Equal(t, "Hello world\n", localsMap["file_contents"].(string))
+	assert.InEpsilon(t, float64(42), localsMap["number_expression"].(float64), 0.0000000001)
 }
 
 func TestGetTerragruntSourceForModuleHappyPath(t *testing.T) {
@@ -1055,7 +1055,7 @@ func TestStartsWith(t *testing.T) {
 			ctx := NewParsingContext(context.Background(), testCase.config)
 			actual, err := startsWith(ctx, testCase.args)
 			require.NoError(t, err)
-			require.Equal(t, testCase.value, actual)
+			assert.Equal(t, testCase.value, actual)
 		})
 	}
 }
@@ -1085,7 +1085,7 @@ func TestEndsWith(t *testing.T) {
 			ctx := NewParsingContext(context.Background(), testCase.config)
 			actual, err := endsWith(ctx, testCase.args)
 			require.NoError(t, err)
-			require.Equal(t, testCase.value, actual)
+			assert.Equal(t, testCase.value, actual)
 		})
 	}
 }
@@ -1106,7 +1106,7 @@ func TestTimeCmp(t *testing.T) {
 		{terragruntOptionsForTest(t, ""), []string{"2017-11-22T01:00:00+01:00", "2017-11-22T01:00:00-01:00"}, -1, ""},
 		{terragruntOptionsForTest(t, ""), []string{"2017-11-22T01:00:00-01:00", "2017-11-22T01:00:00+01:00"}, 1, ""},
 		{terragruntOptionsForTest(t, ""), []string{"2017-11-22T00:00:00Z", "bloop"}, 0, `could not parse second parameter "bloop": not a valid RFC3339 timestamp: cannot use "bloop" as year`},
-		{terragruntOptionsForTest(t, ""), []string{"2017-11-22 00:00:00Z", "2017-11-22T00:00:00Z"}, 0, `could not parse first parameter "2017-11-22 00:00:00Z": not a valid RFC3339 timestamp: missing required time introducer 'T'`},
+		{terragruntOptionsForTest(t, ""), []string{"2017-11-22 00:00:00Z", "2017-11-22T00:00:00Z"}, 0, `could not parse first parameter "2017-11-22 00:00:00Z": not a valid RFC3339 timestamp: missing assertd time introducer 'T'`},
 	}
 
 	for _, testCase := range testCases {
@@ -1178,14 +1178,14 @@ func TestReadTFVarsFiles(t *testing.T) {
 
 	locals := tgConfigMap["locals"].(map[string]interface{})
 
-	require.Equal(t, "string", locals["string_var"].(string))
-	require.InEpsilon(t, float64(42), locals["number_var"].(float64), 0.0000000001)
-	require.True(t, locals["bool_var"].(bool))
-	require.Equal(t, []interface{}{"hello", "world"}, locals["list_var"].([]interface{}))
+	assert.Equal(t, "string", locals["string_var"].(string))
+	assert.InEpsilon(t, float64(42), locals["number_var"].(float64), 0.0000000001)
+	assert.True(t, locals["bool_var"].(bool))
+	assert.Equal(t, []interface{}{"hello", "world"}, locals["list_var"].([]interface{}))
 
-	require.InEpsilon(t, float64(24), locals["json_number_var"].(float64), 0.0000000001)
-	require.Equal(t, "another string", locals["json_string_var"].(string))
-	require.False(t, locals["json_bool_var"].(bool))
+	assert.InEpsilon(t, float64(24), locals["json_number_var"].(float64), 0.0000000001)
+	assert.Equal(t, "another string", locals["json_string_var"].(string))
+	assert.False(t, locals["json_bool_var"].(bool))
 }
 
 func mockConfigWithSource(sourceUrl string) *TerragruntConfig {

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -1106,7 +1106,7 @@ func TestTimeCmp(t *testing.T) {
 		{terragruntOptionsForTest(t, ""), []string{"2017-11-22T01:00:00+01:00", "2017-11-22T01:00:00-01:00"}, -1, ""},
 		{terragruntOptionsForTest(t, ""), []string{"2017-11-22T01:00:00-01:00", "2017-11-22T01:00:00+01:00"}, 1, ""},
 		{terragruntOptionsForTest(t, ""), []string{"2017-11-22T00:00:00Z", "bloop"}, 0, `could not parse second parameter "bloop": not a valid RFC3339 timestamp: cannot use "bloop" as year`},
-		{terragruntOptionsForTest(t, ""), []string{"2017-11-22 00:00:00Z", "2017-11-22T00:00:00Z"}, 0, `could not parse first parameter "2017-11-22 00:00:00Z": not a valid RFC3339 timestamp: missing assertd time introducer 'T'`},
+		{terragruntOptionsForTest(t, ""), []string{"2017-11-22 00:00:00Z", "2017-11-22T00:00:00Z"}, 0, `could not parse first parameter "2017-11-22 00:00:00Z": not a valid RFC3339 timestamp: missing required time introducer 'T'`},
 	}
 
 	for _, testCase := range testCases {

--- a/config/config_partial_test.go
+++ b/config/config_partial_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -24,18 +25,18 @@ dependencies {
 	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t)).WithDecodeList(DependenciesBlock)
 	terragruntConfig, err := PartialParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.NoError(t, err)
-	require.True(t, terragruntConfig.IsPartial)
+	assert.True(t, terragruntConfig.IsPartial)
 
-	require.NotNil(t, terragruntConfig.Dependencies)
-	require.Len(t, terragruntConfig.Dependencies.Paths, 1)
-	require.Equal(t, "../app1", terragruntConfig.Dependencies.Paths[0])
-	require.Equal(t, map[string]interface{}{"app1": "../app1"}, terragruntConfig.Locals)
+	assert.NotNil(t, terragruntConfig.Dependencies)
+	assert.Len(t, terragruntConfig.Dependencies.Paths, 1)
+	assert.Equal(t, "../app1", terragruntConfig.Dependencies.Paths[0])
+	assert.Equal(t, map[string]interface{}{"app1": "../app1"}, terragruntConfig.Locals)
 
-	require.False(t, terragruntConfig.Skip)
-	require.Nil(t, terragruntConfig.PreventDestroy)
-	require.Nil(t, terragruntConfig.Terraform)
-	require.Nil(t, terragruntConfig.RemoteState)
-	require.Nil(t, terragruntConfig.Inputs)
+	assert.False(t, terragruntConfig.Skip)
+	assert.Nil(t, terragruntConfig.PreventDestroy)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Inputs)
 }
 
 func TestPartialParseDoesNotResolveIgnoredBlock(t *testing.T) {
@@ -55,7 +56,7 @@ prevent_destroy = false
 	require.NoError(t, err)
 
 	_, err = PartialParseConfigString(ctx.WithDecodeList(DependenciesBlock), DefaultTerragruntConfigPath, config, nil)
-	require.Error(t, err)
+	assert.Error(t, err)
 }
 
 func TestPartialParseMultipleItems(t *testing.T) {
@@ -73,19 +74,19 @@ skip = true
 	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t)).WithDecodeList(DependenciesBlock, TerragruntFlags)
 	terragruntConfig, err := PartialParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.NoError(t, err)
-	require.True(t, terragruntConfig.IsPartial)
+	assert.True(t, terragruntConfig.IsPartial)
 
-	require.NotNil(t, terragruntConfig.Dependencies)
-	require.Len(t, terragruntConfig.Dependencies.Paths, 1)
-	require.Equal(t, "../app1", terragruntConfig.Dependencies.Paths[0])
+	assert.NotNil(t, terragruntConfig.Dependencies)
+	assert.Len(t, terragruntConfig.Dependencies.Paths, 1)
+	assert.Equal(t, "../app1", terragruntConfig.Dependencies.Paths[0])
 
-	require.True(t, terragruntConfig.Skip)
-	require.True(t, *terragruntConfig.PreventDestroy)
+	assert.True(t, terragruntConfig.Skip)
+	assert.True(t, *terragruntConfig.PreventDestroy)
 
-	require.Nil(t, terragruntConfig.Terraform)
-	require.Nil(t, terragruntConfig.RemoteState)
-	require.Nil(t, terragruntConfig.Inputs)
-	require.Nil(t, terragruntConfig.Locals)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Inputs)
+	assert.Nil(t, terragruntConfig.Locals)
 }
 
 func TestPartialParseOmittedItems(t *testing.T) {
@@ -95,14 +96,14 @@ func TestPartialParseOmittedItems(t *testing.T) {
 	terragruntConfig, err := PartialParseConfigString(ctx, DefaultTerragruntConfigPath, "", nil)
 
 	require.NoError(t, err)
-	require.True(t, terragruntConfig.IsPartial)
-	require.Nil(t, terragruntConfig.Dependencies)
-	require.False(t, terragruntConfig.Skip)
-	require.Nil(t, terragruntConfig.PreventDestroy)
-	require.Nil(t, terragruntConfig.Terraform)
-	require.Nil(t, terragruntConfig.RemoteState)
-	require.Nil(t, terragruntConfig.Inputs)
-	require.Nil(t, terragruntConfig.Locals)
+	assert.True(t, terragruntConfig.IsPartial)
+	assert.Nil(t, terragruntConfig.Dependencies)
+	assert.False(t, terragruntConfig.Skip)
+	assert.Nil(t, terragruntConfig.PreventDestroy)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Inputs)
+	assert.Nil(t, terragruntConfig.Locals)
 }
 
 func TestPartialParseDoesNotResolveIgnoredBlockEvenInParent(t *testing.T) {
@@ -115,7 +116,7 @@ func TestPartialParseDoesNotResolveIgnoredBlockEvenInParent(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = PartialParseConfigFile(ctx.WithDecodeList(DependenciesBlock), opts.TerragruntConfigPath, nil)
-	require.Error(t, err)
+	assert.Error(t, err)
 }
 
 func TestPartialParseOnlyInheritsSelectedBlocksFlags(t *testing.T) {
@@ -127,14 +128,14 @@ func TestPartialParseOnlyInheritsSelectedBlocksFlags(t *testing.T) {
 	terragruntConfig, err := PartialParseConfigFile(ctx, opts.TerragruntConfigPath, nil)
 	require.NoError(t, err)
 
-	require.True(t, terragruntConfig.IsPartial)
-	require.Nil(t, terragruntConfig.Dependencies)
-	require.False(t, terragruntConfig.Skip)
-	require.True(t, *terragruntConfig.PreventDestroy)
-	require.Nil(t, terragruntConfig.Terraform)
-	require.Nil(t, terragruntConfig.RemoteState)
-	require.Nil(t, terragruntConfig.Inputs)
-	require.Nil(t, terragruntConfig.Locals)
+	assert.True(t, terragruntConfig.IsPartial)
+	assert.Nil(t, terragruntConfig.Dependencies)
+	assert.False(t, terragruntConfig.Skip)
+	assert.True(t, *terragruntConfig.PreventDestroy)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Inputs)
+	assert.Nil(t, terragruntConfig.Locals)
 }
 
 func TestPartialParseOnlyInheritsSelectedBlocksDependencies(t *testing.T) {
@@ -146,18 +147,18 @@ func TestPartialParseOnlyInheritsSelectedBlocksDependencies(t *testing.T) {
 	terragruntConfig, err := PartialParseConfigFile(ctx, opts.TerragruntConfigPath, nil)
 	require.NoError(t, err)
 
-	require.True(t, terragruntConfig.IsPartial)
+	assert.True(t, terragruntConfig.IsPartial)
 
-	require.NotNil(t, terragruntConfig.Dependencies)
-	require.Len(t, terragruntConfig.Dependencies.Paths, 1)
-	require.Equal(t, "../app1", terragruntConfig.Dependencies.Paths[0])
+	assert.NotNil(t, terragruntConfig.Dependencies)
+	assert.Len(t, terragruntConfig.Dependencies.Paths, 1)
+	assert.Equal(t, "../app1", terragruntConfig.Dependencies.Paths[0])
 
-	require.False(t, terragruntConfig.Skip)
-	require.Nil(t, terragruntConfig.PreventDestroy)
-	require.Nil(t, terragruntConfig.Terraform)
-	require.Nil(t, terragruntConfig.RemoteState)
-	require.Nil(t, terragruntConfig.Inputs)
-	require.Nil(t, terragruntConfig.Locals)
+	assert.False(t, terragruntConfig.Skip)
+	assert.Nil(t, terragruntConfig.PreventDestroy)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Inputs)
+	assert.Nil(t, terragruntConfig.Locals)
 }
 
 func TestPartialParseDependencyBlockSetsTerragruntDependencies(t *testing.T) {
@@ -172,12 +173,12 @@ dependency "vpc" {
 	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t)).WithDecodeList(DependencyBlock)
 	terragruntConfig, err := PartialParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.NoError(t, err)
-	require.True(t, terragruntConfig.IsPartial)
+	assert.True(t, terragruntConfig.IsPartial)
 
-	require.NotNil(t, terragruntConfig.TerragruntDependencies)
-	require.Len(t, terragruntConfig.TerragruntDependencies, 1)
-	require.Equal(t, "vpc", terragruntConfig.TerragruntDependencies[0].Name)
-	require.Equal(t, cty.StringVal("../app1"), terragruntConfig.TerragruntDependencies[0].ConfigPath)
+	assert.NotNil(t, terragruntConfig.TerragruntDependencies)
+	assert.Len(t, terragruntConfig.TerragruntDependencies, 1)
+	assert.Equal(t, "vpc", terragruntConfig.TerragruntDependencies[0].Name)
+	assert.Equal(t, cty.StringVal("../app1"), terragruntConfig.TerragruntDependencies[0].ConfigPath)
 }
 
 func TestPartialParseMultipleDependencyBlockSetsTerragruntDependencies(t *testing.T) {
@@ -196,14 +197,14 @@ dependency "sql" {
 	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t)).WithDecodeList(DependencyBlock)
 	terragruntConfig, err := PartialParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.NoError(t, err)
-	require.True(t, terragruntConfig.IsPartial)
+	assert.True(t, terragruntConfig.IsPartial)
 
-	require.NotNil(t, terragruntConfig.TerragruntDependencies)
-	require.Len(t, terragruntConfig.TerragruntDependencies, 2)
-	require.Equal(t, "vpc", terragruntConfig.TerragruntDependencies[0].Name)
-	require.Equal(t, cty.StringVal("../app1"), terragruntConfig.TerragruntDependencies[0].ConfigPath)
-	require.Equal(t, "sql", terragruntConfig.TerragruntDependencies[1].Name)
-	require.Equal(t, cty.StringVal("../db1"), terragruntConfig.TerragruntDependencies[1].ConfigPath)
+	assert.NotNil(t, terragruntConfig.TerragruntDependencies)
+	assert.Len(t, terragruntConfig.TerragruntDependencies, 2)
+	assert.Equal(t, "vpc", terragruntConfig.TerragruntDependencies[0].Name)
+	assert.Equal(t, cty.StringVal("../app1"), terragruntConfig.TerragruntDependencies[0].ConfigPath)
+	assert.Equal(t, "sql", terragruntConfig.TerragruntDependencies[1].Name)
+	assert.Equal(t, cty.StringVal("../db1"), terragruntConfig.TerragruntDependencies[1].ConfigPath)
 }
 
 func TestPartialParseDependencyBlockSetsDependencies(t *testing.T) {
@@ -222,11 +223,11 @@ dependency "sql" {
 	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t)).WithDecodeList(DependencyBlock)
 	terragruntConfig, err := PartialParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.NoError(t, err)
-	require.True(t, terragruntConfig.IsPartial)
+	assert.True(t, terragruntConfig.IsPartial)
 
-	require.NotNil(t, terragruntConfig.Dependencies)
-	require.Len(t, terragruntConfig.Dependencies.Paths, 2)
-	require.Equal(t, []string{"../app1", "../db1"}, terragruntConfig.Dependencies.Paths)
+	assert.NotNil(t, terragruntConfig.Dependencies)
+	assert.Len(t, terragruntConfig.Dependencies.Paths, 2)
+	assert.Equal(t, []string{"../app1", "../db1"}, terragruntConfig.Dependencies.Paths)
 }
 
 func TestPartialParseDependencyBlockMergesDependencies(t *testing.T) {
@@ -249,11 +250,11 @@ dependency "sql" {
 	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t)).WithDecodeList(DependenciesBlock, DependencyBlock)
 	terragruntConfig, err := PartialParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.NoError(t, err)
-	require.True(t, terragruntConfig.IsPartial)
+	assert.True(t, terragruntConfig.IsPartial)
 
-	require.NotNil(t, terragruntConfig.Dependencies)
-	require.Len(t, terragruntConfig.Dependencies.Paths, 3)
-	require.Equal(t, []string{"../vpc", "../app1", "../db1"}, terragruntConfig.Dependencies.Paths)
+	assert.NotNil(t, terragruntConfig.Dependencies)
+	assert.Len(t, terragruntConfig.Dependencies.Paths, 3)
+	assert.Equal(t, []string{"../vpc", "../app1", "../db1"}, terragruntConfig.Dependencies.Paths)
 }
 
 func TestPartialParseDependencyBlockMergesDependenciesOrdering(t *testing.T) {
@@ -276,11 +277,11 @@ dependency "sql" {
 	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t)).WithDecodeList(DependencyBlock, DependenciesBlock)
 	terragruntConfig, err := PartialParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.NoError(t, err)
-	require.True(t, terragruntConfig.IsPartial)
+	assert.True(t, terragruntConfig.IsPartial)
 
-	require.NotNil(t, terragruntConfig.Dependencies)
-	require.Len(t, terragruntConfig.Dependencies.Paths, 3)
-	require.Equal(t, []string{"../app1", "../db1", "../vpc"}, terragruntConfig.Dependencies.Paths)
+	assert.NotNil(t, terragruntConfig.Dependencies)
+	assert.Len(t, terragruntConfig.Dependencies.Paths, 3)
+	assert.Equal(t, []string{"../app1", "../db1", "../vpc"}, terragruntConfig.Dependencies.Paths)
 }
 
 func TestPartialParseDependencyBlockMergesDependenciesDedup(t *testing.T) {
@@ -303,11 +304,11 @@ dependency "sql" {
 	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t)).WithDecodeList(DependencyBlock, DependenciesBlock)
 	terragruntConfig, err := PartialParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.NoError(t, err)
-	require.True(t, terragruntConfig.IsPartial)
+	assert.True(t, terragruntConfig.IsPartial)
 
-	require.NotNil(t, terragruntConfig.Dependencies)
-	require.Len(t, terragruntConfig.Dependencies.Paths, 2)
-	require.Equal(t, []string{"../app1", "../db1"}, terragruntConfig.Dependencies.Paths)
+	assert.NotNil(t, terragruntConfig.Dependencies)
+	assert.Len(t, terragruntConfig.Dependencies.Paths, 2)
+	assert.Equal(t, []string{"../app1", "../db1"}, terragruntConfig.Dependencies.Paths)
 }
 
 func TestPartialParseOnlyParsesTerraformSource(t *testing.T) {
@@ -330,11 +331,11 @@ terraform {
 	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t)).WithDecodeList(TerraformSource)
 	terragruntConfig, err := PartialParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.NoError(t, err)
-	require.True(t, terragruntConfig.IsPartial)
+	assert.True(t, terragruntConfig.IsPartial)
 
-	require.NotNil(t, terragruntConfig.Terraform)
-	require.NotNil(t, terragruntConfig.Terraform.Source)
-	require.Equal(t, "../../modules/app", *terragruntConfig.Terraform.Source)
+	assert.NotNil(t, terragruntConfig.Terraform)
+	assert.NotNil(t, terragruntConfig.Terraform.Source)
+	assert.Equal(t, "../../modules/app", *terragruntConfig.Terraform.Source)
 }
 
 func TestOptionalDependenciesAreSkipped(t *testing.T) {
@@ -353,5 +354,5 @@ dependency "ec2" {
 	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t)).WithDecodeList(DependencyBlock)
 	terragruntConfig, err := PartialParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.NoError(t, err)
-	require.Len(t, terragruntConfig.Dependencies.Paths, 1)
+	assert.Len(t, terragruntConfig.Dependencies.Paths, 1)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -834,8 +834,8 @@ terraform {
 		commands = ["fmt"]
 	}
 
-	extra_arguments "assertd_tfvars" {
-		assertd_var_files = [
+	extra_arguments "required_tfvars" {
+		required_var_files = [
 			"file1.tfvars",
 			"file2.tfvars"
 		]
@@ -866,7 +866,7 @@ terraform {
 		assert.Equal(t, "fmt_diff", terragruntConfig.Terraform.ExtraArgs[1].Name)
 		assert.Equal(t, &[]string{"-diff=true"}, terragruntConfig.Terraform.ExtraArgs[1].Arguments)
 		assert.Equal(t, []string{"fmt"}, terragruntConfig.Terraform.ExtraArgs[1].Commands)
-		assert.Equal(t, "assertd_tfvars", terragruntConfig.Terraform.ExtraArgs[2].Name)
+		assert.Equal(t, "required_tfvars", terragruntConfig.Terraform.ExtraArgs[2].Name)
 		assert.Equal(t, &[]string{"file1.tfvars", "file2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[2].RequiredVarFiles)
 		assert.Equal(t, TERRAFORM_COMMANDS_NEED_VARS, terragruntConfig.Terraform.ExtraArgs[2].Commands)
 		assert.Equal(t, "optional_tfvars", terragruntConfig.Terraform.ExtraArgs[3].Name)
@@ -890,8 +890,8 @@ func TestParseTerragruntJsonConfigTerraformWithMultipleExtraArguments(t *testing
 				"arguments": ["-diff=true"],
 				"commands": ["fmt"]
 			},
-			"assertd_tfvars":{
-				"assertd_var_files":[
+			"required_tfvars":{
+				"required_var_files":[
 					"file1.tfvars",
 					"file2.tfvars"
 				],

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -98,7 +98,7 @@ remote_state {}
 	ctx := NewParsingContext(context.Background(), mockOptionsForTest(t))
 	_, err := ParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Missing required argument; The argument \"backend\" is required")
+	assert.Contains(t, err.Error(), "Missing required argument; The argument \"backend\" is required")
 }
 
 func TestParseTerragruntHclConfigRemoteStateFullConfig(t *testing.T) {
@@ -218,8 +218,8 @@ func TestParseTerragruntJsonConfigRetryConfiguration(t *testing.T) {
 	assert.Nil(t, terragruntConfig.Terraform)
 	assert.Empty(t, terragruntConfig.IamRole)
 
-	require.Equal(t, 10, *terragruntConfig.RetryMaxAttempts)
-	require.Equal(t, 60, *terragruntConfig.RetrySleepIntervalSec)
+	assert.Equal(t, 10, *terragruntConfig.RetryMaxAttempts)
+	assert.Equal(t, 60, *terragruntConfig.RetrySleepIntervalSec)
 
 	if assert.NotNil(t, terragruntConfig.RetryableErrors) {
 		assert.Equal(t, []string{"My own little error"}, terragruntConfig.RetryableErrors)
@@ -382,8 +382,8 @@ dependencies {
 		t.Fatal(err)
 	}
 
-	require.NotNil(t, terragruntConfig.Terraform)
-	require.NotNil(t, terragruntConfig.Terraform.Source)
+	assert.NotNil(t, terragruntConfig.Terraform)
+	assert.NotNil(t, terragruntConfig.Terraform.Source)
 	assert.Equal(t, "foo", *terragruntConfig.Terraform.Source)
 	assert.Nil(t, terragruntConfig.RetryableErrors)
 	assert.Empty(t, terragruntConfig.IamRole)
@@ -431,8 +431,8 @@ func TestParseTerragruntJsonConfigRemoteStateDynamoDbTerraformConfigAndDependenc
 		t.Fatal(err)
 	}
 
-	require.NotNil(t, terragruntConfig.Terraform)
-	require.NotNil(t, terragruntConfig.Terraform.Source)
+	assert.NotNil(t, terragruntConfig.Terraform)
+	assert.NotNil(t, terragruntConfig.Terraform.Source)
 	assert.Equal(t, "foo", *terragruntConfig.Terraform.Source)
 	assert.Nil(t, terragruntConfig.RetryableErrors)
 	assert.Empty(t, terragruntConfig.IamRole)
@@ -470,15 +470,15 @@ include {
 	ctx := NewParsingContext(context.Background(), opts)
 	terragruntConfig, err := ParseConfigString(ctx, opts.TerragruntConfigPath, config, nil)
 	if assert.NoError(t, err, "Unexpected error: %v", errors.PrintErrorWithStackTrace(err)) {
-		require.Nil(t, terragruntConfig.Terraform)
+		assert.Nil(t, terragruntConfig.Terraform)
 
 		if assert.NotNil(t, terragruntConfig.RemoteState) {
-			require.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
-			require.NotEmpty(t, terragruntConfig.RemoteState.Config)
-			require.Equal(t, true, terragruntConfig.RemoteState.Config["encrypt"])
-			require.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
-			require.Equal(t, "child/sub-child/sub-sub-child/terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
-			require.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
+			assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
+			assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
+			assert.Equal(t, true, terragruntConfig.RemoteState.Config["encrypt"])
+			assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
+			assert.Equal(t, "child/sub-child/sub-sub-child/terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
+			assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
 		}
 	}
 
@@ -498,15 +498,15 @@ include {
 	ctx := NewParsingContext(context.Background(), opts)
 	terragruntConfig, err := ParseConfigString(ctx, opts.TerragruntConfigPath, config, nil)
 	if assert.NoError(t, err, "Unexpected error: %v", errors.PrintErrorWithStackTrace(err)) {
-		require.Nil(t, terragruntConfig.Terraform)
+		assert.Nil(t, terragruntConfig.Terraform)
 
 		if assert.NotNil(t, terragruntConfig.RemoteState) {
-			require.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
-			require.NotEmpty(t, terragruntConfig.RemoteState.Config)
-			require.Equal(t, true, terragruntConfig.RemoteState.Config["encrypt"])
-			require.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
-			require.Equal(t, "child/sub-child/sub-sub-child/terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
-			require.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
+			assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
+			assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
+			assert.Equal(t, true, terragruntConfig.RemoteState.Config["encrypt"])
+			assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
+			assert.Equal(t, "child/sub-child/sub-sub-child/terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
+			assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
 		}
 	}
 
@@ -538,15 +538,15 @@ remote_state {
 	ctx := NewParsingContext(context.Background(), opts)
 	terragruntConfig, err := ParseConfigString(ctx, opts.TerragruntConfigPath, config, nil)
 	if assert.NoError(t, err, "Unexpected error: %v", errors.PrintErrorWithStackTrace(err)) {
-		require.Nil(t, terragruntConfig.Terraform)
+		assert.Nil(t, terragruntConfig.Terraform)
 
 		if assert.NotNil(t, terragruntConfig.RemoteState) {
-			require.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
-			require.NotEmpty(t, terragruntConfig.RemoteState.Config)
-			require.Equal(t, false, terragruntConfig.RemoteState.Config["encrypt"])
-			require.Equal(t, "override", terragruntConfig.RemoteState.Config["bucket"])
-			require.Equal(t, "override", terragruntConfig.RemoteState.Config["key"])
-			require.Equal(t, "override", terragruntConfig.RemoteState.Config["region"])
+			assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
+			assert.NotEmpty(t, terragruntConfig.RemoteState.Config)
+			assert.Equal(t, false, terragruntConfig.RemoteState.Config["encrypt"])
+			assert.Equal(t, "override", terragruntConfig.RemoteState.Config["bucket"])
+			assert.Equal(t, "override", terragruntConfig.RemoteState.Config["key"])
+			assert.Equal(t, "override", terragruntConfig.RemoteState.Config["region"])
 		}
 	}
 
@@ -587,8 +587,8 @@ dependencies {
 	terragruntConfig, err := ParseConfigString(ctx, opts.TerragruntConfigPath, config, nil)
 	require.NoError(t, err, "Unexpected error: %v", errors.PrintErrorWithStackTrace(err))
 
-	require.NotNil(t, terragruntConfig.Terraform)
-	require.NotNil(t, terragruntConfig.Terraform.Source)
+	assert.NotNil(t, terragruntConfig.Terraform)
+	assert.NotNil(t, terragruntConfig.Terraform.Source)
 	assert.Equal(t, "foo", *terragruntConfig.Terraform.Source)
 
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
@@ -636,8 +636,8 @@ func TestParseTerragruntJsonConfigIncludeOverrideAll(t *testing.T) {
 	terragruntConfig, err := ParseConfigString(ctx, opts.TerragruntConfigPath, config, nil)
 	require.NoError(t, err, "Unexpected error: %v", errors.PrintErrorWithStackTrace(err))
 
-	require.NotNil(t, terragruntConfig.Terraform)
-	require.NotNil(t, terragruntConfig.Terraform.Source)
+	assert.NotNil(t, terragruntConfig.Terraform)
+	assert.NotNil(t, terragruntConfig.Terraform.Source)
 	assert.Equal(t, "foo", *terragruntConfig.Terraform.Source)
 
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
@@ -705,16 +705,16 @@ func TestParseTerragruntConfigEmptyConfig(t *testing.T) {
 	cfg, err := ParseConfigString(ctx, DefaultTerragruntConfigPath, config, nil)
 	require.NoError(t, err)
 
-	require.Nil(t, cfg.Terraform)
-	require.Nil(t, cfg.RemoteState)
-	require.Nil(t, cfg.Dependencies)
-	require.Nil(t, cfg.PreventDestroy)
-	require.False(t, cfg.Skip)
-	require.Empty(t, cfg.IamRole)
-	require.Empty(t, cfg.IamWebIdentityToken)
-	require.Nil(t, cfg.RetryMaxAttempts)
-	require.Nil(t, cfg.RetrySleepIntervalSec)
-	require.Nil(t, cfg.RetryableErrors)
+	assert.Nil(t, cfg.Terraform)
+	assert.Nil(t, cfg.RemoteState)
+	assert.Nil(t, cfg.Dependencies)
+	assert.Nil(t, cfg.PreventDestroy)
+	assert.False(t, cfg.Skip)
+	assert.Empty(t, cfg.IamRole)
+	assert.Empty(t, cfg.IamWebIdentityToken)
+	assert.Nil(t, cfg.RetryMaxAttempts)
+	assert.Nil(t, cfg.RetrySleepIntervalSec)
+	assert.Nil(t, cfg.RetryableErrors)
 }
 
 func TestParseTerragruntConfigEmptyConfigOldConfig(t *testing.T) {
@@ -747,8 +747,8 @@ terraform {}
 	assert.Nil(t, terragruntConfig.RemoteState)
 	assert.Nil(t, terragruntConfig.Dependencies)
 
-	require.NotNil(t, terragruntConfig.Terraform)
-	require.Nil(t, terragruntConfig.Terraform.Source)
+	assert.NotNil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.Terraform.Source)
 }
 
 func TestParseTerragruntConfigTerraformWithSource(t *testing.T) {
@@ -769,8 +769,8 @@ terraform {
 	assert.Nil(t, terragruntConfig.RemoteState)
 	assert.Nil(t, terragruntConfig.Dependencies)
 
-	require.NotNil(t, terragruntConfig.Terraform)
-	require.NotNil(t, terragruntConfig.Terraform.Source)
+	assert.NotNil(t, terragruntConfig.Terraform)
+	assert.NotNil(t, terragruntConfig.Terraform.Source)
 	assert.Equal(t, "foo", *terragruntConfig.Terraform.Source)
 }
 
@@ -834,8 +834,8 @@ terraform {
 		commands = ["fmt"]
 	}
 
-	extra_arguments "required_tfvars" {
-		required_var_files = [
+	extra_arguments "assertd_tfvars" {
+		assertd_var_files = [
 			"file1.tfvars",
 			"file2.tfvars"
 		]
@@ -866,7 +866,7 @@ terraform {
 		assert.Equal(t, "fmt_diff", terragruntConfig.Terraform.ExtraArgs[1].Name)
 		assert.Equal(t, &[]string{"-diff=true"}, terragruntConfig.Terraform.ExtraArgs[1].Arguments)
 		assert.Equal(t, []string{"fmt"}, terragruntConfig.Terraform.ExtraArgs[1].Commands)
-		assert.Equal(t, "required_tfvars", terragruntConfig.Terraform.ExtraArgs[2].Name)
+		assert.Equal(t, "assertd_tfvars", terragruntConfig.Terraform.ExtraArgs[2].Name)
 		assert.Equal(t, &[]string{"file1.tfvars", "file2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[2].RequiredVarFiles)
 		assert.Equal(t, TERRAFORM_COMMANDS_NEED_VARS, terragruntConfig.Terraform.ExtraArgs[2].Commands)
 		assert.Equal(t, "optional_tfvars", terragruntConfig.Terraform.ExtraArgs[3].Name)
@@ -890,8 +890,8 @@ func TestParseTerragruntJsonConfigTerraformWithMultipleExtraArguments(t *testing
 				"arguments": ["-diff=true"],
 				"commands": ["fmt"]
 			},
-			"required_tfvars":{
-				"required_var_files":[
+			"assertd_tfvars":{
+				"assertd_var_files":[
 					"file1.tfvars",
 					"file2.tfvars"
 				],
@@ -913,22 +913,22 @@ func TestParseTerragruntJsonConfigTerraformWithMultipleExtraArguments(t *testing
 	terragruntConfig, err := ParseConfigString(ctx, DefaultTerragruntJsonConfigPath, config, nil)
 	require.NoError(t, err)
 
-	require.Nil(t, terragruntConfig.RemoteState)
-	require.Nil(t, terragruntConfig.Dependencies)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Dependencies)
 
 	if assert.NotNil(t, terragruntConfig.Terraform) {
-		require.Equal(t, "json_output", terragruntConfig.Terraform.ExtraArgs[0].Name)
-		require.Equal(t, &[]string{"-json"}, terragruntConfig.Terraform.ExtraArgs[0].Arguments)
-		require.Equal(t, []string{"output"}, terragruntConfig.Terraform.ExtraArgs[0].Commands)
-		require.Equal(t, "fmt_diff", terragruntConfig.Terraform.ExtraArgs[1].Name)
-		require.Equal(t, &[]string{"-diff=true"}, terragruntConfig.Terraform.ExtraArgs[1].Arguments)
-		require.Equal(t, []string{"fmt"}, terragruntConfig.Terraform.ExtraArgs[1].Commands)
-		require.Equal(t, "required_tfvars", terragruntConfig.Terraform.ExtraArgs[2].Name)
-		require.Equal(t, &[]string{"file1.tfvars", "file2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[2].RequiredVarFiles)
-		require.Equal(t, TERRAFORM_COMMANDS_NEED_VARS, terragruntConfig.Terraform.ExtraArgs[2].Commands)
-		require.Equal(t, "optional_tfvars", terragruntConfig.Terraform.ExtraArgs[3].Name)
-		require.Equal(t, &[]string{"opt1.tfvars", "opt2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[3].OptionalVarFiles)
-		require.Equal(t, TERRAFORM_COMMANDS_NEED_VARS, terragruntConfig.Terraform.ExtraArgs[3].Commands)
+		assert.Equal(t, "json_output", terragruntConfig.Terraform.ExtraArgs[0].Name)
+		assert.Equal(t, &[]string{"-json"}, terragruntConfig.Terraform.ExtraArgs[0].Arguments)
+		assert.Equal(t, []string{"output"}, terragruntConfig.Terraform.ExtraArgs[0].Commands)
+		assert.Equal(t, "fmt_diff", terragruntConfig.Terraform.ExtraArgs[1].Name)
+		assert.Equal(t, &[]string{"-diff=true"}, terragruntConfig.Terraform.ExtraArgs[1].Arguments)
+		assert.Equal(t, []string{"fmt"}, terragruntConfig.Terraform.ExtraArgs[1].Commands)
+		assert.Equal(t, "required_tfvars", terragruntConfig.Terraform.ExtraArgs[2].Name)
+		assert.Equal(t, &[]string{"file1.tfvars", "file2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[2].RequiredVarFiles)
+		assert.Equal(t, TERRAFORM_COMMANDS_NEED_VARS, terragruntConfig.Terraform.ExtraArgs[2].Commands)
+		assert.Equal(t, "optional_tfvars", terragruntConfig.Terraform.ExtraArgs[3].Name)
+		assert.Equal(t, &[]string{"opt1.tfvars", "opt2.tfvars"}, terragruntConfig.Terraform.ExtraArgs[3].OptionalVarFiles)
+		assert.Equal(t, TERRAFORM_COMMANDS_NEED_VARS, terragruntConfig.Terraform.ExtraArgs[3].Commands)
 	}
 }
 
@@ -942,7 +942,7 @@ func TestFindConfigFilesInPathNone(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/none", terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual)
 }
 
 func TestFindConfigFilesInPathOneConfig(t *testing.T) {
@@ -955,7 +955,7 @@ func TestFindConfigFilesInPathOneConfig(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/one-config", terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual)
 }
 
 func TestFindConfigFilesInPathOneJsonConfig(t *testing.T) {
@@ -968,7 +968,7 @@ func TestFindConfigFilesInPathOneJsonConfig(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/one-json-config", terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual)
 }
 
 func TestFindConfigFilesInPathMultipleConfigs(t *testing.T) {
@@ -985,7 +985,7 @@ func TestFindConfigFilesInPathMultipleConfigs(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/multiple-configs", terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.ElementsMatch(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesInPathMultipleJsonConfigs(t *testing.T) {
@@ -1002,7 +1002,7 @@ func TestFindConfigFilesInPathMultipleJsonConfigs(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/multiple-json-configs", terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.ElementsMatch(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesInPathMultipleMixedConfigs(t *testing.T) {
@@ -1019,7 +1019,7 @@ func TestFindConfigFilesInPathMultipleMixedConfigs(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/multiple-mixed-configs", terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.ElementsMatch(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesIgnoresTerragruntCache(t *testing.T) {
@@ -1034,7 +1034,7 @@ func TestFindConfigFilesIgnoresTerragruntCache(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/ignore-cached-config", terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual)
 }
 
 func TestFindConfigFilesIgnoresTerraformDataDir(t *testing.T) {
@@ -1052,7 +1052,7 @@ func TestFindConfigFilesIgnoresTerraformDataDir(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/ignore-terraform-data-dir", terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.ElementsMatch(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesIgnoresTerraformDataDirEnv(t *testing.T) {
@@ -1070,7 +1070,7 @@ func TestFindConfigFilesIgnoresTerraformDataDirEnv(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/ignore-terraform-data-dir", terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.ElementsMatch(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesIgnoresTerraformDataDirEnvPath(t *testing.T) {
@@ -1089,7 +1089,7 @@ func TestFindConfigFilesIgnoresTerraformDataDirEnvPath(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/ignore-terraform-data-dir", terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.ElementsMatch(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesIgnoresTerraformDataDirEnvRoot(t *testing.T) {
@@ -1112,7 +1112,7 @@ func TestFindConfigFilesIgnoresTerraformDataDirEnvRoot(t *testing.T) {
 	actual, err := FindConfigFilesInPath(workingDir, terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.ElementsMatch(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFindConfigFilesIgnoresDownloadDir(t *testing.T) {
@@ -1129,7 +1129,7 @@ func TestFindConfigFilesIgnoresDownloadDir(t *testing.T) {
 	actual, err := FindConfigFilesInPath("../test/fixture-config-files/multiple-configs", terragruntOptions)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.ElementsMatch(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func mockOptionsForTestWithConfigPath(t *testing.T, configPath string) *options.TerragruntOptions {
@@ -1157,10 +1157,10 @@ prevent_destroy = true
 		t.Fatal(err)
 	}
 
-	require.Nil(t, terragruntConfig.Terraform)
-	require.Nil(t, terragruntConfig.RemoteState)
-	require.Nil(t, terragruntConfig.Dependencies)
-	require.True(t, *terragruntConfig.PreventDestroy)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Dependencies)
+	assert.True(t, *terragruntConfig.PreventDestroy)
 }
 
 func TestParseTerragruntConfigPreventDestroyFalse(t *testing.T) {
@@ -1176,10 +1176,10 @@ prevent_destroy = false
 		t.Fatal(err)
 	}
 
-	require.Nil(t, terragruntConfig.Terraform)
-	require.Nil(t, terragruntConfig.RemoteState)
-	require.Nil(t, terragruntConfig.Dependencies)
-	require.False(t, *terragruntConfig.PreventDestroy)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Dependencies)
+	assert.False(t, *terragruntConfig.PreventDestroy)
 }
 
 func TestParseTerragruntConfigSkipTrue(t *testing.T) {
@@ -1195,10 +1195,10 @@ skip = true
 		t.Fatal(err)
 	}
 
-	require.Nil(t, terragruntConfig.Terraform)
-	require.Nil(t, terragruntConfig.RemoteState)
-	require.Nil(t, terragruntConfig.Dependencies)
-	require.True(t, terragruntConfig.Skip)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Dependencies)
+	assert.True(t, terragruntConfig.Skip)
 }
 
 func TestParseTerragruntConfigSkipFalse(t *testing.T) {
@@ -1214,10 +1214,10 @@ skip = false
 		t.Fatal(err)
 	}
 
-	require.Nil(t, terragruntConfig.Terraform)
-	require.Nil(t, terragruntConfig.RemoteState)
-	require.Nil(t, terragruntConfig.Dependencies)
-	require.False(t, terragruntConfig.Skip)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Dependencies)
+	assert.False(t, terragruntConfig.Skip)
 }
 
 func TestIncludeFunctionsWorkInChildConfig(t *testing.T) {
@@ -1312,7 +1312,7 @@ func TestModuleDependenciesMerge(t *testing.T) {
 			}
 
 			target.Merge(source)
-			require.Equal(t, testCase.expected, target.Paths)
+			assert.Equal(t, testCase.expected, target.Paths)
 		})
 	}
 }
@@ -1359,7 +1359,7 @@ func BenchmarkReadTerragruntConfig(b *testing.B) {
 			actual, err := ReadTerragruntConfig(context.Background(), terragruntOptions, DefaultParserOptions(terragruntOptions))
 			b.StopTimer()
 			require.NoError(b, err)
-			require.NotNil(b, actual)
+			assert.NotNil(b, actual)
 		})
 	}
 }

--- a/config/dependency_test.go
+++ b/config/dependency_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/go-commons/env"
 	"github.com/gruntwork-io/terragrunt/config/hclparse"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -34,11 +35,11 @@ dependency "sql" {
 	decoded := terragruntDependency{}
 	require.NoError(t, file.Decode(&decoded, &hcl.EvalContext{}))
 
-	require.Len(t, decoded.Dependencies, 2)
-	require.Equal(t, "vpc", decoded.Dependencies[0].Name)
-	require.Equal(t, cty.StringVal("../vpc"), decoded.Dependencies[0].ConfigPath)
-	require.Equal(t, "sql", decoded.Dependencies[1].Name)
-	require.Equal(t, cty.StringVal("../sql"), decoded.Dependencies[1].ConfigPath)
+	assert.Len(t, decoded.Dependencies, 2)
+	assert.Equal(t, "vpc", decoded.Dependencies[0].Name)
+	assert.Equal(t, cty.StringVal("../vpc"), decoded.Dependencies[0].ConfigPath)
+	assert.Equal(t, "sql", decoded.Dependencies[1].Name)
+	assert.Equal(t, cty.StringVal("../sql"), decoded.Dependencies[1].ConfigPath)
 }
 
 func TestDecodeNoDependencyBlock(t *testing.T) {
@@ -55,7 +56,7 @@ locals {
 
 	decoded := terragruntDependency{}
 	require.NoError(t, file.Decode(&decoded, &hcl.EvalContext{}))
-	require.Empty(t, decoded.Dependencies)
+	assert.Empty(t, decoded.Dependencies)
 }
 
 func TestDecodeDependencyNoLabelIsError(t *testing.T) {
@@ -71,7 +72,7 @@ dependency {
 	require.NoError(t, err)
 
 	decoded := terragruntDependency{}
-	require.Error(t, file.Decode(&decoded, &hcl.EvalContext{}))
+	assert.Error(t, file.Decode(&decoded, &hcl.EvalContext{}))
 }
 
 func TestDecodeDependencyMockOutputs(t *testing.T) {
@@ -93,23 +94,23 @@ dependency "hitchhiker" {
 	decoded := terragruntDependency{}
 	require.NoError(t, file.Decode(&decoded, &hcl.EvalContext{}))
 
-	require.Len(t, decoded.Dependencies, 1)
+	assert.Len(t, decoded.Dependencies, 1)
 	dependency := decoded.Dependencies[0]
-	require.Equal(t, "hitchhiker", dependency.Name)
-	require.Equal(t, cty.StringVal("../answers"), dependency.ConfigPath)
+	assert.Equal(t, "hitchhiker", dependency.Name)
+	assert.Equal(t, cty.StringVal("../answers"), dependency.ConfigPath)
 
 	ctyValueDefault := dependency.MockOutputs
-	require.NotNil(t, ctyValueDefault)
+	assert.NotNil(t, ctyValueDefault)
 
 	var actualDefault struct {
 		TheAnswer int `cty:"the_answer"`
 	}
 	require.NoError(t, gocty.FromCtyValue(*ctyValueDefault, &actualDefault))
-	require.Equal(t, 42, actualDefault.TheAnswer)
+	assert.Equal(t, 42, actualDefault.TheAnswer)
 
 	defaultAllowedCommands := dependency.MockOutputsAllowedTerraformCommands
-	require.NotNil(t, defaultAllowedCommands)
-	require.Equal(t, []string{"validate", "apply"}, *defaultAllowedCommands)
+	assert.NotNil(t, defaultAllowedCommands)
+	assert.Equal(t, []string{"validate", "apply"}, *defaultAllowedCommands)
 }
 func TestParseDependencyBlockMultiple(t *testing.T) {
 	t.Parallel()
@@ -123,9 +124,9 @@ func TestParseDependencyBlockMultiple(t *testing.T) {
 	ctx.TerragruntOptions.Env = env.Parse(os.Environ())
 	tfConfig, err := ParseConfigFile(ctx, filename, nil)
 	require.NoError(t, err)
-	require.Len(t, tfConfig.TerragruntDependencies, 2)
-	require.Equal(t, "dependency_1", tfConfig.TerragruntDependencies[0].Name)
-	require.Equal(t, "dependency_2", tfConfig.TerragruntDependencies[1].Name)
+	assert.Len(t, tfConfig.TerragruntDependencies, 2)
+	assert.Equal(t, "dependency_1", tfConfig.TerragruntDependencies[0].Name)
+	assert.Equal(t, "dependency_2", tfConfig.TerragruntDependencies[1].Name)
 }
 
 func TestDisabledDependency(t *testing.T) {
@@ -146,5 +147,5 @@ dependency "vpc" {
 
 	decoded := terragruntDependency{}
 	require.NoError(t, file.Decode(&decoded, &hcl.EvalContext{}))
-	require.Len(t, decoded.Dependencies, 2)
+	assert.Len(t, decoded.Dependencies, 2)
 }

--- a/config/include_test.go
+++ b/config/include_test.go
@@ -153,7 +153,7 @@ func TestMergeConfigIntoIncludedConfig(t *testing.T) {
 
 		err := testCase.includedConfig.Merge(testCase.config, mockOptionsForTest(t))
 		require.NoError(t, err)
-		require.Equal(t, testCase.expected, testCase.includedConfig)
+		assert.Equal(t, testCase.expected, testCase.includedConfig)
 	}
 }
 

--- a/config/locals_test.go
+++ b/config/locals_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty/gocty"
 
@@ -27,34 +28,34 @@ func TestEvaluateLocalsBlock(t *testing.T) {
 
 	var actualRegion string
 	require.NoError(t, gocty.FromCtyValue(evaluatedLocals["region"], &actualRegion))
-	require.Equal(t, "us-east-1", actualRegion)
+	assert.Equal(t, "us-east-1", actualRegion)
 
 	var actualS3Url string
 	require.NoError(t, gocty.FromCtyValue(evaluatedLocals["s3_url"], &actualS3Url))
-	require.Equal(t, "com.amazonaws.us-east-1.s3", actualS3Url)
+	assert.Equal(t, "com.amazonaws.us-east-1.s3", actualS3Url)
 
 	var actualX float64
 	require.NoError(t, gocty.FromCtyValue(evaluatedLocals["x"], &actualX))
-	require.InEpsilon(t, float64(1), actualX, 0.0000001)
+	assert.InEpsilon(t, float64(1), actualX, 0.0000001)
 
 	var actualY float64
 	require.NoError(t, gocty.FromCtyValue(evaluatedLocals["y"], &actualY))
-	require.InEpsilon(t, float64(2), actualY, 0.0000001)
+	assert.InEpsilon(t, float64(2), actualY, 0.0000001)
 
 	var actualZ float64
 	require.NoError(t, gocty.FromCtyValue(evaluatedLocals["z"], &actualZ))
-	require.InEpsilon(t, float64(3), actualZ, 0.0000001)
+	assert.InEpsilon(t, float64(3), actualZ, 0.0000001)
 
 	var actualFoo struct{ First Foo }
 	require.NoError(t, gocty.FromCtyValue(evaluatedLocals["foo"], &actualFoo))
-	require.Equal(t, Foo{
+	assert.Equal(t, Foo{
 		Region: "us-east-1",
 		Foo:    "bar",
 	}, actualFoo.First)
 
 	var actualBar string
 	require.NoError(t, gocty.FromCtyValue(evaluatedLocals["bar"], &actualBar))
-	require.Equal(t, "us-east-1", actualBar)
+	assert.Equal(t, "us-east-1", actualBar)
 }
 
 func TestEvaluateLocalsBlockMultiDeepReference(t *testing.T) {
@@ -74,7 +75,7 @@ func TestEvaluateLocalsBlockMultiDeepReference(t *testing.T) {
 
 	var actualA string
 	require.NoError(t, gocty.FromCtyValue(evaluatedLocals["a"], &actualA))
-	require.Equal(t, expected, actualA)
+	assert.Equal(t, expected, actualA)
 
 	testCases := []string{
 		"b",
@@ -92,7 +93,7 @@ func TestEvaluateLocalsBlockMultiDeepReference(t *testing.T) {
 
 		var actual string
 		require.NoError(t, gocty.FromCtyValue(evaluatedLocals[testCase], &actual))
-		require.Equal(t, expected, actual)
+		assert.Equal(t, expected, actual)
 	}
 }
 

--- a/config/variable_test.go
+++ b/config/variable_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,30 +14,30 @@ func TestScanVariables(t *testing.T) {
 
 	inputs, err := ParseVariables(opts, "../test/fixture-inputs")
 	require.NoError(t, err)
-	require.Len(t, inputs, 11)
+	assert.Len(t, inputs, 11)
 
 	varByName := map[string]*ParsedVariable{}
 	for _, input := range inputs {
 		varByName[input.Name] = input
 	}
 
-	require.Equal(t, "string", varByName["string"].Type)
-	require.Equal(t, "\"\"", varByName["string"].DefaultValuePlaceholder)
+	assert.Equal(t, "string", varByName["string"].Type)
+	assert.Equal(t, "\"\"", varByName["string"].DefaultValuePlaceholder)
 
-	require.Equal(t, "bool", varByName["bool"].Type)
-	require.Equal(t, "false", varByName["bool"].DefaultValuePlaceholder)
+	assert.Equal(t, "bool", varByName["bool"].Type)
+	assert.Equal(t, "false", varByName["bool"].DefaultValuePlaceholder)
 
-	require.Equal(t, "number", varByName["number"].Type)
-	require.Equal(t, "0", varByName["number"].DefaultValuePlaceholder)
+	assert.Equal(t, "number", varByName["number"].Type)
+	assert.Equal(t, "0", varByName["number"].DefaultValuePlaceholder)
 
-	require.Equal(t, "object", varByName["object"].Type)
-	require.Equal(t, "{}", varByName["object"].DefaultValuePlaceholder)
+	assert.Equal(t, "object", varByName["object"].Type)
+	assert.Equal(t, "{}", varByName["object"].DefaultValuePlaceholder)
 
-	require.Equal(t, "map", varByName["map_bool"].Type)
-	require.Equal(t, "{}", varByName["map_bool"].DefaultValuePlaceholder)
+	assert.Equal(t, "map", varByName["map_bool"].Type)
+	assert.Equal(t, "{}", varByName["map_bool"].DefaultValuePlaceholder)
 
-	require.Equal(t, "list", varByName["list_bool"].Type)
-	require.Equal(t, "[]", varByName["list_bool"].DefaultValuePlaceholder)
+	assert.Equal(t, "list", varByName["list_bool"].Type)
+	assert.Equal(t, "[]", varByName["list_bool"].DefaultValuePlaceholder)
 }
 
 func TestScanDefaultVariables(t *testing.T) {
@@ -45,37 +46,37 @@ func TestScanDefaultVariables(t *testing.T) {
 
 	inputs, err := ParseVariables(opts, "../test/fixture-inputs-defaults")
 	require.NoError(t, err)
-	require.Len(t, inputs, 11)
+	assert.Len(t, inputs, 11)
 
 	varByName := map[string]*ParsedVariable{}
 	for _, input := range inputs {
 		varByName[input.Name] = input
 	}
 
-	require.Equal(t, "string", varByName["project_name"].Type)
-	require.Equal(t, "Project name", varByName["project_name"].Description)
-	require.Equal(t, "\"\"", varByName["project_name"].DefaultValuePlaceholder)
+	assert.Equal(t, "string", varByName["project_name"].Type)
+	assert.Equal(t, "Project name", varByName["project_name"].Description)
+	assert.Equal(t, "\"\"", varByName["project_name"].DefaultValuePlaceholder)
 
-	require.Equal(t, "(variable no_type_value_var does not define a type)", varByName["no_type_value_var"].Type)
-	require.Equal(t, "(variable no_type_value_var did not define a description)", varByName["no_type_value_var"].Description)
-	require.Equal(t, "\"\"", varByName["no_type_value_var"].DefaultValuePlaceholder)
+	assert.Equal(t, "(variable no_type_value_var does not define a type)", varByName["no_type_value_var"].Type)
+	assert.Equal(t, "(variable no_type_value_var did not define a description)", varByName["no_type_value_var"].Description)
+	assert.Equal(t, "\"\"", varByName["no_type_value_var"].DefaultValuePlaceholder)
 
-	require.Equal(t, "number", varByName["number_default"].Type)
-	require.Equal(t, "number variable with default", varByName["number_default"].Description)
-	require.Equal(t, "42", varByName["number_default"].DefaultValue)
-	require.Equal(t, "0", varByName["number_default"].DefaultValuePlaceholder)
+	assert.Equal(t, "number", varByName["number_default"].Type)
+	assert.Equal(t, "number variable with default", varByName["number_default"].Description)
+	assert.Equal(t, "42", varByName["number_default"].DefaultValue)
+	assert.Equal(t, "0", varByName["number_default"].DefaultValuePlaceholder)
 
-	require.Equal(t, "object", varByName["object_var"].Type)
-	require.Equal(t, "{\"num\":42,\"str\":\"default\"}", varByName["object_var"].DefaultValue)
+	assert.Equal(t, "object", varByName["object_var"].Type)
+	assert.Equal(t, "{\"num\":42,\"str\":\"default\"}", varByName["object_var"].DefaultValue)
 
-	require.Equal(t, "map", varByName["map_var"].Type)
-	require.Equal(t, "{\"key\":\"value42\"}", varByName["map_var"].DefaultValue)
+	assert.Equal(t, "map", varByName["map_var"].Type)
+	assert.Equal(t, "{\"key\":\"value42\"}", varByName["map_var"].DefaultValue)
 
-	require.Equal(t, "bool", varByName["enabled"].Type)
-	require.Equal(t, "true", varByName["enabled"].DefaultValue)
-	require.Equal(t, "Enable or disable the module", varByName["enabled"].Description)
+	assert.Equal(t, "bool", varByName["enabled"].Type)
+	assert.Equal(t, "true", varByName["enabled"].DefaultValue)
+	assert.Equal(t, "Enable or disable the module", varByName["enabled"].Description)
 
-	require.Equal(t, "string", varByName["vpc"].Type)
-	require.Equal(t, "\"default-vpc\"", varByName["vpc"].DefaultValue)
-	require.Equal(t, "VPC to be used", varByName["vpc"].Description)
+	assert.Equal(t, "string", varByName["vpc"].Type)
+	assert.Equal(t, "\"default-vpc\"", varByName["vpc"].DefaultValue)
+	assert.Equal(t, "VPC to be used", varByName["vpc"].Description)
 }

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -47,7 +47,7 @@ digraph {
 	"h" -> "c";
 }
 `)
-	require.True(t, strings.Contains(stdout.String(), expected))
+	assert.True(t, strings.Contains(stdout.String(), expected))
 }
 
 func TestGraphTrimPrefix(t *testing.T) {
@@ -84,7 +84,7 @@ digraph {
 	"alpha/beta/h" -> "c";
 }
 `)
-	require.True(t, strings.Contains(stdout.String(), expected))
+	assert.True(t, strings.Contains(stdout.String(), expected))
 }
 
 func TestGraphFlagExcluded(t *testing.T) {
@@ -121,7 +121,7 @@ digraph {
 	"h" -> "c";
 }
 `)
-	require.True(t, strings.Contains(stdout.String(), expected))
+	assert.True(t, strings.Contains(stdout.String(), expected))
 }
 
 func TestCheckForCycles(t *testing.T) {
@@ -200,7 +200,7 @@ func TestCheckForCycles(t *testing.T) {
 			var actualErr DependencyCycleError
 			// actualErr := errors.Unwrap(actual).(DependencyCycleError)
 			errors.As(actual, &actualErr)
-			require.Equal(t, []string(testCase.expected), []string(actualErr), "For modules %v", testCase.modules)
+			assert.Equal(t, []string(testCase.expected), []string(actualErr), "For modules %v", testCase.modules)
 		}
 	}
 }
@@ -233,7 +233,7 @@ func TestRunModulesOneModuleSuccess(t *testing.T) {
 	modules := TerraformModules{moduleA}
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.True(t, aRan)
+	assert.True(t, aRan)
 }
 
 func TestRunModulesOneModuleAssumeAlreadyRan(t *testing.T) {
@@ -254,7 +254,7 @@ func TestRunModulesOneModuleAssumeAlreadyRan(t *testing.T) {
 	modules := TerraformModules{moduleA}
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.False(t, aRan)
+	assert.False(t, aRan)
 }
 
 func TestRunModulesReverseOrderOneModuleSuccess(t *testing.T) {
@@ -274,7 +274,7 @@ func TestRunModulesReverseOrderOneModuleSuccess(t *testing.T) {
 	modules := TerraformModules{moduleA}
 	err = modules.RunModulesReverseOrder(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.True(t, aRan)
+	assert.True(t, aRan)
 }
 
 func TestRunModulesIgnoreOrderOneModuleSuccess(t *testing.T) {
@@ -294,7 +294,7 @@ func TestRunModulesIgnoreOrderOneModuleSuccess(t *testing.T) {
 	modules := TerraformModules{moduleA}
 	err = modules.RunModulesIgnoreOrder(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err, "Unexpected error: %v", err)
-	require.True(t, aRan)
+	assert.True(t, aRan)
 }
 
 func TestRunModulesOneModuleError(t *testing.T) {
@@ -315,7 +315,7 @@ func TestRunModulesOneModuleError(t *testing.T) {
 	modules := TerraformModules{moduleA}
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrA)
-	require.True(t, aRan)
+	assert.True(t, aRan)
 }
 
 func TestRunModulesReverseOrderOneModuleError(t *testing.T) {
@@ -336,7 +336,7 @@ func TestRunModulesReverseOrderOneModuleError(t *testing.T) {
 	modules := TerraformModules{moduleA}
 	err = modules.RunModulesReverseOrder(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrA)
-	require.True(t, aRan)
+	assert.True(t, aRan)
 }
 
 func TestRunModulesIgnoreOrderOneModuleError(t *testing.T) {
@@ -357,7 +357,7 @@ func TestRunModulesIgnoreOrderOneModuleError(t *testing.T) {
 	modules := TerraformModules{moduleA}
 	err = modules.RunModulesIgnoreOrder(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrA)
-	require.True(t, aRan)
+	assert.True(t, aRan)
 }
 
 func TestRunModulesMultipleModulesNoDependenciesSuccess(t *testing.T) {
@@ -394,9 +394,9 @@ func TestRunModulesMultipleModulesNoDependenciesSuccess(t *testing.T) {
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesMultipleModulesNoDependenciesSuccessNoParallelism(t *testing.T) {
@@ -433,9 +433,9 @@ func TestRunModulesMultipleModulesNoDependenciesSuccessNoParallelism(t *testing.
 	err = modules.RunModules(context.Background(), opts, 1)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess(t *testing.T) {
@@ -472,9 +472,9 @@ func TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess(t *testing.T
 	err = modules.RunModulesReverseOrder(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesIgnoreOrderMultipleModulesNoDependenciesSuccess(t *testing.T) {
@@ -511,9 +511,9 @@ func TestRunModulesIgnoreOrderMultipleModulesNoDependenciesSuccess(t *testing.T)
 	err = modules.RunModulesIgnoreOrder(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesMultipleModulesNoDependenciesOneFailure(t *testing.T) {
@@ -551,9 +551,9 @@ func TestRunModulesMultipleModulesNoDependenciesOneFailure(t *testing.T) {
 	err := modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrB)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesMultipleModulesNoDependenciesMultipleFailures(t *testing.T) {
@@ -593,9 +593,9 @@ func TestRunModulesMultipleModulesNoDependenciesMultipleFailures(t *testing.T) {
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrA, expectedErrB, expectedErrC)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesMultipleModulesWithDependenciesSuccess(t *testing.T) {
@@ -632,9 +632,9 @@ func TestRunModulesMultipleModulesWithDependenciesSuccess(t *testing.T) {
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess(t *testing.T) {
@@ -680,10 +680,10 @@ func TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess(t 
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.False(t, cRan)
-	require.True(t, dRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.False(t, cRan)
+	assert.True(t, dRan)
 }
 
 func TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess(t *testing.T) {
@@ -720,9 +720,9 @@ func TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess(t *testing
 	err = modules.RunModulesReverseOrder(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesIgnoreOrderMultipleModulesWithDependenciesSuccess(t *testing.T) {
@@ -759,9 +759,9 @@ func TestRunModulesIgnoreOrderMultipleModulesWithDependenciesSuccess(t *testing.
 	err = modules.RunModulesIgnoreOrder(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesMultipleModulesWithDependenciesOneFailure(t *testing.T) {
@@ -801,9 +801,9 @@ func TestRunModulesMultipleModulesWithDependenciesOneFailure(t *testing.T) {
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrB, expectedErrC)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.False(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.False(t, cRan)
 }
 
 func TestRunModulesMultipleModulesWithDependenciesOneFailureIgnoreDependencyErrors(t *testing.T) {
@@ -847,9 +847,9 @@ func TestRunModulesMultipleModulesWithDependenciesOneFailureIgnoreDependencyErro
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrB)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure(t *testing.T) {
@@ -889,9 +889,9 @@ func TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure(t *test
 	err = modules.RunModulesReverseOrder(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrB, expectedErrA)
 
-	require.False(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.False(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesIgnoreOrderMultipleModulesWithDependenciesOneFailure(t *testing.T) {
@@ -929,9 +929,9 @@ func TestRunModulesIgnoreOrderMultipleModulesWithDependenciesOneFailure(t *testi
 	err = modules.RunModulesIgnoreOrder(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrB)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesMultipleModulesWithDependenciesMultipleFailures(t *testing.T) {
@@ -972,9 +972,9 @@ func TestRunModulesMultipleModulesWithDependenciesMultipleFailures(t *testing.T)
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrA, expectedErrB, expectedErrC)
 
-	require.True(t, aRan)
-	require.False(t, bRan)
-	require.False(t, cRan)
+	assert.True(t, aRan)
+	assert.False(t, bRan)
+	assert.False(t, cRan)
 }
 
 func TestRunModulesIgnoreOrderMultipleModulesWithDependenciesMultipleFailures(t *testing.T) {
@@ -1012,9 +1012,9 @@ func TestRunModulesIgnoreOrderMultipleModulesWithDependenciesMultipleFailures(t 
 	err = modules.RunModulesIgnoreOrder(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrA)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
 }
 
 func TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess(t *testing.T) {
@@ -1075,12 +1075,12 @@ func TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess(t *testin
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	require.NoError(t, err)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
-	require.True(t, dRan)
-	require.True(t, eRan)
-	require.True(t, fRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
+	assert.True(t, dRan)
+	assert.True(t, eRan)
+	assert.True(t, fRan)
 }
 
 func TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure(t *testing.T) {
@@ -1154,13 +1154,13 @@ func TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure(t *te
 	err = modules.RunModules(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrC, expectedErrD, expectedErrF)
 
-	require.True(t, aRan)
-	require.True(t, bRan)
-	require.True(t, cRan)
-	require.False(t, dRan)
-	require.False(t, eRan)
-	require.False(t, fRan)
-	require.True(t, gRan)
+	assert.True(t, aRan)
+	assert.True(t, bRan)
+	assert.True(t, cRan)
+	assert.False(t, dRan)
+	assert.False(t, eRan)
+	assert.False(t, fRan)
+	assert.True(t, gRan)
 }
 
 func TestRunModulesReverseOrderMultipleModulesWithDependenciesLargeGraphPartialFailure(t *testing.T) {
@@ -1225,10 +1225,10 @@ func TestRunModulesReverseOrderMultipleModulesWithDependenciesLargeGraphPartialF
 	err := modules.RunModulesReverseOrder(context.Background(), opts, options.DefaultParallelism)
 	assertMultiErrorContains(t, err, expectedErrC, expectedErrB, expectedErrA)
 
-	require.False(t, aRan)
-	require.False(t, bRan)
-	require.True(t, cRan)
-	require.True(t, dRan)
-	require.True(t, eRan)
-	require.True(t, fRan)
+	assert.False(t, aRan)
+	assert.False(t, bRan)
+	assert.True(t, cRan)
+	assert.True(t, dRan)
+	assert.True(t, eRan)
+	assert.True(t, fRan)
 }

--- a/dynamodb/dynamo_lock_table_test.go
+++ b/dynamodb/dynamo_lock_table_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCreateLockTableIfNecessaryTableDoesntAlreadyExist(t *testing.T) {
@@ -84,7 +83,7 @@ func TestCreateLockTableIfNecessaryTableAlreadyExists(t *testing.T) {
 
 		// Try to create the table the second time and make sure you get no errors
 		err = CreateLockTableIfNecessary(tableName, nil, client, mockOptions)
-		require.NoError(t, err, "Unexpected error: %v", err)
+		assert.NoError(t, err, "Unexpected error: %v", err)
 	})
 }
 
@@ -106,7 +105,7 @@ func TestTableTagging(t *testing.T) {
 
 		// Try to create the table the second time and make sure you get no errors
 		err = CreateLockTableIfNecessary(tableName, nil, client, mockOptions)
-		require.NoError(t, err, "Unexpected error: %v", err)
+		assert.NoError(t, err, "Unexpected error: %v", err)
 	})
 }
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -29,8 +29,8 @@ func TestConvertMetaToProtobuf(t *testing.T) {
 
 	protoMeta, err := convertMetaToProtobuf(meta)
 	require.NoError(t, err)
-	require.NotNil(t, protoMeta)
-	require.Len(t, protoMeta, 2)
+	assert.NotNil(t, protoMeta)
+	assert.Len(t, protoMeta, 2)
 }
 
 func TestReadEngineOutput(t *testing.T) {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCacheCreation(t *testing.T) {
@@ -13,10 +13,10 @@ func TestCacheCreation(t *testing.T) {
 
 	cache := NewCache[string]("test")
 
-	require.NotNil(t, cache.Mutex)
-	require.NotNil(t, cache.Cache)
+	assert.NotNil(t, cache.Mutex)
+	assert.NotNil(t, cache.Cache)
 
-	require.Empty(t, cache.Cache)
+	assert.Empty(t, cache.Cache)
 }
 
 func TestStringCacheOperation(t *testing.T) {
@@ -27,15 +27,15 @@ func TestStringCacheOperation(t *testing.T) {
 
 	value, found := cache.Get(ctx, "potato")
 
-	require.False(t, found)
-	require.Empty(t, value)
+	assert.False(t, found)
+	assert.Empty(t, value)
 
 	cache.Put(ctx, "potato", "carrot")
 	value, found = cache.Get(ctx, "potato")
 
-	require.True(t, found)
-	require.NotEmpty(t, value)
-	require.Equal(t, "carrot", value)
+	assert.True(t, found)
+	assert.NotEmpty(t, value)
+	assert.Equal(t, "carrot", value)
 }
 
 func TestExpiringCacheCreation(t *testing.T) {
@@ -43,10 +43,10 @@ func TestExpiringCacheCreation(t *testing.T) {
 
 	cache := NewExpiringCache[string]("test")
 
-	require.NotNil(t, cache.Mutex)
-	require.NotNil(t, cache.Cache)
+	assert.NotNil(t, cache.Mutex)
+	assert.NotNil(t, cache.Cache)
 
-	require.Empty(t, cache.Cache)
+	assert.Empty(t, cache.Cache)
 }
 
 func TestExpiringCacheOperation(t *testing.T) {
@@ -57,15 +57,15 @@ func TestExpiringCacheOperation(t *testing.T) {
 
 	value, found := cache.Get(ctx, "potato")
 
-	require.False(t, found)
-	require.Empty(t, value)
+	assert.False(t, found)
+	assert.Empty(t, value)
 
 	cache.Put(ctx, "potato", "carrot", time.Now().Add(1*time.Second))
 	value, found = cache.Get(ctx, "potato")
 
-	require.True(t, found)
-	require.NotEmpty(t, value)
-	require.Equal(t, "carrot", value)
+	assert.True(t, found)
+	assert.NotEmpty(t, value)
+	assert.Equal(t, "carrot", value)
 }
 
 func TestExpiringCacheExpiration(t *testing.T) {
@@ -77,7 +77,7 @@ func TestExpiringCacheExpiration(t *testing.T) {
 	cache.Put(ctx, "potato", "carrot", time.Now().Add(-1*time.Second))
 	value, found := cache.Get(ctx, "potato")
 
-	require.False(t, found)
-	require.NotEmpty(t, value)
-	require.Equal(t, "carrot", value)
+	assert.False(t, found)
+	assert.NotEmpty(t, value)
+	assert.Equal(t, "carrot", value)
 }

--- a/remote/remote_state_gcs_test.go
+++ b/remote/remote_state_gcs_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,10 +120,10 @@ func TestGCSConfigValuesEqual(t *testing.T) {
 			}
 
 			actual := gcsConfigValuesEqual(config, testCase.backend, terragruntOptions)
-			require.Equal(t, testCase.shouldBeEqual, actual)
+			assert.Equal(t, testCase.shouldBeEqual, actual)
 
 			// Ensure the config remains unchanged by the comparison
-			require.Equal(t, testCase.config, config)
+			assert.Equal(t, testCase.config, config)
 		})
 	}
 }

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -237,7 +237,7 @@ func TestConfigValuesEqual(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			actual := configValuesEqual(testCase.config, testCase.backend, terragruntOptions)
-			require.Equal(t, testCase.shouldBeEqual, actual)
+			assert.Equal(t, testCase.shouldBeEqual, actual)
 		})
 	}
 }
@@ -285,7 +285,7 @@ func TestForcePathStyleClientSession(t *testing.T) {
 			require.NoError(t, err, "Unexpected error creating client for test: %v", err)
 
 			actual := aws.BoolValue(s3Client.Config.S3ForcePathStyle)
-			require.Equal(t, testCase.expected, actual)
+			assert.Equal(t, testCase.expected, actual)
 		})
 	}
 }
@@ -334,7 +334,7 @@ func TestGetAwsSessionConfig(t *testing.T) {
 			}
 
 			actual := s3ConfigExtended.GetAwsSessionConfig()
-			require.Equal(t, expected, actual)
+			assert.Equal(t, expected, actual)
 		})
 	}
 }
@@ -371,7 +371,7 @@ func TestGetAwsSessionConfigWithAssumeRole(t *testing.T) {
 			}
 
 			actual := s3ConfigExtended.GetAwsSessionConfig()
-			require.Equal(t, expected, actual)
+			assert.Equal(t, expected, actual)
 		})
 	}
 }
@@ -516,10 +516,10 @@ func TestGetTerraformInitArgs(t *testing.T) {
 			actual := initializer.GetTerraformInitArgs(testCase.config)
 
 			if !testCase.shouldBeEqual {
-				require.NotEqual(t, testCase.expected, actual)
+				assert.NotEqual(t, testCase.expected, actual)
 				return
 			}
-			require.Equal(t, testCase.expected, actual)
+			assert.Equal(t, testCase.expected, actual)
 		})
 	}
 }
@@ -568,7 +568,7 @@ func TestNegativePublicAccessResponse(t *testing.T) {
 			t.Parallel()
 			response, err := validatePublicAccessBlock(testCase.response)
 			require.NoError(t, err)
-			require.False(t, response)
+			assert.False(t, response)
 		})
 	}
 }
@@ -618,7 +618,7 @@ func TestValidateS3Config(t *testing.T) {
 			if err != nil {
 				require.ErrorIs(t, err, testCase.expectedErr)
 			}
-			require.Contains(t, buf.String(), testCase.expectedOutput)
+			assert.Contains(t, buf.String(), testCase.expectedOutput)
 		})
 	}
 }

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -121,7 +122,7 @@ func TestToTerraformInitArgsNoBackendConfigs(t *testing.T) {
 
 	for _, state := range remoteStates {
 		args := state.ToTerraformInitArgs()
-		require.Empty(t, args)
+		assert.Empty(t, args)
 	}
 }
 
@@ -286,16 +287,16 @@ func TestDiffersFrom(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			shouldOverride := testCase.stateFromConfig.differsFrom(&testCase.existingBackend, terragruntOptions)
-			require.Equal(t, testCase.shouldOverride, shouldOverride, "Expect differsFrom to return %t but got %t for existingRemoteState %v and remoteStateFromTerragruntConfig %v", testCase.shouldOverride, shouldOverride, testCase.existingBackend, testCase.stateFromConfig)
+			assert.Equal(t, testCase.shouldOverride, shouldOverride, "Expect differsFrom to return %t but got %t for existingRemoteState %v and remoteStateFromTerragruntConfig %v", testCase.shouldOverride, shouldOverride, testCase.existingBackend, testCase.stateFromConfig)
 		})
 	}
 }
 
 func assertTerraformInitArgsEqual(t *testing.T, actualArgs []string, expectedArgs string) {
 	expected := strings.Split(expectedArgs, " ")
-	require.Len(t, actualArgs, len(expected))
+	assert.Len(t, actualArgs, len(expected))
 
 	for _, expectedArg := range expected {
-		require.Contains(t, actualArgs, expectedArg)
+		assert.Contains(t, actualArgs, expectedArg)
 	}
 }

--- a/remote/terraform_state_file_test.go
+++ b/remote/terraform_state_file_test.go
@@ -6,6 +6,7 @@ import (
 
 	"errors"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,8 +46,8 @@ func TestParseTerraformStateLocal(t *testing.T) {
 	actualTerraformState, err := parseTerraformState([]byte(stateFile))
 
 	require.NoError(t, err)
-	require.Equal(t, expectedTerraformState, actualTerraformState)
-	require.False(t, actualTerraformState.IsRemote())
+	assert.Equal(t, expectedTerraformState, actualTerraformState)
+	assert.False(t, actualTerraformState.IsRemote())
 }
 
 func TestParseTerraformStateRemote(t *testing.T) {
@@ -102,8 +103,8 @@ func TestParseTerraformStateRemote(t *testing.T) {
 	actualTerraformState, err := parseTerraformState([]byte(stateFile))
 
 	require.NoError(t, err)
-	require.Equal(t, expectedTerraformState, actualTerraformState)
-	require.True(t, actualTerraformState.IsRemote())
+	assert.Equal(t, expectedTerraformState, actualTerraformState)
+	assert.True(t, actualTerraformState.IsRemote())
 }
 
 func TestParseTerraformStateRemoteFull(t *testing.T) {
@@ -289,8 +290,8 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 	actualTerraformState, err := parseTerraformState([]byte(stateFile))
 
 	require.NoError(t, err)
-	require.Equal(t, expectedTerraformState, actualTerraformState)
-	require.True(t, actualTerraformState.IsRemote())
+	assert.Equal(t, expectedTerraformState, actualTerraformState)
+	assert.True(t, actualTerraformState.IsRemote())
 }
 
 func TestParseTerraformStateEmpty(t *testing.T) {
@@ -303,8 +304,8 @@ func TestParseTerraformStateEmpty(t *testing.T) {
 	actualTerraformState, err := parseTerraformState([]byte(stateFile))
 
 	require.NoError(t, err)
-	require.Equal(t, expectedTerraformState, actualTerraformState)
-	require.False(t, actualTerraformState.IsRemote())
+	assert.Equal(t, expectedTerraformState, actualTerraformState)
+	assert.False(t, actualTerraformState.IsRemote())
 }
 
 func TestParseTerraformStateInvalid(t *testing.T) {
@@ -314,10 +315,10 @@ func TestParseTerraformStateInvalid(t *testing.T) {
 
 	actualTerraformState, err := parseTerraformState([]byte(stateFile))
 
-	require.Nil(t, actualTerraformState)
+	assert.Nil(t, actualTerraformState)
 	require.Error(t, err)
 
 	var jsonSyntaxError *json.SyntaxError
 	ok := errors.As(err, &jsonSyntaxError)
-	require.True(t, ok)
+	assert.True(t, ok)
 }

--- a/shell/run_shell_cmd_output_test.go
+++ b/shell/run_shell_cmd_output_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/util"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/options"
@@ -80,7 +81,7 @@ func testCommandOutput(t *testing.T, withOptions func(*options.TerragruntOptions
 
 	out, err := RunShellCommandWithOutput(context.Background(), terragruntOptions, "", !allocateStdout, false, "../testdata/test_outputs.sh", "same")
 
-	require.NotNil(t, out, "Should get output")
+	assert.NotNil(t, out, "Should get output")
 	require.NoError(t, err, "Should have no error")
 
 	assertResults(allOutputBuffer.String(), out)
@@ -94,13 +95,13 @@ func assertOutputs(
 ) func(string, *util.CmdOutput) {
 	return func(allOutput string, out *util.CmdOutput) {
 		allOutputs := strings.Split(strings.TrimSpace(allOutput), "\n")
-		require.Equal(t, expectedAllOutputs, allOutputs)
+		assert.Equal(t, expectedAllOutputs, allOutputs)
 
 		stdOutputs := strings.Split(strings.TrimSpace(out.Stdout), "\n")
-		require.Equal(t, expectedStdOutputs, stdOutputs)
+		assert.Equal(t, expectedStdOutputs, stdOutputs)
 
 		stdErrs := strings.Split(strings.TrimSpace(out.Stderr), "\n")
-		require.Equal(t, expectedStdErrs, stdErrs)
+		assert.Equal(t, expectedStdErrs, stdErrs)
 	}
 }
 

--- a/shell/run_shell_cmd_test.go
+++ b/shell/run_shell_cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/options"
@@ -22,7 +23,7 @@ func TestRunShellCommand(t *testing.T) {
 	require.NoError(t, cmd)
 
 	cmd = RunShellCommand(context.Background(), terragruntOptions, "terraform", "not-a-real-command")
-	require.Error(t, cmd)
+	assert.Error(t, cmd)
 }
 
 func TestRunShellOutputToStderrAndStdout(t *testing.T) {
@@ -40,8 +41,8 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 	cmd := RunShellCommand(context.Background(), terragruntOptions, "terraform", "--version")
 	require.NoError(t, cmd)
 
-	require.True(t, strings.Contains(stdout.String(), "Terraform"), "Output directed to stdout")
-	require.Empty(t, stderr.String(), "No output to stderr")
+	assert.True(t, strings.Contains(stdout.String(), "Terraform"), "Output directed to stdout")
+	assert.Empty(t, stderr.String(), "No output to stderr")
 
 	stdout = new(bytes.Buffer)
 	stderr = new(bytes.Buffer)
@@ -53,8 +54,8 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 	cmd = RunShellCommand(context.Background(), terragruntOptions, "terraform", "--version")
 	require.NoError(t, cmd)
 
-	require.True(t, strings.Contains(stderr.String(), "Terraform"), "Output directed to stderr")
-	require.Empty(t, stdout.String(), "No output to stdout")
+	assert.True(t, strings.Contains(stderr.String(), "Terraform"), "Output directed to stderr")
+	assert.Empty(t, stdout.String(), "No output to stdout")
 }
 
 func TestLastReleaseTag(t *testing.T) {
@@ -69,8 +70,8 @@ func TestLastReleaseTag(t *testing.T) {
 		"refs/tags/v0.5.1",
 	}
 	lastTag := lastReleaseTag(tags)
-	require.NotEmpty(t, lastTag)
-	require.Equal(t, "v20.1.2", lastTag)
+	assert.NotEmpty(t, lastTag)
+	assert.Equal(t, "v20.1.2", lastTag)
 }
 
 func TestGitLevelTopDirCaching(t *testing.T) {
@@ -78,8 +79,8 @@ func TestGitLevelTopDirCaching(t *testing.T) {
 	ctx := context.Background()
 	ctx = ContextWithTerraformCommandHook(ctx, nil)
 	c := cache.ContextCache[string](ctx, RunCmdCacheContextKey)
-	require.NotNil(t, c)
-	require.Empty(t, len(c.Cache))
+	assert.NotNil(t, c)
+	assert.Empty(t, len(c.Cache))
 	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
 	require.NoError(t, err)
 	path := "."
@@ -87,6 +88,6 @@ func TestGitLevelTopDirCaching(t *testing.T) {
 	require.NoError(t, err)
 	path2, err := GitTopLevelDir(ctx, terragruntOptions, path)
 	require.NoError(t, err)
-	require.Equal(t, path1, path2)
-	require.Len(t, c.Cache, 1)
+	assert.Equal(t, path1, path2)
+	assert.Len(t, c.Cache, 1)
 }

--- a/shell/run_shell_cmd_unix_test.go
+++ b/shell/run_shell_cmd_unix_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 
 	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,15 +35,15 @@ func TestExitCodeUnix(t *testing.T) {
 		}
 		retCode, err := util.GetExitCode(err)
 		require.NoError(t, err)
-		require.Equal(t, i, retCode)
+		assert.Equal(t, i, retCode)
 	}
 
 	// assert a non exec.ExitError returns an error
 	err := goerrors.New("This is an explicit error")
 	retCode, retErr := util.GetExitCode(err)
 	require.Error(t, retErr, "An error was expected")
-	require.Equal(t, err, retErr)
-	require.Equal(t, 0, retCode)
+	assert.Equal(t, err, retErr)
+	assert.Equal(t, 0, retCode)
 }
 
 func TestNewSignalsForwarderWaitUnix(t *testing.T) {
@@ -73,8 +74,8 @@ func TestNewSignalsForwarderWaitUnix(t *testing.T) {
 	require.Error(t, err)
 	retCode, err := util.GetExitCode(err)
 	require.NoError(t, err)
-	require.Equal(t, expectedWait, retCode)
-	require.WithinDuration(t, time.Now(), start.Add(time.Duration(expectedWait)*time.Second), time.Second,
+	assert.Equal(t, expectedWait, retCode)
+	assert.WithinDuration(t, time.Now(), start.Add(time.Duration(expectedWait)*time.Second), time.Second,
 		"Expected to wait 5 (+/-1) seconds after SIGINT")
 
 }
@@ -121,8 +122,8 @@ func TestNewSignalsForwarderMultipleUnix(t *testing.T) {
 	require.Error(t, err)
 	retCode, err := util.GetExitCode(err)
 	require.NoError(t, err)
-	require.LessOrEqual(t, retCode, interrupts, "Subprocess received wrong number of signals")
-	require.Equal(t, expectedInterrupts, retCode, "Subprocess didn't receive multiple signals")
+	assert.LessOrEqual(t, retCode, interrupts, "Subprocess received wrong number of signals")
+	assert.Equal(t, expectedInterrupts, retCode, "Subprocess didn't receive multiple signals")
 }
 
 func TestRunShellCommandWithOutputInterrupt(t *testing.T) {
@@ -144,5 +145,5 @@ func TestRunShellCommandWithOutputInterrupt(t *testing.T) {
 	})
 
 	expectedErr := fmt.Sprintf("[.] exit status %d", expectedWait)
-	require.EqualError(t, <-errCh, expectedErr)
+	assert.EqualError(t, <-errCh, expectedErr)
 }

--- a/telemetry/metrics_test.go
+++ b/telemetry/metrics_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -68,9 +69,9 @@ func TestNewMetricsExporter(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.expectNil {
-				require.Nil(t, exporter)
+				assert.Nil(t, exporter)
 			} else {
-				require.IsType(t, tt.expectedType, exporter)
+				assert.IsType(t, tt.expectedType, exporter)
 			}
 		})
 	}
@@ -124,7 +125,7 @@ func TestCleanMetricName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := cleanMetricName(tc.input)
-			require.Equal(t, tc.expected, result)
+			assert.Equal(t, tc.expected, result)
 		})
 	}
 }

--- a/telemetry/traces_test.go
+++ b/telemetry/traces_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -97,7 +98,7 @@ func TestNewTraceExporter(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.IsType(t, tt.expectedType, exporter)
+				assert.IsType(t, tt.expectedType, exporter)
 			}
 		})
 	}

--- a/terraform/cliconfig/config_test.go
+++ b/terraform/cliconfig/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,8 +90,7 @@ provider_installation {
 		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
 			t.Parallel()
 
-			tempDir, err := os.MkdirTemp("", "*")
-			require.NoError(t, err)
+			tempDir := t.TempDir()
 			configFile := filepath.Join(tempDir, ".terraformrc")
 
 			for _, host := range testCase.hosts {
@@ -104,7 +104,7 @@ provider_installation {
 			hclBytes, err := os.ReadFile(configFile)
 			require.NoError(t, err)
 
-			require.Equal(t, testCase.expectedHCL, string(hclBytes))
+			assert.Equal(t, testCase.expectedHCL, string(hclBytes))
 		})
 	}
 }

--- a/terraform/getter_test.go
+++ b/terraform/getter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/files"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,7 +17,7 @@ func TestGetModuleRegistryURLBasePath(t *testing.T) {
 
 	basePath, err := getModuleRegistryURLBasePath(context.Background(), "registry.terraform.io")
 	require.NoError(t, err)
-	require.Equal(t, "/v1/modules/", basePath)
+	assert.Equal(t, "/v1/modules/", basePath)
 }
 
 func TestGetTerraformHeader(t *testing.T) {
@@ -29,7 +30,7 @@ func TestGetTerraformHeader(t *testing.T) {
 	}
 	terraformGetHeader, err := getTerraformGetHeader(context.Background(), testModuleURL)
 	require.NoError(t, err)
-	require.Contains(t, terraformGetHeader, "github.com/terraform-aws-modules/terraform-aws-vpc")
+	assert.Contains(t, terraformGetHeader, "github.com/terraform-aws-modules/terraform-aws-vpc")
 }
 
 func TestGetDownloadURLFromHeader(t *testing.T) {
@@ -92,7 +93,7 @@ func TestGetDownloadURLFromHeader(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			downloadURL, err := getDownloadURLFromHeader(testCase.moduleURL, testCase.terraformGet)
 			require.NoError(t, err)
-			require.Equal(t, testCase.expectedResult, downloadURL)
+			assert.Equal(t, testCase.expectedResult, downloadURL)
 		})
 	}
 }
@@ -109,11 +110,11 @@ func TestTFRGetterRootDir(t *testing.T) {
 
 	// The dest path must not exist for go getter to work
 	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
-	require.False(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	assert.False(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 
 	tfrGetter := new(RegistryGetter)
 	require.NoError(t, tfrGetter.Get(moduleDestPath, testModuleURL))
-	require.True(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	assert.True(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 }
 
 func TestTFRGetterSubModule(t *testing.T) {
@@ -128,24 +129,24 @@ func TestTFRGetterSubModule(t *testing.T) {
 
 	// The dest path must not exist for go getter to work
 	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
-	require.False(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	assert.False(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 
 	tfrGetter := new(RegistryGetter)
 	require.NoError(t, tfrGetter.Get(moduleDestPath, testModuleURL))
-	require.True(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	assert.True(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 }
 
 func TestBuildRequestUrlFullPath(t *testing.T) {
 	t.Parallel()
 	requestUrl, err := buildRequestUrl("gruntwork.io", "https://gruntwork.io/registry/modules/v1/", "/tfr-project/terraform-aws-tfr", "6.6.6")
 	require.NoError(t, err)
-	require.Equal(t, "https://gruntwork.io/registry/modules/v1/tfr-project/terraform-aws-tfr/6.6.6/download", requestUrl.String())
+	assert.Equal(t, "https://gruntwork.io/registry/modules/v1/tfr-project/terraform-aws-tfr/6.6.6/download", requestUrl.String())
 }
 
 func TestBuildRequestUrlRelativePath(t *testing.T) {
 	t.Parallel()
 	requestUrl, err := buildRequestUrl("gruntwork.io", "/registry/modules/v1", "/tfr-project/terraform-aws-tfr", "6.6.6")
 	require.NoError(t, err)
-	require.Equal(t, "https://gruntwork.io/registry/modules/v1/tfr-project/terraform-aws-tfr/6.6.6/download", requestUrl.String())
+	assert.Equal(t, "https://gruntwork.io/registry/modules/v1/tfr-project/terraform-aws-tfr/6.6.6/download", requestUrl.String())
 
 }

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/tui/command"
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +27,7 @@ func TestScaffoldGitRepo(t *testing.T) {
 
 	modules, err := repo.FindModules(ctx)
 	require.NoError(t, err)
-	require.Len(t, modules, 4)
+	assert.Len(t, modules, 4)
 }
 
 func TestScaffoldGitModule(t *testing.T) {
@@ -48,7 +49,7 @@ func TestScaffoldGitModule(t *testing.T) {
 			auroraModule = m
 		}
 	}
-	require.NotNil(t, auroraModule)
+	assert.NotNil(t, auroraModule)
 
 	testPath := t.TempDir()
 	opts, err := options.NewTerragruntOptionsForTest(testPath)
@@ -61,11 +62,11 @@ func TestScaffoldGitModule(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := readConfig(t, opts)
-	require.NotEmpty(t, cfg.Inputs)
-	require.Len(t, cfg.Inputs, 1)
+	assert.NotEmpty(t, cfg.Inputs)
+	assert.Len(t, cfg.Inputs, 1)
 	_, found := cfg.Inputs["vpc_id"]
-	require.True(t, found)
-	require.Contains(t, *cfg.Terraform.Source, "git::https://github.com/gruntwork-io/terraform-fake-modules.git//modules/aws/aurora")
+	assert.True(t, found)
+	assert.Contains(t, *cfg.Terraform.Source, "git::https://github.com/gruntwork-io/terraform-fake-modules.git//modules/aws/aurora")
 }
 
 func TestScaffoldGitModuleHttps(t *testing.T) {
@@ -87,7 +88,7 @@ func TestScaffoldGitModuleHttps(t *testing.T) {
 			auroraModule = m
 		}
 	}
-	require.NotNil(t, auroraModule)
+	assert.NotNil(t, auroraModule)
 
 	testPath := t.TempDir()
 	opts, err := options.NewTerragruntOptionsForTest(testPath)
@@ -100,17 +101,17 @@ func TestScaffoldGitModuleHttps(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := readConfig(t, opts)
-	require.NotEmpty(t, cfg.Inputs)
-	require.Len(t, cfg.Inputs, 1)
+	assert.NotEmpty(t, cfg.Inputs)
+	assert.Len(t, cfg.Inputs, 1)
 	_, found := cfg.Inputs["vpc_id"]
-	require.True(t, found)
-	require.Contains(t, *cfg.Terraform.Source, "git::https://github.com/gruntwork-io/terraform-fake-modules.git//modules/aws/aurora?ref=v0.0.5")
+	assert.True(t, found)
+	assert.Contains(t, *cfg.Terraform.Source, "git::https://github.com/gruntwork-io/terraform-fake-modules.git//modules/aws/aurora?ref=v0.0.5")
 
 	runTerragrunt(t, "terragrunt init --terragrunt-non-interactive --terragrunt-working-dir "+opts.WorkingDir)
 }
 
 func readConfig(t *testing.T, opts *options.TerragruntOptions) *config.TerragruntConfig {
-	require.FileExists(t, opts.WorkingDir+"/terragrunt.hcl")
+	assert.FileExists(t, opts.WorkingDir+"/terragrunt.hcl")
 
 	opts, err := options.NewTerragruntOptionsForTest(filepath.Join(opts.WorkingDir, "terragrunt.hcl"))
 	require.NoError(t, err)

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -46,9 +46,9 @@ func TestDebugGeneratedInputs(t *testing.T) {
 	)
 
 	debugFile := util.JoinPath(rootPath, terragruntDebugFile)
-	require.True(t, util.FileExists(debugFile))
+	assert.True(t, util.FileExists(debugFile))
 
-	require.Contains(t, stderr.String(), fmt.Sprintf("-chdir=\"%s\"", rootPath))
+	assert.Contains(t, stderr.String(), fmt.Sprintf("-chdir=\"%s\"", rootPath))
 
 	// If the debug file is generated correctly, we should be able to run terraform apply using the generated var file
 	// without going through terragrunt.
@@ -77,7 +77,7 @@ func TestDebugGeneratedInputs(t *testing.T) {
 	var data map[string]interface{}
 	require.NoError(t, json.Unmarshal(debugJsonContents, &data))
 	_, isDefined := data["undefined_var"]
-	require.False(t, isDefined)
+	assert.False(t, isDefined)
 }
 
 func TestTerragruntInputsWithDashes(t *testing.T) {
@@ -202,14 +202,14 @@ func TestRenderJSONConfig(t *testing.T) {
 	terraformBlock, hasTerraform := rendered["terraform"]
 	if assert.True(t, hasTerraform) {
 		source, hasSource := terraformBlock.(map[string]interface{})["source"]
-		require.True(t, hasSource)
-		require.Equal(t, "./module", source)
+		assert.True(t, hasSource)
+		assert.Equal(t, "./module", source)
 	}
 
 	// Make sure included remote_state is rendered out
 	remote_state, hasRemoteState := rendered["remote_state"]
 	if assert.True(t, hasRemoteState) {
-		require.Equal(
+		assert.Equal(
 			t,
 			map[string]interface{}{
 				"backend": "local",
@@ -230,7 +230,7 @@ func TestRenderJSONConfig(t *testing.T) {
 	// Make sure dependency blocks are rendered out
 	dependencyBlocks, hasDependency := rendered["dependency"]
 	if assert.True(t, hasDependency) {
-		require.Equal(
+		assert.Equal(
 			t,
 			map[string]interface{}{
 				"dep": map[string]interface{}{
@@ -253,7 +253,7 @@ func TestRenderJSONConfig(t *testing.T) {
 	// Make sure included generate block is rendered out
 	generateBlocks, hasGenerate := rendered["generate"]
 	if assert.True(t, hasGenerate) {
-		require.Equal(
+		assert.Equal(
 			t,
 			map[string]interface{}{
 				"provider": map[string]interface{}{
@@ -276,7 +276,7 @@ func TestRenderJSONConfig(t *testing.T) {
 	// Make sure all inputs are merged together
 	inputsBlock, hasInputs := rendered["inputs"]
 	if assert.True(t, hasInputs) {
-		require.Equal(
+		assert.Equal(
 			t,
 			map[string]interface{}{
 				"env":        "qa",
@@ -314,14 +314,14 @@ func TestRenderJSONConfigWithIncludesDependenciesAndLocals(t *testing.T) {
 	terraformBlock, hasTerraform := rendered["terraform"]
 	if assert.True(t, hasTerraform) {
 		source, hasSource := terraformBlock.(map[string]interface{})["source"]
-		require.True(t, hasSource)
-		require.Equal(t, "./foo", source)
+		assert.True(t, hasSource)
+		assert.Equal(t, "./foo", source)
 	}
 
 	// Make sure top level locals are rendered out
 	locals, hasLocals := rendered["locals"]
 	if assert.True(t, hasLocals) {
-		require.Equal(
+		assert.Equal(
 			t,
 			map[string]interface{}{
 				"foo": "bar",
@@ -333,7 +333,7 @@ func TestRenderJSONConfigWithIncludesDependenciesAndLocals(t *testing.T) {
 	// Make sure included dependency block is rendered out, and with the outputs rendered
 	dependencyBlocks, hasDependency := rendered["dependency"]
 	if assert.True(t, hasDependency) {
-		require.Equal(
+		assert.Equal(
 			t,
 			map[string]interface{}{
 				"baz": map[string]interface{}{
@@ -356,7 +356,7 @@ func TestRenderJSONConfigWithIncludesDependenciesAndLocals(t *testing.T) {
 	// Make sure generate block is rendered out
 	generateBlocks, hasGenerate := rendered["generate"]
 	if assert.True(t, hasGenerate) {
-		require.Equal(
+		assert.Equal(
 			t,
 			map[string]interface{}{
 				"provider": map[string]interface{}{
@@ -376,7 +376,7 @@ func TestRenderJSONConfigWithIncludesDependenciesAndLocals(t *testing.T) {
 	// Make sure all inputs are merged together
 	inputsBlock, hasInputs := rendered["inputs"]
 	if assert.True(t, hasInputs) {
-		require.Equal(
+		assert.Equal(
 			t,
 			map[string]interface{}{
 				"foo":       "bar",
@@ -416,7 +416,7 @@ func TestRenderJSONConfigRunAll(t *testing.T) {
 	// Make sure top level locals are rendered out
 	bazLocals, bazHasLocals := bazRendered["locals"]
 	if assert.True(t, bazHasLocals) {
-		require.Equal(
+		assert.Equal(
 			t,
 			map[string]interface{}{
 				"self": "baz",
@@ -434,7 +434,7 @@ func TestRenderJSONConfigRunAll(t *testing.T) {
 	// Make sure top level locals are rendered out
 	rootChildLocals, rootChildHasLocals := rootChildRendered["locals"]
 	if assert.True(t, rootChildHasLocals) {
-		require.Equal(
+		assert.Equal(
 			t,
 			map[string]interface{}{
 				"foo": "bar",
@@ -459,9 +459,9 @@ func TestDependencyGraphWithMultiInclude(t *testing.T) {
 	)
 	stdoutStr := stdout.String()
 
-	require.Contains(t, stdoutStr, `"main" -> "depa";`)
-	require.Contains(t, stdoutStr, `"main" -> "depb";`)
-	require.Contains(t, stdoutStr, `"main" -> "depc";`)
+	assert.Contains(t, stdoutStr, `"main" -> "depa";`)
+	assert.Contains(t, stdoutStr, `"main" -> "depb";`)
+	assert.Contains(t, stdoutStr, `"main" -> "depc";`)
 }
 
 func runTerragruntValidateInputs(t *testing.T, moduleDir string, extraArgs []string, isSuccessTest bool) {

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -43,7 +43,7 @@ func TestLocalDownload(t *testing.T) {
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalDownloadPath)
 
 	// As of Terraform 0.14.0 we should be copying the lock file from .terragrunt-cache to the working directory
-	require.FileExists(t, util.JoinPath(testFixtureLocalDownloadPath, util.TerraformLockFile))
+	assert.FileExists(t, util.JoinPath(testFixtureLocalDownloadPath, util.TerraformLockFile))
 
 	// Run a second time to make sure the temporary folder can be reused without errors
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalDownloadPath)
@@ -80,7 +80,7 @@ func TestLocalDownloadWithAllowedHiddenFiles(t *testing.T) {
 	logBufferContentsLineByLine(t, stdout, "output stdout")
 	logBufferContentsLineByLine(t, stderr, "output stderr")
 	require.NoError(t, err)
-	require.Equal(t, "Hello world", stdout.String())
+	assert.Equal(t, "Hello world", stdout.String())
 }
 
 func TestLocalDownloadWithRelativePath(t *testing.T) {
@@ -130,7 +130,7 @@ func TestLocalWithMissingBackend(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, os.Stdout, os.Stderr)
 	if assert.Error(t, err) {
 		underlying := errors.Unwrap(err)
-		require.IsType(t, terraform.BackendNotDefined{}, underlying)
+		assert.IsType(t, terraform.BackendNotDefined{}, underlying)
 	}
 }
 
@@ -159,7 +159,7 @@ func TestInvalidRemoteDownload(t *testing.T) {
 
 	require.Error(t, err)
 	errMessage := "downloading source url"
-	require.Containsf(t, err.Error(), errMessage, "expected error containing %q, got %s", errMessage, err)
+	assert.Containsf(t, err.Error(), errMessage, "expected error containing %q, got %s", errMessage, err)
 
 }
 
@@ -235,7 +235,7 @@ func TestCustomLockFile(t *testing.T) {
 	require.NoError(t, err)
 
 	lockFilePath := util.JoinPath(result.WorkingDir, util.TerraformLockFile)
-	require.FileExists(t, lockFilePath)
+	assert.FileExists(t, lockFilePath)
 
 	readFile, err := os.ReadFile(lockFilePath)
 	require.NoError(t, err)
@@ -243,7 +243,7 @@ func TestCustomLockFile(t *testing.T) {
 	// In our lock file, we intentionally have hashes for an older version of the AWS provider. If the lock file
 	// copying works, then Terraform will stick with this older version. If there is a bug, Terraform will end up
 	// installing a newer version (since the version is not pinned in the .tf code, only in the lock file).
-	require.Contains(t, string(readFile), `version     = "5.23.0"`)
+	assert.Contains(t, string(readFile), `version     = "5.23.0"`)
 }
 
 func TestExcludeDirs(t *testing.T) {
@@ -305,7 +305,7 @@ func TestExcludeDirs(t *testing.T) {
 			require.NoError(t, err)
 			output := showStdout.String()
 			for _, excludedModuleOutput := range testCase.excludedModuleOutputs {
-				require.NotContains(t, output, excludedModuleOutput)
+				assert.NotContains(t, output, excludedModuleOutput)
 			}
 
 		}
@@ -372,7 +372,7 @@ func TestIncludeDirs(t *testing.T) {
 			require.NoError(t, err)
 			output := showStdout.String()
 			for _, includedModuleOutput := range testCase.includedModuleOutputs {
-				require.NotContains(t, output, includedModuleOutput)
+				assert.NotContains(t, output, includedModuleOutput)
 			}
 
 		}
@@ -395,13 +395,13 @@ func TestIncludeDirsDependencyConsistencyRegression(t *testing.T) {
 	}
 
 	includedModulesWithNone := runValidateAllWithIncludeAndGetIncludedModules(t, testPath, []string{}, false)
-	require.NotEmpty(t, includedModulesWithNone)
+	assert.NotEmpty(t, includedModulesWithNone)
 
 	includedModulesWithAmzApp := runValidateAllWithIncludeAndGetIncludedModules(t, testPath, []string{"amazing-app/k8s"}, false)
-	require.Equal(t, []string{"amazing-app/k8s", "clusters/eks"}, includedModulesWithAmzApp)
+	assert.Equal(t, []string{"amazing-app/k8s", "clusters/eks"}, includedModulesWithAmzApp)
 
 	includedModulesWithTestApp := runValidateAllWithIncludeAndGetIncludedModules(t, testPath, []string{"testapp/k8s"}, false)
-	require.Equal(t, []string{"clusters/eks", "testapp/k8s"}, includedModulesWithTestApp)
+	assert.Equal(t, []string{"clusters/eks", "testapp/k8s"}, includedModulesWithTestApp)
 }
 
 func TestIncludeDirsStrict(t *testing.T) {
@@ -421,13 +421,13 @@ func TestIncludeDirsStrict(t *testing.T) {
 	}
 
 	includedModulesWithNone := runValidateAllWithIncludeAndGetIncludedModules(t, testPath, []string{}, true)
-	require.Equal(t, []string{}, includedModulesWithNone)
+	assert.Equal(t, []string{}, includedModulesWithNone)
 
 	includedModulesWithAmzApp := runValidateAllWithIncludeAndGetIncludedModules(t, testPath, []string{"amazing-app/k8s"}, true)
-	require.Equal(t, []string{"amazing-app/k8s"}, includedModulesWithAmzApp)
+	assert.Equal(t, []string{"amazing-app/k8s"}, includedModulesWithAmzApp)
 
 	includedModulesWithTestApp := runValidateAllWithIncludeAndGetIncludedModules(t, testPath, []string{"testapp/k8s"}, true)
-	require.Equal(t, []string{"testapp/k8s"}, includedModulesWithTestApp)
+	assert.Equal(t, []string{"testapp/k8s"}, includedModulesWithTestApp)
 }
 
 func TestTerragruntExternalDependencies(t *testing.T) {
@@ -461,6 +461,6 @@ func TestTerragruntExternalDependencies(t *testing.T) {
 	}
 
 	for _, module := range modules {
-		require.Contains(t, applyAllStdoutString, "Hello World, "+module)
+		assert.Contains(t, applyAllStdoutString, "Hello World, "+module)
 	}
 }

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,7 +56,7 @@ func TestTerragruntWorksWithIncludeLocals(t *testing.T) {
 
 			outputs := map[string]TerraformOutput{}
 			require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-			require.Equal(t, "us-west-1-test", outputs["region"].Value.(string))
+			assert.Equal(t, "us-west-1-test", outputs["region"].Value.(string))
 		})
 	}
 }
@@ -113,9 +114,9 @@ func TestTerragruntRunAllModulesThatIncludeRestrictsSet(t *testing.T) {
 	logBufferContentsLineByLine(t, stderr, "stderr")
 
 	planOutput := stdout.String()
-	require.Contains(t, planOutput, "alpha")
-	require.NotContains(t, planOutput, "beta")
-	require.NotContains(t, planOutput, "charlie")
+	assert.Contains(t, planOutput, "alpha")
+	assert.NotContains(t, planOutput, "beta")
+	assert.NotContains(t, planOutput, "charlie")
 }
 
 func TestTerragruntRunAllModulesWithPrefix(t *testing.T) {
@@ -138,20 +139,20 @@ func TestTerragruntRunAllModulesWithPrefix(t *testing.T) {
 	logBufferContentsLineByLine(t, stderr, "stderr")
 
 	planOutput := stdout.String()
-	require.Contains(t, planOutput, "alpha")
-	require.Contains(t, planOutput, "beta")
-	require.Contains(t, planOutput, "charlie")
+	assert.Contains(t, planOutput, "alpha")
+	assert.Contains(t, planOutput, "beta")
+	assert.Contains(t, planOutput, "charlie")
 
 	stdoutLines := strings.Split(planOutput, "\n")
 	for _, line := range stdoutLines {
 		if strings.Contains(line, "alpha") {
-			require.Contains(t, line, includeRunAllFixturePath+"a")
+			assert.Contains(t, line, includeRunAllFixturePath+"a")
 		}
 		if strings.Contains(line, "beta") {
-			require.Contains(t, line, includeRunAllFixturePath+"b")
+			assert.Contains(t, line, includeRunAllFixturePath+"b")
 		}
 		if strings.Contains(line, "charlie") {
-			require.Contains(t, line, includeRunAllFixturePath+"c")
+			assert.Contains(t, line, includeRunAllFixturePath+"c")
 		}
 	}
 }
@@ -172,13 +173,13 @@ func TestTerragruntWorksWithIncludeDeepMerge(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, "mock", outputs["attribute"].Value.(string))
-	require.Equal(t, "new val", outputs["new_attribute"].Value.(string))
-	require.Equal(t, "old val", outputs["old_attribute"].Value.(string))
-	require.Equal(t, []interface{}{"hello", "mock"}, outputs["list_attr"].Value.([]interface{}))
-	require.Equal(t, map[string]interface{}{"foo": "bar", "bar": "baz", "test": "new val"}, outputs["map_attr"].Value.(map[string]interface{}))
+	assert.Equal(t, "mock", outputs["attribute"].Value.(string))
+	assert.Equal(t, "new val", outputs["new_attribute"].Value.(string))
+	assert.Equal(t, "old val", outputs["old_attribute"].Value.(string))
+	assert.Equal(t, []interface{}{"hello", "mock"}, outputs["list_attr"].Value.([]interface{}))
+	assert.Equal(t, map[string]interface{}{"foo": "bar", "bar": "baz", "test": "new val"}, outputs["map_attr"].Value.(map[string]interface{}))
 
-	require.Equal(
+	assert.Equal(
 		t,
 		map[string]interface{}{
 			"attribute":     "mock",
@@ -231,13 +232,13 @@ func TestTerragruntWorksWithMultipleInclude(t *testing.T) {
 }
 
 func validateMultipleIncludeTestOutput(t *testing.T, outputs map[string]TerraformOutput) {
-	require.Equal(t, "mock", outputs["attribute"].Value.(string))
-	require.Equal(t, "new val", outputs["new_attribute"].Value.(string))
-	require.Equal(t, "old val", outputs["old_attribute"].Value.(string))
-	require.Equal(t, []interface{}{"hello", "mock", "foo"}, outputs["list_attr"].Value.([]interface{}))
-	require.Equal(t, map[string]interface{}{"foo": "bar", "bar": "baz", "test": "new val"}, outputs["map_attr"].Value.(map[string]interface{}))
+	assert.Equal(t, "mock", outputs["attribute"].Value.(string))
+	assert.Equal(t, "new val", outputs["new_attribute"].Value.(string))
+	assert.Equal(t, "old val", outputs["old_attribute"].Value.(string))
+	assert.Equal(t, []interface{}{"hello", "mock", "foo"}, outputs["list_attr"].Value.([]interface{}))
+	assert.Equal(t, map[string]interface{}{"foo": "bar", "bar": "baz", "test": "new val"}, outputs["map_attr"].Value.(map[string]interface{}))
 
-	require.Equal(
+	assert.Equal(
 		t,
 		map[string]interface{}{
 			"attribute":     "mock",
@@ -263,7 +264,7 @@ func validateIncludeRemoteStateReflection(t *testing.T, s3BucketName string, key
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 	remoteStateOut := map[string]interface{}{}
 	require.NoError(t, json.Unmarshal([]byte(outputs["reflect"].Value.(string)), &remoteStateOut))
-	require.Equal(
+	assert.Equal(
 		t,
 		map[string]interface{}{
 			"backend":                         "s3",

--- a/test/integration_local_dev_test.go
+++ b/test/integration_local_dev_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,7 +91,7 @@ func TestGetTerragruntSourceHCL(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, "HCL: "+terraformSource, outputs["terragrunt_source"].Value)
+	assert.Equal(t, "HCL: "+terraformSource, outputs["terragrunt_source"].Value)
 }
 
 func TestGetTerragruntSourceCLI(t *testing.T) {
@@ -115,5 +116,5 @@ func TestGetTerragruntSourceCLI(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, "CLI: "+terraformSource, outputs["terragrunt_source"].Value)
+	assert.Equal(t, "CLI: "+terraformSource, outputs["terragrunt_source"].Value)
 }

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/util"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,8 +30,8 @@ func TestScaffoldModule(t *testing.T) {
 
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_MODULE))
 	require.NoError(t, err)
-	require.Contains(t, stderr, "Scaffolding completed")
-	require.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
+	assert.Contains(t, stderr, "Scaffolding completed")
+	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
 }
 
 func TestScaffoldModuleShortUrl(t *testing.T) {
@@ -41,11 +42,11 @@ func TestScaffoldModuleShortUrl(t *testing.T) {
 
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_MODULE_SHORT))
 	require.NoError(t, err)
-	require.Contains(t, stderr, "Scaffolding completed")
+	assert.Contains(t, stderr, "Scaffolding completed")
 	// check that find_in_parent_folders is generated in terragrunt.hcl
 	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
 	require.NoError(t, err)
-	require.Contains(t, content, "find_in_parent_folders")
+	assert.Contains(t, content, "find_in_parent_folders")
 }
 
 func TestScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
@@ -56,11 +57,11 @@ func TestScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
 
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=EnableRootInclude=false", tmpEnvPath, TEST_SCAFFOLD_MODULE_SHORT))
 	require.NoError(t, err)
-	require.Contains(t, stderr, "Scaffolding completed")
+	assert.Contains(t, stderr, "Scaffolding completed")
 	// check that find_in_parent_folders is NOT generated in  terragrunt.hcl
 	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
 	require.NoError(t, err)
-	require.NotContains(t, content, "find_in_parent_folders")
+	assert.NotContains(t, content, "find_in_parent_folders")
 }
 
 func TestScaffoldModuleDifferentRevision(t *testing.T) {
@@ -72,8 +73,8 @@ func TestScaffoldModuleDifferentRevision(t *testing.T) {
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=Ref=v0.53.1", tmpEnvPath, TEST_SCAFFOLD_MODULE_SHORT))
 
 	require.NoError(t, err)
-	require.Contains(t, stderr, "git::https://github.com/gruntwork-io/terragrunt.git//test/fixture-inputs?ref=v0.53.1")
-	require.Contains(t, stderr, "Scaffolding completed")
+	assert.Contains(t, stderr, "git::https://github.com/gruntwork-io/terragrunt.git//test/fixture-inputs?ref=v0.53.1")
+	assert.Contains(t, stderr, "Scaffolding completed")
 }
 
 func TestScaffoldModuleDifferentRevisionAndSsh(t *testing.T) {
@@ -84,8 +85,8 @@ func TestScaffoldModuleDifferentRevisionAndSsh(t *testing.T) {
 
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=Ref=v0.53.1 --var=SourceUrlType=git-ssh", tmpEnvPath, TEST_SCAFFOLD_MODULE_SHORT))
 	require.NoError(t, err)
-	require.Contains(t, stderr, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixture-inputs?ref=v0.53.1")
-	require.Contains(t, stderr, "Scaffolding completed")
+	assert.Contains(t, stderr, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixture-inputs?ref=v0.53.1")
+	assert.Contains(t, stderr, "Scaffolding completed")
 }
 
 func TestScaffoldModuleSsh(t *testing.T) {
@@ -96,7 +97,7 @@ func TestScaffoldModuleSsh(t *testing.T) {
 
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_MODULE_GIT))
 	require.NoError(t, err)
-	require.Contains(t, stderr, "Scaffolding completed")
+	assert.Contains(t, stderr, "Scaffolding completed")
 }
 
 func TestScaffoldModuleTemplate(t *testing.T) {
@@ -107,9 +108,9 @@ func TestScaffoldModuleTemplate(t *testing.T) {
 
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_TEMPLATE_MODULE))
 	require.NoError(t, err)
-	require.Contains(t, stderr, "Scaffolding completed")
+	assert.Contains(t, stderr, "Scaffolding completed")
 	// check that exists file from .boilerplate dir
-	require.FileExists(t, tmpEnvPath+"/template-file.txt")
+	assert.FileExists(t, tmpEnvPath+"/template-file.txt")
 }
 
 func TestScaffoldModuleExternalTemplate(t *testing.T) {
@@ -120,9 +121,9 @@ func TestScaffoldModuleExternalTemplate(t *testing.T) {
 
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s %s", tmpEnvPath, TEST_SCAFFOLD_MODULE_GIT, TEST_SCAFFOLD_EXTERNAL_TEMPLATE_MODULE))
 	require.NoError(t, err)
-	require.Contains(t, stderr, "Scaffolding completed")
+	assert.Contains(t, stderr, "Scaffolding completed")
 	// check that exists file from external template
-	require.FileExists(t, tmpEnvPath+"/external-template.txt")
+	assert.FileExists(t, tmpEnvPath+"/external-template.txt")
 }
 
 func TestScaffoldErrorNoModuleUrl(t *testing.T) {
@@ -133,7 +134,7 @@ func TestScaffoldErrorNoModuleUrl(t *testing.T) {
 
 	_, _, err = runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold", tmpEnvPath))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "No module URL passed")
+	assert.Contains(t, err.Error(), "No module URL passed")
 }
 
 func TestScaffoldModuleVarFile(t *testing.T) {
@@ -153,11 +154,11 @@ SourceUrlType: "git-ssh"
 
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var-file=%s", tmpEnvPath, TEST_SCAFFOLD_MODULE_SHORT, varFile))
 	require.NoError(t, err)
-	require.Contains(t, stderr, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixture-inputs?ref=v0.53.1")
-	require.Contains(t, stderr, "Scaffolding completed")
+	assert.Contains(t, stderr, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixture-inputs?ref=v0.53.1")
+	assert.Contains(t, stderr, "Scaffolding completed")
 	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
 	require.NoError(t, err)
-	require.NotContains(t, content, "find_in_parent_folders")
+	assert.NotContains(t, content, "find_in_parent_folders")
 }
 
 func TestScaffoldLocalModule(t *testing.T) {
@@ -171,8 +172,8 @@ func TestScaffoldLocalModule(t *testing.T) {
 
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, fmt.Sprintf("%s//%s", workingDir, TEST_SCAFFOLD_LOCAL_MODULE)))
 	require.NoError(t, err)
-	require.Contains(t, stderr, "Scaffolding completed")
-	require.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
+	assert.Contains(t, stderr, "Scaffolding completed")
+	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
 }
 
 func TestScaffold3rdPartyModule(t *testing.T) {
@@ -190,8 +191,8 @@ func TestScaffold3rdPartyModule(t *testing.T) {
 
 	_, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, TEST_SCAFFOLD_3RD_PARTY_MODULE))
 	require.NoError(t, err)
-	require.Contains(t, stderr, "Scaffolding completed")
-	require.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
+	assert.Contains(t, stderr, "Scaffolding completed")
+	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
 
 	// validate the generated files
 	_, _, err = runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s hclvalidate", tmpEnvPath))

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -566,7 +566,7 @@ func TestTerragruntParallelism(t *testing.T) {
 func TestTerragruntWorksWithImpersonateGCSBackend(t *testing.T) {
 	impersonatorKey := os.Getenv("GCLOUD_SERVICE_KEY_IMPERSONATOR")
 	if impersonatorKey == "" {
-		t.Fatalf("assertd environment variable `%s` - not found", "GCLOUD_SERVICE_KEY_IMPERSONATOR")
+		t.Fatalf("required environment variable `%s` - not found", "GCLOUD_SERVICE_KEY_IMPERSONATOR")
 	}
 	tmpImpersonatorCreds := createTmpTerragruntConfigContent(t, impersonatorKey, "impersonator-key.json")
 	defer removeFile(t, tmpImpersonatorCreds)

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	terragruntinfo "github.com/gruntwork-io/terragrunt/cli/commands/terragrunt-info"
@@ -94,7 +95,7 @@ func TestTerragruntProviderCacheWithFilesystemMirror(t *testing.T) {
 	require.NoError(t, err)
 	terraformrc := strings.Join(strings.Fields(string(terraformrcBytes)), " ")
 
-	require.Contains(t, terraformrc, expectedProviderInstallation, "%s\n\n%s", terraformrc, expectedProviderInstallation)
+	assert.Contains(t, terraformrc, expectedProviderInstallation, "%s\n\n%s", terraformrc, expectedProviderInstallation)
 }
 
 func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
@@ -191,7 +192,7 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 	require.NoError(t, err)
 	terraformrc := strings.Join(strings.Fields(string(terraformrcBytes)), " ")
 
-	require.Contains(t, terraformrc, expectedProviderInstallation, "%s\n\n%s", terraformrc, expectedProviderInstallation)
+	assert.Contains(t, terraformrc, expectedProviderInstallation, "%s\n\n%s", terraformrc, expectedProviderInstallation)
 }
 
 func TestTerragruntInputsFromDependency(t *testing.T) {
@@ -240,7 +241,7 @@ func TestTerragruntInputsFromDependency(t *testing.T) {
 		if testCase.downloadDir != "" {
 			entries, err := os.ReadDir(testCase.downloadDir)
 			require.NoError(t, err)
-			require.Equal(t, len(appDirs), len(entries))
+			assert.Equal(t, len(appDirs), len(entries))
 		}
 
 		runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt output --terragrunt-non-interactive --terragrunt-working-dir %s  --terragrunt-download-dir=%s", appDir, testCase.downloadDir), &stdout, &stderr)
@@ -253,7 +254,7 @@ func TestTerragruntInputsFromDependency(t *testing.T) {
 
 		output := stdout.String()
 		for key, value := range expectedOutpus {
-			require.Contains(t, output, fmt.Sprintf("%s = %q\n", key, value))
+			assert.Contains(t, output, fmt.Sprintf("%s = %q\n", key, value))
 		}
 	}
 }
@@ -331,7 +332,7 @@ func TestTerragruntDownloadDir(t *testing.T) {
 			err_unmarshal := json.Unmarshal(stdout.Bytes(), &dat)
 			require.NoError(t, err_unmarshal)
 			// compare the results
-			require.Equal(t, testCase.downloadDirReference, dat.DownloadDir)
+			assert.Equal(t, testCase.downloadDirReference, dat.DownloadDir)
 		})
 	}
 
@@ -367,7 +368,7 @@ func TestExtraArguments(t *testing.T) {
 	out := new(bytes.Buffer)
 	runTerragruntRedirectOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+TEST_FIXTURE_EXTRA_ARGS_PATH, out, os.Stderr)
 	t.Log(out.String())
-	require.Contains(t, out.String(), "Hello, World from dev!")
+	assert.Contains(t, out.String(), "Hello, World from dev!")
 }
 
 func TestExtraArgumentsWithEnv(t *testing.T) {
@@ -375,14 +376,14 @@ func TestExtraArgumentsWithEnv(t *testing.T) {
 	t.Setenv("TF_VAR_env", "prod")
 	runTerragruntRedirectOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+TEST_FIXTURE_EXTRA_ARGS_PATH, out, os.Stderr)
 	t.Log(out.String())
-	require.Contains(t, out.String(), "Hello, World!")
+	assert.Contains(t, out.String(), "Hello, World!")
 }
 
 func TestExtraArgumentsWithEnvVarBlock(t *testing.T) {
 	out := new(bytes.Buffer)
 	runTerragruntRedirectOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+TEST_FIXTURE_ENV_VARS_BLOCK_PATH, out, os.Stderr)
 	t.Log(out.String())
-	require.Contains(t, out.String(), "I'm set in extra_arguments env_vars")
+	assert.Contains(t, out.String(), "I'm set in extra_arguments env_vars")
 }
 
 func TestExtraArgumentsWithRegion(t *testing.T) {
@@ -390,7 +391,7 @@ func TestExtraArgumentsWithRegion(t *testing.T) {
 	t.Setenv("TF_VAR_region", "us-west-2")
 	runTerragruntRedirectOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+TEST_FIXTURE_EXTRA_ARGS_PATH, out, os.Stderr)
 	t.Log(out.String())
-	require.Contains(t, out.String(), "Hello, World from Oregon!")
+	assert.Contains(t, out.String(), "Hello, World from Oregon!")
 }
 
 func TestPreserveEnvVarApplyAll(t *testing.T) {
@@ -405,13 +406,13 @@ func TestPreserveEnvVarApplyAll(t *testing.T) {
 	t.Log(stdout.String())
 
 	// Check the output of each child module to make sure the inputs were overridden by the env var
-	requireEnvVarModule := util.JoinPath(rootPath, "require-envvar")
+	assertEnvVarModule := util.JoinPath(rootPath, "require-envvar")
 	noRequireEnvVarModule := util.JoinPath(rootPath, "no-require-envvar")
-	for _, mod := range []string{requireEnvVarModule, noRequireEnvVarModule} {
+	for _, mod := range []string{assertEnvVarModule, noRequireEnvVarModule} {
 		stdout := bytes.Buffer{}
 		err := runTerragruntCommand(t, "terragrunt output text -no-color --terragrunt-non-interactive --terragrunt-working-dir "+mod, &stdout, os.Stderr)
 		require.NoError(t, err)
-		require.Contains(t, stdout.String(), "Hello from the env")
+		assert.Contains(t, stdout.String(), "Hello from the env")
 	}
 }
 
@@ -422,7 +423,7 @@ func TestPriorityOrderOfArgument(t *testing.T) {
 	t.Log(out.String())
 	// And the result value for test should be the injected variable since the injected arguments are injected before the suplied parameters,
 	// so our override of extra_var should be the last argument.
-	require.Contains(t, out.String(), fmt.Sprintf(`test = "%s"`, injectedValue))
+	assert.Contains(t, out.String(), fmt.Sprintf(`test = "%s"`, injectedValue))
 }
 
 func TestTerragruntValidateInputsWithEnvVar(t *testing.T) {
@@ -479,7 +480,7 @@ func TestTerragruntLogLevelEnvVarOverridesDefault(t *testing.T) {
 		runTerragruntCommand(t, "terragrunt validate --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr),
 	)
 	output := stderr.String()
-	require.Contains(t, output, "level=debug")
+	assert.Contains(t, output, "level=debug")
 }
 
 func TestTerragruntLogLevelEnvVarUnparsableLogsErrorButContinues(t *testing.T) {
@@ -496,7 +497,7 @@ func TestTerragruntLogLevelEnvVarUnparsableLogsErrorButContinues(t *testing.T) {
 	runTerragrunt(t, "terragrunt validate --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 }
 
-// NOTE: the following test requires precise timing for determining parallelism. As such, it can not be run in parallel
+// NOTE: the following test asserts precise timing for determining parallelism. As such, it can not be run in parallel
 // with all the other tests as the system load could impact the duration in which the parallel terragrunt goroutines
 // run.
 
@@ -509,7 +510,7 @@ func testTerragruntParallelism(t *testing.T, parallelism int, numberOfModules in
 	require.NoError(t, err)
 
 	matches := regex.FindAllStringSubmatch(output, -1)
-	require.Len(t, matches, numberOfModules)
+	assert.Len(t, matches, numberOfModules)
 
 	var deploymentTimes = make([]int, 0, len(matches))
 	for _, match := range matches {
@@ -539,7 +540,7 @@ func testTerragruntParallelism(t *testing.T, parallelism int, numberOfModules in
 	maxDiffInSeconds := 5.0 * scalingFactor
 	for i, scaledTime := range scaledTimes {
 		difference := math.Abs(scaledTime - float64(expectedTimings[i]))
-		require.LessOrEqual(t, difference, maxDiffInSeconds, "Expected timing %d but got %f", expectedTimings[i], scaledTime)
+		assert.LessOrEqual(t, difference, maxDiffInSeconds, "Expected timing %d but got %f", expectedTimings[i], scaledTime)
 	}
 }
 
@@ -565,7 +566,7 @@ func TestTerragruntParallelism(t *testing.T) {
 func TestTerragruntWorksWithImpersonateGCSBackend(t *testing.T) {
 	impersonatorKey := os.Getenv("GCLOUD_SERVICE_KEY_IMPERSONATOR")
 	if impersonatorKey == "" {
-		t.Fatalf("Required environment variable `%s` - not found", "GCLOUD_SERVICE_KEY_IMPERSONATOR")
+		t.Fatalf("assertd environment variable `%s` - not found", "GCLOUD_SERVICE_KEY_IMPERSONATOR")
 	}
 	tmpImpersonatorCreds := createTmpTerragruntConfigContent(t, impersonatorKey, "impersonator-key.json")
 	defer removeFile(t, tmpImpersonatorCreds)
@@ -592,7 +593,7 @@ func TestTerragruntWorksWithImpersonateGCSBackend(t *testing.T) {
 			break
 		}
 	}
-	require.True(t, ownerEmail, "Identity email should match the impersonated account")
+	assert.True(t, ownerEmail, "Identity email should match the impersonated account")
 }
 
 func TestTerragruntProduceTelemetryTraces(t *testing.T) {
@@ -606,10 +607,10 @@ func TestTerragruntProduceTelemetryTraces(t *testing.T) {
 	require.NoError(t, err)
 
 	// check that output have Telemetry json output
-	require.Contains(t, output, "\"SpanContext\":")
-	require.Contains(t, output, "\"TraceID\":")
-	require.Contains(t, output, "\"Name\":\"hook_after_hook_1\"")
-	require.Contains(t, output, "\"Name\":\"hook_after_hook_2\"")
+	assert.Contains(t, output, "\"SpanContext\":")
+	assert.Contains(t, output, "\"TraceID\":")
+	assert.Contains(t, output, "\"Name\":\"hook_after_hook_1\"")
+	assert.Contains(t, output, "\"Name\":\"hook_after_hook_2\"")
 }
 
 func TestTerragruntProduceTelemetryMetrics(t *testing.T) {
@@ -626,9 +627,9 @@ func TestTerragruntProduceTelemetryMetrics(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// check that output have Telemetry json output
-	require.Contains(t, output, "{\"Name\":\"hook_after_hook_2_duration\"")
-	require.Contains(t, output, "{\"Name\":\"run_")
-	require.Contains(t, output, ",\"IsMonotonic\":true}}")
+	assert.Contains(t, output, "{\"Name\":\"hook_after_hook_2_duration\"")
+	assert.Contains(t, output, "{\"Name\":\"run_")
+	assert.Contains(t, output, ",\"IsMonotonic\":true}}")
 }
 
 func TestTerragruntOutputJson(t *testing.T) {
@@ -662,11 +663,11 @@ func TestTerragruntOutputJson(t *testing.T) {
 		require.NoError(t, err)
 
 		msg, ok := output["msg"].(string)
-		require.True(t, ok)
+		assert.True(t, ok)
 		msgs = append(msgs, msg)
 	}
 
-	require.Contains(t, strings.Join(msgs, ""), "Downloading Terraform configurations from git::https://github.com/gruntwork-io/terragrunt.git?ref=v0.9.9")
+	assert.Contains(t, strings.Join(msgs, ""), "Downloading Terraform configurations from git::https://github.com/gruntwork-io/terragrunt.git?ref=v0.9.9")
 }
 
 func TestTerragruntTerraformOutputJson(t *testing.T) {
@@ -682,7 +683,7 @@ func TestTerragruntTerraformOutputJson(t *testing.T) {
 	_, stderr, err := runTerragruntCommandWithOutput(t, "terragrunt apply --no-color --terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-non-interactive --terragrunt-working-dir "+testPath)
 	require.Error(t, err)
 
-	require.Contains(t, stderr, "\"level\":\"info\",\"msg\":\"Initializing the backend...")
+	assert.Contains(t, stderr, "\"level\":\"info\",\"msg\":\"Initializing the backend...")
 
 	// check if output can be extracted in json
 	jsonStrings := strings.Split(stderr, "\n")
@@ -693,8 +694,8 @@ func TestTerragruntTerraformOutputJson(t *testing.T) {
 		var output map[string]interface{}
 		err = json.Unmarshal([]byte(jsonString), &output)
 		require.NoErrorf(t, err, "Failed to parse json %s", jsonString)
-		require.NotNil(t, output["level"])
-		require.NotNil(t, output["time"])
+		assert.NotNil(t, output["level"])
+		assert.NotNil(t, output["time"])
 	}
 }
 
@@ -724,7 +725,7 @@ func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {
 			stdout, stderr, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s %s", appTerragruntConfigPath, testCase.arg))
 			require.NoError(t, err)
 			output := fmt.Sprintf("%s %s", stderr, stdout)
-			require.NotContains(t, output, "invalid character")
+			assert.NotContains(t, output, "invalid character")
 		})
 
 	}
@@ -751,19 +752,19 @@ func TestTerragruntJsonPlanJsonOutput(t *testing.T) {
 			require.NoError(t, err)
 			list, err := findFilesWithExtension(tmpDir, ".json")
 			require.NoError(t, err)
-			require.Len(t, list, 2)
+			assert.Len(t, list, 2)
 			for _, file := range list {
-				require.Equal(t, "tfplan.json", filepath.Base(file))
+				assert.Equal(t, "tfplan.json", filepath.Base(file))
 				// verify that file is not empty
 				content, err := os.ReadFile(file)
 				require.NoError(t, err)
-				require.NotEmpty(t, content)
+				assert.NotEmpty(t, content)
 				// check that produced json is valid and can be unmarshalled
 				var plan map[string]interface{}
 				err = json.Unmarshal(content, &plan)
 				require.NoError(t, err)
 				// check that plan is not empty
-				require.NotEmpty(t, plan)
+				assert.NotEmpty(t, plan)
 			}
 		})
 
@@ -782,12 +783,12 @@ func TestTerragruntProduceTelemetryTracesWithRootSpanAndTraceID(t *testing.T) {
 	require.NoError(t, err)
 
 	// check that output have Telemetry json output
-	require.Contains(t, output, "\"SpanContext\":{\"TraceID\":\"b2ff2d54551433d53dd807a6c94e81d1\"")
-	require.Contains(t, output, "\"SpanID\":\"0e6f631d793c718a\"")
-	require.Contains(t, output, "\"SpanContext\":")
-	require.Contains(t, output, "\"TraceID\":")
-	require.Contains(t, output, "\"Name\":\"hook_after_hook_1\"")
-	require.Contains(t, output, "\"Name\":\"hook_after_hook_2\"")
+	assert.Contains(t, output, "\"SpanContext\":{\"TraceID\":\"b2ff2d54551433d53dd807a6c94e81d1\"")
+	assert.Contains(t, output, "\"SpanID\":\"0e6f631d793c718a\"")
+	assert.Contains(t, output, "\"SpanContext\":")
+	assert.Contains(t, output, "\"TraceID\":")
+	assert.Contains(t, output, "\"Name\":\"hook_after_hook_1\"")
+	assert.Contains(t, output, "\"Name\":\"hook_after_hook_2\"")
 }
 
 func TestTerragruntProduceTelemetryInCasOfError(t *testing.T) {
@@ -801,10 +802,10 @@ func TestTerragruntProduceTelemetryInCasOfError(t *testing.T) {
 	output, _, err := runTerragruntCommandWithOutput(t, "terragrunt no-existing-command -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 	require.Error(t, err)
 
-	require.Contains(t, output, "\"SpanContext\":{\"TraceID\":\"b2ff2d54551433d53dd807a6c94e81d1\"")
-	require.Contains(t, output, "\"SpanID\":\"0e6f631d793c718a\"")
-	require.Contains(t, output, "exception.message")
-	require.Contains(t, output, "\"Name\":\"exception\"")
+	assert.Contains(t, output, "\"SpanContext\":{\"TraceID\":\"b2ff2d54551433d53dd807a6c94e81d1\"")
+	assert.Contains(t, output, "\"SpanID\":\"0e6f631d793c718a\"")
+	assert.Contains(t, output, "exception.message")
+	assert.Contains(t, output, "\"Name\":\"exception\"")
 }
 
 // Since this test launches a large number of terraform processes, which sometimes fails with the message `Failed to write to log, write |1: file already closed`, for stability, we need to run it not parallel.
@@ -860,7 +861,7 @@ func TestTerragruntProviderCache(t *testing.T) {
 			require.NoError(t, err)
 
 			lockfile, diags := hclwrite.ParseConfig(lockfileContent, lockfilePath, hcl.Pos{Line: 1, Column: 1})
-			require.False(t, diags.HasErrors())
+			assert.False(t, diags.HasErrors())
 
 			for _, provider := range providers {
 				var (
@@ -870,17 +871,17 @@ func TestTerragruntProviderCache(t *testing.T) {
 				)
 
 				providerBlock := lockfile.Body().FirstMatchingBlock("provider", []string{filepath.Dir(provider)})
-				require.NotNil(t, providerBlock)
+				assert.NotNil(t, providerBlock)
 
 				providerPath := filepath.Join(appPath, ".terraform/providers", provider)
-				require.True(t, util.FileExists(providerPath))
+				assert.True(t, util.FileExists(providerPath))
 
 				entries, err := os.ReadDir(providerPath)
 				require.NoError(t, err)
 
 				for _, entry := range entries {
 					actualProviderSymlinks++
-					require.Equal(t, fs.ModeSymlink, entry.Type())
+					assert.Equal(t, fs.ModeSymlink, entry.Type())
 
 					symlinkPath := filepath.Join(providerPath, entry.Name())
 
@@ -888,12 +889,12 @@ func TestTerragruntProviderCache(t *testing.T) {
 					require.NoError(t, err)
 
 					expectedPath := filepath.Join(providerCacheDir, provider, entry.Name())
-					require.Contains(t, actualPath, expectedPath)
+					assert.Contains(t, actualPath, expectedPath)
 				}
-				require.Equal(t, expectedProviderSymlinks, actualProviderSymlinks)
+				assert.Equal(t, expectedProviderSymlinks, actualProviderSymlinks)
 			}
 		}
-		require.Equal(t, expectedApps, actualApps)
+		assert.Equal(t, expectedApps, actualApps)
 	}
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3821,7 +3821,7 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 					"name":               "var-files",
 					"commands":           []interface{}{"apply", "plan"},
 					"arguments":          nil,
-					"required_var_files":  []interface{}{"extra.tfvars"},
+					"required_var_files": []interface{}{"extra.tfvars"},
 					"optional_var_files": []interface{}{"optional.tfvars"},
 					"env_vars": map[string]interface{}{
 						"TF_VAR_custom_var": "I'm set in extra_arguments env_vars",

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -298,8 +298,8 @@ func TestHclvalidateDiagnostic(t *testing.T) {
 		},
 		&diagnostic.Diagnostic{
 			Severity: diagnostic.DiagnosticSeverity(hcl.DiagError),
-			Summary:  "Missing assertd argument",
-			Detail:   "The argument \"config_path\" is assertd, but no definition was found.",
+			Summary:  "Missing required argument",
+			Detail:   "The argument \"config_path\" is required, but no definition was found.",
 			Range: &diagnostic.Range{
 				Filename: filepath.Join(rootPath, "second/c/terragrunt.hcl"),
 				Start:    diagnostic.Pos{Line: 16, Column: 16, Byte: 219},
@@ -3821,7 +3821,7 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 					"name":               "var-files",
 					"commands":           []interface{}{"apply", "plan"},
 					"arguments":          nil,
-					"assertd_var_files":  []interface{}{"extra.tfvars"},
+					"required_var_files":  []interface{}{"extra.tfvars"},
 					"optional_var_files": []interface{}{"optional.tfvars"},
 					"env_vars": map[string]interface{}{
 						"TF_VAR_custom_var": "I'm set in extra_arguments env_vars",
@@ -6036,7 +6036,7 @@ func TestTimeCmpInvalidTimestamp(t *testing.T) {
 
 	err := runTerragruntCommand(t, "terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
 
-	expectedError := `not a valid RFC3339 timestamp: missing assertd time introducer 'T'`
+	expectedError := `not a valid RFC3339 timestamp: missing required time introducer 'T'`
 	require.ErrorContains(t, err, expectedError)
 }
 
@@ -6438,7 +6438,7 @@ func TestRenderJsonWithInputsNotExistingOutput(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(expectedInputs, inputs))
 }
 
-func TestTerragruntFailIfBucketCreationIsassertd(t *testing.T) {
+func TestTerragruntFailIfBucketCreationIsrequired(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_PATH)
@@ -7134,7 +7134,7 @@ func TestTerragruntAssumeRoleWebIdentityEnv(t *testing.T) {
 	assumeRole := os.Getenv("AWS_TEST_S3_ASSUME_ROLE")
 	tokenEnvVar := os.Getenv("AWS_TEST_S3_IDENTITY_TOKEN_VAR")
 	if tokenEnvVar == "" {
-		t.Skip("Missing assertd env var AWS_TEST_S3_IDENTITY_TOKEN_VAR")
+		t.Skip("Missing required env var AWS_TEST_S3_IDENTITY_TOKEN_VAR")
 		return
 	}
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -248,7 +248,7 @@ func TestTerragruntExcludesFile(t *testing.T) {
 			require.NoError(t, err)
 
 			actualOutput := strings.Split(strings.TrimSpace(stdout), "\n")
-			require.ElementsMatch(t, testCase.expectedOutput, actualOutput)
+			assert.ElementsMatch(t, testCase.expectedOutput, actualOutput)
 		})
 	}
 }
@@ -298,8 +298,8 @@ func TestHclvalidateDiagnostic(t *testing.T) {
 		},
 		&diagnostic.Diagnostic{
 			Severity: diagnostic.DiagnosticSeverity(hcl.DiagError),
-			Summary:  "Missing required argument",
-			Detail:   "The argument \"config_path\" is required, but no definition was found.",
+			Summary:  "Missing assertd argument",
+			Detail:   "The argument \"config_path\" is assertd, but no definition was found.",
 			Range: &diagnostic.Range{
 				Filename: filepath.Join(rootPath, "second/c/terragrunt.hcl"),
 				Start:    diagnostic.Pos{Line: 16, Column: 16, Byte: 219},
@@ -357,7 +357,7 @@ func TestHclvalidateDiagnostic(t *testing.T) {
 	err = json.Unmarshal([]byte(strings.TrimSpace(stdout)), &actualDiags)
 	require.NoError(t, err)
 
-	require.ElementsMatch(t, expectedDiags, actualDiags)
+	assert.ElementsMatch(t, expectedDiags, actualDiags)
 }
 
 func TestHclvalidateInvalidConfigPath(t *testing.T) {
@@ -378,7 +378,7 @@ func TestHclvalidateInvalidConfigPath(t *testing.T) {
 	err = json.Unmarshal([]byte(strings.TrimSpace(stdout)), &actualPaths)
 	require.NoError(t, err)
 
-	require.ElementsMatch(t, expectedPaths, actualPaths)
+	assert.ElementsMatch(t, expectedPaths, actualPaths)
 }
 
 func TestTerragruntProviderCacheMultiplePlatforms(t *testing.T) {
@@ -413,28 +413,28 @@ func TestTerragruntProviderCacheMultiplePlatforms(t *testing.T) {
 
 	for _, appName := range []string{"app1", "app2", "app3"} {
 		appPath := filepath.Join(rootPath, appName)
-		require.True(t, util.FileExists(appPath))
+		assert.True(t, util.FileExists(appPath))
 
 		lockfilePath := filepath.Join(appPath, ".terraform.lock.hcl")
 		lockfileContent, err := os.ReadFile(lockfilePath)
 		require.NoError(t, err)
 
 		lockfile, diags := hclwrite.ParseConfig(lockfileContent, lockfilePath, hcl.Pos{Line: 1, Column: 1})
-		require.False(t, diags.HasErrors())
-		require.NotNil(t, lockfile)
+		assert.False(t, diags.HasErrors())
+		assert.NotNil(t, lockfile)
 
 		for _, provider := range providers {
 			provider := path.Join(registryName, provider)
 
 			providerBlock := lockfile.Body().FirstMatchingBlock("provider", []string{filepath.Dir(provider)})
-			require.NotNil(t, providerBlock)
+			assert.NotNil(t, providerBlock)
 
 			providerPath := filepath.Join(providerCacheDir, provider)
-			require.True(t, util.FileExists(providerPath))
+			assert.True(t, util.FileExists(providerPath))
 
 			for _, platform := range platforms {
 				platformPath := filepath.Join(providerPath, platform)
-				require.True(t, util.FileExists(platformPath))
+				assert.True(t, util.FileExists(platformPath))
 			}
 		}
 	}
@@ -448,7 +448,7 @@ func TestTerragruntInitOnce(t *testing.T) {
 
 	stdout, _, err := runTerragruntCommandWithOutput(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 	require.NoError(t, err)
-	require.Contains(t, stdout, "Initializing modules")
+	assert.Contains(t, stdout, "Initializing modules")
 
 	// update the config creation time without changing content
 	cfgPath := filepath.Join(rootPath, "terragrunt.hcl")
@@ -459,7 +459,7 @@ func TestTerragruntInitOnce(t *testing.T) {
 
 	stdout, _, err = runTerragruntCommandWithOutput(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 	require.NoError(t, err)
-	require.NotContains(t, stdout, "Initializing modules", "init command executed more than once")
+	assert.NotContains(t, stdout, "Initializing modules", "init command executed more than once")
 }
 
 func TestTerragruntDestroyOrder(t *testing.T) {
@@ -473,7 +473,7 @@ func TestTerragruntDestroyOrder(t *testing.T) {
 
 	stdout, _, err := runTerragruntCommandWithOutput(t, "terragrunt run-all destroy --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 	require.NoError(t, err)
-	require.Regexp(t, regexp.MustCompile(`(?smi)(?:(Module E|Module D|Module B).*){3}(?:(Module A|Module C).*){2}`), stdout)
+	assert.Regexp(t, regexp.MustCompile(`(?smi)(?:(Module E|Module D|Module B).*){3}(?:(Module A|Module C).*){2}`), stdout)
 }
 
 func TestTerragruntApplyDestroyOrder(t *testing.T) {
@@ -487,7 +487,7 @@ func TestTerragruntApplyDestroyOrder(t *testing.T) {
 
 	stdout, _, err := runTerragruntCommandWithOutput(t, "terragrunt run-all apply -destroy --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 	require.NoError(t, err)
-	require.Regexp(t, regexp.MustCompile(`(?smi)(?:(Module E|Module D|Module B).*){3}(?:(Module A|Module C).*){2}`), stdout)
+	assert.Regexp(t, regexp.MustCompile(`(?smi)(?:(Module E|Module D|Module B).*){3}(?:(Module A|Module C).*){2}`), stdout)
 }
 
 func TestTerragruntInitHookNoSourceNoBackend(t *testing.T) {
@@ -509,9 +509,9 @@ func TestTerragruntInitHookNoSourceNoBackend(t *testing.T) {
 		t.Errorf("Did not expect to get error: %s", err.Error())
 	}
 
-	require.Equal(t, 1, strings.Count(output, "AFTER_INIT_ONLY_ONCE"), "Hooks on init command executed more than once")
+	assert.Equal(t, 1, strings.Count(output, "AFTER_INIT_ONLY_ONCE"), "Hooks on init command executed more than once")
 	// With no source, `init-from-module` should not execute
-	require.NotContains(t, output, "AFTER_INIT_FROM_MODULE_ONLY_ONCE", "Hooks on init-from-module command executed when no source was specified")
+	assert.NotContains(t, output, "AFTER_INIT_FROM_MODULE_ONLY_ONCE", "Hooks on init-from-module command executed when no source was specified")
 }
 
 func TestTerragruntInitHookNoSourceWithBackend(t *testing.T) {
@@ -539,9 +539,9 @@ func TestTerragruntInitHookNoSourceWithBackend(t *testing.T) {
 		t.Errorf("Did not expect to get error: %s", err.Error())
 	}
 
-	require.Equal(t, 1, strings.Count(output, "AFTER_INIT_ONLY_ONCE"), "Hooks on init command executed more than once")
+	assert.Equal(t, 1, strings.Count(output, "AFTER_INIT_ONLY_ONCE"), "Hooks on init command executed more than once")
 	// With no source, `init-from-module` should not execute
-	require.NotContains(t, output, "AFTER_INIT_FROM_MODULE_ONLY_ONCE", "Hooks on init-from-module command executed when no source was specified")
+	assert.NotContains(t, output, "AFTER_INIT_FROM_MODULE_ONLY_ONCE", "Hooks on init-from-module command executed when no source was specified")
 }
 
 func TestTerragruntInitHookWithSourceNoBackend(t *testing.T) {
@@ -565,8 +565,8 @@ func TestTerragruntInitHookWithSourceNoBackend(t *testing.T) {
 		t.Errorf("Did not expect to get error: %s", err.Error())
 	}
 
-	require.Equal(t, 1, strings.Count(output, "AFTER_INIT_ONLY_ONCE\n"), "Hooks on init command executed more than once")
-	require.Equal(t, 1, strings.Count(output, "AFTER_INIT_FROM_MODULE_ONLY_ONCE\n"), "Hooks on init-from-module command executed more than once")
+	assert.Equal(t, 1, strings.Count(output, "AFTER_INIT_ONLY_ONCE\n"), "Hooks on init command executed more than once")
+	assert.Equal(t, 1, strings.Count(output, "AFTER_INIT_FROM_MODULE_ONLY_ONCE\n"), "Hooks on init-from-module command executed more than once")
 }
 
 func TestTerragruntInitHookWithSourceWithBackend(t *testing.T) {
@@ -596,9 +596,9 @@ func TestTerragruntInitHookWithSourceWithBackend(t *testing.T) {
 	}
 
 	// `init` hook should execute only once
-	require.Equal(t, 1, strings.Count(output, "AFTER_INIT_ONLY_ONCE"), "Hooks on init command executed more than once")
+	assert.Equal(t, 1, strings.Count(output, "AFTER_INIT_ONLY_ONCE"), "Hooks on init command executed more than once")
 	// `init-from-module` hook should execute only once
-	require.Equal(t, 1, strings.Count(output, "AFTER_INIT_FROM_MODULE_ONLY_ONCE"), "Hooks on init-from-module command executed more than once")
+	assert.Equal(t, 1, strings.Count(output, "AFTER_INIT_FROM_MODULE_ONLY_ONCE"), "Hooks on init-from-module command executed more than once")
 }
 
 func TestTerragruntHookRunAllApply(t *testing.T) {
@@ -694,13 +694,13 @@ func TestTerragruntBeforeAndAfterHook(t *testing.T) {
 		t.Errorf("Did not expect to get error: %s", err.Error())
 	}
 
-	require.Equal(t, 0, strings.Count(output, "BEFORE_TERRAGRUNT_READ_CONFIG"), "terragrunt-read-config before_hook should not be triggered")
+	assert.Equal(t, 0, strings.Count(output, "BEFORE_TERRAGRUNT_READ_CONFIG"), "terragrunt-read-config before_hook should not be triggered")
 	t.Logf("output: %s", output)
 
-	require.Equal(t, 1, strings.Count(output, "AFTER_TERRAGRUNT_READ_CONFIG"), "Hooks on terragrunt-read-config command executed more than once")
+	assert.Equal(t, 1, strings.Count(output, "AFTER_TERRAGRUNT_READ_CONFIG"), "Hooks on terragrunt-read-config command executed more than once")
 
 	expectedHookOutput := fmt.Sprintf("TF_PATH=%s COMMAND=terragrunt-read-config HOOK_NAME=after_hook_3", wrappedBinary())
-	require.Equal(t, 1, strings.Count(output, expectedHookOutput))
+	assert.Equal(t, 1, strings.Count(output, expectedHookOutput))
 
 	require.NoError(t, beforeException)
 	require.NoError(t, afterException)
@@ -762,15 +762,15 @@ func TestTerragruntSkipOnError(t *testing.T) {
 
 	output := stdout.String()
 
-	require.Contains(t, output, "BEFORE_SHOULD_DISPLAY")
-	require.NotContains(t, output, "BEFORE_NODISPLAY")
+	assert.Contains(t, output, "BEFORE_SHOULD_DISPLAY")
+	assert.NotContains(t, output, "BEFORE_NODISPLAY")
 
-	require.Contains(t, output, "AFTER_SHOULD_DISPLAY")
-	require.NotContains(t, output, "AFTER_NODISPLAY")
+	assert.Contains(t, output, "AFTER_SHOULD_DISPLAY")
+	assert.NotContains(t, output, "AFTER_NODISPLAY")
 
-	require.Contains(t, output, "ERROR_HOOK_EXECUTED")
-	require.NotContains(t, output, "NOT_MATCHING_ERROR_HOOK")
-	require.Contains(t, output, "PATTERN_MATCHING_ERROR_HOOK")
+	assert.Contains(t, output, "ERROR_HOOK_EXECUTED")
+	assert.NotContains(t, output, "NOT_MATCHING_ERROR_HOOK")
+	assert.Contains(t, output, "PATTERN_MATCHING_ERROR_HOOK")
 }
 
 func TestTerragruntCatchErrorsInTerraformExecution(t *testing.T) {
@@ -791,9 +791,9 @@ func TestTerragruntCatchErrorsInTerraformExecution(t *testing.T) {
 
 	output := stderr.String()
 
-	require.Contains(t, output, "pattern_matching_hook")
-	require.Contains(t, output, "catch_all_matching_hook")
-	require.NotContains(t, output, "not_matching_hook")
+	assert.Contains(t, output, "pattern_matching_hook")
+	assert.Contains(t, output, "catch_all_matching_hook")
+	assert.NotContains(t, output, "not_matching_hook")
 
 }
 
@@ -815,7 +815,7 @@ func TestTerragruntBeforeOneArgAction(t *testing.T) {
 	if err != nil {
 		t.Error("Expected successful execution of terragrunt with 1 before hook execution.")
 	} else {
-		require.Contains(t, output, "Running command: date")
+		assert.Contains(t, output, "Running command: date")
 	}
 }
 
@@ -834,7 +834,7 @@ func TestTerragruntEmptyStringCommandHook(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
 
 	if err != nil {
-		require.Contains(t, err.Error(), "Need at least one non-empty argument in 'execute'.")
+		assert.Contains(t, err.Error(), "Need at least one non-empty argument in 'execute'.")
 	} else {
 		t.Error("Expected an Error with message: 'Need at least one argument'")
 	}
@@ -855,7 +855,7 @@ func TestTerragruntEmptyCommandListHook(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
 
 	if err != nil {
-		require.Contains(t, err.Error(), "Need at least one non-empty argument in 'execute'.")
+		assert.Contains(t, err.Error(), "Need at least one non-empty argument in 'execute'.")
 	} else {
 		t.Error("Expected an Error with message: 'Need at least one argument'")
 	}
@@ -885,7 +885,7 @@ func TestTerragruntHookInterpolation(t *testing.T) {
 		t.Errorf("Did not expect to get error: %s", err.Error())
 	}
 
-	require.Contains(t, output, homePath)
+	assert.Contains(t, output, homePath)
 
 }
 
@@ -945,24 +945,24 @@ func TestTerragruntSetsAccessLoggingForTfSTateS3BuckeToADifferentBucketWithGiven
 	targetLoggingBucket := terraws.GetS3BucketLoggingTarget(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 	targetLoggingBucketPrefix := terraws.GetS3BucketLoggingTargetPrefix(t, TERRAFORM_REMOTE_STATE_S3_REGION, s3BucketName)
 
-	require.Equal(t, s3BucketLogsName, targetLoggingBucket)
-	require.Equal(t, s3BucketLogsTargetPrefix, targetLoggingBucketPrefix)
+	assert.Equal(t, s3BucketLogsName, targetLoggingBucket)
+	assert.Equal(t, s3BucketLogsTargetPrefix, targetLoggingBucketPrefix)
 
 	encryptionConfig, err := bucketEncryption(t, TERRAFORM_REMOTE_STATE_S3_REGION, targetLoggingBucket)
 	require.NoError(t, err)
-	require.NotNil(t, encryptionConfig)
-	require.NotNil(t, encryptionConfig.ServerSideEncryptionConfiguration)
+	assert.NotNil(t, encryptionConfig)
+	assert.NotNil(t, encryptionConfig.ServerSideEncryptionConfiguration)
 	for _, rule := range encryptionConfig.ServerSideEncryptionConfiguration.Rules {
 		if rule.ApplyServerSideEncryptionByDefault != nil {
 			if rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm != nil {
-				require.Equal(t, s3.ServerSideEncryptionAes256, *rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
+				assert.Equal(t, s3.ServerSideEncryptionAes256, *rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
 			}
 		}
 	}
 
 	policy, err := bucketPolicy(t, TERRAFORM_REMOTE_STATE_S3_REGION, targetLoggingBucket)
 	require.NoError(t, err)
-	require.NotNil(t, policy.Policy)
+	assert.NotNil(t, policy.Policy)
 
 	policyInBucket, err := aws_helper.UnmarshalPolicy(*policy.Policy)
 	require.NoError(t, err)
@@ -972,7 +972,7 @@ func TestTerragruntSetsAccessLoggingForTfSTateS3BuckeToADifferentBucketWithGiven
 			enforceSSE = true
 		}
 	}
-	require.True(t, enforceSSE)
+	assert.True(t, enforceSSE)
 }
 
 // Regression test to ensure that `accesslogging_bucket_name` is taken into account
@@ -1005,18 +1005,18 @@ func TestTerragruntSetsAccessLoggingForTfSTateS3BuckeToADifferentBucketWithDefau
 
 	encryptionConfig, err := bucketEncryption(t, TERRAFORM_REMOTE_STATE_S3_REGION, targetLoggingBucket)
 	require.NoError(t, err)
-	require.NotNil(t, encryptionConfig)
-	require.NotNil(t, encryptionConfig.ServerSideEncryptionConfiguration)
+	assert.NotNil(t, encryptionConfig)
+	assert.NotNil(t, encryptionConfig.ServerSideEncryptionConfiguration)
 	for _, rule := range encryptionConfig.ServerSideEncryptionConfiguration.Rules {
 		if rule.ApplyServerSideEncryptionByDefault != nil {
 			if rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm != nil {
-				require.Equal(t, s3.ServerSideEncryptionAes256, *rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
+				assert.Equal(t, s3.ServerSideEncryptionAes256, *rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
 			}
 		}
 	}
 
-	require.Equal(t, s3BucketLogsName, targetLoggingBucket)
-	require.Equal(t, remote.DefaultS3BucketAccessLoggingTargetPrefix, targetLoggingBucketPrefix)
+	assert.Equal(t, s3BucketLogsName, targetLoggingBucket)
+	assert.Equal(t, remote.DefaultS3BucketAccessLoggingTargetPrefix, targetLoggingBucketPrefix)
 }
 
 func TestTerragruntWorksWithGCSBackend(t *testing.T) {
@@ -1084,9 +1084,9 @@ func TestTerragruntWorksWithNonDefaultConfigNamesAndRunAllCommand(t *testing.T) 
 	require.NoError(t, err)
 
 	out := stdout.String()
-	require.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
-	require.Equal(t, 1, strings.Count(out, "dependency_hcl"))
-	require.Equal(t, 1, strings.Count(out, "common_hcl"))
+	assert.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
+	assert.Equal(t, 1, strings.Count(out, "dependency_hcl"))
+	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
 }
 
 func TestTerragruntWorksWithNonDefaultConfigNames(t *testing.T) {
@@ -1102,9 +1102,9 @@ func TestTerragruntWorksWithNonDefaultConfigNames(t *testing.T) {
 	require.NoError(t, err)
 
 	out := stdout.String()
-	require.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
-	require.Equal(t, 1, strings.Count(out, "dependency_hcl"))
-	require.Equal(t, 1, strings.Count(out, "common_hcl"))
+	assert.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
+	assert.Equal(t, 1, strings.Count(out, "dependency_hcl"))
+	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
 }
 
 func TestTerragruntReportsTerraformErrorsWithPlanAll(t *testing.T) {
@@ -1126,8 +1126,8 @@ func TestTerragruntReportsTerraformErrorsWithPlanAll(t *testing.T) {
 	output := stdout.String()
 	errOutput := stderr.String()
 	fmt.Printf("STDERR is %s.\n STDOUT is %s", errOutput, output)
-	require.True(t, strings.Contains(errOutput, "missingvar1") || strings.Contains(output, "missingvar1"))
-	require.True(t, strings.Contains(errOutput, "missingvar2") || strings.Contains(output, "missingvar2"))
+	assert.True(t, strings.Contains(errOutput, "missingvar1") || strings.Contains(output, "missingvar1"))
+	assert.True(t, strings.Contains(errOutput, "missingvar2") || strings.Contains(output, "missingvar2"))
 }
 
 func TestTerragruntGraphDependenciesCommand(t *testing.T) {
@@ -1149,7 +1149,7 @@ func TestTerragruntGraphDependenciesCommand(t *testing.T) {
 	)
 	runTerragruntRedirectOutput(t, "terragrunt graph-dependencies --terragrunt-working-dir "+environmentPath, &stdout, &stderr)
 	output := stdout.String()
-	require.True(t, strings.Contains(output, strings.TrimSpace(`
+	assert.True(t, strings.Contains(output, strings.TrimSpace(`
 digraph {
 	"backend-app" ;
 	"backend-app" -> "mysql";
@@ -1205,11 +1205,11 @@ func TestTerragruntOutputAllCommand(t *testing.T) {
 	runTerragruntRedirectOutput(t, "terragrunt output-all --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath, &stdout, &stderr)
 	output := stdout.String()
 
-	require.True(t, strings.Contains(output, "app1 output"))
-	require.True(t, strings.Contains(output, "app2 output"))
-	require.True(t, strings.Contains(output, "app3 output"))
+	assert.True(t, strings.Contains(output, "app1 output"))
+	assert.True(t, strings.Contains(output, "app2 output"))
+	assert.True(t, strings.Contains(output, "app3 output"))
 
-	require.True(t, (strings.Index(output, "app3 output") < strings.Index(output, "app1 output")) && (strings.Index(output, "app1 output") < strings.Index(output, "app2 output")))
+	assert.True(t, (strings.Index(output, "app3 output") < strings.Index(output, "app1 output")) && (strings.Index(output, "app1 output") < strings.Index(output, "app2 output")))
 }
 
 func TestTerragruntOutputFromDependency(t *testing.T) {
@@ -1236,7 +1236,7 @@ func TestTerragruntOutputFromDependency(t *testing.T) {
 	require.NoError(t, err)
 
 	output := stderr.String()
-	require.NotContains(t, output, "invalid character")
+	assert.NotContains(t, output, "invalid character")
 }
 
 func TestTerragruntValidateAllCommand(t *testing.T) {
@@ -1268,7 +1268,7 @@ func TestTerragruntStdOut(t *testing.T) {
 	runTerragruntRedirectOutput(t, "terragrunt output foo --terragrunt-non-interactive --terragrunt-working-dir "+TEST_FIXTURE_STDOUT, &stdout, &stderr)
 
 	output := stdout.String()
-	require.Equal(t, "\"foo\"\n", output)
+	assert.Equal(t, "\"foo\"\n", output)
 }
 
 func TestTerragruntOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *testing.T) {
@@ -1298,7 +1298,7 @@ func TestTerragruntOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *tes
 	logBufferContentsLineByLine(t, stderr, "output-all stderr")
 
 	// Without --terragrunt-ignore-dependency-errors, app2 never runs because its dependencies have "errors" since they don't have the output "app2_text".
-	require.True(t, strings.Contains(output, "app2 output"))
+	assert.True(t, strings.Contains(output, "app2 output"))
 }
 
 func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules int, timeToDeployEachModule time.Duration) (string, int, error) {
@@ -1404,7 +1404,7 @@ func TestInvalidSource(t *testing.T) {
 	var workingDirNotFoundErr terraform.WorkingDirNotFound
 	// _, ok := errors.Unwrap(err).(terraform.WorkingDirNotFound)
 	ok := goErrors.As(err, &workingDirNotFoundErr)
-	require.True(t, ok)
+	assert.True(t, ok)
 }
 
 // Run terragrunt plan -detailed-exitcode on a folder with some uncreated resources and make sure that you get an exit
@@ -1418,7 +1418,7 @@ func TestExitCode(t *testing.T) {
 
 	exitCode, exitCodeErr := util.GetExitCode(err)
 	require.NoError(t, exitCodeErr)
-	require.Equal(t, 2, exitCode)
+	assert.Equal(t, 2, exitCode)
 }
 
 func TestAutoRetryBasicRerun(t *testing.T) {
@@ -1430,7 +1430,7 @@ func TestAutoRetryBasicRerun(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+modulePath, out, os.Stderr)
 
 	require.NoError(t, err)
-	require.Contains(t, out.String(), "Apply complete!")
+	assert.Contains(t, out.String(), "Apply complete!")
 }
 
 func TestAutoRetrySkip(t *testing.T) {
@@ -1442,7 +1442,7 @@ func TestAutoRetrySkip(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-no-auto-retry --terragrunt-non-interactive --terragrunt-working-dir "+modulePath, out, os.Stderr)
 
 	require.Error(t, err)
-	require.NotContains(t, out.String(), "Apply complete!")
+	assert.NotContains(t, out.String(), "Apply complete!")
 }
 
 func TestPlanfileOrder(t *testing.T) {
@@ -1467,8 +1467,8 @@ func TestAutoRetryExhaustRetries(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+modulePath, out, os.Stderr)
 
 	require.Error(t, err)
-	require.Contains(t, out.String(), "Failed to load backend")
-	require.NotContains(t, out.String(), "Apply complete!")
+	assert.Contains(t, out.String(), "Failed to load backend")
+	assert.NotContains(t, out.String(), "Apply complete!")
 }
 
 func TestAutoRetryCustomRetryableErrors(t *testing.T) {
@@ -1480,8 +1480,8 @@ func TestAutoRetryCustomRetryableErrors(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt apply --auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+modulePath, out, os.Stderr)
 
 	require.NoError(t, err)
-	require.Contains(t, out.String(), "My own little error")
-	require.Contains(t, out.String(), "Apply complete!")
+	assert.Contains(t, out.String(), "My own little error")
+	assert.Contains(t, out.String(), "Apply complete!")
 }
 
 func TestAutoRetryGetDefaultErrors(t *testing.T) {
@@ -1500,8 +1500,8 @@ func TestAutoRetryGetDefaultErrors(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
 	list, hasVal := outputs["retryable_errors"]
-	require.True(t, hasVal)
-	require.ElementsMatch(t, list.Value, append(options.DEFAULT_RETRYABLE_ERRORS, "my special snowflake"))
+	assert.True(t, hasVal)
+	assert.ElementsMatch(t, list.Value, append(options.DEFAULT_RETRYABLE_ERRORS, "my special snowflake"))
 }
 
 func TestAutoRetryCustomRetryableErrorsFailsWhenRetryableErrorsNotSet(t *testing.T) {
@@ -1513,8 +1513,8 @@ func TestAutoRetryCustomRetryableErrorsFailsWhenRetryableErrorsNotSet(t *testing
 	err := runTerragruntCommand(t, "terragrunt apply --auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+modulePath, out, os.Stderr)
 
 	require.Error(t, err)
-	require.Contains(t, out.String(), "My own little error")
-	require.NotContains(t, out.String(), "Apply complete!")
+	assert.Contains(t, out.String(), "My own little error")
+	assert.NotContains(t, out.String(), "Apply complete!")
 }
 
 func TestAutoRetryFlagWithRecoverableError(t *testing.T) {
@@ -1526,7 +1526,7 @@ func TestAutoRetryFlagWithRecoverableError(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-no-auto-retry --terragrunt-non-interactive --terragrunt-working-dir "+modulePath, out, os.Stderr)
 
 	require.Error(t, err)
-	require.NotContains(t, out.String(), "Apply complete!")
+	assert.NotContains(t, out.String(), "Apply complete!")
 }
 
 func TestAutoRetryEnvVarWithRecoverableError(t *testing.T) {
@@ -1537,7 +1537,7 @@ func TestAutoRetryEnvVarWithRecoverableError(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+modulePath, out, os.Stderr)
 
 	require.Error(t, err)
-	require.NotContains(t, out.String(), "Apply complete!")
+	assert.NotContains(t, out.String(), "Apply complete!")
 }
 
 func TestAutoRetryApplyAllDependentModuleRetries(t *testing.T) {
@@ -1550,10 +1550,10 @@ func TestAutoRetryApplyAllDependentModuleRetries(t *testing.T) {
 
 	require.NoError(t, err)
 	s := out.String()
-	require.Contains(t, s, "app1 output")
-	require.Contains(t, s, "app2 output")
-	require.Contains(t, s, "app3 output")
-	require.Contains(t, s, "Apply complete!")
+	assert.Contains(t, s, "app1 output")
+	assert.Contains(t, s, "app2 output")
+	assert.Contains(t, s, "app3 output")
+	assert.Contains(t, s, "Apply complete!")
 }
 
 func TestAutoRetryConfigurableRetries(t *testing.T) {
@@ -1567,8 +1567,8 @@ func TestAutoRetryConfigurableRetries(t *testing.T) {
 	sleeps := regexp.MustCompile("Sleeping 0s before retrying.").FindAllStringIndex(stderr.String(), -1)
 
 	require.NoError(t, err)
-	require.Len(t, sleeps, 4) // 5 retries, so 4 sleeps
-	require.Contains(t, stdout.String(), "Apply complete!")
+	assert.Len(t, sleeps, 4) // 5 retries, so 4 sleeps
+	assert.Contains(t, stdout.String(), "Apply complete!")
 }
 
 func TestAutoRetryConfigurableRetriesErrors(t *testing.T) {
@@ -1593,8 +1593,8 @@ func TestAutoRetryConfigurableRetriesErrors(t *testing.T) {
 
 			err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+modulePath, stdout, stderr)
 			require.Error(t, err)
-			require.NotContains(t, stdout.String(), "Apply complete!")
-			require.Contains(t, err.Error(), tc.errorMessage)
+			assert.NotContains(t, stdout.String(), "Apply complete!")
+			assert.Contains(t, err.Error(), tc.errorMessage)
 		})
 	}
 }
@@ -1623,7 +1623,7 @@ func TestAwsProviderPatch(t *testing.T) {
 	)
 	t.Log(stderr.String())
 
-	require.Regexp(t, "Patching AWS provider in .+test/fixture-aws-provider-patch/example-module/main.tf", stderr.String())
+	assert.Regexp(t, "Patching AWS provider in .+test/fixture-aws-provider-patch/example-module/main.tf", stderr.String())
 
 	// Make sure the resulting terraform code is still valid
 	require.NoError(
@@ -1688,7 +1688,7 @@ func TestTerraformCommandCliArgs(t *testing.T) {
 
 		output := stdout.String()
 		errOutput := stderr.String()
-		require.True(t, strings.Contains(errOutput, testCase.expected) || strings.Contains(output, testCase.expected))
+		assert.True(t, strings.Contains(errOutput, testCase.expected) || strings.Contains(output, testCase.expected))
 	}
 }
 
@@ -1732,7 +1732,7 @@ func TestTerraformSubcommandCliArgs(t *testing.T) {
 		}
 		output := stdout.String()
 		errOutput := stderr.String()
-		require.True(t, strings.Contains(errOutput, testCase.expected) || strings.Contains(output, testCase.expected))
+		assert.True(t, strings.Contains(errOutput, testCase.expected) || strings.Contains(output, testCase.expected))
 	}
 }
 
@@ -1755,7 +1755,7 @@ func TestPreventDestroyNotSet(t *testing.T) {
 
 	if assert.Error(t, err) {
 		underlying := errors.Unwrap(err)
-		require.IsType(t, terraform.ModuleIsProtected{}, underlying)
+		assert.IsType(t, terraform.ModuleIsProtected{}, underlying)
 	}
 }
 
@@ -1771,7 +1771,7 @@ func TestPreventDestroy(t *testing.T) {
 
 	if assert.Error(t, err) {
 		underlying := errors.Unwrap(err)
-		require.IsType(t, terraform.ModuleIsProtected{}, underlying)
+		assert.IsType(t, terraform.ModuleIsProtected{}, underlying)
 	}
 }
 
@@ -1787,7 +1787,7 @@ func TestPreventDestroyApply(t *testing.T) {
 
 	if assert.Error(t, err) {
 		underlying := errors.Unwrap(err)
-		require.IsType(t, terraform.ModuleIsProtected{}, underlying)
+		assert.IsType(t, terraform.ModuleIsProtected{}, underlying)
 	}
 }
 
@@ -1838,7 +1838,7 @@ func TestPreventDestroyDependencies(t *testing.T) {
 
 	if assert.Error(t, err) {
 		underlying := errors.Unwrap(err)
-		require.IsType(t, &multierror.Error{}, underlying)
+		assert.IsType(t, &multierror.Error{}, underlying)
 	}
 
 	// Check that modules C, D and E were deleted and modules A and B weren't.
@@ -1856,31 +1856,31 @@ func TestPreventDestroyDependencies(t *testing.T) {
 		output := showStdout.String()
 		switch moduleName {
 		case "module-a":
-			require.Contains(t, output, "Hello, Module A")
+			assert.Contains(t, output, "Hello, Module A")
 		case "module-b":
-			require.Contains(t, output, "Hello, Module B")
+			assert.Contains(t, output, "Hello, Module B")
 		case "module-c":
-			require.NotContains(t, output, "Hello, Module C")
+			assert.NotContains(t, output, "Hello, Module C")
 		case "module-d":
-			require.NotContains(t, output, "Hello, Module D")
+			assert.NotContains(t, output, "Hello, Module D")
 		case "module-e":
-			require.NotContains(t, output, "Hello, Module E")
+			assert.NotContains(t, output, "Hello, Module E")
 		}
 	}
 }
 
 func validateInputs(t *testing.T, outputs map[string]TerraformOutput) {
-	require.Equal(t, true, outputs["bool"].Value)
-	require.Equal(t, []interface{}{true, false}, outputs["list_bool"].Value)
-	require.Equal(t, []interface{}{1.0, 2.0, 3.0}, outputs["list_number"].Value)
-	require.Equal(t, []interface{}{"a", "b", "c"}, outputs["list_string"].Value)
-	require.Equal(t, map[string]interface{}{"foo": true, "bar": false, "baz": true}, outputs["map_bool"].Value)
-	require.Equal(t, map[string]interface{}{"foo": 42.0, "bar": 12345.0}, outputs["map_number"].Value)
-	require.Equal(t, map[string]interface{}{"foo": "bar"}, outputs["map_string"].Value)
-	require.InEpsilon(t, 42.0, outputs["number"].Value, 0.0000000001)
-	require.Equal(t, map[string]interface{}{"list": []interface{}{1.0, 2.0, 3.0}, "map": map[string]interface{}{"foo": "bar"}, "num": 42.0, "str": "string"}, outputs["object"].Value)
-	require.Equal(t, "string", outputs["string"].Value)
-	require.Equal(t, "default", outputs["from_env"].Value)
+	assert.Equal(t, true, outputs["bool"].Value)
+	assert.Equal(t, []interface{}{true, false}, outputs["list_bool"].Value)
+	assert.Equal(t, []interface{}{1.0, 2.0, 3.0}, outputs["list_number"].Value)
+	assert.Equal(t, []interface{}{"a", "b", "c"}, outputs["list_string"].Value)
+	assert.Equal(t, map[string]interface{}{"foo": true, "bar": false, "baz": true}, outputs["map_bool"].Value)
+	assert.Equal(t, map[string]interface{}{"foo": 42.0, "bar": 12345.0}, outputs["map_number"].Value)
+	assert.Equal(t, map[string]interface{}{"foo": "bar"}, outputs["map_string"].Value)
+	assert.InEpsilon(t, 42.0, outputs["number"].Value, 0.0000000001)
+	assert.Equal(t, map[string]interface{}{"list": []interface{}{1.0, 2.0, 3.0}, "map": map[string]interface{}{"foo": "bar"}, "num": 42.0, "str": "string"}, outputs["object"].Value)
+	assert.Equal(t, "string", outputs["string"].Value)
+	assert.Equal(t, "default", outputs["from_env"].Value)
 }
 
 func TestInputsPassedThroughCorrectly(t *testing.T) {
@@ -1915,7 +1915,7 @@ func TestNoAutoInit(t *testing.T) {
 	logBufferContentsLineByLine(t, stdout, "no force apply stdout")
 	logBufferContentsLineByLine(t, stderr, "no force apply stderr")
 	require.Error(t, err)
-	require.Contains(t, stderr.String(), "This module is not yet installed.")
+	assert.Contains(t, stderr.String(), "This module is not yet installed.")
 }
 
 func TestLocalsParsing(t *testing.T) {
@@ -1934,8 +1934,8 @@ func TestLocalsParsing(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, "Hello world\n", outputs["data"].Value)
-	require.InEpsilon(t, 42.0, outputs["answer"].Value, 0.0000000001)
+	assert.Equal(t, "Hello world\n", outputs["data"].Value)
+	assert.InEpsilon(t, 42.0, outputs["answer"].Value, 0.0000000001)
 }
 
 func TestLocalsInInclude(t *testing.T) {
@@ -1958,22 +1958,22 @@ func TestLocalsInInclude(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(
+	assert.Equal(
 		t,
 		filepath.Join(tmpEnvPath, TEST_FIXTURE_LOCALS_IN_INCLUDE),
 		outputs["parent_terragrunt_dir"].Value,
 	)
-	require.Equal(
+	assert.Equal(
 		t,
 		childPath,
 		outputs["terragrunt_dir"].Value,
 	)
-	require.Equal(
+	assert.Equal(
 		t,
 		"apply",
 		outputs["terraform_command"].Value,
 	)
-	require.Equal(
+	assert.Equal(
 		t,
 		"[\"apply\",\"-auto-approve\",\"-no-color\"]",
 		outputs["terraform_cli_args"].Value,
@@ -2047,7 +2047,7 @@ func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {
 
 	if assert.Error(t, err) {
 		underlying := errors.Unwrap(err)
-		require.IsType(t, &multierror.Error{}, underlying)
+		assert.IsType(t, &multierror.Error{}, underlying)
 	}
 
 	// Check that modules C, D and E were deleted and modules A and B weren't.
@@ -2065,11 +2065,11 @@ func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {
 		output := showStdout.String()
 		switch moduleName {
 		case "module-a":
-			require.Contains(t, output, "Hello, Module A")
+			assert.Contains(t, output, "Hello, Module A")
 		case "module-b":
-			require.Contains(t, output, "Hello, Module B")
+			assert.Contains(t, output, "Hello, Module B")
 		case "module-c":
-			require.NotContains(t, output, "Hello, Module C")
+			assert.NotContains(t, output, "Hello, Module C")
 		}
 	}
 }
@@ -2087,9 +2087,9 @@ func TestTerragruntMissingDependenciesFail(t *testing.T) {
 	require.Error(t, err)
 	var parsedError config.DependencyDirNotFoundError
 	ok := goErrors.As(err, &parsedError)
-	require.True(t, ok)
-	require.Len(t, parsedError.Dir, 1)
-	require.Contains(t, parsedError.Dir[0], "hl3-release")
+	assert.True(t, ok)
+	assert.Len(t, parsedError.Dir, 1)
+	assert.Contains(t, parsedError.Dir[0], "hl3-release")
 }
 
 func TestTerragruntExcludeExternalDependencies(t *testing.T) {
@@ -2125,8 +2125,8 @@ func TestTerragruntExcludeExternalDependencies(t *testing.T) {
 		t.Errorf("Did not expect to get error: %s", err.Error())
 	}
 
-	require.Contains(t, applyAllStdoutString, "Hello World, "+includedModule)
-	require.NotContains(t, applyAllStdoutString, "Hello World, "+excludedModule)
+	assert.Contains(t, applyAllStdoutString, "Hello World, "+includedModule)
+	assert.NotContains(t, applyAllStdoutString, "Hello World, "+excludedModule)
 }
 
 func TestApplySkipTrue(t *testing.T) {
@@ -2146,8 +2146,8 @@ func TestApplySkipTrue(t *testing.T) {
 	stderr := showStderr.String()
 
 	require.NoError(t, err)
-	require.Regexp(t, regexp.MustCompile("Skipping terragrunt module .*fixture-skip/skip-true/terragrunt.hcl due to skip = true."), stderr)
-	require.NotContains(t, stdout, "hello, Hobbs")
+	assert.Regexp(t, regexp.MustCompile("Skipping terragrunt module .*fixture-skip/skip-true/terragrunt.hcl due to skip = true."), stderr)
+	assert.NotContains(t, stdout, "hello, Hobbs")
 }
 
 func TestApplySkipFalse(t *testing.T) {
@@ -2167,8 +2167,8 @@ func TestApplySkipFalse(t *testing.T) {
 	stdout := showStdout.String()
 
 	require.NoError(t, err)
-	require.Contains(t, stdout, "hello, Hobbs")
-	require.NotContains(t, stderr, "Skipping terragrunt module")
+	assert.Contains(t, stdout, "hello, Hobbs")
+	assert.NotContains(t, stderr, "Skipping terragrunt module")
 }
 
 func TestApplyAllSkipTrue(t *testing.T) {
@@ -2188,9 +2188,9 @@ func TestApplyAllSkipTrue(t *testing.T) {
 	stderr := showStderr.String()
 
 	require.NoError(t, err)
-	require.Regexp(t, regexp.MustCompile("Skipping terragrunt module .*fixture-skip/skip-true/terragrunt.hcl due to skip = true."), stderr)
-	require.Contains(t, stdout, "hello, Ernie")
-	require.Contains(t, stdout, "hello, Bert")
+	assert.Regexp(t, regexp.MustCompile("Skipping terragrunt module .*fixture-skip/skip-true/terragrunt.hcl due to skip = true."), stderr)
+	assert.Contains(t, stdout, "hello, Ernie")
+	assert.Contains(t, stdout, "hello, Bert")
 }
 
 func TestApplyAllSkipFalse(t *testing.T) {
@@ -2210,10 +2210,10 @@ func TestApplyAllSkipFalse(t *testing.T) {
 	stderr := showStderr.String()
 
 	require.NoError(t, err)
-	require.Contains(t, stdout, "hello, Hobbs")
-	require.Contains(t, stdout, "hello, Ernie")
-	require.Contains(t, stdout, "hello, Bert")
-	require.NotContains(t, stderr, "Skipping terragrunt module")
+	assert.Contains(t, stdout, "hello, Hobbs")
+	assert.Contains(t, stdout, "hello, Ernie")
+	assert.Contains(t, stdout, "hello, Bert")
+	assert.NotContains(t, stderr, "Skipping terragrunt module")
 }
 
 func TestTerragruntInfo(t *testing.T) {
@@ -2235,9 +2235,9 @@ func TestTerragruntInfo(t *testing.T) {
 	errUnmarshal := json.Unmarshal(showStdout.Bytes(), &dat)
 	require.NoError(t, errUnmarshal)
 
-	require.Equal(t, fmt.Sprintf("%s/%s", rootPath, TERRAGRUNT_CACHE), dat.DownloadDir)
-	require.Equal(t, wrappedBinary(), dat.TerraformBinary)
-	require.Empty(t, dat.IamRole)
+	assert.Equal(t, fmt.Sprintf("%s/%s", rootPath, TERRAGRUNT_CACHE), dat.DownloadDir)
+	assert.Equal(t, wrappedBinary(), dat.TerraformBinary)
+	assert.Empty(t, dat.IamRole)
 }
 
 // Test case for yamldecode bug: https://github.com/gruntwork-io/terragrunt/issues/834
@@ -2261,9 +2261,9 @@ func TestYamlDecodeRegressions(t *testing.T) {
 
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, "003", outputs["test1"].Value)
-	require.Equal(t, "1.00", outputs["test2"].Value)
-	require.Equal(t, "0ba", outputs["test3"].Value)
+	assert.Equal(t, "003", outputs["test1"].Value)
+	assert.Equal(t, "1.00", outputs["test2"].Value)
+	assert.Equal(t, "0ba", outputs["test3"].Value)
 }
 
 // We test the path with remote_state blocks by:
@@ -2325,7 +2325,7 @@ func dependencyOutputOptimizationTest(t *testing.T, moduleName string, forceInit
 
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &outputs))
-	require.Equal(t, expectedOutput, outputs["output"].Value)
+	assert.Equal(t, expectedOutput, outputs["output"].Value)
 
 	// If we want to force reinit, delete the relevant .terraform directories
 	if forceInit {
@@ -2339,13 +2339,13 @@ func dependencyOutputOptimizationTest(t *testing.T, moduleName string, forceInit
 	require.NoError(t, err)
 
 	require.NoError(t, json.Unmarshal([]byte(reout), &outputs))
-	require.Equal(t, expectedOutput, outputs["output"].Value)
+	assert.Equal(t, expectedOutput, outputs["output"].Value)
 
 	for _, logRegexp := range expectedOutputLogs {
 		re, err := regexp.Compile(logRegexp)
 		require.NoError(t, err)
 		matches := re.FindAllString(reerr, -1)
-		require.NotEmpty(t, matches)
+		assert.NotEmpty(t, matches)
 	}
 }
 
@@ -2380,7 +2380,7 @@ func TestDependencyOutputOptimizationDisableTest(t *testing.T) {
 
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &outputs))
-	require.Equal(t, expectedOutput, outputs["output"].Value)
+	assert.Equal(t, expectedOutput, outputs["output"].Value)
 
 	// Now delete the deepdep state and verify it no longer works, because it tries to fetch the deepdep dependency
 	config.ClearOutputCache()
@@ -2411,7 +2411,7 @@ func TestDependencyOutput(t *testing.T) {
 
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, 42, int(outputs["z"].Value.(float64)))
+	assert.Equal(t, 42, int(outputs["z"].Value.(float64)))
 }
 
 func TestDependencyOutputErrorBeforeApply(t *testing.T) {
@@ -2428,7 +2428,7 @@ func TestDependencyOutputErrorBeforeApply(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+app3Path, &showStdout, &showStderr)
 	require.Error(t, err)
 	// Verify that we fail because the dependency is not applied yet
-	require.Contains(t, err.Error(), "has not been applied yet")
+	assert.Contains(t, err.Error(), "has not been applied yet")
 
 	logBufferContentsLineByLine(t, showStdout, "show stdout")
 	logBufferContentsLineByLine(t, showStderr, "show stderr")
@@ -2480,7 +2480,7 @@ func TestDependencyOutputSkipOutputsWithMockOutput(t *testing.T) {
 	)
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, "The answer is 0", outputs["truth"].Value)
+	assert.Equal(t, "The answer is 0", outputs["truth"].Value)
 
 	// Now apply-all so that the dependency is applied, and verify it still uses the mock output
 	err = runTerragruntCommand(t, "terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &showStdout, &showStderr)
@@ -2498,7 +2498,7 @@ func TestDependencyOutputSkipOutputsWithMockOutput(t *testing.T) {
 	)
 	outputs = map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, "The answer is 0", outputs["truth"].Value)
+	assert.Equal(t, "The answer is 0", outputs["truth"].Value)
 }
 
 // Test that when you have a mock_output on a dependency, the dependency will use the mock as the output instead
@@ -2529,7 +2529,7 @@ func TestDependencyMockOutput(t *testing.T) {
 	)
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, "The answer is 0", outputs["truth"].Value)
+	assert.Equal(t, "The answer is 0", outputs["truth"].Value)
 
 	// We need to bust the output cache that stores the dependency outputs so that the second run pulls the outputs.
 	// This is only a problem during testing, where the process is shared across terragrunt runs.
@@ -2551,7 +2551,7 @@ func TestDependencyMockOutput(t *testing.T) {
 	)
 	outputs = map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, "The answer is 42", outputs["truth"].Value)
+	assert.Equal(t, "The answer is 42", outputs["truth"].Value)
 }
 
 // Test default behavior when mock_outputs_merge_with_state is not set. It should behave, as before this parameter was added
@@ -2580,7 +2580,7 @@ func TestDependencyMockOutputMergeWithStateDefault(t *testing.T) {
 	require.Error(t, err)
 	// Verify that we fail because the dependency is not applied yet, and the new attribute is not available and in
 	// this case, mocked outputs are not used.
-	require.Contains(t, err.Error(), "This object does not have an attribute named \"test_output2\"")
+	assert.Contains(t, err.Error(), "This object does not have an attribute named \"test_output2\"")
 
 	logBufferContentsLineByLine(t, stdout, "plan stdout")
 	logBufferContentsLineByLine(t, stderr, "plan stderr")
@@ -2613,7 +2613,7 @@ func TestDependencyMockOutputMergeWithStateFalse(t *testing.T) {
 	require.Error(t, err)
 	// Verify that we fail because the dependency is not applied yet, and the new attribute is not available and in
 	// this case, mocked outputs are not used.
-	require.Contains(t, err.Error(), "This object does not have an attribute named \"test_output2\"")
+	assert.Contains(t, err.Error(), "This object does not have an attribute named \"test_output2\"")
 
 	logBufferContentsLineByLine(t, stdout, "plan stdout")
 	logBufferContentsLineByLine(t, stderr, "plan stderr")
@@ -2657,8 +2657,8 @@ func TestDependencyMockOutputMergeWithStateTrue(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
-	require.Equal(t, "fake-data2", outputs["test_output2_from_parent"].Value)
+	assert.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
+	assert.Equal(t, "fake-data2", outputs["test_output2_from_parent"].Value)
 
 	logBufferContentsLineByLine(t, stdout, "output stdout")
 	logBufferContentsLineByLine(t, stderr, "output stderr")
@@ -2734,8 +2734,8 @@ func TestDependencyMockOutputMergeWithStateNoOverride(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
-	require.Equal(t, "value2", outputs["test_output2_from_parent"].Value)
+	assert.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
+	assert.Equal(t, "value2", outputs["test_output2_from_parent"].Value)
 
 	logBufferContentsLineByLine(t, stdout, "show stdout")
 	logBufferContentsLineByLine(t, stderr, "show stderr")
@@ -2755,7 +2755,7 @@ func TestDependencyMockOutputMergeStrategyWithStateDefault(t *testing.T) {
 
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+childPath, &stdout, &stderr)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "This object does not have an attribute named \"test_output_list_string\"")
+	assert.Contains(t, err.Error(), "This object does not have an attribute named \"test_output_list_string\"")
 	logBufferContentsLineByLine(t, stdout, "apply stdout")
 	logBufferContentsLineByLine(t, stderr, "apply stderr")
 }
@@ -2774,7 +2774,7 @@ func TestDependencyMockOutputMergeStrategyWithStateCompatFalse(t *testing.T) {
 
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+childPath, &stdout, &stderr)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "This object does not have an attribute named \"test_output_list_string\"")
+	assert.Contains(t, err.Error(), "This object does not have an attribute named \"test_output_list_string\"")
 	logBufferContentsLineByLine(t, stdout, "apply stdout")
 	logBufferContentsLineByLine(t, stderr, "apply stderr")
 }
@@ -2805,11 +2805,11 @@ func TestDependencyMockOutputMergeStrategyWithStateCompatTrue(t *testing.T) {
 	logBufferContentsLineByLine(t, stdout, "output stdout")
 	logBufferContentsLineByLine(t, stderr, "output stderr")
 
-	require.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
-	require.Equal(t, "map_root1_sub1_value", util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "map_root1", "map_root1_sub1", "value"))
-	require.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "not_in_state", "abc", "value"))
-	require.Equal(t, "fake-list-data", util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "0"))
-	require.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "1"))
+	assert.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
+	assert.Equal(t, "map_root1_sub1_value", util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "map_root1", "map_root1_sub1", "value"))
+	assert.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "not_in_state", "abc", "value"))
+	assert.Equal(t, "fake-list-data", util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "0"))
+	assert.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "1"))
 }
 
 // Test when both mock_outputs_merge_with_state and mock_outputs_merge_strategy_with_state are set, mock_outputs_merge_strategy_with_state is used
@@ -2838,11 +2838,11 @@ func TestDependencyMockOutputMergeStrategyWithStateCompatConflict(t *testing.T) 
 	logBufferContentsLineByLine(t, stdout, "output stdout")
 	logBufferContentsLineByLine(t, stderr, "output stderr")
 
-	require.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
-	require.Equal(t, "map_root1_sub1_value", util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "map_root1", "map_root1_sub1", "value"))
-	require.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "not_in_state", "abc", "value"))
-	require.Equal(t, "fake-list-data", util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "0"))
-	require.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "1"))
+	assert.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
+	assert.Equal(t, "map_root1_sub1_value", util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "map_root1", "map_root1_sub1", "value"))
+	assert.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "not_in_state", "abc", "value"))
+	assert.Equal(t, "fake-list-data", util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "0"))
+	assert.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "1"))
 }
 
 // Test when mock_outputs_merge_strategy_with_state = "no_merge" that mocks are not merged into the current state
@@ -2859,7 +2859,7 @@ func TestDependencyMockOutputMergeStrategyWithStateNoMerge(t *testing.T) {
 
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+childPath, &stdout, &stderr)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "This object does not have an attribute named \"test_output_list_string\"")
+	assert.Contains(t, err.Error(), "This object does not have an attribute named \"test_output_list_string\"")
 	logBufferContentsLineByLine(t, stdout, "apply stdout")
 	logBufferContentsLineByLine(t, stderr, "apply stderr")
 }
@@ -2891,11 +2891,11 @@ func TestDependencyMockOutputMergeStrategyWithStateShallow(t *testing.T) {
 	logBufferContentsLineByLine(t, stdout, "output stdout")
 	logBufferContentsLineByLine(t, stderr, "output stderr")
 
-	require.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
-	require.Equal(t, "map_root1_sub1_value", util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "map_root1", "map_root1_sub1", "value"))
-	require.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "not_in_state", "abc", "value"))
-	require.Equal(t, "fake-list-data", util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "0"))
-	require.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "1"))
+	assert.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
+	assert.Equal(t, "map_root1_sub1_value", util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "map_root1", "map_root1_sub1", "value"))
+	assert.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "not_in_state", "abc", "value"))
+	assert.Equal(t, "fake-list-data", util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "0"))
+	assert.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "1"))
 }
 
 // Test when mock_outputs_merge_strategy_with_state = "deep" that the existing state is deeply merged into the mocks
@@ -2926,12 +2926,12 @@ func TestDependencyMockOutputMergeStrategyWithStateDeepMapOnly(t *testing.T) {
 	logBufferContentsLineByLine(t, stdout, "output stdout")
 	logBufferContentsLineByLine(t, stderr, "output stderr")
 
-	require.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
-	require.Equal(t, "fake-abc", outputs["test_output2_from_parent"].Value)
-	require.Equal(t, "map_root1_sub1_value", util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "map_root1", "map_root1_sub1", "value"))
-	require.Equal(t, "fake-abc", util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "not_in_state", "abc", "value"))
-	require.Equal(t, "a", util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "0"))
-	require.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "1"))
+	assert.Equal(t, "value1", outputs["test_output1_from_parent"].Value)
+	assert.Equal(t, "fake-abc", outputs["test_output2_from_parent"].Value)
+	assert.Equal(t, "map_root1_sub1_value", util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "map_root1", "map_root1_sub1", "value"))
+	assert.Equal(t, "fake-abc", util.MustWalkTerraformOutput(outputs["test_output_map_map_string_from_parent"].Value, "not_in_state", "abc", "value"))
+	assert.Equal(t, "a", util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "0"))
+	assert.Nil(t, util.MustWalkTerraformOutput(outputs["test_output_list_string"].Value, "1"))
 }
 
 // Test that when you have a mock_output on a dependency, the dependency will use the mock as the output instead
@@ -2950,7 +2950,7 @@ func TestDependencyMockOutputRestricted(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+dependent2Path, &showStdout, &showStderr)
 	require.Error(t, err)
 	// Verify that we fail because the dependency is not applied yet
-	require.Contains(t, err.Error(), "has not been applied yet")
+	assert.Contains(t, err.Error(), "has not been applied yet")
 
 	logBufferContentsLineByLine(t, showStdout, "show stdout")
 	logBufferContentsLineByLine(t, showStderr, "show stderr")
@@ -3018,17 +3018,17 @@ func TestDependencyOutputTypeConversion(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, true, outputs["bool"].Value)
-	require.Equal(t, []interface{}{true, false}, outputs["list_bool"].Value)
-	require.Equal(t, []interface{}{1.0, 2.0, 3.0}, outputs["list_number"].Value)
-	require.Equal(t, []interface{}{"a", "b", "c"}, outputs["list_string"].Value)
-	require.Equal(t, map[string]interface{}{"foo": true, "bar": false, "baz": true}, outputs["map_bool"].Value)
-	require.Equal(t, map[string]interface{}{"foo": 42.0, "bar": 12345.0}, outputs["map_number"].Value)
-	require.Equal(t, map[string]interface{}{"foo": "bar"}, outputs["map_string"].Value)
-	require.InEpsilon(t, 42.0, outputs["number"].Value.(float64), 0.0000001)
-	require.Equal(t, map[string]interface{}{"list": []interface{}{1.0, 2.0, 3.0}, "map": map[string]interface{}{"foo": "bar"}, "num": 42.0, "str": "string"}, outputs["object"].Value)
-	require.Equal(t, "string", outputs["string"].Value)
-	require.Equal(t, "default", outputs["from_env"].Value)
+	assert.Equal(t, true, outputs["bool"].Value)
+	assert.Equal(t, []interface{}{true, false}, outputs["list_bool"].Value)
+	assert.Equal(t, []interface{}{1.0, 2.0, 3.0}, outputs["list_number"].Value)
+	assert.Equal(t, []interface{}{"a", "b", "c"}, outputs["list_string"].Value)
+	assert.Equal(t, map[string]interface{}{"foo": true, "bar": false, "baz": true}, outputs["map_bool"].Value)
+	assert.Equal(t, map[string]interface{}{"foo": 42.0, "bar": 12345.0}, outputs["map_number"].Value)
+	assert.Equal(t, map[string]interface{}{"foo": "bar"}, outputs["map_string"].Value)
+	assert.InEpsilon(t, 42.0, outputs["number"].Value.(float64), 0.0000001)
+	assert.Equal(t, map[string]interface{}{"list": []interface{}{1.0, 2.0, 3.0}, "map": map[string]interface{}{"foo": "bar"}, "num": 42.0, "str": "string"}, outputs["object"].Value)
+	assert.Equal(t, "string", outputs["string"].Value)
+	assert.Equal(t, "default", outputs["from_env"].Value)
 }
 
 // Regression testing for https://github.com/gruntwork-io/terragrunt/issues/1102: Ordering keys from
@@ -3051,7 +3051,7 @@ func TestOrderedMapOutputRegressions1102(t *testing.T) {
 		runTerragruntCommand(t, command, &stdout, &stderr),
 	)
 	expected, _ := os.ReadFile(path)
-	require.Contains(t, string(expected), "local")
+	assert.Contains(t, string(expected), "local")
 
 	// runs terragrunt again. All the outputs must be
 	// equal to the first run.
@@ -3061,7 +3061,7 @@ func TestOrderedMapOutputRegressions1102(t *testing.T) {
 			runTerragruntCommand(t, command, &stdout, &stderr),
 		)
 		actual, _ := os.ReadFile(path)
-		require.Equal(t, expected, actual)
+		assert.Equal(t, expected, actual)
 	}
 }
 
@@ -3100,7 +3100,7 @@ func TestDependencyOutputCycleHandling(t *testing.T) {
 			logBufferContentsLineByLine(t, planStdout, "plan stdout")
 			logBufferContentsLineByLine(t, planStderr, "plan stderr")
 			require.Error(t, err)
-			require.True(t, strings.Contains(err.Error(), "Found a dependency cycle between modules"))
+			assert.True(t, strings.Contains(err.Error(), "Found a dependency cycle between modules"))
 		})
 	}
 }
@@ -3227,14 +3227,14 @@ func TestDependencyOutputWithHooks(t *testing.T) {
 	config.ClearOutputCache()
 
 	// The file should exist in the first run.
-	require.True(t, util.FileExists(depPathFileOut))
-	require.False(t, util.FileExists(mainPathFileOut))
+	assert.True(t, util.FileExists(depPathFileOut))
+	assert.False(t, util.FileExists(mainPathFileOut))
 
 	// Now delete file and run just main again. It should NOT create file.out.
 	require.NoError(t, os.Remove(depPathFileOut))
 	runTerragrunt(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+mainPath)
-	require.False(t, util.FileExists(depPathFileOut))
-	require.False(t, util.FileExists(mainPathFileOut))
+	assert.False(t, util.FileExists(depPathFileOut))
+	assert.False(t, util.FileExists(mainPathFileOut))
 }
 
 func TestDeepDependencyOutputWithMock(t *testing.T) {
@@ -3283,9 +3283,9 @@ func TestAWSGetCallerIdentityFunctions(t *testing.T) {
 
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, outputs["account"].Value, *identity.Account)
-	require.Equal(t, outputs["arn"].Value, *identity.Arn)
-	require.Equal(t, outputs["user_id"].Value, *identity.UserId)
+	assert.Equal(t, outputs["account"].Value, *identity.Account)
+	assert.Equal(t, outputs["arn"].Value, *identity.Arn)
+	assert.Equal(t, outputs["user_id"].Value, *identity.UserId)
 }
 
 func TestGetRepoRoot(t *testing.T) {
@@ -3316,8 +3316,8 @@ func TestGetRepoRoot(t *testing.T) {
 
 	repoRoot, ok := outputs["repo_root"]
 
-	require.True(t, ok)
-	require.Regexp(t, "/tmp/terragrunt-.*/fixture-get-repo-root", repoRoot.Value)
+	assert.True(t, ok)
+	assert.Regexp(t, "/tmp/terragrunt-.*/fixture-get-repo-root", repoRoot.Value)
 }
 
 func TestGetWorkingDirBuiltInFunc(t *testing.T) {
@@ -3368,8 +3368,8 @@ func TestGetWorkingDirBuiltInFunc(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-	require.True(t, ok)
-	require.Equal(t, expectedWorkingDir, workingDir.Value)
+	assert.True(t, ok)
+	assert.Equal(t, expectedWorkingDir, workingDir.Value)
 }
 
 func TestPathRelativeFromInclude(t *testing.T) {
@@ -3399,8 +3399,8 @@ func TestPathRelativeFromInclude(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
 	val, hasVal := outputs["some_output"]
-	require.True(t, hasVal)
-	require.Equal(t, "something else", val.Value)
+	assert.True(t, hasVal)
+	assert.Equal(t, "something else", val.Value)
 
 	// try to destroy module and check if warning is printed in output, also test `get_parent_terragrunt_dir()` func in the parent terragrunt config.
 	stdout = bytes.Buffer{}
@@ -3409,7 +3409,7 @@ func TestPathRelativeFromInclude(t *testing.T) {
 	err = runTerragruntCommand(t, "terragrunt destroy -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+basePath, &stdout, &stderr)
 	require.NoError(t, err)
 
-	require.Contains(t, stderr.String(), "Detected dependent modules:\n"+clusterPath)
+	assert.Contains(t, stderr.String(), "Detected dependent modules:\n"+clusterPath)
 }
 
 func TestGetPathFromRepoRoot(t *testing.T) {
@@ -3441,8 +3441,8 @@ func TestGetPathFromRepoRoot(t *testing.T) {
 
 	pathFromRoot, hasPathFromRoot := outputs["path_from_root"]
 
-	require.True(t, hasPathFromRoot)
-	require.Equal(t, TEST_FIXTURE_GET_PATH_FROM_REPO_ROOT, pathFromRoot.Value)
+	assert.True(t, hasPathFromRoot)
+	assert.Equal(t, TEST_FIXTURE_GET_PATH_FROM_REPO_ROOT, pathFromRoot.Value)
 }
 
 func TestGetPathToRepoRoot(t *testing.T) {
@@ -3480,8 +3480,8 @@ func TestGetPathToRepoRoot(t *testing.T) {
 	} {
 		value, hasValue := outputs[name]
 
-		require.True(t, hasValue)
-		require.Equal(t, expected, value.Value)
+		assert.True(t, hasValue)
+		assert.Equal(t, expected, value.Value)
 	}
 }
 
@@ -3507,8 +3507,8 @@ func TestGetPlatform(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 	platform, hasPlatform := outputs["platform"]
-	require.True(t, hasPlatform)
-	require.Equal(t, runtime.GOOS, platform.Value)
+	assert.True(t, hasPlatform)
+	assert.Equal(t, runtime.GOOS, platform.Value)
 }
 
 func TestDataDir(t *testing.T) {
@@ -3527,14 +3527,14 @@ func TestDataDir(t *testing.T) {
 
 	err := runTerragruntCommand(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
 	require.NoError(t, err)
-	require.Contains(t, stdout.String(), "Initializing provider plugins")
+	assert.Contains(t, stdout.String(), "Initializing provider plugins")
 
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
 
 	err = runTerragruntCommand(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
 	require.NoError(t, err)
-	require.NotContains(t, stdout.String(), "Initializing provider plugins")
+	assert.NotContains(t, stdout.String(), "Initializing provider plugins")
 }
 
 func TestReadTerragruntConfigWithDependency(t *testing.T) {
@@ -3573,17 +3573,17 @@ func TestReadTerragruntConfigWithDependency(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, true, outputs["bool"].Value)
-	require.Equal(t, []interface{}{true, false}, outputs["list_bool"].Value)
-	require.Equal(t, []interface{}{1.0, 2.0, 3.0}, outputs["list_number"].Value)
-	require.Equal(t, []interface{}{"a", "b", "c"}, outputs["list_string"].Value)
-	require.Equal(t, map[string]interface{}{"foo": true, "bar": false, "baz": true}, outputs["map_bool"].Value)
-	require.Equal(t, map[string]interface{}{"foo": 42.0, "bar": 12345.0}, outputs["map_number"].Value)
-	require.Equal(t, map[string]interface{}{"foo": "bar"}, outputs["map_string"].Value)
-	require.InEpsilon(t, 42.0, outputs["number"].Value.(float64), 0.0000001)
-	require.Equal(t, map[string]interface{}{"list": []interface{}{1.0, 2.0, 3.0}, "map": map[string]interface{}{"foo": "bar"}, "num": 42.0, "str": "string"}, outputs["object"].Value)
-	require.Equal(t, "string", outputs["string"].Value)
-	require.Equal(t, "default", outputs["from_env"].Value)
+	assert.Equal(t, true, outputs["bool"].Value)
+	assert.Equal(t, []interface{}{true, false}, outputs["list_bool"].Value)
+	assert.Equal(t, []interface{}{1.0, 2.0, 3.0}, outputs["list_number"].Value)
+	assert.Equal(t, []interface{}{"a", "b", "c"}, outputs["list_string"].Value)
+	assert.Equal(t, map[string]interface{}{"foo": true, "bar": false, "baz": true}, outputs["map_bool"].Value)
+	assert.Equal(t, map[string]interface{}{"foo": 42.0, "bar": 12345.0}, outputs["map_number"].Value)
+	assert.Equal(t, map[string]interface{}{"foo": "bar"}, outputs["map_string"].Value)
+	assert.InEpsilon(t, 42.0, outputs["number"].Value.(float64), 0.0000001)
+	assert.Equal(t, map[string]interface{}{"list": []interface{}{1.0, 2.0, 3.0}, "map": map[string]interface{}{"foo": "bar"}, "num": 42.0, "str": "string"}, outputs["object"].Value)
+	assert.Equal(t, "string", outputs["string"].Value)
+	assert.Equal(t, "default", outputs["from_env"].Value)
 }
 
 func TestReadTerragruntConfigFromDependency(t *testing.T) {
@@ -3615,7 +3615,7 @@ func TestReadTerragruntConfigFromDependency(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, "hello world", outputs["bar"].Value)
+	assert.Equal(t, "hello world", outputs["bar"].Value)
 }
 
 func TestReadTerragruntConfigWithDefault(t *testing.T) {
@@ -3638,7 +3638,7 @@ func TestReadTerragruntConfigWithDefault(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, "default value", outputs["data"].Value)
+	assert.Equal(t, "default value", outputs["data"].Value)
 }
 
 func TestReadTerragruntConfigWithOriginalTerragruntDir(t *testing.T) {
@@ -3666,10 +3666,10 @@ func TestReadTerragruntConfigWithOriginalTerragruntDir(t *testing.T) {
 	depOutputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(depStdout.Bytes(), &depOutputs))
 
-	require.Equal(t, depPathAbs, depOutputs["terragrunt_dir"].Value)
-	require.Equal(t, depPathAbs, depOutputs["original_terragrunt_dir"].Value)
-	require.Equal(t, fooPathAbs, depOutputs["bar_terragrunt_dir"].Value)
-	require.Equal(t, depPathAbs, depOutputs["bar_original_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, depOutputs["terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, depOutputs["original_terragrunt_dir"].Value)
+	assert.Equal(t, fooPathAbs, depOutputs["bar_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, depOutputs["bar_original_terragrunt_dir"].Value)
 
 	// Run apply on the root module and make sure we get the expected outputs
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
@@ -3685,12 +3685,12 @@ func TestReadTerragruntConfigWithOriginalTerragruntDir(t *testing.T) {
 	rootOutputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(rootStdout.Bytes(), &rootOutputs))
 
-	require.Equal(t, fooPathAbs, rootOutputs["terragrunt_dir"].Value)
-	require.Equal(t, rootPathAbs, rootOutputs["original_terragrunt_dir"].Value)
-	require.Equal(t, depPathAbs, rootOutputs["dep_terragrunt_dir"].Value)
-	require.Equal(t, depPathAbs, rootOutputs["dep_original_terragrunt_dir"].Value)
-	require.Equal(t, fooPathAbs, rootOutputs["dep_bar_terragrunt_dir"].Value)
-	require.Equal(t, depPathAbs, rootOutputs["dep_bar_original_terragrunt_dir"].Value)
+	assert.Equal(t, fooPathAbs, rootOutputs["terragrunt_dir"].Value)
+	assert.Equal(t, rootPathAbs, rootOutputs["original_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, rootOutputs["dep_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, rootOutputs["dep_original_terragrunt_dir"].Value)
+	assert.Equal(t, fooPathAbs, rootOutputs["dep_bar_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, rootOutputs["dep_bar_original_terragrunt_dir"].Value)
 
 	// Run 'run-all apply' and make sure all the outputs are identical in the root module and the dependency module
 	runTerragrunt(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
@@ -3717,16 +3717,16 @@ func TestReadTerragruntConfigWithOriginalTerragruntDir(t *testing.T) {
 	runAllDepOutputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(runAllDepStdout.Bytes(), &runAllDepOutputs))
 
-	require.Equal(t, fooPathAbs, runAllRootOutputs["terragrunt_dir"].Value)
-	require.Equal(t, rootPathAbs, runAllRootOutputs["original_terragrunt_dir"].Value)
-	require.Equal(t, depPathAbs, runAllRootOutputs["dep_terragrunt_dir"].Value)
-	require.Equal(t, depPathAbs, runAllRootOutputs["dep_original_terragrunt_dir"].Value)
-	require.Equal(t, fooPathAbs, runAllRootOutputs["dep_bar_terragrunt_dir"].Value)
-	require.Equal(t, depPathAbs, runAllRootOutputs["dep_bar_original_terragrunt_dir"].Value)
-	require.Equal(t, depPathAbs, runAllDepOutputs["terragrunt_dir"].Value)
-	require.Equal(t, depPathAbs, runAllDepOutputs["original_terragrunt_dir"].Value)
-	require.Equal(t, fooPathAbs, runAllDepOutputs["bar_terragrunt_dir"].Value)
-	require.Equal(t, depPathAbs, runAllDepOutputs["bar_original_terragrunt_dir"].Value)
+	assert.Equal(t, fooPathAbs, runAllRootOutputs["terragrunt_dir"].Value)
+	assert.Equal(t, rootPathAbs, runAllRootOutputs["original_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, runAllRootOutputs["dep_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, runAllRootOutputs["dep_original_terragrunt_dir"].Value)
+	assert.Equal(t, fooPathAbs, runAllRootOutputs["dep_bar_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, runAllRootOutputs["dep_bar_original_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, runAllDepOutputs["terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, runAllDepOutputs["original_terragrunt_dir"].Value)
+	assert.Equal(t, fooPathAbs, runAllDepOutputs["bar_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, runAllDepOutputs["bar_original_terragrunt_dir"].Value)
 }
 
 func TestReadTerragruntConfigFull(t *testing.T) {
@@ -3749,26 +3749,26 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, "terragrunt", outputs["terraform_binary"].Value)
-	require.Equal(t, "= 0.12.20", outputs["terraform_version_constraint"].Value)
-	require.Equal(t, "= 0.23.18", outputs["terragrunt_version_constraint"].Value)
-	require.Equal(t, ".terragrunt-cache", outputs["download_dir"].Value)
-	require.Equal(t, "TerragruntIAMRole", outputs["iam_role"].Value)
-	require.Equal(t, "true", outputs["skip"].Value)
-	require.Equal(t, "true", outputs["prevent_destroy"].Value)
+	assert.Equal(t, "terragrunt", outputs["terraform_binary"].Value)
+	assert.Equal(t, "= 0.12.20", outputs["terraform_version_constraint"].Value)
+	assert.Equal(t, "= 0.23.18", outputs["terragrunt_version_constraint"].Value)
+	assert.Equal(t, ".terragrunt-cache", outputs["download_dir"].Value)
+	assert.Equal(t, "TerragruntIAMRole", outputs["iam_role"].Value)
+	assert.Equal(t, "true", outputs["skip"].Value)
+	assert.Equal(t, "true", outputs["prevent_destroy"].Value)
 
 	// Simple maps
 	localstgOut := map[string]interface{}{}
 	require.NoError(t, json.Unmarshal([]byte(outputs["localstg"].Value.(string)), &localstgOut))
-	require.Equal(t, map[string]interface{}{"the_answer": float64(42)}, localstgOut)
+	assert.Equal(t, map[string]interface{}{"the_answer": float64(42)}, localstgOut)
 	inputsOut := map[string]interface{}{}
 	require.NoError(t, json.Unmarshal([]byte(outputs["inputs"].Value.(string)), &inputsOut))
-	require.Equal(t, map[string]interface{}{"doc": "Emmett Brown"}, inputsOut)
+	assert.Equal(t, map[string]interface{}{"doc": "Emmett Brown"}, inputsOut)
 
 	// Complex blocks
 	depsOut := map[string]interface{}{}
 	require.NoError(t, json.Unmarshal([]byte(outputs["dependencies"].Value.(string)), &depsOut))
-	require.Equal(
+	assert.Equal(
 		t,
 		map[string]interface{}{
 			"paths": []interface{}{"../../fixture"},
@@ -3778,7 +3778,7 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 
 	generateOut := map[string]interface{}{}
 	require.NoError(t, json.Unmarshal([]byte(outputs["generate"].Value.(string)), &generateOut))
-	require.Equal(
+	assert.Equal(
 		t,
 		map[string]interface{}{
 			"provider": map[string]interface{}{
@@ -3798,7 +3798,7 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 	)
 	remoteStateOut := map[string]interface{}{}
 	require.NoError(t, json.Unmarshal([]byte(outputs["remote_state"].Value.(string)), &remoteStateOut))
-	require.Equal(
+	assert.Equal(
 		t,
 		map[string]interface{}{
 			"backend":                         "local",
@@ -3811,7 +3811,7 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 	)
 	terraformOut := map[string]interface{}{}
 	require.NoError(t, json.Unmarshal([]byte(outputs["terraformtg"].Value.(string)), &terraformOut))
-	require.Equal(
+	assert.Equal(
 		t,
 		map[string]interface{}{
 			"source":          "./delorean",
@@ -3821,7 +3821,7 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 					"name":               "var-files",
 					"commands":           []interface{}{"apply", "plan"},
 					"arguments":          nil,
-					"required_var_files": []interface{}{"extra.tfvars"},
+					"assertd_var_files":  []interface{}{"extra.tfvars"},
 					"optional_var_files": []interface{}{"optional.tfvars"},
 					"env_vars": map[string]interface{}{
 						"TF_VAR_custom_var": "I'm set in extra_arguments env_vars",
@@ -3870,7 +3870,7 @@ func TestTerragruntGenerateBlockSkipRemove(t *testing.T) {
 	generateTestCase := util.JoinPath(tmpEnvPath, TEST_FIXTURE_CODEGEN_PATH, "remove-file", "skip")
 
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
-	require.FileExists(t, filepath.Join(generateTestCase, "backend.tf"))
+	assert.FileExists(t, filepath.Join(generateTestCase, "backend.tf"))
 }
 
 func TestTerragruntGenerateBlockRemove(t *testing.T) {
@@ -3880,7 +3880,7 @@ func TestTerragruntGenerateBlockRemove(t *testing.T) {
 	generateTestCase := util.JoinPath(tmpEnvPath, TEST_FIXTURE_CODEGEN_PATH, "remove-file", "remove")
 
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
-	require.NoFileExists(t, filepath.Join(generateTestCase, "backend.tf"))
+	assert.NoFileExists(t, filepath.Join(generateTestCase, "backend.tf"))
 }
 
 func TestTerragruntGenerateBlockRemoveTerragruntSuccess(t *testing.T) {
@@ -3890,7 +3890,7 @@ func TestTerragruntGenerateBlockRemoveTerragruntSuccess(t *testing.T) {
 	generateTestCase := util.JoinPath(tmpEnvPath, TEST_FIXTURE_CODEGEN_PATH, "remove-file", "remove_terragrunt")
 
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
-	require.NoFileExists(t, filepath.Join(generateTestCase, "backend.tf"))
+	assert.NoFileExists(t, filepath.Join(generateTestCase, "backend.tf"))
 }
 
 func TestTerragruntGenerateBlockRemoveTerragruntFail(t *testing.T) {
@@ -3904,9 +3904,9 @@ func TestTerragruntGenerateBlockRemoveTerragruntFail(t *testing.T) {
 
 	var generateFileRemoveError codegen.GenerateFileRemoveError
 	ok := goErrors.As(err, &generateFileRemoveError)
-	require.True(t, ok)
+	assert.True(t, ok)
 
-	require.FileExists(t, filepath.Join(generateTestCase, "backend.tf"))
+	assert.FileExists(t, filepath.Join(generateTestCase, "backend.tf"))
 }
 
 func TestTerragruntGenerateBlockSkip(t *testing.T) {
@@ -3916,7 +3916,7 @@ func TestTerragruntGenerateBlockSkip(t *testing.T) {
 	cleanupTerraformFolder(t, generateTestCase)
 	cleanupTerragruntFolder(t, generateTestCase)
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
-	require.False(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
+	assert.False(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
 }
 
 func TestTerragruntGenerateBlockOverwrite(t *testing.T) {
@@ -3928,8 +3928,8 @@ func TestTerragruntGenerateBlockOverwrite(t *testing.T) {
 
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
 	// If the state file was written as foo.tfstate, that means it overwrote the local backend config.
-	require.True(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
-	require.False(t, fileIsInFolder(t, "bar.tfstate", generateTestCase))
+	assert.True(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
+	assert.False(t, fileIsInFolder(t, "bar.tfstate", generateTestCase))
 }
 
 func TestTerragruntGenerateAttr(t *testing.T) {
@@ -3943,7 +3943,7 @@ func TestTerragruntGenerateAttr(t *testing.T) {
 
 	stdout, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s -var text=\"%s\"", generateTestCase, text))
 	require.NoError(t, err)
-	require.Contains(t, stdout, text)
+	assert.Contains(t, stdout, text)
 }
 
 func TestTerragruntGenerateBlockOverwriteTerragruntSuccess(t *testing.T) {
@@ -3955,8 +3955,8 @@ func TestTerragruntGenerateBlockOverwriteTerragruntSuccess(t *testing.T) {
 
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
 	// If the state file was written as foo.tfstate, that means it overwrote the local backend config.
-	require.True(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
-	require.False(t, fileIsInFolder(t, "bar.tfstate", generateTestCase))
+	assert.True(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
+	assert.False(t, fileIsInFolder(t, "bar.tfstate", generateTestCase))
 }
 
 func TestTerragruntGenerateBlockOverwriteTerragruntFail(t *testing.T) {
@@ -3972,7 +3972,7 @@ func TestTerragruntGenerateBlockOverwriteTerragruntFail(t *testing.T) {
 	require.Error(t, err)
 	var generateFileExistsError codegen.GenerateFileExistsError
 	ok := goErrors.As(err, &generateFileExistsError)
-	require.True(t, ok)
+	assert.True(t, ok)
 }
 
 func TestTerragruntGenerateBlockNestedInherit(t *testing.T) {
@@ -3984,10 +3984,10 @@ func TestTerragruntGenerateBlockNestedInherit(t *testing.T) {
 
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
 	// If the state file was written as foo.tfstate, that means it inherited the config
-	require.True(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
-	require.False(t, fileIsInFolder(t, "bar.tfstate", generateTestCase))
+	assert.True(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
+	assert.False(t, fileIsInFolder(t, "bar.tfstate", generateTestCase))
 	// Also check to make sure the child config generate block was included
-	require.True(t, fileIsInFolder(t, "random_file.txt", generateTestCase))
+	assert.True(t, fileIsInFolder(t, "random_file.txt", generateTestCase))
 }
 
 func TestTerragruntGenerateBlockNestedOverwrite(t *testing.T) {
@@ -3999,10 +3999,10 @@ func TestTerragruntGenerateBlockNestedOverwrite(t *testing.T) {
 
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
 	// If the state file was written as bar.tfstate, that means it overwrite the parent config
-	require.False(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
-	require.True(t, fileIsInFolder(t, "bar.tfstate", generateTestCase))
+	assert.False(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
+	assert.True(t, fileIsInFolder(t, "bar.tfstate", generateTestCase))
 	// Also check to make sure the child config generate block was included
-	require.True(t, fileIsInFolder(t, "random_file.txt", generateTestCase))
+	assert.True(t, fileIsInFolder(t, "random_file.txt", generateTestCase))
 }
 
 func TestTerragruntGenerateBlockDisableSignature(t *testing.T) {
@@ -4026,7 +4026,7 @@ func TestTerragruntGenerateBlockDisableSignature(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, "Hello, World!", outputs["text"].Value)
+	assert.Equal(t, "Hello, World!", outputs["text"].Value)
 }
 
 func TestTerragruntGenerateBlockSameNameFail(t *testing.T) {
@@ -4042,9 +4042,9 @@ func TestTerragruntGenerateBlockSameNameFail(t *testing.T) {
 	require.Error(t, err)
 	var parsedError config.DuplicatedGenerateBlocksError
 	ok := goErrors.As(err, &parsedError)
-	require.True(t, ok)
-	require.Len(t, parsedError.BlockName, 1)
-	require.Contains(t, parsedError.BlockName, "backend")
+	assert.True(t, ok)
+	assert.Len(t, parsedError.BlockName, 1)
+	assert.Contains(t, parsedError.BlockName, "backend")
 }
 
 func TestTerragruntGenerateBlockSameNameIncludeFail(t *testing.T) {
@@ -4060,9 +4060,9 @@ func TestTerragruntGenerateBlockSameNameIncludeFail(t *testing.T) {
 	require.Error(t, err)
 	var parsedError config.DuplicatedGenerateBlocksError
 	ok := goErrors.As(err, &parsedError)
-	require.True(t, ok)
-	require.Len(t, parsedError.BlockName, 1)
-	require.Contains(t, parsedError.BlockName, "backend")
+	assert.True(t, ok)
+	assert.Len(t, parsedError.BlockName, 1)
+	assert.Contains(t, parsedError.BlockName, "backend")
 }
 
 func TestTerragruntGenerateBlockMultipleSameNameFail(t *testing.T) {
@@ -4078,10 +4078,10 @@ func TestTerragruntGenerateBlockMultipleSameNameFail(t *testing.T) {
 	require.Error(t, err)
 	var parsedError config.DuplicatedGenerateBlocksError
 	ok := goErrors.As(err, &parsedError)
-	require.True(t, ok)
-	require.Len(t, parsedError.BlockName, 2)
-	require.Contains(t, parsedError.BlockName, "backend")
-	require.Contains(t, parsedError.BlockName, "backend2")
+	assert.True(t, ok)
+	assert.Len(t, parsedError.BlockName, 2)
+	assert.Contains(t, parsedError.BlockName, "backend")
+	assert.Contains(t, parsedError.BlockName, "backend2")
 }
 
 func TestTerragruntGenerateBlockDisable(t *testing.T) {
@@ -4095,7 +4095,7 @@ func TestTerragruntGenerateBlockDisable(t *testing.T) {
 	stderr := bytes.Buffer{}
 	err := runTerragruntCommand(t, "terragrunt init --terragrunt-working-dir "+generateTestCase, &stdout, &stderr)
 	require.NoError(t, err)
-	require.False(t, fileIsInFolder(t, "data.txt", generateTestCase))
+	assert.False(t, fileIsInFolder(t, "data.txt", generateTestCase))
 }
 
 func TestTerragruntGenerateBlockEnable(t *testing.T) {
@@ -4109,7 +4109,7 @@ func TestTerragruntGenerateBlockEnable(t *testing.T) {
 	stderr := bytes.Buffer{}
 	err := runTerragruntCommand(t, "terragrunt init --terragrunt-working-dir "+generateTestCase, &stdout, &stderr)
 	require.NoError(t, err)
-	require.True(t, fileIsInFolder(t, "data.txt", generateTestCase))
+	assert.True(t, fileIsInFolder(t, "data.txt", generateTestCase))
 }
 
 func TestTerragruntRemoteStateCodegenGeneratesBackendBlock(t *testing.T) {
@@ -4122,7 +4122,7 @@ func TestTerragruntRemoteStateCodegenGeneratesBackendBlock(t *testing.T) {
 
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
 	// If the state file was written as foo.tfstate, that means it wrote out the local backend config.
-	require.True(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
+	assert.True(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
 }
 
 func TestTerragruntRemoteStateCodegenOverwrites(t *testing.T) {
@@ -4135,8 +4135,8 @@ func TestTerragruntRemoteStateCodegenOverwrites(t *testing.T) {
 
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
 	// If the state file was written as foo.tfstate, that means it overwrote the local backend config.
-	require.True(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
-	require.False(t, fileIsInFolder(t, "bar.tfstate", generateTestCase))
+	assert.True(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
+	assert.False(t, fileIsInFolder(t, "bar.tfstate", generateTestCase))
 }
 
 func TestTerragruntRemoteStateCodegenGeneratesBackendBlockS3(t *testing.T) {
@@ -4172,7 +4172,7 @@ func TestTerragruntRemoteStateCodegenErrorsIfExists(t *testing.T) {
 	require.Error(t, err)
 	var generateFileExistsError codegen.GenerateFileExistsError
 	ok := goErrors.As(err, &generateFileExistsError)
-	require.True(t, ok)
+	assert.True(t, ok)
 }
 
 func TestTerragruntRemoteStateCodegenDoesNotGenerateWithSkip(t *testing.T) {
@@ -4184,7 +4184,7 @@ func TestTerragruntRemoteStateCodegenDoesNotGenerateWithSkip(t *testing.T) {
 	cleanupTerragruntFolder(t, generateTestCase)
 
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
-	require.False(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
+	assert.False(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
 }
 
 func TestTerragruntValidateAllWithVersionChecks(t *testing.T) {
@@ -4213,9 +4213,9 @@ func TestTerragruntIncludeParentHclFile(t *testing.T) {
 	require.NoError(t, err)
 
 	out := stdout.String()
-	require.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
-	require.Equal(t, 1, strings.Count(out, "dependency_hcl"))
-	require.Equal(t, 1, strings.Count(out, "common_hcl"))
+	assert.Equal(t, 1, strings.Count(out, "parent_hcl_file"))
+	assert.Equal(t, 1, strings.Count(out, "dependency_hcl"))
+	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
 }
 
 func TestTerragruntVersionConstraints(t *testing.T) {
@@ -4302,9 +4302,9 @@ func TestReadTerragruntConfigIamRole(t *testing.T) {
 	output := fmt.Sprintf("%v %v %v", stderr.String(), stdout.String(), err.Error())
 
 	// Check that output contains value defined in IAM role
-	require.Contains(t, output, "666666666666")
+	assert.Contains(t, output, "666666666666")
 	// Ensure that state file wasn't created with default IAM value
-	require.True(t, util.FileNotExists(util.JoinPath(TEST_FIXTURE_READ_IAM_ROLE, identityArn+".txt")))
+	assert.True(t, util.FileNotExists(util.JoinPath(TEST_FIXTURE_READ_IAM_ROLE, identityArn+".txt")))
 }
 
 func TestReadTerragruntAuthProviderCmd(t *testing.T) {
@@ -4324,9 +4324,9 @@ func TestReadTerragruntAuthProviderCmd(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &outputs))
 
-	require.Equal(t, "app1-bar", outputs["foo-app1"].Value)
-	require.Equal(t, "app2-bar", outputs["foo-app2"].Value)
-	require.Equal(t, "app3-bar", outputs["foo-app3"].Value)
+	assert.Equal(t, "app1-bar", outputs["foo-app1"].Value)
+	assert.Equal(t, "app2-bar", outputs["foo-app2"].Value)
+	assert.Equal(t, "app3-bar", outputs["foo-app3"].Value)
 }
 
 func TestIamRolesLoadingFromDifferentModules(t *testing.T) {
@@ -4358,11 +4358,11 @@ func TestIamRolesLoadingFromDifferentModules(t *testing.T) {
 			continue
 		}
 	}
-	require.NotEmptyf(t, component1, "Missing role for component 1")
-	require.NotEmptyf(t, component2, "Missing role for component 2")
+	assert.NotEmptyf(t, component1, "Missing role for component 1")
+	assert.NotEmptyf(t, component2, "Missing role for component 2")
 
-	require.Contains(t, component1, "iam_roles_multiple_modules/component")
-	require.Contains(t, component2, "iam_roles_multiple_modules/component2")
+	assert.Contains(t, component1, "iam_roles_multiple_modules/component")
+	assert.Contains(t, component2, "iam_roles_multiple_modules/component2")
 }
 
 func TestTerragruntVersionConstraintsPartialParse(t *testing.T) {
@@ -4380,7 +4380,7 @@ func TestTerragruntVersionConstraintsPartialParse(t *testing.T) {
 
 	var invalidVersionError terraform.InvalidTerragruntVersion
 	ok := goErrors.As(err, &invalidVersionError)
-	require.True(t, ok)
+	assert.True(t, ok)
 }
 
 func TestLogFailedLocalsEvaluation(t *testing.T) {
@@ -4396,7 +4396,7 @@ func TestLogFailedLocalsEvaluation(t *testing.T) {
 	require.NoError(t, err)
 
 	output := stderr.String()
-	require.Contains(t, output, "Encountered error while evaluating locals in file "+filepath.Join(testdataDir, "terragrunt.hcl"))
+	assert.Contains(t, output, "Encountered error while evaluating locals in file "+filepath.Join(testdataDir, "terragrunt.hcl"))
 }
 
 func TestLogFailingDependencies(t *testing.T) {
@@ -4414,7 +4414,7 @@ func TestLogFailingDependencies(t *testing.T) {
 	require.NoError(t, err)
 
 	output := stderr.String()
-	require.Contains(t, output, fmt.Sprintf("%s invocation failed in %s", wrappedBinary(), testdataDir))
+	assert.Contains(t, output, fmt.Sprintf("%s invocation failed in %s", wrappedBinary(), testdataDir))
 }
 
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {
@@ -4631,13 +4631,13 @@ func validateS3BucketExistsAndIsTagged(t *testing.T, awsRegion string, bucketNam
 		t.Fatalf("Error creating S3 client: %v", err)
 	}
 
-	require.True(t, remote.DoesS3BucketExist(s3Client, &bucketName), "Terragrunt failed to create remote state S3 bucket %s", bucketName)
+	assert.True(t, remote.DoesS3BucketExist(s3Client, &bucketName), "Terragrunt failed to create remote state S3 bucket %s", bucketName)
 
 	if expectedTags != nil {
-		requireS3Tags(expectedTags, bucketName, s3Client, t)
+		assertS3Tags(expectedTags, bucketName, s3Client, t)
 	}
 
-	requireS3PublicAccessBlocks(t, s3Client, bucketName)
+	assertS3PublicAccessBlocks(t, s3Client, bucketName)
 }
 
 // Check that the DynamoDB table of the given name and region exists. Terragrunt should create this table during the test.
@@ -4664,10 +4664,10 @@ func validateDynamoDBTableExistsAndIsTagged(t *testing.T, awsRegion string, tabl
 		actualTags[*element.Key] = *element.Value
 	}
 
-	require.Equal(t, expectedTags, actualTags, "Did not find expected tags on dynamo table.")
+	assert.Equal(t, expectedTags, actualTags, "Did not find expected tags on dynamo table.")
 }
 
-func requireS3Tags(expectedTags map[string]string, bucketName string, client *s3.S3, t *testing.T) {
+func assertS3Tags(expectedTags map[string]string, bucketName string, client *s3.S3, t *testing.T) {
 
 	var in = s3.GetBucketTaggingInput{}
 	in.SetBucket(bucketName)
@@ -4684,20 +4684,20 @@ func requireS3Tags(expectedTags map[string]string, bucketName string, client *s3
 		actualTags[*element.Key] = *element.Value
 	}
 
-	require.Equal(t, expectedTags, actualTags, "Did not find expected tags on s3 bucket.")
+	assert.Equal(t, expectedTags, actualTags, "Did not find expected tags on s3 bucket.")
 }
 
-func requireS3PublicAccessBlocks(t *testing.T, client *s3.S3, bucketName string) {
+func assertS3PublicAccessBlocks(t *testing.T, client *s3.S3, bucketName string) {
 	resp, err := client.GetPublicAccessBlock(
 		&s3.GetPublicAccessBlockInput{Bucket: aws.String(bucketName)},
 	)
 	require.NoError(t, err)
 
 	publicAccessBlockConfig := resp.PublicAccessBlockConfiguration
-	require.True(t, aws.BoolValue(publicAccessBlockConfig.BlockPublicAcls))
-	require.True(t, aws.BoolValue(publicAccessBlockConfig.BlockPublicPolicy))
-	require.True(t, aws.BoolValue(publicAccessBlockConfig.IgnorePublicAcls))
-	require.True(t, aws.BoolValue(publicAccessBlockConfig.RestrictPublicBuckets))
+	assert.True(t, aws.BoolValue(publicAccessBlockConfig.BlockPublicAcls))
+	assert.True(t, aws.BoolValue(publicAccessBlockConfig.BlockPublicPolicy))
+	assert.True(t, aws.BoolValue(publicAccessBlockConfig.IgnorePublicAcls))
+	assert.True(t, aws.BoolValue(publicAccessBlockConfig.RestrictPublicBuckets))
 }
 
 // createS3BucketE create test S3 bucket.
@@ -4893,7 +4893,7 @@ func validateGCSBucketExistsAndIsLabeled(t *testing.T, location string, bucketNa
 	}
 
 	// verify the bucket exists
-	require.True(t, remote.DoesGCSBucketExist(gcsClient, &remoteStateConfig), "Terragrunt failed to create remote state GCS bucket %s", bucketName)
+	assert.True(t, remote.DoesGCSBucketExist(gcsClient, &remoteStateConfig), "Terragrunt failed to create remote state GCS bucket %s", bucketName)
 
 	// verify the bucket location
 	ctx := context.Background()
@@ -4903,10 +4903,10 @@ func validateGCSBucketExistsAndIsLabeled(t *testing.T, location string, bucketNa
 		t.Fatal(err)
 	}
 
-	require.Equal(t, strings.ToUpper(location), attrs.Location, "Did not find GCS bucket in expected location.")
+	assert.Equal(t, strings.ToUpper(location), attrs.Location, "Did not find GCS bucket in expected location.")
 
 	if expectedLabels != nil {
-		requireGCSLabels(t, expectedLabels, bucketName, gcsClient)
+		assertGCSLabels(t, expectedLabels, bucketName, gcsClient)
 	}
 }
 
@@ -4930,7 +4930,7 @@ func gcsObjectAttrs(t *testing.T, bucketName string, objectName string) *storage
 	return attrs
 }
 
-func requireGCSLabels(t *testing.T, expectedLabels map[string]string, bucketName string, client *storage.Client) {
+func assertGCSLabels(t *testing.T, expectedLabels map[string]string, bucketName string, client *storage.Client) {
 	ctx := context.Background()
 	bucket := client.Bucket(bucketName)
 
@@ -4945,7 +4945,7 @@ func requireGCSLabels(t *testing.T, expectedLabels map[string]string, bucketName
 		actualLabels[key] = value
 	}
 
-	require.Equal(t, expectedLabels, actualLabels, "Did not find expected labels on GCS bucket.")
+	assert.Equal(t, expectedLabels, actualLabels, "Did not find expected labels on GCS bucket.")
 }
 
 // Create the specified GCS bucket
@@ -5094,19 +5094,19 @@ func TestSopsDecryptedCorrectly(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, []interface{}{true, false}, outputs["json_bool_array"].Value)
-	require.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["json_string_array"].Value)
-	require.InEpsilon(t, 1234.56789, outputs["json_number"].Value, 0.0001)
-	require.Equal(t, "example_value", outputs["json_string"].Value)
-	require.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["json_hello"].Value)
-	require.Equal(t, []interface{}{true, false}, outputs["yaml_bool_array"].Value)
-	require.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["yaml_string_array"].Value)
-	require.InEpsilon(t, 1234.5679, outputs["yaml_number"].Value, 0.0001)
-	require.Equal(t, "example_value", outputs["yaml_string"].Value)
-	require.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["yaml_hello"].Value)
-	require.Equal(t, "Raw Secret Example", outputs["text_value"].Value)
-	require.Contains(t, outputs["env_value"].Value, "DB_PASSWORD=tomato")
-	require.Contains(t, outputs["ini_value"].Value, "password = potato")
+	assert.Equal(t, []interface{}{true, false}, outputs["json_bool_array"].Value)
+	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["json_string_array"].Value)
+	assert.InEpsilon(t, 1234.56789, outputs["json_number"].Value, 0.0001)
+	assert.Equal(t, "example_value", outputs["json_string"].Value)
+	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["json_hello"].Value)
+	assert.Equal(t, []interface{}{true, false}, outputs["yaml_bool_array"].Value)
+	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["yaml_string_array"].Value)
+	assert.InEpsilon(t, 1234.5679, outputs["yaml_number"].Value, 0.0001)
+	assert.Equal(t, "example_value", outputs["yaml_string"].Value)
+	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["yaml_hello"].Value)
+	assert.Equal(t, "Raw Secret Example", outputs["text_value"].Value)
+	assert.Contains(t, outputs["env_value"].Value, "DB_PASSWORD=tomato")
+	assert.Contains(t, outputs["ini_value"].Value, "password = potato")
 }
 
 func TestSopsDecryptedCorrectlyRunAll(t *testing.T) {
@@ -5127,19 +5127,19 @@ func TestSopsDecryptedCorrectlyRunAll(t *testing.T) {
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
-	require.Equal(t, []interface{}{true, false}, outputs["json_bool_array"].Value)
-	require.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["json_string_array"].Value)
-	require.InEpsilon(t, 1234.56789, outputs["json_number"].Value, 0.0001)
-	require.Equal(t, "example_value", outputs["json_string"].Value)
-	require.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["json_hello"].Value)
-	require.Equal(t, []interface{}{true, false}, outputs["yaml_bool_array"].Value)
-	require.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["yaml_string_array"].Value)
-	require.InEpsilon(t, 1234.5679, outputs["yaml_number"].Value, 0.0001)
-	require.Equal(t, "example_value", outputs["yaml_string"].Value)
-	require.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["yaml_hello"].Value)
-	require.Equal(t, "Raw Secret Example", outputs["text_value"].Value)
-	require.Contains(t, outputs["env_value"].Value, "DB_PASSWORD=tomato")
-	require.Contains(t, outputs["ini_value"].Value, "password = potato")
+	assert.Equal(t, []interface{}{true, false}, outputs["json_bool_array"].Value)
+	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["json_string_array"].Value)
+	assert.InEpsilon(t, 1234.56789, outputs["json_number"].Value, 0.0001)
+	assert.Equal(t, "example_value", outputs["json_string"].Value)
+	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["json_hello"].Value)
+	assert.Equal(t, []interface{}{true, false}, outputs["yaml_bool_array"].Value)
+	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["yaml_string_array"].Value)
+	assert.InEpsilon(t, 1234.5679, outputs["yaml_number"].Value, 0.0001)
+	assert.Equal(t, "example_value", outputs["yaml_string"].Value)
+	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["yaml_hello"].Value)
+	assert.Equal(t, "Raw Secret Example", outputs["text_value"].Value)
+	assert.Contains(t, outputs["env_value"].Value, "DB_PASSWORD=tomato")
+	assert.Contains(t, outputs["ini_value"].Value, "password = potato")
 }
 
 func TestTerragruntRunAllCommandPrompt(t *testing.T) {
@@ -5159,7 +5159,7 @@ func TestTerragruntRunAllCommandPrompt(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt run-all apply --terragrunt-working-dir "+environmentPath, &stdout, &stderr)
 	logBufferContentsLineByLine(t, stdout, "stdout")
 	logBufferContentsLineByLine(t, stderr, "stderr")
-	require.Contains(t, stderr.String(), "Are you sure you want to run 'terragrunt apply' in each folder of the stack described above? (y/n)")
+	assert.Contains(t, stderr.String(), "Are you sure you want to run 'terragrunt apply' in each folder of the stack described above? (y/n)")
 	require.Error(t, err)
 }
 
@@ -5175,7 +5175,7 @@ func TestTerragruntLocalRunOnce(t *testing.T) {
 
 	errout := stdout.String()
 
-	require.Equal(t, 1, strings.Count(errout, "foo"))
+	assert.Equal(t, 1, strings.Count(errout, "foo"))
 }
 
 func TestTerragruntInitRunCmd(t *testing.T) {
@@ -5191,17 +5191,17 @@ func TestTerragruntInitRunCmd(t *testing.T) {
 	errout := stdout.String()
 
 	// Check for cached values between locals and inputs sections
-	require.Equal(t, 1, strings.Count(errout, "potato"))
-	require.Equal(t, 1, strings.Count(errout, "carrot"))
-	require.Equal(t, 1, strings.Count(errout, "bar"))
-	require.Equal(t, 1, strings.Count(errout, "foo"))
+	assert.Equal(t, 1, strings.Count(errout, "potato"))
+	assert.Equal(t, 1, strings.Count(errout, "carrot"))
+	assert.Equal(t, 1, strings.Count(errout, "bar"))
+	assert.Equal(t, 1, strings.Count(errout, "foo"))
 
-	require.Equal(t, 1, strings.Count(errout, "input_variable"))
+	assert.Equal(t, 1, strings.Count(errout, "input_variable"))
 
 	// Commands executed multiple times because of different arguments
-	require.Equal(t, 4, strings.Count(errout, "uuid"))
-	require.Equal(t, 6, strings.Count(errout, "random_arg"))
-	require.Equal(t, 4, strings.Count(errout, "another_arg"))
+	assert.Equal(t, 4, strings.Count(errout, "uuid"))
+	assert.Equal(t, 6, strings.Count(errout, "random_arg"))
+	assert.Equal(t, 4, strings.Count(errout, "another_arg"))
 }
 
 func TestShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
@@ -5232,8 +5232,8 @@ func TestShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
 	require.NoError(t, err)
 
 	output := stderr.String()
-	require.Equal(t, 1, strings.Count(output, appV1Path))
-	require.Equal(t, 1, strings.Count(output, appV2Path))
+	assert.Equal(t, 1, strings.Count(output, appV1Path))
+	assert.Equal(t, 1, strings.Count(output, appV2Path))
 }
 
 func TestTerragruntOutputFromRemoteState(t *testing.T) {
@@ -5269,12 +5269,12 @@ func TestTerragruntOutputFromRemoteState(t *testing.T) {
 	runTerragruntRedirectOutput(t, "terragrunt run-all output --terragrunt-fetch-dependency-output-from-state --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+environmentPath, &stdout, &stderr)
 	output := stdout.String()
 
-	require.True(t, strings.Contains(output, "app1 output"))
-	require.True(t, strings.Contains(output, "app2 output"))
-	require.True(t, strings.Contains(output, "app3 output"))
-	require.False(t, strings.Contains(stderr.String(), "terraform output -json"))
+	assert.True(t, strings.Contains(output, "app1 output"))
+	assert.True(t, strings.Contains(output, "app2 output"))
+	assert.True(t, strings.Contains(output, "app3 output"))
+	assert.False(t, strings.Contains(stderr.String(), "terraform output -json"))
 
-	require.True(t, (strings.Index(output, "app3 output") < strings.Index(output, "app1 output")) && (strings.Index(output, "app1 output") < strings.Index(output, "app2 output")))
+	assert.True(t, (strings.Index(output, "app3 output") < strings.Index(output, "app1 output")) && (strings.Index(output, "app1 output") < strings.Index(output, "app2 output")))
 }
 
 func TestShowErrorWhenRunAllInvokedWithoutArguments(t *testing.T) {
@@ -5289,7 +5289,7 @@ func TestShowErrorWhenRunAllInvokedWithoutArguments(t *testing.T) {
 	require.Error(t, err)
 	var missingCommandError runall.MissingCommand
 	ok := goErrors.As(err, &missingCommandError)
-	require.True(t, ok)
+	assert.True(t, ok)
 }
 
 func TestPathRelativeToIncludeInvokedInCorrectPathFromChild(t *testing.T) {
@@ -5302,8 +5302,8 @@ func TestPathRelativeToIncludeInvokedInCorrectPathFromChild(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt version --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir "+appPath, &stdout, &stderr)
 	require.NoError(t, err)
 	output := stdout.String()
-	require.Equal(t, 1, strings.Count(output, "path_relative_to_inclue: app\n"))
-	require.Equal(t, 0, strings.Count(output, "path_relative_to_inclue: .\n"))
+	assert.Equal(t, 1, strings.Count(output, "path_relative_to_inclue: app\n"))
+	assert.Equal(t, 0, strings.Count(output, "path_relative_to_inclue: .\n"))
 }
 
 func TestTerragruntInitConfirmation(t *testing.T) {
@@ -5321,7 +5321,7 @@ func TestTerragruntInitConfirmation(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt run-all init --terragrunt-working-dir "+tmpEnvPath, &stdout, &stderr)
 	require.Error(t, err)
 	errout := stderr.String()
-	require.Equal(t, 1, strings.Count(errout, "does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n)"))
+	assert.Equal(t, 1, strings.Count(errout, "does not exist or you don't have permissions to access it. Would you like Terragrunt to create it? (y/n)"))
 }
 
 func TestNoMultipleInitsWithoutSourceChange(t *testing.T) {
@@ -5337,7 +5337,7 @@ func TestNoMultipleInitsWithoutSourceChange(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
 	require.NoError(t, err)
 	// providers initialization during first plan
-	require.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
+	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
 
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
@@ -5346,7 +5346,7 @@ func TestNoMultipleInitsWithoutSourceChange(t *testing.T) {
 	require.NoError(t, err)
 	// no initialization expected for second plan run
 	// https://github.com/gruntwork-io/terragrunt/issues/1921
-	require.Equal(t, 0, strings.Count(stdout.String(), "has been successfully initialized!"))
+	assert.Equal(t, 0, strings.Count(stdout.String(), "has been successfully initialized!"))
 }
 
 func TestAutoInitWhenSourceIsChanged(t *testing.T) {
@@ -5370,7 +5370,7 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	err = runTerragruntCommand(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
 	require.NoError(t, err)
 	// providers initialization during first plan
-	require.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
+	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
 
 	updatedHcl = strings.ReplaceAll(contents, "__TAG_VALUE__", "v0.35.2")
 	require.NoError(t, os.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
@@ -5381,7 +5381,7 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	err = runTerragruntCommand(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
 	require.NoError(t, err)
 	// auto initialization when source is changed
-	require.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
+	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
 }
 
 func TestNoColor(t *testing.T) {
@@ -5397,9 +5397,9 @@ func TestNoColor(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt plan -no-color --terragrunt-working-dir "+testPath, &stdout, &stderr)
 	require.NoError(t, err)
 	// providers initialization during first plan
-	require.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
+	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
 
-	require.NotContains(t, stdout.String(), "[")
+	assert.NotContains(t, stdout.String(), "[")
 }
 
 func TestRenderJsonAttributesMetadata(t *testing.T) {
@@ -5436,7 +5436,7 @@ func TestRenderJsonAttributesMetadata(t *testing.T) {
 			"value":    "us-east-1",
 		},
 	}
-	require.True(t, reflect.DeepEqual(expectedInputs, inputs))
+	assert.True(t, reflect.DeepEqual(expectedInputs, inputs))
 
 	var locals = renderedJson[config.MetadataLocals]
 	var expectedLocals = map[string]interface{}{
@@ -5445,63 +5445,63 @@ func TestRenderJsonAttributesMetadata(t *testing.T) {
 			"value":    "us-east-1",
 		},
 	}
-	require.True(t, reflect.DeepEqual(expectedLocals, locals))
+	assert.True(t, reflect.DeepEqual(expectedLocals, locals))
 
 	var downloadDir = renderedJson[config.MetadataDownloadDir]
 	var expecteDownloadDir = map[string]interface{}{
 		"metadata": expectedMetadata,
 		"value":    "/tmp",
 	}
-	require.True(t, reflect.DeepEqual(expecteDownloadDir, downloadDir))
+	assert.True(t, reflect.DeepEqual(expecteDownloadDir, downloadDir))
 
 	var iamAssumeRoleDuration = renderedJson[config.MetadataIamAssumeRoleDuration]
 	expectedIamAssumeRoleDuration := map[string]interface{}{
 		"metadata": expectedMetadata,
 		"value":    float64(666),
 	}
-	require.True(t, reflect.DeepEqual(expectedIamAssumeRoleDuration, iamAssumeRoleDuration))
+	assert.True(t, reflect.DeepEqual(expectedIamAssumeRoleDuration, iamAssumeRoleDuration))
 
 	var iamAssumeRoleName = renderedJson[config.MetadataIamAssumeRoleSessionName]
 	expectedIamAssumeRoleName := map[string]interface{}{
 		"metadata": expectedMetadata,
 		"value":    "qwe",
 	}
-	require.True(t, reflect.DeepEqual(expectedIamAssumeRoleName, iamAssumeRoleName))
+	assert.True(t, reflect.DeepEqual(expectedIamAssumeRoleName, iamAssumeRoleName))
 
 	var iamRole = renderedJson[config.MetadataIamRole]
 	expectedIamRole := map[string]interface{}{
 		"metadata": expectedMetadata,
 		"value":    "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME",
 	}
-	require.True(t, reflect.DeepEqual(expectedIamRole, iamRole))
+	assert.True(t, reflect.DeepEqual(expectedIamRole, iamRole))
 
 	var preventDestroy = renderedJson[config.MetadataPreventDestroy]
 	expectedPreventDestroy := map[string]interface{}{
 		"metadata": expectedMetadata,
 		"value":    true,
 	}
-	require.True(t, reflect.DeepEqual(expectedPreventDestroy, preventDestroy))
+	assert.True(t, reflect.DeepEqual(expectedPreventDestroy, preventDestroy))
 
 	var skip = renderedJson[config.MetadataSkip]
 	expectedSkip := map[string]interface{}{
 		"metadata": expectedMetadata,
 		"value":    true,
 	}
-	require.True(t, reflect.DeepEqual(expectedSkip, skip))
+	assert.True(t, reflect.DeepEqual(expectedSkip, skip))
 
 	var terraformBinary = renderedJson[config.MetadataTerraformBinary]
 	expectedTerraformBinary := map[string]interface{}{
 		"metadata": expectedMetadata,
 		"value":    wrappedBinary(),
 	}
-	require.True(t, reflect.DeepEqual(expectedTerraformBinary, terraformBinary))
+	assert.True(t, reflect.DeepEqual(expectedTerraformBinary, terraformBinary))
 
 	var terraformVersionConstraint = renderedJson[config.MetadataTerraformVersionConstraint]
 	expectedTerraformVersionConstraint := map[string]interface{}{
 		"metadata": expectedMetadata,
 		"value":    ">= 0.11",
 	}
-	require.True(t, reflect.DeepEqual(expectedTerraformVersionConstraint, terraformVersionConstraint))
+	assert.True(t, reflect.DeepEqual(expectedTerraformVersionConstraint, terraformVersionConstraint))
 }
 
 func TestOutputModuleGroups(t *testing.T) {
@@ -5574,7 +5574,7 @@ func TestOutputModuleGroups(t *testing.T) {
 			runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt output-module-groups --terragrunt-working-dir %s %s", environmentPath, tt.subCommand), &stdout, &stderr)
 			output := strings.ReplaceAll(stdout.String(), " ", "")
 			expectedOutput := strings.ReplaceAll(strings.ReplaceAll(tt.expectedOutput, "\t", ""), " ", "")
-			require.True(t, strings.Contains(strings.TrimSpace(output), strings.TrimSpace(expectedOutput)))
+			assert.True(t, strings.Contains(strings.TrimSpace(output), strings.TrimSpace(expectedOutput)))
 		})
 	}
 }
@@ -5614,7 +5614,7 @@ func TestRenderJsonMetadataDependency(t *testing.T) {
 			"value":    "test_value",
 		},
 	}
-	require.True(t, reflect.DeepEqual(expectedInputs, inputs))
+	assert.True(t, reflect.DeepEqual(expectedInputs, inputs))
 
 	var dependencies = renderedJson[config.MetadataDependencies]
 	var expectedDependencies = []interface{}{
@@ -5627,7 +5627,7 @@ func TestRenderJsonMetadataDependency(t *testing.T) {
 			"value":    "../dependency1",
 		},
 	}
-	require.True(t, reflect.DeepEqual(expectedDependencies, dependencies))
+	assert.True(t, reflect.DeepEqual(expectedDependencies, dependencies))
 }
 
 func TestRenderJsonWithMockOutputs(t *testing.T) {
@@ -5678,7 +5678,7 @@ func TestRenderJsonWithMockOutputs(t *testing.T) {
 
 	serializedExpectedDependency, err := json.Marshal(expectedDependency)
 	require.NoError(t, err)
-	require.Equal(t, string(serializedExpectedDependency), string(serializedDependency))
+	assert.Equal(t, string(serializedExpectedDependency), string(serializedDependency))
 }
 
 func TestRenderJsonMetadataIncludes(t *testing.T) {
@@ -5731,7 +5731,7 @@ func TestRenderJsonMetadataIncludes(t *testing.T) {
 			"value":    "123",
 		},
 	}
-	require.True(t, reflect.DeepEqual(expectedInputs, inputs))
+	assert.True(t, reflect.DeepEqual(expectedInputs, inputs))
 
 	var locals = renderedJson[config.MetadataLocals]
 	var expectedLocals = map[string]interface{}{
@@ -5740,7 +5740,7 @@ func TestRenderJsonMetadataIncludes(t *testing.T) {
 			"value":    "xyz",
 		},
 	}
-	require.True(t, reflect.DeepEqual(expectedLocals, locals))
+	assert.True(t, reflect.DeepEqual(expectedLocals, locals))
 
 	var generate = renderedJson[config.MetadataGenerateConfigs]
 	var expectedGenerate = map[string]interface{}{
@@ -5765,7 +5765,7 @@ func TestRenderJsonMetadataIncludes(t *testing.T) {
 	serializedExpectedGenerate, err := json.Marshal(expectedGenerate)
 	require.NoError(t, err)
 
-	require.Equal(t, string(serializedExpectedGenerate), string(serializedGenerate))
+	assert.Equal(t, string(serializedExpectedGenerate), string(serializedGenerate))
 
 	var remoteState = renderedJson[config.MetadataRemoteState]
 	var expectedRemoteState = map[string]interface{}{
@@ -5790,7 +5790,7 @@ func TestRenderJsonMetadataIncludes(t *testing.T) {
 	serializedExpectedRemoteState, err := json.Marshal(expectedRemoteState)
 	require.NoError(t, err)
 
-	require.Equal(t, string(serializedExpectedRemoteState), string(serializedRemoteState))
+	assert.Equal(t, string(serializedExpectedRemoteState), string(serializedRemoteState))
 }
 
 func TestRenderJsonMetadataDepenency(t *testing.T) {
@@ -5862,7 +5862,7 @@ func TestRenderJsonMetadataDepenency(t *testing.T) {
 	serializedExpectedDependency, err := json.Marshal(expectedDependency)
 	require.NoError(t, err)
 
-	require.Equal(t, string(serializedExpectedDependency), string(serializedDependency))
+	assert.Equal(t, string(serializedExpectedDependency), string(serializedDependency))
 }
 
 func TestRenderJsonMetadataTerraform(t *testing.T) {
@@ -5911,7 +5911,7 @@ func TestRenderJsonMetadataTerraform(t *testing.T) {
 	serializedExpectedTerraform, err := json.Marshal(expectedTerraform)
 	require.NoError(t, err)
 
-	require.Equal(t, string(serializedExpectedTerraform), string(serializedTerraform))
+	assert.Equal(t, string(serializedExpectedTerraform), string(serializedTerraform))
 
 	var remoteState = renderedJson[config.MetadataRemoteState]
 	var expectedRemoteState = map[string]interface{}{
@@ -5936,7 +5936,7 @@ func TestRenderJsonMetadataTerraform(t *testing.T) {
 	serializedExpectedRemoteState, err := json.Marshal(expectedRemoteState)
 	require.NoError(t, err)
 
-	require.Equal(t, string(serializedExpectedRemoteState), string(serializedRemoteState))
+	assert.Equal(t, string(serializedExpectedRemoteState), string(serializedRemoteState))
 }
 
 func TestTerragruntRenderJsonHelp(t *testing.T) {
@@ -5956,8 +5956,8 @@ func TestTerragruntRenderJsonHelp(t *testing.T) {
 
 	output := showStdout.String()
 
-	require.Contains(t, output, "terragrunt render-json")
-	require.Contains(t, output, "--with-metadata")
+	assert.Contains(t, output, "terragrunt render-json")
+	assert.Contains(t, output, "--with-metadata")
 }
 
 func TestStartsWith(t *testing.T) {
@@ -6036,7 +6036,7 @@ func TestTimeCmpInvalidTimestamp(t *testing.T) {
 
 	err := runTerragruntCommand(t, "terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
 
-	expectedError := `not a valid RFC3339 timestamp: missing required time introducer 'T'`
+	expectedError := `not a valid RFC3339 timestamp: missing assertd time introducer 'T'`
 	require.ErrorContains(t, err, expectedError)
 }
 
@@ -6138,7 +6138,7 @@ func TestInitFailureModulePrefix(t *testing.T) {
 		runTerragruntCommand(t, "terragrunt init -no-color --terragrunt-include-module-prefix --terragrunt-non-interactive --terragrunt-working-dir "+initTestCase, &stdout, &stderr),
 	)
 	logBufferContentsLineByLine(t, stderr, "init")
-	require.Contains(t, stderr.String(), "[fixture-init-error] Error")
+	assert.Contains(t, stderr.String(), "[fixture-init-error] Error")
 }
 
 func TestDependencyOutputModulePrefix(t *testing.T) {
@@ -6162,7 +6162,7 @@ func TestDependencyOutputModulePrefix(t *testing.T) {
 	// validate that output is valid json
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	require.Equal(t, 42, int(outputs["z"].Value.(float64)))
+	assert.Equal(t, 42, int(outputs["z"].Value.(float64)))
 }
 
 func TestErrorExplaining(t *testing.T) {
@@ -6181,7 +6181,7 @@ func TestErrorExplaining(t *testing.T) {
 	require.Error(t, err)
 
 	explanation := shell.ExplainError(err)
-	require.Contains(t, explanation, "Check your credentials and permissions")
+	assert.Contains(t, explanation, "Check your credentials and permissions")
 }
 
 func TestExplainingMissingCredentials(t *testing.T) {
@@ -6201,7 +6201,7 @@ func TestExplainingMissingCredentials(t *testing.T) {
 
 	err := runTerragruntCommand(t, "terragrunt init -no-color --terragrunt-include-module-prefix --terragrunt-non-interactive --terragrunt-working-dir "+initTestCase, &stdout, &stderr)
 	explanation := shell.ExplainError(err)
-	require.Contains(t, explanation, "Missing AWS credentials")
+	assert.Contains(t, explanation, "Missing AWS credentials")
 }
 
 func TestModulePathInPlanErrorMessage(t *testing.T) {
@@ -6216,8 +6216,8 @@ func TestModulePathInPlanErrorMessage(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt plan -no-color --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
 	require.Error(t, err)
 	output := fmt.Sprintf("%s\n%s\n%v\n", stdout.String(), stderr.String(), err.Error())
-	require.Contains(t, output, fmt.Sprintf("prefix=[%s]", util.JoinPath(tmpEnvPath, TEST_FIXTURE_MODULE_PATH_ERROR, "d1")))
-	require.Contains(t, output, "1 error occurred")
+	assert.Contains(t, output, fmt.Sprintf("prefix=[%s]", util.JoinPath(tmpEnvPath, TEST_FIXTURE_MODULE_PATH_ERROR, "d1")))
+	assert.Contains(t, output, "1 error occurred")
 }
 
 func TestModulePathInRunAllPlanErrorMessage(t *testing.T) {
@@ -6232,8 +6232,8 @@ func TestModulePathInRunAllPlanErrorMessage(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt run-all plan -no-color --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
 	require.Error(t, err)
 	output := fmt.Sprintf("%s\n%s\n%v\n", stdout.String(), stderr.String(), err.Error())
-	require.Contains(t, output, "finished with an error")
-	require.Contains(t, output, "Module "+util.JoinPath(tmpEnvPath, TEST_FIXTURE_MODULE_PATH_ERROR, "d1"))
+	assert.Contains(t, output, "finished with an error")
+	assert.Contains(t, output, "Module "+util.JoinPath(tmpEnvPath, TEST_FIXTURE_MODULE_PATH_ERROR, "d1"))
 
 }
 
@@ -6258,7 +6258,7 @@ func TestHclFmtDiff(t *testing.T) {
 	require.NoError(t, err)
 
 	logBufferContentsLineByLine(t, stdout, "output")
-	require.Contains(t, output, string(expectedDiff))
+	assert.Contains(t, output, string(expectedDiff))
 }
 
 func TestDestroyDependentModule(t *testing.T) {
@@ -6286,11 +6286,11 @@ func TestDestroyDependentModule(t *testing.T) {
 	err = runTerragruntCommand(t, "terragrunt destroy -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+util.JoinPath(rootPath, "c"), &stdout, &stderr)
 	require.NoError(t, err)
 
-	require.True(t, strings.Contains(stderr.String(), util.JoinPath(rootPath, "b", "terragrunt.hcl")))
-	require.True(t, strings.Contains(stderr.String(), util.JoinPath(rootPath, "a", "terragrunt.hcl")))
+	assert.True(t, strings.Contains(stderr.String(), util.JoinPath(rootPath, "b", "terragrunt.hcl")))
+	assert.True(t, strings.Contains(stderr.String(), util.JoinPath(rootPath, "a", "terragrunt.hcl")))
 
-	require.True(t, strings.Contains(stderr.String(), "\"value\": \"module-b.txt\""))
-	require.True(t, strings.Contains(stderr.String(), "\"value\": \"module-a.txt\""))
+	assert.True(t, strings.Contains(stderr.String(), "\"value\": \"module-b.txt\""))
+	assert.True(t, strings.Contains(stderr.String(), "\"value\": \"module-a.txt\""))
 }
 
 func TestDownloadSourceWithRef(t *testing.T) {
@@ -6363,8 +6363,8 @@ func TestInitSkipCache(t *testing.T) {
 	)
 
 	// verify that init was invoked
-	require.Contains(t, stdout.String(), "has been successfully initialized!")
-	require.Contains(t, stderr.String(), "Running command: "+wrappedBinary()+" init")
+	assert.Contains(t, stdout.String(), "has been successfully initialized!")
+	assert.Contains(t, stderr.String(), "Running command: "+wrappedBinary()+" init")
 
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
@@ -6375,8 +6375,8 @@ func TestInitSkipCache(t *testing.T) {
 	)
 
 	// verify that init wasn't invoked second time since cache directories are ignored
-	require.NotContains(t, stdout.String(), "has been successfully initialized!")
-	require.NotContains(t, stderr.String(), "Running command: "+wrappedBinary()+" init")
+	assert.NotContains(t, stdout.String(), "has been successfully initialized!")
+	assert.NotContains(t, stderr.String(), "Running command: "+wrappedBinary()+" init")
 
 	// verify that after adding new file, init is executed
 	tfFile := util.JoinPath(tmpEnvPath, TEST_FIXTURE_INIT_CACHE, "app", "project.tf")
@@ -6393,8 +6393,8 @@ func TestInitSkipCache(t *testing.T) {
 	)
 
 	// verify that init was invoked
-	require.Contains(t, stdout.String(), "has been successfully initialized!")
-	require.Contains(t, stderr.String(), "Running command: "+wrappedBinary()+" init")
+	assert.Contains(t, stdout.String(), "has been successfully initialized!")
+	assert.Contains(t, stderr.String(), "Running command: "+wrappedBinary()+" init")
 }
 
 func TestRenderJsonWithInputsNotExistingOutput(t *testing.T) {
@@ -6435,10 +6435,10 @@ func TestRenderJsonWithInputsNotExistingOutput(t *testing.T) {
 			"value":    "",
 		},
 	}
-	require.True(t, reflect.DeepEqual(expectedInputs, inputs))
+	assert.True(t, reflect.DeepEqual(expectedInputs, inputs))
 }
 
-func TestTerragruntFailIfBucketCreationIsRequired(t *testing.T) {
+func TestTerragruntFailIfBucketCreationIsassertd(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath := copyEnvironment(t, TEST_FIXTURE_PATH)
@@ -6503,8 +6503,8 @@ func TestTerragruntPassNullValues(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 
 	// check that the null values are passed correctly
-	require.Nil(t, outputs["output1"].Value)
-	require.Equal(t, "variable 2", outputs["output2"].Value)
+	assert.Nil(t, outputs["output1"].Value)
+	assert.Equal(t, "variable 2", outputs["output2"].Value)
 
 	// check that file with null values is removed
 	cachePath := filepath.Join(TEST_FIXTURE_NULL_VALUE, TERRAGRUNT_CACHE)
@@ -6519,7 +6519,7 @@ func TestTerragruntPassNullValues(t *testing.T) {
 			}
 			return nil
 		})
-	require.Falsef(t, foundNullValuesFile, "Found %s file in cache directory", terraform.NullTFVarsFile)
+	assert.Falsef(t, foundNullValuesFile, "Found %s file in cache directory", terraform.NullTFVarsFile)
 	require.NoError(t, err)
 }
 
@@ -6542,8 +6542,8 @@ func TestTerragruntPrintAwsErrors(t *testing.T) {
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigFile, rootPath), &stdout, &stderr)
 	require.Error(t, err)
 	message := err.Error()
-	require.True(t, strings.Contains(message, "AllAccessDisabled: All access to this object has been disabled") || strings.Contains(message, "BucketRegionError: incorrect region"))
-	require.Contains(t, message, s3BucketName)
+	assert.True(t, strings.Contains(message, "AllAccessDisabled: All access to this object has been disabled") || strings.Contains(message, "BucketRegionError: incorrect region"))
+	assert.Contains(t, message, s3BucketName)
 }
 
 func TestTerragruntErrorWhenStateBucketIsInDifferentRegion(t *testing.T) {
@@ -6571,7 +6571,7 @@ func TestTerragruntErrorWhenStateBucketIsInDifferentRegion(t *testing.T) {
 	stderr = bytes.Buffer{}
 	err = runTerragruntCommand(t, fmt.Sprintf("terragrunt apply --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigFile, rootPath), &stdout, &stderr)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "BucketRegionError: incorrect region")
+	assert.Contains(t, err.Error(), "BucketRegionError: incorrect region")
 }
 
 func TestTerragruntCheckMissingGCSBucket(t *testing.T) {
@@ -6588,7 +6588,7 @@ func TestTerragruntCheckMissingGCSBucket(t *testing.T) {
 	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, TEST_FIXTURE_GCS_NO_BUCKET, project, TERRAFORM_REMOTE_STATE_GCP_REGION, gcsBucketName, config.DefaultTerragruntConfigPath)
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntGCSConfigPath, TEST_FIXTURE_GCS_NO_BUCKET), &stdout, &stderr)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Missing required GCS remote state configuration bucket")
+	assert.Contains(t, err.Error(), "Missing required GCS remote state configuration bucket")
 }
 
 func TestTerragruntNoPrefixGCSBucket(t *testing.T) {
@@ -6621,7 +6621,7 @@ func TestTerragruntNoWarningLocalPath(t *testing.T) {
 
 	err := runTerragruntCommand(t, "terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
 	require.NoError(t, err)
-	require.NotContains(t, stderr.String(), "No double-slash (//) found in source URL")
+	assert.NotContains(t, stderr.String(), "No double-slash (//) found in source URL")
 }
 
 func TestTerragruntNoWarningRemotePath(t *testing.T) {
@@ -6636,7 +6636,7 @@ func TestTerragruntNoWarningRemotePath(t *testing.T) {
 
 	err := runTerragruntCommand(t, "terragrunt init --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
 	require.NoError(t, err)
-	require.NotContains(t, stderr.String(), "No double-slash (//) found in source URL")
+	assert.NotContains(t, stderr.String(), "No double-slash (//) found in source URL")
 }
 
 func TestTerragruntDisabledDependency(t *testing.T) {
@@ -6652,10 +6652,10 @@ func TestTerragruntDisabledDependency(t *testing.T) {
 	err := runTerragruntCommand(t, "terragrunt run-all plan --terragrunt-non-interactive  --terragrunt-log-level debug --terragrunt-working-dir "+testPath, &stdout, &stderr)
 	require.NoError(t, err)
 	// check that only enabled dependencies are evaluated
-	require.Contains(t, stderr.String(), util.JoinPath(tmpEnvPath, TEST_FIXTURE_DISABLED_MODULE, "app"))
-	require.Contains(t, stderr.String(), util.JoinPath(tmpEnvPath, TEST_FIXTURE_DISABLED_MODULE, "m1"))
-	require.Contains(t, stderr.String(), util.JoinPath(tmpEnvPath, TEST_FIXTURE_DISABLED_MODULE, "m3"))
-	require.NotContains(t, stderr.String(), util.JoinPath(tmpEnvPath, TEST_FIXTURE_DISABLED_MODULE, "m2"))
+	assert.Contains(t, stderr.String(), util.JoinPath(tmpEnvPath, TEST_FIXTURE_DISABLED_MODULE, "app"))
+	assert.Contains(t, stderr.String(), util.JoinPath(tmpEnvPath, TEST_FIXTURE_DISABLED_MODULE, "m1"))
+	assert.Contains(t, stderr.String(), util.JoinPath(tmpEnvPath, TEST_FIXTURE_DISABLED_MODULE, "m3"))
+	assert.NotContains(t, stderr.String(), util.JoinPath(tmpEnvPath, TEST_FIXTURE_DISABLED_MODULE, "m2"))
 }
 
 func TestTerragruntHandleEmptyStateFile(t *testing.T) {
@@ -6691,8 +6691,8 @@ func TestRenderJsonDependentModulesTerraform(t *testing.T) {
 
 	var dependentModules = renderedJson[config.MetadataDependentModules].([]interface{})
 	// check if value list contains app-v1 and app-v2
-	require.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, TEST_FIXTURE_DESTROY_WARNING, "app-v1"))
-	require.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, TEST_FIXTURE_DESTROY_WARNING, "app-v2"))
+	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, TEST_FIXTURE_DESTROY_WARNING, "app-v1"))
+	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, TEST_FIXTURE_DESTROY_WARNING, "app-v2"))
 }
 
 func TestRenderJsonDisableDependentModulesTerraform(t *testing.T) {
@@ -6712,7 +6712,7 @@ func TestRenderJsonDisableDependentModulesTerraform(t *testing.T) {
 	require.NoError(t, json.Unmarshal(jsonBytes, &renderedJson))
 
 	_, found := renderedJson[config.MetadataDependentModules].([]interface{})
-	require.False(t, found)
+	assert.False(t, found)
 }
 
 func TestRenderJsonDependentModulesMetadataTerraform(t *testing.T) {
@@ -6734,8 +6734,8 @@ func TestRenderJsonDependentModulesMetadataTerraform(t *testing.T) {
 
 	dependentModules := renderedJson[config.MetadataDependentModules]["value"].([]interface{})
 	// check if value list contains app-v1 and app-v2
-	require.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, TEST_FIXTURE_DESTROY_WARNING, "app-v1"))
-	require.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, TEST_FIXTURE_DESTROY_WARNING, "app-v2"))
+	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, TEST_FIXTURE_DESTROY_WARNING, "app-v1"))
+	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, TEST_FIXTURE_DESTROY_WARNING, "app-v2"))
 }
 
 func TestTerragruntSkipConfirmExternalDependencies(t *testing.T) {
@@ -6787,8 +6787,8 @@ func TestTerragruntSkipConfirmExternalDependencies(t *testing.T) {
 	captured := <-capturedOutput
 
 	require.NoError(t, err)
-	require.NotContains(t, captured, "Should Terragrunt apply the external dependency?")
-	require.NotContains(t, captured, "/tmp/external1")
+	assert.NotContains(t, captured, "Should Terragrunt apply the external dependency?")
+	assert.NotContains(t, captured, "/tmp/external1")
 }
 
 func TestTerragruntInvokeTerraformTests(t *testing.T) {
@@ -6807,7 +6807,7 @@ func TestTerragruntInvokeTerraformTests(t *testing.T) {
 
 	err := runTerragruntCommand(t, "terragrunt test --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
 	require.NoError(t, err)
-	require.Contains(t, stdout.String(), "1 passed, 0 failed")
+	assert.Contains(t, stdout.String(), "1 passed, 0 failed")
 }
 
 func TestTerragruntCommandsThatNeedInput(t *testing.T) {
@@ -6819,7 +6819,7 @@ func TestTerragruntCommandsThatNeedInput(t *testing.T) {
 
 	stdout, _, err := runTerragruntCommandWithOutput(t, "terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir "+testPath)
 	require.NoError(t, err)
-	require.Contains(t, stdout, "Apply complete")
+	assert.Contains(t, stdout, "Apply complete")
 }
 
 func TestTerragruntParallelStateInit(t *testing.T) {
@@ -6890,7 +6890,7 @@ func TestTerragruntAssumeRole(t *testing.T) {
 
 	// validate generated backend.tf
 	backendFile := filepath.Join(testPath, "backend.tf")
-	require.FileExists(t, backendFile)
+	assert.FileExists(t, backendFile)
 
 	content, err := files.ReadFileAsString(backendFile)
 	require.NoError(t, err)
@@ -6901,9 +6901,9 @@ func TestTerragruntAssumeRole(t *testing.T) {
 	identityARN, err := aws_helper.GetAWSIdentityArn(nil, opts)
 	require.NoError(t, err)
 
-	require.Contains(t, content, "role_arn     = \""+identityARN+"\"")
-	require.Contains(t, content, "external_id  = \"external_id_123\"")
-	require.Contains(t, content, "session_name = \"session_name_example\"")
+	assert.Contains(t, content, "role_arn     = \""+identityARN+"\"")
+	assert.Contains(t, content, "external_id  = \"external_id_123\"")
+	assert.Contains(t, content, "session_name = \"session_name_example\"")
 }
 
 func TestTerragruntUpdatePolicy(t *testing.T) {
@@ -6977,11 +6977,11 @@ func TestTerragruntDestroyGraph(t *testing.T) {
 			output := fmt.Sprintf("%v\n%v\n", stdout, stderr)
 
 			for _, module := range testCase.expectedModules {
-				require.Containsf(t, output, "/"+module+"\n", "Expected module %s to be in output", module)
+				assert.Containsf(t, output, "/"+module+"\n", "Expected module %s to be in output", module)
 			}
 
 			for _, module := range testCase.notExpectedModules {
-				require.NotContainsf(t, output, "Module "+tmpModulePath+"/"+module+"\n", "Expected module %s must not to be in output", module)
+				assert.NotContainsf(t, output, "Module "+tmpModulePath+"/"+module+"\n", "Expected module %s must not to be in output", module)
 			}
 		})
 	}
@@ -7024,11 +7024,11 @@ func TestTerragruntApplyGraph(t *testing.T) {
 			output := fmt.Sprintf("%v\n%v\n", stdout, stderr)
 
 			for _, module := range testCase.expectedModules {
-				require.Containsf(t, output, "/"+module+"\n", "Expected module %s to be in output", module)
+				assert.Containsf(t, output, "/"+module+"\n", "Expected module %s to be in output", module)
 			}
 
 			for _, module := range testCase.notExpectedModules {
-				require.NotContainsf(t, output, "Module "+tmpModulePath+"/"+module+"\n", "Expected module %s must not to be in output", module)
+				assert.NotContainsf(t, output, "Module "+tmpModulePath+"/"+module+"\n", "Expected module %s must not to be in output", module)
 			}
 		})
 	}
@@ -7068,12 +7068,12 @@ func TestTerragruntSkipDependenciesWithSkipFlag(t *testing.T) {
 
 	output := fmt.Sprintf("%s %s", stderr.String(), stdout.String())
 
-	require.NotContains(t, output, "Error reading partial config for dependency")
-	require.NotContains(t, output, "Call to function \"find_in_parent_folders\" failed")
-	require.NotContains(t, output, "ParentFileNotFoundError")
+	assert.NotContains(t, output, "Error reading partial config for dependency")
+	assert.NotContains(t, output, "Call to function \"find_in_parent_folders\" failed")
+	assert.NotContains(t, output, "ParentFileNotFoundError")
 
-	require.Contains(t, output, "first/terragrunt.hcl due to skip = true")
-	require.Contains(t, output, "second/terragrunt.hcl due to skip = true")
+	assert.Contains(t, output, "first/terragrunt.hcl due to skip = true")
+	assert.Contains(t, output, "second/terragrunt.hcl due to skip = true")
 	// check that no test_file.txt was created in module directory
 	_, err = os.Stat(util.JoinPath(tmpEnvPath, TEST_FIXTURE_SKIP_DEPENDENCIES, "first", "test_file.txt"))
 	require.Error(t, err)
@@ -7114,7 +7114,7 @@ func TestTerragruntAssumeRoleDuration(t *testing.T) {
 	require.NoError(t, err)
 
 	output := fmt.Sprintf("%s %s", stderr.String(), stdout.String())
-	require.Contains(t, output, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
+	assert.Contains(t, output, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
 	// run one more time to check that no init is performed
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
@@ -7123,9 +7123,9 @@ func TestTerragruntAssumeRoleDuration(t *testing.T) {
 	require.NoError(t, err)
 
 	output = fmt.Sprintf("%s %s", stderr.String(), stdout.String())
-	require.NotContains(t, output, "Initializing the backend...")
-	require.NotContains(t, output, "has been successfully initialized!")
-	require.Contains(t, output, "no changes are needed.")
+	assert.NotContains(t, output, "Initializing the backend...")
+	assert.NotContains(t, output, "has been successfully initialized!")
+	assert.Contains(t, output, "no changes are needed.")
 }
 
 func TestTerragruntAssumeRoleWebIdentityEnv(t *testing.T) {
@@ -7134,7 +7134,7 @@ func TestTerragruntAssumeRoleWebIdentityEnv(t *testing.T) {
 	assumeRole := os.Getenv("AWS_TEST_S3_ASSUME_ROLE")
 	tokenEnvVar := os.Getenv("AWS_TEST_S3_IDENTITY_TOKEN_VAR")
 	if tokenEnvVar == "" {
-		t.Skip("Missing required env var AWS_TEST_S3_IDENTITY_TOKEN_VAR")
+		t.Skip("Missing assertd env var AWS_TEST_S3_IDENTITY_TOKEN_VAR")
 		return
 	}
 
@@ -7162,7 +7162,7 @@ func TestTerragruntAssumeRoleWebIdentityEnv(t *testing.T) {
 	require.NoError(t, err)
 
 	output := fmt.Sprintf("%s %s", stderr.String(), stdout.String())
-	require.Contains(t, output, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
+	assert.Contains(t, output, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
 }
 
 func TestTerragruntAssumeRoleWebIdentityFile(t *testing.T) {
@@ -7195,7 +7195,7 @@ func TestTerragruntAssumeRoleWebIdentityFile(t *testing.T) {
 	require.NoError(t, err)
 
 	output := fmt.Sprintf("%s %s", stderr.String(), stdout.String())
-	require.Contains(t, output, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
+	assert.Contains(t, output, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
 }
 
 func prepareGraphFixture(t *testing.T) string {
@@ -7244,14 +7244,14 @@ func TestStorePlanFilesRunAllPlanApply(t *testing.T) {
 	_, output, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all plan --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-out-dir %s", testPath, tmpDir))
 	require.NoError(t, err)
 
-	require.Contains(t, output, "Using output file "+tmpDir)
+	assert.Contains(t, output, "Using output file "+tmpDir)
 
 	// verify that tfplan files are created in the tmpDir, 2 files
 	list, err := findFilesWithExtension(tmpDir, ".tfplan")
 	require.NoError(t, err)
-	require.Len(t, list, 2)
+	assert.Len(t, list, 2)
 	for _, file := range list {
-		require.Equal(t, "tfplan.tfplan", filepath.Base(file))
+		assert.Equal(t, "tfplan.tfplan", filepath.Base(file))
 	}
 
 	_, _, err = runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-out-dir %s", testPath, tmpDir))
@@ -7276,22 +7276,22 @@ func TestStorePlanFilesRunAllDestroy(t *testing.T) {
 	// remove all tfstate files from temp directory to prepare destroy
 	list, err := findFilesWithExtension(tmpDir, ".tfplan")
 	require.NoError(t, err)
-	require.Len(t, list, 2)
+	assert.Len(t, list, 2)
 	for _, file := range list {
-		require.Equal(t, "tfplan.tfplan", filepath.Base(file))
+		assert.Equal(t, "tfplan.tfplan", filepath.Base(file))
 	}
 
 	// prepare destroy plan
 	_, output, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all plan -destroy --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-out-dir %s", testPath, tmpDir))
 	require.NoError(t, err)
 
-	require.Contains(t, output, "Using output file "+tmpDir)
+	assert.Contains(t, output, "Using output file "+tmpDir)
 	// verify that tfplan files are created in the tmpDir, 2 files
 	list, err = findFilesWithExtension(tmpDir, ".tfplan")
 	require.NoError(t, err)
-	require.Len(t, list, 2)
+	assert.Len(t, list, 2)
 	for _, file := range list {
-		require.Equal(t, "tfplan.tfplan", filepath.Base(file))
+		assert.Equal(t, "tfplan.tfplan", filepath.Base(file))
 	}
 
 	_, _, err = runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir %s --terragrunt-out-dir %s", testPath, tmpDir))
@@ -7309,19 +7309,19 @@ func TestPlanJsonFilesRunAll(t *testing.T) {
 	// verify that was generated json files with plan data
 	list, err := findFilesWithExtension(tmpDir, ".json")
 	require.NoError(t, err)
-	require.Len(t, list, 2)
+	assert.Len(t, list, 2)
 	for _, file := range list {
-		require.Equal(t, "tfplan.json", filepath.Base(file))
+		assert.Equal(t, "tfplan.json", filepath.Base(file))
 		// verify that file is not empty
 		content, err := os.ReadFile(file)
 		require.NoError(t, err)
-		require.NotEmpty(t, content)
+		assert.NotEmpty(t, content)
 		// check that produced json is valid and can be unmarshalled
 		var plan map[string]interface{}
 		err = json.Unmarshal(content, &plan)
 		require.NoError(t, err)
 		// check that plan is not empty
-		require.NotEmpty(t, plan)
+		assert.NotEmpty(t, plan)
 	}
 
 }
@@ -7342,21 +7342,21 @@ func TestPlanJsonPlanBinaryRunAll(t *testing.T) {
 	// verify that was generated json files with plan data
 	list, err := findFilesWithExtension(tmpDir, ".json")
 	require.NoError(t, err)
-	require.Len(t, list, 2)
+	assert.Len(t, list, 2)
 	for _, file := range list {
-		require.Equal(t, "tfplan.json", filepath.Base(file))
+		assert.Equal(t, "tfplan.json", filepath.Base(file))
 		// verify that file is not empty
 		content, err := os.ReadFile(file)
 		require.NoError(t, err)
-		require.NotEmpty(t, content)
+		assert.NotEmpty(t, content)
 	}
 
 	// verify that was generated binary plan files
 	list, err = findFilesWithExtension(tmpDir, ".tfplan")
 	require.NoError(t, err)
-	require.Len(t, list, 2)
+	assert.Len(t, list, 2)
 	for _, file := range list {
-		require.Equal(t, "tfplan.tfplan", filepath.Base(file))
+		assert.Equal(t, "tfplan.tfplan", filepath.Base(file))
 	}
 
 }
@@ -7385,7 +7385,7 @@ func TestTerragruntRunAllPlanAndShow(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that output contains the plan and not just the actual state output
-	require.Contains(t, stdout, "No changes. Your infrastructure matches the configuration.")
+	assert.Contains(t, stdout, "No changes. Your infrastructure matches the configuration.")
 }
 
 func TestTerragruntLogSopsErrors(t *testing.T) {
@@ -7400,8 +7400,8 @@ func TestTerragruntLogSopsErrors(t *testing.T) {
 	_, errorOut, err := runTerragruntCommandWithOutput(t, "terragrunt apply --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+testPath)
 	require.Error(t, err)
 
-	require.Contains(t, errorOut, "error decrypting key: [error decrypting key")
-	require.Contains(t, errorOut, "error base64-decoding encrypted data key: illegal base64 data at input byte")
+	assert.Contains(t, errorOut, "error decrypting key: [error decrypting key")
+	assert.Contains(t, errorOut, "error base64-decoding encrypted data key: illegal base64 data at input byte")
 }
 
 func TestGetRepoRootCaching(t *testing.T) {
@@ -7420,14 +7420,14 @@ func TestGetRepoRootCaching(t *testing.T) {
 
 	output := fmt.Sprintf("%s %s", stdout, stderr)
 	count := strings.Count(output, "git show-toplevel result")
-	require.Equal(t, 1, count)
+	assert.Equal(t, 1, count)
 }
 
 func validateOutput(t *testing.T, outputs map[string]TerraformOutput, key string, value interface{}) {
 	t.Helper()
 	output, hasPlatform := outputs[key]
-	require.Truef(t, hasPlatform, "Expected output %s to be defined", key)
-	require.Equalf(t, output.Value, value, "Expected output %s to be %t", key, value)
+	assert.Truef(t, hasPlatform, "Expected output %s to be defined", key)
+	assert.Equalf(t, output.Value, value, "Expected output %s to be %t", key, value)
 }
 
 // wrappedBinary - return which binary will be wrapped by Terragrunt, useful in CICD to run same tests against tofu and terraform

--- a/tflint/tflint_test.go
+++ b/tflint/tflint_test.go
@@ -3,6 +3,7 @@ package tflint
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,6 +36,6 @@ func TestInputsToTflintVar(t *testing.T) {
 	for _, testCase := range testCases {
 		actual, err := inputsToTflintVar(testCase.inputs)
 		require.NoError(t, err)
-		require.ElementsMatch(t, testCase.expected, actual)
+		assert.ElementsMatch(t, testCase.expected, actual)
 	}
 }

--- a/util/collections_test.go
+++ b/util/collections_test.go
@@ -3,7 +3,7 @@ package util
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMatchesAny(t *testing.T) {
@@ -33,7 +33,7 @@ func TestMatchesAny(t *testing.T) {
 
 	for _, testCase := range testCases {
 		actual := MatchesAny(testCase.list, testCase.element)
-		require.Equal(t, testCase.expected, actual, "For list %v and element %s", testCase.list, testCase.element)
+		assert.Equal(t, testCase.expected, actual, "For list %v and element %s", testCase.list, testCase.element)
 	}
 }
 
@@ -55,7 +55,7 @@ func TestListContainsElement(t *testing.T) {
 
 	for _, testCase := range testCases {
 		actual := ListContainsElement(testCase.list, testCase.element)
-		require.Equal(t, testCase.expected, actual, "For list %v and element %s", testCase.list, testCase.element)
+		assert.Equal(t, testCase.expected, actual, "For list %v and element %s", testCase.list, testCase.element)
 	}
 }
 
@@ -79,7 +79,7 @@ func TestListEquals(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		actual := ListEquals(testCase.a, testCase.b)
-		require.Equal(t, testCase.expected, actual, "For list %v and list %v", testCase.a, testCase.b)
+		assert.Equal(t, testCase.expected, actual, "For list %v and list %v", testCase.a, testCase.b)
 	}
 }
 
@@ -116,7 +116,7 @@ func TestListContainsSublist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		actual := ListContainsSublist(testCase.list, testCase.sublist)
-		require.Equal(t, testCase.expected, actual, "For list %v and sublist %v", testCase.list, testCase.sublist)
+		assert.Equal(t, testCase.expected, actual, "For list %v and sublist %v", testCase.list, testCase.sublist)
 	}
 }
 
@@ -143,7 +143,7 @@ func TestListHasPrefix(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		actual := ListHasPrefix(testCase.list, testCase.prefix)
-		require.Equal(t, testCase.expected, actual, "For list %v and prefix %v", testCase.list, testCase.prefix)
+		assert.Equal(t, testCase.expected, actual, "For list %v and prefix %v", testCase.list, testCase.prefix)
 	}
 }
 
@@ -166,7 +166,7 @@ func TestRemoveElementFromList(t *testing.T) {
 
 	for _, testCase := range testCases {
 		actual := RemoveElementFromList(testCase.list, testCase.element)
-		require.Equal(t, testCase.expected, actual, "For list %v and element %s", testCase.list, testCase.element)
+		assert.Equal(t, testCase.expected, actual, "For list %v and element %s", testCase.list, testCase.element)
 	}
 }
 
@@ -192,7 +192,7 @@ func TestRemoveDuplicatesFromList(t *testing.T) {
 		if testCase.reverse {
 			f = RemoveDuplicatesFromListKeepLast[[]string]
 		}
-		require.Equal(t, testCase.expected, f(testCase.list), "For list %v", testCase.list)
+		assert.Equal(t, testCase.expected, f(testCase.list), "For list %v", testCase.list)
 		t.Logf("%v passed", testCase.list)
 	}
 }
@@ -210,7 +210,7 @@ func TestCommaSeparatedStrings(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		require.Equal(t, testCase.expected, CommaSeparatedStrings(testCase.list), "For list %v", testCase.list)
+		assert.Equal(t, testCase.expected, CommaSeparatedStrings(testCase.list), "For list %v", testCase.list)
 		t.Logf("%v passed", testCase.list)
 	}
 }
@@ -231,7 +231,7 @@ func TestStringListInsert(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		require.Equal(t, testCase.expected, StringListInsert(testCase.list, testCase.element, testCase.index), "For list %v", testCase.list)
+		assert.Equal(t, testCase.expected, StringListInsert(testCase.list, testCase.element, testCase.index), "For list %v", testCase.list)
 		t.Logf("%v passed", testCase.list)
 	}
 }

--- a/util/datetime_test.go
+++ b/util/datetime_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,7 @@ func TestParseTimestamp(t *testing.T) {
 		{"2017-11-22T00:00:00Z", time.Date(2017, time.Month(11), 22, 0, 0, 0, 0, time.UTC), ""},
 		{"2017-11-22T01:00:00+01:00", time.Date(2017, time.Month(11), 22, 1, 0, 0, 0, time.FixedZone("", 3600)), ""},
 		{"bloop", time.Time{}, `not a valid RFC3339 timestamp: cannot use "bloop" as year`},
-		{"2017-11-22 00:00:00Z", time.Time{}, `not a valid RFC3339 timestamp: missing required time introducer 'T'`},
+		{"2017-11-22 00:00:00Z", time.Time{}, `not a valid RFC3339 timestamp: missing assertd time introducer 'T'`},
 	}
 
 	for _, testCase := range testCases {
@@ -35,7 +36,7 @@ func TestParseTimestamp(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			require.Equal(t, testCase.value, actual)
+			assert.Equal(t, testCase.value, actual)
 		})
 	}
 }

--- a/util/datetime_test.go
+++ b/util/datetime_test.go
@@ -20,7 +20,7 @@ func TestParseTimestamp(t *testing.T) {
 		{"2017-11-22T00:00:00Z", time.Date(2017, time.Month(11), 22, 0, 0, 0, 0, time.UTC), ""},
 		{"2017-11-22T01:00:00+01:00", time.Date(2017, time.Month(11), 22, 1, 0, 0, 0, time.FixedZone("", 3600)), ""},
 		{"bloop", time.Time{}, `not a valid RFC3339 timestamp: cannot use "bloop" as year`},
-		{"2017-11-22 00:00:00Z", time.Time{}, `not a valid RFC3339 timestamp: missing assertd time introducer 'T'`},
+		{"2017-11-22 00:00:00Z", time.Time{}, `not a valid RFC3339 timestamp: missing required time introducer 'T'`},
 	}
 
 	for _, testCase := range testCases {

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -191,17 +191,17 @@ func TestFileManifest(t *testing.T) {
 	manifest := newFileManifest(dir, ".terragrunt-test-manifest")
 	require.NoError(t, manifest.Create())
 	// check the file manifest has been created
-	require.FileExists(t, filepath.Join(manifest.ManifestFolder, manifest.ManifestFile))
+	assert.FileExists(t, filepath.Join(manifest.ManifestFolder, manifest.ManifestFile))
 	for _, file := range testfiles {
 		require.NoError(t, manifest.AddFile(file))
 	}
 	// check for a non-existent directory as well
 	assert.NoError(t, manifest.AddDirectory(path.Join(dir, "ephemeral-directory-that-doesnt-exist")))
 
-	require.NoError(t, manifest.Clean())
+	assert.NoError(t, manifest.Clean())
 	// test if the files have been deleted
 	for _, file := range testfiles {
-		require.False(t, FileExists(file))
+		assert.False(t, FileExists(file))
 	}
 
 }
@@ -308,8 +308,8 @@ func TestIncludeInCopy(t *testing.T) {
 	fileContent := []byte("source file")
 	for _, testCase := range testCases {
 		path := filepath.Join(source, testCase.path)
-		require.NoError(t, os.MkdirAll(filepath.Dir(path), os.ModePerm))
-		require.NoError(t, os.WriteFile(path, fileContent, 0644))
+		assert.NoError(t, os.MkdirAll(filepath.Dir(path), os.ModePerm))
+		assert.NoError(t, os.WriteFile(path, fileContent, 0644))
 	}
 
 	require.NoError(t, CopyFolderContents(source, destination, ".terragrunt-test", includeInCopy))

--- a/util/jsons_test.go
+++ b/util/jsons_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,6 +21,6 @@ func TestAsTerraformEnvVarJsonValue(t *testing.T) {
 	for _, testCase := range testCases {
 		actual, err := AsTerraformEnvVarJsonValue(testCase.value)
 		require.NoError(t, err)
-		require.Equal(t, testCase.expected, actual)
+		assert.Equal(t, testCase.expected, actual)
 	}
 }

--- a/util/prefix-writer_test.go
+++ b/util/prefix-writer_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,9 +46,9 @@ func TestPrefixWriter(t *testing.T) {
 		for _, input := range testCase.values {
 			written, err := pw.Write([]byte(input))
 			require.NoError(t, err)
-			require.Len(t, input, written)
+			assert.Len(t, input, written)
 		}
-		require.Equal(t, testCase.expected, b.String())
+		assert.Equal(t, testCase.expected, b.String())
 	}
 }
 
@@ -73,7 +74,7 @@ func TestPrefixWriterFail(t *testing.T) {
 		for _, input := range testCase.values {
 			written, err := pw.Write([]byte(input))
 			require.Error(t, err)
-			require.Empty(t, written)
+			assert.Empty(t, written)
 		}
 	}
 }


### PR DESCRIPTION
## Description

I went a bit too far with the changes in #3334.

It's inconvenient for developers to always use `require`. This updates the change so that they're only replced from `assert` when they evaluate errors.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated tests.

