### PR TITLE
feat: Adding `thelpher` and `wastedassign` lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,12 +66,16 @@ linters:
     - unused
     - unparam
     - wsl
+    - thelper
+    - wastedassign
+
   enable-all: false
   disable:
     - depguard
     - gosec
     - gocyclo
     - exhaustruct
+
   fast: false
   mnd:
     ignored-functions: strconv.Format*,os.*,strconv.Parse*,strings.SplitN,bytes.SplitN

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -202,6 +202,8 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 // We can't do a direct comparison between TerragruntOptions objects because we can't compare Logger or RunTerragrunt
 // instances. Therefore, we have to manually check everything else.
 func assertOptionsEqual(t *testing.T, expected options.TerragruntOptions, actual options.TerragruntOptions, msgAndArgs ...interface{}) {
+	t.Helper()
+
 	assert.NotNil(t, expected.Logger, msgAndArgs...)
 	assert.NotNil(t, actual.Logger, msgAndArgs...)
 
@@ -219,6 +221,8 @@ func assertOptionsEqual(t *testing.T, expected options.TerragruntOptions, actual
 }
 
 func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool, includeExternalDependencies bool, logLevel logrus.Level, debug bool) *options.TerragruntOptions {
+	t.Helper()
+
 	opts, err := options.NewTerragruntOptionsForTest(terragruntConfigPath)
 	if err != nil {
 		t.Fatalf("error: %v\n", errors.WithStackTrace(err))
@@ -237,6 +241,8 @@ func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, t
 }
 
 func mockOptionsWithIamRole(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool, iamRole string) *options.TerragruntOptions {
+	t.Helper()
+
 	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors, false, defaultLogLevel, false)
 	opts.OriginalIAMRoleOptions.RoleARN = iamRole
 	opts.IAMRoleOptions.RoleARN = iamRole
@@ -245,6 +251,8 @@ func mockOptionsWithIamRole(t *testing.T, terragruntConfigPath string, workingDi
 }
 
 func mockOptionsWithIamAssumeRoleDuration(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool, iamAssumeRoleDuration int64) *options.TerragruntOptions {
+	t.Helper()
+
 	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors, false, defaultLogLevel, false)
 	opts.OriginalIAMRoleOptions.AssumeRoleDuration = iamAssumeRoleDuration
 	opts.IAMRoleOptions.AssumeRoleDuration = iamAssumeRoleDuration
@@ -253,6 +261,8 @@ func mockOptionsWithIamAssumeRoleDuration(t *testing.T, terragruntConfigPath str
 }
 
 func mockOptionsWithIamAssumeRoleSessionName(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool, iamAssumeRoleSessionName string) *options.TerragruntOptions {
+	t.Helper()
+
 	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors, false, defaultLogLevel, false)
 	opts.OriginalIAMRoleOptions.AssumeRoleSessionName = iamAssumeRoleSessionName
 	opts.IAMRoleOptions.AssumeRoleSessionName = iamAssumeRoleSessionName
@@ -261,6 +271,8 @@ func mockOptionsWithIamAssumeRoleSessionName(t *testing.T, terragruntConfigPath 
 }
 
 func mockOptionsWithIamWebIdentityToken(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool, webIdentityToken string) *options.TerragruntOptions {
+	t.Helper()
+
 	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors, false, defaultLogLevel, false)
 	opts.OriginalIAMRoleOptions.WebIdentityToken = webIdentityToken
 	opts.IAMRoleOptions.WebIdentityToken = webIdentityToken
@@ -268,6 +280,8 @@ func mockOptionsWithIamWebIdentityToken(t *testing.T, terragruntConfigPath strin
 }
 
 func mockOptionsWithSourceMap(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, sourceMap map[string]string) *options.TerragruntOptions {
+	t.Helper()
+
 	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, false, "", false, false, defaultLogLevel, false)
 	opts.SourceMap = sourceMap
 	return opts

--- a/cli/commands/terraform/action_test.go
+++ b/cli/commands/terraform/action_test.go
@@ -117,6 +117,8 @@ func TestTerragruntTerraformCodeCheck(t *testing.T) {
 		// get updated due to concurrency within the scope of t.Run(..) below
 		testCase := testCase
 		testFunc := func(t *testing.T) {
+			t.Helper()
+
 			opts, err := options.NewTerragruntOptionsForTest("mock-path-for-test.hcl")
 			require.NoError(t, err)
 			opts.WorkingDir = testCase.workingDir
@@ -447,6 +449,8 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 var defaultLogLevel = util.GetDefaultLogLevel()
 
 func mockCmdOptions(t *testing.T, workingDir string, terraformCliArgs []string) *options.TerragruntOptions {
+	t.Helper()
+
 	o := mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, terraformCliArgs, true, "", false, false, defaultLogLevel, false)
 	return o
 }
@@ -464,6 +468,8 @@ func mockExtraArgs(arguments, commands, requiredVarFiles, optionalVarFiles []str
 }
 
 func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool, includeExternalDependencies bool, logLevel logrus.Level, debug bool) *options.TerragruntOptions {
+	t.Helper()
+
 	opts, err := options.NewTerragruntOptionsForTest(terragruntConfigPath)
 	if err != nil {
 		t.Fatalf("error: %v\n", errors.WithStackTrace(err))
@@ -482,6 +488,8 @@ func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, t
 }
 
 func createTempFile(t *testing.T) string {
+	t.Helper()
+
 	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %s\n", err.Error())

--- a/cli/commands/terraform/download_source_test.go
+++ b/cli/commands/terraform/download_source_test.go
@@ -371,6 +371,8 @@ func TestDownloadTerraformSourceFromLocalFolderWithManifest(t *testing.T) {
 }
 
 func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, downloadDir string, sourceUpdate bool, expectedFileContents string, requireInitFile bool) {
+	t.Helper()
+
 	terraformSource, terragruntOptions, terragruntConfig, err := createConfig(t, canonicalUrl, downloadDir, sourceUpdate)
 
 	require.NoError(t, err)
@@ -391,6 +393,8 @@ func testDownloadTerraformSourceIfNecessary(t *testing.T, canonicalUrl string, d
 }
 
 func createConfig(t *testing.T, canonicalUrl string, downloadDir string, sourceUpdate bool) (*tgTerraform.Source, *options.TerragruntOptions, *config.TerragruntConfig, error) {
+	t.Helper()
+
 	logger := logrus.New()
 	logger.Out = io.Discard
 	terraformSource := &tgTerraform.Source{
@@ -420,6 +424,8 @@ func createConfig(t *testing.T, canonicalUrl string, downloadDir string, sourceU
 }
 
 func testAlreadyHaveLatestCode(t *testing.T, canonicalUrl string, downloadDir string, expected bool) {
+	t.Helper()
+
 	logger := logrus.New()
 	logger.Out = io.Discard
 	terraformSource := &tgTerraform.Source{
@@ -439,6 +445,8 @@ func testAlreadyHaveLatestCode(t *testing.T, canonicalUrl string, downloadDir st
 }
 
 func tmpDir(t *testing.T) string {
+	t.Helper()
+
 	dir, err := os.MkdirTemp("", "download-source-test")
 	if err != nil {
 		t.Fatal(err)
@@ -447,6 +455,8 @@ func tmpDir(t *testing.T) string {
 }
 
 func absPath(t *testing.T, path string) string {
+	t.Helper()
+
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		t.Fatal(err)
@@ -455,6 +465,8 @@ func absPath(t *testing.T, path string) string {
 }
 
 func parseUrl(t *testing.T, str string) *url.URL {
+	t.Helper()
+
 	// URLs should have only forward slashes, whereas on Windows, the file paths may be backslashes
 	rawUrl := strings.Join(strings.Split(str, string(filepath.Separator)), "/")
 
@@ -466,6 +478,8 @@ func parseUrl(t *testing.T, str string) *url.URL {
 }
 
 func readFile(t *testing.T, path string) string {
+	t.Helper()
+
 	contents, err := util.ReadFileAsString(path)
 	if err != nil {
 		t.Fatal(err)
@@ -474,6 +488,8 @@ func readFile(t *testing.T, path string) string {
 }
 
 func copyFolder(t *testing.T, src string, dest string) {
+	t.Helper()
+
 	err := util.CopyFolderContents(filepath.FromSlash(src), filepath.FromSlash(dest), ".terragrunt-test", nil)
 	require.NoError(t, err)
 }

--- a/cli/commands/terraform/version_check_test.go
+++ b/cli/commands/terraform/version_check_test.go
@@ -88,6 +88,8 @@ func TestParseTerraformVersionInvalidSyntax(t *testing.T) {
 }
 
 func testCheckTerraformVersionMeetsConstraint(t *testing.T, currentVersion string, versionConstraint string, versionMeetsConstraint bool) {
+	t.Helper()
+
 	current, err := version.NewVersion(currentVersion)
 	if err != nil {
 		t.Fatalf("Invalid current version specified in test: %v", err)
@@ -102,6 +104,8 @@ func testCheckTerraformVersionMeetsConstraint(t *testing.T, currentVersion strin
 }
 
 func testParseTerraformVersion(t *testing.T, versionString string, expectedVersion string, expectedErr error) {
+	t.Helper()
+
 	actualVersion, actualErr := terraform.ParseTerraformVersion(versionString)
 	if expectedErr == nil {
 		expected, err := version.NewVersion(expectedVersion)
@@ -143,6 +147,8 @@ func TestCheckTerragruntVersionMeetsConstraintLessMajor(t *testing.T) {
 }
 
 func testCheckTerragruntVersionMeetsConstraint(t *testing.T, currentVersion string, versionConstraint string, versionMeetsConstraint bool) {
+	t.Helper()
+
 	current, err := version.NewVersion(currentVersion)
 	if err != nil {
 		t.Fatalf("Invalid current version specified in test: %v", err)

--- a/cli/provider_cache_test.go
+++ b/cli/provider_cache_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func createFakeProvider(t *testing.T, cacheDir, relativePath string) string {
+	t.Helper()
+
 	err := os.MkdirAll(filepath.Join(cacheDir, filepath.Dir(relativePath)), os.ModePerm)
 	require.NoError(t, err)
 

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -194,6 +194,8 @@ func TestTerraformConfigAsCtyDrift(t *testing.T) {
 }
 
 func terragruntConfigStructFieldToMapKey(t *testing.T, fieldName string) (string, bool) {
+	t.Helper()
+
 	switch fieldName {
 	case "Catalog":
 		return "catalog", true
@@ -255,6 +257,8 @@ func terragruntConfigStructFieldToMapKey(t *testing.T, fieldName string) (string
 }
 
 func remoteStateStructFieldToMapKey(t *testing.T, fieldName string) (string, bool) {
+	t.Helper()
+
 	switch fieldName {
 	case "Backend":
 		return "backend", true

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -238,6 +238,8 @@ func TestRunCommand(t *testing.T) {
 }
 
 func absPath(t *testing.T, path string) string {
+	t.Helper()
+
 	out, err := filepath.Abs(path)
 	require.NoError(t, err)
 	return out
@@ -613,6 +615,8 @@ func TestResolveCliArgsInterpolationConfigString(t *testing.T) {
 }
 
 func toStringSlice(t *testing.T, value interface{}) []string {
+	t.Helper()
+
 	if value == nil {
 		return nil
 	}
@@ -652,6 +656,8 @@ func TestGetTerragruntDirRelPath(t *testing.T) {
 }
 
 func testGetTerragruntDir(t *testing.T, configPath string, expectedPath string) {
+	t.Helper()
+
 	terragruntOptions, err := options.NewTerragruntOptionsForTest(configPath)
 	require.NoError(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
 
@@ -663,6 +669,8 @@ func testGetTerragruntDir(t *testing.T, configPath string, expectedPath string) 
 }
 
 func terragruntOptionsForTest(t *testing.T, configPath string) *options.TerragruntOptions {
+	t.Helper()
+
 	opts, err := options.NewTerragruntOptionsForTest(configPath)
 	if err != nil {
 		t.Fatalf("Failed to create TerragruntOptions: %v", err)
@@ -671,12 +679,16 @@ func terragruntOptionsForTest(t *testing.T, configPath string) *options.Terragru
 }
 
 func terragruntOptionsForTestWithMaxFolders(t *testing.T, configPath string, maxFoldersToCheck int) *options.TerragruntOptions {
+	t.Helper()
+
 	opts := terragruntOptionsForTest(t, configPath)
 	opts.MaxFoldersToCheck = maxFoldersToCheck
 	return opts
 }
 
 func terragruntOptionsForTestWithEnv(t *testing.T, configPath string, env map[string]string) *options.TerragruntOptions {
+	t.Helper()
+
 	opts := terragruntOptionsForTest(t, configPath)
 	opts.Env = env
 	return opts

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1134,6 +1134,8 @@ func TestFindConfigFilesIgnoresDownloadDir(t *testing.T) {
 }
 
 func mockOptionsForTestWithConfigPath(t *testing.T, configPath string) *options.TerragruntOptions {
+	t.Helper()
+
 	opts, err := options.NewTerragruntOptionsForTest(configPath)
 	if err != nil {
 		t.Fatalf("Failed to create TerragruntOptions: %v", err)
@@ -1142,6 +1144,8 @@ func mockOptionsForTestWithConfigPath(t *testing.T, configPath string) *options.
 }
 
 func mockOptionsForTest(t *testing.T) *options.TerragruntOptions {
+	t.Helper()
+
 	return mockOptionsForTestWithConfigPath(t, "test-time-mock")
 }
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -570,6 +570,7 @@ func isAwsS3NoSuchKey(err error) bool {
 	if goErrors.As(errors.Unwrap(err), &awsErr) {
 		return awsErr.Code() == "NoSuchKey"
 	}
+
 	return false
 }
 

--- a/config/variable.go
+++ b/config/variable.go
@@ -51,7 +51,8 @@ func ParseVariables(opts *options.TerragruntOptions, directoryPath string) ([]*P
 					if len(block.Labels[0]) > 0 {
 						// extract variable attributes
 						name := block.Labels[0]
-						descriptionAttrText := ""
+
+						var descriptionAttrText string
 
 						descriptionAttr, err := readBlockAttribute(ctx, block, "description")
 						if err != nil {
@@ -66,13 +67,11 @@ func ParseVariables(opts *options.TerragruntOptions, directoryPath string) ([]*P
 							descriptionAttrText = fmt.Sprintf("(variable %s did not define a description)", name)
 						}
 
-						typeAttrText := ""
+						var typeAttrText string
 
 						typeAttr, err := readBlockAttribute(ctx, block, "type")
 						if err != nil {
 							opts.Logger.Warnf("Failed to read type attribute for %s %v", name, err)
-
-							descriptionAttr = nil
 						}
 
 						if typeAttr != nil {

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -85,7 +85,7 @@ func (module *TerraformModule) checkForCyclesUsingDepthFirstSearch(visitedPaths 
 
 // planFile - return plan file location, if output folder is set
 func (module *TerraformModule) planFile(terragruntOptions *options.TerragruntOptions) string {
-	planFile := ""
+	var planFile string
 
 	// set plan file location if output folder is set
 	planFile = module.outputFile(terragruntOptions)

--- a/configstack/running_module_test.go
+++ b/configstack/running_module_test.go
@@ -487,6 +487,8 @@ func TestToRunningModulesMultipleModulesWithAndWithoutDependenciesIgnoreOrder(t 
 }
 
 func testToRunningModules(t *testing.T, modules configstack.TerraformModules, order configstack.DependencyOrder, expected configstack.RunningModules) {
+	t.Helper()
+
 	actual, err := modules.ToRunningModules(order)
 	if assert.NoError(t, err, "For modules %v and order %v", modules, order) {
 		assertRunningModuleMapsEqual(t, expected, actual, true, "For modules %v and order %v", modules, order)

--- a/configstack/stack_test.go
+++ b/configstack/stack_test.go
@@ -159,6 +159,8 @@ func createTestStack() *configstack.Stack {
 }
 
 func createTempFolder(t *testing.T) string {
+	t.Helper()
+
 	tmpFolder, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %s\n", err.Error())
@@ -169,6 +171,8 @@ func createTempFolder(t *testing.T) string {
 
 // Create a dummy Terragrunt config file at each of the given paths
 func writeDummyTerragruntConfigs(t *testing.T, tmpFolder string, paths []string) {
+	t.Helper()
+
 	contents := []byte("terraform {\nsource = \"test\"\n}\n")
 	for _, path := range paths {
 		absPath := util.JoinPath(tmpFolder, path)
@@ -184,6 +188,8 @@ func writeDummyTerragruntConfigs(t *testing.T, tmpFolder string, paths []string)
 }
 
 func createDirIfNotExist(t *testing.T, path string) {
+	t.Helper()
+
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		err = os.MkdirAll(path, os.ModePerm)
 		if err != nil {

--- a/configstack/test_helpers_test.go
+++ b/configstack/test_helpers_test.go
@@ -32,6 +32,8 @@ func (byPath RunningModuleByPath) Less(i, j int) bool {
 // We can't use assert.Equals on TerraformModule or any data structure that contains it because it contains some
 // fields (e.g. TerragruntOptions) that cannot be compared directly
 func assertModuleListsEqual(t *testing.T, expectedModules configstack.TerraformModules, actualModules configstack.TerraformModules, messageAndArgs ...interface{}) {
+	t.Helper()
+
 	if !assert.Equal(t, len(expectedModules), len(actualModules), messageAndArgs...) {
 		t.Logf("%s != %s", expectedModules, actualModules)
 		return
@@ -50,6 +52,8 @@ func assertModuleListsEqual(t *testing.T, expectedModules configstack.TerraformM
 // We can't use assert.Equals on TerraformModule because it contains some fields (e.g. TerragruntOptions) that cannot
 // be compared directly
 func assertModulesEqual(t *testing.T, expected *configstack.TerraformModule, actual *configstack.TerraformModule, messageAndArgs ...interface{}) {
+	t.Helper()
+
 	if assert.NotNil(t, actual, messageAndArgs...) {
 		// When comparing the TerragruntConfig objects, we need to normalize the dependency list to explicitly set the
 		// expected to empty list when nil, as the parsing routine will set it to empty list instead of nil.
@@ -73,6 +77,8 @@ func assertModulesEqual(t *testing.T, expected *configstack.TerraformModule, act
 // We can't use assert.Equals on TerraformModule or any data structure that contains it (e.g. configstack.RunningModule) because it
 // contains some fields (e.g. TerragruntOptions) that cannot be compared directly
 func assertRunningModuleMapsEqual(t *testing.T, expectedModules map[string]*configstack.RunningModule, actualModules map[string]*configstack.RunningModule, doDeepCheck bool, messageAndArgs ...interface{}) {
+	t.Helper()
+
 	if !assert.Equal(t, len(expectedModules), len(actualModules), messageAndArgs...) {
 		t.Logf("%v != %v", expectedModules, actualModules)
 		return
@@ -89,6 +95,8 @@ func assertRunningModuleMapsEqual(t *testing.T, expectedModules map[string]*conf
 // We can't use assert.Equals on TerraformModule or any data structure that contains it (e.g. configstack.RunningModule) because it
 // contains some fields (e.g. TerragruntOptions) that cannot be compared directly
 func assertRunningModuleListsEqual(t *testing.T, expectedModules []*configstack.RunningModule, actualModules []*configstack.RunningModule, doDeepCheck bool, messageAndArgs ...interface{}) {
+	t.Helper()
+
 	if !assert.Equal(t, len(expectedModules), len(actualModules), messageAndArgs...) {
 		t.Logf("%v != %v", expectedModules, actualModules)
 		return
@@ -107,6 +115,8 @@ func assertRunningModuleListsEqual(t *testing.T, expectedModules []*configstack.
 // We can't use assert.Equals on TerraformModule or any data structure that contains it (e.g. configstack.RunningModule) because it
 // contains some fields (e.g. TerragruntOptions) that cannot be compared directly
 func assertRunningModulesEqual(t *testing.T, expected *configstack.RunningModule, actual *configstack.RunningModule, doDeepCheck bool, messageAndArgs ...interface{}) {
+	t.Helper()
+
 	if assert.NotNil(t, actual, messageAndArgs...) {
 		assert.Equal(t, expected.Status, actual.Status, messageAndArgs...)
 
@@ -126,6 +136,8 @@ func assertRunningModulesEqual(t *testing.T, expected *configstack.RunningModule
 // contains an array, and in Go, trying to compare arrays gives a "comparing uncomparable type
 // configstack.configstack.UnrecognizedDependencyError" panic. Therefore, we have to compare that error more manually.
 func assertErrorsEqual(t *testing.T, expected error, actual error, messageAndArgs ...interface{}) {
+	t.Helper()
+
 	actual = errors.Unwrap(actual)
 
 	var unrecognizedDependencyError configstack.UnrecognizedDependencyError
@@ -143,6 +155,8 @@ func assertErrorsEqual(t *testing.T, expected error, actual error, messageAndArg
 // We can't do a direct comparison between TerragruntOptions objects because we can't compare Logger or RunTerragrunt
 // instances. Therefore, we have to manually check everything else.
 func assertOptionsEqual(t *testing.T, expected options.TerragruntOptions, actual options.TerragruntOptions, messageAndArgs ...interface{}) {
+	t.Helper()
+
 	assert.NotNil(t, expected.Logger, messageAndArgs...)
 	assert.NotNil(t, actual.Logger, messageAndArgs...)
 
@@ -154,6 +168,8 @@ func assertOptionsEqual(t *testing.T, expected options.TerragruntOptions, actual
 
 // Return the absolute path for the given path
 func canonical(t *testing.T, path string) string {
+	t.Helper()
+
 	out, err := util.CanonicalPath(path, ".")
 	if err != nil {
 		t.Fatal(err)
@@ -162,6 +178,8 @@ func canonical(t *testing.T, path string) string {
 }
 
 func globCanonical(t *testing.T, path string) []string {
+	t.Helper()
+
 	out, err := util.GlobCanonicalPath(path, ".")
 	if err != nil {
 		t.Fatal(err)
@@ -172,6 +190,8 @@ func globCanonical(t *testing.T, path string) []string {
 // Create a mock TerragruntOptions object and configure its RunTerragrunt command to return the given error object. If
 // the RunTerragrunt command is called, this method will also set the executed boolean to true.
 func optionsWithMockTerragruntCommand(t *testing.T, terragruntConfigPath string, toReturnFromTerragruntCommand error, executed *bool) *options.TerragruntOptions {
+	t.Helper()
+
 	opts, err := options.NewTerragruntOptionsForTest(terragruntConfigPath)
 	if err != nil {
 		t.Fatalf("Error creating terragrunt options for test %v", err)
@@ -184,6 +204,8 @@ func optionsWithMockTerragruntCommand(t *testing.T, terragruntConfigPath string,
 }
 
 func assertMultiErrorContains(t *testing.T, actualError error, expectedErrors ...error) {
+	t.Helper()
+
 	actualError = errors.Unwrap(actualError)
 	var multiError *multierror.Error
 	isMultiError := goErrors.As(actualError, &multiError)

--- a/dynamodb/dynamo_lock_table_test.go
+++ b/dynamodb/dynamo_lock_table_test.go
@@ -103,8 +103,8 @@ func TestTableTagging(t *testing.T) {
 	withLockTableTagged(t, tags, func(tableName string, client *awsDynamodb.DynamoDB) {
 		assertCanWriteToTable(t, tableName, client)
 
-		t.Logf("Not worth immediately checking tags on dynamo table. Tags can take a while to show up. Trying in 1 second.")
-		time.Sleep(1 * time.Second)
+		t.Logf("Not worth immediately checking tags on dynamo table. Tags can take a while to show up. Checking after a short delay.")
+		time.Sleep(5 * time.Second)
 
 		assertTags(t, tags, tableName, client)
 

--- a/dynamodb/dynamo_lock_table_test.go
+++ b/dynamodb/dynamo_lock_table_test.go
@@ -103,7 +103,7 @@ func TestTableTagging(t *testing.T) {
 	withLockTableTagged(t, tags, func(tableName string, client *awsDynamodb.DynamoDB) {
 		assertCanWriteToTable(t, tableName, client)
 
-		assertTags(tags, tableName, client, t)
+		assertTags(t, tags, tableName, client)
 
 		// Try to create the table the second time and make sure you get no errors
 		err = dynamodb.CreateLockTableIfNecessary(tableName, nil, client, mockOptions)
@@ -111,7 +111,9 @@ func TestTableTagging(t *testing.T) {
 	})
 }
 
-func assertTags(expectedTags map[string]string, tableName string, client *awsDynamodb.DynamoDB, t *testing.T) {
+func assertTags(t *testing.T, expectedTags map[string]string, tableName string, client *awsDynamodb.DynamoDB) {
+	t.Helper()
+
 	var description, err = client.DescribeTable(&awsDynamodb.DescribeTableInput{TableName: aws.String(tableName)})
 
 	if err != nil {

--- a/dynamodb/dynamo_lock_table_test.go
+++ b/dynamodb/dynamo_lock_table_test.go
@@ -104,9 +104,6 @@ func TestTableTagging(t *testing.T) {
 	withLockTableTagged(t, tags, func(tableName string, client *awsDynamodb.DynamoDB) {
 		assertCanWriteToTable(t, tableName, client)
 
-		t.Logf("Not worth immediately checking tags on dynamo table. Tags can take a while to show up. Checking after a short delay.")
-		time.Sleep(5 * time.Second)
-
 		assertTags(t, tags, tableName, client)
 
 		// Try to create the table the second time and make sure you get no errors

--- a/dynamodb/dynamo_lock_table_test.go
+++ b/dynamodb/dynamo_lock_table_test.go
@@ -103,6 +103,9 @@ func TestTableTagging(t *testing.T) {
 	withLockTableTagged(t, tags, func(tableName string, client *awsDynamodb.DynamoDB) {
 		assertCanWriteToTable(t, tableName, client)
 
+		t.Logf("Not worth immediately checking tags on dynamo table. Tags can take a while to show up. Trying in 1 second.")
+		time.Sleep(1 * time.Second)
+
 		assertTags(t, tags, tableName, client)
 
 		// Try to create the table the second time and make sure you get no errors

--- a/dynamodb/dynamo_lock_test_utils_test.go
+++ b/dynamodb/dynamo_lock_test_utils_test.go
@@ -17,6 +17,8 @@ const DEFAULT_TEST_REGION = "us-east-1"
 
 // Create a DynamoDB client we can use at test time. If there are any errors creating the client, fail the test.
 func createDynamoDbClientForTest(t *testing.T) *awsDynamodb.DynamoDB {
+	t.Helper()
+
 	mockOptions, err := options.NewTerragruntOptionsForTest("dynamo_lock_test_utils")
 	if err != nil {
 		t.Fatal(err)
@@ -38,11 +40,15 @@ func uniqueTableNameForTest() string {
 }
 
 func cleanupTableForTest(t *testing.T, tableName string, client *awsDynamodb.DynamoDB) {
+	t.Helper()
+
 	err := dynamodb.DeleteTable(tableName, client)
 	require.NoError(t, err, "Unexpected error: %v", err)
 }
 
 func assertCanWriteToTable(t *testing.T, tableName string, client *awsDynamodb.DynamoDB) {
+	t.Helper()
+
 	item := createKeyFromItemId(util.UniqueId())
 
 	_, err := client.PutItem(&awsDynamodb.PutItemInput{
@@ -54,10 +60,14 @@ func assertCanWriteToTable(t *testing.T, tableName string, client *awsDynamodb.D
 }
 
 func withLockTable(t *testing.T, action func(tableName string, client *awsDynamodb.DynamoDB)) {
+	t.Helper()
+
 	withLockTableTagged(t, nil, action)
 }
 
 func withLockTableTagged(t *testing.T, tags map[string]string, action func(tableName string, client *awsDynamodb.DynamoDB)) {
+	t.Helper()
+
 	client := createDynamoDbClientForTest(t)
 	tableName := uniqueTableNameForTest()
 

--- a/pkg/cli/bool_flag_test.go
+++ b/pkg/cli/bool_flag_test.go
@@ -100,6 +100,8 @@ func TestBoolFlagApply(t *testing.T) {
 }
 
 func testBoolFlagApply(t *testing.T, flag *cli.BoolFlag, args []string, envs map[string]string, expectedValue bool, expectedErr error) {
+	t.Helper()
+
 	var (
 		actualValue          bool
 		destDefined          bool

--- a/pkg/cli/generic_flag_test.go
+++ b/pkg/cli/generic_flag_test.go
@@ -166,6 +166,8 @@ func TestGenericFlagInt64Apply(t *testing.T) {
 }
 
 func testGenericFlagApply[T cli.GenericType](t *testing.T, flag *cli.GenericFlag[T], args []string, envs map[string]string, expectedValue T, expectedErr error) {
+	t.Helper()
+
 	var (
 		actualValue          T
 		destDefined          bool

--- a/pkg/cli/map_flag_test.go
+++ b/pkg/cli/map_flag_test.go
@@ -123,6 +123,7 @@ func TestMapFlagStringIntApply(t *testing.T) {
 }
 
 func testMapFlagApply[K cli.MapFlagKeyType, V cli.MapFlagValueType](t *testing.T, flag *cli.MapFlag[K, V], args []string, envs map[string]string, expectedValue map[K]V, expectedErr error) {
+	t.Helper()
 
 	var (
 		actualValue          = map[K]V{}

--- a/pkg/cli/slice_flag_test.go
+++ b/pkg/cli/slice_flag_test.go
@@ -159,6 +159,7 @@ func TestSliceFlagInt64Apply(t *testing.T) {
 }
 
 func testSliceFlagApply[T cli.SliceFlagType](t *testing.T, flag *cli.SliceFlag[T], args []string, envs map[string]string, expectedValue []T, expectedErr error) {
+	t.Helper()
 
 	var (
 		actualValue          []T

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -294,6 +294,8 @@ func TestDiffersFrom(t *testing.T) {
 }
 
 func assertTerraformInitArgsEqual(t *testing.T, actualArgs []string, expectedArgs string) {
+	t.Helper()
+
 	expected := strings.Split(expectedArgs, " ")
 	assert.Len(t, actualArgs, len(expected))
 

--- a/shell/run_shell_cmd_output_test.go
+++ b/shell/run_shell_cmd_output_test.go
@@ -47,6 +47,8 @@ var STDOUT = []string{"stdout1", "stdout2"}
 var STDERR = []string{"stderr1", "stderr2", "stderr3"}
 
 func testCommandOutputOrder(t *testing.T, withPtty bool, fullOutput []string, stdout []string, stderr []string) {
+	t.Helper()
+
 	testCommandOutput(t, noop[*options.TerragruntOptions], assertOutputs(t, fullOutput, stdout, stderr), withPtty)
 }
 
@@ -69,6 +71,8 @@ func TestCommandOutputPrefix(t *testing.T) {
 }
 
 func testCommandOutput(t *testing.T, withOptions func(*options.TerragruntOptions), assertResults func(string, *util.CmdOutput), allocateStdout bool) {
+	t.Helper()
+
 	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
 	require.NoError(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
 
@@ -96,6 +100,8 @@ func assertOutputs(
 	expectedStdOutputs []string,
 	expectedStdErrs []string,
 ) func(string, *util.CmdOutput) {
+	t.Helper()
+
 	return func(allOutput string, out *util.CmdOutput) {
 		allOutputs := strings.Split(strings.TrimSpace(allOutput), "\n")
 		assert.Equal(t, expectedAllOutputs, allOutputs)

--- a/terraform/getproviders/hash_test.go
+++ b/terraform/getproviders/hash_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func createFakeZipArchive(t *testing.T, content []byte) string {
+	t.Helper()
+
 	file, err := os.CreateTemp("", "*")
 	require.NoError(t, err)
 	defer file.Close()

--- a/test/cliconfig.go
+++ b/test/cliconfig.go
@@ -66,6 +66,8 @@ type CLIConfigSettings struct {
 }
 
 func createCLIConfig(t *testing.T, file *os.File, settings *CLIConfigSettings) {
+	t.Helper()
+
 	tmp, err := template.New("cliconfig").Parse(testCLIConfigTemplate)
 	require.NoError(t, err)
 

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -111,6 +111,8 @@ func TestScaffoldGitModuleHttps(t *testing.T) {
 }
 
 func readConfig(t *testing.T, opts *options.TerragruntOptions) *config.TerragruntConfig {
+	t.Helper()
+
 	assert.FileExists(t, opts.WorkingDir+"/terragrunt.hcl")
 
 	opts, err := options.NewTerragruntOptionsForTest(filepath.Join(opts.WorkingDir, "terragrunt.hcl"))

--- a/test/integration_common_test.go
+++ b/test/integration_common_test.go
@@ -45,6 +45,8 @@ func testRunAllPlan(t *testing.T, args string) (string, string, string, error) {
 }
 
 func runNetworkMirrorServer(t *testing.T, ctx context.Context, urlPrefix, providerDir, token string) *url.URL {
+	t.Helper()
+
 	serverTLSConf, clientTLSConf := certSetup(t)
 
 	http.DefaultTransport = &http.Transport{
@@ -107,6 +109,8 @@ func (provider *FakeProvider) filename() string {
 }
 
 func (provider *FakeProvider) CreateMirror(t *testing.T, rootDir string) {
+	t.Helper()
+
 	providerDir := filepath.Join(rootDir, provider.RegistryName, provider.Namespace, provider.Name)
 
 	err := os.MkdirAll(providerDir, os.ModePerm)
@@ -118,6 +122,8 @@ func (provider *FakeProvider) CreateMirror(t *testing.T, rootDir string) {
 }
 
 func (provider *FakeProvider) createVersionJSON(t *testing.T, providerDir string) {
+	t.Helper()
+
 	type VersionProvider struct {
 		Hashes []string `json:"hashes"`
 		URL    string   `json:"url"`
@@ -136,6 +142,8 @@ func (provider *FakeProvider) createVersionJSON(t *testing.T, providerDir string
 }
 
 func (provider *FakeProvider) createIndexJSON(t *testing.T, providerDir string) {
+	t.Helper()
+
 	type Index struct {
 		Versions map[string]any `json:"versions"`
 	}
@@ -149,6 +157,8 @@ func (provider *FakeProvider) createIndexJSON(t *testing.T, providerDir string) 
 }
 
 func (provider *FakeProvider) createZipArchive(t *testing.T, providerDir string) {
+	t.Helper()
+
 	file, err := os.Create(filepath.Join(providerDir, provider.filename()))
 	require.NoError(t, err)
 	defer func() {
@@ -186,6 +196,8 @@ func (provider *FakeProvider) createZipArchive(t *testing.T, providerDir string)
 }
 
 func unmarshalFile(t *testing.T, filename string, dest any) {
+	t.Helper()
+
 	if !util.FileExists(filename) {
 		return
 	}
@@ -197,6 +209,8 @@ func unmarshalFile(t *testing.T, filename string, dest any) {
 }
 
 func marshalFile(t *testing.T, filename string, dest any) {
+	t.Helper()
+
 	data, err := json.Marshal(dest)
 	require.NoError(t, err)
 	err = os.WriteFile(filename, data, 0666)
@@ -204,6 +218,8 @@ func marshalFile(t *testing.T, filename string, dest any) {
 }
 
 func certSetup(t *testing.T) (*tls.Config, *tls.Config) {
+	t.Helper()
+
 	// set up our CA certificate
 	serialNumber, err := strconv.ParseInt(time.Now().Format("20060102150405"), 10, 64)
 	require.NoError(t, err)

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -465,6 +465,8 @@ func TestDependencyGraphWithMultiInclude(t *testing.T) {
 }
 
 func runTerragruntValidateInputs(t *testing.T, moduleDir string, extraArgs []string, isSuccessTest bool) {
+	t.Helper()
+
 	maybeNested := filepath.Join(moduleDir, "module")
 	if util.FileExists(maybeNested) {
 		// Nested module test case with included file, so run terragrunt from the nested module.

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -234,6 +234,8 @@ func TestTerragruntWorksWithMultipleInclude(t *testing.T) {
 }
 
 func validateMultipleIncludeTestOutput(t *testing.T, outputs map[string]TerraformOutput) {
+	t.Helper()
+
 	assert.Equal(t, "mock", outputs["attribute"].Value.(string))
 	assert.Equal(t, "new val", outputs["new_attribute"].Value.(string))
 	assert.Equal(t, "old val", outputs["old_attribute"].Value.(string))
@@ -257,6 +259,8 @@ func validateMultipleIncludeTestOutput(t *testing.T, outputs map[string]Terrafor
 }
 
 func validateIncludeRemoteStateReflection(t *testing.T, s3BucketName string, keyPath string, configPath string, workingDir string) {
+	t.Helper()
+
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-config %s --terragrunt-working-dir %s", configPath, workingDir), &stdout, &stderr)

--- a/test/integration_registry_test.go
+++ b/test/integration_registry_test.go
@@ -39,6 +39,8 @@ func TestTerraformRegistryFetchingSubdirWithReferenceModule(t *testing.T) {
 }
 
 func testTerraformRegistryFetching(t *testing.T, modPath, expectedOutputKey string) {
+	t.Helper()
+
 	modFullPath := util.JoinPath(registryFixturePath, modPath)
 	cleanupTerraformFolder(t, modFullPath)
 	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+modFullPath)

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -503,6 +503,8 @@ func TestTerragruntLogLevelEnvVarUnparsableLogsErrorButContinues(t *testing.T) {
 // run.
 
 func testTerragruntParallelism(t *testing.T, parallelism int, numberOfModules int, timeToDeployEachModule time.Duration, expectedTimings []int) {
+	t.Helper()
+
 	output, testStart, err := testRemoteFixtureParallelism(t, parallelism, numberOfModules, timeToDeployEachModule)
 	require.NoError(t, err)
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1307,6 +1307,8 @@ func TestTerragruntOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *tes
 }
 
 func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules int, timeToDeployEachModule time.Duration) (string, int, error) {
+	t.Helper()
+
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(uniqueId())
 
 	// copy the template `numberOfModules` times into the app
@@ -1875,6 +1877,8 @@ func TestPreventDestroyDependencies(t *testing.T) {
 }
 
 func validateInputs(t *testing.T, outputs map[string]TerraformOutput) {
+	t.Helper()
+
 	assert.Equal(t, true, outputs["bool"].Value)
 	assert.Equal(t, []interface{}{true, false}, outputs["list_bool"].Value)
 	assert.Equal(t, []interface{}{1.0, 2.0, 3.0}, outputs["list_number"].Value)
@@ -2305,6 +2309,8 @@ func TestDependencyOutputOptimizationNoGenerate(t *testing.T) {
 }
 
 func dependencyOutputOptimizationTest(t *testing.T, moduleName string, forceInit bool, expectedOutputLogs []string) {
+	t.Helper()
+
 	expectedOutput := `They said, "No, The answer is 42"`
 	generatedUniqueId := uniqueId()
 
@@ -4436,6 +4442,8 @@ func TestLogFailingDependencies(t *testing.T) {
 }
 
 func cleanupTerraformFolder(t *testing.T, templatesPath string) {
+	t.Helper()
+
 	removeFile(t, util.JoinPath(templatesPath, TERRAFORM_STATE))
 	removeFile(t, util.JoinPath(templatesPath, TERRAFORM_STATE_BACKUP))
 	removeFile(t, util.JoinPath(templatesPath, terragruntDebugFile))
@@ -4443,10 +4451,14 @@ func cleanupTerraformFolder(t *testing.T, templatesPath string) {
 }
 
 func cleanupTerragruntFolder(t *testing.T, templatesPath string) {
+	t.Helper()
+
 	removeFolder(t, util.JoinPath(templatesPath, TERRAGRUNT_CACHE))
 }
 
 func removeFile(t *testing.T, path string) {
+	t.Helper()
+
 	if util.FileExists(path) {
 		if err := os.Remove(path); err != nil {
 			t.Fatalf("Error while removing %s: %v", path, err)
@@ -4455,6 +4467,8 @@ func removeFile(t *testing.T, path string) {
 }
 
 func removeFolder(t *testing.T, path string) {
+	t.Helper()
+
 	if util.FileExists(path) {
 		if err := os.RemoveAll(path); err != nil {
 			t.Fatalf("Error while removing %s: %v", path, err)
@@ -4463,6 +4477,8 @@ func removeFolder(t *testing.T, path string) {
 }
 
 func runTerragruntCommand(t *testing.T, command string, writer io.Writer, errwriter io.Writer) error {
+	t.Helper()
+
 	args := strings.Split(command, " ")
 	t.Log(args)
 
@@ -4471,15 +4487,21 @@ func runTerragruntCommand(t *testing.T, command string, writer io.Writer, errwri
 }
 
 func runTerragruntVersionCommand(t *testing.T, ver string, command string, writer io.Writer, errwriter io.Writer) error {
+	t.Helper()
+
 	version.Version = ver
 	return runTerragruntCommand(t, command, writer, errwriter)
 }
 
 func runTerragrunt(t *testing.T, command string) {
+	t.Helper()
+
 	runTerragruntRedirectOutput(t, command, os.Stdout, os.Stderr)
 }
 
 func runTerragruntCommandWithOutput(t *testing.T, command string) (string, string, error) {
+	t.Helper()
+
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 	err := runTerragruntCommand(t, command, &stdout, &stderr)
@@ -4489,6 +4511,8 @@ func runTerragruntCommandWithOutput(t *testing.T, command string) (string, strin
 }
 
 func runTerragruntRedirectOutput(t *testing.T, command string, writer io.Writer, errwriter io.Writer) {
+	t.Helper()
+
 	if err := runTerragruntCommand(t, command, writer, errwriter); err != nil {
 		stdout := "(see log output above)"
 		if stdoutAsBuffer, stdoutIsBuffer := writer.(*bytes.Buffer); stdoutIsBuffer {
@@ -4505,6 +4529,8 @@ func runTerragruntRedirectOutput(t *testing.T, command string, writer io.Writer,
 }
 
 func copyEnvironment(t *testing.T, environmentPath string, includeInCopy ...string) string {
+	t.Helper()
+
 	tmpDir, err := os.MkdirTemp("", "terragrunt-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir due to error: %v", err)
@@ -4518,6 +4544,8 @@ func copyEnvironment(t *testing.T, environmentPath string, includeInCopy ...stri
 }
 
 func createTmpTerragruntConfigWithParentAndChild(t *testing.T, parentPath string, childRelPath string, s3BucketName string, parentConfigFileName string, childConfigFileName string) string {
+	t.Helper()
+
 	tmpDir, err := os.MkdirTemp("", "terragrunt-parent-child-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir due to error: %v", err)
@@ -4541,6 +4569,8 @@ func createTmpTerragruntConfigWithParentAndChild(t *testing.T, parentPath string
 }
 
 func createTmpTerragruntConfig(t *testing.T, templatesPath string, s3BucketName string, lockTableName string, configFileName string) string {
+	t.Helper()
+
 	tmpFolder, err := os.MkdirTemp("", "terragrunt-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp folder due to error: %v", err)
@@ -4554,6 +4584,8 @@ func createTmpTerragruntConfig(t *testing.T, templatesPath string, s3BucketName 
 }
 
 func createTmpTerragruntConfigContent(t *testing.T, contents string, configFileName string) string {
+	t.Helper()
+
 	tmpFolder, err := os.MkdirTemp("", "terragrunt-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp folder due to error: %v", err)
@@ -4569,6 +4601,8 @@ func createTmpTerragruntConfigContent(t *testing.T, contents string, configFileN
 }
 
 func createTmpTerragruntGCSConfig(t *testing.T, templatesPath string, project string, location string, gcsBucketName string, configFileName string) string {
+	t.Helper()
+
 	tmpFolder, err := os.MkdirTemp("", "terragrunt-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp folder due to error: %v", err)
@@ -4582,6 +4616,8 @@ func createTmpTerragruntGCSConfig(t *testing.T, templatesPath string, project st
 }
 
 func copyTerragruntConfigAndFillPlaceholders(t *testing.T, configSrcPath string, configDestPath string, s3BucketName string, lockTableName string, region string) {
+	t.Helper()
+
 	copyAndFillMapPlaceholders(t, configSrcPath, configDestPath, map[string]string{
 		"__FILL_IN_BUCKET_NAME__":      s3BucketName,
 		"__FILL_IN_LOCK_TABLE_NAME__":  lockTableName,
@@ -4591,6 +4627,8 @@ func copyTerragruntConfigAndFillPlaceholders(t *testing.T, configSrcPath string,
 }
 
 func copyAndFillMapPlaceholders(t *testing.T, srcPath string, destPath string, placeholders map[string]string) {
+	t.Helper()
+
 	contents, err := util.ReadFileAsString(srcPath)
 	if err != nil {
 		t.Fatalf("Error reading file at %s: %v", srcPath, err)
@@ -4606,6 +4644,8 @@ func copyAndFillMapPlaceholders(t *testing.T, srcPath string, destPath string, p
 }
 
 func copyTerragruntGCSConfigAndFillPlaceholders(t *testing.T, configSrcPath string, configDestPath string, project string, location string, gcsBucketName string) {
+	t.Helper()
+
 	email := os.Getenv("GOOGLE_IDENTITY_EMAIL")
 
 	copyAndFillMapPlaceholders(t, configSrcPath, configDestPath, map[string]string{
@@ -4635,6 +4675,8 @@ func uniqueId() string {
 // Check that the S3 Bucket of the given name and region exists. Terragrunt should create this bucket during the test.
 // Also check if bucket got tagged properly and that public access is disabled completely.
 func validateS3BucketExistsAndIsTagged(t *testing.T, awsRegion string, bucketName string, expectedTags map[string]string) {
+	t.Helper()
+
 	mockOptions, err := options.NewTerragruntOptionsForTest("integration_test")
 	if err != nil {
 		t.Fatalf("Error creating mockOptions: %v", err)
@@ -4652,7 +4694,7 @@ func validateS3BucketExistsAndIsTagged(t *testing.T, awsRegion string, bucketNam
 	assert.True(t, remote.DoesS3BucketExist(s3Client, &bucketName), "Terragrunt failed to create remote state S3 bucket %s", bucketName)
 
 	if expectedTags != nil {
-		assertS3Tags(expectedTags, bucketName, s3Client, t)
+		assertS3Tags(t, expectedTags, bucketName, s3Client)
 	}
 
 	assertS3PublicAccessBlocks(t, s3Client, bucketName)
@@ -4661,6 +4703,8 @@ func validateS3BucketExistsAndIsTagged(t *testing.T, awsRegion string, bucketNam
 // Check that the DynamoDB table of the given name and region exists. Terragrunt should create this table during the test.
 // Also check if table got tagged properly
 func validateDynamoDBTableExistsAndIsTagged(t *testing.T, awsRegion string, tableName string, expectedTags map[string]string) {
+	t.Helper()
+
 	client := createDynamoDbClientForTest(t, awsRegion)
 
 	var description, err = client.DescribeTable(&dynamodb.DescribeTableInput{TableName: aws.String(tableName)})
@@ -4685,7 +4729,8 @@ func validateDynamoDBTableExistsAndIsTagged(t *testing.T, awsRegion string, tabl
 	assert.Equal(t, expectedTags, actualTags, "Did not find expected tags on dynamo table.")
 }
 
-func assertS3Tags(expectedTags map[string]string, bucketName string, client *s3.S3, t *testing.T) {
+func assertS3Tags(t *testing.T, expectedTags map[string]string, bucketName string, client *s3.S3) {
+	t.Helper()
 
 	var in = s3.GetBucketTaggingInput{}
 	in.SetBucket(bucketName)
@@ -4706,6 +4751,8 @@ func assertS3Tags(expectedTags map[string]string, bucketName string, client *s3.
 }
 
 func assertS3PublicAccessBlocks(t *testing.T, client *s3.S3, bucketName string) {
+	t.Helper()
+
 	resp, err := client.GetPublicAccessBlock(
 		&s3.GetPublicAccessBlockInput{Bucket: aws.String(bucketName)},
 	)
@@ -4720,12 +4767,16 @@ func assertS3PublicAccessBlocks(t *testing.T, client *s3.S3, bucketName string) 
 
 // createS3Bucket creates a test S3 bucket for state.
 func createS3Bucket(t *testing.T, awsRegion string, bucketName string) {
+	t.Helper()
+
 	err := createS3BucketE(t, awsRegion, bucketName)
 	require.NoError(t, err)
 }
 
 // createS3BucketE create test S3 bucket.
 func createS3BucketE(t *testing.T, awsRegion string, bucketName string) error {
+	t.Helper()
+
 	mockOptions, err := options.NewTerragruntOptionsForTest("integration_test")
 	if err != nil {
 		t.Logf("Error creating mockOptions: %v", err)
@@ -4752,12 +4803,16 @@ func createS3BucketE(t *testing.T, awsRegion string, bucketName string) error {
 
 // createDynamoDbTable creates a test DynamoDB table.
 func createDynamoDbTable(t *testing.T, awsRegion string, tableName string) {
+	t.Helper()
+
 	err := createDynamoDbTableE(t, awsRegion, tableName)
 	require.NoError(t, err)
 }
 
 // createDynamoDbTableE creates a test DynamoDB table, and returns an error if the table creation fails.
 func createDynamoDbTableE(t *testing.T, awsRegion string, tableName string) error {
+	t.Helper()
+
 	client := createDynamoDbClientForTest(t, awsRegion)
 	_, err := client.CreateTable(&dynamodb.CreateTableInput{
 		AttributeDefinitions: []*dynamodb.AttributeDefinition{
@@ -4788,6 +4843,8 @@ func createDynamoDbTableE(t *testing.T, awsRegion string, tableName string) erro
 // deleteS3BucketWithRetry will attempt to delete the specified S3 bucket, retrying up to 3 times if there are errors to
 // handle eventual consistency issues.
 func deleteS3BucketWithRetry(t *testing.T, awsRegion string, bucketName string) {
+	t.Helper()
+
 	for i := 0; i < 3; i++ {
 		err := deleteS3BucketE(t, awsRegion, bucketName)
 		if err == nil {
@@ -4802,9 +4859,13 @@ func deleteS3BucketWithRetry(t *testing.T, awsRegion string, bucketName string) 
 
 // Delete the specified S3 bucket to clean up after a test
 func deleteS3Bucket(t *testing.T, awsRegion string, bucketName string, opts ...options.TerragruntOptionsFunc) {
+	t.Helper()
+
 	require.NoError(t, deleteS3BucketE(t, awsRegion, bucketName, opts...))
 }
 func deleteS3BucketE(t *testing.T, awsRegion string, bucketName string, opts ...options.TerragruntOptionsFunc) error {
+	t.Helper()
+
 	mockOptions, err := options.NewTerragruntOptionsForTest("integration_test", opts...)
 	if err != nil {
 		t.Logf("Error creating mockOptions: %v", err)
@@ -4856,6 +4917,8 @@ func deleteS3BucketE(t *testing.T, awsRegion string, bucketName string, opts ...
 }
 
 func bucketEncryption(t *testing.T, awsRegion string, bucketName string) (*s3.GetBucketEncryptionOutput, error) {
+	t.Helper()
+
 	mockOptions, err := options.NewTerragruntOptionsForTest("integration_test")
 	if err != nil {
 		t.Logf("Error creating mockOptions: %v", err)
@@ -4883,6 +4946,8 @@ func bucketEncryption(t *testing.T, awsRegion string, bucketName string) (*s3.Ge
 }
 
 func bucketPolicy(t *testing.T, awsRegion string, bucketName string) (*s3.GetBucketPolicyOutput, error) {
+	t.Helper()
+
 	mockOptions, err := options.NewTerragruntOptionsForTest("integration_test")
 	if err != nil {
 		t.Logf("Error creating mockOptions: %v", err)
@@ -4928,6 +4993,8 @@ func createDynamoDbClient(awsRegion, awsProfile string, iamRoleArn string) (*dyn
 }
 
 func createDynamoDbClientForTest(t *testing.T, awsRegion string) *dynamodb.DynamoDB {
+	t.Helper()
+
 	client, err := createDynamoDbClient(awsRegion, "", "")
 	if err != nil {
 		t.Fatal(err)
@@ -4936,6 +5003,8 @@ func createDynamoDbClientForTest(t *testing.T, awsRegion string) *dynamodb.Dynam
 }
 
 func cleanupTableForTest(t *testing.T, tableName string, awsRegion string) {
+	t.Helper()
+
 	client := createDynamoDbClientForTest(t, awsRegion)
 	err := terragruntDynamoDb.DeleteTable(tableName, client)
 	require.NoError(t, err)
@@ -4944,6 +5013,8 @@ func cleanupTableForTest(t *testing.T, tableName string, awsRegion string) {
 // Check that the GCS Bucket of the given name and location exists. Terragrunt should create this bucket during the test.
 // Also check if bucket got labeled properly.
 func validateGCSBucketExistsAndIsLabeled(t *testing.T, location string, bucketName string, expectedLabels map[string]string) {
+	t.Helper()
+
 	remoteStateConfig := remote.RemoteStateConfigGCS{Bucket: bucketName}
 
 	gcsClient, err := remote.CreateGCSClient(remoteStateConfig)
@@ -4971,6 +5042,8 @@ func validateGCSBucketExistsAndIsLabeled(t *testing.T, location string, bucketNa
 
 // gcsObjectAttrs returns the attributes of the specified object in the bucket
 func gcsObjectAttrs(t *testing.T, bucketName string, objectName string) *storage.ObjectAttrs {
+	t.Helper()
+
 	remoteStateConfig := remote.RemoteStateConfigGCS{Bucket: bucketName}
 
 	gcsClient, err := remote.CreateGCSClient(remoteStateConfig)
@@ -4990,6 +5063,8 @@ func gcsObjectAttrs(t *testing.T, bucketName string, objectName string) *storage
 }
 
 func assertGCSLabels(t *testing.T, expectedLabels map[string]string, bucketName string, client *storage.Client) {
+	t.Helper()
+
 	ctx := context.Background()
 	bucket := client.Bucket(bucketName)
 
@@ -5009,6 +5084,8 @@ func assertGCSLabels(t *testing.T, expectedLabels map[string]string, bucketName 
 
 // Create the specified GCS bucket
 func createGCSBucket(t *testing.T, projectID string, location string, bucketName string) {
+	t.Helper()
+
 	var gcsConfig remote.RemoteStateConfigGCS
 	gcsClient, err := remote.CreateGCSClient(gcsConfig)
 	if err != nil {
@@ -5032,6 +5109,8 @@ func createGCSBucket(t *testing.T, projectID string, location string, bucketName
 
 // Delete the specified GCS bucket to clean up after a test
 func deleteGCSBucket(t *testing.T, bucketName string) {
+	t.Helper()
+
 	var gcsConfig remote.RemoteStateConfigGCS
 	gcsClient, err := remote.CreateGCSClient(gcsConfig)
 	if err != nil {
@@ -5072,6 +5151,8 @@ func deleteGCSBucket(t *testing.T, bucketName string) {
 }
 
 func fileIsInFolder(t *testing.T, name string, path string) bool {
+	t.Helper()
+
 	found := false
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		require.NoError(t, err)
@@ -5085,6 +5166,8 @@ func fileIsInFolder(t *testing.T, name string, path string) bool {
 }
 
 func runValidateAllWithIncludeAndGetIncludedModules(t *testing.T, rootModulePath string, includeModulePaths []string, strictInclude bool) []string {
+	t.Helper()
+
 	cmd_parts := []string{
 		"terragrunt", "run-all", "validate",
 		"--terragrunt-non-interactive",


### PR DESCRIPTION
## Description

Adds `thelpher` and `wastedassign` lints.

The former is a lint that will make sure we call `t.Helper()` in all test helper functions. The latter will prevent unnecessary assignments to variables.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added `thelpher` lint.
Added `wastedassign` lint.

