### PR TITLE
fix: Adding truncation to release announcement

### DIFF
--- a/.github/scripts/announce-release.sh
+++ b/.github/scripts/announce-release.sh
@@ -10,6 +10,13 @@ USERNAME="${USERNAME:?Required environment variable USERNAME}"
 AVATAR_URL="${AVATAR_URL:?Required environment variable AVATAR_URL}"
 
 if RELEASE_JSON=$(gh -R "$REPO" release view "$TAG_NAME" --json body --json url --json name); then
+	RELEASE_NOTES_LENGTH=$(jq '.body | length' <<<"$RELEASE_JSON")
+
+	if [ "$RELEASE_NOTES_LENGTH" -gt 2000 ]; then
+		echo "Release notes are too long ($RELEASE_NOTES_LENGTH characters), truncating to 1997 characters, truncating the last line, then appending '…'"
+		RELEASE_JSON=$(jq '.body |= .[:1997]' <<<"$RELEASE_JSON" | jq '.body | split("\r\n") | del(.[-1]) | join("\r\n")' | jq '. + "\r\n…"')
+	fi
+
 	RELEASE_NOTES=$(jq '.body' <<<"$RELEASE_JSON")
 
 	PAYLOAD=$(

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -3,6 +3,11 @@ on:
   release:
     # This is intentionally not `published` to avoid announcing pre-releases
     types: [released]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'The tag name of the release'
+        required: true
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -15,7 +20,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          TAG_NAME: ${{ github.event.release.tag_name || inputs.tag_name }}
           URL: ${{ secrets.RELEASE_ANNOUNCEMENT_URL }}
           ROLE_ID: ${{ secrets.RELEASE_ANNOUNCEMENT_ROLE_ID }}
           USERNAME: ${{ secrets.RELEASE_ANNOUNCEMENT_USERNAME }}


### PR DESCRIPTION
## Description

Fixes #000.

Best way I knew how to test this locally without sending the notification without reivew:

```bash
$ gh release view --json body --json url --json name | jq '.body |= .[:1997]' | jq '.body | split("\r\n") | del(.[-1]) | join("\r\n")' | jq '. + "\r\n…"'
"## ✨ New Features\r\n\r\n### Stack `run` command\r\n\r\nThe `terragrunt stack` command now supports a new `run` sub-command.\r\n\r\nThe `run` command automatically generates a Terragrunt stack using the `terragrunt.stack.hcl` file found in the current directory, then runs all the units within it in a fashion very similar to the `run-all` command.\r\n\r\nTo try it out, make sure you enable the [stacks experiment](https://terragrunt.gruntwork.io/docs/reference/experiments/#stacks).\r\n\r\nRead [the docs](https://terragrunt.gruntwork.io/docs/reference/cli-options/#stack) to learn more.\r\n\r\nExample usage:\r\n\r\n![tg-stack-run-example](https://github.com/user-attachments/assets/999f60ed-6ca2-4d01-b67f-6af642b1ab2b)\r\n\r\n### Native OpenTofu State Encryption\r\n\r\nTerragrunt now has native support for OpenTofu state encryption configurations.\r\n\r\nIn addition to the existing `backend` and `config` attributes on the `remote_state` configuration block, Terragrunt now supports an `encryption` attribute that configures OpenTofu backend state encryption automatically, with type validation for a native experience using state encryption.\r\n\r\nThe currently supported key providers are:\r\n\r\n- `pbkdf2`\r\n- `aws_kms`\r\n- `gcp_kms`\r\n\r\nTo integrate this new feature into your projects read [the docs](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#encryption).\r\n\r\nSpecial thanks for @norman-zon for taking on the work of integrating this into Terragrunt and collaborating with us on resolution!\r\n\r\n## What's Changed\r\n* feat: add encryption to remote_state by @norman-zon in https://github.com/gruntwork-io/terragrunt/pull/3586\r\n* feat: add `stack run` command by @denis256 in https://github.com/gruntwork-io/terragrunt/pull/3762\r\n* fix: Addressing #3586 review feedback by @yhakbar in https://github.com/gruntwork-io/terragrunt/pull/3773\r\n* docs: Update status of stacks experiment by @denis256 in https://github.com/gruntwork-io/terragrunt/pull/3774\r\n…"
```

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated Discord notification system to truncate messages if they're too long.
