### PR TITLE
fix: Fixing `root-file-name` default

### DIFF
--- a/cli/commands/catalog/command.go
+++ b/cli/commands/catalog/command.go
@@ -32,6 +32,10 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 				repoPath = val
 			}
 
+			if opts.ScaffoldRootFileName == "" {
+				opts.ScaffoldRootFileName = commands.GetDefaultRootFileName(opts)
+			}
+
 			return Run(ctx, opts.OptionsFromContext(ctx), repoPath)
 		},
 	}

--- a/cli/commands/scaffold/command.go
+++ b/cli/commands/scaffold/command.go
@@ -47,6 +47,10 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 				templateURL = val
 			}
 
+			if opts.ScaffoldRootFileName == "" {
+				opts.ScaffoldRootFileName = commands.GetDefaultRootFileName(opts)
+			}
+
 			return Run(ctx, opts.OptionsFromContext(ctx), moduleURL, templateURL)
 		},
 	}


### PR DESCRIPTION
## Description

I missed that the `Action` for a flag wouldn't fire when not set, so I accidentally made it so that `scaffold` and `catalog` had no defaults.

This fixes that, and makes it so that they are set to the expected defaults when no flag is set.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `scaffold`.
Updated `catalog`.

