### PR TITLE
feat: add encryption to remote_state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,14 @@ run_integration_test: &run_integration_test
     run-go-tests --packages "$(go list ./... | grep /test | tr '\n' ' ')" | tee logs/test-results.log
   no_output_timeout: 30m
 
+run_integration_tofu_only_test: &run_integration_tofu_only_test
+  name: Run tofu-only integration tests
+  command: |
+    run-go-tests --packages "-tags tofu -run ^TestTofu ./..." | tee logs/test-results.log
+  no_output_timeout: 30m
+  environment:
+    TERRAGRUNT_TFPATH: tofu
+
 run_integration_gcp_test: &run_integration_gcp_test
   name: Run integration tests GCP
   command: |
@@ -316,6 +324,27 @@ jobs:
           <<: *run_integration_test
           environment:
             TERRAGRUNT_TFPATH: tofu
+      - run:
+          <<: *run_terratest_log_parser
+      - store_artifacts:
+          path: logs
+      - store_test_results:
+          path: logs
+
+  integration_test_tofu_only:
+    resource_class: medium
+    <<: *defaults
+    <<: *env
+    steps:
+      - checkout
+      - run:
+          <<: *install_tofu
+      - run:
+          <<: *install_tflint
+      - run:
+          <<: *setup_test_environment
+      - run:
+          <<: *run_integration_tofu_only_test
       - run:
           <<: *run_terratest_log_parser
       - store_artifacts:
