### PR TITLE
docs: Adding linting docs to the contribution page

### DIFF
--- a/docs/_docs/03_community/01-contributing.md
+++ b/docs/_docs/03_community/01-contributing.md
@@ -114,7 +114,7 @@ any go command that compiles the code (`build`, `run`, `test`, etc.).
 
 ### Linting
 
-Terragrunt uses [golangci-lint](https://golangci-lint.run/) to lint the codebase. This is a helpful form of static analysis that can catch common bugs and issues related to performance, style and maintainability.
+Terragrunt uses [golangci-lint](https://golangci-lint.run/) to lint the golang code in the codebase. This is a helpful form of static analysis that can catch common bugs and issues related to performance, style and maintainability.
 
 We use the linter as a guide to learn about how we can improve the Terragrunt codebase. We do not enforce 100% compliance with the linter. If you believe that an error thrown by the linter is irrelevant, use the documentation on [false-positives](https://golangci-lint.run/usage/false-positives/) to suppress that error, along with an explanation of why you believe the error is a false positive.
 
@@ -175,6 +175,19 @@ make run-strict-lint
 ```
 
 In our continuous integration suite, we run the strict linter on the files that have changed with respect to the `main` branch, and very intentionally do not enforce that the lints pass. We pay more attention to the results when the lint fails for a pull request that are changing few small files, as those are much more likely to pass. In those cases, maintainers will review the results, and may suggest changes that are necessary to improve code quality if they believe the cost of implementing the changes is low.
+
+#### Markdownlint
+
+In addition to the golang linter, we also use [markdownlint](https://github.com/DavidAnson/markdownlint) to lint the markdown files in the codebase. This is to ensure that the documentation is consistent and easy to read.
+
+You'll want to check that the markdown files are linted correctly before submitting a pull request to update the docs. You can do this by running:
+
+```bash
+markdownlint \
+    --disable MD013 MD024 \
+    -- \
+    docs
+```
 
 ### Running tests
 

--- a/docs/_docs/03_community/01-contributing.md
+++ b/docs/_docs/03_community/01-contributing.md
@@ -11,13 +11,9 @@ nav_title_link: /docs/
 slug: contributing
 ---
 
-Terragrunt is an open source project, and contributions from the community are very welcome\! Please check out the
-[Contribution Guidelines](#contribution-guidelines) and [Developing Terragrunt](#developing-terragrunt) for
-instructions.
-
 ## Contribution Guidelines
 
-Contributions to this repo are very welcome! We follow a fairly standard [pull request
+Contributions to Terragrunt are very welcome! We follow a fairly standard [pull request
 process](https://help.github.com/articles/about-pull-requests/) for contributions, subject to the following guidelines:
 
 - [Contribution Guidelines](#contribution-guidelines)
@@ -30,6 +26,7 @@ process](https://help.github.com/articles/about-pull-requests/) for contribution
 - [Developing Terragrunt](#developing-terragrunt)
   - [Running locally](#running-locally)
   - [Dependencies](#dependencies)
+  - [Linting](#linting)
   - [Running tests](#running-tests)
   - [Debug logging](#debug-logging)
   - [Error handling](#error-handling)
@@ -114,6 +111,70 @@ go run main.go plan
 Terragrunt uses go modules (read more about the modules system in [the official
 wiki](https://github.com/golang/go/wiki/Modules)). This means that dependencies are automatically installed when you use
 any go command that compiles the code (`build`, `run`, `test`, etc.).
+
+### Linting
+
+Terragrunt uses [golangci-lint](https://golangci-lint.run/) to lint the codebase. This is a helpful form of static analysis that can catch common bugs and issues related to performance, style and maintainability.
+
+We use the linter as a guide to learn about how we can improve the Terragrunt codebase. We do not enforce 100% compliance with the linter. If you believe that an error thrown by the linter is irrelevant, use the documentation on [false-positives](https://golangci-lint.run/usage/false-positives/) to suppress that error, along with an explanation of why you believe the error is a false positive.
+
+If you feel like the linter is missing a check that would be useful for improving the code quality of Terragrunt, please open an issue to discuss it, then open a pull request to add the check.
+
+There are two lint configurations currently in use:
+
+- **Default linter**
+
+  This is the default configuration that is used when running `golangci-lint run`. The configuration for this lint is defined in the `.golangci.yml` file.
+
+  These lints **must** pass before any code is merged into the `main` branch.
+
+- **Strict linter**
+
+  This is the more strict configuration that is used to check for additional issues in pull requests. This configuration is defined in the `.strict.golanci.yml` file.
+
+  These lints **do not have to pass** before code is merged into the `main` branch, but the results are useful to look at to improve code quality.
+
+#### Default linter
+
+Before any tests run in our continuous integration suite, they must pass the default linter. This is to ensure an acceptable floor for code quality in the codebase.
+
+To run the default linter directly, use:
+
+```bash
+golangci-lint run
+```
+
+There's also a Makefile recipe that runs the default linter:
+
+```bash
+make run-lint
+```
+
+If possible, you are advised to [integrate the linter into your code editor](https://golangci-lint.run/welcome/integrations/) to get immediate feedback as edit Terragrunt code.
+
+#### Strict linter
+
+To run the strict linter, use:
+
+```bash
+golangci-lint run -c .strict.golangci.yml
+```
+
+It's generally not practical to run the strict linter on the entire codebase, as it's very strict and will likely produce a lot of errors. Instead, you can run it on the files that have changed with respect to the `main` branch.
+
+You can do that like so:
+
+```bash
+golangci-lint run -c .strict.golangci.yml --new-from-rev origin/main ./...
+```
+
+This is basically what the `run-strict-lint` Makefile recipe does:
+
+```bash
+make run-strict-lint
+```
+
+In our continuous integration suite, we run the strict linter on the files that have changed with respect to the `main` branch, and very intentionally do not enforce that the lints pass. We pay more attention to the results when the lint fails for a pull request that are changing few small files, as those are much more likely to pass. In those cases, maintainers will review the results, and may suggest changes that are necessary to improve code quality if they believe the cost of implementing the changes is low.
 
 ### Running tests
 


### PR DESCRIPTION
## Description

Adds linting documentation to the Contributing guide.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added `linting` documentation to the Contributing guide.
