### PR TITLE
fix: Back out migrate command pending resolution

### DIFF
--- a/cli/commands/backend/cli.go
+++ b/cli/commands/backend/cli.go
@@ -2,9 +2,9 @@
 package backend
 
 import (
+	// "github.com/gruntwork-io/terragrunt/cli/commands/backend/migrate"
 	"github.com/gruntwork-io/terragrunt/cli/commands/backend/bootstrap"
 	"github.com/gruntwork-io/terragrunt/cli/commands/backend/delete"
-	// "github.com/gruntwork-io/terragrunt/cli/commands/backend/migrate"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"

--- a/cli/commands/backend/cli.go
+++ b/cli/commands/backend/cli.go
@@ -4,7 +4,7 @@ package backend
 import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/backend/bootstrap"
 	"github.com/gruntwork-io/terragrunt/cli/commands/backend/delete"
-	"github.com/gruntwork-io/terragrunt/cli/commands/backend/migrate"
+	// "github.com/gruntwork-io/terragrunt/cli/commands/backend/migrate"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
@@ -20,7 +20,11 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		Subcommands: cli.Commands{
 			bootstrap.NewCommand(opts),
 			delete.NewCommand(opts),
-			migrate.NewCommand(opts),
+			// NOTE: This has been backed out pending resolution of
+			// some fallback behavior for use-cases with mixed
+			// and unsupported backend types.
+			//
+			// migrate.NewCommand(opts),
 		},
 		ErrorOnUndefinedFlag: true,
 		Before: func(ctx *cli.Context) error {

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -214,6 +214,11 @@ func TestAwsBootstrapBackendWithoutVersioning(t *testing.T) {
 }
 
 func TestAwsMigrateBackendWithoutVersioning(t *testing.T) {
+	// NOTE: This is being backed out because the migration command
+	// needs some work to handle the case where the source and destination
+	// backends have unsupported types or differ.
+	t.Skip("Skipping test for now, as it needs to be reworked to handle unsupported backend types")
+
 	t.Parallel()
 
 	helpers.CleanupTerraformFolder(t, testFixtureS3Backend)
@@ -294,6 +299,11 @@ func TestAwsDeleteBackend(t *testing.T) {
 }
 
 func TestAwsMigrateBackend(t *testing.T) {
+	// NOTE: This is being backed out because the migration command
+	// needs some work to handle the case where the source and destination
+	// backends have unsupported types or differ.
+	t.Skip("Skipping test for now, as it needs to be reworked to handle unsupported backend types")
+
 	t.Parallel()
 
 	helpers.CleanupTerraformFolder(t, testFixtureS3Backend)

--- a/test/integration_gcp_test.go
+++ b/test/integration_gcp_test.go
@@ -126,6 +126,11 @@ func TestGcpBootstrapBackendWithoutVersioning(t *testing.T) {
 }
 
 func TestGcpMigrateBackendWithoutVersioning(t *testing.T) {
+	// NOTE: This is being backed out because the migration command
+	// needs some work to handle the case where the source and destination
+	// backends have unsupported types or differ.
+	t.Skip("Skipping test for now, as it needs to be reworked to handle unsupported backend types")
+
 	t.Parallel()
 
 	helpers.CleanupTerraformFolder(t, testFixtureGCSBackend)
@@ -193,6 +198,11 @@ func TestGcpDeleteBackend(t *testing.T) {
 }
 
 func TestGcpMigrateBackend(t *testing.T) {
+	// NOTE: This is being backed out because the migration command
+	// needs some work to handle the case where the source and destination
+	// backends have unsupported types or differ.
+	t.Skip("Skipping test for now, as it needs to be reworked to handle unsupported backend types")
+
 	t.Parallel()
 
 	helpers.CleanupTerraformFolder(t, testFixtureGCSBackend)


### PR DESCRIPTION
## Description

Backs out the migrate command until we're ready to release it.

There's some integration tests that are going to fail, and I have to back those out too.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Removed `backend migrate` pending ready for release.

