### PR TITLE
feat: Only check TF version when necessary

### DIFF
--- a/cli/commands/terraform/version_check.go
+++ b/cli/commands/terraform/version_check.go
@@ -14,10 +14,6 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-// DefaultTerraformVersionConstraint uses the constraint syntax from https://github.com/hashicorp/go-version
-// This version of Terragrunt was tested to work with Terraform 0.12.0 and above only
-const DefaultTerraformVersionConstraint = ">= v0.12.0"
-
 // TerraformVersionRegex verifies that terraform --version output is in one of the following formats:
 // - OpenTofu v1.6.0-dev
 // - Terraform v0.9.5-dev (cad024a5fe131a546936674ef85445215bbc4226+CHANGES)
@@ -54,17 +50,14 @@ func checkVersionConstraints(ctx context.Context, terragruntOptions *options.Ter
 		terragruntOptions.TerraformPath = partialTerragruntConfig.TerraformBinary
 	}
 
-	if err := PopulateTerraformVersion(ctx, terragruntOptions); err != nil {
-		return err
-	}
+	if terraformVersionConstraint := partialTerragruntConfig.TerraformVersionConstraint; terraformVersionConstraint != "" {
+		if err := PopulateTerraformVersion(ctx, terragruntOptions); err != nil {
+			return err
+		}
 
-	terraformVersionConstraint := DefaultTerraformVersionConstraint
-	if partialTerragruntConfig.TerraformVersionConstraint != "" {
-		terraformVersionConstraint = partialTerragruntConfig.TerraformVersionConstraint
-	}
-
-	if err := CheckTerraformVersion(terraformVersionConstraint, terragruntOptions); err != nil {
-		return err
+		if err := CheckTerraformVersion(terraformVersionConstraint, terragruntOptions); err != nil {
+			return err
+		}
 	}
 
 	if partialTerragruntConfig.TerragruntVersionConstraint != "" {


### PR DESCRIPTION
## Description

Makes it so that `terragrunt --version`/`tofu --version`/`terraform --version` are only run when a version constraint is defined in configuration.

This saves a couple milliseconds on every HCL parse, which can add up over time.

This change also removes the baked in Minimum Supported Version of Terraform from the `terragrunt` binary. The version that was being checked is very old, and it's unlikely that anyone is still using it. If you are, you will still be at risk of running into issues getting support with Terragrunt. The [compatiblity table](https://terragrunt.gruntwork.io/docs/getting-started/supported-versions/) is still respected.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `version_check`.

