### PR TITLE
fix: Use env vars for `sops_decrypt_file`

### DIFF
--- a/internal/locks/lock.go
+++ b/internal/locks/lock.go
@@ -1,0 +1,11 @@
+// Package locks contains global locks used throughout Terragrunt.
+package locks
+
+import "sync"
+
+// EnvLock is the lock acquired when writing environment variables in a way
+// that is not safe for concurrent access.
+//
+// When possible, prefer to spawn a new process with the environment variables
+// you want, or avoid setting environment variables instead of using this lock.
+var EnvLock sync.Mutex

--- a/internal/locks/lock.go
+++ b/internal/locks/lock.go
@@ -8,4 +8,4 @@ import "sync"
 //
 // When possible, prefer to spawn a new process with the environment variables
 // you want, or avoid setting environment variables instead of using this lock.
-var EnvLock sync.Mutex
+var EnvLock sync.Mutex //nolint:gochecknoglobals

--- a/test/fixtures/auth-provider-cmd/sops/creds.config
+++ b/test/fixtures/auth-provider-cmd/sops/creds.config
@@ -1,0 +1,4 @@
+access_key_id=__FILL_AWS_ACCESS_KEY_ID__
+secret_access_key=__FILL_AWS_SECRET_ACCESS_KEY__
+session_token=
+tf_var_foo=

--- a/test/fixtures/auth-provider-cmd/sops/main.tf
+++ b/test/fixtures/auth-provider-cmd/sops/main.tf
@@ -1,0 +1,6 @@
+variable "hello" {}
+
+output "hello" {
+  value = var.hello
+}
+

--- a/test/fixtures/auth-provider-cmd/sops/secrets.json
+++ b/test/fixtures/auth-provider-cmd/sops/secrets.json
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:+u+2NzL7vRX52H/cmY9wOOVvCXlMpECsRDIbNiM0SsJmW3xnzRoDlgOzeGmtR9+8Y2fR37Ctou/vvXBUKp6TMHlXrtKZy0WdcM0dXGAGQHTijq56RqeEqrw+FRwfUS87zMks43TSXoAwU+PlIkzd1xhAnyghgVIeuxqCYRCrr0XIZ3ytQlQBZlnj71suNOyScEiVxKFrH68NR9Rek1LsjU4FpySlXUHFjERZFKw5LJ1Z8g/XcTsFThz9EKPiKim0kA+vxl2AMYyZkwsvxh0SZIUKbRKXDdfORgARdmbKkbH2ssbM4zYgZA==,iv:OcpVr6Va6wVzAse5u3wGVbRiNsTuF+0zIZpfsreEAAo=,tag:4UjnPurkAi9PFtBGmY85wg==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-1:087285199408:key/bd372994-d969-464a-a261-6cc850c58a92",
+				"created_at": "2024-09-26T12:19:43Z",
+				"enc": "AQICAHi+J98ytR8eNxKA5Tt6E5ILIMsUjvQf2k7quGoMjNULtgH+PP0HJ1hFlHfbNdVna1PaAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMqYcRjvhJ6EZodmUWAgEQgDvWUXLyQXYgDjl9mwTNMMqz76lXdlbfxG3SASRkMFZyhpcCNVsGIV4fcbcA4NzfT98JqPo6/XVHPc4LpA==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2024-09-26T12:19:43Z",
+		"mac": "ENC[AES256_GCM,data:xqRGYCj5euTgeFHgoKVM9moAH/+dpg2CE1466sM5T+e34bCEvVqJccCLIcDDhn1XGWpU0Ga8056oX6HIShZLiTiW/8443eUdX8n+sEe91ILNnOc+BGd+a8AC2bXHD3g+rIsRKNJ+Dau6ry+FeJPjAc9g+qVFefVCa4Ab1RmHIfw=,iv:81wJEhqdwvWRh3pRoA0cI+FqJeRBD69zWC3eq9gBRak=,tag:DtYI36PIIMCQZlhyB0Mbiw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.0"
+	}
+}

