### PR TITLE
feat: Integrate includes into units reading

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -441,14 +441,18 @@ func (modules TerraformModules) flagIncludedDirs(opts *options.TerragruntOptions
 // flagUnitsThatAreIncluded iterates over a module slice and flags all modules that include at least one file in
 // the specified include list on the TerragruntOptions ModulesThatInclude attribute.
 func (modules TerraformModules) flagUnitsThatAreIncluded(opts *options.TerragruntOptions) (TerraformModules, error) {
-	// If no ModulesThatInclude is specified return the modules list instantly
-	if len(opts.ModulesThatInclude) == 0 {
+	// The two flags ModulesThatInclude and UnitsReading should both be considered when determining which
+	// units to include in the run queue.
+	unitsThatInclude := append(opts.ModulesThatInclude, opts.UnitsReading...)
+
+	// If no unitsThatInclude is specified return the modules list instantly
+	if len(unitsThatInclude) == 0 {
 		return modules, nil
 	}
 
 	modulesThatIncludeCanonicalPaths := []string{}
 
-	for _, includePath := range opts.ModulesThatInclude {
+	for _, includePath := range unitsThatInclude {
 		canonicalPath, err := util.CanonicalPath(includePath, opts.WorkingDir)
 		if err != nil {
 			return nil, err

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -1288,8 +1288,11 @@ and then will apply this filter on the set of modules that it found.
 You can pass this argument in multiple times to provide a list of include files to consider. When multiple files are
 passed in, the set will be the union of modules that includes at least one of the files in the list.
 
-NOTE: When using relative paths, the paths are relative to the working directory. This is either the current working
+**NOTE**: When using relative paths, the paths are relative to the working directory. This is either the current working
 directory, or any path passed in to [terragrunt-working-dir](#terragrunt-working-dir).
+
+**TIP**: This flag is functionally covered by the `--terragrunt-queue-include-units-reading` flag, but is more explicitly
+only for the `include` configuration block.
 
 ### terragrunt-queue-include-units-reading
 
@@ -1304,11 +1307,11 @@ directory, or any path passed in to [terragrunt-working-dir](#terragrunt-working
 - [destroy-all (DEPRECATED: use run-all)](#destroy-all-deprecated-use-run-all)
 - [validate-all (DEPRECATED: use run-all)](#validate-all-deprecated-use-run-all)
 
-This flag works very similarly to the `--terragrunt-modules-that-include` flag, but instead of looking for included configurations,
-it instead looks for configurations that read a given file.
+This flag works very similarly to the `--terragrunt-modules-that-include` flag, but instead of looking only for included configurations,
+it also looks for configurations that read a given file.
 
 When passed in, the `*-all` commands will include all units (modules) that read a given file into the queue. This is useful
-when you want to trigger an update on all units that read a given file using HCL functions in their configurations.
+when you want to trigger an update on all units that read or include a given file using HCL functions in their configurations.
 
 Consider the following folder structure:
 

--- a/test/fixtures/units-reading/including/terragrunt.hcl
+++ b/test/fixtures/units-reading/including/terragrunt.hcl
@@ -1,0 +1,3 @@
+include "shared" {
+	path = find_in_parent_folders("shared.hcl")
+}


### PR DESCRIPTION
## Description

Integrates the logic from `--terragrunt-modules-that-include` into `--terragrunt-queue-include-units-reading`.

Upon starting integration into Gruntwork Pipelines, it was discovered that there wasn't really a purpose to having two separate flags for this functionality. The `--terragrunt-modules-that-include` flag can remain supported for backwards compatibility and to ensure that users can still use it if they specifically want to include only the units that include particular configurations.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `--terragrunt-queue-include-units-reading` to include the inclusion logic from `--terragrunt-modules-that-include`.

