### PR TITLE
fix #3784 add support for using `h`,`j`,`k`,`l` in catalog command.

### DIFF
--- a/cli/commands/catalog/tui/keys.go
+++ b/cli/commands/catalog/tui/keys.go
@@ -12,20 +12,20 @@ func newListKeyMap() list.KeyMap {
 	return list.KeyMap{
 		// Browsing.
 		CursorUp: key.NewBinding(
-			key.WithKeys("up", "ctrl+p"),
-			key.WithHelp("↑/ctrl+p", "move up"),
+			key.WithKeys("k", "up", "ctrl+p"),
+			key.WithHelp("k/↑/ctrl+p", "move up"),
 		),
 		CursorDown: key.NewBinding(
-			key.WithKeys("down", "ctrl+n"),
-			key.WithHelp("↓/ctrl+n", "move down"),
+			key.WithKeys("j", "down", "ctrl+n"),
+			key.WithHelp("j/↓/ctrl+n", "move down"),
 		),
 		PrevPage: key.NewBinding(
-			key.WithKeys("left", "pgup", "alt+v"),
-			key.WithHelp("←/pgup/alt+v", "prev page"),
+			key.WithKeys("h", "left", "pgup", "alt+v"),
+			key.WithHelp("h/←/pgup/alt+v", "prev page"),
 		),
 		NextPage: key.NewBinding(
-			key.WithKeys("right", "pgdown", "ctrl+v"),
-			key.WithHelp("→/pgdn/ctrl+v", "next page"),
+			key.WithKeys("l", "right", "pgdown", "ctrl+v"),
+			key.WithHelp("l/→/pgdn/ctrl+v", "next page"),
 		),
 		GoToStart: key.NewBinding(
 			key.WithKeys("home", "ctrl+a"),
@@ -177,20 +177,20 @@ func newPagerKeyMap() pagerKeyMap {
 				key.WithDisabled(),
 			),
 			Up: key.NewBinding(
-				key.WithKeys("up", "ctrl+p"),
-				key.WithHelp("↑/ctrl+p", "move up"),
+				key.WithKeys("k", "up", "ctrl+p"),
+				key.WithHelp("k/↑/ctrl+p", "move up"),
 			),
 			Down: key.NewBinding(
-				key.WithKeys("down", "ctrl+n"),
-				key.WithHelp("↓/ctrl+n", "move down"),
+				key.WithKeys("j", "down", "ctrl+n"),
+				key.WithHelp("j/↓/ctrl+n", "move down"),
 			),
 			PageDown: key.NewBinding(
-				key.WithKeys("right", "pgdown", "ctrl+v"),
-				key.WithHelp("→/pgdn/ctrl+v", "page down"),
+				key.WithKeys("l", "right", "pgdown", "ctrl+v"),
+				key.WithHelp("l/→/pgdn/ctrl+v", "page down"),
 			),
 			PageUp: key.NewBinding(
-				key.WithKeys("left", "pgup", "alt+v"),
-				key.WithHelp("←/pgup/alt+v", "page up"),
+				key.WithKeys("h", "left", "pgup", "alt+v"),
+				key.WithHelp("h/←/pgup/alt+v", "page up"),
 			),
 		},
 		help: help.New(),


### PR DESCRIPTION
## Description

Fixes #3784 add support for using `h`,`j`,`k`,`l` in catalog command

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added support for using `h`, `j`, `k`, and `l` for navigation in the catalog command.

### Migration Guide
n/a

