### PR TITLE
feat: add telemetry for find/list

### DIFF
--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -45,6 +45,7 @@ func Run(ctx context.Context, opts *Options) error {
 	}
 
 	var cfgs discovery.DiscoveredConfigs
+
 	var discoverErr error
 
 	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "find_discover", map[string]any{
@@ -75,7 +76,9 @@ func Run(ctx context.Context, opts *Options) error {
 			if queueErr != nil {
 				return queueErr
 			}
+
 			cfgs = q.Configs()
+
 			return nil
 		})
 		if err != nil {
@@ -88,12 +91,14 @@ func Run(ctx context.Context, opts *Options) error {
 	}
 
 	var foundCfgs FoundConfigs
+
 	err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "find_discovered_to_found", map[string]any{
 		"working_dir":  opts.WorkingDir,
 		"config_count": len(cfgs),
 	}, func(ctx context.Context) error {
 		var convErr error
 		foundCfgs, convErr = discoveredToFound(cfgs, opts)
+
 		return convErr
 	})
 	if err != nil {

--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -47,7 +47,6 @@ func Run(ctx context.Context, opts *Options) error {
 	var cfgs discovery.DiscoveredConfigs
 	var discoverErr error
 
-	// Wrap the d.Discover() call with telemetry
 	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "find_discover", map[string]any{
 		"working_dir":  opts.WorkingDir,
 		"hidden":       opts.Hidden,

--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -65,16 +65,7 @@ func Run(ctx context.Context, opts *Options) error {
 
 	switch opts.Mode {
 	case ModeNormal:
-		err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "find_mode_normal", map[string]any{
-			"working_dir":  opts.WorkingDir,
-			"config_count": len(cfgs),
-		}, func(ctx context.Context) error {
-			cfgs = cfgs.Sort()
-			return nil
-		})
-		if err != nil {
-			return errors.New(err)
-		}
+		cfgs = cfgs.Sort()
 	case ModeDAG:
 		err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "find_mode_dag", map[string]any{
 			"working_dir":  opts.WorkingDir,

--- a/cli/commands/list/list.go
+++ b/cli/commands/list/list.go
@@ -45,6 +45,7 @@ func Run(ctx context.Context, opts *Options) error {
 	}
 
 	var cfgs discovery.DiscoveredConfigs
+
 	var discoverErr error
 
 	// Wrap discovery with telemetry
@@ -74,9 +75,12 @@ func Run(ctx context.Context, opts *Options) error {
 			if queueErr != nil {
 				return queueErr
 			}
+
 			cfgs = q.Configs()
+
 			return nil
 		})
+
 		if err != nil {
 			return errors.New(err)
 		}
@@ -87,14 +91,18 @@ func Run(ctx context.Context, opts *Options) error {
 	}
 
 	var listedCfgs ListedConfigs
+
 	err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "list_discovered_to_listed", map[string]any{
 		"working_dir":  opts.WorkingDir,
 		"config_count": len(cfgs),
 	}, func(ctx context.Context) error {
 		var convErr error
+
 		listedCfgs, convErr = discoveredToListed(cfgs, opts)
+
 		return convErr
 	})
+
 	if err != nil {
 		return errors.New(err)
 	}

--- a/cli/commands/list/list.go
+++ b/cli/commands/list/list.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gruntwork-io/terragrunt/telemetry"
+
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/tree"
 	"github.com/charmbracelet/x/term"
@@ -42,7 +44,20 @@ func Run(ctx context.Context, opts *Options) error {
 		})
 	}
 
-	cfgs, err := d.Discover(ctx, opts.TerragruntOptions)
+	var cfgs discovery.DiscoveredConfigs
+	var discoverErr error
+
+	// Wrap discovery with telemetry
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "list_discover", map[string]any{
+		"working_dir":  opts.WorkingDir,
+		"hidden":       opts.Hidden,
+		"dependencies": shouldDiscoverDependencies(opts),
+		"external":     opts.External,
+	}, func(ctx context.Context) error {
+		cfgs, discoverErr = d.Discover(ctx, opts.TerragruntOptions)
+		return discoverErr
+	})
+
 	if err != nil {
 		opts.Logger.Debugf("Errors encountered while discovering configurations:\n%s", err)
 	}
