### PR TITLE
Added --output-folder flag to scaffold

### DIFF
--- a/cli/commands/scaffold/action.go
+++ b/cli/commands/scaffold/action.go
@@ -116,6 +116,11 @@ func Run(ctx context.Context, opts *options.TerragruntOptions, moduleURL, templa
 		}
 	}()
 
+	outputDir := opts.ScaffoldOutputFolder
+	if outputDir == "" {
+		outputDir = opts.WorkingDir
+	}
+
 	// scaffold only in empty directories
 	if empty, err := util.IsDirectoryEmpty(opts.WorkingDir); !empty || err != nil {
 		if err != nil {
@@ -149,7 +154,7 @@ func Run(ctx context.Context, opts *options.TerragruntOptions, moduleURL, templa
 		return errors.New(err)
 	}
 
-	opts.Logger.Infof("Scaffolding a new Terragrunt module %s to %s", moduleURL, opts.WorkingDir)
+	opts.Logger.Infof("Scaffolding a new Terragrunt module %s to %s", moduleURL, outputDir)
 
 	if _, err := getter.GetAny(ctx, tempDir, moduleURL); err != nil {
 		return errors.New(err)
@@ -188,9 +193,9 @@ func Run(ctx context.Context, opts *options.TerragruntOptions, moduleURL, templa
 		opts.Logger.Warnf("The %s variable is already set in the var flag(s). The --%s flag will be ignored.", rootFileName, NoIncludeRootFlagName)
 	}
 
-	opts.Logger.Infof("Running boilerplate generation to %s", opts.WorkingDir)
+	opts.Logger.Infof("Running boilerplate generation to %s", outputDir)
 	boilerplateOpts := &boilerplate_options.BoilerplateOptions{
-		OutputFolder:    opts.WorkingDir,
+		OutputFolder:    outputDir,
 		OnMissingKey:    boilerplate_options.DefaultMissingKeyAction,
 		OnMissingConfig: boilerplate_options.DefaultMissingConfigAction,
 		Vars:            vars,
@@ -205,7 +210,7 @@ func Run(ctx context.Context, opts *options.TerragruntOptions, moduleURL, templa
 		return errors.New(err)
 	}
 
-	opts.Logger.Infof("Running fmt on generated code %s", opts.WorkingDir)
+	opts.Logger.Infof("Running fmt on generated code %s", outputDir)
 
 	if err := hclfmt.Run(opts); err != nil {
 		return errors.New(err)

--- a/cli/commands/scaffold/command.go
+++ b/cli/commands/scaffold/command.go
@@ -17,6 +17,7 @@ const (
 
 	RootFileNameFlagName  = "root-file-name"
 	NoIncludeRootFlagName = "no-include-root"
+	OutputFolderFlagName  = "output-folder"
 	VarFlagName           = "var"
 	VarFileFlagName       = "var-file"
 )
@@ -52,6 +53,12 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			EnvVars:     tgPrefix.EnvVars(NoIncludeRootFlagName),
 			Destination: &opts.ScaffoldNoIncludeRoot,
 			Usage:       "Do not include root unit in scaffolding done by catalog.",
+		}),
+
+		flags.NewFlag(&cli.GenericFlag[string]{
+			Name:        OutputFolderFlagName,
+			Destination: &opts.ScaffoldOutputFolder,
+			Usage:       "Output folder for scaffold output.",
 		}),
 
 		flags.NewFlag(&cli.SliceFlag[string]{

--- a/docs/_docs/02_features/05-catalog.md
+++ b/docs/_docs/02_features/05-catalog.md
@@ -16,7 +16,7 @@ Launch the user interface for searching and managing your module catalog.
 Example:
 
 ```bash
-terragrunt catalog <repo-url> [--no-include-root] [--root-file-name]
+terragrunt catalog <repo-url> [--no-include-root] [--root-file-name] [--output-folder]
 ```
 
 [![screenshot](/assets/img/screenshots/catalog-screenshot.png){: width="50%" }](https://terragrunt.gruntwork.io/assets/img/screenshots/catalog-screenshot.png)
@@ -52,3 +52,4 @@ The following `catalog` flags control behavior of the underlying `scaffold` comm
 
 - `--no-include-root` - Do not include the root configuration file in any generated `terragrunt.hcl` during scaffolding.
 - `--root-file-name` - The name of the root configuration file to include in any generated `terragrunt.hcl` during scaffolding. This value also controls the name of the root configuration file to search for when trying to determine Catalog urls.
+- `--output-folder` - Location for generated `terragrunt.hcl`. If flag is not provided current working directory is selected.

--- a/options/options.go
+++ b/options/options.go
@@ -311,6 +311,9 @@ type TerragruntOptions struct {
 	// Name of the root Terragrunt configuration file, if used.
 	ScaffoldRootFileName string
 
+	// Path to folder of scaffold output
+	ScaffoldOutputFolder string
+
 	// Root directory for graph command.
 	GraphRoot string
 

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -189,3 +189,15 @@ func TestScaffold3rdPartyModule(t *testing.T) {
 	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt hclvalidate --terragrunt-non-interactive --terragrunt-working-dir "+tmpEnvPath)
 	require.NoError(t, err)
 }
+
+func TestScaffoldOutputFolderFlag(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := t.TempDir()
+
+	outputFolder := tmpEnvPath + "/foo/bar"
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --output-folder %s", tmpEnvPath, testScaffoldModuleURL, outputFolder))
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "Scaffolding completed")
+	assert.FileExists(t, outputFolder+"/terragrunt.hcl")
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Added --output-folder flag for scaffold 

Fixes #3652.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].
Added --output-folder flag for scaffold

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an `--output-folder` flag for the scaffolding command, allowing users to specify a custom location for generated files (defaulting to the working directory if not set).

- **Documentation**
  - Updated the catalog command documentation to reflect the new output folder option, enhancing clarity on how to manage file output locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->