### PR TITLE
chore: update website header

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,9 +5,9 @@
     </head>
     <body{% if page.slug %} class="{{ page.slug }}{% if page.slug != 'index-page' and page.slug !='how-it-works' and page.slug != 'guides' %} sub-page{% endif %}" {% endif %}>
         {% include banner.html
-            text="✨&nbsp;&nbsp;Terragrunt v0.52.0 now supports OpenTofu."
-            link_url="https://github.com/gruntwork-io/terragrunt/releases/tag/v0.52.0"
-            link_text="View release notes"
+            text="✨&nbsp;&nbsp;Read The Road to Terragrunt 1.0 "
+            link_url="https://blog.gruntwork.io/the-road-to-terragrunt-1-0-4d5a0b416086"
+            link_text="Blog Post"
             target="_blank"
             has_button=false
         %}


### PR DESCRIPTION
Advertise the 1.0 blog post on the terragrunt main website

![image](https://github.com/user-attachments/assets/51756050-ce43-424c-8c98-f01ddcf79fae)
