### PR TITLE
fix: Fixing race condition in `TestDownloadTerraformSourceFromLocalFolderWithManifest` test

### DIFF
--- a/cli/commands/terraform/download_source_test.go
+++ b/cli/commands/terraform/download_source_test.go
@@ -301,6 +301,9 @@ func TestDownloadInvalidPathToFilePath(t *testing.T) {
 	assert.True(t, ok)
 }
 
+// The test cases are run sequentially because they depend on each other.
+//
+//nolint:tparallel
 func TestDownloadTerraformSourceFromLocalFolderWithManifest(t *testing.T) {
 	t.Parallel()
 
@@ -358,11 +361,13 @@ func TestDownloadTerraformSourceFromLocalFolderWithManifest(t *testing.T) {
 			},
 		},
 	}
+
+	// The test cases are run sequentially because they depend on each other.
+	//
+	//nolint:paralleltest
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
 			copyFolder(t, testCase.sourceURL, downloadDir)
 			assert.Condition(t, testCase.comp)
 		})


### PR DESCRIPTION
## Description

It's not clear how, but it seems like the feature introduced in https://github.com/gruntwork-io/terragrunt/pull/3543 caused a race condition to bubble up in this test.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `TestDownloadTerraformSourceFromLocalFolderWithManifest` test.