### PR TITLE
feat: Adding `render` command

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -586,7 +586,7 @@ func TestAutocomplete(t *testing.T) { //nolint:paralleltest
 		},
 		{
 			"run-all ren",
-			[]string{"render-json"},
+			[]string{"render", "render-json"},
 		},
 	}
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/find"
 	"github.com/gruntwork-io/terragrunt/cli/commands/info"
 	"github.com/gruntwork-io/terragrunt/cli/commands/list"
+	"github.com/gruntwork-io/terragrunt/cli/commands/render"
 	"github.com/gruntwork-io/terragrunt/cli/commands/stack"
 	"github.com/gruntwork-io/terragrunt/options"
 
@@ -90,6 +91,7 @@ func New(opts *options.TerragruntOptions) cli.Commands {
 		info.NewCommand(opts),               // info
 		terragruntinfo.NewCommand(opts),     // terragrunt-info
 		renderjson.NewCommand(opts),         // render-json
+		render.NewCommand(opts),             // render
 		helpCmd.NewCommand(opts),            // help (hidden)
 		versionCmd.NewCommand(opts),         // version (hidden)
 		awsproviderpatch.NewCommand(opts),   // aws-provider-patch (hidden)

--- a/cli/commands/render-json/cli.go
+++ b/cli/commands/render-json/cli.go
@@ -1,4 +1,6 @@
 // Package renderjson provides the command to render the final terragrunt config, with all variables, includes, and functions resolved, as json.
+// Deprecated: This package is deprecated and will be removed in a future version.
+// Use the 'terragrunt render' command instead.
 package renderjson
 
 import (

--- a/cli/commands/render/cli.go
+++ b/cli/commands/render/cli.go
@@ -1,0 +1,81 @@
+// Package render provides the command to render the final terragrunt config in various formats.
+package render
+
+import (
+	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
+	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
+	"github.com/gruntwork-io/terragrunt/cli/commands/run"
+	"github.com/gruntwork-io/terragrunt/cli/flags"
+	"github.com/gruntwork-io/terragrunt/internal/cli"
+	"github.com/gruntwork-io/terragrunt/options"
+)
+
+const (
+	CommandName = "render"
+
+	FormatFlagName                  = "format"
+	WriteFlagName                   = "write"
+	OutFlagName                     = "out"
+	WithMetadataFlagName            = "with-metadata"
+	DisableDependentModulesFlagName = "disable-dependent-modules"
+)
+
+func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
+	tgPrefix := prefix.Prepend(flags.TgPrefix)
+
+	return cli.Flags{
+		flags.NewFlag(&cli.GenericFlag[string]{
+			Name:        FormatFlagName,
+			EnvVars:     tgPrefix.EnvVars(FormatFlagName),
+			Destination: &opts.Format,
+			Usage:       "The output format to render the config in. Currently supports: json",
+		}),
+
+		flags.NewFlag(&cli.BoolFlag{
+			Name:        WriteFlagName,
+			EnvVars:     tgPrefix.EnvVars(WriteFlagName),
+			Destination: &opts.Write,
+			Usage:       "Write the rendered config to a file.",
+		}),
+
+		flags.NewFlag(&cli.GenericFlag[string]{
+			Name:        OutFlagName,
+			EnvVars:     tgPrefix.EnvVars(OutFlagName),
+			Destination: &opts.JSONOut,
+			Usage:       "The file name that terragrunt should use when rendering the terragrunt.hcl config (next to the unit configuration).",
+		}),
+
+		flags.NewFlag(&cli.BoolFlag{
+			Name:        WithMetadataFlagName,
+			EnvVars:     tgPrefix.EnvVars(WithMetadataFlagName),
+			Destination: &opts.RenderJSONWithMetadata,
+			Usage:       "Add metadata to the rendered output file.",
+		}),
+
+		flags.NewFlag(&cli.BoolFlag{
+			Name:        DisableDependentModulesFlagName,
+			EnvVars:     tgPrefix.EnvVars(DisableDependentModulesFlagName),
+			Destination: &opts.JSONDisableDependentModules,
+			Usage:       "Disable identification of dependent modules when rendering config.",
+		}),
+	}
+}
+
+func NewCommand(opts *options.TerragruntOptions) *cli.Command {
+	prefix := flags.Prefix{CommandName}
+	renderOpts := NewOptions(opts)
+
+	cmd := &cli.Command{
+		Name:                 CommandName,
+		Usage:                "Render the final terragrunt config, with all variables, includes, and functions resolved, in the specified format.",
+		Description:          "This is useful for enforcing policies using static analysis tools like Open Policy Agent, or for debugging your terragrunt config.",
+		Flags:                append(run.NewFlags(opts, nil), NewFlags(renderOpts, prefix)...),
+		Action:               func(ctx *cli.Context) error { return Run(ctx, renderOpts) },
+		ErrorOnUndefinedFlag: true,
+	}
+
+	cmd = runall.WrapCommand(opts, cmd)
+	cmd = graph.WrapCommand(opts, cmd)
+
+	return cmd
+}

--- a/cli/commands/render/cli.go
+++ b/cli/commands/render/cli.go
@@ -2,11 +2,11 @@
 package render
 
 import (
-	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	"github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
+	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -14,7 +14,9 @@ const (
 	CommandName = "render"
 
 	FormatFlagName                  = "format"
+	JSONFlagName                    = "json"
 	WriteFlagName                   = "write"
+	WriteAliasFlagName              = "w"
 	OutFlagName                     = "out"
 	WithMetadataFlagName            = "with-metadata"
 	DisableDependentModulesFlagName = "disable-dependent-modules"
@@ -29,11 +31,46 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			EnvVars:     tgPrefix.EnvVars(FormatFlagName),
 			Destination: &opts.Format,
 			Usage:       "The output format to render the config in. Currently supports: json",
+			Action: func(ctx *cli.Context, value string) error {
+				// Set the default output path based on the format.
+				switch value {
+				case FormatJSON:
+					if opts.OutputPath == "" {
+						opts.OutputPath = "terragrunt.rendered.json"
+					}
+
+					return nil
+				case FormatHCL:
+					if opts.OutputPath == "" {
+						opts.OutputPath = "terragrunt.rendered.hcl"
+					}
+
+					return nil
+				default:
+					return errors.New("invalid format: " + value)
+				}
+			},
+		}),
+
+		flags.NewFlag(&cli.BoolFlag{
+			Name:    JSONFlagName,
+			EnvVars: tgPrefix.EnvVars(JSONFlagName),
+			Usage:   "Render the config in JSON format. Equivalent to --format=json.",
+			Action: func(ctx *cli.Context, value bool) error {
+				opts.Format = FormatJSON
+
+				if opts.OutputPath == "" {
+					opts.OutputPath = "terragrunt.rendered.json"
+				}
+
+				return nil
+			},
 		}),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        WriteFlagName,
 			EnvVars:     tgPrefix.EnvVars(WriteFlagName),
+			Aliases:     []string{WriteAliasFlagName},
 			Destination: &opts.Write,
 			Usage:       "Write the rendered config to a file.",
 		}),
@@ -41,21 +78,21 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        OutFlagName,
 			EnvVars:     tgPrefix.EnvVars(OutFlagName),
-			Destination: &opts.JSONOut,
+			Destination: &opts.OutputPath,
 			Usage:       "The file name that terragrunt should use when rendering the terragrunt.hcl config (next to the unit configuration).",
 		}),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        WithMetadataFlagName,
 			EnvVars:     tgPrefix.EnvVars(WithMetadataFlagName),
