### PR TITLE
feat: Adding logging docs

### DIFF
--- a/cli/commands/terraform/action.go
+++ b/cli/commands/terraform/action.go
@@ -283,7 +283,7 @@ func generateConfig(terragruntConfig *config.TerragruntConfig, updatedTerragrunt
 
 // Runs terraform with the given options and CLI args.
 // This will forward all the args and extra_arguments directly to Terraform.
-
+//
 // This function takes in the "original" terragrunt options which has the unmodified 'WorkingDir' from before downloading the code from the source URL,
 // and the "updated" terragrunt options that will contain the updated 'WorkingDir' into which the code has been downloaded
 func runTerragruntWithConfig(ctx context.Context, originalTerragruntOptions *options.TerragruntOptions, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig, target *Target) error {
@@ -674,6 +674,7 @@ func prepareInitOptions(terragruntOptions *options.TerragruntOptions) (*options.
 	initOptions.TerraformCliArgs = []string{terraform.CommandNameInit}
 	initOptions.WorkingDir = terragruntOptions.WorkingDir
 	initOptions.TerraformCommand = terraform.CommandNameInit
+	initOptions.Headless = true
 
 	initOutputForCommands := []string{terraform.CommandNamePlan, terraform.CommandNameApply}
 	terraformCommand := util.FirstArg(terragruntOptions.TerraformCliArgs)

--- a/docs/_docs/04_reference/log-formatting.md
+++ b/docs/_docs/04_reference/log-formatting.md
@@ -5,7 +5,7 @@ category: reference
 categories_url: reference
 excerpt: Learn how customize Terragrunt logging.
 tags: ["log"]
-order: 408
+order: 409
 nav_title: Documentation
 nav_title_link: /docs/
 redirect_from:
@@ -276,11 +276,15 @@ Specific options for placeholders:
 
 The examples below replicate the preset formats specified with `--terragrunt-log-format`. They can be useful if you need to change existing formats to suit your needs.
 
+### Pretty
+
 `--terragrunt-log-format pretty`
 
 ```shell
 --terragrunt-log-custom-format "%time(color=light-black) %level(case=upper,width=6,color=preset) %prefix(path=short-relative,color=gradient,suffix=' ')%tf-path(color=cyan,suffix=': ')%msg(path=relative)"
 ```
+
+### Bare
 
 `--terragrunt-log-format bare`
 
@@ -288,11 +292,15 @@ The examples below replicate the preset formats specified with `--terragrunt-log
 --terragrunt-forward-tf-stdout --terragrunt-log-custom-format "%level(case=upper,width=4)[%interval] %msg %prefix(path=short,prefix='prefix=[',suffix=']')"
 ```
 
+### Key-value
+
 `--terragrunt-log-format key-value`
 
 ```shell
 --terragrunt-log-custom-format "time=%time(format=rfc3339) level=%level prefix=%prefix(path=short-relative) tf-path=%tf-path(path=filename) msg=%msg(path=relative,color=disable)"
 ```
+
+### JSON
 
 `--terragrunt-log-format json`
 

--- a/docs/_docs/04_reference/logging.md
+++ b/docs/_docs/04_reference/logging.md
@@ -28,7 +28,7 @@ The `STDOUT` and `STDERR` log levels are non-standard, and exist due to Terragru
 
 For the most part, whenever you use Terragrunt to run something using another tool (like OpenTofu or Terraform), Terragrunt will capture the stdout and stderr terminal output from that tool, enrich it with additional information, then _log_ it as `STDOUT` or `STDERR` respectively.
 
-The exception to this is when Terragrunt is running a process in "Headless Mode", where it will instead emit stdout and stderr terminal output to `INFO` and `ERROR` log levels respectively. This happens when 
+The exception to this is when Terragrunt is running a process in "Headless Mode", where it will instead emit stdout and stderr terminal output to `INFO` and `ERROR` log levels respectively. This happens when
 
 All other log levels are standard, and are used by Terragrunt to log its own messages.
 
@@ -68,7 +68,6 @@ Here, we have three types of log messages:
 1. `DEBUG` messages from Terragrunt itself. By default, Terragrunt's log level is `INFO`, but we've set it to `DEBUG` using the `--terragrunt-log-level` flag.
 2. `STDOUT` messages from OpenTofu. These are messages that OpenTofu would normally print directly to the terminal, but instead, Terragrunt captures them and logs them as `STDOUT` log messages, along with timestamps and other metadata.
 3. `INFO` messages from Terragrunt [auto-init](/docs/features/auto-init). These were initially emitted by OpenTofu, however the user did not specifically ask for them, so Terragrunt logs them as `INFO` messages.
-
 
 ## Enrichment
 

--- a/docs/_docs/04_reference/logging.md
+++ b/docs/_docs/04_reference/logging.md
@@ -1,0 +1,255 @@
+---
+layout: collection-browser-doc
+title: Logging
+category: reference
+categories_url: reference
+excerpt: Learn how Terragrunt decides what to log, and when.
+tags: ["log"]
+order: 408
+nav_title: Documentation
+nav_title_link: /docs/
+---
+
+Terragrunt logs messages as it runs to help you understand what it's doing. Given that Terragrunt is an IaC orchestrator, this can result in messages that are surprising if you don't understand what Terragrunt is doing behind the scenes.
+
+## Log Levels
+
+To start with, Terragrunt has the following log levels:
+
+- `STDERR`
+- `STDOUT`
+- `ERROR`
+- `WARN`
+- `INFO`
+- `DEBUG`
+- `TRACE`
+
+The `STDOUT` and `STDERR` log levels are non-standard, and exist due to Terragrunt's special responsibility as an IaC orchestrator.
+
+For the most part, whenever you use Terragrunt to run something using another tool (like OpenTofu or Terraform), Terragrunt will capture the stdout and stderr terminal output from that tool, enrich it with additional information, then _log_ it as `STDOUT` or `STDERR` respectively.
+
+The exception to this is when Terragrunt is running a process in "Headless Mode", where it will instead emit stdout and stderr terminal output to `INFO` and `ERROR` log levels respectively. This happens when 
+
+All other log levels are standard, and are used by Terragrunt to log its own messages.
+
+For example:
+
+```bash
+$ terragrunt --terragrunt-log-level debug plan
+14:20:38.431 DEBUG  Terragrunt Version: 0.0.0
+14:20:38.431 DEBUG  Did not find any locals block: skipping evaluation.
+14:20:38.431 DEBUG  Running command: tofu --version
+14:20:38.431 DEBUG  Engine is not enabled, running command directly in .
+14:20:38.451 DEBUG  tofu version: 1.8.5
+14:20:38.451 DEBUG  Reading Terragrunt config file at ./terragrunt.hcl
+14:20:38.451 DEBUG  Did not find any locals block: skipping evaluation.
+14:20:38.451 DEBUG  Did not find any locals block: skipping evaluation.
+14:20:38.452 DEBUG  Running command: tofu init
+14:20:38.452 DEBUG  Engine is not enabled, running command directly in .
+14:20:38.469 INFO   tofu: Initializing the backend...
+14:20:38.470 INFO   tofu: Initializing provider plugins...
+14:20:38.470 INFO   tofu: OpenTofu has been successfully initialized!
+14:20:38.470 INFO   tofu:
+14:20:38.470 INFO   tofu: You may now begin working with OpenTofu. Try running "tofu plan" to see
+14:20:38.470 INFO   tofu: any changes that are required for your infrastructure. All OpenTofu commands
+14:20:38.470 INFO   tofu: should now work.
+14:20:38.470 INFO   tofu: If you ever set or change modules or backend configuration for OpenTofu,
+14:20:38.470 INFO   tofu: rerun this command to reinitialize your working directory. If you forget, other
+14:20:38.470 INFO   tofu: commands will detect it and remind you to do so if necessary.
+14:20:38.470 DEBUG  Running command: tofu plan
+14:20:38.470 DEBUG  Engine is not enabled, running command directly in .
+14:20:38.490 STDOUT tofu: No changes. Your infrastructure matches the configuration.
+14:20:38.490 STDOUT tofu: OpenTofu has compared your real infrastructure against your configuration and
+14:20:38.490 STDOUT tofu: found no differences, so no changes are needed.
+```
+
+Here, we have three types of log messages:
+
+1. `DEBUG` messages from Terragrunt itself. By default, Terragrunt's log level is `INFO`, but we've set it to `DEBUG` using the `--terragrunt-log-level` flag.
+2. `STDOUT` messages from OpenTofu. These are messages that OpenTofu would normally print directly to the terminal, but instead, Terragrunt captures them and logs them as `STDOUT` log messages, along with timestamps and other metadata.
+3. `INFO` messages from Terragrunt [auto-init](/docs/features/auto-init). These were initially emitted by OpenTofu, however the user did not specifically ask for them, so Terragrunt logs them as `INFO` messages.
+
+
+## Enrichment
+
+The reason Terragrunt enriches stdout/stderr from the processes is that it is often very useful to have this extra metadata.
+
+For example:
+
+```bash
+$ terragrunt run-all plan
+14:27:45.359 INFO   The stack at . will be processed in the following order for command plan:
+Group 1
+- Module ./unit-1
+- Module ./unit-2
+
+
+14:27:45.399 INFO   [unit-2] tofu: Initializing the backend...
+14:27:45.399 INFO   [unit-1] tofu: Initializing the backend...
+14:27:45.400 INFO   [unit-2] tofu: Initializing provider plugins...
+14:27:45.400 INFO   [unit-2] tofu: OpenTofu has been successfully initialized!
+14:27:45.400 INFO   [unit-2] tofu:
+14:27:45.400 INFO   [unit-2] tofu: You may now begin working with OpenTofu. Try running "tofu plan" to see
+14:27:45.400 INFO   [unit-2] tofu: any changes that are required for your infrastructure. All OpenTofu commands
+14:27:45.400 INFO   [unit-2] tofu: should now work.
+14:27:45.400 INFO   [unit-2] tofu: If you ever set or change modules or backend configuration for OpenTofu,
+14:27:45.400 INFO   [unit-2] tofu: rerun this command to reinitialize your working directory. If you forget, other
+14:27:45.400 INFO   [unit-2] tofu: commands will detect it and remind you to do so if necessary.
+14:27:45.400 INFO   [unit-1] tofu: Initializing provider plugins...
+14:27:45.400 INFO   [unit-1] tofu: OpenTofu has been successfully initialized!
+14:27:45.400 INFO   [unit-1] tofu:
+14:27:45.400 INFO   [unit-1] tofu: You may now begin working with OpenTofu. Try running "tofu plan" to see
+14:27:45.400 INFO   [unit-1] tofu: any changes that are required for your infrastructure. All OpenTofu commands
+14:27:45.400 INFO   [unit-1] tofu: should now work.
+14:27:45.400 INFO   [unit-1] tofu: If you ever set or change modules or backend configuration for OpenTofu,
+14:27:45.400 INFO   [unit-1] tofu: rerun this command to reinitialize your working directory. If you forget, other
+14:27:45.400 INFO   [unit-1] tofu: commands will detect it and remind you to do so if necessary.
+14:27:45.422 STDOUT [unit-2] tofu: No changes. Your infrastructure matches the configuration.
+14:27:45.423 STDOUT [unit-2] tofu: OpenTofu has compared your real infrastructure against your configuration and
+14:27:45.423 STDOUT [unit-2] tofu: found no differences, so no changes are needed.
+14:27:45.423 STDOUT [unit-1] tofu: No changes. Your infrastructure matches the configuration.
+14:27:45.423 STDOUT [unit-1] tofu: OpenTofu has compared your real infrastructure against your configuration and
+14:27:45.423 STDOUT [unit-1] tofu: found no differences, so no changes are needed.
+```
+
+Here you see two different units being run by Terragrunt concurrently, and stdout/stderr for each being emitted in real time. This is really helpful when managing IaC at scale, as it lets you know exactly what each unit in your stack is doing, and how long it is taking.
+
+It's easier to see the impact of this enrichment if we turn it off, so let's use the [bare](/docs/reference/log-formatting/#bare) preset described in [Log Formatting](docs/reference/log-formatting).
+
+```bash
+$ terragrunt run-all --terragrunt-log-format bare plan
+INFO[0000] The stack at /Users/yousif/tmp/testing-stdout-stderr-split will be processed in the following order for command plan:
+Group 1
+- Module /Users/yousif/tmp/testing-stdout-stderr-split/unit-1
+- Module /Users/yousif/tmp/testing-stdout-stderr-split/unit-2
+
+
+
+Initializing the backend...
+
+Initializing provider plugins...
+
+OpenTofu has been successfully initialized!
+
+You may now begin working with OpenTofu. Try running "tofu plan" to see
+any changes that are required for your infrastructure. All OpenTofu commands
+should now work.
+
+If you ever set or change modules or backend configuration for OpenTofu,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+
+No changes. Your infrastructure matches the configuration.
+
+OpenTofu has compared your real infrastructure against your configuration and
+found no differences, so no changes are needed.
+
+Initializing the backend...
+
+Initializing provider plugins...
+
+OpenTofu has been successfully initialized!
+
+You may now begin working with OpenTofu. Try running "tofu plan" to see
+any changes that are required for your infrastructure. All OpenTofu commands
+should now work.
+
+If you ever set or change modules or backend configuration for OpenTofu,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+
+No changes. Your infrastructure matches the configuration.
+
+OpenTofu has compared your real infrastructure against your configuration and
+found no differences, so no changes are needed.
+```
+
+This tells Terragrunt to log messages from OpenTofu/Terraform without any enrichment. As you can see, it's not as easy to disambiguate the messages from the two units, so Terragrunt automatically buffers the output from each unit and logs them in order so that you can see what each unit is doing.
+
+## Exceptions to enrichment
+
+There are exceptions to the general rule that Terragrunt logs stdout/stderr from the processes it runs as `STDOUT` and `STDERR` respectively when not in Headless Mode.
+
+Because Terragrunt is an IaC orchestrator, it uses its awareness of OpenTofu/Terraform usage to recognize certain circumstances when a user is likely to want stdout/stderr to be emitted exactly as it would when running a process directly.
+
+An example of this is `terragrunt output`:
+
+```bash
+$ terragrunt output -json
+15:20:07.759 INFO   tofu: Initializing the backend...
+15:20:07.759 INFO   tofu: Initializing provider plugins...
+15:20:07.759 INFO   tofu: OpenTofu has been successfully initialized!
+15:20:07.759 INFO   tofu:
+15:20:07.759 INFO   tofu: You may now begin working with OpenTofu. Try running "tofu plan" to see
+15:20:07.759 INFO   tofu: any changes that are required for your infrastructure. All OpenTofu commands
+15:20:07.759 INFO   tofu: should now work.
+15:20:07.759 INFO   tofu: If you ever set or change modules or backend configuration for OpenTofu,
+15:20:07.759 INFO   tofu: rerun this command to reinitialize your working directory. If you forget, other
+15:20:07.759 INFO   tofu: commands will detect it and remind you to do so if necessary.
+{
+  "something": {
+    "sensitive": false,
+    "type": "string",
+    "value": "Hello, World!"
+  },
+  "something_else": {
+    "sensitive": false,
+    "type": "string",
+    "value": "Goodbye, World!"
+  }
+}
+```
+
+As you can see, the output from OpenTofu here isn't being enriched even though the user explicitly asked Terragrunt to run `output -json`.
+
+This is because the user is pretty likely to want to programmatically interact with the output of `output`, and so Terragrunt doesn't enrich it.
+
+If, for example, you wanted to use a tool like `jq` to parse the output of `terragrunt output -json`, you could do that without having to worry about Terragrunt's metadata getting in the way, or disabling anything with an extra flag.
+
+```bash
+$ terragrunt output -json | jq '.something'
+15:24:40.310 INFO   tofu: Initializing the backend...
+15:24:40.311 INFO   tofu: Initializing provider plugins...
+15:24:40.311 INFO   tofu: OpenTofu has been successfully initialized!
+15:24:40.311 INFO   tofu:
+15:24:40.311 INFO   tofu: You may now begin working with OpenTofu. Try running "tofu plan" to see
+15:24:40.311 INFO   tofu: any changes that are required for your infrastructure. All OpenTofu commands
+15:24:40.311 INFO   tofu: should now work.
+15:24:40.311 INFO   tofu: If you ever set or change modules or backend configuration for OpenTofu,
+15:24:40.311 INFO   tofu: rerun this command to reinitialize your working directory. If you forget, other
+15:24:40.311 INFO   tofu: commands will detect it and remind you to do so if necessary.
+{
+  "sensitive": false,
+  "type": "string",
+  "value": "Hello, World!"
+}
+```
+
+## Disabling Logs
+
+Finally, you can also disable logs entirely like so:
+
+```bash
+$ terragrunt --terragrunt-log-disable plan
+
+Initializing the backend...
+
+Initializing provider plugins...
+
+OpenTofu has been successfully initialized!
+
+You may now begin working with OpenTofu. Try running "tofu plan" to see
+any changes that are required for your infrastructure. All OpenTofu commands
+should now work.
+
+If you ever set or change modules or backend configuration for OpenTofu,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+
+No changes. Your infrastructure matches the configuration.
+
+OpenTofu has compared your real infrastructure against your configuration and
+found no differences, so no changes are needed.
+```
+
+This will give you the closes experience to using OpenTofu/Terraform directly, with Terragrunt doing all of its work in the background.

--- a/options/options.go
+++ b/options/options.go
@@ -386,6 +386,15 @@ type TerragruntOptions struct {
 
 	// Errors is a configuration for error handling.
 	Errors *ErrorsConfig
+
+	// Headless is set when Terragrunt is running in
+	// headless mode. In this mode, Terragrunt will not
+	// return stdout/stderr directly to the caller.
+	//
+	// It will instead write the output to INFO,
+	// as it's not something intended for a user
+	// to use in a programmatic way.
+	Headless bool
 }
 
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests
@@ -672,6 +681,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) (*TerragruntOp
 		Errors:                cloneErrorsConfig(opts.Errors),
 		ScaffoldNoIncludeRoot: opts.ScaffoldNoIncludeRoot,
 		ScaffoldRootFileName:  opts.ScaffoldRootFileName,
+		Headless:              opts.Headless,
 	}, nil
 }
 

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -139,25 +139,31 @@ func RunShellCommandWithOutput(
 				WithField(placeholders.TFCmdArgsKeyName, args)
 
 			if opts.JSONLogFormat && !cli.Args(args).Normalize(cli.SingleDashFlag).Contains(terraform.FlagNameJSON) {
-				outWriter = writer.New(
-					writer.WithLogger(logger.WithOptions(log.WithOutput(errWriter))),
-					writer.WithDefaultLevel(log.StdoutLevel),
+				outWriter = buildOutWriter(
+					opts,
+					logger,
+					outWriter,
+					errWriter,
 				)
 
-				errWriter = writer.New(
-					writer.WithLogger(logger.WithOptions(log.WithOutput(errWriter))),
-					writer.WithDefaultLevel(log.StderrLevel),
+				errWriter = buildErrWriter(
+					opts,
+					logger,
+					errWriter,
 				)
 			} else if !shouldForceForwardTFStdout(args) {
-				outWriter = writer.New(
-					writer.WithLogger(logger.WithOptions(log.WithOutput(errWriter))),
-					writer.WithDefaultLevel(log.StdoutLevel),
+				outWriter = buildOutWriter(
+					opts,
+					logger,
+					outWriter,
+					errWriter,
 					writer.WithMsgSeparator(logMsgSeparator),
 				)
 
-				errWriter = writer.New(
-					writer.WithLogger(logger.WithOptions(log.WithOutput(errWriter))),
-					writer.WithDefaultLevel(log.StderrLevel),
+				errWriter = buildErrWriter(
+					opts,
+					logger,
+					errWriter,
 					writer.WithMsgSeparator(logMsgSeparator),
 					writer.WithParseFunc(terraform.ParseLogFunc(tfLogMsgPrefix, false)),
 				)
@@ -243,6 +249,53 @@ func RunShellCommandWithOutput(
 	})
 
 	return &output, err
+}
+
+// buildOutWriter returns the writer for the command's stdout.
+//
+// When Terragrunt is running in Headless mode, we want to forward
+// any stdout to the INFO log level, otherwise, we want to forward
+// stdout to the STDOUT log level.
+//
+// Also accepts any additional writer options desired.
+func buildOutWriter(opts *options.TerragruntOptions, logger log.Logger, outWriter, errWriter io.Writer, writerOptions ...writer.Option) io.Writer {
+	logLevel := log.StdoutLevel
+
+	if opts.Headless {
+		logLevel = log.InfoLevel
+		outWriter = errWriter
+	}
+
+	options := []writer.Option{
+		writer.WithLogger(logger.WithOptions(log.WithOutput(outWriter))),
+		writer.WithDefaultLevel(logLevel),
+	}
+	options = append(options, writerOptions...)
+
+	return writer.New(options...)
+}
+
+// buildErrWriter returns the writer for the command's stderr.
+//
+// When Terragrunt is running in Headless mode, we want to forward
+// any stderr to the ERROR log level, otherwise, we want to forward
+// stderr to the STDERR log level.
+//
+// Also accepts any additional writer options desired.
+func buildErrWriter(opts *options.TerragruntOptions, logger log.Logger, errWriter io.Writer, writerOptions ...writer.Option) io.Writer {
+	logLevel := log.StderrLevel
+
+	if opts.Headless {
+		logLevel = log.ErrorLevel
+	}
+
+	options := []writer.Option{
+		writer.WithLogger(logger.WithOptions(log.WithOutput(errWriter))),
+		writer.WithDefaultLevel(logLevel),
+	}
+	options = append(options, writerOptions...)
+
+	return writer.New(options...)
 }
 
 // isTerraformCommandThatNeedsPty returns true if the sub command of terraform we are running requires a pty.

--- a/test/integration_docs_test.go
+++ b/test/integration_docs_test.go
@@ -25,13 +25,13 @@ func TestDocsQuickStart(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
 		require.NoError(t, err)
-		assert.Contains(t, stderr, "Plan: 1 to add, 0 to change, 0 to destroy.")
+		assert.Contains(t, stdout, "Plan: 1 to add, 0 to change, 0 to destroy.")
 
-		_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
 		require.NoError(t, err)
-		assert.Contains(t, stderr, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
+		assert.Contains(t, stdout, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
 
 	})
 

--- a/test/integration_errors_test.go
+++ b/test/integration_errors_test.go
@@ -57,12 +57,12 @@ func TestRunAllIgnoreError(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testRunAllIgnoreErrors)
 	rootPath := util.JoinPath(tmpEnvPath, testRunAllIgnoreErrors)
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Ignoring error example1")
 	assert.NotContains(t, stderr, "Ignoring error example2")
-	assert.Contains(t, stderr, "value-from-app-2")
+	assert.Contains(t, stdout, "value-from-app-2")
 }
 
 func TestRetryError(t *testing.T) {


### PR DESCRIPTION
## Description

Adds dedicated docs for logging (not just formatting). 

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added `Logging` docs.

