### PR TITLE
feat: Improving the quick start experience

### DIFF
--- a/docs/_docs/01_getting-started/add-to-existing-project.md
+++ b/docs/_docs/01_getting-started/add-to-existing-project.md
@@ -1,0 +1,459 @@
+---
+layout: collection-browser-doc
+title: Add to Existing Project
+category: getting-started
+excerpt: Add Terragrunt to an existing OpenTofu/Terraform project.
+tags: ["tofu", "opentofu", "terraform", "tf"]
+order: 105
+nav_title: Documentation
+nav_title_link: /docs/
+---
+
+## Add `terragrunt.hcl` to your project
+
+If you are currently using OpenTofu or Terraform, and you want to start using Terragrunt in your project, simply run the following where your OpenTofu project is located:
+
+```shell
+touch terragrunt.hcl
+```
+
+This creates an empty Terragrunt configuration file in the directory where you are using OpenTofu. You can now start using `terragrunt` instead of `tofu` or `terraform` to run your OpenTofu/Terraform commands as if you were simply using OpenTofu or Terraform.
+
+Depending on why you're looking to adopt Terragrunt, this may be all you need to do!
+
+With just this empty file, you've made it so that you no longer need to run `tofu init` or `terraform init` before running `tofu apply` or `terraform apply`. Terragrunt will automatically run `init` for you if necessary. This is a feature called [Auto-init](/docs/features/auto-init/).
+
+This might not be very impressive so far, so you may be wondering _why_ one might want to start using Terragrunt to manage their OpenTofu/Terraform projects. A quick overview of the main benefits of using Terragrunt are covered in the [Quick start](/docs/getting-started/quick-start/), and there is a comprehensive list of features in the [Features](/docs/features/) section.
+
+## Tutorial
+
+What follows is a gentle step-by-step guide to integrating Terragrunt to an existing OpenTofu/Terraform project.
+
+For the sake of this tutorial, a minimal set of OpenTofu configurations will be used so that you can follow along. Following these steps will give you an idea of how to integrate Terragrunt into an existing project, even if yours is more complex.
+
+This tutorial will assume the following:
+
+1. You have OpenTofu [installed](https://opentofu.org/docs/intro/install/).
+2. You have a basic understanding of OpenTofu or Terraform.
+3. You are using a Unix-like operating system.
+
+If you start to feel lost, or don't understand a concept, consider reading the [Terminology](/docs/getting-started/terminology/) page before continuing with this tutorial. It has a brief overview of most of the common terms used when discussing Terragrunt.
+
+### Step 1: Create a new Terragrunt project
+
+Let's say you have the following `main.tf` in directory `foo`:
+
+```hcl
+# foo/main.tf
+resource "local_file" "file" {
+  content  = "Hello, World!"
+  filename = "${path.module}/hi.txt"
+}
+```
+
+As we learned above, making this project integrated with Terragrunt is as simple as creating a `terragrunt.hcl` file in the same directory:
+
+```bash
+touch foo/terragrunt.hcl
+```
+
+You can now run `terragrunt` commands within the `foo` directory, as if you were using `tofu` or `terraform`.
+
+```bash
+$ cd foo
+$ terragrunt apply -auto-approve
+18:44:26.066 STDOUT tofu: Initializing the backend...
+18:44:26.067 STDOUT tofu: Initializing provider plugins...
+18:44:26.067 STDOUT tofu: - Finding latest version of hashicorp/local...
+18:44:26.717 STDOUT tofu: - Installing hashicorp/local v2.5.2...
+18:44:27.033 STDOUT tofu: - Installed hashicorp/local v2.5.2 (signed, key ID 0C0AF313E5FD9F80)
+18:44:27.033 STDOUT tofu: Providers are signed by their developers.
+18:44:27.033 STDOUT tofu: If you'd like to know more about provider signing, you can read about it here:
+18:44:27.033 STDOUT tofu: https://opentofu.org/docs/cli/plugins/signing/
+18:44:27.034 STDOUT tofu: OpenTofu has created a lock file .terraform.lock.hcl to record the provider
+18:44:27.034 STDOUT tofu: selections it made above. Include this file in your version control repository
+18:44:27.034 STDOUT tofu: so that OpenTofu can guarantee to make the same selections by default when
+18:44:27.034 STDOUT tofu: you run "tofu init" in the future.
+18:44:27.034 STDOUT tofu: OpenTofu has been successfully initialized!
+18:44:27.035 STDOUT tofu:
+18:44:27.035 STDOUT tofu: You may now begin working with OpenTofu. Try running "tofu plan" to see
+18:44:27.035 STDOUT tofu: any changes that are required for your infrastructure. All OpenTofu commands
+18:44:27.035 STDOUT tofu: should now work.
+18:44:27.035 STDOUT tofu: If you ever set or change modules or backend configuration for OpenTofu,
+18:44:27.035 STDOUT tofu: rerun this command to reinitialize your working directory. If you forget, other
+18:44:27.035 STDOUT tofu: commands will detect it and remind you to do so if necessary.
+18:44:27.362 STDOUT tofu: OpenTofu used the selected providers to generate the following execution
+18:44:27.362 STDOUT tofu: plan. Resource actions are indicated with the following symbols:
+18:44:27.362 STDOUT tofu:   + create
+18:44:27.362 STDOUT tofu: OpenTofu will perform the following actions:
+18:44:27.362 STDOUT tofu:   # local_file.file will be created
+18:44:27.362 STDOUT tofu:   + resource "local_file" "file" {
+18:44:27.362 STDOUT tofu:       + content              = "Hello, World!"
+18:44:27.362 STDOUT tofu:       + content_base64sha256 = (known after apply)
+18:44:27.362 STDOUT tofu:       + content_base64sha512 = (known after apply)
+18:44:27.362 STDOUT tofu:       + content_md5          = (known after apply)
+18:44:27.362 STDOUT tofu:       + content_sha1         = (known after apply)
+18:44:27.362 STDOUT tofu:       + content_sha256       = (known after apply)
+18:44:27.362 STDOUT tofu:       + content_sha512       = (known after apply)
+18:44:27.362 STDOUT tofu:       + directory_permission = "0777"
+18:44:27.362 STDOUT tofu:       + file_permission      = "0777"
+18:44:27.362 STDOUT tofu:       + filename             = "./hi.txt"
+18:44:27.362 STDOUT tofu:       + id                   = (known after apply)
+18:44:27.362 STDOUT tofu:     }
+18:44:27.362 STDOUT tofu: Plan: 1 to add, 0 to change, 0 to destroy.
+18:44:27.362 STDOUT tofu:
+18:44:27.383 STDOUT tofu: local_file.file: Creating...
+18:44:27.384 STDOUT tofu: local_file.file: Creation complete after 0s [id=0a0a9f2a6772942557ab5355d76af442f8f65e01]
+18:44:27.392 STDOUT tofu:
+18:44:27.392 STDOUT tofu: Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+18:44:27.392 STDOUT tofu:
+```
+
+You might notice that this is a little more verbose than the output you're used to seeing from running `tofu` or `terraform` directly. This is because Terragrunt does a bit of work behind the scenes to make sure that you can scale your OpenTofu/Terraform usage without running into common problems. As you get more comfortable with using Terragrunt on larger projects, you may find the extra information helpful.
+
+If you would prefer that Terragrunt output look more like the output from `tofu` or `terraform`, you can use the `--terragrunt-log-format bare` flag (or set the environment variable `TERRAGRUNT_LOG_FORMAT=bare`) to reduce the verbosity of the output.
+
+e.g.
+
+```bash
+$ terragrunt --terragrunt-log-format bare apply
+local_file.file: Refreshing state... [id=0a0a9f2a6772942557ab5355d76af442f8f65e01]
+
+No changes. Your infrastructure matches the configuration.
+
+OpenTofu has compared your real infrastructure against your configuration and
+found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+```
+
+The way dynamicity is handled in OpenTofu is via `variable` configuration blocks. Let's add one to our `main.tf` so that we can control the content of the file we're creating:
+
+```hcl
+# foo/main.tf
+variable "content" {}
+
+resource "local_file" "file" {
+  content  = var.content
+  filename = "${path.module}/hi.txt"
+}
+```
+
+Now, just like when using `tofu` alone, you can pass in the value for the `content` variable using the `-var` flag:
+
+```bash
+terragrunt apply -auto-approve -var 'content=Hello, Terragrunt!'
+```
+
+This is a common pattern when working with Infrastructure as Code (IaC). You typically create IaC that is relatively static, and then as you need to make configurations dynamic, you add variables to your configuration files to introduce dynamicity.
+
+### Step 2: Add a new Terragrunt unit
+
+In the context of Terragrunt, a "unit" is a directory that contains a `terragrunt.hcl` file, and it represents a single piece of infrastructure. You can think of a unit as a single instance of an OpenTofu/Terraform module.
+
+Let's create a copy of the `foo` directory and call it `bar`:
+
+```bash
+cd ..
+cp -r foo bar
+```
+
+We now have two identical units in our project, `foo` and `bar`. We also have identical code in each of these directories, which is not ideal if we want to be able to avoid duplicating effort when we make changes to our infrastructure.
+
+### Step 3: Create a shared module
+
+To avoid this duplication, we can introduce a new `shared` directory, and reference that directory from both `foo` and `bar`. This way, we can make changes to our infrastructure in one place and have those changes apply to both units.
+
+Let's create a new directory called `shared`:
+
+```bash
+mkdir shared
+```
+
+Now, move the `main.tf` file from `foo` to `shared`:
+
+```bash
+mv foo/main.tf shared/main.tf
+```
+
+Finally, let's update the `foo` and `bar` directories to reference the `shared` directory. Update the `main.tf` files in both `foo` and `bar` to look like this:
+
+```hcl
+# foo/main.tf and bar/main.tf
+variable "content" {}
+
+module "shared" {
+  source = "../shared"
+
+  content = var.content
+}
+```
+
+There's now one place where the logic for the resource `local_file.file` is defined, and both `foo` and `bar` reference that logic. You can imagine that as your infrastructure grows, it can become more and more advantageous to put repeated logic into shared modules like this.
+
+This setup does have some problems, however. While you could keep navigating to the different units and running `terragrunt apply` in each one with the appropriate `-var` flags, this can quickly become tedious, as you have to know which units require which set of vars applied. You might decide to work around this by creating a file named `terraform.tfvars` in each unit directory, but this also comes with some limitations that Terragrunt can help you avoid.
+
+### Step 4: Use Terragrunt to manage your units
+
+Luckily, Terragrunt has a built-in feature to control the inputs passed to your OpenTofu/Terraform configurations. This feature is called (aptly enough) [inputs](/docs/reference/config-blocks-and-attributes/#inputs).
+
+Let's add inputs to both `terragrunt.hcl` files in the `foo` and `bar` directories:
+
+```hcl
+# foo/terragrunt.hcl
+inputs = {
+  content = "Hello from foo, Terragrunt!"
+}
+```
+
+```hcl
+# bar/terragrunt.hcl
+inputs = {
+  content = "Hello from bar, Terragrunt!"
+}
+```
+
+Furthermore, you don't have to maintain the extra `main.tf` files just to instantiate the `module` blocks. You can use the `terraform` block to handle this for you. Update the `terragrunt.hcl` files in `foo` and `bar` to look like this:
+
+```hcl
+# foo/terragrunt.hcl
+terraform {
+  source = "../shared"
+}
+
+inputs = {
+  content = "Hello from foo, Terragrunt!"
+}
+```
+
+```hcl
+# bar/terragrunt.hcl
+terraform {
+  source = "../shared"
+}
+
+inputs = {
+  content = "Hello from bar, Terragrunt!"
+}
+```
+
+And you can delete the `main.tf` files from both `foo` and `bar`:
+
+```bash
+rm foo/main.tf bar/main.tf
+```
+
+This saves you some duplicated content, as you no longer need to maintain that extra `content` variable in each `main.tf` file. You can imagine that for especially large modules, the ability to define inputs in the `terragrunt.hcl` file can save you a lot of time and effort. The patterns for your infrastructure are exclusively defined in `.tf` files now, and the `terragrunt.hcl` files are used to manage the instances of those patterns as units.
+
+If you run `terragrunt apply -auto-approve` in the `foo` and `bar` directories, you'll see that the `content` variable is set to the value you defined in the `inputs` block of the `terragrunt.hcl` file. You might also notice that there's now a special `.terragrunt-cache` directory generated for you in each unit directory. This is where Terragrunt copies the contents of modules, and performs any necessary additional code generation to make sure that your OpenTofu/Terraform code is ready to be run.
+
+The `.terragrunt-cache` directory is typically added to `.gitignore` files, similar to the `.terraform` directory that OpenTofu generates.
+
+### Step 5: Use Terragrunt to manage your stacks
+
+In the context of Terragrunt, a "stack" is a collection of units that are managed together. You can think of a stack as a single environment, such as `dev`, `staging`, or `prod`, or an entire project.
+
+One of the main reasons users adopt Terragrunt is how it can help manage the complexity of managing multiple units across multiple environments.
+
+e.g. Let's say we wanted to update both our `foo` and `bar` environments simultaneously.
+
+In the directory above `foo` and `bar`, run the following:
+
+```bash
+$ terragrunt run-all apply -auto-approve
+08:42:00.150 INFO   The stack at . will be processed in the following order for command apply:
+Group 1
+- Module ./bar
+- Module ./foo
+
+
+Are you sure you want to run 'terragrunt apply' in each folder of the stack described above? (y/n) y
+08:43:10.702 STDOUT [foo] tofu: local_file.file: Refreshing state... [id=c4ae21736a6297f44ea86791e528338e9d14a0e9]
+08:43:10.702 STDOUT [bar] tofu: local_file.file: Refreshing state... [id=f855394a0316da09618c8b1fde7b91e00e759f80]
+08:43:10.708 STDOUT [bar] tofu: No changes. Your infrastructure matches the configuration.
+08:43:10.708 STDOUT [bar] tofu: OpenTofu has compared your real infrastructure against your configuration and
+08:43:10.708 STDOUT [bar] tofu: found no differences, so no changes are needed.
+08:43:10.708 STDOUT [foo] tofu: No changes. Your infrastructure matches the configuration.
+08:43:10.708 STDOUT [foo] tofu: OpenTofu has compared your real infrastructure against your configuration and
+08:43:10.708 STDOUT [foo] tofu: found no differences, so no changes are needed.
+08:43:10.716 STDOUT [foo] tofu:
+08:43:10.716 STDOUT [foo] tofu: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+08:43:10.716 STDOUT [foo] tofu:
+08:43:10.720 STDOUT [bar] tofu:
+08:43:10.720 STDOUT [bar] tofu: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+08:43:10.720 STDOUT [bar] tofu:
+```
+
+This is where that additional verbosity in Terragrunt logging is really handy. You can see that Terragrunt concurrently ran `apply -auto-approve` in both the `foo` and `bar` units. The extra logging for Terragrunt also included information on the names of the units that were processed, and disambiguated the output from each unit.
+
+Similar to the `tofu` CLI, there is a prompt to confirm that you are sure you want to run the command in each unit when performing a command that's potentially destructive. You can skip this prompt by using the `--terragrunt-non-interactive` flag, just as you would with `-auto-approve` in OpenTofu.
+
+```bash
+$ terragrunt run-all --terragrunt-non-interactive apply -auto-approve
+```
+
+### Step 6: Use Terragrunt to manage your DAG
+
+In the context of Terragrunt, a "DAG" is a Directed Acyclic Graph that represents the dependencies between units in your stack. Terragrunt uses the DAG to determine the order in which to run commands across your stack.
+
+For example, let's say that the `content` of the `bar` unit depended on the `content` of the `foo` unit. You can express this dependency first by adding an `output` block to the `shared` module:
+
+```hcl
+# shared/output.tf
+output "content" {
+  value = local_file.file.content
+}
+```
+
+Then, you can update the `bar` unit to depend on the `foo` unit by using the `dependencies` block in the `terragrunt.hcl` file:
+
+```hcl
+# bar/terragrunt.hcl
+terraform {
+	source = "../shared"
+}
+
+dependency "foo" {
+	config_path = "../foo"
+}
+
+inputs = {
+	content = "Foo content: ${dependency.foo.outputs.content}"
+}
+```
+
+Being good citizens of the IaC world, we should run a `plan` before an `apply` to see what changes Terragrunt will make to our infrastructure (note that you will get an error here. This is expected, and we'll fix it in the next step):
+
+```bash
+$ terragrunt run-all plan
+08:57:09.271 INFO   The stack at . will be processed in the following order for command plan:
+Group 1
+- Module ./foo
+
+Group 2
+- Module ./bar
+
+...
+
+08:57:09.936 ERROR  [bar] Module ./bar has finished with an error
+08:57:09.936 ERROR  error occurred:
+
+* ./foo/terragrunt.hcl is a dependency of ./bar/terragrunt.hcl but detected no outputs. Either the target module has not been applied yet, or the module has no outputs. If this is expected, set the skip_outputs flag to true on the dependency block.
+
+08:57:09.936 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
+```
+
+Oh no! We got an error. This is because the way in which dependencies are resolved by default in Terragrunt is to run `terragrunt output` within the dependent unit in order to fetch them for the dependent unit. In this case, the `foo` unit has not been applied yet, so there are no outputs to fetch.
+
+You should notice, however, that Terragrunt has already figured out the order in which to run the `plan` command across the units in your stack. This is what we mean when we say that Terragrunt uses a DAG to determine the order in which to run commands across your stack. Terragrunt analyzes the dependencies across your units, and determines the order in which to run updates so that outputs are ready to be used as inputs in dependent units.
+
+If you instead decided to run `terragrunt run-all apply -auto-approve`, you would instead see Terragrunt complete the `apply` in the `foo` unit first, and then complete the `apply` in the `bar` unit, as it's aware that the `bar` unit might need some outputs from the `foo` unit.
+
+### Step 7: Use mocks to handle unavailable outputs
+
+In this scenario, most Terragrunt users leverage `mock_outputs` to handle unavailable outputs (see [limitations on accessing exposed config](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#limitations-on-accessing-exposed-config)). Given that it's expected that the `foo` unit won't be able to provide outputs until it's applied, you can use the `mock_outputs` block to provide a placeholder value for the `content` output during the `plan` phase.
+
+```hcl
+# bar/terragrunt.hcl
+terraform {
+  source = "../shared"
+}
+
+dependency "foo" {
+  config_path = "../foo"
+  mock_outputs = {
+    content = "Mocked content from foo"
+  }
+}
+
+inputs = {
+  content = "Foo content: ${dependency.foo.outputs.content}"
+}
+```
+
+Re-running the `plan` command should now complete successfully:
+
+```bash
+$ terragrunt run-all plan
+09:29:03.461 INFO   The stack at . will be processed in the following order for command plan:
+Group 1
+- Module ./foo
+
+Group 2
+- Module ./bar
+
+...
+
+09:29:03.644 WARN   [bar] Config ./foo/terragrunt.hcl is a dependency of ./bar/terragrunt.hcl that has no outputs, but mock outputs provided and returning those in dependency output.
+
+...
+
+09:29:03.898 STDOUT [bar] tofu:   + resource "local_file" "file" {
+09:29:03.898 STDOUT [bar] tofu:       + content              = "Foo content: Mocked content from foo"
+09:29:03.898 STDOUT [bar] tofu:       + content_base64sha256 = (known after apply)
+09:29:03.898 STDOUT [bar] tofu:       + content_base64sha512 = (known after apply)
+09:29:03.898 STDOUT [bar] tofu:       + content_md5          = (known after apply)
+09:29:03.898 STDOUT [bar] tofu:       + content_sha1         = (known after apply)
+09:29:03.898 STDOUT [bar] tofu:       + content_sha256       = (known after apply)
+09:29:03.898 STDOUT [bar] tofu:       + content_sha512       = (known after apply)
+09:29:03.898 STDOUT [bar] tofu:       + directory_permission = "0777"
+09:29:03.898 STDOUT [bar] tofu:       + file_permission      = "0777"
+09:29:03.898 STDOUT [bar] tofu:       + filename             = "./hi.txt"
+09:29:03.898 STDOUT [bar] tofu:       + id                   = (known after apply)
+09:29:03.898 STDOUT [bar] tofu:     }
+```
+
+If you're concerned about the `mock_outputs` attribute resulting in invalid configurations, note that during an apply, the outputs of `foo` will be known, and Terragrunt won't use `mock_outputs` to resolve the outputs of `foo`.
+
+```bash
+$ terragrunt run-all --terragrunt-non-interactive apply -auto-approve
+
+...
+
+09:31:21.587 STDOUT [bar] tofu:   + resource "local_file" "file" {
+09:31:21.587 STDOUT [bar] tofu:       + content              = "Foo content: Hello from foo, Terragrunt!"
+09:31:21.587 STDOUT [bar] tofu:       + content_base64sha256 = (known after apply)
+09:31:21.587 STDOUT [bar] tofu:       + content_base64sha512 = (known after apply)
+09:31:21.587 STDOUT [bar] tofu:       + content_md5          = (known after apply)
+09:31:21.587 STDOUT [bar] tofu:       + content_sha1         = (known after apply)
+09:31:21.587 STDOUT [bar] tofu:       + content_sha256       = (known after apply)
+09:31:21.587 STDOUT [bar] tofu:       + content_sha512       = (known after apply)
+09:31:21.587 STDOUT [bar] tofu:       + directory_permission = "0777"
+09:31:21.587 STDOUT [bar] tofu:       + file_permission      = "0777"
+09:31:21.587 STDOUT [bar] tofu:       + filename             = "./hi.txt"
+09:31:21.587 STDOUT [bar] tofu:       + id                   = (known after apply)
+09:31:21.587 STDOUT [bar] tofu:     }
+
+...
+```
+
+You can also be explicit about the fact that you only want to use `mock_outputs` during the `plan` phase by specifying that in your `mock_outputs` configuration:
+
+```hcl
+# bar/terragrunt.hcl
+terraform {
+  source = "../shared"
+}
+
+dependency "foo" {
+  config_path = "../foo"
+  mock_outputs = {
+    content = "Mocked content from foo"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["plan"]
+}
+
+inputs = {
+  content = "Foo content: ${dependency.foo.outputs.content}"
+}
+```
+
+### Step 8: Continue learning and exploring!
+
+Hopefully, following this tutorial has given you confidence in integrating Terragrunt into your existing OpenTofu/Terraform projects. Starting small, and gradually introducing more complex features, is a great way to learn how Terragrunt can help you manage your infrastructure more effectively.
+
+There are many more features and capabilities in Terragrunt. You can find more information on them in the [Features](/docs/features/) section of the documentation.
+
+If you need help with a particular problem, take a look at the resources available to you in the [Support](/docs/community/support/) section.
+

--- a/docs/_docs/01_getting-started/add-to-opentofu-project.md
+++ b/docs/_docs/01_getting-started/add-to-opentofu-project.md
@@ -1,6 +1,6 @@
 ---
 layout: collection-browser-doc
-title: Add to Existing Project
+title: Add to OpenTofu Project
 category: getting-started
 excerpt: Add Terragrunt to an existing OpenTofu/Terraform project.
 tags: ["tofu", "opentofu", "terraform", "tf"]
@@ -21,7 +21,7 @@ This creates an empty Terragrunt configuration file in the directory where you a
 
 Depending on why you're looking to adopt Terragrunt, this may be all you need to do!
 
-With just this empty file, you've made it so that you no longer need to run `tofu init` or `terraform init` before running `tofu apply` or `terraform apply`. Terragrunt will automatically run `init` for you if necessary. This is a feature called [Auto-init](/docs/features/auto-init/).
+With just this empty file, you've already made it so that you no longer need to run `tofu init` or `terraform init` before running `tofu apply` or `terraform apply`. Terragrunt will automatically run `init` for you if necessary. This is a feature called [Auto-init](/docs/features/auto-init/).
 
 This might not be very impressive so far, so you may be wondering _why_ one might want to start using Terragrunt to manage their OpenTofu/Terraform projects. A quick overview of the main benefits of using Terragrunt are covered in the [Quick start](/docs/getting-started/quick-start/), and there is a comprehensive list of features in the [Features](/docs/features/) section.
 

--- a/docs/_docs/01_getting-started/add-to-opentofu-project.md
+++ b/docs/_docs/01_getting-started/add-to-opentofu-project.md
@@ -289,7 +289,7 @@ This is where that additional verbosity in Terragrunt logging is really handy. Y
 Similar to the `tofu` CLI, there is a prompt to confirm that you are sure you want to run the command in each unit when performing a command that's potentially destructive. You can skip this prompt by using the `--terragrunt-non-interactive` flag, just as you would with `-auto-approve` in OpenTofu.
 
 ```bash
-$ terragrunt run-all --terragrunt-non-interactive apply -auto-approve
+terragrunt run-all --terragrunt-non-interactive apply -auto-approve
 ```
 
 ### Step 6: Use Terragrunt to manage your DAG
@@ -310,15 +310,15 @@ Then, you can update the `bar` unit to depend on the `foo` unit by using the `de
 ```hcl
 # bar/terragrunt.hcl
 terraform {
-	source = "../shared"
+ source = "../shared"
 }
 
 dependency "foo" {
-	config_path = "../foo"
+ config_path = "../foo"
 }
 
 inputs = {
-	content = "Foo content: ${dependency.foo.outputs.content}"
+ content = "Foo content: ${dependency.foo.outputs.content}"
 }
 ```
 
@@ -449,11 +449,10 @@ inputs = {
 }
 ```
 
-### Step 8: Continue learning and exploring!
+### Step 8: Continue learning and exploring
 
 Hopefully, following this tutorial has given you confidence in integrating Terragrunt into your existing OpenTofu/Terraform projects. Starting small, and gradually introducing more complex features, is a great way to learn how Terragrunt can help you manage your infrastructure more effectively.
 
 There are many more features and capabilities in Terragrunt. You can find more information on them in the [Features](/docs/features/) section of the documentation.
 
 If you need help with a particular problem, take a look at the resources available to you in the [Support](/docs/community/support/) section.
-

--- a/docs/_docs/01_getting-started/add-to-opentofu-project.md
+++ b/docs/_docs/01_getting-started/add-to-opentofu-project.md
@@ -449,9 +449,13 @@ inputs = {
 }
 ```
 
+Something a little subtle just happened there. Note that the `inputs` attribute is dynamic. This addresses some of the limitations mentioned earlier about using `terraform.tfvars` files to manage inputs for units. Given that the `bar` unit is dependent on output values from the `foo` unit, you wouldn't be able to use a `terraform.tfvars` file to populate this variable without some additional tooling to populate it dynamically.
+
+Terragrunt was spawned organically out of supporting Gruntwork customers using Terraform at scale, and features in the product are designed to address common problems like these that arise when managing OpenTofu/Terraform projects at scale in production.
+
 ### Step 8: Continue learning and exploring
 
-Hopefully, following this tutorial has given you confidence in integrating Terragrunt into your existing OpenTofu/Terraform projects. Starting small, and gradually introducing more complex features, is a great way to learn how Terragrunt can help you manage your infrastructure more effectively.
+Hopefully, following this simple tutorial has given you confidence in integrating Terragrunt into your existing OpenTofu/Terraform projects. Starting small, and gradually introducing more complex Terragrunt features is a great way to learn how Terragrunt can help you manage your infrastructure more effectively.
 
 There are many more features and capabilities in Terragrunt. You can find more information on them in the [Features](/docs/features/) section of the documentation.
 

--- a/docs/_docs/01_getting-started/configuration.md
+++ b/docs/_docs/01_getting-started/configuration.md
@@ -47,7 +47,7 @@ Refer to the following pages for a complete reference of supported features in t
 
 ## Configuration parsing order
 
-It is important to be aware of the terragrunt configuration parsing order when using features like [locals]({{site.baseurl}}/docs/features/locals/#locals) and [dependency outputs]({{site.baseurl}}/docs/features/execute-terraform-commands-on-multiple-modules-at-once/#passing-outputs-between-modules), where you can reference attributes of other blocks in the config in your `inputs`. For example, because `locals` are evaluated before `dependency` blocks, you can not bind outputs from `dependency` into `locals`. On the other hand, for the same reason, you can use `locals` in the `dependency` blocks.
+It is important to be aware of the terragrunt configuration parsing order when using features like [locals]({{site.baseurl}}/docs/features/locals/#locals) and [dependency outputs]({{site.baseurl}}/docs/features/execute-terraform-commands-on-multiple-units-at-once/#passing-outputs-between-units), where you can reference attributes of other blocks in the config in your `inputs`. For example, because `locals` are evaluated before `dependency` blocks, you can not bind outputs from `dependency` into `locals`. On the other hand, for the same reason, you can use `locals` in the `dependency` blocks.
 
 Currently terragrunt parses the config in the following order:
 
@@ -59,7 +59,7 @@ Currently terragrunt parses the config in the following order:
 
 4. `dependencies` block
 
-5. `dependency` blocks, including calling `terragrunt output` on the dependent modules to retrieve the outputs
+5. `dependency` blocks, including calling `terragrunt output` on the dependent units to retrieve the outputs
 
 6. Everything else
 
@@ -81,13 +81,13 @@ Note that the parsing order is slightly different when using the `-all` flavors 
 
 5. `dependencies` block of all configurations in the tree
 
-The results of this pass are then used to build the dependency graph of the modules in the tree. Once the graph is constructed, Terragrunt will loop through the modules and run the specified command. It will then revert to the single configuration parsing order specified above for each module as it runs the command.
+The results of this pass are then used to build the dependency graph of the units in the stack. Once the graph is constructed, Terragrunt will loop through the units and run the specified command. It will then revert to the single configuration parsing order specified above for each unit as it runs the command.
 
-This allows Terragrunt to avoid resolving `dependency` on modules that haven’t been applied yet when doing a clean deployment from scratch with `run-all apply`.
+This allows Terragrunt to avoid resolving `dependency` on units that haven’t been applied yet when doing a clean deployment from scratch with `run-all apply`.
 
-## Formatting hcl files
+## Formatting HCL files
 
-You can rewrite the hcl files to a canonical format using the `hclfmt` command built into `terragrunt`. Similar to `terraform fmt`, this command applies a subset of [the OpenTofu/Terraform language style conventions](https://www.terraform.io/docs/configuration/style.html), along with other minor adjustments for readability.
+You can rewrite the HCL files to a canonical format using the `hclfmt` command built into `terragrunt`. Similar to `tofu fmt`, this command applies a subset of [the OpenTofu/Terraform language style conventions](https://www.terraform.io/docs/configuration/style.html), along with other minor adjustments for readability.
 
 This command will recursively search for hcl files and format all of them under a given directory tree. Consider the following file structure:
 
@@ -122,4 +122,4 @@ If you run `terragrunt hclfmt` at the `root`, this will update:
 
 You can set `--terragrunt-diff` option. `terragrunt hclfmt --terragrunt-diff` will output the diff in a unified format which can be redirected to your favourite diff tool. `diff` utility must be presented in PATH.
 
-Additionally, there’s a flag `--terragrunt-check`. `terragrunt hclfmt --terragrunt-check` will only verify if the files are correctly formatted **without rewriting** them. The command will return exit status 1 if any matching files are improperly formatted, or 0 if all matching .hcl files are correctly formatted.
+Additionally, there’s a flag `--terragrunt-check`. `terragrunt hclfmt --terragrunt-check` will only verify if the files are correctly formatted **without rewriting** them. The command will return exit status 1 if any matching files are improperly formatted, or 0 if all matching `.hcl` files are correctly formatted.

--- a/docs/_docs/01_getting-started/quick-start.md
+++ b/docs/_docs/01_getting-started/quick-start.md
@@ -32,7 +32,7 @@ terragrunt output
 terragrunt destroy
 ```
 
-Terragrunt will forward almost all commands, arguments, and options directly to OpenTofu/Terraform, but based on the settings in your `terragrunt.hcl` file.
+Terragrunt will forward almost all commands, arguments, and options directly to OpenTofu/Terraform, with adjustments made based on the settings in your `terragrunt.hcl` file.
 
 ## Example
 
@@ -111,18 +111,6 @@ NOTE: Heads up, not all Registry modules can be deployed with Terragrunt, see [A
 registry]({{ site.baseurl }}/docs/reference/config-blocks-and-attributes#a-note-about-using-modules-from-the-registry) for details.
 
 ## Key features
-
-Terragrunt can help you accomplish the following:
-
-- [Introduction](#introduction)
-- [Example](#example)
-  - [terragrunt.hcl](#terragrunthcl)
-- [Key features](#key-features)
-  - [Keep your backend configuration DRY](#keep-your-backend-configuration-dry)
-  - [Keep your provider configuration DRY](#keep-your-provider-configuration-dry)
-  - [Keep your OpenTofu/Terraform CLI arguments DRY](#keep-your-opentofuterraform-cli-arguments-dry)
-  - [Promote immutable, versioned OpenTofu/Terraform modules across environments](#promote-immutable-versioned-opentofuterraform-modules-across-environments)
-- [Next steps](#next-steps)
 
 ### Keep your backend configuration DRY
 
@@ -585,4 +573,6 @@ Now that you’ve seen the basics of Terragrunt, here is some further reading to
 
 2. [Documentation]({{site.baseurl}}/docs/): Check out the detailed Terragrunt documentation.
 
-3. [_Terraform: Up & Running_](https://www.terraformupandrunning.com/): This book is the fastest way to get up and running with Terraform\! Terragrunt is a direct implementation of many of the ideas from this book.
+3. [Fundamentals of DevOps and Software Delivery](https://www.gruntwork.io/fundamentals-of-devops): Learn the fundamentals of DevOps and Software Delivery from one of the founders of Gruntwork!
+
+4. [_Terraform: Up & Running_](https://www.terraformupandrunning.com/): This book is the fastest way to get up and running with Terraform\! Terragrunt is a direct implementation of many of the ideas from this book.

--- a/docs/_docs/01_getting-started/quick-start.md
+++ b/docs/_docs/01_getting-started/quick-start.md
@@ -573,6 +573,8 @@ Now that you’ve seen the basics of Terragrunt, here is some further reading to
 
 2. [Documentation]({{site.baseurl}}/docs/): Check out the detailed Terragrunt documentation.
 
-3. [Fundamentals of DevOps and Software Delivery](https://www.gruntwork.io/fundamentals-of-devops): Learn the fundamentals of DevOps and Software Delivery from one of the founders of Gruntwork!
+3. [Add Terragrunt to your OpenTofu project]({{site.baseurl}}/docs/getting-started/add-to-opentofu-project): Follow the step-by-step guide to add Terragrunt to an existing OpenTofu/Terraform project.
 
-4. [_Terraform: Up & Running_](https://www.terraformupandrunning.com/): This book is the fastest way to get up and running with Terraform\! Terragrunt is a direct implementation of many of the ideas from this book.
+4. [Fundamentals of DevOps and Software Delivery](https://www.gruntwork.io/fundamentals-of-devops): Learn the fundamentals of DevOps and Software Delivery from one of the founders of Gruntwork!
+
+5. [_Terraform: Up & Running_](https://www.terraformupandrunning.com/): This book is the fastest way to get up and running with Terraform\! Terragrunt is a direct implementation of many of the ideas from this book.

--- a/docs/_docs/01_getting-started/quick-start.md
+++ b/docs/_docs/01_getting-started/quick-start.md
@@ -141,7 +141,7 @@ terraform {
 }
 ```
 
-The code above tells OpenTofu/Terraform to store the state for a `frontend-app` module in an S3 bucket called `my-terraform-state` under the path `stage/frontend-app/terraform.tfstate`, and to use a DynamoDB table called `my-lock-table` for locking. This is a great feature that almost every single OpenTofu/Terraform team uses to collaborate, but it comes with one major gotcha: the `backend` configuration does not support variables or expressions of any sort (this may change in the near future with [OpenTofu v1.8.0!](https://github.com/opentofu/opentofu/releases/tag/v1.8.0-alpha1). That is, the following will NOT work:
+The code above tells OpenTofu/Terraform to store the state for a `frontend-app` module in an S3 bucket called `my-terraform-state` under the path `stage/frontend-app/terraform.tfstate`, and to use a DynamoDB table called `my-lock-table` for locking. This is a great feature that almost every single OpenTofu/Terraform team uses to collaborate, but it comes with one major gotcha: the `backend` configuration does not support variables or expressions of any sort (this may change in the near future with [OpenTofu v1.8.0!](https://github.com/opentofu/opentofu/releases/tag/v1.8.0-alpha1)). That is, the following will NOT work:
 
 ``` hcl
 # stage/frontend-app/main.tf
@@ -233,7 +233,7 @@ include "root" {
 
 The `find_in_parent_folders()` helper will automatically search up the directory tree to find the root `terragrunt.hcl` and inherit the `remote_state` configuration from it.
 
-Now, [install Terragrunt]({{site.baseurl}}/docs/getting-started/install), and run all the OpenTofu/Terraform commands you’re used to, but with `terragrunt` as the command name rather than `tofu`/`terraform` (e.g., `terragrunt apply` instead of `terraform apply`). To deploy the database module, you would run:
+Now, [install Terragrunt]({{site.baseurl}}/docs/getting-started/install), and run all the OpenTofu/Terraform commands you’re used to, but with `terragrunt` as the command name rather than `tofu`/`terraform` (e.g., `terragrunt apply` instead of `tofu apply`). To deploy the database module, you would run:
 
 ``` bash
 cd stage/mysql
@@ -341,7 +341,7 @@ foo        = "bar"
 You can tell OpenTofu/Terraform to use these variables using the `-var-file` argument:
 
 ``` bash
-$ terraform apply \
+$ tofu apply \
     -var-file=../../common.tfvars \
     -var-file=../region.tfvars
 ```
@@ -366,9 +366,7 @@ Now, when you run the `plan` or `apply` commands, Terragrunt will automatically 
 
 ``` bash
 $ terragrunt apply
-
-Running command: terraform with arguments
-[apply -var-file=../../common.tfvars -var-file=../region.tfvars]
+# Runs tofu apply -var-file=../../common.tfvars -var-file=../region.tfvars
 ```
 
 You can even use the `get_terraform_commands_that_need_vars()` built-in function to automatically get the list of all commands that accept `-var-file` and `-var` arguments:
@@ -426,7 +424,7 @@ Therefore, you typically want to break up your infrastructure across multiple mo
         └── outputs.tf
 ```
 
-The folder structure above shows how to separate the code for each environment (`prod`, `qa`, `stage`) and for each type of infrastructure (apps, databases, VPCs). However, the downside is that it isn’t DRY. The `.tf` files will contain a LOT of duplication. You can reduce it somewhat by defining all the infrastructure in [reusable OpenTofu/Terraform modules](https://blog.gruntwork.io/how-to-create-reusable-infrastructure-with-terraform-modules-25526d65f73d), but even the code to instantiate a module—including configuring the `provider`, `backend`, the module’s input variables, and `output` variables—means you still end up with dozens or hundreds of lines of copy/paste for every module in every environment:
+The folder structure above shows how to separate the code for each environment (`prod`, `qa`, `stage`) and for each type of infrastructure (apps, databases, VPCs). However, the downside is that it isn’t DRY. The `.tf` files will contain a LOT of duplication. You can reduce it somewhat by defining all the infrastructure in [reusable OpenTofu/Terraform modules](https://blog.gruntwork.io/how-to-create-reusable-infrastructure-with-terraform-modules-25526d65f73d), but even the code to instantiate a module—including configuring the `provider`, `backend`, the module’s input variables, and `output` variables means you still end up with dozens or hundreds of lines of copy/paste for every module in every environment:
 
 ``` hcl
 # prod/app/main.tf
@@ -434,15 +432,18 @@ provider "aws" {
   region = "us-east-1"
   # ... other provider settings ...
 }
+
 terraform {
   backend "s3" {}
 }
+
 module "app" {
   source = "../../../app"
   instance_type  = "m4.large"
   instance_count = 10
   # ... other app settings ...
 }
+
 # prod/app/outputs.tf
 output "url" {
   value = module.app.url
@@ -460,21 +461,24 @@ provider "aws" {
   region = "us-east-1"
   # ... other provider settings ...
 }
+
 terraform {
   backend "s3" {}
 }
+
 module "app" {
   source = "../../../app"
   instance_type  = var.instance_type
   instance_count = var.instance_count
   # ... other app settings ...
 }
+
 # infrastructure-modules/app/outputs.tf
 output "url" {
   value = module.app.url
 }
-# infrastructure-modules/app/variables.tf
 
+# infrastructure-modules/app/variables.tf
 variable "instance_type" {}
 variable "instance_count" {}
 ```

--- a/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
+++ b/docs/_docs/02_features/execute-terraform-commands-on-multiple-modules-at-once.md
@@ -1,30 +1,30 @@
 ---
 layout: collection-browser-doc
-title: Execute OpenTofu/Terraform commands on multiple modules at once
+title: Execute OpenTofu/Terraform commands on multiple units at once
 category: features
 categories_url: features
-excerpt: Learn how to avoid tedious tasks of running commands on each module separately.
-tags: ["DRY", "Modules", "Use cases", "CLI"]
+excerpt: Learn how to avoid tedious tasks of running commands on each unit separately.
+tags: ["DRY", "Unit", "Modules", "Use cases", "CLI"]
 order: 220
 nav_title: Documentation
 nav_title_link: /docs/
 ---
 
-## Execute OpenTofu/Terraform commands on multiple modules at once
+## Execute OpenTofu/Terraform commands on multiple units at once
 
-- [Execute OpenTofu/Terraform commands on multiple modules at once](#execute-opentofuterraform-commands-on-multiple-modules-at-once)
+- [Execute OpenTofu/Terraform commands on multiple units at once](#execute-opentofuterraform-commands-on-multiple-units-at-once)
   - [Motivation](#motivation)
   - [The run-all command](#the-run-all-command)
-  - [Passing outputs between modules](#passing-outputs-between-modules)
+  - [Passing outputs between units](#passing-outputs-between-units)
     - [Unapplied dependency and mock outputs](#unapplied-dependency-and-mock-outputs)
-  - [Dependencies between modules](#dependencies-between-modules)
-  - [Testing multiple modules locally](#testing-multiple-modules-locally)
-  - [Limiting the module execution parallelism](#limiting-the-module-execution-parallelism)
+  - [Dependencies between units](#dependencies-between-units)
+  - [Testing multiple units locally](#testing-multiple-units-locally)
+  - [Limiting the unit execution parallelism](#limiting-the-unit-execution-parallelism)
   - [Saving OpenTofu/Terraform plan output](#saving-opentofuterraform-plan-output)
 
 ### Motivation
 
-Let’s say your infrastructure is defined across multiple OpenTofu/Terraform modules:
+Let’s say your infrastructure is defined across multiple OpenTofu/Terraform units:
 
 ```tree
 root
@@ -40,11 +40,11 @@ root
     └── main.tf
 ```
 
-There is one module to deploy a frontend-app, another to deploy a backend-app, another for the MySQL database, and so on. To deploy such an environment, you’d have to manually run `tofu apply`/`terraform apply` in each of the subfolder, wait for it to complete, and then run `tofu apply`/`terraform apply` in the next subfolder. How do you avoid this tedious and time-consuming process?
+There is one unit to deploy a frontend-app, another to deploy a backend-app, another for the MySQL database, and so on. To deploy such an environment, you’d have to manually run `tofu apply`/`terraform apply` in each of the subfolder, wait for it to complete, and then run `tofu apply`/`terraform apply` in the next subfolder. How do you avoid this tedious and time-consuming process?
 
 ### The run-all command
 
-To be able to deploy multiple OpenTofu/Terraform modules in a single command, add a `terragrunt.hcl` file to each module:
+To be able to deploy multiple OpenTofu/Terraform units in a single command, add a `terragrunt.hcl` file to each unit:
 
 ```tree
 root
@@ -65,7 +65,7 @@ root
     └── terragrunt.hcl
 ```
 
-Now you can go into the `root` folder and deploy all the modules within it by using the `run-all` command with
+Now you can go into the `root` folder and deploy all the units within it by using the `run-all` command with
 `apply`:
 
 ```bash
@@ -75,7 +75,7 @@ terragrunt run-all apply
 
 When you run this command, Terragrunt will recursively look through all the subfolders of the current working directory, find all folders with a `terragrunt.hcl` file, and run `terragrunt apply` in each of those folders concurrently.
 
-Similarly, to undeploy all the OpenTofu/Terraform modules, you can use the `run-all` command with `destroy`:
+Similarly, to undeploy all the OpenTofu/Terraform units, you can use the `run-all` command with `destroy`:
 
 ```bash
 cd root
@@ -94,18 +94,18 @@ Finally, if you make some changes to your project, you could evaluate the impact
 Note: It is important to realize that you could get errors running `run-all plan` if you have dependencies between your
 projects and some of those dependencies haven’t been applied yet.
 
-*Ex: If module A depends on module B and module B hasn’t been applied yet, then run-all plan will show the plan for B, but exit with an error when trying to show the plan for A.*
+*Ex: If unit A depends on unit B and unit B hasn’t been applied yet, then run-all plan will show the plan for B, but exit with an error when trying to show the plan for A.*
 
 ```bash
 cd root
 terragrunt run-all plan
 ```
 
-If your modules have dependencies between them—for example, you can’t deploy the backend-app until MySQL and redis are deployed—you’ll need to express those dependencies in your Terragrunt configuration as explained in the next section.
+If your units have dependencies between them, for example, you can’t deploy the backend-app until MySQL and redis are deployed—you’ll need to express those dependencies in your Terragrunt configuration as explained in the next section.
 
-Additional note: If your modules have dependencies between them, and you run a `terragrunt run-all destroy` command, Terragrunt will destroy all the modules under the current working directory, *as well as each of the module dependencies* (that is, modules you depend on via `dependencies` and `dependency` blocks)! If you wish to use exclude dependencies from being destroyed, add the `--terragrunt-ignore-external-dependencies` flag, or use the `--terragrunt-exclude-dir` once for each directory you wish to exclude.
+Additional note: If your units have dependencies between them, and you run a `terragrunt run-all destroy` command, Terragrunt will destroy all the units under the current working directory, *as well as each of the unit dependencies* (that is, units you depend on via `dependencies` and `dependency` blocks)! If you wish to use exclude dependencies from being destroyed, add the `--terragrunt-ignore-external-dependencies` flag, or use the `--terragrunt-exclude-dir` once for each directory you wish to exclude.
 
-### Passing outputs between modules
+### Passing outputs between units
 
 Consider the following file structure:
 
@@ -125,11 +125,11 @@ root
     └── terragrunt.hcl
 ```
 
-Suppose that you wanted to pass in the VPC ID of the VPC that is created from the `vpc` module in the folder structure above to the `mysql` module as an input variable. Or if you wanted to pass in the subnet IDs of the private subnet that is allocated as part of the `vpc` module.
+Suppose that you wanted to pass in the VPC ID of the VPC that is created from the `vpc` unit in the folder structure above to the `mysql` unit as an input variable. Or if you wanted to pass in the subnet IDs of the private subnet that is allocated as part of the `vpc` unit.
 
-You can use the `dependency` block to extract the output variables to access another module’s output variables in the terragrunt `inputs` attribute.
+You can use the `dependency` block to extract the output variables to access another unit’s output variables in the terragrunt `inputs` attribute.
 
-For example, suppose the `vpc` module outputs the ID under the name `vpc_id`. To access that output, you would specify in `mysql/terragrunt.hcl`:
+For example, suppose the `vpc` unit outputs the ID under the name `vpc_id`. To access that output, you would specify in `mysql/terragrunt.hcl`:
 
 ```hcl
 dependency "vpc" {
@@ -141,9 +141,9 @@ inputs = {
 }
 ```
 
-When you apply this module, the output will be read from the `vpc` module and passed in as an input to the `mysql` module right before calling `tofu apply`/`terraform apply`.
+When you apply this unit, the output will be read from the `vpc` unit and passed in as an input to the `mysql` unit right before calling `tofu apply`/`terraform apply`.
 
-You can also specify multiple `dependency` blocks to access multiple different module output variables. For example, in the above folder structure, you might want to reference the `domain` output of the `redis` and `mysql` modules for use as `inputs` in the `backend-app` module. To access those outputs, you would specify in `backend-app/terragrunt.hcl`:
+You can also specify multiple `dependency` blocks to access multiple different unit output variables. For example, in the above folder structure, you might want to reference the `domain` output of the `redis` and `mysql` units for use as `inputs` in the `backend-app` unit. To access those outputs, you would specify in `backend-app/terragrunt.hcl`:
 
 ```hcl
 dependency "mysql" {
@@ -160,7 +160,7 @@ inputs = {
 }
 ```
 
-Note that each `dependency` is automatically considered a dependency in Terragrunt. This means that when you run `run-all apply` on a config that has `dependency` blocks, Terragrunt will not attempt to deploy the config until all the modules referenced in `dependency` blocks have been applied. So for the above example, the order for the `run-all apply` command would be:
+Note that each `dependency` is automatically considered a dependency in Terragrunt. This means that when you run `run-all apply` on a config that has `dependency` blocks, Terragrunt will not attempt to deploy the config until all the units referenced in `dependency` blocks have been applied. So for the above example, the order for the `run-all apply` command would be:
 
 1. Deploy the VPC
 
@@ -168,19 +168,19 @@ Note that each `dependency` is automatically considered a dependency in Terragru
 
 3. Deploy the backend-app
 
-If any of the modules failed to deploy, then Terragrunt will not attempt to deploy the modules that depend on them.
+If any of the units failed to deploy, then Terragrunt will not attempt to deploy the units that depend on them.
 
 **Note**: Not all blocks are able to access outputs passed by `dependency` blocks. See the section on [Configuration parsing order]({{site.baseurl}}/docs/getting-started/configuration/#configuration-parsing-order) for more information.
 
 #### Unapplied dependency and mock outputs
 
-Terragrunt will return an error indicating the dependency hasn’t been applied yet if the terraform module managed by the terragrunt config referenced in a `dependency` block has not been applied yet. This is because you cannot actually fetch outputs out of an unapplied OpenTofu/Terraform module, even if there are no resources being created in the module.
+Terragrunt will return an error indicating the dependency hasn’t been applied yet if the unit referenced in a `dependency` block has not been applied yet. This is because you cannot actually fetch outputs out of an unapplied unit, even if there are no resources being created in the unit.
 
-This is most problematic when running commands that do not modify state (e.g `run-all plan` and `run-all validate`) on a completely new setup where no infrastructure has been deployed. You won’t be able to `plan` or `validate` a module if you can’t determine the `inputs`. If the module depends on the outputs of another module that hasn’t been applied yet, you won’t be able to compute the `inputs` unless the dependencies are all applied. However, in real life usage, you would want to run `run-all validate` or `run-all plan` on a completely new set of infrastructure.
+This is most problematic when running commands that do not modify state (e.g `run-all plan` and `run-all validate`) on a completely new setup where no infrastructure has been deployed. You won’t be able to `plan` or `validate` a unit if you can’t determine the `inputs`. If the unit depends on the outputs of another unit that hasn’t been applied yet, you won’t be able to compute the `inputs` unless the dependencies are all applied. However, in real life usage, you would want to run `run-all validate` or `run-all plan` on a completely new set of infrastructure.
 
-To address this, you can provide mock outputs to use when a module hasn’t been applied yet. This is configured using the `mock_outputs` attribute on the `dependency` block and it corresponds to a map that will be injected in place of the actual dependency outputs if the target config hasn’t been applied yet.
+To address this, you can provide mock outputs to use when a unit hasn’t been applied yet. This is configured using the `mock_outputs` attribute on the `dependency` block and it corresponds to a map that will be injected in place of the actual dependency outputs if the target config hasn’t been applied yet.
 
-For example, in the previous example with a `mysql` module and `vpc` module, suppose you wanted to place in a temporary, dummy value for the `vpc_id` during a `run-all validate` for the `mysql` module. You can specify in `mysql/terragrunt.hcl`:
+For example, in the previous example with a `mysql` unit and `vpc` unit, suppose you wanted to place in a temporary, dummy value for the `vpc_id` during a `run-all validate` for the `mysql` unit. You can specify in `mysql/terragrunt.hcl`:
 
 ```hcl
 dependency "vpc" {
@@ -196,7 +196,7 @@ inputs = {
 }
 ```
 
-You can now run `validate` on this config before the `vpc` module is applied because Terragrunt will use the map `{vpc_id = "temporary-dummy-id"}` as the `outputs` attribute on the dependency instead of erroring out.
+You can now run `validate` on this config before the `vpc` unit is applied because Terragrunt will use the map `{vpc_id = "temporary-dummy-id"}` as the `outputs` attribute on the dependency instead of erroring out.
 
 What if you wanted to restrict this behavior to only the `validate` command? For example, you might not want to use the defaults for a `plan` operation because the plan doesn’t give you any indication of what is actually going to be created.
 
@@ -257,7 +257,7 @@ dependency "vpc" {
 
 If the state outputs only contains `vpc_id`, this value will be preserved. And `new_output` which is not existing, the mock value will be used.
 
-### Dependencies between modules
+### Dependencies between units
 
 You can also specify dependencies explicitly. Consider the following file structure:
 
@@ -280,7 +280,7 @@ root
     └── terragrunt.hcl
 ```
 
-Let’s assume you have the following dependencies between OpenTofu/Terraform modules:
+Let’s assume you have the following dependencies between OpenTofu/Terraform units:
 
 - `backend-app` depends on `mysql`, `redis`, and `vpc`
 
@@ -318,7 +318,7 @@ Once you’ve specified the dependencies in each `terragrunt.hcl` file, when you
 
 4. Deploy the frontend-app
 
-If any of the modules fail to deploy, then Terragrunt will not attempt to deploy the modules that depend on them. Once you’ve fixed the error, it’s usually safe to re-run the `run-all apply` or `run-all destroy` command again, since it’ll be a no-op for the modules that already deployed successfully, and should only affect the ones that had an error the last time around.
+If any of the units fail to deploy, then Terragrunt will not attempt to deploy the units that depend on them. Once you’ve fixed the error, it’s usually safe to re-run the `run-all apply` or `run-all destroy` command again, since it’ll be a no-op for the units that already deployed successfully, and should only affect the ones that had an error the last time around.
 
 To check all of your dependencies and validate the code in them, you can use the `run-all validate` command.
 
@@ -336,18 +336,18 @@ In the example above it'll generate this graph
 Note that this graph shows the dependency relationship in the direction of the arrow (top down), however terragrunt will run the action
 in reverse order (bottom up)
 
-**Note:** During execution of `destroy` command, Terragrunt will try to find all dependent modules and show a confirmation prompt with a list of all detected dependencies, because once resources will be destroyed, any commands on dependent modules will fail with missing dependencies. For example, if `destroy` was called on the `redis` module, you will be asked to confirm the action because `backend-app` depends on `redis`. You can avoid the prompt by using `--terragrunt-non-interactive`.
+**Note:** During execution of `destroy` command, Terragrunt will try to find all dependent units and show a confirmation prompt with a list of all detected dependencies, because once resources will be destroyed, any commands on dependent units will fail with missing dependencies. For example, if `destroy` was called on the `redis` unit, you will be asked to confirm the action because `backend-app` depends on `redis`. You can avoid the prompt by using `--terragrunt-non-interactive`.
 
-### Testing multiple modules locally
+### Testing multiple units locally
 
-If you are using Terragrunt to configure [remote OpenTofu/Terraform configurations]({{site.baseurl}}/docs/features/keep-your-terraform-code-dry/#remote-terraform-configurations) and all of your modules have the `source` parameter set to a Git URL, but you want to test with a local checkout of the code, you can use the `--terragrunt-source` parameter:
+If you are using Terragrunt to configure [remote OpenTofu/Terraform configurations]({{site.baseurl}}/docs/features/keep-your-terraform-code-dry/#remote-terraform-configurations) and all of your units have the `source` parameter set to a Git URL, but you want to test with a local checkout of the code, you can use the `--terragrunt-source` parameter:
 
 ```bash
 cd root
 terragrunt run-all plan --terragrunt-source /source/modules
 ```
 
-If you set the `--terragrunt-source` parameter, the `run-all` commands will assume that parameter is pointing to a folder on your local file system that has a local checkout of all of your OpenTofu/Terraform modules. For each module that is being processed via a `run-all` command, Terragrunt will read in the `source` parameter in that module’s `terragrunt.hcl` file, parse out the path (the portion after the double-slash), and append the path to the `--terragrunt-source` parameter to create the final local path for that module.
+If you set the `--terragrunt-source` parameter, the `run-all` commands will assume that parameter is pointing to a folder on your local file system that has a local checkout of all of your OpenTofu/Terraform modules. For each unit that is being processed via a `run-all` command, Terragrunt will read in the `source` parameter in that unit’s `terragrunt.hcl` file, parse out the path (the portion after the double-slash), and append the path to the `--terragrunt-source` parameter to create the final local path for that unit.
 
 For example, consider the following `terragrunt.hcl` file:
 
@@ -359,14 +359,14 @@ terraform {
 
 If you run `terragrunt run-all apply --terragrunt-source /source/infrastructure-modules`, then the local path Terragrunt will compute for the module above will be `/source/infrastructure-modules//networking/vpc`.
 
-### Limiting the module execution parallelism
+### Limiting the unit execution parallelism
 
-By default Terragrunt will not impose a limit on the number of modules it executes when it traverses the dependency graph,
-meaning that if it finds 5 modules it'll run OpenTofu/Terraform 5 times in parallel once in each module. Sometimes
-this might create a problem if there are a lot of modules in the dependency graph like hitting a rate limit on some
+By default Terragrunt will not impose a limit on the number of units it executes when it traverses the dependency graph,
+meaning that if it finds 5 units it'll run OpenTofu/Terraform 5 times in parallel once in each unit. Sometimes
+this might create a problem if there are a lot of units in the dependency graph like hitting a rate limit on some
 cloud provider.
 
-To limit the maximum number of module executions at any given time use the `--terragrunt-parallelism [number]` flag
+To limit the maximum number of unit executions at any given time use the `--terragrunt-parallelism [number]` flag
 
 ```sh
 terragrunt run-all apply --terragrunt-parallelism 4
@@ -437,7 +437,7 @@ $ tree /tmp/all
 
 Notes:
 
-- The plan for each module will be saved the same hierarchy as the module structure.
+- The plan for each unit will be saved the same hierarchy as the unit structure.
 - The file name for the plans are `tfplan.tfplan` for the plan binary and `tfplan.json` for the plan JSON.
 - JSON plan files can't be used with `terragrunt run-all apply` command, only binary plan files can be used.
 - Output directories can be combined which will lead to saving both binary and JSON plans.

--- a/docs/_docs/03_community/support.md
+++ b/docs/_docs/03_community/support.md
@@ -12,19 +12,23 @@ nav_title_link: /docs/
 
 ## Github Discussions
 
-Search our [Knowledge Base](https://github.com/gruntwork-io/knowledge-base/discussions) to find existing questions or ask your own. Github Discussions is a good place for general discussions and questions.
+Search [Terragrunt GitHub Discussions](https://gruntwork-io/terragrunt/discussions) for existing questions or ask your own. [Gruntwork GitHub Discussions](https://github.com/gruntwork-io/knowledge-base/discussions) is a good place for general discussions and questions about Gruntwork tools.
+
+## Join the Discord Community
+
+Join the [Gruntwork Discord Community](https://discord.gg/SPu4Degs5f) to chat with maintainers and members of the community.
 
 ## Github Issues
 
 Read through [existing issues](https://github.com/gruntwork-io/terragrunt/issues) or post a new one. Github issues is a good place to:
 
-- report a bug,
+- Report a bug
 
-- ask for a help,
+- Ask for improvements
 
-- ask for improvements,
+- Propose a change to how Terragrunt works
 
-- to start contributing by solving simple issues.
+- Start contributing by solving issues
 
 ## Commercial support
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Improves the Quick Start experience by doing the following:

1. Adds a new guide called `Add to OpenTofu Project` that explains how to add Terragrunt to an existing OpenTofu project.
2. Updates the `Quick Start` guide to include a reference to the new `Add to OpenTofu Project` guide.
3. Updates the `Quick Start` guide to include a reference to the Fundamentals of DevOps and Software Delivery book.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `Add to OpenTofu Project` as another part of the Getting started guide.
Updated `Quick start` guide with extra information and a reference to the `Add to OpenTofu Project` guide.

