### PR TITLE
feat: Adding Strict Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,3 @@ Please see the following for more info, including install instructions and compl
 ## License
 
 This code is released under the MIT License. See [LICENSE.txt](LICENSE.txt).
-

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ Please see the following for more info, including install instructions and compl
 ## License
 
 This code is released under the MIT License. See [LICENSE.txt](LICENSE.txt).
+

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gruntwork-io/go-commons/collections"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/strict"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/cli"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -142,6 +143,14 @@ const (
 
 	TerragruntForwardTFStdoutFlagName = "terragrunt-forward-tf-stdout"
 	TerragruntForwardTFStdoutEnvName  = "TERRAGRUNT_FORWARD_TF_STDOUT"
+
+	// Strict Mode related flags/envs
+
+	TerragruntStrictModeFlagName = "strict-mode"
+	TerragruntStrictModeEnvName  = "TERRAGRUNT_STRICT_MODE"
+
+	TerragruntStrictControlFlagName = "strict-control"
+	TerragruntStrictControlEnvName  = "TERRAGRUNT_STRICT_CONTROL"
 
 	// Terragrunt Provider Cache related flags/envs
 
@@ -455,6 +464,22 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 			EnvVar:      TerragruntDisableCommandValidationEnvName,
 			Destination: &opts.DisableCommandValidation,
 			Usage:       "When this flag is set, Terragrunt will not validate the terraform command.",
