### PR TITLE
feat: support discovery of symlinked modules

### DIFF
--- a/cli/commands/catalog/module/repo.go
+++ b/cli/commands/catalog/module/repo.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/gruntwork-io/terragrunt/util"
+
 	"github.com/gitsight/go-vcsurl"
 	"github.com/gruntwork-io/go-commons/files"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
@@ -82,7 +84,7 @@ func (repo *Repo) FindModules(ctx context.Context) (Modules, error) {
 			continue
 		}
 
-		err := filepath.Walk(modulesPath,
+		err := util.WalkWithSymlinks(modulesPath,
 			func(dir string, remote os.FileInfo, err error) error {
 				if err != nil {
 					return err

--- a/config/config.go
+++ b/config/config.go
@@ -650,7 +650,7 @@ func GetDefaultConfigPath(workingDir string) string {
 func FindConfigFilesInPath(rootPath string, terragruntOptions *options.TerragruntOptions) ([]string, error) {
 	configFiles := []string{}
 
-	err := filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
+	err := util.WalkWithSymlinks(rootPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/terraform/source.go
+++ b/terraform/source.go
@@ -58,7 +58,7 @@ func (src Source) EncodeSourceVersion() (string, error) {
 		sourceHash := sha256.New()
 		sourceDir := filepath.Clean(src.CanonicalSourceURL.Path)
 
-		err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		err := util.WalkWithSymlinks(sourceDir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				// If we've encountered an error while walking the tree, give up
 				return err

--- a/test/fixtures/stack/disjoint-symlinks/a/terragrunt.hcl
+++ b/test/fixtures/stack/disjoint-symlinks/a/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "../module"
+}

--- a/test/fixtures/stack/disjoint-symlinks/module/main.tf
+++ b/test/fixtures/stack/disjoint-symlinks/module/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "a" {}
+
+output "a" {
+  value = null_resource.a.id
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #1611.

<!-- Description of the changes introduced by this PR. -->
This PR continues the work that was started by @aslafy-z in the staled #3101 PR as following:
- It adds a `WalkWithSymlinks` function to the `util` package, here is the reason for having it's own implementation in the Terragrunt codebase:
  -  the [facebookgo/symwalk](https://pkg.go.dev/github.com/facebookgo/symwalk) implementation is the closest one for Terragrunt's use case, however that library is archived and the license does not adhere to Terragrunt's rules, it also does not handle circular symlinks.
  - the [edwardrf/symwalk](https://github.com/edwardrf/symwalk) implementation does handle circular symlinks, but it does not allow walking the full logical folder structure, therefore the end result provided by it won't match the expectations of this issue.
  - It is also important to clarify the usage of the `edwardrf/symwalk` on the original implementation was working only because the usage of `helpers.CopyEnvironment` in the tests, was resolving copying and symlinks statically, and not really preserving it on the temporary env path, which defeats the purpose of test and does not mimic what terragrunt will be doing when running targeting a real directory with symlinks directly into it, this issue was addressed in my tests and a comment regarding to it was left in the codebase.
- The integration tests are also adding some tests regarding to `.terragrunt-cache` invalidation, which was one of the concerns added by @denis256 https://github.com/gruntwork-io/terragrunt/pull/3101#issuecomment-2313224375

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added support for discovery of symlinked modules


