### PR TITLE
Add support for all assume_role block arguments for s3 backend

### DIFF
--- a/awshelper/config.go
+++ b/awshelper/config.go
@@ -34,6 +34,7 @@ type AwsSessionConfig struct {
 	DisableComputeChecksums bool
 	ExternalID              string
 	SessionName             string
+	Tags                    map[string]string
 }
 
 // addUserAgent - Add terragrunt version to the user agent for AWS API calls.

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -298,6 +298,7 @@ func RemoteStateConfigToTerraformCode(backend string, config map[string]any, enc
 			// Parsing into a struct first, enabling hclsimple.Decode() to deal with complex types.
 			// Then copying values into the assumeRoleMap for rendering to HCL.
 			assumeRoleMap := make(map[string]any)
+
 			type assumeRoleConfig struct {
 				RoleArn           string            `hcl:"role_arn"`
 				Duration          string            `hcl:"duration,optional"`
@@ -309,11 +310,13 @@ func RemoteStateConfigToTerraformCode(backend string, config map[string]any, enc
 				Tags              map[string]string `hcl:"tags,optional"`
 				TransitiveTagKeys []string          `hcl:"transitive_tag_keys,optional"`
 			}
+
 			var parsedConfig assumeRoleConfig
 			// split single line hcl to default multiline file
 			hclValue := strings.TrimSuffix(assumeRoleValue, "}")
 			hclValue = strings.TrimPrefix(hclValue, "{")
 			hclValue = strings.ReplaceAll(hclValue, ",", "\n")
+
 			err := hclsimple.Decode("s3_assume_role.hcl", []byte(hclValue), nil, &parsedConfig)
 			if err != nil {
 				return nil, errors.New(err)
@@ -323,27 +326,35 @@ func RemoteStateConfigToTerraformCode(backend string, config map[string]any, enc
 			if parsedConfig.RoleArn != "" {
 				assumeRoleMap["role_arn"] = parsedConfig.RoleArn
 			}
+
 			if parsedConfig.Duration != "" {
 				assumeRoleMap["duration"] = parsedConfig.Duration
 			}
+
 			if parsedConfig.ExternalID != "" {
 				assumeRoleMap["external_id"] = parsedConfig.ExternalID
 			}
+
 			if parsedConfig.Policy != "" {
 				assumeRoleMap["policy"] = parsedConfig.Policy
 			}
+
 			if len(parsedConfig.PolicyArns) > 0 {
 				assumeRoleMap["policy_arns"] = parsedConfig.PolicyArns
 			}
+
 			if parsedConfig.SessionName != "" {
 				assumeRoleMap["session_name"] = parsedConfig.SessionName
 			}
+
 			if parsedConfig.SourceIdentity != "" {
 				assumeRoleMap["source_identity"] = parsedConfig.SourceIdentity
 			}
+
 			if len(parsedConfig.Tags) > 0 {
 				assumeRoleMap["tags"] = parsedConfig.Tags
 			}
+
 			if len(parsedConfig.TransitiveTagKeys) > 0 {
 				assumeRoleMap["transitive_tag_keys"] = parsedConfig.TransitiveTagKeys
 			}

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -297,12 +297,11 @@ func RemoteStateConfigToTerraformCode(backend string, config map[string]any, enc
 			// Extracting the values requires two steps.
 			// Parsing into a struct first, enabling hclsimple.Decode() to deal with complex types.
 			// Then copying values into the assumeRoleMap for rendering to HCL.
-			var assumeRoleMap map[string]any
-			assumeRoleMap = make(map[string]any)
+			assumeRoleMap := make(map[string]any)
 			type assumeRoleConfig struct {
 				RoleArn           string            `hcl:"role_arn"`
 				Duration          string            `hcl:"duration,optional"`
-				ExternalId        string            `hcl:"external_id,optional"`
+				ExternalID        string            `hcl:"external_id,optional"`
 				Policy            string            `hcl:"policy,optional"`
 				PolicyArns        []string          `hcl:"policy_arns,optional"`
 				SessionName       string            `hcl:"session_name,optional"`
@@ -327,8 +326,8 @@ func RemoteStateConfigToTerraformCode(backend string, config map[string]any, enc
 			if parsedConfig.Duration != "" {
 				assumeRoleMap["duration"] = parsedConfig.Duration
 			}
-			if parsedConfig.ExternalId != "" {
-				assumeRoleMap["external_id"] = parsedConfig.ExternalId
+			if parsedConfig.ExternalID != "" {
+				assumeRoleMap["external_id"] = parsedConfig.ExternalID
 			}
 			if parsedConfig.Policy != "" {
 				assumeRoleMap["policy"] = parsedConfig.Policy

--- a/docs/_docs/04_reference/04-config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/04-config-blocks-and-attributes.md
@@ -470,9 +470,15 @@ For the `s3` backend, the following additional properties are supported in the `
 - `bucket_sse_algorithm`: (Optional) The algorithm to use for server side encryption of the state bucket. Defaults to `aws:kms`.
 - `bucket_sse_kms_key_id`: (Optional) The KMS Key to use when the encryption algorithm is `aws:kms`. Defaults to the AWS Managed `aws/s3` key.
 - `assume_role`: (Optional) A configuration `map` to use when assuming a role (starting with Terraform 1.6 for Terraform). Override top level arguments
-  - `role_arn` - (Optional) The role to be assumed.
+  - `role_arn` - (Required) The role to be assumed.
+  - `duration` - (Optional) The duration the credentials will be valid.
   - `external_id` - (Optional) The external ID to use when assuming the role.
+  - `policy` - (Optional) Policy JSON to further restrict the role.
+  - `policy_arns` - (Optional) A list of policy ARNs to further restrict the role.
   - `session_name` - (Optional) The session name to use when assuming the role.
+  - `source_identity` - (Optional) The source identity to use when assuming the role.
+  - `tags` - (Optional) A map of key value pairs used as assume role session tags.
+  - `transitive_tag_keys` - (Optional) A list of tag keys that to be passed.
 
 For the `gcs` backend, the following additional properties are supported in the `config` attribute:
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -212,6 +212,7 @@ func (s3Config *RemoteStateConfigS3) GetSessionTags() map[string]string {
 	if len(s3Config.AssumeRole.Tags) != 0 {
 		return s3Config.AssumeRole.Tags
 	}
+
 	return nil
 }
 

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -209,12 +209,10 @@ func (s3Config *RemoteStateConfigS3) GetSessionRoleArn() string {
 }
 
 func (s3Config *RemoteStateConfigS3) GetSessionTags() map[string]string {
-	//if s3Config.AssumeRole.SessionName != "" {}
 	if len(s3Config.AssumeRole.Tags) != 0 {
 		return s3Config.AssumeRole.Tags
 	}
 	return nil
-	//return map[string]string{}
 }
 
 // GetExternalID returns the external ID defined in the AssumeRole struct

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -94,9 +94,15 @@ var terragruntOnlyConfigs = []string{
 }
 
 type RemoteStateConfigS3AssumeRole struct {
-	RoleArn     string `mapstructure:"role_arn"`
-	ExternalID  string `mapstructure:"external_id"`
-	SessionName string `mapstructure:"session_name"`
+	RoleArn           string            `mapstructure:"role_arn"`
+	Duration          string            `mapstructure:"duration"`
+	ExternalID        string            `mapstructure:"external_id"`
+	Policy            string            `mapstructure:"policy"`
+	PolicyArns        []string          `mapstructure:"policy_arns"`
+	SessionName       string            `mapstructure:"session_name"`
+	SourceIdentity    string            `mapstructure:"source_identity"`
+	Tags              map[string]string `mapstructure:"tags"`
+	TransitiveTagKeys []string          `mapstructure:"transitive_tag_keys"`
 }
 
 type RemoteStateConfigS3Endpoints struct {
@@ -144,6 +150,7 @@ func (c *ExtendedRemoteStateConfigS3) GetAwsSessionConfig() *awshelper.AwsSessio
 		CustomDynamoDBEndpoint:  dynamoDBEndpoint,
 		Profile:                 c.RemoteStateConfigS3.Profile,
 		RoleArn:                 c.RemoteStateConfigS3.GetSessionRoleArn(),
+		Tags:                    c.RemoteStateConfigS3.GetSessionTags(),
 		ExternalID:              c.RemoteStateConfigS3.GetExternalID(),
 		SessionName:             c.RemoteStateConfigS3.GetSessionName(),
 		CredsFilename:           c.RemoteStateConfigS3.CredsFilename,
@@ -199,6 +206,15 @@ func (s3Config *RemoteStateConfigS3) GetSessionRoleArn() string {
 	}
 
 	return s3Config.RoleArn
+}
+
+func (s3Config *RemoteStateConfigS3) GetSessionTags() map[string]string {
+	//if s3Config.AssumeRole.SessionName != "" {}
+	if len(s3Config.AssumeRole.Tags) != 0 {
+		return s3Config.AssumeRole.Tags
+	}
+	return nil
+	//return map[string]string{}
 }
 
 // GetExternalID returns the external ID defined in the AssumeRole struct

--- a/remote/remote_state_s3_test.go
+++ b/remote/remote_state_s3_test.go
@@ -399,6 +399,10 @@ func TestAwsGetAwsSessionConfigWithAssumeRole(t *testing.T) {
 	}{
 		{
 			"all-values",
+			map[string]interface{}{"role_arn": "arn::it", "external_id": "123", "session_name": "foobar", "tags": map[string]string{"foo": "bar"}},
+		},
+		{
+			"no-tags",
 			map[string]interface{}{"role_arn": "arn::it", "external_id": "123", "session_name": "foobar"},
 		},
 	}
@@ -419,6 +423,7 @@ func TestAwsGetAwsSessionConfigWithAssumeRole(t *testing.T) {
 				RoleArn:     s3ConfigExtended.RemoteStateConfigS3.AssumeRole.RoleArn,
 				ExternalID:  s3ConfigExtended.RemoteStateConfigS3.AssumeRole.ExternalID,
 				SessionName: s3ConfigExtended.RemoteStateConfigS3.AssumeRole.SessionName,
+				Tags:        s3ConfigExtended.RemoteStateConfigS3.AssumeRole.Tags,
 			}
 
 			actual := s3ConfigExtended.GetAwsSessionConfig()


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
<!-- Description of the changes introduced by this PR. -->
This introduces support for all documented arguments for the `assume_role` block in `remote_state` terragrunt blocks.
List at https://opentofu.org/docs/language/settings/backends/s3/#assume-role-configuration.

Fixes #2744.



## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->

Added: Support for all `assume_role` block arguments for s3 backend in `remote_state` configs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced AWS session configuration with support for session tags and extended role assumption options.
	- Improved S3 backend configuration, allowing users to specify additional parameters such as duration, policy details, source identity, and transitive tag keys.
- **Documentation**
	- Updated configuration documentation to reflect the new required and optional parameters for role assumption.
- **Tests**
	- Added test cases to ensure accurate handling of the enhanced assume role and session tag configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->