### PR TITLE
feat: Adding `find` command

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -2,6 +2,7 @@
 package commands
 
 import (
+	"github.com/gruntwork-io/terragrunt/cli/commands/find"
 	"github.com/gruntwork-io/terragrunt/cli/commands/info"
 	"github.com/gruntwork-io/terragrunt/cli/commands/stack"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -33,6 +34,8 @@ const (
 	MainCommandsCategoryName = "Main commands"
 	// CatalogCommandsCategoryName represents commands for managing Terragrunt catalogs.
 	CatalogCommandsCategoryName = "Catalog commands"
+	// DiscoveryCommandsCategoryName represents commands for discovering Terragrunt configurations.
+	DiscoveryCommandsCategoryName = "Discovery commands"
 	// ConfigurationCommandsCategoryName represents commands for managing Terragrunt configurations.
 	ConfigurationCommandsCategoryName = "Configuration commands"
 	// ShortcutsCommandsCategoryName represents OpenTofu-specific shortcut commands.
@@ -65,6 +68,15 @@ func New(opts *options.TerragruntOptions) cli.Commands {
 		},
 	)
 
+	discoveryCommands := cli.Commands{
+		find.NewCommand(opts), // find
+	}.SetCategory(
+		&cli.Category{
+			Name:  DiscoveryCommandsCategoryName,
+			Order: 30, //nolint: mnd
+		},
+	)
+
 	configurationCommands := cli.Commands{
 		graphdependencies.NewCommand(opts),  // graph-dependencies
 		outputmodulegroups.NewCommand(opts), // output-module-groups
@@ -80,19 +92,20 @@ func New(opts *options.TerragruntOptions) cli.Commands {
 	}.SetCategory(
 		&cli.Category{
 			Name:  ConfigurationCommandsCategoryName,
-			Order: 30, //nolint: mnd
+			Order: 40, //nolint: mnd
 		},
 	)
 
 	shortcutsCommands := NewShortcutsCommands(opts).SetCategory(
 		&cli.Category{
 			Name:  ShortcutsCommandsCategoryName,
-			Order: 40, //nolint: mnd
+			Order: 50, //nolint: mnd
 		},
 	)
 
 	allCommands := mainCommands.
 		Merge(catalogCommands...).
+		Merge(discoveryCommands...).
 		Merge(configurationCommands...).
 		Merge(shortcutsCommands...).
 		Merge(NewDeprecatedCommands(opts)...)

--- a/cli/commands/find/action.go
+++ b/cli/commands/find/action.go
@@ -1,0 +1,88 @@
+package find
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/mgutz/ansi"
+)
+
+func Run(ctx context.Context, opts *Options) error {
+	configs, err := discovery.DiscoverConfigs(opts.TerragruntOptions)
+	if err != nil {
+		return err
+	}
+
+	switch opts.Format {
+	case "text":
+		return outputText(opts, configs)
+	case "json":
+		return outputJSON(configs)
+	default:
+		return errors.New("invalid format: " + opts.Format)
+	}
+}
+
+type JSONOutput struct {
+	Units  []string `json:"units,omitempty"`
+	Stacks []string `json:"stacks,omitempty"`
+}
+
+func outputJSON(configs discovery.DiscoveredConfigs) error {
+	output := JSONOutput{
+		Units:  configs.Filter(discovery.ConfigTypeUnit).Paths(),
+		Stacks: configs.Filter(discovery.ConfigTypeStack).Paths(),
+	}
+
+	jsonBytes, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonBytes))
+	return nil
+}
+
+type Colorizer struct {
+	unitColorizer  func(string) string
+	stackColorizer func(string) string
+}
+
+func NewColorizer() *Colorizer {
+	return &Colorizer{
+		unitColorizer:  ansi.ColorFunc(ansi.LightGreen),
+		stackColorizer: ansi.ColorFunc(ansi.LightBlue),
+	}
+}
+
+func (c *Colorizer) colorize(config *discovery.DiscoveredConfig) string {
+	switch config.ConfigType() {
+	case discovery.ConfigTypeUnit:
+		return c.unitColorizer(config.Path())
+	case discovery.ConfigTypeStack:
+		return c.stackColorizer(config.Path())
+	default:
+		return config.Path()
+	}
+}
+
+func outputText(opts *Options, configs discovery.DiscoveredConfigs) error {
+	if opts.TerragruntOptions.Logger.Formatter().DisabledColors() {
+		for _, config := range configs {
+			fmt.Println(config.Path(), ansi.Reset)
+		}
+
+		return nil
+	}
+
+	colorizer := NewColorizer()
+
+	for _, config := range configs {
+		fmt.Println(colorizer.colorize(config), ansi.Reset)
+	}
+
+	return nil
+}

