### PR TITLE
feat: add engine support to dependencies

### DIFF
--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -454,10 +454,12 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 
 		case EngineBlock:
 			decoded := terragruntEngine{}
+
 			err := file.Decode(&decoded, evalParsingContext)
 			if err != nil {
 				return nil, err
 			}
+
 			output.Engine = decoded.Engine
 
 		case TerragruntFlags:

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -119,6 +119,12 @@ type terragruntInputs struct {
 	Remain hcl.Body   `hcl:",remain"`
 }
 
+// terragruntEngine is a struct that can only be used to decode the engine block.
+type terragruntEngine struct {
+	Engine *EngineConfig `hcl:"engine,block"`
+	Remain hcl.Body      `hcl:",remain"`
+}
+
 // DecodeBaseBlocks takes in a parsed HCL2 file and decodes the base blocks. Base blocks are blocks that should always
 // be decoded even in partial decoding, because they provide bindings that are necessary for parsing any block in the
 // file. Currently base blocks are:
@@ -445,15 +451,14 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 			} else {
 				output.Dependencies = dependencies
 			}
-		case EngineBlock:
-			decoded := EngineConfig{}
 
+		case EngineBlock:
+			decoded := terragruntEngine{}
 			err := file.Decode(&decoded, evalParsingContext)
 			if err != nil {
 				return nil, err
 			}
-
-			output.Engine = &decoded
+			output.Engine = decoded.Engine
 
 		case TerragruntFlags:
 			decoded := terragruntFlags{}

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -35,6 +35,7 @@ const (
 	TerragruntVersionConstraints
 	RemoteStateBlock
 	FeatureFlagsBlock
+	EngineBlock
 	ExcludeBlock
 	ErrorsBlock
 )
