### PR TITLE
feat: Strict control for old deprecated env vars

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -231,16 +231,6 @@ func runAction(cliCtx *cli.Context, opts *options.TerragruntOptions, action cli.
 
 // mostly preparing terragrunt options
 func initialSetup(cliCtx *cli.Context, opts *options.TerragruntOptions) error {
-	// The env vars are renamed to "..._NO_AUTO_..." in the global flags`. These ones are left for backwards compatibility.
-	opts.AutoInit = env.GetBool(os.Getenv("TERRAGRUNT_AUTO_INIT"), opts.AutoInit)
-	opts.AutoRetry = env.GetBool(os.Getenv("TERRAGRUNT_AUTO_RETRY"), opts.AutoRetry)
-	opts.RunAllAutoApprove = env.GetBool(os.Getenv("TERRAGRUNT_AUTO_APPROVE"), opts.RunAllAutoApprove)
-
-	// `TF_INPUT` is the old env var for`--terragrunt-non-interactive` flag, now is replaced with `TERRAGRUNT_NON_INTERACTIVE` but kept for backwards compatibility.
-	// If `TF_INPUT` is false then `opts.NonInteractive` is true.
-	opts.NonInteractive = env.GetNegativeBool(os.Getenv("TF_INPUT"), opts.NonInteractive)
-
-	// --- Args
 	// convert the rest flags (intended for terraform) to one dash, e.g. `--input=true` to `-input=true`
 	args := cliCtx.Args().WithoutBuiltinCmdSep().Normalize(cli.SingleDashFlag)
 	cmdName := cliCtx.Command.Name

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -339,17 +339,21 @@ func TestParseMultiStringArg(t *testing.T) {
 		{[]string{commands.CommandNamePlanAll, "--test", "value", flagName, "bar1", flagName}, []string{"default_bar"}, nil, argMissingValueError(run.UnitsThatIncludeFlagName)},
 	}
 
-	for _, testCase := range testCases {
-		opts := options.NewTerragruntOptions()
-		opts.ModulesThatInclude = testCase.defaultValue
-		actualOptions, actualErr := runAppTest(testCase.args, opts)
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedErr != nil {
-			assert.EqualError(t, actualErr, testCase.expectedErr.Error())
-		} else {
-			require.NoError(t, actualErr)
-			assert.Equal(t, testCase.expectedVals, actualOptions.ModulesThatInclude, "For args %q", testCase.args)
-		}
+			opts := options.NewTerragruntOptions()
+			opts.ModulesThatInclude = testCase.defaultValue
+			actualOptions, actualErr := runAppTest(testCase.args, opts)
+
+			if testCase.expectedErr != nil {
+				assert.EqualError(t, actualErr, testCase.expectedErr.Error())
+			} else {
+				require.NoError(t, actualErr)
+				assert.Equal(t, testCase.expectedVals, actualOptions.ModulesThatInclude, "For args %q", testCase.args)
+			}
+		})
 	}
 }
 

--- a/cli/commands/exec/command.go
+++ b/cli/commands/exec/command.go
@@ -53,11 +53,14 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		},
 		Flags:                NewFlags(opts, cmdOpts, nil).Sort(),
 		ErrorOnUndefinedFlag: true,
-		Action: func(ctx *cli.Context) error {
+		Before: func(ctx *cli.Context) error {
 			if !opts.Experiments.Evaluate(experiment.CLIRedesign) {
 				return cli.NewExitError(errors.Errorf("requires that the %[1]s experiment is enabled. e.g. --experiment %[1]s", experiment.CLIRedesign), cli.ExitCodeGeneralError)
 			}
 
+			return nil
+		},
+		Action: func(ctx *cli.Context) error {
 			tgArgs, cmdArgs := ctx.Args().Split(cli.BuiltinCmdSep)
 
 			// Use unspecified arguments from the terragrunt command if the user

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -99,8 +99,11 @@ const (
 	DeprecatedSourceUpdateFlagName                   = "source-update"
 	DeprecatedSourceFlagName                         = "source"
 	DeprecatedNoAutoApproveFlagName                  = "no-auto-approve"
+	DeprecatedAutoApproveFlagName                    = "auto-approve"
 	DeprecatedNoAutoRetryFlagName                    = "no-auto-retry"
+	DeprecatedAutoRetryFlagName                      = "auto-retry"
 	DeprecatedNoAutoInitFlagName                     = "no-auto-init"
+	DeprecatedAutoInitFlagName                       = "auto-init"
 	DeprecatedNoDestroyDependenciesCheckFlagName     = "no-destroy-dependencies-check"
 	DeprecatedDisableCommandValidationFlagName       = "disable-command-validation"
 	DeprecatedDisableBucketUpdateFlagName            = "disable-bucket-update"
@@ -153,7 +156,10 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			Negative:    true,
 			Destination: &opts.AutoInit,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedNoAutoInitFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedNoAutoInitFlagName), terragruntPrefixControl),
+			flags.WithDeprecatedFlag(&cli.BoolFlag{
+				EnvVars: terragruntPrefix.EnvVars(DeprecatedAutoInitFlagName),
+			}, nil, terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        NoAutoRetryFlagName,
@@ -162,7 +168,10 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			Usage:       "Don't automatically re-run command in case of transient errors.",
 			Negative:    true,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedNoAutoRetryFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedNoAutoRetryFlagName), terragruntPrefixControl),
