### PR TITLE
fix: Simplifying root configuration lookup

### DIFF
--- a/config/catalog.go
+++ b/config/catalog.go
@@ -14,27 +14,17 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-const (
-	rootConfigFmt = `
-include "root" {
-  path = find_in_parent_folders("%s")
-}
-`
-	// matches a block and ignores commented out config, where the block name is passed as the first argument to fmt, e.g.
-	// `fmt.Sprintf(hclBlockRegExprFmt, "include")` returns a regexp expression matching the `include` block:
-	//
-	// ```hcl
-	// include {
-	//
-	// }
-	// ```
-	hclBlockRegExprFmt = `(?is)(?:^|^((?:[^/]|/[^*])*)(?:/\*.*?\*/)?((?:[^/]|/[^*])*)\n)(%s[ {][^\}]+)`
-)
+// matches a block and ignores commented out config, where the block name is passed as the first argument to fmt, e.g.
+// `fmt.Sprintf(hclBlockRegExprFmt, "include")` returns a regexp expression matching the `include` block:
+//
+// ```hcl
+// include {
+//
+// }
+// ```
+const hclBlockRegExprFmt = `(?is)(?:^|^((?:[^/]|/[^*])*)(?:/\*.*?\*/)?((?:[^/]|/[^*])*)\n)(%s[ {][^\}]+)`
 
