### PR TITLE
fix: `ProviderCacheWithProviderCacheDir` test

### DIFF
--- a/cli/provider_cache_test.go
+++ b/cli/provider_cache_test.go
@@ -186,7 +186,7 @@ func TestProviderCacheWithProviderCacheDir(t *testing.T) {
 		require.NoError(t, err, "ProviderCache shouldn't read HOME environment variable")
 	})
 
-	t.Run("NoNewDirectoriesAtHOME", func(t *testing.T) { //nolint:paralleltest
+	t.Run("NoNewDirectoriesAtHOME", func(t *testing.T) {
 		home := t.TempDir()
 		cacheDir := t.TempDir()
 

--- a/cli/provider_cache_test.go
+++ b/cli/provider_cache_test.go
@@ -167,12 +167,14 @@ func TestProviderCache(t *testing.T) {
 func TestProviderCacheWithProviderCacheDir(t *testing.T) {
 	// testing.T can Setenv, but can't Unsetenv
 	unsetEnv := func(t *testing.T, v string) {
+		t.Helper()
+
 		// let testing.T do the recovery and work around t.Parallel()
 		t.Setenv(v, "")
 		require.NoError(t, os.Unsetenv(v))
 	}
 
-	t.Run("Homeless", func(t *testing.T) {
+	t.Run("Homeless", func(t *testing.T) { //nolint:paralleltest
 		cacheDir := t.TempDir()
 
 		unsetEnv(t, "HOME")
@@ -184,7 +186,7 @@ func TestProviderCacheWithProviderCacheDir(t *testing.T) {
 		require.NoError(t, err, "ProviderCache shouldn't read HOME environment variable")
 	})
 
-	t.Run("NoNewDirectoriesAtHOME", func(t *testing.T) {
+	t.Run("NoNewDirectoriesAtHOME", func(t *testing.T) { //nolint:paralleltest
 		home := t.TempDir()
 		cacheDir := t.TempDir()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

```
INFO [runner] linters took 2.838018917s with stages: goanalysis_metalinter: 2.805573583s
cli/provider_cache_test.go:175:2: Function TestProviderCacheWithProviderCacheDir missing the call to method parallel in the test run (paralleltest)
        t.Run("Homeless", func(t *testing.T) {
        ^
cli/provider_cache_test.go:169:14: test helper function should start from t.Helper() (thelper)
        unsetEnv := func(t *testing.T, v string) {
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