-			Destination: &opts.RenderJSONWithMetadata,
+			Destination: &opts.RenderMetadata,
 			Usage:       "Add metadata to the rendered output file.",
 		}),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        DisableDependentModulesFlagName,
 			EnvVars:     tgPrefix.EnvVars(DisableDependentModulesFlagName),
-			Destination: &opts.JSONDisableDependentModules,
+			Destination: &opts.DisableDependentModules,
 			Usage:       "Disable identification of dependent modules when rendering config.",
 		}),
 	}
@@ -66,16 +103,21 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 	renderOpts := NewOptions(opts)
 
 	cmd := &cli.Command{
-		Name:                 CommandName,
-		Usage:                "Render the final terragrunt config, with all variables, includes, and functions resolved, in the specified format.",
-		Description:          "This is useful for enforcing policies using static analysis tools like Open Policy Agent, or for debugging your terragrunt config.",
-		Flags:                append(run.NewFlags(opts, nil), NewFlags(renderOpts, prefix)...),
-		Action:               func(ctx *cli.Context) error { return Run(ctx, renderOpts) },
+		Name:        CommandName,
+		Usage:       "Render the final terragrunt config, with all variables, includes, and functions resolved, in the specified format.",
+		Description: "This is useful for enforcing policies using static analysis tools like Open Policy Agent, or for debugging your terragrunt config.",
+		Flags:       append(run.NewFlags(opts, nil), NewFlags(renderOpts, prefix)...),
+		Action: func(ctx *cli.Context) error {
+			tgOpts := opts.OptionsFromContext(ctx)
+			renderOpts := renderOpts.Clone()
+			renderOpts.TerragruntOptions = tgOpts
+
+			return Run(ctx, renderOpts)
+		},
 		ErrorOnUndefinedFlag: true,
 	}
 
 	cmd = runall.WrapCommand(opts, cmd)
-	cmd = graph.WrapCommand(opts, cmd)
 
 	return cmd
 }

--- a/cli/commands/render/cli.go
+++ b/cli/commands/render/cli.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -113,6 +114,13 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 			renderOpts.TerragruntOptions = tgOpts
 
 			return Run(ctx, renderOpts)
+		},
+		Before: func(ctx *cli.Context) error {
+			if !opts.Experiments.Evaluate(experiment.CLIRedesign) {
+				return cli.NewExitError(errors.Errorf("requires that the %[1]s experiment is enabled. e.g. --experiment %[1]s", experiment.CLIRedesign), cli.ExitCodeGeneralError)
+			}
+
+			return nil
 		},
 		ErrorOnUndefinedFlag: true,
 	}

--- a/cli/commands/render/options.go
+++ b/cli/commands/render/options.go
@@ -6,6 +6,9 @@ import (
 )
 
 const (
+	// FormatHCL outputs the config in HCL format.
+	FormatHCL = "hcl"
+
 	// FormatJSON outputs the config in JSON format.
 	FormatJSON = "json"
 )
@@ -16,26 +19,39 @@ type Options struct {
 	// Format determines the format of the output.
 	Format string
 
+	// OutputPath is the path to the file to write the rendered config to.
+	// This configuration is relative to the Terragrunt config path.
+	OutputPath string
+
 	// Write the rendered config to a file.
 	Write bool
+
+	// RenderMetadata adds metadata to the rendered config.
+	RenderMetadata bool
+
+	// DisableDependentModules disables the identification of dependent modules when rendering config.
+	DisableDependentModules bool
 }
 
 func NewOptions(opts *options.TerragruntOptions) *Options {
 	return &Options{
-		TerragruntOptions: opts,
-		Format:            FormatJSON,
-		Write:             false,
+		TerragruntOptions:       opts,
+		Format:                  FormatHCL,
+		Write:                   false,
+		RenderMetadata:          false,
+		DisableDependentModules: false,
 	}
 }
 
