### PR TITLE
feat: Redesign CLI help

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -219,7 +219,7 @@ func TerragruntCommands(opts *options.TerragruntOptions) cli.Commands {
 	}.SetCategory(
 		&cli.Category{
 			Name:  MainCommandsCategoryName,
-			Order: 10,
+			Order: 10, //nolint: mnd
 		},
 	)
 
@@ -229,7 +229,7 @@ func TerragruntCommands(opts *options.TerragruntOptions) cli.Commands {
 	}.SetCategory(
 		&cli.Category{
 			Name:  CatalogCommandsCategoryName,
-			Order: 20,
+			Order: 20, //nolint: mnd
 		},
 	)
 
@@ -248,14 +248,14 @@ func TerragruntCommands(opts *options.TerragruntOptions) cli.Commands {
 	}.SetCategory(
 		&cli.Category{
 			Name:  ConfigurationCommandsCategoryName,
-			Order: 30,
+			Order: 30, //nolint: mnd
 		},
 	)
 
 	shortcutsCommands := commands.NewShortcutsCommands(opts).SetCategory(
 		&cli.Category{
 			Name:  ShortcutsCommandsCategoryName,
-			Order: 40,
+			Order: 40, //nolint: mnd
 		},
 	)
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -54,6 +54,14 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
 )
 
