### PR TITLE
fix: Avoid panic in sops decrypt

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -1110,7 +1110,7 @@ func extractSopsErrors(err error) *errors.MultiError {
 	}
 
 	// append the original error if no group results were found
-	if errs.Len() == 0 {
+	if errs == nil {
 		errs = errs.Append(err)
 	}
 

--- a/test/fixtures/sops-missing/terragrunt.hcl
+++ b/test/fixtures/sops-missing/terragrunt.hcl
@@ -1,0 +1,3 @@
+locals {
+  secret_vars = yamldecode(sops_decrypt_file("${get_terragrunt_dir()}/missing.yaml"))
+}

--- a/test/integration_sops_test.go
+++ b/test/integration_sops_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	testFixtureSops       = "fixtures/sops"
-	testFixtureSopsErrors = "fixtures/sops-errors"
+	testFixtureSops        = "fixtures/sops"
+	testFixtureSopsErrors  = "fixtures/sops-errors"
+	testFixtureSopsMissing = "fixtures/sops-missing"
 )
 
 func TestSopsDecryptedCorrectly(t *testing.T) {
@@ -96,4 +97,18 @@ func TestTerragruntLogSopsErrors(t *testing.T) {
 
 	assert.Contains(t, errorOut, "error decrypting key: [error decrypting key")
 	assert.Contains(t, errorOut, "error base64-decoding encrypted data key: illegal base64 data at input byte")
+}
+
+func TestSopsDecryptOnMissing(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, testFixtureSopsMissing)
+	tmpEnvPath := copyEnvironment(t, testFixtureSopsMissing)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureSopsMissing)
+
+	// apply and check for errors
+	_, errorOut, err := runTerragruntCommandWithOutput(t, "terragrunt apply --terragrunt-non-interactive --terragrunt-log-level debug --terragrunt-working-dir "+rootPath)
+	require.Error(t, err)
+
+	assert.Contains(t, errorOut, "Encountered error while evaluating locals in file ./terragrunt.hcl")
 }


### PR DESCRIPTION
## Description

Fixes #3486.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `sops_decrypt_file` by avoiding panics when the file is empty.

