### PR TITLE
fix: Fixing some docs for list

### DIFF
--- a/docs-starlight/src/data/commands/find.mdx
+++ b/docs-starlight/src/data/commands/find.mdx
@@ -34,9 +34,9 @@ examples:
     code: |
       terragrunt find --json
   - description: |
-      Sort configurations based on their dependencies (DAG order).
+      Sort configurations based on their dependencies using DAG mode.
     code: |
-      terragrunt find --sort 'dag'
+      terragrunt find --dag
   - description: |
       Include dependency information in the output.
     code: |
@@ -95,21 +95,18 @@ terragrunt find --json
 
 The JSON output includes additional metadata about each configuration, such as its type (unit or stack) and path.
 
-## Sorting
+## DAG Mode
 
-The `find` command supports two sorting modes:
+The `find` command supports DAG mode to sort output based on dependencies using the `--dag` flag.
 
-- `alpha` (default): Sort configurations alphabetically by path
-- `dag`: Sort configurations based on their dependencies, ensuring dependencies are listed before their dependents
-
-When using DAG sorting, configurations with no dependencies appear first, followed by configurations that depend on them:
+When using DAG mode, configurations with no dependencies appear first, followed by configurations that depend on them, maintaining the correct dependency order:
 
 ```bash
-terragrunt find --sort=dag
+terragrunt find --dag
 unitA           # no dependencies
 unitB           # no dependencies
 unitC           # depends on unitA
-unitD           # depends on unitA and unitB
+unitD           # depends on unitC
 ```
 
 If multiple configurations share common dependencies, they will be sorted in lexical order.
@@ -155,6 +152,14 @@ terragrunt find --dependencies --external --format=json
     "dependencies": []
   }
 ]
+```
+
+## Hidden Configurations
+
+By default, hidden directories (those starting with `.`) are excluded from the search. Use the `--hidden` flag to include them:
+
+```bash
+terragrunt find --hidden
 ```
 
 ## Disabling Color Output

--- a/docs-starlight/src/data/commands/list.mdx
+++ b/docs-starlight/src/data/commands/list.mdx
@@ -103,25 +103,51 @@ The tree format provides a hierarchical view of your configurations:
 
 ![list-tree](../../assets/img/screenshots/list-tree.png)
 
-## Sorting and Grouping
+By default, configurations in tree format are displayed ordered by name and grouped by directory:
 
-The `list` command supports different sorting and grouping options to help you organize output:
+```bash
+.
+╰── live
+    ├── dev
+    │   ├── db
+    │   ├── ec2
+    │   ╰── vpc
+    ╰── prod
+        ├── db
+        ├── ec2
+        ╰── vpc
+```
 
-### Sorting
+## DAG Mode
 
-- `alpha` (default): Sort configurations alphabetically by path
-- `dag`: Sort configurations based on their dependencies
+The `list` command supports DAG mode to sort and group output based on dependencies using the `--dag` flag. When using DAG mode, configurations with no dependencies appear first, followed by configurations that depend on them, maintaining the correct dependency order.
 
-### Grouping
+For example, in default text format:
 
-The `--group-by` flag controls how dependencies are represented in the output:
+```bash
+# Default alphabetical order
+$ terragrunt list
+a-dependent b-dependency
 
-- `fs` (default): Shows dependencies as nested lists with entries as children of parent directories
-- `dag`: Shows dependencies in a tree structure from a DAG perspective
+# DAG mode order
+$ terragrunt list --dag
+b-dependency a-dependent
+```
 
-<Aside type="tip">
-  The `--dag` flag is a shorthand that sets both `--sort=dag` and `--group-by=dag`.
-</Aside>
+When using `--dag` with the tree format, configurations are sorted by dependency order and grouped by relationship in the dependency graph:
+
+```bash
+$ terragrunt list --tree --dag
+.
+├── live/dev/vpc
+│   ├── live/dev/db
+│   │   ╰── live/dev/ec2
+│   ╰── live/dev/ec2
+╰── live/prod/vpc
+    ├── live/prod/db
+    │   ╰── live/prod/ec2
+    ╰── live/prod/ec2
+```
 
 ## Dependencies and Discovery
 

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -733,7 +733,7 @@ When using DAG mode, configurations with no dependencies appear first, followed 
 By default, configurations are sorted alphabetically:
 
 ```bash
-$ terragrunt list --sort=alpha
+$ terragrunt list
 a-dependent b-dependency
 ```
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes some documentation errors related to `find` and `list`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `find` docs.
Updated `list` docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Terragrunt command instructions to clarify dependency ordering by introducing the term "DAG Mode."
	- Revised the `find` command usage to simplify syntax (using `--dag`) and updated examples, including details on hidden configurations.
	- Enhanced the `list` command documentation with a dedicated DAG Mode section that integrates sorting and grouping, and removed explicit alphabetical sorting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->