### PR TITLE
bug: added limitation on detection of stack files

### DIFF
--- a/config/stack.go
+++ b/config/stack.go
@@ -704,6 +704,12 @@ func listStackFiles(opts *options.TerragruntOptions, dir string) ([]string, erro
 			return nil
 		}
 
+		// skip files in Terragrunt cache directory
+		if strings.Contains(path, string(os.PathSeparator)+util.TerragruntCacheDir+string(os.PathSeparator)) ||
+			filepath.Base(path) == util.TerragruntCacheDir {
+			return filepath.SkipDir
+		}
+
 		if len(path) >= generationMaxPath {
 			return errors.Errorf("Cycle detected: maximum path length (%d) exceeded at %s", generationMaxPath, path)
 		}

--- a/test/fixtures/stacks/self-include/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/self-include/live/terragrunt.stack.hcl
@@ -1,0 +1,13 @@
+locals {
+  version = "stack-scanning-4111"
+}
+
+unit "app1" {
+  source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/self-include/units?ref=${local.version}"
+  path   = "app1"
+  values = {
+    data = "example-data"
+  }
+}
+
+

--- a/test/fixtures/stacks/self-include/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/self-include/live/terragrunt.stack.hcl
@@ -3,7 +3,7 @@ locals {
 }
 
 unit "app1" {
-  source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/self-include/units?ref=${local.version}"
+  source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/self-include/unit?ref=${local.version}"
   path   = "app1"
   values = {
     data = "example-data"

--- a/test/fixtures/stacks/self-include/module/main.tf
+++ b/test/fixtures/stacks/self-include/module/main.tf
@@ -1,0 +1,5 @@
+variable "data" {}
+
+output "data" {
+  value = var.data
+}

--- a/test/fixtures/stacks/self-include/module/terragrunt.hcl
+++ b/test/fixtures/stacks/self-include/module/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  data = values.data
+}

--- a/test/fixtures/stacks/self-include/unit/terragrunt.hcl
+++ b/test/fixtures/stacks/self-include/unit/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/self-include/units?ref=stack-scanning-4111"
+  source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/self-include/module?ref=stack-scanning-4111"
 }
 
 input = {

--- a/test/fixtures/stacks/self-include/unit/terragrunt.hcl
+++ b/test/fixtures/stacks/self-include/unit/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/self-include/units?ref=stack-scanning-4111"
+}
+
+input = {
+  data = values.data
+}

--- a/test/fixtures/stacks/self-include/unit/terragrunt.hcl
+++ b/test/fixtures/stacks/self-include/unit/terragrunt.hcl
@@ -2,6 +2,6 @@ terraform {
   source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/self-include/module?ref=stack-scanning-4111"
 }
 
-input = {
+inputs = {
   data = values.data
 }

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -45,6 +45,7 @@ const (
 	testFixtureNoStackNoDir                    = "fixtures/stacks/no-stack-dir"
 	testFixtureMultipleStacks                  = "fixtures/stacks/multiple-stacks"
 	testFixtureReadStack                       = "fixtures/stacks/read-stack"
+	testFixtureStackSelfInclude                = "fixtures/stacks/self-include"
 )
 
 func TestStacksGenerateBasic(t *testing.T) {
@@ -1082,6 +1083,19 @@ func validateNoStackDirs(t *testing.T, rootPath string) {
 
 	assert.DirExists(t, secondStackUnitConfigDir)
 	assert.FileExists(t, secondStackUnitConfig)
+}
+
+func TestStacksSelfInclude(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackSelfInclude)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackSelfInclude)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStackSelfInclude, "live")
+
+	helpers.RunTerragrunt(t, "terragrunt --experiment stacks stack run apply --non-interactive --working-dir "+rootPath)
+
+	path := util.JoinPath(rootPath, ".terragrunt-stack")
+	validateStackDir(t, path)
 }
 
 // check if the stack directory is created and contains files.

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -1096,6 +1096,9 @@ func TestStacksSelfInclude(t *testing.T) {
 
 	path := util.JoinPath(rootPath, ".terragrunt-stack")
 	validateStackDir(t, path)
+
+	// validate that subsequent runs don't fail
+	helpers.RunTerragrunt(t, "terragrunt --experiment stacks stack run apply --non-interactive --working-dir "+rootPath)
 }
 
 // check if the stack directory is created and contains files.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Added limitation on detection of stack files not to include `.terragrunt-cache`
* Added integration test to track that `.terragrunt-cache` files are skipped


Fixes #4111.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved stack file processing by excluding cache directories, ensuring faster and more accurate stack detection.
  - Introduced new configuration templates that support self-inclusion, including local variable definitions and integrations with external module sources.
- **Tests**
  - Added an integration test to validate the self-inclusion behavior, ensuring stability in stack operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->