### PR TITLE
fix: Fixing configurable `root` include

### DIFF
--- a/cli/commands/scaffold/action.go
+++ b/cli/commands/scaffold/action.go
@@ -58,7 +58,7 @@ terraform {
 }
 {{ if .EnableRootInclude }}
 include "root" {
-  path = find_in_parent_folders()
+  path = find_in_parent_folders("{{ .RootFileName }}")
 }
 {{ end }}
 inputs = {


### PR DESCRIPTION
## Description

Fixes configurable root include. This was somehow dropped in the refactor to make the root include configurable.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `catalog`.

