### PR TITLE
feat: Upgrading `go-getter` to v2 in scaffold

### DIFF
--- a/cli/commands/scaffold/action.go
+++ b/cli/commands/scaffold/action.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terratest/modules/files"
-	"github.com/hashicorp/go-getter"
+	"github.com/hashicorp/go-getter/v2"
 )
 
 const (
@@ -142,7 +142,7 @@ func Run(ctx context.Context, opts *options.TerragruntOptions, moduleURL, templa
 
 	opts.Logger.Infof("Scaffolding a new Terragrunt module %s to %s", moduleURL, opts.WorkingDir)
 
-	if err := getter.GetAny(tempDir, moduleURL); err != nil {
+	if _, err := getter.GetAny(ctx, tempDir, moduleURL); err != nil {
 		return errors.New(err)
 	}
 
@@ -222,7 +222,7 @@ func prepareBoilerplateFiles(ctx context.Context, opts *options.TerragruntOption
 		// downloading template
 		opts.Logger.Infof("Using template from %s", templateURL)
 
-		if err := getter.GetAny(templateDir, templateURL); err != nil {
+		if _, err := getter.GetAny(ctx, templateDir, templateURL); err != nil {
 			return "", errors.New(err)
 		}
 	}

--- a/cli/commands/scaffold/action_test.go
+++ b/cli/commands/scaffold/action_test.go
@@ -91,5 +91,4 @@ func TestDefaultTemplateVariables(t *testing.T) {
 	_, found := cfg.Inputs["required_var_1"]
 	require.True(t, found)
 	require.Equal(t, "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8", *cfg.Terraform.Source)
-
 }


### PR DESCRIPTION
## Description

Was written to address #3031, but that issue is more closely related to #3460.

It doesn't hurt to merge this in if we don't have any problems with it, though.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `go-getter` to `v2` for the `scaffold` command.

