### PR TITLE
Allow pre-release versions to pass version constraints

### DIFF
--- a/cli/commands/terraform/version_check.go
+++ b/cli/commands/terraform/version_check.go
@@ -141,7 +141,18 @@ func CheckTerragruntVersionMeetsConstraint(currentVersion *version.Version, cons
 		return err
 	}
 
-	if !versionConstraint.Check(currentVersion) {
+	checkedVersion := currentVersion
+
+	if currentVersion.Prerelease() != "" {
+		// The logic in hashicorp/go-version is such that it will not consider a prerelease version to be
+		// compatible with a constraint that does not have a prerelease version. This is not the behavior we want
+		// for Terragrunt, so we strip the prerelease version before checking the constraint.
+		//
+		// https://github.com/hashicorp/go-version/issues/130
+		checkedVersion = currentVersion.Core()
+	}
+
+	if !versionConstraint.Check(checkedVersion) {
 		return errors.WithStackTrace(InvalidTerragruntVersion{CurrentVersion: currentVersion, VersionConstraints: versionConstraint})
 	}
 

--- a/cli/commands/terraform/version_check_test.go
+++ b/cli/commands/terraform/version_check_test.go
@@ -120,6 +120,8 @@ func testParseTerraformVersion(t *testing.T, versionString string, expectedVersi
 	}
 }
 
+// TODO: Refactor these into a test table.
+
 // Terragrunt Version Checking
 func TestCheckTerragruntVersionMeetsConstraintEqual(t *testing.T) {
 	t.Parallel()
@@ -144,6 +146,11 @@ func TestCheckTerragruntVersionMeetsConstraintLessPatch(t *testing.T) {
 func TestCheckTerragruntVersionMeetsConstraintLessMajor(t *testing.T) {
 	t.Parallel()
 	testCheckTerragruntVersionMeetsConstraint(t, "v0.22.15", ">= v0.23.18", false)
+}
+
+func TestCheckTerragruntVersionMeetsConstraintPrerelease(t *testing.T) {
+	t.Parallel()
+	testCheckTerragruntVersionMeetsConstraint(t, "v0.23.18-alpha202409013", ">= v0.23.18", true)
 }
 
 func testCheckTerragruntVersionMeetsConstraint(t *testing.T, currentVersion string, versionConstraint string, versionMeetsConstraint bool) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2409,27 +2409,39 @@ func TestTerragruntVersionConstraints(t *testing.T) {
 			true,
 		},
 		{
-			"version meets constriant greater patch",
+			"version meets constraint greater patch",
 			"v0.23.19",
 			"terragrunt_version_constraint = \">= v0.23.18\"",
 			true,
 		},
 		{
-			"version meets constriant greater major",
+			"version meets constraint greater major",
 			"v1.0.0",
 			"terragrunt_version_constraint = \">= v0.23.18\"",
 			true,
 		},
 		{
-			"version meets constriant less patch",
+			"version fails constraint less patch",
 			"v0.23.17",
 			"terragrunt_version_constraint = \">= v0.23.18\"",
 			false,
 		},
 		{
-			"version meets constriant less major",
+			"version fails constraint less major",
 			"v0.22.18",
 			"terragrunt_version_constraint = \">= v0.23.18\"",
+			false,
+		},
+		{
+			"version meets constraint pre-release",
+			"v0.23.18-alpha2024091301",
+			"terragrunt_version_constraint = \">= v0.23.18\"",
+			true,
+		},
+		{
+			"version fails constraint pre-release",
+			"v0.23.18-alpha2024091301",
+			"terragrunt_version_constraint = \"< v0.23.18\"",
 			false,
 		},
 	}


### PR DESCRIPTION
## Description

Fixes #3402.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `version_constraint` logic to ignore pre-release information.