### PR TITLE
feat: Avoiding parallel usage of `runTerragruntVersionCommand`

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2464,9 +2464,10 @@ func TestTerragruntRemoteStateCodegenDoesNotGenerateWithSkip(t *testing.T) {
 	assert.False(t, fileIsInFolder(t, "foo.tfstate", generateTestCase))
 }
 
+// This function cannot be parallelized as it changes the global version.Version
+//
+//nolint:paralleltest
 func TestTerragruntValidateAllWithVersionChecks(t *testing.T) {
-	t.Parallel()
-
 	tmpEnvPath := copyEnvironment(t, "fixtures/version-check")
 
 	stdout := bytes.Buffer{}
@@ -2495,12 +2496,12 @@ func TestTerragruntIncludeParentHclFile(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(out, "common_hcl"))
 }
 
-// The over all test here can run in parallel, but the subtests cannot.
+// The tests here cannot be parallelized.
 // This is due to a race condition brought about by overriding `version.Version` in
 // runTerragruntVersionCommand
-func TestTerragruntVersionConstraints(t *testing.T) { //nolint:tparallel
-	t.Parallel()
-
+//
+//nolint:paralleltest,tparallel
+func TestTerragruntVersionConstraints(t *testing.T) {
 	tc := []struct {
 		name                 string
 		terragruntVersion    string
@@ -2640,9 +2641,10 @@ func TestIamRolesLoadingFromDifferentModules(t *testing.T) {
 	assert.NotEmptyf(t, component2, "Missing role for component 2")
 }
 
+// This function cannot be parallelized as it changes the global version.Version
+//
+//nolint:paralleltest
 func TestTerragruntVersionConstraintsPartialParse(t *testing.T) {
-	t.Parallel()
-
 	fixturePath := "fixtures/partial-parse/terragrunt-version-constraint"
 	cleanupTerragruntFolder(t, fixturePath)
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3804,7 +3804,10 @@ func TestTerragruntTerraformOutputJson(t *testing.T) {
 	_, stderr, err := runTerragruntCommandWithOutput(t, "terragrunt apply --no-color --terragrunt-json-log --terragrunt-tf-logs-to-json --terragrunt-forward-tf-stdout --terragrunt-non-interactive --terragrunt-working-dir "+testPath)
 	require.Error(t, err)
 
-	assert.Contains(t, stderr, `"msg":"Initializing the backend..."`)
+	// Sometimes, this is the error returned by AWS.
+	if !strings.Contains(stderr, "Error: Failed to get existing workspaces: operation error S3: ListObjectsV2, https response error StatusCode: 301") {
+		assert.Contains(t, stderr, `"msg":"Initializing the backend..."`)
+	}
 
 	// check if output can be extracted in json
 	jsonStrings := strings.Split(stderr, "\n")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2500,7 +2500,7 @@ func TestTerragruntIncludeParentHclFile(t *testing.T) {
 // This is due to a race condition brought about by overriding `version.Version` in
 // runTerragruntVersionCommand
 //
-//nolint:paralleltest,tparallel
+//nolint:paralleltest,funlen
 func TestTerragruntVersionConstraints(t *testing.T) {
 	tc := []struct {
 		name                 string


### PR DESCRIPTION
## Description

Reduces flakiness of tests.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated tests.