-var (
-	includeBlockReg = regexp.MustCompile(fmt.Sprintf(hclBlockRegExprFmt, MetadataInclude))
-	catalogBlockReg = regexp.MustCompile(fmt.Sprintf(hclBlockRegExprFmt, MetadataCatalog))
-)
+var catalogBlockReg = regexp.MustCompile(fmt.Sprintf(hclBlockRegExprFmt, MetadataCatalog))
 
 type CatalogConfig struct {
 	URLs []string `hcl:"urls,attr" cty:"urls"`

--- a/config/catalog.go
+++ b/config/catalog.go
@@ -82,6 +82,17 @@ func ReadCatalogConfig(parentCtx context.Context, opts *options.TerragruntOption
 var ErrCatalogConfigNotFound = errors.New("catalog configuration not found")
 
 func findCatalogConfig(ctx context.Context, opts *options.TerragruntOptions) (string, string, error) {
+	if util.FileExists(opts.ScaffoldRootFileName) {
+		configString, err := util.ReadFileAsString(opts.ScaffoldRootFileName)
+		if err != nil {
+			return "", "", err
+		}
+
+		if catalogBlockReg.MatchString(configString) {
+			return opts.ScaffoldRootFileName, configString, nil
+		}
+	}
+
 	newConfigPath, err := FindInParentFolders(NewParsingContext(ctx, opts), []string{opts.ScaffoldRootFileName})
 	if err != nil {
 		var parentFileNotFoundError ParentFileNotFoundError

--- a/config/catalog.go
+++ b/config/catalog.go
@@ -96,8 +96,11 @@ func findCatalogConfig(ctx context.Context, opts *options.TerragruntOptions) (st
 	newConfigPath, err := FindInParentFolders(NewParsingContext(ctx, opts), []string{opts.ScaffoldRootFileName})
 	if err != nil {
 		var parentFileNotFoundError ParentFileNotFoundError
-		if ok := errors.As(err, &parentFileNotFoundError); !ok {
-			return "", "", err
+		if ok := errors.As(err, &parentFileNotFoundError); ok {
+			opts.Logger.Error("Failed to find root terragrunt configuration from current working directory")
+			opts.Logger.Error("For more information, read the documentation here: https://terragrunt.gruntwork.io/docs/features/catalog")
+
+			return "", "", ErrCatalogConfigNotFound
 		}
 
 		return "", "", err

--- a/config/catalog_test.go
+++ b/config/catalog_test.go
@@ -23,11 +23,13 @@ func TestCatalogParseConfigFile(t *testing.T) {
 
 	testCases := []struct {
 		configPath     string
+		rootFileName   string
 		expectedConfig *config.CatalogConfig
 		expectedErr    error
 	}{
 		{
 			filepath.Join(basePath, "config1.hcl"),
+			"config1.hcl",
 			&config.CatalogConfig{
 				URLs: []string{
 					filepath.Join(basePath, "terraform-aws-eks"), // this path exists in the fixture directory and must be converted to the absolute path.
@@ -41,16 +43,19 @@ func TestCatalogParseConfigFile(t *testing.T) {
 		},
 		{
 			filepath.Join(basePath, "config2.hcl"),
+			"config2.hcl",
 			nil,
 			nil,
 		},
 		{
 			filepath.Join(basePath, "config3.hcl"),
+			"config3.hcl",
 			&config.CatalogConfig{},
 			nil,
 		},
 		{
 			filepath.Join(basePath, "complex-legacy-root/terragrunt.hcl"),
+			"terragrunt.hcl",
 			&config.CatalogConfig{
 				URLs: []string{
 					filepath.Join(basePath, "complex-legacy-root/dev/us-west-1/modules/terraform-aws-eks"),
@@ -62,6 +67,7 @@ func TestCatalogParseConfigFile(t *testing.T) {
 		},
 		{
 			filepath.Join(basePath, "complex/root.hcl"),
+			"root.hcl",
 			&config.CatalogConfig{
 				URLs: []string{
 					filepath.Join(basePath, "complex/dev/us-west-1/modules/terraform-aws-eks"),
@@ -73,6 +79,7 @@ func TestCatalogParseConfigFile(t *testing.T) {
 		},
 		{
 			filepath.Join(basePath, "complex-legacy-root/dev/terragrunt.hcl"),
+			"terragrunt.hcl",
 			&config.CatalogConfig{
 				URLs: []string{
 					filepath.Join(basePath, "complex-legacy-root/dev/us-west-1/modules/terraform-aws-eks"),
@@ -83,7 +90,8 @@ func TestCatalogParseConfigFile(t *testing.T) {
 			nil,
 		},
 		{
-			filepath.Join(basePath, "complex/dev/root.hcl"),
+			filepath.Join(basePath, "complex/dev/terragrunt.hcl"),
+			"root.hcl",
 			&config.CatalogConfig{
 				URLs: []string{
 					filepath.Join(basePath, "complex/dev/us-west-1/modules/terraform-aws-eks"),
@@ -95,6 +103,7 @@ func TestCatalogParseConfigFile(t *testing.T) {
 		},
 		{
 			filepath.Join(basePath, "complex/dev/us-west-1/terragrunt.hcl"),
+			"root.hcl",
 			&config.CatalogConfig{
 				URLs: []string{
 					filepath.Join(basePath, "complex/dev/us-west-1/modules/terraform-aws-eks"),
@@ -106,6 +115,7 @@ func TestCatalogParseConfigFile(t *testing.T) {
 		},
 		{
 			filepath.Join(basePath, "complex/dev/us-west-1/modules/terragrunt.hcl"),
+			"root.hcl",
 			&config.CatalogConfig{
 				URLs: []string{
 					filepath.Join(basePath, "complex/dev/us-west-1/modules/terraform-aws-eks"),
@@ -117,6 +127,7 @@ func TestCatalogParseConfigFile(t *testing.T) {
 		},
 		{
 			filepath.Join(basePath, "complex/prod/terragrunt.hcl"),
+			"root.hcl",
 			&config.CatalogConfig{
 				URLs: []string{
 					filepath.Join(basePath, "complex/dev/us-west-1/modules/terraform-aws-eks"),
@@ -135,7 +146,7 @@ func TestCatalogParseConfigFile(t *testing.T) {
 			opts, err := options.NewTerragruntOptionsWithConfigPath(tt.configPath)
 			require.NoError(t, err)
 
-			opts.ScaffoldRootFileName = filepath.Base(tt.configPath)
+			opts.ScaffoldRootFileName = tt.rootFileName
 
 			config, err := config.ReadCatalogConfig(context.Background(), opts)
 


### PR DESCRIPTION
## Description

There's currently logic that includes ignoring certain configurations when found, etc.

Instead of doing that, let's just look for configuration in parents that have valid catalog configurations, and use those.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `catalog`.