--- a/cli/commands/find/command.go
+++ b/cli/commands/find/command.go
@@ -1,0 +1,64 @@
+// Package find provides the ability to find Terragrunt configurations in your codebase
+// via the `terragrunt find` command.
+package find
+
+import (
+	"github.com/gruntwork-io/terragrunt/cli/flags"
+	"github.com/gruntwork-io/terragrunt/internal/cli"
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/options"
+)
+
+const (
+	CommandName = "find"
+
+	FormatFlagName = "format"
+	SortFlagName   = "sort"
+)
+
+func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
+	tgPrefix := prefix.Prepend(flags.TgPrefix)
+
+	return cli.Flags{
+		flags.NewFlag(&cli.GenericFlag[string]{
+			Name:        FormatFlagName,
+			EnvVars:     tgPrefix.EnvVars(FormatFlagName),
+			Destination: &opts.Format,
+			Usage:       "Output format for the find results. Valid values: text, json",
+			DefaultText: "text",
+		}),
+		flags.NewFlag(&cli.GenericFlag[string]{
+			Name:        SortFlagName,
+			EnvVars:     tgPrefix.EnvVars(SortFlagName),
+			Destination: &opts.Sort,
+			Usage:       "Sort order for the find results. Valid values: alpha", // TODO: add dag
+			DefaultText: "alpha",
+		}),
+	}
+}
+
+func NewCommand(opts *options.TerragruntOptions) *cli.Command {
+	cmdOpts := NewOptions(opts)
+
+	return &cli.Command{
+		Name:                 CommandName,
+		Usage:                "Find relevant Terragrunt configurations.",
+		ErrorOnUndefinedFlag: true,
+		Flags:                NewFlags(cmdOpts, nil),
+		Before: func(ctx *cli.Context) error {
+			if !opts.Experiments.Evaluate(experiment.CLIRedesign) {
+				return cli.NewExitError(errors.Errorf("requires that the %[1]s experiment is enabled. e.g. --experiment %[1]s", experiment.CLIRedesign), cli.ExitCodeGeneralError)
+			}
+
+			if !opts.Experiments.Evaluate(experiment.Stacks) {
+				return cli.NewExitError(errors.Errorf("requires that the %[1]s experiment is enabled. e.g. --experiment %[1]s", experiment.Stacks), cli.ExitCodeGeneralError)
+			}
+
+			return nil
+		},
+		Action: func(ctx *cli.Context) error {
+			return Run(ctx, cmdOpts)
+		},
+	}
+}

