### PR TITLE
feat: Improve handling of ExcludeFromCopy configuration in Terragrunt

### DIFF
--- a/cli/commands/terraform/download_source.go
+++ b/cli/commands/terraform/download_source.go
@@ -211,14 +211,14 @@ func readVersionFile(terraformSource *terraform.Source) (string, error) {
 	return util.ReadFileAsString(terraformSource.VersionFile)
 }
 
-// updateGetters returns the customized go-getter interfaces that Terragrunt relies on. Specifically:
+// UpdateGetters returns the customized go-getter interfaces that Terragrunt relies on. Specifically:
 //   - Local file path getter is updated to copy the files instead of creating symlinks, which is what go-getter defaults
 //     to.
 //   - Include the customized getter for fetching sources from the Terraform Registry.
 //
 // This creates a closure that returns a function so that we have access to the terragrunt configuration, which is
 // necessary for customizing the behavior of the file getter.
-func updateGetters(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) func(*getter.Client) error {
+func UpdateGetters(terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) func(*getter.Client) error {
 	return func(client *getter.Client) error {
 		// We copy all the default getters from the go-getter library, but replace the "file" getter. We shallow clone the
 		// getter map here rather than using getter.Getters directly because (a) we shouldn't change the original,
@@ -270,7 +270,7 @@ func downloadSource(terraformSource *terraform.Source, terragruntOptions *option
 		canonicalSourceURL,
 		terraformSource.DownloadDir)
 
-	if err := getter.GetAny(terraformSource.DownloadDir, terraformSource.CanonicalSourceURL.String(), updateGetters(terragruntOptions, terragruntConfig)); err != nil {
+	if err := getter.GetAny(terraformSource.DownloadDir, terraformSource.CanonicalSourceURL.String(), UpdateGetters(terragruntOptions, terragruntConfig)); err != nil {
 		return errors.New(err)
 	}
 

--- a/cli/commands/terraform/download_source_test.go
+++ b/cli/commands/terraform/download_source_test.go
@@ -534,7 +534,6 @@ func TestUpdateGettersExcludeFromCopy(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // create a local copy of the test case to avoid race conditions
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cli/commands/terraform/download_source_test.go
+++ b/cli/commands/terraform/download_source_test.go
@@ -537,11 +537,9 @@ func TestUpdateGettersExcludeFromCopy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Create mock TerragruntOptions
 			terragruntOptions, err := options.NewTerragruntOptionsForTest("./test")
 			require.NoError(t, err)
 
-			// Create a go-getter client
 			client := &getter.Client{}
 
 			// Call updateGetters


### PR DESCRIPTION
## Description

This PR addresses a subtle configuration handling issue in Terragrunt's source downloading mechanism, specifically related to the `ExcludeFromCopy` configuration. It fixes #3767 (ar at least, contributes to fixing/closing it)

### Problem Statement

In the previous implementation, there was a bug in how `ExcludeFromCopy` was being processed during source downloading. The original code incorrectly assigned the exclusion configuration, potentially leading to unexpected file copying behavior. Somehow, this wast not caught by the existing tests. 

### Key Changes

- Added comprehensive test case `TestUpdateGettersExcludeFromCopy` to validate `ExcludeFromCopy` configuration handling
- Ensured `FileCopyGetter` correctly respects the `ExcludeFromCopy` configuration
- Improved test coverage for configuration-driven file exclusion scenarios

### Rationale

The bug in [PR #3766](https://github.com/gruntwork-io/terragrunt/pull/3766) highlighted a some sort of weakness in terragrunt's configuration handling (in the download-source logic):
- Incorrect assignment of configuration values
- Lack of explicit test coverage for edge cases
- Potential for silent misconfigurations during module source downloading

### Technical Details

- Added unit test with two scenarios:
  1. Handling `nil` `ExcludeFromCopy` configuration
  2. Handling non-`nil` `ExcludeFromCopy` with specific exclusion patterns
- Verified that `UpdateGetters` correctly populates `FileCopyGetter` with exclusion configuration
- Ensured no regressions in existing source downloading functionality


## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Add comprehensive test case
- [ ] Update documentation (if necessary)
- [x] Run relevant tests successfully
- [ ] Ensure 3rd party code adheres to license policy

## Release Notes

Added enhanced test coverage and fixed configuration handling for `ExcludeFromCopy` in Terragrunt source downloading mechanism.

### Migration Guide

No breaking changes. Users can continue to use `exclude_from_copy` configuration as before.