### PR TITLE
Add provider cache offline errors handling 

### DIFF
--- a/terraform/cache/handlers/provider.go
+++ b/terraform/cache/handlers/provider.go
@@ -4,6 +4,8 @@ package handlers
 import (
 	"context"
 	liberrors "errors"
+	"fmt"
+	"strings"
 	"syscall"
 
 	"github.com/gruntwork-io/terragrunt/terraform/cache/models"
@@ -34,6 +36,10 @@ var availablePlatforms []*models.Platform = []*models.Platform{
 var offlineErrors = []error{
 	syscall.ECONNREFUSED,
 	syscall.ECONNRESET,
+	syscall.ECONNABORTED,
+	syscall.EHOSTUNREACH,
+	syscall.ENETUNREACH,
+	syscall.ENETDOWN,
 }
 
 // ProviderHandlers is a slice of ProviderHandler.
@@ -145,9 +151,9 @@ func isOfflineError(err error) bool {
 	if liberrors.As(err, &NotFoundWellKnownURL{}) {
 		return true
 	}
-
 	for _, connErr := range offlineErrors {
-		if liberrors.Is(err, connErr) {
+		fmt.Printf("err: %v, connErr: %v\n", err, connErr)
+		if liberrors.Is(err, connErr) || strings.Contains(err.Error(), connErr.Error()) {
 			return true
 		}
 	}

--- a/terraform/cache/handlers/provider.go
+++ b/terraform/cache/handlers/provider.go
@@ -130,7 +130,7 @@ func (handler *CommonProviderHandler) DiscoveryURL(ctx context.Context, registry
 
 	urls, err := DiscoveryURL(ctx, registryName)
 	if err != nil {
-		if !isOfflineError(err) {
+		if !IsOfflineError(err) {
 			return nil, err
 		}
 
@@ -145,8 +145,8 @@ func (handler *CommonProviderHandler) DiscoveryURL(ctx context.Context, registry
 	return urls, nil
 }
 
-// isOfflineError returns true if the given error is an offline error and can be use default URL.
-func isOfflineError(err error) bool {
+// IsOfflineError returns true if the given error is an offline error and can be use default URL.
+func IsOfflineError(err error) bool {
 	if liberrors.As(err, &NotFoundWellKnownURL{}) {
 		return true
 	}

--- a/terraform/cache/handlers/provider.go
+++ b/terraform/cache/handlers/provider.go
@@ -150,10 +150,12 @@ func isOfflineError(err error) bool {
 	if liberrors.As(err, &NotFoundWellKnownURL{}) {
 		return true
 	}
+
 	for _, connErr := range offlineErrors {
 		if liberrors.Is(err, connErr) || strings.Contains(err.Error(), connErr.Error()) {
 			return true
 		}
 	}
+
 	return false
 }

--- a/terraform/cache/handlers/provider.go
+++ b/terraform/cache/handlers/provider.go
@@ -4,7 +4,6 @@ package handlers
 import (
 	"context"
 	liberrors "errors"
-	"fmt"
 	"strings"
 	"syscall"
 
@@ -152,7 +151,6 @@ func isOfflineError(err error) bool {
 		return true
 	}
 	for _, connErr := range offlineErrors {
-		fmt.Printf("err: %v, connErr: %v\n", err, connErr)
 		if liberrors.Is(err, connErr) || strings.Contains(err.Error(), connErr.Error()) {
 			return true
 		}

--- a/terraform/cache/handlers/provider_test.go
+++ b/terraform/cache/handlers/provider_test.go
@@ -26,6 +26,7 @@ func TestIsOfflineError(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			result := isOfflineError(tc.err)
 			assert.Equal(t, tc.expected, result, "Expected result for %v is %v", tc.desc, tc.expected)
 		})

--- a/terraform/cache/handlers/provider_test.go
+++ b/terraform/cache/handlers/provider_test.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsOfflineError(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		err      error
+		expected bool
+		desc     string
+	}{
+		{syscall.ECONNREFUSED, true, "connection refused"},
+		{syscall.ECONNRESET, true, "connection reset by peer"},
+		{syscall.ECONNABORTED, true, "connection aborted"},
+		{syscall.ENETUNREACH, true, "network is unreachable"},
+		{errors.New("get \"https://registry.terraform.io/.well-known/terraform.json\": dial tcp: lookup registry.terraform.io on 185.12.64.1:53: dial udp 185.12.64.1:53: connect: network is unreachable"), true, "network is unreachable"},
+		{errors.New("get \"https://registry.terraform.io/.well-known/terraform.json\": read tcp 10.10.230.10:58328->10.245.10.15:443: read: connection reset by peer"), true, "network is unreachable"},
+		{errors.New("random error"), false, "a random error that should not be offline"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := isOfflineError(tc.err)
+			assert.Equal(t, tc.expected, result, "Expected result for %v is %v", tc.desc, tc.expected)
+		})
+	}
+}

--- a/terraform/cache/handlers/provider_test.go
+++ b/terraform/cache/handlers/provider_test.go
@@ -2,9 +2,10 @@ package handlers_test
 
 import (
 	"errors"
-	"github.com/gruntwork-io/terragrunt/terraform/cache/handlers"
 	"syscall"
 	"testing"
+
+	"github.com/gruntwork-io/terragrunt/terraform/cache/handlers"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/terraform/cache/handlers/provider_test.go
+++ b/terraform/cache/handlers/provider_test.go
@@ -1,7 +1,8 @@
-package handlers
+package handlers_test
 
 import (
 	"errors"
+	"github.com/gruntwork-io/terragrunt/terraform/cache/handlers"
 	"syscall"
 	"testing"
 
@@ -27,7 +28,7 @@ func TestIsOfflineError(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			result := isOfflineError(tc.err)
+			result := handlers.IsOfflineError(tc.err)
 			assert.Equal(t, tc.expected, result, "Expected result for %v is %v", tc.desc, tc.expected)
 		})
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This pull request introduces improvements to the provider caching mechanism, specifically targeting scenarios where the system is offline or in an air-gapped environment. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Improved offline error detection in the provider cache to handle air-gapped environments.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

