### PR TITLE
feat: Adding release announcement workflow

### DIFF
--- a/.github/scripts/announce-release.sh
+++ b/.github/scripts/announce-release.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+URL="${URL:?Required environment variable URL}"
+REPO="${REPO:?Required environment variable REPO}"
+TAG_NAME="${TAG_NAME:?Required environment variable TAG_NAME}"
+ROLE_ID="${ROLE_ID:?Required environment variable ROLE_ID}"
+USERNAME="${USERNAME:?Required environment variable USERNAME}"
+AVATAR_URL="${AVATAR_URL:?Required environment variable AVATAR_URL}"
+
+if RELEASE_JSON=$(gh -R "$REPO" release view "$TAG_NAME" --json body --json url --json name); then
+	RELEASE_NOTES=$(jq '.body' <<<"$RELEASE_JSON")
+
+	PAYLOAD=$(
+		jq \
+			--argjson release_notes "$RELEASE_NOTES" \
+			--arg username "$USERNAME" \
+			--arg avatar_url "$AVATAR_URL" \
+			-cn '{"content": $release_notes, username: $username, avatar_url: $avatar_url, "flags": 4}'
+	)
+
+	tmpfile=$(mktemp)
+	jq '.content = "'"<@&$ROLE_ID> $(jq -r '.name' <<<"$RELEASE_JSON")\n"'>>> " + .content + "'"\n\n**[View release on GitHub]($(jq -r '.url' <<<"$RELEASE_JSON"))**"'"' <<<"$PAYLOAD" >"$tmpfile"
+
+	curl -X POST \
+		--data-binary "@$tmpfile" \
+		-H "Content-Type: application/json" \
+		"$URL"
+fi

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -1,0 +1,22 @@
+name: Announce Release
+on:
+  release:
+    # This is intentionally not `published` to avoid announcing pre-releases
+    types: [released]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Announce Release
+        run: ./.github/scripts/announce-release.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          URL: ${{ secrets.RELEASE_ANNOUNCEMENT_URL }}
+          ROLE_ID: ${{ secrets.RELEASE_ANNOUNCEMENT_ROLE_ID }}
+          USERNAME: ${{ secrets.RELEASE_ANNOUNCEMENT_USERNAME }}
+          AVATAR_URL: ${{ secrets.RELEASE_ANNOUNCEMENT_AVATAR_URL }}


### PR DESCRIPTION
## Description

Adds release announcement workflow.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added GitHub Actions workflow to automate release announcements.

