### PR TITLE
Implement terragrunt-dont-check-dependent-modules flag

### DIFF
--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -127,8 +127,8 @@ const (
 	TerragruntJSONOutDirFlagEnvName = "TERRAGRUNT_JSON_OUT_DIR"
 	TerragruntJSONOutDirFlagName    = "terragrunt-json-out-dir"
 
-	TerragruntNoCheckDependentModulesFlagEnvName = "TERRAGRUNT_NO_CHECK_DEPENDENT_MODULES"
-	TerragruntNoCheckDependentModulesFlagName    = "terragrunt-no-check-dependent-modules"
+	TerragruntNoDestroyDependenciesCheckFlagEnvName = "TERRAGRUNT_NO_DESTROY_DEPENDENCIES_CHECK"
+	TerragruntNoDestroyDependenciesCheckFlagName    = "terragrunt-no-destroy-dependencies-check"
 
 	// Logs related flags/envs
 
@@ -469,9 +469,9 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 			Usage:       "When this flag is set, Terragrunt will not validate the terraform command.",
 		},
 		&cli.BoolFlag{
-			Name:        TerragruntNoCheckDependentModulesFlagName,
-			EnvVar:      TerragruntNoCheckDependentModulesFlagEnvName,
-			Destination: &opts.NoCheckDependentModules,
+			Name:        TerragruntNoDestroyDependenciesCheckFlagName,
+			EnvVar:      TerragruntNoDestroyDependenciesCheckFlagEnvName,
+			Destination: &opts.NoDestroyDependenciesCheck,
 			Usage:       "When this flag is set, Terragrunt will not check for dependent modules when destroying.",
 		},
 		// Strict Mode flags

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -127,6 +127,9 @@ const (
 	TerragruntJSONOutDirFlagEnvName = "TERRAGRUNT_JSON_OUT_DIR"
 	TerragruntJSONOutDirFlagName    = "terragrunt-json-out-dir"
 
+	TerragruntDontCheckDependentModulesFlagEnvName = "TERRAGRUNT_DONT_CHECK_DEPENDENT_MODULES"
+	TerragruntDontCheckDependentModulesFlagName    = "terragrunt-dont-check-dependent-modules"
+
 	// Logs related flags/envs
 
 	TerragruntLogLevelFlagName = "terragrunt-log-level"
@@ -464,6 +467,12 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 			EnvVar:      TerragruntDisableCommandValidationEnvName,
 			Destination: &opts.DisableCommandValidation,
 			Usage:       "When this flag is set, Terragrunt will not validate the terraform command.",
+		},
+		&cli.BoolFlag{
+			Name:        TerragruntDontCheckDependentModulesFlagName,
+			EnvVar:      TerragruntDontCheckDependentModulesFlagEnvName,
+			Destination: &opts.DontCheckDependentModules,
+			Usage:       "When this flag is set, Terragrunt will not check for dependent modules when destroying.",
 		},
 		// Strict Mode flags
 		&cli.BoolFlag{

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -127,8 +127,8 @@ const (
 	TerragruntJSONOutDirFlagEnvName = "TERRAGRUNT_JSON_OUT_DIR"
 	TerragruntJSONOutDirFlagName    = "terragrunt-json-out-dir"
 
-	TerragruntDontCheckDependentModulesFlagEnvName = "TERRAGRUNT_DONT_CHECK_DEPENDENT_MODULES"
-	TerragruntDontCheckDependentModulesFlagName    = "terragrunt-dont-check-dependent-modules"
+	TerragruntNoCheckDependentModulesFlagEnvName = "TERRAGRUNT_NO_CHECK_DEPENDENT_MODULES"
+	TerragruntNoCheckDependentModulesFlagName    = "terragrunt-no-check-dependent-modules"
 
 	// Logs related flags/envs
 
@@ -469,9 +469,9 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 			Usage:       "When this flag is set, Terragrunt will not validate the terraform command.",
 		},
 		&cli.BoolFlag{
-			Name:        TerragruntDontCheckDependentModulesFlagName,
-			EnvVar:      TerragruntDontCheckDependentModulesFlagEnvName,
-			Destination: &opts.DontCheckDependentModules,
+			Name:        TerragruntNoCheckDependentModulesFlagName,
+			EnvVar:      TerragruntNoCheckDependentModulesFlagEnvName,
+			Destination: &opts.NoCheckDependentModules,
 			Usage:       "When this flag is set, Terragrunt will not check for dependent modules when destroying.",
 		},
 		// Strict Mode flags

--- a/cli/commands/terraform/command.go
+++ b/cli/commands/terraform/command.go
@@ -32,7 +32,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 func Action(opts *options.TerragruntOptions) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
 		if opts.TerraformCommand == terraform.CommandNameDestroy {
-			opts.CheckDependentModules = !opts.NoCheckDependentModules
+			opts.CheckDependentModules = !opts.NoDestroyDependenciesCheck
 		}
 
 		if !opts.DisableCommandValidation && !collections.ListContainsElement(nativeTerraformCommands, opts.TerraformCommand) {

--- a/cli/commands/terraform/command.go
+++ b/cli/commands/terraform/command.go
@@ -32,7 +32,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 func Action(opts *options.TerragruntOptions) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
 		if opts.TerraformCommand == terraform.CommandNameDestroy {
-			opts.CheckDependentModules = !opts.DontCheckDependentModules
+			opts.CheckDependentModules = !opts.NoCheckDependentModules
 		}
 
 		if !opts.DisableCommandValidation && !collections.ListContainsElement(nativeTerraformCommands, opts.TerraformCommand) {

--- a/cli/commands/terraform/command.go
+++ b/cli/commands/terraform/command.go
@@ -32,7 +32,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 func Action(opts *options.TerragruntOptions) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
 		if opts.TerraformCommand == terraform.CommandNameDestroy {
-			opts.CheckDependentModules = true
+			opts.CheckDependentModules = !opts.DontCheckDependentModules
 		}
 
 		if !opts.DisableCommandValidation && !collections.ListContainsElement(nativeTerraformCommands, opts.TerraformCommand) {

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -89,7 +89,7 @@ This page documents the CLI commands and options available with Terragrunt:
   - [terragrunt-json-out-dir](#terragrunt-json-out-dir)
   - [terragrunt-disable-log-formatting](#terragrunt-disable-log-formatting)
   - [terragrunt-forward-tf-stdout](#terragrunt-forward-tf-stdout)
-  - [terragrunt-no-check-dependent-modules](#terragrunt-no-check-dependent-modules)
+  - [terragrunt-no-destroy-dependencies-check](#terragrunt-no-destroy-dependencies-check)
 
 ## CLI commands
 
@@ -794,7 +794,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
   - [terragrunt-json-out-dir](#terragrunt-json-out-dir)
   - [terragrunt-disable-log-formatting](#terragrunt-disable-log-formatting)
   - [terragrunt-forward-tf-stdout](#terragrunt-forward-tf-stdout)
-  - [terragrunt-no-check-dependent-modules](#terragrunt-no-check-dependent-modules)
+  - [terragrunt-no-destroy-dependencies-check](#terragrunt-no-destroy-dependencies-check)
 
 ### terragrunt-config
 
@@ -1525,9 +1525,9 @@ plan. Resource actions are indicated with the following symbols:
 OpenTofu will perform the following actions:
 ```
 
-### terragrunt-dont-check-dependent-modules
+### terragrunt-no-destroy-dependencies-check
 
-**CLI Arg**: `--terragrunt-no-check-dependent-modules`<br/>
-**Environment Variable**: `TERRAGRUNT_NO_CHECK_DEPENDENT_MODULES`<br/>
+**CLI Arg**: `--terragrunt-no-destroy-dependencies-check`<br/>
+**Environment Variable**: `TERRAGRUNT_NO_DESTROY_DEPENDENCIES_CHECK`<br/>
 
 If specified, Terragrunt will not check dependent modules when running `destroy` command. By default, Terragrunt checks dependent modules when running `destroy` command.

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -89,6 +89,7 @@ This page documents the CLI commands and options available with Terragrunt:
   - [terragrunt-json-out-dir](#terragrunt-json-out-dir)
   - [terragrunt-disable-log-formatting](#terragrunt-disable-log-formatting)
   - [terragrunt-forward-tf-stdout](#terragrunt-forward-tf-stdout)
+  - [terragrunt-dont-check-dependent-modules](#terragrunt-dont-check-dependent-modules)
 
 ## CLI commands
 
@@ -793,6 +794,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
   - [terragrunt-json-out-dir](#terragrunt-json-out-dir)
   - [terragrunt-disable-log-formatting](#terragrunt-disable-log-formatting)
   - [terragrunt-forward-tf-stdout](#terragrunt-forward-tf-stdout)
+  - [terragrunt-dont-check-dependent-modules](#terragrunt-dont-check-dependent-modules)
 
 ### terragrunt-config
 
@@ -1522,3 +1524,10 @@ plan. Resource actions are indicated with the following symbols:
 
 OpenTofu will perform the following actions:
 ```
+
+### terragrunt-dont-check-dependent-modules
+
+**CLI Arg**: `--terragrunt-dont-check-dependent-modules`<br/>
+**Environment Variable**: `TERRAGRUNT_DONT_CHECK_DEPENDENT_MODULES`<br/>
+
+If specified, Terragrunt will not check dependent modules when running `destroy` command. By default, Terragrunt checks dependent modules when running `destroy` command.

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -89,7 +89,7 @@ This page documents the CLI commands and options available with Terragrunt:
   - [terragrunt-json-out-dir](#terragrunt-json-out-dir)
   - [terragrunt-disable-log-formatting](#terragrunt-disable-log-formatting)
   - [terragrunt-forward-tf-stdout](#terragrunt-forward-tf-stdout)
-  - [terragrunt-dont-check-dependent-modules](#terragrunt-dont-check-dependent-modules)
+  - [terragrunt-no-check-dependent-modules](#terragrunt-no-check-dependent-modules)
 
 ## CLI commands
 
@@ -794,7 +794,7 @@ prefix `--terragrunt-` (e.g., `--terragrunt-config`). The currently available op
   - [terragrunt-json-out-dir](#terragrunt-json-out-dir)
   - [terragrunt-disable-log-formatting](#terragrunt-disable-log-formatting)
   - [terragrunt-forward-tf-stdout](#terragrunt-forward-tf-stdout)
-  - [terragrunt-dont-check-dependent-modules](#terragrunt-dont-check-dependent-modules)
+  - [terragrunt-no-check-dependent-modules](#terragrunt-no-check-dependent-modules)
 
 ### terragrunt-config
 
@@ -1527,7 +1527,7 @@ OpenTofu will perform the following actions:
 
 ### terragrunt-dont-check-dependent-modules
 
-**CLI Arg**: `--terragrunt-dont-check-dependent-modules`<br/>
-**Environment Variable**: `TERRAGRUNT_DONT_CHECK_DEPENDENT_MODULES`<br/>
+**CLI Arg**: `--terragrunt-no-check-dependent-modules`<br/>
+**Environment Variable**: `TERRAGRUNT_NO_CHECK_DEPENDENT_MODULES`<br/>
 
 If specified, Terragrunt will not check dependent modules when running `destroy` command. By default, Terragrunt checks dependent modules when running `destroy` command.

--- a/options/options.go
+++ b/options/options.go
@@ -264,7 +264,7 @@ type TerragruntOptions struct {
 	CheckDependentModules bool
 
 	// True if is required not to show dependent modules and confirm action
-	DontCheckDependentModules bool
+	NoCheckDependentModules bool
 
 	// This is an experimental feature, used to speed up dependency processing by getting the output from the state
 	FetchDependencyOutputFromState bool
@@ -589,7 +589,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) (*TerragruntOp
 		JSONLogFormat:                  opts.JSONLogFormat,
 		Check:                          opts.Check,
 		CheckDependentModules:          opts.CheckDependentModules,
-		DontCheckDependentModules:      opts.DontCheckDependentModules,
+		NoCheckDependentModules:        opts.NoCheckDependentModules,
 		FetchDependencyOutputFromState: opts.FetchDependencyOutputFromState,
 		UsePartialParseConfigCache:     opts.UsePartialParseConfigCache,
 		ForwardTFStdout:                opts.ForwardTFStdout,

--- a/options/options.go
+++ b/options/options.go
@@ -264,7 +264,7 @@ type TerragruntOptions struct {
 	CheckDependentModules bool
 
 	// True if is required not to show dependent modules and confirm action
-	NoCheckDependentModules bool
+	NoDestroyDependenciesCheck bool
 
 	// This is an experimental feature, used to speed up dependency processing by getting the output from the state
 	FetchDependencyOutputFromState bool
@@ -589,7 +589,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) (*TerragruntOp
 		JSONLogFormat:                  opts.JSONLogFormat,
 		Check:                          opts.Check,
 		CheckDependentModules:          opts.CheckDependentModules,
-		NoCheckDependentModules:        opts.NoCheckDependentModules,
+		NoDestroyDependenciesCheck:     opts.NoDestroyDependenciesCheck,
 		FetchDependencyOutputFromState: opts.FetchDependencyOutputFromState,
 		UsePartialParseConfigCache:     opts.UsePartialParseConfigCache,
 		ForwardTFStdout:                opts.ForwardTFStdout,

--- a/options/options.go
+++ b/options/options.go
@@ -263,6 +263,9 @@ type TerragruntOptions struct {
 	// True if is required to show dependent modules and confirm action
 	CheckDependentModules bool
 
+	// True if is required not to show dependent modules and confirm action
+	DontCheckDependentModules bool
+
 	// This is an experimental feature, used to speed up dependency processing by getting the output from the state
 	FetchDependencyOutputFromState bool
 
@@ -586,6 +589,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) (*TerragruntOp
 		JSONLogFormat:                  opts.JSONLogFormat,
 		Check:                          opts.Check,
 		CheckDependentModules:          opts.CheckDependentModules,
+		DontCheckDependentModules:      opts.DontCheckDependentModules,
 		FetchDependencyOutputFromState: opts.FetchDependencyOutputFromState,
 		UsePartialParseConfigCache:     opts.UsePartialParseConfigCache,
 		ForwardTFStdout:                opts.ForwardTFStdout,

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -153,6 +153,17 @@ func TestShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
 	output := stderr.String()
 	assert.Equal(t, 1, strings.Count(output, appV1Path))
 	assert.Equal(t, 1, strings.Count(output, appV2Path))
+
+	// try to destroy vpc module and check if warning is not printed in output
+	stdout = bytes.Buffer{}
+	stderr = bytes.Buffer{}
+
+	err = runTerragruntCommand(t, "terragrunt destroy --terragrunt-non-interactive --terragrunt-dont-check-dependent-modules --terragrunt-working-dir "+vpcPath, &stdout, &stderr)
+	require.NoError(t, err)
+
+	outputDontCheck := stderr.String()
+	assert.Equal(t, 0, strings.Count(outputDontCheck, appV1Path))
+	assert.Equal(t, 0, strings.Count(outputDontCheck, appV2Path))
 }
 
 func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -153,17 +153,39 @@ func TestShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
 	output := stderr.String()
 	assert.Equal(t, 1, strings.Count(output, appV1Path))
 	assert.Equal(t, 1, strings.Count(output, appV2Path))
+}
+
+func TestNoShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
+	t.Parallel()
+
+	rootPath := copyEnvironment(t, testFixtureDestroyWarning)
+
+	rootPath = util.JoinPath(rootPath, testFixtureDestroyWarning)
+	vpcPath := util.JoinPath(rootPath, "vpc")
+	appV1Path := util.JoinPath(rootPath, "app-v1")
+	appV2Path := util.JoinPath(rootPath, "app-v2")
+
+	cleanupTerraformFolder(t, rootPath)
+	cleanupTerraformFolder(t, vpcPath)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := runTerragruntCommand(t, "terragrunt run-all init --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
+	require.NoError(t, err)
+	err = runTerragruntCommand(t, "terragrunt run-all apply --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &stdout, &stderr)
+	require.NoError(t, err)
 
 	// try to destroy vpc module and check if warning is not printed in output
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
 
-	err = runTerragruntCommand(t, "terragrunt destroy --terragrunt-non-interactive --terragrunt-dont-check-dependent-modules --terragrunt-working-dir "+vpcPath, &stdout, &stderr)
+	err = runTerragruntCommand(t, "terragrunt destroy --terragrunt-non-interactive --terragrunt-no-check-dependent-modules --terragrunt-working-dir "+vpcPath, &stdout, &stderr)
 	require.NoError(t, err)
 
-	outputDontCheck := stderr.String()
-	assert.Equal(t, 0, strings.Count(outputDontCheck, appV1Path))
-	assert.Equal(t, 0, strings.Count(outputDontCheck, appV2Path))
+	output := stderr.String()
+	assert.Equal(t, 0, strings.Count(output, appV1Path))
+	assert.Equal(t, 0, strings.Count(output, appV2Path))
 }
 
 func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -180,7 +180,7 @@ func TestNoShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
 
-	err = runTerragruntCommand(t, "terragrunt destroy --terragrunt-non-interactive --terragrunt-no-check-dependent-modules --terragrunt-working-dir "+vpcPath, &stdout, &stderr)
+	err = runTerragruntCommand(t, "terragrunt destroy --terragrunt-non-interactive --terragrunt-no-destroy-dependencies-check --terragrunt-working-dir "+vpcPath, &stdout, &stderr)
 	require.NoError(t, err)
 
 	output := stderr.String()


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3526.

<!-- Description of the changes introduced by this PR. -->

This PR implements:
- **--terragrunt-dont-check-dependent-modules** command line argument
- **TERRAGRUNT_DONT_CHECK_DEPENDENT_MODULES** environment variable

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added [terragrunt-dont-check-dependent-modules] command line argument and environment variable.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
There are no incompatible changes, without providing cmd argument or env variable, everything remains the same.