+		},
+		// Strict Mode flags
+		&cli.BoolFlag{
+			Name:        TerragruntStrictModeFlagName,
+			EnvVar:      TerragruntStrictModeEnvName,
+			Destination: &opts.StrictMode,
+			Usage:       "Enables strict mode for Terragrunt. For more information, see https://terragrunt.gruntwork.io/docs/reference/strict-mode .",
+		},
+		&cli.SliceFlag[string]{
+			Name:        TerragruntStrictControlFlagName,
+			EnvVar:      TerragruntStrictControlEnvName,
+			Destination: &opts.StrictControls,
+			Usage:       "Enables specific strict controls. For a list of available controls, see https://terragrunt.gruntwork.io/docs/reference/strict-mode .",
+			Action: func(ctx *cli.Context, val []string) error {
+				return strict.StrictControls.ValidateControlNames(val)
+			},
 		},
 		// Terragrunt Provider Cache flags
 		&cli.BoolFlag{

--- a/cli/deprecated_commands.go
+++ b/cli/deprecated_commands.go
@@ -48,7 +48,7 @@ func replaceDeprecatedCommandFunc(terragruntCommandName, terraformCommandName st
 			deprecatedCommandName := ctx.Command.Name
 			newCommandFriendly := fmt.Sprintf("terragrunt %s %s", terragruntCommandName, strings.Join(args, " "))
 
-			control, ok := strict.GetStrictControl(strict.PlanAll)
+			control, ok := strict.GetStrictControl(deprecatedCommandName)
 			if ok {
 				warning, err := control.Evaluate(opts)
 				if err != nil {

--- a/cli/deprecated_commands.go
+++ b/cli/deprecated_commands.go
@@ -50,7 +50,7 @@ func replaceDeprecatedCommandFunc(terragruntCommandName, terraformCommandName st
 
 			control, ok := strict.GetStrictControl(strict.PlanAll)
 			if ok {
-				warning, err := control.Evaluate()
+				warning, err := control.Evaluate(opts)
 				if err != nil {
 					return err //nolint:wrapcheck
 				}

--- a/cli/deprecated_commands.go
+++ b/cli/deprecated_commands.go
@@ -52,16 +52,16 @@ func replaceDeprecatedCommandFunc(terragruntCommandName, terraformCommandName st
 			if ok {
 				warning, err := control.Evaluate()
 				if err != nil {
-					return err
+					return err //nolint:wrapcheck
 				}
 
 				opts.Logger.Warn(warning)
 
-			} else { //nolint:wsl
+			} else { //nolint:wsl,whitespace
 				// This else clause should never be hit, as all the commands above are accounted for.
 				// This might be missed accidentally in the future, so we'll keep it for safety.
 				opts.Logger.Warnf(
-					"'%s' is deprecated. Running '%s' instead. Please update your workflows to use '%s', as '%s' may be removed in the future!\n",
+					"'%s' is deprecated. Running '%s' instead. Please update your workflows to use '%s', as '%s' may be removed in the future!\n", //nolint:lll
 					deprecatedCommandName,
 					newCommandFriendly,
 					newCommandFriendly,

--- a/docs/_docs/04_reference/strict-mode.md
+++ b/docs/_docs/04_reference/strict-mode.md
@@ -65,13 +65,13 @@ $ TERRAGRUNT_STRICT_CONTROL='plan-all,apply-all' bash -c 'terragrunt plan-all; t
 
 The following strict mode controls are available:
 
-- [spin-up](#tg_strict_spin_up)
-- [tear-down](#tg_strict_tear_down)
-- [plan-all](#tg_strict_plan_all)
-- [apply-all](#tg_strict_apply_all)
-- [destroy-all](#tg_strict_destroy_all)
-- [output-all](#tg_strict_output_all)
-- [validate-all](#tg_strict_validate_all)
+- [spin-up](#spin-up)
+- [tear-down](#tear-down)
+- [plan-all](#plan-all)
+- [apply-all](#apply-all)
+- [destroy-all](#destroy-all)
+- [output-all](#output-all)
+- [validate-all](#validate-all)
 
 ### spin-up
 

--- a/docs/_docs/04_reference/strict-mode.md
+++ b/docs/_docs/04_reference/strict-mode.md
@@ -55,10 +55,10 @@ You can also enable multiple strict controls at once with a comma delimited list
 
 ```bash
 $ TERRAGRUNT_STRICT_CONTROL='plan-all,apply-all' bash -c 'terragrunt plan-all; terragrunt apply-all'
-15:17:34.462 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
-15:17:34.462 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
-15:17:34.524 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
-15:17:34.525 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
+15:26:46.521 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
+15:26:46.521 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
+15:26:46.564 ERROR  The `apply-all` command is no longer supported. Use `terragrunt run-all apply` instead.
+15:26:46.564 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
 ```
 
 ## Strict Mode Controls

--- a/docs/_docs/04_reference/strict-mode.md
+++ b/docs/_docs/04_reference/strict-mode.md
@@ -23,7 +23,7 @@ However, in Strict Mode, these warnings will be converted to errors, which will 
 
 ## Controlling Strict Mode
 
-The simplest way to enable strict mode is to set the `TG_STRICT` environment variable to `true`.
+The simplest way to enable strict mode is to set the `TERRAGRUNT_STRICT_MODE` environment variable to `true`.
 
 This will enable strict mode for all Terragrunt commands, for all strict mode controls.
 
@@ -33,73 +33,83 @@ $ terragrunt plan-all
 ```
 
 ```bash
-$ TG_STRICT_MODE='true' tg plan-all
+$ TERRAGRUNT_STRICT_MODE='true' tg plan-all
 15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
 ```
 
-Instead of setting this environment variable, you can also enable strict mode for specific controls by setting an
-environment variable that's specific to a particular strict control.
+Instead of setting this environment variable, you can also enable strict mode for specific controls by setting the `TERRAGRUNT_STRICT_CONTROL`
+environment variable to a value that's specific to a particular strict control.
 This can allow you to gradually increase your confidence in the future compatibility of your Terragrunt usage.
 
 ```bash
-$ TG_STRICT_APPLY_ALL='true' terragrunt plan-all
+$ TERRAGRUNT_STRICT_CONTROL='apply-all' terragrunt plan-all
 15:26:08.585 WARN   The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all plan` instead.
 ```
 
 ```bash
-$ TG_STRICT_PLAN_ALL='true' terragrunt plan-all
+$ TERRAGRUNT_STRICT_CONTROL='plan-all' terragrunt plan-all
 15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
+```
+
+You can also enable multiple strict controls at once with a comma delimited list.
+
+```bash
+$ TERRAGRUNT_STRICT_CONTROL='plan-all,apply-all' bash -c 'terragrunt plan-all; terragrunt apply-all'
+15:17:34.462 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
+15:17:34.462 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
+15:17:34.524 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
+15:17:34.525 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
 ```
 
 ## Strict Mode Controls
 
 The following strict mode controls are available:
 
-- [TG_STRICT_SPIN_UP](#tg_strict_spin_up)
-- [TG_STRICT_TEAR_DOWN](#tg_strict_tear_down)
-- [TG_STRICT_PLAN_ALL](#tg_strict_plan_all)
-- [TG_STRICT_APPLY_ALL](#tg_strict_apply_all)
-- [TG_STRICT_DESTROY_ALL](#tg_strict_destroy_all)
-- [TG_STRICT_OUTPUT_ALL](#tg_strict_output_all)
-- [TG_STRICT_VALIDATE_ALL](#tg_strict_validate_all)
+- [spin-up](#tg_strict_spin_up)
+- [tear-down](#tg_strict_tear_down)
+- [plan-all](#tg_strict_plan_all)
+- [apply-all](#tg_strict_apply_all)
+- [destroy-all](#tg_strict_destroy_all)
+- [output-all](#tg_strict_output_all)
+- [validate-all](#tg_strict_validate_all)
 
-### TG_STRICT_SPIN_UP
+### spin-up
 
 Throw an error when using the `spin-up` command.
 
 **Reason**: The `spin-up` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.
 
-### TG_STRICT_TEAR_DOWN
+### tear-down
 
 Throw an error when using the `tear-down` command.
 
 **Reason**: The `tear-down` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.
 
-### TG_STRICT_PLAN_ALL
+### plan-all
 
 Throw an error when using the `plan-all` command.
 
 **Reason**: The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all plan` instead.
 
-### TG_STRICT_APPLY_ALL
+### apply-all
 
 Throw an error when using the `apply-all` command.
 
 **Reason**: The `apply-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.
 
-### TG_STRICT_DESTROY_ALL
+### destroy-all
 
 Throw an error when using the `destroy-all` command.
 
 **Reason**: The `destroy-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.
 
-### TG_STRICT_OUTPUT_ALL
+### output-all
 
 Throw an error when using the `output-all` command.
 
 **Reason**: The `output-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all output` instead.
 
-### TG_STRICT_VALIDATE_ALL
+### validate-all
 
 Throw an error when using the `validate-all` command.
 

--- a/docs/_docs/04_reference/strict-mode.md
+++ b/docs/_docs/04_reference/strict-mode.md
@@ -1,0 +1,107 @@
+---
+layout: collection-browser-doc
+title: Strict Mode
+category: reference
+categories_url: reference
+excerpt: >-
+  Opt-in to strict mode to avoid deprecated features and ensure your code is future-proof.
+tags: ["CLI"]
+order: 404
+nav_title: Documentation
+nav_title_link: /docs/
+---
+
+Terragrunt supports operating in a mode referred to as "Strict Mode".
+
+Strict Mode is a set of controls that can be enabled to ensure that your Terragrunt usage is future-proof 
+by making deprecated features throw errors instead of warnings. This can be useful when you want to ensure 
+that your Terragrunt code is up-to-date with the latest conventions to avoid breaking changes in 
+future versions of Terragrunt.
+
+Whenever possible, Terragrunt will initially provide you with a warning when you use a deprecated feature, without throwing an error.
+However, in Strict Mode, these warnings will be converted to errors, which will cause the Terragrunt command to fail.
+
+## Controlling Strict Mode
+
+The simplest way to enable strict mode is to set the `TG_STRICT` environment variable to `true`.
+
+This will enable strict mode for all Terragrunt commands, for all strict mode controls.
+
+```bash
+$ terragrunt plan-all
+15:26:08.585 WARN   The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all plan` instead.
+```
+
+```bash
+$ TG_STRICT_MODE='true' tg plan-all
+15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
+```
+
+Instead of setting this environment variable, you can also enable strict mode for specific controls by setting an
+environment variable that's specific to a particular strict control.
+This can allow you to gradually increase your confidence in the future compatibility of your Terragrunt usage.
+
+```bash
+$ TG_STRICT_APPLY_ALL='true' terragrunt plan-all
+15:26:08.585 WARN   The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all plan` instead.
+```
+
+```bash
+$ TG_STRICT_PLAN_ALL='true' terragrunt plan-all
+15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
+```
+
+## Strict Mode Controls
+
+The following strict mode controls are available:
+
+- [TG_STRICT_SPIN_UP](#tg_strict_spin_up)
+- [TG_STRICT_TEAR_DOWN](#tg_strict_tear_down)
+- [TG_STRICT_PLAN_ALL](#tg_strict_plan_all)
+- [TG_STRICT_APPLY_ALL](#tg_strict_apply_all)
+- [TG_STRICT_DESTROY_ALL](#tg_strict_destroy_all)
+- [TG_STRICT_OUTPUT_ALL](#tg_strict_output_all)
+- [TG_STRICT_VALIDATE_ALL](#tg_strict_validate_all)
+
+### TG_STRICT_SPIN_UP
+
+Throw an error when using the `spin-up` command.
+
+**Reason**: The `spin-up` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.
+
+### TG_STRICT_TEAR_DOWN
+
+Throw an error when using the `tear-down` command.
+
+**Reason**: The `tear-down` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.
+
+### TG_STRICT_PLAN_ALL
+
+Throw an error when using the `plan-all` command.
+
+**Reason**: The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all plan` instead.
+
+### TG_STRICT_APPLY_ALL
+
+Throw an error when using the `apply-all` command.
+
+**Reason**: The `apply-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.
+
+### TG_STRICT_DESTROY_ALL
+
+Throw an error when using the `destroy-all` command.
+
+**Reason**: The `destroy-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.
+
+### TG_STRICT_OUTPUT_ALL
+
+Throw an error when using the `output-all` command.
+
+**Reason**: The `output-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all output` instead.
+
+### TG_STRICT_VALIDATE_ALL
+
+Throw an error when using the `validate-all` command.
+
+**Reason**: The `validate-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all validate` instead.
+

--- a/docs/_docs/04_reference/strict-mode.md
+++ b/docs/_docs/04_reference/strict-mode.md
@@ -13,9 +13,9 @@ nav_title_link: /docs/
 
 Terragrunt supports operating in a mode referred to as "Strict Mode".
 
-Strict Mode is a set of controls that can be enabled to ensure that your Terragrunt usage is future-proof 
-by making deprecated features throw errors instead of warnings. This can be useful when you want to ensure 
-that your Terragrunt code is up-to-date with the latest conventions to avoid breaking changes in 
+Strict Mode is a set of controls that can be enabled to ensure that your Terragrunt usage is future-proof
+by making deprecated features throw errors instead of warnings. This can be useful when you want to ensure
+that your Terragrunt code is up-to-date with the latest conventions to avoid breaking changes in
 future versions of Terragrunt.
 
 Whenever possible, Terragrunt will initially provide you with a warning when you use a deprecated feature, without throwing an error.
@@ -104,4 +104,3 @@ Throw an error when using the `output-all` command.
 Throw an error when using the `validate-all` command.
 
 **Reason**: The `validate-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all validate` instead.
-

--- a/internal/strict/strict.go
+++ b/internal/strict/strict.go
@@ -8,9 +8,9 @@ import (
 	"os"
 )
 
-// StrictControl represents a control that can be enabled or disabled in strict mode.
+// Control represents a control that can be enabled or disabled in strict mode.
 // When the control is enabled, Terragrunt will behave in a way that is not backwards compatible.
-type StrictControl struct {
+type Control struct {
 	// FlagName is the environment variable that will enable this control.
 	FlagName string
 	// Error is the error that will be returned when the control is enabled.
@@ -20,25 +20,34 @@ type StrictControl struct {
 }
 
 const (
+	// StrictModeEnvVar is the environment variable that will enable strict mode.
 	StrictModeEnvVar = "TG_STRICT_MODE"
 
-	SpinUp      string = "spin-up"
-	TearDown    string = "tear-down"
-	PlanAll     string = "plan-all"
-	ApplyAll    string = "apply-all"
-	DestroyAll  string = "destroy-all"
-	OutputAll   string = "output-all"
+	// SpinUp is the control that prevents the deprecated `spin-up` command from being used.
+	SpinUp string = "spin-up"
+	// TearDown is the control that prevents the deprecated `tear-down` command from being used.
+	TearDown string = "tear-down"
+	// PlanAll is the control that prevents the deprecated `plan-all` command from being used.
+	PlanAll string = "plan-all"
+	// ApplyAll is the control that prevents the deprecated `apply-all` command from being used.
+	ApplyAll string = "apply-all"
+	// DestroyAll is the control that prevents the deprecated `destroy-all` command from being used.
+	DestroyAll string = "destroy-all"
+	// OutputAll is the control that prevents the deprecated `output-all` command from being used.
+	OutputAll string = "output-all"
+	// ValidateAll is the control that prevents the deprecated `validate-all` command from being used.
 	ValidateAll string = "validate-all"
 )
 
 // GetStrictControl returns the strict control with the given name.
-func GetStrictControl(name string) (StrictControl, bool) {
+func GetStrictControl(name string) (Control, bool) {
 	control, ok := strictControls[name]
+
 	return control, ok
 }
 
 // Evaluate returns a warning if the control is not enabled, and an error if the control is enabled.
-func (control StrictControl) Evaluate() (string, error) {
+func (control Control) Evaluate() (string, error) {
 	strictMode := os.Getenv(StrictModeEnvVar)
 	if strictMode == "true" {
 		return "", control.Error
@@ -52,24 +61,27 @@ func (control StrictControl) Evaluate() (string, error) {
 	return control.Warning, nil
 }
 
+//nolint:stylecheck,lll,revive
 var (
-	ErrSpinUp            = errors.New("the `spin-up` command is no longer supported. Use `terragrunt run-all apply` instead")
-	ErrTearDown          = errors.New("the `tear-down` command is no longer supported. Use `terragrunt run-all destroy` instead")
-	ErrStrictPlanAll     = errors.New("the `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead")
-	ErrStrictApplyAll    = errors.New("the `apply-all` command is no longer supported. Use `terragrunt run-all apply` instead")
-	ErrStrictDestroyAll  = errors.New("the `destroy-all` command is no longer supported. Use `terragrunt run-all destroy` instead")
-	ErrStrictOutputAll   = errors.New("the `output-all` command is no longer supported. Use `terragrunt run-all output` instead")
-	ErrStrictValidateAll = errors.New("the `validate-all` command is no longer supported. Use `terragrunt run-all validate` instead")
+	ErrSpinUp            = errors.New("The `spin-up` command is no longer supported. Use `terragrunt run-all apply` instead.")
+	ErrTearDown          = errors.New("The `tear-down` command is no longer supported. Use `terragrunt run-all destroy` instead.")
+	ErrStrictPlanAll     = errors.New("The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.")
+	ErrStrictApplyAll    = errors.New("The `apply-all` command is no longer supported. Use `terragrunt run-all apply` instead.")
+	ErrStrictDestroyAll  = errors.New("The `destroy-all` command is no longer supported. Use `terragrunt run-all destroy` instead.")
+	ErrStrictOutputAll   = errors.New("The `output-all` command is no longer supported. Use `terragrunt run-all output` instead.")
+	ErrStrictValidateAll = errors.New("The `validate-all` command is no longer supported. Use `terragrunt run-all validate` instead.")
 )
-var strictControls = map[string]StrictControl{
+
+//nolint:lll,gochecknoglobals
+var strictControls = map[string]Control{
 	SpinUp: {
 		FlagName: "TG_STRICT_SPIN_UP",
-		Error:    errors.New("the `spin-up` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead"),
+		Error:    ErrSpinUp,
 		Warning:  "The `spin-up` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.",
 	},
 	TearDown: {
 		FlagName: "TG_STRICT_TEAR_DOWN",
-		Error:    errors.New("the `tear-down` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead"),
+		Error:    ErrTearDown,
 		Warning:  "The `tear-down` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.",
 	},
 	PlanAll: {
@@ -79,22 +91,22 @@ var strictControls = map[string]StrictControl{
 	},
 	ApplyAll: {
 		FlagName: "TG_STRICT_APPLY_ALL",
-		Error:    errors.New("the `apply-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead"),
+		Error:    ErrStrictApplyAll,
 		Warning:  "The `apply-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.",
 	},
 	DestroyAll: {
 		FlagName: "TG_STRICT_DESTROY_ALL",
-		Error:    errors.New("the `destroy-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead"),
+		Error:    ErrStrictDestroyAll,
 		Warning:  "The `destroy-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.",
 	},
 	OutputAll: {
 		FlagName: "TG_STRICT_OUTPUT_ALL",
-		Error:    errors.New("the `output-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all output` instead"),
+		Error:    ErrStrictOutputAll,
 		Warning:  "The `output-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all output` instead.",
 	},
 	ValidateAll: {
 		FlagName: "TG_STRICT_VALIDATE_ALL",
-		Error:    errors.New("the `validate-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all validate` instead"),
+		Error:    ErrStrictValidateAll,
 		Warning:  "The `validate-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all validate` instead.",
 	},
 }

--- a/internal/strict/strict.go
+++ b/internal/strict/strict.go
@@ -69,47 +69,36 @@ func (control Control) Evaluate(opts *options.TerragruntOptions) (string, error)
 	return control.Warning, nil
 }
 
-//nolint:stylecheck,lll,revive
-var (
-	ErrSpinUp            = errors.New("The `spin-up` command is no longer supported. Use `terragrunt run-all apply` instead.")
-	ErrTearDown          = errors.New("The `tear-down` command is no longer supported. Use `terragrunt run-all destroy` instead.")
-	ErrStrictPlanAll     = errors.New("The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.")
-	ErrStrictApplyAll    = errors.New("The `apply-all` command is no longer supported. Use `terragrunt run-all apply` instead.")
-	ErrStrictDestroyAll  = errors.New("The `destroy-all` command is no longer supported. Use `terragrunt run-all destroy` instead.")
-	ErrStrictOutputAll   = errors.New("The `output-all` command is no longer supported. Use `terragrunt run-all output` instead.")
-	ErrStrictValidateAll = errors.New("The `validate-all` command is no longer supported. Use `terragrunt run-all validate` instead.")
-)
-
 type Controls map[string]Control
 
-//nolint:lll,gochecknoglobals
+//nolint:lll,gochecknoglobals,stylecheck
 var StrictControls = Controls{
 	SpinUp: {
-		Error:   ErrSpinUp,
+		Error:   errors.New("The `spin-up` command is no longer supported. Use `terragrunt run-all apply` instead."),
 		Warning: "The `spin-up` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.",
 	},
 	TearDown: {
-		Error:   ErrTearDown,
+		Error:   errors.New("The `tear-down` command is no longer supported. Use `terragrunt run-all destroy` instead."),
 		Warning: "The `tear-down` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.",
 	},
 	PlanAll: {
-		Error:   ErrStrictPlanAll,
+		Error:   errors.New("The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead."),
 		Warning: "The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all plan` instead.",
 	},
 	ApplyAll: {
-		Error:   ErrStrictApplyAll,
+		Error:   errors.New("The `apply-all` command is no longer supported. Use `terragrunt run-all apply` instead."),
 		Warning: "The `apply-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.",
 	},
 	DestroyAll: {
-		Error:   ErrStrictDestroyAll,
+		Error:   errors.New("The `destroy-all` command is no longer supported. Use `terragrunt run-all destroy` instead."),
 		Warning: "The `destroy-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.",
 	},
 	OutputAll: {
-		Error:   ErrStrictOutputAll,
+		Error:   errors.New("The `output-all` command is no longer supported. Use `terragrunt run-all output` instead."),
 		Warning: "The `output-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all output` instead.",
 	},
 	ValidateAll: {
-		Error:   ErrStrictValidateAll,
+		Error:   errors.New("The `validate-all` command is no longer supported. Use `terragrunt run-all validate` instead."),
 		Warning: "The `validate-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all validate` instead.",
 	},
 }

--- a/internal/strict/strict.go
+++ b/internal/strict/strict.go
@@ -1,18 +1,22 @@
 // Package strict provides utilities used by Terragrunt to support a "strict" mode.
 // By default strict mode is disabled, but when enabled, any breaking changes
 // to Terragrunt behavior that is not backwards compatible will result in an error.
+//
+// Note that any behavior outlined here should be documented in /docs/_docs/04_reference/strict-mode.md
+//
+// That is how users will know what to expect when they enable strict mode, and how to customize it.
 package strict
 
 import (
 	"errors"
-	"os"
+	"strings"
+
+	"github.com/gruntwork-io/terragrunt/options"
 )
 
 // Control represents a control that can be enabled or disabled in strict mode.
 // When the control is enabled, Terragrunt will behave in a way that is not backwards compatible.
 type Control struct {
-	// FlagName is the environment variable that will enable this control.
-	FlagName string
 	// Error is the error that will be returned when the control is enabled.
 	Error error
 	// Warning is a warning that will be logged when the control is not enabled.
@@ -20,42 +24,46 @@ type Control struct {
 }
 
 const (
-	// StrictModeEnvVar is the environment variable that will enable strict mode.
-	StrictModeEnvVar = "TG_STRICT_MODE"
-
 	// SpinUp is the control that prevents the deprecated `spin-up` command from being used.
-	SpinUp string = "spin-up"
+	SpinUp = "spin-up"
 	// TearDown is the control that prevents the deprecated `tear-down` command from being used.
-	TearDown string = "tear-down"
+	TearDown = "tear-down"
 	// PlanAll is the control that prevents the deprecated `plan-all` command from being used.
-	PlanAll string = "plan-all"
+	PlanAll = "plan-all"
 	// ApplyAll is the control that prevents the deprecated `apply-all` command from being used.
-	ApplyAll string = "apply-all"
+	ApplyAll = "apply-all"
 	// DestroyAll is the control that prevents the deprecated `destroy-all` command from being used.
-	DestroyAll string = "destroy-all"
+	DestroyAll = "destroy-all"
 	// OutputAll is the control that prevents the deprecated `output-all` command from being used.
-	OutputAll string = "output-all"
+	OutputAll = "output-all"
 	// ValidateAll is the control that prevents the deprecated `validate-all` command from being used.
-	ValidateAll string = "validate-all"
+	ValidateAll = "validate-all"
 )
 
 // GetStrictControl returns the strict control with the given name.
 func GetStrictControl(name string) (Control, bool) {
-	control, ok := strictControls[name]
+	control, ok := StrictControls[name]
 
 	return control, ok
 }
 
 // Evaluate returns a warning if the control is not enabled, and an error if the control is enabled.
-func (control Control) Evaluate() (string, error) {
-	strictMode := os.Getenv(StrictModeEnvVar)
-	if strictMode == "true" {
+func (control Control) Evaluate(opts *options.TerragruntOptions) (string, error) {
+	if opts.StrictMode {
 		return "", control.Error
 	}
 
-	enabled := os.Getenv(control.FlagName)
-	if enabled == "true" {
-		return "", control.Error
+	for _, controlName := range opts.StrictControls {
+		strictControl, ok := StrictControls[controlName]
+		if !ok {
+			// This should never happen, but if it does, it's a bug in Terragrunt.
+			// The slice of StrictControls should be validated before they're used.
+			return "", errors.New("Invalid strict control: " + controlName)
+		}
+
+		if strictControl == control {
+			return "", control.Error
+		}
 	}
 
 	return control.Warning, nil
@@ -72,41 +80,53 @@ var (
 	ErrStrictValidateAll = errors.New("The `validate-all` command is no longer supported. Use `terragrunt run-all validate` instead.")
 )
 
+type Controls map[string]Control
+
 //nolint:lll,gochecknoglobals
-var strictControls = map[string]Control{
+var StrictControls = Controls{
 	SpinUp: {
-		FlagName: "TG_STRICT_SPIN_UP",
-		Error:    ErrSpinUp,
-		Warning:  "The `spin-up` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.",
+		Error:   ErrSpinUp,
+		Warning: "The `spin-up` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.",
 	},
 	TearDown: {
-		FlagName: "TG_STRICT_TEAR_DOWN",
-		Error:    ErrTearDown,
-		Warning:  "The `tear-down` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.",
+		Error:   ErrTearDown,
+		Warning: "The `tear-down` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.",
 	},
 	PlanAll: {
-		FlagName: "TG_STRICT_PLAN_ALL",
-		Error:    ErrStrictPlanAll,
-		Warning:  "The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all plan` instead.",
+		Error:   ErrStrictPlanAll,
+		Warning: "The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all plan` instead.",
 	},
 	ApplyAll: {
-		FlagName: "TG_STRICT_APPLY_ALL",
-		Error:    ErrStrictApplyAll,
-		Warning:  "The `apply-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.",
+		Error:   ErrStrictApplyAll,
+		Warning: "The `apply-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.",
 	},
 	DestroyAll: {
-		FlagName: "TG_STRICT_DESTROY_ALL",
-		Error:    ErrStrictDestroyAll,
-		Warning:  "The `destroy-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.",
+		Error:   ErrStrictDestroyAll,
+		Warning: "The `destroy-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.",
 	},
 	OutputAll: {
-		FlagName: "TG_STRICT_OUTPUT_ALL",
-		Error:    ErrStrictOutputAll,
-		Warning:  "The `output-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all output` instead.",
+		Error:   ErrStrictOutputAll,
+		Warning: "The `output-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all output` instead.",
 	},
 	ValidateAll: {
-		FlagName: "TG_STRICT_VALIDATE_ALL",
-		Error:    ErrStrictValidateAll,
-		Warning:  "The `validate-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all validate` instead.",
+		Error:   ErrStrictValidateAll,
+		Warning: "The `validate-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all validate` instead.",
 	},
+}
+
+func (controls Controls) ValidateControlNames(strictControlNames []string) error {
+	invalidControls := []string{}
+
+	for _, controlName := range strictControlNames {
+		_, ok := controls[controlName]
+		if !ok {
+			invalidControls = append(invalidControls, controlName)
+		}
+	}
+
+	if len(invalidControls) > 0 {
+		return errors.New("Invalid strict controls: " + strings.Join(invalidControls, ", "))
+	}
+
+	return nil
 }

--- a/internal/strict/strict.go
+++ b/internal/strict/strict.go
@@ -13,8 +13,6 @@ import (
 type StrictControl struct {
 	// FlagName is the environment variable that will enable this control.
 	FlagName string
-	// EnabledByDefault is true if the control is enabled by default.
-	EnabledByDefault bool
 	// Error is the error that will be returned when the control is enabled.
 	Error error
 	// Warning is a warning that will be logged when the control is not enabled.
@@ -48,10 +46,6 @@ func (control StrictControl) Evaluate() (string, error) {
 
 	enabled := os.Getenv(control.FlagName)
 	if enabled == "true" {
-		return "", control.Error
-	}
-
-	if control.EnabledByDefault {
 		return "", control.Error
 	}
 

--- a/internal/strict/strict.go
+++ b/internal/strict/strict.go
@@ -3,27 +3,104 @@
 // to Terragrunt behavior that is not backwards compatible will result in an error.
 package strict
 
-import "errors"
+import (
+	"errors"
+	"os"
+)
 
-type StrictFeature struct {
+// StrictControl represents a control that can be enabled or disabled in strict mode.
+// When the control is enabled, Terragrunt will behave in a way that is not backwards compatible.
+type StrictControl struct {
+	// FlagName is the environment variable that will enable this control.
+	FlagName string
+	// EnabledByDefault is true if the control is enabled by default.
 	EnabledByDefault bool
-	Error            error
-	Warning          string
+	// Error is the error that will be returned when the control is enabled.
+	Error error
+	// Warning is a warning that will be logged when the control is not enabled.
+	Warning string
 }
 
-const PlanAll featureName = "run-all"
+const (
+	StrictModeEnvVar = "TG_STRICT_MODE"
 
-type featureName string
+	SpinUp      string = "spin-up"
+	TearDown    string = "tear-down"
+	PlanAll     string = "plan-all"
+	ApplyAll    string = "apply-all"
+	DestroyAll  string = "destroy-all"
+	OutputAll   string = "output-all"
+	ValidateAll string = "validate-all"
+)
 
-var strictFeatures = map[featureName]StrictFeature{
-	PlanAll: {
-		Error:   errors.New("the `plan-all` is no longer supported. Use the `terragrunt run-all plan` command instead"),
-		Warning: "The `plan-all` command is no longer supported. Use of `plan-all` will result in an error in a future version of Terragrunt < `1.0`. Use the `terragrunt run-all plan` command instead.",
+// GetStrictControl returns the strict control with the given name.
+func GetStrictControl(name string) (StrictControl, bool) {
+	control, ok := strictControls[name]
+	return control, ok
+}
+
+// Evaluate returns a warning if the control is not enabled, and an error if the control is enabled.
+func (control StrictControl) Evaluate() (string, error) {
+	strictMode := os.Getenv(StrictModeEnvVar)
+	if strictMode == "true" {
+		return "", control.Error
+	}
+
+	enabled := os.Getenv(control.FlagName)
+	if enabled == "true" {
+		return "", control.Error
+	}
+
+	if control.EnabledByDefault {
+		return "", control.Error
+	}
+
+	return control.Warning, nil
+}
+
+var (
+	ErrSpinUp            = errors.New("the `spin-up` command is no longer supported. Use `terragrunt run-all apply` instead")
+	ErrTearDown          = errors.New("the `tear-down` command is no longer supported. Use `terragrunt run-all destroy` instead")
+	ErrStrictPlanAll     = errors.New("the `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead")
+	ErrStrictApplyAll    = errors.New("the `apply-all` command is no longer supported. Use `terragrunt run-all apply` instead")
+	ErrStrictDestroyAll  = errors.New("the `destroy-all` command is no longer supported. Use `terragrunt run-all destroy` instead")
+	ErrStrictOutputAll   = errors.New("the `output-all` command is no longer supported. Use `terragrunt run-all output` instead")
+	ErrStrictValidateAll = errors.New("the `validate-all` command is no longer supported. Use `terragrunt run-all validate` instead")
+)
+var strictControls = map[string]StrictControl{
+	SpinUp: {
+		FlagName: "TG_STRICT_SPIN_UP",
+		Error:    errors.New("the `spin-up` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead"),
+		Warning:  "The `spin-up` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.",
 	},
-}
-
-// GetStrictFeature returns the strict feature with the given name.
-func GetStrictFeature(name featureName) (StrictFeature, bool) {
-	feature, ok := strictFeatures[name]
-	return feature, ok
+	TearDown: {
+		FlagName: "TG_STRICT_TEAR_DOWN",
+		Error:    errors.New("the `tear-down` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead"),
+		Warning:  "The `tear-down` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.",
+	},
+	PlanAll: {
+		FlagName: "TG_STRICT_PLAN_ALL",
+		Error:    ErrStrictPlanAll,
+		Warning:  "The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all plan` instead.",
+	},
+	ApplyAll: {
+		FlagName: "TG_STRICT_APPLY_ALL",
+		Error:    errors.New("the `apply-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead"),
+		Warning:  "The `apply-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all apply` instead.",
+	},
+	DestroyAll: {
+		FlagName: "TG_STRICT_DESTROY_ALL",
+		Error:    errors.New("the `destroy-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead"),
+		Warning:  "The `destroy-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all destroy` instead.",
+	},
+	OutputAll: {
+		FlagName: "TG_STRICT_OUTPUT_ALL",
+		Error:    errors.New("the `output-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all output` instead"),
+		Warning:  "The `output-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all output` instead.",
+	},
+	ValidateAll: {
+		FlagName: "TG_STRICT_VALIDATE_ALL",
+		Error:    errors.New("the `validate-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all validate` instead"),
+		Warning:  "The `validate-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all validate` instead.",
+	},
 }

--- a/internal/strict/strict.go
+++ b/internal/strict/strict.go
@@ -1,0 +1,29 @@
+// Package strict provides utilities used by Terragrunt to support a "strict" mode.
+// By default strict mode is disabled, but when enabled, any breaking changes
+// to Terragrunt behavior that is not backwards compatible will result in an error.
+package strict
+
+import "errors"
+
+type StrictFeature struct {
+	EnabledByDefault bool
+	Error            error
+	Warning          string
+}
+
+const PlanAll featureName = "run-all"
+
+type featureName string
+
+var strictFeatures = map[featureName]StrictFeature{
+	PlanAll: {
+		Error:   errors.New("the `plan-all` is no longer supported. Use the `terragrunt run-all plan` command instead"),
+		Warning: "The `plan-all` command is no longer supported. Use of `plan-all` will result in an error in a future version of Terragrunt < `1.0`. Use the `terragrunt run-all plan` command instead.",
+	},
+}
+
+// GetStrictFeature returns the strict feature with the given name.
+func GetStrictFeature(name featureName) (StrictFeature, bool) {
+	feature, ok := strictFeatures[name]
+	return feature, ok
+}

--- a/internal/strict/strict_test.go
+++ b/internal/strict/strict_test.go
@@ -22,7 +22,7 @@ func TestStrictControl(t *testing.T) {
 			name:             "control enabled",
 			enableControl:    true,
 			enableStrictMode: false,
-			expectedErr:      strict.ErrStrictPlan,
+			expectedErr:      strict.ErrStrictPlanAll,
 		},
 		{
 			name:             "control disabled",
@@ -34,13 +34,13 @@ func TestStrictControl(t *testing.T) {
 			name:             "control enabled, strict mode enabled",
 			enableControl:    true,
 			enableStrictMode: true,
-			expectedErr:      strict.ErrStrictPlan,
+			expectedErr:      strict.ErrStrictPlanAll,
 		},
 		{
 			name:             "control disabled, strict mode enabled",
 			enableControl:    false,
 			enableStrictMode: true,
-			expectedErr:      strict.ErrStrictPlan,
+			expectedErr:      strict.ErrStrictPlanAll,
 		},
 	}
 

--- a/internal/strict/strict_test.go
+++ b/internal/strict/strict_test.go
@@ -26,7 +26,7 @@ func TestStrictControl(t *testing.T) {
 			name:             "control enabled",
 			enableControl:    true,
 			enableStrictMode: false,
-			expectedErr:      strict.ErrStrictPlanAll,
+			expectedErr:      strict.StrictControls[strict.PlanAll].Error,
 		},
 		{
 			name:             "control disabled",
@@ -38,13 +38,13 @@ func TestStrictControl(t *testing.T) {
 			name:             "control enabled, strict mode enabled",
 			enableControl:    true,
 			enableStrictMode: true,
-			expectedErr:      strict.ErrStrictPlanAll,
+			expectedErr:      strict.StrictControls[strict.PlanAll].Error,
 		},
 		{
 			name:             "control disabled, strict mode enabled",
 			enableControl:    false,
 			enableStrictMode: true,
-			expectedErr:      strict.ErrStrictPlanAll,
+			expectedErr:      strict.StrictControls[strict.PlanAll].Error,
 		},
 	}
 

--- a/internal/strict/strict_test.go
+++ b/internal/strict/strict_test.go
@@ -44,7 +44,7 @@ func TestStrictControl(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:varnamelen
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("TG_STRICT_MODE", "false")
 			t.Setenv("TG_STRICT_PLAN_ALL", "false")

--- a/internal/strict/strict_test.go
+++ b/internal/strict/strict_test.go
@@ -1,0 +1,73 @@
+package strict_test
+
+// Add some basic tests that confirm that by default, a warning is emitted when strict mode is disabled,
+// and an error is emitted when a specific control is enabled.
+// Make sure to test both when the specific control is enabled, and when the global strict mode is enabled.
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/strict"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStrictControl(t *testing.T) {
+	tests := []struct {
+		name             string
+		enableControl    bool
+		enableStrictMode bool
+		expectedErr      error
+	}{
+		{
+			name:             "control enabled",
+			enableControl:    true,
+			enableStrictMode: false,
+			expectedErr:      strict.ErrStrictPlan,
+		},
+		{
+			name:             "control disabled",
+			enableControl:    false,
+			enableStrictMode: false,
+			expectedErr:      nil,
+		},
+		{
+			name:             "control enabled, strict mode enabled",
+			enableControl:    true,
+			enableStrictMode: true,
+			expectedErr:      strict.ErrStrictPlan,
+		},
+		{
+			name:             "control disabled, strict mode enabled",
+			enableControl:    false,
+			enableStrictMode: true,
+			expectedErr:      strict.ErrStrictPlan,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TG_STRICT_MODE", "false")
+			t.Setenv("TG_STRICT_PLAN_ALL", "false")
+
+			if tt.enableControl {
+				t.Setenv("TG_STRICT_PLAN_ALL", "true")
+			}
+
+			if tt.enableStrictMode {
+				t.Setenv("TG_STRICT_MODE", "true")
+			}
+
+			planAll, ok := strict.GetStrictControl(strict.PlanAll)
+			require.True(t, ok, "control not found")
+
+			warning, err := planAll.Evaluate()
+			require.Equal(t, tt.expectedErr, err)
+
+			if tt.enableControl || tt.enableStrictMode {
+				require.Empty(t, warning)
+			} else {
+				require.NotEmpty(t, warning)
+			}
+		})
+	}
+}

--- a/options/options.go
+++ b/options/options.go
@@ -341,6 +341,12 @@ type TerragruntOptions struct {
 
 	// Options to use engine for running IaC operations.
 	Engine *EngineOptions
+
+	// StrictMode is a flag to enable strict mode for terragrunt.
+	StrictMode bool
+
+	// StrictControls is a slice of strict controls enabled.
+	StrictControls []string
 }
 
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests

--- a/pkg/cli/flag.go
+++ b/pkg/cli/flag.go
@@ -13,12 +13,6 @@ var (
 	FlagSplitter = strings.Split
 )
 
-// ActionableFlag is an interface that wraps Flag interface and RunAction operation.
-type ActionableFlag interface {
-	Flag
-	RunAction(*Context) error
-}
-
 type FlagType[T any] interface {
 	libflag.Getter
 	Clone(dest *T) FlagType[T]
@@ -39,6 +33,7 @@ type FlagValue interface {
 type Flag interface {
 	Value() FlagValue
 	GetHidden() bool
+	RunAction(*Context) error
 	// `urfave/cli/v2` uses to generate help
 	cli.DocGenerationFlag
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -76,10 +76,8 @@ func (flags Flags) Swap(i, j int) {
 func (flags Flags) RunActions(ctx *Context) error {
 	for _, flag := range flags {
 		if flag.Value().IsSet() {
-			if flag, ok := flag.(ActionableFlag); ok {
-				if err := flag.RunAction(ctx); err != nil {
-					return err
-				}
+			if err := flag.RunAction(ctx); err != nil {
+				return err
 			}
 		}
 	}

--- a/test/integration_strict_test.go
+++ b/test/integration_strict_test.go
@@ -1,0 +1,82 @@
+package test_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/strict"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStrictMode(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, testFixtureEmptyState)
+
+	tc := []struct {
+		name           string
+		controls       []string
+		strictMode     bool
+		expectedStderr string
+		expectedError  error
+	}{
+		{
+			name:           "plan-all",
+			controls:       []string{},
+			strictMode:     false,
+			expectedStderr: "The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all plan` instead.",
+			expectedError:  nil,
+		},
+		{
+			name:           "plan-all with plan-all strict control",
+			controls:       []string{"plan-all"},
+			strictMode:     false,
+			expectedStderr: "",
+			expectedError:  strict.StrictControls[strict.PlanAll].Error,
+		},
+		{
+			name:           "plan-all with multiple strict controls",
+			controls:       []string{"plan-all", "apply-all"},
+			strictMode:     false,
+			expectedStderr: "",
+			expectedError:  strict.StrictControls[strict.PlanAll].Error,
+		},
+		{
+			name:           "plan-all with strict mode",
+			controls:       []string{},
+			strictMode:     true,
+			expectedStderr: "",
+			expectedError:  strict.StrictControls[strict.PlanAll].Error,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpEnvPath := copyEnvironment(t, testFixtureEmptyState)
+			rootPath := util.JoinPath(tmpEnvPath, testFixtureEmptyState)
+
+			args := "--terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir " + rootPath
+			if tt.strictMode {
+				args = "--strict-mode " + args
+			}
+
+			for _, control := range tt.controls {
+				args = " --strict-control " + control + " " + args
+			}
+
+			_, stderr, err := runTerragruntCommandWithOutput(t, "terragrunt plan-all "+args)
+
+			if tt.expectedError != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Contains(t, stderr, tt.expectedStderr)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds `strict` package.

This allows users to opt-in for deprecations as breaking changes in Terragrunt.

Users can either use the global `TG_STRICT_MODE` to make Terragrunt throw an error when it encounters a deprecation, or use the relevant `TG_STRICT_` environment variable to opt-in for a specific deprecation.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added `strict` package.

### Migration Guide

If users would like to make Terragrunt throw an error when it encounters a deprecation, they can set the `TG_STRICT_MODE` environment variable to `true`. 
If they would like to opt-in for a specific deprecation, they can set the relevant `TG_STRICT_` environment variable to `true`.

Neither are required and users can continue to use Terragrunt as they have been.

