### PR TITLE
fix: Adjusting Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Please see the following for more info, including install instructions and compl
 
 ## Join the Discord!
 
-Join [our community](https://discord.gg/SPu4Degs5f) for discussions, support, and contributions:
+Join [our community](https://discord.gg/YENaT9h8jh) for discussions, support, and contributions:
 
-[![](https://dcbadge.limes.pink/api/server/https://discord.gg/SPu4Degs5f)](https://discord.gg/SPu4Degs5f)
+[![](https://dcbadge.limes.pink/api/server/https://discord.gg/YENaT9h8jh)](https://discord.gg/YENaT9h8jh)
 
 ## License
 

--- a/docs/_docs/01_getting-started/quick-start.md
+++ b/docs/_docs/01_getting-started/quick-start.md
@@ -480,4 +480,4 @@ The next step of the Getting Started guide is to follow the [Overview](/docs/get
 
 If you're ready to get your hands dirty with more advanced Terragrunt features yourself, you can skip ahead to the [Features](/docs#features) section of the documentation.
 
-If you ever need help with a particular problem, take a look at the resources available to you in the [Support](/docs/community/support/) section. You are especially encouraged to join the [Terragrunt Discord](https://discord.gg/SPu4Degs5f) server, and become part of the Terragrunt community.
+If you ever need help with a particular problem, take a look at the resources available to you in the [Support](/docs/community/support/) section. You are especially encouraged to join the [Terragrunt Discord](https://discord.gg/YENaT9h8jh) server, and become part of the Terragrunt community.

--- a/docs/_docs/03_community/support.md
+++ b/docs/_docs/03_community/support.md
@@ -16,7 +16,7 @@ Search [Terragrunt GitHub Discussions](https://gruntwork-io/terragrunt/discussio
 
 ## Join the Discord Community
 
-Join the [Gruntwork Discord Community](https://discord.gg/SPu4Degs5f) to chat with maintainers and members of the community.
+Join the [Gruntwork Discord Community](https://discord.gg/YENaT9h8jh) to chat with maintainers and members of the community.
 
 ## Github Issues
 

--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -24,7 +24,7 @@
             </a>
           </li>
           <li>
-            <a href="https://discord.gg/SPu4Degs5f" ga-on="click" ga-event-category="nav-discord" ga-event-action="discord" class="discord-nav-link">
+            <a href="https://discord.gg/YENaT9h8jh" ga-on="click" ga-event-category="nav-discord" ga-event-action="discord" class="discord-nav-link">
               <img src="{{ site.baseurl}}/assets/img/logos/discord-logo.png" alt="Discord" />
             </a>
           </li>


### PR DESCRIPTION
## Description

Adjusts the Discord invite link so that users end up in #intros by default.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated Discord invite link to direct users to #intros by default.

