### PR TITLE
fix: Fixing CLI option for `--queue-include-unit-reading`

### DIFF
--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -1539,14 +1539,14 @@ passed in, the set will be the union of modules that includes at least one of th
 **NOTE**: When using relative paths, the paths are relative to the working directory. This is either the current working
 directory, or any path passed in to [working-dir](#working-dir).
 
-**TIP**: This flag is functionally covered by the `--terragrunt-queue-include-units-reading` flag, but is more explicitly
+**TIP**: This flag is functionally covered by the `--queue-include-units-reading` flag, but is more explicitly
 only for the `include` configuration block.
 
-### terragrunt-queue-include-units-reading
+### queue-include-units-reading
 
-**CLI Arg**: `--terragrunt-queue-include-units-reading`<br/>
+**CLI Arg**: `--queue-include-units-reading`<br/>
 **Environment Variable**: `TERRAGRUNT_QUEUE_INCLUDE_UNITS_READING`<br/>
-**CLI Arg Alias**: `` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
+**CLI Arg Alias**: `--terragrunt-queue-include-units-reading` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
 **Environment Variable Alias**: `` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
 **Commands**:
 


### PR DESCRIPTION
## Description

We renamed this flag, but didn't update the docs for it.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `queue-include-units-reading` in cli-options.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated CLI options documentation to reflect new naming conventions.
  - Renamed a primary command-line argument and adjusted its alias.
  - Marked the previous environment variable alias as deprecated for a smoother transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->