### PR TITLE
feat: Adding test for slash in source name

### DIFF
--- a/test/fixtures/download/remote-relative-with-slash/terragrunt.hcl
+++ b/test/fixtures/download/remote-relative-with-slash/terragrunt.hcl
@@ -1,0 +1,7 @@
+inputs = {
+  name = "World"
+}
+
+terraform {
+  source = "github.com/gruntwork-io/terragrunt.git?ref=test%2Fdo-no-delete//test/fixture-download/relative"
+}

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -26,6 +26,7 @@ const (
 	testFixtureOverrideDonwloadPath                   = "fixtures/download/override"
 	testFixtureLocalRelativeDownloadPath              = "fixtures/download/local-relative"
 	testFixtureRemoteRelativeDownloadPath             = "fixtures/download/remote-relative"
+	testFixtureRemoteRelativeDownloadPathWithSlash    = "fixtures/download/remote-relative-with-slash"
 	testFixtureLocalWithBackend                       = "fixtures/download/local-with-backend"
 	testFixtureLocalWithExcludeDir                    = "fixtures/download/local-with-exclude-dir"
 	testFixtureLocalWithIncludeDir                    = "fixtures/download/local-with-include-dir"
@@ -186,6 +187,17 @@ func TestRemoteDownloadWithRelativePath(t *testing.T) {
 
 	// Run a second time to make sure the temporary folder can be reused without errors
 	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureRemoteRelativeDownloadPath)
+}
+
+func TestRemoteDownloadWithRelativePathAndSlashInBranch(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureRemoteRelativeDownloadPathWithSlash)
+
+	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureRemoteRelativeDownloadPathWithSlash)
+
+	// Run a second time to make sure the temporary folder can be reused without errors
+	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureRemoteRelativeDownloadPathWithSlash)
 }
 
 func TestRemoteDownloadOverride(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #2473.

There's a workaround that was uncovered by @denis256's issue [here](https://github.com/hashicorp/terraform/issues/34554#issuecomment-1937798831).

The recommended solution for folks should be to use the hex code `%2F` to escape `/` in source URLs. This adds a test verifying that so that we can reliably reproduce this guidance in the future.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated tests to include `%2F` as a valid escape character for source URLs.

