### PR TITLE
feat: add support for no_validation attribute for stack and unit

### DIFF
--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -792,6 +792,11 @@ func stackToCty(stack *Stack) (cty.Value, error) {
 		output["no_dot_terragrunt_stack"] = goboolToCty(*stack.NoStack)
 	}
 
+	// Handle NoValidation if available
+	if stack.NoValidation != nil {
+		output["no_validation"] = goboolToCty(*stack.NoValidation)
+	}
+
 	return convertValuesMapToCtyVal(output)
 }
 
@@ -815,6 +820,11 @@ func unitToCty(unit *Unit) (cty.Value, error) {
 	// Handle NoStack if available
 	if unit.NoStack != nil {
 		output["no_dot_terragrunt_stack"] = goboolToCty(*unit.NoStack)
+	}
+
+	// Handle NoValidation if available
+	if unit.NoValidation != nil {
+		output["no_validation"] = goboolToCty(*unit.NoValidation)
 	}
 
 	return convertValuesMapToCtyVal(output)

--- a/config/config_as_cty.go
+++ b/config/config_as_cty.go
@@ -792,7 +792,6 @@ func stackToCty(stack *Stack) (cty.Value, error) {
 		output["no_dot_terragrunt_stack"] = goboolToCty(*stack.NoStack)
 	}
 
-	// Handle NoValidation if available
 	if stack.NoValidation != nil {
 		output["no_validation"] = goboolToCty(*stack.NoValidation)
 	}
@@ -822,7 +821,6 @@ func unitToCty(unit *Unit) (cty.Value, error) {
 		output["no_dot_terragrunt_stack"] = goboolToCty(*unit.NoStack)
 	}
 
-	// Handle NoValidation if available
 	if unit.NoValidation != nil {
 		output["no_validation"] = goboolToCty(*unit.NoValidation)
 	}

--- a/config/stack.go
+++ b/config/stack.go
@@ -526,7 +526,7 @@ func processComponent(ctx context.Context, opts *options.TerragruntOptions, cmp 
 
 	skipValidation := false
 
-	if !cmp.noStack {
+	if cmp.noStack {
 		opts.Logger.Debugf("Skipping validation for %s %s due to no_stack flag", kindStr, cmp.name)
 
 		skipValidation = true
@@ -538,7 +538,7 @@ func processComponent(ctx context.Context, opts *options.TerragruntOptions, cmp 
 		skipValidation = true
 	}
 
-	if skipValidation {
+	if !skipValidation {
 		// validate what was copied to the destination, don't do validation for special noStack components
 		expectedFile := DefaultTerragruntConfigPath
 

--- a/docs-starlight/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -1674,6 +1674,7 @@ The `unit` block supports the following arguments:
 - `path` (attribute): The relative path where this unit should be deployed within the stack directory (`.terragrunt-stack`). Also take note of the `no_dot_terragrunt_stack` attribute below, which can impact this.
 - `values` (attribute, optional): A map of values that will be passed to the unit as inputs.
 - `no_dot_terragrunt_stack` (attribute, optional): A boolean flag (`true` or `false`). When set to `true`, the unit **will not** be placed inside the `.terragrunt-stack` directory but will instead be generated in the same directory where `terragrunt.stack.hcl` is located. This allows for a **soft adoption** of stacks, making it easier for users to start using `terragrunt.stack.hcl` without modifying existing directory structures, or performing state migrations.
+- `no_validation` (attribute, optional): A boolean flag (`true` or `false`) that controls whether Terragrunt should validate the unit's configuration. When set to `true`, Terragrunt will skip validation checks for this unit.
 
 Example:
 
@@ -1790,6 +1791,7 @@ The `stack` block supports the following arguments:
 - `path` (attribute): The relative path within `.terragrunt-stack` where this stack should be generated.If an absolute path is provided here, Terragrunt will generate the stack in that location, instead of generating it in a path relative to the `.terragrunt-stack` directory. Also take note of the `no_dot_terragrunt_stack` attribute below, which can impact this.
 - `values` (attribute, optional): A map of custom values that can be passed to the stack. These values can be referenced within the stack's configuration files, allowing for customization without modifying the stack source.
 - `no_dot_terragrunt_stack` (attribute, optional): A boolean flag (`true` or `false`). When set to `true`, the stack **will not** be placed inside the `.terragrunt-stack` directory but will instead be generated in the same directory where `terragrunt.stack.hcl` is located. This allows for a **soft adoption** of stacks, making it easier for users to start using `terragrunt.stack.hcl` without modifying existing directory structures, or performing state migrations.
+- `no_validation` (attribute, optional): A boolean flag (`true` or `false`) that controls whether Terragrunt should validate the stack's configuration. When set to `true`, Terragrunt will skip validation checks for this stack.
 
 Example:
 

--- a/docs/_docs/04_reference/04-config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/04-config-blocks-and-attributes.md
@@ -1665,6 +1665,7 @@ The `unit` block supports the following arguments:
 - `path` (attribute): The relative path where this unit should be deployed within the stack directory (`.terragrunt-stack`). If an absolute path is provided here, Terragrunt will generate the stack in that location, instead of generating it in a path relative to the `.terragrunt-stack` directory. Also take note of the `no_dot_terragrunt_stack` attribute below, which can impact this.
 - `values` (attribute, optional): A map of values that will be passed to the unit as inputs.
 - `no_dot_terragrunt_stack` (attribute, optional): A boolean flag (`true` or `false`). When set to `true`, the unit **will not** be placed inside the `.terragrunt-stack` directory but will instead be generated in the same directory where `terragrunt.stack.hcl` is located. This allows for a **soft adoption** of stacks, making it easier for users to start using `terragrunt.stack.hcl` without modifying existing directory structures, or performing state migrations.
+- `no_validation` (attribute, optional): A boolean flag (`true` or `false`) that controls whether Terragrunt should validate the unit's configuration. When set to `true`, Terragrunt will skip validation checks for this unit.
 
 Example:
 
@@ -1775,6 +1776,7 @@ The `stack` block supports the following arguments:
 - `path` (attribute): The relative path within `.terragrunt-stack` where this stack should be generated.If an absolute path is provided here, Terragrunt will generate the stack in that location, instead of generating it in a path relative to the `.terragrunt-stack` directory. Also take note of the `no_dot_terragrunt_stack` attribute below, which can impact this.
 - `values` (attribute, optional): A map of custom values that can be passed to the stack. These values can be referenced within the stack's configuration files, allowing for customization without modifying the stack source.
 - `no_dot_terragrunt_stack` (attribute, optional): A boolean flag (`true` or `false`). When set to `true`, the stack **will not** be placed inside the `.terragrunt-stack` directory but will instead be generated in the same directory where `terragrunt.stack.hcl` is located. This allows for a **soft adoption** of stacks, making it easier for users to start using `terragrunt.stack.hcl` without modifying existing directory structures, or performing state migrations.
+- `no_validation` (attribute, optional): A boolean flag (`true` or `false`) that controls whether Terragrunt should validate the stack's configuration. When set to `true`, Terragrunt will skip validation checks for this stack.
 
 Example:
 

--- a/test/fixtures/stacks/no-validation/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/no-validation/live/terragrunt.stack.hcl
@@ -1,0 +1,12 @@
+unit "unit1" {
+  source        = "../units"
+  path          = "unit1"
+  no_validation = true
+}
+
+unit "stack1" {
+  source        = "../stacks"
+  path          = "stack1"
+  no_validation = true
+}
+

--- a/test/fixtures/stacks/no-validation/stacks/stack1/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/no-validation/stacks/stack1/terragrunt.stack.hcl
@@ -1,0 +1,5 @@
+unit "unit2" {
+  source        = "../../../../units"
+  path          = "unit2"
+  no_validation = true
+}

--- a/test/fixtures/stacks/no-validation/units/app1/code/main.tf
+++ b/test/fixtures/stacks/no-validation/units/app1/code/main.tf
@@ -1,0 +1,4 @@
+resource "local_file" "file" {
+  content  = "test file"
+  filename = "${path.module}/file.txt"
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Added support for no_validation attribute for stack and unit
* Added integration tests for no_validation
* Updated documentation

Fixes #4148.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration attribute `no_validation` for both unit and stack blocks, allowing users to bypass validation checks during deployments.
- **Documentation**
	- Updated the configuration references to include the new `no_validation` option with usage guidelines.
- **Tests**
	- Added new tests to ensure the correct behavior when the validation process is intentionally skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->