### PR TITLE
chore: Bumping golangci-lint to `v1.63.4`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,6 +80,11 @@ linters:
     - wrapcheck
     - varnamelen
 
+    # TODO: We intentionally mix and match pointer and non-pointer
+    # receivers in the codebase. We might want to revisit this,
+    # but not while upgrading the linter.
+    - recvcheck
+
   fast: false
   mnd:
     ignored-functions: strconv.Format*,os.*,strconv.Parse*,strings.SplitN,bytes.SplitN

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean:
 	rm -f terragrunt
 
 install-lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 
 run-lint:
 	golangci-lint run -v --timeout=10m ./...

--- a/cli/commands/terraform/action_test.go
+++ b/cli/commands/terraform/action_test.go
@@ -480,12 +480,12 @@ func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, t
 func createTempFile(t *testing.T) string {
 	t.Helper()
 
-	tmpFile, err := os.CreateTemp("", "")
+	tmpDir, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %s\n", err.Error())
 	}
 
-	return filepath.ToSlash(tmpFile.Name())
+	return filepath.ToSlash(tmpDir.Name())
 }
 
 func TestShouldCopyLockFile(t *testing.T) {

--- a/cli/commands/terraform/action_test.go
+++ b/cli/commands/terraform/action_test.go
@@ -480,12 +480,12 @@ func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, t
 func createTempFile(t *testing.T) string {
 	t.Helper()
 
-	tmpDir, err := os.CreateTemp(t.TempDir(), "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %s\n", err.Error())
 	}
 
-	return filepath.ToSlash(tmpDir.Name())
+	return filepath.ToSlash(tmpFile.Name())
 }
 
 func TestShouldCopyLockFile(t *testing.T) {

--- a/cli/commands/terraform/download_source_test.go
+++ b/cli/commands/terraform/download_source_test.go
@@ -453,11 +453,9 @@ func testAlreadyHaveLatestCode(t *testing.T, canonicalURL string, downloadDir st
 func tmpDir(t *testing.T) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "download-source-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return filepath.FromSlash(dir)
+	tmpDir := t.TempDir()
+
+	return filepath.FromSlash(tmpDir)
 }
 
 func absPath(t *testing.T, path string) string {

--- a/config/variable_test.go
+++ b/config/variable_test.go
@@ -68,10 +68,10 @@ func TestScanDefaultVariables(t *testing.T) {
 	assert.Equal(t, "0", varByName["number_default"].DefaultValuePlaceholder)
 
 	assert.Equal(t, "object", varByName["object_var"].Type)
-	assert.Equal(t, "{\"num\":42,\"str\":\"default\"}", varByName["object_var"].DefaultValue)
+	assert.JSONEq(t, "{\"num\":42,\"str\":\"default\"}", varByName["object_var"].DefaultValue)
 
 	assert.Equal(t, "map", varByName["map_var"].Type)
-	assert.Equal(t, "{\"key\":\"value42\"}", varByName["map_var"].DefaultValue)
+	assert.JSONEq(t, "{\"key\":\"value42\"}", varByName["map_var"].DefaultValue)
 
 	assert.Equal(t, "bool", varByName["enabled"].Type)
 	assert.Equal(t, "true", varByName["enabled"].DefaultValue)

--- a/configstack/module_test.go
+++ b/configstack/module_test.go
@@ -50,7 +50,7 @@ digraph {
 	"h" -> "c";
 }
 `)
-	assert.True(t, strings.Contains(stdout.String(), expected))
+	assert.Contains(t, stdout.String(), expected)
 }
 
 func TestGraphTrimPrefix(t *testing.T) {
@@ -89,7 +89,7 @@ digraph {
 	"alpha/beta/h" -> "c";
 }
 `)
-	assert.True(t, strings.Contains(stdout.String(), expected))
+	assert.Contains(t, stdout.String(), expected)
 }
 
 func TestGraphFlagExcluded(t *testing.T) {
@@ -128,7 +128,7 @@ digraph {
 	"h" -> "c";
 }
 `)
-	assert.True(t, strings.Contains(stdout.String(), expected))
+	assert.Contains(t, stdout.String(), expected)
 }
 
 func TestCheckForCycles(t *testing.T) {

--- a/configstack/stack_test.go
+++ b/configstack/stack_test.go
@@ -162,12 +162,9 @@ func createTestStack() *configstack.Stack {
 func createTempFolder(t *testing.T) string {
 	t.Helper()
 
-	tmpFolder, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s\n", err.Error())
-	}
+	tmpDir := t.TempDir()
 
-	return filepath.ToSlash(tmpFolder)
+	return filepath.ToSlash(tmpDir)
 }
 
 // Create a dummy Terragrunt config file at each of the given paths

--- a/docs/_docs/03_community/01-contributing.md
+++ b/docs/_docs/03_community/01-contributing.md
@@ -116,6 +116,8 @@ any go command that compiles the code (`build`, `run`, `test`, etc.).
 
 Terragrunt uses [golangci-lint](https://golangci-lint.run/) to lint the golang code in the codebase. This is a helpful form of static analysis that can catch common bugs and issues related to performance, style and maintainability.
 
+To ensure that you're using the same version of `golangci-lint` as the maintainers, you can use the `make install-lint` Makefile recipe to install the version of `golangci-lint` that we use locally, and in CI.
+
 We use the linter as a guide to learn about how we can improve the Terragrunt codebase. We do not enforce 100% compliance with the linter. If you believe that an error thrown by the linter is irrelevant, use the documentation on [false-positives](https://golangci-lint.run/usage/false-positives/) to suppress that error, along with an explanation of why you believe the error is a false positive.
 
 If you feel like the linter is missing a check that would be useful for improving the code quality of Terragrunt, please open an issue to discuss it, then open a pull request to add the check.

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -1119,7 +1119,7 @@ Other credential configurations will be supported in the future, but until then,
 **Requires an argument**: `--terragrunt-iam-role "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"`<br/>
 
 Assume the specified IAM role ARN for running OpenTofu/Terraform or AWS commands. This is a convenient way to use Terragrunt
-and OpenTofu/Terraform with multiple AWS accounts. 
+and OpenTofu/Terraform with multiple AWS accounts.
 
 When using this option, AWS authentication takes place right before an OpenTofu/Terraform run. This takes place after `terragrunt.hcl` files are fully parsed, so HCL functions like [`get_aws_account_id`](/docs/reference/built-in-functions/#get_aws_account_id) and [`run_cmd`](/docs/reference/built-in-functions/#run_cmd) will not run after assuming the role. If you need roles to be assumed prior to parsing Terragrunt configurations, use [`terragrunt-auth-provider-cmd`](#terragrunt-auth-provider-cmd) instead.
 

--- a/shell/run_shell_cmd_test.go
+++ b/shell/run_shell_cmd_test.go
@@ -3,7 +3,6 @@ package shell_test
 import (
 	"bytes"
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
@@ -42,7 +41,7 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 	cmd := shell.RunShellCommand(context.Background(), terragruntOptions, "terraform", "--version")
 	require.NoError(t, cmd)
 
-	assert.True(t, strings.Contains(stdout.String(), "Terraform"), "Output directed to stdout")
+	assert.Contains(t, stdout.String(), "Terraform", "Output directed to stdout")
 	assert.Empty(t, stderr.String(), "No output to stderr")
 
 	stdout = new(bytes.Buffer)
@@ -55,7 +54,7 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 	cmd = shell.RunShellCommand(context.Background(), terragruntOptions, "terraform", "--version")
 	require.NoError(t, cmd)
 
-	assert.True(t, strings.Contains(stderr.String(), "Terraform"), "Output directed to stderr")
+	assert.Contains(t, stderr.String(), "Terraform", "Output directed to stderr")
 	assert.Empty(t, stdout.String(), "No output to stdout")
 }
 

--- a/terraform/cliconfig/config_test.go
+++ b/terraform/cliconfig/config_test.go
@@ -19,8 +19,7 @@ func TestConfig(t *testing.T) {
 		exclude = []string{"registry.opentofu.org/*/*"}
 	)
 
-	tempCacheDir, err := os.MkdirTemp("", "*")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	testCases := []struct {
 		providerInstallationMethods []cliconfig.ProviderInstallationMethod
@@ -30,7 +29,7 @@ func TestConfig(t *testing.T) {
 	}{
 		{
 			providerInstallationMethods: []cliconfig.ProviderInstallationMethod{
-				cliconfig.NewProviderInstallationFilesystemMirror(tempCacheDir, include, exclude),
+				cliconfig.NewProviderInstallationFilesystemMirror(tmpDir, include, exclude),
 				cliconfig.NewProviderInstallationNetworkMirror("https://network-mirror.io/providers/", include, exclude),
 				cliconfig.NewProviderInstallationDirect(include, exclude),
 			},
@@ -54,7 +53,7 @@ host "registry.terraform.io" {
 provider_installation {
 
    "filesystem_mirror" {
-    path    = "` + tempCacheDir + `"
+    path    = "` + tmpDir + `"
     include = ["registry.terraform.io/*/*"]
     exclude = ["registry.opentofu.org/*/*"]
   }
@@ -73,11 +72,11 @@ provider_installation {
 		{
 			config: cliconfig.Config{
 				DisableCheckpoint: false,
-				PluginCacheDir:    tempCacheDir,
+				PluginCacheDir:    tmpDir,
 			},
 			expectedHCL: `disable_checkpoint           = false
 disable_checkpoint_signature = false
-plugin_cache_dir             = "` + tempCacheDir + `"
+plugin_cache_dir             = "` + tmpDir + `"
 
 provider_installation {
 }
@@ -99,7 +98,7 @@ provider_installation {
 			}
 			testCase.config.AddProviderInstallationMethods(testCase.providerInstallationMethods...)
 
-			err = testCase.config.Save(configFile)
+			err := testCase.config.Save(configFile)
 			require.NoError(t, err)
 
 			hclBytes, err := os.ReadFile(configFile)

--- a/terraform/getproviders/hash_test.go
+++ b/terraform/getproviders/hash_test.go
@@ -13,7 +13,7 @@ import (
 func createFakeZipArchive(t *testing.T, content []byte) string {
 	t.Helper()
 
-	file, err := os.CreateTemp("", "*")
+	file, err := os.CreateTemp(t.TempDir(), "*")
 	require.NoError(t, err)
 	defer file.Close()
 

--- a/terraform/getter_test.go
+++ b/terraform/getter_test.go
@@ -3,7 +3,6 @@ package terraform_test
 import (
 	"context"
 	"net/url"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -111,12 +110,10 @@ func TestTFRGetterRootDir(t *testing.T) {
 	testModuleURL, err := url.Parse("tfr://registry.terraform.io/terraform-aws-modules/vpc/aws?version=3.3.0")
 	require.NoError(t, err)
 
-	dstPath, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dstPath)
+	tmpDir := t.TempDir()
 
 	// The dest path must not exist for go getter to work
-	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
+	moduleDestPath := filepath.Join(tmpDir, "terraform-aws-vpc")
 	assert.False(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 
 	tfrGetter := new(terraform.RegistryGetter)
@@ -132,12 +129,10 @@ func TestTFRGetterSubModule(t *testing.T) {
 	testModuleURL, err := url.Parse("tfr://registry.terraform.io/terraform-aws-modules/vpc/aws//modules/vpc-endpoints?version=3.3.0")
 	require.NoError(t, err)
 
-	dstPath, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dstPath)
+	tmpDir := t.TempDir()
 
 	// The dest path must not exist for go getter to work
-	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
+	moduleDestPath := filepath.Join(tmpDir, "terraform-aws-vpc")
 	assert.False(t, files.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 
 	tfrGetter := new(terraform.RegistryGetter)

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -81,10 +81,7 @@ type TerraformOutput struct {
 func CopyEnvironment(t *testing.T, environmentPath string, includeInCopy ...string) string {
 	t.Helper()
 
-	tmpDir, err := os.MkdirTemp("", "terragrunt-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir due to error: %v", err)
-	}
+	tmpDir := t.TempDir()
 
 	t.Logf("Copying %s to %s", environmentPath, tmpDir)
 
@@ -99,12 +96,9 @@ func CopyEnvironment(t *testing.T, environmentPath string, includeInCopy ...stri
 func CreateTmpTerragruntConfig(t *testing.T, templatesPath string, s3BucketName string, lockTableName string, configFileName string) string {
 	t.Helper()
 
-	tmpFolder, err := os.MkdirTemp("", "terragrunt-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp folder due to error: %v", err)
-	}
+	tmpDir := t.TempDir()
 
-	tmpTerragruntConfigFile := util.JoinPath(tmpFolder, configFileName)
+	tmpTerragruntConfigFile := util.JoinPath(tmpDir, configFileName)
 	originalTerragruntConfigPath := util.JoinPath(templatesPath, configFileName)
 	CopyTerragruntConfigAndFillPlaceholders(t, originalTerragruntConfigPath, tmpTerragruntConfigFile, s3BucketName, lockTableName, "not-used")
 
@@ -114,12 +108,9 @@ func CreateTmpTerragruntConfig(t *testing.T, templatesPath string, s3BucketName 
 func CreateTmpTerragruntConfigContent(t *testing.T, contents string, configFileName string) string {
 	t.Helper()
 
-	tmpFolder, err := os.MkdirTemp("", "terragrunt-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp folder due to error: %v", err)
-	}
+	tmpDir := t.TempDir()
 
-	tmpTerragruntConfigFile := util.JoinPath(tmpFolder, configFileName)
+	tmpTerragruntConfigFile := util.JoinPath(tmpDir, configFileName)
 
 	if err := os.WriteFile(tmpTerragruntConfigFile, []byte(contents), readPermissions); err != nil {
 		t.Fatalf("Error writing temp Terragrunt config to %s: %v", tmpTerragruntConfigFile, err)
@@ -838,10 +829,7 @@ func RunTerragruntValidateInputs(t *testing.T, moduleDir string, extraArgs []str
 func CreateTmpTerragruntConfigWithParentAndChild(t *testing.T, parentPath string, childRelPath string, s3BucketName string, parentConfigFileName string, childConfigFileName string) string {
 	t.Helper()
 
-	tmpDir, err := os.MkdirTemp("", "terragrunt-parent-child-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir due to error: %v", err)
-	}
+	tmpDir := t.TempDir()
 
 	childDestPath := util.JoinPath(tmpDir, childRelPath)
 

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -180,10 +180,9 @@ func TestTerragruntValidateInputsWithStrictModeDisabledAndUnusedInputs(t *testin
 func TestRenderJSONConfig(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "terragrunt-render-json-*")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
+
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
-	defer os.RemoveAll(tmpDir)
 
 	helpers.CleanupTerraformFolder(t, fixtureRenderJSONMainModulePath)
 	helpers.CleanupTerraformFolder(t, fixtureRenderJSONDepModulePath)
@@ -292,10 +291,9 @@ func TestRenderJSONConfig(t *testing.T) {
 func TestRenderJSONConfigWithIncludesDependenciesAndLocals(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "terragrunt-render-json-*")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
+
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
-	defer os.RemoveAll(tmpDir)
 
 	tmpEnvPath := helpers.CopyEnvironment(t, fixtureRenderJSONRegression)
 	workDir := filepath.Join(tmpEnvPath, fixtureRenderJSONRegression)

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -42,7 +41,7 @@ func TestTerragruntDestroyOrder(t *testing.T) {
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all destroy --terragrunt-non-interactive --terragrunt-forward-tf-stdout --terragrunt-working-dir "+rootPath)
 	require.NoError(t, err)
-	assert.Regexp(t, regexp.MustCompile(`(?smi)(?:(Module E|Module D|Module B).*){3}(?:(Module A|Module C).*){2}`), stdout)
+	assert.Regexp(t, `(?smi)(?:(Module E|Module D|Module B).*){3}(?:(Module A|Module C).*){2}`, stdout)
 }
 
 func TestTerragruntApplyDestroyOrder(t *testing.T) {
@@ -56,7 +55,7 @@ func TestTerragruntApplyDestroyOrder(t *testing.T) {
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -destroy --terragrunt-non-interactive --terragrunt-forward-tf-stdout --terragrunt-working-dir "+rootPath)
 	require.NoError(t, err)
-	assert.Regexp(t, regexp.MustCompile(`(?smi)(?:(Module E|Module D|Module B).*){3}(?:(Module A|Module C).*){2}`), stdout)
+	assert.Regexp(t, `(?smi)(?:(Module E|Module D|Module B).*){3}(?:(Module A|Module C).*){2}`, stdout)
 }
 
 func TestPreventDestroyOverride(t *testing.T) {

--- a/test/integration_functions_test.go
+++ b/test/integration_functions_test.go
@@ -220,7 +220,7 @@ func TestGetRepoRoot(t *testing.T) {
 	repoRoot, ok := outputs["repo_root"]
 
 	assert.True(t, ok)
-	assert.Regexp(t, "/tmp/terragrunt-.*/fixtures/get-repo-root", repoRoot.Value)
+	assert.Regexp(t, ".*/fixtures/get-repo-root", repoRoot.Value)
 }
 
 func TestGetWorkingDirBuiltInFunc(t *testing.T) {

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -26,27 +26,25 @@ const (
 func TestScaffoldModule(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, testScaffoldModuleURL))
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpDir, testScaffoldModuleURL))
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Scaffolding completed")
-	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
+	assert.FileExists(t, tmpDir+"/terragrunt.hcl")
 }
 
 func TestScaffoldModuleShortUrl(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, testScaffoldModuleShort))
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpDir, testScaffoldModuleShort))
 
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Scaffolding completed")
 	// check that find_in_parent_folders is generated in terragrunt.hcl
-	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
+	content, err := util.ReadFileAsString(tmpDir + "/terragrunt.hcl")
 	require.NoError(t, err)
 	assert.Contains(t, content, "find_in_parent_folders")
 }
@@ -54,14 +52,13 @@ func TestScaffoldModuleShortUrl(t *testing.T) {
 func TestScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=EnableRootInclude=false", tmpEnvPath, testScaffoldModuleShort))
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=EnableRootInclude=false", tmpDir, testScaffoldModuleShort))
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Scaffolding completed")
 	// check that find_in_parent_folders is NOT generated in  terragrunt.hcl
-	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
+	content, err := util.ReadFileAsString(tmpDir + "/terragrunt.hcl")
 	require.NoError(t, err)
 	assert.NotContains(t, content, "find_in_parent_folders")
 }
@@ -69,10 +66,9 @@ func TestScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
 func TestScaffoldModuleDifferentRevision(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=Ref=v0.67.4", tmpEnvPath, testScaffoldModuleShort))
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=Ref=v0.67.4", tmpDir, testScaffoldModuleShort))
 
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.67.4")
@@ -82,10 +78,9 @@ func TestScaffoldModuleDifferentRevision(t *testing.T) {
 func TestScaffoldModuleDifferentRevisionAndSsh(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=Ref=v0.67.4 --var=SourceUrlType=git-ssh", tmpEnvPath, testScaffoldModuleShort))
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var=Ref=v0.67.4 --var=SourceUrlType=git-ssh", tmpDir, testScaffoldModuleShort))
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.67.4")
 	assert.Contains(t, stderr, "Scaffolding completed")
@@ -94,10 +89,9 @@ func TestScaffoldModuleDifferentRevisionAndSsh(t *testing.T) {
 func TestScaffoldModuleSsh(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, testScaffoldModuleGit))
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpDir, testScaffoldModuleGit))
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Scaffolding completed")
 }
@@ -105,36 +99,33 @@ func TestScaffoldModuleSsh(t *testing.T) {
 func TestScaffoldModuleTemplate(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, testScaffoldTemplateModule))
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpDir, testScaffoldTemplateModule))
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Scaffolding completed")
 	// check that exists file from .boilerplate dir
-	assert.FileExists(t, tmpEnvPath+"/template-file.txt")
+	assert.FileExists(t, tmpDir+"/template-file.txt")
 }
 
 func TestScaffoldModuleExternalTemplate(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s %s", tmpEnvPath, testScaffoldModuleGit, testScaffoldExternalTemplateModule))
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s %s", tmpDir, testScaffoldModuleGit, testScaffoldExternalTemplateModule))
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Scaffolding completed")
 	// check that exists file from external template
-	assert.FileExists(t, tmpEnvPath+"/external-template.txt")
+	assert.FileExists(t, tmpDir+"/external-template.txt")
 }
 
 func TestScaffoldErrorNoModuleUrl(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold", tmpEnvPath))
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold", tmpDir))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "No module URL passed")
 }
@@ -151,14 +142,13 @@ SourceUrlType: "git-ssh"
 	err := os.WriteFile(varFile, []byte(varFileContent), 0644)
 	require.NoError(t, err)
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var-file=%s", tmpEnvPath, testScaffoldModuleShort, varFile))
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s --var-file=%s", tmpDir, testScaffoldModuleShort, varFile))
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.67.4")
 	assert.Contains(t, stderr, "Scaffolding completed")
-	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
+	content, err := util.ReadFileAsString(tmpDir + "/terragrunt.hcl")
 	require.NoError(t, err)
 	assert.NotContains(t, content, "find_in_parent_folders")
 }
@@ -166,29 +156,28 @@ SourceUrlType: "git-ssh"
 func TestScaffoldLocalModule(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	workingDir, err := os.Getwd()
 	require.NoError(t, err)
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, fmt.Sprintf("%s//%s", workingDir, testScaffoldLocalModulePath)))
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpDir, fmt.Sprintf("%s//%s", workingDir, testScaffoldLocalModulePath)))
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Scaffolding completed")
-	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
+	assert.FileExists(t, tmpDir+"/terragrunt.hcl")
 }
 
 func TestScaffold3rdPartyModule(t *testing.T) {
 	t.Parallel()
 
-	tmpRoot, err := os.MkdirTemp("", "terragrunt-scaffold-test")
-	require.NoError(t, err)
-	tmpEnvPath := filepath.Join(tmpRoot, "app")
-	err = os.MkdirAll(tmpEnvPath, 0755)
+	tmpDir := t.TempDir()
+
+	tmpEnvPath := filepath.Join(tmpDir, "app")
+	err := os.MkdirAll(tmpEnvPath, 0755)
 	require.NoError(t, err)
 
 	// create "root" terragrunt.hcl
-	err = os.WriteFile(filepath.Join(tmpRoot, "terragrunt.hcl"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(tmpDir, "terragrunt.hcl"), []byte(""), 0644)
 	require.NoError(t, err)
 
 	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --terragrunt-non-interactive --terragrunt-working-dir %s scaffold %s", tmpEnvPath, testScaffold3rdPartyModulePath))

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -67,7 +67,7 @@ func TestTerragruntProviderCacheWithFilesystemMirror(t *testing.T) {
 	ctx := context.Background()
 	defer ctx.Done()
 
-	cliConfigFilename, err := os.CreateTemp("", "*")
+	cliConfigFilename, err := os.CreateTemp(t.TempDir(), "*")
 	require.NoError(t, err)
 	defer cliConfigFilename.Close()
 
@@ -147,7 +147,7 @@ func TestTerragruntProviderCacheWithNetworkMirror(t *testing.T) {
 
 	providerCacheDir := filepath.Join(rootPath, "providers-cache")
 
-	cliConfigFilename, err := os.CreateTemp("", "*")
+	cliConfigFilename, err := os.CreateTemp(t.TempDir(), "*")
 	require.NoError(t, err)
 	defer cliConfigFilename.Close()
 

--- a/test/integration_sops_test.go
+++ b/test/integration_sops_test.go
@@ -112,6 +112,6 @@ func TestSopsDecryptOnMissing(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Contains(t, errorOut, "Encountered error while evaluating locals in file ./terragrunt.hcl")
-	assert.Regexp(t, ".*missing.yaml:.*no such file*", errorOut)
+	assert.Regexp(t, "(?m).*missing.yaml:.*no such file.*", errorOut)
 
 }

--- a/test/integration_sops_test.go
+++ b/test/integration_sops_test.go
@@ -112,6 +112,6 @@ func TestSopsDecryptOnMissing(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Contains(t, errorOut, "Encountered error while evaluating locals in file ./terragrunt.hcl")
-	assert.Regexp(t, "(?m).*missing.yaml:.*no such file.*", errorOut)
+	assert.Regexp(t, "(?ms).*missing.yaml:.*no such file.*", errorOut)
 
 }

--- a/test/integration_sops_test.go
+++ b/test/integration_sops_test.go
@@ -112,6 +112,6 @@ func TestSopsDecryptOnMissing(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Contains(t, errorOut, "Encountered error while evaluating locals in file ./terragrunt.hcl")
-	assert.Contains(t, errorOut, "./missing.yaml: no such file")
+	assert.Regexp(t, ".*missing.yaml:.*no such file*", errorOut)
 
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3171,7 +3171,7 @@ func TestOutputModuleGroups(t *testing.T) {
 			helpers.RunTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt output-module-groups --terragrunt-working-dir %s %s", environmentPath, tt.subCommand), &stdout, &stderr)
 			output := strings.ReplaceAll(stdout.String(), " ", "")
 			expectedOutput := strings.ReplaceAll(strings.ReplaceAll(tt.expectedOutput, "\t", ""), " ", "")
-			assert.True(t, strings.Contains(strings.TrimSpace(output), strings.TrimSpace(expectedOutput)))
+			assert.Contains(t, strings.TrimSpace(output), strings.TrimSpace(expectedOutput))
 		})
 	}
 }

--- a/test/integration_windows_test.go
+++ b/test/integration_windows_test.go
@@ -150,13 +150,12 @@ func TestWindowsScaffold(t *testing.T) {
 	t.Parallel()
 
 	// create temp dir
-	tmpDir, err := os.MkdirTemp("", "terragrunt-test")
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt scaffold github.com/gruntwork-io/terragrunt-infrastructure-modules-example//modules/mysql --terragrunt-working-dir %s", tmpDir))
 
 	// check that terragrunt.hcl was created
-	_, err = os.Stat(filepath.Join(tmpDir, "terragrunt.hcl"))
+	_, err := os.Stat(filepath.Join(tmpDir, "terragrunt.hcl"))
 	assert.NoError(t, err)
 }
 
@@ -164,13 +163,12 @@ func TestWindowsScaffoldRef(t *testing.T) {
 	t.Parallel()
 
 	// create temp dir
-	tmpDir, err := os.MkdirTemp("", "terragrunt-test")
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt scaffold github.com/gruntwork-io/terragrunt-infrastructure-modules-example//modules/mysql?ref=v0.8.1 --terragrunt-working-dir %s", tmpDir))
 
 	// check that terragrunt.hcl was created
-	_, err = os.Stat(filepath.Join(tmpDir, "terragrunt.hcl"))
+	_, err := os.Stat(filepath.Join(tmpDir, "terragrunt.hcl"))
 	assert.NoError(t, err)
 }
 
@@ -184,10 +182,7 @@ func CopyEnvironmentToPath(t *testing.T, environmentPath, targetPath string) {
 }
 
 func CopyEnvironmentWithTflint(t *testing.T, environmentPath string) string {
-	tmpDir, err := os.MkdirTemp("", "terragrunt-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir due to error: %v", err)
-	}
+	tmpDir := t.TempDir()
 
 	t.Logf("Copying %s to %s", environmentPath, tmpDir)
 

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -206,20 +206,20 @@ func TestFileManifest(t *testing.T) {
 	files := []string{"file1", "file2"}
 	var testfiles = make([]string, 0, len(files))
 
-	// create temp dir
-	dir, err := os.MkdirTemp("", ".terragrunt-test-dir")
-	require.NoError(t, err)
+	// create temp tmpDir
+	tmpDir := t.TempDir()
+
 	for _, file := range files {
 		// create temp files in the dir
-		f, err := os.CreateTemp(dir, file)
+		f, err := os.CreateTemp(tmpDir, file)
 		require.NoError(t, err)
 		testfiles = append(testfiles, f.Name())
 	}
 	// will later test if the file already doesn't exist
-	testfiles = append(testfiles, path.Join(dir, "ephemeral-file-that-doesnt-exist.txt"))
+	testfiles = append(testfiles, path.Join(tmpDir, "ephemeral-file-that-doesnt-exist.txt"))
 
 	// create a manifest
-	manifest := util.NewFileManifest(log.New(), dir, ".terragrunt-test-manifest")
+	manifest := util.NewFileManifest(log.New(), tmpDir, ".terragrunt-test-manifest")
 	require.NoError(t, manifest.Create())
 	// check the file manifest has been created
 	assert.FileExists(t, filepath.Join(manifest.ManifestFolder, manifest.ManifestFile))
@@ -227,7 +227,7 @@ func TestFileManifest(t *testing.T) {
 		require.NoError(t, manifest.AddFile(file))
 	}
 	// check for a non-existent directory as well
-	assert.NoError(t, manifest.AddDirectory(path.Join(dir, "ephemeral-directory-that-doesnt-exist")))
+	assert.NoError(t, manifest.AddDirectory(path.Join(tmpDir, "ephemeral-directory-that-doesnt-exist")))
 
 	assert.NoError(t, manifest.Clean())
 	// test if the files have been deleted


### PR DESCRIPTION
## Description

Bumps `golangci-lint` to `v1.63.4`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `golangci-lint` to `v1.63.4`.

### Migration Guide

If you're a contributor to Terragrunt, make sure to run `make install-lint` to upgrade to the latest version of `golangci-lint`.
