### PR TITLE
fix #2072 make sure the `generated` code is formatted before writing it to a file.

### DIFF
--- a/docs/_docs/04_reference/04-config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/04-config-blocks-and-attributes.md
@@ -1299,6 +1299,8 @@ The `generate` block supports the following arguments:
   `false`. Optional.
 - `contents` (attribute): The contents of the generated file.
 - `disable` (attribute): Disables this generate block.
+- `hcl_fmt` (attribute): Unless disabled (set to `false`), files with `.hcl`, `.tf`, and `.tofu` extensions will be formatted before being written to disk.
+  If explicitly set to `true`, formatting will be applied to the generated files.
 
 Example:
 


### PR DESCRIPTION
## Description

Fixes #2072 make sure the `generated` code is formatted before writing it to a file.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)
Updated the `generated` block to format the `HCL` syntax before writing it to a file, fix for #2072.

### Migration Guide

n/a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new `hcl_fmt` attribute in the `generate` block for automatic formatting of `.hcl`, `.tf`, and `.tofu` files before writing.
  
- **Tests**
  - Added automated tests to validate the formatting of generated files, ensuring compliance with the new capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->