### PR TITLE
Downloading of latest engine

### DIFF
--- a/config/catalog.go
+++ b/config/catalog.go
@@ -44,8 +44,8 @@ func (cfg *CatalogConfig) String() string {
 	return fmt.Sprintf("Catalog{URLs = %v}", cfg.URLs)
 }
 
-func (cfg *CatalogConfig) normalize(cofnigPath string) {
-	configDir := filepath.Dir(cofnigPath)
+func (cfg *CatalogConfig) normalize(configPath string) {
+	configDir := filepath.Dir(configPath)
 
 	// transform relative paths to absolute ones
 	for i, url := range cfg.URLs {

--- a/docs/_docs/02_features/engine.md
+++ b/docs/_docs/02_features/engine.md
@@ -97,7 +97,6 @@ To disable this feature, set the environment variable:
 export TG_ENGINE_SKIP_CHECK=0 
 ```
 
-
 ### Engine Metadata
 
 The `meta` block is used to pass metadata to the engine. This metadata can be used to configure the engine or pass additional information to the engine.

--- a/docs/_docs/02_features/engine.md
+++ b/docs/_docs/02_features/engine.md
@@ -19,7 +19,7 @@ To try it out, all you need to do is include the following in your `terragrunt.h
 ```hcl
 engine {
   source  = "github.com/gruntwork-io/terragrunt-engine-opentofu"
-  version = "v0.0.5"
+  version = "v0.0.7"
 }
 ```
 
@@ -27,7 +27,13 @@ This example leverages the official OpenTofu engine, [publicly available on GitH
 
 This engine currently leverages the locally available installation of the `tofu` binary, just like Terragrunt does by default without use of engine configurations. It provides a convenient example of how to build engines for Terragrunt.
 
-In the future, this plugin will expand in capability to include additional features and configurations.
+In the future, this engine will expand in capability to include additional features and configurations.
+
+Due to the fact that this functionality is still experimental, and not recommended for general production usage, set the following environment variable to opt-in to this functionality:
+
+```sh
+export TG_EXPERIMENTAL_ENGINE=1
+```
 
 ### Use Cases
 
@@ -45,7 +51,7 @@ e.g.
 
 ### HTTPS Sources
 
-Use an HTTP(S) URL to specify the path to the plugin:
+Use an HTTP(S) URL to specify the path to the engine:
 
 ```hcl
 engine {
@@ -67,9 +73,9 @@ engine {
 ### Parameters
 
 * `source`: (Required) The source of the plugin. Multiple engine approaches are supported, including GitHub repositories, HTTP(S) paths, and local absolute paths.
-* `version`: (Required for GitHub) The version of the plugin to download from GitHub releases.
+* `version`: The version of the engine to download from GitHub releases, if not specified, the latest release is downloaded.
 * `type`: (Optional) Currently, the only supported type is `rpc`.
-* `meta`: (Optional) A block for setting plugin-specific metadata. This can include various configuration settings required by the plugin.
+* `meta`: (Optional) A block for setting engine-specific metadata. This can include various configuration settings required by the engine.
 
 ### Caching
 
@@ -91,22 +97,17 @@ To disable this feature, set the environment variable:
 export TG_ENGINE_SKIP_CHECK=0 
 ```
 
-Due to the fact that this functionality is still experimental, and not recommended for general production usage, set the following environment variable to opt-in to this functionality:
-
-```sh
-export TG_EXPERIMENTAL_ENGINE=1
-```
 
 ### Engine Metadata
 
 The `meta` block is used to pass metadata to the engine. This metadata can be used to configure the engine or pass additional information to the engine.
 
-The metadata block is a map of key-value pairs. Plugins can read the information passed via the metadata map to configure themselves or to pass additional information to the engine.
+The metadata block is a map of key-value pairs. Engine implementations can read the information passed via the metadata map to configure themselves or to pass additional information to the engine.
 
 ```hcl
 engine {
-   source  = "/home/users/iac-engines/my-custom-plugin"
-   # Optionally set metadata for the plugin.
+   source  = "/home/users/iac-engines/my-custom-engine"
+   # Optionally set metadata for the engine.
    meta = { 
      key_1 = ["value1", "value2"]
      key_2 = "1.6.0"

--- a/docs/_docs/02_features/engine.md
+++ b/docs/_docs/02_features/engine.md
@@ -73,7 +73,7 @@ engine {
 ### Parameters
 
 * `source`: (Required) The source of the plugin. Multiple engine approaches are supported, including GitHub repositories, HTTP(S) paths, and local absolute paths.
-* `version`: The version of the engine to download from GitHub releases, if not specified, the latest release is downloaded.
+* `version`: The version of the engine to download from GitHub releases, if not specified, the latest release is always downloaded.
 * `type`: (Optional) Currently, the only supported type is `rpc`.
 * `meta`: (Optional) A block for setting engine-specific metadata. This can include various configuration settings required by the engine.
 

--- a/docs/_docs/02_features/engine.md
+++ b/docs/_docs/02_features/engine.md
@@ -101,7 +101,7 @@ export TG_ENGINE_SKIP_CHECK=0
 
 The `meta` block is used to pass metadata to the engine. This metadata can be used to configure the engine or pass additional information to the engine.
 
-The metadata block is a map of key-value pairs. Engine implementations can read the information passed via the metadata map to configure themselves or to pass additional information to the engine.
+The metadata block is a map of key-value pairs. Engines can read the information passed via the metadata map to configure themselves.
 
 ```hcl
 engine {

--- a/test/fixtures/engine/opentofu-latest-run-all/app1/main.tf
+++ b/test/fixtures/engine/opentofu-latest-run-all/app1/main.tf
@@ -1,0 +1,5 @@
+
+resource "local_file" "test" {
+  content  = "app1"
+  filename = "${path.module}/test.txt"
+}

--- a/test/fixtures/engine/opentofu-latest-run-all/app1/terragrunt.hcl
+++ b/test/fixtures/engine/opentofu-latest-run-all/app1/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path   = find_in_parent_folders()
+}

--- a/test/fixtures/engine/opentofu-latest-run-all/app2/main.tf
+++ b/test/fixtures/engine/opentofu-latest-run-all/app2/main.tf
@@ -1,0 +1,5 @@
+
+resource "local_file" "test" {
+  content  = "app1"
+  filename = "${path.module}/test.txt"
+}

--- a/test/fixtures/engine/opentofu-latest-run-all/app2/terragrunt.hcl
+++ b/test/fixtures/engine/opentofu-latest-run-all/app2/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path   = find_in_parent_folders()
+}

--- a/test/fixtures/engine/opentofu-latest-run-all/app3/main.tf
+++ b/test/fixtures/engine/opentofu-latest-run-all/app3/main.tf
@@ -1,0 +1,5 @@
+
+resource "local_file" "test" {
+  content  = "app1"
+  filename = "${path.module}/test.txt"
+}

--- a/test/fixtures/engine/opentofu-latest-run-all/app3/terragrunt.hcl
+++ b/test/fixtures/engine/opentofu-latest-run-all/app3/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path   = find_in_parent_folders()
+}

--- a/test/fixtures/engine/opentofu-latest-run-all/app4/main.tf
+++ b/test/fixtures/engine/opentofu-latest-run-all/app4/main.tf
@@ -1,0 +1,5 @@
+
+resource "local_file" "test" {
+  content  = "app1"
+  filename = "${path.module}/test.txt"
+}

--- a/test/fixtures/engine/opentofu-latest-run-all/app4/terragrunt.hcl
+++ b/test/fixtures/engine/opentofu-latest-run-all/app4/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path   = find_in_parent_folders()
+}

--- a/test/fixtures/engine/opentofu-latest-run-all/app5/main.tf
+++ b/test/fixtures/engine/opentofu-latest-run-all/app5/main.tf
@@ -1,0 +1,5 @@
+
+resource "local_file" "test" {
+  content  = "app1"
+  filename = "${path.module}/test.txt"
+}

--- a/test/fixtures/engine/opentofu-latest-run-all/app5/terragrunt.hcl
+++ b/test/fixtures/engine/opentofu-latest-run-all/app5/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path   = find_in_parent_folders()
+}

