### PR TITLE
Added handling of TERRAGRUNT_TEMP_QUOTE_NULL

### DIFF
--- a/cli/commands/terraform/action.go
+++ b/cli/commands/terraform/action.go
@@ -787,7 +787,7 @@ func filterTerraformEnvVarsFromExtraArgs(terragruntOptions *options.TerragruntOp
 // natively.
 func ToTerraformEnvVars(opts *options.TerragruntOptions, vars map[string]interface{}) (map[string]string, error) {
 	if useLegacyNullValues() {
-		opts.Logger.Warnf("%s is a temporary workaround to bypass the breaking change in #2663.\nThis flag will be removed in the future.\nDo not rely on it.", useLegacyNullValuesEnvVar)
+		opts.Logger.Warnf("⚠️ %s is a temporary workaround to bypass the breaking change in #2663.\nThis flag will be removed in the future.\nDo not rely on it.", useLegacyNullValuesEnvVar)
 	}
 
 	out := map[string]string{}
@@ -795,7 +795,7 @@ func ToTerraformEnvVars(opts *options.TerragruntOptions, vars map[string]interfa
 	for varName, varValue := range vars {
 		if varValue == nil {
 			if useLegacyNullValues() {
-				opts.Logger.Warnf("Input `%s` has value `null`. Quoting due to %s.", varName, useLegacyNullValuesEnvVar)
+				opts.Logger.Warnf("⚠️ Input `%s` has value `null`. Quoting due to %s.", varName, useLegacyNullValuesEnvVar)
 			} else {
 				continue
 			}

--- a/cli/commands/terraform/action.go
+++ b/cli/commands/terraform/action.go
@@ -787,9 +787,7 @@ func filterTerraformEnvVarsFromExtraArgs(terragruntOptions *options.TerragruntOp
 // natively.
 func ToTerraformEnvVars(opts *options.TerragruntOptions, vars map[string]interface{}) (map[string]string, error) {
 	if useLegacyNullValues() {
-		opts.Logger.Warnf("%s is a temporary workaround to bypass the breaking change in #2663.", useLegacyNullValuesEnvVar)
-		opts.Logger.Warn("This flag will be removed in the future.")
-		opts.Logger.Warn("Do not rely on it.")
+		opts.Logger.Warnf("%s is a temporary workaround to bypass the breaking change in #2663.\nThis flag will be removed in the future.\nDo not rely on it.", useLegacyNullValuesEnvVar)
 	}
 
 	out := map[string]string{}
@@ -847,5 +845,5 @@ func setTerragruntNullValues(terragruntOptions *options.TerragruntOptions, terra
 }
 
 func useLegacyNullValues() bool {
-	return os.Getenv(useLegacyNullValuesEnvVar) != ""
+	return os.Getenv(useLegacyNullValuesEnvVar) == "1"
 }

--- a/cli/commands/terraform/action.go
+++ b/cli/commands/terraform/action.go
@@ -791,13 +791,14 @@ func ToTerraformEnvVars(opts *options.TerragruntOptions, vars map[string]interfa
 		opts.Logger.Warn("This flag will be removed in the future.")
 		opts.Logger.Warn("Do not rely on it.")
 	}
+
 	out := map[string]string{}
+
 	for varName, varValue := range vars {
-		if useLegacyNullValues() {
-			opts.Logger.Warnf("Input `%s` has value `null`. Quoting due to %s.", varName, useLegacyNullValuesEnvVar)
-		} else {
-			// skip variables with null values
-			if varValue == nil {
+		if varValue == nil {
+			if useLegacyNullValues() {
+				opts.Logger.Warnf("Input `%s` has value `null`. Quoting due to %s.", varName, useLegacyNullValuesEnvVar)
+			} else {
 				continue
 			}
 		}

--- a/cli/commands/terraform/action.go
+++ b/cli/commands/terraform/action.go
@@ -36,6 +36,8 @@ import (
 const (
 	CommandNameTerragruntReadConfig = "terragrunt-read-config"
 	NullTFVarsFile                  = ".terragrunt-null-vars.auto.tfvars.json"
+
+	useLegacyNullValuesEnvVar = "TERRAGRUNT_TEMP_QUOTE_NULL"
 )
 
 var TerraformCommandsThatUseState = []string{
@@ -297,18 +299,20 @@ func runTerragruntWithConfig(ctx context.Context, originalTerragruntOptions *opt
 		}
 	}
 
-	fileName, err := setTerragruntNullValues(terragruntOptions, terragruntConfig)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		if fileName != "" {
-			if err := os.Remove(fileName); err != nil {
-				terragruntOptions.Logger.Debugf("Failed to remove null values file %s: %v", fileName, err)
-			}
+	if !useLegacyNullValues() {
+		fileName, err := setTerragruntNullValues(terragruntOptions, terragruntConfig)
+		if err != nil {
+			return err
 		}
-	}()
+
+		defer func() {
+			if fileName != "" {
+				if err := os.Remove(fileName); err != nil {
+					terragruntOptions.Logger.Debugf("Failed to remove null values file %s: %v", fileName, err)
+				}
+			}
+		}()
+	}
 
 	// Now that we've run 'init' and have all the source code locally, we can finally run the patch command
 	if target.isPoint(TargetPointInitCommand) {
@@ -419,7 +423,7 @@ func runActionWithHooks(ctx context.Context, description string, terragruntOptio
 // The Terragrunt configuration can contain a set of inputs to pass to Terraform as environment variables. This method
 // sets these environment variables in the given terragruntOptions.
 func SetTerragruntInputsAsEnvVars(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) error {
-	asEnvVars, err := ToTerraformEnvVars(terragruntConfig.Inputs)
+	asEnvVars, err := ToTerraformEnvVars(terragruntOptions, terragruntConfig.Inputs)
 	if err != nil {
 		return err
 	}
@@ -781,13 +785,21 @@ func filterTerraformEnvVarsFromExtraArgs(terragruntOptions *options.TerragruntOp
 // Convert the given variables to a map of environment variables that will expose those variables to Terraform. The
 // keys will be of the format TF_VAR_xxx and the values will be converted to JSON, which Terraform knows how to read
 // natively.
-func ToTerraformEnvVars(vars map[string]interface{}) (map[string]string, error) {
+func ToTerraformEnvVars(opts *options.TerragruntOptions, vars map[string]interface{}) (map[string]string, error) {
+	if useLegacyNullValues() {
+		opts.Logger.Warnf("%s is a temporary workaround to bypass the breaking change in #2663.", useLegacyNullValuesEnvVar)
+		opts.Logger.Warn("This flag will be removed in the future.")
+		opts.Logger.Warn("Do not rely on it.")
+	}
 	out := map[string]string{}
-
 	for varName, varValue := range vars {
-		// skip variables with null values
-		if varValue == nil {
-			continue
+		if useLegacyNullValues() {
+			opts.Logger.Warnf("Input `%s` has value `null`. Quoting due to %s.", varName, useLegacyNullValuesEnvVar)
+		} else {
+			// skip variables with null values
+			if varValue == nil {
+				continue
+			}
 		}
 
 		envVarName := fmt.Sprintf(terraform.EnvNameTFVarFmt, varName)
@@ -831,4 +843,8 @@ func setTerragruntNullValues(terragruntOptions *options.TerragruntOptions, terra
 	}
 
 	return varFile, nil
+}
+
+func useLegacyNullValues() bool {
+	return os.Getenv(useLegacyNullValuesEnvVar) != ""
 }

--- a/cli/commands/terraform/action_test.go
+++ b/cli/commands/terraform/action_test.go
@@ -321,8 +321,9 @@ func TestToTerraformEnvVars(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.description, func(t *testing.T) {
 			t.Parallel()
-
-			actual, err := terraform.ToTerraformEnvVars(testCase.vars)
+			opts, err := options.NewTerragruntOptionsForTest("")
+			require.NoError(t, err)
+			actual, err := terraform.ToTerraformEnvVars(opts, testCase.vars)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.expected, actual)
 		})

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3399,7 +3399,7 @@ func TestTerragruntHandleLegacyNullValues(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(stdout), &outputs))
 
 	// check that null value is passed as "null"
-	assert.Equal(t, outputs["output1"].Value, "null")
+	assert.Equal(t, "null", outputs["output1"].Value)
 	assert.Equal(t, "variable 2", outputs["output2"].Value)
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3346,31 +3346,28 @@ func TestTerragruntPassNullValues(t *testing.T) {
 	t.Parallel()
 
 	generateTestCase := testFixtureNullValue
-	cleanupTerraformFolder(t, generateTestCase)
-	cleanupTerragruntFolder(t, generateTestCase)
+	tmpEnv := copyEnvironment(t, generateTestCase)
+	cleanupTerraformFolder(t, tmpEnv)
+	cleanupTerragruntFolder(t, tmpEnv)
+	tmpEnv = util.JoinPath(tmpEnv, generateTestCase)
 
-	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase)
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+tmpEnv)
 
 	// Now check the outputs to make sure they are as expected
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
+	stdout, _, err := runTerragruntCommandWithOutput(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir "+tmpEnv)
 
-	require.NoError(
-		t,
-		runTerragruntCommand(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir "+generateTestCase, &stdout, &stderr),
-	)
-
+	require.NoError(t, err)
 	outputs := map[string]TerraformOutput{}
-	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
+	require.NoError(t, json.Unmarshal([]byte(stdout), &outputs))
 
 	// check that the null values are passed correctly
 	assert.Nil(t, outputs["output1"].Value)
 	assert.Equal(t, "variable 2", outputs["output2"].Value)
 
 	// check that file with null values is removed
-	cachePath := filepath.Join(testFixtureNullValue, terragruntCache)
+	cachePath := filepath.Join(tmpEnv, terragruntCache)
 	foundNullValuesFile := false
-	err := filepath.Walk(cachePath,
+	err = filepath.Walk(cachePath,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
@@ -3382,6 +3379,28 @@ func TestTerragruntPassNullValues(t *testing.T) {
 		})
 	assert.Falsef(t, foundNullValuesFile, "Found %s file in cache directory", terraform.NullTFVarsFile)
 	require.NoError(t, err)
+}
+
+func TestTerragruntHandleLegacyNullValues(t *testing.T) {
+	// no parallel since we need to set env vars
+	t.Setenv("TERRAGRUNT_TEMP_QUOTE_NULL", "1")
+	generateTestCase := testFixtureNullValue
+	tmpEnv := copyEnvironment(t, generateTestCase)
+	cleanupTerraformFolder(t, tmpEnv)
+	cleanupTerragruntFolder(t, tmpEnv)
+	tmpEnv = util.JoinPath(tmpEnv, generateTestCase)
+
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+tmpEnv)
+
+	stdout, _, err := runTerragruntCommandWithOutput(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir "+tmpEnv)
+
+	require.NoError(t, err)
+	outputs := map[string]TerraformOutput{}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &outputs))
+
+	// check that null value is passed as "null"
+	assert.Equal(t, outputs["output1"].Value, "null")
+	assert.Equal(t, "variable 2", outputs["output2"].Value)
 }
 
 func TestTerragruntNoWarningLocalPath(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3390,10 +3390,11 @@ func TestTerragruntHandleLegacyNullValues(t *testing.T) {
 	cleanupTerragruntFolder(t, tmpEnv)
 	tmpEnv = util.JoinPath(tmpEnv, generateTestCase)
 
-	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+tmpEnv)
+	_, stderr, err := runTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+tmpEnv)
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "Input `var1` has value `null`. Quoting due to TERRAGRUNT_TEMP_QUOTE_NULL")
 
 	stdout, _, err := runTerragruntCommandWithOutput(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir "+tmpEnv)
-
 	require.NoError(t, err)
 	outputs := map[string]TerraformOutput{}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &outputs))


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* added handling of TERRAGRUNT_TEMP_QUOTE_NULL env var
* added test for checking passing null values
* added basic integration test to track this change

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added `TERRAGRUNT_TEMP_QUOTE_NULL`

This undcoumented feature flag allows users to temporarily revert the breaking change in release [v0.50.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.50.0) to avoid sending the string "null" as the value of an input to OpenTofu/Terraform instead of not setting an input at all.

The flag is being introduced into the codebase for a temporary duration to support Enterprise customers that have asked for this as a stop gap while they update their codebase to no longer need it.

Terragrunt will not support this flag in the future. Do not rely on it.

We will be coordinating closely with Enterprise customers to determine when they no longer need it supported.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

