### PR TITLE
fix: Revert accidental early removal of `--terragrunt` prefix from log formatting

### DIFF
--- a/docs/_docs/04_reference/10-log-formatting.md
+++ b/docs/_docs/04_reference/10-log-formatting.md
@@ -13,7 +13,7 @@ redirect_from:
 slug: log-formatting
 ---
 
-Using the `--log-custom-format <format>` flag you can customize the way Terragrunt logs with total control over the logging format.
+Using the `--terragrunt-log-custom-format <format>` flag you can customize the way Terragrunt logs with total control over the logging format.
 
 The argument passed to this flag is a Terragrunt native format string that has special syntax, as described below.
 
@@ -24,7 +24,7 @@ The format string consists of placeholders and text. Placeholders start with the
 e.g.
 
 ```shell
---log-custom-format "%time %level %msg"
+--terragrunt-log-custom-format "%time %level %msg"
 ```
 
 Output:
@@ -38,7 +38,7 @@ To escape the `%` character, use `%%`.
 e.g.
 
 ```shell
---log-custom-format "%time %level %%msg"
+--terragrunt-log-custom-format "%time %level %%msg"
 ```
 
 Output:
@@ -74,7 +74,7 @@ Any other text is considered plain text. The parser always tries to find the lon
 e.g.
 
 ```shell
---log-custom-format "time=%time level=%level message=%msg"
+--terragrunt-log-custom-format "time=%time level=%level message=%msg"
 ```
 
 Output:
@@ -92,7 +92,7 @@ Placeholder formatting uses the following syntax:
 e.g.
 
 ```shell
---log-custom-format "%time(format='Y-m-d H:i:sv') %level(format=short,case=upper) %msg"
+--terragrunt-log-custom-format "%time(format='Y-m-d H:i:sv') %level(format=short,case=upper) %msg"
 ```
 
 Output:
@@ -108,7 +108,7 @@ Even if you don't pass options, the empty parenthesis are added implicitly. Thus
 e.g.
 
 ```shell
---log-custom-format "%time(plain-text)"
+--terragrunt-log-custom-format "%time(plain-text)"
 ```
 
 Output:
@@ -122,7 +122,7 @@ If you would like to escape parentheses so that they appear as plain text in log
 e.g.
 
 ```shell
---log-custom-format "%time()(plain-text)"
+--terragrunt-log-custom-format "%time()(plain-text)"
 ```
 
 Output:
@@ -136,7 +136,7 @@ You can format plain text as well by using an unnamed placeholder.
 e.g.
 
 ```shell
---log-custom-format "%(content='time=',color=magenta)%time %(content='level=',color=light-blue)%level %(content='msg=',color=green)%msg"
+--terragrunt-log-custom-format "%(content='time=',color=magenta)%time %(content='level=',color=light-blue)%level %(content='msg=',color=green)%msg"
 ```
 
 Output:
@@ -277,36 +277,36 @@ Specific options for placeholders:
 
 ## Presets
 
-The examples below replicate the preset formats specified with `--log-format`. They can be useful if you need to change existing formats to suit your needs.
+The examples below replicate the preset formats specified with `--terragrunt-log-format`. They can be useful if you need to change existing formats to suit your needs.
 
 ### Pretty
 
-`--log-format pretty`
+`--terragrunt-log-format pretty`
 
 ```shell
---log-custom-format "%time(color=light-black) %level(case=upper,width=6,color=preset) %prefix(path=short-relative,color=gradient,suffix=' ')%tf-path(color=cyan,suffix=': ')%msg(path=relative)"
+--terragrunt-log-custom-format "%time(color=light-black) %level(case=upper,width=6,color=preset) %prefix(path=short-relative,color=gradient,suffix=' ')%tf-path(color=cyan,suffix=': ')%msg(path=relative)"
 ```
 
 ### Bare
 
-`--log-format bare`
+`--terragrunt-log-format bare`
 
 ```shell
---tf-forward-stdout --log-custom-format "%level(case=upper,width=4)[%interval] %msg %prefix(path=short,prefix='prefix=[',suffix=']')"
+--tf-forward-stdout --terragrunt-log-custom-format "%level(case=upper,width=4)[%interval] %msg %prefix(path=short,prefix='prefix=[',suffix=']')"
 ```
 
 ### Key-value
 
-`--log-format key-value`
+`--terragrunt-log-format key-value`
 
 ```shell
---log-custom-format "time=%time(format=rfc3339) level=%level prefix=%prefix(path=short-relative) tf-path=%tf-path(path=filename) msg=%msg(path=relative,color=disable)"
+--terragrunt-log-custom-format "time=%time(format=rfc3339) level=%level prefix=%prefix(path=short-relative) tf-path=%tf-path(path=filename) msg=%msg(path=relative,color=disable)"
 ```
 
 ### JSON
 
-`--log-format json`
+`--terragrunt-log-format json`
 
 ```shell
---log-custom-format '{"time":"%time(format=rfc3339,escape=json)", "level":"%level(escape=json)", "prefix":"%prefix(path=short-relative,escape=json)", "tf-path":"%tf-path(path=filename,escape=json)", "msg":"%msg(path=relative,escape=json,color=disable)"}'
+--terragrunt-log-custom-format '{"time":"%time(format=rfc3339,escape=json)", "level":"%level(escape=json)", "prefix":"%prefix(path=short-relative,escape=json)", "tf-path":"%tf-path(path=filename,escape=json)", "msg":"%msg(path=relative,escape=json,color=disable)"}'
 ```


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes log formatting page. Accidentally introduced docs updates in anticipation of CLI Redesign.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `log-format` docs page.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