--- a/test/fixtures/engine/opentofu-latest-run-all/terragrunt.hcl
+++ b/test/fixtures/engine/opentofu-latest-run-all/terragrunt.hcl
@@ -1,0 +1,4 @@
+engine {
+  // use latest OpenTofu engine to do basic validation of implementation
+  source  = "github.com/gruntwork-io/terragrunt-engine-opentofu"
+}

--- a/test/integration_engine_test.go
+++ b/test/integration_engine_test.go
@@ -20,10 +20,11 @@ import (
 )
 
 const (
-	testFixtureLocalEngine    = "fixtures/engine/local-engine"
-	testFixtureRemoteEngine   = "fixtures/engine/remote-engine"
-	testFixtureOpenTofuEngine = "fixtures/engine/opentofu-engine"
-	testFixtureOpenTofuRunAll = "fixtures/engine/opentofu-run-all"
+	testFixtureLocalEngine          = "fixtures/engine/local-engine"
+	testFixtureRemoteEngine         = "fixtures/engine/remote-engine"
+	testFixtureOpenTofuEngine       = "fixtures/engine/opentofu-engine"
+	testFixtureOpenTofuRunAll       = "fixtures/engine/opentofu-run-all"
+	testFixtureOpenTofuLatestRunAll = "fixtures/engine/opentofu-latest-run-all"
 
 	envVarExperimental = "TG_EXPERIMENTAL_ENGINE"
 )
@@ -198,6 +199,22 @@ func TestEngineDisableChecksumCheck(t *testing.T) {
 
 	_, _, err = runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all apply -no-color -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath))
 	require.NoError(t, err)
+}
+
+func TestEngineOpentofuLatestRunAll(t *testing.T) {
+	t.Setenv(envVarExperimental, "1")
+
+	cleanupTerraformFolder(t, testFixtureOpenTofuLatestRunAll)
+	tmpEnvPath := copyEnvironment(t, testFixtureOpenTofuLatestRunAll)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureOpenTofuLatestRunAll)
+
+	stdout, _, err := runTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all apply -no-color -auto-approve --terragrunt-non-interactive --terragrunt-forward-tf-stdout --terragrunt-working-dir %s", rootPath))
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "resource \"local_file\" \"test\"")
+	assert.Contains(t, stdout, "filename             = \"./test.txt\"\n")
+	assert.Contains(t, stdout, "Tofu Shutdown completed")
+	assert.Contains(t, stdout, "Apply complete!")
 }
 
 func setupEngineCache(t *testing.T) (string, string) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* added detection of latest release tag for github releases
* added tests to track latest release usage for opentofu engine
* updated engine documentation to reflect optional version
* fixed typo in var name for in catalog code

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added support for downloading latest engine release in case of Github sources.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

