### PR TITLE
fix: Reintroduce symlink work behind experiment flag

### DIFF
--- a/cli/commands/catalog/action.go
+++ b/cli/commands/catalog/action.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/catalog/tui"
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
 )
@@ -39,7 +40,10 @@ func Run(ctx context.Context, opts *options.TerragruntOptions, repoURL string) e
 	for _, repoURL := range repoURLs {
 		tempDir := filepath.Join(os.TempDir(), fmt.Sprintf(tempDirFormat, util.EncodeBase64Sha1(repoURL)))
 
-		repo, err := module.NewRepo(ctx, opts.Logger, repoURL, tempDir)
+		experiment := opts.Experiments[experiment.Symlinks]
+		walkWithSymlinks := experiment.Evaluate(opts.ExperimentMode)
+
+		repo, err := module.NewRepo(ctx, opts.Logger, repoURL, tempDir, walkWithSymlinks)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/catalog/action.go
+++ b/cli/commands/catalog/action.go
@@ -37,11 +37,11 @@ func Run(ctx context.Context, opts *options.TerragruntOptions, repoURL string) e
 
 	var modules module.Modules
 
+	experiment := opts.Experiments[experiment.Symlinks]
+	walkWithSymlinks := experiment.Evaluate(opts.ExperimentMode)
+
 	for _, repoURL := range repoURLs {
 		tempDir := filepath.Join(os.TempDir(), fmt.Sprintf(tempDirFormat, util.EncodeBase64Sha1(repoURL)))
-
-		experiment := opts.Experiments[experiment.Symlinks]
-		walkWithSymlinks := experiment.Evaluate(opts.ExperimentMode)
 
 		repo, err := module.NewRepo(ctx, opts.Logger, repoURL, tempDir, walkWithSymlinks)
 		if err != nil {

--- a/cli/commands/catalog/module/repo_test.go
+++ b/cli/commands/catalog/module/repo_test.go
@@ -63,7 +63,7 @@ func TestFindModules(t *testing.T) {
 
 			ctx := context.Background()
 
-			repo, err := module.NewRepo(ctx, log.New(), testCase.repoPath, "")
+			repo, err := module.NewRepo(ctx, log.New(), testCase.repoPath, "", false)
 			require.NoError(t, err)
 
 			modules, err := repo.FindModules(ctx)

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -549,6 +549,10 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 					log.Warn(warning)
 				}
 
+				if err := experiments.EnableExperiments(val); err != nil {
+					return cli.NewExitError(err, 1)
+				}
+
 				opts.Experiments = experiments
 
 				return nil

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log/writer"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/telemetry"
 
@@ -656,10 +657,17 @@ func GetDefaultConfigPath(workingDir string) string {
 
 // FindConfigFilesInPath returns a list of all Terragrunt config files in the given path or any subfolder of the path. A file is a Terragrunt
 // config file if it has a name as returned by the DefaultConfigPath method
-func FindConfigFilesInPath(rootPath string, terragruntOptions *options.TerragruntOptions) ([]string, error) {
+func FindConfigFilesInPath(rootPath string, opts *options.TerragruntOptions) ([]string, error) {
 	configFiles := []string{}
 
-	err := util.WalkWithSymlinks(rootPath, func(path string, info os.FileInfo, err error) error {
+	experiment := opts.Experiments[experiment.Symlinks]
+
+	walkFunc := filepath.Walk
+	if experiment.Evaluate(opts.ExperimentMode) {
+		walkFunc = util.WalkWithSymlinks
+	}
+
+	err := walkFunc(rootPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -668,13 +676,13 @@ func FindConfigFilesInPath(rootPath string, terragruntOptions *options.Terragrun
 			return nil
 		}
 
-		if ok, err := isTerragruntModuleDir(path, terragruntOptions); err != nil {
+		if ok, err := isTerragruntModuleDir(path, opts); err != nil {
 			return err
 		} else if !ok {
 			return filepath.SkipDir
 		}
 
-		for _, configFile := range append(DefaultTerragruntConfigPaths, filepath.Base(terragruntOptions.TerragruntConfigPath)) {
+		for _, configFile := range append(DefaultTerragruntConfigPaths, filepath.Base(opts.TerragruntConfigPath)) {
 			if !filepath.IsAbs(configFile) {
 				configFile = util.JoinPath(path, configFile)
 			}

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/locks"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
@@ -573,7 +574,10 @@ func getWorkingDir(ctx *ParsingContext) (string, error) {
 		return ctx.TerragruntOptions.WorkingDir, nil
 	}
 
-	source, err := terraform.NewSource(sourceURL, ctx.TerragruntOptions.DownloadDir, ctx.TerragruntOptions.WorkingDir, ctx.TerragruntOptions.Logger)
+	experiment := ctx.TerragruntOptions.Experiments[experiment.Symlinks]
+	walkWithSymlinks := experiment.Evaluate(ctx.TerragruntOptions.ExperimentMode)
+
+	source, err := terraform.NewSource(sourceURL, ctx.TerragruntOptions.DownloadDir, ctx.TerragruntOptions.WorkingDir, ctx.TerragruntOptions.Logger, walkWithSymlinks)
 	if err != nil {
 		return "", err
 	}

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -789,7 +790,7 @@ func canGetRemoteState(remoteState *remote.RemoteState) bool {
 // terragruntAlreadyInit returns true if it detects that the module specified by the given terragrunt configuration is
 // already initialized with the terraform source. This will also return the working directory where you can run
 // terraform.
-func terragruntAlreadyInit(terragruntOptions *options.TerragruntOptions, configPath string, ctx *ParsingContext) (bool, string, error) {
+func terragruntAlreadyInit(opts *options.TerragruntOptions, configPath string, ctx *ParsingContext) (bool, string, error) {
 	// We need to first determine the working directory where the terraform source should be located. This is dependent
 	// on the source field of the terraform block in the config.
 	terraformBlockTGConfig, err := PartialParseConfigFile(ctx.WithDecodeList(TerraformSource), configPath, nil)
@@ -799,7 +800,7 @@ func terragruntAlreadyInit(terragruntOptions *options.TerragruntOptions, configP
 
 	var workingDir string
 
-	sourceURL, err := GetTerraformSourceURL(terragruntOptions, terraformBlockTGConfig)
+	sourceURL, err := GetTerraformSourceURL(opts, terraformBlockTGConfig)
 	if err != nil {
 		return false, "", err
 	}
@@ -813,7 +814,10 @@ func terragruntAlreadyInit(terragruntOptions *options.TerragruntOptions, configP
 			workingDir = filepath.Dir(configPath)
 		}
 	} else {
-		terraformSource, err := terraform.NewSource(sourceURL, terragruntOptions.DownloadDir, terragruntOptions.WorkingDir, terragruntOptions.Logger)
+		experiment := opts.Experiments[experiment.Symlinks]
+		walkWithSymlinks := experiment.Evaluate(opts.ExperimentMode)
+
+		terraformSource, err := terraform.NewSource(sourceURL, opts.DownloadDir, opts.WorkingDir, opts.Logger, walkWithSymlinks)
 		if err != nil {
 			return false, "", err
 		}

--- a/config/variable.go
+++ b/config/variable.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/hashicorp/hcl/v2"
@@ -25,8 +26,11 @@ type ParsedVariable struct {
 
 // ParseVariables - parse variables from tf files.
 func ParseVariables(opts *options.TerragruntOptions, directoryPath string) ([]*ParsedVariable, error) {
+	experiment := opts.Experiments[experiment.Symlinks]
+	walkWithSymlinks := experiment.Evaluate(opts.ExperimentMode)
+
 	// list all tf files
-	tfFiles, err := util.ListTfFiles(directoryPath)
+	tfFiles, err := util.ListTfFiles(directoryPath, walkWithSymlinks)
 	if err != nil {
 		return nil, errors.New(err)
 	}

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -95,6 +95,10 @@ This page documents the CLI commands and options available with Terragrunt:
   - [terragrunt-forward-tf-stdout](#terragrunt-forward-tf-stdout)
   - [terragrunt-no-destroy-dependencies-check](#terragrunt-no-destroy-dependencies-check)
   - [feature](#feature)
+  - [experiment](#experiment)
+  - [experiment-mode](#experiment-mode)
+  - [strict-control](#strict-control)
+  - [strict-mode](#strict-mode)
 
 ## CLI commands
 
@@ -1759,3 +1763,40 @@ Setting feature flags through environment variables:
 export TERRAGRUNT_FEATURE=int_feature_flag=123,bool_feature_flag=true,string_feature_flag=app1
 terragrunt apply
 ```
+
+### experiment
+
+**CLI Arg**: `--experiment`<br/>
+**Environment Variable**: `TERRAGRUNT_EXPERIMENT`<br/>
+
+Enable experimental features in Terragrunt before they're stable.
+
+For more information, see the [Experiments](/docs/reference/experiments) documentation.
+
+### experiment-mode
+
+**CLI Arg**: `--experiment-mode`<br/>
+**Environment Variable**: `TERRAGRUNT_EXPERIMENT_MODE`<br/>
+
+Enable all experimental features in Terragrunt before they're stable.
+
+For more information, see the [Experiments](/docs/reference/experiments) documentation.
+
+### strict-control
+
+**CLI Arg**: `--strict-control`<br/>
+**Environment Variable**: `TERRAGRUNT_STRICT_CONTROL`<br/>
+
+Enable strict controls that opt-in future breaking changes in Terragrunt.
+
+For more information, see the [Strict Mode](/docs/reference/strict-mode) documentation.
+
+### strict-mode
+
+**CLI Arg**: `--strict-mode`<br/>
+**Environment Variable**: `TERRAGRUNT_STRICT_MODE`<br/>
+
+Enable all strict controls that opt-in future breaking changes in Terragrunt.
+
+For more information, see the [Strict Mode](/docs/reference/strict-mode) documentation.
+

--- a/docs/_docs/04_reference/cli-options.md
+++ b/docs/_docs/04_reference/cli-options.md
@@ -1799,4 +1799,3 @@ For more information, see the [Strict Mode](/docs/reference/strict-mode) documen
 Enable all strict controls that opt-in future breaking changes in Terragrunt.
 
 For more information, see the [Strict Mode](/docs/reference/strict-mode) documentation.
-

--- a/docs/_docs/04_reference/experiments.md
+++ b/docs/_docs/04_reference/experiments.md
@@ -1,0 +1,87 @@
+---
+layout: collection-browser-doc
+title: Experiments
+category: reference
+categories_url: reference
+excerpt: >-
+  Opt-in to experimental features before they're stable.
+tags: ["CLI"]
+order: 405
+nav_title: Documentation
+nav_title_link: /docs/
+---
+
+Terragrunt supports operating in a mode referred to as "Experiment Mode".
+
+Experiment Mode is a set of controls that can be enabled to opt-in to experimental features before they're stable.
+These features are subject to change and may be removed or altered at any time.
+They generally provide early access to new features or changes that are being considered for inclusion in future releases.
+
+Those experiments will be documented here so that you know the following:
+1. What the experiment is.
+2. What the experiment does.
+3. How to provide feedback on the experiment.
+4. What criteria must be met for the experiment to be considered stable.
+
+Sometimes, the criteria for an experiment to be considered stable is unknown, as there may not be a clear path to stabilization. In that case, this will be noted in the experiment documentation, and collaboration with the community will be encouraged to help determine the future of the experiment.
+
+## Controlling Experiment Mode
+
+The simplest way to enable experiment mode is to set the [experiment-mode](/docs/reference/cli-options/#experiment-mode) flag.
+
+This will enable experiment mode for all Terragrunt commands, for all experiments (note that this isn't generally recommended, unless you are following Terragrunt development closely and are prepared for the possibility of breaking changes).
+
+```bash
+$ terragrunt plan --experiment-mode
+```
+
+You can also use the environment variable, which can be more useful in CI/CD pipelines:
+
+```bash
+$ TERRAGRUNT_EXPERIMENT_MODE='true' terragrunt plan
+```
+
+Instead of enabling experiment mode, you can also enable specific experiments by setting the [experiment](/docs/reference/cli-options/#experiment)
+flag to a value that's specific to a experiment.
+This can allow you to experiment with a specific unstable feature that you think might be useful to you.
+
+```bash
+$ terragrunt plan --experiment symlinks
+```
+
+Again, you can also use the environment variable, which can be more useful in CI/CD pipelines:
+
+```bash
+$ TERRAGRUNT_EXPERIMENT='symlinks' terragrunt plan
+```
+
+You can also enable multiple experiments at once with a comma delimited list.
+
+**TODO**: Will add an example here once there's more than one officially supported experiment. The existing experiments are scattered throughout configuration, so they need to be pulled into this system first.
+
+## Active Experiments
+
+The following strict mode controls are available:
+
+- [symlinks](#symlinks)
+
+### symlinks
+
+Support symlink resolution for Terragrunt units.
+
+#### What it does
+
+By default, Terragrunt will ignore symlinks when determining which units it should run. By enabling this experiment, Terragrunt will resolve symlinks and add them to the list of units being run.
+
+#### How to provide feedback
+
+Provide your feedback on the [Experiment: Symlinks](https://github.com/gruntwork-io/terragrunt/discussions/3671) discussion.
+
+#### Criteria for stabilization
+
+To stabilize this feature, the following need to be resolved, at a minimum:
+
+- [ ] Ensure that symlink support continues to work for users referencing symlinks in flags. See [#3622](https://github.com/gruntwork-io/terragrunt/issues/3622).
+  - [ ] Add integration tests for all filesystem flags to confirm support with symlinks (or document the fact that they cannot be supported).
+- [ ] Ensure that MacOS integration tests still work. See [#3616](https://github.com/gruntwork-io/terragrunt/issues/3616).
+  - [ ] Add integration tests for MacOS in CI.

--- a/docs/_docs/04_reference/experiments.md
+++ b/docs/_docs/04_reference/experiments.md
@@ -18,6 +18,7 @@ These features are subject to change and may be removed or altered at any time.
 They generally provide early access to new features or changes that are being considered for inclusion in future releases.
 
 Those experiments will be documented here so that you know the following:
+
 1. What the experiment is.
 2. What the experiment does.
 3. How to provide feedback on the experiment.
@@ -32,13 +33,13 @@ The simplest way to enable experiment mode is to set the [experiment-mode](/docs
 This will enable experiment mode for all Terragrunt commands, for all experiments (note that this isn't generally recommended, unless you are following Terragrunt development closely and are prepared for the possibility of breaking changes).
 
 ```bash
-$ terragrunt plan --experiment-mode
+terragrunt plan --experiment-mode
 ```
 
 You can also use the environment variable, which can be more useful in CI/CD pipelines:
 
 ```bash
-$ TERRAGRUNT_EXPERIMENT_MODE='true' terragrunt plan
+TERRAGRUNT_EXPERIMENT_MODE='true' terragrunt plan
 ```
 
 Instead of enabling experiment mode, you can also enable specific experiments by setting the [experiment](/docs/reference/cli-options/#experiment)
@@ -46,13 +47,13 @@ flag to a value that's specific to a experiment.
 This can allow you to experiment with a specific unstable feature that you think might be useful to you.
 
 ```bash
-$ terragrunt plan --experiment symlinks
+terragrunt plan --experiment symlinks
 ```
 
 Again, you can also use the environment variable, which can be more useful in CI/CD pipelines:
 
 ```bash
-$ TERRAGRUNT_EXPERIMENT='symlinks' terragrunt plan
+TERRAGRUNT_EXPERIMENT='symlinks' terragrunt plan
 ```
 
 You can also enable multiple experiments at once with a comma delimited list.

--- a/docs/_docs/04_reference/strict-mode.md
+++ b/docs/_docs/04_reference/strict-mode.md
@@ -21,9 +21,16 @@ future versions of Terragrunt.
 Whenever possible, Terragrunt will initially provide you with a warning when you use a deprecated feature, without throwing an error.
 However, in Strict Mode, these warnings will be converted to errors, which will cause the Terragrunt command to fail.
 
+A good practice for using strict controls is to enable Strict Mode in your CI/CD pipelines for lower environments
+to catch any deprecated features early on. This allows you to fix them before they become a problem
+in production in a future Terragrunt release.
+
+If you are unsure about the impact of enabling strict controls, you can enable them for specific controls to
+gradually increase your confidence in the future compatibility of your Terragrunt usage.
+
 ## Controlling Strict Mode
 
-The simplest way to enable strict mode is to set the `TERRAGRUNT_STRICT_MODE` environment variable to `true`.
+The simplest way to enable strict mode is to set the [strict-mode](/docs/reference/cli-options/#strict-mode) flag.
 
 This will enable strict mode for all Terragrunt commands, for all strict mode controls.
 
@@ -33,25 +40,53 @@ $ terragrunt plan-all
 ```
 
 ```bash
+$ terragrunt --strict-mode plan-all
+15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
+```
+
+You can also use the environment variable, which can be more useful in CI/CD pipelines:
+
+```bash
 $ TERRAGRUNT_STRICT_MODE='true' terragrunt plan-all
 15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
 ```
 
-Instead of setting this environment variable, you can also enable strict mode for specific controls by setting the `TERRAGRUNT_STRICT_CONTROL`
-environment variable to a value that's specific to a particular strict control.
+Instead of enabling strict mode like this, you can also enable specific strict controls by setting the [strict-control](/docs/reference/cli-options/#strict-control)
+flag to a value that's specific to a particular strict control.
 This can allow you to gradually increase your confidence in the future compatibility of your Terragrunt usage.
 
 ```bash
-$ TERRAGRUNT_STRICT_CONTROL='apply-all' terragrunt plan-all
+$ terragrunt plan-all --strict-control apply-all
 15:26:08.585 WARN   The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run-all plan` instead.
 ```
+
+```bash
+$ terragrunt plan-all --strict-control plan-all
+15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
+```
+
+Again, you can also use the environment variable, which might be more useful in CI/CD pipelines:
 
 ```bash
 $ TERRAGRUNT_STRICT_CONTROL='plan-all' terragrunt plan-all
 15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
 ```
 
-You can also enable multiple strict controls at once with a comma delimited list.
+You can enable multiple strict controls at once:
+
+```bash
+$ terragrunt plan-all --strict-control plan-all --strict-control apply-all
+15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
+15:26:46.521 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
+```
+
+```bash
+$ terragrunt apply-all --strict-control plan-all --strict-control apply-all
+15:26:46.564 ERROR  The `apply-all` command is no longer supported. Use `terragrunt run-all apply` instead.
+15:26:46.564 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
+```
+
+You can also enable multiple strict controls at once when using the environment variable by using a comma delimited list.
 
 ```bash
 $ TERRAGRUNT_STRICT_CONTROL='plan-all,apply-all' bash -c 'terragrunt plan-all; terragrunt apply-all'

--- a/docs/_docs/04_reference/supported-versions.md
+++ b/docs/_docs/04_reference/supported-versions.md
@@ -5,7 +5,7 @@ category: reference
 categories_url: reference
 excerpt: Learn which Terraform and OpenTofu versions are compatible with which versions of Terragrunt.
 tags: [ "install" ]
-order: 405
+order: 406
 nav_title: Documentation
 nav_title_link: /docs/
 ---

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -1,0 +1,113 @@
+// Package experiment provides utilities used by Terragrunt to support an "experiment" mode.
+// By default experiment mode is disabled, but when enabled, experimental features can be enabled.
+// These features are not yet stable and may change in the future.
+//
+// Note that any behavior outlined here should be documented in /docs/_docs/04_reference/experiment-mode.md
+//
+// That is how users will know what to expect when they enable experiment mode, and how to customize it.
+package experiment
+
+import (
+	"strings"
+)
+
+// NewExperiments returns a new Experiments map with all experiments disabled.
+//
+// Bottom values for each experiment are the defaults, so only the names of experiments need to be set.
+func NewExperiments() Experiments {
+	return Experiments{
+		Symlinks: Experiment{
+			Name: Symlinks,
+		},
+	}
+}
+
+// Experiment represents an experiment that can be enabled.
+// When the experiment is enabled, Terragrunt will behave in a way that uses some experimental functionality.
+type Experiment struct {
+	// Enabled determines if the experiment is enabled.
+	Enabled bool
+	// Name is the name of the experiment.
+	Name string
+	// Status is the status of the experiment.
+	Status int
+}
+
+func (e Experiment) String() string {
+	return e.Name
+}
+
+const (
+	// Symlinks is the experiment that allows symlinks to be used in Terragrunt configurations.
+	Symlinks = "symlinks"
+)
+
+const (
+	// StatusOngoing is the status of an experiment that is ongoing.
+	StatusOngoing = iota
+	// StatusCompleted is the status of an experiment that is completed.
+	StatusCompleted
+)
+
+type Experiments map[string]Experiment
+
+// ValidateExperimentNames validates the given slice of experiment names are valid.
+func (e Experiments) ValidateExperimentNames(experimentNames []string) (string, error) {
+	completedExperiments := []string{}
+	invalidExperiments := []string{}
+
+	for _, name := range experimentNames {
+		experiment, ok := e[name]
+		if !ok {
+			invalidExperiments = append(invalidExperiments, name)
+			continue
+		}
+
+		if experiment.Status == StatusCompleted {
+			completedExperiments = append(completedExperiments, name)
+		}
+	}
+
+	var warning string
+	if len(completedExperiments) > 0 {
+		warning = CompletedExperimentsWarning{
+			ExperimentNames: completedExperiments,
+		}.String()
+	}
+
+	var err error
+	if len(invalidExperiments) > 0 {
+		err = InvalidExperimentsError{
+			ExperimentNames: invalidExperiments,
+		}
+	}
+
+	return warning, err
+}
+
+// CompletedExperimentsWarning is a warning that is returned when completed experiments are requested.
+type CompletedExperimentsWarning struct {
+	ExperimentNames []string
+}
+
+func (e CompletedExperimentsWarning) String() string {
+	return "The following experiment(s) are already completed: " + strings.Join(e.ExperimentNames, ", ") + ". Please remove any completed experiments, as setting them no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://terragrunt.gruntwork.io/docs/reference/experiment-mode"
+}
+
+// InvalidExperimentsError is an error that is returned when an invalid experiments are requested.
+type InvalidExperimentsError struct {
+	ExperimentNames []string
+}
+
+func (e InvalidExperimentsError) Error() string {
+	return "The following experiment(s) are invalid: " + strings.Join(e.ExperimentNames, ", ") + ". For a list of all valid experiments, see https://terragrunt.gruntwork.io/docs/reference/experiment-mode"
+}
+
+// Evaluate returns true if either the experiment is enabled, or experiment mode is enabled.
+func (experiment Experiment) Evaluate(experimentMode bool) bool {
+	if experimentMode {
+		return true
+	}
+
+	return experiment.Enabled
+}

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -9,6 +9,8 @@ package experiment
 
 import (
 	"strings"
+
+	"github.com/gruntwork-io/terragrunt/internal/errors"
 )
 
 // NewExperiments returns a new Experiments map with all experiments disabled.
@@ -77,9 +79,9 @@ func (e *Experiments) ValidateExperimentNames(experimentNames []string) (string,
 
 	var err error
 	if len(invalidExperiments) > 0 {
-		err = InvalidExperimentsError{
+		err = errors.New(InvalidExperimentsError{
 			ExperimentNames: invalidExperiments,
-		}
+		})
 	}
 
 	return warning, err
@@ -101,9 +103,9 @@ func (e *Experiments) EnableExperiments(experimentNames []string) error {
 	}
 
 	if len(invalidExperiments) > 0 {
-		return InvalidExperimentsError{
+		return errors.New(InvalidExperimentsError{
 			ExperimentNames: invalidExperiments,
-		}
+		})
 	}
 
 	return nil

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -104,10 +104,10 @@ func (e InvalidExperimentsError) Error() string {
 }
 
 // Evaluate returns true if either the experiment is enabled, or experiment mode is enabled.
-func (experiment Experiment) Evaluate(experimentMode bool) bool {
+func (e Experiment) Evaluate(experimentMode bool) bool {
 	if experimentMode {
 		return true
 	}
 
-	return experiment.Enabled
+	return e.Enabled
 }

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -52,12 +52,12 @@ const (
 type Experiments map[string]Experiment
 
 // ValidateExperimentNames validates the given slice of experiment names are valid.
-func (e Experiments) ValidateExperimentNames(experimentNames []string) (string, error) {
+func (e *Experiments) ValidateExperimentNames(experimentNames []string) (string, error) {
 	completedExperiments := []string{}
 	invalidExperiments := []string{}
 
 	for _, name := range experimentNames {
-		experiment, ok := e[name]
+		experiment, ok := (*e)[name]
 		if !ok {
 			invalidExperiments = append(invalidExperiments, name)
 			continue
@@ -83,6 +83,30 @@ func (e Experiments) ValidateExperimentNames(experimentNames []string) (string, 
 	}
 
 	return warning, err
+}
+
+// EnableExperiments enables the given experiments.
+func (e *Experiments) EnableExperiments(experimentNames []string) error {
+	invalidExperiments := []string{}
+
+	for _, name := range experimentNames {
+		experiment, ok := (*e)[name]
+		if !ok {
+			invalidExperiments = append(invalidExperiments, name)
+			continue
+		}
+
+		experiment.Enabled = true
+		(*e)[name] = experiment
+	}
+
+	if len(invalidExperiments) > 0 {
+		return InvalidExperimentsError{
+			ExperimentNames: invalidExperiments,
+		}
+	}
+
+	return nil
 }
 
 // CompletedExperimentsWarning is a warning that is returned when completed experiments are requested.

--- a/internal/experiment/experiment_test.go
+++ b/internal/experiment/experiment_test.go
@@ -49,7 +49,7 @@ func TestValidateExperiments(t *testing.T) {
 				},
 			},
 			experimentNames: []string{experiment.Symlinks},
-			expectedWarning: "The following experiment(s) are already completed: symlinks. Please remove this experiment flag, as it no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://terragrunt.gruntwork.io/docs/reference/experiment-mode",
+			expectedWarning: "The following experiment(s) are already completed: symlinks. Please remove any completed experiments, as setting them no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://terragrunt.gruntwork.io/docs/reference/experiment-mode",
 			expectedError:   nil,
 		},
 		{
@@ -61,7 +61,7 @@ func TestValidateExperiments(t *testing.T) {
 				},
 			},
 			experimentNames: []string{"invalid", experiment.Symlinks},
-			expectedWarning: "The following experiment(s) are already completed: symlinks. Please remove this experiment flag, as it no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://terragrunt.gruntwork.io/docs/reference/experiment-mode",
+			expectedWarning: "The following experiment(s) are already completed: symlinks. Please remove any completed experiments, as setting them no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://terragrunt.gruntwork.io/docs/reference/experiment-mode",
 			expectedError: experiment.InvalidExperimentsError{
 				ExperimentNames: []string{"invalid"},
 			},

--- a/internal/experiment/experiment_test.go
+++ b/internal/experiment/experiment_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateExperiments(t *testing.T) {
@@ -75,7 +76,12 @@ func TestValidateExperiments(t *testing.T) {
 			warning, err := tt.experiments.ValidateExperimentNames(tt.experimentNames)
 
 			assert.Equal(t, tt.expectedWarning, warning)
-			assert.Equal(t, tt.expectedError, err)
+
+			if tt.expectedError != nil {
+				require.EqualError(t, err, tt.expectedError.Error())
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/internal/experiment/experiment_test.go
+++ b/internal/experiment/experiment_test.go
@@ -1,0 +1,81 @@
+package experiment_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateExperiments(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name            string
+		experiments     experiment.Experiments
+		experimentNames []string
+		expectedWarning string
+		expectedError   error
+	}{
+		{
+			name:            "no experiments",
+			experiments:     experiment.NewExperiments(),
+			experimentNames: []string{},
+			expectedWarning: "",
+			expectedError:   nil,
+		},
+		{
+			name:            "valid experiment",
+			experiments:     experiment.NewExperiments(),
+			experimentNames: []string{experiment.Symlinks},
+			expectedWarning: "",
+			expectedError:   nil,
+		},
+		{
+			name:            "invalid experiment",
+			experiments:     experiment.NewExperiments(),
+			experimentNames: []string{"invalid"},
+			expectedWarning: "",
+			expectedError: experiment.InvalidExperimentsError{
+				ExperimentNames: []string{"invalid"},
+			},
+		},
+		{
+			name: "completed experiment",
+			experiments: experiment.Experiments{
+				experiment.Symlinks: experiment.Experiment{
+					Name:   experiment.Symlinks,
+					Status: experiment.StatusCompleted,
+				},
+			},
+			experimentNames: []string{experiment.Symlinks},
+			expectedWarning: "The following experiment(s) are already completed: symlinks. Please remove this experiment flag, as it no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://terragrunt.gruntwork.io/docs/reference/experiment-mode",
+			expectedError:   nil,
+		},
+		{
+			name: "invalid and completed experiment",
+			experiments: experiment.Experiments{
+				experiment.Symlinks: experiment.Experiment{
+					Name:   experiment.Symlinks,
+					Status: experiment.StatusCompleted,
+				},
+			},
+			experimentNames: []string{"invalid", experiment.Symlinks},
+			expectedWarning: "The following experiment(s) are already completed: symlinks. Please remove this experiment flag, as it no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://terragrunt.gruntwork.io/docs/reference/experiment-mode",
+			expectedError: experiment.InvalidExperimentsError{
+				ExperimentNames: []string{"invalid"},
+			},
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			warning, err := tt.experiments.ValidateExperimentNames(tt.experimentNames)
+
+			assert.Equal(t, tt.expectedWarning, warning)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}

--- a/options/options.go
+++ b/options/options.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
@@ -363,6 +364,12 @@ type TerragruntOptions struct {
 
 	// StrictControls is a slice of strict controls enabled.
 	StrictControls []string
+
+	// ExperimentMode is a flag to enable experiment mode for terragrunt.
+	ExperimentMode bool
+
+	// Experiments is a map of experiments, and their status.
+	Experiments experiment.Experiments
 
 	// FeatureFlags is a map of feature flags to enable.
 	FeatureFlags map[string]string

--- a/options/options.go
+++ b/options/options.go
@@ -655,6 +655,11 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) (*TerragruntOp
 		EngineLogLevel:                 opts.EngineLogLevel,
 		EngineSkipChecksumCheck:        opts.EngineSkipChecksumCheck,
 		Engine:                         cloneEngineOptions(opts.Engine),
+		ExperimentMode:                 opts.ExperimentMode,
+		// This doesn't have to be deep cloned, as the same experiments
+		// are used across all units in a `run-all`. If that changes in
+		// the future, we can deep clone this as well.
+		Experiments: opts.Experiments,
 		// copy array
 		StrictControls: util.CloneStringList(opts.StrictControls),
 		FeatureFlags:   opts.FeatureFlags,

--- a/options/options.go
+++ b/options/options.go
@@ -493,6 +493,8 @@ func NewTerragruntOptionsWithWriters(stdout, stderr io.Writer) *TerragruntOption
 		JSONOutputFolder:           "",
 		FeatureFlags:               map[string]string{},
 		ReadFiles:                  xsync.NewMapOf[string, []string](),
+		ExperimentMode:             false,
+		Experiments:                experiment.NewExperiments(),
 	}
 }
 

--- a/terraform/source.go
+++ b/terraform/source.go
@@ -46,7 +46,7 @@ type Source struct {
 	WalkWithSymlinks bool
 }
 
-func (src *Source) String() string {
+func (src Source) String() string {
 	return fmt.Sprintf("Source{CanonicalSourceURL = %v, DownloadDir = %v, WorkingDir = %v, VersionFile = %v}", src.CanonicalSourceURL, src.DownloadDir, src.WorkingDir, src.VersionFile)
 }
 

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -22,10 +22,10 @@ func TestCatalogGitRepoUpdate(t *testing.T) {
 
 	tempDir := t.TempDir()
 
-	_, err := module.NewRepo(ctx, log.New(), "github.com/gruntwork-io/terraform-fake-modules.git", tempDir)
+	_, err := module.NewRepo(ctx, log.New(), "github.com/gruntwork-io/terraform-fake-modules.git", tempDir, false)
 	require.NoError(t, err)
 
-	_, err = module.NewRepo(ctx, log.New(), "github.com/gruntwork-io/terraform-fake-modules.git", tempDir)
+	_, err = module.NewRepo(ctx, log.New(), "github.com/gruntwork-io/terraform-fake-modules.git", tempDir, false)
 	require.NoError(t, err)
 }
 
@@ -36,7 +36,7 @@ func TestScaffoldGitRepo(t *testing.T) {
 
 	tempDir := t.TempDir()
 
-	repo, err := module.NewRepo(ctx, log.New(), "github.com/gruntwork-io/terraform-fake-modules.git", tempDir)
+	repo, err := module.NewRepo(ctx, log.New(), "github.com/gruntwork-io/terraform-fake-modules.git", tempDir, false)
 	require.NoError(t, err)
 
 	modules, err := repo.FindModules(ctx)
@@ -51,7 +51,7 @@ func TestScaffoldGitModule(t *testing.T) {
 
 	tempDir := t.TempDir()
 
-	repo, err := module.NewRepo(ctx, log.New(), "https://github.com/gruntwork-io/terraform-fake-modules.git", tempDir)
+	repo, err := module.NewRepo(ctx, log.New(), "https://github.com/gruntwork-io/terraform-fake-modules.git", tempDir, false)
 	require.NoError(t, err)
 
 	modules, err := repo.FindModules(ctx)
@@ -89,7 +89,7 @@ func TestScaffoldGitModuleHttps(t *testing.T) {
 
 	tempDir := t.TempDir()
 
-	repo, err := module.NewRepo(ctx, log.New(), "https://github.com/gruntwork-io/terraform-fake-modules", tempDir)
+	repo, err := module.NewRepo(ctx, log.New(), "https://github.com/gruntwork-io/terraform-fake-modules", tempDir, false)
 	require.NoError(t, err)
 
 	modules, err := repo.FindModules(ctx)

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -236,7 +236,7 @@ func TestCustomLockFile(t *testing.T) {
 
 	source := "../custom-lock-file-module"
 	downloadDir := util.JoinPath(rootPath, helpers.TerragruntCache)
-	result, err := tfsource.NewSource(source, downloadDir, rootPath, createLogger())
+	result, err := tfsource.NewSource(source, downloadDir, rootPath, createLogger(), false)
 	require.NoError(t, err)
 
 	lockFilePath := util.JoinPath(result.WorkingDir, util.TerraformLockFile)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -820,21 +820,21 @@ func TestTerragruntStackCommandsWithSymlinks(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, disjointSymlinksEnvironmentPath)
 
 	// perform the first initialization
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all init --terragrunt-log-level info --terragrunt-non-interactive --terragrunt-working-dir "+disjointSymlinksEnvironmentPath)
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all init --experiment symlinks --terragrunt-log-level info --terragrunt-non-interactive --terragrunt-working-dir "+disjointSymlinksEnvironmentPath)
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Downloading Terraform configurations from ./module into ./a/.terragrunt-cache")
 	assert.Contains(t, stderr, "Downloading Terraform configurations from ./module into ./b/.terragrunt-cache")
 	assert.Contains(t, stderr, "Downloading Terraform configurations from ./module into ./c/.terragrunt-cache")
 
 	// perform the second initialization and make sure that the cache is not downloaded again
-	_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all init --terragrunt-log-level info --terragrunt-non-interactive --terragrunt-working-dir "+disjointSymlinksEnvironmentPath)
+	_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all init --experiment symlinks --terragrunt-log-level info --terragrunt-non-interactive --terragrunt-working-dir "+disjointSymlinksEnvironmentPath)
 	require.NoError(t, err)
 	assert.NotContains(t, stderr, "Downloading Terraform configurations from ./module into ./a/.terragrunt-cache")
 	assert.NotContains(t, stderr, "Downloading Terraform configurations from ./module into ./b/.terragrunt-cache")
 	assert.NotContains(t, stderr, "Downloading Terraform configurations from ./module into ./c/.terragrunt-cache")
 
 	// validate the modules
-	_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all validate --terragrunt-log-level info --terragrunt-non-interactive --terragrunt-working-dir "+disjointSymlinksEnvironmentPath)
+	_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all validate --experiment symlinks --terragrunt-log-level info --terragrunt-non-interactive --terragrunt-working-dir "+disjointSymlinksEnvironmentPath)
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Module ./a")
 	assert.Contains(t, stderr, "Module ./b")
@@ -844,7 +844,7 @@ func TestTerragruntStackCommandsWithSymlinks(t *testing.T) {
 	require.NoError(t, os.Chtimes(util.JoinPath(disjointSymlinksEnvironmentPath, "module/main.tf"), time.Now(), time.Now()))
 
 	// perform the initialization and make sure that the cache is downloaded again
-	_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all init --terragrunt-log-level info --terragrunt-non-interactive --terragrunt-working-dir "+disjointSymlinksEnvironmentPath)
+	_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all init --experiment symlinks --terragrunt-log-level info --terragrunt-non-interactive --terragrunt-working-dir "+disjointSymlinksEnvironmentPath)
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Downloading Terraform configurations from ./module into ./a/.terragrunt-cache")
 	assert.Contains(t, stderr, "Downloading Terraform configurations from ./module into ./b/.terragrunt-cache")
@@ -873,12 +873,12 @@ func TestTerragruntOutputModuleGroupsWithSymlinks(t *testing.T) {
 	}`, disjointSymlinksEnvironmentPath)
 
 	helpers.CleanupTerraformFolder(t, disjointSymlinksEnvironmentPath)
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output-module-groups --terragrunt-working-dir %s apply", disjointSymlinksEnvironmentPath))
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output-module-groups --experiment symlinks --terragrunt-working-dir %s apply", disjointSymlinksEnvironmentPath))
 	require.NoError(t, err)
 
 	output := strings.ReplaceAll(stdout, " ", "")
 	expectedOutput := strings.ReplaceAll(strings.ReplaceAll(expectedApplyOutput, "\t", ""), " ", "")
-	assert.True(t, strings.Contains(strings.TrimSpace(output), strings.TrimSpace(expectedOutput)))
+	assert.Contains(t, strings.TrimSpace(output), strings.TrimSpace(expectedOutput))
 }
 
 func TestInvalidSource(t *testing.T) {

--- a/util/file.go
+++ b/util/file.go
@@ -656,8 +656,8 @@ func ListTfFiles(directoryPath string, walkWithSymlinks bool) ([]string, error) 
 
 		return nil
 	})
-	return tfFiles, err
 
+	return tfFiles, err
 }
 
 // IsDirectoryEmpty - returns true if the given path exists and is a empty directory.

--- a/util/file.go
+++ b/util/file.go
@@ -637,10 +637,15 @@ func (err PathIsNotFile) Error() string {
 }
 
 // ListTfFiles returns a list of all TF files in the specified directory.
-func ListTfFiles(directoryPath string) ([]string, error) {
+func ListTfFiles(directoryPath string, walkWithSymlinks bool) ([]string, error) {
 	var tfFiles []string
 
-	err := WalkWithSymlinks(directoryPath, func(path string, info os.FileInfo, err error) error {
+	walkFunc := filepath.Walk
+	if walkWithSymlinks {
+		walkFunc = WalkWithSymlinks
+	}
+
+	err := walkFunc(directoryPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -651,8 +656,8 @@ func ListTfFiles(directoryPath string) ([]string, error) {
 
 		return nil
 	})
-
 	return tfFiles, err
+
 }
 
 // IsDirectoryEmpty - returns true if the given path exists and is a empty directory.


### PR DESCRIPTION
## Description

Closes #3654.

We have other experiments like the following that need to be pulled into this system if we don't have any problems with the design:

- [Provider Cache Server](https://terragrunt.gruntwork.io/docs/features/provider-cache-server/).
- [IaC Engines](https://terragrunt.gruntwork.io/docs/features/engine/).

To ensure backwards compatibility, when they get pulled in, the existing flags that they use will be added to a strict control that warns users they are using a legacy experiment control mechanism, and should switch to using this new system.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added new `experiment` system. This system allows you to enable experimental features of Terragrunt before they're stable.
Removed Symlink support by default. Users have to opt-in to use it via the new `experiment` system.

### Migration Guide

Users using the current ability to find symlinked units in their stacks will now need to explicitly enable the `symlinks` experiment to continue using this feature.

e.g.

```bash
terragrunt run-all plan --experiment symlinks
```

For information on how to use the new `experiment` system, see the [Experiments documentation](https://terragrunt.gruntwork.io/docs/reference/experiments/) (which will go live once this PR is merged).
