### PR TITLE
chore: Bumping go to `1.22`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ env: &env
 
 defaults: &defaults
   docker:
-    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.21.9-tf1.5-tg58.8-pck1.8-ci56.0
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.22.6-tf1.5-tg58.8-pck1.8-ci56.0
 
 # Install Terraform which is not available in the default image
 install_terraform_latest: &install_terraform_latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   timeout: 2m
   issues-exit-code: 1
   tests: true
-  go: "1.21"
+  go: "1.22"
 output:
   formats:
     - format: colored-line-number

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ run-lint:
 	golangci-lint run -v --timeout=5m ./...
 
 install-mockery:
-	go install github.com/vektra/mockery/v2@v2.36.0
+	go install github.com/vektra/mockery/v2@v2.44.1
 
 generate-mocks:
 	go generate ./...

--- a/_ci/install-golang.ps1
+++ b/_ci/install-golang.ps1
@@ -1,5 +1,5 @@
 # Install golang using Chocolatey
-choco install golang --version 1.21.1 -y
+choco install golang --version 1.22.6 -y
 # Verify installation
 Get-Command go
 go version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gruntwork-io/terragrunt
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/storage v1.42.0


### PR DESCRIPTION
## Description

Fixes #3337.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated go to `1.22`.

