### PR TITLE
fix: Fixing notification truncation

### DIFF
--- a/.github/scripts/announce-release.sh
+++ b/.github/scripts/announce-release.sh
@@ -12,12 +12,12 @@ AVATAR_URL="${AVATAR_URL:?Required environment variable AVATAR_URL}"
 if RELEASE_JSON=$(gh -R "$REPO" release view "$TAG_NAME" --json body --json url --json name); then
 	RELEASE_NOTES_LENGTH=$(jq '.body | length' <<<"$RELEASE_JSON")
 
+	RELEASE_NOTES=$(jq '.body' <<<"$RELEASE_JSON")
+
 	if [ "$RELEASE_NOTES_LENGTH" -gt 2000 ]; then
 		echo "Release notes are too long ($RELEASE_NOTES_LENGTH characters), truncating to 1997 characters, truncating the last line, then appending '…'"
-		RELEASE_JSON=$(jq '.body |= .[:1997]' <<<"$RELEASE_JSON" | jq '.body | split("\r\n") | del(.[-1]) | join("\r\n")' | jq '. + "\r\n…"')
+		RELEASE_NOTES=$(jq '.body |= .[:1997]' <<<"$RELEASE_JSON" | jq '.body | split("\r\n") | del(.[-1]) | join("\r\n")' | jq '. + "\r\n…"')
 	fi
-
-	RELEASE_NOTES=$(jq '.body' <<<"$RELEASE_JSON")
 
 	PAYLOAD=$(
 		jq \

--- a/.github/scripts/announce-release.sh
+++ b/.github/scripts/announce-release.sh
@@ -14,9 +14,16 @@ if RELEASE_JSON=$(gh -R "$REPO" release view "$TAG_NAME" --json body --json url 
 
 	RELEASE_NOTES=$(jq '.body' <<<"$RELEASE_JSON")
 
-	if [ "$RELEASE_NOTES_LENGTH" -gt 2000 ]; then
-		echo "Release notes are too long ($RELEASE_NOTES_LENGTH characters), truncating to 1997 characters, truncating the last line, then appending '…'"
-		RELEASE_NOTES=$(jq '.body |= .[:1997]' <<<"$RELEASE_JSON" | jq '.body | split("\r\n") | del(.[-1]) | join("\r\n")' | jq '. + "\r\n…"')
+	# This math is a little weird.
+	# We have a budget of 200 characters for everything we add around the release notes.
+	# We also lower the budget by 3 characters for the ellipsis we add at the end when truncating.
+	# So, it's 2000 characters for the release notes,
+	# minus 200 characters for everything else,
+	# minus 3 characters for the ellipsis
+	# = 1797 characters.
+	if [ "$RELEASE_NOTES_LENGTH" -gt 1800 ]; then
+		echo "Release notes are too long ($RELEASE_NOTES_LENGTH characters), truncating to 1797 characters, truncating the last line, then appending '…'"
+		RELEASE_NOTES=$(jq '.body |= .[:1797]' <<<"$RELEASE_JSON" | jq '.body | split("\r\n") | del(.[-1]) | join("\r\n")' | jq '. + "\r\n…"')
 	fi
 
 	PAYLOAD=$(

--- a/.github/scripts/announce-release.sh
+++ b/.github/scripts/announce-release.sh
@@ -30,6 +30,8 @@ if RELEASE_JSON=$(gh -R "$REPO" release view "$TAG_NAME" --json body --json url 
 	tmpfile=$(mktemp)
 	jq '.content = "'"<@&$ROLE_ID> $(jq -r '.name' <<<"$RELEASE_JSON")\n"'>>> " + .content + "'"\n\n**[View release on GitHub]($(jq -r '.url' <<<"$RELEASE_JSON"))**"'"' <<<"$PAYLOAD" >"$tmpfile"
 
+	jq '.content' <"$tmpfile"
+
 	curl -X POST \
 		--data-binary "@$tmpfile" \
 		-H "Content-Type: application/json" \


### PR DESCRIPTION
## Description

Fixes Discord notification truncation.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated Discord notification truncation.