### PR TITLE
Introducing Terragrunt Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![GoDoc](https://godoc.org/github.com/gruntwork-io/terragrunt?status.svg)](https://godoc.org/github.com/gruntwork-io/terragrunt)
 ![OpenTofu Version](https://img.shields.io/badge/tofu-%3E%3D1.6.0-blue.svg)
 ![Terraform Version](https://img.shields.io/badge/tf-%3E%3D0.12.0-blue.svg)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Terragrunt%20Guru-006BFF)](https://gurubase.io/g/terragrunt)
 
 Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in [OpenTofu](https://opentofu.org)/[Terraform](https://www.terraform.io) to scale.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Terragrunt Guru](https://gurubase.io/g/terragrunt) to Gurubase. Terragrunt Guru uses the data from this repo and data from the [docs](https://terragrunt.gruntwork.io/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Terragrunt Guru", which highlights that Terragrunt now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Terragrunt Guru in Gurubase, just let me know that's totally fine.
