### PR TITLE
feat: Clean up TF commands help

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -459,9 +459,9 @@ func TestTerraformHelp(t *testing.T) {
 		args     []string
 		expected string
 	}{
-		{[]string{"terragrunt", tf.CommandNamePlan, "--help"}, "(?s)Usage: terragrunt plan.*-detailed-exitcode"},
-		{[]string{"terragrunt", tf.CommandNameApply, "-help"}, "(?s)Usage: terragrunt apply.*-destroy"},
-		{[]string{"terragrunt", tf.CommandNameApply, "-h"}, "(?s)Usage: terragrunt apply.*-destroy"},
+		{[]string{"terragrunt", tf.CommandNamePlan, "--help"}, "(?s)Usage: terragrunt \\[global options\\] plan.*-detailed-exitcode"},
+		{[]string{"terragrunt", tf.CommandNameApply, "-help"}, "(?s)Usage: terragrunt \\[global options\\] apply.*-destroy"},
+		{[]string{"terragrunt", tf.CommandNameApply, "-h"}, "(?s)Usage: terragrunt \\[global options\\] apply.*-destroy"},
 	}
 
 	for _, testCase := range testCases {

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/cli"
@@ -456,15 +455,13 @@ func TestTerragruntHelp(t *testing.T) {
 func TestTerraformHelp(t *testing.T) {
 	t.Parallel()
 
-	wrappedBinary := options.DefaultWrappedPath
-
 	testCases := []struct {
 		args     []string
 		expected string
 	}{
-		{[]string{"terragrunt", tf.CommandNamePlan, "--help"}, "Usage: " + wrappedBinary + " .* plan"},
-		{[]string{"terragrunt", tf.CommandNameApply, "-help"}, "Usage: " + wrappedBinary + " .* apply"},
-		{[]string{"terragrunt", tf.CommandNameApply, "-h"}, "Usage: " + wrappedBinary + " .* apply"},
+		{[]string{"terragrunt", tf.CommandNamePlan, "--help"}, "(?s)Usage: terragrunt plan.*-detailed-exitcode"},
+		{[]string{"terragrunt", tf.CommandNameApply, "-help"}, "(?s)Usage: terragrunt apply.*-destroy"},
+		{[]string{"terragrunt", tf.CommandNameApply, "-h"}, "(?s)Usage: terragrunt apply.*-destroy"},
 	}
 
 	for _, testCase := range testCases {
@@ -474,10 +471,7 @@ func TestTerraformHelp(t *testing.T) {
 		err := app.Run(testCase.args)
 		require.NoError(t, err)
 
-		expectedRegex, err := regexp.Compile(testCase.expected)
-		require.NoError(t, err)
-
-		assert.Regexp(t, expectedRegex, output.String())
+		assert.Regexp(t, testCase.expected, output.String())
 	}
 }
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -29,7 +29,7 @@ import (
 
 // Command category names.
 const (
-	// MainCommandsCategoryName represents primary Terragrunt operations like run, run-all.
+	// MainCommandsCategoryName represents primary Terragrunt operations like run, exec.
 	MainCommandsCategoryName = "Main commands"
 	// CatalogCommandsCategoryName represents commands for managing Terragrunt catalogs.
 	CatalogCommandsCategoryName = "Catalog commands"

--- a/cli/commands/help/command.go
+++ b/cli/commands/help/command.go
@@ -38,7 +38,7 @@ func Action(ctx *cli.Context, opts *options.TerragruntOptions) error {
 		}
 	}
 
-	if args.CommandName() == "" {
+	if cmdName := args.CommandName(); cmdName == "" || cmds.Get(cmdName) == nil {
 		return cli.ShowAppHelp(ctx)
 	}
 
@@ -58,7 +58,7 @@ func Action(ctx *cli.Context, opts *options.TerragruntOptions) error {
 	}
 
 	if ctx.Command != nil {
-		return cli.NewExitError(cli.ShowCommandHelp(ctx), cli.ExitCodeGeneralError)
+		return cli.ShowCommandHelp(ctx)
 	}
 
 	return cli.NewExitError(errors.New(cli.InvalidCommandNameError(args.First())), cli.ExitCodeGeneralError)

--- a/cli/commands/run/command.go
+++ b/cli/commands/run/command.go
@@ -55,6 +55,7 @@ func NewSubcommands(opts *options.TerragruntOptions) cli.Commands {
 		subcommands[i] = &cli.Command{
 			Name:                 name,
 			Usage:                usage,
+			UsageText:            "terragrunt run " + name + " [options]",
 			Hidden:               !visible,
 			CustomHelp:           ShowTFHelp(opts),
 			ErrorOnUndefinedFlag: true,
@@ -65,15 +66,6 @@ func NewSubcommands(opts *options.TerragruntOptions) cli.Commands {
 	}
 
 	return subcommands
-}
-
-// ShowTFHelp prints TF help for the given `ctx.Command` command.
-func ShowTFHelp(opts *options.TerragruntOptions) cli.HelpFunc {
-	return func(ctx *cli.Context) error {
-		terraformHelpCmd := append([]string{tf.FlagNameHelpLong, ctx.Command.Name}, ctx.Args()...)
-
-		return tf.RunCommand(ctx, opts, terraformHelpCmd...)
-	}
 }
 
 func Action(opts *options.TerragruntOptions) cli.ActionFunc {
@@ -95,9 +87,17 @@ func validateCommand(opts *options.TerragruntOptions) error {
 		return nil
 	}
 
-	if strings.HasSuffix(opts.TerraformPath, options.TerraformDefaultPath) {
+	if isTerraformPath(opts) {
 		return WrongTerraformCommand(opts.TerraformCommand)
 	}
 
 	return WrongTofuCommand(opts.TerraformCommand)
+}
+
+func isTerraformPath(opts *options.TerragruntOptions) bool {
+	if strings.HasSuffix(opts.TerraformPath, options.TerraformDefaultPath) {
+		return true
+	}
+
+	return false
 }

--- a/cli/commands/run/command.go
+++ b/cli/commands/run/command.go
@@ -95,9 +95,5 @@ func validateCommand(opts *options.TerragruntOptions) error {
 }
 
 func isTerraformPath(opts *options.TerragruntOptions) bool {
-	if strings.HasSuffix(opts.TerraformPath, options.TerraformDefaultPath) {
-		return true
-	}
-
-	return false
+	return strings.HasSuffix(opts.TerraformPath, options.TerraformDefaultPath)
 }

--- a/cli/commands/run/command.go
+++ b/cli/commands/run/command.go
@@ -55,7 +55,6 @@ func NewSubcommands(opts *options.TerragruntOptions) cli.Commands {
 		subcommands[i] = &cli.Command{
 			Name:                 name,
 			Usage:                usage,
-			UsageText:            "terragrunt run " + name + " [options]",
 			Hidden:               !visible,
 			CustomHelp:           ShowTFHelp(opts),
 			ErrorOnUndefinedFlag: true,

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -542,6 +542,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 	return flags.Sort()
 }
 
+// NewTFPathFlag creates a flag for specifying the OpenTofu/Terraform binary path.
 func NewTFPathFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.Flag {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 	terragruntPrefix := prefix.Prepend(flags.TerragruntPrefix)

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -165,13 +165,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 		},
 			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedConfigFlagName), terragruntPrefixControl)),
 
-		flags.NewFlag(&cli.GenericFlag[string]{
-			Name:        TFPathFlagName,
-			EnvVars:     tgPrefix.EnvVars(TFPathFlagName),
-			Destination: &opts.TerraformPath,
-			Usage:       "Path to the OpenTofu/Terraform binary. Default is tofu (on PATH).",
-		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedTfpathFlagName), terragruntPrefixControl)),
+		NewTFPathFlag(opts, prefix),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        NoAutoInitFlagName,
@@ -546,4 +540,18 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 	}
 
 	return flags.Sort()
+}
+
+func NewTFPathFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.Flag {
+	tgPrefix := prefix.Prepend(flags.TgPrefix)
+	terragruntPrefix := prefix.Prepend(flags.TerragruntPrefix)
+	terragruntPrefixControl := flags.StrictControlsByGlobalFlags(opts.StrictControls)
+
+	return flags.NewFlag(&cli.GenericFlag[string]{
+		Name:        TFPathFlagName,
+		EnvVars:     tgPrefix.EnvVars(TFPathFlagName),
+		Destination: &opts.TerraformPath,
+		Usage:       "Path to the OpenTofu/Terraform binary. Default is tofu (on PATH).",
+	},
+		flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedTfpathFlagName), terragruntPrefixControl))
 }