--- a/test/fixtures/auth-provider-cmd/sops/terragrunt.hcl
+++ b/test/fixtures/auth-provider-cmd/sops/terragrunt.hcl
@@ -1,0 +1,8 @@
+locals {
+  data = jsondecode(jsondecode(sops_decrypt_file("secrets.json")).data)
+}
+
+inputs = {
+  hello = local.data.hello
+}
+

--- a/test/fixtures/sops-kms/main.tf
+++ b/test/fixtures/sops-kms/main.tf
@@ -1,0 +1,103 @@
+variable "json_string_array" {
+  type = list(string)
+}
+
+variable "json_bool_array" {
+  type = list(bool)
+}
+
+variable "json_string" {
+  type = string
+}
+
+variable "json_number" {
+  type = number
+}
+
+variable "json_hello" {
+  type = string
+}
+
+variable "yaml_string_array" {
+  type = list(string)
+}
+
+variable "yaml_bool_array" {
+  type = list(bool)
+}
+
+variable "yaml_string" {
+  type = string
+}
+
+variable "yaml_number" {
+  type = number
+}
+
+variable "yaml_hello" {
+  type = string
+}
+
+variable "text_value" {
+  type = string
+}
+
+variable "env_value" {
+  type = string
+}
+
+variable "ini_value" {
+  type = string
+}
+
+output "json_string_array" {
+  value = var.json_string_array
+}
+
+output "json_bool_array" {
+  value = var.json_bool_array
+}
+
+output "json_string" {
+  value = var.json_string
+}
+
+output "json_number" {
+  value = var.json_number
+}
+
+output "json_hello" {
+  value = var.json_hello
+}
+
+output "yaml_string_array" {
+  value = var.yaml_string_array
+}
+
+output "yaml_bool_array" {
+  value = var.yaml_bool_array
+}
+
+output "yaml_string" {
+  value = var.yaml_string
+}
+
+output "yaml_number" {
+  value = var.yaml_number
+}
+
+output "yaml_hello" {
+  value = var.yaml_hello
+}
+
+output "text_value" {
+  value = var.text_value
+}
+
+output "env_value" {
+  value = var.env_value
+}
+
+output "ini_value" {
+  value = var.ini_value
+}

