### PR TITLE
refactor: replace `golang.org/x/exp` with stdlib

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-
 	"slices"
+	"strings"
 
 	"github.com/gruntwork-io/terragrunt/engine"
 	"github.com/gruntwork-io/terragrunt/internal/os/exec"

--- a/cli/commands/run/creds/getter.go
+++ b/cli/commands/run/creds/getter.go
@@ -3,10 +3,10 @@ package creds
 
 import (
 	"context"
+	"maps"
 
 	"github.com/gruntwork-io/terragrunt/cli/commands/run/creds/providers"
 	"github.com/gruntwork-io/terragrunt/options"
-	"golang.org/x/exp/maps"
 )
 
 type Getter struct {

--- a/cli/commands/run/creds/providers/externalcmd/provider.go
+++ b/cli/commands/run/creds/providers/externalcmd/provider.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/cli/commands/run/creds/providers"
@@ -12,7 +13,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
-	"golang.org/x/exp/maps"
 )
 
 // Provider runs external command that returns a json string with credentials.

--- a/cli/flags/flag_opts.go
+++ b/cli/flags/flag_opts.go
@@ -2,7 +2,6 @@ package flags
 
 import (
 	"fmt"
-
 	"slices"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli"

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,33 @@ go 1.23
 
 require (
 	cloud.google.com/go/storage v1.50.0
+	dario.cat/mergo v1.0.1
+	github.com/NYTimes/gziphandler v1.1.1
+	github.com/ProtonMail/go-crypto v1.1.5
 	github.com/aws/aws-sdk-go v1.55.6
+	github.com/aws/aws-sdk-go-v2 v1.36.1
+	github.com/charmbracelet/bubbles v0.20.0
+	github.com/charmbracelet/bubbletea v1.3.3
+	github.com/charmbracelet/glamour v0.8.0
+	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/creack/pty v1.1.24
 	github.com/fatih/structs v1.1.0
+	github.com/getsops/sops/v3 v3.9.4
+	github.com/gitsight/go-vcsurl v1.0.1
 	github.com/go-errors/errors v1.5.1
+	github.com/gofrs/flock v0.12.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/google/uuid v1.6.0
+	github.com/gruntwork-io/boilerplate v0.6.0
+	github.com/gruntwork-io/go-commons v0.17.2
+	github.com/gruntwork-io/terragrunt-engine-go v0.0.8
 	github.com/gruntwork-io/terratest v0.47.2
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-getter v1.7.8
+	github.com/hashicorp/go-getter/v2 v2.2.3
+	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-plugin v1.6.3
 	github.com/hashicorp/go-safetemp v1.0.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl/v2 v2.23.0
@@ -21,63 +39,25 @@ require (
 	// can't use terraform as a library after v0.15.3, so we pull that in here.
 	github.com/hashicorp/terraform v0.15.3
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210318070130-9a80970d6b34
-	github.com/mattn/go-zglob v0.0.6
-	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/mapstructure v1.5.0
-	github.com/sirupsen/logrus v1.9.3
-	github.com/stretchr/testify v1.10.0
-	github.com/zclconf/go-cty v1.16.2
-	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/oauth2 v0.26.0
-	golang.org/x/sync v0.11.0
-	golang.org/x/sys v0.30.0
-	google.golang.org/api v0.220.0
-)
-
-require (
-	cloud.google.com/go v0.118.2 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
-	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
-	github.com/hashicorp/vault/api v1.15.0 // indirect
-	github.com/klauspost/compress v1.17.11 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.1
-	github.com/pquerna/otp v1.4.0 // indirect
-	github.com/terraform-linters/tflint v0.55.0
-	github.com/ulikunitz/xz v0.5.12 // indirect
-	golang.org/x/time v0.10.0 // indirect
-	google.golang.org/genproto v0.0.0-20250204164813-702378808489 // indirect
-)
-
-require (
-	dario.cat/mergo v1.0.1
-	github.com/NYTimes/gziphandler v1.1.1
-	github.com/ProtonMail/go-crypto v1.1.5
-	github.com/aws/aws-sdk-go-v2 v1.36.1
-	github.com/charmbracelet/bubbles v0.20.0
-	github.com/charmbracelet/bubbletea v1.3.3
-	github.com/charmbracelet/glamour v0.8.0
-	github.com/charmbracelet/lipgloss v1.0.0
-	github.com/getsops/sops/v3 v3.9.4
-	github.com/gitsight/go-vcsurl v1.0.1
-	github.com/gofrs/flock v0.12.1
-	github.com/google/uuid v1.6.0
-	github.com/gruntwork-io/boilerplate v0.6.0
-	github.com/gruntwork-io/go-commons v0.17.2
-	github.com/gruntwork-io/terragrunt-engine-go v0.0.8
-	github.com/hashicorp/go-getter/v2 v2.2.3
-	github.com/hashicorp/go-hclog v1.6.3
-	github.com/hashicorp/go-plugin v1.6.3
 	github.com/hashicorp/terraform-svchost v0.1.1
 	github.com/huandu/go-clone v1.7.2
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/mattn/go-isatty v0.0.20
+	github.com/mattn/go-zglob v0.0.6
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-wordwrap v1.0.1
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3
 	github.com/puzpuzpuz/xsync/v3 v3.5.0
+	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.10.0
+	github.com/terraform-linters/tflint v0.55.0
 	github.com/urfave/cli/v2 v2.27.5
+	github.com/zclconf/go-cty v1.16.2
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.34.0
@@ -89,10 +69,13 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	golang.org/x/mod v0.23.0
+	golang.org/x/oauth2 v0.26.0
+	golang.org/x/sync v0.11.0
+	golang.org/x/sys v0.30.0
 	golang.org/x/term v0.29.0
 	golang.org/x/text v0.22.0
+	google.golang.org/api v0.220.0
 	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.5
 	gopkg.in/ini.v1 v1.67.0
@@ -103,6 +86,7 @@ require (
 	atomicgo.dev/keyboard v0.2.9 // indirect
 	atomicgo.dev/schedule v0.1.0 // indirect
 	cel.dev/expr v0.19.1 // indirect
+	cloud.google.com/go v0.118.2 // indirect
 	cloud.google.com/go/auth v0.14.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
@@ -196,13 +180,16 @@ require (
 	github.com/goware/prefixer v0.0.0-20160118172347-395022866408 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.9 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
+	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.4 // indirect
+	github.com/hashicorp/vault/api v1.15.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3 // indirect
@@ -210,6 +197,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jstemmer/go-junit-report v1.0.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/lib/pq v1.10.9 // indirect
@@ -231,6 +219,7 @@ require (
 	github.com/owenrumney/go-sarif v1.1.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20241121165744-79df5c4772f2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pquerna/otp v1.4.0 // indirect
 	github.com/pterm/pterm v0.12.80 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
@@ -244,6 +233,7 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/terraform-linters/tflint-plugin-sdk v0.22.0 // indirect
 	github.com/terraform-linters/tflint-ruleset-terraform v0.10.0 // indirect
+	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/urfave/cli v1.22.16 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
@@ -260,8 +250,12 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
+	golang.org/x/crypto v0.32.0 // indirect
+	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/net v0.34.0 // indirect
+	golang.org/x/time v0.10.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect
+	google.golang.org/genproto v0.0.0-20250204164813-702378808489 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250204164813-702378808489 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250204164813-702378808489 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/internal/cli/bool_flag_test.go
+++ b/internal/cli/bool_flag_test.go
@@ -4,6 +4,7 @@ import (
 	libflag "flag"
 	"fmt"
 	"io"
+	"maps"
 	"strconv"
 	"testing"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 )
 
 func TestBoolFlagApply(t *testing.T) {

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,9 +1,8 @@
 package cli
 
 import (
-	"strings"
-
 	"slices"
+	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/urfave/cli/v2"

--- a/internal/strict/category.go
+++ b/internal/strict/category.go
@@ -1,9 +1,8 @@
 package strict
 
 import (
-	"sort"
-
 	"slices"
+	"sort"
 )
 
 // Categories is multiple of DeprecatedFlag Category.

--- a/internal/strict/control.go
+++ b/internal/strict/control.go
@@ -2,10 +2,9 @@ package strict
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"strings"
-
-	"slices"
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )

--- a/internal/strict/controls/deprecated_env_var.go
+++ b/internal/strict/controls/deprecated_env_var.go
@@ -2,7 +2,6 @@ package controls
 
 import (
 	"context"
-
 	"slices"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli"

--- a/internal/strict/controls/deprecated_flag_name.go
+++ b/internal/strict/controls/deprecated_flag_name.go
@@ -2,7 +2,6 @@ package controls
 
 import (
 	"context"
-
 	"slices"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli"

--- a/pkg/log/format/format.go
+++ b/pkg/log/format/format.go
@@ -3,12 +3,13 @@ package format
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	. "github.com/gruntwork-io/terragrunt/pkg/log/format/options"      //nolint:stylecheck,revive
 	. "github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders" //nolint:stylecheck,revive
-	"golang.org/x/exp/maps"
 )
 
 const (
@@ -148,5 +149,5 @@ func ParseFormat(str string) (Placeholders, error) {
 		}
 	}
 
-	return nil, errors.Errorf("available values: %s", strings.Join(maps.Keys(presets), ","))
+	return nil, errors.Errorf("available values: %s", strings.Join(slices.Collect(maps.Keys(presets)), ","))
 }

--- a/pkg/log/format/options/color.go
+++ b/pkg/log/format/options/color.go
@@ -1,6 +1,8 @@
 package options
 
 import (
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -9,7 +11,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/mgutz/ansi"
 	"github.com/puzpuzpuz/xsync/v3"
-	"golang.org/x/exp/maps"
 )
 
 // ColorOptionName is the option name.
@@ -107,7 +108,7 @@ func (val *ColorList) Parse(str string) error {
 	}
 
 	if err := val.MapValue.Parse(str); err != nil {
-		return errors.Errorf("available values: 0..255,%s", strings.Join(maps.Values(val.list), ","))
+		return errors.Errorf("available values: 0..255,%s", strings.Join(slices.Collect(maps.Values(val.list)), ","))
 	}
 
 	return nil

--- a/pkg/log/format/options/common.go
+++ b/pkg/log/format/options/common.go
@@ -2,12 +2,12 @@ package options
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"golang.org/x/exp/maps"
 )
 
 type CommonOption[T comparable] struct {
@@ -111,8 +111,7 @@ func (val *MapValue[T]) Parse(str string) error {
 		}
 	}
 
-	list := maps.Values(val.list)
-	sort.Strings(list)
+	list := slices.Sorted(maps.Values(val.list))
 
 	return errors.Errorf("available values: %s", strings.Join(list, ","))
 }

--- a/pkg/log/format/options/time_format.go
+++ b/pkg/log/format/options/time_format.go
@@ -1,11 +1,10 @@
 package options
 
 import (
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/maps"
 )
 
 // TimeFormatOptionName is the option name.
@@ -83,11 +82,9 @@ func NewTimeFormatValue(list map[string]string) *TimeFormatValue {
 func (val TimeFormatValue) SortedKeys() []string {
 	keys := maps.Keys(val.list)
 
-	sort.Slice(keys, func(i, j int) bool {
-		return val.list[keys[i]] < val.list[keys[j]]
+	return slices.SortedFunc(keys, func(a, b string) int {
+		return strings.Compare(val.list[a], val.list[b])
 	})
-
-	return keys
 }
 
 func (val TimeFormatValue) Set(v string) *TimeFormatValue {

--- a/tf/getproviders/lock.go
+++ b/tf/getproviders/lock.go
@@ -8,11 +8,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
-
-	"slices"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/tf"


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

The experimental functions are now available in the standard library in Go 1.21 (https://go.dev/doc/go1.21#slices) and Go 1.23 (https://go.dev/doc/go1.23#iterators).

The difference is that `maps.Keys`/`maps.Values` in the `golang.org/x/exp/maps` package return a slice, whereas `maps.Keys`/`maps.Values` in the standard library return an iterator. To work with slices, we need to use `slices.Collect` to convert the iterator into a slice.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->

Replace `golang.org/x/exp` with stdlib

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restored essential string processing for consistent CLI output.

- **Refactor**
  - Migrated from experimental libraries to stable, built-in modules for slice and map operations.

- **Chores**
  - Streamlined dependency management and updated project dependencies for improved maintainability.

- **Tests**
  - Aligned test imports with the updated standard library usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->