### PR TITLE
feat: Handling of incorrectly used flag

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/cli/commands"
 	"github.com/gruntwork-io/terragrunt/cli/commands/graph"
+	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/global"
 
 	"github.com/gruntwork-io/go-commons/version"
@@ -49,6 +50,8 @@ type App struct {
 
 // NewApp creates the Terragrunt CLI App.
 func NewApp(opts *options.TerragruntOptions) *App {
+	terragruntCommands := commands.New(opts)
+
 	app := cli.NewApp()
 	app.Name = "terragrunt"
 	app.Usage = "Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale.\nFor documentation, see https://terragrunt.gruntwork.io/."
@@ -57,10 +60,11 @@ func NewApp(opts *options.TerragruntOptions) *App {
 	app.Writer = opts.Writer
 	app.ErrWriter = opts.ErrWriter
 	app.Flags = global.NewFlagsWithDeprecatedMovedFlags(opts)
-	app.Commands = commands.New(opts).WrapAction(WrapWithTelemetry(opts))
+	app.Commands = terragruntCommands.WrapAction(WrapWithTelemetry(opts))
 	app.Before = beforeAction(opts)
 	app.OsExiter = OSExiter
 	app.ExitErrHandler = ExitErrHandler
+	app.FlagErrHandler = flags.ErrorHandler(terragruntCommands)
 
 	return &App{app, opts}
 }

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -61,13 +61,13 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		{
 			[]string{"--foo", "--bar"},
 			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"-foo", "-bar"}, false, "", false, false, defaultLogLevel, false),
-			clipkg.UndefinedFlagError("flag provided but not defined: -foo"),
+			clipkg.UndefinedFlagError("foo"),
 		},
 
 		{
 			[]string{"--foo", "apply", "--bar"},
 			mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"apply", "-foo", "-bar"}, false, "", false, false, defaultLogLevel, false),
-			clipkg.UndefinedFlagError("flag provided but not defined: -foo"),
+			clipkg.UndefinedFlagError("foo"),
 		},
 
 		{

--- a/cli/flags/error_handler.go
+++ b/cli/flags/error_handler.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
@@ -21,24 +22,35 @@ func ErrorHandler(commands cli.Commands) cli.FlagErrHandlerFunc {
 
 		undefFlag := string(undefinedFlagErr)
 
-		for _, cmd := range commands {
-			for _, flag := range cmd.Flags {
-				flagNames := flag.Names()
+		if cmds, flag := findFlagInCommands(commands, undefFlag); cmds != nil {
+			flagName := util.FirstElement(util.RemoveEmptyElements(flag.Names()))
 
-				if flag, ok := flag.(interface{ DeprecatedNames() []string }); ok {
-					flagNames = append(flagNames, flag.DeprecatedNames()...)
-				}
-
-				if !slices.Contains(flagNames, undefFlag) {
-					continue
-				}
-
-				flagName := util.FirstElement(util.RemoveEmptyElements(flag.Names()))
-
-				return errors.Errorf(flagHintFmt, undefFlag, ctx.Command.Name, cmd.Name, flagName)
-			}
+			return errors.Errorf(flagHintFmt, undefFlag, ctx.Command.Name, strings.Join(cmds.Names(), " "), flagName)
 		}
 
 		return err
 	}
+}
+
+func findFlagInCommands(commands cli.Commands, undefFlag string) (cli.Commands, cli.Flag) {
+	for _, cmd := range commands {
+		for _, flag := range cmd.Flags {
+			flagNames := flag.Names()
+
+			if flag, ok := flag.(interface{ DeprecatedNames() []string }); ok {
+				flagNames = append(flagNames, flag.DeprecatedNames()...)
+			}
+
+			if slices.Contains(flagNames, undefFlag) {
+				return cli.Commands{cmd}, flag
+			}
+		}
+
+		if cmd.Subcommands != nil {
+			if cmds, flag := findFlagInCommands(cmd.Subcommands, undefFlag); cmds != nil {
+				return append(cli.Commands{cmd}, cmds...), flag
+			}
+		}
+	}
+	return nil, nil
 }

--- a/cli/flags/error_handler.go
+++ b/cli/flags/error_handler.go
@@ -38,6 +38,10 @@ func ErrorHandler(commands cli.Commands) cli.FlagErrHandlerFunc {
 }
 
 func findFlagInCommands(commands cli.Commands, undefFlag string) (cli.Commands, cli.Flag) {
+	if len(commands) == 0 {
+		return nil, nil
+	}
+
 	for _, cmd := range commands {
 		for _, flag := range cmd.Flags {
 			flagNames := flag.Names()
@@ -51,10 +55,8 @@ func findFlagInCommands(commands cli.Commands, undefFlag string) (cli.Commands, 
 			}
 		}
 
-		if cmd.Subcommands != nil {
-			if cmds, flag := findFlagInCommands(cmd.Subcommands, undefFlag); cmds != nil {
-				return append(cli.Commands{cmd}, cmds...), flag
-			}
+		if cmds, flag := findFlagInCommands(cmd.Subcommands, undefFlag); cmds != nil {
+			return append(cli.Commands{cmd}, cmds...), flag
 		}
 	}
 

--- a/cli/flags/error_handler.go
+++ b/cli/flags/error_handler.go
@@ -57,5 +57,6 @@ func findFlagInCommands(commands cli.Commands, undefFlag string) (cli.Commands, 
 			}
 		}
 	}
+
 	return nil, nil
 }

