### PR TITLE
Fixing running pseudo-tty commands

### DIFF
--- a/internal/errors/util.go
+++ b/internal/errors/util.go
@@ -83,7 +83,7 @@ func UnwrapMultiErrors(err error) []error {
 				index--
 
 				for _, err := range err.Unwrap() {
-					errs = append(errs, New(err))
+					errs = append(errs, err)
 				}
 
 				break

--- a/internal/errors/util.go
+++ b/internal/errors/util.go
@@ -82,9 +82,7 @@ func UnwrapMultiErrors(err error) []error {
 				errs = append(errs[:index], errs[index+1:]...)
 				index--
 
-				for _, err := range err.Unwrap() {
-					errs = append(errs, err)
-				}
+				errs = append(errs, err.Unwrap()...)
 
 				break
 			}

--- a/internal/os/exec/ptty_unix.go
+++ b/internal/os/exec/ptty_unix.go
@@ -22,6 +22,12 @@ import (
 // stderr is being shared.
 // NOTE: This is based on the quickstart example from https://github.com/creack/pty
 func runCommandWithPTY(logger log.Logger, cmd *exec.Cmd) (err error) {
+	cmdStdout := cmd.Stdout
+
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
 	// NOTE: in order to ensure we can return errors that occur in cleanup, we use a variable binding for the return
 	// value so that it can be updated.
 	pseudoTerminal, startErr := pty.Start(cmd)
@@ -85,7 +91,7 @@ func runCommandWithPTY(logger log.Logger, cmd *exec.Cmd) (err error) {
 	}()
 
 	// ... and the pty to stdout.
-	_, copyStdoutErr := io.Copy(cmd.Stdout, pseudoTerminal)
+	_, copyStdoutErr := io.Copy(cmdStdout, pseudoTerminal)
 	if copyStdoutErr != nil {
 		return errors.New(copyStdoutErr)
 	}

--- a/internal/os/exec/ptty_unix.go
+++ b/internal/os/exec/ptty_unix.go
@@ -4,17 +4,20 @@
 package exec
 
 import (
+	"context"
 	"io"
 	"os"
 	"os/exec"
 	"os/signal"
 	"syscall"
 
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/term"
 
 	"github.com/creack/pty"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/util"
 )
 
 // runCommandWithPTY will allocate a pseudo-tty to run the subcommand in. This is only necessary when running
@@ -30,21 +33,24 @@ func runCommandWithPTY(logger log.Logger, cmd *exec.Cmd) (err error) {
 
 	// NOTE: in order to ensure we can return errors that occur in cleanup, we use a variable binding for the return
 	// value so that it can be updated.
-	pseudoTerminal, startErr := pty.Start(cmd)
+	pseudoTerminal, err := pty.Start(cmd)
+	if err != nil {
+		return errors.New(err)
+	}
+
 	defer func() {
 		if closeErr := pseudoTerminal.Close(); closeErr != nil {
-			logger.Errorf("Error closing pty: %s", closeErr)
+			closeErr = errors.Errorf("Error closing pty: w", closeErr)
+
 			// Only overwrite the previous error if there was no error since this error has lower priority than any
 			// errors in the main routine
 			if err == nil {
-				err = errors.New(closeErr)
+				err = closeErr
+			} else {
+				logger.Error(closeErr)
 			}
 		}
 	}()
-
-	if startErr != nil {
-		return errors.New(startErr)
-	}
 
 	// Every time the current terminal size changes, we need to make sure the PTY also updates the size.
 	ch := make(chan os.Signal, 1)
@@ -53,52 +59,65 @@ func runCommandWithPTY(logger log.Logger, cmd *exec.Cmd) (err error) {
 	go func() {
 		for range ch {
 			if inheritSizeErr := pty.InheritSize(os.Stdin, pseudoTerminal); inheritSizeErr != nil {
+				inheritSizeErr = errors.Errorf("Error resizing pty: %w", inheritSizeErr)
+
 				// We don't propagate this error upstream because it does not affect normal operation of the command
-				logger.Errorf("error resizing pty: %s", inheritSizeErr)
+				logger.Error(inheritSizeErr)
 			}
 		}
 	}()
 	ch <- syscall.SIGWINCH // Make sure the pty matches current size
 
 	// Set stdin in raw mode so that we preserve readline properties
-	oldState, setRawErr := term.MakeRaw(int(os.Stdin.Fd()))
-	if setRawErr != nil {
-		return errors.New(setRawErr)
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return errors.New(err)
 	}
 
 	defer func() {
 		if restoreErr := term.Restore(int(os.Stdin.Fd()), oldState); restoreErr != nil {
-			logger.Errorf("Error restoring terminal state: %s", restoreErr)
+			restoreErr = errors.Errorf("error restoring terminal state: %w", restoreErr)
+
 			// Only overwrite the previous error if there was no error since this error has lower priority than any
 			// errors in the main routine
 			if err == nil {
-				err = errors.New(restoreErr)
+				err = restoreErr
+			} else {
+				logger.Error(restoreErr)
 			}
 		}
 	}()
 
-	stdinDone := make(chan error, 1)
-	// Copy stdin to the pty
-	go func() {
-		_, copyStdinErr := io.Copy(pseudoTerminal, os.Stdin)
-		// We don't propagate this error upstream because it does not affect normal operation of the command. A repeat
-		// of the same stdin in this case should resolve the issue.
-		if copyStdinErr != nil {
-			logger.Errorf("Error forwarding stdin: %s", copyStdinErr)
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errGroup, ctx := errgroup.WithContext(ctx)
+
+	// Copy stdout to the pty.
+	errGroup.Go(func() error {
+		defer cancel()
+
+		if _, err := util.Copy(ctx, cmdStdout, pseudoTerminal); err != nil {
+			return errors.Errorf("error forwarding stdout: %w", err)
 		}
-		// signal that stdin copy is done
-		stdinDone <- copyStdinErr
-	}()
 
-	// ... and the pty to stdout.
-	_, copyStdoutErr := io.Copy(cmdStdout, pseudoTerminal)
-	if copyStdoutErr != nil {
-		return errors.New(copyStdoutErr)
-	}
+		return nil
+	})
 
-	// Wait for stdin copy to complete before returning
-	if copyStdinErr := <-stdinDone; copyStdinErr != nil && !errors.IsError(copyStdinErr, io.EOF) {
-		logger.Errorf("Error forwarding stdin: %s", copyStdinErr)
+	// Copy stdin to the pty.
+	errGroup.Go(func() error {
+		defer cancel()
+
+		if _, err := util.Copy(ctx, pseudoTerminal, os.Stdin); err != nil {
+			return errors.Errorf("error forwarding stdin: %w", err)
+		}
+
+		return nil
+	})
+
+	if err := errGroup.Wait(); err != nil && !errors.IsError(err, io.EOF) && !errors.IsContextCanceled(err) {
+		return err
 	}
 
 	return nil

--- a/internal/os/exec/ptty_unix.go
+++ b/internal/os/exec/ptty_unix.go
@@ -40,7 +40,7 @@ func runCommandWithPTY(logger log.Logger, cmd *exec.Cmd) (err error) {
 
 	defer func() {
 		if closeErr := pseudoTerminal.Close(); closeErr != nil {
-			closeErr = errors.Errorf("Error closing pty: w", closeErr)
+			closeErr = errors.Errorf("Error closing pty: %w", closeErr)
 
 			// Only overwrite the previous error if there was no error since this error has lower priority than any
 			// errors in the main routine
@@ -89,6 +89,7 @@ func runCommandWithPTY(logger log.Logger, cmd *exec.Cmd) (err error) {
 	}()
 
 	ctx := context.Background()
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -117,7 +118,7 @@ func runCommandWithPTY(logger log.Logger, cmd *exec.Cmd) (err error) {
 	})
 
 	if err := errGroup.Wait(); err != nil && !errors.IsError(err, io.EOF) && !errors.IsContextCanceled(err) {
-		return err
+		return errors.New(err)
 	}
 
 	return nil

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -190,13 +190,14 @@ func RunShellCommandWithOutput(
 			exec.WithForwardSignalDelay(SignalForwardingDelay),
 		)
 
-		if err := cmd.Start(); err != nil {
+		if err := cmd.Start(); err != nil { //nolint:contextcheck
 			err = util.ProcessExecutionError{
 				Err:        err,
 				Args:       args,
 				Command:    command,
 				WorkingDir: cmd.Dir,
 			}
+
 			return errors.New(err)
 		}
 

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -197,7 +197,6 @@ func RunShellCommandWithOutput(
 				Command:    command,
 				WorkingDir: cmd.Dir,
 			}
-
 			return errors.New(err)
 		}
 

--- a/terraform/cache/helpers/http.go
+++ b/terraform/cache/helpers/http.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/hashicorp/go-getter/v2"
+	"github.com/gruntwork-io/terragrunt/util"
 )
 
 func Fetch(ctx context.Context, req *http.Request, dst io.Writer) error {
@@ -34,7 +34,7 @@ func Fetch(ctx context.Context, req *http.Request, dst io.Writer) error {
 		return err
 	}
 
-	if written, err := getter.Copy(ctx, dst, reader); err != nil {
+	if written, err := util.Copy(ctx, dst, reader); err != nil {
 		return errors.New(err)
 	} else if resp.ContentLength != -1 && written != resp.ContentLength {
 		return errors.Errorf("incorrect response size: expected %d bytes, but got %d bytes", resp.ContentLength, written)

--- a/util/file.go
+++ b/util/file.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/gob"
 	"io"
@@ -785,4 +786,46 @@ func FileSHA256(filePath string) ([]byte, error) {
 	}
 
 	return hash.Sum(nil), nil
+}
+
+// readerFunc is syntactic sugar for read interface.
+type readerFunc func(p []byte) (n int, err error)
+
+func (rf readerFunc) Read(p []byte) (n int, err error) { return rf(p) }
+
+// writerFunc is syntactic sugar for write interface.
+type writerFunc func(p []byte) (n int, err error)
+
+func (wf writerFunc) Write(p []byte) (n int, err error) { return wf(p) }
+
+// Copy is a io.Copy cancellable by context
+func Copy(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
+	n, err := io.Copy(
+		writerFunc(func(p []byte) (int, error) {
+			select {
+			case <-ctx.Done():
+				// context has been canceled stop process and propagate "context canceled" error
+				return 0, ctx.Err()
+			default:
+				// otherwise just run default io.Writer implementation
+				return dst.Write(p)
+			}
+		}),
+		readerFunc(func(p []byte) (int, error) {
+			select {
+			case <-ctx.Done():
+				// context has been canceled stop process and propagate "context canceled" error
+				return 0, ctx.Err()
+			default:
+				// otherwise just run default io.Reader implementation
+				return src.Read(p)
+			}
+		}),
+	)
+
+	if err != nil {
+		err = errors.New(err)
+	}
+
+	return n, err
 }

--- a/util/file.go
+++ b/util/file.go
@@ -789,36 +789,36 @@ func FileSHA256(filePath string) ([]byte, error) {
 }
 
 // readerFunc is syntactic sugar for read interface.
-type readerFunc func(p []byte) (n int, err error)
+type readerFunc func(data []byte) (int, error)
 
-func (rf readerFunc) Read(p []byte) (n int, err error) { return rf(p) }
+func (rf readerFunc) Read(data []byte) (int, error) { return rf(data) }
 
 // writerFunc is syntactic sugar for write interface.
-type writerFunc func(p []byte) (n int, err error)
+type writerFunc func(data []byte) (int, error)
 
-func (wf writerFunc) Write(p []byte) (n int, err error) { return wf(p) }
+func (wf writerFunc) Write(data []byte) (int, error) { return wf(data) }
 
-// Copy is a io.Copy cancellable by context
+// Copy is a io.Copy cancellable by context.
 func Copy(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
-	n, err := io.Copy(
-		writerFunc(func(p []byte) (int, error) {
+	num, err := io.Copy(
+		writerFunc(func(data []byte) (int, error) {
 			select {
 			case <-ctx.Done():
-				// context has been canceled stop process and propagate "context canceled" error
+				// context has been canceled stop process and propagate "context canceled" error.
 				return 0, ctx.Err()
 			default:
-				// otherwise just run default io.Writer implementation
-				return dst.Write(p)
+				// otherwise just run default io.Writer implementation.
+				return dst.Write(data)
 			}
 		}),
-		readerFunc(func(p []byte) (int, error) {
+		readerFunc(func(data []byte) (int, error) {
 			select {
 			case <-ctx.Done():
-				// context has been canceled stop process and propagate "context canceled" error
+				// context has been canceled stop process and propagate "context canceled" error.
 				return 0, ctx.Err()
 			default:
-				// otherwise just run default io.Reader implementation
-				return src.Read(p)
+				// otherwise just run default io.Reader implementation.
+				return src.Read(data)
 			}
 		}),
 	)
@@ -827,5 +827,5 @@ func Copy(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
 		err = errors.New(err)
 	}
 
-	return n, err
+	return num, err
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3507.

The PR also fixed the error message `error forwarding stdin: write /dev/ptmx: input/output error` that was always displayed when exiting the console.


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

