### PR TITLE
Fix for CVE-2024-0406, GHSA-rhh4-rh7c-7r5v: Bump anchore/archiver version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/labstack/echo/v4 v4.11.4
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/mholt/archiver/v3 v3.5.1
+	github.com/mholt/archiver/v3 v3.5.2
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
## Description

Bumps dependency 'anchore/archiver' from v3.5.1 to v3.5.2, to remediate CVE-2024-0406, GHSA-rhh4-rh7c-7r5v. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Fix for CVE-2024-0406, GHSA-rhh4-rh7c-7r5v, by upgrading 'anchore/archiver' to v3.5.2.

### Migration Guide


