### PR TITLE
fix: Adjusting docs for install

### DIFF
--- a/docs/_docs/01_getting-started/install.md
+++ b/docs/_docs/01_getting-started/install.md
@@ -135,10 +135,13 @@ Colleagues and CI/CD pipelines can then install the associated tool manager, and
 
 Note that the tools Terragrunt integrates with, such as OpenTofu and Terraform, can also be managed by these tool managers, so you can also pin the versions of those tools in the same file.
 
-Also note that the asdf plugin that both of these tools rely on is maintained by a third party:
+Also note that the asdf plugin that `asdf` relies on is maintained by a third party:
 <https://github.com/ohmer/asdf-terragrunt>
 
 Gruntwork makes no guarantees about the safety or reliability of third-party plugins.
+
+The asdf plugin relied upon by `mise` is maintained by Gruntwork, as requested by the community:
+<https://github.com/gruntwork-io/asdf-terragrunt>
 
 ## Building from source
 


### PR DESCRIPTION
## Description

We adopted the plugin as requested by @ohmer, but asdf maintainers haven't merged the pull request yet to move the default to our fork:
<https://github.com/asdf-vm/asdf-plugins/pull/1073>

@jdx was more responsive:
<https://github.com/jdx/mise/pull/3486>

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `install` docs.

