### PR TITLE
fix #3845 set the correct exit code when a retry is successful.

### DIFF
--- a/test/fixtures/detailed-exitcode/error/app2/terragrunt.hcl
+++ b/test/fixtures/detailed-exitcode/error/app2/terragrunt.hcl
@@ -1,1 +1,11 @@
-# Intentionally empty
+/*
+  Sequential dependency on app1 to ensure proper test execution.
+  This prevents flaky tests since:
+  - Local provider returns exit code 2 for managed resources
+  - Local provider returns exit code 1 for data sources
+  - Only the last exit code in the sequence can be checked
+*/
+
+dependencies {
+  paths = ["../app1"]
+}

--- a/test/fixtures/detailed-exitcode/fail-on-first-run/main.tf
+++ b/test/fixtures/detailed-exitcode/fail-on-first-run/main.tf
@@ -1,0 +1,16 @@
+data "external" "script" {
+  program = [
+    "/bin/bash",
+    "-c",
+    <<EOT
+      set -euo pipefail
+      if [[ -f .file ]]; then
+        echo '{}'
+        rm .file
+      else
+        touch .file
+        exit 1
+      fi
+    EOT
+  ]
+}

--- a/test/fixtures/detailed-exitcode/fail-on-first-run/terragrunt.hcl
+++ b/test/fixtures/detailed-exitcode/fail-on-first-run/terragrunt.hcl
@@ -1,0 +1,3 @@
+retry_max_attempts       = 2
+retry_sleep_interval_sec = 1
+retryable_errors = [".*"]

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -233,6 +233,23 @@ func TestDetailedExitCodeChangesPresentAll(t *testing.T) {
 	assert.Equal(t, 2, exitCode.Get())
 }
 
+func TestDetailedExitCodeFailOnFirstRun(t *testing.T) {
+	t.Parallel()
+
+	testFixturePath := filepath.Join(testFixtureDetailedExitCode, "fail-on-first-run")
+
+	helpers.CleanupTerraformFolder(t, testFixturePath)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixturePath)
+
+	var exitCode tf.DetailedExitCode
+	ctx := context.Background()
+	ctx = tf.ContextWithDetailedExitCode(ctx, &exitCode)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutputWithContext(t, ctx, "terragrunt run-all plan --terragrunt-log-level trace --terragrunt-non-interactive -detailed-exitcode --terragrunt-working-dir "+util.JoinPath(tmpEnvPath, testFixturePath))
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode.Get())
+}
+
 func TestDetailedExitCodeChangesPresentOne(t *testing.T) {
 	t.Parallel()
 

--- a/tf/detailed_exitcode.go
+++ b/tf/detailed_exitcode.go
@@ -4,10 +4,6 @@ import (
 	"sync"
 )
 
-const (
-	DetailedExitCodeError = 1
-)
-
 // DetailedExitCode is the TF detailed exit code. https://opentofu.org/docs/cli/commands/plan/
 type DetailedExitCode struct {
 	Code int
@@ -26,18 +22,9 @@ func (coder *DetailedExitCode) Get() int {
 // - 0 = Success
 // - 1 = Error
 // - 2 = Success with changes pending
-// The method only updates if:
-// - The current code is not 1 (error state)
-// - The new code is greater than current OR equals 1
 func (coder *DetailedExitCode) Set(newCode int) {
 	coder.mu.Lock()
 	defer coder.mu.Unlock()
 
-	if coder.Code == DetailedExitCodeError {
-		return
-	}
-
-	if coder.Code < newCode || newCode == DetailedExitCodeError {
-		coder.Code = newCode
-	}
+	coder.Code = newCode
 }

--- a/tf/run_cmd.go
+++ b/tf/run_cmd.go
@@ -74,6 +74,10 @@ func RunCommandWithOutput(ctx context.Context, opts *options.TerragruntOptions, 
 		if code != 1 {
 			return output, nil
 		}
+	} else {
+		if exitCode := DetailedExitCodeFromContext(ctx); exitCode != nil {
+			exitCode.Set(0)
+		}
 	}
 
 	return output, err


### PR DESCRIPTION
## Description

Fixes #3845 set the correct exit code when a retry is successful.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Fixes #3845 set the correct exit code when a retry is successful.

### Migration Guide

n/a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a data source that checks for file existence and manages output accordingly.
	- Added configurable retry options with set maximum attempts and pause intervals for improved error-handling during operations.
	- Added dependency declarations to enforce test execution order and prevent flaky tests.
- **Bug Fixes**
	- Enhanced exit code management to ensure successful executions are accurately reflected.
- **Refactor**
	- Simplified the logic for setting detailed exit codes to allow unrestricted assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->