### PR TITLE
[WIP] feature: Move force_path_style to use_path_style

### DIFF
--- a/docs/_docs/02_features/keep-your-remote-state-configuration-dry.md
+++ b/docs/_docs/02_features/keep-your-remote-state-configuration-dry.md
@@ -245,7 +245,7 @@ remote_state {
 
     shared_credentials_file     = "/path/to/credentials/file"
     skip_metadata_api_check     = true
-    force_path_style            = true
+    use_path_style            = true
   }
 }
 ```

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -115,7 +115,7 @@ type RemoteStateConfigS3 struct {
 	LockTable        string                        `mapstructure:"lock_table"`   // Deprecated in Terraform version 0.13 or newer.
 	DynamoDBTable    string                        `mapstructure:"dynamodb_table"`
 	CredsFilename    string                        `mapstructure:"shared_credentials_file"`
-	S3ForcePathStyle bool                          `mapstructure:"force_path_style"`
+	S3UsePathStyle   bool                          `mapstructure:"use_path_style"`
 	AssumeRole       RemoteStateConfigS3AssumeRole `mapstructure:"assume_role"`
 }
 
@@ -131,7 +131,7 @@ func (c *ExtendedRemoteStateConfigS3) GetAwsSessionConfig() *awshelper.AwsSessio
 		ExternalID:              c.RemoteStateConfigS3.GetExternalID(),
 		SessionName:             c.RemoteStateConfigS3.GetSessionName(),
 		CredsFilename:           c.RemoteStateConfigS3.CredsFilename,
-		S3ForcePathStyle:        c.RemoteStateConfigS3.S3ForcePathStyle,
+		S3UsePathStyle:          c.RemoteStateConfigS3.S3UsePathStyle,
 		DisableComputeChecksums: c.DisableAWSClientChecksums,
 	}
 }

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -245,7 +245,7 @@ func TestAwsConfigValuesEqual(t *testing.T) {
 	}
 }
 
-func TestAwsForcePathStyleClientSession(t *testing.T) {
+func TestAwsUsePathStyleClientSession(t *testing.T) {
 	t.Parallel()
 
 	terragruntOptions, err := options.NewTerragruntOptionsForTest("s3_client_test")
@@ -258,12 +258,12 @@ func TestAwsForcePathStyleClientSession(t *testing.T) {
 	}{
 		{
 			"path-style-true",
-			map[string]interface{}{"force_path_style": true},
+			map[string]interface{}{"use_path_style": true},
 			true,
 		},
 		{
 			"path-style-false",
-			map[string]interface{}{"force_path_style": false},
+			map[string]interface{}{"use_path_style": false},
 			false,
 		},
 		{
@@ -287,7 +287,7 @@ func TestAwsForcePathStyleClientSession(t *testing.T) {
 			s3Client, err := remote.CreateS3Client(s3ConfigExtended.GetAwsSessionConfig(), terragruntOptions)
 			require.NoError(t, err, "Unexpected error creating client for test: %v", err)
 
-			actual := aws.BoolValue(s3Client.Config.S3ForcePathStyle)
+			actual := aws.BoolValue(s3Client.Config.S3UsePathStyle)
 			assert.Equal(t, testCase.expected, actual)
 		})
 	}
@@ -302,7 +302,7 @@ func TestAwsGetAwsSessionConfig(t *testing.T) {
 	}{
 		{
 			"all-values",
-			map[string]interface{}{"region": "foo", "endpoint": "bar", "profile": "baz", "role_arn": "arn::it", "shared_credentials_file": "my-file", "force_path_style": true},
+			map[string]interface{}{"region": "foo", "endpoint": "bar", "profile": "baz", "role_arn": "arn::it", "shared_credentials_file": "my-file", "use_path_style": true},
 		},
 		{
 			"no-values",
@@ -310,7 +310,7 @@ func TestAwsGetAwsSessionConfig(t *testing.T) {
 		},
 		{
 			"extra-values",
-			map[string]interface{}{"something": "unexpected", "region": "foo", "endpoint": "bar", "dynamodb_endpoint": "foobar", "profile": "baz", "role_arn": "arn::it", "shared_credentials_file": "my-file", "force_path_style": false},
+			map[string]interface{}{"something": "unexpected", "region": "foo", "endpoint": "bar", "dynamodb_endpoint": "foobar", "profile": "baz", "role_arn": "arn::it", "shared_credentials_file": "my-file", "use_path_style": false},
 		},
 	}
 
@@ -332,7 +332,7 @@ func TestAwsGetAwsSessionConfig(t *testing.T) {
 				Profile:                 s3ConfigExtended.RemoteStateConfigS3.Profile,
 				RoleArn:                 s3ConfigExtended.RemoteStateConfigS3.RoleArn,
 				CredsFilename:           s3ConfigExtended.RemoteStateConfigS3.CredsFilename,
-				S3ForcePathStyle:        s3ConfigExtended.RemoteStateConfigS3.S3ForcePathStyle,
+				S3UsePathStyle:        s3ConfigExtended.RemoteStateConfigS3.S3UsePathStyle,
 				DisableComputeChecksums: s3ConfigExtended.DisableAWSClientChecksums,
 			}
 

--- a/remote/remote_state_test.go
+++ b/remote/remote_state_test.go
@@ -42,13 +42,13 @@ func TestToTerraformInitArgs(t *testing.T) {
 			"skip_bucket_versioning": true,
 
 			"shared_credentials_file": "my-file",
-			"force_path_style":        true,
+			"use_path_style":        true,
 		},
 	}
 	args := remoteState.ToTerraformInitArgs()
 
 	// must not contain s3_bucket_tags or dynamodb_table_tags or accesslogging_bucket_tags or skip_bucket_versioning
-	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1 -backend-config=force_path_style=true -backend-config=shared_credentials_file=my-file")
+	assertTerraformInitArgsEqual(t, args, "-backend-config=encrypt=true -backend-config=bucket=my-bucket -backend-config=key=terraform.tfstate -backend-config=region=us-east-1 -backend-config=use_path_style=true -backend-config=shared_credentials_file=my-file")
 }
 
 func TestToTerraformInitArgsForGCS(t *testing.T) {


### PR DESCRIPTION


<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

As per the documentation linked below the force_path_style option is now deprecated and should be changed to use_path_style.

https://developer.hashicorp.com/terraform/language/backend/s3#force_path_style

It may be better to add both to allow people to migrate from one to the other but given this is only in one place in the docs I expect there isn't a lot of use and highlighting as a breaking change will make future migration easier and stop being using the now deprecated option.

Fixes #3472 .

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated force_path_style

### Migration Guide

Change

```hcl
force_path_style = true
```

to 

```hcl
use_path_style = true
```
<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

