### PR TITLE
[WIP] feat: add encryption block

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1384,3 +1384,70 @@ func BenchmarkReadTerragruntConfig(b *testing.B) {
 		})
 	}
 }
+func TestParseTerragruntConfigEncryptionMinimalConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+encryption {
+  config  = {}
+}
+`
+
+	ctx := config.NewParsingContext(context.Background(), mockOptionsForTest(t))
+	terragruntConfig, err := config.ParseConfigString(ctx, config.DefaultTerragruntConfigPath, cfg, nil)
+	require.NoError(t, err)
+
+	assert.Nil(t, terragruntConfig.Terraform)
+
+	assert.Empty(t, terragruntConfig.IamRole)
+
+	if assert.NotNil(t, terragruntConfig.Encryption) {
+		assert.Empty(t, terragruntConfig.Encryption.Config)
+	}
+}
+
+func TestParseTerragruntConfigEncryptionAttrMinimalConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+encryption = {
+  config  = {}
+}
+`
+
+	ctx := config.NewParsingContext(context.Background(), mockOptionsForTest(t))
+	terragruntConfig, err := config.ParseConfigString(ctx, config.DefaultTerragruntConfigPath, cfg, nil)
+	require.NoError(t, err)
+
+	assert.Nil(t, terragruntConfig.Terraform)
+
+	assert.Empty(t, terragruntConfig.IamRole)
+
+	if assert.NotNil(t, terragruntConfig.Encryption) {
+		assert.Empty(t, terragruntConfig.Encryption.Config)
+	}
+}
+
+func TestParseTerragruntJsonConfigEncryptionMinimalConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+{
+	"encryption": {
+		"config": {}
+	}
+}
+`
+
+	ctx := config.NewParsingContext(context.Background(), mockOptionsForTest(t))
+	terragruntConfig, err := config.ParseConfigString(ctx, config.DefaultTerragruntJSONConfigPath, cfg, nil)
+	require.NoError(t, err)
+
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.RetryableErrors)
+	assert.Empty(t, terragruntConfig.IamRole)
+
+	if assert.NotNil(t, terragruntConfig.Encryption) {
+		assert.Empty(t, terragruntConfig.Encryption.Config)
+	}
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3495.

<!-- Description of the changes introduced by this PR. -->

## TODOs

This is a raw draft! I tried to add a `encryption` block to the config, that is handled in a similar way to the `remote_state` block to solve #3495 .

But, as stated in the issue, I have very limited experience with Go and have never worked with neither the `hcl` nor `cty` package. 

Any help is highly appreciated!

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

