### PR TITLE
feat: Adding exclude support to list and find

### DIFF
--- a/cli/commands/find/cli.go
+++ b/cli/commands/find/cli.go
@@ -25,6 +25,9 @@ const (
 	Dependencies   = "dependencies"
 	External       = "external"
 	Exclude        = "exclude"
+
+	QueueConstructAsFlagName  = "queue-construct-as"
+	QueueConstructAsFlagAlias = "as"
 )
 
 func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
@@ -74,6 +77,13 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			EnvVars:     tgPrefix.EnvVars(External),
 			Destination: &opts.External,
 			Usage:       "Discover external dependencies from initial results, and add them to top-level results.",
+		}),
+		flags.NewFlag(&cli.GenericFlag[string]{
+			Name:        QueueConstructAsFlagName,
+			EnvVars:     tgPrefix.EnvVars(QueueConstructAsFlagName),
+			Destination: &opts.QueueConstructAs,
+			Usage:       "Construct the queue as if a specific command was run.",
+			Aliases:     []string{QueueConstructAsFlagAlias},
 		}),
 	}
 }

--- a/cli/commands/find/cli.go
+++ b/cli/commands/find/cli.go
@@ -24,6 +24,7 @@ const (
 	HiddenFlagName = "hidden"
 	Dependencies   = "dependencies"
 	External       = "external"
+	Exclude        = "exclude"
 )
 
 func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
@@ -61,6 +62,12 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			EnvVars:     tgPrefix.EnvVars(Dependencies),
 			Destination: &opts.Dependencies,
 			Usage:       "Include dependencies in the results (only when using --format=json).",
+		}),
+		flags.NewFlag(&cli.BoolFlag{
+			Name:        Exclude,
+			EnvVars:     tgPrefix.EnvVars(Exclude),
+			Destination: &opts.Exclude,
+			Usage:       "Display exclude configurations in the results (only when using --format=json).",
 		}),
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        External,

--- a/cli/commands/find/cli.go
+++ b/cli/commands/find/cli.go
@@ -110,6 +110,12 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 				cmdOpts.Mode = ModeDAG
 			}
 
+			// Requesting a specific command to be used for queue construction
+			// implies DAG mode.
+			if cmdOpts.QueueConstructAs != "" {
+				cmdOpts.Mode = ModeDAG
+			}
+
 			if err := cmdOpts.Validate(); err != nil {
 				return cli.NewExitError(err, cli.ExitCodeGeneralError)
 			}

--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -31,7 +31,7 @@ func Run(ctx context.Context, opts *Options) error {
 		d = d.WithDiscoverExternalDependencies()
 	}
 
