### PR TITLE
fix: Improving logic for scaffold default root discovery

### DIFF
--- a/cli/commands/scaffold/command.go
+++ b/cli/commands/scaffold/command.go
@@ -112,27 +112,18 @@ func GetDefaultRootFileName(ctx context.Context, opts *options.TerragruntOptions
 
 	// Check to see if you can find the recommended parent config name first,
 	// if a user has it defined, go ahead and use it.
-	foldersToCheck := opts.MaxFoldersToCheck
-
 	dir := opts.WorkingDir
-	for dir != string(os.PathSeparator) && dir != "" && dir != "." {
+
+	prevDir := ""
+	for foldersToCheck := opts.MaxFoldersToCheck; dir != prevDir && dir != "" && foldersToCheck > 0; foldersToCheck-- {
+		prevDir = dir
+
 		_, err := os.Stat(filepath.Join(dir, config.RecommendedParentConfigName))
 		if err == nil {
 			return config.RecommendedParentConfigName
 		}
 
 		dir = filepath.Dir(dir)
-
-		foldersToCheck--
-
-		if foldersToCheck <= 0 {
-			opts.Logger.Warnf(
-				"Reached the maximum number of folders to check for %s, using the default value instead.",
-				config.RecommendedParentConfigName,
-			)
-
-			break
-		}
 	}
 
 	return config.DefaultTerragruntConfigPath


### PR DESCRIPTION
## Description

Addresses feedback on #4022.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated Logic for root file discovery in scaffold.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the configuration file discovery, allowing the system to more efficiently determine the appropriate configuration without unnecessary notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->