### PR TITLE
feat: Adding `skip-error-summary` flag

### DIFF
--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -151,6 +151,9 @@ const (
 	TerragruntLogCustomFormatFlagName = "terragrunt-log-custom-format"
 	TerragruntLogCustomFormatEnvName  = "TERRAGRUNT_LOG_CUSTOM_FORMAT"
 
+	TerragruntSkippErrorSummaryFlagName = "terragrunt-skip-error-summary"
+	TerragruntSkippErrorSummaryEnvName  = "TERRAGRUNT_SKIP_ERROR_SUMMARY"
+
 	// Strict Mode related flags/envs
 	TerragruntStrictModeFlagName = "strict-mode"
 	TerragruntStrictModeEnvName  = "TERRAGRUNT_STRICT_MODE"
@@ -641,6 +644,12 @@ func NewGlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 			Destination: &opts.EngineLogLevel,
 			Usage:       "Terragrunt engine log level.",
 			Hidden:      true,
+		},
+		&cli.BoolFlag{
+			Name:        TerragruntSkippErrorSummaryFlagName,
+			EnvVar:      TerragruntSkippErrorSummaryEnvName,
+			Destination: &opts.SkipErrorSummary,
+			Usage:       "Skip error summary at the end of the command.",
 		},
 	}
 

--- a/options/options.go
+++ b/options/options.go
@@ -386,6 +386,12 @@ type TerragruntOptions struct {
 
 	// Errors is a configuration for error handling.
 	Errors *ErrorsConfig
+
+	// SkipErrorSummary is a flag to skip the error summary
+	// provided at the end of Terragrunt execution to
+	// recap all that was emitted in stderr throughout
+	// the run of an orchestrated process.
+	SkipErrorSummary bool
 }
 
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests
@@ -672,6 +678,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) (*TerragruntOp
 		Errors:                cloneErrorsConfig(opts.Errors),
 		ScaffoldNoIncludeRoot: opts.ScaffoldNoIncludeRoot,
 		ScaffoldRootFileName:  opts.ScaffoldRootFileName,
+		SkipErrorSummary:      opts.SkipErrorSummary,
 	}, nil
 }
 

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -215,10 +215,11 @@ func RunShellCommandWithOutput(
 
 		if err := cmd.Start(); err != nil { //nolint:contextcheck
 			err = util.ProcessExecutionError{
-				Err:        err,
-				Args:       args,
-				Command:    command,
-				WorkingDir: cmd.Dir,
+				Err:         err,
+				Args:        args,
+				Command:     command,
+				WorkingDir:  cmd.Dir,
+				SkipSummary: opts.SkipErrorSummary,
 			}
 
 			return errors.New(err)
@@ -229,11 +230,12 @@ func RunShellCommandWithOutput(
 
 		if err := cmd.Wait(); err != nil {
 			err = util.ProcessExecutionError{
-				Err:        err,
-				Args:       args,
-				Command:    command,
-				Output:     output,
-				WorkingDir: cmd.Dir,
+				Err:         err,
+				Args:        args,
+				Command:     command,
+				Output:      output,
+				WorkingDir:  cmd.Dir,
+				SkipSummary: opts.SkipErrorSummary,
 			}
 
 			return errors.New(err)

--- a/util/shell.go
+++ b/util/shell.go
@@ -75,20 +75,30 @@ func GetExitCode(err error) (int, error) {
 
 // ProcessExecutionError - error returned when a command fails, contains StdOut and StdErr
 type ProcessExecutionError struct {
-	Err        error
-	Output     CmdOutput
-	WorkingDir string
-	Command    string
-	Args       []string
+	Err         error
+	Output      CmdOutput
+	WorkingDir  string
+	Command     string
+	Args        []string
+	SkipSummary bool
 }
 
 func (err ProcessExecutionError) Error() string {
+	if err.SkipSummary {
+		return fmt.Sprintf("Failed to execute \"%s %s\" in %s",
+			err.Command,
+			strings.Join(err.Args, " "),
+			err.WorkingDir,
+		)
+	}
+
 	return fmt.Sprintf("Failed to execute \"%s %s\" in %s\n%s\n%v",
 		err.Command,
 		strings.Join(err.Args, " "),
 		err.WorkingDir,
 		err.Output.Stderr.String(),
-		err.Err)
+		err.Err,
+	)
 }
 
 func (err ProcessExecutionError) ExitStatus() (int, error) {


### PR DESCRIPTION
## Description

Adds a flag to optionally skip the error summary at the end of a failed Terragrunt run.

This won't be merged as-is. We're currently undergoing quite a bit of CLI redesign at the moment, so I'm going to coordinate with @levkohimins to see when the right time and place is for this kind of functionality to be added.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `--skip-error-summary` flag to optionally skip the error summary at the end of a failed Terragrunt run.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

