### PR TITLE
fix: Fix spelling of `RenderJSONithMetadata` as `RenderJSONWithMetadata`

### DIFF
--- a/cli/commands/render-json/action.go
+++ b/cli/commands/render-json/action.go
@@ -49,7 +49,7 @@ func runRenderJSON(ctx context.Context, opts *options.TerragruntOptions, cfg *co
 
 	var terragruntConfigCty cty.Value
 
-	if opts.RenderJSONithMetadata {
+	if opts.RenderJSONWithMetadata {
 		cty, err := config.TerragruntConfigAsCtyWithMetadata(cfg)
 		if err != nil {
 			return err

--- a/cli/commands/render-json/command.go
+++ b/cli/commands/render-json/command.go
@@ -23,7 +23,7 @@ func NewFlags(opts *options.TerragruntOptions) cli.Flags {
 		},
 		&cli.BoolFlag{
 			Name:        FlagNameWithMetadata,
-			Destination: &opts.RenderJSONithMetadata,
+			Destination: &opts.RenderJSONWithMetadata,
 			Usage:       "Add metadata to the rendered JSON file.",
 		},
 		&cli.BoolFlag{

--- a/options/options.go
+++ b/options/options.go
@@ -281,7 +281,7 @@ type TerragruntOptions struct {
 	UsePartialParseConfigCache bool
 
 	// Include fields metadata in render-json
-	RenderJSONithMetadata bool
+	RenderJSONWithMetadata bool
 
 	// Disable TF output formatting
 	ForwardTFStdout bool


### PR DESCRIPTION
## Description

Fixes #3578.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

