### PR TITLE
fix: Fixing optional default template

### DIFF
--- a/config/catalog.go
+++ b/config/catalog.go
@@ -38,7 +38,7 @@ var (
 )
 
 type CatalogConfig struct {
-	DefaultTemplate string   `hcl:"default_template,attr" cty:"default_template"`
+	DefaultTemplate string   `hcl:"default_template,optional" cty:"default_template"`
 	URLs            []string `hcl:"urls,attr" cty:"urls"`
 }
 


### PR DESCRIPTION
## Description

Fixes bug where `default_template` threw an error that it was required.

I can't actually reproduce the error that prompted this, but a customer reported it as a bug in their CI run, and it _is_ technically incorrect usage of the library.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `default_template` attribute of `catalog` config block to be optional.

