### PR TITLE
Improved errors printing in case of terraform/tofu invocation

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func checkForErrorsAndExit(logger log.Logger) func(error) {
 			os.Exit(0)
 		} else {
 			logger.Debugf(printErrorWithStackTrace(err))
-			logger.Errorf(printError(err))
+			logger.Errorf(err.Error())
 
 			// exit with the underlying error code
 			exitCode, exitCodeErr := util.GetExitCode(err)
@@ -52,32 +52,6 @@ func checkForErrorsAndExit(logger log.Logger) func(error) {
 			os.Exit(exitCode)
 		}
 	}
-}
-
-func printError(err error) string {
-	if err == nil {
-		return ""
-	}
-
-	var sb strings.Builder
-
-	var processError util.ProcessExecutionError
-
-	if goErrors.As(err, &processError) {
-		if len(processError.Stderr) > 0 {
-			sb.WriteString(processError.Stderr)
-			sb.WriteString("\n")
-		}
-
-		if len(processError.Stdout) > 0 {
-			sb.WriteString(processError.Stdout)
-			sb.WriteString("\n")
-		}
-	}
-
-	sb.WriteString(err.Error())
-
-	return sb.String()
 }
 
 func printErrorWithStackTrace(err error) string {

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func checkForErrorsAndExit(logger log.Logger) func(error) {
 			os.Exit(0)
 		} else {
 			logger.Debugf(printErrorWithStackTrace(err))
-			logger.Errorf(err.Error())
+			logger.Errorf(printError(err))
 
 			// exit with the underlying error code
 			exitCode, exitCodeErr := util.GetExitCode(err)
@@ -52,6 +52,29 @@ func checkForErrorsAndExit(logger log.Logger) func(error) {
 			os.Exit(exitCode)
 		}
 	}
+}
+
+func printError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var sb strings.Builder
+	var processError util.ProcessExecutionError
+
+	if goErrors.As(err, &processError) {
+		if len(processError.Stderr) > 0 {
+			sb.WriteString(processError.Stderr)
+			sb.WriteString("\n")
+		}
+		if len(processError.Stdout) > 0 {
+			sb.WriteString(processError.Stdout)
+			sb.WriteString("\n")
+		}
+	}
+
+	sb.WriteString(err.Error())
+	return sb.String()
 }
 
 func printErrorWithStackTrace(err error) string {

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func printError(err error) string {
 	}
 
 	var sb strings.Builder
+
 	var processError util.ProcessExecutionError
 
 	if goErrors.As(err, &processError) {
@@ -67,6 +68,7 @@ func printError(err error) string {
 			sb.WriteString(processError.Stderr)
 			sb.WriteString("\n")
 		}
+
 		if len(processError.Stdout) > 0 {
 			sb.WriteString(processError.Stdout)
 			sb.WriteString("\n")
@@ -74,6 +76,7 @@ func printError(err error) string {
 	}
 
 	sb.WriteString(err.Error())
+
 	return sb.String()
 }
 

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -253,7 +253,7 @@ func RunShellCommandWithOutput(
 		}
 
 		if err != nil {
-			opts.Logger.Debugf("Error running command %s in %s\n%s\n%s\n%v", command+" "+strings.Join(args, " "), cmd.Dir, stdoutBuf.String(), stderrBuf.String(), err)
+			opts.Logger.Warnf("Failed to execute %s in %s\n%s\n%s\n%v", command+" "+strings.Join(args, " "), cmd.Dir, stdoutBuf.String(), stderrBuf.String(), err)
 			err = util.ProcessExecutionError{
 				Err:        err,
 				Stdout:     stdoutBuf.String(),

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -253,6 +253,7 @@ func RunShellCommandWithOutput(
 		}
 
 		if err != nil {
+			opts.Logger.Debugf("Error running command %s in %s\n%s\n%s\n%v", command+" "+strings.Join(args, " "), cmd.Dir, stdoutBuf.String(), stderrBuf.String(), err)
 			err = util.ProcessExecutionError{
 				Err:        err,
 				Stdout:     stdoutBuf.String(),

--- a/test/fixtures/error-print/custom-tf-script.sh
+++ b/test/fixtures/error-print/custom-tf-script.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-echo "Custom script to generate error" >&2
+echo "Custom error from script" >&2
 
 exit 1

--- a/test/fixtures/error-print/custom-tf-script.sh
+++ b/test/fixtures/error-print/custom-tf-script.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Custom script to generate error" >&2
+
+exit 1

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3914,6 +3914,8 @@ func TestErrorMessageIncludeInOutput(t *testing.T) {
 	cleanupTerraformFolder(t, tmpEnvPath)
 	testPath := util.JoinPath(tmpEnvPath, testFixtureErrorPrint)
 
-	_, _, err := runTerragruntCommandWithOutput(t, "terragrunt apply  --terragrunt-non-interactive --terragrunt-working-dir "+testPath+" --terragrunt-tfpath "+testPath+"/custom-tf-script.sh --terragrunt-log-level debug")
+	_, stderr, err := runTerragruntCommandWithOutput(t, "terragrunt apply  --terragrunt-non-interactive --terragrunt-working-dir "+testPath+" --terragrunt-tfpath "+testPath+"/custom-tf-script.sh --terragrunt-log-level debug")
 	require.Error(t, err)
+
+	assert.Contains(t, stderr, "Custom error from script")
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -103,6 +103,7 @@ const (
 	testFixtureStack                          = "fixtures/stack/"
 	testFixtureStdout                         = "fixtures/download/stdout-test"
 	testFixtureTfTest                         = "fixtures/tftest/"
+	testFixtureErrorPrint                     = "fixtures/error-print"
 
 	terraformFolder = ".terraform"
 
@@ -3904,4 +3905,15 @@ func TestTerragruntJsonPlanJsonOutput(t *testing.T) {
 		})
 
 	}
+}
+
+func TestErrorMessageIncludeInOutput(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := copyEnvironment(t, testFixtureErrorPrint)
+	cleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, testFixtureErrorPrint)
+
+	_, _, err := runTerragruntCommandWithOutput(t, "terragrunt apply  --terragrunt-non-interactive --terragrunt-working-dir "+testPath+" --terragrunt-tfpath "+testPath+"/custom-tf-script.sh --terragrunt-log-level debug")
+	require.Error(t, err)
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Updated error handling to print more details about catched process error
* Since it is printed process stdout/stderr - output may be in multiple lines
* Added tests for this

Example output:
![image](https://github.com/user-attachments/assets/3df64b92-5215-4908-a3ba-1a4d0f3a184f)


Fixes #3422.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

