### PR TITLE
CVE fixes and dependencies update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ env: &env
 
 defaults: &defaults
   docker:
-    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.22.6-tf1.5-tg58.8-pck1.8-ci56.0
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.23.1-tf1.5-tg58.8-pck1.8-ci58.2
 
 # Install Terraform which is not available in the default image
 install_terraform_latest: &install_terraform_latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   timeout: 2m
   issues-exit-code: 1
   tests: true
-  go: "1.22"
+  go: "1.23"
 output:
   formats:
     - format: colored-line-number

--- a/.strict.golangci.yml
+++ b/.strict.golangci.yml
@@ -2,7 +2,7 @@ run:
   timeout: 2m
   issues-exit-code: 1
   tests: true
-  go: "1.22"
+  go: "1.23"
 output:
   formats:
     - format: colored-line-number

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean:
 	rm -f terragrunt
 
 install-lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 
 run-lint:
 	golangci-lint run -v --timeout=5m ./...

--- a/_ci/install-golang.ps1
+++ b/_ci/install-golang.ps1
@@ -1,5 +1,5 @@
 # Install golang using Chocolatey
-choco install golang --version 1.22.6 -y
+choco install golang --version 1.23.1 -y
 # Verify installation
 Get-Command go
 go version

--- a/awshelper/config.go
+++ b/awshelper/config.go
@@ -228,6 +228,7 @@ func CreateAwsSession(config *AwsSessionConfig, terragruntOptions *options.Terra
 	}
 
 	if _, err = sess.Config.Credentials.Get(); err != nil {
+		// construct dynamic error message based on the configuration
 		msg := "Error finding AWS credentials (did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables?)"
 		if config != nil && len(config.CredsFilename) > 0 {
 			msg = fmt.Sprintf("Error finding AWS credentials in file '%s' (did you set the correct file name and/or profile?)", config.CredsFilename)

--- a/awshelper/config.go
+++ b/awshelper/config.go
@@ -233,7 +233,7 @@ func CreateAwsSession(config *AwsSessionConfig, terragruntOptions *options.Terra
 			msg = fmt.Sprintf("Error finding AWS credentials in file '%s' (did you set the correct file name and/or profile?)", config.CredsFilename)
 		}
 
-		return nil, errors.WithStackTraceAndPrefix(err, msg)
+		return nil, errors.WithStackTraceAndPrefix(err, msg) //nolint:govet
 	}
 
 	return sess, nil

--- a/cli/app.go
+++ b/cli/app.go
@@ -180,7 +180,7 @@ func WrapWithTelemetry(opts *options.TerragruntOptions) func(ctx *cli.Context, a
 			"args":             opts.TerraformCliArgs,
 			"dir":              opts.WorkingDir,
 		}, func(childCtx context.Context) error {
-			ctx.Context = childCtx
+			ctx.Context = childCtx //nolint:fatcontext
 			if err := initialSetup(ctx, opts); err != nil {
 				return err
 			}

--- a/cli/provider_cache.go
+++ b/cli/provider_cache.go
@@ -122,6 +122,7 @@ func InitProviderCacheServer(opts *options.TerragruntOptions) (*ProviderCache, e
 			providerHandlers = append(providerHandlers, handlers.NewProviderDirectHandler(providerService, CacheProviderHTTPStatusCode, method, cliCfg.CredentialsSource()))
 			directIsdefined = true
 		}
+
 		method.AppendExclude(excludeAddrs)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gruntwork-io/terragrunt
 
-go 1.22
+go 1.23
 
 require (
 	cloud.google.com/go/storage v1.43.0

--- a/internal/view/human_render.go
+++ b/internal/view/human_render.go
@@ -167,6 +167,7 @@ func (render *HumanRender) Diagnostic(diag *diagnostic.Diagnostic) (string, erro
 		ruleBuf.WriteString(line)
 		ruleBuf.WriteByte('\n')
 	}
+
 	ruleBuf.WriteString(leftRuleEnd)
 
 	return ruleBuf.String(), nil

--- a/shell/run_shell_cmd_test.go
+++ b/shell/run_shell_cmd_test.go
@@ -81,7 +81,7 @@ func TestGitLevelTopDirCaching(t *testing.T) {
 	ctx = shell.ContextWithTerraformCommandHook(ctx, nil)
 	c := cache.ContextCache[string](ctx, shell.RunCmdCacheContextKey)
 	assert.NotNil(t, c)
-	assert.Empty(t, len(c.Cache))
+	assert.Empty(t, c.Cache)
 	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
 	require.NoError(t, err)
 	path := "."


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* updated to Go 1.23
* linter config update for Go 1.23
* updated code to follow new lint rules
* disabled lint check in cases where it is not possible to fix now

Fixes #3434.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated to Go 1.23

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

