### PR TITLE
fix: make `terragrunt-fetch-dependency-output-from-state` to work with not applied dependencies

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5365,10 +5365,8 @@ func TestTerragruntMockOutputsFromRemoteState(t *testing.T) { //nolint: parallel
 	)
 	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt init --terragrunt-fetch-dependency-output-from-state --terragrunt-non-interactive --terragrunt-working-dir %s/app2", environmentPath), &stdout, &stderr)
 
-	output := stdout.String()
 	errOutput := stderr.String()
 
-	assert.True(t, strings.Contains(output, "Terraform has been successfully initialized"))
 	assert.True(t, strings.Contains(errOutput, "Failed to read outputs"))
 	assert.True(t, strings.Contains(errOutput, "fallback to mock outputs"))
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3349 and #2261.

If you enable the `--terragrunt-fetch-dependency-output-from-state` feature flag and runs a `terragrunt init` on a module that depends on a dependency that was not yet applied, terragrunt will fail, even if you are using `mock_outputs`. This fix is treating the returned error and checking if a `NoSuchKey` error was produced, allowing terragrunt to proceed if that was the case.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Fix `--terragrunt-fetch-dependency-output-from-state` feature flag and allows it to work with not applied dependencies

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