--- a/test/fixtures/sops-kms/secrets.env
+++ b/test/fixtures/sops-kms/secrets.env
@@ -1,0 +1,10 @@
+DB_USER=ENC[AES256_GCM,data:5yinT3k=,iv:DP5bS4hJeC8Znc4wHCVIpkJjvdPQOmzwy0KRimvPuuY=,tag:UWl/WagEPWdB+k5j3YQpxA==,type:str]
+DB_PASSWORD=ENC[AES256_GCM,data:1/x9ozAM,iv:2KaZz1fKcZ3h5L/8XAgKHtqLDW2AeQ0mTFOxjTBFX2Q=,tag:vGqg7EJHcQhtpAQ2/7oaAA==,type:str]
+sops_kms__list_0__map_arn=arn:aws:kms:us-east-1:087285199408:key/bd372994-d969-464a-a261-6cc850c58a92
+sops_kms__list_0__map_aws_profile=
+sops_kms__list_0__map_created_at=2024-09-26T12:55:27Z
+sops_kms__list_0__map_enc=AQICAHi+J98ytR8eNxKA5Tt6E5ILIMsUjvQf2k7quGoMjNULtgEXDu/IQ2Kn9wFn+855eUHqAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMl+eJ6qMUSMxmnlEdAgEQgDsmXsaJulpUVuL2YNPSwEBEgmCx20iXKMqXwiGMZPM45w3HnV/Bjqtx2yZsiwHaR5g0GrVFya9Pi69u4A==
+sops_lastmodified=2024-09-26T12:55:27Z
+sops_mac=ENC[AES256_GCM,data:0z4OU1YSM5is/qi4l0FG0P9j1CY00Db42bR2We9iVbEbZOwRFv8XbLKxPgquVr/d756uVDUXUHU67YXZrd1z82Se0RRy6ERfOH62V0Zya/KV26Iku7k+EyZ/piHgnbpIhT0xhlaVqT6mFGphG/pdVELGwkE1l46o7xoaIq/77n4=,iv:6eamZcbm++PZU0HrflHDjsP3aqdr53g/GfNT5BDaSyo=,tag:1mOYIGgVoZOFxeZ5T2oR8A==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.9.0

--- a/test/fixtures/sops-kms/secrets.ini
+++ b/test/fixtures/sops-kms/secrets.ini
@@ -1,0 +1,13 @@
+[terragrunt]
+user     = ENC[AES256_GCM,data:v7hX9P4=,iv:k+sFBEDdUjWL5BNm9Qhkwr+GMiwmnZiKktPCiUh3oYU=,tag:SjIp1kc977n0qFPZdiH84w==,type:str]
+password = ENC[AES256_GCM,data:aASx6oEW,iv:SvW2FnbBa+nbJRvmzYsPFO5vi9AuM3W9y9OMjmJkAyc=,tag:MptmHHnwggP9eAP/89i59A==,type:str]
+
+[sops]
+lastmodified                 = 2024-09-26T12:55:27Z
+kms__list_0__map_arn         = arn:aws:kms:us-east-1:087285199408:key/bd372994-d969-464a-a261-6cc850c58a92
+kms__list_0__map_created_at  = 2024-09-26T12:55:27Z
+mac                          = ENC[AES256_GCM,data:Mf0pwX+ClEmMiG3BKgeTqVmOtwqjAMUMuVEwGfIDC7cKG5ZujVs0VDIX5vxtCildeqMC77EICmkL7ajHIYFOQBGkuks5Bd4fZ+nWg85xKBTFTf+037db9o8uKVDtlpH6za9tWC5m7O36QZsQ7yRbk6iZh8Xui5k+N6R3CTDpkis=,iv:Jf9VN/bTcC8LwWXe4cs1Nx4iRGM/zPs9JdZbmWu0IVg=,tag:lKJuo/EpI8GKToeS+enJiQ==,type:str]
+version                      = 3.9.0
+kms__list_0__map_enc         = AQICAHi+J98ytR8eNxKA5Tt6E5ILIMsUjvQf2k7quGoMjNULtgG6SyRaS5/aqtE4oneGrnRMAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMioe9eMXjGoLW/NWLAgEQgDv82HUHtC/zXxkbdkaEOXf97p4MXHUCTGb9pBPFSQePYM49Y/eq0eMxgpuNMddqKlbV8S62elrk/d3qig==
+kms__list_0__map_aws_profile = 
+unencrypted_suffix           = _unencrypted

--- a/test/fixtures/sops-kms/secrets.json
+++ b/test/fixtures/sops-kms/secrets.json
@@ -1,0 +1,32 @@
+{
+	"hello": "ENC[AES256_GCM,data:chBszAAAR0LJsYe4bEm4cjbG+e+sdTS9pHdTwQ6mrH1ohbjsFidUJRExtKMKAw==,iv:WWw7Luz0OX9JrE8HUVcZzhko1mtp6NZPGi8dId8KaUM=,tag:DE7KwBkrrpaYFYSsZZLasw==,type:str]",
+	"example_key": "ENC[AES256_GCM,data:xbQTqmd9HGE5z6JaHw==,iv:0xn2eM0rEmd0oZyuJNzvEXsa6NSHYMueOkTUvahD90Y=,tag:WIqU6W9FC4d/zoJP/COhVQ==,type:str]",
+	"example_array": [
+		"ENC[AES256_GCM,data:sF/AnbmGaH4rqPASEhU=,iv:5aywEQePONgZkwwavOssMY2s+WDrswuODxLl2lLMSks=,tag:EnGDzBaiUQ+2DybAu4sCfg==,type:str]",
+		"ENC[AES256_GCM,data:iSmgNloOVDQMjLlG7FY=,iv:sKv9zK38XRT9VFBbKWqDHmzOhXh9w53wa5u2RFXQwYk=,tag:RXIjEQ4kE1CjwWuT7tV0JQ==,type:str]"
+	],
+	"example_number": "ENC[AES256_GCM,data:K/1D8tDBNNOapA==,iv:5Djbqi7oyZ4nTFpJvMlMYBIYWwRQ3VCRS0JAu103u6g=,tag:b+WfoiHTwgoX4CkoNOIf/w==,type:float]",
+	"example_booleans": [
+		"ENC[AES256_GCM,data:6bIc5A==,iv:02H7C/7RlwXpOguEy+IeLpJxxY8W8K4zKHT9Ivhniqo=,tag:f6sCenNwOJjcuVeDj/V7Pg==,type:bool]",
+		"ENC[AES256_GCM,data:0x8KKeo=,iv:8AK/o4fuq5daQJDRz7qonbd7ZEpxWHcaT2fNCizbGI0=,tag:OmXXNL7poYITcc3g4f926g==,type:bool]"
+	],
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-1:087285199408:key/bd372994-d969-464a-a261-6cc850c58a92",
+				"created_at": "2024-09-26T12:55:27Z",
+				"enc": "AQICAHi+J98ytR8eNxKA5Tt6E5ILIMsUjvQf2k7quGoMjNULtgFBAq5l6JQ7H6GTZ0s6/k8nAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMZ7I5xuFWUUyrSD2hAgEQgDt6p+gM9IpPQo1adat2MfDHbdigWDZW1oUSIt+XmvLSzU8stPsjSBVlgdMIncnCaEp/28eT2+fJOOHPhw==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2024-09-26T12:55:28Z",
+		"mac": "ENC[AES256_GCM,data:sqV9clMyATtpp26a1xReJwZMoCrn9Ee/XETXzP/1flnVQ0RHXqbQYLd0zWIppK/eaXpYkZiwhQ6mpzuiDDTA53P4K4qMdpAt1zQ1enw2tAggDMD3O9zJ5ZvyXaYhhZKxYuUOWmwzchaQXTxvFClcAfCDA5MyrFNylHd7vV06ERY=,iv:VO2RgVFRDa7KqKZC91Mmo4JWKqz0hI8/JRG3sHBEh3I=,tag:FKyzL5oCQdacmOaPRz0gmg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.0"
+	}
+}

