### PR TITLE
Add test fixtures for incorrect relative source in stacks

### DIFF
--- a/test/fixtures/stacks/errors/relative-source-incorrect/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/errors/relative-source-incorrect/live/terragrunt.stack.hcl
@@ -1,0 +1,5 @@
+
+unit "app1" {
+	source = "../../units/app1" # The correct source is "../units/app1"
+	path   = "app1"
+}

--- a/test/fixtures/stacks/errors/relative-source-incorrect/units/app1/terragrunt.hcl
+++ b/test/fixtures/stacks/errors/relative-source-incorrect/units/app1/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

The error for wrong relative source input to a stack is misleading.
<img width="605" alt="Screenshot 2025-03-25 at 2 24 34 PM" src="https://github.com/user-attachments/assets/15ac6a48-e92c-4534-8ac4-3f2093e8f14b" />

Consider messaging like 👇 

```
Failed to fetch <unit|stack> <name> at <path>

Try:
1. Check if your source path is correct relative to the stack file location
2. Verify the units or stacks directory exists at the expected location
3. ...
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration block for a new unit that defines its module source and path settings.
  - Added a Terraform configuration file to establish the proper module source reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->