--- a/cli/commands/find/options.go
+++ b/cli/commands/find/options.go
@@ -1,0 +1,62 @@
+package find
+
+import (
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/options"
+)
+
+type Options struct {
+	*options.TerragruntOptions
+
+	// Format determines the format of the output.
+	Format string
+
+	// Sort determines the sort order of the output.
+	Sort string
+}
+
+func NewOptions(opts *options.TerragruntOptions) *Options {
+	return &Options{
+		TerragruntOptions: opts,
+		Format:            "text",
+		Sort:              "alpha",
+	}
+}
+
+func (o *Options) Validate() error {
+	errs := []error{}
+
+	if err := o.validateFormat(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := o.validateSort(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return errors.New(errors.Join(errs...))
+	}
+
+	return nil
+}
+
+func (o *Options) validateFormat() error {
+	switch o.Format {
+	case "text":
+		return nil
+	case "json":
+		return nil
+	default:
+		return errors.New("invalid format: " + o.Format)
+	}
+}
+
+func (o *Options) validateSort() error {
+	switch o.Sort {
+	case "alpha":
+		return nil
+	default:
+		return errors.New("invalid sort: " + o.Sort)
+	}
+}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -1,0 +1,124 @@
+// Package discovery provides functionality for discovering Terragrunt configurations.
+
+package discovery
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/gruntwork-io/terragrunt/options"
+)
+
+type ConfigType string
+
+const (
+	ConfigTypeUnit  ConfigType = "unit"
+	ConfigTypeStack ConfigType = "stack"
+)
+
+// DiscoveredConfig represents a discovered Terragrunt configuration.
+type DiscoveredConfig struct {
+	config ConfigType
+	path   string
+}
+
+func (c *DiscoveredConfig) Path() string {
+	return c.path
+}
+
+func (c *DiscoveredConfig) ConfigType() ConfigType {
+	return c.config
+}
+
+func (c *DiscoveredConfig) String() string {
+	return string(c.config) + ": " + c.path
+}
+
+type DiscoveredConfigs []*DiscoveredConfig
+
+func DiscoverConfigs(opts *options.TerragruntOptions) (DiscoveredConfigs, error) {
+	var units DiscoveredConfigs
+
+	walkFn := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return errors.New(err.Error())
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if filepath.Base(path) == filepath.Base(opts.TerragruntConfigPath) {
+			relPath, err := filepath.Rel(opts.WorkingDir, path)
+			if err != nil {
+				return errors.New(err.Error())
+			}
+
+			units = append(units, &DiscoveredConfig{
+				config: ConfigTypeUnit,
+				path:   filepath.Dir(relPath),
+			})
+		}
+
+		if filepath.Base(path) == filepath.Base(opts.TerragruntStackConfigPath) {
+			relPath, err := filepath.Rel(opts.WorkingDir, path)
+			if err != nil {
+				return errors.New(err.Error())
+			}
+
+			units = append(units, &DiscoveredConfig{
+				config: ConfigTypeStack,
+				path:   filepath.Dir(relPath),
+			})
+		}
+
+		return nil
+	}
+
+	if err := filepath.Walk(opts.WorkingDir, walkFn); err != nil {
+		return nil, errors.New(err.Error())
+	}
+
+	return units, nil
+}
+
+func (c DiscoveredConfigs) Sort() DiscoveredConfigs {
+	sort.Slice(c, func(i, j int) bool {
+		return c[i].path < c[j].path
+	})
+
+	return c
+}
+
+func (c DiscoveredConfigs) Filter(configType ConfigType) DiscoveredConfigs {
+	filtered := make(DiscoveredConfigs, 0, len(c))
+	for _, config := range c {
+		if config.config == configType {
+			filtered = append(filtered, config)
+		}
+	}
+
+	return filtered
+}
+
+func (c DiscoveredConfigs) FilterByPath(path string) DiscoveredConfigs {
+	filtered := make(DiscoveredConfigs, 0, len(c))
+	for _, config := range c {
+		if config.path == path {
+			filtered = append(filtered, config)
+		}
+	}
+
+	return filtered
+}
+
+func (c DiscoveredConfigs) Paths() []string {
+	paths := make([]string, 0, len(c))
+	for _, config := range c {
+		paths = append(paths, config.path)
+	}
+
+	return paths
+}


### PR DESCRIPTION
## Description

Adds `find` command. Relates to #3445.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added `find` command.