--- a/test/fixtures/sops-kms/secrets.txt
+++ b/test/fixtures/sops-kms/secrets.txt
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:gbo1A3QA/JGY49OwjwESxxlA,iv:hZe6bia9/114NsW++jWAxis2fpHdQ+CUJlgrUVD9n88=,tag:z6fo5qFE82otY4JTBWzFPQ==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-1:087285199408:key/bd372994-d969-464a-a261-6cc850c58a92",
+				"created_at": "2024-09-26T12:55:28Z",
+				"enc": "AQICAHi+J98ytR8eNxKA5Tt6E5ILIMsUjvQf2k7quGoMjNULtgGeVuQinJDidP/+IEwoH4qbAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMCSYnXMXk1Htl2232AgEQgDvSL7+snq0vI68TvmzvYQllB/j77Fhd/i5I1oVfk0Hg9n7iUDcqFt65HHx6cuy6qLCf6ZZrWMu/VvtwJw==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2024-09-26T12:55:28Z",
+		"mac": "ENC[AES256_GCM,data:Da2QYj51vS0BRvAwA8wQWOYgS9clOeKlPxSKXdnM8up04mFfnSl1GDC8uGrHa3ZurCjjzK4mi9Ug/0uXt9cNFTPu9WWBVpmK2NGUjB5j1dfwwFPI4LWwICogYPcODE/RtIy0ROhHfNa4ZRpgEwUyGikFqtG1gWjdaPT4sdpu0u0=,iv:qb17WZHOfWZLdiJQAzYHr9PY8XKccsizNTriw7KQI3o=,tag:g+NaMWPpG8fOvIA4f0EejQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.0"
+	}
+}

