### PR TITLE
Add CICD test to build without go proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,10 +550,9 @@ jobs:
     steps:
       - checkout
       - run:
-         name: Disable go proxy
-         command: |
-           export GOPROXY=direct
-      - run: build-go-binaries --app-name terragrunt --dest-path bin --ld-flags "-X github.com/gruntwork-io/go-commons/version.Version=$CIRCLE_TAG -extldflags '-static'"
+          name: Building Terragrunt without Go proxy
+          command: |
+            GOPROXY=direct build-go-binaries --app-name terragrunt --dest-path bin --ld-flags "-X github.com/gruntwork-io/go-commons/version.Version=$CIRCLE_TAG -extldflags '-static'"
 
   test_signing:
     <<: *env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,6 +543,18 @@ jobs:
           root: .
           paths: [bin]
 
+  test_build_no_proxy:
+    # build Terragrunt without Go proxy to ensure all dependencies have correct checksums
+    resource_class: xlarge
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+         name: Disable go proxy
+         command: |
+           export GOPROXY=direct
+      - run: build-go-binaries --app-name terragrunt --dest-path bin --ld-flags "-X github.com/gruntwork-io/go-commons/version.Version=$CIRCLE_TAG -extldflags '-static'"
+
   test_signing:
     <<: *env
     macos:
@@ -806,6 +818,14 @@ workflows:
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
             - APPLE__OSX__code-signing
+      - test_build_no_proxy:
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GCP__automated-tests
+            - GITHUB__PAT__gruntwork-ci
       - deploy:
           requires:
             - build


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Added CICD tests to build without go proxy to identify cases when checksums will be changed.

Related: #3474

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

