### PR TITLE
feat: Improving Error Message for Invalid Strict Controls

### DIFF
--- a/docs/_docs/04_reference/strict-mode.md
+++ b/docs/_docs/04_reference/strict-mode.md
@@ -33,7 +33,7 @@ $ terragrunt plan-all
 ```
 
 ```bash
-$ TERRAGRUNT_STRICT_MODE='true' tg plan-all
+$ TERRAGRUNT_STRICT_MODE='true' terragrunt plan-all
 15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
 ```
 

--- a/internal/strict/strict.go
+++ b/internal/strict/strict.go
@@ -118,7 +118,7 @@ func (controls Controls) Names() []string {
 
 var (
 	// ErrInvalidStrictControl is returned when an invalid strict control is used.
-	ErrInvalidStrictControl = errors.New("Invalid value(s) used for --strict-control.")
+	ErrInvalidStrictControl = errors.New("Invalid value(s) used for --strict-control.") //nolint:stylecheck
 )
 
 // ValidateControlNames validates that the given control names are valid.

--- a/internal/strict/strict.go
+++ b/internal/strict/strict.go
@@ -9,9 +9,11 @@ package strict
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/util"
 )
 
 // Control represents a control that can be enabled or disabled in strict mode.
@@ -103,18 +105,31 @@ var StrictControls = Controls{
 	},
 }
 
+func (controls Controls) Names() []string {
+	names := []string{}
+
+	for name := range controls {
+		names = append(names, name)
+	}
+
+	return names
+}
+
 func (controls Controls) ValidateControlNames(strictControlNames []string) error {
 	invalidControls := []string{}
+	validControls := controls.Names()
 
 	for _, controlName := range strictControlNames {
-		_, ok := controls[controlName]
-		if !ok {
+		if !util.ListContainsElement(validControls, controlName) {
 			invalidControls = append(invalidControls, controlName)
 		}
 	}
 
 	if len(invalidControls) > 0 {
-		return errors.New("Invalid strict controls: " + strings.Join(invalidControls, ", "))
+		return fmt.Errorf("Invalid value(s) used for --strict-control.\nInvalid value(s):\n- %s\nAllowed value(s):\n- %s", //nolint:stylecheck
+			strings.Join(invalidControls, "\n- "),
+			strings.Join(validControls, "\n- "),
+		)
 	}
 
 	return nil

--- a/internal/strict/strict.go
+++ b/internal/strict/strict.go
@@ -118,7 +118,7 @@ func (controls Controls) Names() []string {
 
 var (
 	// ErrInvalidStrictControl is returned when an invalid strict control is used.
-	ErrInvalidStrictControl = errors.New("Invalid value(s) used for --strict-control.") //nolint:stylecheck
+	ErrInvalidStrictControl = errors.New("Invalid value(s) used for --strict-control.") //nolint:stylecheck,revive
 )
 
 // ValidateControlNames validates that the given control names are valid.
@@ -133,7 +133,7 @@ func (controls Controls) ValidateControlNames(strictControlNames []string) error
 	}
 
 	if len(invalidControls) > 0 {
-		return fmt.Errorf("%w\nInvalid value(s):\n- %s\nAllowed value(s):\n- %s", //nolint:stylecheck
+		return fmt.Errorf("%w\nInvalid value(s):\n- %s\nAllowed value(s):\n- %s",
 			ErrInvalidStrictControl,
 			strings.Join(invalidControls, "\n- "),
 			strings.Join(validControls, "\n- "),

--- a/internal/strict/strict.go
+++ b/internal/strict/strict.go
@@ -105,6 +105,7 @@ var StrictControls = Controls{
 	},
 }
 
+// Names returns the names of all strict controls.
 func (controls Controls) Names() []string {
 	names := []string{}
 
@@ -115,6 +116,12 @@ func (controls Controls) Names() []string {
 	return names
 }
 
+var (
+	// ErrInvalidStrictControl is returned when an invalid strict control is used.
+	ErrInvalidStrictControl = errors.New("Invalid value(s) used for --strict-control.")
+)
+
+// ValidateControlNames validates that the given control names are valid.
 func (controls Controls) ValidateControlNames(strictControlNames []string) error {
 	invalidControls := []string{}
 	validControls := controls.Names()
@@ -126,7 +133,8 @@ func (controls Controls) ValidateControlNames(strictControlNames []string) error
 	}
 
 	if len(invalidControls) > 0 {
-		return fmt.Errorf("Invalid value(s) used for --strict-control.\nInvalid value(s):\n- %s\nAllowed value(s):\n- %s", //nolint:stylecheck
+		return fmt.Errorf("%w\nInvalid value(s):\n- %s\nAllowed value(s):\n- %s", //nolint:stylecheck
+			ErrInvalidStrictControl,
 			strings.Join(invalidControls, "\n- "),
 			strings.Join(validControls, "\n- "),
 		)


### PR DESCRIPTION
## Description

Improves error message for invalid strict controls.

What the error looks like now:

```bash
$ terragrunt plan-all --strict-control plan-alls
14:08:35.531 ERROR  Invalid value(s) used for --strict-control.
Invalid value(s):
- plan-alls
Allowed value(s):
- plan-all
- apply-all
- destroy-all
- output-all
- validate-all
- spin-up
- tear-down

```

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `strict` Package.

