### PR TITLE
add new built-in function get_aws_account_alias(), fix #2483

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -52,6 +52,7 @@ const (
 	FuncNameGetTerraformCommand                     = "get_terraform_command"
 	FuncNameGetTerraformCLIArgs                     = "get_terraform_cli_args"
 	FuncNameGetParentTerragruntDir                  = "get_parent_terragrunt_dir"
+	FuncNameGetAWSAccountAlias                      = "get_aws_account_alias"
 	FuncNameGetAWSAccountID                         = "get_aws_account_id"
 	FuncNameGetAWSCallerIdentityArn                 = "get_aws_caller_identity_arn"
 	FuncNameGetAWSCallerIdentityUserID              = "get_aws_caller_identity_user_id"
@@ -156,6 +157,7 @@ func createTerragruntEvalContext(ctx *ParsingContext, configPath string) (*hcl.E
 		FuncNameGetTerraformCommand:                     wrapVoidToStringAsFuncImpl(ctx, getTerraformCommand),
 		FuncNameGetTerraformCLIArgs:                     wrapVoidToStringSliceAsFuncImpl(ctx, getTerraformCliArgs),
 		FuncNameGetParentTerragruntDir:                  wrapStringSliceToStringAsFuncImpl(ctx, GetParentTerragruntDir),
+		FuncNameGetAWSAccountAlias:                      wrapVoidToStringAsFuncImpl(ctx, getAWSAccountAlias),
 		FuncNameGetAWSAccountID:                         wrapVoidToStringAsFuncImpl(ctx, getAWSAccountID),
 		FuncNameGetAWSCallerIdentityArn:                 wrapVoidToStringAsFuncImpl(ctx, getAWSCallerIdentityARN),
 		FuncNameGetAWSCallerIdentityUserID:              wrapVoidToStringAsFuncImpl(ctx, getAWSCallerIdentityUserID),
@@ -587,6 +589,16 @@ func getTerraformCliArgs(ctx *ParsingContext) ([]string, error) {
 // getDefaultRetryableErrors returns default retryable errors
 func getDefaultRetryableErrors(ctx *ParsingContext) ([]string, error) {
 	return options.DefaultRetryableErrors, nil
+}
+
+// Return the AWS account alias
+func getAWSAccountAlias(ctx *ParsingContext) (string, error) {
+	accountAlias, err := awshelper.GetAWSAccountAlias(nil, ctx.TerragruntOptions)
+	if err == nil {
+		return accountAlias, nil
+	}
+
+	return "", err
 }
 
 // Return the AWS account id associated to the current set of credentials

--- a/docs/_docs/04_reference/built-in-functions.md
+++ b/docs/_docs/04_reference/built-in-functions.md
@@ -29,6 +29,7 @@ Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, ju
 - [get\_terraform\_commands\_that\_need\_input](#get_terraform_commands_that_need_input)
 - [get\_terraform\_commands\_that\_need\_locking](#get_terraform_commands_that_need_locking)
 - [get\_terraform\_commands\_that\_need\_parallelism](#get_terraform_commands_that_need_parallelism)
+- [get\_aws\_account\_alias](#get_aws_account_alias)
 - [get\_aws\_account\_id](#get_aws_account_id)
 - [get\_aws\_caller\_identity\_arn](#get_aws_caller_identity_arn)
 - [get\_terraform\_command](#get_terraform_command)
@@ -552,6 +553,18 @@ terraform {
   }
 }
 ```
+
+## get_aws_account_alias
+
+`get_aws_account_alias()` returns the AWS account alias associated with the current set of credentials. If the alias cannot be found, it will return an empty string. Example:
+
+```hcl
+inputs = {
+  account_alias = get_aws_account_alias()
+}
+```
+
+**Note:** value returned by `get_aws_account_alias()` can change during parsing of HCL code, for example after evaluation of `iam_role` attribute.
 
 ## get_aws_account_id
 

--- a/test/fixtures/get-aws-account-alias/main.tf
+++ b/test/fixtures/get-aws-account-alias/main.tf
@@ -1,0 +1,7 @@
+variable "account_alias" {
+  type = string
+}
+
+output "account_alias" {
+  value = var.account_alias
+}

--- a/test/fixtures/get-aws-account-alias/terragrunt.hcl
+++ b/test/fixtures/get-aws-account-alias/terragrunt.hcl
@@ -1,0 +1,3 @@
+inputs = {
+  account_alias = get_aws_account_alias()
+}


### PR DESCRIPTION
## Description
add new built-in function `get_aws_account_alias()`. Fixes #2483.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added new built-in function `get_aws_account_alias()`. Fixes #2483.

### Migration Guide
n/a
