### PR TITLE
fix: Reducing noise for skipped dependency inputs

### DIFF
--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -497,7 +497,7 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 
 			logger := log.ContextWithLogger(ctx, ctx.TerragruntOptions.Logger)
 			if err := skipDependenciesInputs.Evaluate(logger); err != nil {
-				ctx.TerragruntOptions.Logger.Warnf("Skipping inputs parse from %v in dependency for better performance", file.ConfigPath)
+				ctx.TerragruntOptions.Logger.Debugf("Skipping inputs parse from %v in dependency for better performance", file.ConfigPath)
 
 				break
 			}

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -497,7 +497,11 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 
 			logger := log.ContextWithLogger(ctx, ctx.TerragruntOptions.Logger)
 			if err := skipDependenciesInputs.Evaluate(logger); err != nil {
-				ctx.TerragruntOptions.Logger.Debugf("Skipping inputs parse from %v in dependency for better performance", file.ConfigPath)
+				ctx.TerragruntOptions.Logger.Debugf(
+					"Skipping inputs parse from %v in dependency for better performance, due to usage of %s strict control",
+					file.ConfigPath,
+					controls.SkipDependenciesInputs,
+				)
 
 				break
 			}


### PR DESCRIPTION
## Description

Fixes #4006.

It's best for users not to get this warning when they are using strict controls, as it's not really a warning they should do anything about.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `skip-dependencies-inputs` to not warn when skipping inputs parse.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced internal logging to provide more detailed contextual information during processing. This update improves diagnostic clarity and aids in troubleshooting while keeping overall functionality unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->