### PR TITLE
Updated stack output help flags

### DIFF
--- a/cli/commands/stack/command.go
+++ b/cli/commands/stack/command.go
@@ -24,33 +24,8 @@ const (
 )
 
 // NewFlags builds the flags for stack.
-func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
-	tgPrefix := prefix.Prepend(flags.TgPrefix)
-
-	return cli.Flags{
-		flags.NewFlag(&cli.GenericFlag[string]{
-			Name:        OutputFormatFlagName,
-			EnvVars:     tgPrefix.EnvVars(OutputFormatFlagName),
-			Destination: &opts.StackOutputFormat,
-			Usage:       "Stack output format. Valid values are: json, raw",
-		}),
-		flags.NewFlag(&cli.BoolFlag{
-			Name:  RawFormatFlagName,
-			Usage: "Stack output in raw format",
-			Action: func(ctx *cli.Context, value bool) error {
-				opts.StackOutputFormat = rawOutputFormat
-				return nil
-			},
-		}),
-		flags.NewFlag(&cli.BoolFlag{
-			Name:  JSONFormatFlagName,
-			Usage: "Stack output in json format",
-			Action: func(ctx *cli.Context, value bool) error {
-				opts.StackOutputFormat = jsonOutputFormat
-				return nil
-			},
-		}),
-	}
+func NewFlags(_ *options.TerragruntOptions) cli.Flags {
+	return cli.Flags{}
 }
 
 // NewCommand builds the command for stack.
@@ -59,7 +34,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		Name:                 CommandName,
 		Usage:                "Terragrunt stack commands.",
 		ErrorOnUndefinedFlag: true,
-		Flags:                NewFlags(opts, nil).Sort(),
+		Flags:                NewFlags(opts).Sort(),
 		Subcommands: cli.Commands{
 			&cli.Command{
 				Name:  generateCommandName,
@@ -86,6 +61,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 					}
 					return RunOutput(ctx.Context, opts.OptionsFromContext(ctx), index)
 				},
+				Flags: outputFlags(opts, nil),
 			},
 			&cli.Command{
 				Name:  cleanCommandName,
@@ -96,5 +72,34 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 			},
 		},
 		Action: cli.ShowCommandHelp,
+	}
+}
+
+func outputFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
+	tgPrefix := prefix.Prepend(flags.TgPrefix)
+
+	return cli.Flags{
+		flags.NewFlag(&cli.GenericFlag[string]{
+			Name:        OutputFormatFlagName,
+			EnvVars:     tgPrefix.EnvVars(OutputFormatFlagName),
+			Destination: &opts.StackOutputFormat,
+			Usage:       "Stack output format. Valid values are: json, raw",
+		}),
+		flags.NewFlag(&cli.BoolFlag{
+			Name:  RawFormatFlagName,
+			Usage: "Stack output in raw format",
+			Action: func(ctx *cli.Context, value bool) error {
+				opts.StackOutputFormat = rawOutputFormat
+				return nil
+			},
+		}),
+		flags.NewFlag(&cli.BoolFlag{
+			Name:  JSONFormatFlagName,
+			Usage: "Stack output in json format",
+			Action: func(ctx *cli.Context, value bool) error {
+				opts.StackOutputFormat = jsonOutputFormat
+				return nil
+			},
+		}),
 	}
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* updated stack output help to include output format

![image](https://github.com/user-attachments/assets/26ed3a84-01b9-434e-8007-ec606a8018cd)


![image](https://github.com/user-attachments/assets/abb98990-cd81-4ded-b813-401d510454cd)


Fixes https://github.com/gruntwork-io/terragrunt/issues/3875

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the CLI flag handling for stack commands by reorganizing the output formatting options.
	- Improved separation of concerns in flag configuration while maintaining the same end-user behavior and output functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->