### PR TITLE
feat: Adding a bit more docs for stacks

### DIFF
--- a/docs-starlight/src/content/docs/04-reference/01-hcl/01-overview.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/01-overview.mdx
@@ -10,7 +10,7 @@ import { FileTree } from '@astrojs/starlight/components';
 
 Terragrunt configuration is defined in [HCL](https://github.com/hashicorp/hcl) files. This uses the same HCL syntax as OpenTofu/Terraform itself.
 
-Here’s an example:
+Here's an example:
 
 ```hcl
 # terragrunt.hcl
@@ -68,7 +68,7 @@ Currently terragrunt parses the config in the following order:
 
 8. A merge operation between the config referenced by `include` and the current config.
 
-Blocks that are parsed earlier in the process will be made available for use in the parsing of later blocks. Similarly, you cannot use blocks that are parsed later earlier in the process (e.g you can’t reference `dependency` in `locals`, `include`, or `dependencies` blocks).
+Blocks that are parsed earlier in the process will be made available for use in the parsing of later blocks. Similarly, you cannot use blocks that are parsed later earlier in the process (e.g you can't reference `dependency` in `locals`, `include`, or `dependencies` blocks).
 
 Note that the parsing order is slightly different when using the `--all` flag of the [`run`](/docs/reference/cli/commands/run) command. When using the `--all` flag, Terragrunt parses the configuration twice. In the first pass, it follows the following parsing order:
 
@@ -84,17 +84,19 @@ Note that the parsing order is slightly different when using the `--all` flag of
 
 The results of this pass are then used to build the dependency graph of the units in the stack. Once the graph is constructed, Terragrunt will loop through the units and run the specified command. It will then revert to the single configuration parsing order specified above for each unit as it runs the command.
 
-This allows Terragrunt to avoid resolving `dependency` on units that haven’t been applied yet when doing a clean deployment from scratch with `run-all apply`.
+This allows Terragrunt to avoid resolving `dependency` on units that haven't been applied yet when doing a clean deployment from scratch with `run-all apply`.
 
 ## Stacks
 
 When multiple units, each with their own `terragrunt.hcl` file exist in child directories of a single parent directory, that parent directory becomes a [stack](/docs/getting-started/terminology#stack).
 
-To make it easier to generate configurations like this, Terragrunt has special tooling in the form of `terragrunt.stack.hcl` files.
+To make it easier to generate configurations like this, Terragrunt has special tooling in the form of `terragrunt.stack.hcl` files. `terragrunt.stack.hcl` files support all the same HCL functions as `terragrunt.hcl` files, however, they don't support any top-level attributes, and the configuration blocks they support are limited to the following:
 
-These special configurations are used by the [stack generate](/docs/reference/cli/commands/stack/generate) (and all the other `stack` prefixed) commands to generate units programmatically.
+- [unit](/docs/reference/hcl/blocks#unit)
+- [stack](/docs/reference/hcl/blocks#stack)
+- [locals](/docs/reference/hcl/blocks#locals)
 
-Stacks are still an [experiment](/docs/reference/experiments#stacks). Expect more documentation on stacks by the time they are generally available.
+These special configurations are used by the [stack generate command](/docs/reference/cli/commands/stack/generate) (and all the other `stack` prefixed commands) to generate units programmatically, on demand. The units they generate are valid unit configurations, and can be read and used as if they were manually authored.
 
 ## Included Configurations
 
@@ -141,7 +143,7 @@ If you run `terragrunt hclfmt` at the `root`, this will update:
 
 You can set `--diff` option. `terragrunt hclfmt --diff` will output the diff in a unified format which can be redirected to your favourite diff tool. `diff` utility must be presented in PATH.
 
-Additionally, there’s a flag `--check`. `terragrunt hclfmt --check` will only verify if the files are correctly formatted **without rewriting** them. The command will return exit status 1 if any matching files are improperly formatted, or 0 if all matching `.hcl` files are correctly formatted.
+Additionally, there's a flag `--check`. `terragrunt hclfmt --check` will only verify if the files are correctly formatted **without rewriting** them. The command will return exit status 1 if any matching files are improperly formatted, or 0 if all matching `.hcl` files are correctly formatted.
 
 You can exclude directories from the formatting process by using the `--hclfmt-exclude-dir` flag. For example, `terragrunt hclfmt --hclfmt-exclude-dir=qa/services`.
 

--- a/docs/_docs/04_reference/01-configuration.md
+++ b/docs/_docs/04_reference/01-configuration.md
@@ -11,7 +11,7 @@ nav_title_link: /docs/
 slug: configuration
 ---
 
-Terragrunt configuration is defined in a `terragrunt.hcl` file. This uses the same HCL syntax as OpenTofu/Terraform itself.
+Terragrunt unit configuration is defined in `terragrunt.hcl` files. These files use the same HCL syntax as OpenTofu/Terraform itself.
 
 Here’s an example:
 
@@ -83,6 +83,18 @@ Note that the parsing order is slightly different when using the `-all` flavors 
 The results of this pass are then used to build the dependency graph of the units in the stack. Once the graph is constructed, Terragrunt will loop through the units and run the specified command. It will then revert to the single configuration parsing order specified above for each unit as it runs the command.
 
 This allows Terragrunt to avoid resolving `dependency` on units that haven’t been applied yet when doing a clean deployment from scratch with `run-all apply`.
+
+## Stacks
+
+When multiple units, each with their own `terragrunt.hcl` file exist in child directories of a single parent directory, that parent directory becomes a [stack](/docs/getting-started/terminology#stack).
+
+To make it easier to generate configurations like this, Terragrunt has special tooling in the form of `terragrunt.stack.hcl` files. `terragrunt.stack.hcl` files support all the same HCL functions as `terragrunt.hcl` files, however, they don't support any top-level attributes, and the configuration blocks they support are limited to the following:
+
+- [unit](/docs/reference/hcl/config-blocks-and-attributes#unit)
+- [stack](/docs/reference/hcl/config-blocks-and-attributes#stack)
+- [locals](/docs/reference/hcl/config-blocks-and-attributes#locals)
+
+These special configurations are used by the [stack generate command](/docs/reference/cli/commands/stack/generate) (and all the other `stack` prefixed commands) to generate units programmatically, on demand. The units they generate are valid unit configurations, and can be read and used as if they were manually authored.
 
 ## Formatting HCL files
 


### PR DESCRIPTION
## Description

Adds a bit more docs for stacks so that users have a single place they can go to learn more about how to author them.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added a dedicated section on `terragrunt.stack.hcl` configurations so that users have a single place where they can start learning about them.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved text clarity and consistency through grammatical corrections.
	- Expanded explanations on configuration differences, helping users better understand unit setups.
	- Added a new section detailing how multi-unit configurations are managed and generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->