### PR TITLE
[WIP] Stacks RFC: values with dependencies

### DIFF
--- a/config/hclparse/file.go
+++ b/config/hclparse/file.go
@@ -75,11 +75,22 @@ func (file *File) Decode(out any, evalContext *hcl.EvalContext) (err error) {
 
 // Blocks takes a parsed HCL file and extracts a reference to the `name` block, if there are defined.
 func (file *File) Blocks(name string, isMultipleAllowed bool) ([]*Block, error) {
+	var labelNames []string
+	switch name {
+	case "dependency":
+		labelNames = []string{"name"}
+	case "values":
+		// values block doesn't have labels
+		labelNames = []string{}
+	default:
+		labelNames = []string{"name"}
+	}
+
 	catalogSchema := &hcl.BodySchema{
 		Blocks: []hcl.BlockHeaderSchema{
 			{
 				Type:       name,
-				LabelNames: []string{"name"},
+				LabelNames: labelNames,
 			},
 		},
 	}

--- a/config/hclparse/file.go
+++ b/config/hclparse/file.go
@@ -77,7 +77,10 @@ func (file *File) Decode(out any, evalContext *hcl.EvalContext) (err error) {
 func (file *File) Blocks(name string, isMultipleAllowed bool) ([]*Block, error) {
 	catalogSchema := &hcl.BodySchema{
 		Blocks: []hcl.BlockHeaderSchema{
-			{Type: name},
+			{
+				Type:       name,
+				LabelNames: []string{"name"},
+			},
 		},
 	}
 	// We use PartialContent here, because we are only interested in parsing out the catalog block.
@@ -98,13 +101,7 @@ func (file *File) Blocks(name string, isMultipleAllowed bool) ([]*Block, error) 
 	}
 
 	if len(extractedBlocks) > 1 && !isMultipleAllowed {
-		return nil, errors.New(
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  fmt.Sprintf("Multiple %s block", name),
-				Detail:   fmt.Sprintf(multipleBlockDetailFmt, name),
-			},
-		)
+		return nil, errors.New(fmt.Sprintf(multipleBlockDetailFmt, name))
 	}
 
 	return extractedBlocks, nil

--- a/config/stack.go
+++ b/config/stack.go
@@ -421,7 +421,7 @@ func ReadValues(ctx context.Context, opts *options.TerragruntOptions, directory 
 
 	// First, decode any dependency blocks to get their outputs
 	dependencies := map[string]cty.Value{}
-	dependencyBlocks, err := file.Blocks("dependency", false)
+	dependencyBlocks, err := file.Blocks("dependency", true)
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -468,7 +468,9 @@ func ReadValues(ctx context.Context, opts *options.TerragruntOptions, directory 
 			return nil, errors.Errorf("failed to parse outputs from dependency %s: %w", depName, err)
 		}
 
-		dependencies[depName] = cty.ObjectVal(outputMap)
+		dependencies[depName] = cty.ObjectVal(map[string]cty.Value{
+			"outputs": cty.ObjectVal(outputMap),
+		})
 	}
 
 	// Create evaluation context with dependencies


### PR DESCRIPTION
## Description

Easily pass values between unit definitions from the terragrunt.stack.hcl file while maintaining backwards compatibility with units.

Context:
- [Original Request](https://github.com/gruntwork-io/terragrunt/issues/3313#issuecomment-2705391439): Now that stacks can create multiple instances of a single unit, should the coupling of implementation details with units be revisited? It feels at odds with the stack concept of dynamically setting up units.
- [Response](https://github.com/gruntwork-io/terragrunt/issues/3313#issuecomment-2721552458): Can you think of a way to define dependencies for units inside the terragrunt.stack.hcl file that doesn't break this?
- [Solution Description](https://github.com/gruntwork-io/terragrunt/issues/3313#issuecomment-2723936374): Continue to use the values file interface.

This PR implements the following format:

```
# terragrunt.stack.hcl

unit "dep" {
  source = "modules/imadep"
  path   = "imadep"
}

unit "test" {
  source = "modules/test"
  path   = "test"
  values = {
    a = "a"
    b = unit.dep.output_b
  }
}


# .terragrunt-stack/test/terragrunt.values.hcl (auto-generated)

values {
    a = "a"
    b = dependency.dep.outputs.output_b
}

dependency "dep" {
    config_path = "../imadep"
}
```

Before merging:
- Confirm that this behavior is in line with the Stacks RFC vision
- Handle all error cases
- Ensure performance is not degraded

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

