### PR TITLE
fix: Fixing remote state init skip

### DIFF
--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/gruntwork-io/terragrunt/cli/commands"
 	"github.com/gruntwork-io/terragrunt/codegen"
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -100,7 +101,7 @@ func (remoteState *RemoteState) Initialize(ctx context.Context, terragruntOption
 // 4. The remote state initializer for this backend type, if there is one, says initialization is necessary
 func (remoteState *RemoteState) NeedsInit(terragruntOptions *options.TerragruntOptions) (bool, error) {
 	if terragruntOptions.DisableBucketUpdate {
-		terragruntOptions.Logger.Debugf("Skipping remote state initialization due to --terragrunt-disable-bucket-update flag")
+		terragruntOptions.Logger.Debugf("Skipping remote state initialization due to %s flag", commands.TerragruntDisableBucketUpdateFlagName)
 		return false, nil
 	}
 

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -94,10 +94,16 @@ func (remoteState *RemoteState) Initialize(ctx context.Context, terragruntOption
 
 // Returns true if remote state needs to be configured. This will be the case when:
 //
-// 1. Remote state has not already been configured
-// 2. Remote state has been configured, but with a different configuration
-// 3. The remote state initializer for this backend type, if there is one, says initialization is necessary
+// 1. Remote state auto-initialization has been disabled
+// 2. Remote state has not already been configured
+// 3. Remote state has been configured, but with a different configuration
+// 4. The remote state initializer for this backend type, if there is one, says initialization is necessary
 func (remoteState *RemoteState) NeedsInit(terragruntOptions *options.TerragruntOptions) (bool, error) {
+	if terragruntOptions.DisableBucketUpdate {
+		terragruntOptions.Logger.Debugf("Skipping remote state initialization due to --terragrunt-disable-bucket-update flag")
+		return false, nil
+	}
+
 	state, err := ParseTerraformStateFileFromLocation(remoteState.Backend, remoteState.Config, terragruntOptions.WorkingDir, terragruntOptions.DataDir())
 	if err != nil {
 		return false, err

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -1,12 +1,19 @@
 terraform {
   backend "s3" {}
+
+  required_providers {
+    external = {
+      source  = "hashicorp/external"
+      version = "2.3.3"
+    }
+  }
 }
 
-# Create an arbitrary local resource
-data "template_file" "test" {
-  template = "Hello, I am a template. My sample_var value = $${sample_var}"
+data "external" "hello" {
+  program = ["bash", "-c", "sample_var=\"$$(cat - jq '.sample_var')\" && echo '{\"output\": \"Hello, I am a template. My sample_var value = $$sample_var\"}'"]
 
-  vars = {
+  query = {
     sample_var = var.sample_var
   }
 }
+

--- a/test/fixture/outputs.tf
+++ b/test/fixture/outputs.tf
@@ -1,3 +1,4 @@
 output "rendered_template" {
-  value = data.template_file.test.rendered
+  value = data.external.hello.result["output"]
 }
+


### PR DESCRIPTION
## Description

Fixes #2082.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated package `remote`.

