### PR TITLE
Add redirect for unused contact page.

### DIFF
--- a/docs/_pages/contact/index.html
+++ b/docs/_pages/contact/index.html
@@ -1,34 +1,5 @@
 ---
-layout: contact
-title: contact
-subtitle: Get help via email, chat, and phone/video from the team that created Terragrunt.
-excerpt: Get help via email, chat, and phone/video from the team that created Terragrunt.
 permalink: /contact/
-slug: contact
-nav_title: Contact
-nav_title_link: /docs/
-custom_js:
-  - prism
-  - collection-browser_toc
-  - contact-form
-use_recaptcha: true
+redirect_to: https://gruntwork.io/contact
 ---
-
-<div class="contact__page">
-  <div class="col-md-6 contact-column">
-    <h1>Contact Us</h1>
-    <p class="contact-subtitle">
-      Speak to a real human! 
-    </p>
-    <p class="contact-subtitle">
-      Use the form below or send an email to
-      <a href="mailto:info@gruntwork.io" >info@gruntwork.io.</a>
-    </p>
-    <img class='contact-subtitle-back hidden-shape-xs' src='{{ site.baseurl}}/assets/img/contact/bottom.svg' alt='contact-form-back' />
-  </div>
-  <div class="col-md-6 form-column">
-    {% include_relative _contact-form.html %}
-    <img src='{{site.baseurl}}/assets/img/commercial-support/terragrunt-mobile-links.svg' alt='Shape' class="header-shapes-bottom hidden-shape" />
-  </div>
-</div>
 


### PR DESCRIPTION
Changes:



## Description
This seems to be an orphaned contact page that needs to be removed and redirected for the time being to ensure we don't lose leads.

### Changes
- Remove content of /contact
- Add a redirect to https://gruntwork.io/contact


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Removed `/contact`, replaced with redirect to `gruntwork.io/contact`


