### PR TITLE
fix: Suppressing warning for catalog when determining default file name

### DIFF
--- a/cli/commands/scaffold/cli.go
+++ b/cli/commands/scaffold/cli.go
@@ -40,6 +40,8 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 
 				if value != opts.TerragruntConfigPath {
 					opts.ScaffoldRootFileName = value
+
+					return nil
 				}
 
 				if err := opts.StrictControls.FilterByNames(controls.RootTerragruntHCL).Evaluate(ctx); err != nil {

--- a/cli/commands/scaffold/cli.go
+++ b/cli/commands/scaffold/cli.go
@@ -106,7 +106,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 }
 
 func GetDefaultRootFileName(ctx context.Context, opts *options.TerragruntOptions) string {
-	if err := opts.StrictControls.FilterByNames(controls.RootTerragruntHCL).Evaluate(ctx); err != nil {
+	if err := opts.StrictControls.FilterByNames(controls.RootTerragruntHCL).SuppressWarning().Evaluate(ctx); err != nil {
 		return config.RecommendedParentConfigName
 	}
 

--- a/internal/strict/control.go
+++ b/internal/strict/control.go
@@ -72,6 +72,15 @@ func (ctrls Controls) Names() ControlNames {
 	return names
 }
 
+// SuppressWarning suppresses the warning message from being displayed.
+func (ctrls Controls) SuppressWarning() Controls {
+	for _, ctrl := range ctrls {
+		ctrl.SuppressWarning()
+	}
+
+	return ctrls
+}
+
 // FilterByStatus filters `ctrls` by given statuses.
 func (ctrls Controls) FilterByStatus(statuses ...Status) Controls {
 	var filtered Controls


### PR DESCRIPTION
## Description

Suppresses the warning emitted when evaluating the default value for the root file name.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `catalog` logic to suppress warning when evaluating the default value for the root file name.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Suppressed unnecessary warning messages during configuration evaluation to provide a cleaner user experience.
  
- **Refactor**
	- Streamlined CLI flag processing with an early exit strategy to reduce redundant error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->