### PR TITLE
feat: added self-hosted gitlab to catalog command

### DIFF
--- a/cli/commands/catalog/module/repo.go
+++ b/cli/commands/catalog/module/repo.go
@@ -26,6 +26,7 @@ const (
 	gitlabHost            = "gitlab.com"
 	azuredevHost          = "dev.azure.com"
 	bitbucketHost         = "bitbucket.org"
+	gitlabSelfHostedRegex = `^(gitlab\.(.+))$`
 )
 
 var (
@@ -125,6 +126,7 @@ func (repo *Repo) FindModules(ctx context.Context) (Modules, error) {
 }
 
 var githubEnterprisePatternReg = regexp.MustCompile(githubEnterpriseRegex)
+var gitlabSelfHostedPatternReg = regexp.MustCompile(gitlabSelfHostedRegex)
 
 // ModuleURL returns the URL of the module in this repository. `moduleDir` is the path from the repository root.
 func (repo *Repo) ModuleURL(moduleDir string) (string, error) {
@@ -152,6 +154,10 @@ func (repo *Repo) ModuleURL(moduleDir string) (string, error) {
 	// // Hosts that require special handling
 	if githubEnterprisePatternReg.MatchString(string(remote.Host)) {
 		return fmt.Sprintf("https://%s/%s/tree/%s/%s", remote.Host, remote.FullName, repo.BranchName, moduleDir), nil
+	}
+
+	if gitlabSelfHostedPatternReg.MatchString(string(remote.Host)) {
+		return fmt.Sprintf("https://%s/%s/-/tree/%s/%s", remote.Host, remote.FullName, repo.BranchName, moduleDir), nil
 	}
 
 	return "", errors.Errorf("hosting: %q is not supported yet", remote.Host)

--- a/cli/commands/catalog/module/repo_test.go
+++ b/cli/commands/catalog/module/repo_test.go
@@ -120,6 +120,13 @@ func TestModuleURL(t *testing.T) {
 			nil,
 		},
 		{
+			"gitlab self-hosted",
+			newRepo(t, "https://gitlab.acme.com/acme/terraform-aws-modules"),
+			".",
+			"https://gitlab.acme.com/acme/terraform-aws-modules/-/tree/main/.",
+			nil,
+		},
+		{
 			"bitbucket",
 			newRepo(t, "https://bitbucket.org/acme/terraform-aws-modules"),
 			".",


### PR DESCRIPTION
## Description

Fixes #3800.

This PR just adds a regex for "self-hosted gitlab" matching any domain that begins with `gitlab.`. The regex could probably be a bit better, but I just kept it consistent with the github enterprise regex because it also worked for my self-hosted instance.

I've attached screenshots of the catalog command working with my self-hosted gitlab, although there isn't anything in the TUI that shows that so you'll have to take my word for it.

<img width="1151" alt="Screenshot 2025-02-10 at 1 56 53 PM" src="https://github.com/user-attachments/assets/6f4e44d3-7015-4ee0-986e-874c89a03232" />
<img width="2242" alt="Screenshot 2025-02-10 at 1 57 31 PM" src="https://github.com/user-attachments/assets/cc6d7912-c7d4-47d6-8a15-18f0237a047d" />

Something to note: for my specific, self-hosted gitlab repo, I'm using git submodules for all terraform/tofu modules under the `modules` directory.  Subsequent executions of the catalog command are failing.  Seems that go-getter can successfully clone the repo and pull the submodules on the first execution, but for whatever reason it's failing afterwards with this:
```txt
19:08:52.408 INFO   Cloning repository "git::https://gitlab.self-hosted.com/terraform/meta?ref=main" to temporary directory "/tmp/catalog4d474a6d6732674d7a5a4e565f7658416230364d36756f44367a45/meta"
19:08:57.524 ERROR  error downloading 'https://gitlab.self-hosted.com/terraform/meta?ref=HEAD': /usr/local/bin/git exited with 128: fatal: not a git repository: modules/cert-manager/../../.git/modules/cert-manager

19:08:57.526 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
```
Upon inspecting the .git folder of the repo, it doesn't have the modules folder as it should.  This is a separate issue that I can file and potentially look into.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs. (There wasn't anything specific for the catalog command for github enterprise so I didn't add anything for self-hosted gitlab either).
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated the `catalog` command to accept self-hosted GitLab URLs.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded support for GitLab by enabling correct URL generation for self-hosted GitLab repositories alongside standard ones.
  
- **Tests**
  - Added a test case to verify proper URL formatting for self-hosted GitLab instances, ensuring reliable functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->