### PR TITLE
3364 - Update Remote State Encryption When Configurations Are Updated

### DIFF
--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -330,8 +330,19 @@ func ConfigValuesEqual(config map[string]interface{}, existingBackend *Terraform
 }
 
 // buildInitializerCacheKey returns a unique key for the given S3 config that can be used to cache the initialization
-func (s3Initializer S3Initializer) buildInitializerCacheKey(s3Config *RemoteStateConfigS3, s3ConfigExtended *ExtendedRemoteStateConfigS3) string {
-	return fmt.Sprintf("%s-%s-%s-%s-%s-%s", s3Config.Bucket, s3Config.Region, s3Config.LockTable, s3Config.DynamoDBTable, s3ConfigExtended.BucketSSEAlgorithm, s3ConfigExtended.BucketSSEKMSKeyID)
+func (s3Initializer S3Initializer) buildInitializerCacheKey(
+	s3Config *RemoteStateConfigS3,
+	s3ConfigExtended *ExtendedRemoteStateConfigS3,
+) string {
+	return fmt.Sprintf(
+		"%s-%s-%s-%s-%s-%s",
+		s3Config.Bucket,
+		s3Config.Region,
+		s3Config.LockTable,
+		s3Config.DynamoDBTable,
+		s3ConfigExtended.BucketSSEAlgorithm,
+		s3ConfigExtended.BucketSSEKMSKeyID,
+	)
 }
 
 // Initialize the remote state S3 bucket specified in the given config. This function will validate the config
@@ -1329,7 +1340,11 @@ func fetchEncryptionAlgorithm(config *ExtendedRemoteStateConfigS3) string {
 	return algorithm
 }
 
-func checkIfSSEForS3MatchesConfig(s3Client *s3.S3, config *ExtendedRemoteStateConfigS3, terragruntOptions *options.TerragruntOptions) (bool, error) {
+func checkIfSSEForS3MatchesConfig(
+	s3Client *s3.S3,
+	config *ExtendedRemoteStateConfigS3,
+	terragruntOptions *options.TerragruntOptions,
+) (bool, error) {
 	terragruntOptions.Logger.Debugf("Checking if SSE is enabled for AWS S3 bucket %s", config.RemoteStateConfigS3.Bucket)
 
 	input := &s3.GetBucketEncryptionInput{Bucket: aws.String(config.RemoteStateConfigS3.Bucket)}


### PR DESCRIPTION
## Description

Fixes #3364.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `remote` Package.