### PR TITLE
feat: Adding error handling for discovery

### DIFF
--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -14,7 +14,9 @@ import (
 
 // Run runs the find command.
 func Run(ctx context.Context, opts *Options) error {
-	d := discovery.NewDiscovery(opts.WorkingDir)
+	d := discovery.
+		NewDiscovery(opts.WorkingDir).
+		WithSuppressParseErrors()
 
 	if opts.Hidden {
 		d = d.WithHidden()
@@ -30,7 +32,7 @@ func Run(ctx context.Context, opts *Options) error {
 
 	cfgs, err := d.Discover(ctx, opts.TerragruntOptions)
 	if err != nil {
-		return errors.New(err)
+		opts.Logger.Warnf("Error discovering configurations:\n%s", err)
 	}
 
 	switch opts.Mode {

--- a/cli/commands/list/list.go
+++ b/cli/commands/list/list.go
@@ -18,7 +18,9 @@ import (
 
 // Run runs the list command.
 func Run(ctx context.Context, opts *Options) error {
-	d := discovery.NewDiscovery(opts.WorkingDir)
+	d := discovery.
+		NewDiscovery(opts.WorkingDir).
+		WithSuppressParseErrors()
 
 	if opts.Hidden {
 		d = d.WithHidden()

--- a/docs/_docs/04_reference/06-experiments.md
+++ b/docs/_docs/04_reference/06-experiments.md
@@ -166,8 +166,8 @@ To transition `cli-redesign` features to a stable release, the following must be
   - [x] Add support for `find` with `--sort=dag` flag.
   - [ ] Add support for `find` with the `exclude` block used to exclude units from the search.
   - [ ] Add integration with `symlinks` experiment to support finding units/stacks via symlinks.
-  - [ ] Add handling of broken configurations or configurations requiring authentication.
-  - [ ] Add integration test for `find` with `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
+  - [x] Add handling of broken configurations or configurations requiring authentication.
+  - [x] Add integration test for `find` with `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
 - [ ] Add support for the `list` command.
   - [x] Add support for `list` without flags.
   - [x] Add support for `list` with colorful output.
@@ -181,8 +181,8 @@ To transition `cli-redesign` features to a stable release, the following must be
   - [x] Add support for `list` with `--group-by=dag` flag.
   - [ ] Add support for `list` with the `exclude` block used to exclude units from the search.
   - [ ] Add integration with `symlinks` experiment to support listing units/stacks via symlinks.
-  - [ ] Add handling of broken configurations or configurations requiring authentication.
-  - [ ] Add integration test for `list` with `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
+  - [x] Add handling of broken configurations or configurations requiring authentication.
+  - [x] Add integration test for `list` with `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
 
 ### `cas`
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -557,6 +557,13 @@ func (c DiscoveredConfigs) RemoveCycles() (DiscoveredConfigs, error) {
 			break
 		}
 
+		// Cfg should never be nil if err is not nil,
+		// but we do this check to avoid a nil pointer dereference
+		// if our assumptions change in the future.
+		if cfg == nil {
+			break
+		}
+
 		c = c.RemoveByPath(cfg.Path)
 	}
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 )
 
 const (
@@ -332,6 +334,10 @@ func (d *DependencyDiscovery) DiscoverDependencies(ctx context.Context, opts *op
 	// Suppress logging to avoid cluttering the output.
 	parseOpts.Writer = io.Discard
 	parseOpts.ErrWriter = io.Discard
+	parseOpts.Logger = log.New(
+		log.WithOutput(io.Discard),
+		log.WithFormatter(format.NewFormatter(format.NewPrettyFormatPlaceholders())),
+	)
 
 	// We can assume this is a unit config, because we already filtered out
 	// stack configs above.

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -377,12 +377,14 @@ func TestDiscoveredConfigsCycleCheck(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := tt.configs.CycleCheck()
+			cfg, err := tt.configs.CycleCheck()
 			if tt.errorExpected {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "cycle detected")
+				assert.NotNil(t, cfg)
 			} else {
 				require.NoError(t, err)
+				assert.Nil(t, cfg)
 			}
 		})
 	}

--- a/test/integration_parse_test.go
+++ b/test/integration_parse_test.go
@@ -1,7 +1,9 @@
 //go:build parse
 
-// This test consumes so much memory that it causes the CI runner to crash.
-// As a result, we have to run it on its own.
+// These tests consume so much memory that they cause the CI runner to crash.
+// As a result, we have to run them on their own.
+//
+// In the future, we should make improvements to parsing so that this isn't necessary.
 
 package test_test
 
@@ -93,17 +95,17 @@ func TestParseFindListAllComponents(t *testing.T) {
 			assert.Empty(t, stderr)
 			assert.NotEmpty(t, stdout)
 
-			lines := strings.Split(stdout, "\n")
+			fields := strings.Fields(stdout)
 
 			aDepLine := 0
 			bDepLine := 0
 
-			for i, line := range lines {
-				if line == "fixtures/find/dag/a-dependency" {
+			for i, field := range fields {
+				if field == "fixtures/find/dag/a-dependent" {
 					aDepLine = i
 				}
 
-				if line == "fixtures/find/dag/b-dependency" {
+				if field == "fixtures/find/dag/b-dependency" {
 					bDepLine = i
 				}
 			}
@@ -137,17 +139,17 @@ func TestParseFindListAllComponentsWithDAG(t *testing.T) {
 			assert.NotEmpty(t, stderr)
 			assert.NotEmpty(t, stdout)
 
-			lines := strings.Split(stdout, "\n")
+			fields := strings.Fields(stdout)
 
 			aDepLine := 0
 			bDepLine := 0
 
-			for i, line := range lines {
-				if line == "fixtures/find/dag/a-dependency" {
+			for i, field := range fields {
+				if field == "fixtures/find/dag/a-dependent" {
 					aDepLine = i
 				}
 
-				if line == "fixtures/find/dag/b-dependency" {
+				if field == "fixtures/find/dag/b-dependency" {
 					bDepLine = i
 				}
 			}
@@ -181,17 +183,17 @@ func TestParseFindListAllComponentsWithDAGAndExternal(t *testing.T) {
 			assert.NotEmpty(t, stderr)
 			assert.NotEmpty(t, stdout)
 
-			lines := strings.Split(stdout, "\n")
+			fields := strings.Fields(stdout)
 
 			aDepLine := 0
 			bDepLine := 0
 
-			for i, line := range lines {
-				if line == "fixtures/find/dag/a-dependency" {
+			for i, field := range fields {
+				if field == "fixtures/find/dag/a-dependent" {
 					aDepLine = i
 				}
 
-				if line == "fixtures/find/dag/b-dependency" {
+				if field == "fixtures/find/dag/b-dependency" {
 					bDepLine = i
 				}
 			}

--- a/test/integration_parse_test.go
+++ b/test/integration_parse_test.go
@@ -82,6 +82,8 @@ func TestParseFindListAllComponents(t *testing.T) {
 
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(
 				t,
 				tt.command,
@@ -124,13 +126,15 @@ func TestParseFindListAllComponentsWithDAG(t *testing.T) {
 
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(
 				t,
 				tt.command,
 			)
 			require.NoError(t, err)
 
-			assert.Empty(t, stderr)
+			assert.NotEmpty(t, stderr)
 			assert.NotEmpty(t, stdout)
 
 			lines := strings.Split(stdout, "\n")
@@ -166,13 +170,15 @@ func TestParseFindListAllComponentsWithDAGAndExternal(t *testing.T) {
 
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(
 				t,
 				tt.command,
 			)
 			require.NoError(t, err)
 
-			assert.Empty(t, stderr)
+			assert.NotEmpty(t, stderr)
 			assert.NotEmpty(t, stdout)
 
 			lines := strings.Split(stdout, "\n")
@@ -190,7 +196,7 @@ func TestParseFindListAllComponentsWithDAGAndExternal(t *testing.T) {
 				}
 			}
 
-			assert.Less(t, aDepLine, bDepLine)
+			assert.Greater(t, aDepLine, bDepLine)
 		})
 	}
 }

--- a/test/integration_parse_test.go
+++ b/test/integration_parse_test.go
@@ -69,7 +69,7 @@ func TestParseAllFixtureFiles(t *testing.T) {
 	}
 }
 
-func TestFindListAllComponents(t *testing.T) {
+func TestParseFindListAllComponents(t *testing.T) {
 	t.Parallel()
 
 	tc := []struct {
@@ -111,7 +111,7 @@ func TestFindListAllComponents(t *testing.T) {
 	}
 }
 
-func TestFindListAllComponentsWithDAG(t *testing.T) {
+func TestParseFindListAllComponentsWithDAG(t *testing.T) {
 	t.Parallel()
 
 	tc := []struct {
@@ -153,7 +153,7 @@ func TestFindListAllComponentsWithDAG(t *testing.T) {
 	}
 }
 
-func TestFindListAllComponentsWithDAGAndExternal(t *testing.T) {
+func TestParseFindListAllComponentsWithDAGAndExternal(t *testing.T) {
 	t.Parallel()
 
 	tc := []struct {


### PR DESCRIPTION
## Description

Adds error handling for discovery.

This is important, as it allows the `list` and `find` commands to operate without failure when running against directories of configurations with requirements like authentication, etc. that aren't relevant to the discovery process.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `discovery` to handle errors gracefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CLI commands now handle minor configuration issues more gracefully by logging warnings instead of abruptly terminating, ensuring smoother operation.
  - Enhanced discovery process with improved error handling and suppression of parse errors.

- **Documentation**
  - Updated reference materials now reflect the finalized experimental tasks related to improved command processing, including completed integration tests for CLI commands. 

- **Tests**
  - Expanded test coverage for Terragrunt command functionalities with new test cases and improved memory management in the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->