-func (o *Options) WithWrite() *Options {
-	o.Write = true
-	return o
-}
-
-func (o *Options) WithFormat(format string) *Options {
-	o.Format = format
-	return o
+func (o *Options) Clone() *Options {
+	return &Options{
+		TerragruntOptions:       o.TerragruntOptions.Clone(),
+		Format:                  o.Format,
+		OutputPath:              o.OutputPath,
+		Write:                   o.Write,
+		RenderMetadata:          o.RenderMetadata,
+		DisableDependentModules: o.DisableDependentModules,
+	}
 }
 
 func (o *Options) Validate() error {
@@ -48,6 +64,8 @@ func (o *Options) Validate() error {
 
 func (o *Options) validateFormat() error {
 	switch o.Format {
+	case FormatHCL:
+		return errors.New("the HCL format will be implemented in a future version, but is not yet supported. Use --format json to render the config in JSON format.")
 	case FormatJSON:
 		return nil
 	default:

--- a/cli/commands/render/options.go
+++ b/cli/commands/render/options.go
@@ -1,0 +1,56 @@
+package render
+
+import (
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/options"
+)
+
+const (
+	// FormatJSON outputs the config in JSON format.
+	FormatJSON = "json"
+)
+
+type Options struct {
+	*options.TerragruntOptions
+
+	// Format determines the format of the output.
+	Format string
+
+	// Write the rendered config to a file.
+	Write bool
+}
+
+func NewOptions(opts *options.TerragruntOptions) *Options {
+	return &Options{
+		TerragruntOptions: opts,
+		Format:            FormatJSON,
+		Write:             false,
+	}
+}
+
+func (o *Options) WithWrite() *Options {
+	o.Write = true
+	return o
+}
+
+func (o *Options) WithFormat(format string) *Options {
+	o.Format = format
+	return o
+}
+
+func (o *Options) Validate() error {
+	if err := o.validateFormat(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *Options) validateFormat() error {
+	switch o.Format {
+	case FormatJSON:
+		return nil
+	default:
+		return errors.New("invalid format: " + o.Format)
+	}
+}

--- a/cli/commands/render/render.go
+++ b/cli/commands/render/render.go
@@ -1,0 +1,137 @@
+// Package render provides the command to render the final terragrunt config in various formats.
+package render
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gruntwork-io/terragrunt/cli/commands/run"
+	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/configstack"
+	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+func Run(ctx context.Context, opts *Options) error {
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	target := run.NewTarget(run.TargetPointParseConfig, runRender(opts))
+
+	return run.RunWithTarget(ctx, opts.TerragruntOptions, target)
+}
+
+func runRender(opts *Options) func(ctx context.Context, terragruntOpts *options.TerragruntOptions, cfg *config.TerragruntConfig) error {
+	return func(ctx context.Context, terragruntOpts *options.TerragruntOptions, cfg *config.TerragruntConfig) error {
+		if cfg == nil {
+			return errors.New("terragrunt was not able to render the config because it received no config. This is almost certainly a bug in Terragrunt. Please open an issue on github.com/gruntwork-io/terragrunt with this message and the contents of your terragrunt.hcl")
+		}
+
+		switch opts.Format {
+		case FormatJSON:
+			return renderJSON(ctx, opts, cfg)
+		default:
+			return fmt.Errorf("unsupported render format: %s", opts.Format)
+		}
+	}
+}
+
+func renderJSON(ctx context.Context, opts *Options, cfg *config.TerragruntConfig) error {
+	if !opts.JSONDisableDependentModules {
+		dependentModules := configstack.FindWhereWorkingDirIsIncluded(ctx, opts.TerragruntOptions, cfg)
+
+		var dependentModulesPath []*string
+		for _, module := range dependentModules {
+			dependentModulesPath = append(dependentModulesPath, &module.Path)
+		}
+
+		cfg.DependentModulesPath = dependentModulesPath
+		cfg.SetFieldMetadata(config.MetadataDependentModules, map[string]any{config.FoundInFile: opts.TerragruntConfigPath})
+	}
+
+	var terragruntConfigCty cty.Value
+
+	if opts.RenderJSONWithMetadata {
+		cty, err := config.TerragruntConfigAsCtyWithMetadata(cfg)
+		if err != nil {
+			return err
+		}
+
+		terragruntConfigCty = cty
+	} else {
+		cty, err := config.TerragruntConfigAsCty(cfg)
+		if err != nil {
+			return err
+		}
+
+		terragruntConfigCty = cty
+	}
+
+	jsonBytes, err := marshalCtyValueJSONWithoutType(terragruntConfigCty)
+	if err != nil {
+		return err
+	}
+
+	if opts.Write {
+		return writeRendered(opts, jsonBytes)
+	}
+
+	_, err = opts.Writer.Write(jsonBytes)
+	if err != nil {
+		return errors.New(err)
+	}
+
+	return nil
+}
+
+func writeRendered(opts *Options, data []byte) error {
+	jsonOutPath := opts.JSONOut
+	if !filepath.IsAbs(jsonOutPath) {
+		terragruntConfigDir := filepath.Dir(opts.TerragruntConfigPath)
+		jsonOutPath = filepath.Join(terragruntConfigDir, jsonOutPath)
+	}
+
+	if err := util.EnsureDirectory(filepath.Dir(jsonOutPath)); err != nil {
+		return err
+	}
+
+	opts.Logger.Debugf("Rendering config %s to JSON %s", opts.TerragruntConfigPath, jsonOutPath)
+
+	const ownerWriteGlobalReadPerms = 0644
+	if err := os.WriteFile(jsonOutPath, data, ownerWriteGlobalReadPerms); err != nil {
+		return errors.New(err)
+	}
+
+	return nil
+}
+
+// marshalCtyValueJSONWithoutType marshals the given cty.Value object into a JSON object that does not have the type.
+// Using ctyjson directly would render a json object with two attributes, "value" and "type", and this function returns
+// just the "value".
+// NOTE: We have to do two marshalling passes so that we can extract just the value.
+func marshalCtyValueJSONWithoutType(ctyVal cty.Value) ([]byte, error) {
+	jsonBytesIntermediate, err := ctyjson.Marshal(ctyVal, cty.DynamicPseudoType)
+	if err != nil {
+		return nil, errors.New(err)
+	}
+
+	var ctyJSONOutput ctyhelper.CtyJSONOutput
+	if err := json.Unmarshal(jsonBytesIntermediate, &ctyJSONOutput); err != nil {
+		return nil, errors.New(err)
+	}
+
+	jsonBytes, err := json.MarshalIndent(ctyJSONOutput.Value, "", "  ")
+	if err != nil {
+		return nil, errors.New(err)
+	}
+
+	return jsonBytes, nil
+}

--- a/cli/commands/run-all/cli.go
+++ b/cli/commands/run-all/cli.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	graphdependencies "github.com/gruntwork-io/terragrunt/cli/commands/graph-dependencies"
 	"github.com/gruntwork-io/terragrunt/cli/commands/hclfmt"
+	"github.com/gruntwork-io/terragrunt/cli/commands/render"
 	renderjson "github.com/gruntwork-io/terragrunt/cli/commands/render-json"
 	"github.com/gruntwork-io/terragrunt/cli/commands/run"
 	terragruntinfo "github.com/gruntwork-io/terragrunt/cli/commands/terragrunt-info"
@@ -53,6 +54,7 @@ func subCommands(opts *options.TerragruntOptions) cli.Commands {
 		validateinputs.NewCommand(opts),    // validate-inputs
 		graphdependencies.NewCommand(opts), // graph-dependencies
 		hclfmt.NewCommand(opts),            // hclfmt
+		render.NewCommand(opts),            // render
 		renderjson.NewCommand(opts),        // render-json
 		awsproviderpatch.NewCommand(opts),  // aws-provider-patch
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1011,7 +1011,8 @@ func decodeAsTerragruntConfigFile(ctx *ParsingContext, file *hclparse.File, eval
 		ok := errors.As(err, &diagErr)
 
 		// in case of render-json command and inputs reference error, we update the inputs with default value
-		if !ok || !isRenderJSONCommand(ctx) || !isRenderCommand(ctx) || !isAttributeAccessError(diagErr) {
+		if !(ok && isRenderJSONCommand(ctx) && isAttributeAccessError(diagErr)) &&
+			!(ok && isRenderCommand(ctx) && isAttributeAccessError(diagErr)) {
 			return &terragruntConfig, err
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1011,7 +1011,7 @@ func decodeAsTerragruntConfigFile(ctx *ParsingContext, file *hclparse.File, eval
 		ok := errors.As(err, &diagErr)
 
 		// in case of render-json command and inputs reference error, we update the inputs with default value
-		if !ok || !isRenderJSONCommand(ctx) || !isAttributeAccessError(diagErr) {
+		if !ok || !isRenderJSONCommand(ctx) || !isRenderCommand(ctx) || !isAttributeAccessError(diagErr) {
 			return &terragruntConfig, err
 		}
 

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -536,7 +536,7 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 				ok := errors.As(err, &diagErr)
 
 				// in case of render-json command and inputs reference error, we update the inputs with default value
-				if !ok || !isRenderJSONCommand(ctx) || !isAttributeAccessError(diagErr) {
+				if !ok || !isRenderJSONCommand(ctx) || !isRenderCommand(ctx) || !isAttributeAccessError(diagErr) {
 					return nil, err
 				}
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -39,7 +39,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/util"
 )
 
-const renderJSONCommand = "render-json"
+const (
+	renderJSONCommand = "render-json"
+	renderCommand     = "render"
+)
 
 type Dependencies []Dependency
 
@@ -541,7 +544,7 @@ func (dep Dependency) shouldReturnMockOutputs(ctx *ParsingContext) bool {
 			len(*dep.MockOutputsAllowedTerraformCommands) == 0 ||
 			util.ListContainsElement(*dep.MockOutputsAllowedTerraformCommands, ctx.TerragruntOptions.OriginalTerraformCommand)
 
-	return defaultOutputsSet && allowedCommand || isRenderJSONCommand(ctx)
+	return defaultOutputsSet && allowedCommand || isRenderJSONCommand(ctx) || isRenderCommand(ctx)
 }
 
 // Return the output from the state of another module, managed by terragrunt. This function will parse the provided
@@ -556,7 +559,7 @@ func getTerragruntOutput(ctx *ParsingContext, dependencyConfig Dependency) (*cty
 
 	jsonBytes, err := getOutputJSONWithCaching(ctx, targetConfigPath)
 	if err != nil {
-		if !isRenderJSONCommand(ctx) && !isAwsS3NoSuchKey(err) {
+		if !isRenderJSONCommand(ctx) && !isRenderCommand(ctx) && !isAwsS3NoSuchKey(err) {
 			return nil, true, err
 		}
 
@@ -596,6 +599,11 @@ func isAwsS3NoSuchKey(err error) bool {
 // isRenderJSONCommand This function will true if terragrunt was invoked with render-json
 func isRenderJSONCommand(ctx *ParsingContext) bool {
 	return util.ListContainsElement(ctx.TerragruntOptions.TerraformCliArgs, renderJSONCommand)
+}
+
+// isRenderCommand will return true if terragrunt was invoked with render
+func isRenderCommand(ctx *ParsingContext) bool {
+	return util.ListContainsElement(ctx.TerragruntOptions.TerraformCliArgs, renderCommand)
 }
 
 // getOutputJSONWithCaching will run terragrunt output on the target config if it is not already cached.

--- a/docs-starlight/src/data/commands/render.mdx
+++ b/docs-starlight/src/data/commands/render.mdx
@@ -17,6 +17,8 @@ examples:
       terragrunt render --format=json
 flags:
   - render-format
+  - render-write
+  - render-all
 ---
 
 Render the Terragrunt configuration in the current working directory, with as much work done as possible beforehand (that is, with all includes merged, dependencies resolved/interpolated, function calls executed, etc).
@@ -53,10 +55,19 @@ You can also use the `--write` flag to write the rendered configuration to a can
 Example:
 
 ```bash
-# Note the use of the `--json` shortcut flag. The `--write` flag also has a shorter alias of `-w`.
+# Note the use of the `--json` shortcut flag.
 terragrunt render --json --write
 ```
 
 This will write the rendered configuration to `terragrunt.rendered.json` in the current working directory.
 
 This can be useful when rendering many configurations in a given directory, and you want to keep the rendered configurations in the same directory as the original configurations, without leveraging external tools or scripts.
+
+This is also useful when combined with the `--all` flag, which will render all configurations discovered from the current working directory.
+
+```bash
+# Note the use of the `-w` alias for the `--write` flag.
+terragrunt render --all --json -w
+```
+
+This will render all configurations discovered from the current working directory and write the rendered configurations to `terragrunt.rendered.json` files adjacent to the configurations they are derived from.

--- a/docs-starlight/src/data/commands/render.mdx
+++ b/docs-starlight/src/data/commands/render.mdx
@@ -4,7 +4,8 @@ path: render
 category: configuration
 sidebar:
   order: 1100
-description: Render a simplified, but equivalent Terragrunt config.
+description: |
+  Render the Terragrunt configuration in the current working directory, with as much work done as possible beforehand (that is, with all includes merged, dependencies resolved/interpolated, function calls executed, etc).
 usage: |
   Generate a simplified version of the Terragrunt configuration with all includes and dependencies resolved.
 experiment:
@@ -17,3 +18,45 @@ examples:
 flags:
   - render-format
 ---
+
+Render the Terragrunt configuration in the current working directory, with as much work done as possible beforehand (that is, with all includes merged, dependencies resolved/interpolated, function calls executed, etc).
+
+The only supported format at the moment is JSON, but support for HCL will be added in a future version.
+
+Example:
+
+The following `terragrunt.hcl`:
+
+```hcl
+locals {
+  aws_region = "us-east-1"
+}
+
+inputs = {
+  aws_region = local.aws_region
+}
+```
+
+Renders to the following JSON:
+
+```bash
+$ terragrunt render --format json
+{
+  "locals": { "aws_region": "us-east-1" },
+  "inputs": { "aws_region": "us-east-1" }
+  // NOTE: other attributes are omitted for brevity
+}
+```
+
+You can also use the `--write` flag to write the rendered configuration to a canonically named file in the same working directory as the `terragrunt.hcl` file.
+
+Example:
+
+```bash
+# Note the use of the `--json` shortcut flag. The `--write` flag also has a shorter alias of `-w`.
+terragrunt render --json --write
+```
+
+This will write the rendered configuration to `terragrunt.rendered.json` in the current working directory.
+
+This can be useful when rendering many configurations in a given directory, and you want to keep the rendered configurations in the same directory as the original configurations, without leveraging external tools or scripts.

--- a/docs-starlight/src/data/flags/render-all.mdx
+++ b/docs-starlight/src/data/flags/render-all.mdx
@@ -1,0 +1,23 @@
+---
+name: all
+description: Render all configurations discovered from the current working directory.
+type: boolean
+env:
+  - TG_ALL
+aliases:
+  - a
+---
+
+Example:
+
+```bash
+terragrunt render --all --json
+```
+
+This will render all configurations discovered from the current working directory and write the rendered configurations to `terragrunt.rendered.json` files adjacent to the configurations they are derived from.
+
+Combining this with the `--write` flag will write the rendered configurations to `terragrunt.rendered.json` files adjacent to the configurations they are derived from.
+
+```bash
+terragrunt render -a --json --write
+```

--- a/docs-starlight/src/data/flags/render-write.mdx
+++ b/docs-starlight/src/data/flags/render-write.mdx
@@ -1,0 +1,17 @@
+---
+name: write
+description: Write the rendered configuration to a file (terragrunt.rendered.hcl or terragrunt.rendered.json by default).
+type: boolean
+env:
+  - TG_WRITE
+aliases:
+  - w
+---
+
+Example:
+
+```bash
+terragrunt render --write --json
+```
+
+This will write the rendered configuration to `terragrunt.rendered.json` in the current working directory.

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -1131,6 +1131,50 @@ This may produce output such as:
 }
 ```
 
+#### render
+
+Render the Terragrunt configuration in the current working directory, with as much work done as possible beforehand (that is, with all includes merged, dependencies resolved/interpolated, function calls executed, etc).
+
+The only supported format at the moment is JSON, but support for HCL will be added in a future version.
+
+Example:
+
+The following `terragrunt.hcl`:
+
+```hcl
+locals {
+  aws_region = "us-east-1"
+}
+
+inputs = {
+  aws_region = local.aws_region
+}
+```
+
+Renders to the following JSON:
+
+```bash
+$ terragrunt render --format json
+{
+  "locals": { "aws_region": "us-east-1" },
+  "inputs": { "aws_region": "us-east-1" }
+  // NOTE: other attributes are omitted for brevity
+}
+```
+
+You can also use the `--write` flag to write the rendered configuration to a canonically named file in the same working directory as the `terragrunt.hcl` file.
+
+Example:
+
+```bash
+# Note the use of the `--json` shortcut flag. The `--write` flag also has a shorter alias of `-w`.
+terragrunt render --json --write
+```
+
+This will write the rendered configuration to `terragrunt.rendered.json` in the current working directory.
+
+This can be useful when rendering many configurations in a given directory, and you want to keep the rendered configurations in the same directory as the original configurations, without leveraging external tools or scripts.
+
 #### render-json
 
 Render out the final interpreted `terragrunt.hcl` file (that is, with all the includes merged, dependencies
@@ -1359,6 +1403,7 @@ This command will exit with an error if terragrunt detects any unused inputs or 
     - [hclfmt](#hclfmt)
     - [hclvalidate](#hclvalidate)
     - [output-module-groups](#output-module-groups)
+    - [render](#render)
     - [render-json](#render-json)
     - [info](#info)
       - [Strict command](#strict-command)

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -1167,13 +1167,22 @@ You can also use the `--write` flag to write the rendered configuration to a can
 Example:
 
 ```bash
-# Note the use of the `--json` shortcut flag. The `--write` flag also has a shorter alias of `-w`.
+# Note the use of the `--json` shortcut flag.
 terragrunt render --json --write
 ```
 
 This will write the rendered configuration to `terragrunt.rendered.json` in the current working directory.
 
 This can be useful when rendering many configurations in a given directory, and you want to keep the rendered configurations in the same directory as the original configurations, without leveraging external tools or scripts.
+
+This is also useful when combined with the `--all` flag, which will render all configurations discovered from the current working directory.
+
+```bash
+# Note the use of the `-w` alias for the `--write` flag.
+terragrunt render --all --json -w
+```
+
+This will render all configurations discovered from the current working directory and write the rendered configurations to `terragrunt.rendered.json` files adjacent to the configurations they are derived from.
 
 #### render-json
 

--- a/test/integration_json_test.go
+++ b/test/integration_json_test.go
@@ -1074,7 +1074,7 @@ func TestRenderJsonDependentModulesTerraformExp(t *testing.T) {
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)

--- a/test/integration_json_test.go
+++ b/test/integration_json_test.go
@@ -953,7 +953,7 @@ func TestRenderJsonMetadataDependencyModulePrefixExp(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "dependency", "app")
 
-	helpers.RunTerragrunt(t, "terragrunt run-all render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir "+tmpDir)
+	helpers.RunTerragrunt(t, "terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir "+tmpDir)
 }
 
 func TestRenderJsonDependentModulesMetadataTerraform(t *testing.T) {

--- a/test/integration_json_test.go
+++ b/test/integration_json_test.go
@@ -124,6 +124,108 @@ func TestRenderJsonAttributesMetadata(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(expectedTerraformVersionConstraint, terraformVersionConstraint))
 }
 
+func TestRenderJsonAttributesMetadataExp(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderJSONMetadata)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	tmpDir := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "attributes")
+
+	terragruntHCL := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "attributes", "terragrunt.hcl")
+
+	var expectedMetadata = map[string]any{
+		"found_in_file": terragruntHCL,
+	}
+
+	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
+
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+
+	jsonBytes, err := os.ReadFile(jsonOut)
+	require.NoError(t, err)
+
+	var renderedJSON = map[string]any{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &renderedJSON))
+
+	var inputs = renderedJSON[config.MetadataInputs]
+	var expectedInputs = map[string]any{
+		"name": map[string]any{
+			"metadata": expectedMetadata,
+			"value":    "us-east-1-bucket",
+		},
+		"region": map[string]any{
+			"metadata": expectedMetadata,
+			"value":    "us-east-1",
+		},
+	}
+	assert.True(t, reflect.DeepEqual(expectedInputs, inputs))
+
+	var locals = renderedJSON[config.MetadataLocals]
+	var expectedLocals = map[string]any{
+		"aws_region": map[string]any{
+			"metadata": expectedMetadata,
+			"value":    "us-east-1",
+		},
+	}
+	assert.True(t, reflect.DeepEqual(expectedLocals, locals))
+
+	var downloadDir = renderedJSON[config.MetadataDownloadDir]
+	var expecteDownloadDir = map[string]any{
+		"metadata": expectedMetadata,
+		"value":    "/tmp",
+	}
+	assert.True(t, reflect.DeepEqual(expecteDownloadDir, downloadDir))
+
+	var iamAssumeRoleDuration = renderedJSON[config.MetadataIamAssumeRoleDuration]
+	expectedIamAssumeRoleDuration := map[string]any{
+		"metadata": expectedMetadata,
+		"value":    float64(666),
+	}
+	assert.True(t, reflect.DeepEqual(expectedIamAssumeRoleDuration, iamAssumeRoleDuration))
+
+	var iamAssumeRoleName = renderedJSON[config.MetadataIamAssumeRoleSessionName]
+	expectedIamAssumeRoleName := map[string]any{
+		"metadata": expectedMetadata,
+		"value":    "qwe",
+	}
+	assert.True(t, reflect.DeepEqual(expectedIamAssumeRoleName, iamAssumeRoleName))
+
+	var iamRole = renderedJSON[config.MetadataIamRole]
+	expectedIamRole := map[string]any{
+		"metadata": expectedMetadata,
+		"value":    "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME",
+	}
+	assert.True(t, reflect.DeepEqual(expectedIamRole, iamRole))
+
+	var preventDestroy = renderedJSON[config.MetadataPreventDestroy]
+	expectedPreventDestroy := map[string]any{
+		"metadata": expectedMetadata,
+		"value":    true,
+	}
+	assert.True(t, reflect.DeepEqual(expectedPreventDestroy, preventDestroy))
+
+	var skip = renderedJSON[config.MetadataSkip]
+	expectedSkip := map[string]any{
+		"metadata": expectedMetadata,
+		"value":    true,
+	}
+	assert.True(t, reflect.DeepEqual(expectedSkip, skip))
+
+	var terraformBinary = renderedJSON[config.MetadataTerraformBinary]
+	expectedTerraformBinary := map[string]any{
+		"metadata": expectedMetadata,
+		"value":    wrappedBinary(),
+	}
+	assert.True(t, reflect.DeepEqual(expectedTerraformBinary, terraformBinary), "expected: %v, got: %v", expectedTerraformBinary, terraformBinary)
+
+	var terraformVersionConstraint = renderedJSON[config.MetadataTerraformVersionConstraint]
+	expectedTerraformVersionConstraint := map[string]any{
+		"metadata": expectedMetadata,
+		"value":    ">= 0.11",
+	}
+	assert.True(t, reflect.DeepEqual(expectedTerraformVersionConstraint, terraformVersionConstraint))
+}
+
 func TestRenderJsonWithInputsNotExistingOutput(t *testing.T) {
 	t.Parallel()
 
@@ -136,6 +238,47 @@ func TestRenderJsonWithInputsNotExistingOutput(t *testing.T) {
 	helpers.RunTerragrunt(t, "terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-working-dir "+appPath)
 
 	jsonOut := filepath.Join(appPath, "terragrunt_rendered.json")
+
+	jsonBytes, err := os.ReadFile(jsonOut)
+	require.NoError(t, err)
+
+	var renderedJSON = map[string]any{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &renderedJSON))
+
+	var includeMetadata = map[string]any{
+		"found_in_file": util.JoinPath(appPath, "terragrunt.hcl"),
+	}
+
+	var inputs = renderedJSON[config.MetadataInputs]
+	var expectedInputs = map[string]any{
+		"static_value": map[string]any{
+			"metadata": includeMetadata,
+			"value":    "static_value",
+		},
+		"value": map[string]any{
+			"metadata": includeMetadata,
+			"value":    "output_value",
+		},
+		"not_existing_value": map[string]any{
+			"metadata": includeMetadata,
+			"value":    "",
+		},
+	}
+	assert.True(t, reflect.DeepEqual(expectedInputs, inputs))
+}
+
+func TestRenderJsonWithInputsNotExistingOutputExp(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderJSONInputs)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	dependencyPath := util.JoinPath(tmpEnvPath, testFixtureRenderJSONInputs, "dependency")
+	appPath := util.JoinPath(tmpEnvPath, testFixtureRenderJSONInputs, "app")
+
+	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+dependencyPath)
+	helpers.RunTerragrunt(t, "terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir "+appPath)
+
+	jsonOut := filepath.Join(appPath, "terragrunt.rendered.json")
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -216,6 +359,57 @@ func TestRenderJsonWithMockOutputs(t *testing.T) {
 	assert.Equal(t, string(serializedExpectedDependency), string(serializedDependency))
 }
 
+func TestRenderJsonWithMockOutputsExp(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderJSONMockOutputs)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	tmpDir := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMockOutputs, "app")
+
+	var expectedMetadata = map[string]any{
+		"found_in_file": util.JoinPath(tmpDir, "terragrunt.hcl"),
+	}
+
+	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
+
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+
+	jsonBytes, err := os.ReadFile(jsonOut)
+	require.NoError(t, err)
+
+	var renderedJSON = map[string]any{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &renderedJSON))
+
+	dependency := renderedJSON[config.MetadataDependency]
+
+	var expectedDependency = map[string]any{
+		"module": map[string]any{
+			"metadata": expectedMetadata,
+			"value": map[string]any{
+				"config_path": "../dependency",
+				"enabled":     nil,
+				"mock_outputs": map[string]any{
+					"bastion_host_security_group_id": "123",
+					"security_group_id":              "sg-abcd1234",
+				},
+				"mock_outputs_allowed_terraform_commands": [1]string{"validate"},
+				"mock_outputs_merge_strategy_with_state":  nil,
+				"mock_outputs_merge_with_state":           nil,
+				"name":                                    "module",
+				"outputs":                                 nil,
+				"inputs":                                  nil,
+				"skip":                                    nil,
+			},
+		},
+	}
+	serializedDependency, err := json.Marshal(dependency)
+	require.NoError(t, err)
+
+	serializedExpectedDependency, err := json.Marshal(expectedDependency)
+	require.NoError(t, err)
+	assert.Equal(t, string(serializedExpectedDependency), string(serializedDependency))
+}
+
 func TestRenderJsonMetadataIncludes(t *testing.T) {
 	t.Parallel()
 
@@ -248,6 +442,120 @@ func TestRenderJsonMetadataIncludes(t *testing.T) {
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
 
 	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
+
+	jsonBytes, err := os.ReadFile(jsonOut)
+	require.NoError(t, err)
+
+	var renderedJSON = map[string]any{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &renderedJSON))
+
+	var inputs = renderedJSON[config.MetadataInputs]
+	var expectedInputs = map[string]any{
+		"content": map[string]any{
+			"metadata": localsMetadata,
+			"value":    "test",
+		},
+		"qwe": map[string]any{
+			"metadata": inputMetadata,
+			"value":    "123",
+		},
+	}
+	assert.True(t, reflect.DeepEqual(expectedInputs, inputs))
+
+	var locals = renderedJSON[config.MetadataLocals]
+	var expectedLocals = map[string]any{
+		"abc": map[string]any{
+			"metadata": terragruntMetadata,
+			"value":    "xyz",
+		},
+	}
+	assert.True(t, reflect.DeepEqual(expectedLocals, locals))
+
+	var generate = renderedJSON[config.MetadataGenerateConfigs]
+	var expectedGenerate = map[string]any{
+		"provider": map[string]any{
+			"metadata": generateMetadata,
+			"value": map[string]any{
+				"comment_prefix":    "# ",
+				"contents":          "# test\n",
+				"disable_signature": false,
+				"disable":           false,
+				"if_exists":         "overwrite",
+				"if_disabled":       "skip",
+				"hcl_fmt":           nil,
+				"path":              "provider.tf",
+			},
+		},
+	}
+
+	// compare fields by serialization in json since map from "value" field is not deterministic
+	serializedGenerate, err := json.Marshal(generate)
+	require.NoError(t, err)
+
+	serializedExpectedGenerate, err := json.Marshal(expectedGenerate)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(serializedExpectedGenerate), string(serializedGenerate))
+
+	var remoteState = renderedJSON[config.MetadataRemoteState]
+	var expectedRemoteState = map[string]any{
+		"metadata": commonMetadata,
+		"value": map[string]any{
+			"backend":                         "s3",
+			"disable_dependency_optimization": false,
+			"disable_init":                    false,
+			"generate":                        nil,
+			"config": map[string]any{
+				"bucket": "mybucket",
+				"key":    "path/to/my/key",
+				"region": "us-east-1",
+			},
+			"encryption": nil,
+		},
+	}
+
+	// compare fields by serialization in json since map from "value" field is not deterministic
+	serializedRemoteState, err := json.Marshal(remoteState)
+	require.NoError(t, err)
+
+	serializedExpectedRemoteState, err := json.Marshal(expectedRemoteState)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(serializedExpectedRemoteState), string(serializedRemoteState))
+}
+
+func TestRenderJsonMetadataIncludesExp(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderJSONMetadata)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	tmpDir := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "includes", "app")
+
+	terragruntHcl := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "includes", "app", "terragrunt.hcl")
+	localsHcl := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "includes", "app", "locals.hcl")
+	inputHcl := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "includes", "app", "inputs.hcl")
+	generateHcl := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "includes", "app", "generate.hcl")
+	commonHcl := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "includes", "common", "common.hcl")
+
+	var terragruntMetadata = map[string]any{
+		"found_in_file": terragruntHcl,
+	}
+	var localsMetadata = map[string]any{
+		"found_in_file": localsHcl,
+	}
+	var inputMetadata = map[string]any{
+		"found_in_file": inputHcl,
+	}
+	var generateMetadata = map[string]any{
+		"found_in_file": generateHcl,
+	}
+	var commonMetadata = map[string]any{
+		"found_in_file": commonHcl,
+	}
+
+	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
+
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -402,6 +710,78 @@ func TestRenderJsonMetadataDependency(t *testing.T) {
 	assert.Equal(t, string(serializedExpectedDependency), string(serializedDependency))
 }
 
+func TestRenderJsonMetadataDependencyExp(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderJSONMetadata)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	tmpDir := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "dependency", "app")
+
+	terragruntHcl := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "dependency", "app", "terragrunt.hcl")
+
+	var terragruntMetadata = map[string]any{
+		"found_in_file": terragruntHcl,
+	}
+
+	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
+
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+
+	jsonBytes, err := os.ReadFile(jsonOut)
+	require.NoError(t, err)
+
+	var renderedJSON = map[string]any{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &renderedJSON))
+
+	var dependency = renderedJSON[config.MetadataDependency]
+
+	var expectedDependency = map[string]any{
+		"dep": map[string]any{
+			"metadata": terragruntMetadata,
+			"value": map[string]any{
+				"config_path": "../dependency",
+				"mock_outputs": map[string]any{
+					"test": "value",
+				},
+				"mock_outputs_allowed_terraform_commands": nil,
+				"mock_outputs_merge_strategy_with_state":  nil,
+				"mock_outputs_merge_with_state":           nil,
+				"name":                                    "dep",
+				"outputs":                                 nil,
+				"inputs":                                  nil,
+				"skip":                                    nil,
+				"enabled":                                 nil,
+			},
+		},
+		"dep2": map[string]any{
+			"metadata": terragruntMetadata,
+			"value": map[string]any{
+				"config_path": "../dependency2",
+				"enabled":     nil,
+				"mock_outputs": map[string]any{
+					"test2": "value2",
+				},
+				"mock_outputs_allowed_terraform_commands": nil,
+				"mock_outputs_merge_strategy_with_state":  nil,
+				"mock_outputs_merge_with_state":           nil,
+				"name":                                    "dep2",
+				"outputs":                                 nil,
+				"inputs":                                  nil,
+				"skip":                                    nil,
+			},
+		},
+	}
+
+	// compare fields by serialization in json since map from "value" field is not deterministic
+	serializedDependency, err := json.Marshal(dependency)
+	require.NoError(t, err)
+
+	serializedExpectedDependency, err := json.Marshal(expectedDependency)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(serializedExpectedDependency), string(serializedDependency))
+}
+
 func TestRenderJsonMetadataTerraform(t *testing.T) {
 	t.Parallel()
 
@@ -479,6 +859,83 @@ func TestRenderJsonMetadataTerraform(t *testing.T) {
 	assert.Equal(t, string(serializedExpectedRemoteState), string(serializedRemoteState))
 }
 
+func TestRenderJsonMetadataTerraformExp(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderJSONMetadata)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	tmpDir := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "terraform-remote-state", "app")
+
+	commonHcl := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "terraform-remote-state", "common", "terraform.hcl")
+	remoteStateHcl := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "terraform-remote-state", "common", "remote_state.hcl")
+	var terragruntMetadata = map[string]any{
+		"found_in_file": commonHcl,
+	}
+	var remoteMetadata = map[string]any{
+		"found_in_file": remoteStateHcl,
+	}
+
+	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
+
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+
+	jsonBytes, err := os.ReadFile(jsonOut)
+	require.NoError(t, err)
+
+	var renderedJSON = map[string]any{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &renderedJSON))
+
+	var terraform = renderedJSON[config.MetadataTerraform]
+	var expectedTerraform = map[string]any{
+		"metadata": terragruntMetadata,
+		"value": map[string]any{
+			"after_hook":               map[string]any{},
+			"before_hook":              map[string]any{},
+			"error_hook":               map[string]any{},
+			"extra_arguments":          map[string]any{},
+			"include_in_copy":          nil,
+			"exclude_from_copy":        nil,
+			"source":                   "../terraform",
+			"copy_terraform_lock_file": nil,
+		},
+	}
+
+	// compare fields by serialization in json since map from "value" field is not deterministic
+	serializedTerraform, err := json.Marshal(terraform)
+	require.NoError(t, err)
+
+	serializedExpectedTerraform, err := json.Marshal(expectedTerraform)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(serializedExpectedTerraform), string(serializedTerraform))
+
+	var remoteState = renderedJSON[config.MetadataRemoteState]
+	var expectedRemoteState = map[string]any{
+		"metadata": remoteMetadata,
+		"value": map[string]any{
+			"backend": "s3",
+			"config": map[string]any{
+				"bucket": "mybucket",
+				"key":    "path/to/my/key",
+				"region": "us-east-1",
+			},
+			"encryption":                      nil,
+			"disable_dependency_optimization": false,
+			"disable_init":                    false,
+			"generate":                        nil,
+		},
+	}
+
+	// compare fields by serialization in json since map from "value" field is not deterministic
+	serializedRemoteState, err := json.Marshal(remoteState)
+	require.NoError(t, err)
+
+	serializedExpectedRemoteState, err := json.Marshal(expectedRemoteState)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(serializedExpectedRemoteState), string(serializedRemoteState))
+}
+
 func TestRenderJsonMetadataDependencyModulePrefix(t *testing.T) {
 	t.Parallel()
 
@@ -487,6 +944,16 @@ func TestRenderJsonMetadataDependencyModulePrefix(t *testing.T) {
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "dependency", "app")
 
 	helpers.RunTerragrunt(t, "terragrunt run-all render-json --terragrunt-forward-tf-stdout --with-metadata --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+tmpDir)
+}
+
+func TestRenderJsonMetadataDependencyModulePrefixExp(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderJSONMetadata)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	tmpDir := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "dependency", "app")
+
+	helpers.RunTerragrunt(t, "terragrunt run-all render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir "+tmpDir)
 }
 
 func TestRenderJsonDependentModulesMetadataTerraform(t *testing.T) {
@@ -498,6 +965,29 @@ func TestRenderJsonDependentModulesMetadataTerraform(t *testing.T) {
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
 	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
+
+	jsonBytes, err := os.ReadFile(jsonOut)
+	require.NoError(t, err)
+
+	var renderedJSON = map[string]map[string]any{}
+
+	require.NoError(t, json.Unmarshal(jsonBytes, &renderedJSON))
+
+	dependentModules := renderedJSON[config.MetadataDependentModules]["value"].([]any)
+	// check if value list contains app-v1 and app-v2
+	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "app-v1"))
+	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "app-v2"))
+}
+
+func TestRenderJsonDependentModulesMetadataTerraformExp(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDestroyWarning)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
+
+	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -533,6 +1023,27 @@ func TestTerragruntRenderJsonHelp(t *testing.T) {
 	assert.Contains(t, output, "--with-metadata")
 }
 
+func TestTerragruntRenderJsonHelpExp(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureHooksInitOnceWithSourceNoBackend)
+	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures/hooks/init-once")
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureHooksInitOnceWithSourceNoBackend)
+
+	showStdout := bytes.Buffer{}
+	showStderr := bytes.Buffer{}
+
+	err := helpers.RunTerragruntCommand(t, "terragrunt render --experiment cli-redesign --help --non-interactive --working-dir "+rootPath, &showStdout, &showStderr)
+	require.NoError(t, err)
+
+	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
+
+	output := showStdout.String()
+
+	assert.Contains(t, output, "terragrunt render")
+	assert.Contains(t, output, "--with-metadata")
+}
+
 func TestRenderJsonDependentModulesTerraform(t *testing.T) {
 	t.Parallel()
 
@@ -555,6 +1066,28 @@ func TestRenderJsonDependentModulesTerraform(t *testing.T) {
 	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "app-v2"))
 }
 
+func TestRenderJsonDependentModulesTerraformExp(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDestroyWarning)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
+
+	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+
+	jsonBytes, err := os.ReadFile(jsonOut)
+	require.NoError(t, err)
+
+	var renderedJSON = map[string]any{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &renderedJSON))
+
+	var dependentModules = renderedJSON[config.MetadataDependentModules].([]any)
+	// check if value list contains app-v1 and app-v2
+	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "app-v1"))
+	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "app-v2"))
+}
+
 func TestRenderJsonDisableDependentModulesTerraform(t *testing.T) {
 	t.Parallel()
 
@@ -564,6 +1097,26 @@ func TestRenderJsonDisableDependentModulesTerraform(t *testing.T) {
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
 	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-json-disable-dependent-modules --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
+
+	jsonBytes, err := os.ReadFile(jsonOut)
+	require.NoError(t, err)
+
+	var renderedJSON = map[string]any{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &renderedJSON))
+
+	_, found := renderedJSON[config.MetadataDependentModules].([]any)
+	assert.False(t, found)
+}
+
+func TestRenderJsonDisableDependentModulesTerraformExp(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDestroyWarning)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
+
+	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --disable-dependent-modules --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -743,13 +743,14 @@ func TestParseTFLog(t *testing.T) {
 	}
 }
 
-// This test is flacky when run in parallel. Need to figure it out. Most likely after these changes
+// This test is flaky when run in parallel. Need to figure it out. Most likely after these changes
 // https://github.com/gruntwork-io/terragrunt/issues/3864 or because of global variables in codes.
 func TestTerragruntGraphNonTerraformCommandExecution(t *testing.T) {
 	testCases := []struct {
 		args string
 	}{
 		{"graph render-json --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-graph-root %s"},
+		// NOTE: This command doesn't have an equivalent in the new CLI redesign, as it doesn't really make sense to support a `graph` flag for the `render` command.
 		{"render-json --graph --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-graph-root %s"},
 	}
 

--- a/test/integration_tofu_state_encryption_test.go
+++ b/test/integration_tofu_state_encryption_test.go
@@ -78,16 +78,13 @@ func TestTofuStateEncryptionAWSKMS(t *testing.T) {
 func TestTofuRenderJSONConfigWithEncryption(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "terragrunt-render-json-*")
-	require.NoError(t, err)
-	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
-	defer os.RemoveAll(tmpDir)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderJSONWithEncryption)
+	workDir := util.JoinPath(tmpEnvPath, testFixtureRenderJSONWithEncryption)
+	mainPath := util.JoinPath(workDir, "main")
+	jsonOut := filepath.Join(mainPath, "terragrunt_rendered.json")
 
-	helpers.CleanupTerraformFolder(t, fixtureRenderJSONMainModulePath)
-	helpers.CleanupTerraformFolder(t, fixtureRenderJSONDepModulePath)
-
-	helpers.RunTerragrunt(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+testFixtureRenderJSONWithEncryption)
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s --terragrunt-json-out %s", testFixtureRenderJSONWithEncryptionMainModulePath, jsonOut))
+	helpers.RunTerragrunt(t, "terragrunt run-all apply -auto-approve --non-interactive --log-level trace --working-dir "+workDir)
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --non-interactive --log-level trace --working-dir %s --json-out %s", mainPath, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -195,16 +192,13 @@ func TestTofuRenderJSONConfigWithEncryption(t *testing.T) {
 func TestTofuRenderJSONConfigWithEncryptionExp(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "terragrunt-render-json-*")
-	require.NoError(t, err)
-	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
-	defer os.RemoveAll(tmpDir)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderJSONWithEncryption)
+	workDir := util.JoinPath(tmpEnvPath, testFixtureRenderJSONWithEncryption)
+	mainPath := util.JoinPath(workDir, "main")
+	jsonOut := filepath.Join(mainPath, "terragrunt.rendered.json")
 
-	helpers.CleanupTerraformFolder(t, fixtureRenderJSONMainModulePath)
-	helpers.CleanupTerraformFolder(t, fixtureRenderJSONDepModulePath)
-
-	helpers.RunTerragrunt(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+testFixtureRenderJSONWithEncryption)
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json  -w --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s --terragrunt-json-out %s", testFixtureRenderJSONWithEncryptionMainModulePath, jsonOut))
+	helpers.RunTerragrunt(t, "terragrunt run-all apply -auto-approve --non-interactive --log-level trace --working-dir "+workDir)
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json  -w --non-interactive --log-level trace --working-dir %s --out %s", mainPath, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)

--- a/test/integration_tofu_state_encryption_test.go
+++ b/test/integration_tofu_state_encryption_test.go
@@ -191,6 +191,123 @@ func TestTofuRenderJSONConfigWithEncryption(t *testing.T) {
 	}
 }
 
+// This will eventually be the only test for rendering JSON config with encryption
+func TestTofuRenderJSONConfigWithEncryptionExp(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, err := os.MkdirTemp("", "terragrunt-render-json-*")
+	require.NoError(t, err)
+	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
+	defer os.RemoveAll(tmpDir)
+
+	helpers.CleanupTerraformFolder(t, fixtureRenderJSONMainModulePath)
+	helpers.CleanupTerraformFolder(t, fixtureRenderJSONDepModulePath)
+
+	helpers.RunTerragrunt(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+testFixtureRenderJSONWithEncryption)
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json  -w --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s --terragrunt-json-out %s", testFixtureRenderJSONWithEncryptionMainModulePath, jsonOut))
+
+	jsonBytes, err := os.ReadFile(jsonOut)
+	require.NoError(t, err)
+
+	var rendered map[string]interface{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &rendered))
+
+	// Make sure all terraform block is visible
+	terraformBlock, hasTerraform := rendered["terraform"]
+	if assert.True(t, hasTerraform) {
+		source, hasSource := terraformBlock.(map[string]interface{})["source"]
+		assert.True(t, hasSource)
+		assert.Equal(t, "./module", source)
+	}
+
+	// Make sure included remoteState is rendered out
+	remoteState, hasRemoteState := rendered["remote_state"]
+	if assert.True(t, hasRemoteState) {
+		assert.Equal(
+			t,
+			map[string]interface{}{
+				"backend": "local",
+				"generate": map[string]interface{}{
+					"path":      "backend.tf",
+					"if_exists": "overwrite_terragrunt",
+				},
+				"config": map[string]interface{}{
+					"path": "foo.tfstate",
+				},
+				"encryption": map[string]interface{}{
+					"key_provider": "pbkdf2",
+					"passphrase":   "correct-horse-battery-staple",
+				},
+				"disable_init":                    false,
+				"disable_dependency_optimization": false,
+			},
+			remoteState.(map[string]interface{}),
+		)
+	}
+
+	// Make sure dependency blocks are rendered out
+	dependencyBlocks, hasDependency := rendered["dependency"]
+	if assert.True(t, hasDependency) {
+		assert.Equal(
+			t,
+			map[string]interface{}{
+				"dep": map[string]interface{}{
+					"name":         "dep",
+					"config_path":  "../dep",
+					"outputs":      nil,
+					"inputs":       nil,
+					"mock_outputs": nil,
+					"enabled":      nil,
+					"mock_outputs_allowed_terraform_commands": nil,
+					"mock_outputs_merge_strategy_with_state":  nil,
+					"mock_outputs_merge_with_state":           nil,
+					"skip":                                    nil,
+				},
+			},
+			dependencyBlocks.(map[string]interface{}),
+		)
+	}
+
+	// Make sure included generate block is rendered out
+	generateBlocks, hasGenerate := rendered["generate"]
+	if assert.True(t, hasGenerate) {
+		assert.Equal(
+			t,
+			map[string]interface{}{
+				"provider": map[string]interface{}{
+					"path":              "provider.tf",
+					"comment_prefix":    "# ",
+					"disable_signature": false,
+					"disable":           false,
+					"if_exists":         "overwrite_terragrunt",
+					"if_disabled":       "skip",
+					"hcl_fmt":           nil,
+					"contents": `provider "aws" {
+  region = "us-east-1"
+}
+`,
+				},
+			},
+			generateBlocks.(map[string]interface{}),
+		)
+	}
+
+	// Make sure all inputs are merged together
+	inputsBlock, hasInputs := rendered["inputs"]
+	if assert.True(t, hasInputs) {
+		assert.Equal(
+			t,
+			map[string]interface{}{
+				"env":        "qa",
+				"name":       "dep",
+				"type":       "main",
+				"aws_region": "us-east-1",
+			},
+			inputsBlock.(map[string]interface{}),
+		)
+	}
+}
+
 // Check the statefile contains an encrypted_data key
 // and that the encrypted_data is base64 encoded
 func validateStateIsEncrypted(t *testing.T, fileName string, path string) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds `render` command to replace `render-json`

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `render` command to replace `render-json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new CLI command, **render**, to output Terragrunt configurations in JSON or HCL formats with options for file writing and metadata.
  - Integrated the render command into run-all and enhanced autocomplete suggestions to include both "render" and "render-json".
  - Deprecated the previous renderjson functionality in favor of the new command.

- **Documentation**
  - Expanded CLI documentation with a dedicated render section and updated flag descriptions (e.g., **render-write**, **render-all**) alongside detailed usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->