### PR TITLE
[WIP] feat: Support version constraints for Terraform Registry modules

### DIFF
--- a/docs/_docs/04_reference/04-config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/04-config-blocks-and-attributes.md
@@ -97,7 +97,7 @@ The `terraform` block supports the following arguments:
     registry]({{site.baseurl}}/docs/getting-started/quick-start#a-note-about-using-modules-from-the-registry) for more
     information about using modules from the Terraform Registry with Terragrunt.
   - VERSION can be a specific version number (e.g., `1.2.3`) or a version constraint (e.g., `>= 1.2.3, <=3.2.1`) following syntax
-    defined in the [Terraform documentation](https://developer.hashicorp.com/terraform/language/expressions/version-constraints).
+    defined in the [OpenTofu documentation](https://opentofu.org/docs/language/expressions/version-constraints/).
 
 - `include_in_copy` (attribute): A list of glob patterns (e.g., `["*.txt"]`) that should always be copied into the
   OpenTofu/Terraform working directory. When you use the `source` param in your Terragrunt config and run `terragrunt <command>`,

--- a/docs/_docs/04_reference/04-config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/04-config-blocks-and-attributes.md
@@ -96,6 +96,8 @@ The `terraform` block supports the following arguments:
   - Refer to [A note about using modules from the
     registry]({{site.baseurl}}/docs/getting-started/quick-start#a-note-about-using-modules-from-the-registry) for more
     information about using modules from the Terraform Registry with Terragrunt.
+  - VERSION can be a specific version number (e.g., `1.2.3`) or a version constraint (e.g., `>= 1.2.3, <=3.2.1`) following syntax
+    defined in the [Terraform documentation](https://developer.hashicorp.com/terraform/language/expressions/version-constraints).
 
 - `include_in_copy` (attribute): A list of glob patterns (e.g., `["*.txt"]`) that should always be copied into the
   OpenTofu/Terraform working directory. When you use the `source` param in your Terragrunt config and run `terragrunt <command>`,

--- a/test/fixtures/tfr/version/terragrunt.hcl
+++ b/test/fixtures/tfr/version/terragrunt.hcl
@@ -1,0 +1,8 @@
+# Retrieve a module from the public terraform registry to use with terragrunt
+locals {
+  base_source = "tfr:///terraform-aws-modules/iam/aws"
+  version     = "~>5.0, <5.51.0, !=5.50.0"
+}
+terraform {
+  source = "${local.base_source}?version=${local.version}"
+}

--- a/test/integration_registry_test.go
+++ b/test/integration_registry_test.go
@@ -17,6 +17,7 @@ const (
 	registryFixtureRootShorthandModulePath       = "root-shorthand"
 	registryFixtureSubdirModulePath              = "subdir"
 	registryFixtureSubdirWithReferenceModulePath = "subdir-with-reference"
+	registryFixtureVersion                       = "version"
 )
 
 func TestTerraformRegistryFetchingRootModule(t *testing.T) {
@@ -55,5 +56,15 @@ func testTerraformRegistryFetching(t *testing.T, modPath, expectedOutputKey stri
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
 	_, hasOutput := outputs[expectedOutputKey]
 	assert.True(t, hasOutput)
+}
 
+// test that the version of the module is correctly resolved and downloaded when running a terragrunt init
+func TestTerraformRegistryVersionResolution(t *testing.T) {
+	t.Parallel()
+
+	versionFixture := util.JoinPath(registryFixturePath, registryFixtureVersion)
+	helpers.CleanupTerragruntFolder(t, versionFixture)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt init --working-dir "+versionFixture)
+	require.NoError(t, err)
 }

--- a/test/integration_registry_test.go
+++ b/test/integration_registry_test.go
@@ -58,7 +58,6 @@ func testTerraformRegistryFetching(t *testing.T, modPath, expectedOutputKey stri
 	assert.True(t, hasOutput)
 }
 
-// test that the version of the module is correctly resolved and downloaded when running a terragrunt init
 func TestTerraformRegistryVersionResolution(t *testing.T) {
 	t.Parallel()
 

--- a/tf/errors.go
+++ b/tf/errors.go
@@ -41,13 +41,13 @@ func (err RegistryAPIErr) Error() string {
 	return fmt.Sprintf("Failed to fetch url %s: status code %d", err.url, err.statusCode)
 }
 
-// ModuleVersionsErr is returned if we failed to fetch the module versions from the registry.
-type ModuleVersionsErr struct {
-	moduleName string
+// ModuleVersionsFetchErr is returned if we failed to fetch the module versions from the registry.
+type ModuleVersionsFetchErr struct {
+	sourceURL string
 }
 
-func (err ModuleVersionsErr) Error() string {
-	return fmt.Sprintf("Failed to fetch versions for module %s. Ensure you're properly authenticated and your registry is reachable", err.moduleName)
+func (err ModuleVersionsFetchErr) Error() string {
+	return fmt.Sprintf("Failed to fetch versions from %s. Please check authentication and registry is reachable", err.sourceURL)
 }
 
 // ModuleVersionConstraintErr is returned if the version constraint is not satisfied. This means there are no

--- a/tf/errors.go
+++ b/tf/errors.go
@@ -40,3 +40,40 @@ type RegistryAPIErr struct {
 func (err RegistryAPIErr) Error() string {
 	return fmt.Sprintf("Failed to fetch url %s: status code %d", err.url, err.statusCode)
 }
+
+// ModuleVersionsErr is returned if we failed to fetch the module versions from the registry.
+type ModuleVersionsErr struct {
+	moduleName string
+}
+
+func (err ModuleVersionsErr) Error() string {
+	return fmt.Sprintf("Failed to fetch versions for module %s. Ensure you're properly authenticated and your registry is reachable", err.moduleName)
+}
+
+// ModuleVersionConstraintErr is returned if the version constraint is not satisfied. This means there are no
+// available versions for the module that satisfy the constraint.
+type ModuleVersionConstraintErr struct {
+	versionConstraint string
+}
+
+func (err ModuleVersionConstraintErr) Error() string {
+	return fmt.Sprintf("Version constraint %s not satisfied", err.versionConstraint)
+}
+
+// ModuleVersionConstraintMalformedErr is returned if the version constraint is malformed and cannot be parsed.
+type ModuleVersionConstraintMalformedErr struct {
+	versionConstraint string
+}
+
+func (err ModuleVersionConstraintMalformedErr) Error() string {
+	return fmt.Sprintf("Version constraint %s is malformed and cannot be parsed", err.versionConstraint)
+}
+
+// ModuleVersionMalformedErr is returned if the version string is malformed and cannot be parsed.
+type ModuleVersionMalformedErr struct {
+	version string
+}
+
+func (err ModuleVersionMalformedErr) Error() string {
+	return fmt.Sprintf("Version %s is malformed and cannot be parsed", err.version)
+}

--- a/tf/getter.go
+++ b/tf/getter.go
@@ -224,6 +224,9 @@ func GetTargetVersion(ctx context.Context, logger log.Logger, registryDomain str
 	if err := json.Unmarshal(bodyData, &responseJSON); err != nil {
 		return "", errors.New(ModuleVersionsErr{moduleName: modulePath})
 	}
+	if len(responseJSON.Modules) == 0 {
+		return "", errors.New(ModuleVersionsErr{moduleName: modulePath})
+	}
 	availableVersions := responseJSON.Modules[0].ModuleVersions
 
 	// Filter the available versions based on the version constraint

--- a/tf/getter.go
+++ b/tf/getter.go
@@ -207,6 +207,10 @@ func getHighestVersion(availableVersions []*version.Version) string {
 }
 
 func GetTargetVersion(ctx context.Context, logger log.Logger, registryDomain string, moduleRegistryBasePath string, modulePath string, versionQuery string) (string, error) {
+	// Handle the case where the registry domain is not part of the module registry base path
+	if !strings.HasPrefix(moduleRegistryBasePath, "https://") {
+		moduleRegistryBasePath = fmt.Sprintf("https://%s%s", registryDomain, moduleRegistryBasePath)
+	}
 	// Retrieve the available versions for the module
 	moduleRegistryBasePath = strings.TrimSuffix(moduleRegistryBasePath, "/")
 	modulePath = strings.TrimSuffix(modulePath, "/")
@@ -224,7 +228,7 @@ func GetTargetVersion(ctx context.Context, logger log.Logger, registryDomain str
 	if err := json.Unmarshal(bodyData, &responseJSON); err != nil {
 		return "", errors.New(ModuleVersionsErr{moduleName: modulePath})
 	}
-	if len(responseJSON.Modules) == 0 {
+	if len(responseJSON.Modules) == 0 || len(responseJSON.Modules[0].ModuleVersions) == 0 {
 		return "", errors.New(ModuleVersionsErr{moduleName: modulePath})
 	}
 	availableVersions := responseJSON.Modules[0].ModuleVersions

--- a/tf/getter.go
+++ b/tf/getter.go
@@ -315,14 +315,14 @@ func GetTargetVersion(ctx context.Context, logger log.Logger, url url.URL, versi
 		return "", errors.New(ModuleVersionsFetchErr{sourceURL: url.String()})
 	}
 
-	// Filter the available module versions based on the version constraint
-	filteredVersions, err := getCompatibleVersions(responseJSON.Modules[0].ModuleVersions, versionQuery)
+	// Filter the available module versions based on the version constraint to get the compatible versions
+	compatibleVersions, err := getCompatibleVersions(responseJSON.Modules[0].ModuleVersions, versionQuery)
 	if err != nil {
 		return "", err
 	}
 
-	// Get the highest version from the filtered versions
-	targetVersion := getHighestVersion(filteredVersions)
+	// Get the highest version from the compatible versions
+	targetVersion := getHighestVersion(compatibleVersions)
 	if targetVersion == "" {
 		return "", errors.New(ModuleVersionConstraintErr{versionConstraint: versionQuery})
 	}
@@ -474,10 +474,10 @@ func getHighestVersion(availableVersions []*version.Version) string {
 	return availableVersions[len(availableVersions)-1].String()
 }
 
-// getCompatibleVersions returns the list of versions that satisfy the version constraint.
+// getCompatibleVersions returns the list of versions within availableVersions that satisfy the version
+// constraint defined by versionQuery.
 func getCompatibleVersions(availableVersions []ModuleVersion, versionQuery string) ([]*version.Version, error) {
-	// Filter the available versions based on the version constraint
-	filteredVersions := []*version.Version{}
+	var compatibleVersions []*version.Version
 
 	versionConstraint, err := version.NewConstraint(versionQuery)
 	if err != nil {
@@ -491,9 +491,9 @@ func getCompatibleVersions(availableVersions []ModuleVersion, versionQuery strin
 		}
 
 		if versionConstraint.Check(availableVersionParsed) {
-			filteredVersions = append(filteredVersions, availableVersionParsed)
+			compatibleVersions = append(compatibleVersions, availableVersionParsed)
 		}
 	}
 
-	return filteredVersions, nil
+	return compatibleVersions, nil
 }

--- a/tf/getter.go
+++ b/tf/getter.go
@@ -206,8 +206,12 @@ func getHighestVersion(availableVersions []*version.Version) string {
 	return availableVersions[len(availableVersions)-1].String()
 }
 
+// GetTargetVersion retrieves the target version of the module based on the version constraint provided. This function
+// will return the highest version that satisfies the version constraint. If no version satisfies the constraint, an
+// error will be returned.
 func GetTargetVersion(ctx context.Context, logger log.Logger, registryDomain string, moduleRegistryBasePath string, modulePath string, versionQuery string) (string, error) {
 	// Handle the case where the registry domain is not part of the module registry base path
+	// since sometimes the registry domain is not part of the base path, but other times it is.
 	if !strings.HasPrefix(moduleRegistryBasePath, "https://") {
 		moduleRegistryBasePath = fmt.Sprintf("https://%s%s", registryDomain, moduleRegistryBasePath)
 	}

--- a/tf/getter_test.go
+++ b/tf/getter_test.go
@@ -155,7 +155,6 @@ func TestBuildRequestUrlRelativePath(t *testing.T) {
 	assert.Equal(t, "https://gruntwork.io/registry/modules/v1/tfr-project/terraform-aws-tfr/6.6.6/download", requestURL.String())
 }
 
-// Combine all the tests cases below into one test function, including the last one where a non existant module is requested
 func TestGetTargetVersion(t *testing.T) {
 	t.Parallel()
 	registryDomain := "registry.terraform.io"

--- a/tf/getter_test.go
+++ b/tf/getter_test.go
@@ -153,5 +153,82 @@ func TestBuildRequestUrlRelativePath(t *testing.T) {
 	requestURL, err := tf.BuildRequestURL("gruntwork.io", "/registry/modules/v1", "/tfr-project/terraform-aws-tfr", "6.6.6")
 	require.NoError(t, err)
 	assert.Equal(t, "https://gruntwork.io/registry/modules/v1/tfr-project/terraform-aws-tfr/6.6.6/download", requestURL.String())
+}
 
+// Combine all the tests cases below into one test function, including the last one where a non existant module is requested
+func TestGetTargetVersion(t *testing.T) {
+	t.Parallel()
+	registryDomain := "registry.terraform.io"
+	moduleRegistryBasePath := "/v1/modules/"
+	tc := []struct {
+		name           string
+		modulePath     string
+		targetVersion  string
+		expectedResult string
+	}{
+		{
+			name:           "FixedVersion",
+			modulePath:     "/terraform-aws-modules/iam/aws",
+			targetVersion:  "3.3.0",
+			expectedResult: "3.3.0",
+		},
+		{
+			name:           "PessimisticPatchVersion",
+			modulePath:     "/terraform-aws-modules/iam/aws",
+			targetVersion:  "~> 0.0.1",
+			expectedResult: "0.0.7",
+		},
+		{
+			name:           "PessimisticMinorVersion",
+			modulePath:     "/terraform-aws-modules/iam/aws",
+			targetVersion:  "~> 3.3",
+			expectedResult: "3.16.0",
+		},
+		{
+			name:           "ComplexConstraint",
+			modulePath:     "/terraform-aws-modules/iam/aws",
+			targetVersion:  ">= 3.3.0, <5.0.0,!= 4.24.1,!=4.24.0",
+			expectedResult: "4.23.0",
+		},
+		{
+			name:           "InvalidConstraint",
+			modulePath:     "/terraform-aws-modules/iam/aws",
+			targetVersion:  ">= 3.3.0 and >4.24.1",
+			expectedResult: "",
+		},
+		{
+			name:           "UnsatisfiableConstraint",
+			modulePath:     "/terraform-aws-modules/iam/aws",
+			targetVersion:  ">= 3.3.0, <3.2.0",
+			expectedResult: "",
+		},
+		{
+			name:           "InvalidVersion",
+			modulePath:     "/terraform-aws-modules/iam/aws",
+			targetVersion:  "~> a.b.c",
+			expectedResult: "",
+		},
+		{
+			name:           "NotExistingModule",
+			modulePath:     "/terraform-not-existing-modules/not-existing-module",
+			targetVersion:  "3.3.0",
+			expectedResult: "",
+		},
+	}
+
+	for _, tt := range tc {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			targetVersion, err := tf.GetTargetVersion(context.Background(), log.New(), registryDomain, moduleRegistryBasePath, tt.modulePath, tt.targetVersion)
+			if tt.expectedResult == "" {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, targetVersion)
+			}
+		})
+	}
 }

--- a/tf/getter_test.go
+++ b/tf/getter_test.go
@@ -162,55 +162,55 @@ func TestGetTargetVersion(t *testing.T) {
 	tc := []struct {
 		name           string
 		modulePath     string
-		targetVersion  string
+		versionQuery   string
 		expectedResult string
 	}{
 		{
 			name:           "FixedVersion",
 			modulePath:     "/terraform-aws-modules/iam/aws",
-			targetVersion:  "3.3.0",
+			versionQuery:   "3.3.0",
 			expectedResult: "3.3.0",
 		},
 		{
 			name:           "PessimisticPatchVersion",
 			modulePath:     "/terraform-aws-modules/iam/aws",
-			targetVersion:  "~> 0.0.1",
+			versionQuery:   "~> 0.0.1",
 			expectedResult: "0.0.7",
 		},
 		{
 			name:           "PessimisticMinorVersion",
 			modulePath:     "/terraform-aws-modules/iam/aws",
-			targetVersion:  "~> 3.3",
+			versionQuery:   "~> 3.3",
 			expectedResult: "3.16.0",
 		},
 		{
 			name:           "ComplexConstraint",
 			modulePath:     "/terraform-aws-modules/iam/aws",
-			targetVersion:  ">= 3.3.0, <5.0.0,!= 4.24.1,!=4.24.0",
+			versionQuery:   ">= 3.3.0, <5.0.0,!= 4.24.1,!=4.24.0",
 			expectedResult: "4.23.0",
 		},
 		{
 			name:           "InvalidConstraint",
 			modulePath:     "/terraform-aws-modules/iam/aws",
-			targetVersion:  ">= 3.3.0 and >4.24.1",
+			versionQuery:   ">= 3.3.0 and >4.24.1",
 			expectedResult: "",
 		},
 		{
 			name:           "UnsatisfiableConstraint",
 			modulePath:     "/terraform-aws-modules/iam/aws",
-			targetVersion:  ">= 3.3.0, <3.2.0",
+			versionQuery:   ">= 3.3.0, <3.2.0",
 			expectedResult: "",
 		},
 		{
 			name:           "InvalidVersion",
 			modulePath:     "/terraform-aws-modules/iam/aws",
-			targetVersion:  "~> a.b.c",
+			versionQuery:   "~> a.b.c",
 			expectedResult: "",
 		},
 		{
 			name:           "NotExistingModule",
 			modulePath:     "/terraform-not-existing-modules/not-existing-module",
-			targetVersion:  "3.3.0",
+			versionQuery:   "3.3.0",
 			expectedResult: "",
 		},
 	}
@@ -221,7 +221,10 @@ func TestGetTargetVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			targetVersion, err := tf.GetTargetVersion(context.Background(), log.New(), registryDomain, moduleRegistryBasePath, tt.modulePath, tt.targetVersion)
+			moduleVersionsURL, err := tf.BuildModuleVersionsURL(registryDomain, moduleRegistryBasePath, tt.modulePath)
+			require.NoError(t, err)
+
+			targetVersion, err := tf.GetTargetVersion(context.Background(), log.New(), *moduleVersionsURL, tt.versionQuery)
 			if tt.expectedResult == "" {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #1930
Fixes #2572 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added support for version constraints for Terraform Registry modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced module version management with clearer error messages for various failure scenarios.
  - Improved module version retrieval process, ensuring accurate version selection and increased logging transparency during downloads.
  - New configuration file for Terragrunt to retrieve modules from the public Terraform registry.
  - Added a new test for Terraform registry version resolution to ensure correct functionality.

- **Documentation**
  - Updated documentation for the `VERSION` argument in the `terraform` block to clarify acceptable formats.

- **Tests**
  - Expanded test coverage for the `GetTargetVersion` function to handle various input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->