### PR TITLE
Stacks: stack values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -897,7 +897,7 @@ func ParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChild *Inc
 
 	// read unit files and add to context
 	if ctx.TerragruntOptions.Experiments.Evaluate(experiment.Stacks) {
-		unitValues, err := ReadUnitValues(ctx.Context, ctx.TerragruntOptions, filepath.Dir(file.ConfigPath))
+		unitValues, err := ReadValues(ctx.Context, ctx.TerragruntOptions, filepath.Dir(file.ConfigPath))
 		if err != nil {
 			return nil, err
 		}

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -350,7 +350,7 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 
 	// read unit files and add to context
 	if ctx.TerragruntOptions.Experiments.Evaluate(experiment.Stacks) {
-		unitValues, err := ReadUnitValues(ctx.Context, ctx.TerragruntOptions, filepath.Dir(file.ConfigPath))
+		unitValues, err := ReadValues(ctx.Context, ctx.TerragruntOptions, filepath.Dir(file.ConfigPath))
 		if err != nil {
 			return nil, err
 		}

--- a/config/cty_helpers.go
+++ b/config/cty_helpers.go
@@ -419,38 +419,3 @@ func CtyValueAsString(val cty.Value) (string, error) {
 
 	return string(jsonBytes), nil
 }
-
-// MergeValues takes two cty.Value objects (which must be object types) and merges
-// them by shallowly copying all attributes from base, then overwriting with
-// any attributes found in override.
-func MergeValues(base, override *cty.Value) *cty.Value {
-	// If both are nil, nothing to merge
-	if base == nil && override == nil {
-		return nil
-	}
-	// If only one is nil, return the non-nil one
-	if base == nil {
-		return override
-	}
-	if override == nil {
-		return base
-	}
-
-	// Convert each to map
-	baseMap := base.AsValueMap()
-	overrideMap := override.AsValueMap()
-
-	// Copy baseMap
-	merged := make(map[string]cty.Value, len(baseMap)+len(overrideMap))
-	for k, v := range baseMap {
-		merged[k] = v
-	}
-
-	// Override with values from overrideMap
-	for k, v := range overrideMap {
-		merged[k] = v
-	}
-
-	result := cty.ObjectVal(merged)
-	return &result
-}

--- a/config/cty_helpers.go
+++ b/config/cty_helpers.go
@@ -419,3 +419,38 @@ func CtyValueAsString(val cty.Value) (string, error) {
 
 	return string(jsonBytes), nil
 }
+
+// MergeValues takes two cty.Value objects (which must be object types) and merges
+// them by shallowly copying all attributes from base, then overwriting with
+// any attributes found in override.
+func MergeValues(base, override *cty.Value) *cty.Value {
+	// If both are nil, nothing to merge
+	if base == nil && override == nil {
+		return nil
+	}
+	// If only one is nil, return the non-nil one
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+
+	// Convert each to map
+	baseMap := base.AsValueMap()
+	overrideMap := override.AsValueMap()
+
+	// Copy baseMap
+	merged := make(map[string]cty.Value, len(baseMap)+len(overrideMap))
+	for k, v := range baseMap {
+		merged[k] = v
+	}
+
+	// Override with values from overrideMap
+	for k, v := range overrideMap {
+		merged[k] = v
+	}
+
+	result := cty.ObjectVal(merged)
+	return &result
+}

--- a/config/stack.go
+++ b/config/stack.go
@@ -145,7 +145,9 @@ func StackOutput(ctx context.Context, opts *options.TerragruntOptions) (map[stri
 	return unitOutputs, nil
 }
 
-// generateStackFile processes a single stack file by reading its configuration, creating necessary directories,\n// and generating units and stacks.\n//\n// This function reads the values and stack configuration from the specified stack file path. It creates a target\n// directory for the stack and processes each unit and stack within the configuration. The function logs each\n// operation and returns early if any error is encountered.\n//\n// Parameters:\n//   - ctx: The context for managing timeouts and cancellation signals.\n//   - opts: A pointer to TerragruntOptions, which contains the logger and other configuration settings.\n//   - stackFilePath: A string representing the path to the stack file to be processed.\n//\n// Returns:\n//   - An error if any operation fails, such as reading values, creating directories, or generating units/stacks.\n//     If all operations succeed, it returns nil.\n
+// generateStackFile processes the Terragrunt stack configuration from the given stackFilePath,
+// reads necessary values, and generates units and stacks in the target directory.
+// It handles the creation of required directories and returns any errors encountered.
 func generateStackFile(ctx context.Context, opts *options.TerragruntOptions, stackFilePath string) error {
 	stackSourceDir := filepath.Dir(stackFilePath)
 
@@ -177,7 +179,9 @@ func generateStackFile(ctx context.Context, opts *options.TerragruntOptions, sta
 	return nil
 }
 
-// generateUnits processes each unit by resolving its destination path and copying files from the source.\n// It then writes the unit's values file and logs any errors encountered.\n// In case of an error, the function exits early.\n//\n// This function iterates over a list of Unit objects, determines the absolute destination path for each unit,\n// and copies the necessary files from the source to the destination. It also generates a values file for each unit\n// using the writeValues function. The function logs each operation and returns early if any error is encountered.\n//\n// Parameters:\n//   - ctx: The context for managing timeouts and cancellation signals.\n//   - opts: A pointer to TerragruntOptions, which contains the logger and other configuration settings.\n//   - stackSourceDir: A string representing the source directory where the unit files are located.\n//   - stackTargetDir: A string representing the target directory where the unit files will be copied.\n//   - units: A slice of pointers to Unit objects that need to be processed.\n//\n// Returns:\n//   - An error if any operation fails, such as resolving paths, copying files, or writing values.\n//     If all operations succeed, it returns nil.\n
+// generateUnits iterates through a slice of Unit objects, processing each one by copying
+// source files to their destination paths and writing unit-specific values.
+// It logs the processing progress and returns any errors encountered during the operation.
 func generateUnits(ctx context.Context, opts *options.TerragruntOptions, stackSourceDir, stackTargetDir string, units []*Unit) error {
 	for _, unit := range units {
 		opts.Logger.Infof("Processing unit %s", unit.Name)

--- a/config/stack.go
+++ b/config/stack.go
@@ -49,9 +49,10 @@ type Unit struct {
 
 // Stack represents the stack block in the configuration.
 type Stack struct {
-	Name   string `hcl:",label"`
-	Source string `hcl:"source,attr"`
-	Path   string `hcl:"path,attr"`
+	Name   string     `hcl:",label"`
+	Source string     `hcl:"source,attr"`
+	Path   string     `hcl:"path,attr"`
+	Values *cty.Value `hcl:"values,attr"`
 }
 
 // GenerateStacks generates the stack files.

--- a/config/stack.go
+++ b/config/stack.go
@@ -183,11 +183,11 @@ func generateStackFile(ctx context.Context, opts *options.TerragruntOptions, sta
 // generateUnits iterates through a slice of Unit objects, processing each one by copying
 // source files to their destination paths and writing unit-specific values.
 // It logs the processing progress and returns any errors encountered during the operation.
-func generateUnits(ctx context.Context, opts *options.TerragruntOptions, stackSourceDir, stackTargetDir string, units []*Unit) error {
+func generateUnits(ctx context.Context, opts *options.TerragruntOptions, sourceDir, targetDir string, units []*Unit) error {
 	for _, unit := range units {
 		item := itemToProcess{
-			sourceDir: stackSourceDir,
-			targetDir: stackTargetDir,
+			sourceDir: sourceDir,
+			targetDir: targetDir,
 			name:      unit.Name,
 			path:      unit.Path,
 			source:    unit.Source,
@@ -206,11 +206,11 @@ func generateUnits(ctx context.Context, opts *options.TerragruntOptions, stackSo
 
 // generateStacks processes each stack by resolving its destination path and copying files from the source.
 // It logs each operation and returns early if any error is encountered.
-func generateStacks(ctx context.Context, opts *options.TerragruntOptions, stackSourceDir, stackTargetDir string, stacks []*Stack) error {
+func generateStacks(ctx context.Context, opts *options.TerragruntOptions, sourceDir, targetDir string, stacks []*Stack) error {
 	for _, stack := range stacks {
 		item := itemToProcess{
-			sourceDir: stackSourceDir,
-			targetDir: stackTargetDir,
+			sourceDir: sourceDir,
+			targetDir: targetDir,
 			name:      stack.Name,
 			path:      stack.Path,
 			source:    stack.Source,

--- a/config/stack.go
+++ b/config/stack.go
@@ -116,6 +116,7 @@ func StackOutput(ctx context.Context, opts *options.TerragruntOptions) (map[stri
 		// read stack values file
 		dir := filepath.Dir(path)
 		values, err := ReadValues(ctx, opts, dir)
+
 		if err != nil {
 			return nil, errors.New(err)
 		}
@@ -344,13 +345,16 @@ func ReadStackConfigFile(ctx context.Context, opts *options.TerragruntOptions, f
 	opts.Logger.Debugf("Reading Terragrunt stack config file at %s", filePath)
 
 	parser := NewParsingContext(ctx, opts)
+
 	if values != nil {
 		parser = parser.WithValues(values)
 	}
+
 	file, err := hclparse.NewParser(parser.ParserOptions...).ParseFromFile(filePath)
 	if err != nil {
 		return nil, errors.New(err)
 	}
+
 	//nolint:contextcheck
 	if err := processLocals(parser, opts, file); err != nil {
 		return nil, errors.New(err)
@@ -379,6 +383,7 @@ func writeValues(opts *options.TerragruntOptions, values *cty.Value, directory s
 		opts.Logger.Debugf("No values to write in %s", directory)
 		return nil
 	}
+
 	if directory == "" {
 		return errors.New("writeValues: unit directory path cannot be empty")
 	}
@@ -386,6 +391,7 @@ func writeValues(opts *options.TerragruntOptions, values *cty.Value, directory s
 	if err := os.MkdirAll(directory, unitDirPerm); err != nil {
 		return errors.Errorf("failed to create directory %s: %w", directory, err)
 	}
+
 	opts.Logger.Debugf("Writing values file in %s", directory)
 	filePath := filepath.Join(directory, valuesFile)
 

--- a/config/stack.go
+++ b/config/stack.go
@@ -145,7 +145,7 @@ func StackOutput(ctx context.Context, opts *options.TerragruntOptions) (map[stri
 	return unitOutputs, nil
 }
 
-// generateStackFile process single stack file.
+// generateStackFile processes a single stack file by reading its configuration, creating necessary directories,\n// and generating units and stacks.\n//\n// This function reads the values and stack configuration from the specified stack file path. It creates a target\n// directory for the stack and processes each unit and stack within the configuration. The function logs each\n// operation and returns early if any error is encountered.\n//\n// Parameters:\n//   - ctx: The context for managing timeouts and cancellation signals.\n//   - opts: A pointer to TerragruntOptions, which contains the logger and other configuration settings.\n//   - stackFilePath: A string representing the path to the stack file to be processed.\n//\n// Returns:\n//   - An error if any operation fails, such as reading values, creating directories, or generating units/stacks.\n//     If all operations succeed, it returns nil.\n
 func generateStackFile(ctx context.Context, opts *options.TerragruntOptions, stackFilePath string) error {
 	stackSourceDir := filepath.Dir(stackFilePath)
 
@@ -177,9 +177,7 @@ func generateStackFile(ctx context.Context, opts *options.TerragruntOptions, sta
 	return nil
 }
 
-// generateUnits processes each unit by resolving its destination path and copying files from the source.
-// It then writes the unit's values file and logs any errors encountered.
-// In case of an error, the function exits early.
+// generateUnits processes each unit by resolving its destination path and copying files from the source.\n// It then writes the unit's values file and logs any errors encountered.\n// In case of an error, the function exits early.\n//\n// This function iterates over a list of Unit objects, determines the absolute destination path for each unit,\n// and copies the necessary files from the source to the destination. It also generates a values file for each unit\n// using the writeValues function. The function logs each operation and returns early if any error is encountered.\n//\n// Parameters:\n//   - ctx: The context for managing timeouts and cancellation signals.\n//   - opts: A pointer to TerragruntOptions, which contains the logger and other configuration settings.\n//   - stackSourceDir: A string representing the source directory where the unit files are located.\n//   - stackTargetDir: A string representing the target directory where the unit files will be copied.\n//   - units: A slice of pointers to Unit objects that need to be processed.\n//\n// Returns:\n//   - An error if any operation fails, such as resolving paths, copying files, or writing values.\n//     If all operations succeed, it returns nil.\n
 func generateUnits(ctx context.Context, opts *options.TerragruntOptions, stackSourceDir, stackTargetDir string, units []*Unit) error {
 	for _, unit := range units {
 		opts.Logger.Infof("Processing unit %s", unit.Name)

--- a/config/stack.go
+++ b/config/stack.go
@@ -154,7 +154,7 @@ func generateStackFile(ctx context.Context, opts *options.TerragruntOptions, sta
 
 	values, err := ReadValues(ctx, opts, stackSourceDir)
 	if err != nil {
-		return errors.Errorf("Failed to read values file %s in %s %v", stackFilePath, stackSourceDir, err)
+		return errors.Errorf("failed to read values from directory %s: %v", stackSourceDir, err)
 	}
 
 	stackFile, err := ReadStackConfigFile(ctx, opts, stackFilePath, values)
@@ -397,7 +397,7 @@ func ReadStackConfigFile(ctx context.Context, opts *options.TerragruntOptions, f
 	return config, nil
 }
 
-// writeValues generates and writes unit values to a terragrunt.values.hcl file in the specified unit directory.
+// writeValues generates and writes values to a terragrunt.values.hcl file in the specified directory.
 func writeValues(opts *options.TerragruntOptions, values *cty.Value, directory string) error {
 	if values == nil {
 		opts.Logger.Debugf("No values to write in %s", directory)
@@ -435,7 +435,7 @@ func writeValues(opts *options.TerragruntOptions, values *cty.Value, directory s
 	return nil
 }
 
-// ReadValues reads the unit values from the terragrunt.values.hcl file.
+// ReadValues reads values from the terragrunt.values.hcl file in the specified directory.
 func ReadValues(ctx context.Context, opts *options.TerragruntOptions, directory string) (*cty.Value, error) {
 	if directory == "" {
 		return nil, errors.New("ReadValues: directory path cannot be empty")

--- a/docs/_docs/04_reference/04-config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/04-config-blocks-and-attributes.md
@@ -1718,7 +1718,7 @@ stack "services" {
 ```
 
 In this example, the `services` stack is defined with path `services`, which will be generated at `.terragrunt-stack/services`.
-The stack is also provided with custom values for `project` and `env`, which can be used within the stack's configuration files.
+The stack is also provided with custom values for `project` and `cidr`, which can be used within the stack's configuration files.
 Terragrunt will recursively generate a stack using the contents of the `.terragrunt-stack/services/terragrunt.stack.hcl` file until the entire stack is fully generated.
 
 ## Attributes

--- a/docs/_docs/04_reference/04-config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/04-config-blocks-and-attributes.md
@@ -1701,6 +1701,7 @@ The `stack` block supports the following arguments:
 - `name` (label): A unique identifier for the stack. This is used to reference the stack elsewhere in your configuration.
 - `source` (attribute): Specifies where to find the Terragrunt configuration files for this stack. This follows the same syntax as the `source` parameter in the `terraform` block.
 - `path` (attribute): The relative path within `.terragrunt-stack` where this stack should be generated.If an absolute path is provided here, Terragrunt will generate the stack in that location, instead of generating it in a path relative to the `.terragrunt-stack` directory.
+- `values` (attribute, optional): A map of custom values that can be passed to the stack. These values can be referenced within the stack's configuration files, allowing for customization without modifying the stack source.
 
 Example:
 
@@ -1709,10 +1710,15 @@ Example:
 stack "services" {
     source = "github.com/gruntwork-io/terragrunt-stacks//stacks/mock/services?ref=v0.0.1"
     path   = "services"
+    values = {
+        project = "dev-services"
+        cidr    = "10.0.0.0/16"
+    }
 }
 ```
 
 In this example, the `services` stack is defined with path `services`, which will be generated at `.terragrunt-stack/services`.
+The stack is also provided with custom values for `project` and `env`, which can be used within the stack's configuration files.
 Terragrunt will recursively generate a stack using the contents of the `.terragrunt-stack/services/terragrunt.stack.hcl` file until the entire stack is fully generated.
 
 ## Attributes

--- a/docs/_docs/04_reference/04-config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/04-config-blocks-and-attributes.md
@@ -1715,6 +1715,15 @@ stack "services" {
         cidr    = "10.0.0.0/16"
     }
 }
+
+# github.com/gruntwork-io/terragrunt-stacks//stacks/mock/services/terragrunt.stack.hcl
+# ...
+unit "vpc" {
+  # ...
+  values = {
+    cidr = values.cidr
+  }
+}
 ```
 
 In this example, the `services` stack is defined with path `services`, which will be generated at `.terragrunt-stack/services`.

--- a/test/fixtures/stacks/stack-values/project/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-values/project/terragrunt.stack.hcl
@@ -1,0 +1,20 @@
+
+stack "dev" {
+  source = "${get_repo_root()}/stacks/dev"
+  path = "dev"
+  values = {
+    project = "dev-project"
+    env = "dev"
+  }
+}
+
+
+stack "prod" {
+  source = "${get_repo_root()}/stacks/prod"
+  path = "prod"
+  values = {
+      project = "prod-project"
+      env = "prod"
+  }
+}
+

--- a/test/fixtures/stacks/stack-values/project/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-values/project/terragrunt.stack.hcl
@@ -8,7 +8,6 @@ stack "dev" {
   }
 }
 
-
 stack "prod" {
   source = "${get_repo_root()}/stacks/prod"
   path = "prod"

--- a/test/fixtures/stacks/stack-values/stacks/dev/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-values/stacks/dev/terragrunt.stack.hcl
@@ -1,0 +1,19 @@
+unit "dev-app-1" {
+	source = "${get_repo_root()}/units/app"
+	path   = "dev-app-1"
+	values = {
+		project = values.project
+		env = values.env
+		data = "dev-app-1"
+	}
+}
+
+unit "dev-app-2" {
+	source = "${get_repo_root()}/units/app"
+	path   = "dev-app-2"
+	values = {
+		project = values.project
+		env = values.env
+		data = "dev-app-2"
+	}
+}

--- a/test/fixtures/stacks/stack-values/stacks/prod/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-values/stacks/prod/terragrunt.stack.hcl
@@ -1,0 +1,19 @@
+unit "prod-app-1" {
+	source = "${get_repo_root()}/units/app"
+	path   = "prod-app-1"
+	values = {
+		project = values.project
+		env = values.env
+		data = "prod-app-1"
+	}
+}
+
+unit "prod-app-2" {
+	source = "${get_repo_root()}/units/app"
+	path   = "prod-app-2"
+	values = {
+		project = values.project
+		env = values.env
+		data = "prod-app-2"
+	}
+}

--- a/test/fixtures/stacks/stack-values/units/app/main.tf
+++ b/test/fixtures/stacks/stack-values/units/app/main.tf
@@ -1,0 +1,17 @@
+
+variable "project" {}
+
+variable "env" {}
+
+locals {
+  config = "${var.project} ${var.env}"
+}
+
+resource "local_file" "file" {
+  content  = local.config
+  filename = "${path.module}/file.txt"
+}
+
+output "config" {
+  value = local.config
+}

--- a/test/fixtures/stacks/stack-values/units/app/main.tf
+++ b/test/fixtures/stacks/stack-values/units/app/main.tf
@@ -3,8 +3,10 @@ variable "project" {}
 
 variable "env" {}
 
+variable "data" {}
+
 locals {
-  config = "${var.project} ${var.env}"
+  config = "${var.project} ${var.env} ${var.data}"
 }
 
 resource "local_file" "file" {
@@ -14,4 +16,16 @@ resource "local_file" "file" {
 
 output "config" {
   value = local.config
+}
+
+output "project" {
+  value = var.project
+}
+
+output "env" {
+  value = var.env
+}
+
+output "data" {
+  value = var.data
 }

--- a/test/fixtures/stacks/stack-values/units/app/main.tf
+++ b/test/fixtures/stacks/stack-values/units/app/main.tf
@@ -1,9 +1,17 @@
+variable "project" {
+  description = "The project identifier"
+  type        = string
+}
 
-variable "project" {}
+variable "env" {
+  description = "The environment name"
+  type        = string
+}
 
-variable "env" {}
-
-variable "data" {}
+variable "data" {
+  description = "Additional data for the configuration"
+  type        = string
+}
 
 locals {
   config = "${var.project} ${var.env} ${var.data}"
@@ -15,17 +23,21 @@ resource "local_file" "file" {
 }
 
 output "config" {
-  value = local.config
+  value       = local.config
+  description = "The combined configuration string"
 }
 
 output "project" {
-  value = var.project
+  value       = var.project
+  description = "The project identifier"
 }
 
 output "env" {
-  value = var.env
+  value       = var.env
+  description = "The environment name"
 }
 
 output "data" {
-  value = var.data
+  value       = var.data
+  description = "Additional data used in the configuration"
 }

--- a/test/fixtures/stacks/stack-values/units/app/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-values/units/app/terragrunt.hcl
@@ -2,4 +2,5 @@
 inputs = {
   project = values.project
   env = values.env
+  data = values.data
 }

--- a/test/fixtures/stacks/stack-values/units/app/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-values/units/app/terragrunt.hcl
@@ -1,0 +1,5 @@
+
+inputs = {
+  project = values.project
+  env = values.env
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

 * Added support for values in stack block:

```
stack "dev" {
  source = "${get_repo_root()}/stacks/dev"
  path = "dev"
  values = {
    project = "dev-project"
    env = "dev"
  }
}

```
* Added integration tests to track this
* Documentation update

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an optional “values” attribute for stacks and units, allowing users to set custom key-value configurations.
	- Introduced sample configurations for both development and production environments.
	- Enhanced value management in stack configurations for improved integration.

- **Documentation**
	- Updated reference materials with examples on using the new “values” attribute.

- **Tests**
	- Expanded integration tests to verify stack configuration generation, application, and output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->