### PR TITLE
fix: Fixing `backend delete` safety features

### DIFF
--- a/cli/commands/backend/delete/cli.go
+++ b/cli/commands/backend/delete/cli.go
@@ -11,7 +11,8 @@ import (
 const (
 	CommandName = "delete"
 
-	BucketFlagName = "bucket"
+	BucketFlagName             = "bucket"
+	ForceBackendDeleteFlagName = "force"
 )
 
 func NewFlags(cmdOpts *Options, prefix flags.Prefix) cli.Flags {
@@ -24,6 +25,12 @@ func NewFlags(cmdOpts *Options, prefix flags.Prefix) cli.Flags {
 			Usage:       "Delete the entire bucket.",
 			Hidden:      true,
 			Destination: &cmdOpts.DeleteBucket,
+		}),
+		flags.NewFlag(&cli.BoolFlag{
+			Name:        ForceBackendDeleteFlagName,
+			EnvVars:     tgPrefix.EnvVars(ForceBackendDeleteFlagName),
+			Usage:       "Force the backend to be deleted, even if the bucket is not versioned.",
+			Destination: &cmdOpts.ForceBackendDelete,
 		}),
 	}
 

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -115,15 +115,7 @@ func (cmd *Command) VisibleSubcommands() Commands {
 		return nil
 	}
 
-	visibleSubcommands := make(Commands, 0, len(cmd.Subcommands))
-
-	for _, subcommand := range cmd.Subcommands {
-		if !subcommand.Hidden {
-			visibleSubcommands = append(visibleSubcommands, subcommand)
-		}
-	}
-
-	return visibleSubcommands
+	return cmd.Subcommands.VisibleCommands()
 }
 
 // Run parses the given args for the presence of flags as well as subcommands.

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -115,7 +115,15 @@ func (cmd *Command) VisibleSubcommands() Commands {
 		return nil
 	}
 
-	return cmd.Subcommands.VisibleCommands()
+	visibleSubcommands := make(Commands, 0, len(cmd.Subcommands))
+
+	for _, subcommand := range cmd.Subcommands {
+		if !subcommand.Hidden {
+			visibleSubcommands = append(visibleSubcommands, subcommand)
+		}
+	}
+
+	return visibleSubcommands
 }
 
 // Run parses the given args for the presence of flags as well as subcommands.

