### PR TITLE
feat: Adding integration testing to the `find` command.

### DIFF
--- a/cli/commands/find/action.go
+++ b/cli/commands/find/action.go
@@ -15,6 +15,10 @@ import (
 func Run(ctx context.Context, opts *Options) error {
 	d := discovery.NewDiscovery(opts.WorkingDir)
 
+	if opts.Hidden {
+		d = d.WithHidden()
+	}
+
 	configs, err := d.Discover()
 	if err != nil {
 		return errors.New(err)

--- a/cli/commands/find/options.go
+++ b/cli/commands/find/options.go
@@ -1,9 +1,6 @@
 package find
 
 import (
-	"io"
-	"os"
-
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 )
@@ -23,11 +20,6 @@ type Options struct {
 
 	// Hidden determines whether to detect hidden directories.
 	Hidden bool
-
-	// Writer is the writer to write the output to.
-	// If not set, the output will be written to stdout.
-	// Useful for testing.
-	Writer io.Writer
 }
 
 func NewOptions(opts *options.TerragruntOptions) *Options {
@@ -36,7 +28,6 @@ func NewOptions(opts *options.TerragruntOptions) *Options {
 		Format:            "text",
 		Sort:              "alpha",
 		Hidden:            false,
-		Writer:            os.Stdout,
 	}
 }
 

--- a/test/fixtures/find/basic/stack/terragrunt.stack.hcl
+++ b/test/fixtures/find/basic/stack/terragrunt.stack.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/find/basic/unit/terragrunt.hcl
+++ b/test/fixtures/find/basic/unit/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/find/hidden/.hide/unit/terragrunt.hcl
+++ b/test/fixtures/find/hidden/.hide/unit/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/find/hidden/stack/terragrunt.stack.hcl
+++ b/test/fixtures/find/hidden/stack/terragrunt.stack.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/find/hidden/unit/terragrunt.hcl
+++ b/test/fixtures/find/hidden/unit/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -1,7 +1,6 @@
 package test_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -19,14 +18,11 @@ func TestFindBasic(t *testing.T) {
 
 	helpers.CleanupTerraformFolder(t, testFixtureFindBasic)
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
-	err := helpers.RunTerragruntCommand(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic, stdout, stderr)
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic)
 	require.NoError(t, err)
 
-	assert.Equal(t, "", stderr.String())
-	assert.Equal(t, "stack\nunit\n", stdout.String())
+	assert.Empty(t, stderr)
+	assert.Equal(t, "stack\nunit\n", stdout)
 }
 
 func TestFindBasicJSON(t *testing.T) {
@@ -34,14 +30,11 @@ func TestFindBasicJSON(t *testing.T) {
 
 	helpers.CleanupTerraformFolder(t, testFixtureFindBasic)
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
-	err := helpers.RunTerragruntCommand(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic+" --json", stdout, stderr)
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic+" --json")
 	require.NoError(t, err)
 
-	assert.Equal(t, "", stderr.String())
-	assert.JSONEq(t, `[{"type": "stack", "path": "stack"}, {"type": "unit", "path": "unit"}]`, stdout.String())
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, `[{"type": "stack", "path": "stack"}, {"type": "unit", "path": "unit"}]`, stdout)
 }
 
 func TestFindHidden(t *testing.T) {
@@ -69,20 +62,17 @@ func TestFindHidden(t *testing.T) {
 
 			helpers.CleanupTerraformFolder(t, testFixtureFindHidden)
 
-			stdout := &bytes.Buffer{}
-			stderr := &bytes.Buffer{}
-
 			cmd := "terragrunt find --experiment cli-redesign --no-color --working-dir " + testFixtureFindHidden
 
 			if tt.hidden {
 				cmd += " --hidden"
 			}
 
-			err := helpers.RunTerragruntCommand(t, cmd, stdout, stderr)
+			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
 			require.NoError(t, err)
 
-			assert.Equal(t, "", stderr.String())
-			assert.Equal(t, tt.expected, stdout.String())
+			assert.Empty(t, stderr)
+			assert.Equal(t, tt.expected, stdout)
 		})
 	}
 }

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -1,0 +1,88 @@
+package test_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFixtureFindBasic  = "fixtures/find/basic"
+	testFixtureFindHidden = "fixtures/find/hidden"
+)
+
+func TestFindBasic(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureFindBasic)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	err := helpers.RunTerragruntCommand(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic, stdout, stderr)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", stderr.String())
+	assert.Equal(t, "stack\nunit\n", stdout.String())
+}
+
+func TestFindBasicJSON(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureFindBasic)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	err := helpers.RunTerragruntCommand(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic+" --json", stdout, stderr)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, `[{"type": "stack", "path": "stack"}, {"type": "unit", "path": "unit"}]`, stdout.String())
+}
+
+func TestFindHidden(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name     string
+		hidden   bool
+		expected string
+	}{
+		{
+			name:     "hidden",
+			expected: "stack\nunit\n",
+		},
+		{
+			name:     "hidden",
+			hidden:   true,
+			expected: ".hide/unit\nstack\nunit\n",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			helpers.CleanupTerraformFolder(t, testFixtureFindHidden)
+
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+
+			cmd := "terragrunt find --experiment cli-redesign --no-color --working-dir " + testFixtureFindHidden
+
+			if tt.hidden {
+				cmd += " --hidden"
+			}
+
+			err := helpers.RunTerragruntCommand(t, cmd, stdout, stderr)
+			require.NoError(t, err)
+
+			assert.Equal(t, "", stderr.String())
+			assert.Equal(t, tt.expected, stdout.String())
+		})
+	}
+}

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -53,7 +53,7 @@ func TestFindHidden(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "hidden",
+			name:     "visible",
 			expected: "stack\nunit\n",
 		},
 		{


### PR DESCRIPTION
## Description

Adds integration tests for the `find` command.

Also updates the stdout writing logic so that it's leveraging the writer from TerragruntOptions instead of one specifically setup for the `find` command.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `find` command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the discovery process to include hidden configurations when the hidden option is enabled.
  - Improved JSON output mode, providing well-structured results.

- **Tests**
  - Added new test cases and integration tests to validate that both visible and hidden configurations are correctly discovered.

- **Chores**
  - Streamlined output handling by removing the previous output redirection mechanism.
  - Added multiple new empty configuration files for testing purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->