### PR TITLE
fix: Rephrasing missing dependency a bit

### DIFF
--- a/config/errors.go
+++ b/config/errors.go
@@ -242,8 +242,7 @@ func (err TerragruntOutputTargetNoOutputs) Unwrap() error {
 
 func (err TerragruntOutputTargetNoOutputs) Error() string {
 	msg := `
-If this dependency is accessed before the outputs are ready (which can happen during the planning phase of an unapplied stack), consider using mock_outputs.
-e.g.
+If this dependency is accessed before the outputs are ready (which can happen during the planning phase of an unapplied stack), consider using mock_outputs:
 
 dependency "` + err.targetName + `" {
     config_path = "` + err.targetPath + `"
@@ -253,7 +252,7 @@ dependency "` + err.targetName + `" {
     }
 }
 
-For further details, refer to this resource:
+For more info, see:
 https://terragrunt.gruntwork.io/docs/features/stacks/#unapplied-dependency-and-mock-outputs
 
 If you do not require outputs from your dependency, consider using the dependencies block instead:
@@ -261,7 +260,7 @@ https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#dep
 `
 
 	return fmt.Sprintf(
-		"%s is a dependency of %s but detected no outputs. Either the target module has not been applied yet, or the module has no outputs. If this is expected, set the skip_outputs flag to true on the dependency block.\n%s",
+		"%s is a dependency of %s but detected no outputs. Either the target module has not been applied yet, or the module has no outputs.\n%s",
 		err.targetConfig,
 		err.currentConfig,
 		msg,


### PR DESCRIPTION
## Description

Per feedback from our product team, this is a clearer message, and better guidance.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated the error message returned when dependencies are missing during a plan.