+			flags.WithDeprecatedFlag(&cli.BoolFlag{
+				EnvVars: terragruntPrefix.EnvVars(DeprecatedAutoRetryFlagName),
+			}, nil, terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        NoAutoApproveFlagName,
@@ -171,7 +180,10 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			Usage:       "Don't automatically append '-auto-approve' to the underlying OpenTofu/Terraform commands run with 'run-all'.",
 			Negative:    true,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedNoAutoApproveFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedNoAutoApproveFlagName), terragruntPrefixControl),
+			flags.WithDeprecatedFlag(&cli.BoolFlag{
+				EnvVars: terragruntPrefix.EnvVars(DeprecatedAutoApproveFlagName),
+			}, nil, terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        DownloadDirFlagName,

--- a/cli/flags/global/flags.go
+++ b/cli/flags/global/flags.go
@@ -57,6 +57,7 @@ const (
 	DeprecatedLogCustomFormatFlagName = "log-custom-format"
 	DeprecatedNoColorFlagName         = "no-color"
 	DeprecatedNonInteractiveFlagName  = "non-interactive"
+	DeprecatedTFInputFlagName         = "tf-input"
 	DeprecatedWorkingDirFlagName      = "working-dir"
 	DeprecatedStrictModeFlagName      = "strict-mode"
 	DeprecatedStrictControlFlagName   = "strict-control"
@@ -201,7 +202,11 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			Destination: &opts.NonInteractive,
 			Usage:       `Assume "yes" for all prompts.`,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedNonInteractiveFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedNonInteractiveFlagName), terragruntPrefixControl),
+			flags.WithDeprecatedFlag(&cli.BoolFlag{
+				Negative: true,
+				EnvVars:  flags.Prefix{}.EnvVars(DeprecatedTFInputFlagName),
+			}, nil, terragruntPrefixControl)),
 
 		// Experiment Mode flags.
 

--- a/cli/help.go
+++ b/cli/help.go
@@ -19,7 +19,7 @@ Author: {{ range .App.Authors }}{{ . }}{{ end }} {{ end }}
 `
 
 // CommandHelpTemplate is the command CLI help template.
-const CommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Command.UsageText 3 }}{{ else }}{{ range $index, $parent := parentCommands . }}{{ $parent.HelpName }} {{ if not $index }}[global options] {{ end }}{{ end }}{{ .Command.HelpName }}{{ if .Command.VisibleSubcommands }} <command>{{ end }}{{ if .Command.VisibleFlags }} [options]{{ end }}{{ end }}{{ $description := .Command.Usage }}{{ if .Command.Description }}{{ $description = .Command.Description }}{{ end }}{{ if $description }}
+const CommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Command.UsageText 3 }}{{ else }}{{ range $index, $parent := parentCommands . }}{{ $parent.HelpName }} {{ end }}{{ .Command.HelpName }}{{ if .Command.VisibleSubcommands }} <command>{{ end }}{{ if .Command.VisibleFlags }} [options]{{ end }}{{ end }}{{ $description := .Command.Usage }}{{ if .Command.Description }}{{ $description = .Command.Description }}{{ end }}{{ if $description }}
 
    {{ wrap $description 3 }}{{ end }}{{ if .Command.Examples }}
 

--- a/cli/help.go
+++ b/cli/help.go
@@ -19,14 +19,14 @@ Author: {{ range .App.Authors }}{{ . }}{{ end }} {{ end }}
 `
 
 // CommandHelpTemplate is the command CLI help template.
