### PR TITLE
Minor Code Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,7 @@ jobs:
     executor:
       name: win/default
       size: "large"
+    <<: *env
     steps:
       - checkout
       - run:
@@ -200,6 +201,7 @@ jobs:
   # performance penalty.
   unit_test:
     <<: *defaults
+    <<: *env
     steps:
       - checkout
       # Run pre-commit hooks and fail the build if any hook finds required changes.
@@ -240,6 +242,7 @@ jobs:
   integration_test_terraform_1_5:
     resource_class: xlarge
     <<: *defaults
+    <<: *env
     steps:
       - checkout
       - run:
@@ -258,6 +261,7 @@ jobs:
   integration_test_terraform_with_provider_cache:
     resource_class: xlarge
     <<: *defaults
+    <<: *env
     steps:
       - checkout
       - run:
@@ -278,6 +282,7 @@ jobs:
   integration_test_terraform_latest:
     resource_class: xlarge
     <<: *defaults
+    <<: *env
     steps:
       - checkout
       - run:
@@ -298,6 +303,7 @@ jobs:
   integration_test_tofu:
     resource_class: xlarge
     <<: *defaults
+    <<: *env
     steps:
       - checkout
       - run:
@@ -320,6 +326,7 @@ jobs:
   integration_test_tofu_with_provider_cache:
     resource_class: xlarge
     <<: *defaults
+    <<: *env
     steps:
       - checkout
       - run:
@@ -497,6 +504,7 @@ jobs:
   strict_lint:
     resource_class: medium
     <<: *defaults
+    <<: *env
     steps:
       - checkout
       # The `run-strict-lint` target requires the `main` ref for comparison.
@@ -511,6 +519,7 @@ jobs:
   integration_test_tflint:
     resource_class: large
     <<: *defaults
+    <<: *env
     steps:
       - checkout
       - run:
@@ -531,6 +540,7 @@ jobs:
   race_test:
     resource_class: medium
     <<: *defaults
+    <<: *env
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,9 @@ env: &env
     GRUNTWORK_INSTALLER_VERSION: v0.0.39
     MODULE_CI_VERSION: v0.57.0
     OPENTOFU_VERSION: "1.8.8"
-    TOFU_ENGINE_VERSION: "0.0.9"
     TERRAFORM_VERSION: "1.9.7"
     TFLINT_VERSION: "0.47.0"
+    TOFU_ENGINE_VERSION: "v0.0.11"
 
 defaults: &defaults
   docker:
@@ -65,8 +65,8 @@ install_tofu_engine: &install_tofu_engine
     # Download the OpenTofu Engine binary
     set -x
     export REPO="gruntwork-io/terragrunt-engine-opentofu"
-    export ASSET_NAME="terragrunt-iac-engine-opentofu_rpc_v${TOFU_ENGINE_VERSION}_linux_amd64.zip"
-    wget -O "engine.zip" "https://github.com/${REPO}/releases/download/v${TOFU_ENGINE_VERSION}/${ASSET_NAME}"
+    export ASSET_NAME="terragrunt-iac-engine-opentofu_rpc_${TOFU_ENGINE_VERSION}_linux_amd64.zip"
+    wget -O "engine.zip" "https://github.com/${REPO}/releases/download/${TOFU_ENGINE_VERSION}/${ASSET_NAME}"
     unzip -o "engine.zip"
 
 setup_test_environment: &setup_test_environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,10 @@ env: &env
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.39
     MODULE_CI_VERSION: v0.57.0
-    TOFU_ENGINE_VERSION: "v0.0.9"
+    OPENTOFU_VERSION: "1.8.8"
+    TOFU_ENGINE_VERSION: "0.0.9"
+    TERRAFORM_VERSION: "1.9.7"
+    TFLINT_VERSION: "0.47.0"
 
 defaults: &defaults
   docker:
@@ -20,7 +23,6 @@ install_terraform_latest: &install_terraform_latest
   command: |
     pushd .
     cd /tmp
-    export TERRAFORM_VERSION=1.9.7
     curl -L "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -o terraform.zip
     unzip -o terraform.zip
     sudo install -m 0755 terraform /usr/local/bin/terraform
@@ -34,7 +36,7 @@ install_tofu: &install_tofu
   command: |
     pushd .
     cd /tmp
-    curl -L "https://github.com/opentofu/opentofu/releases/download/v1.8.3/tofu_1.8.3_linux_amd64.zip" -o tofu.zip
+    curl -L "https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_amd64.zip" -o tofu.zip
     unzip -o tofu.zip
     sudo install -m 0755 tofu /usr/local/bin/tofu
     rm -rf tofu
@@ -49,7 +51,7 @@ install_tflint: &install_tflint
   command: |
     pushd .
     cd /tmp
-    curl -L "https://github.com/terraform-linters/tflint/releases/download/v0.47.0/tflint_linux_amd64.zip" -o tflint.zip
+    curl -L "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip" -o tflint.zip
     unzip -o tflint.zip
     sudo install -m 0755 tflint /usr/local/bin/tflint
     rm -rf tflint
@@ -63,8 +65,8 @@ install_tofu_engine: &install_tofu_engine
     # Download the OpenTofu Engine binary
     set -x
     export REPO="gruntwork-io/terragrunt-engine-opentofu"
