### PR TITLE
feat: Adding `.cursor` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ mocks/
 .go-version
 .terragrunt-stack
 .devcontainer.json
+.cursor/


### PR DESCRIPTION
## Description

Allows devs to conveniently have some `.cursor` configurations in this project without committing it to the project.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added `.cursor` to the `.gitignore` configurations for the project.
