### PR TITLE
fix: Adjusting delay to reduce flakiness

### DIFF
--- a/test/fixtures/streaming/unit1/main.tf
+++ b/test/fixtures/streaming/unit1/main.tf
@@ -15,6 +15,6 @@ resource "null_resource" "empty" {
   }
 
   provisioner "local-exec" {
-    command = "echo 'sleeping...'; sleep 1; echo 'done sleeping'"
+    command = "echo 'sleeping...'; sleep 3; echo 'done sleeping'"
   }
 }

--- a/test/fixtures/streaming/unit2/main.tf
+++ b/test/fixtures/streaming/unit2/main.tf
@@ -15,6 +15,6 @@ resource "null_resource" "empty" {
   }
 
   provisioner "local-exec" {
-    command = "echo 'sleeping...'; sleep 1; echo 'done sleeping'"
+    command = "echo 'sleeping...'; sleep 3; echo 'done sleeping'"
   }
 }


### PR DESCRIPTION
## Description

This test that I introduced is a little flaky because we're too tight with the threshold for time. This makes it more reliable.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `streaming` fixture.

