### PR TITLE
feat: add TERRAGRUNT_INCLUDE_DIR var

### DIFF
--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -213,6 +213,7 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 		&cli.SliceFlag[string]{
 			Name:        TerragruntIncludeDirFlagName,
 			Destination: &opts.IncludeDirs,
+			EnvVar:      "TERRAGRUNT_INCLUDE_DIR",
 			Usage:       "Unix-style glob of directories to include when running *-all commands",
 		},
 		&cli.BoolFlag{

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -1002,6 +1002,7 @@ module, not its dependencies.
 ### terragrunt-include-dir
 
 **CLI Arg**: `--terragrunt-include-dir`<br/>
+**Environment Variable**: `TERRAGRUNT_INCLUDE_DIR`<br/>
 **Requires an argument**: `--terragrunt-include-dir /path/to/dirs/to/include*`<br/>
 
 Can be supplied multiple times: `--terragrunt-include-dir /path/to/dirs/to/include --terragrunt-include-dir /another/path/to/dirs/to/include`


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Added a `TERRAGRUNT_INCLUDE_DIR` variable, to control --terragrunt-include-dir via env variables (usefule in CI/CD pipelines)

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added parsing of `TERRAGRUNT_INCLUDE_DIR` env to control `--terragrunt-include-dir` parameter.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

