### PR TITLE
Locals doc: Fix/improve 'Reading from other HCL files'

### DIFF
--- a/docs/_docs/02_features/locals.md
+++ b/docs/_docs/02_features/locals.md
@@ -111,8 +111,8 @@ locals {
 ```hcl
 # child/terragrunt.hcl
 locals {
-  parent_computed_value = read_terragrunt_config(find_in_parent_folders("computed.hcl"))
-  message = "${local.parent_computed_value.computed_value} world!" # <-- Hello world!
+  parent_config = read_terragrunt_config(find_in_parent_folders("computed.hcl"))
+  message = "${local.parent_config.locals.computed_value} world!" # <-- Hello world!
 }
 ```
 


### PR DESCRIPTION
## Description

Fix in the Locals documentation the incomplete invocation of local variable when it's read from another HCL file.

Also renamed an example variable to something I believe best describes its contents.