--- a/cli/commands/run/help.go
+++ b/cli/commands/run/help.go
@@ -21,7 +21,7 @@ const TFCommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Comman
 
    It wraps the ` + "`{{ tfCommand }}`" + ` command of the binary defined by ` + "`tf-path`" + `.
 
-{{ if isTerraformPath }}Terraform{{ else }}OpenTofu{{ end }} ` + "`{{ tfCommand }}`" + ` help:{{ $tfHelp := tfHelp }}{{ if $tfHelp }}
+{{ if isTerraformPath }}Terraform{{ else }}OpenTofu{{ end }} ` + "`{{ tfCommand }}`" + ` help:{{ $tfHelp := runTFHelp }}{{ if $tfHelp }}
 
 {{ $tfHelp }}{{ end }}
 `
@@ -37,8 +37,8 @@ func ShowTFHelp(opts *options.TerragruntOptions) cli.HelpFunc {
 			"isTerraformPath": func() bool {
 				return isTerraformPath(opts)
 			},
-			"tfHelp": func() string {
-				return tfHelp(ctx, opts)
+			"runTFHelp": func() string {
+				return runTFHelp(ctx, opts)
 			},
 			"tfCommand": func() string {
 				return ctx.Command.Name
@@ -49,7 +49,7 @@ func ShowTFHelp(opts *options.TerragruntOptions) cli.HelpFunc {
 	}
 }
 
-func tfHelp(ctx *cli.Context, opts *options.TerragruntOptions) string {
+func runTFHelp(ctx *cli.Context, opts *options.TerragruntOptions) string {
 	opts = opts.Clone()
 	opts.Writer = io.Discard
 

--- a/cli/commands/run/help.go
+++ b/cli/commands/run/help.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TFCommandHelpTemplate is the TF command CLI help template.
-const TFCommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Command.UsageText 3 }}{{ else }}{{ range $parent := parentCommands . }}{{ $parent.HelpName }} {{ end }}{{ .Command.HelpName }}{{ if .Command.VisibleSubcommands }} <command>{{ end }}{{ if .Command.VisibleFlags }} [options]{{ end }}{{ end }}{{ $description := .Command.Usage }}{{ if .Command.Description }}{{ $description = .Command.Description }}{{ end }}{{ if $description }}
+const TFCommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Command.UsageText 3 }}{{ else }}{{ range $parent := parentCommands . }}{{ $parent.HelpName }} {{ end }}[global options] {{ .Command.HelpName }} [options]{{ if eq .Command.Name "` + tf.CommandNameApply + `" }} [PLAN]{{ end }}{{ end }}{{ $description := .Command.Usage }}{{ if .Command.Description }}{{ $description = .Command.Description }}{{ end }}{{ if $description }}
 
    {{ wrap $description 3 }}{{ end }}{{ if ne .Parent.Command.Name "` + CommandName + `" }}
 

--- a/cli/commands/run/help.go
+++ b/cli/commands/run/help.go
@@ -1,0 +1,81 @@
+package run
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli"
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/tf"
+	"github.com/gruntwork-io/terragrunt/util"
+)
+
+// TFCommandHelpTemplate is the TF command CLI help template.
+const TFCommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Command.UsageText 3 }}{{ else }}{{ range $parent := parentCommands . }}{{ $parent.HelpName }} {{ end }}{{ .Command.HelpName }}{{ if .Command.VisibleSubcommands }} <command>{{ end }}{{ if .Command.VisibleFlags }} [options]{{ end }}{{ end }}{{ $description := .Command.Usage }}{{ if .Command.Description }}{{ $description = .Command.Description }}{{ end }}{{ if $description }}
+
+   {{ wrap $description 3 }}{{ end }}{{ if ne .Parent.Command.Name "` + CommandName + `" }}
+
+   This is a shortcut for the command ` + "`terragrunt " + CommandName + "`" + `.{{ end }}
+
+   It wraps the ` + "`{{ tfCommand }}`" + ` command of the binary defined by ` + "`tf-path`" + `.
+
+{{ if isTerraformPath }}Terraform{{ else }}OpenTofu{{ end }} ` + "`{{ tfCommand }}`" + ` help:{{ $tfHelp := tfHelp }}{{ if $tfHelp }}
+
+{{ $tfHelp }}{{ end }}
+`
+
+// ShowTFHelp prints TF help for the given `ctx.Command` command.
+func ShowTFHelp(opts *options.TerragruntOptions) cli.HelpFunc {
+	return func(ctx *cli.Context) error {
+		if err := NewTFPathFlag(opts, nil).Parse(ctx.Args()); err != nil {
+			return err
+		}
+
+		cli.HelpPrinterCustom(ctx, TFCommandHelpTemplate, map[string]any{
+			"isTerraformPath": func() bool {
+				return isTerraformPath(opts)
+			},
+			"tfHelp": func() string {
+				return tfHelp(ctx, opts)
+			},
+			"tfCommand": func() string {
+				return ctx.Command.Name
+			},
+		})
+
+		return nil
+	}
+}
+
+func tfHelp(ctx *cli.Context, opts *options.TerragruntOptions) string {
+	opts = opts.Clone()
+	opts.Writer = io.Discard
+
+	terraformHelpCmd := []string{tf.FlagNameHelpLong, ctx.Command.Name}
+
+	out, err := tf.RunCommandWithOutput(ctx, opts, terraformHelpCmd...)
+	if err != nil {
+		var processError util.ProcessExecutionError
+		if ok := errors.As(err, &processError); ok {
+			err = processError.Err
+		}
+
+		return fmt.Sprintf("Failed to execute \"%s %s\": %s", opts.TerraformPath, strings.Join(terraformHelpCmd, " "), err.Error())
+	}
+
+	result := out.Stdout.String()
+	lines := strings.Split(result, "\n")
+
+	// Trim first empty lines or that has prefix "Usage:".
+	for i := 0; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" || strings.HasPrefix(lines[i], "Usage:") {
+			continue
+		}
+
+		return strings.Join(lines[i:], "\n")
+	}
+
+	return result
+}

