### PR TITLE
fix: Removing integrity check on hubspot script

### DIFF
--- a/docs/_pages/index/_form.html
+++ b/docs/_pages/index/_form.html
@@ -27,8 +27,7 @@
   </div>
 </div>
 
-<script src="https://js.hsforms.net/forms/v2.js"
-  integrity="sha384-q76RAq6B4dY4CMbjZq8VvC7aCwpEKifANmGs8hSbR2p7aWzsGOhqij/8mNG7S08u"></script>
+<script src="https://js.hsforms.net/forms/v2.js"></script>
 
 <script>
   document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
## Description

I initially asked that we add this, as it's problematic not to have it.

HubSpot doesn't provide a way to support this out of the box:
https://community.hubspot.com/t5/APIs-Integrations/Subresource-integrity-check/m-p/347255

We'll have to trust HubSpot for now. We can revisit this later if it becomes a problem.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated HubSpot forms script.

