### PR TITLE
fix: Split stdout and stderr streams even when using custom logging

### DIFF
--- a/cli/commands/terraform/action.go
+++ b/cli/commands/terraform/action.go
@@ -283,7 +283,7 @@ func generateConfig(terragruntConfig *config.TerragruntConfig, updatedTerragrunt
 
 // Runs terraform with the given options and CLI args.
 // This will forward all the args and extra_arguments directly to Terraform.
-
+//
 // This function takes in the "original" terragrunt options which has the unmodified 'WorkingDir' from before downloading the code from the source URL,
 // and the "updated" terragrunt options that will contain the updated 'WorkingDir' into which the code has been downloaded
 func runTerragruntWithConfig(ctx context.Context, originalTerragruntOptions *options.TerragruntOptions, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig, target *Target) error {
@@ -674,6 +674,7 @@ func prepareInitOptions(terragruntOptions *options.TerragruntOptions) (*options.
 	initOptions.TerraformCliArgs = []string{terraform.CommandNameInit}
 	initOptions.WorkingDir = terragruntOptions.WorkingDir
 	initOptions.TerraformCommand = terraform.CommandNameInit
+	initOptions.Headless = true
 
 	initOutputForCommands := []string{terraform.CommandNamePlan, terraform.CommandNameApply}
 	terraformCommand := util.FirstArg(terragruntOptions.TerraformCliArgs)

--- a/options/options.go
+++ b/options/options.go
@@ -386,6 +386,15 @@ type TerragruntOptions struct {
 
 	// Errors is a configuration for error handling.
 	Errors *ErrorsConfig
+
+	// Headless is set when Terragrunt is running in
+	// headless mode. In this mode, Terragrunt will not
+	// return stdout/stderr directly to the caller.
+	//
+	// It will instead write the output to INFO,
+	// as it's not something intended for a user
+	// to use in a programmatic way.
+	Headless bool
 }
 
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests
@@ -672,6 +681,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) (*TerragruntOp
 		Errors:                cloneErrorsConfig(opts.Errors),
 		ScaffoldNoIncludeRoot: opts.ScaffoldNoIncludeRoot,
 		ScaffoldRootFileName:  opts.ScaffoldRootFileName,
+		Headless:              opts.Headless,
 	}, nil
 }
 

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -139,25 +139,31 @@ func RunShellCommandWithOutput(
 				WithField(placeholders.TFCmdArgsKeyName, args)
 
 			if opts.JSONLogFormat && !cli.Args(args).Normalize(cli.SingleDashFlag).Contains(terraform.FlagNameJSON) {
-				outWriter = writer.New(
-					writer.WithLogger(logger.WithOptions(log.WithOutput(errWriter))),
-					writer.WithDefaultLevel(log.StdoutLevel),
+				outWriter = buildOutWriter(
+					opts,
+					logger,
+					outWriter,
+					errWriter,
 				)
 
-				errWriter = writer.New(
-					writer.WithLogger(logger.WithOptions(log.WithOutput(errWriter))),
-					writer.WithDefaultLevel(log.StderrLevel),
+				errWriter = buildErrWriter(
+					opts,
+					logger,
+					errWriter,
 				)
 			} else if !shouldForceForwardTFStdout(args) {
-				outWriter = writer.New(
-					writer.WithLogger(logger.WithOptions(log.WithOutput(errWriter))),
-					writer.WithDefaultLevel(log.StdoutLevel),
+				outWriter = buildOutWriter(
+					opts,
+					logger,
+					outWriter,
+					errWriter,
 					writer.WithMsgSeparator(logMsgSeparator),
 				)
 
-				errWriter = writer.New(
-					writer.WithLogger(logger.WithOptions(log.WithOutput(errWriter))),
-					writer.WithDefaultLevel(log.StderrLevel),
+				errWriter = buildErrWriter(
+					opts,
+					logger,
+					errWriter,
 					writer.WithMsgSeparator(logMsgSeparator),
 					writer.WithParseFunc(terraform.ParseLogFunc(tfLogMsgPrefix, false)),
 				)
@@ -243,6 +249,53 @@ func RunShellCommandWithOutput(
 	})
 
 	return &output, err
+}
+
+// buildOutWriter returns the writer for the command's stdout.
+//
+// When Terragrunt is running in Headless mode, we want to forward
+// any stdout to the INFO log level, otherwise, we want to forward
+// stdout to the STDOUT log level.
+//
+// Also accepts any additional writer options desired.
+func buildOutWriter(opts *options.TerragruntOptions, logger log.Logger, outWriter, errWriter io.Writer, writerOptions ...writer.Option) io.Writer {
+	logLevel := log.StdoutLevel
+
+	if opts.Headless {
+		logLevel = log.InfoLevel
+		outWriter = errWriter
+	}
+
+	options := []writer.Option{
+		writer.WithLogger(logger.WithOptions(log.WithOutput(outWriter))),
+		writer.WithDefaultLevel(logLevel),
+	}
+	options = append(options, writerOptions...)
+
+	return writer.New(options...)
+}
+
+// buildErrWriter returns the writer for the command's stderr.
+//
+// When Terragrunt is running in Headless mode, we want to forward
+// any stderr to the ERROR log level, otherwise, we want to forward
+// stderr to the STDERR log level.
+//
+// Also accepts any additional writer options desired.
+func buildErrWriter(opts *options.TerragruntOptions, logger log.Logger, errWriter io.Writer, writerOptions ...writer.Option) io.Writer {
+	logLevel := log.StderrLevel
+
+	if opts.Headless {
+		logLevel = log.ErrorLevel
+	}
+
+	options := []writer.Option{
+		writer.WithLogger(logger.WithOptions(log.WithOutput(errWriter))),
+		writer.WithDefaultLevel(logLevel),
+	}
+	options = append(options, writerOptions...)
+
+	return writer.New(options...)
 }
 
 // isTerraformCommandThatNeedsPty returns true if the sub command of terraform we are running requires a pty.

--- a/test/integration_docs_test.go
+++ b/test/integration_docs_test.go
@@ -25,13 +25,13 @@ func TestDocsQuickStart(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
 		require.NoError(t, err)
-		assert.Contains(t, stderr, "Plan: 1 to add, 0 to change, 0 to destroy.")
+		assert.Contains(t, stdout, "Plan: 1 to add, 0 to change, 0 to destroy.")
 
-		_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
 		require.NoError(t, err)
-		assert.Contains(t, stderr, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
+		assert.Contains(t, stdout, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
 
 	})
 


### PR DESCRIPTION
## Description

Fixes #3667.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated log processing for commands run by Terragrunt so that the stdout/stderr streams still forward to the appropriate streams out of Terragrunt.

The exception to this behavior is for "headless" operations that Terragrunt does, like [auto-init](https://terragrunt.gruntwork.io/docs/features/auto-init/). In these cases, Terragrunt will instead forward to the stderr stream of the logger, and use a log level indicating that the stdout/stderr streams are part of internal Terragrunt operation, not something done by an orchestrated process (`INFO`/`ERROR` instead of `STDOUT`/`STDERR`).

### Migration Guide

If you are currently relying, or working around the buggy behavior present in Terragrunt where stderr has the stream of the underlying orchestrated process stdout, you will need to adjust any workarounds or scripts that rely on this behavior.

This is a breaking change.

