### PR TITLE
fix: Addressing stricter lint findings

### DIFF
--- a/awshelper/config_test.go
+++ b/awshelper/config_test.go
@@ -53,8 +53,8 @@ func TestAwsSessionValidationFail(t *testing.T) {
 func TestAwsNegativePublicAccessResponse(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
-		name     string
 		response *s3.GetPublicAccessBlockOutput
+		name     string
 	}{
 		{
 			name: "nil-response",

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -57,22 +57,26 @@ func TestAwsBootstrapBackend(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
+		checkExpectedResultFn func(t *testing.T, err error, output string, s3BucketName, dynamoDBName string)
 		name                  string
 		args                  string
-		checkExpectedResultFn func(t *testing.T, err error, output string, s3BucketName, dynamoDBName string)
 	}{
 		{
-			"no bootstrap s3 backend without flag",
-			"run apply",
-			func(t *testing.T, err error, output string, s3BucketName, dynamoDBName string) {
+			name: "no bootstrap s3 backend without flag",
+			args: "run apply",
+			checkExpectedResultFn: func(t *testing.T, err error, output string, s3BucketName, dynamoDBName string) {
+				t.Helper()
+
 				require.Error(t, err)
 				assert.Regexp(t, "(S3 bucket must have been previously created)|(S3 bucket does not exist)", output)
 			},
 		},
 		{
-			"bootstrap s3 backend with flag",
-			"run apply --backend-bootstrap",
-			func(t *testing.T, err error, output string, s3BucketName, dynamoDBName string) {
+			name: "bootstrap s3 backend with flag",
+			args: "run apply --backend-bootstrap",
+			checkExpectedResultFn: func(t *testing.T, err error, output string, s3BucketName, dynamoDBName string) {
+				t.Helper()
+
 				require.NoError(t, err)
 
 				validateS3BucketExistsAndIsTagged(t, helpers.TerraformRemoteStateS3Region, s3BucketName, nil)
@@ -80,9 +84,11 @@ func TestAwsBootstrapBackend(t *testing.T) {
 			},
 		},
 		{
-			"bootstrap s3 backend by backend command",
-			"backend bootstrap",
-			func(t *testing.T, err error, output string, s3BucketName, dynamoDBName string) {
+			name: "bootstrap s3 backend by backend command",
+			args: "backend bootstrap",
+			checkExpectedResultFn: func(t *testing.T, err error, output string, s3BucketName, dynamoDBName string) {
+				t.Helper()
+
 				require.NoError(t, err)
 
 				validateS3BucketExistsAndIsTagged(t, helpers.TerraformRemoteStateS3Region, s3BucketName, nil)
@@ -92,7 +98,7 @@ func TestAwsBootstrapBackend(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			helpers.CleanupTerraformFolder(t, testFixtureBootstrapS3Backend)
@@ -1523,6 +1529,8 @@ func createS3Bucket(t *testing.T, awsRegion string, bucketName string) {
 }
 
 func deleteS3Bucket(t *testing.T, bucketName string, awsRegion string) {
+	t.Helper()
+
 	helpers.DeleteS3Bucket(t, awsRegion, bucketName)
 }
 

--- a/test/integration_serial_aws_test.go
+++ b/test/integration_serial_aws_test.go
@@ -25,14 +25,14 @@ func TestTerragruntParallelism(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
+		expectedTimings        []int
 		parallelism            int
 		numberOfModules        int
 		timeToDeployEachModule time.Duration
-		expectedTimings        []int
 	}{
-		{1, 10, 5 * time.Second, []int{5, 10, 15, 20, 25, 30, 35, 40, 45, 50}},
-		{3, 10, 5 * time.Second, []int{5, 5, 5, 10, 10, 10, 15, 15, 15, 20}},
-		{5, 10, 5 * time.Second, []int{5, 5, 5, 5, 5, 5, 5, 5, 5, 5}},
+		{parallelism: 1, numberOfModules: 10, timeToDeployEachModule: 5 * time.Second, expectedTimings: []int{5, 10, 15, 20, 25, 30, 35, 40, 45, 50}},
+		{parallelism: 3, numberOfModules: 10, timeToDeployEachModule: 5 * time.Second, expectedTimings: []int{5, 5, 5, 10, 10, 10, 15, 15, 15, 20}},
+		{parallelism: 5, numberOfModules: 10, timeToDeployEachModule: 5 * time.Second, expectedTimings: []int{5, 5, 5, 5, 5, 5, 5, 5, 5, 5}},
 	}
 	for _, tc := range testCases {
 


### PR DESCRIPTION
## Description

My local linter throws errors on these, presumably because I'm using a different version or something.

Not gonna worry about it too much and just fix them.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated test files to fix linting errors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced test case clarity and consistency to improve internal debugging and maintenance.
  
- **Refactor**
  - Reorganized internal test structures for improved readability without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->