### PR TITLE
Fix concurrent map write due to read lock and delete

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -84,8 +84,8 @@ func NewExpiringCache[V any](name string) *ExpiringCache[V] {
 
 // Get - fetch value from cache by key
 func (c *ExpiringCache[V]) Get(ctx context.Context, key string) (V, bool) {
-	c.Mutex.RLock()
-	defer c.Mutex.RUnlock()
+	c.Mutex.Lock()
+	defer c.Mutex.Unlock()
 	item, found := c.Cache[key]
 	telemetry.Count(ctx, c.Name+"_cache_get", 1)
 


### PR DESCRIPTION
## Description

Fix a panic during race conditions. ExpiringCache requires a write lock as during an expiry it will make a delete call to the underlying map.

Fixes #3456.

## TODOs

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated ExpiringCache to prevent a panic during race conditions (#3456).

