### PR TITLE
feat: added support for parsing stack config from string

### DIFF
--- a/config/stack.go
+++ b/config/stack.go
@@ -503,6 +503,7 @@ func ReadStackConfigFile(ctx context.Context, opts *options.TerragruntOptions, f
 		return nil, errors.New(err)
 	}
 
+	//nolint:contextcheck
 	return ParseStackConfig(parser, opts, file, values)
 }
 
@@ -514,7 +515,6 @@ func ReadStackConfigString(
 	configString string,
 	values *cty.Value,
 ) (*StackConfig, error) {
-
 	parser := NewParsingContext(ctx, opts)
 
 	if values != nil {
@@ -526,6 +526,7 @@ func ReadStackConfigString(
 		return nil, errors.New(err)
 	}
 
+	//nolint:contextcheck
 	return ParseStackConfig(parser, opts, hclFile, values)
 }
 

--- a/config/stack.go
+++ b/config/stack.go
@@ -498,13 +498,41 @@ func ReadStackConfigFile(ctx context.Context, opts *options.TerragruntOptions, f
 
 	parser := NewParsingContext(ctx, opts)
 
+	file, err := hclparse.NewParser(parser.ParserOptions...).ParseFromFile(filePath)
+	if err != nil {
+		return nil, errors.New(err)
+	}
+
+	return ParseStackConfig(parser, opts, file, values)
+}
+
+// ReadStackConfigString reads and parses a Terragrunt stack configuration from a string.
+func ReadStackConfigString(
+	ctx context.Context,
+	opts *options.TerragruntOptions,
+	configPath string,
+	configString string,
+	values *cty.Value,
+) (*StackConfig, error) {
+
+	parser := NewParsingContext(ctx, opts)
+
 	if values != nil {
 		parser = parser.WithValues(values)
 	}
 
-	file, err := hclparse.NewParser(parser.ParserOptions...).ParseFromFile(filePath)
+	hclFile, err := hclparse.NewParser(parser.ParserOptions...).ParseFromString(configString, configPath)
 	if err != nil {
 		return nil, errors.New(err)
+	}
+
+	return ParseStackConfig(parser, opts, hclFile, values)
+}
+
+// ParseStackConfig parses the stack configuration from the given file and values.
+func ParseStackConfig(parser *ParsingContext, opts *options.TerragruntOptions, file *hclparse.File, values *cty.Value) (*StackConfig, error) {
+	if values != nil {
+		parser = parser.WithValues(values)
 	}
 
 	//nolint:contextcheck

--- a/config/stack_test.go
+++ b/config/stack_test.go
@@ -1,0 +1,152 @@
+package config_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTerragruntStackConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+locals {
+	project = "my-project"
+}
+
+unit "unit1" {
+	source = "units/app1"
+	path   = "unit1"
+}
+
+stack "projects" {
+	source = "../projects"
+	path = "projects"
+}
+
+`
+	opts := mockOptionsForTest(t)
+	ctx := config.NewParsingContext(context.Background(), opts)
+	terragruntStackConfig, err := config.ReadStackConfigString(ctx, opts, config.DefaultStackFile, cfg, nil)
+	require.NoError(t, err)
+
+	assert.NotNil(t, terragruntStackConfig)
+
+	assert.NotNil(t, terragruntStackConfig.Locals)
+	assert.Len(t, terragruntStackConfig.Locals, 1)
+	assert.Equal(t, "my-project", terragruntStackConfig.Locals["project"])
+
+	assert.NotNil(t, terragruntStackConfig.Units)
+	assert.Len(t, terragruntStackConfig.Units, 1)
+
+	unit := terragruntStackConfig.Units[0]
+	assert.Equal(t, "unit1", unit.Name)
+	assert.Equal(t, "units/app1", unit.Source)
+	assert.Equal(t, "unit1", unit.Path)
+	assert.Nil(t, unit.NoStack)
+
+	assert.NotNil(t, terragruntStackConfig.Stacks)
+	assert.Len(t, terragruntStackConfig.Stacks, 1)
+
+	stack := terragruntStackConfig.Stacks[0]
+	assert.Equal(t, "projects", stack.Name)
+	assert.Equal(t, "../projects", stack.Source)
+	assert.Equal(t, "projects", stack.Path)
+	assert.Nil(t, stack.NoStack)
+}
+
+func TestParseTerragruntStackConfigComplex(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+locals {
+    project = "my-project"
+    env     = "dev"
+}
+
+unit "unit1" {
+    source = "units/app1"
+    path   = "unit1"
+    no_dot_terragrunt_stack = true
+    values = {
+        name = "app1"
+        port = 8080
+    }
+}
+
+unit "unit2" {
+    source = "units/app2"
+    path   = "unit2"
+    no_dot_terragrunt_stack = false
+    values = {
+        name = "app2"
+        port = 9090
+    }
+}
+
+stack "projects" {
+    source = "../projects"
+    path = "projects"
+    values = {
+        region = "us-west-2"
+    }
+}
+
+stack "network" {
+    source = "../network"
+    path = "network"
+    no_dot_terragrunt_stack = true
+}
+`
+	opts := mockOptionsForTest(t)
+	ctx := config.NewParsingContext(context.Background(), opts)
+	terragruntStackConfig, err := config.ReadStackConfigString(ctx, opts, config.DefaultStackFile, cfg, nil)
+	require.NoError(t, err)
+
+	// Check that config is not nil
+	assert.NotNil(t, terragruntStackConfig)
+
+	assert.NotNil(t, terragruntStackConfig.Locals)
+	assert.Len(t, terragruntStackConfig.Locals, 2)
+	assert.Equal(t, "my-project", terragruntStackConfig.Locals["project"])
+	assert.Equal(t, "dev", terragruntStackConfig.Locals["env"])
+
+	assert.NotNil(t, terragruntStackConfig.Units)
+	assert.Len(t, terragruntStackConfig.Units, 2)
+
+	unit1 := terragruntStackConfig.Units[0]
+	assert.Equal(t, "unit1", unit1.Name)
+	assert.Equal(t, "units/app1", unit1.Source)
+	assert.Equal(t, "unit1", unit1.Path)
+	assert.NotNil(t, unit1.NoStack)
+	assert.True(t, *unit1.NoStack)
+	assert.NotNil(t, unit1.Values)
+
+	unit2 := terragruntStackConfig.Units[1]
+	assert.Equal(t, "unit2", unit2.Name)
+	assert.Equal(t, "units/app2", unit2.Source)
+	assert.Equal(t, "unit2", unit2.Path)
+	assert.NotNil(t, unit2.NoStack)
+	assert.False(t, *unit2.NoStack)
+	assert.NotNil(t, unit2.Values)
+
+	assert.NotNil(t, terragruntStackConfig.Stacks)
+	assert.Len(t, terragruntStackConfig.Stacks, 2)
+
+	stack1 := terragruntStackConfig.Stacks[0]
+	assert.Equal(t, "projects", stack1.Name)
+	assert.Equal(t, "../projects", stack1.Source)
+	assert.Equal(t, "projects", stack1.Path)
+	assert.Nil(t, stack1.NoStack)
+	assert.NotNil(t, stack1.Values)
+
+	stack2 := terragruntStackConfig.Stacks[1]
+	assert.Equal(t, "network", stack2.Name)
+	assert.Equal(t, "../network", stack2.Source)
+	assert.Equal(t, "network", stack2.Path)
+	assert.NotNil(t, stack2.NoStack)
+	assert.True(t, *stack2.NoStack)
+}

--- a/config/stack_test.go
+++ b/config/stack_test.go
@@ -150,3 +150,18 @@ stack "network" {
 	assert.NotNil(t, stack2.NoStack)
 	assert.True(t, *stack2.NoStack)
 }
+
+func TestParseTerragruntStackConfigInvalidSyntax(t *testing.T) {
+	t.Parallel()
+
+	invalidCfg := `
+locals {
+	project = "my-project
+}
+`
+	opts := mockOptionsForTest(t)
+	ctx := config.NewParsingContext(context.Background(), opts)
+	_, err := config.ReadStackConfigString(ctx, opts, config.DefaultStackFile, invalidCfg, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid multi-line string")
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Added support for parsing stack configuration from a raw string input
* Introduced basic unit tests to validate correct parsing behavior

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled the ability to load Terragrunt stack configurations directly from a string, offering more flexibility beyond file-based inputs.
  
- **Tests**
  - Enhanced test coverage with new scenarios validating both simple and complex configuration setups, including error handling for invalid syntax, to ensure robustness and accuracy in parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->