@@ -51,19 +66,35 @@ func Run(ctx context.Context, opts *Options) error {
 	case ModeNormal:
 		cfgs = cfgs.Sort()
 	case ModeDAG:
-		q, err := queue.NewQueue(cfgs)
+		err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "list_mode_dag", map[string]any{
+			"working_dir":  opts.WorkingDir,
+			"config_count": len(cfgs),
+		}, func(ctx context.Context) error {
+			q, queueErr := queue.NewQueue(cfgs)
+			if queueErr != nil {
+				return queueErr
+			}
+			cfgs = q.Configs()
+			return nil
+		})
 		if err != nil {
 			return errors.New(err)
 		}
-
-		cfgs = q.Configs()
 	default:
 		// This should never happen, because of validation in the command.
 		// If it happens, we want to throw so we can fix the validation.
 		return errors.New("invalid mode: " + opts.Mode)
 	}
 
-	listedCfgs, err := discoveredToListed(cfgs, opts)
+	var listedCfgs ListedConfigs
+	err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "list_discovered_to_listed", map[string]any{
+		"working_dir":  opts.WorkingDir,
+		"config_count": len(cfgs),
+	}, func(ctx context.Context) error {
+		var convErr error
+		listedCfgs, convErr = discoveredToListed(cfgs, opts)
+		return convErr
+	})
 	if err != nil {
 		return errors.New(err)
 	}

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -1369,7 +1369,7 @@ The `dag` command is used to interact with the Directed Acyclic Graph.
 
 It will soon replace the [`graph-dependencies`](#graph-dependencies) command. See the [CLI Redesign](/docs/reference/experiments/#cli-redesign) documentation for more information.
 
-##### Print graph
+##### dag graph
 
 Print a visual representation of the Terragrunt dependency graph in DOT language format. This command analyzes your Terragrunt configuration and outputs a directed acyclic graph (DAG) showing the relationships and dependencies between your Terraform modules.
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gruntwork-io/terragrunt/telemetry"
+
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -330,43 +332,63 @@ func (d *Discovery) Discover(ctx context.Context, opts *options.TerragruntOption
 	}
 
 	if d.discoverDependencies {
-		dependencyDiscovery := NewDependencyDiscovery(cfgs, d.maxDependencyDepth)
+		err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "discover_dependencies", map[string]any{
+			"working_dir":                    d.workingDir,
+			"config_count":                   len(cfgs),
+			"discover_external_dependencies": d.discoverExternalDependencies,
+			"max_dependency_depth":           d.maxDependencyDepth,
+		}, func(ctx context.Context) error {
+			dependencyDiscovery := NewDependencyDiscovery(cfgs, d.maxDependencyDepth)
 
-		if d.discoveryContext != nil {
-			dependencyDiscovery = dependencyDiscovery.WithDiscoveryContext(d.discoveryContext)
-		}
-
-		if d.discoverExternalDependencies {
-			dependencyDiscovery = dependencyDiscovery.WithDiscoverExternalDependencies()
-		}
-
-		if d.suppressParseErrors {
-			dependencyDiscovery = dependencyDiscovery.WithSuppressParseErrors()
-		}
-
-		err := dependencyDiscovery.DiscoverAllDependencies(ctx, opts)
-		if err != nil {
-			opts.Logger.Warnf("Parsing errors where encountered while discovering dependencies. They were suppressed, and can be found in the debug logs.")
-
-			opts.Logger.Debugf("Errors: %w", err)
-		}
-
-		cfgs = dependencyDiscovery.cfgs
-
-		if _, err := cfgs.CycleCheck(); err != nil {
-			opts.Logger.Warnf("Cycle detected in dependency graph, attempting removal of cycles.")
-
-			opts.Logger.Debugf("Cycle: %w", err)
-
-			cfgs, err = cfgs.RemoveCycles()
-			if err != nil {
-				errs = append(errs, errors.New(err))
+			if d.discoveryContext != nil {
+				dependencyDiscovery = dependencyDiscovery.WithDiscoveryContext(d.discoveryContext)
 			}
+
+			if d.discoverExternalDependencies {
+				dependencyDiscovery = dependencyDiscovery.WithDiscoverExternalDependencies()
+			}
+
+			if d.suppressParseErrors {
+				dependencyDiscovery = dependencyDiscovery.WithSuppressParseErrors()
+			}
+
+			err := dependencyDiscovery.DiscoverAllDependencies(ctx, opts)
+			if err != nil {
+				opts.Logger.Warnf("Parsing errors where encountered while discovering dependencies. They were suppressed, and can be found in the debug logs.")
+
+				opts.Logger.Debugf("Errors: %w", err)
+			}
+
+			cfgs = dependencyDiscovery.cfgs
+			return nil
+		})
+		if err != nil {
+			return cfgs, errors.New(err)
 		}
 
-		if len(errs) > 0 {
-			return cfgs, errors.Join(errs...)
+		err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "discovery_cycle_check", map[string]any{
+			"working_dir":  d.workingDir,
+			"config_count": len(cfgs),
+		}, func(ctx context.Context) error {
+			if _, err := cfgs.CycleCheck(); err != nil {
+				opts.Logger.Warnf("Cycle detected in dependency graph, attempting removal of cycles.")
+
+				opts.Logger.Debugf("Cycle: %w", err)
+
+				cfgs, err = cfgs.RemoveCycles()
+				if err != nil {
+					errs = append(errs, errors.New(err))
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return cfgs, errors.New(err)
 		}
+	}
+
+	if len(errs) > 0 {
+		return cfgs, errors.Join(errs...)
 	}
 
 	return cfgs, nil

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -360,6 +360,7 @@ func (d *Discovery) Discover(ctx context.Context, opts *options.TerragruntOption
 			}
 
 			cfgs = dependencyDiscovery.cfgs
+
 			return nil
 		})
 		if err != nil {
@@ -380,6 +381,7 @@ func (d *Discovery) Discover(ctx context.Context, opts *options.TerragruntOption
 					errs = append(errs, errors.New(err))
 				}
 			}
+
 			return nil
 		})
 		if err != nil {

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -520,6 +520,40 @@ func TestTerragruntStackProduceTelemetryTraces(t *testing.T) {
 	assert.Contains(t, output, "\"Name\":\"stack_generate\"")
 }
 
+func TestTerragruntFindProduceTelemetryTraces(t *testing.T) {
+	t.Setenv("TG_TELEMETRY_TRACE_EXPORTER", "console")
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksBasic)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksBasic)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksBasic)
+
+	output, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --experiment cli-redesign --working-dir "+rootPath)
+	require.NoError(t, err)
+
+	// check that output have Telemetry json output
+	assert.Contains(t, output, "\"SpanContext\":")
+	assert.Contains(t, output, "\"TraceID\":")
+	assert.Contains(t, output, "\"Name\":\"find_discover\"")
+	assert.Contains(t, output, "\"Name\":\"find_discovered_to_found\"")
+}
+
+func TestTerragruntListProduceTelemetryTraces(t *testing.T) {
+	t.Setenv("TG_TELEMETRY_TRACE_EXPORTER", "console")
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksBasic)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksBasic)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksBasic)
+
+	output, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt list --experiment cli-redesign --working-dir "+rootPath)
+	require.NoError(t, err)
+
+	// check that output have Telemetry json output
+	assert.Contains(t, output, "\"SpanContext\":")
+	assert.Contains(t, output, "\"TraceID\":")
+	assert.Contains(t, output, "\"Name\":\"list_discover\"")
+	assert.Contains(t, output, "\"Name\":\"list_discovered_to_listed\"")
+}
+
 func TestTerragruntProduceTelemetryMetrics(t *testing.T) {
 	t.Setenv("TG_TELEMETRY_METRIC_EXPORTER", "console")
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* added telemetry collection for find and list commands
* added integration tests
* small documentation update

find telemetry:
![image](https://github.com/user-attachments/assets/eb5ff11a-e90f-4b5d-bec0-c99cb1419f57)

list telemetry:
![image](https://github.com/user-attachments/assets/7af232f1-e822-4aae-8230-12257c359d21)



<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added telemetry tracing to the `find` and `list` commands, enabling enhanced tracking of command execution phases.

- **Documentation**
  - Updated CLI reference documentation to clarify the "dag graph" command section.

- **Tests**
  - Introduced new integration tests to verify that telemetry trace output is produced for the `find` and `list` commands when telemetry is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->