### PR TITLE
fix: Adding `graph` to list of commands that force forward

### DIFF
--- a/tf/run_cmd.go
+++ b/tf/run_cmd.go
@@ -153,6 +153,7 @@ func shouldForceForwardTFStdout(args cli.Args) bool {
 		CommandNameState,
 		CommandNameVersion,
 		CommandNameConsole,
+		CommandNameGraph,
 	}
 
 	tfFlags := []string{


### PR DESCRIPTION
## Description

Now that the CLI Redesign allows for the `graph` OpenTofu/Terraform command to be conveniently run from Terragrunt, we should add it to the list of commands that Terragrunt won't enrich by default.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `shouldForceForwardTFStdout` to include `graph` command.