--- a/internal/remotestate/backend/gcs/backend.go
+++ b/internal/remotestate/backend/gcs/backend.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
@@ -108,7 +109,7 @@ func (backend *Backend) Init(ctx context.Context, backendConfig backend.Config, 
 	// If bucket is specified and skip_bucket_versioning is false then warn user if versioning is disabled on bucket
 	if !extGCSCfg.SkipBucketVersioning && bucketName != "" {
 		// TODO: Remove lint suppression
-		if err := client.CheckIfGCSVersioningEnabled(bucketName); err != nil { //nolint:contextcheck
+		if _, err := client.CheckIfGCSVersioningEnabled(bucketName); err != nil { //nolint:contextcheck
 			return err
 		}
 	}
@@ -128,6 +129,17 @@ func (backend *Backend) Delete(ctx context.Context, backendConfig backend.Config
 	client, err := NewClient(ctx, extGCSCfg, opts.Logger)
 	if err != nil {
 		return err
+	}
+
+	if !opts.ForceBackendDelete {
+		versioned, err := client.CheckIfGCSVersioningEnabled(extGCSCfg.RemoteStateConfigGCS.Bucket)
+		if err != nil {
+			return err
+		}
+
+		if !versioned {
+			return errors.New("bucket is not versioned, refusing to delete backend state. If you are sure you want to delete the backend state anyways, use the --force flag")
+		}
 	}
 
 	var (

--- a/internal/remotestate/backend/gcs/backend.go
+++ b/internal/remotestate/backend/gcs/backend.go
@@ -109,7 +109,7 @@ func (backend *Backend) Init(ctx context.Context, backendConfig backend.Config, 
 	// If bucket is specified and skip_bucket_versioning is false then warn user if versioning is disabled on bucket
 	if !extGCSCfg.SkipBucketVersioning && bucketName != "" {
 		// TODO: Remove lint suppression
-		if _, err := client.CheckIfGCSVersioningEnabled(bucketName); err != nil { //nolint:contextcheck
+		if _, err := client.CheckIfGCSVersioningEnabled(ctx, bucketName); err != nil { //nolint:contextcheck
 			return err
 		}
 	}
@@ -132,7 +132,7 @@ func (backend *Backend) Delete(ctx context.Context, backendConfig backend.Config
 	}
 
 	if !opts.ForceBackendDelete {
-		versioned, err := client.CheckIfGCSVersioningEnabled(extGCSCfg.RemoteStateConfigGCS.Bucket)
+		versioned, err := client.CheckIfGCSVersioningEnabled(ctx, extGCSCfg.RemoteStateConfigGCS.Bucket)
 		if err != nil {
 			return err
 		}

--- a/internal/remotestate/backend/gcs/client.go
+++ b/internal/remotestate/backend/gcs/client.go
@@ -156,21 +156,21 @@ func (client *Client) CreateGCSBucketIfNecessary(ctx context.Context, bucketName
 }
 
 // CheckIfGCSVersioningEnabled checks if versioning is enabled for the GCS bucket specified in the given config and warn the user if it is not
-func (client *Client) CheckIfGCSVersioningEnabled(bucketName string) error {
+func (client *Client) CheckIfGCSVersioningEnabled(bucketName string) (bool, error) {
 	ctx := context.Background()
 	bucket := client.Bucket(bucketName)
 
 	attrs, err := bucket.Attrs(ctx)
 	if err != nil {
 		// ErrBucketNotExist
-		return errors.New(err)
+		return false, errors.New(err)
 	}
 
 	if !attrs.VersioningEnabled {
-		client.logger.Warnf("Versioning is not enabled for the remote state GCS bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", bucketName)
+		client.logger.Warnf("Versioning is not enabled for the remote state GCS bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your OpenTofu/Terraform state in case of error.", bucketName)
 	}
 
-	return nil
+	return attrs.VersioningEnabled, nil
 }
 
 // CreateGCSBucketWithVersioning creates the given GCS bucket and enables versioning for it.

--- a/internal/remotestate/backend/gcs/client.go
+++ b/internal/remotestate/backend/gcs/client.go
@@ -156,8 +156,7 @@ func (client *Client) CreateGCSBucketIfNecessary(ctx context.Context, bucketName
 }
 
 // CheckIfGCSVersioningEnabled checks if versioning is enabled for the GCS bucket specified in the given config and warn the user if it is not
-func (client *Client) CheckIfGCSVersioningEnabled(bucketName string) (bool, error) {
-	ctx := context.Background()
+func (client *Client) CheckIfGCSVersioningEnabled(ctx context.Context, bucketName string) (bool, error) {
 	bucket := client.Bucket(bucketName)
 
 	attrs, err := bucket.Attrs(ctx)

--- a/internal/remotestate/backend/s3/client.go
+++ b/internal/remotestate/backend/s3/client.go
@@ -416,7 +416,7 @@ func (client *Client) CheckIfVersioningEnabled(ctx context.Context, bucketName s
 	// NOTE: There must be a bug in the AWS SDK since res == nil when versioning is not enabled. In the future,
 	// check the AWS SDK for updates to see if we can remove "res == nil ||".
 	if res == nil || res.Status == nil || *res.Status != s3.BucketVersioningStatusEnabled {
-		client.logger.Warnf("Versioning is not enabled for the remote state S3 bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your Terraform state in case of error.", bucketName)
+		client.logger.Warnf("Versioning is not enabled for the remote state S3 bucket %s. We recommend enabling versioning so that you can roll back to previous versions of your OpenTofu/Terraform state in case of error.", bucketName)
 		return false, nil
 	}
 

--- a/options/options.go
+++ b/options/options.go
@@ -284,6 +284,8 @@ type TerragruntOptions struct {
 	Graph bool
 	// BackendBootstrap automatically bootstraps backend infrastructure before attempting to use it.
 	BackendBootstrap bool
+	// ForceBackendDelete forces the backend to be deleted, even if the bucket is not versioned.
+	ForceBackendDelete bool
 }
 
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests

--- a/test/fixtures/bootstrap-gcs-backend/common.hcl
+++ b/test/fixtures/bootstrap-gcs-backend/common.hcl
@@ -1,3 +1,7 @@
+feature "disable_versioning" {
+  default = false
+}
+
 remote_state {
   backend = "gcs"
 
@@ -11,5 +15,7 @@ remote_state {
     location = "__FILL_IN_LOCATION__"
     project  = "__FILL_IN_PROJECT__"
     bucket   = "__FILL_IN_BUCKET_NAME__"
+
+    skip_bucket_versioning = feature.disable_versioning.value
   }
 }

--- a/test/fixtures/bootstrap-s3-backend/common.hcl
+++ b/test/fixtures/bootstrap-s3-backend/common.hcl
@@ -1,3 +1,7 @@
+feature "disable_versioning" {
+  default = false
+}
+
 remote_state {
   backend = "s3"
   generate = {
@@ -9,5 +13,7 @@ remote_state {
     bucket         = "__FILL_IN_BUCKET_NAME__"
     region         = "__FILL_IN_REGION__"
     dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
+
+    skip_bucket_versioning = feature.disable_versioning.value
   }
 }

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -125,6 +125,39 @@ func TestAwsBootstrapBackend(t *testing.T) {
 	}
 }
 
+func TestAwsBootstrapBackendWithoutVersioning(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureBootstrapS3Backend)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureBootstrapS3Backend)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureBootstrapS3Backend)
+
+	testID := strings.ToLower(helpers.UniqueID())
+
+	s3BucketName := "terragrunt-test-bucket-" + testID
+	dynamoDBName := "terragrunt-test-dynamodb-" + testID
+
+	defer func() {
+		deleteS3Bucket(t, s3BucketName, helpers.TerraformRemoteStateS3Region)
+		cleanupTableForTest(t, dynamoDBName, helpers.TerraformRemoteStateS3Region)
+	}()
+
+	commonConfigPath := util.JoinPath(rootPath, "common.hcl")
+	helpers.CopyTerragruntConfigAndFillPlaceholders(t, commonConfigPath, commonConfigPath, s3BucketName, dynamoDBName, helpers.TerraformRemoteStateS3Region)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --log-level debug --strict-control require-explicit-bootstrap --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true --backend-bootstrap apply")
+	require.NoError(t, err)
+
+	validateS3BucketExistsAndIsTagged(t, helpers.TerraformRemoteStateS3Region, s3BucketName, nil)
+	validateDynamoDBTableExistsAndIsTagged(t, helpers.TerraformRemoteStateS3Region, dynamoDBName, nil)
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --strict-control require-explicit-bootstrap --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true backend delete --all")
+	require.Error(t, err)
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --strict-control require-explicit-bootstrap --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true backend delete --all --force")
+	require.NoError(t, err)
+}
+
 func TestAwsDeleteBackend(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds requisite check that the backend state bucket is versioned before performing any state deletion as a safeguard for users.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `--force` flag to bypass safety feature disallowing usage of `backend delete` on buckets that are not versioned.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new CLI option, `--force`, for backend deletion. When used, it allows the deletion to proceed even if bucket versioning isn’t enabled.
  - Introduced a configuration option to conditionally skip bucket versioning during remote state bootstrapping.
  
- **Tests**
  - Expanded integration tests for AWS and GCP backends to cover scenarios with versioning disabled and to verify the behavior of the new force deletion capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->