--- a/cli/flags/flag.go
+++ b/cli/flags/flag.go
@@ -126,7 +126,7 @@ func (newFlag *Flag) Parse(args cli.Args) error {
 
 	const maxFlagsParse = 1000 // Maximum flags parse
 
-	for i := 0; i < maxFlagsParse && args.Len() > 0; i++ {
+	for range maxFlagsParse {
 		err := flagSet.Parse(args)
 		if err == nil {
 			break

--- a/cli/help.go
+++ b/cli/help.go
@@ -19,25 +19,25 @@ Author: {{ range .App.Authors }}{{ . }}{{ end }} {{ end }}
 `
 
 // CommandHelpTemplate is the command CLI help template.
-const CommandHelpTemplate = `Usage: {{if .Command.UsageText}}{{wrap .Command.UsageText 3}}{{else}}{{range $parent := parentCommands . }}{{$parent.HelpName}} {{end}}{{.Command.HelpName}}{{if .Command.VisibleSubcommands}} <command>{{end}}{{if .Command.VisibleFlags}} [options]{{end}}{{end}}{{$description := .Command.Usage}}{{if .Command.Description}}{{$description = .Command.Description}}{{end}}{{if $description}}
+const CommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Command.UsageText 3 }}{{ else }}{{ range $parent := parentCommands . }}{{ $parent.HelpName }} {{ end }}{{ .Command.HelpName }}{{ if .Command.VisibleSubcommands }} <command>{{ end }}{{ if .Command.VisibleFlags }} [options]{{ end }}{{ end }}{{ $description := .Command.Usage }}{{ if .Command.Description }}{{ $description = .Command.Description }}{{ end }}{{ if $description }}
 
-   {{wrap $description 3}}{{end}}{{if .Command.Examples}}
+   {{ wrap $description 3 }}{{ end }}{{ if .Command.Examples }}
 
 Examples:
-   {{$s := join .Command.Examples "\n\n"}}{{wrap $s 3}}{{end}}{{if .Command.VisibleSubcommands}}
+   {{ $s := join .Command.Examples "\n\n" }}{{ wrap $s 3 }}{{ end }}{{ if .Command.VisibleSubcommands }}
 
-Subcommands:{{ $cv := offsetCommands .Command.VisibleSubcommands 5}}{{range .Command.VisibleSubcommands}}
-   {{$s := .HelpName}}{{$s}}{{ $sp := subtract $cv (offset $s 3) }}{{ indent $sp ""}} {{wrap .Usage $cv}}{{end}}{{end}}{{if .Command.VisibleFlags}}
+Subcommands:{{ $cv := offsetCommands .Command.VisibleSubcommands 5 }}{{ range .Command.VisibleSubcommands }}
+   {{ $s := .HelpName }}{{ $s }}{{ $sp := subtract $cv (offset $s 3) }}{{ indent $sp ""}} {{ wrap .Usage $cv }}{{ end }}{{ end }}{{ if .Command.VisibleFlags }}
 
 Options:
-   {{range $index, $option := .Command.VisibleFlags}}{{if $index}}
-   {{end}}{{wrap $option.String 6}}{{end}}{{end}}{{if .App.VisibleFlags}}
+   {{ range $index, $option := .Command.VisibleFlags }}{{ if $index }}
+   {{ end }}{{ wrap $option.String 6 }}{{ end }}{{ end }}{{ if .App.VisibleFlags }}
 
 Global Options:
-   {{range $index, $option := .App.VisibleFlags}}{{if $index}}
-   {{end}}{{wrap $option.String 6}}{{end}}{{end}}
+   {{ range $index, $option := .App.VisibleFlags }}{{ if $index }}
+   {{ end }}{{ wrap $option.String 6 }}{{ end }}{{ end }}
 
 `
 
-const AppVersionTemplate = `{{.App.Name}} version {{.App.Version}}
+const AppVersionTemplate = `{{ .App.Name }} version {{ .App.Version }}
 `

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -213,7 +213,7 @@ func (cmd *Command) flagSetParse(ctx *Context, flagSet *libflag.FlagSet, args Ar
 
 	const maxFlagsParse = 1000 // Maximum flags parse
 
-	for i := 0; i < maxFlagsParse && args.Len() > 0; i++ {
+	for range maxFlagsParse {
 		// check if the error is due to an undefArgs flag
 		var undefArg string
 

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const errFlagUndefined = "flag provided but not defined:"
+const ErrFlagUndefined = "flag provided but not defined:"
 
 type Command struct {
 	// Name is the command name.
@@ -211,7 +211,9 @@ func (cmd *Command) flagSetParse(ctx *Context, flagSet *libflag.FlagSet, args Ar
 		return undefArgs, nil
 	}
 
-	for {
+	const maxFlagsParse = 1000 // Maximum flags parse
+
+	for i := 0; i < maxFlagsParse && args.Len() > 0; i++ {
 		// check if the error is due to an undefArgs flag
 		var undefArg string
 
@@ -220,9 +222,9 @@ func (cmd *Command) flagSetParse(ctx *Context, flagSet *libflag.FlagSet, args Ar
 			break
 		}
 
-		if errStr := err.Error(); strings.HasPrefix(errStr, errFlagUndefined) {
+		if errStr := err.Error(); strings.HasPrefix(errStr, ErrFlagUndefined) {
 			err = UndefinedFlagError(errStr)
-			undefArg = strings.Trim(strings.TrimPrefix(errStr, errFlagUndefined), " -")
+			undefArg = strings.Trim(strings.TrimPrefix(errStr, ErrFlagUndefined), " -")
 		} else {
 			break
 		}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/exp/maps"
 )
 
 var (
@@ -45,8 +46,16 @@ func ShowAppHelp(ctx *Context) error {
 
 // ShowCommandHelp prints command help for the given `ctx`.
 func ShowCommandHelp(ctx *Context) error {
+	if ctx.Command.HelpName == "" {
+		ctx.Command.HelpName = ctx.Command.Name
+	}
+
 	if ctx.Command.CustomHelp != nil {
-		return ctx.Command.CustomHelp(ctx)
+		if err := ctx.Command.CustomHelp(ctx); err != nil {
+			return err
+		}
+
+		return NewExitError(nil, ExitCodeSuccess)
 	}
 
 	tpl := ctx.Command.CustomHelpTemplate
@@ -58,16 +67,22 @@ func ShowCommandHelp(ctx *Context) error {
 		return errors.Errorf("command help template not defined")
 	}
 
-	if ctx.Command.HelpName == "" {
-		ctx.Command.HelpName = ctx.Command.Name
-	}
-
-	cli.HelpPrinterCustom(ctx.App.Writer, tpl, ctx, map[string]any{
-		"parentCommands": parentCommands,
-		"offsetCommands": offsetCommands,
-	})
+	HelpPrinterCustom(ctx, tpl, nil)
 
 	return NewExitError(nil, ExitCodeSuccess)
+}
+
+func HelpPrinterCustom(ctx *Context, tpl string, customFuncs map[string]any) {
+	var funcs = map[string]any{
+		"parentCommands": parentCommands,
+		"offsetCommands": offsetCommands,
+	}
+
+	if customFuncs != nil {
+		maps.Copy(funcs, customFuncs)
+	}
+
+	cli.HelpPrinterCustom(ctx.App.Writer, tpl, ctx, funcs)
 }
 
 func ShowVersion(ctx *Context) error {

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -5,9 +5,10 @@ import (
 
 	"slices"
 
+	"maps"
+
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/exp/maps"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 	opts := options.NewTerragruntOptions()
 
 	// Immediately parse the `TG_LOG_LEVEL` environment variable, e.g. to set the TRACE level.
-	if err := global.NewLogLevelFlag(opts, nil).ParseEnvVars(); err != nil {
+	if err := global.NewLogLevelFlag(opts, nil).Parse(os.Args); err != nil {
 		opts.Logger.Error(err.Error())
 		os.Exit(1)
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3833 .

```
terragrunt --help init
Usage: terragrunt init [options]

   Prepare your working directory for other commands.

   This is a shortcut for the command `terragrunt run`.

   It wraps the `init` command of the binary defined by `tf-path`.

OpenTofu `init` help:

  Initialize a new or existing OpenTofu working directory by creating
  initial files, loading any remote state, downloading modules, etc.
  ...
```

```
TG_TF_PATH=not-exist terragrunt --help init
Usage: terragrunt init [options]

   Prepare your working directory for other commands.

   This is a shortcut for the command `terragrunt run`.

   It wraps the `init` command of the binary defined by `tf-path`.

OpenTofu `init` help:

Failed to execute "not-exist -help init": exec: "not-exist": executable file not found in $PATH
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Updated primary command operations: the "exec" command is now included, and "run-all" is no longer referenced.
  - Introduced structured and clearer help output for Terraform commands with explicit usage guidance.

- **Refactor**
  - Streamlined command and flag parsing to improve consistency and robustness.
  - Enhanced help text formatting for improved clarity and user experience.
  - Modularized flag creation for better organization.

- **Bug Fixes**
  - Adjusted error handling in help displays to prevent help invocations from being misinterpreted as errors.
  - Improved error handling for undefined flags to enhance clarity in user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->