### PR TITLE
docs: Adding OpenTofu/Terraform debugging guidance

### DIFF
--- a/docs/_docs/05_troubleshooting/01-debugging.md
+++ b/docs/_docs/05_troubleshooting/01-debugging.md
@@ -139,7 +139,8 @@ the sun.
 In this example we've seen how debug options can help us root cause issues
 in dependency and local variable resolution.
 
-<!-- See
-https://github.com/gruntwork-io/terragrunt/blob/eb692a83bee285b0baaaf4b271c66230f99b6358/docs/_docs/02_features/debugging.md
-for thoughts on other potential features to implement.
--->
+## Additional OpenTofu/Terraform Debugging
+
+If you're still having trouble, you may want to try adjusting the `TF_LOG` environment variables to instruct OpenTofu/Terraform to emit more detailed logs.
+
+You can learn more about OpenTofu/Terraform debug logging [here](https://opentofu.org/docs/internals/debugging/).


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

We don't actually document that users should read OpenTofu/Terraform documentation for tools to debug OpenTofu/Terraform. It can be a useful hint for users encountering errors from OpenTofu/Terraform.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

