### PR TITLE
fix: Remove usage of template provider

### DIFF
--- a/test/fixtures/destroy-order/hello/main.tf
+++ b/test/fixtures/destroy-order/hello/main.tf
@@ -1,15 +1,29 @@
-data "template_file" "test" {
-  template = "${module.hello.hello}, ${var.name}"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 variable "name" {
   description = "Specify a name"
-}
-
-output "test" {
-  value = data.template_file.test.rendered
+  type        = string
 }
 
 module "hello" {
   source = "./hello"
+}
+
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo '${module.hello.hello}, ${var.name}'"
+  }
+}
+
+output "test" {
+  value = "${module.hello.hello}, ${var.name}"
 }

--- a/test/fixtures/download/hello-world-no-remote/main.tf
+++ b/test/fixtures/download/hello-world-no-remote/main.tf
@@ -1,15 +1,29 @@
-data "template_file" "test" {
-  template = "${module.hello.hello}, ${var.name}"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 variable "name" {
   description = "Specify a name"
-}
-
-output "test" {
-  value = data.template_file.test.rendered
+  type        = string
 }
 
 module "hello" {
   source = "..//hello-world/hello"
+}
+
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo '${module.hello.hello}, ${var.name}'"
+  }
+}
+
+output "test" {
+  value = "${module.hello.hello}, ${var.name}"
 }

--- a/test/fixtures/download/hello-world-with-backend/main.tf
+++ b/test/fixtures/download/hello-world-with-backend/main.tf
@@ -1,16 +1,28 @@
-data "template_file" "test" {
-  template = "hello, ${var.name}"
+terraform {
+  # These settings will be filled in by Terragrunt
+  backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 variable "name" {
   description = "Specify a name"
+  type        = string
+}
+
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo 'hello, ${var.name}'"
+  }
 }
 
 output "test" {
-  value = data.template_file.test.rendered
-}
-
-terraform {
-  # These settings will be filled in by Terragrunt
-  backend "s3" {}
+  value = "hello, ${var.name}"
 }