--- a/test/fixtures/sops-kms/secrets.yaml
+++ b/test/fixtures/sops-kms/secrets.yaml
@@ -1,0 +1,25 @@
+hello: ENC[AES256_GCM,data:UctdQHxu6o2NCEM4CtRZDYNDQM2FSG0kbz4ZiTBrD1dQu9gHOQHqVyvVffaC/A==,iv:txyqGoTHwiM07kGIa0WQvMLZsicLpavYfbLCWQZZ/ME=,tag:VhGqTrCBievJIe0Xbbuzzg==,type:str]
+example_key: ENC[AES256_GCM,data:5UeifFtzkkfUF72Fyg==,iv:heBSgumZKtl9SEBI8hxLMXRGy9TAQAWuAwOr9zI75d4=,tag:+ePgvZ46ZpvjRarvNO+acw==,type:str]
+#ENC[AES256_GCM,data:uK3RAvakhDn/GXfblb7iiQ==,iv:hHr/W4qRoON+B1gWHIJL5yRbYkFJ+n5IiG6Zzd3WnOU=,tag:E9Tv6j85gFCjjVlAW4AxIw==,type:comment]
+example_array:
+    - ENC[AES256_GCM,data:vqHuKNctFSMHgqjwlEM=,iv:c4lP+AhlyMLWibKy9CponrUUMOfIO4o5gDIoKp+Nx4Y=,tag:d29u2zfxxbIlYr+73rqWZQ==,type:str]
+    - ENC[AES256_GCM,data:uJwuLNoKYY9v40Kq3LY=,iv:guNMIvtzpUimYHsnqZ20WYsEVhWpQhQbh3ggw6uSIzA=,tag:V32h8FtuDUnlBZI6JYkQgw==,type:str]
+example_number: ENC[AES256_GCM,data:3yc0r2aSfHxy,iv:3wrKIene9z0q4NuS/Nc3SqZG506tpFETbaTGtUUoQkc=,tag:EwBNV3sBFQev4aukf20XTw==,type:float]
+example_booleans:
+    - ENC[AES256_GCM,data:kqRt/A==,iv:qssmJd6Of8tfTpIozUzXu5+xcJuEMNWa6W5I7vOaPME=,tag:3hUar1Yp4/eoq2Z75EdidA==,type:bool]
+    - ENC[AES256_GCM,data:GKuXxS8=,iv:rHeGQpu/GPwykvlQebE+nliyMJQsLrmiCG0HCt06A7c=,tag:Jb3H/HTkB0NaWLZsXSpDzQ==,type:bool]
+sops:
+    kms:
+        - arn: arn:aws:kms:us-east-1:087285199408:key/bd372994-d969-464a-a261-6cc850c58a92
+          created_at: "2024-09-26T12:55:28Z"
+          enc: AQICAHi+J98ytR8eNxKA5Tt6E5ILIMsUjvQf2k7quGoMjNULtgHK/dxuabG3Ua5XjTrtqSBQAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM4MCxCLTdfXZmRg2WAgEQgDufPkOmTiJyNkD+k3o75tJAwAUz/rDuADkGT3GP3Gs8I6BIzoQDkTJO7RgCcq6GMi3ClEtsflvgpP+WqQ==
+          aws_profile: ""
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-09-26T12:55:28Z"
+    mac: ENC[AES256_GCM,data:cZaMv1T0LEWA+N40FIiZrTTIC18/XkODrFmoK81+fb8CyxxJB2iciTgS0lRlL0imJ1uo+RfZ4+OKSK9O4L2x4RR9lGte4y7XMvb6g1+zIB5VH8SxNnQzJZLR2xlVdMsrqQu7F7LypKGuD07Rhk+exRlyF+opHjY551SEREpIftU=,iv:xH+iSvF1Akp8bkuxIpiLd8TUPE+1IBKPvAMnSlHofIQ=,tag:9Nl4U7+rJ0IFEhfQYhfIDQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.0

--- a/test/fixtures/sops-kms/terragrunt.hcl
+++ b/test/fixtures/sops-kms/terragrunt.hcl
@@ -1,0 +1,23 @@
+locals {
+  json = jsondecode(sops_decrypt_file("${get_terragrunt_dir()}/secrets.json"))
+  yaml = yamldecode(sops_decrypt_file("${get_terragrunt_dir()}/secrets.yaml"))
+  text = sops_decrypt_file("${get_terragrunt_dir()}/secrets.txt")
+  env  = sops_decrypt_file("${get_terragrunt_dir()}/secrets.env")
+  ini  = sops_decrypt_file("${get_terragrunt_dir()}/secrets.ini")
+}
+
+inputs = {
+  json_string_array = local.json["example_array"]
+  json_bool_array   = local.json["example_booleans"]
+  json_string       = local.json["example_key"]
+  json_number       = local.json["example_number"]
+  json_hello        = local.json["hello"]
+  yaml_string_array = local.yaml["example_array"]
+  yaml_bool_array   = local.yaml["example_booleans"]
+  yaml_string       = local.yaml["example_key"]
+  yaml_number       = local.yaml["example_number"]
+  yaml_hello        = local.yaml["hello"]
+  text_value        = local.text
+  env_value         = local.env
+  ini_value         = local.ini
+}

--- a/test/integration_sops_kms_test.go
+++ b/test/integration_sops_kms_test.go
@@ -1,0 +1,51 @@
+//go:build aws
+
+package test_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFixtureSopsKMS = "fixtures/sops-kms"
+)
+
+// sops decrypting for inputs
+func TestAwsSopsDecryptedKMSCorrectly(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, testFixtureSopsKMS)
+	tmpEnvPath := copyEnvironment(t, testFixtureSopsKMS)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureSopsKMS)
+
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
+	require.NoError(t, err)
+
+	outputs := map[string]TerraformOutput{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
+
+	assert.Equal(t, []interface{}{true, false}, outputs["json_bool_array"].Value)
+	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["json_string_array"].Value)
+	assert.InEpsilon(t, 1234.56789, outputs["json_number"].Value, 0.0001)
+	assert.Equal(t, "example_value", outputs["json_string"].Value)
+	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["json_hello"].Value)
+	assert.Equal(t, []interface{}{true, false}, outputs["yaml_bool_array"].Value)
+	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["yaml_string_array"].Value)
+	assert.InEpsilon(t, 1234.5679, outputs["yaml_number"].Value, 0.0001)
+	assert.Equal(t, "example_value", outputs["yaml_string"].Value)
+	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["yaml_hello"].Value)
+	assert.Equal(t, "Raw Secret Example", outputs["text_value"].Value)
+	assert.Contains(t, outputs["env_value"].Value, "DB_PASSWORD=tomato")
+	assert.Contains(t, outputs["ini_value"].Value, "password = potato")
+}