-const CommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Command.UsageText 3 }}{{ else }}{{ range $parent := parentCommands . }}{{ $parent.HelpName }} {{ end }}{{ .Command.HelpName }}{{ if .Command.VisibleSubcommands }} <command>{{ end }}{{ if .Command.VisibleFlags }} [options]{{ end }}{{ end }}{{ $description := .Command.Usage }}{{ if .Command.Description }}{{ $description = .Command.Description }}{{ end }}{{ if $description }}
+const CommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Command.UsageText 3 }}{{ else }}{{ range $index, $parent := parentCommands . }}{{ $parent.HelpName }} {{ if not $index }}[global options] {{ end }}{{ end }}{{ .Command.HelpName }}{{ if .Command.VisibleSubcommands }} <command>{{ end }}{{ if .Command.VisibleFlags }} [options]{{ end }}{{ end }}{{ $description := .Command.Usage }}{{ if .Command.Description }}{{ $description = .Command.Description }}{{ end }}{{ if $description }}
 
    {{ wrap $description 3 }}{{ end }}{{ if .Command.Examples }}
 
 Examples:
    {{ $s := join .Command.Examples "\n\n" }}{{ wrap $s 3 }}{{ end }}{{ if .Command.VisibleSubcommands }}
 
-Subcommands:{{ $cv := offsetCommands .Command.VisibleSubcommands 5 }}{{ range .Command.VisibleSubcommands }}
+Commands:{{ $cv := offsetCommands .Command.VisibleSubcommands 5 }}{{ range .Command.VisibleSubcommands }}
    {{ $s := .HelpName }}{{ $s }}{{ $sp := subtract $cv (offset $s 3) }}{{ indent $sp ""}} {{ wrap .Usage $cv }}{{ end }}{{ end }}{{ if .Command.VisibleFlags }}
 
 Options:

--- a/cli/help_test.go
+++ b/cli/help_test.go
@@ -91,7 +91,7 @@ Examples:
    # Run a plan against a Stack of configurations in the current directory
    terragrunt run --all -- plan
 
-Subcommands:
+Commands:
    fmt        Recursively find hcl files and rewrite them into a canonical format.
    validate   Find all hcl files from the config stack and validate them.
 

--- a/internal/cli/flag.go
+++ b/internal/cli/flag.go
@@ -272,7 +272,9 @@ func ApplyFlag(flag Flag, set *libflag.FlagSet) error {
 	}
 
 	for _, name := range flag.Names() {
-		set.Var(flag.Value().Getter(name), name, flag.GetUsage())
+		if name != "" {
+			set.Var(flag.Value().Getter(name), name, flag.GetUsage())
+		}
 	}
 
 	return nil

--- a/internal/strict/controls/deprecated_env_var.go
+++ b/internal/strict/controls/deprecated_env_var.go
@@ -3,6 +3,7 @@ package controls
 import (
 	"context"
 	"slices"
+	"strconv"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
@@ -69,6 +70,10 @@ func (ctrl *DeprecatedEnvVar) Evaluate(ctx context.Context) error {
 		envName = names[0]
 
 		value := ctrl.newFlag.Value().String()
+
+		if v, ok := ctrl.newFlag.Value().Get().(bool); ok && ctrl.newFlag.Value().IsNegativeBoolFlag() {
+			value = strconv.FormatBool(!v)
+		}
 
 		if value == "" {
 			value = ctrl.deprecatedFlag.Value().String()


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Put the following deprecated env vars under strict control:

```
TERRAGRUNT_AUTO_INIT
TERRAGRUNT_AUTO_RETRY
TERRAGRUNT_AUTO_APPROVE
TF_INPUT
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a pre-execution validation step requiring an experimental CLI redesign to be enabled.
  - Introduced deprecated flag options to support legacy usage.

- **Refactor**
  - Removed legacy environment variable configurations to streamline option handling.
  - Enhanced processing and validation of deprecated flags for improved reliability.

- **Documentation**
  - Updated help output labels (e.g., changed “Subcommands:” to “Commands:”) to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->