### PR TITLE
docs(cli-options): add a warning message about non-functionnal glob curly braces expansion for TERRAGRUNT_INCLUDE_DIR and TERRAGRUNT_EXCLUDE_DIR env variables

### DIFF
--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -1008,6 +1008,9 @@ excluded during execution of the commands. If a relative path is specified, it s
 [--terragrunt-working-dir](#terragrunt-working-dir). Flag can be specified multiple times. This will only exclude the
 module, not its dependencies.
 
+Please note that the glob curly braces expansion is not taken in account using environment variable unlike of its equivalent as a parameter on the command line.
+You should consider using `TERRAGRUNT_EXCLUDE_DIR="foo/module,bar/module"` instead of `TERRAGRUNT_EXCLUDE_DIR="{foo,bar}/module"`.
+
 ### terragrunt-include-dir
 
 **CLI Arg**: `--terragrunt-include-dir`<br/>
@@ -1019,6 +1022,9 @@ Can be supplied multiple times: `--terragrunt-include-dir /path/to/dirs/to/inclu
 Unix-style glob of directories to include when running `*-all` commands. Only modules under these directories (and all
 dependent modules) will be included during execution of the commands. If a relative path is specified, it should be
 relative from `--terragrunt-working-dir`. Flag can be specified multiple times.
+
+Please note that the glob curly braces expansion is not taken in account using environment variable unlike of its equivalent as a parameter on the command line.
+You should consider using `TERRAGRUNT_INCLUDE_DIR="foo/module,bar/module"` instead of `TERRAGRUNT_INCLUDE_DIR="{foo,bar}/module"`.
 
 ### terragrunt-strict-include
 


### PR DESCRIPTION
## Description

Fixes #3462

This P.R adds a warning message in CLI options documentation of `--terragrunt-include-dir` and `--terragrunt-exclude-dir` args about not supporting glob curly expansion braces with environment variables.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated docs to add a warning message for non supported glob braces expansion using TERRAGRUNT_INCLUDE_DIR and TERRAGRUNT_EXCLUDE_DIR environment variables.