--- a/test/integration_sops_test.go
+++ b/test/integration_sops_test.go
@@ -16,7 +16,6 @@ const (
 	testFixtureSopsErrors = "fixtures/sops-errors"
 )
 
-// sops decrypting for inputs
 func TestSopsDecryptedCorrectly(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration_sops_test.go
+++ b/test/integration_sops_test.go
@@ -1,0 +1,100 @@
+package test_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFixtureSops       = "fixtures/sops"
+	testFixtureSopsErrors = "fixtures/sops-errors"
+)
+
+// sops decrypting for inputs
+func TestSopsDecryptedCorrectly(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, testFixtureSops)
+	tmpEnvPath := copyEnvironment(t, testFixtureSops)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureSops)
+
+	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
+	require.NoError(t, err)
+
+	outputs := map[string]TerraformOutput{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
+
+	assert.Equal(t, []interface{}{true, false}, outputs["json_bool_array"].Value)
+	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["json_string_array"].Value)
+	assert.InEpsilon(t, 1234.56789, outputs["json_number"].Value, 0.0001)
+	assert.Equal(t, "example_value", outputs["json_string"].Value)
+	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["json_hello"].Value)
+	assert.Equal(t, []interface{}{true, false}, outputs["yaml_bool_array"].Value)
+	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["yaml_string_array"].Value)
+	assert.InEpsilon(t, 1234.5679, outputs["yaml_number"].Value, 0.0001)
+	assert.Equal(t, "example_value", outputs["yaml_string"].Value)
+	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["yaml_hello"].Value)
+	assert.Equal(t, "Raw Secret Example", outputs["text_value"].Value)
+	assert.Contains(t, outputs["env_value"].Value, "DB_PASSWORD=tomato")
+	assert.Contains(t, outputs["ini_value"].Value, "password = potato")
+}
+
+func TestSopsDecryptedCorrectlyRunAll(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, testFixtureSops)
+	tmpEnvPath := copyEnvironment(t, testFixtureSops)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureSops)
+
+	runTerragrunt(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s/../.. --terragrunt-include-dir %s", rootPath, testFixtureSops))
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir %s/../.. --terragrunt-include-dir %s", rootPath, testFixtureSops), &stdout, &stderr)
+	require.NoError(t, err)
+
+	outputs := map[string]TerraformOutput{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
+
+	assert.Equal(t, []interface{}{true, false}, outputs["json_bool_array"].Value)
+	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["json_string_array"].Value)
+	assert.InEpsilon(t, 1234.56789, outputs["json_number"].Value, 0.0001)
+	assert.Equal(t, "example_value", outputs["json_string"].Value)
+	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["json_hello"].Value)
+	assert.Equal(t, []interface{}{true, false}, outputs["yaml_bool_array"].Value)
+	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["yaml_string_array"].Value)
+	assert.InEpsilon(t, 1234.5679, outputs["yaml_number"].Value, 0.0001)
+	assert.Equal(t, "example_value", outputs["yaml_string"].Value)
+	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["yaml_hello"].Value)
+	assert.Equal(t, "Raw Secret Example", outputs["text_value"].Value)
+	assert.Contains(t, outputs["env_value"].Value, "DB_PASSWORD=tomato")
+	assert.Contains(t, outputs["ini_value"].Value, "password = potato")
+}
+
+func TestTerragruntLogSopsErrors(t *testing.T) {
+	t.Parallel()
+
+	// create temporary directory for plan files
+	tmpEnvPath := copyEnvironment(t, testFixtureSopsErrors)
+	cleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, testFixtureSopsErrors)
+
+	// apply and check for errors
+	_, errorOut, err := runTerragruntCommandWithOutput(t, "terragrunt apply --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+testPath)
+	require.Error(t, err)
+
+	assert.Contains(t, errorOut, "error decrypting key: [error decrypting key")
+	assert.Contains(t, errorOut, "error base64-decoding encrypted data key: illegal base64 data at input byte")
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -98,8 +98,6 @@ const (
 	testFixtureRefSource                      = "fixtures/download/remote-ref"
 	testFixtureSkip                           = "fixtures/skip/"
 	testFixtureSkipDependencies               = "fixtures/skip-dependencies"
-	testFixtureSops                           = "fixtures/sops"
-	testFixtureSopsErrors                     = "fixtures/sops-errors"
 	testFixtureSourceMapSlashes               = "fixtures/source-map/slashes-in-ref"
 	testFixtureStack                          = "fixtures/stack/"
 	testFixtureStdout                         = "fixtures/download/stdout-test"
@@ -2960,73 +2958,6 @@ func runValidateAllWithIncludeAndGetIncludedModules(t *testing.T, rootModulePath
 	return includedModules
 }
 
-// sops decrypting for inputs
-func TestSopsDecryptedCorrectly(t *testing.T) {
-	t.Parallel()
-
-	cleanupTerraformFolder(t, testFixtureSops)
-	tmpEnvPath := copyEnvironment(t, testFixtureSops)
-	rootPath := util.JoinPath(tmpEnvPath, testFixtureSops)
-
-	runTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
-
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-
-	err := runTerragruntCommand(t, "terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
-	require.NoError(t, err)
-
-	outputs := map[string]TerraformOutput{}
-	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-
-	assert.Equal(t, []interface{}{true, false}, outputs["json_bool_array"].Value)
-	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["json_string_array"].Value)
-	assert.InEpsilon(t, 1234.56789, outputs["json_number"].Value, 0.0001)
-	assert.Equal(t, "example_value", outputs["json_string"].Value)
-	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["json_hello"].Value)
-	assert.Equal(t, []interface{}{true, false}, outputs["yaml_bool_array"].Value)
-	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["yaml_string_array"].Value)
-	assert.InEpsilon(t, 1234.5679, outputs["yaml_number"].Value, 0.0001)
-	assert.Equal(t, "example_value", outputs["yaml_string"].Value)
-	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["yaml_hello"].Value)
-	assert.Equal(t, "Raw Secret Example", outputs["text_value"].Value)
-	assert.Contains(t, outputs["env_value"].Value, "DB_PASSWORD=tomato")
-	assert.Contains(t, outputs["ini_value"].Value, "password = potato")
-}
-
-func TestSopsDecryptedCorrectlyRunAll(t *testing.T) {
-	t.Parallel()
-
-	cleanupTerraformFolder(t, testFixtureSops)
-	tmpEnvPath := copyEnvironment(t, testFixtureSops)
-	rootPath := util.JoinPath(tmpEnvPath, testFixtureSops)
-
-	runTerragrunt(t, fmt.Sprintf("terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s/../.. --terragrunt-include-dir %s", rootPath, testFixtureSops))
-
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt run-all output -no-color -json --terragrunt-non-interactive --terragrunt-working-dir %s/../.. --terragrunt-include-dir %s", rootPath, testFixtureSops), &stdout, &stderr)
-	require.NoError(t, err)
-
-	outputs := map[string]TerraformOutput{}
-	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-
-	assert.Equal(t, []interface{}{true, false}, outputs["json_bool_array"].Value)
-	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["json_string_array"].Value)
-	assert.InEpsilon(t, 1234.56789, outputs["json_number"].Value, 0.0001)
-	assert.Equal(t, "example_value", outputs["json_string"].Value)
-	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["json_hello"].Value)
-	assert.Equal(t, []interface{}{true, false}, outputs["yaml_bool_array"].Value)
-	assert.Equal(t, []interface{}{"example_value1", "example_value2"}, outputs["yaml_string_array"].Value)
-	assert.InEpsilon(t, 1234.5679, outputs["yaml_number"].Value, 0.0001)
-	assert.Equal(t, "example_value", outputs["yaml_string"].Value)
-	assert.Equal(t, "Welcome to SOPS! Edit this file as you please!", outputs["yaml_hello"].Value)
-	assert.Equal(t, "Raw Secret Example", outputs["text_value"].Value)
-	assert.Contains(t, outputs["env_value"].Value, "DB_PASSWORD=tomato")
-	assert.Contains(t, outputs["ini_value"].Value, "password = potato")
-}
-
 func TestShowErrorWhenRunAllInvokedWithoutArguments(t *testing.T) {
 	t.Parallel()
 
@@ -3774,22 +3705,6 @@ func TestTerragruntRunAllPlanAndShow(t *testing.T) {
 
 	// Verify that output contains the plan and not just the actual state output
 	assert.Contains(t, stdout, "No changes. Your infrastructure matches the configuration.")
-}
-
-func TestTerragruntLogSopsErrors(t *testing.T) {
-	t.Parallel()
-
-	// create temporary directory for plan files
-	tmpEnvPath := copyEnvironment(t, testFixtureSopsErrors)
-	cleanupTerraformFolder(t, tmpEnvPath)
-	testPath := util.JoinPath(tmpEnvPath, testFixtureSopsErrors)
-
-	// apply and check for errors
-	_, errorOut, err := runTerragruntCommandWithOutput(t, "terragrunt apply --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+testPath)
-	require.Error(t, err)
-
-	assert.Contains(t, errorOut, "error decrypting key: [error decrypting key")
-	assert.Contains(t, errorOut, "error base64-decoding encrypted data key: illegal base64 data at input byte")
 }
 
 func createTmpTerragruntConfigWithParentAndChild(t *testing.T, parentPath string, childRelPath string, s3BucketName string, parentConfigFileName string, childConfigFileName string) string {


### PR DESCRIPTION
## Description

Fixes #3438.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `sops_decrypt_file` to use environment variables that might have been set by `terragrunt-auth-provider-cmd`.