+// Command category names.
+const (
+	MainCommandsCategoryName          = "Main commands"
+	CatalogCommandsCategoryName       = "Catalog commands"
+	ConfigurationCommandsCategoryName = "Configuration commands"
+	ShortcutsCommandsCategoryName     = "OpenTofu shortcuts"
+)
+
 func init() {
 	cli.AppVersionTemplate = AppVersionTemplate
 	cli.AppHelpTemplate = AppHelpTemplate
@@ -69,7 +77,7 @@ type App struct {
 func NewApp(opts *options.TerragruntOptions) *App {
 	app := cli.NewApp()
 	app.Name = "terragrunt"
-	app.Usage = "Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale. For documentation, see https://terragrunt.gruntwork.io/."
+	app.Usage = "Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale.\nFor documentation, see https://terragrunt.gruntwork.io/."
 	app.Author = "Gruntwork <www.gruntwork.io>"
 	app.Version = version.GetVersion()
 	app.Writer = opts.Writer
@@ -142,7 +150,7 @@ func (app *App) RunContext(ctx context.Context, args []string) error {
 	return nil
 }
 
-// GlobalFlags returns global flags. For backward compatibility, the slice contains flags that have been moved to other commands and are hidden from the CLI help,
+// GlobalFlags returns global flags. For backward compatibility, the slice contains flags that have been moved to other commands and are hidden from the CLI help.
 func GlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 	globalFlags := global.NewFlags(opts, nil)
 
@@ -158,17 +166,17 @@ func GlobalFlags(opts *options.TerragruntOptions) cli.Flags {
 		graph.NewCommand(opts),              // graph
 	}
 
-	var knownFlags []string
+	var seen []string
 
 	for _, cmd := range commands {
 		for _, flag := range cmd.Flags {
 			flagName := util.FirstElement(util.RemoveEmptyElements(flag.Names()))
 
-			if slices.Contains(knownFlags, flagName) {
+			if slices.Contains(seen, flagName) {
 				continue
 			}
 
-			knownFlags = append(knownFlags, flagName)
+			seen = append(seen, flagName)
 			globalFlags = append(globalFlags, flags.NewMovedFlag(flag, cmd.Name, flags.StrictControlsByMovedGlobalFlags(opts.StrictControls, cmd.Name)))
 		}
 	}
@@ -202,30 +210,62 @@ func removeNoColorFlagDuplicates(args []string) []string {
 
 // TerragruntCommands returns the set of Terragrunt commands.
 func TerragruntCommands(opts *options.TerragruntOptions) cli.Commands {
-	cmds := cli.Commands{
-		runCmd.NewCommand(opts),             // run
-		runall.NewCommand(opts),             // runAction-all
-		terragruntinfo.NewCommand(opts),     // terragrunt-info
-		validateinputs.NewCommand(opts),     // validate-inputs
-		graphdependencies.NewCommand(opts),  // graph-dependencies
-		hclfmt.NewCommand(opts),             // hclfmt
-		renderjson.NewCommand(opts),         // render-json
-		awsproviderpatch.NewCommand(opts),   // aws-provider-patch
-		outputmodulegroups.NewCommand(opts), // output-module-groups
-		catalog.NewCommand(opts),            // catalog
-		scaffold.NewCommand(opts),           // scaffold
-		stack.NewCommand(opts),              // stack
-		graph.NewCommand(opts),              // graph
-		hclvalidate.NewCommand(opts),        // hclvalidate
-		execCmd.NewCommand(opts),            // exec
-		helpCmd.NewCommand(opts),            // help
-		versionCmd.NewCommand(opts),         // version
-		info.NewCommand(opts),               // info
-	}
-	cmds = append(cmds, commands.NewShortcutsCommands(opts)...)
-	cmds = append(cmds, commands.NewDeprecatedCommands(opts)...)
+	mainCommands := cli.Commands{
+		runall.NewCommand(opts),  // run-all
+		runCmd.NewCommand(opts),  // run
+		stack.NewCommand(opts),   // stack
+		graph.NewCommand(opts),   // graph
+		execCmd.NewCommand(opts), // exec
+	}.SetCategory(
+		&cli.Category{
+			Name:  MainCommandsCategoryName,
+			Order: 10,
+		},
+	)
 
-	return cmds
+	catalogCommands := cli.Commands{
+		catalog.NewCommand(opts),  // catalog
+		scaffold.NewCommand(opts), // scaffold
+	}.SetCategory(
+		&cli.Category{
+			Name:  CatalogCommandsCategoryName,
+			Order: 20,
+		},
+	)
+
+	configurationCommands := cli.Commands{
+		graphdependencies.NewCommand(opts),  // graph-dependencies
+		outputmodulegroups.NewCommand(opts), // output-module-groups
+		validateinputs.NewCommand(opts),     // validate-inputs
+		hclvalidate.NewCommand(opts),        // hclvalidate
+		hclfmt.NewCommand(opts),             // hclfmt
+		info.NewCommand(opts),               // info
+		terragruntinfo.NewCommand(opts),     // terragrunt-info
+		renderjson.NewCommand(opts),         // render-json
+		helpCmd.NewCommand(opts),            // help (hidden)
+		versionCmd.NewCommand(opts),         // version (hidden)
+		awsproviderpatch.NewCommand(opts),   // aws-provider-patch (hidden)
+	}.SetCategory(
+		&cli.Category{
+			Name:  ConfigurationCommandsCategoryName,
+			Order: 30,
+		},
+	)
+
+	shortcutsCommands := commands.NewShortcutsCommands(opts).SetCategory(
+		&cli.Category{
+			Name:  ShortcutsCommandsCategoryName,
+			Order: 40,
+		},
+	)
+
+	allCommands := mainCommands.
+		Merge(catalogCommands...).
+		Merge(configurationCommands...).
+		Merge(shortcutsCommands...).
+		Merge(commands.NewDeprecatedCommands(opts)...)
+
+	return allCommands
 }
 
 // WrapWithTelemetry wraps CLI command execution with setting of telemetry context and labels, if telemetry is disabled, just runAction the command.

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -543,7 +543,7 @@ func TestAutocomplete(t *testing.T) { //nolint:paralleltest
 	}{
 		{
 			"",
-			[]string{"aws-provider-patch", "graph-dependencies", "hclfmt", "output-module-groups", "render-json", "run-all", "terragrunt-info", "validate-inputs"},
+			[]string{"graph-dependencies", "hclfmt", "output-module-groups", "render-json", "run-all", "terragrunt-info", "validate-inputs"},
 		},
 		{
 			"--versio",
@@ -566,7 +566,7 @@ func TestAutocomplete(t *testing.T) { //nolint:paralleltest
 		opts := options.NewTerragruntOptionsWithWriters(output, os.Stderr)
 		app := cli.NewApp(opts)
 
-		app.Commands = app.Commands.Filter([]string{"aws-provider-patch", "graph-dependencies", "hclfmt", "output-module-groups", "render-json", "run-all", "terragrunt-info", "validate-inputs"})
+		app.Commands = app.Commands.FilterByNames([]string{"graph-dependencies", "hclfmt", "output-module-groups", "render-json", "run-all", "terragrunt-info", "validate-inputs"})
 
 		err := app.Run([]string{"terragrunt"})
 		require.NoError(t, err)

--- a/cli/commands/aws-provider-patch/command.go
+++ b/cli/commands/aws-provider-patch/command.go
@@ -64,6 +64,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 	return &cli.Command{
 		Name:   CommandName,
 		Usage:  "Overwrite settings on nested AWS providers to work around a Terraform bug (issue #13018).",
+		Hidden: true,
 		Flags:  append(run.NewFlags(opts, nil), NewFlags(opts, nil)...).Sort(),
 		Action: func(ctx *cli.Context) error { return Run(ctx, opts.OptionsFromContext(ctx)) },
 	}

--- a/cli/help.go
+++ b/cli/help.go
@@ -1,24 +1,20 @@
 package cli
 
-const AppHelpTemplate = `NAME:
-   {{$v := offset .App.HelpName 6}}{{wrap .App.HelpName 3}}{{if .App.Usage}} - {{wrap .App.Usage $v}}{{end}}
+const AppHelpTemplate = `Usage: {{ if .App.UsageText }}{{ wrap .App.UsageText 3 }}{{ else }}{{ .App.HelpName }} [global options] <command> [options]{{ end }}{{ $description := .App.Usage }}{{ if .App.Description }}{{ $description = .App.Description }}{{ end }}{{ if $description }}
 
-USAGE:
-   {{if .App.UsageText}}{{wrap .App.UsageText 3}}{{else}}{{.App.HelpName}} <command> [options]{{end}} {{if .App.Description}}
+   {{ wrap $description 3 }}{{ end }}{{ $commands := .App.VisibleCommands }}{{ if $commands }}{{ $cv := offsetCommands $commands 5 }}
+{{ $categories := $commands.GetCategories.Sort }}{{ range $index, $category := $categories }}{{ $categoryCommands := $commands.FilterByCategory $category }}{{ if $index }}
+{{ end }}
+{{ $category.Name }}:{{ range $categoryCommands }}
+   {{ $s := .HelpName }}{{ $s }}{{ $sp := subtract $cv (offset $s 3) }}{{ indent $sp ""}} {{ wrap .Usage $cv }}{{ end }}{{ end }}{{ end }}{{ if .App.VisibleFlags }}
 
-DESCRIPTION:
-   {{wrap .App.Description 3}}{{end}}{{if .App.VisibleCommands}}
+Global Options:
+   {{ range $index, $option := .App.VisibleFlags }}{{ if $index }}
+   {{ end }}{{ wrap $option.String 6 }}{{ end }}{{ end }}{{ if not .App.HideVersion }}
 
-COMMANDS:{{ $cv := offsetCommands .App.VisibleCommands 5}}{{range .App.VisibleCommands}}
-   {{$s := .HelpName}}{{$s}}{{ $sp := subtract $cv (offset $s 3) }}{{ indent $sp ""}} {{wrap .Usage $cv}}{{end}}{{end}}
+Version: {{ .App.Version }}{{ end }}{{ if len .App.Authors }}
 
-GLOBAL OPTIONS:{{if .App.VisibleFlags}}
-   {{range $index, $option := .App.VisibleFlags}}{{if $index}}
-   {{end}}{{wrap $option.String 6}}{{end}}{{end}}{{if not .App.HideVersion}}
-
-VERSION: {{.App.Version}}{{if len .App.Authors}}{{end}}
-
-AUTHOR: {{range .App.Authors}}{{.}}{{end}} {{end}}
+Author: {{ range .App.Authors }}{{ . }}{{ end }} {{ end }}
 `
 
 const CommandHelpTemplate = `Usage: {{if .Command.UsageText}}{{wrap .Command.UsageText 3}}{{else}}{{range $parent := parentCommands . }}{{$parent.HelpName}} {{end}}{{.Command.HelpName}}{{if .Command.VisibleSubcommands}} <command>{{end}}{{if .Command.VisibleFlags}} [options]{{end}}{{end}}{{$description := .Command.Usage}}{{if .Command.Description}}{{$description = .Command.Description}}{{end}}{{if $description}}

--- a/cli/help.go
+++ b/cli/help.go
@@ -1,5 +1,6 @@
 package cli
 
+// AppHelpTemplate is the main CLI help template.
 const AppHelpTemplate = `Usage: {{ if .App.UsageText }}{{ wrap .App.UsageText 3 }}{{ else }}{{ .App.HelpName }} [global options] <command> [options]{{ end }}{{ $description := .App.Usage }}{{ if .App.Description }}{{ $description = .App.Description }}{{ end }}{{ if $description }}
 
    {{ wrap $description 3 }}{{ end }}{{ $commands := .App.VisibleCommands }}{{ if $commands }}{{ $cv := offsetCommands $commands 5 }}
@@ -17,6 +18,7 @@ Version: {{ .App.Version }}{{ end }}{{ if len .App.Authors }}
 Author: {{ range .App.Authors }}{{ . }}{{ end }} {{ end }}
 `
 
+// CommandHelpTemplate is the command CLI help template.
 const CommandHelpTemplate = `Usage: {{if .Command.UsageText}}{{wrap .Command.UsageText 3}}{{else}}{{range $parent := parentCommands . }}{{$parent.HelpName}} {{end}}{{.Command.HelpName}}{{if .Command.VisibleSubcommands}} <command>{{end}}{{if .Command.VisibleFlags}} [options]{{end}}{{end}}{{$description := .Command.Usage}}{{if .Command.Description}}{{$description = .Command.Description}}{{end}}{{if $description}}
 
    {{wrap $description 3}}{{end}}{{if .Command.Examples}}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -151,7 +151,7 @@ func (app *App) VisibleFlags() Flags {
 }
 
 // VisibleCommands returns a slice of the Commands used for help.
-func (app *App) VisibleCommands() []*cli.Command {
+func (app *App) VisibleCommands() Commands {
 	if app.Commands == nil {
 		return nil
 	}

--- a/internal/cli/category.go
+++ b/internal/cli/category.go
@@ -31,7 +31,7 @@ func (categories Categories) Less(i, j int) bool {
 	return categories[i].Order < categories[j].Order
 }
 
-// Swan implements `sort.Interface` interface.
+// Swap implements `sort.Interface` interface.
 func (categories Categories) Swap(i, j int) {
 	categories[i], categories[j] = categories[j], categories[i]
 }

--- a/internal/cli/category.go
+++ b/internal/cli/category.go
@@ -1,0 +1,44 @@
+package cli
+
+import "sort"
+
+// Category represents a command category used to group commands when displaying them.
+type Category struct {
+	// Name is the name of the category.
+	Name string
+	// Order is a number indicating the order in the category list.
+	Order uint
+}
+
+// String implements `fmt.Stringer` interface.
+func (category *Category) String() string {
+	return category.Name
+}
+
+type Categories []*Category
+
+// Len implements `sort.Interface` interface.
+func (categories Categories) Len() int {
+	return len(categories)
+}
+
+// Less implements `sort.Interface` interface.
+func (categories Categories) Less(i, j int) bool {
+	if categories[i].Order == categories[j].Order {
+		return categories[i].Name < categories[j].Name
+	}
+
+	return categories[i].Order < categories[j].Order
+}
+
+// Swan implements `sort.Interface` interface.
+func (categories Categories) Swap(i, j int) {
+	categories[i], categories[j] = categories[j], categories[i]
+}
+
+// Sort returns `categories` in sorted order.
+func (categories Categories) Sort() Categories {
+	sort.Sort(categories)
+
+	return categories
+}

--- a/internal/cli/category.go
+++ b/internal/cli/category.go
@@ -15,6 +15,7 @@ func (category *Category) String() string {
 	return category.Name
 }
 
+// Categories is a slice of `Category`.
 type Categories []*Category
 
 // Len implements `sort.Interface` interface.

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	libflag "flag"
 	"strings"
-
-	"github.com/urfave/cli/v2"
 )
 
 const errFlagUndefined = "flag provided but not defined:"
@@ -23,6 +21,8 @@ type Command struct {
 	Description string
 	// Examples is list of examples of using the command in the help.
 	Examples []string
+	// Category is the category the command belongs to.
+	Category *Category
 	// Flags is list of flags to parse.
 	Flags Flags
 	// ErrorOnUndefinedFlag causes the application to exit and return an error on any undefined flag.
@@ -90,7 +90,7 @@ func (cmd *Command) VisibleFlags() Flags {
 
 // VisibleSubcommands returns a slice of the Commands with Hidden=false.
 // Used by `urfave/cli` package to generate help.
-func (cmd *Command) VisibleSubcommands() []*cli.Command {
+func (cmd *Command) VisibleSubcommands() Commands {
 	if cmd.Subcommands == nil {
 		return nil
 	}

--- a/internal/cli/command_test.go
+++ b/internal/cli/command_test.go
@@ -297,15 +297,15 @@ func TestCommandVisibleSubcommand(t *testing.T) {
 
 	testCases := []struct {
 		command  cli.Command
-		expected []*urfaveCli.Command
+		expected cli.Commands
 	}{
 		{
 			cli.Command{Name: "foo", Subcommands: cli.Commands{&cli.Command{Name: "bar"}, &cli.Command{Name: "baz", HelpName: "helpBaz"}}},
-			[]*urfaveCli.Command{{Name: "bar", HelpName: "bar"}, {Name: "baz", HelpName: "helpBaz"}},
+			cli.Commands{{Name: "bar", HelpName: "bar"}, {Name: "baz", HelpName: "helpBaz"}},
 		},
 		{
 			cli.Command{Name: "foo", Subcommands: cli.Commands{&cli.Command{Name: "bar", Hidden: true}, &cli.Command{Name: "baz"}}},
-			[]*urfaveCli.Command{{Name: "baz", HelpName: "baz"}},
+			cli.Commands{{Name: "baz", HelpName: "baz"}},
 		},
 	}
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"sort"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 type Commands []*Command
@@ -39,6 +39,7 @@ func (commands Commands) FilterByNames(names []string) Commands {
 	return filtered
 }
 
+// FilterByCategory returns a list of commands filtered by the given `categories`.
 func (commands Commands) FilterByCategory(categories ...*Category) Commands {
 	var filtered Commands
 
@@ -117,6 +118,7 @@ func (commands Commands) SetCategory(category *Category) Commands {
 	return commands
 }
 
+// GetCategories returns unique categories commands.
 func (commands Commands) GetCategories() Categories {
 	var categories Categories
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -102,27 +102,16 @@ func parentCommands(ctx *Context) Commands {
 	return cmds
 }
 
-// this function tries to find the max width of the names column
-// so say we have the following rows for help
-//
-//	foo1, foo2, foo3  some string here
-//	bar1, b2 some other string here
-//
-// We want to offset the 2nd row usage by some amount so that everything
-// is aligned
-//
-//	foo1, foo2, foo3  some string here
-//	bar1, b2          some other string here
-//
-// to find that offset we find the length of all the rows and use the max
-// to calculate the offset
+// offsetCommands tries to find the max width of the names column.
 func offsetCommands(cmds Commands, fixed int) int {
-	var max int = 0
+	var max = 0
+
 	for _, cmd := range cmds {
 		s := strings.Join(cmd.Names(), ", ")
 		if len(s) > max {
 			max = len(s)
 		}
 	}
+
 	return max + fixed
 }

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -104,14 +104,14 @@ func parentCommands(ctx *Context) Commands {
 
 // offsetCommands tries to find the max width of the names column.
 func offsetCommands(cmds Commands, fixed int) int {
-	var max = 0
+	var width = 0
 
 	for _, cmd := range cmds {
 		s := strings.Join(cmd.Names(), ", ")
-		if len(s) > max {
-			max = len(s)
+		if len(s) > width {
+			width = len(s)
 		}
 	}
 
-	return max + fixed
+	return width + fixed
 }


### PR DESCRIPTION
## Description

Redesign main CLI help. 

#### New view

```
Usage: terragrunt [global options] <command> [options]

   Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale.
   For documentation, see https://terragrunt.gruntwork.io/.

Main commands:
   exec                   Execute an arbitrary command.
   graph                  Execute commands on the full graph of dependent modules for the current module, ensuring correct execution order.
   run                    Run an OpenTofu/Terraform command.
   run-all                Run a terraform command against a 'stack' by running the specified command in each subfolder.
   stack                  Terragrunt stack commands.

Catalog commands:
   catalog                Launch the user interface for searching and managing your module catalog.
   scaffold               Scaffold a new Terragrunt module.

Configuration commands:
   graph-dependencies     Prints the terragrunt dependency graph to stdout.
   hclfmt                 Recursively find hcl files and rewrite them into a canonical format.
   hclvalidate            Find all hcl files from the config stack and validate them.
   info                   List of commands to display Terragrunt settings.
   output-module-groups   Output groups of modules ordered by command (apply or destroy) as a list of list in JSON (useful for CI use cases).
   render-json            Render the final terragrunt config, with all variables, includes, and functions resolved, as json.
   terragrunt-info        Emits limited terragrunt state on stdout and exits.
   validate-inputs        Checks if the terragrunt configured inputs align with the terraform defined variables.

OpenTofu shortcuts:
   apply                  Create or update infrastructure.
   destroy                Destroy previously-created infrastructure.
   force-unlock           Release a stuck lock on the current workspace.
   import                 Associate existing infrastructure with a OpenTofu/Terraform resource.
   init                   Prepare your working directory for other commands.
   output                 Show output values from your root module.
   plan                   Show changes required by the current configuration.
   refresh                Update the state to match remote systems.
   show                   Show the current state or a saved plan.
   state                  Advanced state management.
   test                   Execute integration tests for OpenTofu/Terraform modules.
   validate               Check whether the configuration is valid.

Global Options:
   --experiment value         Enables specific experiments. For a list of available experiments, see https://terragrunt.gruntwork.io/docs/reference/experiment-mode . [$TG_EXPERIMENT]
   --experiment-mode          Enables experiment mode for Terragrunt. For more information, see https://terragrunt.gruntwork.io/docs/reference/experiment-mode . [$TG_EXPERIMENT_MODE]
   --log-custom-format value  Set the custom log formatting. [$TG_LOG_CUSTOM_FORMAT]
   --log-disable              Disable logging. [$TG_LOG_DISABLE]
   --log-format value         Set the log format. [$TG_LOG_FORMAT]
   --log-level value          Sets the logging level for Terragrunt. Supported levels: stderr, stdout, error, warn, info, debug, trace. (default: trace) [$TG_LOG_LEVEL]
   --log-show-abs-paths       Show absolute paths in logs. (default: false) [$TG_LOG_SHOW_ABS_PATHS]
   --no-color                 Disable color output. [$TG_NO_COLOR]
   --non-interactive          Assume "yes" for all prompts. (default: false) [$TG_NON_INTERACTIVE]
   --strict-control value     Enables specific strict controls. For a list of available controls, run 'terragrunt info strict'. [$TG_STRICT_CONTROL]
   --strict-mode              Enables strict mode for Terragrunt. For more information, run 'terragrunt info strict'. [$TG_STRICT_MODE]
   --working-dir value        The path to the directory of Terragrunt configurations. Default is current directory. [$TG_WORKING_DIR]
   --help, -h                 Show help.
   --version, -v              Show terragrunt version.

Version: latest

Author: Gruntwork <www.gruntwork.io>
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced intuitive CLI command categorization for easier navigation.
  - Updated autocomplete functionality to display a refined set of commands.
  - Enhanced help output with improved formatting and organization.
- **Refactor**
  - Streamlined command filtering and organization for better future scalability.
- **Tests**
  - Revised autocomplete tests to match the updated command filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->