--- a/cli/flags/error_handler.go
+++ b/cli/flags/error_handler.go
@@ -1,0 +1,44 @@
+package flags
+
+import (
+	"slices"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli"
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/util"
+)
+
+const flagHintFmt = "flag `--%s` is not a valid flag for `%s`. Did you mean to use `%s --%s`?"
+
+// ErrorHandler returns `FlagErrHandlerFunc` which takes a flag parsing error
+// and tries to suggest the correct command to use that flag. Otherwise returns the error as is.
+func ErrorHandler(commands cli.Commands) cli.FlagErrHandlerFunc {
+	return func(ctx *cli.Context, err error) error {
+		var undefinedFlagErr cli.UndefinedFlagError
+		if !errors.As(err, &undefinedFlagErr) {
+			return err
+		}
+
+		undefFlag := string(undefinedFlagErr)
+
+		for _, cmd := range commands {
+			for _, flag := range cmd.Flags {
+				flagNames := flag.Names()
+
+				if flag, ok := flag.(interface{ DeprecatedNames() []string }); ok {
+					flagNames = append(flagNames, flag.DeprecatedNames()...)
+				}
+
+				if !slices.Contains(flagNames, undefFlag) {
+					continue
+				}
+
+				flagName := util.FirstElement(util.RemoveEmptyElements(flag.Names()))
+
+				return errors.Errorf(flagHintFmt, undefFlag, ctx.Command.Name, cmd.Name, flagName)
+			}
+		}
+
+		return err
+	}
+}

--- a/cli/flags/errors.go
+++ b/cli/flags/errors.go
@@ -1,0 +1,45 @@
+package flags
+
+import "fmt"
+
+var _ error = new(GlobalFlagHintError)
+
+type GlobalFlagHintError struct {
+	undefFlag string
+	cmdHint   string
+	flagHint  string
+}
+
+func NewGlobalFlagHintError(undefFlag, cmdHint, flagHint string) *GlobalFlagHintError {
+	return &GlobalFlagHintError{
+		undefFlag: undefFlag,
+		cmdHint:   cmdHint,
+		flagHint:  flagHint,
+	}
+}
+
+func (err GlobalFlagHintError) Error() string {
+	return fmt.Sprintf("flag `--%s` is not a valid global flag. Did you mean to use `%s --%s`?", err.undefFlag, err.cmdHint, err.flagHint)
+}
+
+var _ error = new(CommandFlagHintError)
+
+type CommandFlagHintError struct {
+	undefFlag string
+	wrongCmd  string
+	cmdHint   string
+	flagHint  string
+}
+
+func NewCommandFlagHintError(wrongCmd, undefFlag, cmdHint, flagHint string) *CommandFlagHintError {
+	return &CommandFlagHintError{
+		undefFlag: undefFlag,
+		wrongCmd:  wrongCmd,
+		cmdHint:   cmdHint,
+		flagHint:  flagHint,
+	}
+}
+
+func (err CommandFlagHintError) Error() string {
+	return fmt.Sprintf("flag `--%s` is not a valid flag for `%s`. Did you mean to use `%s --%s`?", err.undefFlag, err.wrongCmd, err.cmdHint, err.flagHint)
+}

--- a/cli/flags/flag.go
+++ b/cli/flags/flag.go
@@ -51,6 +51,7 @@ func (newFlag *Flag) TakesValue() bool {
 	return !ok || !val
 }
 
