### PR TITLE
fix: Fixing some stacks docs

### DIFF
--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -28,6 +28,7 @@ The commands relevant to managing a Terragrunt stack are:
 - [Stack commands](#stack-commands)
   - [stack generate](#stack-generate)
   - [stack run](#stack-run)
+  - [stack output](#stack-output)
 
 The commands relevant to managing an IaC catalog are:
 

--- a/docs/_docs/04_reference/06-experiments.md
+++ b/docs/_docs/04_reference/06-experiments.md
@@ -112,6 +112,8 @@ To transition the `stacks` feature to a stable release, the following must be ad
 
 - [x] Add support for `stack run *` command
 - [x] Add support for `stack output` commands to extend stack-level operations.
+- [ ] Add support for stack "values".
+- [ ] Add support for recursive stacks.
 - [ ] Integration testing for recursive stack handling across typical workflows, ensuring smooth transitions during `plan`, `apply`, and `destroy` operations.
 - [ ] Confirm compatibility with parallelism flags (e.g., `--parallel`), especially for stacks with dependencies.
 - [ ] Ensure that error handling and failure recovery strategies work as intended across large and nested stacks.


### PR DESCRIPTION
## Description

Fixes up some stacks docs.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated stacks docs.
