### PR TITLE
fix: Adding missing cautionary asides

### DIFF
--- a/docs-starlight/src/content/docs/02-features/02-stacks.mdx
+++ b/docs-starlight/src/content/docs/02-features/02-stacks.mdx
@@ -112,6 +112,8 @@ If your units have dependencies between them, for example, you can’t deploy th
 <Aside type="danger">
 If your units have dependencies between them, and you run a `terragrunt run --all destroy` command, Terragrunt will destroy all the units under the current working directory, _as well as each of the unit dependencies_ (that is, units you depend on via `dependencies` and `dependency` blocks)!
 
+In the above example- this would mean that destroying the backend-app would also destroy Valkey and MySQL!
+
 If you wish to prevent external dependencies from being destroyed, add the [`--queue-exclude-external` flag](/docs/reference/cli/commands/run#queue-exclude-external), or use the [`--exclude-dir` flag](/docs/reference/cli/commands/run#exclude-dir) once for each directory you wish to exclude.
 </Aside>
 

--- a/docs-starlight/src/content/docs/02-features/02-stacks.mdx
+++ b/docs-starlight/src/content/docs/02-features/02-stacks.mdx
@@ -107,7 +107,7 @@ terragrunt run --all plan
 
 \* Note that the units _might_ run concurrently, but some units can be blocked from running until their dependencies are run.
 
-If your units have dependencies between them, for example, you can’t deploy the backend-app until MySQL and redis are deployed. You’ll need to express those dependencies in your Terragrunt configuration as explained in the next section.
+If your units have dependencies between them, for example, you can’t deploy the backend-app until MySQL and valkey are deployed. You’ll need to express those dependencies in your Terragrunt configuration as explained in the next section.
 
 <Aside type="danger">
 If your units have dependencies between them, and you run a `terragrunt run --all destroy` command, Terragrunt will destroy all the units under the current working directory, _as well as each of the unit dependencies_ (that is, units you depend on via `dependencies` and `dependency` blocks)!

--- a/docs-starlight/src/content/docs/02-features/02-stacks.mdx
+++ b/docs-starlight/src/content/docs/02-features/02-stacks.mdx
@@ -6,7 +6,7 @@ sidebar:
   order: 2
 ---
 
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 
 ## Motivation
 
@@ -109,7 +109,11 @@ terragrunt run --all plan
 
 If your units have dependencies between them, for example, you can’t deploy the backend-app until MySQL and redis are deployed. You’ll need to express those dependencies in your Terragrunt configuration as explained in the next section.
 
-Additional note: If your units have dependencies between them, and you run a `terragrunt run --all destroy` command, Terragrunt will destroy all the units under the current working directory, _as well as each of the unit dependencies_ (that is, units you depend on via `dependencies` and `dependency` blocks)! If you wish to prevent external dependencies from being destroyed, add the `--queue-exclude-external` flag, or use the `--exclude-dir` once for each directory you wish to exclude.
+<Aside type="danger">
+If your units have dependencies between them, and you run a `terragrunt run --all destroy` command, Terragrunt will destroy all the units under the current working directory, _as well as each of the unit dependencies_ (that is, units you depend on via `dependencies` and `dependency` blocks)!
+
+If you wish to prevent external dependencies from being destroyed, add the [`--queue-exclude-external` flag](/docs/reference/cli/commands/run#queue-exclude-external), or use the [`--exclude-dir` flag](/docs/reference/cli/commands/run#exclude-dir) once for each directory you wish to exclude.
+</Aside>
 
 ## Cutting down the file count
 
@@ -356,7 +360,13 @@ Any error encountered in an individual unit during a `run --all` command will pr
 
 To check all of your dependencies and validate the code in them, you can use the `run --all validate` command.
 
-**Note:** During `destroy` runs, Terragrunt will try to find all dependent units and show a confirmation prompt with a list of detected dependencies. This is because Terragrunt knows that once resources in a dependency are destroyed, any commands run on dependent units may fail. For example, if `destroy` was called on the `redis` unit, you'll be asked for confirmation, as the `backend-app` depends on `redis`. You can avoid the prompt by using `--non-interactive`.
+<Aside type="note">
+During `destroy` runs, Terragrunt will try to find all dependent units and show a confirmation prompt with a list of detected dependencies.
+
+This is because Terragrunt knows that once resources in a dependency are destroyed, any commands run on dependent units may fail.
+
+For example, if `destroy` was called on the `redis` unit, you'd be asked for confirmation, as the `backend-app` depends on `redis`. You can suppress the prompt by using the `--non-interactive` flag.
+</Aside>
 
 ## Visualizing the DAG
 

--- a/docs-starlight/src/content/docs/02-features/02-stacks.mdx
+++ b/docs-starlight/src/content/docs/02-features/02-stacks.mdx
@@ -367,7 +367,7 @@ During `destroy` runs, Terragrunt will try to find all dependent units and show 
 
 This is because Terragrunt knows that once resources in a dependency are destroyed, any commands run on dependent units may fail.
 
-For example, if `destroy` was called on the `redis` unit, you'd be asked for confirmation, as the `backend-app` depends on `redis`. You can suppress the prompt by using the `--non-interactive` flag.
+For example, if `destroy` was called on the `Valkey` unit, you'd be asked for confirmation, as the `backend-app` depends on `Valkey`. You can suppress the prompt by using the `--non-interactive` flag.
 </Aside>
 
 ## Visualizing the DAG

--- a/docs-starlight/src/content/docs/04-reference/02-cli/02-commands/hcl/0902-lint.md
+++ b/docs-starlight/src/content/docs/04-reference/02-cli/02-commands/hcl/0902-lint.md
@@ -1,0 +1,13 @@
+---
+title: lint
+description: Lint Terragrunt HCL configuration.
+slug: docs/reference/cli/commands/hcl/lint
+sidebar:
+  order: 902
+  badge:
+    text: exp
+    variant: tip
+---
+
+<!-- This page is intentionally empty. Commands are defined in `src/pages/docs/reference/cli/commands/[...slug.astro] -->
+<!-- This file is a placeholder to ensure that other pages see commands in their sidebars, and so that the data is accessible in the docs collection. -->

--- a/docs-starlight/src/data/commands/hcl/lint.mdx
+++ b/docs-starlight/src/data/commands/hcl/lint.mdx
@@ -1,0 +1,27 @@
+---
+name: lint
+path: hcl/lint
+category: configuration
+sidebar:
+  order: 902
+description: Lint Terragrunt HCL configuration.
+usage: |
+   Lint Terragrunt HCL configuration.
+experiment:
+  control: cli-redesign
+  name: cli redesign
+examples:
+  - description: Lint all HCL files in the current directory.
+    code: |
+      terragrunt hcl lint
+  - description: Throw an error if any variables are not set by the module a unit provisions.
+    code: |
+      terragrunt hcl lint --inputs
+  - description: Throw an error if any inputs are set that are not defined in the module.
+    code: |
+      terragrunt hcl lint --inputs --strict
+
+flags:
+  - hcl-lint-inputs
+  - hcl-lint-strict
+---

--- a/docs-starlight/src/data/commands/run.mdx
+++ b/docs-starlight/src/data/commands/run.mdx
@@ -74,6 +74,8 @@ flags:
   - use-partial-parse-config-cache
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 ## Running multiple units
 
 Note that the `run` command is a more explicit and flexible way to run OpenTofu/Terraform commands in comparison to [OpenTofu shortcuts](/docs/reference/cli/commands/opentofu-shortcuts).

--- a/docs-starlight/src/data/commands/run.mdx
+++ b/docs-starlight/src/data/commands/run.mdx
@@ -90,3 +90,19 @@ You may, at times, need to explicitly separate the arguments used for Terragrunt
 ```bash
 terragrunt run -- plan -no-color
 ```
+
+<Aside type="caution">
+When using `run --all plan` with units that have dependencies (e.g. via `dependency` or `dependencies` blocks), the command will fail if those dependencies have never been deployed. This is because Terragrunt cannot resolve dependency outputs without existing state.
+
+To work around this issue, use [mock outputs in dependency blocks](/docs/reference/hcl/blocks/#dependency).
+</Aside>
+
+<Aside type="caution">
+Do not set `TF_PLUGIN_CACHE_DIR` when using `run --all`. This can cause concurrent access issues with the provider cache. Instead, use Terragrunt's built-in [Provider Cache Server](/docs/features/provider-cache-server/).
+
+We are working with the OpenTofu team to improve this behavior in the future.
+</Aside>
+
+<Aside type="caution">
+When using `run --all` with `apply` or `destroy`, Terragrunt automatically adds the `-auto-approve` flag due to limitations with shared stdin making individual approvals impossible.
+</Aside>

--- a/docs-starlight/src/data/flags/all.mdx
+++ b/docs-starlight/src/data/flags/all.mdx
@@ -25,7 +25,7 @@ Terragrunt has a notion of "external dependencies". These are units that are not
 
 When running an `--all` command, Terragrunt will discover any external dependencies and prompt you to confirm that you want to run them as well.
 
-If would like to suppress this prompt, you can use the [`--non-interactive` flag](/docs/reference/cli/commands/run#non-interactive). You can also prevent this behavior by setting  [`--queue-exclude-external`](/docs/reference/cli/commands/run#queue-exclude-external).
+If you would like to suppress this prompt, you can use the [`--non-interactive` flag](/docs/reference/cli/commands/run#non-interactive). You can also prevent this behavior by setting  [`--queue-exclude-external`](/docs/reference/cli/commands/run#queue-exclude-external).
 </Aside>
 
 <Aside type="danger">

--- a/docs-starlight/src/data/flags/all.mdx
+++ b/docs-starlight/src/data/flags/all.mdx
@@ -6,6 +6,8 @@ env:
   - TG_ALL
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 When this flag is set, Terragrunt will run the specified OpenTofu/Terraform command against all units in the current stack. This is useful when you want to apply changes across multiple units at once.
 
 For example:
@@ -17,3 +19,17 @@ terragrunt run --all plan
 This will run the `plan` command against all units in the current stack.
 
 To learn more about how to use this flag, see the [Stacks](/docs/features/stacks/#the-run---all-command) feature documentation.
+
+<Aside type="note">
+Terragrunt has a notion of "external dependencies". These are units that are not part of the current stack, from the perspective of the current working directory, but are dependencies of units that are part of the current stack.
+
+When running an `--all` command, Terragrunt will discover any external dependencies and prompt you to confirm that you want to run them as well.
+
+If would like to suppress this prompt, you can use the [`--non-interactive` flag](/docs/reference/cli/commands/run#non-interactive). You can also prevent this behavior by setting  [`--queue-exclude-external`](/docs/reference/cli/commands/run#queue-exclude-external).
+</Aside>
+
+<Aside type="danger">
+When running a `run --all destroy` command, Terragrunt will destroy all dependencies of the units under the current working directory, in addition to the units themselves by default!
+
+If you wish to prevent external dependencies from being destroyed, add the [`--queue-exclude-external` flag](/docs/reference/cli/commands/run#queue-exclude-external), or use the [`--exclude-dir` flag](/docs/reference/cli/commands/run#exclude-dir) once for each directory you wish to exclude.
+</Aside>

--- a/docs-starlight/src/data/flags/auth-provider-cmd.mdx
+++ b/docs-starlight/src/data/flags/auth-provider-cmd.mdx
@@ -7,6 +7,8 @@ env:
   - TG_AUTH_PROVIDER_CMD
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 The command and arguments used to obtain authentication credentials dynamically. If specified, Terragrunt runs this command whenever it might need authentication. This includes HCL parsing, where it might be useful to authenticate with a cloud provider _before_ running HCL functions like [`get_aws_account_id`](/docs/reference/hcl/functions#get_aws_account_id) where authentication has to already have taken place. It can also be useful for HCL functions like [`run_cmd`](/docs/reference/hcl/functions#run_cmd) where it may be useful to be authenticated before calling the function.
 
 The output must be valid JSON of the following schema:
@@ -52,5 +54,10 @@ Similarly, if you would like Terragrunt to assume an AWS role on your behalf, yo
 
 Other credential configurations will be supported in the future, but until then, if your provider authenticates via environment variables, you can use the `envs` field to fetch credentials dynamically from a secret store, etc before Terragrunt executes any IAC.
 
-**Note**: The `awsRole` configuration is only used when the `awsCredentials` configuration is not present. If both are present, the `awsCredentials` configuration will take precedence.
+<Aside type="note">
+The `awsRole` configuration is only used when the `awsCredentials` configuration is not present. If both are present, the `awsCredentials` configuration will take precedence.
+</Aside>
 
+<Aside type="caution">
+When using `iam-assume-role`, AWS authentication takes place right before a Terraform run, after `terragrunt.hcl` files are fully parsed. This means HCL functions like `get_aws_account_id` and `run_cmd` will not run with the assumed role credentials. If you need roles to be assumed prior to parsing configurations, use `auth-provider-cmd` instead.
+</Aside>

--- a/docs-starlight/src/data/flags/dependency-fetch-output-from-state.mdx
+++ b/docs-starlight/src/data/flags/dependency-fetch-output-from-state.mdx
@@ -15,7 +15,7 @@ The main benefit this flag provides is performance. Reading directly from state 
 The limitation of this approach is that it is only supported by the S3 backend, and OpenTofu/Terraform may change the schema of the state file in the future, breaking this functionality.
 
 <Aside type="caution">
-This is an experimental feature. When enabled, Terragrunt will fetch dependency outputs directly from the state file instead of using `terraform output`.
+This is an experimental feature. When enabled, Terragrunt will fetch dependency outputs directly from the state file instead of using `tofu output`.
 
 Currently, only the S3 backend is supported. Use with caution in production environments, as this feature is experimental and may change in the future.
 </Aside>

--- a/docs-starlight/src/data/flags/dependency-fetch-output-from-state.mdx
+++ b/docs-starlight/src/data/flags/dependency-fetch-output-from-state.mdx
@@ -17,5 +17,5 @@ The limitation of this approach is that it is only supported by the S3 backend, 
 <Aside type="caution">
 This is an experimental feature. When enabled, Terragrunt will fetch dependency outputs directly from the state file instead of using `terraform output`.
 
-Currently only AWS S3 backend is supported. Use with caution in production environments, as this feature is experimental and may change in the future.
+Currently, only the S3 backend is supported. Use with caution in production environments, as this feature is experimental and may change in the future.
 </Aside>

--- a/docs-starlight/src/data/flags/dependency-fetch-output-from-state.mdx
+++ b/docs-starlight/src/data/flags/dependency-fetch-output-from-state.mdx
@@ -6,8 +6,16 @@ env:
   - TG_DEPENDENCY_FETCH_OUTPUT_FROM_STATE
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 This flag modifies how Terragrunt retrieves output values from dependent units. When enabled, Terragrunt will read the outputs directly from the state file instead of running `terraform output` or `tofu output`.
 
 The main benefit this flag provides is performance. Reading directly from state is typically faster than executing the OpenTofu/Terraform binary to get the same outputs.
 
 The limitation of this approach is that it is only supported by the S3 backend, and OpenTofu/Terraform may change the schema of the state file in the future, breaking this functionality.
+
+<Aside type="caution">
+This is an experimental feature. When enabled, Terragrunt will fetch dependency outputs directly from the state file instead of using `terraform output`.
+
+Currently only AWS S3 backend is supported. Use with caution in production environments, as this feature is experimental and may change in the future.
+</Aside>

--- a/docs-starlight/src/data/flags/download-dir.mdx
+++ b/docs-starlight/src/data/flags/download-dir.mdx
@@ -17,9 +17,3 @@ The download directory (`.terragrunt-cache` by default) can grow significantly o
 
 Remember to add this directory to your `.gitignore` file and consider periodic cleanup of old cached content.
 </Aside>
-
-<Aside type="caution">
-The download directory (`.terragrunt-cache` by default) can grow significantly over time with multiple versions of modules.
-
-Remember to add this directory to your `.gitignore` file and consider periodic cleanup of old cached content.
-</Aside>

--- a/docs-starlight/src/data/flags/download-dir.mdx
+++ b/docs-starlight/src/data/flags/download-dir.mdx
@@ -6,8 +6,20 @@ env:
   - TG_DOWNLOAD_DIR
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 Specifies a custom directory where Terragrunt will download and cache OpenTofu/Terraform modules.
 
 By default, modules are downloaded to `.terragrunt-cache` in the working directory.
 
-This flag is not recommended as a mechanism for sharing providers between units. Instead, use the [Provider Cache Server](/docs/features/provider-cache-server) feature.
+<Aside type="note">
+The download directory (`.terragrunt-cache` by default) can grow significantly over time with multiple versions of modules.
+
+Remember to add this directory to your `.gitignore` file and consider periodic cleanup of old cached content.
+</Aside>
+
+<Aside type="caution">
+The download directory (`.terragrunt-cache` by default) can grow significantly over time with multiple versions of modules.
+
+Remember to add this directory to your `.gitignore` file and consider periodic cleanup of old cached content.
+</Aside>

--- a/docs-starlight/src/data/flags/graph.mdx
+++ b/docs-starlight/src/data/flags/graph.mdx
@@ -6,6 +6,8 @@ env:
   - TG_GRAPH
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 When this flag is set, Terragrunt will run the specified OpenTofu/Terraform command against the graph of dependencies for the unit in the current working directory. The graph consists of all units that depend on the unit in the current working directory via a `dependency` or `dependencies` blocks, plus all the units that depend on those units, and all the units that depend on those units, and so on, recursively up the tree, up to the Git repository root.
 
 The command will be executed following the order of dependencies: it'll run on the unit in the current working directory first, then on units that depend on it directly, then on the units that depend on those units, and so on. Note that if the command is `destroy`, it will run in the opposite order (the final dependents, then their dependencies, etc. up to the unit you ran the command in).
@@ -71,3 +73,15 @@ Notes:
 - `lambda` units aren't affected at all
 
 To learn more about how to use this flag, see the [Stacks](/docs/features/stacks) feature documentation.
+
+<Aside type="caution">
+When running `graph destroy`, the execution order is reversed compared to other commands. Dependencies will be destroyed in reverse order to ensure resources are safely removed (dependents are destroyed before their dependencies).
+
+Always verify the execution plan before running destructive commands.
+</Aside>
+
+<Aside type="danger">
+External dependencies (units outside your current working directory) are not automatically included in graph runs.
+
+You must explicitly include them using [`--queue-include-external`](/docs/reference/cli/commands/run#queue-include-external) if they need to be part of the execution.
+</Aside>

--- a/docs-starlight/src/data/flags/hcl-lint-inputs.mdx
+++ b/docs-starlight/src/data/flags/hcl-lint-inputs.mdx
@@ -1,0 +1,15 @@
+---
+name: inputs
+description: Validate that all variables are set by the module a unit provisions.
+type: bool
+env:
+  - TG_HCLVALIDATE_INPUTS
+---
+
+When enabled, Terragrunt will validate that all variables are set by the module a unit provisions.
+
+Example:
+
+```bash
+terragrunt hcl lint --inputs
+```

--- a/docs-starlight/src/data/flags/hcl-lint-strict.mdx
+++ b/docs-starlight/src/data/flags/hcl-lint-strict.mdx
@@ -1,0 +1,15 @@
+---
+name: strict
+description: Throw an error if any inputs are set that are not defined in the module that a unit provisions.
+type: bool
+env:
+  - TG_HCLVALIDATE_STRICT
+---
+
+When enabled, Terragrunt will throw an error if any inputs are set that are not defined in the module that a unit provisions.
+
+Example:
+
+```bash
+terragrunt hcl lint --inputs --strict
+```

--- a/docs-starlight/src/data/flags/no-auto-init.mdx
+++ b/docs-starlight/src/data/flags/no-auto-init.mdx
@@ -6,6 +6,14 @@ env:
   - TG_NO_AUTO_INIT
 ---
 
-When enabled, Terragrunt will not automatically run `init` before other OpenTofu/Terraform commands. This means you'll need to manually run `init` when required.
+import { Aside } from '@astrojs/starlight/components';
+
+When enabled, Terragrunt will not automatically run `init` before other OpenTofu/Terraform commands.
 
 To learn more about how to use this flag, see the [Auto-init](/docs/features/auto-init) feature documentation.
+
+<Aside type="caution">
+When `--no-auto-init` is enabled, you must manually run `terragrunt init` if needed. Terragrunt will fail if it detects that initialization is required but auto-init is disabled.
+
+This is particularly important when using custom plugin directories or when working in CI/CD environments.
+</Aside>

--- a/docs-starlight/src/data/flags/no-destroy-dependencies-check.mdx
+++ b/docs-starlight/src/data/flags/no-destroy-dependencies-check.mdx
@@ -6,6 +6,12 @@ env:
   - TG_NO_DESTROY_DEPENDENCIES_CHECK
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 Disables Terragrunt's dependency validation during destroy operations. When enabled, Terragrunt will not verify if there are dependent units that would be affected by destroying the current unit.
 
 This results in faster destroy operations, but may result in orphaned resources.
+
+<Aside type="caution">
+Disabling dependency checks during destroy operations can lead to orphaned resources or broken infrastructure dependencies.
+</Aside>

--- a/docs-starlight/src/data/flags/non-interactive.mdx
+++ b/docs-starlight/src/data/flags/non-interactive.mdx
@@ -6,4 +6,12 @@ env:
   - TG_NON_INTERACTIVE
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 When enabled, Terragrunt will automatically answer "yes" to any prompts that would normally require user input. This is particularly useful in automated environments or CI/CD pipelines where user interaction isn't possible.
+
+<Aside type="caution">
+When using `--non-interactive`, Terragrunt will automatically answer "yes" to all prompts except for external dependency inclusion prompts.
+
+These will default to "no" for safety. Use [`--queue-include-external`](/docs/reference/cli/commands/run#queue-include-external) to explicitly include external dependencies.
+</Aside>

--- a/docs-starlight/src/data/flags/parallelism.mdx
+++ b/docs-starlight/src/data/flags/parallelism.mdx
@@ -6,4 +6,12 @@ env:
   - TG_PARALLELISM
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 Sets the maximum number of concurrent operations when running commands with `--all`. This helps control resource usage and API rate limits when working with multiple units.
+
+<Aside type="caution">
+When using `--parallelism` with provider caching, `terraform init` is always executed sequentially if OpenTofu/Terraform provider plugin cache is configured.
+
+To safely run concurrent operations with provider caching, enable the [Provider Cache Server](/docs/features/provider-cache-server/) instead.
+</Aside>

--- a/docs-starlight/src/data/flags/provider-cache-dir.mdx
+++ b/docs-starlight/src/data/flags/provider-cache-dir.mdx
@@ -6,6 +6,4 @@ env:
   - TG_PROVIDER_CACHE_DIR
 ---
 
-Specifies the directory where Terragrunt will store cached provider files. This flag is only used when [`provider-cache`](/docs/reference/cli/commands/run#provider-cache) is enabled.
-
-To learn more about how to use this flag, see the [Provider Cache Server](/docs/features/provider-cache-server) feature documentation.
+Specifies the directory where Terragrunt will store cached provider files. This flag is only used when the [Provider Cache Server](/docs/features/provider-cache-server) is enabled.

--- a/docs-starlight/src/data/flags/provider-cache-hostname.mdx
+++ b/docs-starlight/src/data/flags/provider-cache-hostname.mdx
@@ -6,6 +6,4 @@ env:
   - TG_PROVIDER_CACHE_HOSTNAME
 ---
 
-Sets the hostname for connecting to the Provider Cache server. This flag is only used when [`provider-cache`](/docs/reference/cli/commands/run#provider-cache) is enabled.
-
-To learn more about how to use this flag, see the [Provider Cache Server](/docs/features/provider-cache-server) feature documentation.
+Sets the hostname for connecting to the Provider Cache server. This flag is only used when the [Provider Cache Server](/docs/features/provider-cache-server) is enabled.

--- a/docs-starlight/src/data/flags/provider-cache-port.mdx
+++ b/docs-starlight/src/data/flags/provider-cache-port.mdx
@@ -6,6 +6,4 @@ env:
   - TG_PROVIDER_CACHE_PORT
 ---
 
-Specifies the port number for connecting to the Provider Cache server. This flag is only used when [`provider-cache`](/docs/reference/cli/commands/run#provider-cache) is enabled.
-
-To learn more about how to use this flag, see the [Provider Cache Server](/docs/features/provider-cache-server) feature documentation.
+Specifies the port number for connecting to the Provider Cache server. This flag is only used when the [Provider Cache Server](/docs/features/provider-cache-server) is enabled.

--- a/docs-starlight/src/data/flags/provider-cache-registry-names.mdx
+++ b/docs-starlight/src/data/flags/provider-cache-registry-names.mdx
@@ -6,6 +6,4 @@ env:
   - TG_PROVIDER_CACHE_REGISTRY_NAMES
 ---
 
-Specifies which provider registries should be cached by the Provider Cache server. This flag is only used when [`provider-cache`](/docs/reference/cli/commands/run#provider-cache) is enabled.
-
-To learn more about how to use this flag, see the [Provider Cache Server](/docs/features/provider-cache-server) feature documentation.
+Specifies which provider registries should be cached by the Provider Cache server. This flag is only used when the [Provider Cache Server](/docs/features/provider-cache-server) is enabled.

--- a/docs-starlight/src/data/flags/provider-cache-token.mdx
+++ b/docs-starlight/src/data/flags/provider-cache-token.mdx
@@ -6,6 +6,4 @@ env:
   - TG_PROVIDER_CACHE_TOKEN
 ---
 
-Sets the authentication token for connecting to the Provider Cache server. This flag is only used when [`provider-cache`](/docs/reference/cli/commands/run#provider-cache-enable) is enabled.
-
-To learn more about how to use this flag, see the [Provider Cache Server](/docs/features/provider-cache-server) feature documentation.
+Sets the authentication token for connecting to the Provider Cache server. This flag is only used when the [Provider Cache Server](/docs/features/provider-cache-server) is enabled.

--- a/docs-starlight/src/data/flags/provider-cache.mdx
+++ b/docs-starlight/src/data/flags/provider-cache.mdx
@@ -6,6 +6,12 @@ env:
   - TG_PROVIDER_CACHE
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 When enabled, Terragrunt will use its provider caching system to speed up provider downloads.
 
 For more information, see the [Provider Cache Server](/docs/features/provider-cache-server) feature documentation.
+
+<Aside type="note">
+The `tofu init` command is always executed sequentially if the provider plugin cache is used without the Provider Cache Server.
+</Aside>

--- a/docs-starlight/src/data/flags/queue-exclude-dir.mdx
+++ b/docs-starlight/src/data/flags/queue-exclude-dir.mdx
@@ -6,8 +6,22 @@ env:
   - TG_QUEUE_EXCLUDE_DIR
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 Specifies directories to exclude when running commands with [`all`](/docs/reference/cli/commands/run#all).
 
 This flag can be specified multiple times to exclude multiple directories. When using the `TG_QUEUE_EXCLUDE_DIR` environment variable, specify the directories as a comma-separated list.
 
 To learn more about how to use this flag, see the [Stacks](/docs/features/stacks/#the-run---all-command) feature documentation.
+
+<Aside type="note">
+When using `--queue-exclude-dir`, only the specified units are excluded, not their dependencies.
+
+Dependencies of excluded units will still be run unless they are also explicitly excluded.
+</Aside>
+
+<Aside type="note">
+The glob curly braces expansion behaves differently when using environment variables versus command line parameters.
+
+Use `TG_QUEUE_EXCLUDE_DIR="foo/module,bar/module"` instead of `TG_QUEUE_EXCLUDE_DIR="{foo,bar}/module"`.
+</Aside>

--- a/docs-starlight/src/data/flags/queue-ignore-errors.mdx
+++ b/docs-starlight/src/data/flags/queue-ignore-errors.mdx
@@ -6,8 +6,18 @@ env:
   - TG_QUEUE_IGNORE_ERRORS
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 When enabled, Terragrunt will continue processing remaining units even if one fails. This can be useful when you want to see all potential errors in your configuration, rather than stopping at the first failure.
 
 Note that this may lead to incomplete or inconsistent states if used with commands that modify infrastructure.
 
 To learn more about how to use this flag, see the [Stacks](/docs/features/stacks/#the-run---all-command) feature documentation.
+
+<Aside type="danger">
+Using `--queue-ignore-errors` can lead to inconsistent state if dependencies fail but dependent modules continue running.
+
+Use this flag with caution, especially with `apply` or `destroy` commands.
+
+For more fine-grained error handling, see the [errors block](/docs/reference/hcl/blocks#errors) in the HCL reference.
+</Aside>

--- a/docs-starlight/src/data/flags/queue-include-external.mdx
+++ b/docs-starlight/src/data/flags/queue-include-external.mdx
@@ -6,4 +6,4 @@ env:
   - TG_QUEUE_INCLUDE_EXTERNAL
 ---
 
-When enabled, Terragrunt will include external dependencies (dependencies outside the current working directory) in the queue when running commands with [`--all`](/docs/reference/cli/commands/run#all).
+When enabled, Terragrunt will include external dependencies (dependencies discovered outside the current working directory) in the queue when running commands with [`--all`](/docs/reference/cli/commands/run#all) or [`--graph`](/docs/reference/cli/commands/run#graph).

--- a/docs-starlight/src/data/flags/queue-include-units-reading.mdx
+++ b/docs-starlight/src/data/flags/queue-include-units-reading.mdx
@@ -6,7 +6,7 @@ env:
   - TG_QUEUE_INCLUDE_UNITS_READING
 ---
 
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 
 This flag works very similarly to the [`--queue-units-that-include`](/docs/reference/cli/commands/run#queue-units-that-include) flag, but instead of looking only for included configurations,
 it also looks for configurations that read a given file.
@@ -62,7 +62,8 @@ inputs = {
   filename = local.filename
 }
 ```
+<Aside type="caution">
+Due to how Terragrunt parses configurations during `run-all`, functions will only properly mark files as read if they are used in the `locals` block.
 
-**⚠️**: Due to the way that Terragrunt parses configurations during a `run-all`, functions will only properly mark files as read
-if they are used in the `locals` block. Reading a file directly in the `inputs` block will not mark the file as read, as the `inputs`
-block is not evaluated until _after_ the queue has been populated with units to run.
+Reading a file directly in the `inputs` block will not mark the file as read, as the `inputs` block is not evaluated until after the queue has already been populated.
+</Aside>

--- a/docs-starlight/src/data/flags/queue-strict-include.mdx
+++ b/docs-starlight/src/data/flags/queue-strict-include.mdx
@@ -6,7 +6,7 @@ env:
   - TG_QUEUE_STRICT_INCLUDE
 ---
 
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 
 When enabled, Terragrunt will only process directories that match the patterns specified by [`--queue-include-dir`](/docs/reference/cli/commands/run#queue-include-dir).
 
@@ -30,3 +30,9 @@ For example, with the following directory structure:
 Running `terragrunt run --all plan --queue-include-dir "prod/*"` would process all directories, but the [`--all`](/docs/reference/cli/commands/run#all) flag includes by default when no [excludes](/docs/reference/cli/commands/run#queue-exclude-dir) are provided, so the `stage` stack would also be included by default.
 
 Running `terragrunt run --all plan --queue-include-dir "prod/*" --queue-strict-include` tells Terragrunt to exclude by default, so it only include units `prod/app` and `prod/db`.
+
+<Aside type="danger">
+When using `--queue-strict-include`, all dependencies of included directories will be excluded if they are not explicitly included. This can lead to unexpected behavior if you're not careful with your include patterns.
+
+Always verify the modules that will be included before running destructive commands.
+</Aside>

--- a/docs-starlight/src/data/flags/source-map.mdx
+++ b/docs-starlight/src/data/flags/source-map.mdx
@@ -6,6 +6,8 @@ env:
   - TG_SOURCE_MAP
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 Allows you to replace source URLs that match a specified pattern with a different URL. This affects both direct source references and sources specified in dependency blocks.
 
 The format is `source-regex=replacement-source`.
@@ -17,3 +19,7 @@ terragrunt run plan --source-map "git::ssh://git@github.com/org/repo.git=../loca
 ```
 
 This will replace any source URL that matches `github.com/example/infrastructure//modules/vpc` with `github.com/example/infrastructure//modules/vpc-new`.
+
+<Aside type="caution">
+Source mapping only performs literal matches on the URL portion. For example, a map key of `ssh://git@github.com/org/repo.git` will not match sources of the form `git::ssh://git@github.com/org/repo.git`. The latter requires a map key of `git::ssh://git@github.com/org/repo.git`.
+</Aside>

--- a/docs-starlight/src/data/flags/stack-output-raw.mdx
+++ b/docs-starlight/src/data/flags/stack-output-raw.mdx
@@ -6,6 +6,8 @@ env:
   - TG_RAW
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 A convenience flag that formats the stack output as a raw string. This is equivalent to using `--format raw`.
 
 This is particularly useful when you need to use the output in shell scripts or other automation.
@@ -16,3 +18,7 @@ Example:
 # Store the output in a variable
 APP_ID=$(terragrunt stack output --raw app.id)
 ```
+
+<Aside type="caution">
+When using `--stack-output-raw`, you must use index-based access. Attempting to access nested structures directly may result in unexpected output or errors.
+</Aside>

--- a/docs-starlight/src/data/flags/strict-control.mdx
+++ b/docs-starlight/src/data/flags/strict-control.mdx
@@ -6,8 +6,16 @@ env:
   - TG_STRICT_CONTROL
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 Enables specific strict controls in Terragrunt. For a list of available controls and their descriptions, run `terragrunt info strict`.
 
 This flag provides finer-grained control compared to `--strict-mode`, allowing you to enable specific controls rather than all of them.
 
 For more information, see the [strict controls documentation](/docs/reference/strict-controls).
+
+<Aside type="caution">
+When accessing complex data structures using the `raw` format, you must use index-based access.
+
+Attempting to access nested structures directly may result in unexpected output or errors.
+</Aside>

--- a/docs-starlight/src/data/flags/use-partial-parse-config-cache.mdx
+++ b/docs-starlight/src/data/flags/use-partial-parse-config-cache.mdx
@@ -6,6 +6,8 @@ env:
   - TG_USE_PARTIAL_PARSE_CONFIG_CACHE
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 This flag can be used to drastically decrease time required for parsing Terragrunt configuration files. The effect will only show if a lot of similar includes are expected such as the root terragrunt configuration (e.g. `root.hcl`) include.
 
 NOTE: This is an experimental feature, use with caution.
@@ -21,3 +23,9 @@ This is the case for scenarios like:
 These configurations are generally safe to cache, but due to the nature of HCL being a dynamic configuration language, there are some edge cases where caching these can lead to incorrect behavior.
 
 Once this flag has been tested thoroughly, we will consider making it the default behavior.
+
+<Aside type="caution">
+This is an experimental feature. While it can significantly improve performance with frequently included configurations, the caching behavior may lead to unexpected results in some edge cases due to HCL's dynamic nature.
+
+Test thoroughly in your environment before using in production environments.
+</Aside>

--- a/docs-starlight/src/data/flags/working-dir.mdx
+++ b/docs-starlight/src/data/flags/working-dir.mdx
@@ -6,6 +6,8 @@ env:
   - TG_WORKING_DIR
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 Specifies the working directory where Terragrunt should execute its commands. By default, Terragrunt uses the current directory.
 
 Example:
@@ -13,3 +15,9 @@ Example:
 ```bash
 terragrunt run plan --working-dir /path/to/infrastructure/prod
 ```
+
+<Aside type="note">
+The `--working-dir` flag behaves differently for `run --all` commands versus single unit commands.
+
+For `run --all`, Terragrunt will execute in all subdirectories of the working directory, while for `run` commands it will execute only in the specified directory.
+</Aside>


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds asides to call out cautionary info that was present in the original docs but not in the new docs.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated the docs to include cautionary info that was present in the original docs but not in the new docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced overall clarity through refined presentation of critical notes and warnings using improved visual components.
  - Introduced new documentation entries for commands (e.g., linting and validation features) to boost discoverability.
  - Updated guidance on various flags and command behaviors, providing clearer instructions on dependency management, provider caching, and execution flows.
  - Added cautionary notes to highlight potential risks and best practices for specific commands and flags.
  - Reformatted existing notes into structured components for better visibility and emphasis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->