### PR TITLE
Fix reference to root migration doc

### DIFF
--- a/docs/_docs/01_getting-started/04-terminology.md
+++ b/docs/_docs/01_getting-started/04-terminology.md
@@ -52,7 +52,7 @@ A common pattern used in the repository structure for Terragrunt projects is to 
 
 Note that units don't technically need to call their configuration files `terragrunt.hcl` (that's configurable via [--config](/docs/reference/cli-options/#config)), and users don't technically need to use a root `root.hcl` file or to name it that. This is a common pattern followed by the community, however, and deviation from this pattern should be justified in the context of the project. It can help others with Terragrunt experience understand the project more easily if industry standard patterns are followed.
 
-Previously, a best practice recommended by Terragrunt maintainers was to name the root configuration included by units `terragrunt.hcl`. Which might be why you might see a different naming convention in your project. That has since been deprecated. You can learn more about that [here](//docs/migrate/migrating-from-root-terragrunt-hcl).
+Previously, a best practice recommended by Terragrunt maintainers was to name the root configuration included by units `terragrunt.hcl`. Which might be why you might see a different naming convention in your project. That has since been deprecated. You can learn more about that [here](/docs/migrate/migrating-from-root-terragrunt-hcl).
 
 ### Stack
 


### PR DESCRIPTION
## Description

Fixes docs broken link to root migration doc

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

