### PR TITLE
fix: Fixing concurrent access to read files map

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -747,6 +747,10 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GCP__automated-tests
+            - GITHUB__PAT__gruntwork-ci
       - integration_test_tofu_engine:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,6 +743,10 @@ workflows:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
+      - race_test:
+          filters:
+            tags:
+              only: /^v.*/
       - integration_test_tofu_engine:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,6 +519,22 @@ jobs:
       - run:
           <<: *run_tflint_test
       - run:
+          <<: *run_terratest_log_parser
+      - store_artifacts:
+          path: logs
+      - store_test_results:
+          path: logs
+
+  race_test:
+    resource_class: medium
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          <<: *install_tofu
+      - run:
+          <<: *setup_test_environment
+      - run:
           <<: *run_race_test
       - run:
           <<: *run_terratest_log_parser

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,12 @@ run_tflint_test: &run_tflint_test
     run-go-tests --packages "-tags tflint -run TestTflint ./test" | tee logs/test-results.log
   no_output_timeout: 30m
 
+run_race_test: &run_race_test
+  name: Run Race tests
+  command: |
+    run-go-tests --packages "-run '.*WithRacing' -race ./test" | tee logs/test-results.log
+  no_output_timeout: 30m
+
 run_terratest_log_parser: &run_terratest_log_parser
   name: Terratest log parser
   command: |
@@ -512,6 +518,8 @@ jobs:
           <<: *setup_test_environment
       - run:
           <<: *run_tflint_test
+      - run:
+          <<: *run_race_test
       - run:
           <<: *run_terratest_log_parser
       - store_artifacts:

--- a/options/options.go
+++ b/options/options.go
@@ -478,6 +478,7 @@ func NewTerragruntOptionsWithWriters(stdout, stderr io.Writer) *TerragruntOption
 		OutputFolder:               "",
 		JSONOutputFolder:           "",
 		FeatureFlags:               map[string]string{},
+		ReadFiles:                  xsync.NewMapOf[string, []string](),
 	}
 }
 

--- a/options/options.go
+++ b/options/options.go
@@ -765,16 +765,6 @@ func (opts *TerragruntOptions) DidReadFile(file, unit string) bool {
 		return false
 	}
 
-	// TODO: Get rid of this.
-	opts.ReadFiles.Range(func(key string, value []string) bool {
-		fmt.Println("key: " + key)
-		for _, v := range value {
-			fmt.Println("value: " + v)
-		}
-
-		return true
-	})
-
 	units, ok := opts.ReadFiles.Load(file)
 	if !ok {
 		return false

--- a/test/race_test.go
+++ b/test/race_test.go
@@ -1,0 +1,20 @@
+// Tests specific to race conditions are verified here
+
+package test_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStrictModeWithRacing(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("race_test")
+	require.NoError(t, err)
+
+	go opts.AppendReadFile("file.json", "unit")
+	go opts.AppendReadFile("file.json", "other-unit")
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3614.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated read files map implementation to be concurrency safe.
