### PR TITLE
feat: Adding DAG support to find

### DIFF
--- a/cli/commands/find/action.go
+++ b/cli/commands/find/action.go
@@ -64,7 +64,7 @@ type FoundConfig struct {
 }
 
 func discoveredToFound(configs discovery.DiscoveredConfigs, opts *Options) (FoundConfigs, error) {
-	foundCfgs := FoundConfigs{}
+	foundCfgs := make(FoundConfigs, 0, len(configs))
 	errs := []error{}
 
 	for _, config := range configs {

--- a/cli/commands/find/action.go
+++ b/cli/commands/find/action.go
@@ -33,10 +33,6 @@ func Run(ctx context.Context, opts *Options) error {
 	case SortAlpha:
 		cfgs = cfgs.Sort()
 	case SortDAG:
-		// Sort alphabetically first,
-		// just so that the output is deterministic.
-		cfgs = cfgs.Sort()
-
 		q := queue.NewQueue(cfgs)
 		cfgs = q.Entries()
 	}

--- a/cli/commands/find/action.go
+++ b/cli/commands/find/action.go
@@ -19,15 +19,15 @@ func Run(ctx context.Context, opts *Options) error {
 		d = d.WithHidden()
 	}
 
-	configs, err := d.Discover()
+	configs, err := d.Discover(ctx, opts.TerragruntOptions)
 	if err != nil {
 		return errors.New(err)
 	}
 
 	switch opts.Format {
-	case "text":
+	case FormatText:
 		return outputText(opts, configs)
-	case "json":
+	case FormatJSON:
 		return outputJSON(opts, configs)
 	default:
 		// This should never happen, because of validation in the command.

--- a/cli/commands/find/action.go
+++ b/cli/commands/find/action.go
@@ -15,6 +15,10 @@ import (
 func Run(ctx context.Context, opts *Options) error {
 	d := discovery.NewDiscovery(opts.WorkingDir)
 
+	if opts.Hidden {
+		d = d.WithHidden()
+	}
+
 	configs, err := d.Discover()
 	if err != nil {
 		return errors.New(err)

--- a/cli/commands/find/action_test.go
+++ b/cli/commands/find/action_test.go
@@ -250,14 +250,14 @@ func TestColorizer(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		config *discovery.DiscoveredConfig
+		config *find.FoundConfig
 		// We can't test exact ANSI codes as they might vary by environment,
 		// so we'll test that different types result in different outputs
 		shouldBeDifferent []discovery.ConfigType
 	}{
 		{
 			name: "unit config",
-			config: &discovery.DiscoveredConfig{
+			config: &find.FoundConfig{
 				Type: discovery.ConfigTypeUnit,
 				Path: "path/to/unit",
 			},
@@ -265,7 +265,7 @@ func TestColorizer(t *testing.T) {
 		},
 		{
 			name: "stack config",
-			config: &discovery.DiscoveredConfig{
+			config: &find.FoundConfig{
 				Type: discovery.ConfigTypeStack,
 				Path: "path/to/stack",
 			},
@@ -282,7 +282,7 @@ func TestColorizer(t *testing.T) {
 
 			// Test that different types produce different colorized outputs
 			for _, diffType := range tt.shouldBeDifferent {
-				diffConfig := &discovery.DiscoveredConfig{
+				diffConfig := &find.FoundConfig{
 					Type: diffType,
 					Path: tt.config.Path,
 				}

--- a/cli/commands/find/action_test.go
+++ b/cli/commands/find/action_test.go
@@ -129,7 +129,7 @@ func TestRun(t *testing.T) {
 				t.Helper()
 
 				// Verify the output is valid JSON
-				var configs []discovery.DiscoveredConfig
+				var configs find.FoundConfigs
 				err := json.Unmarshal([]byte(output), &configs)
 				require.NoError(t, err)
 
@@ -503,10 +503,8 @@ dependency "B" {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
-			// FIXME: Restore.
-			// t.Parallel()
+			t.Parallel()
 
 			// Setup test directory
 			tmpDir := tt.setup(t)

--- a/cli/commands/find/action_test.go
+++ b/cli/commands/find/action_test.go
@@ -24,6 +24,7 @@ func TestRun(t *testing.T) {
 		setup         func(t *testing.T) string
 		expectedPaths []string
 		format        string
+		sort          string
 		hidden        bool
 		validate      func(t *testing.T, output string, expectedPaths []string)
 	}{
@@ -66,6 +67,7 @@ func TestRun(t *testing.T) {
 			},
 			expectedPaths: []string{"unit1", "unit2", "nested/unit4", "stack1"},
 			format:        "text",
+			sort:          "alpha",
 			validate: func(t *testing.T, output string, expectedPaths []string) {
 				t.Helper()
 
@@ -122,6 +124,7 @@ func TestRun(t *testing.T) {
 			},
 			expectedPaths: []string{"unit1", "unit2", "stack1"},
 			format:        "json",
+			sort:          "alpha",
 			validate: func(t *testing.T, output string, expectedPaths []string) {
 				t.Helper()
 
@@ -202,12 +205,308 @@ func TestRun(t *testing.T) {
 				assert.ElementsMatch(t, expectedPaths, lines)
 			},
 		},
+		{
+			name: "dag sorting - simple dependencies",
+			setup: func(t *testing.T) string {
+				t.Helper()
+
+				tmpDir := t.TempDir()
+
+				// Create test directory structure with dependencies:
+				// unit2 -> unit1
+				// unit3 -> unit2
+				testDirs := []string{
+					"unit1",
+					"unit2",
+					"unit3",
+				}
+
+				for _, dir := range testDirs {
+					err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755)
+					require.NoError(t, err)
+				}
+
+				// Create test files with dependencies
+				testFiles := map[string]string{
+					"unit1/terragrunt.hcl": "",
+					"unit2/terragrunt.hcl": `
+dependency "unit1" {
+  config_path = "../unit1"
+}`,
+					"unit3/terragrunt.hcl": `
+dependency "unit2" {
+  config_path = "../unit2"
+}`,
+				}
+
+				for path, content := range testFiles {
+					err := os.WriteFile(filepath.Join(tmpDir, path), []byte(content), 0644)
+					require.NoError(t, err)
+				}
+
+				return tmpDir
+			},
+			expectedPaths: []string{"unit1", "unit2", "unit3"},
+			format:        "text",
+			sort:          "dag",
+			validate: func(t *testing.T, output string, expectedPaths []string) {
+				t.Helper()
+
+				// Split output into lines and trim whitespace
+				lines := strings.Split(strings.TrimSpace(output), "\n")
+
+				// Verify we have the expected number of lines
+				assert.Len(t, lines, len(expectedPaths))
+
+				// For DAG sorting, order matters - verify exact order
+				assert.Equal(t, expectedPaths, lines)
+			},
+		},
+		{
+			name: "dag sorting - reversed dependencies",
+			setup: func(t *testing.T) string {
+				t.Helper()
+
+				tmpDir := t.TempDir()
+
+				// Create test directory structure with dependencies:
+				// unit3 -> unit2
+				// unit2 -> unit1
+				testDirs := []string{
+					"unit1",
+					"unit2",
+					"unit3",
+				}
+
+				for _, dir := range testDirs {
+					err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755)
+					require.NoError(t, err)
+				}
+
+				// Create test files with dependencies
+				testFiles := map[string]string{
+					"unit1/terragrunt.hcl": `
+dependency "unit2" {
+  config_path = "../unit2"
+}`,
+					"unit2/terragrunt.hcl": `
+dependency "unit3" {
+  config_path = "../unit3"
+}`,
+					"unit3/terragrunt.hcl": "",
+				}
+
+				for path, content := range testFiles {
+					err := os.WriteFile(filepath.Join(tmpDir, path), []byte(content), 0644)
+					require.NoError(t, err)
+				}
+
+				return tmpDir
+			},
+			expectedPaths: []string{"unit1", "unit2", "unit3"},
+			format:        "text",
+			sort:          "dag",
+			validate: func(t *testing.T, output string, expectedPaths []string) {
+				t.Helper()
+
+				// Split output into lines and trim whitespace
+				lines := strings.Split(strings.TrimSpace(output), "\n")
+
+				// Verify we have the expected number of lines
+				assert.Len(t, lines, len(expectedPaths))
+
+				// For DAG sorting, order matters - verify exact order
+				assert.Equal(t, expectedPaths, lines)
+
+				// Helper to find index of a path
+				findIndex := func(path string) int {
+					for i, line := range lines {
+						if line == path {
+							return i
+						}
+					}
+					return -1
+				}
+
+				// Verify dependency ordering
+				unit1Index := findIndex("unit1")
+				unit2Index := findIndex("unit2")
+				unit3Index := findIndex("unit3")
+
+				assert.Less(t, unit3Index, unit2Index, "unit3 should come before unit2")
+				assert.Less(t, unit2Index, unit1Index, "unit2 should come before unit1")
+			},
+		},
+		{
+			name: "dag sorting - complex dependencies",
+			setup: func(t *testing.T) string {
+				t.Helper()
+
+				tmpDir := t.TempDir()
+
+				// Create test directory structure with complex dependencies:
+				// A (no deps)
+				// B (no deps)
+				// C -> A
+				// D -> A,B
+				// E -> C
+				// F -> C
+				testDirs := []string{
+					"A", "B", "C", "D", "E", "F",
+				}
+
+				for _, dir := range testDirs {
+					err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755)
+					require.NoError(t, err)
+				}
+
+				// Create test files with dependencies
+				testFiles := map[string]string{
+					"A/terragrunt.hcl": "",
+					"B/terragrunt.hcl": "",
+					"C/terragrunt.hcl": `
+dependency "A" {
+  config_path = "../A"
+}`,
+					"D/terragrunt.hcl": `
+dependency "A" {
+  config_path = "../A"
+}
+dependency "B" {
+  config_path = "../B"
+}`,
+					"E/terragrunt.hcl": `
+dependency "C" {
+  config_path = "../C"
+}`,
+					"F/terragrunt.hcl": `
+dependency "C" {
+  config_path = "../C"
+}`,
+				}
+
+				for path, content := range testFiles {
+					err := os.WriteFile(filepath.Join(tmpDir, path), []byte(content), 0644)
+					require.NoError(t, err)
+				}
+
+				return tmpDir
+			},
+			expectedPaths: []string{"A", "B", "C", "D", "E", "F"},
+			format:        "text",
+			sort:          "dag",
+			validate: func(t *testing.T, output string, expectedPaths []string) {
+				t.Helper()
+
+				// Split output into lines and trim whitespace
+				lines := strings.Split(strings.TrimSpace(output), "\n")
+
+				// Verify we have the expected number of lines
+				assert.Len(t, lines, len(expectedPaths))
+
+				// For DAG sorting, order matters - verify exact order
+				// and also verify relative ordering constraints
+				assert.Equal(t, expectedPaths, lines)
+
+				// Helper to find index of a path
+				findIndex := func(path string) int {
+					for i, line := range lines {
+						if line == path {
+							return i
+						}
+					}
+					return -1
+				}
+
+				// Verify dependency ordering
+				aIndex := findIndex("A")
+				bIndex := findIndex("B")
+				cIndex := findIndex("C")
+				dIndex := findIndex("D")
+				eIndex := findIndex("E")
+				fIndex := findIndex("F")
+
+				// Level 0 items should be before their dependents
+				assert.Less(t, aIndex, cIndex, "A should come before C")
+				assert.Less(t, aIndex, dIndex, "A should come before D")
+				assert.Less(t, bIndex, dIndex, "B should come before D")
+
+				// Level 1 items should be before their dependents
+				assert.Less(t, cIndex, eIndex, "C should come before E")
+				assert.Less(t, cIndex, fIndex, "C should come before F")
+			},
+		},
+		{
+			name: "dag sorting - json output",
+			setup: func(t *testing.T) string {
+				t.Helper()
+
+				tmpDir := t.TempDir()
+
+				// Create test directory structure with dependencies
+				testDirs := []string{
+					"A", "B", "C",
+				}
+
+				for _, dir := range testDirs {
+					err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755)
+					require.NoError(t, err)
+				}
+
+				// Create test files with dependencies
+				testFiles := map[string]string{
+					"A/terragrunt.hcl": "",
+					"B/terragrunt.hcl": `
+dependency "A" {
+  config_path = "../A"
+}`,
+					"C/terragrunt.hcl": `
+dependency "B" {
+  config_path = "../B"
+}`,
+				}
+
+				for path, content := range testFiles {
+					err := os.WriteFile(filepath.Join(tmpDir, path), []byte(content), 0644)
+					require.NoError(t, err)
+				}
+
+				return tmpDir
+			},
+			expectedPaths: []string{"A", "B", "C"},
+			format:        "json",
+			sort:          "dag",
+			validate: func(t *testing.T, output string, expectedPaths []string) {
+				t.Helper()
+
+				// Verify the output is valid JSON
+				var configs []find.FoundConfig
+				err := json.Unmarshal([]byte(output), &configs)
+				require.NoError(t, err)
+
+				// Verify we have the expected number of configs
+				assert.Len(t, configs, len(expectedPaths))
+
+				// Extract paths and verify order
+				var paths []string
+				for _, config := range configs {
+					paths = append(paths, config.Path)
+				}
+				assert.Equal(t, expectedPaths, paths)
+
+				// Verify dependencies are correctly represented in JSON
+				assert.Empty(t, configs[0].Dependencies, "A should have no dependencies")
+				assert.Equal(t, []string{"A"}, configs[1].Dependencies, "B should depend on A")
+				assert.Equal(t, []string{"B"}, configs[2].Dependencies, "C should depend on B")
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			// FIXME: Restore.
+			// t.Parallel()
 
 			// Setup test directory
 			tmpDir := tt.setup(t)
@@ -219,6 +518,7 @@ func TestRun(t *testing.T) {
 			opts := find.NewOptions(tgOpts)
 			opts.Format = tt.format
 			opts.Hidden = tt.hidden
+			opts.Sort = tt.sort
 
 			// Create a pipe to capture output
 			r, w, err := os.Pipe()

--- a/cli/commands/find/command.go
+++ b/cli/commands/find/command.go
@@ -29,7 +29,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			EnvVars:     tgPrefix.EnvVars(FormatFlagName),
 			Destination: &opts.Format,
 			Usage:       "Output format for the find results. Valid values: text, json",
-			DefaultText: "text",
+			DefaultText: FormatText,
 		}),
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        JSONFlagName,
@@ -42,7 +42,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			EnvVars:     tgPrefix.EnvVars(SortFlagName),
 			Destination: &opts.Sort,
 			Usage:       "Sort order for the find results. Valid values: alpha", // TODO: add dag
-			DefaultText: "alpha",
+			DefaultText: SortAlpha,
 		}),
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        HiddenFlagName,
@@ -68,7 +68,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 			}
 
 			if cmdOpts.JSON {
-				cmdOpts.Format = "json"
+				cmdOpts.Format = FormatJSON
 			}
 
 			if err := cmdOpts.Validate(); err != nil {

--- a/cli/commands/find/options.go
+++ b/cli/commands/find/options.go
@@ -5,6 +5,20 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
+const (
+	// FormatText outputs the discovered configurations in text format.
+	FormatText = "text"
+
+	// FormatJSON outputs the discovered configurations in JSON format.
+	FormatJSON = "json"
+
+	// SortAlpha sorts the discovered configurations in alphabetical order.
+	SortAlpha = "alpha"
+
+	// SortDAG sorts the discovered configurations in a topological sort order.
+	SortDAG = "dag"
+)
+
 type Options struct {
 	*options.TerragruntOptions
 
@@ -25,8 +39,8 @@ type Options struct {
 func NewOptions(opts *options.TerragruntOptions) *Options {
 	return &Options{
 		TerragruntOptions: opts,
-		Format:            "text",
-		Sort:              "alpha",
+		Format:            FormatText,
+		Sort:              SortAlpha,
 		Hidden:            false,
 	}
 }
@@ -51,9 +65,9 @@ func (o *Options) Validate() error {
 
 func (o *Options) validateFormat() error {
 	switch o.Format {
-	case "text":
+	case FormatText:
 		return nil
-	case "json":
+	case FormatJSON:
 		return nil
 	default:
 		return errors.New("invalid format: " + o.Format)
@@ -62,7 +76,9 @@ func (o *Options) validateFormat() error {
 
 func (o *Options) validateSort() error {
 	switch o.Sort {
-	case "alpha":
+	case SortAlpha:
+		return nil
+	case SortDAG:
 		return nil
 	default:
 		return errors.New("invalid sort: " + o.Sort)

--- a/cli/commands/find/options.go
+++ b/cli/commands/find/options.go
@@ -1,9 +1,6 @@
 package find
 
 import (
-	"io"
-	"os"
-
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 )
@@ -23,11 +20,6 @@ type Options struct {
 
 	// Hidden determines whether to detect hidden directories.
 	Hidden bool
-
-	// Writer is the writer to write the output to.
-	// If not set, the output will be written to stdout.
-	// Useful for testing.
-	Writer io.Writer
 }
 
 func NewOptions(opts *options.TerragruntOptions) *Options {
@@ -36,7 +28,6 @@ func NewOptions(opts *options.TerragruntOptions) *Options {
 		Format:            "text",
 		Sort:              "alpha",
 		Hidden:            false,
-		Writer:            os.Stdout,
 	}
 }
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -19,11 +19,6 @@ const (
 	ConfigTypeUnit ConfigType = "unit"
 	// ConfigTypeStack is the type of Terragrunt configuration for a stack.
 	ConfigTypeStack ConfigType = "stack"
-
-	// SortAlpha sorts the discovered configurations in alphabetical order.
-	SortAlpha Sort = "alpha"
-	// SortDAG sorts the discovered configurations in a topological sort order.
-	SortDAG Sort = "dag"
 )
 
 // ConfigType is the type of Terragrunt configuration.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -282,6 +282,7 @@ func (d *DependencyDiscovery) DiscoverDependencies(ctx context.Context, opts *op
 		config.ExcludeBlock,
 	)
 
+	//nolint: contextcheck
 	cfg, err := config.PartialParseConfigFile(parsingCtx, opts.TerragruntConfigPath, nil)
 	if err != nil {
 		return errors.New(err)

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -31,11 +31,11 @@ type DiscoveredConfigs []*DiscoveredConfig
 
 // Discovery is the configuration for a Terragrunt discovery.
 type Discovery struct {
-	// WorkingDir is the directory to search for Terragrunt configurations.
-	WorkingDir string
+	// workingDir is the directory to search for Terragrunt configurations.
+	workingDir string
 
-	// Hidden determines whether to detect configurations in hidden directories.
-	Hidden bool
+	// hidden determines whether to detect configurations in hidden directories.
+	hidden bool
 }
 
 // DiscoveryOption is a function that modifies a Discovery.
@@ -44,8 +44,8 @@ type DiscoveryOption func(*Discovery)
 // NewDiscovery creates a new Discovery.
 func NewDiscovery(dir string, opts ...DiscoveryOption) *Discovery {
 	discovery := &Discovery{
-		WorkingDir: dir,
-		Hidden:     false,
+		workingDir: dir,
+		hidden:     false,
 	}
 
 	for _, opt := range opts {
@@ -55,16 +55,9 @@ func NewDiscovery(dir string, opts ...DiscoveryOption) *Discovery {
 	return discovery
 }
 
-// NewDiscoverySettings creates a new Discovery with default settings.
-func NewDiscoverySettings() *Discovery {
-	return &Discovery{
-		Hidden: false,
-	}
-}
-
 // WithHidden sets the Hidden flag to true.
 func (d *Discovery) WithHidden() *Discovery {
-	d.Hidden = true
+	d.hidden = true
 
 	return d
 }
@@ -87,12 +80,12 @@ func (d *Discovery) Discover() (DiscoveredConfigs, error) {
 			return nil
 		}
 
-		path, err = filepath.Rel(d.WorkingDir, path)
+		path, err = filepath.Rel(d.workingDir, path)
 		if err != nil {
 			return errors.New(err)
 		}
 
-		if !d.Hidden && isInHiddenDirectory(path) {
+		if !d.hidden && isInHiddenDirectory(path) {
 			return nil
 		}
 
@@ -112,7 +105,7 @@ func (d *Discovery) Discover() (DiscoveredConfigs, error) {
 		return nil
 	}
 
-	if err := filepath.WalkDir(d.WorkingDir, walkFn); err != nil {
+	if err := filepath.WalkDir(d.workingDir, walkFn); err != nil {
 		return nil, errors.New(err)
 	}
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -2,28 +2,53 @@
 package discovery
 
 import (
+	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/options"
 )
 
 const (
-	ConfigTypeUnit  ConfigType = "unit"
+	// ConfigTypeUnit is the type of Terragrunt configuration for a unit.
+	ConfigTypeUnit ConfigType = "unit"
+	// ConfigTypeStack is the type of Terragrunt configuration for a stack.
 	ConfigTypeStack ConfigType = "stack"
+
+	// SortAlpha sorts the discovered configurations in alphabetical order.
+	SortAlpha Sort = "alpha"
+	// SortDAG sorts the discovered configurations in a topological sort order.
+	SortDAG Sort = "dag"
 )
 
 // ConfigType is the type of Terragrunt configuration.
 type ConfigType string
 
+// Sort is the sort order of the discovered configurations.
+type Sort string
+
+// Exclude is the exclude configuration for a discovered configuration.
+type Exclude struct {
+	If                  string   `json:"if"`
+	Actions             []string `json:"actions"`
+	ExcludeDependencies bool     `json:"exclude_dependencies"`
+}
+
 // DiscoveredConfig represents a discovered Terragrunt configuration.
 type DiscoveredConfig struct {
 	Type ConfigType `json:"type"`
 	Path string     `json:"path"`
+
+	Dependencies DiscoveredConfigs `json:"dependencies,omitempty"`
+	Exclude      Exclude           `json:"exclude,omitempty"`
+
+	External bool `json:"external,omitempty"`
 }
 
 // DiscoveredConfigs is a list of discovered Terragrunt configurations.
@@ -36,6 +61,18 @@ type Discovery struct {
 
 	// hidden determines whether to detect configurations in hidden directories.
 	hidden bool
+
+	// sort determines the sort order of the discovered configurations.
+	sort Sort
+
+	// discoverDependencies determines whether to discover dependencies.
+	discoverDependencies bool
+
+	// discoverExternalDependencies determines whether to discover external dependencies.
+	discoverExternalDependencies bool
+
+	// maxDependencyDepth is the maximum depth of the dependency tree to discover.
+	maxDependencyDepth int
 }
 
 // DiscoveryOption is a function that modifies a Discovery.
@@ -62,14 +99,46 @@ func (d *Discovery) WithHidden() *Discovery {
 	return d
 }
 
+// WithSort sets the Sort flag to the given sort.
+func (d *Discovery) WithSort(sort Sort) *Discovery {
+	d.sort = sort
+
+	return d
+}
+
+// WithDiscoverDependencies sets the DiscoverDependencies flag to true.
+func (d *Discovery) WithDiscoverDependencies() *Discovery {
+	d.discoverDependencies = true
+
+	if d.maxDependencyDepth == 0 {
+		d.maxDependencyDepth = 1000
+	}
+
+	return d
+}
+
+// WithMaxDependencyDepth sets the MaxDependencyDepth flag to the given depth.
+func (d *Discovery) WithMaxDependencyDepth(depth int) *Discovery {
+	d.maxDependencyDepth = depth
+
+	return d
+}
+
+// WithDiscoverExternalDependencies sets the DiscoverExternalDependencies flag to true.
+func (d *Discovery) WithDiscoverExternalDependencies() *Discovery {
+	d.discoverExternalDependencies = true
+
+	return d
+}
+
 // String returns a string representation of a DiscoveredConfig.
 func (c *DiscoveredConfig) String() string {
 	return string(c.Type) + ": " + c.Path
 }
 
 // Discover discovers Terragrunt configurations in the WorkingDir.
-func (d *Discovery) Discover() (DiscoveredConfigs, error) {
-	var units DiscoveredConfigs
+func (d *Discovery) Discover(ctx context.Context, opts *options.TerragruntOptions) (DiscoveredConfigs, error) {
+	var cfgs DiscoveredConfigs
 
 	walkFn := func(path string, e fs.DirEntry, err error) error {
 		if err != nil {
@@ -91,12 +160,12 @@ func (d *Discovery) Discover() (DiscoveredConfigs, error) {
 
 		switch filepath.Base(path) {
 		case config.DefaultTerragruntConfigPath:
-			units = append(units, &DiscoveredConfig{
+			cfgs = append(cfgs, &DiscoveredConfig{
 				Type: ConfigTypeUnit,
 				Path: filepath.Dir(path),
 			})
 		case config.DefaultStackFile:
-			units = append(units, &DiscoveredConfig{
+			cfgs = append(cfgs, &DiscoveredConfig{
 				Type: ConfigTypeStack,
 				Path: filepath.Dir(path),
 			})
@@ -109,8 +178,195 @@ func (d *Discovery) Discover() (DiscoveredConfigs, error) {
 		return nil, errors.New(err)
 	}
 
-	return units, nil
+	if d.discoverDependencies {
+		dependencyDiscovery := NewDependencyDiscovery(cfgs, d.maxDependencyDepth, d.discoverExternalDependencies)
+
+		err := dependencyDiscovery.DiscoverAllDependencies(ctx, opts)
+		if err != nil {
+			return nil, errors.New(err)
+		}
+	}
+
+	return cfgs, nil
 }
+
+type DependencyDiscovery struct {
+	cfgs             DiscoveredConfigs
+	depthRemaining   int
+	discoverExternal bool
+	mu               sync.RWMutex
+}
+
+func NewDependencyDiscovery(cfgs DiscoveredConfigs, depthRemaining int, discoverExternal bool) *DependencyDiscovery {
+	return &DependencyDiscovery{
+		cfgs:             cfgs,
+		depthRemaining:   depthRemaining,
+		discoverExternal: discoverExternal,
+		mu:               sync.RWMutex{},
+	}
+}
+
+func (d *DependencyDiscovery) DiscoverAllDependencies(ctx context.Context, opts *options.TerragruntOptions) error {
+	errs := []error{}
+
+	for _, cfg := range d.cfgs {
+		if cfg.Type == ConfigTypeStack {
+			continue
+		}
+
+		err := d.DiscoverDependencies(ctx, opts, cfg)
+		if err != nil {
+			errs = append(errs, errors.New(err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+func (d *DependencyDiscovery) DiscoverDependencies(ctx context.Context, opts *options.TerragruntOptions, dCfg *DiscoveredConfig) error {
+	if d.depthRemaining <= 0 {
+		return errors.New("max dependency depth reached while discovering dependencies")
+	}
+
+	opts = opts.Clone()
+	opts.TerragruntConfigPath = dCfg.Path
+	opts.WorkingDir = filepath.Dir(dCfg.Path)
+
+	parsingCtx := config.NewParsingContext(ctx, opts)
+
+	cfg, err := config.PartialParseConfigFile(parsingCtx, dCfg.Path, nil)
+	if err != nil {
+		return errors.New(err)
+	}
+
+	dependencyBlocks := cfg.TerragruntDependencies
+
+	dependencyPaths := make([]string, 0, len(dependencyBlocks))
+
+	errs := []error{}
+
+	for _, dependency := range dependencyBlocks {
+		depPath, err := filepath.Rel(opts.WorkingDir, dependency.ConfigPath.AsString())
+		if err != nil {
+			errs = append(errs, errors.New(err))
+
+			continue
+		}
+
+		dependencyPaths = append(dependencyPaths, depPath)
+	}
+
+	if cfg.Dependencies != nil {
+		for _, dependency := range cfg.Dependencies.Paths {
+			depPath, err := filepath.Rel(opts.WorkingDir, dependency)
+			if err != nil {
+				errs = append(errs, errors.New(err))
+
+				continue
+			}
+
+			dependencyPaths = append(dependencyPaths, depPath)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	deduped := make(map[string]struct{}, len(dependencyPaths))
+
+	for _, dependencyPath := range dependencyPaths {
+		deduped[dependencyPath] = struct{}{}
+	}
+
+	for dependencyPath := range deduped {
+		external := true
+
+		for _, c := range d.cfgs {
+			if c.Path == dependencyPath {
+				external = false
+
+				dCfg.Dependencies = append(dCfg.Dependencies, c)
+			}
+		}
+
+		if external {
+			ext := &DiscoveredConfig{
+				Type:     ConfigTypeUnit,
+				Path:     dependencyPath,
+				External: true,
+			}
+
+			d.cfgs = append(d.cfgs, ext)
+
+			if d.discoverExternal {
+				err := d.DiscoverDependencies(ctx, opts, ext)
+				if err != nil {
+					errs = append(errs, errors.New(err))
+				}
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+// // DiscoverDependenciesWithDepthRemaining discovers dependencies for the given DiscoveredConfig with a given depth budget remaining.
+// func (c *DiscoveredConfig) DiscoverDependenciesWithDepthRemaining(ctx context.Context, opts *options.TerragruntOptions, discoverExternalDependencies bool, depthRemaining int) (DiscoveredConfigs, error) {
+// 	if depthRemaining <= 0 {
+// 		return nil, errors.New("max dependency depth reached while discovering dependencies for " + c.Path)
+// 	}
+//
+// 	opts = opts.Clone()
+// 	opts.TerragruntConfigPath = c.Path
+// 	opts.WorkingDir = filepath.Dir(c.Path)
+//
+// 	parsingCtx := config.NewParsingContext(ctx, opts)
+//
+// 	cfg, err := config.PartialParseConfigFile(parsingCtx, c.Path, nil)
+// 	if err != nil {
+// 		return nil, errors.New(err)
+// 	}
+//
+// 	dependencyBlocks := cfg.TerragruntDependencies
+//
+// 	dependencyPaths := make([]string, 0, len(dependencyBlocks))
+// 	for _, dependency := range dependencyBlocks {
+// 		dependencyPaths = append(dependencyPaths, dependency.ConfigPath.AsString())
+// 	}
+//
+// 	dependenciesBlock := cfg.Dependencies
+// 	if dependenciesBlock != nil {
+// 		dependencyPaths = append(dependencyPaths, dependenciesBlock.Paths...)
+// 	}
+//
+// 	dependencies := make(DiscoveredConfigs, 0, len(dependencyPaths))
+//
+// 	for _, dependencyPath := range dependencyPaths {
+// 		dependency := &DiscoveredConfig{
+// 			Type: ConfigTypeUnit,
+// 			Path: dependencyPath,
+// 		}
+//
+// 		// Recursively discover dependencies up the dependency tree.
+// 		dependency.Dependencies, err = dependency.DiscoverDependenciesWithDepthRemaining(ctx, opts, depthRemaining-1)
+// 		if err != nil {
+// 			return nil, errors.New(err)
+// 		}
+//
+// 		dependencies = append(dependencies, dependency)
+// 	}
+//
+// 	return dependencies, nil
+// }
 
 // Sort sorts the DiscoveredConfigs by path.
 func (c DiscoveredConfigs) Sort() DiscoveredConfigs {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -205,8 +205,10 @@ func (d *Discovery) Discover(ctx context.Context, opts *options.TerragruntOption
 
 		err := dependencyDiscovery.DiscoverAllDependencies(ctx, opts)
 		if err != nil {
-			return cfgs, errors.New(err)
+			return dependencyDiscovery.cfgs, errors.New(err)
 		}
+
+		cfgs = dependencyDiscovery.cfgs
 
 		if err := cfgs.CycleCheck(); err != nil {
 			return cfgs, errors.New(err)
@@ -333,9 +335,11 @@ func (d *DependencyDiscovery) DiscoverDependencies(ctx context.Context, opts *op
 				External: true,
 			}
 
-			d.cfgs = append(d.cfgs, ext)
+			dCfg.Dependencies = append(dCfg.Dependencies, ext)
 
 			if d.discoverExternal {
+				d.cfgs = append(d.cfgs, ext)
+
 				err := d.DiscoverDependencies(ctx, opts, ext)
 				if err != nil {
 					errs = append(errs, errors.New(err))

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -1,6 +1,7 @@
 package discovery_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,9 +44,7 @@ func TestDiscovery(t *testing.T) {
 
 	for path, content := range testFiles {
 		err := os.WriteFile(filepath.Join(tmpDir, path), []byte(content), 0644)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 
 	tests := []struct {
@@ -73,7 +72,7 @@ func TestDiscovery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			configs, err := tt.discovery.Discover()
+			configs, err := tt.discovery.Discover(context.Background(), nil)
 			if !tt.errorExpected {
 				require.NoError(t, err)
 			}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,0 +1,58 @@
+// Package queue provides a run queue implementation.
+// The queue is a double-ended queue (deque) that allows for efficient adding and removing of elements from both ends.
+// The queue is used to manage the order of Terragrunt runs.
+//
+// The algorithm for populating the queue is as follows:
+// 1. Given a list of discovered configurations, start with an empty queue.
+// 2. For each discovered configuration, add the configuration to the queue as close to the front as possible.
+// 3. When a configuration is added to the queue, check to see if any entry in the queue depends on the configuration.
+// 4. If a configuration is found that has a dependency on the configuration being added, add the configuration in front of the configuration being added.
+// 5. Repeat step 2 until all configurations are in the queue.
+// 6. The queue is now populated with the Terragrunt run order.
+//
+// During operations like applies, entries will be dequeued from the front of the queue and run.
+// During operations like destroys, entries will be dequeued from the back of the queue and run.
+// This is to ensure that dependencies are run first for applies, and dependents are run first for destroys.
+package queue
+
+import "github.com/gruntwork-io/terragrunt/internal/discovery"
+
+type Queue struct {
+	entries []*discovery.DiscoveredConfig
+}
+
+// Entries returns the queue entries. Used for testing.
+func (q *Queue) Entries() []*discovery.DiscoveredConfig {
+	return q.entries
+}
+
+// NewQueue creates a new queue from a list of discovered configurations.
+// The queue is populated with the correct Terragrunt run order.
+func NewQueue(discovered []*discovery.DiscoveredConfig) *Queue {
+	entries := make([]*discovery.DiscoveredConfig, 0, len(discovered))
+
+	for _, cfg := range discovered {
+		inserted := false
+		// Try to insert the config at each position, starting from the front
+		for i := 0; i < len(entries); i++ {
+			// Check if any existing entry depends on the new config
+			// in its ancestry.
+			if entries[i].ContainsDependencyInAncestry(cfg.Path) {
+				// Insert cfg before the dependent entry
+				entries = append(entries[:i], append([]*discovery.DiscoveredConfig{cfg}, entries[i:]...)...)
+				inserted = true
+
+				break
+			}
+		}
+
+		// If no dependencies were found, append to the end
+		if !inserted {
+			entries = append(entries, cfg)
+		}
+	}
+
+	return &Queue{
+		entries: entries,
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -3,19 +3,28 @@
 // The queue is used to manage the order of Terragrunt runs.
 //
 // The algorithm for populating the queue is as follows:
-// 1. Given a list of discovered configurations, start with an empty queue.
-// 2. For each discovered configuration, add the configuration to the queue as close to the front as possible.
-// 3. When a configuration is added to the queue, check to see if any entry in the queue depends on the configuration.
-// 4. If a configuration is found that has a dependency on the configuration being added, add the configuration in front of the configuration being added.
-// 5. Repeat step 2 until all configurations are in the queue.
-// 6. The queue is now populated with the Terragrunt run order.
+//  1. Given a list of discovered configurations, start with an empty queue.
+//  2. Sort configurations alphabetically to ensure deterministic ordering of independent items.
+//  3. For each discovered configuration:
+//     a. If the configuration has no dependencies, append it to the queue.
+//     b. Otherwise, find the position after its last dependency.
+//     c. Among items that depend on the same dependency, maintain alphabetical order.
+//
+// The resulting queue will have:
+// - Configurations with no dependencies at the front
+// - Configurations with dependents are ordered after their dependencies
+// - Alphabetical ordering only between items that share the same dependencies
 //
 // During operations like applies, entries will be dequeued from the front of the queue and run.
 // During operations like destroys, entries will be dequeued from the back of the queue and run.
-// This is to ensure that dependencies are run first for applies, and dependents are run first for destroys.
+// This ensures that dependencies are satisfied in both cases:
+// - For applies: Dependencies (front) are run before their dependents (back)
+// - For destroys: Dependents (back) are run before their dependencies (front)
 package queue
 
 import (
+	"sort"
+
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 )
 
@@ -30,31 +39,97 @@ func (q *Queue) Entries() []*discovery.DiscoveredConfig {
 
 // NewQueue creates a new queue from a list of discovered configurations.
 // The queue is populated with the correct Terragrunt run order.
+// Dependencies are guaranteed to come before their dependents.
+// Items with the same dependencies are sorted alphabetically.
 func NewQueue(discovered discovery.DiscoveredConfigs) *Queue {
-	entries := make(discovery.DiscoveredConfigs, 0, len(discovered))
-
-	// First, sort the discovered configs by path to ensure deterministic ordering
-	// of parallel dependencies
+	// First sort by path to ensure deterministic ordering of independent items
 	sortedConfigs := discovered.Sort()
+	entries := make(discovery.DiscoveredConfigs, 0, len(sortedConfigs))
 
-	for _, cfg := range sortedConfigs {
-		inserted := false
-		// Try to insert the config at each position, starting from the front
-		for i := 0; i < len(entries); i++ {
-			// Check if any existing entry depends on the new config
-			// in its ancestry.
-			if entries[i].ContainsDependencyInAncestry(cfg.Path) {
-				// Insert cfg before the dependent entry
-				entries = append(entries[:i], append(discovery.DiscoveredConfigs{cfg}, entries[i:]...)...)
-				inserted = true
-				break
+	// Helper to check if all dependencies of a config are in the queue
+	hasDependenciesInQueue := func(cfg *discovery.DiscoveredConfig, upToIndex int) bool {
+		for _, dep := range cfg.Dependencies {
+			found := false
+
+			for i := 0; i <= upToIndex; i++ {
+				if entries[i].Path == dep.Path {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				return false
 			}
 		}
 
-		// If no dependencies were found, append to the end
-		if !inserted {
-			entries = append(entries, cfg)
+		return true
+	}
+
+	// Helper to get the index of the last dependency in the queue
+	getLastDependencyIndex := func(cfg *discovery.DiscoveredConfig) int {
+		lastIndex := -1
+
+		for _, dep := range cfg.Dependencies {
+			for i, entry := range entries {
+				if entry.Path == dep.Path && i > lastIndex {
+					lastIndex = i
+				}
+			}
 		}
+
+		return lastIndex
+	}
+
+	// First, add all configs with no dependencies, sorted alphabetically
+	var (
+		noDeps   discovery.DiscoveredConfigs
+		withDeps discovery.DiscoveredConfigs
+	)
+
+	for _, cfg := range sortedConfigs {
+		if len(cfg.Dependencies) == 0 {
+			noDeps = append(noDeps, cfg)
+		} else {
+			withDeps = append(withDeps, cfg)
+		}
+	}
+
+	entries = append(entries, noDeps...)
+
+	// Keep processing configs until all are added
+	remaining := withDeps
+	for len(remaining) > 0 {
+		// Find all configs whose dependencies are satisfied
+		var (
+			nextBatch      discovery.DiscoveredConfigs
+			stillRemaining discovery.DiscoveredConfigs
+		)
+
+		for _, cfg := range remaining {
+			if hasDependenciesInQueue(cfg, len(entries)-1) {
+				nextBatch = append(nextBatch, cfg)
+			} else {
+				stillRemaining = append(stillRemaining, cfg)
+			}
+		}
+
+		// Sort the next batch by:
+		// 1. Last dependency position (primary)
+		// 2. Path (secondary, for items with same dependencies)
+		sort.SliceStable(nextBatch, func(i, j int) bool {
+			iLastDep := getLastDependencyIndex(nextBatch[i])
+			jLastDep := getLastDependencyIndex(nextBatch[j])
+
+			if iLastDep != jLastDep {
+				return iLastDep < jLastDep
+			}
+
+			return nextBatch[i].Path < nextBatch[j].Path
+		})
+
+		entries = append(entries, nextBatch...)
+		remaining = stillRemaining
 	}
 
 	return &Queue{

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -56,4 +56,80 @@ func TestNewQueue(t *testing.T) {
 		assert.Equal(t, "second", q.Entries()[1].Path)
 		assert.Equal(t, "third", q.Entries()[2].Path)
 	})
+
+	t.Run("complex dag with multiple paths", func(t *testing.T) {
+		// Create a more complex dependency graph:
+		//   A -> B -> C
+		//   |         ^
+		//   +-> D ----+
+		//   |
+		//   +-> E -> F
+		configs := []*discovery.DiscoveredConfig{
+			{Path: "F", Dependencies: []*discovery.DiscoveredConfig{{Path: "E"}}},
+			{Path: "E", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+			{Path: "D", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+			{Path: "C", Dependencies: []*discovery.DiscoveredConfig{{Path: "B"}, {Path: "D"}}},
+			{Path: "B", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+			{Path: "A", Dependencies: []*discovery.DiscoveredConfig{}},
+		}
+
+		q := queue.NewQueue(configs)
+		entries := q.Entries()
+
+		// Verify that dependencies are satisfied
+		// A must come before B, D, and E
+		aIndex := findIndex(entries, "A")
+		bIndex := findIndex(entries, "B")
+		dIndex := findIndex(entries, "D")
+		eIndex := findIndex(entries, "E")
+		assert.Less(t, aIndex, bIndex, "A should come before B")
+		assert.Less(t, aIndex, dIndex, "A should come before D")
+		assert.Less(t, aIndex, eIndex, "A should come before E")
+
+		// B and D must come before C
+		cIndex := findIndex(entries, "C")
+		assert.Less(t, bIndex, cIndex, "B should come before C")
+		assert.Less(t, dIndex, cIndex, "D should come before C")
+
+		// E must come before F
+		fIndex := findIndex(entries, "F")
+		assert.Less(t, eIndex, fIndex, "E should come before F")
+	})
+
+	t.Run("deterministic ordering of parallel paths", func(t *testing.T) {
+		// Create a graph with parallel paths that could be ordered multiple ways:
+		//   A -> B
+		//   A -> C
+		//   A -> D
+		configs := []*discovery.DiscoveredConfig{
+			{Path: "D", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+			{Path: "C", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+			{Path: "B", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+			{Path: "A", Dependencies: []*discovery.DiscoveredConfig{}},
+		}
+
+		// Run multiple times to verify deterministic ordering
+		for i := 0; i < 5; i++ {
+			q := queue.NewQueue(configs)
+			entries := q.Entries()
+
+			// A should always be first
+			assert.Equal(t, "A", entries[0].Path)
+
+			// B, C, D should maintain alphabetical order since they're all at the same level
+			assert.Equal(t, "B", entries[1].Path)
+			assert.Equal(t, "C", entries[2].Path)
+			assert.Equal(t, "D", entries[3].Path)
+		}
+	})
+}
+
+// findIndex returns the index of the config with the given path in the slice
+func findIndex(configs []*discovery.DiscoveredConfig, path string) int {
+	for i, cfg := range configs {
+		if cfg.Path == path {
+			return i
+		}
+	}
+	return -1
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,0 +1,59 @@
+package queue_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/queue"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewQueue(t *testing.T) {
+	t.Run("no dependencies", func(t *testing.T) {
+		// Create configs with no dependencies
+		configs := []*discovery.DiscoveredConfig{
+			{Path: "first", Dependencies: []*discovery.DiscoveredConfig{}},
+			{Path: "second", Dependencies: []*discovery.DiscoveredConfig{}},
+			{Path: "third", Dependencies: []*discovery.DiscoveredConfig{}},
+		}
+
+		q := queue.NewQueue(configs)
+
+		// Order should remain the same as input
+		assert.Equal(t, "first", q.Entries()[0].Path)
+		assert.Equal(t, "second", q.Entries()[1].Path)
+		assert.Equal(t, "third", q.Entries()[2].Path)
+	})
+
+	t.Run("already ordered dependencies", func(t *testing.T) {
+		// Create configs where dependencies are already in correct order
+		configs := []*discovery.DiscoveredConfig{
+			{Path: "first", Dependencies: []*discovery.DiscoveredConfig{}},
+			{Path: "second", Dependencies: []*discovery.DiscoveredConfig{{Path: "first"}}},
+			{Path: "third", Dependencies: []*discovery.DiscoveredConfig{{Path: "second"}}},
+		}
+
+		q := queue.NewQueue(configs)
+
+		// Order should remain the same as input
+		assert.Equal(t, "first", q.Entries()[0].Path)
+		assert.Equal(t, "second", q.Entries()[1].Path)
+		assert.Equal(t, "third", q.Entries()[2].Path)
+	})
+
+	t.Run("reorder needed for dependencies", func(t *testing.T) {
+		// Create configs where order needs to be adjusted
+		configs := []*discovery.DiscoveredConfig{
+			{Path: "third", Dependencies: []*discovery.DiscoveredConfig{{Path: "second"}}},
+			{Path: "second", Dependencies: []*discovery.DiscoveredConfig{{Path: "first"}}},
+			{Path: "first", Dependencies: []*discovery.DiscoveredConfig{}},
+		}
+
+		q := queue.NewQueue(configs)
+
+		// Order should be rearranged to satisfy dependencies
+		assert.Equal(t, "first", q.Entries()[0].Path)
+		assert.Equal(t, "second", q.Entries()[1].Path)
+		assert.Equal(t, "third", q.Entries()[2].Path)
+	})
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -9,7 +9,11 @@ import (
 )
 
 func TestNewQueue(t *testing.T) {
+	t.Parallel()
+
 	t.Run("no dependencies - maintains alphabetical order", func(t *testing.T) {
+		t.Parallel()
+
 		// Create configs with no dependencies - should maintain alphabetical order at front
 		configs := []*discovery.DiscoveredConfig{
 			{Path: "c", Dependencies: []*discovery.DiscoveredConfig{}},
@@ -27,6 +31,8 @@ func TestNewQueue(t *testing.T) {
 	})
 
 	t.Run("dependencies - ordered by dependency level", func(t *testing.T) {
+		t.Parallel()
+
 		// Create configs with dependencies - should order by dependency level
 		configs := []*discovery.DiscoveredConfig{
 			{Path: "c", Dependencies: []*discovery.DiscoveredConfig{{Path: "b"}}},
@@ -46,6 +52,8 @@ func TestNewQueue(t *testing.T) {
 	})
 
 	t.Run("complex dag - ordered by dependency level and alphabetically", func(t *testing.T) {
+		t.Parallel()
+
 		// Create a more complex dependency graph:
 		//   A (no deps)
 		//   B (no deps)
@@ -95,6 +103,8 @@ func TestNewQueue(t *testing.T) {
 	})
 
 	t.Run("deterministic ordering of parallel dependencies", func(t *testing.T) {
+		t.Parallel()
+
 		// Create a graph with parallel dependencies that could be ordered multiple ways:
 		//   A (no deps)
 		//   B -> A
@@ -108,7 +118,7 @@ func TestNewQueue(t *testing.T) {
 		}
 
 		// Run multiple times to verify deterministic ordering
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			q := queue.NewQueue(configs)
 			entries := q.Entries()
 

--- a/test/fixtures/find/basic/stack/terragrunt.stack.hcl
+++ b/test/fixtures/find/basic/stack/terragrunt.stack.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/find/basic/unit/terragrunt.hcl
+++ b/test/fixtures/find/basic/unit/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/find/dag/a-dependent/terragrunt.hcl
+++ b/test/fixtures/find/dag/a-dependent/terragrunt.hcl
@@ -1,0 +1,3 @@
+dependency "dep" {
+    config_path = "../dependency"
+}

--- a/test/fixtures/find/dag/a-dependent/terragrunt.hcl
+++ b/test/fixtures/find/dag/a-dependent/terragrunt.hcl
@@ -1,3 +1,3 @@
 dependency "dep" {
-    config_path = "../dependency"
+    config_path = "../b-dependency"
 }

--- a/test/fixtures/find/dag/b-dependency/terragrunt.hcl
+++ b/test/fixtures/find/dag/b-dependency/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/find/hidden/.hide/unit/terragrunt.hcl
+++ b/test/fixtures/find/hidden/.hide/unit/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/find/hidden/stack/terragrunt.stack.hcl
+++ b/test/fixtures/find/hidden/stack/terragrunt.stack.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/find/hidden/unit/terragrunt.hcl
+++ b/test/fixtures/find/hidden/unit/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -1,7 +1,6 @@
 package test_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -19,14 +18,11 @@ func TestFindBasic(t *testing.T) {
 
 	helpers.CleanupTerraformFolder(t, testFixtureFindBasic)
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
-	err := helpers.RunTerragruntCommand(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic, stdout, stderr)
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic)
 	require.NoError(t, err)
 
-	assert.Equal(t, "", stderr.String())
-	assert.Equal(t, "stack\nunit\n", stdout.String())
+	assert.Empty(t, stderr)
+	assert.Equal(t, "stack\nunit\n", stdout)
 }
 
 func TestFindBasicJSON(t *testing.T) {
@@ -34,14 +30,11 @@ func TestFindBasicJSON(t *testing.T) {
 
 	helpers.CleanupTerraformFolder(t, testFixtureFindBasic)
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
-	err := helpers.RunTerragruntCommand(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic+" --json", stdout, stderr)
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic+" --json")
 	require.NoError(t, err)
 
-	assert.Equal(t, "", stderr.String())
-	assert.JSONEq(t, `[{"type": "stack", "path": "stack"}, {"type": "unit", "path": "unit"}]`, stdout.String())
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, `[{"type": "stack", "path": "stack"}, {"type": "unit", "path": "unit"}]`, stdout)
 }
 
 func TestFindHidden(t *testing.T) {
@@ -69,20 +62,17 @@ func TestFindHidden(t *testing.T) {
 
 			helpers.CleanupTerraformFolder(t, testFixtureFindHidden)
 
-			stdout := &bytes.Buffer{}
-			stderr := &bytes.Buffer{}
-
 			cmd := "terragrunt find --experiment cli-redesign --no-color --working-dir " + testFixtureFindHidden
 
 			if tt.hidden {
 				cmd += " --hidden"
 			}
 
-			err := helpers.RunTerragruntCommand(t, cmd, stdout, stderr)
+			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
 			require.NoError(t, err)
 
-			assert.Equal(t, "", stderr.String())
-			assert.Equal(t, tt.expected, stdout.String())
+			assert.Empty(t, stderr)
+			assert.Equal(t, tt.expected, stdout)
 		})
 	}
 }

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -11,6 +11,7 @@ import (
 const (
 	testFixtureFindBasic  = "fixtures/find/basic"
 	testFixtureFindHidden = "fixtures/find/hidden"
+	testFixtureFindDAG    = "fixtures/find/dag"
 )
 
 func TestFindBasic(t *testing.T) {
@@ -69,6 +70,33 @@ func TestFindHidden(t *testing.T) {
 			}
 
 			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+			require.NoError(t, err)
+
+			assert.Empty(t, stderr)
+			assert.Equal(t, tt.expected, stdout)
+		})
+	}
+}
+
+func TestFindDAG(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name     string
+		sort     string
+		expected string
+	}{
+		{name: "alpha", sort: "alpha", expected: "a-dependent\nb-dependency\n"},
+		{name: "dag", sort: "dag", expected: "b-dependency\na-dependent\n"},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			helpers.CleanupTerraformFolder(t, testFixtureFindDAG)
+
+			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --experiment cli-redesign --sort="+tt.sort+" --no-color --working-dir "+testFixtureFindDAG)
 			require.NoError(t, err)
 
 			assert.Empty(t, stderr)

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -1,0 +1,88 @@
+package test_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFixtureFindBasic  = "fixtures/find/basic"
+	testFixtureFindHidden = "fixtures/find/hidden"
+)
+
+func TestFindBasic(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureFindBasic)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	err := helpers.RunTerragruntCommand(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic, stdout, stderr)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", stderr.String())
+	assert.Equal(t, "stack\nunit\n", stdout.String())
+}
+
+func TestFindBasicJSON(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureFindBasic)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	err := helpers.RunTerragruntCommand(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic+" --json", stdout, stderr)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, `[{"type": "stack", "path": "stack"}, {"type": "unit", "path": "unit"}]`, stdout.String())
+}
+
+func TestFindHidden(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name     string
+		hidden   bool
+		expected string
+	}{
+		{
+			name:     "hidden",
+			expected: "stack\nunit\n",
+		},
+		{
+			name:     "hidden",
+			hidden:   true,
+			expected: ".hide/unit\nstack\nunit\n",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			helpers.CleanupTerraformFolder(t, testFixtureFindHidden)
+
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+
+			cmd := "terragrunt find --experiment cli-redesign --no-color --working-dir " + testFixtureFindHidden
+
+			if tt.hidden {
+				cmd += " --hidden"
+			}
+
+			err := helpers.RunTerragruntCommand(t, cmd, stdout, stderr)
+			require.NoError(t, err)
+
+			assert.Equal(t, "", stderr.String())
+			assert.Equal(t, tt.expected, stdout.String())
+		})
+	}
+}

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -53,7 +53,7 @@ func TestFindHidden(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "hidden",
+			name:     "visible",
 			expected: "stack\nunit\n",
 		},
 		{


### PR DESCRIPTION
## Description

Adds support for the `dag` sort option in the `find` command.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added `dag` option to `find` command sorting.
