### PR TITLE
fix: Preventing log enrichment for bare mode

### DIFF
--- a/internal/cli/bool_flag.go
+++ b/internal/cli/bool_flag.go
@@ -44,6 +44,10 @@ func (flag *BoolFlag) Apply(set *libflag.FlagSet) error {
 		return ApplyFlag(flag, set)
 	}
 
+	if flag.Destination == nil {
+		flag.Destination = new(bool)
+	}
+
 	valueType := newBoolVar(flag.Destination, flag.Negative)
 	value := newGenericValue(valueType, flag.Setter)
 

--- a/internal/cli/bool_flag_test.go
+++ b/internal/cli/bool_flag_test.go
@@ -122,9 +122,11 @@ func testBoolFlagApply(t *testing.T, flag *cli.BoolFlag, args []string, envs map
 		expectedDefaultValue string
 	)
 
-	if val := flag.Destination; val != nil {
-		expectedDefaultValue = strconv.FormatBool(*val)
+	if flag.Destination == nil {
+		flag.Destination = new(bool)
 	}
+
+	expectedDefaultValue = strconv.FormatBool(*flag.Destination)
 
 	flag.LookupEnvFunc = func(key string) []string {
 		if envs == nil {

--- a/internal/cli/generic_flag.go
+++ b/internal/cli/generic_flag.go
@@ -46,6 +46,10 @@ func (flag *GenericFlag[T]) Apply(set *libflag.FlagSet) error {
 		return ApplyFlag(flag, set)
 	}
 
+	if flag.Destination == nil {
+		flag.Destination = new(T)
+	}
+
 	valueType := &genericVar[T]{dest: flag.Destination}
 	value := newGenericValue(valueType, flag.Setter)
 

--- a/internal/cli/generic_flag_test.go
+++ b/internal/cli/generic_flag_test.go
@@ -187,9 +187,11 @@ func testGenericFlagApply[T cli.GenericType](t *testing.T, flag *cli.GenericFlag
 		expectedDefaultValue string
 	)
 
-	if val := flag.Destination; val != nil {
-		expectedDefaultValue = fmt.Sprintf("%v", *val)
+	if flag.Destination == nil {
+		flag.Destination = new(T)
 	}
+
+	expectedDefaultValue = fmt.Sprintf("%v", *flag.Destination)
 
 	flag.LookupEnvFunc = func(key string) []string {
 		if envs == nil {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4112,3 +4112,17 @@ func TestLogStreaming(t *testing.T) {
 		require.GreaterOrEqualf(t, secondTimestamp.Sub(firstTimestamp), 1*time.Second, "Second log entry for unit %s is not at least 1 second after the first log entry", unit)
 	}
 }
+
+func TestLogFormatBare(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureEmptyState)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, testFixtureEmptyState)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt init --log-format=bare --no-color --non-interactive --working-dir "+testPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Initializing the backend...")
+	assert.NotContains(t, stdout, "STDO[0000] Initializing the backend...")
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3885.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `log-format` auto-adjustment in options.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved flag handling to ensure default values are always initialized, reducing the risk of runtime errors.
- **Tests**
	- Added an integration test to verify that the log output for the bare format option is displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->