### PR TITLE
fix: Adding redirect entries for all the pages that were renamed

### DIFF
--- a/docs/_docs/02_features/aws-authentication.md
+++ b/docs/_docs/02_features/aws-authentication.md
@@ -8,6 +8,9 @@ tags: ["AWS", "Use cases", "CLI", "AWS IAM"]
 order: 225
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+    - /docs/features/aws-auth/
+    - /docs/features/work-with-multiple-aws-accounts/
 ---
 
 ## Motivation

--- a/docs/_docs/02_features/extra-arguments.md
+++ b/docs/_docs/02_features/extra-arguments.md
@@ -8,6 +8,8 @@ tags: ["DRY", "Use cases", "CLI"]
 order: 215
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+    - /docs/features/keep-your-cli-flags-dry/
 ---
 
 - [Motivation](#motivation)

--- a/docs/_docs/02_features/includes.md
+++ b/docs/_docs/02_features/includes.md
@@ -8,6 +8,8 @@ tags: ["DRY", "Use cases", "include"]
 order: 203
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+    - /docs/features/keep-your-terragrunt-architecture-dry/
 ---
 
 - [Motivation](#motivation)

--- a/docs/_docs/02_features/provider-cache-server.md
+++ b/docs/_docs/02_features/provider-cache-server.md
@@ -8,6 +8,8 @@ tags: ["cache", "provider"]
 order: 280
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+    - /docs/features/provider-cache/
 ---
 
 Terragrunt has the ability to cache OpenTofu/Terraform providers across all OpenTofu/Terraform instances, ensuring that each provider is only ever downloaded and stored on disk exactly once by running a local provider cache server while running Terragrunt.

--- a/docs/_docs/02_features/runtime-control.md
+++ b/docs/_docs/02_features/runtime-control.md
@@ -8,6 +8,8 @@ tags: ["CLI"]
 order: 250
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+    - /docs/features/auto-retry/
 ---
 
 Sometimes, you need to have Terragrunt behave differently at runtime due to specific context that you have in your environment.

--- a/docs/_docs/02_features/stacks.md
+++ b/docs/_docs/02_features/stacks.md
@@ -8,6 +8,8 @@ tags: ["DRY", "Unit", "Modules", "Use cases", "CLI", "Stack"]
 order: 202
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+    - /docs/features/execute-terraform-commands-on-multiple-units-at-once/
 ---
 
 - [Motivation](#motivation)

--- a/docs/_docs/02_features/state-backend.md
+++ b/docs/_docs/02_features/state-backend.md
@@ -8,6 +8,8 @@ tags: ["DRY", "remote", "Use cases", "CLI", "state"]
 order: 204
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+    - /docs/features/keep-your-remote-state-configuration-dry/
 ---
 
 - [Motivation](#motivation)

--- a/docs/_docs/02_features/units.md
+++ b/docs/_docs/02_features/units.md
@@ -8,6 +8,10 @@ tags: ["DRY", "Use cases", "backend", "unit"]
 order: 200
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+  - /docs/features/inputs/
+  - /docs/features/locals/
+  - /docs/features/keep-your-terraform-code-dry/
 ---
 
 - [Motivation](#motivation)

--- a/docs/_docs/04_reference/lock-file-handling.md
+++ b/docs/_docs/04_reference/lock-file-handling.md
@@ -8,6 +8,8 @@ tags: ["CLI", "DRY"]
 order: 407
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+    - /docs/features/lock-file-handling/
 ---
 
 ## How to use lock files with Terragrunt

--- a/docs/_docs/04_reference/log-formatting.md
+++ b/docs/_docs/04_reference/log-formatting.md
@@ -8,6 +8,8 @@ tags: ["log"]
 order: 408
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+    - /docs/features/custom-log-format/
 ---
 
 Using the `--terragrunt-log-custom-format <format>` flag you can customize the way Terragrunt logs with total control over the logging format.

--- a/docs/_docs/04_reference/terragrunt-cache.md
+++ b/docs/_docs/04_reference/terragrunt-cache.md
@@ -8,6 +8,8 @@ tags: [ "install" ]
 order: 406
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+    - /docs/features/caching/
 ---
 
 Terragrunt uses a cache directory (`.terragrunt-cache`) to store downloaded modules when using the `source` attribute in the `terraform` block.

--- a/docs/_docs/05_troubleshooting/debugging.md
+++ b/docs/_docs/05_troubleshooting/debugging.md
@@ -8,6 +8,8 @@ tags: ["Debugging", "Troubleshooting"]
 order: 501
 nav_title: Documentation
 nav_title_link: /docs/
+redirect_from:
+    - /docs/features/debugging/
 ---
 
 Terragrunt and OpenTofu/Terraform usually play well together in helping you


### PR DESCRIPTION
## Description

I foolishly didn't include fallback redirects for all the feature pages that were renamed, but in retrospect, it should have been done.

This adds a redirect for every feature page that was renamed.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added redirects for all pages renamed in #3640.

