### PR TITLE
fix: Adding docs from role assumption updates in Jekyll docs

### DIFF
--- a/docs-starlight/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -428,9 +428,15 @@ For the `s3` backend, the following additional properties are supported in the `
 - `bucket_sse_algorithm`: (Optional) The algorithm to use for server-side encryption of the state bucket. Defaults to `aws:kms`.
 - `bucket_sse_kms_key_id`: (Optional) The KMS Key to use when the encryption algorithm is `aws:kms`. Defaults to the AWS Managed `aws/s3` key.
 - `assume_role`: (Optional) A configuration `map` to use when assuming a role (starting with Terraform 1.6 for Terraform). Override top level arguments
-  - `role_arn` - (Optional) The role to be assumed.
+  - `role_arn` - (Required) The role to be assumed.
+  - `duration` - (Optional) The duration the credentials will be valid.
   - `external_id` - (Optional) The external ID to use when assuming the role.
+  - `policy` - (Optional) Policy JSON to further restrict the role.
+  - `policy_arns` - (Optional) A list of policy ARNs to further restrict the role.
   - `session_name` - (Optional) The session name to use when assuming the role.
+  - `source_identity` - (Optional) The source identity to use when assuming the role.
+  - `tags` - (Optional) A map of key value pairs used as assume role session tags.
+  - `transitive_tag_keys` - (Optional) A list of tag keys that to be passed.
 
 For the `gcs` backend, the following additional properties are supported in the `config` attribute:
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the S3 backend configuration section in the remote state documentation.
  - Changed the role identifier to a required setting.
  - Added optional settings for credential duration, policy restrictions, policy ARN list, source identity, session tags, and transitive tag keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->