-	if opts.Exclude {
+	if opts.Exclude || opts.QueueConstructAs != "" {
 		d = d.WithParseExclude()
 	}
 
@@ -91,6 +91,14 @@ func discoveredToFound(configs discovery.DiscoveredConfigs, opts *Options) (Foun
 	for _, config := range configs {
 		if config.External && !opts.External {
 			continue
+		}
+
+		if opts.QueueConstructAs != "" {
+			if config.Parsed != nil && config.Parsed.Exclude != nil {
+				if config.Parsed.Exclude.IsActionListed(opts.QueueConstructAs) {
+					continue
+				}
+			}
 		}
 
 		relPath, err := filepath.Rel(opts.WorkingDir, config.Path)

--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -31,8 +31,15 @@ func Run(ctx context.Context, opts *Options) error {
 		d = d.WithDiscoverExternalDependencies()
 	}
 
-	if opts.Exclude || opts.QueueConstructAs != "" {
+	if opts.Exclude {
 		d = d.WithParseExclude()
+	}
+
+	if opts.QueueConstructAs != "" {
+		d = d.WithParseExclude()
+		d = d.WithDiscoveryContext(&discovery.DiscoveryContext{
+			Cmd: opts.QueueConstructAs,
+		})
 	}
 
 	cfgs, err := d.Discover(ctx, opts.TerragruntOptions)

--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -49,7 +49,7 @@ func Run(ctx context.Context, opts *Options) error {
 			return errors.New(err)
 		}
 
-		cfgs = q.Entries()
+		cfgs = q.Configs()
 	default:
 		// This should never happen, because of validation in the command.
 		// If it happens, we want to throw so we can fix the validation.

--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, opts *Options) error {
 
 	cfgs, err := d.Discover(ctx, opts.TerragruntOptions)
 	if err != nil {
-		opts.Logger.Warnf("Error discovering configurations:\n%s", err)
+		opts.Logger.Debugf("Errors encountered while discovering configurations:\n%s", err)
 	}
 
 	switch opts.Mode {

--- a/cli/commands/find/options.go
+++ b/cli/commands/find/options.go
@@ -34,6 +34,9 @@ type Options struct {
 	// Mode determines the mode of the find command.
 	Mode string
 
+	// QueueConstructAs constructs the queue as if a particular command was run.
+	QueueConstructAs string
+
 	// JSON determines if the output should be in JSON format.
 	// Alias for --format=json.
 	JSON bool
@@ -52,9 +55,6 @@ type Options struct {
 
 	// External determines if external dependencies should be included in the output.
 	External bool
-
-	// QueueConstructAs constructs the queue as if a particular command was run.
-	QueueConstructAs string
 }
 
 func NewOptions(opts *options.TerragruntOptions) *Options {

--- a/cli/commands/find/options.go
+++ b/cli/commands/find/options.go
@@ -52,6 +52,9 @@ type Options struct {
 
 	// External determines if external dependencies should be included in the output.
 	External bool
+
+	// QueueConstructAs constructs the queue as if a particular command was run.
+	QueueConstructAs string
 }
 
 func NewOptions(opts *options.TerragruntOptions) *Options {

--- a/cli/commands/find/options.go
+++ b/cli/commands/find/options.go
@@ -47,6 +47,9 @@ type Options struct {
 	// Dependencies determines if dependencies should be included in the output.
 	Dependencies bool
 
+	// Exclude determines if exclude configurations should be included in the output.
+	Exclude bool
+
 	// External determines if external dependencies should be included in the output.
 	External bool
 }

--- a/cli/commands/list/cli.go
+++ b/cli/commands/list/cli.go
@@ -117,6 +117,12 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 				cmdOpts.Mode = ModeDAG
 			}
 
+			// Requesting a specific command to be used for queue construction
+			// implies DAG mode.
+			if cmdOpts.QueueConstructAs != "" {
+				cmdOpts.Mode = ModeDAG
+			}
+
 			if err := cmdOpts.Validate(); err != nil {
 				return cli.NewExitError(err, cli.ExitCodeGeneralError)
 			}

--- a/cli/commands/list/cli.go
+++ b/cli/commands/list/cli.go
@@ -27,6 +27,9 @@ const (
 	ExternalFlagName     = "external"
 
 	DAGFlagName = "dag"
+
+	QueueConstructAsFlagName  = "queue-construct-as"
+	QueueConstructAsFlagAlias = "as"
 )
 
 func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
@@ -77,6 +80,13 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			EnvVars:     tgPrefix.EnvVars(DAGFlagName),
 			Destination: &opts.DAG,
 			Usage:       "Use DAG mode to sort and group output.",
+		}),
+		flags.NewFlag(&cli.GenericFlag[string]{
+			Name:        QueueConstructAsFlagName,
+			EnvVars:     tgPrefix.EnvVars(QueueConstructAsFlagName),
+			Destination: &opts.QueueConstructAs,
+			Usage:       "Construct the queue as if a specific command was run.",
+			Aliases:     []string{QueueConstructAsFlagAlias},
 		}),
 	}
 }

--- a/cli/commands/list/list.go
+++ b/cli/commands/list/list.go
@@ -52,7 +52,7 @@ func Run(ctx context.Context, opts *Options) error {
 			return errors.New(err)
 		}
 
-		cfgs = q.Entries()
+		cfgs = q.Configs()
 	default:
 		// This should never happen, because of validation in the command.
 		// If it happens, we want to throw so we can fix the validation.

--- a/cli/commands/list/list.go
+++ b/cli/commands/list/list.go
@@ -36,6 +36,10 @@ func Run(ctx context.Context, opts *Options) error {
 
 	if opts.QueueConstructAs != "" {
 		d = d.WithParseExclude()
+		d = d.WithDiscoverDependencies()
+		d = d.WithDiscoveryContext(&discovery.DiscoveryContext{
+			Cmd: opts.QueueConstructAs,
+		})
 	}
 
 	cfgs, err := d.Discover(ctx, opts.TerragruntOptions)

--- a/cli/commands/list/list.go
+++ b/cli/commands/list/list.go
@@ -34,6 +34,10 @@ func Run(ctx context.Context, opts *Options) error {
 		d = d.WithDiscoverExternalDependencies()
 	}
 
+	if opts.QueueConstructAs != "" {
+		d = d.WithParseExclude()
+	}
+
 	cfgs, err := d.Discover(ctx, opts.TerragruntOptions)
 	if err != nil {
 		return errors.New(err)
@@ -129,6 +133,14 @@ func discoveredToListed(configs discovery.DiscoveredConfigs, opts *Options) (Lis
 	for _, config := range configs {
 		if config.External && !opts.External {
 			continue
+		}
+
+		if opts.QueueConstructAs != "" {
+			if config.Parsed != nil && config.Parsed.Exclude != nil {
+				if config.Parsed.Exclude.IsActionListed(opts.QueueConstructAs) {
+					continue
+				}
+			}
 		}
 
 		relPath, err := filepath.Rel(opts.WorkingDir, config.Path)

--- a/cli/commands/list/list.go
+++ b/cli/commands/list/list.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, opts *Options) error {
 
 	cfgs, err := d.Discover(ctx, opts.TerragruntOptions)
 	if err != nil {
-		return errors.New(err)
+		opts.Logger.Debugf("Errors encountered while discovering configurations:\n%s", err)
 	}
 
 	switch opts.Mode {

--- a/cli/commands/list/options.go
+++ b/cli/commands/list/options.go
@@ -37,6 +37,9 @@ type Options struct {
 	// Mode determines the mode of the list command.
 	Mode string
 
+	// QueueConstructAs constructs the queue as if a particular command was run.
+	QueueConstructAs string
+
 	// Hidden determines whether to detect hidden directories.
 	Hidden bool
 
@@ -54,9 +57,6 @@ type Options struct {
 
 	// DAG determines whether to output in DAG format.
 	DAG bool
-
-	// QueueConstructAs constructs the queue as if a particular command was run.
-	QueueConstructAs string
 }
 
 func NewOptions(opts *options.TerragruntOptions) *Options {

--- a/cli/commands/list/options.go
+++ b/cli/commands/list/options.go
@@ -54,6 +54,9 @@ type Options struct {
 
 	// DAG determines whether to output in DAG format.
 	DAG bool
+
+	// QueueConstructAs constructs the queue as if a particular command was run.
+	QueueConstructAs string
 }
 
 func NewOptions(opts *options.TerragruntOptions) *Options {

--- a/docs-starlight/src/content/docs/04-reference/04-experiments.md
+++ b/docs-starlight/src/content/docs/04-reference/04-experiments.md
@@ -154,9 +154,20 @@ To transition `cli-redesign` features to a stable release, the following must be
 - [x] Add OpenTofu commands as explicit shortcuts in the CLI instead of forwarding all unknown commands to OpenTofu/Terraform.
 - [ ] Add support for the `backend` command.
 - [ ] Add support for the `render` command.
-- [ ] Add support for the `info` command.
+- [x] Add support for the `info` command.
 - [ ] Add support for the `dag` command.
-ith `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
+- [ ] Add support for the `find` command.
+  - [x] Add support for `find` without flags.
+  - [x] Add support for `find` with colorful output.
+  - [x] Add support for `find` with `--format=json` flag.
+  - [x] Add support for `find` with stdout redirection detection.
+  - [x] Add support for `find` with `--hidden` flag.
+  - [x] Add support for `find` with `--sort=alpha` flag.
+  - [x] Add support for `find` with `--sort=dag` flag.
+  - [x] Add support for `find` with the `exclude` block used to exclude units from the search.
+  - [ ] Add integration with `symlinks` experiment to support finding units/stacks via symlinks.
+  - [x] Add handling of broken configurations or configurations requiring authentication.
+  - [x] Add integration test for `find` with `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
 - [ ] Add support for the `list` command.
   - [x] Add support for `list` without flags.
   - [x] Add support for `list` with colorful output.
@@ -168,10 +179,10 @@ ith `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
   - [x] Add support for `list` with `--sort=dag` flag.
   - [x] Add support for `list` with `--group-by=fs` flag.
   - [x] Add support for `list` with `--group-by=dag` flag.
-  - [ ] Add support for `list` with the `exclude` block used to exclude units from the search.
+  - [x] Add support for `list` with the `exclude` block used to exclude units from the search.
   - [ ] Add integration with `symlinks` experiment to support listing units/stacks via symlinks.
-  - [ ] Add handling of broken configurations or configurations requiring authentication.
-  - [ ] Add integration test for `list` with `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
+  - [x] Add handling of broken configurations or configurations requiring authentication.
+  - [x] Add integration test for `list` with `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
 
 ### `cas`
 

--- a/docs-starlight/src/data/commands/find.mdx
+++ b/docs-starlight/src/data/commands/find.mdx
@@ -38,6 +38,32 @@ examples:
     code: |
       terragrunt find --dag
   - description: |
+      Sort configurations based on dependency graph as if running plan command.
+    code: |
+      $ terragrunt find --queue-construct-as=plan
+      stacks/live/dev
+      stacks/live/prod
+      units/live/dev/vpc
+      units/live/prod/vpc
+      units/live/dev/db
+      units/live/prod/db
+      units/live/dev/ec2
+      units/live/prod/ec2
+
+  - description: |
+      Sort configurations based on dependency graph as if running destroy command.
+    code: |
+      $ terragrunt find --queue-construct-as=destroy
+      stacks/live/dev
+      stacks/live/prod
+      units/live/dev/ec2
+      units/live/prod/ec2
+      units/live/dev/db
+      units/live/prod/db
+      units/live/dev/vpc
+      units/live/prod/vpc
+
+  - description: |
       Include dependency information in the output.
     code: |
       terragrunt find --dependencies --format 'json'
@@ -52,6 +78,7 @@ flags:
   - find-hidden
   - find-dependencies
   - find-external
+  - queue-construct-as
 ---
 
 import { Aside, Badge } from '@astrojs/starlight/components';
@@ -110,6 +137,44 @@ unitD           # depends on unitC
 ```
 
 If multiple configurations share common dependencies, they will be sorted in lexical order.
+
+## Queue Construct As
+
+The `find` command supports the `--queue-construct-as` flag (or its shorter alias `--as`) to sort output based on the dependency graph, as if a particular command was run.
+
+For example, when using the `plan` command:
+
+```bash
+terragrunt find --queue-construct-as=plan
+stacks/live/dev
+stacks/live/prod
+units/live/dev/vpc
+units/live/prod/vpc
+units/live/dev/db
+units/live/prod/db
+units/live/dev/ec2
+units/live/prod/ec2
+```
+
+This will sort the output based on the dependency graph, as if the `plan` command was run. All dependent units will appear *after* the units they depend on.
+
+When using the `destroy` command:
+
+```bash
+terragrunt find --as=destroy
+stacks/live/dev
+stacks/live/prod
+units/live/dev/ec2
+units/live/prod/ec2
+units/live/dev/db
+units/live/prod/db
+units/live/dev/vpc
+units/live/prod/vpc
+```
+
+This will sort the output based on the dependency graph, as if the `destroy` command was run. All dependent units will appear *before* the units they depend on.
+
+**Note:** The `--queue-construct-as` flag implies the `--dag` flag.
 
 ## Dependencies
 

--- a/docs-starlight/src/data/commands/find.mdx
+++ b/docs-starlight/src/data/commands/find.mdx
@@ -68,6 +68,10 @@ examples:
     code: |
       terragrunt find --dependencies --format 'json'
   - description: |
+      Include exclude configuration in the output.
+    code: |
+      terragrunt find --exclude --format 'json'
+  - description: |
       Include external dependencies in the output.
     code: |
       terragrunt find --dependencies --external --format 'json'
@@ -77,6 +81,7 @@ flags:
   - find-dag
   - find-hidden
   - find-dependencies
+  - find-exclude
   - find-external
   - queue-construct-as
 ---
@@ -195,6 +200,37 @@ terragrunt find --dependencies --format=json
   }
 ]
 ```
+
+## Exclude Configuration
+
+You can include exclude configuration in the output using the `--exclude` flag. When enabled, the JSON output will include the configurations of the `exclude` block in the discovered units:
+
+```bash
+terragrunt find --exclude --format=json
+[
+  {
+    "type": "unit",
+    "path": "action/exclude-apply",
+    "exclude": {
+      "exclude_dependencies": true,
+      "actions": [
+        "apply"
+      ],
+      "if": true
+    }
+  }
+]
+```
+
+You can combine this with the `--queue-construct-as` flag to dry-run behavior relevant to excludes:
+
+```bash
+terragrunt find --exclude --queue-construct-as=plan --format=json
+```
+
+`find` will remove any units that would match the exclude configuration.
+
+## External Dependencies
 
 By default, external dependencies (those outside the working directory) are not part of the overall results (although, they will be mentioned in the dependency section of the JSON output). Use the `--external` flag to include them as top-level results:
 

--- a/docs-starlight/src/data/commands/list.mdx
+++ b/docs-starlight/src/data/commands/list.mdx
@@ -65,6 +65,22 @@ examples:
       unit  b-dependency
       unit  a-dependent   b-dependency
 
+  - description: |
+      List all units in dependency order as if running plan command.
+    code: |
+      $ terragrunt list --queue-construct-as=plan
+      stacks/live/dev      stacks/live/prod     units/live/dev/vpc
+      units/live/prod/vpc  units/live/dev/db    units/live/prod/db
+      units/live/dev/ec2   units/live/prod/ec2
+
+  - description: |
+      List all units in dependency order as if running destroy command.
+    code: |
+      $ terragrunt list --queue-construct-as=destroy
+      stacks/live/dev      stacks/live/prod     units/live/dev/ec2
+      units/live/prod/ec2  units/live/dev/db    units/live/prod/db
+      units/live/dev/vpc   units/live/prod/vpc
+
 flags:
   - list-format
   - list-hidden
@@ -73,6 +89,7 @@ flags:
   - list-tree
   - list-long
   - list-dag
+  - queue-construct-as
 ---
 
 import { Aside, Badge } from '@astrojs/starlight/components';
@@ -148,6 +165,34 @@ $ terragrunt list --tree --dag
     │   ╰── live/prod/ec2
     ╰── live/prod/ec2
 ```
+
+## Queue Construct As
+
+The `list` command supports the `--queue-construct-as` flag (or its shorter alias `--as`) to sort output based on the dependency graph, as if a particular command was run.
+
+For example, when using the `plan` command:
+
+```bash
+$ terragrunt list --queue-construct-as=plan
+stacks/live/dev      stacks/live/prod     units/live/dev/vpc
+units/live/prod/vpc  units/live/dev/db    units/live/prod/db
+units/live/dev/ec2   units/live/prod/ec2
+```
+
+This will sort the output based on the dependency graph, as if the `plan` command was run. All dependent units will appear *after* the units they depend on.
+
+When using the `destroy` command:
+
+```bash
+$ terragrunt list --queue-construct-as=destroy
+stacks/live/dev      stacks/live/prod     units/live/dev/ec2
+units/live/prod/ec2  units/live/dev/db    units/live/prod/db
+units/live/dev/vpc   units/live/prod/vpc
+```
+
+This will sort the output based on the dependency graph, as if the `destroy` command was run. All dependent units will appear *before* the units they depend on.
+
+**Note:** The `--queue-construct-as` flag implies the `--dag` flag.
 
 ## Dependencies and Discovery
 

--- a/docs-starlight/src/data/flags/find-exclude.mdx
+++ b/docs-starlight/src/data/flags/find-exclude.mdx
@@ -1,0 +1,89 @@
+---
+name: find-exclude
+description: Include exclude configuration in the output
+type: boolean
+env:
+  - TG_FIND_EXCLUDE
+---
+
+Include exclude configuration in the output. When enabled, the JSON output will include the configurations of the `exclude` block in the discovered units.
+
+## Usage
+
+```bash
+--exclude
+```
+
+## Examples
+
+Show exclude configurations in JSON format:
+```bash
+terragrunt find --exclude --format=json
+```
+
+Show exclude configurations with queue construct simulation:
+```bash
+terragrunt find --exclude --queue-construct-as=plan --format=json
+```
+
+## Behavior
+
+When enabled, the JSON output will include any `exclude` block configurations found in the units:
+
+```bash
+$ terragrunt find --exclude --format=json | jq
+[
+  {
+    "type": "unit",
+    "path": "action/exclude-apply",
+    "exclude": {
+      "exclude_dependencies": true,
+      "actions": [
+        "apply"
+      ],
+      "if": true
+    }
+  },
+  {
+    "type": "unit",
+    "path": "action/exclude-plan",
+    "exclude": {
+      "exclude_dependencies": true,
+      "actions": [
+        "plan"
+      ],
+      "if": true
+    }
+  },
+  {
+    "type": "unit",
+    "path": "all-except-output/app1",
+    "exclude": {
+      "exclude_dependencies": true,
+      "actions": [
+        "all_except_output"
+      ],
+      "if": true
+    }
+  }
+]
+```
+
+Note that you can combine this with the `--queue-construct-as` flag to dry-run behavior relevant to excludes.
+
+```bash
+$ terragrunt find --exclude --queue-construct-as=plan --format=json | jq
+[
+  {
+    "type": "unit",
+    "path": "action/exclude-apply",
+    "exclude": {
+      "exclude_dependencies": true,
+      "actions": [
+        "apply"
+      ],
+      "if": true
+    }
+  }
+]
+```

--- a/docs-starlight/src/data/flags/queue-construct-as.mdx
+++ b/docs-starlight/src/data/flags/queue-construct-as.mdx
@@ -1,0 +1,45 @@
+---
+name: queue-construct-as
+description: |
+  Sort output based on the dependency graph, as if a particular command was run. This flag implies the `--dag` flag.
+
+  The flag has a shorter alias `--as`.
+type: string
+env:
+  - TG_QUEUE_CONSTRUCT_AS
+aliases:
+  - --as
+---
+
+Sort output based on the dependency graph, as if a particular command was run. This flag implies the `--dag` flag.
+
+The flag has a shorter alias `--as`.
+
+## Usage
+
+```bash
+--queue-construct-as=COMMAND
+--as=COMMAND
+```
+
+Where `COMMAND` is the command to simulate (e.g., `plan`, `destroy`).
+
+## Examples
+
+Sort output as if running plan command (dependencies after dependents):
+```bash
+terragrunt find --queue-construct-as=plan
+```
+
+Sort output as if running destroy command (dependencies before dependents):
+```bash
+terragrunt find --queue-construct-as=destroy
+```
+
+## Behavior
+
+When using `plan` command, all dependent units will appear *after* the units they depend on.
+
+When using `destroy` command, all dependent units will appear *before* the units they depend on.
+
+**Note:** This flag implies the `--dag` flag.

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -747,7 +747,7 @@ units/live/dev/ec2
 units/live/prod/ec2
 ```
 
-This will sort the output based on the dependency graph, as if the `plan` command was run. Meaning that all dependent units will appear *after* the units they depend on.
+This will sort the output based on the dependency graph, as if the `plan` command was run. Meaning that all dependent units will appear _after_ the units they depend on.
 
 ```bash
 # Note that you can also use the shorter alias of the flag, `--as`.
@@ -762,7 +762,7 @@ units/live/dev/vpc
 units/live/prod/vpc
 ```
 
-This will sort the output based on the dependency graph, as if the `destroy` command was run. Meaning that all dependent units will appear *before* the units they depend on.
+This will sort the output based on the dependency graph, as if the `destroy` command was run. Meaning that all dependent units will appear _before_ the units they depend on.
 
 **Note:** The `--queue-construct-as` flag implies the `--dag` flag.
 
@@ -996,7 +996,7 @@ units/live/prod/vpc  units/live/dev/db    units/live/prod/db
 units/live/dev/ec2   units/live/prod/ec2
 ```
 
-This will sort the output based on the dependency graph, as if the `plan` command was run. Meaning that all dependent units will appear *after* the units they depend on.
+This will sort the output based on the dependency graph, as if the `plan` command was run. Meaning that all dependent units will appear _after_ the units they depend on.
 
 ```bash
 $ terragrunt list --queue-construct-as=destroy
@@ -1005,7 +1005,7 @@ units/live/prod/ec2  units/live/dev/db    units/live/prod/db
 units/live/dev/vpc   units/live/prod/vpc
 ```
 
-This will sort the output based on the dependency graph, as if the `destroy` command was run. Meaning that all dependent units will appear *before* the units they depend on.
+This will sort the output based on the dependency graph, as if the `destroy` command was run. Meaning that all dependent units will appear _before_ the units they depend on.
 
 **Note:** The `--queue-construct-as` flag implies the `--dag` flag.
 

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -731,6 +731,41 @@ unitC # depends on unitA
 unitD # depends on unitC
 ```
 
+##### Find Queue Construct As
+
+The `find` command supports the `--queue-construct-as` flag to sort output based on the dependency graph, as if a particular command was run.
+
+```bash
+$ terragrunt find --queue-construct-as=plan
+stacks/live/dev
+stacks/live/prod
+units/live/dev/vpc
+units/live/prod/vpc
+units/live/dev/db
+units/live/prod/db
+units/live/dev/ec2
+units/live/prod/ec2
+```
+
+This will sort the output based on the dependency graph, as if the `plan` command was run. Meaning that all dependent units will appear *after* the units they depend on.
+
+```bash
+# Note that you can also use the shorter alias of the flag, `--as`.
+$ terragrunt find --as=destroy
+stacks/live/dev
+stacks/live/prod
+units/live/dev/ec2
+units/live/prod/ec2
+units/live/dev/db
+units/live/prod/db
+units/live/dev/vpc
+units/live/prod/vpc
+```
+
+This will sort the output based on the dependency graph, as if the `destroy` command was run. Meaning that all dependent units will appear *before* the units they depend on.
+
+**Note:** The `--queue-construct-as` flag implies the `--dag` flag.
+
 ##### Find Dependencies
 
 You can include dependency information in the output using the `--dependencies` flag. When enabled, the JSON output will include the dependency relationships between configurations:
@@ -750,6 +785,70 @@ $ terragrunt find --dependencies --format=json | jq
   }
 ]
 ```
+
+##### Find Exclude
+
+You can also include exclude configuration in the output using the `--exclude` flag. When enabled, the JSON output will include the configurations of the `exclude` block in the discovered units.
+
+```bash
+$ terragrunt find --exclude --format=json | jq
+[
+  {
+    "type": "unit",
+    "path": "action/exclude-apply",
+    "exclude": {
+      "exclude_dependencies": true,
+      "actions": [
+        "apply"
+      ],
+      "if": true
+    }
+  },
+  {
+    "type": "unit",
+    "path": "action/exclude-plan",
+    "exclude": {
+      "exclude_dependencies": true,
+      "actions": [
+        "plan"
+      ],
+      "if": true
+    }
+  },
+  {
+    "type": "unit",
+    "path": "all-except-output/app1",
+    "exclude": {
+      "exclude_dependencies": true,
+      "actions": [
+        "all_except_output"
+      ],
+      "if": true
+    }
+  }
+]
+```
+
+Note that you can combine this with the `--queue-construct-as` flag to dry-run behavior relevant to excludes.
+
+```bash
+$ terragrunt find --exclude --queue-construct-as=plan --format=json | jq
+[
+  {
+    "type": "unit",
+    "path": "action/exclude-apply",
+    "exclude": {
+      "exclude_dependencies": true,
+      "actions": [
+        "apply"
+      ],
+      "if": true
+    }
+  }
+]
+```
+
+`find` will remove any units that would match the exclude configuration.
 
 ##### Find External Dependencies
 
@@ -885,6 +984,30 @@ $ terragrunt list --tree --dag
     ╰── live/prod/ec2
 
 ```
+
+##### List Queue Construct As
+
+Just like the `find` command, the `list` command supports the `--queue-construct-as` flag to sort output based on the dependency graph, as if a particular command was run.
+
+```bash
+$ terragrunt list --queue-construct-as=plan
+stacks/live/dev      stacks/live/prod     units/live/dev/vpc
+units/live/prod/vpc  units/live/dev/db    units/live/prod/db
+units/live/dev/ec2   units/live/prod/ec2
+```
+
+This will sort the output based on the dependency graph, as if the `plan` command was run. Meaning that all dependent units will appear *after* the units they depend on.
+
+```bash
+$ terragrunt list --queue-construct-as=destroy
+stacks/live/dev      stacks/live/prod     units/live/dev/ec2
+units/live/prod/ec2  units/live/dev/db    units/live/prod/db
+units/live/dev/vpc   units/live/prod/vpc
+```
+
+This will sort the output based on the dependency graph, as if the `destroy` command was run. Meaning that all dependent units will appear *before* the units they depend on.
+
+**Note:** The `--queue-construct-as` flag implies the `--dag` flag.
 
 ### Configuration commands
 
@@ -1219,7 +1342,9 @@ This command will exit with an error if terragrunt detects any unused inputs or 
     - [find](#find)
       - [Find Output Format](#find-output-format)
       - [Find DAG Mode](#find-dag-mode)
+      - [Find Queue Construct As](#find-queue-construct-as)
       - [Find Dependencies](#find-dependencies)
+      - [Find Exclude](#find-exclude)
       - [Find External Dependencies](#find-external-dependencies)
       - [Find Hidden Configurations](#find-hidden-configurations)
     - [list](#list)
@@ -1228,6 +1353,7 @@ This command will exit with an error if terragrunt detects any unused inputs or 
         - [Long Format](#long-format)
         - [Tree Format](#tree-format)
       - [DAG Mode](#dag-mode)
+      - [List Queue Construct As](#list-queue-construct-as)
   - [Configuration commands](#configuration-commands)
     - [graph-dependencies](#graph-dependencies)
     - [hclfmt](#hclfmt)
@@ -1236,6 +1362,7 @@ This command will exit with an error if terragrunt detects any unused inputs or 
     - [render-json](#render-json)
     - [info](#info)
       - [Strict command](#strict-command)
+      - [Print command](#print-command)
     - [terragrunt-info](#terragrunt-info)
     - [validate-inputs](#validate-inputs)
 - [Flags](#flags)

--- a/docs/_docs/04_reference/06-experiments.md
+++ b/docs/_docs/04_reference/06-experiments.md
@@ -164,7 +164,7 @@ To transition `cli-redesign` features to a stable release, the following must be
   - [x] Add support for `find` with `--hidden` flag.
   - [x] Add support for `find` with `--sort=alpha` flag.
   - [x] Add support for `find` with `--sort=dag` flag.
-  - [ ] Add support for `find` with the `exclude` block used to exclude units from the search.
+  - [x] Add support for `find` with the `exclude` block used to exclude units from the search.
   - [ ] Add integration with `symlinks` experiment to support finding units/stacks via symlinks.
   - [x] Add handling of broken configurations or configurations requiring authentication.
   - [x] Add integration test for `find` with `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
@@ -179,7 +179,7 @@ To transition `cli-redesign` features to a stable release, the following must be
   - [x] Add support for `list` with `--sort=dag` flag.
   - [x] Add support for `list` with `--group-by=fs` flag.
   - [x] Add support for `list` with `--group-by=dag` flag.
-  - [ ] Add support for `list` with the `exclude` block used to exclude units from the search.
+  - [x] Add support for `list` with the `exclude` block used to exclude units from the search.
   - [ ] Add integration with `symlinks` experiment to support listing units/stacks via symlinks.
   - [x] Add handling of broken configurations or configurations requiring authentication.
   - [x] Add integration test for `list` with `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -186,9 +186,13 @@ func (c *DiscoveredConfig) Parse(ctx context.Context, opts *options.TerragruntOp
 		log.WithFormatter(format.NewFormatter(format.NewPrettyFormatPlaceholders())),
 	)
 
-	// We can assume this is a unit config, because we already filtered out
-	// stack configs above.
-	parseOpts.TerragruntConfigPath = filepath.Join(parseOpts.WorkingDir, config.DefaultTerragruntConfigPath)
+	filename := config.DefaultTerragruntConfigPath
+
+	if c.Type == ConfigTypeStack {
+		filename = config.DefaultStackFile
+	}
+
+	parseOpts.TerragruntConfigPath = filepath.Join(parseOpts.WorkingDir, filename)
 
 	parsingCtx := config.NewParsingContext(ctx, parseOpts).WithDecodeList(
 		config.DependenciesBlock,

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -208,6 +208,7 @@ func (c *DiscoveredConfig) Parse(ctx context.Context, opts *options.TerragruntOp
 		log.WithOutput(io.Discard),
 		log.WithFormatter(format.NewFormatter(format.NewPrettyFormatPlaceholders())),
 	)
+	parseOpts.SkipOutput = true
 
 	filename := config.DefaultTerragruntConfigPath
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -275,6 +275,8 @@ func (d *Discovery) Discover(ctx context.Context, opts *options.TerragruntOption
 		return cfgs, errors.New(err)
 	}
 
+	errs := []error{}
+
 	// We do an initial parse loop if we know we need to parse configurations,
 	// as we might need to parse configurations for multiple reasons.
 	// e.g. dependencies, exclude, etc.
@@ -282,7 +284,7 @@ func (d *Discovery) Discover(ctx context.Context, opts *options.TerragruntOption
 		for _, cfg := range cfgs {
 			_, err := cfg.Parse(ctx, opts, d.suppressParseErrors)
 			if err != nil {
-				return cfgs, errors.New(err)
+				errs = append(errs, errors.New(err))
 			}
 		}
 	}
@@ -297,8 +299,6 @@ func (d *Discovery) Discover(ctx context.Context, opts *options.TerragruntOption
 		if d.suppressParseErrors {
 			dependencyDiscovery = dependencyDiscovery.WithSuppressParseErrors()
 		}
-
-		errs := []error{}
 
 		err := dependencyDiscovery.DiscoverAllDependencies(ctx, opts)
 		if err != nil {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
+	"github.com/zclconf/go-cty/cty"
 )
 
 const (
@@ -456,6 +457,12 @@ func (d *DependencyDiscovery) DiscoverDependencies(ctx context.Context, opts *op
 	errs := []error{}
 
 	for _, dependency := range dependencyBlocks {
+		if dependency.ConfigPath.Type() != cty.String {
+			errs = append(errs, errors.New("dependency config path is not a string"))
+
+			continue
+		}
+
 		depPath := dependency.ConfigPath.AsString()
 
 		if !filepath.IsAbs(depPath) {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -23,118 +23,227 @@
 package queue
 
 import (
+	"errors"
+	"slices"
 	"sort"
 
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
-	"github.com/gruntwork-io/terragrunt/internal/errors"
 )
 
-type Queue struct {
-	entries discovery.DiscoveredConfigs
+type Entry struct {
+	Config *discovery.DiscoveredConfig
+	Status Status
 }
 
-// Entries returns the queue entries. Used for testing.
-func (q *Queue) Entries() []*discovery.DiscoveredConfig {
-	return q.entries
+type Status byte
+
+const (
+	StatusPending Status = iota
+	StatusBlocked
+	StatusUnsorted
+	StatusReady
+)
+
+// UpdateBlocked updates the status of the entry to blocked, if it is blocked.
+// An entry is blocked if:
+//  1. It is an "up" command (none of destroy, apply -destroy or plan -destroy)
+//     and it has dependencies that are not ready.
+//  2. It is a "down" command (destroy, apply -destroy or plan -destroy)
+//     and it has dependents that are not ready.
+//
+// If the entry isn't blocked, then it is marked as unsorted, and is ready to be sorted.
+func (e *Entry) UpdateBlocked(entries Entries) {
+	// If the entry is already ready, we can skip the rest of the logic.
+	if e.Status == StatusReady {
+		return
+	}
+
+	if e.IsUp() {
+		for _, dep := range e.Config.Dependencies {
+			depEntry := entries.Entry(dep)
+			if depEntry == nil {
+				continue
+			}
+
+			if !depEntry.IsUp() {
+				continue
+			}
+
+			if depEntry.Status != StatusReady {
+				e.Status = StatusBlocked
+				return
+			}
+		}
+
+		e.Status = StatusUnsorted
+
+		return
+	}
+
+	// If the entry is a "down" command, we need to check if all of its dependents are ready.
+	for _, qEntry := range entries {
+		if qEntry.Config.Dependencies == nil {
+			continue
+		}
+
+		if !slices.Contains(qEntry.Config.Dependencies, e.Config) {
+			continue
+		}
+
+		if qEntry.IsUp() {
+			continue
+		}
+
+		if qEntry.Status != StatusReady {
+			e.Status = StatusBlocked
+			return
+		}
+	}
+
+	e.Status = StatusUnsorted
+}
+
+// IsUp returns true if the entry is an "up" command.
+func (e *Entry) IsUp() bool {
+	// If we don't have a discovery context,
+	// we should assume the command is an "up" command.
+	if e.Config.DiscoveryContext == nil {
+		return true
+	}
+
+	if e.Config.DiscoveryContext.Cmd == "destroy" {
+		return false
+	}
+
+	if e.Config.DiscoveryContext.Cmd == "apply" && slices.Contains(e.Config.DiscoveryContext.Args, "-destroy") {
+		return false
+	}
+
+	if e.Config.DiscoveryContext.Cmd == "plan" && slices.Contains(e.Config.DiscoveryContext.Args, "-destroy") {
+		return false
+	}
+
+	return true
+}
+
+type Queue struct {
+	Entries Entries
+}
+
+type Entries []*Entry
+
+// Entry returns a given entry from the queue.
+func (e Entries) Entry(cfg *discovery.DiscoveredConfig) *Entry {
+	for _, entry := range e {
+		if entry.Config.Path == cfg.Path {
+			return entry
+		}
+	}
+
+	return nil
+}
+
+// Configs returns the queue configs.
+func (q *Queue) Configs() discovery.DiscoveredConfigs {
+	result := make(discovery.DiscoveredConfigs, 0, len(q.Entries))
+	for _, entry := range q.Entries {
+		result = append(result, entry.Config)
+	}
+
+	return result
 }
 
 // NewQueue creates a new queue from a list of discovered configurations.
 // The queue is populated with the correct Terragrunt run order.
-// Dependencies are guaranteed to come before their dependents.
-// Items with the same dependencies are sorted alphabetically.
-// Passing dependencies that that haven't been checked for cycles is unsafe.
+//
+// Discovered configurations will be sorted based on two criteria:
+//
+//  1. The discovery context of the configuration:
+//     - If the configuration is for an "up" command (none of destroy, apply -destroy or plan -destroy),
+//     it will be inserted at the front of the queue, before its dependencies.
+//     - Otherwise, it is considered a "down" command, and will be inserted at the back of the queue,
+//     after its dependents.
+//
+//  2. The name of the configuration. Configurations of the same "level" are sorted alphabetically.
+//
+// Passing configurations that haven't been checked for cycles in their dependency graph is unsafe.
 // If any cycles are present, the queue construction will halt after N
 // iterations, where N is the number of discovered configs, and throw an error.
 func NewQueue(discovered discovery.DiscoveredConfigs) (*Queue, error) {
 	if len(discovered) == 0 {
 		return &Queue{
-			entries: discovered,
+			Entries: Entries{},
 		}, nil
 	}
 
-	// Create a map for O(1) lookups of configs by path
-	configMap := make(map[string]*discovery.DiscoveredConfig, len(discovered))
+	// First, we need to take all the discovered configs
+	// and assign them a status of pending.
+	entries := make(Entries, 0, len(discovered))
+
 	for _, cfg := range discovered {
-		configMap[cfg.Path] = cfg
+		entries = append(entries, &Entry{
+			Config: cfg,
+			Status: StatusPending,
+		})
 	}
 
-	// Track if a given config has been processed
-	visited := make(map[string]bool, len(discovered))
+	q := &Queue{
+		Entries: entries,
+	}
 
-	// result will store configs in dependency order
-	result := make(discovery.DiscoveredConfigs, 0, len(discovered))
-
-	// depthBudget is initially the maximum dependency depth of the queue
-	// Given that a cycle-free graph has a maximum depth of N, we can
-	// use the length of the discovered configs as a safe upper bound.
-	depthBudget := len(discovered)
-
-	// Process nodes level by level, with deterministic ordering within each level
-	var processLevel func(configs discovery.DiscoveredConfigs) error
-	processLevel = func(configs discovery.DiscoveredConfigs) error {
-		// We need to check to see if we've reached
-		// the maximum allowed iterations.
-		if depthBudget < 0 {
-			return errors.New("cycle detected during queue construction")
+	// readyPending returns the index of the first pending entry if there is one,
+	// or -1 if there are no pending entries.
+	readyPending := func(entries Entries) int {
+		// Next, we need to iterate through the entries
+		// and check if any of them are blocked.
+		for _, entry := range entries {
+			entry.UpdateBlocked(entries)
 		}
 
-		depthBudget--
-
-		levelNodes := make([]*discovery.DiscoveredConfig, 0, len(configs))
-
-		for _, cfg := range configs {
-			if visited[cfg.Path] {
-				continue
+		// Next, we need to sort the entries by status and path.
+		sort.SliceStable(entries, func(i, j int) bool {
+			if entries[i].Status > entries[j].Status {
+				return true
 			}
 
-			hasUnprocessedDeps := false
-
-			// Only consider dependencies that exist in our discovered configs
-			for _, dep := range cfg.Dependencies {
-				if _, exists := configMap[dep.Path]; !exists {
-					continue // Skip dependencies that don't exist in our discovered configs
-				}
-
-				if !visited[dep.Path] {
-					hasUnprocessedDeps = true
-					break
-				}
+			if entries[i].Status == entries[j].Status {
+				return entries[i].Config.Path < entries[j].Config.Path
 			}
 
-			if !hasUnprocessedDeps {
-				levelNodes = append(levelNodes, cfg)
-			}
-		}
-
-		// Sort nodes by path for deterministic ordering within each level
-		sort.SliceStable(levelNodes, func(i, j int) bool {
-			return levelNodes[i].Path < levelNodes[j].Path
+			return false
 		})
 
-		// Add all nodes at this level to result
-		for _, node := range levelNodes {
-			visited[node.Path] = true
+		// Now, we can mark all unsorted entries as ready,
+		// and check if all entries are ready.
+		for idx, entry := range entries {
+			if entry.Status == StatusUnsorted {
+				entry.Status = StatusReady
+			}
 
-			result = append(result, node)
+			if entry.Status != StatusReady {
+				return idx
+			}
 		}
 
-		// If every node has been visited, we're done
-		if len(visited) == len(discovered) {
-			return nil
+		return -1
+	}
+
+	// We need to iterate through the entries until all entries are ready.
+	// We can use the length of the entries as a safe upper bound for the number of iterations,
+	// because a cycle-free graph has a maximum depth of N, where N is the number of discovered configs.
+	maxIterations := len(entries)
+
+	// We keep track of the index of the first pending entry
+	// to save us from iterating through the entire list of entries
+	// on each iteration.
+	firstPending := 0
+
+	for range maxIterations {
+		firstPending = readyPending(entries[firstPending:])
+		if firstPending == -1 {
+			return q, nil
 		}
-
-		// Process next level
-		return processLevel(configs)
 	}
 
-	// Start with all configs
-	if err := processLevel(discovered); err != nil {
-		return &Queue{
-			entries: result,
-		}, err
-	}
-
-	return &Queue{
-		entries: result,
-	}, nil
+	return q, errors.New("cycle detected during queue construction")
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -206,7 +206,7 @@ func NewQueue(discovered discovery.DiscoveredConfigs) (*Queue, error) {
 				return true
 			}
 
-			if entries[i].Status == entries[j].Status {
+			if entries[i].Status == StatusUnsorted && entries[j].Status == StatusUnsorted {
 				return entries[i].Config.Path < entries[j].Config.Path
 			}
 

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -31,6 +31,8 @@ func TestNoDependenciesMaintainsAlphabeticalOrder(t *testing.T) {
 }
 
 func TestDependenciesOrderedByDependencyLevel(t *testing.T) {
+	t.Parallel()
+
 	// Create configs with dependencies - should order by dependency level
 	aCfg := &discovery.DiscoveredConfig{Path: "a", Dependencies: []*discovery.DiscoveredConfig{}}
 	bCfg := &discovery.DiscoveredConfig{Path: "b", Dependencies: []*discovery.DiscoveredConfig{aCfg}}
@@ -52,6 +54,8 @@ func TestDependenciesOrderedByDependencyLevel(t *testing.T) {
 }
 
 func TestComplexDagOrderedByDependencyLevelAndAlphabetically(t *testing.T) {
+	t.Parallel()
+
 	// Create a more complex dependency graph:
 	// Create a more complex dependency graph:
 	//   A (no deps)
@@ -104,6 +108,8 @@ func TestComplexDagOrderedByDependencyLevelAndAlphabetically(t *testing.T) {
 }
 
 func TestDeterministicOrderingOfParallelDependencies(t *testing.T) {
+	t.Parallel()
+
 	// Create a graph with parallel dependencies that could be ordered multiple ways:
 	// Create a graph with parallel dependencies that could be ordered multiple ways:
 	//   A (no deps)
@@ -135,6 +141,8 @@ func TestDeterministicOrderingOfParallelDependencies(t *testing.T) {
 }
 
 func TestDepthBasedOrderingVerification(t *testing.T) {
+	t.Parallel()
+
 	// Create a graph where depth matters:
 	// Create a graph where depth matters:
 	//   A (no deps, depth 0)
@@ -183,6 +191,8 @@ func TestDepthBasedOrderingVerification(t *testing.T) {
 }
 
 func TestErrorHandlingCycle(t *testing.T) {
+	t.Parallel()
+
 	// Create a cycle: A -> B -> C -> A
 	// Create a cycle: A -> B -> C -> A
 	configs := []*discovery.DiscoveredConfig{
@@ -197,6 +207,8 @@ func TestErrorHandlingCycle(t *testing.T) {
 }
 
 func TestErrorHandlingEmptyConfigList(t *testing.T) {
+	t.Parallel()
+
 	// Create an empty config list
 	configs := []*discovery.DiscoveredConfig{}
 

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -9,209 +9,200 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewQueue(t *testing.T) {
+func TestNoDependenciesMaintainsAlphabeticalOrder(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no dependencies - maintains alphabetical order", func(t *testing.T) {
-		t.Parallel()
+	// Create configs with no dependencies - should maintain alphabetical order at front
+	configs := []*discovery.DiscoveredConfig{
+		{Path: "c", Dependencies: []*discovery.DiscoveredConfig{}},
+		{Path: "a", Dependencies: []*discovery.DiscoveredConfig{}},
+		{Path: "b", Dependencies: []*discovery.DiscoveredConfig{}},
+	}
 
-		// Create configs with no dependencies - should maintain alphabetical order at front
-		configs := []*discovery.DiscoveredConfig{
-			{Path: "c", Dependencies: []*discovery.DiscoveredConfig{}},
-			{Path: "a", Dependencies: []*discovery.DiscoveredConfig{}},
-			{Path: "b", Dependencies: []*discovery.DiscoveredConfig{}},
-		}
+	q, err := queue.NewQueue(configs)
+	require.NoError(t, err)
 
+	entries := q.Entries()
+
+	// Should be sorted alphabetically at front since none have dependencies
+	assert.Equal(t, "a", entries[0].Path)
+	assert.Equal(t, "b", entries[1].Path)
+	assert.Equal(t, "c", entries[2].Path)
+}
+
+func TestDependenciesOrderedByDependencyLevel(t *testing.T) {
+	// Create configs with dependencies - should order by dependency level
+	configs := []*discovery.DiscoveredConfig{
+		{Path: "c", Dependencies: []*discovery.DiscoveredConfig{{Path: "b"}}},
+		{Path: "b", Dependencies: []*discovery.DiscoveredConfig{{Path: "a"}}},
+		{Path: "a", Dependencies: []*discovery.DiscoveredConfig{}},
+	}
+
+	q, err := queue.NewQueue(configs)
+	require.NoError(t, err)
+
+	entries := q.Entries()
+
+	// 'a' has no deps so should be at front
+	// 'b' depends on 'a' so should be after
+	// 'c' depends on 'b' so should be at back
+	assert.Equal(t, "a", entries[0].Path)
+	assert.Equal(t, "b", entries[1].Path)
+	assert.Equal(t, "c", entries[2].Path)
+}
+
+func TestComplexDagOrderedByDependencyLevelAndAlphabetically(t *testing.T) {
+	// Create a more complex dependency graph:
+	// Create a more complex dependency graph:
+	//   A (no deps)
+	//   B (no deps)
+	//   C -> A
+	//   D -> A,B
+	//   E -> C
+	//   F -> C
+	configs := []*discovery.DiscoveredConfig{
+		{Path: "F", Dependencies: []*discovery.DiscoveredConfig{{Path: "C"}}},
+		{Path: "E", Dependencies: []*discovery.DiscoveredConfig{{Path: "C"}}},
+		{Path: "D", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}, {Path: "B"}}},
+		{Path: "C", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+		{Path: "B", Dependencies: []*discovery.DiscoveredConfig{}},
+		{Path: "A", Dependencies: []*discovery.DiscoveredConfig{}},
+	}
+
+	q, err := queue.NewQueue(configs)
+	require.NoError(t, err)
+
+	entries := q.Entries()
+
+	// Verify ordering by dependency level and alphabetically within levels:
+	// Level 0 (no deps): A, B
+	// Level 1 (depends on level 0): C, D
+	// Level 2 (depends on level 1): E, F
+	assert.Equal(t, "A", entries[0].Path)
+	assert.Equal(t, "B", entries[1].Path)
+	assert.Equal(t, "C", entries[2].Path)
+	assert.Equal(t, "D", entries[3].Path)
+	assert.Equal(t, "E", entries[4].Path)
+	assert.Equal(t, "F", entries[5].Path)
+
+	// Also verify relative ordering
+	aIndex := findIndex(entries, "A")
+	bIndex := findIndex(entries, "B")
+	cIndex := findIndex(entries, "C")
+	dIndex := findIndex(entries, "D")
+	eIndex := findIndex(entries, "E")
+	fIndex := findIndex(entries, "F")
+
+	// Level 0 items should be before their dependents
+	assert.Less(t, aIndex, cIndex, "A should come before C")
+	assert.Less(t, aIndex, dIndex, "A should come before D")
+	assert.Less(t, bIndex, dIndex, "B should come before D")
+
+	// Level 1 items should be before their dependents
+	assert.Less(t, cIndex, eIndex, "C should come before E")
+	assert.Less(t, cIndex, fIndex, "C should come before F")
+}
+
+func TestDeterministicOrderingOfParallelDependencies(t *testing.T) {
+	// Create a graph with parallel dependencies that could be ordered multiple ways:
+	// Create a graph with parallel dependencies that could be ordered multiple ways:
+	//   A (no deps)
+	//   B -> A
+	//   C -> A
+	//   D -> A
+	configs := []*discovery.DiscoveredConfig{
+		{Path: "D", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+		{Path: "C", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+		{Path: "B", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+		{Path: "A", Dependencies: []*discovery.DiscoveredConfig{}},
+	}
+
+	// Run multiple times to verify deterministic ordering
+	for range 5 {
 		q, err := queue.NewQueue(configs)
 		require.NoError(t, err)
 
 		entries := q.Entries()
 
-		// Should be sorted alphabetically at front since none have dependencies
-		assert.Equal(t, "a", entries[0].Path)
-		assert.Equal(t, "b", entries[1].Path)
-		assert.Equal(t, "c", entries[2].Path)
-	})
-
-	t.Run("dependencies - ordered by dependency level", func(t *testing.T) {
-		t.Parallel()
-
-		// Create configs with dependencies - should order by dependency level
-		configs := []*discovery.DiscoveredConfig{
-			{Path: "c", Dependencies: []*discovery.DiscoveredConfig{{Path: "b"}}},
-			{Path: "b", Dependencies: []*discovery.DiscoveredConfig{{Path: "a"}}},
-			{Path: "a", Dependencies: []*discovery.DiscoveredConfig{}},
-		}
-
-		q, err := queue.NewQueue(configs)
-		require.NoError(t, err)
-
-		entries := q.Entries()
-
-		// 'a' has no deps so should be at front
-		// 'b' depends on 'a' so should be after
-		// 'c' depends on 'b' so should be at back
-		assert.Equal(t, "a", entries[0].Path)
-		assert.Equal(t, "b", entries[1].Path)
-		assert.Equal(t, "c", entries[2].Path)
-	})
-
-	t.Run("complex dag - ordered by dependency level and alphabetically", func(t *testing.T) {
-		t.Parallel()
-
-		// Create a more complex dependency graph:
-		//   A (no deps)
-		//   B (no deps)
-		//   C -> A
-		//   D -> A,B
-		//   E -> C
-		//   F -> C
-		configs := []*discovery.DiscoveredConfig{
-			{Path: "F", Dependencies: []*discovery.DiscoveredConfig{{Path: "C"}}},
-			{Path: "E", Dependencies: []*discovery.DiscoveredConfig{{Path: "C"}}},
-			{Path: "D", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}, {Path: "B"}}},
-			{Path: "C", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
-			{Path: "B", Dependencies: []*discovery.DiscoveredConfig{}},
-			{Path: "A", Dependencies: []*discovery.DiscoveredConfig{}},
-		}
-
-		q, err := queue.NewQueue(configs)
-		require.NoError(t, err)
-
-		entries := q.Entries()
-
-		// Verify ordering by dependency level and alphabetically within levels:
-		// Level 0 (no deps): A, B
-		// Level 1 (depends on level 0): C, D
-		// Level 2 (depends on level 1): E, F
+		// A should be first (no deps)
 		assert.Equal(t, "A", entries[0].Path)
+
+		// B, C, D should maintain alphabetical order since they're all at the same level
 		assert.Equal(t, "B", entries[1].Path)
 		assert.Equal(t, "C", entries[2].Path)
 		assert.Equal(t, "D", entries[3].Path)
-		assert.Equal(t, "E", entries[4].Path)
-		assert.Equal(t, "F", entries[5].Path)
+	}
+}
 
-		// Also verify relative ordering
-		aIndex := findIndex(entries, "A")
-		bIndex := findIndex(entries, "B")
-		cIndex := findIndex(entries, "C")
-		dIndex := findIndex(entries, "D")
-		eIndex := findIndex(entries, "E")
-		fIndex := findIndex(entries, "F")
+func TestDepthBasedOrderingVerification(t *testing.T) {
+	// Create a graph where depth matters:
+	// Create a graph where depth matters:
+	//   A (no deps, depth 0)
+	//   B (no deps, depth 0)
+	//   C -> A (depth 1)
+	//   D -> B (depth 1)
+	//   E -> C,D (depth 2)
+	configs := []*discovery.DiscoveredConfig{
+		{Path: "E", Dependencies: []*discovery.DiscoveredConfig{{Path: "C"}, {Path: "D"}}},
+		{Path: "D", Dependencies: []*discovery.DiscoveredConfig{{Path: "B"}}},
+		{Path: "C", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+		{Path: "B", Dependencies: []*discovery.DiscoveredConfig{}},
+		{Path: "A", Dependencies: []*discovery.DiscoveredConfig{}},
+	}
 
-		// Level 0 items should be before their dependents
-		assert.Less(t, aIndex, cIndex, "A should come before C")
-		assert.Less(t, aIndex, dIndex, "A should come before D")
-		assert.Less(t, bIndex, dIndex, "B should come before D")
+	q, err := queue.NewQueue(configs)
+	require.NoError(t, err)
 
-		// Level 1 items should be before their dependents
-		assert.Less(t, cIndex, eIndex, "C should come before E")
-		assert.Less(t, cIndex, fIndex, "C should come before F")
-	})
+	entries := q.Entries()
 
-	t.Run("deterministic ordering of parallel dependencies", func(t *testing.T) {
-		t.Parallel()
+	// Verify that items are grouped by their depth levels
+	// Level 0: A,B (no deps)
+	// Level 1: C,D (depend on level 0)
+	// Level 2: E (depends on level 1)
 
-		// Create a graph with parallel dependencies that could be ordered multiple ways:
-		//   A (no deps)
-		//   B -> A
-		//   C -> A
-		//   D -> A
-		configs := []*discovery.DiscoveredConfig{
-			{Path: "D", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
-			{Path: "C", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
-			{Path: "B", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
-			{Path: "A", Dependencies: []*discovery.DiscoveredConfig{}},
-		}
+	// First verify the basic ordering
+	assert.Len(t, entries, 5, "Should have all 5 entries")
 
-		// Run multiple times to verify deterministic ordering
-		for range 5 {
-			q, err := queue.NewQueue(configs)
-			require.NoError(t, err)
+	// Find indices
+	aIndex := findIndex(entries, "A")
+	bIndex := findIndex(entries, "B")
+	cIndex := findIndex(entries, "C")
+	dIndex := findIndex(entries, "D")
+	eIndex := findIndex(entries, "E")
 
-			entries := q.Entries()
+	// Level 0 items should be at the start (indices 0 or 1)
+	assert.LessOrEqual(t, aIndex, 1, "A should be in first two positions")
+	assert.LessOrEqual(t, bIndex, 1, "B should be in first two positions")
 
-			// A should be first (no deps)
-			assert.Equal(t, "A", entries[0].Path)
+	// Level 1 items should be in the middle (indices 2 or 3)
+	assert.True(t, cIndex >= 2 && cIndex <= 3, "C should be in middle positions")
+	assert.True(t, dIndex >= 2 && dIndex <= 3, "D should be in middle positions")
 
-			// B, C, D should maintain alphabetical order since they're all at the same level
-			assert.Equal(t, "B", entries[1].Path)
-			assert.Equal(t, "C", entries[2].Path)
-			assert.Equal(t, "D", entries[3].Path)
-		}
-	})
+	// Level 2 item should be at the end (index 4)
+	assert.Equal(t, 4, eIndex, "E should be in last position")
+}
 
-	t.Run("depth-based ordering verification", func(t *testing.T) {
-		t.Parallel()
+func TestErrorHandlingCycle(t *testing.T) {
+	// Create a cycle: A -> B -> C -> A
+	// Create a cycle: A -> B -> C -> A
+	configs := []*discovery.DiscoveredConfig{
+		{Path: "C", Dependencies: []*discovery.DiscoveredConfig{{Path: "B"}}},
+		{Path: "B", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
+		{Path: "A", Dependencies: []*discovery.DiscoveredConfig{{Path: "C"}}},
+	}
 
-		// Create a graph where depth matters:
-		//   A (no deps, depth 0)
-		//   B (no deps, depth 0)
-		//   C -> A (depth 1)
-		//   D -> B (depth 1)
-		//   E -> C,D (depth 2)
-		configs := []*discovery.DiscoveredConfig{
-			{Path: "E", Dependencies: []*discovery.DiscoveredConfig{{Path: "C"}, {Path: "D"}}},
-			{Path: "D", Dependencies: []*discovery.DiscoveredConfig{{Path: "B"}}},
-			{Path: "C", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
-			{Path: "B", Dependencies: []*discovery.DiscoveredConfig{}},
-			{Path: "A", Dependencies: []*discovery.DiscoveredConfig{}},
-		}
+	q, err := queue.NewQueue(configs)
+	require.Error(t, err)
+	assert.NotNil(t, q)
+}
 
-		q, err := queue.NewQueue(configs)
-		require.NoError(t, err)
+func TestErrorHandlingEmptyConfigList(t *testing.T) {
+	// Create an empty config list
+	configs := []*discovery.DiscoveredConfig{}
 
-		entries := q.Entries()
-
-		// Verify that items are grouped by their depth levels
-		// Level 0: A,B (no deps)
-		// Level 1: C,D (depend on level 0)
-		// Level 2: E (depends on level 1)
-
-		// First verify the basic ordering
-		assert.Len(t, entries, 5, "Should have all 5 entries")
-
-		// Find indices
-		aIndex := findIndex(entries, "A")
-		bIndex := findIndex(entries, "B")
-		cIndex := findIndex(entries, "C")
-		dIndex := findIndex(entries, "D")
-		eIndex := findIndex(entries, "E")
-
-		// Level 0 items should be at the start (indices 0 or 1)
-		assert.LessOrEqual(t, aIndex, 1, "A should be in first two positions")
-		assert.LessOrEqual(t, bIndex, 1, "B should be in first two positions")
-
-		// Level 1 items should be in the middle (indices 2 or 3)
-		assert.True(t, cIndex >= 2 && cIndex <= 3, "C should be in middle positions")
-		assert.True(t, dIndex >= 2 && dIndex <= 3, "D should be in middle positions")
-
-		// Level 2 item should be at the end (index 4)
-		assert.Equal(t, 4, eIndex, "E should be in last position")
-	})
-
-	t.Run("error handling - cycle", func(t *testing.T) {
-		t.Parallel()
-
-		// Create a cycle: A -> B -> C -> A
-		configs := []*discovery.DiscoveredConfig{
-			{Path: "C", Dependencies: []*discovery.DiscoveredConfig{{Path: "B"}}},
-			{Path: "B", Dependencies: []*discovery.DiscoveredConfig{{Path: "A"}}},
-			{Path: "A", Dependencies: []*discovery.DiscoveredConfig{{Path: "C"}}},
-		}
-
-		q, err := queue.NewQueue(configs)
-		require.Error(t, err)
-		assert.NotNil(t, q)
-	})
-
-	t.Run("error handling - empty config list", func(t *testing.T) {
-		t.Parallel()
-
-		q, err := queue.NewQueue([]*discovery.DiscoveredConfig{})
-		require.NoError(t, err)
-		assert.Empty(t, q.Entries())
-	})
+	q, err := queue.NewQueue(configs)
+	require.NoError(t, err)
+	assert.Empty(t, q.Entries())
 }
 
 // findIndex returns the index of the config with the given path in the slice

--- a/test/fixtures/exclude/basic/unit1/terragrunt.hcl
+++ b/test/fixtures/exclude/basic/unit1/terragrunt.hcl
@@ -1,0 +1,4 @@
+exclude {
+  if      = true
+  actions = ["plan"]
+}

--- a/test/fixtures/exclude/basic/unit2/terragrunt.hcl
+++ b/test/fixtures/exclude/basic/unit2/terragrunt.hcl
@@ -1,0 +1,4 @@
+exclude {
+  if      = true
+  actions = ["apply"]
+}

--- a/test/fixtures/exclude/basic/unit3/terragrunt.hcl
+++ b/test/fixtures/exclude/basic/unit3/terragrunt.hcl
@@ -1,0 +1,1 @@
+// No exclude configuration

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -1,9 +1,13 @@
 package test_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/cli/commands/find"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,6 +18,7 @@ const (
 	testFixtureFindHidden            = "fixtures/find/hidden"
 	testFixtureFindDAG               = "fixtures/find/dag"
 	testFixtureFindInternalVExternal = "fixtures/find/internal-v-external"
+	testFixtureFindExclude           = "fixtures/exclude/basic"
 )
 
 func TestFindBasic(t *testing.T) {
@@ -131,4 +136,76 @@ func TestFindExternalDependencies(t *testing.T) {
 
 	assert.Empty(t, stderr)
 	assert.Equal(t, "a-dependent\nb-dependency\n", stdout)
+}
+
+func TestFindExclude(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		args           string
+		expectedOutput string
+		expectedPaths  []string
+	}{
+		{
+			name:          "show exclude configs",
+			args:          "--exclude",
+			expectedPaths: []string{"unit1", "unit2", "unit3"},
+		},
+		{
+			name:          "exclude plan command",
+			args:          "--queue-construct-as plan",
+			expectedPaths: []string{"unit2", "unit3"},
+		},
+		{
+			name:          "exclude apply command",
+			args:          "--queue-construct-as apply",
+			expectedPaths: []string{"unit1", "unit3"},
+		},
+		{
+			name:          "show exclude configs with json",
+			args:          "--exclude --json",
+			expectedPaths: []string{"unit1", "unit2", "unit3"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			helpers.CleanupTerraformFolder(t, testFixtureFindExclude)
+
+			cmd := fmt.Sprintf("terragrunt find --experiment cli-redesign --no-color --working-dir %s %s", testFixtureFindExclude, tc.args)
+			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+			require.NoError(t, err)
+			assert.Empty(t, stderr)
+
+			if strings.Contains(tc.args, "--json") {
+				var configs find.FoundConfigs
+				err = json.Unmarshal([]byte(stdout), &configs)
+				require.NoError(t, err)
+
+				var paths []string
+				for _, config := range configs {
+					paths = append(paths, config.Path)
+					if strings.Contains(tc.args, "--exclude") {
+						switch config.Path {
+						case "unit1":
+							assert.NotNil(t, config.Exclude)
+							assert.Contains(t, config.Exclude.Actions, "plan")
+						case "unit2":
+							assert.NotNil(t, config.Exclude)
+							assert.Contains(t, config.Exclude.Actions, "apply")
+						default:
+							assert.Nil(t, config.Exclude)
+						}
+					}
+				}
+				assert.ElementsMatch(t, tc.expectedPaths, paths)
+			} else {
+				paths := strings.Fields(stdout)
+				assert.ElementsMatch(t, tc.expectedPaths, paths)
+			}
+		})
+	}
 }

--- a/test/integration_list_test.go
+++ b/test/integration_list_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testFixtureListBasic = "fixtures/list/basic"
+	testFixtureListDag   = "fixtures/list/dag"
+)
+
 func TestListCommand(t *testing.T) {
 	t.Parallel()
 
@@ -20,13 +25,13 @@ func TestListCommand(t *testing.T) {
 	}{
 		{
 			name:           "Basic list with default format",
-			workingDir:     "fixtures/list/basic",
+			workingDir:     testFixtureListBasic,
 			args:           []string{"list"},
 			expectedOutput: "a-unit  b-unit  \n",
 		},
 		{
 			name:       "List with long format",
-			workingDir: "fixtures/list/basic",
+			workingDir: testFixtureListBasic,
 			args:       []string{"list", "--long"},
 			expectedOutput: `Type  Path
 unit  a-unit
@@ -35,7 +40,7 @@ unit  b-unit
 		},
 		{
 			name:       "List with tree format",
-			workingDir: "fixtures/list/basic",
+			workingDir: testFixtureListBasic,
 			args:       []string{"list", "--tree"},
 			expectedOutput: `.
 ├── a-unit
@@ -74,7 +79,7 @@ func TestListCommandWithDependencies(t *testing.T) {
 	}{
 		{
 			name:       "List with dependencies in tree format",
-			workingDir: "fixtures/list/dag",
+			workingDir: testFixtureListDag,
 			args:       []string{"list", "--tree", "--dag"},
 			expected: `.
 ├── stacks/live/dev
@@ -91,7 +96,7 @@ func TestListCommandWithDependencies(t *testing.T) {
 		},
 		{
 			name:       "List with dependencies in long format",
-			workingDir: "fixtures/list/dag",
+			workingDir: testFixtureListDag,
 			args:       []string{"list", "--long", "--dependencies"},
 			expected: `Type  Path                 Dependencies
 stack stacks/live/dev


### PR DESCRIPTION
## Description

Adds support for `list` and `find` to use the `--queue-construct-as` flag (aliased to `--as`) to allow for them to construct the run queue as if they were a particular command.

In addition, adds support for the `--exclude` flag, which displays information related to the `exclude` block when using the `find` command with the `--json` flag.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added `--queue-construct-as` to the `find`/`list` commands.
Added `--exclude` flag to the `find` command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new flag to the **find** command that lets you include or filter out configurations based on exclusion rules.
  - Introduced a **queue construction** flag (with shorthand) for both **find** and **list** commands that simulates command execution (e.g., plan or destroy), automatically enabling dependency graph ordering.

- **Documentation**
  - Updated CLI reference materials and examples to clearly explain how to use the new flags and their effects on dependency and exclusion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->