@@ -725,6 +754,14 @@ workflows:
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
       - integration_test_tofu:
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GCP__automated-tests
+            - GITHUB__PAT__gruntwork-ci
+      - integration_test_tofu_only:
           filters:
             tags:
               only: /^v.*/

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -297,7 +297,6 @@ func RemoteStateConfigToTerraformCode(backend string, config map[string]interfac
 		if !found {
 			return nil, fmt.Errorf(encryptionKeyProviderKey + " is mandatory but not found in the encryption map")
 		}
-
 		keyProviderTraversal := hcl.Traversal{
 			hcl.TraverseRoot{Name: encryptionKeyProviderKey},
 			hcl.TraverseAttr{Name: keyProvider},

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -343,7 +343,17 @@ func RemoteStateConfigToTerraformCode(backend string, config map[string]interfac
 				continue
 			}
 
-			ctyVal, err := convertValue(encryption[key])
+			value, ok := encryption[key]
+			if !ok {
+				continue
+			}
+
+			// Skip basic types with zero values
+			if value == "" || value == 0 {
+				continue
+			}
+
+			ctyVal, err := convertValue(value)
 			if err != nil {
 				return nil, errors.New(err)
 			}

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -292,11 +292,12 @@ func RemoteStateConfigToTerraformCode(backend string, config map[string]interfac
 
 	// encryption can be empty
 	if len(encryption) > 0 {
-		//extract key_provider first to create key_provider block
+		// extract key_provider first to create key_provider block
 		keyProvider, found := encryption[encryptionKeyProviderKey].(string)
 		if !found {
-			return nil, fmt.Errorf(encryptionKeyProviderKey + " is mandatory but not found in the encryption map")
+			return nil, errors.New(encryptionKeyProviderKey + " is mandatory but not found in the encryption map")
 		}
+
 		keyProviderTraversal := hcl.Traversal{
 			hcl.TraverseRoot{Name: encryptionKeyProviderKey},
 			hcl.TraverseAttr{Name: keyProvider},
@@ -341,10 +342,12 @@ func RemoteStateConfigToTerraformCode(backend string, config map[string]interfac
 			if key == encryptionKeyProviderKey {
 				continue
 			}
+
 			ctyVal, err := convertValue(encryption[key])
 			if err != nil {
 				return nil, errors.New(err)
 			}
+
 			if keyProviderBlockBody != nil {
 				keyProviderBlockBody.SetAttributeValue(key, ctyVal.Value)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -288,6 +288,8 @@ func (remoteState *remoteStateConfigFile) toConfig() (*remote.RemoteState, error
 		}
 
 		config.Encryption = remoteStateEncryption
+	} else {
+		config.Encryption = nil
 	}
 
 	if remoteState.DisableInit != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -286,6 +286,7 @@ func (remoteState *remoteStateConfigFile) toConfig() (*remote.RemoteState, error
 		if err != nil {
 			return nil, err
 		}
+
 		config.Encryption = remoteStateEncryption
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -254,6 +254,7 @@ type remoteStateConfigFile struct {
 	DisableDependencyOptimization *bool                      `hcl:"disable_dependency_optimization,attr"`
 	Generate                      *remoteStateConfigGenerate `hcl:"generate,attr"`
 	Config                        cty.Value                  `hcl:"config,attr"`
+	Encryption                    *cty.Value                 `hcl:"encryption,attr"`
 }
 
 func (remoteState *remoteStateConfigFile) String() string {
@@ -279,6 +280,14 @@ func (remoteState *remoteStateConfigFile) toConfig() (*remote.RemoteState, error
 	}
 
 	config.Config = remoteStateConfig
+
+	if remoteState.Encryption != nil && !remoteState.Encryption.IsNull() {
+		remoteStateEncryption, err := ParseCtyValueToMap(*remoteState.Encryption)
+		if err != nil {
+			return nil, err
+		}
+		config.Encryption = remoteStateEncryption
+	}
 
 	if remoteState.DisableInit != nil {
 		config.DisableInit = *remoteState.DisableInit

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -599,8 +599,8 @@ func terraformConfigAsCty(config *TerraformConfig) (cty.Value, error) {
 }
 
 // RemoteStateAsCty serializes RemoteState to a cty Value. We can't directly
-// serialize the struct because `config` is an arbitrary
-// interface whose type we do not know, so we have to do a hack to go through json.
+// serialize the struct because `config` and `encryption` are arbitrary
+// interfaces whose type we do not know, so we have to do a hack to go through json.
 func RemoteStateAsCty(remoteState *remote.RemoteState) (cty.Value, error) {
 	if remoteState == nil {
 		return cty.NilVal, nil
@@ -624,6 +624,7 @@ func RemoteStateAsCty(remoteState *remote.RemoteState) (cty.Value, error) {
 	}
 
 	output["config"] = ctyJSONVal
+	output["encryption"] = ctyJSONVal
 
 	return convertValuesMapToCtyVal(output)
 }

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -624,6 +624,12 @@ func RemoteStateAsCty(remoteState *remote.RemoteState) (cty.Value, error) {
 	}
 
 	output["config"] = ctyJSONVal
+
+	ctyJSONVal, err = convertToCtyWithJSON(remoteState.Encryption)
+	if err != nil {
+		return cty.NilVal, err
+	}
+
 	output["encryption"] = ctyJSONVal
 
 	return convertValuesMapToCtyVal(output)

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -178,6 +178,9 @@ func TestRemoteStateAsCtyDrift(t *testing.T) {
 		Config: map[string]interface{}{
 			"bar": "baz",
 		},
+		Encryption: map[string]interface{}{
+			"bar": "baz",
+		},
 	}
 
 	ctyVal, err := config.RemoteStateAsCty(&testConfig)
@@ -301,6 +304,8 @@ func remoteStateStructFieldToMapKey(t *testing.T, fieldName string) (string, boo
 		return "generate", true
 	case "Config":
 		return "config", true
+	case "Encryption":
+		return "encryption", true
 	default:
 		t.Fatalf("Unknown struct property: %s", fieldName)
 		// This should not execute

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,8 +30,9 @@ func TestParseTerragruntConfigRemoteStateMinimalConfig(t *testing.T) {
 
 	cfg := `
 remote_state {
-  backend = "s3"
-  config  = {}
+  backend 	  = "s3"
+  config  	  = {}
+  encryption  = {}
 }
 `
 
@@ -46,6 +47,7 @@ remote_state {
 	if assert.NotNil(t, terragruntConfig.RemoteState) {
 		assert.Equal(t, "s3", terragruntConfig.RemoteState.Backend)
 		assert.Empty(t, terragruntConfig.RemoteState.Config)
+		assert.Empty(t, terragruntConfig.RemoteState.Encryption)
 	}
 }
 
@@ -124,6 +126,10 @@ remote_state {
   		key = "terraform.tfstate"
   		region = "us-east-1"
 	}
+	encryption = {
+		key_provider = "pbkdf2"
+		passphrase = "correct-horse-battery-staple"
+	}
 }
 `
 
@@ -144,6 +150,8 @@ remote_state {
 		assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
 		assert.Equal(t, "terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
 		assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
+		assert.Equal(t, "pbkdf2", terragruntConfig.RemoteState.Encryption["key_provider"])
+		assert.Equal(t, "correct-horse-battery-staple", terragruntConfig.RemoteState.Encryption["passphrase"])
 	}
 }
 
@@ -159,6 +167,10 @@ func TestParseTerragruntJsonConfigRemoteStateFullConfig(t *testing.T) {
 			"bucket": "my-bucket",
 			"key": "terraform.tfstate",
 			"region":"us-east-1"
+		},
+		"encryption":{
+			"key_provider": "pbkdf2",
+			"passphrase": "correct-horse-battery-staple"
 		}
 	}
 }
@@ -180,6 +192,8 @@ func TestParseTerragruntJsonConfigRemoteStateFullConfig(t *testing.T) {
 		assert.Equal(t, "my-bucket", terragruntConfig.RemoteState.Config["bucket"])
 		assert.Equal(t, "terraform.tfstate", terragruntConfig.RemoteState.Config["key"])
 		assert.Equal(t, "us-east-1", terragruntConfig.RemoteState.Config["region"])
+		assert.Equal(t, "pbkdf2", terragruntConfig.RemoteState.Encryption["key_provider"])
+		assert.Equal(t, "correct-horse-battery-staple", terragruntConfig.RemoteState.Encryption["passphrase"])
 	}
 }
 

--- a/docs/_docs/04_reference/config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/config-blocks-and-attributes.md
@@ -587,7 +587,7 @@ remote_state {
 
   encryption = {
     key_provider = "pbkdf2"
-    passphrase = "SUPERSECRETPASSPHRASE"
+    passphrase   = get_env("PBKDF2_PASSPHRASE")
   }
 }
 ```

--- a/remote/remote_encryption.go
+++ b/remote/remote_encryption.go
@@ -84,6 +84,7 @@ type RemoteEncryptionKeyProviderAWSKMS struct {
 	RemoteEncryptionKeyProviderBase `mapstructure:",squash"`
 	KmsKeyID                        string `mapstructure:"kms_key_id"`
 	KeySpec                         string `mapstructure:"key_spec"`
+	Region                          string `mapstructure:"region"`
 }
 
 type RemoteEncryptionKeyProviderGCPKMS struct {

--- a/remote/remote_encryption.go
+++ b/remote/remote_encryption.go
@@ -1,0 +1,89 @@
+package remote
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+type RemoteEncryptionConfig interface {
+	UnmarshalConfig(encryptionConfig map[string]interface{}) error
+	ToMap() (map[string]interface{}, error)
+}
+
+type RemoteEncryptionKeyProvider interface {
+	RemoteEncryptionKeyProviderPBKDF2 | RemoteEncryptionKeyProviderGCPKMS | RemoteEncryptionKeyProviderAWSKMS
+}
+
+type RemoteEncryptionKeyProviderBase struct {
+	KeyProvider string `mapstructure:"key_provider"`
+}
+
+type GenericRemoteEncryptionKeyProvider[T RemoteEncryptionKeyProvider] struct {
+	T T
+}
+
+func (b *GenericRemoteEncryptionKeyProvider[T]) UnmarshalConfig(encryptionConfig map[string]interface{}) error {
+	// Decode the key provider type using the default decoder config
+	if err := mapstructure.Decode(encryptionConfig, &b); err != nil {
+		return fmt.Errorf("failed to decode key provider: %w", err)
+	}
+
+	// Decode the key provider properties using, setting ErrorUnused to true to catch any unused properties
+	decoderConfig := &mapstructure.DecoderConfig{
+		Result:      &b.T,
+		ErrorUnused: true,
+	}
+	decoder, err := mapstructure.NewDecoder(decoderConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create decoder: %w", err)
+	}
+	if err := decoder.Decode(encryptionConfig); err != nil {
+		return fmt.Errorf("failed to decode key provider properties: %w", err)
+	}
+
+	return nil
+}
+
+func (b *GenericRemoteEncryptionKeyProvider[T]) ToMap() (map[string]interface{}, error) {
+	var result map[string]interface{}
+	err := mapstructure.Decode(b.T, &result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode struct to map: %w", err)
+	}
+	return result, nil
+}
+
+func NewRemoteEncryptionKeyProvider(providerType string) (RemoteEncryptionConfig, error) {
+	switch providerType {
+	case "pbkdf2":
+		return &GenericRemoteEncryptionKeyProvider[RemoteEncryptionKeyProviderPBKDF2]{}, nil
+	case "gcp_kms":
+		return &GenericRemoteEncryptionKeyProvider[RemoteEncryptionKeyProviderGCPKMS]{}, nil
+	case "aws_kms":
+		return &GenericRemoteEncryptionKeyProvider[RemoteEncryptionKeyProviderAWSKMS]{}, nil
+	default:
+		return nil, fmt.Errorf("unknown provider type: %s", providerType)
+	}
+}
+
+type RemoteEncryptionKeyProviderPBKDF2 struct {
+	RemoteEncryptionKeyProviderBase `mapstructure:",squash"`
+	Passphrase                      string `mapstructure:"passphrase"`
+	KeyLength                       int    `mapstructure:"key_length"`
+	Iterations                      int    `mapstructure:"iterations"`
+	SaltLength                      int    `mapstructure:"salt_length"`
+	HashFunction                    string `mapstructure:"hash_function"`
+}
+
+type RemoteEncryptionKeyProviderAWSKMS struct {
+	RemoteEncryptionKeyProviderBase `mapstructure:",squash"`
+	KmsKeyID                        string `mapstructure:"kms_key_id"`
+	KeySpec                         string `mapstructure:"key_spec"`
+}
+
+type RemoteEncryptionKeyProviderGCPKMS struct {
+	RemoteEncryptionKeyProviderBase `mapstructure:",squash"`
+	KmsEncryptionKey                string `mapstructure:"kms_encryption_key"`
+	KeyLength                       int    `mapstructure:"key_length"`
+}

--- a/remote/remote_encryption.go
+++ b/remote/remote_encryption.go
@@ -20,7 +20,7 @@ type RemoteEncryptionKeyProviderBase struct {
 }
 
 type GenericRemoteEncryptionKeyProvider[T RemoteEncryptionKeyProvider] struct {
-	T T
+	T T `mapstructure:",squash"`
 }
 
 func (b *GenericRemoteEncryptionKeyProvider[T]) UnmarshalConfig(encryptionConfig map[string]interface{}) error {
@@ -35,9 +35,11 @@ func (b *GenericRemoteEncryptionKeyProvider[T]) UnmarshalConfig(encryptionConfig
 		ErrorUnused: true,
 	}
 	decoder, err := mapstructure.NewDecoder(decoderConfig)
+
 	if err != nil {
 		return fmt.Errorf("failed to create decoder: %w", err)
 	}
+
 	if err := decoder.Decode(encryptionConfig); err != nil {
 		return fmt.Errorf("failed to decode key provider properties: %w", err)
 	}
@@ -48,9 +50,11 @@ func (b *GenericRemoteEncryptionKeyProvider[T]) UnmarshalConfig(encryptionConfig
 func (b *GenericRemoteEncryptionKeyProvider[T]) ToMap() (map[string]interface{}, error) {
 	var result map[string]interface{}
 	err := mapstructure.Decode(b.T, &result)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode struct to map: %w", err)
 	}
+
 	return result, nil
 }
 

--- a/remote/remote_encryption_test.go
+++ b/remote/remote_encryption_test.go
@@ -1,0 +1,206 @@
+package remote_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/remote"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerType     string
+		encryptionConfig map[string]interface{}
+		expectedError    bool
+	}{
+		{
+			name:         "PBKDF2 valid config",
+			providerType: "pbkdf2",
+			encryptionConfig: map[string]interface{}{
+				"key_provider":  "pbkdf2",
+				"passphrase":    "passphrase",
+				"key_length":    32,
+				"iterations":    10000,
+				"salt_length":   16,
+				"hash_function": "sha256",
+			},
+			expectedError: false,
+		},
+		{
+			name:         "PBKDF2 invalid property",
+			providerType: "pbkdf2",
+			encryptionConfig: map[string]interface{}{
+				"key_provider": "pbkdf2",
+				"password":     "password123", // Invalid property
+			},
+			expectedError: true,
+		},
+		{
+			name:         "PBKDF2 invalid config",
+			providerType: "pbkdf2",
+			encryptionConfig: map[string]interface{}{
+				"key_provider": "pbkdf2",
+				"passphrase":   123, // Invalid type
+			},
+			expectedError: true,
+		},
+		{
+			name:         "AWSKMS valid config",
+			providerType: "aws_kms",
+			encryptionConfig: map[string]interface{}{
+				"key_provider": "aws_kms",
+				"kms_key_id":   123456789,
+				"key_spec":     "AES_256",
+			},
+			expectedError: false,
+		},
+		{
+			name:         "AWSKMS invalid property",
+			providerType: "aws_kms",
+			encryptionConfig: map[string]interface{}{
+				"key_provider": "aws_kms",
+				"password":     "password123", // Invalid property
+			},
+			expectedError: true,
+		},
+		{
+			name:         "AWSKMS invalid config",
+			providerType: "aws_kms",
+			encryptionConfig: map[string]interface{}{
+				"key_provider": "aws_kms",
+				"kms_key_id":   "invalid_id", // Invalid type
+				"key_spec":     "AES_256",
+			},
+			expectedError: true,
+		},
+		{
+			name:         "GCPKMS valid config",
+			providerType: "gcp_kms",
+			encryptionConfig: map[string]interface{}{
+				"key_provider":       "gcp_kms",
+				"kms_encryption_key": "projects/123456789/locations/global/keyRings/my-key-ring/cryptoKeys/my-key",
+				"key_length":         32,
+			},
+			expectedError: false,
+		},
+		{
+			name:         "GCPKMS invalid property",
+			providerType: "gcp_kms",
+			encryptionConfig: map[string]interface{}{
+				"key_provider": "gcp_kms",
+				"password":     "password123", // Invalid property
+			},
+			expectedError: true,
+		},
+		{
+			name:         "GCPKMS invalid config",
+			providerType: "gcp_kms",
+			encryptionConfig: map[string]interface{}{
+				"key_provider":       "gcp_kms",
+				"kms_encryption_key": 123456789, // Invalid type
+				"key_length":         32,
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := remote.NewRemoteEncryptionKeyProvider(tt.providerType)
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+
+			err = provider.UnmarshalConfig(tt.encryptionConfig)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+func TestToMap(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerType     string
+		encryptionConfig map[string]interface{}
+		expectedMap      map[string]interface{}
+		expectedError    bool
+	}{
+		{
+			name:         "PBKDF2 valid config",
+			providerType: "pbkdf2",
+			encryptionConfig: map[string]interface{}{
+				"key_provider":  "pbkdf2",
+				"passphrase":    "passphrase",
+				"key_length":    32,
+				"iterations":    10000,
+				"salt_length":   16,
+				"hash_function": "sha256",
+			},
+			expectedMap: map[string]interface{}{
+				"key_provider":  "pbkdf2",
+				"passphrase":    "passphrase",
+				"key_length":    32,
+				"iterations":    10000,
+				"salt_length":   16,
+				"hash_function": "sha256",
+			},
+			expectedError: false,
+		},
+		{
+			name:         "AWSKMS valid config",
+			providerType: "aws_kms",
+			encryptionConfig: map[string]interface{}{
+				"key_provider": "aws_kms",
+				"kms_key_id":   123456789,
+				"key_spec":     "AES_256",
+			},
+			expectedMap: map[string]interface{}{
+				"key_provider": "aws_kms",
+				"kms_key_id":   123456789,
+				"key_spec":     "AES_256",
+			},
+			expectedError: false,
+		},
+		{
+			name:         "GCPKMS valid config",
+			providerType: "gcp_kms",
+			encryptionConfig: map[string]interface{}{
+				"key_provider":       "gcp_kms",
+				"kms_encryption_key": "projects/123456789/locations/global/keyRings/my-key-ring/cryptoKeys/my-key",
+				"key_length":         32,
+			},
+			expectedMap: map[string]interface{}{
+				"key_provider":       "gcp_kms",
+				"kms_encryption_key": "projects/123456789/locations/global/keyRings/my-key-ring/cryptoKeys/my-key",
+				"key_length":         32,
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := remote.NewRemoteEncryptionKeyProvider(tt.providerType)
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+
+			err = provider.UnmarshalConfig(tt.encryptionConfig)
+			if err != nil {
+				t.Fatalf("failed to unmarshal config: %v", err)
+			}
+
+			result, err := provider.ToMap()
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedMap, result)
+			}
+		})
+	}
+}

--- a/remote/remote_encryption_test.go
+++ b/remote/remote_encryption_test.go
@@ -181,12 +181,14 @@ func TestToMap(t *testing.T) {
 			providerType: "aws_kms",
 			encryptionConfig: map[string]interface{}{
 				"key_provider": "aws_kms",
-				"kms_key_id":   123456789,
+				"region":       "us-west-1",
+				"kms_key_id":   "123456789",
 				"key_spec":     "AES_256",
 			},
 			expectedMap: map[string]interface{}{
 				"key_provider": "aws_kms",
-				"kms_key_id":   123456789,
+				"region":       "us-west-1",
+				"kms_key_id":   "123456789",
 				"key_spec":     "AES_256",
 			},
 			expectedError: false,

--- a/remote/remote_encryption_test.go
+++ b/remote/remote_encryption_test.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/remote"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnmarshalConfig(t *testing.T) {
-	tests := []struct {
+	t.Parallel()
+
+	tc := []struct {
 		name             string
 		providerType     string
 		encryptionConfig map[string]interface{}
@@ -105,8 +108,12 @@ func TestUnmarshalConfig(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tc {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			provider, err := remote.NewRemoteEncryptionKeyProvider(tt.providerType)
 			if err != nil {
 				t.Fatalf("failed to create provider: %v", err)
@@ -114,15 +121,17 @@ func TestUnmarshalConfig(t *testing.T) {
 
 			err = provider.UnmarshalConfig(tt.encryptionConfig)
 			if tt.expectedError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
 }
 func TestToMap(t *testing.T) {
-	tests := []struct {
+	t.Parallel()
+
+	tc := []struct {
 		name             string
 		providerType     string
 		encryptionConfig map[string]interface{}
@@ -182,8 +191,12 @@ func TestToMap(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tc {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			provider, err := remote.NewRemoteEncryptionKeyProvider(tt.providerType)
 			if err != nil {
 				t.Fatalf("failed to create provider: %v", err)
@@ -198,7 +211,7 @@ func TestToMap(t *testing.T) {
 			if tt.expectedError {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expectedMap, result)
 			}
 		})

--- a/remote/remote_encryption_test.go
+++ b/remote/remote_encryption_test.go
@@ -18,7 +18,7 @@ func TestUnmarshalConfig(t *testing.T) {
 		expectedError    bool
 	}{
 		{
-			name:         "PBKDF2 valid config",
+			name:         "PBKDF2 full config",
 			providerType: "pbkdf2",
 			encryptionConfig: map[string]interface{}{
 				"key_provider":  "pbkdf2",
@@ -49,7 +49,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:         "AWSKMS valid config",
+			name:         "AWSKMS full config",
 			providerType: "aws_kms",
 			encryptionConfig: map[string]interface{}{
 				"key_provider": "aws_kms",
@@ -78,7 +78,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:         "GCPKMS valid config",
+			name:         "GCPKMS full config",
 			providerType: "gcp_kms",
 			encryptionConfig: map[string]interface{}{
 				"key_provider":       "gcp_kms",
@@ -139,7 +139,7 @@ func TestToMap(t *testing.T) {
 		expectedError    bool
 	}{
 		{
-			name:         "PBKDF2 valid config",
+			name:         "PBKDF2 full config",
 			providerType: "pbkdf2",
 			encryptionConfig: map[string]interface{}{
 				"key_provider":  "pbkdf2",
@@ -160,7 +160,24 @@ func TestToMap(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:         "AWSKMS valid config",
+			name:         "PBKDF2 partial config",
+			providerType: "pbkdf2",
+			encryptionConfig: map[string]interface{}{
+				"key_provider": "pbkdf2",
+				"passphrase":   "passphrase",
+			},
+			expectedMap: map[string]interface{}{
+				"key_provider":  "pbkdf2",
+				"passphrase":    "passphrase",
+				"key_length":    0,
+				"iterations":    0,
+				"salt_length":   0,
+				"hash_function": "",
+			},
+			expectedError: false,
+		},
+		{
+			name:         "AWSKMS full config",
 			providerType: "aws_kms",
 			encryptionConfig: map[string]interface{}{
 				"key_provider": "aws_kms",
@@ -175,7 +192,7 @@ func TestToMap(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:         "GCPKMS valid config",
+			name:         "GCPKMS full config",
 			providerType: "gcp_kms",
 			encryptionConfig: map[string]interface{}{
 				"key_provider":       "gcp_kms",

--- a/remote/remote_encryption_test.go
+++ b/remote/remote_encryption_test.go
@@ -53,7 +53,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			providerType: "aws_kms",
 			encryptionConfig: map[string]interface{}{
 				"key_provider": "aws_kms",
-				"kms_key_id":   123456789,
+				"kms_key_id":   "123456789",
 				"key_spec":     "AES_256",
 			},
 			expectedError: false,
@@ -72,7 +72,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			providerType: "aws_kms",
 			encryptionConfig: map[string]interface{}{
 				"key_provider": "aws_kms",
-				"kms_key_id":   "invalid_id", // Invalid type
+				"kms_key_id":   123456789, // Invalid type
 				"key_spec":     "AES_256",
 			},
 			expectedError: true,

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -24,6 +24,7 @@ type RemoteState struct {
 	DisableDependencyOptimization bool                   `mapstructure:"disable_dependency_optimization" json:"DisableDependencyOptimization"`
 	Generate                      *RemoteStateGenerate   `mapstructure:"generate" json:"Generate"`
 	Config                        map[string]interface{} `mapstructure:"config" json:"Config"`
+	Encryption                    map[string]interface{} `mapstructure:"encryption" json:"Encryption"`
 }
 
 // map to store mutexes for each state bucket action
@@ -40,12 +41,13 @@ var initializedRemoteStateCache = cache.NewCache[bool](initializedRemoteStateCac
 
 func (state *RemoteState) String() string {
 	return fmt.Sprintf(
-		"RemoteState{Backend = %v, DisableInit = %v, DisableDependencyOptimization = %v, Generate = %v, Config = %v}",
+		"RemoteState{Backend = %v, DisableInit = %v, DisableDependencyOptimization = %v, Generate = %v, Config = %v, Encryption = %v}",
 		state.Backend,
 		state.DisableInit,
 		state.DisableDependencyOptimization,
 		state.Generate,
 		state.Config,
+		state.Encryption,
 	)
 }
 
@@ -231,6 +233,8 @@ func (state *RemoteState) GenerateTerraformCode(terragruntOptions *options.Terra
 	// Make sure to strip out terragrunt specific configurations from the config.
 	config := state.Config
 
+	encryption := state.Encryption
+
 	initializer, hasInitializer := remoteStateInitializers[state.Backend]
 	if hasInitializer {
 		config = initializer.GetTerraformInitArgs(config)
@@ -242,7 +246,7 @@ func (state *RemoteState) GenerateTerraformCode(terragruntOptions *options.Terra
 		return err
 	}
 
-	configBytes, err := codegen.RemoteStateConfigToTerraformCode(state.Backend, config)
+	configBytes, err := codegen.RemoteStateConfigToTerraformCode(state.Backend, config, encryption)
 	if err != nil {
 		return err
 	}

--- a/remote/remote_state.go
+++ b/remote/remote_state.go
@@ -241,7 +241,7 @@ func (state *RemoteState) GenerateTerraformCode(terragruntOptions *options.Terra
 
 	encryptionProvider, err := NewRemoteEncryptionKeyProvider(keyProvider)
 	if err != nil {
-		return fmt.Errorf("error creating provider: %v", err)
+		return fmt.Errorf("error creating provider: %w", err)
 	}
 
 	err = encryptionProvider.UnmarshalConfig(state.Encryption)
@@ -251,7 +251,7 @@ func (state *RemoteState) GenerateTerraformCode(terragruntOptions *options.Terra
 
 	encryption, err := encryptionProvider.ToMap()
 	if err != nil {
-		return fmt.Errorf("error decoding struct to map: %v", err)
+		return fmt.Errorf("error decoding struct to map: %w", err)
 	}
 
 	initializer, hasInitializer := remoteStateInitializers[state.Backend]

--- a/test/fixtures/read-config/full/source.hcl
+++ b/test/fixtures/read-config/full/source.hcl
@@ -21,6 +21,9 @@ remote_state {
   config = {
     path = "foo.tfstate"
   }
+  encryption = {
+    key_provider = "foo"
+  }
 }
 
 terraform {

--- a/test/fixtures/render-json-with-encryption/common_vars.hcl
+++ b/test/fixtures/render-json-with-encryption/common_vars.hcl
@@ -1,0 +1,8 @@
+dependency "dep" {
+  config_path = "../dep"
+}
+
+inputs = {
+  env  = "qa"
+  name = dependency.dep.outputs.name
+}

--- a/test/fixtures/render-json-with-encryption/dep/main.tf
+++ b/test/fixtures/render-json-with-encryption/dep/main.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = "dep"
+}

--- a/test/fixtures/render-json-with-encryption/dep/terragrunt.hcl
+++ b/test/fixtures/render-json-with-encryption/dep/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/render-json-with-encryption/main/module/main.tf
+++ b/test/fixtures/render-json-with-encryption/main/module/main.tf
@@ -1,0 +1,17 @@
+variable "aws_region" {}
+variable "env" {}
+variable "name" {}
+variable "type" {}
+
+output "aws_region" {
+  value = var.aws_region
+}
+output "env" {
+  value = var.env
+}
+output "name" {
+  value = var.name
+}
+output "type" {
+  value = var.type
+}

--- a/test/fixtures/render-json-with-encryption/main/terragrunt.hcl
+++ b/test/fixtures/render-json-with-encryption/main/terragrunt.hcl
@@ -1,0 +1,15 @@
+terraform {
+  source = "./module"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "envcommon" {
+  path = find_in_parent_folders("common_vars.hcl")
+}
+
+inputs = {
+  type = "main"
+}

--- a/test/fixtures/render-json-with-encryption/root.hcl
+++ b/test/fixtures/render-json-with-encryption/root.hcl
@@ -7,6 +7,10 @@ remote_state {
   config = {
     path = "foo.tfstate"
   }
+  encryption = {
+    key_provider = "pbkdf2"
+    passphrase   = "correct-horse-battery-staple"
+  }
 }
 
 generate "provider" {

--- a/test/fixtures/render-json/root.hcl
+++ b/test/fixtures/render-json/root.hcl
@@ -7,6 +7,9 @@ remote_state {
   config = {
     path = "foo.tfstate"
   }
+  encryption = {
+    key_provider = "foo"
+  }
 }
 
 generate "provider" {

--- a/test/fixtures/tofu-state-encryption/aws-kms/terragrunt.hcl
+++ b/test/fixtures/tofu-state-encryption/aws-kms/terragrunt.hcl
@@ -13,6 +13,7 @@ remote_state {
 
   encryption = {
     key_provider = "aws_kms"
+    region       = "__FILL_IN_AWS_REGION__"
     kms_key_id   = "__FILL_IN_KMS_KEY_ID__"
     key_spec     = "AES_256"
   }

--- a/test/fixtures/tofu-state-encryption/aws-kms/terragrunt.hcl
+++ b/test/fixtures/tofu-state-encryption/aws-kms/terragrunt.hcl
@@ -1,0 +1,19 @@
+# Test AWS KMS encryption with local state
+remote_state {
+  backend = "local"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+
+  config = {
+    path = "${get_terragrunt_dir()}/${path_relative_to_include()}/terraform.tfstate"
+  }
+
+  encryption = {
+    key_provider = "aws_kms"
+    kms_key_id   = "__FILL_IN_KMS_KEY_ID__"
+    key_spec     = "AES_256"
+  }
+}

--- a/test/fixtures/tofu-state-encryption/gcp-kms/terragrunt.hcl
+++ b/test/fixtures/tofu-state-encryption/gcp-kms/terragrunt.hcl
@@ -1,0 +1,19 @@
+# Test GCP KMS encryption with local state
+remote_state {
+  backend = "local"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+
+  config = {
+    path = "${get_terragrunt_dir()}/${path_relative_to_include()}/terraform.tfstate"
+  }
+
+  encryption = {
+    key_provider       = "gcp_kms"
+    kms_encryption_key = "__FILL_IN_KMS_KEY_ID__"
+    key_length         = 1024
+  }
+}

--- a/test/fixtures/tofu-state-encryption/pbkdf2/terragrunt.hcl
+++ b/test/fixtures/tofu-state-encryption/pbkdf2/terragrunt.hcl
@@ -1,0 +1,18 @@
+# Test PBKDF2 encryption with local state
+remote_state {
+  backend = "local"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+
+  config = {
+    path = "${get_terragrunt_dir()}/${path_relative_to_include()}/terraform.tfstate"
+  }
+
+  encryption = {
+    key_provider = "pbkdf2"
+    passphrase = "randompassphrase123456"
+  }
+}

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -219,6 +219,9 @@ func TestRenderJSONConfig(t *testing.T) {
 				"config": map[string]interface{}{
 					"path": "foo.tfstate",
 				},
+				"encryption": map[string]interface{}{
+					"key_provider": "foo",
+				},
 				"disable_init":                    false,
 				"disable_dependency_optimization": false,
 			},

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -220,6 +220,7 @@ func TestRenderJSONConfig(t *testing.T) {
 					"path": "foo.tfstate",
 				},
 				"disable_init":                    false,
+				"encryption":                      nil,
 				"disable_dependency_optimization": false,
 			},
 			remoteState.(map[string]interface{}),

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -219,9 +219,6 @@ func TestRenderJSONConfig(t *testing.T) {
 				"config": map[string]interface{}{
 					"path": "foo.tfstate",
 				},
-				"encryption": map[string]interface{}{
-					"key_provider": "foo",
-				},
 				"disable_init":                    false,
 				"disable_dependency_optimization": false,
 			},

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -284,6 +284,7 @@ func validateIncludeRemoteStateReflection(t *testing.T, s3BucketName string, key
 				"key":     keyPath + "/terraform.tfstate",
 				"region":  "us-west-2",
 			},
+			"encryption": nil,
 		},
 		remoteStateOut,
 	)

--- a/test/integration_json_test.go
+++ b/test/integration_json_test.go
@@ -315,6 +315,7 @@ func TestRenderJsonMetadataIncludes(t *testing.T) {
 				"key":    "path/to/my/key",
 				"region": "us-east-1",
 			},
+			"encryption": nil,
 		},
 	}
 
@@ -460,6 +461,7 @@ func TestRenderJsonMetadataTerraform(t *testing.T) {
 				"key":    "path/to/my/key",
 				"region": "us-east-1",
 			},
+			"encryption":                      nil,
 			"disable_dependency_optimization": false,
 			"disable_init":                    false,
 			"generate":                        nil,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2386,6 +2386,7 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 			"disable_dependency_optimization": false,
 			"generate":                        map[string]interface{}{"path": "backend.tf", "if_exists": "overwrite_terragrunt"},
 			"config":                          map[string]interface{}{"path": "foo.tfstate"},
+			"encryption":                      map[string]interface{}{"key_provider": "foo"},
 		},
 		remoteStateOut,
 	)

--- a/test/integration_tofu_state_encryption_test.go
+++ b/test/integration_tofu_state_encryption_test.go
@@ -75,7 +75,7 @@ func TestTofuStateEncryptionAWSKMS(t *testing.T) {
 	validateStateIsEncrypted(t, stateFile, workDir)
 }
 
-func TestRenderJSONConfigWithEncryption(t *testing.T) {
+func TestTofuRenderJSONConfigWithEncryption(t *testing.T) {
 	t.Parallel()
 
 	tmpDir, err := os.MkdirTemp("", "terragrunt-render-json-*")

--- a/test/integration_tofu_state_encryption_test.go
+++ b/test/integration_tofu_state_encryption_test.go
@@ -1,0 +1,100 @@
+//go:build tofu
+
+package test_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFixtureTofuStateEncryptionPBKDF2 = "fixtures/tofu-state-encryption/pbkdf2"
+	testFixtureTofuStateEncryptionGCPKMS = "fixtures/tofu-state-encryption/gcp-kms"
+	testFixtureTofuStateEncryptionAWSKMS = "fixtures/tofu-state-encryption/aws-kms"
+	gcpKMSKeyID                          = "projects/terragrunt-test/locations/global/keyRings/terragrunt-test/cryptoKeys/terragrunt-test-key"
+	awsKMSKeyID                          = "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
+	stateFile                            = "terraform.tfstate"
+	awsKMSKeyRegion                      = "us-west-2"
+)
+
+func TestTofuStateEncryptionPBKDF2(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureTofuStateEncryptionPBKDF2)
+	workDir := util.JoinPath(tmpEnvPath, testFixtureTofuStateEncryptionPBKDF2)
+
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", workDir))
+	assert.True(t, helpers.FileIsInFolder(t, stateFile, workDir))
+	validateStateIsEncrypted(t, stateFile, workDir)
+}
+
+func TestTofuStateEncryptionGCPKMS(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureTofuStateEncryptionGCPKMS)
+	workDir := util.JoinPath(tmpEnvPath, testFixtureTofuStateEncryptionGCPKMS)
+	configPath := util.JoinPath(workDir, "terragrunt.hcl")
+
+	helpers.CopyAndFillMapPlaceholders(t, configPath, configPath, map[string]string{
+		"__FILL_IN_KMS_KEY_ID__": gcpKMSKeyID,
+	})
+
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", workDir))
+	assert.True(t, helpers.FileIsInFolder(t, stateFile, workDir))
+	validateStateIsEncrypted(t, stateFile, workDir)
+}
+
+func TestTofuStateEncryptionAWSKMS(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureTofuStateEncryptionAWSKMS)
+	workDir := util.JoinPath(tmpEnvPath, testFixtureTofuStateEncryptionAWSKMS)
+	configPath := util.JoinPath(workDir, "terragrunt.hcl")
+
+	helpers.CopyAndFillMapPlaceholders(t, configPath, configPath, map[string]string{
+		"__FILL_IN_KMS_KEY_ID__": awsKMSKeyID,
+	})
+
+	os.Setenv("AWS_REGION", awsKMSKeyRegion)
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", workDir))
+	assert.True(t, helpers.FileIsInFolder(t, stateFile, workDir))
+	validateStateIsEncrypted(t, stateFile, workDir)
+}
+
+// Check the statefile contains an encrypted_data key
+// and that the encrypted_data is base64 encoded
+func validateStateIsEncrypted(t *testing.T, fileName string, path string) {
+	t.Helper()
+
+	filePath := filepath.Join(path, fileName)
+	file, err := os.Open(filePath)
+	require.NoError(t, err)
+	defer file.Close()
+
+	byteValue, err := io.ReadAll(file)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(byteValue, &result)
+	assert.NoError(t, err, "Error unmarshalling the state file '%s'", fileName)
+
+	encryptedData, exists := result["encrypted_data"]
+	assert.True(t, exists, "The key 'encrypted_data' should exist in the state '%s'", fileName)
+
+	// Check if the encrypted_data is base64 encoded (common for AES-256 encrypted data)
+	encryptedDataStr, ok := encryptedData.(string)
+	assert.True(t, ok, "The value of 'encrypted_data' should be a string")
+
+	_, err = base64.StdEncoding.DecodeString(encryptedDataStr)
+	assert.NoError(t, err, "The value of 'encrypted_data' should be base64 encoded, indicating AES-256 encryption")
+}

--- a/test/integration_tofu_state_encryption_test.go
+++ b/test/integration_tofu_state_encryption_test.go
@@ -63,9 +63,9 @@ func TestTofuStateEncryptionAWSKMS(t *testing.T) {
 
 	helpers.CopyAndFillMapPlaceholders(t, configPath, configPath, map[string]string{
 		"__FILL_IN_KMS_KEY_ID__": awsKMSKeyID,
+		"__FILL_IN_AWS_REGION__": awsKMSKeyRegion,
 	})
 
-	os.Setenv("AWS_REGION", awsKMSKeyRegion)
 	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir %s", workDir))
 	assert.True(t, helpers.FileIsInFolder(t, stateFile, workDir))
 	validateStateIsEncrypted(t, stateFile, workDir)

--- a/test/integration_tofu_state_encryption_test.go
+++ b/test/integration_tofu_state_encryption_test.go
@@ -22,9 +22,9 @@ const (
 	testFixtureTofuStateEncryptionGCPKMS = "fixtures/tofu-state-encryption/gcp-kms"
 	testFixtureTofuStateEncryptionAWSKMS = "fixtures/tofu-state-encryption/aws-kms"
 	gcpKMSKeyID                          = "projects/terragrunt-test/locations/global/keyRings/terragrunt-test/cryptoKeys/terragrunt-test-key"
-	awsKMSKeyID                          = "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
+	awsKMSKeyID                          = "bd372994-d969-464a-a261-6cc850c58a92"
 	stateFile                            = "terraform.tfstate"
-	awsKMSKeyRegion                      = "us-west-2"
+	awsKMSKeyRegion                      = "us-east-1"
 )
 
 func TestTofuStateEncryptionPBKDF2(t *testing.T) {
@@ -39,6 +39,7 @@ func TestTofuStateEncryptionPBKDF2(t *testing.T) {
 }
 
 func TestTofuStateEncryptionGCPKMS(t *testing.T) {
+	t.Skip("Skipping test as the GCP KMS key is not available. You have to setup your own GCP KMS key to run this test.")
 	t.Parallel()
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureTofuStateEncryptionGCPKMS)


### PR DESCRIPTION
add the most basic and naive implementation of an encryption attribute to the remote_state block, to generate encryption config for the backend

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3495.

<!-- Description of the changes introduced by this PR. -->
This PR adds an attribute `encryption` to the `remote_state` block that generates a `encryption` block in the backend config. This allow to use the [OpenTofu state encryption](https://opentofu.org/docs/language/state/encryption/) directly from within terragrunt, thus keeping encryption config DRY.


## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

