### PR TITLE
Don't require HOME if TERRAGRUNT_PROVIDER_CACHE_DIR is set

### DIFF
--- a/cli/provider_cache.go
+++ b/cli/provider_cache.go
@@ -62,17 +62,18 @@ type ProviderCache struct {
 }
 
 func InitProviderCacheServer(opts *options.TerragruntOptions) (*ProviderCache, error) {
-	cacheDir, err := util.GetCacheDir()
-	if err != nil {
-		return nil, err
-	}
-
 	// ProviderCacheDir has the same file structure as terraform plugin_cache_dir.
 	// https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
 	if opts.ProviderCacheDir == "" {
+		cacheDir, err := util.GetCacheDir()
+		if err != nil {
+			return nil, err
+		}
+
 		opts.ProviderCacheDir = filepath.Join(cacheDir, "providers")
 	}
 
+	var err error
 	if opts.ProviderCacheDir, err = filepath.Abs(opts.ProviderCacheDir); err != nil {
 		return nil, errors.New(err)
 	}

--- a/cli/provider_cache_test.go
+++ b/cli/provider_cache_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gruntwork-io/terragrunt/cli"
+	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/terraform/cache"
 	"github.com/gruntwork-io/terragrunt/terraform/cache/handlers"
@@ -161,4 +162,42 @@ func TestProviderCache(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestProviderCacheWithProviderCacheDir(t *testing.T) {
+	// testing.T can Setenv, but can't Unsetenv
+	unsetEnv := func(t *testing.T, v string) {
+		// let testing.T do the recovery and work around t.Parallel()
+		t.Setenv(v, "")
+		require.NoError(t, os.Unsetenv(v))
+	}
+
+	t.Run("Homeless", func(t *testing.T) {
+		cacheDir := t.TempDir()
+
+		unsetEnv(t, "HOME")
+		unsetEnv(t, "XDG_CACHE_HOME")
+
+		_, err := cli.InitProviderCacheServer(&options.TerragruntOptions{
+			ProviderCacheDir: cacheDir,
+		})
+		require.NoError(t, err, "ProviderCache shouldn't read HOME environment variable")
+	})
+
+	t.Run("NoNewDirectoriesAtHOME", func(t *testing.T) {
+		home := t.TempDir()
+		cacheDir := t.TempDir()
+
+		t.Setenv("HOME", home)
+
+		_, err := cli.InitProviderCacheServer(&options.TerragruntOptions{
+			ProviderCacheDir: cacheDir,
+		})
+		require.NoError(t, err)
+
+		// Cache server shouldn't create any directory at $HOME when ProviderCacheDir is specified
+		entries, err := os.ReadDir(home)
+		require.NoError(t, err)
+		require.Empty(t, entries, "No new directories should be created at $HOME")
+	})
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

I run Terragrunt in a homeless environment. I explicitly specify `TERRAGRUNT_PROVIDER_CACHE_DIR` but Terragrunt unconditionally checks whether `HOME` or `XDG_CACHE_HOME` exists despite that the result isn't used.

## Release Notes (draft)

### Updated
Having no `HOME` doesn't trigger error anymore if `TERRAGRUNT_PROVIDER_CACHE_DIR` is set.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

