### PR TITLE
Enhanced clarity of error messages for missing mock outputs

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -514,6 +514,8 @@ func getTerragruntOutputIfAppliedElseConfiguredDefault(ctx *ParsingContext, depe
 	// returning mocks is not allowed. So return a useful error message indicating that we expected outputs, but they
 	// did not exist.
 	err := TerragruntOutputTargetNoOutputs{
+		targetName:    dependencyConfig.Name,
+		targetPath:    dependencyConfig.ConfigPath.AsString(),
 		targetConfig:  targetConfig,
 		currentConfig: ctx.TerragruntOptions.TerragruntConfigPath,
 	}


### PR DESCRIPTION
## Description

Enhanced clarity of error messages for missing mock outputs when using the dependencies block - Fixes #3567 

before:
![before](https://github.com/user-attachments/assets/c8fba090-df76-4b06-9c28-5cda80416ac1)

after:
![after](https://github.com/user-attachments/assets/a090be35-f9cc-4c4f-8d7f-23ec6bc98ea6)


## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated - Enhanced clarity of error messages for missing mock outputs when using the dependencies block, Fix #3567 

### Migration Guide

n/a