--- a/test/fixtures/download/hello-world/main.tf
+++ b/test/fixtures/download/hello-world/main.tf
@@ -1,17 +1,31 @@
-data "template_file" "test" {
-  template = "${module.hello.hello}, ${var.name}"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 variable "name" {
   description = "Specify a name"
-}
-
-output "test" {
-  value = data.template_file.test.rendered
+  type        = string
 }
 
 module "hello" {
   source = "./hello"
+}
+
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo '${module.hello.hello}, ${var.name}'"
+  }
+}
+
+output "test" {
+  value = "${module.hello.hello}, ${var.name}"
 }
 
 module "remote" {

--- a/test/fixtures/download/local-windows/JZwoL6Viko8bzuRvTOQFx3Jh8vs/3mU4huxMLOXOW5ZgJOFXGUFDKc8/main.tf
+++ b/test/fixtures/download/local-windows/JZwoL6Viko8bzuRvTOQFx3Jh8vs/3mU4huxMLOXOW5ZgJOFXGUFDKc8/main.tf
@@ -1,17 +1,31 @@
-data "template_file" "test" {
-  template = "${module.hello.hello}, ${var.name}"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 variable "name" {
   description = "Specify a name"
-}
-
-output "test" {
-  value = data.template_file.test.rendered
+  type        = string
 }
 
 module "hello" {
   source = "./hello"
+}
+
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo '${module.hello.hello}, ${var.name}'"
+  }
+}
+
+output "test" {
+  value = "${module.hello.hello}, ${var.name}"
 }
 
 module "remote" {

--- a/test/fixtures/download/stdout/main.tf
+++ b/test/fixtures/download/stdout/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "foo" {
-  template = "foo"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "foo" {
+  provisioner "local-exec" {
+    command = "echo foo"
+  }
 }
 
 output "foo" {
-  value = data.template_file.foo.rendered
+  value = "foo"
 }

--- a/test/fixtures/gcs-byo-bucket/main.tf
+++ b/test/fixtures/gcs-byo-bucket/main.tf
@@ -1,12 +1,19 @@
 terraform {
   backend "gcs" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "test" {
-  template = "Hello, I am a template. My sample_var value = $${sample_var}"
-
-  vars = {
-    sample_var = var.sample_var
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo Hello, World!"
   }
 }

--- a/test/fixtures/gcs-byo-bucket/outputs.tf
+++ b/test/fixtures/gcs-byo-bucket/outputs.tf
@@ -1,3 +1,0 @@
-output "rendered_template" {
-  value = data.template_file.test.rendered
-}

--- a/test/fixtures/gcs-byo-bucket/vars.tf
+++ b/test/fixtures/gcs-byo-bucket/vars.tf
@@ -1,5 +1,0 @@
-# Configure these variables
-variable "sample_var" {
-  description = "A sample_var to pass to the template."
-  default     = "hello"
-}

--- a/test/fixtures/gcs/main.tf
+++ b/test/fixtures/gcs/main.tf
@@ -1,12 +1,18 @@
 terraform {
   backend "gcs" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
-# Create an arbitrary local resource
-data "template_file" "test" {
-  template = "Hello, I am a template. My sample_var value = $${sample_var}"
-
-  vars = {
-    sample_var = var.sample_var
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo Hello, World!"
   }
 }

--- a/test/fixtures/gcs/outputs.tf
+++ b/test/fixtures/gcs/outputs.tf
@@ -1,3 +1,0 @@
-output "rendered_template" {
-  value = data.template_file.test.rendered
-}

--- a/test/fixtures/gcs/terragrunt.hcl
+++ b/test/fixtures/gcs/terragrunt.hcl
@@ -6,7 +6,7 @@ remote_state {
     project  = "__FILL_IN_PROJECT__"
     location = "__FILL_IN_LOCATION__"
     bucket   = "__FILL_IN_BUCKET_NAME__"
-    prefix   = "terraform.tfstate"
+    prefix   = "tofu.tfstate"
 
     gcs_bucket_labels = {
       owner = "terragrunt_test"

--- a/test/fixtures/gcs/vars.tf
+++ b/test/fixtures/gcs/vars.tf
@@ -1,5 +1,0 @@
-# Configure these variables
-variable "sample_var" {
-  description = "A sample_var to pass to the template."
-  default     = "hello"
-}

--- a/test/fixtures/hooks/after-only/main.tf
+++ b/test/fixtures/hooks/after-only/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/hooks/all/after-only/main.tf
+++ b/test/fixtures/hooks/all/after-only/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/hooks/all/before-only/main.tf
+++ b/test/fixtures/hooks/all/before-only/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/hooks/bad-arg-action/empty-command-list/main.tf
+++ b/test/fixtures/hooks/bad-arg-action/empty-command-list/main.tf
@@ -1,7 +1,16 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
-output "example" {
-  value = data.template_file.example.rendered
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo Hello, World!"
+  }
 }

--- a/test/fixtures/hooks/bad-arg-action/empty-string-command/main.tf
+++ b/test/fixtures/hooks/bad-arg-action/empty-string-command/main.tf
@@ -1,5 +1,18 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo Hello, World!"
+  }
 }
 
 output "example" {

--- a/test/fixtures/hooks/before-after-and-error-merge/qa/my-app/main.tf
+++ b/test/fixtures/hooks/before-after-and-error-merge/qa/my-app/main.tf
@@ -1,11 +1,22 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
-data "template_file" "example" {
-  template = "hello, world"
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/hooks/before-after-and-on-error/main.tf
+++ b/test/fixtures/hooks/before-after-and-on-error/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/hooks/before-and-after/main.tf
+++ b/test/fixtures/hooks/before-and-after/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/hooks/before-only/main.tf
+++ b/test/fixtures/hooks/before-only/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/hooks/init-once/base-module/main.tf
+++ b/test/fixtures/hooks/init-once/base-module/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/hooks/init-once/no-source-no-backend/main.tf
+++ b/test/fixtures/hooks/init-once/no-source-no-backend/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/hooks/init-once/no-source-with-backend/main.tf
+++ b/test/fixtures/hooks/init-once/no-source-with-backend/main.tf
@@ -1,11 +1,18 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
-data "template_file" "example" {
-  template = "hello, world"
-}
-
-output "example" {
-  value = data.template_file.example.rendered
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo Hello, World!"
+  }
 }

--- a/test/fixtures/hooks/interpolations/main.tf
+++ b/test/fixtures/hooks/interpolations/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/hooks/one-arg-action/main.tf
+++ b/test/fixtures/hooks/one-arg-action/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/hooks/skip-on-error/main.tf
+++ b/test/fixtures/hooks/skip-on-error/main.tf
@@ -1,7 +1,20 @@
-data "template_file" "example" {
-  template = "hello, world"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command = "echo hello, world"
+  }
 }
 
 output "example" {
-  value = data.template_file.example.rendered
+  value = "hello, world"
 }

--- a/test/fixtures/include/qa/my-app/main.tf
+++ b/test/fixtures/include/qa/my-app/main.tf
@@ -1,9 +1,25 @@
-# Create an arbitrary local resource
-data "template_file" "test" {
-  template = "Hello, I am a template."
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
-variable "reflect" {}
+# Create an arbitrary local resource
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo Hello, World!"
+  }
+}
+
+variable "reflect" {
+  type = string
+}
+
 output "reflect" {
   value = var.reflect
 }

--- a/test/fixtures/include/stage/my-app/main.tf
+++ b/test/fixtures/include/stage/my-app/main.tf
@@ -1,13 +1,28 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "test" {
-  template = "Hello, I am a template."
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo Hello, World!"
+  }
 }
 
-variable "reflect" {}
+variable "reflect" {
+  type = string
+}
+
+
 output "reflect" {
   value = var.reflect
 }

--- a/test/fixtures/parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/main.tf
+++ b/test/fixtures/parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/main.tf
@@ -1,8 +1,19 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "test" {
-  template = "Hello, I am a template."
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo Hello, World!"
+  }
 }