-    export ASSET_NAME="terragrunt-iac-engine-opentofu_rpc_${TOFU_ENGINE_VERSION}_linux_amd64.zip"
-    wget -O "engine.zip" "https://github.com/${REPO}/releases/download/${TOFU_ENGINE_VERSION}/${ASSET_NAME}"
+    export ASSET_NAME="terragrunt-iac-engine-opentofu_rpc_v${TOFU_ENGINE_VERSION}_linux_amd64.zip"
+    wget -O "engine.zip" "https://github.com/${REPO}/releases/download/v${TOFU_ENGINE_VERSION}/${ASSET_NAME}"
     unzip -o "engine.zip"
 
 setup_test_environment: &setup_test_environment
@@ -151,6 +153,7 @@ jobs:
     executor:
       name: win/default
       size: "large"
+    <<: *env
     steps:
       - checkout
       - run:

--- a/_ci/install-opentofu.ps1
+++ b/_ci/install-opentofu.ps1
@@ -2,14 +2,15 @@ OpenTofuInstallPath = "C:\Program Files\tofu\tofu.exe"
 $OpenTofuTmpPath = "C:\OpenTofutmp"
 $OpenTofuTmpBinaryPath = "C:\OpenTofutmp\tofu.exe"
 $OpenTofuPath = "C:\Program Files\tofu"
+$OpenTofuVersion = $Env:OPENTOFU_VERSION
 # Remove any old OpenTofu installation, if present
 if (Test-Path -Path $OpenTofuInstallPath)
 {
 	Remove-Item $OpenTofuInstallPath -Recurse
 }
 # Download OpenTofu and unpack it
-$OpenTofuURI = "https://github.com/opentofu/opentofu/releases/download/v1.8.3/tofu_1.8.3_windows_amd64.zip"
-$output = "tofu_1.8.3_windows_amd64.zip"
+$OpenTofuURI = "https://github.com/opentofu/opentofu/releases/download/v$OpenTofuVersion/tofu_${OpenTofuVersion}_windows_amd64.zip"
+$output = "tofu_${OpenTofuVersion}_windows_amd64.zip"
 $ProgressPreference = "SilentlyContinue"
 Invoke-WebRequest -Uri $OpenTofuURI -OutFile $output
 New-Item -ItemType "directory" -Path $OpenTofuTmpPath

--- a/_ci/install-terraform.ps1
+++ b/_ci/install-terraform.ps1
@@ -1,5 +1,6 @@
 # Install terraform using Chocolatey
-choco install terraform --version 1.9.7 -y
+$TerraformVersion = $Env:TERRAFORM_VERSION
+choco install terraform --version $TerraformVersion -y
 # Verify installation
 Get-Command terraform
 terraform version

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -290,7 +290,7 @@ func PartialParseConfigFile(ctx *ParsingContext, configPath string, include *Inc
 func TerragruntConfigFromPartialConfig(ctx *ParsingContext, file *hclparse.File, includeFromChild *IncludeConfig) (*TerragruntConfig, error) {
 	var cacheKey = fmt.Sprintf("%#v-%#v-%#v-%#v", file.ConfigPath, file.Content(), includeFromChild, ctx.PartialParseDecodeList)
 
-	terragruntConfigCache := cache.ContextCache[*TerragruntConfig](ctx, RunCmdCacheContextKey)
+	terragruntConfigCache := cache.ContextCache[*TerragruntConfig](ctx, TerragruntConfigCacheContextKey)
 	if ctx.TerragruntOptions.UsePartialParseConfigCache {
 		if config, found := terragruntConfigCache.Get(ctx, cacheKey); found {
 			ctx.TerragruntOptions.Logger.Debugf("Cache hit for '%s' (partial parsing), decodeList: '%v'.", ctx.TerragruntOptions.TerragruntConfigPath, ctx.PartialParseDecodeList)

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -6,8 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/strict"
-
-	clone "github.com/huandu/go-clone"
+	"github.com/huandu/go-clone"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -40,12 +40,12 @@ const (
 	engineCookieKey   = "engine"
 	engineCookieValue = "terragrunt"
 
-	defaultCacheDir        = ".cache"
-	defaultEngineCachePath = "terragrunt/plugins/iac-engine"
-	prefixTrim             = "terragrunt-"
-	fileNameFormat         = "terragrunt-iac-%s_%s_%s_%s_%s"
-	checksumFileNameFormat = "terragrunt-iac-%s_%s_%s_SHA256SUMS"
-
+	defaultCacheDir                             = ".cache"
+	defaultEngineCachePath                      = "terragrunt/plugins/iac-engine"
+	prefixTrim                                  = "terragrunt-"
+	fileNameFormat                              = "terragrunt-iac-%s_%s_%s_%s_%s"
+	checksumFileNameFormat                      = "terragrunt-iac-%s_%s_%s_SHA256SUMS"
+	engineLogLevelEnv                           = "TG_ENGINE_LOG_LEVEL"
 	defaultEngineRepoRoot                       = "github.com/"
 	terraformCommandContextKey engineClientsKey = iota
 	locksContextKey            engineLocksKey   = iota
@@ -517,6 +517,8 @@ func createEngine(terragruntOptions *options.TerragruntOptions) (*proto.EngineCl
 	})
 
 	cmd := exec.Command(localEnginePath)
+	// pass log level to engine
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", engineLogLevelEnv, engineLogLevel))
 	client := plugin.NewClient(&plugin.ClientConfig{
 		Logger: logger,
 		HandshakeConfig: plugin.HandshakeConfig{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* Added passing of `TG_ENGINE_LOG_LEVEL` to invoked engine
* Updated cache key for partial cache key
* Extracted CICD env variables
* Updated Opentofu to 1.8.8 in CICD

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

