### PR TITLE
Stacks: run

### DIFF
--- a/cli/commands/stack/action.go
+++ b/cli/commands/stack/action.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	runall "github.com/gruntwork-io/terragrunt/cli/commands/run-all"
+
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 
 	"github.com/gruntwork-io/terragrunt/config"
@@ -19,7 +21,7 @@ import (
 )
 
 const (
-	stackCacheDir    = ".terragrunt-stack"
+	stackDir         = ".terragrunt-stack"
 	defaultStackFile = "terragrunt.stack.hcl"
 	dirPerm          = 0755
 )
@@ -40,8 +42,16 @@ func Run(ctx context.Context, opts *options.TerragruntOptions) error {
 	if !stacksEnabled.Enabled {
 		return errors.New("stacks experiment is not enabled use --experiment stacks to enable it")
 	}
-	opts.Logger.Infof("Running stack command")
-	return nil
+
+	// prepare options for execution
+	// navigate to stack directory
+	opts.WorkingDir = filepath.Join(opts.WorkingDir, stackDir)
+	// remove 0 element from args
+	opts.TerraformCliArgs = opts.TerraformCliArgs[1:]
+	opts.TerraformCommand = opts.TerraformCliArgs[0]
+	opts.OriginalTerraformCommand = strings.Join(opts.TerraformCliArgs, " ")
+
+	return runall.Run(ctx, opts)
 }
 
 func generateStack(ctx context.Context, opts *options.TerragruntOptions) error {
@@ -61,7 +71,7 @@ func generateStack(ctx context.Context, opts *options.TerragruntOptions) error {
 }
 
 func processStackFile(ctx context.Context, opts *options.TerragruntOptions, stackFile *config.StackConfigFile) error {
-	baseDir := filepath.Join(opts.WorkingDir, stackCacheDir)
+	baseDir := filepath.Join(opts.WorkingDir, stackDir)
 	if err := os.MkdirAll(baseDir, dirPerm); err != nil {
 		return errors.New(fmt.Errorf("failed to create base directory: %w", err))
 	}

--- a/cli/commands/stack/action.go
+++ b/cli/commands/stack/action.go
@@ -43,6 +43,10 @@ func Run(ctx context.Context, opts *options.TerragruntOptions) error {
 		return errors.New("stacks experiment is not enabled use --experiment stacks to enable it")
 	}
 
+	if err := RunGenerate(ctx, opts); err != nil {
+		return err
+	}
+
 	// prepare options for execution
 	// navigate to stack directory
 	opts.WorkingDir = filepath.Join(opts.WorkingDir, stackDir)

--- a/cli/commands/stack/action.go
+++ b/cli/commands/stack/action.go
@@ -36,12 +36,17 @@ func RunGenerate(ctx context.Context, opts *options.TerragruntOptions) error {
 
 // Run execute stack command.
 func Run(ctx context.Context, opts *options.TerragruntOptions) error {
+	stacksEnabled := opts.Experiments[experiment.Stacks]
+	if !stacksEnabled.Enabled {
+		return errors.New("stacks experiment is not enabled use --experiment stacks to enable it")
+	}
 	opts.Logger.Infof("Running stack command")
 	return nil
 }
 
 func generateStack(ctx context.Context, opts *options.TerragruntOptions) error {
 	opts.TerragruntStackConfigPath = filepath.Join(opts.WorkingDir, defaultStackFile)
+	opts.Logger.Infof("Generating stack from %s", opts.TerragruntStackConfigPath)
 	stackFile, err := config.ReadStackConfigFile(ctx, opts)
 
 	if err != nil {
@@ -62,6 +67,8 @@ func processStackFile(ctx context.Context, opts *options.TerragruntOptions, stac
 	}
 
 	for _, unit := range stackFile.Units {
+		opts.Logger.Infof("Processing unit %s", unit.Name)
+
 		destPath := filepath.Join(baseDir, unit.Path)
 		dest, err := filepath.Abs(destPath)
 

--- a/cli/commands/stack/action.go
+++ b/cli/commands/stack/action.go
@@ -34,6 +34,12 @@ func RunGenerate(ctx context.Context, opts *options.TerragruntOptions) error {
 	return generateStack(ctx, opts)
 }
 
+// Run execute stack command.
+func Run(ctx context.Context, opts *options.TerragruntOptions) error {
+	opts.Logger.Infof("Running stack command")
+	return nil
+}
+
 func generateStack(ctx context.Context, opts *options.TerragruntOptions) error {
 	opts.TerragruntStackConfigPath = filepath.Join(opts.WorkingDir, defaultStackFile)
 	stackFile, err := config.ReadStackConfigFile(ctx, opts)
@@ -48,6 +54,7 @@ func generateStack(ctx context.Context, opts *options.TerragruntOptions) error {
 
 	return nil
 }
+
 func processStackFile(ctx context.Context, opts *options.TerragruntOptions, stackFile *config.StackConfigFile) error {
 	baseDir := filepath.Join(opts.WorkingDir, stackCacheDir)
 	if err := os.MkdirAll(baseDir, dirPerm); err != nil {

--- a/cli/commands/stack/command.go
+++ b/cli/commands/stack/command.go
@@ -10,6 +10,7 @@ const (
 	// CommandName stack command name.
 	CommandName = "stack"
 	generate    = "generate"
+	run         = "run"
 )
 
 // NewFlags builds the flags for stack.
@@ -26,10 +27,18 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		Flags:                  NewFlags(opts).Sort(),
 		Subcommands: cli.Commands{
 			&cli.Command{
-				Name:  "generate",
-				Usage: "Generate the stack file.",
+				Name:  generate,
+				Usage: "Generate stack",
 				Action: func(ctx *cli.Context) error {
 					return RunGenerate(ctx.Context, opts.OptionsFromContext(ctx))
+
+				},
+			},
+			&cli.Command{
+				Name:  run,
+				Usage: "Run command on stack",
+				Action: func(ctx *cli.Context) error {
+					return Run(ctx.Context, opts.OptionsFromContext(ctx))
 
 				},
 			},

--- a/cli/commands/stack/command.go
+++ b/cli/commands/stack/command.go
@@ -39,7 +39,6 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 				Usage: "Run command on stack",
 				Action: func(ctx *cli.Context) error {
 					return Run(ctx.Context, opts.OptionsFromContext(ctx))
-
 				},
 			},
 		},

--- a/cli/commands/stack/command.go
+++ b/cli/commands/stack/command.go
@@ -28,7 +28,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		Subcommands: cli.Commands{
 			&cli.Command{
 				Name:  generate,
-				Usage: "Generate stack",
+				Usage: "Generate a stack from a terragrunt.stack.hcl file",
 				Action: func(ctx *cli.Context) error {
 					return RunGenerate(ctx.Context, opts.OptionsFromContext(ctx))
 
@@ -36,7 +36,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 			},
 			&cli.Command{
 				Name:  run,
-				Usage: "Run command on stack",
+				Usage: "Run a command on the stack generated from the current directory",
 				Action: func(ctx *cli.Context) error {
 					return Run(ctx.Context, opts.OptionsFromContext(ctx))
 				},

--- a/test/fixtures/stacks/basic/units/chick/main.tf
+++ b/test/fixtures/stacks/basic/units/chick/main.tf
@@ -1,0 +1,9 @@
+
+resource "local_file" "file" {
+  content  = "test"
+  filename = "${path.module}/test.txt"
+}
+
+output "output" {
+  value = local_file.file.filename
+}

--- a/test/fixtures/stacks/basic/units/chick/main.tf
+++ b/test/fixtures/stacks/basic/units/chick/main.tf
@@ -1,6 +1,6 @@
 
 resource "local_file" "file" {
-  content  = "test"
+  content  = "chick"
   filename = "${path.module}/test.txt"
 }
 

--- a/test/fixtures/stacks/basic/units/chick/terragrunt.hcl
+++ b/test/fixtures/stacks/basic/units/chick/terragrunt.hcl
@@ -1,0 +1,4 @@
+
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/basic/units/chicken/main.tf
+++ b/test/fixtures/stacks/basic/units/chicken/main.tf
@@ -1,0 +1,9 @@
+
+resource "local_file" "file" {
+  content  = "test"
+  filename = "${path.module}/test.txt"
+}
+
+output "output" {
+  value = local_file.file.filename
+}

--- a/test/fixtures/stacks/basic/units/chicken/main.tf
+++ b/test/fixtures/stacks/basic/units/chicken/main.tf
@@ -1,6 +1,6 @@
 
 resource "local_file" "file" {
-  content  = "test"
+  content  = "chicken"
   filename = "${path.module}/test.txt"
 }
 

--- a/test/fixtures/stacks/basic/units/chicken/terragrunt.hcl
+++ b/test/fixtures/stacks/basic/units/chicken/terragrunt.hcl
@@ -1,0 +1,4 @@
+
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/basic/units/father/main.tf
+++ b/test/fixtures/stacks/basic/units/father/main.tf
@@ -1,6 +1,6 @@
 
 resource "local_file" "file" {
-  content  = "test"
+  content  = "father"
   filename = "${path.module}/test.txt"
 }
 

--- a/test/fixtures/stacks/basic/units/father/main.tf
+++ b/test/fixtures/stacks/basic/units/father/main.tf
@@ -1,0 +1,9 @@
+
+resource "local_file" "file" {
+  content  = "test"
+  filename = "${path.module}/test.txt"
+}
+
+output "output" {
+  value = local_file.file.filename
+}

--- a/test/fixtures/stacks/basic/units/father/terragrunt.hcl
+++ b/test/fixtures/stacks/basic/units/father/terragrunt.hcl
@@ -1,0 +1,4 @@
+
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/basic/units/mother/main.tf
+++ b/test/fixtures/stacks/basic/units/mother/main.tf
@@ -1,0 +1,9 @@
+
+resource "local_file" "file" {
+  content  = "test"
+  filename = "${path.module}/test.txt"
+}
+
+output "output" {
+  value = local_file.file.filename
+}

--- a/test/fixtures/stacks/basic/units/mother/main.tf
+++ b/test/fixtures/stacks/basic/units/mother/main.tf
@@ -1,6 +1,6 @@
 
 resource "local_file" "file" {
-  content  = "test"
+  content  = "mother"
   filename = "${path.module}/test.txt"
 }
 

--- a/test/fixtures/stacks/basic/units/mother/terragrunt.hcl
+++ b/test/fixtures/stacks/basic/units/mother/terragrunt.hcl
@@ -1,0 +1,4 @@
+
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/inputs/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/inputs/terragrunt.stack.hcl
@@ -1,0 +1,9 @@
+unit "unit1" {
+	source = "units/app"
+	path   = "unit1"
+}
+
+unit "unit2" {
+	source = "units/app"
+	path   = "unit2"
+}

--- a/test/fixtures/stacks/inputs/units/app/main.tf
+++ b/test/fixtures/stacks/inputs/units/app/main.tf
@@ -1,0 +1,17 @@
+variable "content" {
+  type = string
+}
+
+variable "filename" {
+  type    = string
+  default = "file.txt"
+}
+
+resource "local_file" "file" {
+  content  = var.content
+  filename = "${path.module}/${var.filename}"
+}
+
+output "output" {
+  value = local_file.file.filename
+}

--- a/test/fixtures/stacks/inputs/units/app/terragrunt.hcl
+++ b/test/fixtures/stacks/inputs/units/app/terragrunt.hcl
@@ -1,0 +1,8 @@
+
+terraform {
+  source = "."
+}
+
+inputs = {
+  content = "content"
+}

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -83,3 +83,16 @@ func validateStackDir(t *testing.T, path string) {
 
 	assert.True(t, hasSubdirectories, "The .terragrunt-stack directory should contain at least one subdirectory")
 }
+
+func TestStacksBasic(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksBasic)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksBasic)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksBasic)
+
+	helpers.RunTerragrunt(t, "terragrunt stack run apply -auto-approve --experiment stacks --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+
+	path := util.JoinPath(rootPath, ".terragrunt-stack")
+	validateStackDir(t, path)
+}

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -1,7 +1,10 @@
 package test_test
 
 import (
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 
@@ -24,6 +27,9 @@ func TestStacksGenerateBasic(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksBasic)
 
 	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stacks --terragrunt-working-dir "+rootPath)
+
+	path := util.JoinPath(rootPath, ".terragrunt-stack")
+	validateStackDir(t, path)
 }
 
 func TestStacksGenerateLocals(t *testing.T) {
@@ -55,4 +61,25 @@ func TestStacksGenerateRemote(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksRemote)
 
 	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stacks --terragrunt-working-dir "+rootPath)
+
+	path := util.JoinPath(rootPath, ".terragrunt-stack")
+	validateStackDir(t, path)
+}
+
+func validateStackDir(t *testing.T, path string) {
+	assert.DirExists(t, path)
+
+	// check that path is not empty directory
+	entries, err := os.ReadDir(path)
+	require.NoError(t, err, "Failed to read directory contents")
+
+	hasSubdirectories := false
+	for _, entry := range entries {
+		if entry.IsDir() {
+			hasSubdirectories = true
+			break
+		}
+	}
+
+	assert.True(t, hasSubdirectories, "The .terragrunt-stack directory should contain at least one subdirectory")
 }

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -91,6 +91,7 @@ func TestStacksBasic(t *testing.T) {
 		if !info.IsDir() && strings.HasSuffix(info.Name(), ".txt") {
 			txtFiles = append(txtFiles, filePath)
 		}
+
 		return nil
 	})
 
@@ -155,7 +156,7 @@ func TestStacksDestroy(t *testing.T) {
 	assert.Contains(t, stdout, "local_file.file: Destroying...")
 }
 
-// check if the stack directory is created and contains files
+// check if the stack directory is created and contains files.
 func validateStackDir(t *testing.T, path string) {
 	t.Helper()
 	assert.DirExists(t, path)
@@ -168,6 +169,7 @@ func validateStackDir(t *testing.T, path string) {
 	for _, entry := range entries {
 		if entry.IsDir() {
 			hasSubdirectories = true
+
 			break
 		}
 	}

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -73,7 +73,7 @@ func TestStacksBasic(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksBasic)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksBasic)
 
-	helpers.RunTerragrunt(t, "terragrunt --experiment stacks stack run apply --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt --experiment stacks stack run applymmi --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	path := util.JoinPath(rootPath, ".terragrunt-stack")
 	validateStackDir(t, path)

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -157,6 +157,7 @@ func TestStacksDestroy(t *testing.T) {
 
 // check if the stack directory is created and contains files
 func validateStackDir(t *testing.T, path string) {
+	t.Helper()
 	assert.DirExists(t, path)
 
 	// check that path is not empty directory

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -2,6 +2,8 @@ package test_test
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,8 +79,25 @@ func TestStacksBasic(t *testing.T) {
 
 	path := util.JoinPath(rootPath, ".terragrunt-stack")
 	validateStackDir(t, path)
+
+	// check that the stack was applied and .txt files got generated in the stack directory
+	var txtFiles []string
+
+	err := filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(info.Name(), ".txt") {
+			txtFiles = append(txtFiles, filePath)
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, txtFiles, 4)
 }
 
+// check if the stack directory is created and contains files
 func validateStackDir(t *testing.T, path string) {
 	assert.DirExists(t, path)
 

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -19,6 +19,7 @@ const (
 	testFixtureStacksLocals      = "fixtures/stacks/locals"
 	testFixtureStacksLocalsError = "fixtures/stacks/locals-error"
 	testFixtureStacksRemote      = "fixtures/stacks/remote"
+	testFixtureStacksInputs      = "fixtures/stacks/inputs"
 )
 
 func TestStacksGenerateBasic(t *testing.T) {
@@ -95,6 +96,19 @@ func TestStacksBasic(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Len(t, txtFiles, 4)
+}
+
+func TestStacksInputs(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksInputs)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksInputs)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksInputs)
+
+	helpers.RunTerragrunt(t, "terragrunt stack run plan --experiment stacks --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+
+	path := util.JoinPath(rootPath, ".terragrunt-stack")
+	validateStackDir(t, path)
 }
 
 // check if the stack directory is created and contains files

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -73,7 +73,7 @@ func TestStacksBasic(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksBasic)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksBasic)
 
-	helpers.RunTerragrunt(t, "terragrunt --experiment stacks stack run applymmi --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt --experiment stacks stack run apply --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	path := util.JoinPath(rootPath, ".terragrunt-stack")
 	validateStackDir(t, path)

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -66,6 +66,19 @@ func TestStacksGenerateRemote(t *testing.T) {
 	validateStackDir(t, path)
 }
 
+func TestStacksBasic(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksBasic)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksBasic)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksBasic)
+
+	helpers.RunTerragrunt(t, "terragrunt --experiment stacks stack run apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+
+	path := util.JoinPath(rootPath, ".terragrunt-stack")
+	validateStackDir(t, path)
+}
+
 func validateStackDir(t *testing.T, path string) {
 	assert.DirExists(t, path)
 
@@ -82,17 +95,4 @@ func validateStackDir(t *testing.T, path string) {
 	}
 
 	assert.True(t, hasSubdirectories, "The .terragrunt-stack directory should contain at least one subdirectory")
-}
-
-func TestStacksBasic(t *testing.T) {
-	t.Parallel()
-
-	helpers.CleanupTerraformFolder(t, testFixtureStacksBasic)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksBasic)
-	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksBasic)
-
-	helpers.RunTerragrunt(t, "terragrunt stack run apply -auto-approve --experiment stacks --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
-
-	path := util.JoinPath(rootPath, ".terragrunt-stack")
-	validateStackDir(t, path)
 }

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -111,6 +111,20 @@ func TestStacksInputs(t *testing.T) {
 	validateStackDir(t, path)
 }
 
+func TestStacksApply(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksInputs)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksInputs)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksInputs)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack run apply --experiment stacks --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed")
+	assert.Contains(t, stdout, "local_file.file: Creation complete")
+}
+
 // check if the stack directory is created and contains files
 func validateStackDir(t *testing.T, path string) {
 	assert.DirExists(t, path)

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -125,6 +125,23 @@ func TestStacksApply(t *testing.T) {
 	assert.Contains(t, stdout, "local_file.file: Creation complete")
 }
 
+func TestStacksDestroy(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksInputs)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksInputs)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksInputs)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack run apply --experiment stacks --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	require.NoError(t, err)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack run destroy --experiment stacks --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Plan: 0 to add, 0 to change, 1 to destroy")
+	assert.Contains(t, stdout, "local_file.file: Destroying...")
+}
+
 // check if the stack directory is created and contains files
 func validateStackDir(t *testing.T, path string) {
 	assert.DirExists(t, path)

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -111,6 +111,20 @@ func TestStacksInputs(t *testing.T) {
 	validateStackDir(t, path)
 }
 
+func TestStacksPlan(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksInputs)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksInputs)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksInputs)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack run plan --experiment stacks --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Plan: 1 to add, 0 to change, 0 to destroy")
+	assert.Contains(t, stdout, "local_file.file will be created")
+}
+
 func TestStacksApply(t *testing.T) {
 	t.Parallel()
 
@@ -132,8 +146,7 @@ func TestStacksDestroy(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksInputs)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksInputs)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack run apply --experiment stacks --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
-	require.NoError(t, err)
+	helpers.RunTerragrunt(t, "terragrunt stack run apply --experiment stacks --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack run destroy --experiment stacks --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 	require.NoError(t, err)

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -3,7 +3,6 @@ package test_test
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,7 +87,7 @@ func TestStacksBasic(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() && strings.HasSuffix(info.Name(), ".txt") {
+		if !info.IsDir() && info.Name() == "test.txt" {
 			txtFiles = append(txtFiles, filePath)
 		}
 

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -73,7 +73,7 @@ func TestStacksBasic(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksBasic)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksBasic)
 
-	helpers.RunTerragrunt(t, "terragrunt --experiment stacks stack run apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt --experiment stacks stack run apply --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	path := util.JoinPath(rootPath, ".terragrunt-stack")
 	validateStackDir(t, path)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:

* added support for `stack run *` command
* execution of generate before run
* added end to end tests to track `stack run` functionality


RFC: https://github.com/gruntwork-io/terragrunt/issues/3313

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

