### PR TITLE
fix: Avoiding duplicate description in flag names

### DIFF
--- a/docs-starlight/src/data/flags/backend-require-bootstrap.mdx
+++ b/docs-starlight/src/data/flags/backend-require-bootstrap.mdx
@@ -1,12 +1,13 @@
 ---
 name: backend-require-bootstrap
-description: When this flag is set Terragrunt will fail if the remote state bucket needs to be created.
+description: |
+  When this flag is set, Terragrunt will throw an error if remote state needs to be created via the `backend bootstrap` command.
 type: bool
 env:
   - TG_BACKEND_REQUIRE_BOOTSTRAP
 ---
 
-This flag provides a safety mechanism when working with remote state backends. When enabled, Terragrunt will fail with an error if it detects that the remote state bucket does not exist and would need to be created.
+This flag provides a safety mechanism when working with remote state backends.
 
 This is particularly useful in production environments where you want to ensure that:
 

--- a/docs-starlight/src/data/flags/dependency-fetch-output-from-state.mdx
+++ b/docs-starlight/src/data/flags/dependency-fetch-output-from-state.mdx
@@ -1,6 +1,7 @@
 ---
 name: dependency-fetch-output-from-state
-description: The option fetches dependency output directly from the state file instead of using tofu/terraform output.
+description: |
+  Fetch dependency outputs directly from the state file instead of using `tofu output`.
 type: bool
 env:
   - TG_DEPENDENCY_FETCH_OUTPUT_FROM_STATE

--- a/docs-starlight/src/data/flags/disable-bucket-update.mdx
+++ b/docs-starlight/src/data/flags/disable-bucket-update.mdx
@@ -1,12 +1,13 @@
 ---
 name: disable-bucket-update
-description: When this flag is set Terragrunt will not update the remote state bucket.
+description: |
+  When this flag is set, Terragrunt will not update the remote state resources.
 type: bool
 env:
   - TG_DISABLE_BUCKET_UPDATE
 ---
 
-This flag prevents Terragrunt from making any modifications to the remote state bucket configuration. When enabled, Terragrunt will fail if it detects that the remote state bucket needs to be updated.
+When enabled, Terragrunt will throw an error if it detects that remote state resources need to be updated.
 
 This is useful in scenarios where:
 - You want to ensure state bucket configurations remain unchanged during operations

--- a/docs-starlight/src/data/flags/log-format.mdx
+++ b/docs-starlight/src/data/flags/log-format.mdx
@@ -1,9 +1,10 @@
 ---
 name: log-format
-description: Set the log format.
+description: |
+  Set the format for Terragrunt's log output.
 type: string
 env:
   - TG_LOG_FORMAT
 ---
 
-Sets the format for Terragrunt's log output. For a list of available formats and their descriptions, see the [log formatting documentation](/docs/reference/logging/formatting).
+For a list of available formats and their descriptions, see the [log formatting documentation](/docs/reference/logging/formatting).

--- a/docs-starlight/src/data/flags/no-destroy-dependencies-check.mdx
+++ b/docs-starlight/src/data/flags/no-destroy-dependencies-check.mdx
@@ -1,6 +1,7 @@
 ---
 name: no-destroy-dependencies-check
-description: When this flag is set, Terragrunt will not check for dependent units when destroying.
+description: |
+  Disables Terragrunt's dependency validation during destroy operations.
 type: bool
 env:
   - TG_NO_DESTROY_DEPENDENCIES_CHECK
@@ -8,7 +9,7 @@ env:
 
 import { Aside } from '@astrojs/starlight/components';
 
-Disables Terragrunt's dependency validation during destroy operations. When enabled, Terragrunt will not verify if there are dependent units that would be affected by destroying the current unit.
+When enabled, Terragrunt will not verify if there are dependent units that would be affected by destroying the current unit.
 
 This results in faster destroy operations, but may result in orphaned resources.
 


### PR DESCRIPTION
## Description

The description shows up as the first line of flag body in the flag list for each command.

There's some duplication here, as the first line is basically the first line of the body, and can be cut.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated the body of flag content to remove duplications of the description.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced flag descriptions for improved clarity.
  - Clarified error conditions related to remote state creation and resource updates.
  - Refined instructions for fetching dependency outputs, specifying the exact command reference.
  - Expanded log format details to emphasize log output for Terragrunt.
  - Streamlined information for dependency validation during destroy operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->