@@ -80,6 +81,12 @@ type terragruntTerraformSource struct {
 type terraformConfigSourceOnly struct {
 	Source *string  `hcl:"source,attr"`
 	Remain hcl.Body `hcl:",remain"`
+}
+
+// terragruntEngine is a struct that can be used to store decoded engine configs
+type terragruntEngine struct {
+	Engine EngineConfig `hcl:"engine,block"`
+	Remain hcl.Body     `hcl:",remain"`
 }
 
 // terragruntFlags is a struct that can be used to only decode the flag attributes (skip and prevent_destroy)
@@ -329,6 +336,7 @@ func TerragruntConfigFromPartialConfig(ctx *ParsingContext, file *hclparse.File,
 //     the config.
 //   - RemoteStateBlock: Parses the `remote_state` block in the config
 //   - FeatureFlagsBlock: Parses the `feature` block in the config
+//   - EngineBlock: Parses the `engine` block in the config
 //   - ExcludeBlock : Parses the `exclude` block in the config
 //
 // Note that the following blocks are always decoded:
@@ -443,6 +451,14 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 			} else {
 				output.Dependencies = dependencies
 			}
+		case EngineBlock:
+			decoded := EngineConfig{}
+
+			err := file.Decode(&decoded, evalParsingContext)
+			if err != nil {
+				return nil, err
+			}
+			output.Engine = &decoded
 
 		case TerragruntFlags:
 			decoded := terragruntFlags{}

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -83,12 +83,6 @@ type terraformConfigSourceOnly struct {
 	Remain hcl.Body `hcl:",remain"`
 }
 
-// terragruntEngine is a struct that can be used to store decoded engine configs
-type terragruntEngine struct {
-	Engine EngineConfig `hcl:"engine,block"`
-	Remain hcl.Body     `hcl:",remain"`
-}
-
 // terragruntFlags is a struct that can be used to only decode the flag attributes (skip and prevent_destroy)
 type terragruntFlags struct {
 	IamRole             *string  `hcl:"iam_role,attr"`

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -452,6 +452,7 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 			if err != nil {
 				return nil, err
 			}
+
 			output.Engine = &decoded
 
 		case TerragruntFlags:

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -757,7 +757,8 @@ func getTerragruntOutputJSON(ctx *ParsingContext, targetConfig string) ([]byte, 
 	parseOptions := append(ctx.ParserOptions, hclparse.WithDiagnosticsWriter(io.Discard, true))
 
 	remoteStateTGConfig, err := PartialParseConfigFile(ctx.WithParseOption(parseOptions).WithDecodeList(RemoteStateBlock, TerragruntFlags, EngineBlock), targetConfig, nil)
-	if err != nil || !canGetRemoteState(remoteStateTGConfig.RemoteState) {
+	// NOTE: can't use dependency optimization if engine is enabled
+	if err != nil || remoteStateTGConfig.Engine != nil || !canGetRemoteState(remoteStateTGConfig.RemoteState) {
 		targetOpts, err := cloneTerragruntOptionsForDependency(ctx, targetConfig)
 		if err != nil {
 			return nil, err

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -756,7 +756,8 @@ func getTerragruntOutputJSON(ctx *ParsingContext, targetConfig string) ([]byte, 
 	// we need to suspend logging diagnostic errors on this attempt
 	parseOptions := append(ctx.ParserOptions, hclparse.WithDiagnosticsWriter(io.Discard, true))
 
-	remoteStateTGConfig, err := PartialParseConfigFile(ctx.WithParseOption(parseOptions).WithDecodeList(RemoteStateBlock, TerragruntFlags, EngineBlock), targetConfig, nil)
+	remoteStateTGConfig, err := PartialParseConfigFile(ctx.WithParseOption(parseOptions).WithDecodeList(
+		RemoteStateBlock, TerragruntFlags, EngineBlock), targetConfig, nil)
 	if err != nil || !canGetRemoteState(remoteStateTGConfig.RemoteState) {
 		targetOpts, err := cloneTerragruntOptionsForDependency(ctx, targetConfig)
 		if err != nil {
@@ -786,7 +787,8 @@ func getTerragruntOutputJSON(ctx *ParsingContext, targetConfig string) ([]byte, 
 		return getTerragruntOutputJSONFromInitFolder(ctx, workingDir, remoteStateTGConfig.GetIAMRoleOptions(), engineOpts)
 	}
 
-	return getTerragruntOutputJSONFromRemoteState(ctx, targetConfig, remoteStateTGConfig.RemoteState, remoteStateTGConfig.GetIAMRoleOptions(), engineOpts)
+	return getTerragruntOutputJSONFromRemoteState(ctx, targetConfig, remoteStateTGConfig.RemoteState,
+		remoteStateTGConfig.GetIAMRoleOptions(), engineOpts)
 }
 
 // canGetRemoteState returns true if the remote state block is not nil and dependency optimization is not disabled
@@ -839,7 +841,8 @@ func terragruntAlreadyInit(opts *options.TerragruntOptions, configPath string, c
 
 // getTerragruntOutputJSONFromInitFolder will retrieve the outputs directly from the module's working directory without
 // running init.
-func getTerragruntOutputJSONFromInitFolder(ctx *ParsingContext, terraformWorkingDir string, iamRoleOpts options.IAMRoleOptions, engineOpts *options.EngineOptions) ([]byte, error) {
+func getTerragruntOutputJSONFromInitFolder(ctx *ParsingContext, terraformWorkingDir string, iamRoleOpts options.IAMRoleOptions,
+	engineOpts *options.EngineOptions) ([]byte, error) {
 	targetConfigPath := ctx.TerragruntOptions.TerragruntConfigPath
 
 	targetTGOptions, err := setupTerragruntOptionsForBareTerraform(ctx, terraformWorkingDir, targetConfigPath, iamRoleOpts, engineOpts)
@@ -1024,7 +1027,8 @@ func getTerragruntOutputJSONFromRemoteStateS3(terragruntOptions *options.Terragr
 
 // setupTerragruntOptionsForBareTerraform sets up a new TerragruntOptions struct that can be used to run terraform
 // without going through the full RunTerragrunt operation.
-func setupTerragruntOptionsForBareTerraform(ctx *ParsingContext, workingDir string, configPath string, iamRoleOpts options.IAMRoleOptions, engineOpts *options.EngineOptions) (*options.TerragruntOptions, error) {
+func setupTerragruntOptionsForBareTerraform(ctx *ParsingContext, workingDir string, configPath string, iamRoleOpts options.IAMRoleOptions,
+	engineOpts *options.EngineOptions) (*options.TerragruntOptions, error) {
 	// Here we clone the terragrunt options again since we need to make further modifications to it to allow running
 	// terraform directly.
 	// Set the terraform working dir to the tempdir, and set stdout writer to io.Discard so that output content is

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -756,7 +756,7 @@ func getTerragruntOutputJSON(ctx *ParsingContext, targetConfig string) ([]byte, 
 	// we need to suspend logging diagnostic errors on this attempt
 	parseOptions := append(ctx.ParserOptions, hclparse.WithDiagnosticsWriter(io.Discard, true))
 
-	remoteStateTGConfig, err := PartialParseConfigFile(ctx.WithParseOption(parseOptions).WithDecodeList(RemoteStateBlock, TerragruntFlags), targetConfig, nil)
+	remoteStateTGConfig, err := PartialParseConfigFile(ctx.WithParseOption(parseOptions).WithDecodeList(RemoteStateBlock, TerragruntFlags, EngineBlock), targetConfig, nil)
 	if err != nil || !canGetRemoteState(remoteStateTGConfig.RemoteState) {
 		targetOpts, err := cloneTerragruntOptionsForDependency(ctx, targetConfig)
 		if err != nil {

--- a/test/fixtures/engine/engine-dependencies/.gitignore
+++ b/test/fixtures/engine/engine-dependencies/.gitignore
@@ -1,0 +1,2 @@
+backend.gen.tf
+test.txt

--- a/test/fixtures/engine/engine-dependencies/app1/main.tf
+++ b/test/fixtures/engine/engine-dependencies/app1/main.tf
@@ -1,0 +1,3 @@
+output "value" {
+  value = "app1-test"
+}

--- a/test/fixtures/engine/engine-dependencies/app1/terragrunt.hcl
+++ b/test/fixtures/engine/engine-dependencies/app1/terragrunt.hcl
@@ -1,0 +1,9 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+engine {
+  source  = "github.com/gruntwork-io/terragrunt-engine-opentofu"
+  version = "v0.0.16"
+  type    = "rpc"
+}

--- a/test/fixtures/engine/engine-dependencies/app2/main.tf
+++ b/test/fixtures/engine/engine-dependencies/app2/main.tf
@@ -1,0 +1,8 @@
+variable "app1_output" {
+  type = string
+}
+
+resource "local_file" "test" {
+  content  = var.app1_output
+  filename = "${path.module}/test.txt"
+}

--- a/test/fixtures/engine/engine-dependencies/app2/terragrunt.hcl
+++ b/test/fixtures/engine/engine-dependencies/app2/terragrunt.hcl
@@ -1,0 +1,17 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+engine {
+  source  = "github.com/gruntwork-io/terragrunt-engine-opentofu"
+  version = "v0.0.16"
+  type    = "rpc"
+}
+
+dependency "app1" {
+  config_path = "../app1"
+}
+
+inputs = {
+  app1_output = dependency.app1.outputs.value
+}

--- a/test/fixtures/engine/engine-dependencies/root.hcl
+++ b/test/fixtures/engine/engine-dependencies/root.hcl
@@ -1,0 +1,10 @@
+remote_state {
+  backend = "local"
+  generate = {
+    path = "backend.gen.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    path = "${get_terragrunt_dir()}/terraform.tfstate"
+  }
+}


### PR DESCRIPTION
## Description

Fixes #3973 

Add support for parsing the `engine` block to `PartialParseConfig` so that terraform commands run in `dependency` blocks use the engine config if present and enabled.


## TODOs


- [x] Update the docs.
  - No docs update necessary, as this functionality isn't mentioned either way
- [x] Run the relevant tests successfully, including pre-commit checks.
  - NOTE: some tests I couldn't run locally as I couldn't do PGP decryption
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)


Added support for IaC engines to dependency blocks.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for an engine configuration block in Terragrunt configuration files, enabling users to include engine-specific settings.
	- Introduced new output variables and configuration files for managing engine dependencies in Terraform.
	- Added a new `.gitignore` file to exclude specific files from version control.
- **Bug Fixes**
	- Improved error handling and control flow related to engine options in configuration parsing.
- **Documentation**
	- Updated help notes to reflect the enhanced configuration parsing with the new engine settings support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->