+// DeprecatedNames returns all deprecated names for this flag.
 func (newFlag *Flag) DeprecatedNames() []string {
 	var names []string
 

--- a/cli/flags/flag.go
+++ b/cli/flags/flag.go
@@ -51,6 +51,20 @@ func (newFlag *Flag) TakesValue() bool {
 	return !ok || !val
 }
 
+func (newFlag *Flag) DeprecatedNames() []string {
+	var names []string
+
+	if flag, ok := newFlag.Flag.(interface{ DeprecatedNames() []string }); ok {
+		names = flag.DeprecatedNames()
+	}
+
+	for _, deprecated := range newFlag.deprecatedFlags {
+		names = append(names, deprecated.Names()...)
+	}
+
+	return names
+}
+
 // Value implements `cli.Flag` interface.
 func (newFlag *Flag) Value() cli.FlagValue {
 	for _, deprecatedFlag := range newFlag.deprecatedFlags {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -73,8 +73,6 @@ type App struct {
 	// library. This library supports bash, zsh and fish. To add support
 	// for other shells, please see that library.
 	AutocompleteInstaller AutocompleteInstaller
-
-	// HandleFlagError
 }
 
 // NewApp returns app new App instance.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -49,6 +49,9 @@ type App struct {
 	// is used as the default behavior.
 	ExitErrHandler ExitErrHandlerFunc
 
+	// FlagErrHandler processes any error encountered while parsing flags.
+	FlagErrHandler FlagErrHandlerFunc
+
 	// Autocomplete enables or disables subcommand auto-completion support.
 	// This is enabled by default when NewApp is called. Otherwise, this
 	// must enabled explicitly.
@@ -70,6 +73,8 @@ type App struct {
 	// library. This library supports bash, zsh and fish. To add support
 	// for other shells, please see that library.
 	AutocompleteInstaller AutocompleteInstaller
+
+	// HandleFlagError
 }
 
 // NewApp returns app new App instance.

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const ErrFlagUndefined = "flag provided but not defined:"
-
 type Command struct {
 	// Name is the command name.
 	Name string
@@ -102,11 +100,15 @@ func (cmd *Command) VisibleSubcommands() Commands {
 // If this is the final command, starts its execution.
 func (cmd *Command) Run(ctx *Context, args Args) (err error) {
 	args, err = cmd.parseFlags(ctx, args.Slice())
+	ctx = ctx.NewCommandContext(cmd, args)
+
 	if err != nil {
+		if flagErrHandler := ctx.App.FlagErrHandler; flagErrHandler != nil {
+			err = flagErrHandler(ctx, err)
+		}
+
 		return NewExitError(err, ExitCodeGeneralError)
 	}
-
-	ctx = ctx.NewCommandContext(cmd, args)
 
 	subCmdName := ctx.Args().CommandName()
 	subCmdArgs := ctx.Args().Remove(subCmdName)
@@ -223,8 +225,8 @@ func (cmd *Command) flagSetParse(ctx *Context, flagSet *libflag.FlagSet, args Ar
 		}
 
 		if errStr := err.Error(); strings.HasPrefix(errStr, ErrFlagUndefined) {
-			err = UndefinedFlagError(errStr)
 			undefArg = strings.Trim(strings.TrimPrefix(errStr, ErrFlagUndefined), " -")
+			err = UndefinedFlagError(undefArg)
 		} else {
 			break
 		}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -19,6 +19,17 @@ func (commands Commands) Get(name string) *Command {
 	return nil
 }
 
+// Names returns names of the commands.
+func (commands Commands) Names() []string {
+	var names = make([]string, len(commands))
+
+	for i, cmd := range commands {
+		names[i] = cmd.Name
+	}
+
+	return names
+}
+
 // Add adds a new cmd to the list.
 func (commands *Commands) Add(cmd *Command) {
 	*commands = append(*commands, cmd)

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -107,8 +107,10 @@ func (err InvalidValueError) Unwrap() error {
 	return err.underlyingError
 }
 
+const ErrFlagUndefined = "flag provided but not defined:"
+
 type UndefinedFlagError string
 
-func (err UndefinedFlagError) Error() string {
-	return string(err)
+func (flag UndefinedFlagError) Error() string {
+	return ErrFlagUndefined + " -" + string(flag)
 }

--- a/internal/cli/funcs.go
+++ b/internal/cli/funcs.go
@@ -21,3 +21,6 @@ type SplitterFunc func(s, sep string) []string
 // ExitErrHandlerFunc is executed if provided in order to handle exitError values
 // returned by Actions and Before/After functions.
 type ExitErrHandlerFunc func(ctx *Context, err error) error
+
+// FlagErrHandlerFunc is executed if an error occurs while parsing flags.
+type FlagErrHandlerFunc func(ctx *Context, err error) error

--- a/test/fixtures/cli-flag-hints/main.hcl
+++ b/test/fixtures/cli-flag-hints/main.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/cli-flag-hints/terragrunt.hcl
+++ b/test/fixtures/cli-flag-hints/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3836.

```
> terragrunt run --no-include-root init
22:53:14.431 ERROR  flag `--no-include-root` is not a valid flag for `run`. Did you mean to use `catalog --no-include-root`?
```

```
> terragrunt -raw init 
02:23:24.431 ERROR  flag `--raw` is not a valid global flag. Did you mean to use `stack output --raw`?
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced CLI error handling now provides clearer, concise messages for invalid or unrecognized flags, offering actionable hints for correction.
	- Added support for identifying deprecated flag options, gently guiding users to current usage.
	- Introduced a new method for retrieving command names within the CLI.
	- New test cases added to validate command-line flag hints.

- **Bug Fixes**
	- Refined flag parsing results in consistent, simplified error outputs, improving the overall command-line experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->