### PR TITLE
Update mark_as_read example and docs

### DIFF
--- a/docs-starlight/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -962,11 +962,13 @@ For example:
 # terragrunt.hcl
 
 locals {
-  filename = mark_as_read("file-read-by-tofu.txt")
+  filename   = mark_as_read("/path/to/my/file-read-by-tofu.txt")
+  many_files = [for f in fileset("./config", "*.yaml") : file(mark_as_read(abspath("${get_terragrunt_dir()}/config/${f}")))]
 }
 
 inputs = {
-  filename = local.filename
+  filename   = local.filename
+  many_files = local.many_files
 }
 ```
 
@@ -974,6 +976,8 @@ By using `mark_as_read` on `file-read-by-tofu.txt`, you can ensure that the `ter
 any `run-all` run where the flag `--queue-include-units-reading file-read-by-tofu.txt` is set.
 
 The same technique can be used to mark a file as read when a file is read using code in `run_cmd`.
+
+**NOTE**: Due to the way that Terragrunt enqueues files we require an absolute path for mark_as_read to avoid multiple inclusions.
 
 **NOTE**: Due to the way that Terragrunt parses configurations during a `run-all`, functions will only properly mark files as read
 if they are used in the `locals` block. Reading a file directly in the `inputs` block will not mark the file as read, as the `inputs`

--- a/docs/_docs/04_reference/03-built-in-functions.md
+++ b/docs/_docs/04_reference/03-built-in-functions.md
@@ -887,15 +887,19 @@ remote_state {
 
 This is useful for situations when you want to mark a file as read, but are not reading it using a native Terragrunt HCL function.
 
+
+
 For example:
 
 ```hcl
 locals {
-  filename = mark_as_read("file-read-by-tofu.txt")
+  filename   = mark_as_read("/path/to/my/file-read-by-tofu.txt")
+  many_files = [for f in fileset("./config", "*.yaml") : file(mark_as_read(abspath("${get_terragrunt_dir()}/config/${f}")))]
 }
 
 inputs = {
-  filename = local.filename
+  filename   = local.filename
+  many_files = local.many_files
 }
 ```
 
@@ -903,6 +907,8 @@ By using `mark_as_read` on `file-read-by-tofu.txt`, you can ensure that the `ter
 any `run-all` run where the flag `--queue-include-units-reading file-read-by-tofu.txt` is set.
 
 The same technique can be used to mark a file as read when reading a file using code in `run_cmd`, etc.
+
+**NOTE**: Due to the way that Terragrunt enqueues files we require an absolute path for mark_as_read to avoid multiple inclusions.
 
 **NOTE**: Due to the way that Terragrunt parses configurations during a `run-all`, functions will only properly mark files as read
 if they are used in the `locals` block. Reading a file directly in the `inputs` block will not mark the file as read, as the `inputs`

--- a/docs/_docs/04_reference/03-built-in-functions.md
+++ b/docs/_docs/04_reference/03-built-in-functions.md
@@ -887,8 +887,6 @@ remote_state {
 
 This is useful for situations when you want to mark a file as read, but are not reading it using a native Terragrunt HCL function.
 
-
-
 For example:
 
 ```hcl


### PR DESCRIPTION

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds a better example for mark_as_read and add a callout for requiring abspath.
<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for processing multiple files in batch operations.

- **Enhancements**
  - Updated file path references to use absolute paths for more consistent behavior.
  - Introduced a new variable to manage a list of files marked as read.

- **Documentation**
  - Included clarifications on the requirement for absolute paths to avoid duplicate processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->