### PR TITLE
feat: Adding strict lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ jobs:
           path: logs
 
   strict_lint:
-    resource_class: small
+    resource_class: medium
     <<: *defaults
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,6 +372,19 @@ jobs:
       - store_test_results:
           path: logs
 
+  strict_lint:
+    resource_class: small
+    <<: *defaults
+    steps:
+      - checkout
+      # The `run-strict-lint` target requires the `master` ref for comparison.
+      - run: git fetch
+      - run:
+          name: Run strict lint
+          command: |
+            make install-lint
+            make run-strict-lint
+
   # Run TFLint tests separately as tflint during execution change working directory.
   integration_test_tflint:
     resource_class: large
@@ -560,6 +573,14 @@ workflows:
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
       - test_mocks:
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GCP__automated-tests
+            - GITHUB__PAT__gruntwork-ci
+      - strict_lint:
           filters:
             tags:
               only: /^v.*/

--- a/.strict.golangci.yml
+++ b/.strict.golangci.yml
@@ -79,9 +79,9 @@ linters:
     - performance
     - unused
     - test
-    # NOTE: These two are only in the strict lint right now
-    # - style
-    # - complexity
+    # These two are only in the strict lint right now
+    - style
+    - complexity
 
 issues:
   exclude-dirs:

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,13 @@ install-lint:
 run-lint:
 	golangci-lint run -v --timeout=5m ./...
 
+run-strict-lint:
+	golangci-lint run -v --timeout=5m -c .strict.golangci.yml --new-from-rev origin/master ./...
+
 install-mockery:
 	go install github.com/vektra/mockery/v2@v2.44.1
 
 generate-mocks:
 	go generate ./...
 
-.PHONY: help fmtcheck fmt install-fmt-hook clean install-lint run-lint
+.PHONY: help fmtcheck fmt install-fmt-hook clean install-lint run-lint run-strict-lint


### PR DESCRIPTION
## Description

Adds strict linting for pull requests. This ensures that new code being introduced adheres to improved code quality standards.

The two lints being added here are for `style` and `complexity`. The current codebase violates these rules basically everywhere, so it's not feasible to enable these lints for everything.

Instead, we'll enable these lints for all new code being introduced or edited in pull requests, which should help us gradually improve the code quality over time.

I think if we're OK with introducing this, we should selectively ignore rules when they are too strict for a given file or require too much refactoring.

For a sense of the kinds of things we would change, you can take a look at this in-draft PR that I closed because it was unreasonably large:

https://github.com/gruntwork-io/terragrunt/pull/3347

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added strict lint rules.

