### PR TITLE
fix: Upgrading `golangci-lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean:
 	rm -f terragrunt
 
 install-lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.6
 
 run-lint:
 	golangci-lint run -v --timeout=10m ./...

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -558,7 +558,7 @@ func TestAutocomplete(t *testing.T) { //nolint:paralleltest
 	}
 
 	for _, testCase := range testCases {
-		os.Setenv("COMP_LINE", "terragrunt "+testCase.compLine)
+		t.Setenv("COMP_LINE", "terragrunt "+testCase.compLine)
 
 		output := &bytes.Buffer{}
 		opts := options.NewTerragruntOptionsWithWriters(output, os.Stderr)

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -318,9 +318,9 @@ func TestAwsOutputAllCommand(t *testing.T) {
 	helpers.RunTerragruntRedirectOutput(t, "terragrunt output-all --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath, &stdout, &stderr)
 	output := stdout.String()
 
-	assert.True(t, strings.Contains(output, "app1 output"))
-	assert.True(t, strings.Contains(output, "app2 output"))
-	assert.True(t, strings.Contains(output, "app3 output"))
+	assert.Contains(t, output, "app1 output")
+	assert.Contains(t, output, "app2 output")
+	assert.Contains(t, output, "app3 output")
 
 	assert.True(t, (strings.Index(output, "app3 output") < strings.Index(output, "app1 output")) && (strings.Index(output, "app1 output") < strings.Index(output, "app2 output")))
 }
@@ -395,11 +395,11 @@ func TestAwsOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *testing.T)
 	helpers.LogBufferContentsLineByLine(t, stderr, "output-all stderr")
 
 	// Without --terragrunt-ignore-dependency-errors, app2 never runs because its dependencies have "errors" since they don't have the output "app2_text".
-	assert.True(t, strings.Contains(output, "app2 output"))
+	assert.Contains(t, output, "app2 output")
 }
 
 func TestAwsStackCommands(t *testing.T) { //nolint paralleltest
-	// It seems that disabling parallel test execution helps avoid the CircleCi error: “NoSuchBucket Policy: The bucket policy does not exist.”
+	// It seems that disabling parallel test execution helps avoid the CircleCi error: "NoSuchBucket Policy: The bucket policy does not exist."
 	// t.Parallel()
 
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
@@ -967,10 +967,10 @@ func TestAwsOutputFromRemoteState(t *testing.T) { //nolint: paralleltest
 	helpers.RunTerragruntRedirectOutput(t, "terragrunt run-all output --terragrunt-fetch-dependency-output-from-state --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+environmentPath, &stdout, &stderr)
 	output := stdout.String()
 
-	assert.True(t, strings.Contains(output, "app1 output"))
-	assert.True(t, strings.Contains(output, "app2 output"))
-	assert.True(t, strings.Contains(output, "app3 output"))
-	assert.False(t, strings.Contains(stderr.String(), "terraform output -json"))
+	assert.Contains(t, output, "app1 output")
+	assert.Contains(t, output, "app2 output")
+	assert.Contains(t, output, "app3 output")
+	assert.NotContains(t, stderr.String(), "terraform output -json")
 
 	assert.True(t, (strings.Index(output, "app3 output") < strings.Index(output, "app1 output")) && (strings.Index(output, "app1 output") < strings.Index(output, "app2 output")))
 }
@@ -1007,10 +1007,7 @@ func TestAwsMockOutputsFromRemoteState(t *testing.T) { //nolint: paralleltest
 func TestAwsParallelStateInit(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-test")
-	if err != nil {
-		require.NoError(t, err)
-	}
+	tmpEnvPath := t.TempDir()
 	for i := 0; i < 20; i++ {
 		err := util.CopyFolderContents(createLogger(), testFixtureParallelStateInit, tmpEnvPath, ".terragrunt-test", nil, nil)
 		require.NoError(t, err)

--- a/test/integration_serial_aws_test.go
+++ b/test/integration_serial_aws_test.go
@@ -99,10 +99,7 @@ func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
 
 	// copy the template `numberOfModules` times into the app
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir due to error: %v", err)
-	}
+	tmpEnvPath := t.TempDir()
 	for i := 0; i < numberOfModules; i++ {
 		err := util.CopyFolderContents(createLogger(), testFixtureParallelism, tmpEnvPath, ".terragrunt-test", nil, nil)
 		if err != nil {

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -666,14 +666,8 @@ func TestReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
 	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 
-	// I'm not sure why, but this test doesn't work with tenv
-	t.Setenv("AWS_ACCESS_KEY_ID", "")     //nolint: tenv
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "") //nolint: tenv
-
-	defer func() {
-		t.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)
-		t.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey)
-	}()
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 
 	credsConfig := util.JoinPath(rootPath, "creds.config")
 

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -667,12 +667,12 @@ func TestReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
 	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 
 	// I'm not sure why, but this test doesn't work with tenv
-	os.Setenv("AWS_ACCESS_KEY_ID", "")     //nolint: tenv
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "") //nolint: tenv
+	t.Setenv("AWS_ACCESS_KEY_ID", "")     //nolint: tenv
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "") //nolint: tenv
 
 	defer func() {
-		os.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)
-		os.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey)
+		t.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)
+		t.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey)
 	}()
 
 	credsConfig := util.JoinPath(rootPath, "creds.config")

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -666,8 +666,14 @@ func TestReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
 	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 
-	t.Setenv("AWS_ACCESS_KEY_ID", "")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	// I'm not sure why, but this test doesn't work with tenv
+	os.Setenv("AWS_ACCESS_KEY_ID", "")     //nolint: tenv,usetesting
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "") //nolint: tenv,usetesting
+
+	defer func() {
+		os.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)         //nolint: tenv,usetesting
+		os.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey) //nolint: tenv,usetesting
+	}()
 
 	credsConfig := util.JoinPath(rootPath, "creds.config")
 


### PR DESCRIPTION
## Description

Upgrading `golangci-lint` to `1.64.6`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `golangci-lint` version in `Makefile`, and addressed resulting findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the linting tool dependency to enhance code quality checks.

- **Tests**
  - Improved environment variable management in test cases for better isolation and clarity.
  - Refined assertion methods for clarity and consistency in testing routines.
  - Streamlined temporary directory handling, enhancing test clarity and reducing error management.

These internal improvements ensure more robust development practices and greater test reliability for an overall enhanced experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->