--- a/test/fixtures/stack/mgmt/bastion-host/main.tf
+++ b/test/fixtures/stack/mgmt/bastion-host/main.tf
@@ -1,18 +1,30 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "text" {
-  template = "[I am a bastion-host template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}]"
+resource "null_resource" "text" {
+  provisioner "local-exec" {
+    command = "echo '[I am a bastion host template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}]'"
+  }
 }
 
 output "text" {
-  value = data.template_file.text.rendered
+  value = "[I am a bastion host template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}]"
 }
 
 variable "terraform_remote_state_s3_bucket" {
   description = "The name of the S3 bucket where Terraform remote state is stored"
+  type        = string
 }
 
 data "terraform_remote_state" "vpc" {

--- a/test/fixtures/stack/mgmt/kms-master-key/main.tf
+++ b/test/fixtures/stack/mgmt/kms-master-key/main.tf
@@ -1,12 +1,23 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "text" {
-  template = "[I am a kms-master-key template.]"
+resource "null_resource" "text" {
+  provisioner "local-exec" {
+    command = "echo '[I am a kms-master-key template.]'"
+  }
 }
 
 output "text" {
-  value = data.template_file.text.rendered
+  value = "[I am a kms-master-key template.]"
 }

--- a/test/fixtures/stack/mgmt/vpc/main.tf
+++ b/test/fixtures/stack/mgmt/vpc/main.tf
@@ -1,12 +1,23 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "text" {
-  template = "[I am a mgmt vpc template. I have no dependencies.]"
+resource "null_resource" "text" {
+  provisioner "local-exec" {
+    command = "echo '[I am a mgmt vpc template. I have no dependencies.]'"
+  }
 }
 
 output "text" {
-  value = data.template_file.text.rendered
+  value = "[I am a mgmt vpc template. I have no dependencies.]"
 }

--- a/test/fixtures/stack/stage/backend-app/main.tf
+++ b/test/fixtures/stack/stage/backend-app/main.tf
@@ -1,18 +1,30 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "text" {
-  template = "[I am a backend-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}, bastion-host = ${data.terraform_remote_state.bastion_host.outputs.text}, mysql = ${data.terraform_remote_state.mysql.outputs.text}, search-app = ${data.terraform_remote_state.search_app.outputs.text}]"
+resource "null_resource" "text" {
+  provisioner "local-exec" {
+    command = "echo '[I am a backend-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}, bastion-host = ${data.terraform_remote_state.bastion_host.outputs.text}, mysql = ${data.terraform_remote_state.mysql.outputs.text}, search-app = ${data.terraform_remote_state.search_app.outputs.text}]'"
+  }
 }
 
 output "text" {
-  value = data.template_file.text.rendered
+  value = "[I am a backend-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}, bastion-host = ${data.terraform_remote_state.bastion_host.outputs.text}, mysql = ${data.terraform_remote_state.mysql.outputs.text}, search-app = ${data.terraform_remote_state.search_app.outputs.text}]"
 }
 
 variable "terraform_remote_state_s3_bucket" {
   description = "The name of the S3 bucket where Terraform remote state is stored"
+  type        = string
 }
 
 data "terraform_remote_state" "vpc" {

--- a/test/fixtures/stack/stage/frontend-app/main.tf
+++ b/test/fixtures/stack/stage/frontend-app/main.tf
@@ -1,18 +1,30 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "text" {
-  template = "[I am a frontend-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}, bastion-host = ${data.terraform_remote_state.bastion_host.outputs.text}, backend-app = ${data.terraform_remote_state.backend_app.outputs.text}]"
+resource "null_resource" "text" {
+  provisioner "local-exec" {
+    command = "echo '[I am a frontend-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}, bastion-host = ${data.terraform_remote_state.bastion_host.outputs.text}, backend-app = ${data.terraform_remote_state.backend_app.outputs.text}]'"
+  }
 }
 
 output "text" {
-  value = data.template_file.text.rendered
+  value = "[I am a frontend-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}, bastion-host = ${data.terraform_remote_state.bastion_host.outputs.text}, backend-app = ${data.terraform_remote_state.backend_app.outputs.text}]"
 }
 
 variable "terraform_remote_state_s3_bucket" {
   description = "The name of the S3 bucket where Terraform remote state is stored"
+  type        = string
 }
 
 data "terraform_remote_state" "vpc" {
@@ -32,7 +44,6 @@ data "terraform_remote_state" "backend_app" {
     key    = "stage/backend-app/terraform.tfstate"
   }
 }
-
 
 data "terraform_remote_state" "bastion_host" {
   backend = "s3"

--- a/test/fixtures/stack/stage/mysql/main.tf
+++ b/test/fixtures/stack/stage/mysql/main.tf
@@ -1,18 +1,30 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "text" {
-  template = "[I am a mysql template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}]"
+resource "null_resource" "text" {
+  provisioner "local-exec" {
+    command = "echo '[I am a mysql template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}]'"
+  }
 }
 
 output "text" {
-  value = data.template_file.text.rendered
+  value = "[I am a mysql template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}]"
 }
 
 variable "terraform_remote_state_s3_bucket" {
   description = "The name of the S3 bucket where Terraform remote state is stored"
+  type        = string
 }
 
 data "terraform_remote_state" "vpc" {

--- a/test/fixtures/stack/stage/redis/main.tf
+++ b/test/fixtures/stack/stage/redis/main.tf
@@ -1,18 +1,30 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "text" {
-  template = "[I am a redis template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}]"
+resource "null_resource" "text" {
+  provisioner "local-exec" {
+    command = "echo '[I am a redis template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}]'"
+  }
 }
 
 output "text" {
-  value = data.template_file.text.rendered
+  value = "[I am a redis template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}]"
 }
 
 variable "terraform_remote_state_s3_bucket" {
   description = "The name of the S3 bucket where Terraform remote state is stored"
+  type        = string
 }
 
 data "terraform_remote_state" "vpc" {

--- a/test/fixtures/stack/stage/search-app/example-module/main.tf
+++ b/test/fixtures/stack/stage/search-app/example-module/main.tf
@@ -4,3 +4,7 @@ resource "null_resource" "test" {
     command = "echo Hello, World!"
   }
 }
+
+output "text" {
+  value = "[I am an example module template.]"
+}

--- a/test/fixtures/stack/stage/search-app/example-module/main.tf
+++ b/test/fixtures/stack/stage/search-app/example-module/main.tf
@@ -1,8 +1,6 @@
 # Create an arbitrary local resource
-data "template_file" "text" {
-  template = "Example text from a module"
-}
-
-output "text" {
-  value = data.template_file.text.rendered
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "echo Hello, World!"
+  }
 }

--- a/test/fixtures/stack/stage/search-app/main.tf
+++ b/test/fixtures/stack/stage/search-app/main.tf
@@ -1,22 +1,30 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "text" {
-  template = "[I am a search-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}, redis = ${data.terraform_remote_state.redis.outputs.text}, example_module = ${module.example_module.text}]"
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "[I am a search-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}, redis = ${data.terraform_remote_state.redis.outputs.text}, example_module = ${module.example_module.text}]"
+  }
 }
 
 module "example_module" {
   source = "./example-module"
 }
 
-output "text" {
-  value = data.template_file.text.rendered
-}
-
 variable "terraform_remote_state_s3_bucket" {
   description = "The name of the S3 bucket where Terraform remote state is stored"
+  type        = string
 }
 
 data "terraform_remote_state" "vpc" {

--- a/test/fixtures/stack/stage/search-app/main.tf
+++ b/test/fixtures/stack/stage/search-app/main.tf
@@ -14,7 +14,7 @@ terraform {
 # Create an arbitrary local resource
 resource "null_resource" "test" {
   provisioner "local-exec" {
-    command = "[I am a search-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}, redis = ${data.terraform_remote_state.redis.outputs.text}, example_module = ${module.example_module.text}]"
+    command = "echo '[I am a search-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}, redis = ${data.terraform_remote_state.redis.outputs.text}, example_module = ${module.example_module.text}]'"
   }
 }
 
@@ -43,4 +43,8 @@ data "terraform_remote_state" "redis" {
     bucket = var.terraform_remote_state_s3_bucket
     key    = "stage/redis/terraform.tfstate"
   }
+}
+
+output "text" {
+  value = "[I am a search-app template. Data from my dependencies: vpc = ${data.terraform_remote_state.vpc.outputs.text}, redis = ${data.terraform_remote_state.redis.outputs.text}, example_module = ${module.example_module.text}]"
 }

--- a/test/fixtures/stack/stage/vpc/main.tf
+++ b/test/fixtures/stack/stage/vpc/main.tf
@@ -1,18 +1,30 @@
 terraform {
   backend "s3" {}
+
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+  }
 }
 
 # Create an arbitrary local resource
-data "template_file" "text" {
-  template = "[I am a stage vpc template. Data from my dependencies: vpc = ${data.terraform_remote_state.mgmt_vpc.outputs.text}]"
+resource "null_resource" "text" {
+  provisioner "local-exec" {
+    command = "echo '[I am a stage vpc template. Data from my dependencies: vpc = ${data.terraform_remote_state.mgmt_vpc.outputs.text}]'"
+  }
 }
 
 output "text" {
-  value = data.template_file.text.rendered
+  value = "[I am a stage vpc template. Data from my dependencies: vpc = ${data.terraform_remote_state.mgmt_vpc.outputs.text}]"
 }
 
 variable "terraform_remote_state_s3_bucket" {
   description = "The name of the S3 bucket where Terraform remote state is stored"
+  type        = string
 }
 
 data "terraform_remote_state" "mgmt_vpc" {


### PR DESCRIPTION
## Description

Eliminates usage of the template provider.

This is important, as ARM64 workstations don't have the ability to run the provider out of the box, and this should increase the likelihood of community members being able to run the tests locally on their workstations.

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Removed usage of `template` provider in fixtures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Outputs now deliver clear, direct messages using a streamlined execution approach instead of indirect templating.

- **Refactor**
  - Configurations have been standardized to enforce a minimum Terraform version and explicit provider requirements.
  - Variable definitions now explicitly specify types for enhanced reliability.
  - Deprecated output and variable configurations were removed to simplify resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->