### PR TITLE
fix: Remove warning message for unimplemented backends

### DIFF
--- a/internal/remotestate/backend/common.go
+++ b/internal/remotestate/backend/common.go
@@ -31,9 +31,7 @@ func (backend *CommonBackend) Name() string {
 
 // NeedsBootstrap implements `backends.NeedsBootstrap` interface.
 func (backend *CommonBackend) NeedsBootstrap(ctx context.Context, config Config, opts *options.TerragruntOptions) (bool, error) {
-	opts.Logger.Warnf("NeedsBootstrap for %s backend not implemented", backend.Name())
-
-	return true, nil
+	return false, nil
 }
 
 // Bootstrap implements `backends.Bootstrap` interface.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixed display of warning message for unimplemented backends https://github.com/gruntwork-io/terragrunt/issues/4105#issuecomment-2783322811

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the bootstrapping check to accurately indicate that no additional initialization is necessary, eliminating prior misleading warning messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->