### PR TITLE
fix: Closing gap from CLI Redesign

### DIFF
--- a/docs-starlight/src/content/docs/01-getting-started/01-quick-start.mdx
+++ b/docs-starlight/src/content/docs/01-getting-started/01-quick-start.mdx
@@ -130,7 +130,7 @@ You can also see what to expect in your filesystem at each step [here](https://g
    
    You might notice that this is a little more verbose than the output you're used to seeing from running `tofu` or `terraform` directly. This is because Terragrunt does a bit of work behind the scenes to make sure that you can scale your OpenTofu/Terraform usage without running into common problems. As you get more comfortable with using Terragrunt on larger projects, you may find the extra information helpful.
    
-   If you would prefer that Terragrunt output look more like the output from `tofu` or `terraform`, you can use the `--log-format bare` flag (or set the environment variable `TERRAGRUNT_LOG_FORMAT=bare`) to reduce the verbosity of the output.
+   If you prefer that Terragrunt terminal output look more like that from `tofu` or `terraform`, you can use the `--log-format bare` flag (or set the environment variable `TERRAGRUNT_LOG_FORMAT=bare`) to reduce the verbosity of the output.
    
    e.g.
    

--- a/docs-starlight/src/content/docs/01-getting-started/01-quick-start.mdx
+++ b/docs-starlight/src/content/docs/01-getting-started/01-quick-start.mdx
@@ -46,7 +46,7 @@ This tutorial will not assume the following:
 2. You have any experience with Terragrunt.
 3. You have any existing Terragrunt, OpenTofu or Terraform projects.
 
-\* Note that if you have _both_ OpenTofu and Terraform installed, you'll want to read the [terragrunt-tfpath](/docs/reference/cli-options/#terragrunt-tfpath) docs to understand how Terragrunt determines which binary to use.
+\* Note that if you have _both_ OpenTofu and Terraform installed, you'll want to read the [tf-path](/docs/reference/cli-options/#tf-path) docs to understand how Terragrunt determines which binary to use.
 
 If you would like a less gentle introduction geared towards users with an active AWS account, familiarity with OpenTofu/Terraform, and potentially a team actively using Terragrunt, consider starting with the [Overview](/docs/getting-started/overview/).
 
@@ -130,12 +130,12 @@ You can also see what to expect in your filesystem at each step [here](https://g
    
    You might notice that this is a little more verbose than the output you're used to seeing from running `tofu` or `terraform` directly. This is because Terragrunt does a bit of work behind the scenes to make sure that you can scale your OpenTofu/Terraform usage without running into common problems. As you get more comfortable with using Terragrunt on larger projects, you may find the extra information helpful.
    
-   If you would prefer that Terragrunt output look more like the output from `tofu` or `terraform`, you can use the `--terragrunt-log-format bare` flag (or set the environment variable `TERRAGRUNT_LOG_FORMAT=bare`) to reduce the verbosity of the output.
+   If you would prefer that Terragrunt output look more like the output from `tofu` or `terraform`, you can use the `--log-format bare` flag (or set the environment variable `TERRAGRUNT_LOG_FORMAT=bare`) to reduce the verbosity of the output.
    
    e.g.
    
    ```bash
-   $ terragrunt --terragrunt-log-format bare apply
+   $ terragrunt --log-format bare apply
    local_file.file: Refreshing state... [id=0a0a9f2a6772942557ab5355d76af442f8f65e01]
    
    No changes. Your infrastructure matches the configuration.
@@ -315,10 +315,10 @@ You can also see what to expect in your filesystem at each step [here](https://g
    
    This is where that additional verbosity in Terragrunt logging is really handy. You can see that Terragrunt concurrently ran `apply -auto-approve` in both the `foo` and `bar` units. The extra logging for Terragrunt also included information on the names of the units that were processed, and disambiguated the output from each unit.
    
-   Similar to the `tofu` CLI, there is a prompt to confirm that you are sure you want to run the command in each unit when performing a command that's potentially destructive. You can skip this prompt by using the `--terragrunt-non-interactive` flag, just as you would with `-auto-approve` in OpenTofu.
+   Similar to the `tofu` CLI, there is a prompt to confirm that you are sure you want to run the command in each unit when performing a command that's potentially destructive. You can skip this prompt by using the `--non-interactive` flag, just as you would with `-auto-approve` in OpenTofu.
    
    ```bash
-   terragrunt run-all --terragrunt-non-interactive apply
+   terragrunt run-all --non-interactive apply
    ```
 
 6. **Use Terragrunt to manage your DAG**
@@ -451,7 +451,7 @@ You can also see what to expect in your filesystem at each step [here](https://g
    If you're concerned about the `mock_outputs` attribute resulting in invalid configurations, note that during an apply, the outputs of `foo` will be known, and Terragrunt won't use `mock_outputs` to resolve the outputs of `foo`.
    
    ```bash
-   $ terragrunt run-all --terragrunt-non-interactive apply
+   $ terragrunt run-all --non-interactive apply
    
    ...
    

--- a/docs-starlight/src/content/docs/01-getting-started/04-terminology.md
+++ b/docs-starlight/src/content/docs/01-getting-started/04-terminology.md
@@ -48,7 +48,7 @@ While not a requirement, a general tendency experienced when working with Terrag
 
 A common pattern used in the repository structure for Terragrunt projects is to have a single `terragrunt.hcl` file located at the root of the repository, and multiple subdirectories each containing their own `terragrunt.hcl` file. This is typically done to promote code-reuse, as it allows for any configuration common to all units to be defined in the root `terragrunt.hcl` file, and for unit-specific configuration to be defined in child directories. In this pattern, the root `terragrunt.hcl` file is not considered a unit, while all the child directories containing `terragrunt.hcl` files are.
 
-Note that units don't technically need to call their configuration files `terragrunt.hcl` (that's configurable via the [--terragrunt-config](/docs/reference/cli-options/#terragrunt-config)), and users don't technically need to use a root `terragrunt.hcl` file or to name it that. This is the most common pattern followed by the community, however, and deviation from this pattern should be justified in the context of the project. It can help others with Terragrunt experience understand the project more easily if industry standard patterns are followed.
+Note that units don't technically need to call their configuration files `terragrunt.hcl` (that's configurable via the [--config](/docs/reference/cli-options/#config)), and users don't technically need to use a root `terragrunt.hcl` file or to name it that. This is the most common pattern followed by the community, however, and deviation from this pattern should be justified in the context of the project. It can help others with Terragrunt experience understand the project more easily if industry standard patterns are followed.
 
 ### Stack
 
@@ -156,7 +156,7 @@ The Run Queue is the queue of all units that Terragrunt will do work on over one
 
 Certain commands like [run-all](/docs/reference/cli-options/#run-all) populate the Run Queue with all units in a stack, while other commands like `plan` or `apply` will only populate the Run Queue with the unit that the command was run in.
 
-Certain flags like [--terragrunt-include-dir](/docs/reference/cli-options/#terragrunt-include-dir) can be used to adjust the Run Queue to include additional units. Conversely, there are flags like [--terragrunt-exclude-dir](/docs/reference/cli-options/#terragrunt-exclude-dir) that can be used to adjust the Run Queue to exclude units.
+Certain flags like [--include-dir](/docs/reference/cli-options/#include-dir) can be used to adjust the Run Queue to include additional units. Conversely, there are flags like [--exclude-dir](/docs/reference/cli-options/#exclude-dir) that can be used to adjust the Run Queue to exclude units.
 
 Terragrunt will always attempt to run until the Run Queue is empty.
 
@@ -164,7 +164,7 @@ Terragrunt will always attempt to run until the Run Queue is empty.
 
 The Runner Pool is the pool of available resources that Terragrunt can use to execute runs.
 
-Units are dequeued from the Runner Pool into the Runner Pool depending on factors like [terragrunt-parallelism](/docs/reference/cli-options/#terragrunt-parallelism) and the DAG.
+Units are dequeued from the Runner Pool into the Runner Pool depending on factors like [parallelism](/docs/reference/cli-options/#parallelism) and the DAG.
 
 Units are only considered "running" when they are in the Runner Pool.
 
@@ -207,7 +207,7 @@ By default, Terragrunt will interact with OpenTofu/Terraform in order to retriev
 
 Terragrunt does have the ability to mock outputs, which is useful when dependencies do not yet have outputs to be consumed (e.g. during the run of a unit with a dependency that has not been applied).
 
-Terragrunt also has the ability to fetch outputs without interacting with OpenTofu/Terraform via [--terragrunt-fetch-dependency-output-from-state](/docs/reference/cli-options/#terragrunt-fetch-dependency-output-from-state) for dependencies where state is stored in AWS. This is an experimental feature, and more tooling is planned to make this easier to use.
+Terragrunt also has the ability to fetch outputs without interacting with OpenTofu/Terraform via [--fetch-dependency-output-from-state](/docs/reference/cli-options/#fetch-dependency-output-from-state) for dependencies where state is stored in AWS. This is an experimental feature, and more tooling is planned to make this easier to use.
 
 ### Feature
 

--- a/docs-starlight/src/content/docs/02-features/01-units.mdx
+++ b/docs-starlight/src/content/docs/02-features/01-units.mdx
@@ -153,7 +153,7 @@ terragrunt apply
 
 When Terragrunt finds the `terraform` block with a `source` parameter in `live/stage/app/terragrunt.hcl` file, it will:
 
-1. Download the configurations specified via the `source` parameter into the `--terragrunt-download-dir` folder (by default `.terragrunt-cache` in the working directory, which we recommend adding to `.gitignore`). This downloading is done by using the same [go-getter library](https://github.com/hashicorp/go-getter) OpenTofu/Terraform uses, so the `source` parameter supports the exact same syntax as the [module source](https://opentofu.org/docs/language/modules/sources/) parameter, including local file paths, Git URLs, and Git URLs with `ref` parameters (useful for checking out a specific tag, commit, or branch of Git repo). Terragrunt will download all the code in the repo (i.e. the part before the double-slash `//`) so that relative paths work correctly between modules in that repo.
+1. Download the configurations specified via the `source` parameter into the `--download-dir` folder (by default `.terragrunt-cache` in the working directory, which we recommend adding to `.gitignore`). This downloading is done by using the same [go-getter library](https://github.com/hashicorp/go-getter) OpenTofu/Terraform uses, so the `source` parameter supports the exact same syntax as the [module source](https://opentofu.org/docs/language/modules/sources/) parameter, including local file paths, Git URLs, and Git URLs with `ref` parameters (useful for checking out a specific tag, commit, or branch of Git repo). Terragrunt will download all the code in the repo (i.e. the part before the double-slash `//`) so that relative paths work correctly between modules in that repo.
 
 2. Copy all files from the current working directory into the temporary folder.
 
@@ -175,11 +175,11 @@ This idea is inspired by Kief Morris' blog post [Using Pipelines to Manage Envir
 
 ## Working locally
 
-If you’re testing changes to a local copy of the `modules` repo, you can use the `--terragrunt-source` command-line option or the `TERRAGRUNT_SOURCE` environment variable to override the `source` parameter. This is useful to point Terragrunt at a local checkout of your code so you can do rapid, iterative, make-a-change-and-rerun development:
+If you’re testing changes to a local copy of the `modules` repo, you can use the `--source` command-line option or the `TERRAGRUNT_SOURCE` environment variable to override the `source` parameter. This is useful to point Terragrunt at a local checkout of your code so you can do rapid, iterative, make-a-change-and-rerun development:
 
 ```bash
 cd live/stage/app
-terragrunt apply --terragrunt-source ../../../modules//app
+terragrunt apply --source ../../../modules//app
 ```
 
 _(Note: the double slash (`//`) here too is intentional and required. Terragrunt downloads all the code in the folder before the double-slash into the temporary folder so that relative paths between modules work correctly. OpenTofu/Terraform may display a "OpenTofu/Terraform initialized in an empty directory" warning, but you can safely ignore it.)_
@@ -196,9 +196,9 @@ See the [Lock File Handling docs](/docs/reference/lock-files) for more details.
 
 The first time you set the `source` parameter to a remote URL, Terragrunt will download the code from that URL into a tmp folder. It will _NOT_ download it again afterwards unless you change that URL. That’s because downloading code—and more importantly, reinitializing remote state, redownloading provider plugins, and redownloading modules—can take a long time. To avoid adding 10-90 seconds of overhead to every Terragrunt command, Terragrunt assumes all remote URLs are immutable, and only downloads them once.
 
-Therefore, when working locally, you should use the `--terragrunt-source` parameter and point it at a local file path as described in the previous section. Terragrunt will copy the local files every time you run it, which is nearly instantaneous, and doesn’t require reinitializing everything, so you’ll be able to iterate quickly.
+Therefore, when working locally, you should use the `--source` parameter and point it at a local file path as described in the previous section. Terragrunt will copy the local files every time you run it, which is nearly instantaneous, and doesn’t require reinitializing everything, so you’ll be able to iterate quickly.
 
-If you need to force Terragrunt to redownload something from a remote URL, run Terragrunt with the `--terragrunt-source-update` flag and it’ll delete the tmp folder, download the files from scratch, and reinitialize everything. This can take a while, so avoid it and use `--terragrunt-source` when you can\!
+If you need to force Terragrunt to redownload something from a remote URL, run Terragrunt with the `--source-update` flag and it’ll delete the tmp folder, download the files from scratch, and reinitialize everything. This can take a while, so avoid it and use `--source` when you can\!
 
 ## Working with relative file paths
 

--- a/docs-starlight/src/content/docs/02-features/01-units.mdx
+++ b/docs-starlight/src/content/docs/02-features/01-units.mdx
@@ -153,7 +153,7 @@ terragrunt apply
 
 When Terragrunt finds the `terraform` block with a `source` parameter in `live/stage/app/terragrunt.hcl` file, it will:
 
-1. Download the configurations specified via the `source` parameter into the `--download-dir` folder (by default `.terragrunt-cache` in the working directory, which we recommend adding to `.gitignore`). This downloading is done by using the same [go-getter library](https://github.com/hashicorp/go-getter) OpenTofu/Terraform uses, so the `source` parameter supports the exact same syntax as the [module source](https://opentofu.org/docs/language/modules/sources/) parameter, including local file paths, Git URLs, and Git URLs with `ref` parameters (useful for checking out a specific tag, commit, or branch of Git repo). Terragrunt will download all the code in the repo (i.e. the part before the double-slash `//`) so that relative paths work correctly between modules in that repo.
+1. Download the configurations specified via the `source` parameter into the `--download-dir` folder (by default `.terragrunt-cache` in the working directory, which we recommend adding to `.gitignore`). This downloading is done by using the same [go-getter library](https://github.com/hashicorp/go-getter) OpenTofu/Terraform uses, so the `source` parameter supports the same syntax as the [module source](https://opentofu.org/docs/language/modules/sources/) parameter, including local file paths, Git URLs, and Git URLs with `ref` parameters (useful for checking out a specific tag, commit, or branch of Git repo). Terragrunt will download all the code in the repo (i.e. the part before the double-slash `//`) so that relative paths work correctly between modules in that repo.
 
 2. Copy all files from the current working directory into the temporary folder.
 
@@ -198,7 +198,7 @@ The first time you set the `source` parameter to a remote URL, Terragrunt will d
 
 Therefore, when working locally, you should use the `--source` parameter and point it at a local file path as described in the previous section. Terragrunt will copy the local files every time you run it, which is nearly instantaneous, and doesn’t require reinitializing everything, so you’ll be able to iterate quickly.
 
-If you need to force Terragrunt to redownload something from a remote URL, run Terragrunt with the `--source-update` flag and it’ll delete the tmp folder, download the files from scratch, and reinitialize everything. This can take a while, so avoid it and use `--source` when you can\!
+If you need to force Terragrunt to redownload something from a remote URL, run Terragrunt with the `--source-update` flag, and it’ll delete the tmp folder, download the files from scratch, and reinitialize everything. This can take a while, so avoid it and use `--source` when you can\!
 
 ## Working with relative file paths
 

--- a/docs-starlight/src/content/docs/02-features/02-stacks.mdx
+++ b/docs-starlight/src/content/docs/02-features/02-stacks.mdx
@@ -356,7 +356,7 @@ Any error encountered in an individual unit during a `run-all` command will prev
 
 To check all of your dependencies and validate the code in them, you can use the `run-all validate` command.
 
-**Note:** During `destroy` runs, Terragrunt will try to find all dependent units and show a confirmation prompt with a list of detected dependencies. This is because Terragrunt knows that once resources in a dependency is destroyed, any commands run on dependent units may fail. For example, if `destroy` was called on the `redis` unit, you'll be asked for confirmation, as the `backend-app` depends on `redis`. You can avoid the prompt by using `--non-interactive`.
+**Note:** During `destroy` runs, Terragrunt will try to find all dependent units and show a confirmation prompt with a list of detected dependencies. This is because Terragrunt knows that once resources in a dependency are destroyed, any commands run on dependent units may fail. For example, if `destroy` was called on the `redis` unit, you'll be asked for confirmation, as the `backend-app` depends on `redis`. You can avoid the prompt by using `--non-interactive`.
 
 ## Visualizing the DAG
 

--- a/docs-starlight/src/content/docs/02-features/02-stacks.mdx
+++ b/docs-starlight/src/content/docs/02-features/02-stacks.mdx
@@ -109,7 +109,7 @@ terragrunt run-all plan
 
 If your units have dependencies between them, for example, you can’t deploy the backend-app until MySQL and redis are deployed. You’ll need to express those dependencies in your Terragrunt configuration as explained in the next section.
 
-Additional note: If your units have dependencies between them, and you run a `terragrunt run-all destroy` command, Terragrunt will destroy all the units under the current working directory, _as well as each of the unit dependencies_ (that is, units you depend on via `dependencies` and `dependency` blocks)! If you wish to use exclude dependencies from being destroyed, add the `--terragrunt-ignore-external-dependencies` flag, or use the `--terragrunt-exclude-dir` once for each directory you wish to exclude.
+Additional note: If your units have dependencies between them, and you run a `terragrunt run-all destroy` command, Terragrunt will destroy all the units under the current working directory, _as well as each of the unit dependencies_ (that is, units you depend on via `dependencies` and `dependency` blocks)! If you wish to use exclude dependencies from being destroyed, add the `--ignore-external-dependencies` flag, or use the `--exclude-dir` once for each directory you wish to exclude.
 
 ## Cutting down the file count
 
@@ -356,7 +356,7 @@ Any error encountered in an individual unit during a `run-all` command will prev
 
 To check all of your dependencies and validate the code in them, you can use the `run-all validate` command.
 
-**Note:** During `destroy` runs, Terragrunt will try to find all dependent units and show a confirmation prompt with a list of detected dependencies. This is because Terragrunt knows that once resources in a dependency is destroyed, any commands run on dependent units may fail. For example, if `destroy` was called on the `redis` unit, you'll be asked for confirmation, as the `backend-app` depends on `redis`. You can avoid the prompt by using `--terragrunt-non-interactive`.
+**Note:** During `destroy` runs, Terragrunt will try to find all dependent units and show a confirmation prompt with a list of detected dependencies. This is because Terragrunt knows that once resources in a dependency is destroyed, any commands run on dependent units may fail. For example, if `destroy` was called on the `redis` unit, you'll be asked for confirmation, as the `backend-app` depends on `redis`. You can avoid the prompt by using `--non-interactive`.
 
 ## Visualizing the DAG
 
@@ -380,20 +380,20 @@ The exception to this rule is during the `destroy` (and `plan -destroy`) command
 
 ## Testing multiple units locally
 
-If you are using Terragrunt to download [remote OpenTofu/Terraform modules](/docs/features/units#remote-opentofuterraform-modules) and all of your units have the `source` parameter set to a Git URL, but you want to test with a local checkout of the code, you can use the `--terragrunt-source` parameter to override that value:
+If you are using Terragrunt to download [remote OpenTofu/Terraform modules](/docs/features/units#remote-opentofuterraform-modules) and all of your units have the `source` parameter set to a Git URL, but you want to test with a local checkout of the code, you can use the `--source` parameter to override that value:
 
 ```bash
 cd root
-terragrunt run-all plan --terragrunt-source /source/modules
+terragrunt run-all plan --source /source/modules
 ```
 
-If you set the `--terragrunt-source` parameter, the `run-all` command will assume that parameter is pointing to a folder on your local file system that has a local checkout of all of your OpenTofu/Terraform modules.
+If you set the `--source` parameter, the `run-all` command will assume that parameter is pointing to a folder on your local file system that has a local checkout of all of your OpenTofu/Terraform modules.
 
 For each unit that is being processed via a `run-all` command, Terragrunt will:
 
 1. Read in the `source` parameter in that unit’s `terragrunt.hcl` file.
 2. Parse out the path (the portion after the double-slash).
-3. Append the path to the `--terragrunt-source` parameter to create the final local path for that unit.
+3. Append the path to the `--source` parameter to create the final local path for that unit.
 
 For example, consider the following `terragrunt.hcl` file:
 
@@ -408,7 +408,7 @@ terraform {
 Running the following:
 
 ```bash
-terragrunt run-all apply --terragrunt-source /source/infrastructure-modules
+terragrunt run-all apply --source /source/infrastructure-modules
 ```
 
 Will result in a unit with the configuration for the source above being resolved to `/source/infrastructure-modules//networking/vpc`.
@@ -421,10 +421,10 @@ meaning that if it finds 5 units without dependencies, it'll run OpenTofu/Terraf
 Sometimes, this can create a problem if there are a lot of units in the dependency graph, like hitting a rate limit on a
 cloud provider.
 
-To limit the maximum number of unit executions at any given time use the `--terragrunt-parallelism [number]` flag
+To limit the maximum number of unit executions at any given time use the `--parallelism [number]` flag
 
 ```sh
-terragrunt run-all apply --terragrunt-parallelism 4
+terragrunt run-all apply --parallelism 4
 ```
 
 ## Saving OpenTofu/Terraform plan output
@@ -434,10 +434,10 @@ A powerful feature of OpenTofu/Terraform is the ability to [save the result of a
 Terragrunt provides special tooling in `run-all` execution in order to ensure that the saved plan for a `run-all` against a stack has
 a corresponding entry for each unit in the stack in a directory structure that mirrors the stack structure.
 
-To save plan against a stack, use the `--terragrunt-out-dir` flag (or `TERRAGRUNT_OUT_DIR` environment variable) as demonstrated below:
+To save plan against a stack, use the `--out-dir` flag (or `TERRAGRUNT_OUT_DIR` environment variable) as demonstrated below:
 
 ```bash
-$ terragrunt run-all plan --terragrunt-out-dir /tmp/tfplan
+$ terragrunt run-all plan --out-dir /tmp/tfplan
 ```
 
 <FileTree>
@@ -455,20 +455,20 @@ $ terragrunt run-all plan --terragrunt-out-dir /tmp/tfplan
 </FileTree>
 
 ```bash
-$ terragrunt run-all apply --terragrunt-out-dir /tmp/tfplan
+$ terragrunt run-all apply --out-dir /tmp/tfplan
 ```
 
 For planning a destroy operation, use the following commands:
 
 ```bash
-terragrunt run-all plan -destroy --terragrunt-out-dir /tmp/tfplan
-terragrunt run-all apply --terragrunt-out-dir /tmp/tfplan
+terragrunt run-all plan -destroy --out-dir /tmp/tfplan
+terragrunt run-all apply --out-dir /tmp/tfplan
 ```
 
-To save plan in json format use `--terragrunt-json-out-dir` flag (or `TERRAGRUNT_JSON_OUT_DIR` environment variable):
+To save plan in json format use `--json-out-dir` flag (or `TERRAGRUNT_JSON_OUT_DIR` environment variable):
 
 ```bash
-terragrunt run-all plan --terragrunt-json-out-dir /tmp/json
+terragrunt run-all plan --json-out-dir /tmp/json
 ```
 
 <FileTree>
@@ -487,7 +487,7 @@ terragrunt run-all plan --terragrunt-json-out-dir /tmp/json
 
 
 ```bash
-terragrunt run-all plan --terragrunt-out-dir /tmp/all --terragrunt-json-out-dir /tmp/all
+terragrunt run-all plan --out-dir /tmp/all --json-out-dir /tmp/all
 ```
 
 <FileTree>
@@ -553,6 +553,6 @@ Terragrunt will only include the units in the `us-east-1` stack and its children
 
 Generally speaking, this is the primary tool Terragrunt users use to control the blast radius of their changes. For the most part, it is the current working directory that determines the blast radius of a `run-all` command.
 
-In addition to using your working directory to control what's included in a [run queue](/docs/getting-started/terminology/#run-queue), you can also use flags like [--terragrunt-include-dir](/docs/reference/cli-options/#terragrunt-include-dir) and [--terragrunt-exclude-dir](/docs/reference/cli-options/#terragrunt-exclude-dir) to explicitly control what's included in a run queue within a stack, or outside of it.
+In addition to using your working directory to control what's included in a [run queue](/docs/getting-started/terminology/#run-queue), you can also use flags like [--include-dir](/docs/reference/cli-options/#include-dir) and [--exclude-dir](/docs/reference/cli-options/#exclude-dir) to explicitly control what's included in a run queue within a stack, or outside of it.
 
 There are more flags that control the behavior of the `run-all` command, which you can find in the [CLI Options](/docs/reference/cli-options) section.

--- a/docs-starlight/src/content/docs/02-features/03-includes.mdx
+++ b/docs-starlight/src/content/docs/02-features/03-includes.mdx
@@ -443,7 +443,7 @@ multiple files that were not touched at all in the commit. In our previous examp
 the `_env/app.hcl` file, we need to apply the change to all the modules that `include` that common environment
 configuration.
 
-The most comprehensive approach to managing this is to use the [--terragrunt-queue-include-units-reading](https://terragrunt.gruntwork.io/docs/reference/cli-options/#terragrunt-queue-include-units-reading)
+The most comprehensive approach to managing this is to use the [--queue-include-units-reading](https://terragrunt.gruntwork.io/docs/reference/cli-options/#queue-include-units-reading)
 flag. This flag will automatically add all units that read the file to the queue of units to be run. This includes
 both units that include the file, and units that read the file using something like `read_terragrunt_config` (make
 to read the documentation on this so that you know the limitations of this flag).
@@ -451,7 +451,7 @@ to read the documentation on this so that you know the limitations of this flag)
 In the previous example, your CI/CD pipeline can run:
 
 ```bash
-terragrunt run-all plan --terragrunt-queue-include-units-reading _env/app.hcl
+terragrunt run-all plan --queue-include-units-reading _env/app.hcl
 ```
 
 This will:
@@ -465,19 +465,19 @@ Thereby allowing you to only run those modules that need to be updated by the co
 
 Alternatively, you can implement a promotion workflow if you have multiple environments that depend on the
 `_env/app.hcl` configuration. In the above example, suppose you wanted to progressively roll out the changes through the
-environments, `qa`, `stage`, and `prod` in order. In this case, you can use `--terragrunt-working-dir` to scope down the
+environments, `qa`, `stage`, and `prod` in order. In this case, you can use `--working-dir` to scope down the
 updates from the common file:
 
 ```bash
 # Roll out the change to the qa environment first
-terragrunt run-all plan --terragrunt-queue-include-units-reading _env/app.hcl --terragrunt-working-dir qa
-terragrunt run-all apply --terragrunt-queue-include-units-reading _env/app.hcl --terragrunt-working-dir qa
+terragrunt run-all plan --queue-include-units-reading _env/app.hcl --working-dir qa
+terragrunt run-all apply --queue-include-units-reading _env/app.hcl --working-dir qa
 # If the apply succeeds to qa, move on to the stage environment
-terragrunt run-all plan --terragrunt-queue-include-units-reading _env/app.hcl --terragrunt-working-dir stage
-terragrunt run-all apply --terragrunt-queue-include-units-reading _env/app.hcl --terragrunt-working-dir stage
+terragrunt run-all plan --queue-include-units-reading _env/app.hcl --working-dir stage
+terragrunt run-all apply --queue-include-units-reading _env/app.hcl --working-dir stage
 # And finally, prod.
-terragrunt run-all plan --terragrunt-queue-include-units-reading _env/app.hcl --terragrunt-working-dir prod
-terragrunt run-all apply --terragrunt-queue-include-units-reading _env/app.hcl --terragrunt-working-dir prod
+terragrunt run-all plan --queue-include-units-reading _env/app.hcl --working-dir prod
+terragrunt run-all apply --queue-include-units-reading _env/app.hcl --working-dir prod
 ```
 
 This allows you to have flexibility in how changes are rolled out. For example, you can add extra validation stages

--- a/docs-starlight/src/content/docs/02-features/08-aws-authentication.md
+++ b/docs-starlight/src/content/docs/02-features/08-aws-authentication.md
@@ -40,10 +40,10 @@ To avoid these frustrating trade-offs, you can configure Terragrunt to assume an
 
 ## Configuring Terragrunt to assume an IAM role
 
-To tell Terragrunt to assume an IAM role, just set the [`--terragrunt-iam-role`](/docs/reference/cli-options/#terragrunt-iam-role) command line argument:
+To tell Terragrunt to assume an IAM role, just set the [`--iam-role`](/docs/reference/cli-options/#iam-role) command line argument:
 
 ```bash
-terragrunt apply --terragrunt-iam-role "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+terragrunt apply --iam-role "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
 ```
 
 Alternatively, you can set the `TERRAGRUNT_IAM_ROLE` environment variable:
@@ -67,16 +67,16 @@ Terragrunt will call the `sts assume-role` API on your behalf and expose the cre
 
 ## Leveraging OIDC role assumption
 
-In addition, you can combine the `--terragrunt-iam-role` flag with the [`--terragrunt-iam-web-identity-token`](/docs/reference/cli-options/#terragrunt-iam-web-identity-token) to use the `AssumeRoleWithWebIdentity` API instead of the `AssumeRole` API.
+In addition, you can combine the `--iam-role` flag with the [`--iam-web-identity-token`](/docs/reference/cli-options/#iam-web-identity-token) to use the `AssumeRoleWithWebIdentity` API instead of the `AssumeRole` API.
 
 This is especially convenient in the context of CI/CD pipelines, as it's generally a best practice to assume roles there via OIDC.
 
-Configuring OIDC role assumption largely works like the `--terragrunt-iam-role` flag, with the addition of the `--terragrunt-iam-web-identity-token` flag. One special aspect of the `--terragrunt-iam-web-identity-token` flag is that it can use both a token, and the path to a file containing the token.
+Configuring OIDC role assumption largely works like the `--iam-role` flag, with the addition of the `--iam-web-identity-token` flag. One special aspect of the `--iam-web-identity-token` flag is that it can use both a token, and the path to a file containing the token.
 
 As a command line argument:
 
 ```bash
-terragrunt apply --terragrunt-iam-role "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME" --terragrunt-iam-web-identity-token "$TOKEN"
+terragrunt apply --iam-role "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME" --iam-web-identity-token "$TOKEN"
 ```
 
 As environment variables:
@@ -106,10 +106,10 @@ This technique is especially useful in the following circumstances:
 - On a shared development repository, where you might want to use different roles for different developers, or even different roles for the same developer, depending on the task at hand.
 - In a setup where units in different accounts depend on each other, and you want to assume a different role for each account.
 
-The [`--terragrunt-auth-provider-cmd`](/docs/reference/cli-options/#terragrunt-auth-provider-cmd) flag allows you to specify a command that can be executed by Terragrunt to fetch credentials at runtime.
+The [`--auth-provider-cmd`](/docs/reference/cli-options/#auth-provider-cmd) flag allows you to specify a command that can be executed by Terragrunt to fetch credentials at runtime.
 
 ```bash
-terragrunt apply --terragrunt-auth-provider-cmd /path/to/auth-script.sh
+terragrunt apply --auth-provider-cmd /path/to/auth-script.sh
 ```
 
 As with all other flags, you can also set this as an environment variable:

--- a/docs-starlight/src/content/docs/02-features/09-hooks.md
+++ b/docs-starlight/src/content/docs/02-features/09-hooks.md
@@ -101,7 +101,7 @@ aws s3 ls "s3://$BUCKET_NAME"
 ```
 
 Note that the `TG_CTX_TF_PATH` environment variable is used here to ensure compatibility, regardless of the
-value of [terragrunt-tfpath](/docs/reference/cli-options/#terragrunt-tfpath). This can be a useful practice
+value of [tf-path](/docs/reference/cli-options/#tf-path). This can be a useful practice
 if you are migrating between OpenTofu or Terraform.
 
 You will also have access to all the `inputs` set in the `terragrunt.hcl` file as environment variables prefixed
@@ -272,7 +272,7 @@ Any desired extra configuration should be added in the `.tflint.hcl` file.
 It will work with a `.tflint.hcl` file in the current folder or any parent folder.
 To utilize an alternative configuration file, use the `--config` flag with the path to the configuration file.
 
-If there is a need to run `tflint` from the operating system directly, use the extra parameter `--terragrunt-external-tflint`.
+If there is a need to run `tflint` from the operating system directly, use the extra parameter `--external-tflint`.
 This will result in usage of the `tflint` binary found in the `PATH` environment variable.
 
 For example:
@@ -283,7 +283,7 @@ For example:
 terraform {
     before_hook "tflint" {
     commands = ["apply", "plan"]
-    execute = ["tflint" , "--terragrunt-external-tflint", "--minimum-failure-severity=error", "--config", "custom.tflint.hcl"]
+    execute = ["tflint" , "--external-tflint", "--minimum-failure-severity=error", "--config", "custom.tflint.hcl"]
   }
 }
 ```

--- a/docs-starlight/src/content/docs/02-features/10-auto-init.md
+++ b/docs-starlight/src/content/docs/02-features/10-auto-init.md
@@ -25,6 +25,6 @@ In some cases, it might be desirable to disable Auto-Init.
 
 For example, you might want to specify a different `-plugin-dir` option to `tofu init` (and don't want to have it set in `extra_arguments`).
 
-To disable Auto-Init, use the `--terragrunt-no-auto-init` command line option or set the `TERRAGRUNT_NO_AUTO_INIT` environment variable to `true`.
+To disable Auto-Init, use the `--no-auto-init` command line option or set the `TERRAGRUNT_NO_AUTO_INIT` environment variable to `true`.
 
 Disabling Auto-Init requires you to explicitly run `terragrunt init` before executing any other Terragrunt commands for that configuration. If Auto-Init is disabled and Terragrunt detects that `init` should have been run, it will throw an error.

--- a/docs-starlight/src/content/docs/04-reference/01-hcl/01-overview.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/01-overview.mdx
@@ -28,7 +28,7 @@ Terragrunt also supports [JSON-serialized HCL](https://github.com/hashicorp/hcl/
 
 Terragrunt figures out the path to its config file according to the following rules:
 
-1. The value of the `--terragrunt-config` command-line option, if specified.
+1. The value of the `--config` command-line option, if specified.
 
 2. The value of the `TERRAGRUNT_CONFIG` environment variable, if defined.
 
@@ -121,10 +121,10 @@ If you run `terragrunt hclfmt` at the `root`, this will update:
 
 - `root/qa/services/service01/terragrunt.hcl`
 
-You can set `--terragrunt-diff` option. `terragrunt hclfmt --terragrunt-diff` will output the diff in a unified format which can be redirected to your favourite diff tool. `diff` utility must be presented in PATH.
+You can set `--diff` option. `terragrunt hclfmt --diff` will output the diff in a unified format which can be redirected to your favourite diff tool. `diff` utility must be presented in PATH.
 
-Additionally, there’s a flag `--terragrunt-check`. `terragrunt hclfmt --terragrunt-check` will only verify if the files are correctly formatted **without rewriting** them. The command will return exit status 1 if any matching files are improperly formatted, or 0 if all matching `.hcl` files are correctly formatted.
+Additionally, there’s a flag `--check`. `terragrunt hclfmt --check` will only verify if the files are correctly formatted **without rewriting** them. The command will return exit status 1 if any matching files are improperly formatted, or 0 if all matching `.hcl` files are correctly formatted.
 
-You can exclude directories from the formatting process by using the `--terragrunt-hclfmt-exclude-dir` flag. For example, `terragrunt hclfmt --terragrunt-hclfmt-exclude-dir=qa/services`.
+You can exclude directories from the formatting process by using the `--hclfmt-exclude-dir` flag. For example, `terragrunt hclfmt --hclfmt-exclude-dir=qa/services`.
 
-If you want to format a single file, you can use the `--terragrunt-hclfmt-file` flag. For example, `terragrunt hclfmt --terragrunt-hclfmt-file qa/services/services.hcl`.
+If you want to format a single file, you can use the `--hclfmt-file` flag. For example, `terragrunt hclfmt --hclfmt-file qa/services/services.hcl`.

--- a/docs-starlight/src/content/docs/04-reference/01-hcl/02-blocks.md
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/02-blocks.md
@@ -82,7 +82,7 @@ The `terraform` block supports the following arguments:
     `tofu`/`terraform` like `required_var_files`, only any files that do not exist are ignored.
 
 - `before_hook` (block): Nested blocks used to specify command hooks that should be run before `tofu`/`terraform` is called.
-  Hooks run from the directory with the OpenTofu/Terraform module, except for hooks related to `terragrunt-read-config` and
+  Hooks run from the directory with the OpenTofu/Terraform module, except for hooks related to `read-config` and
   `init-from-module`. These hooks run in the terragrunt configuration directory (the directory where `terragrunt.hcl`
   lives).
   Supports the following arguments:
@@ -92,7 +92,7 @@ The `terraform` block supports the following arguments:
     `["echo", "Foo"]`, the command `echo Foo` will be run.
   - `working_dir` (optional) : The path to set as the working directory of the hook. Terragrunt will switch directory
     to this path before running the hook command. Defaults to the terragrunt configuration directory for
-    `terragrunt-read-config` and `init-from-module` hooks, and the OpenTofu/Terraform module directory for other command hooks.
+    `read-config` and `init-from-module` hooks, and the OpenTofu/Terraform module directory for other command hooks.
   - `run_on_error` (optional) : If set to true, this hook will run even if a previous hook hit an error, or in the
     case of "after" hooks, if the OpenTofu/Terraform command hit an error. Default is false.
   - `suppress_stdout` (optional) : If set to true, the stdout output of the executed commands will be suppressed. This can be useful when there are scripts relying on OpenTofu/Terraform's output and any other output would break their parsing.
@@ -106,10 +106,10 @@ The `terraform` block supports the following arguments:
 In addition to supporting before and after hooks for all OpenTofu/Terraform commands, the following specialized hooks are also
 supported:
 
-- `terragrunt-read-config` (after hook only): `terragrunt-read-config` is a special hook command that you can use with
+- `read-config` (after hook only): `read-config` is a special hook command that you can use with
   the `after_hook` subblock to run an action immediately after terragrunt finishes loading the config. This hook will
   run on every invocation of terragrunt. Note that you can only use this hook with `after_hooks`. Any `before_hooks`
-  with the command `terragrunt-read-config` will be ignored. The working directory for hooks associated with this
+  with the command `read-config` will be ignored. The working directory for hooks associated with this
   command will be the terragrunt config directory.
 
 - `init-from-module` and `init`: Terragrunt has two stages of initialization: one is to download [remote
@@ -207,10 +207,10 @@ terraform {
   }
 
   # A special after_hook. Use this hook if you wish to run commands immediately after terragrunt finishes loading its
-  # configurations. If "terragrunt-read-config" is defined as a before_hook, it will be ignored as this config would
+  # configurations. If "read-config" is defined as a before_hook, it will be ignored as this config would
   # not be loaded before the action is done.
-  after_hook "terragrunt-read-config" {
-    commands = ["terragrunt-read-config"]
+  after_hook "read-config" {
+    commands = ["read-config"]
     execute  = ["bash", "script/get_aws_credentials.sh"]
   }
 }
@@ -1116,7 +1116,7 @@ When reading Terragrunt HCL configurations, you might read in a computed configu
 # computed.hcl
 
 locals {
-  computed_value = run_cmd("--terragrunt-quiet", "python3", "-c", "print('Hello,')")
+  computed_value = run_cmd("--quiet", "python3", "-c", "print('Hello,')")
 }
 ```
 
@@ -1413,7 +1413,7 @@ with external feature flag services like [LaunchDarkly](https://launchdarkly.com
 # terragrunt.hcl
 
 feature "feature_name" {
-  default = run_cmd("--terragrunt-quiet", "<command-to-fetch-feature-flag-value>")
+  default = run_cmd("--quiet", "<command-to-fetch-feature-flag-value>")
 }
 ```
 

--- a/docs-starlight/src/content/docs/04-reference/01-hcl/03-attributes.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/03-attributes.mdx
@@ -112,7 +112,7 @@ Variables loaded in OpenTofu/Terraform will consequently use the following prece
 
 The terragrunt `download_dir` string option can be used to override the default download directory.
 
-The precedence is as follows: `--terragrunt-download-dir` command line option → `TERRAGRUNT_DOWNLOAD` env variable →
+The precedence is as follows: `--download-dir` command line option → `TERRAGRUNT_DOWNLOAD` env variable →
 `download_dir` attribute of the `terragrunt.hcl` file in the module directory → `download_dir` attribute of the included
 `terragrunt.hcl`.
 
@@ -177,7 +177,7 @@ explicitly redefined in the current's module `terragrunt.hcl` file.
 
 The `iam_role` attribute can be used to specify an IAM role that Terragrunt should assume before invoking OpenTofu/Terraform.
 
-The precedence is as follows: `--terragrunt-iam-role` command line option → `TERRAGRUNT_IAM_ROLE` env variable →
+The precedence is as follows: `--iam-role` command line option → `TERRAGRUNT_IAM_ROLE` env variable →
 `iam_role` attribute of the `terragrunt.hcl` file in the module directory → `iam_role` attribute of the included
 `terragrunt.hcl`.
 
@@ -198,7 +198,7 @@ iam_role = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
 
 The `iam_assume_role_duration` attribute can be used to specify the STS session duration, in seconds, for the IAM role that Terragrunt should assume before invoking OpenTofu/Terraform.
 
-The precedence is as follows: `--terragrunt-iam-assume-role-duration` command line option → `TERRAGRUNT_IAM_ASSUME_ROLE_DURATION` env variable →
+The precedence is as follows: `--iam-assume-role-duration` command line option → `TERRAGRUNT_IAM_ASSUME_ROLE_DURATION` env variable →
 `iam_assume_role_duration` attribute of the `terragrunt.hcl` file in the module directory → `iam_assume_role_duration` attribute of the included
 `terragrunt.hcl`.
 
@@ -214,7 +214,7 @@ iam_assume_role_duration = 14400
 
 The `iam_assume_role_session_name` attribute can be used to specify the STS session name, for the IAM role that Terragrunt should assume before running OpenTofu/Terraform.
 
-The precedence is as follows: `--terragrunt-iam-assume-role-session-name` command line option → `TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME` env variable →
+The precedence is as follows: `--iam-assume-role-session-name` command line option → `TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME` env variable →
 `iam_assume_role_session_name` attribute of the `terragrunt.hcl` file in the module directory → `iam_assume_role_session_name` attribute of the included
 `terragrunt.hcl`.
 
@@ -222,7 +222,7 @@ The precedence is as follows: `--terragrunt-iam-assume-role-session-name` comman
 
 The `iam_web_identity_token` attribute can be used along with `iam_role` to assume a role using AssumeRoleWithWebIdentity. `iam_web_identity_token` can be set to either the token value (typically using `get_env()`), or the path to a file on disk.
 
-The precedence is as follows: `--terragrunt-iam-web-identity-token` command line option → `TERRAGRUNT_IAM_ASSUME_ROLE_WEB_IDENTITY_TOKEN` env variable →
+The precedence is as follows: `--iam-web-identity-token` command line option → `TERRAGRUNT_IAM_ASSUME_ROLE_WEB_IDENTITY_TOKEN` env variable →
 `iam_web_identity_token` attribute of the `terragrunt.hcl` file in the module directory → `iam_web_identity_token` attribute of the included
 `terragrunt.hcl`.
 
@@ -268,7 +268,7 @@ iam_web_identity_token = "/path/to/token/file"
 The terragrunt `terraform_binary` string option can be used to override the default binary Terragrunt calls (which is
 `tofu`).
 
-The precedence is as follows: `--terragrunt-tfpath` command line option → `TERRAGRUNT_TFPATH` env variable →
+The precedence is as follows: `--tf-path` command line option → `TERRAGRUNT_TFPATH` env variable →
 `terragrunt.hcl` in the module directory → included `terragrunt.hcl`
 
 ## terraform_version_constraint

--- a/docs-starlight/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -712,10 +712,10 @@ remote_state {
 }
 ```
 
-If the command you are running has the potential to output sensitive values, you may wish to redact the output from appearing in the terminal. To do so, use the special `--terragrunt-quiet` argument which must be passed as one of the first arguments to `run_cmd()`:
+If the command you are running has the potential to output sensitive values, you may wish to redact the output from appearing in the terminal. To do so, use the special `--quiet` argument which must be passed as one of the first arguments to `run_cmd()`:
 
 ```hcl
-super_secret_value = run_cmd("--terragrunt-quiet", "./decrypt_secret.sh", "foo")
+super_secret_value = run_cmd("--quiet", "./decrypt_secret.sh", "foo")
 ```
 
 **Note:** This will prevent terragrunt from displaying the output from the command in its output. However, the value could still be displayed in the OpenTofu/Terraform output if OpenTofu/Terraform does not treat it as a [sensitive value](https://www.terraform.io/docs/configuration/outputs.html#sensitive-suppressing-values-in-cli-output).
@@ -767,10 +767,10 @@ carrot
 - Output contains multiple times `uuid3`, +1 more output comparing to `uuid1` and `uuid2` - because `uuid3` is declared in locals and inputs which add one more evaluation
 - Output contains only once `uuid4` since it is declared only once in `inputs`, `inputs` is not evaluated twice
 
-You can modify this caching behavior to ignore the existing directory if you know the command you are running is not dependent on the current directory path. To do so, use the special `--terragrunt-global-cache` argument which must be passed as one of the first arguments to `run_cmd()` (and can be combined with `--terragrunt-quiet` in any order):
+You can modify this caching behavior to ignore the existing directory if you know the command you are running is not dependent on the current directory path. To do so, use the special `--global-cache` argument which must be passed as one of the first arguments to `run_cmd()` (and can be combined with `--quiet` in any order):
 
 ```hcl
-value = run_cmd("--terragrunt-global-cache", "--terragrunt-quiet", "/usr/local/bin/get-account-map")
+value = run_cmd("--global-cache", "--quiet", "/usr/local/bin/get-account-map")
 ```
 
 ## read_terragrunt_config
@@ -896,7 +896,7 @@ inputs = merge(
 
 ## get_terragrunt_source_cli_flag
 
-`get_terragrunt_source_cli_flag()` returns the value passed in via the CLI `--terragrunt-source` or an environment variable `TERRAGRUNT_SOURCE`. Note that this will return an empty string when either of those values are not provided.
+`get_terragrunt_source_cli_flag()` returns the value passed in via the CLI `--source` or an environment variable `TERRAGRUNT_SOURCE`. Note that this will return an empty string when either of those values are not provided.
 
 This is useful for constructing before and after hooks, or TF flags that only apply to local development (e.g., setting up debug flags, or adjusting the `iam_role` parameter).
 
@@ -952,7 +952,7 @@ remote_state {
 
 ## mark_as_read
 
-`mark_as_read(file_path)` marks a file as read so that it can be picked up for inclusion by the [queue-include-units-reading](/docs/reference/cli-options/#terragrunt-queue-include-units-reading) flag.
+`mark_as_read(file_path)` marks a file as read so that it can be picked up for inclusion by the [queue-include-units-reading](/docs/reference/cli-options/#queue-include-units-reading) flag.
 
 This is useful for situations when you want to mark a file as read, but are not reading it using a native Terragrunt HCL function.
 

--- a/docs-starlight/src/content/docs/05-troubleshooting/01-debugging.mdx
+++ b/docs-starlight/src/content/docs/05-troubleshooting/01-debugging.mdx
@@ -12,15 +12,15 @@ Terragrunt and OpenTofu/Terraform usually play well together in helping you
 write DRY, reusable infrastructure. But how do we figure out what
 went wrong in the rare case that they _don't_ play well?
 
-Terragrunt provides a way to configure logging level through the `--terragrunt-log-level`
-command flag. Additionally, Terragrunt provides `--terragrunt-debug`, that can be used
+Terragrunt provides a way to configure logging level through the `--log-level`
+command flag. Additionally, Terragrunt provides `--debug-inputs`, that can be used
 to generate `terragrunt-debug.tfvars.json`.
 
 For example you could use it like this to debug an `apply` that's producing
 unexpected output:
 
 ```shell
-terragrunt apply --terragrunt-log-level debug --terragrunt-debug
+terragrunt apply --log-level debug --debug-inputs
 ```
 
 Running this command will do two things for you:
@@ -94,7 +94,7 @@ elements, but you know that the cluster only has 4 VMs in it! What's happening?
 Let's figure it out. Run this:
 
 ```shell
-terragrunt apply --terragrunt-log-level debug --terragrunt-debug
+terragrunt apply --log-level debug --debug-inputs
 ```
 
 After applying, you will see this output on standard error


### PR DESCRIPTION
## Description

Closes the gap a bit with the docs update here:
https://github.com/gruntwork-io/terragrunt/pull/3723

There's still some delta that needs to be addressed, but for now this brings the docs rewrite closer to what the docs will look like when the CLI Redesign PR is merged.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `docs-starlight` to use flags from the CLI Redesign PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised command-line flag names and usage examples for improved clarity.
  - Streamlined terminology across configuration, debugging, authentication, caching, and other command options.
  - Enhanced documentation readability and consistency throughout various guides and reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->