### PR TITLE
fix: Improving getting started guide

### DIFF
--- a/docs/_docs/01_getting-started/01-quick-start.md
+++ b/docs/_docs/01_getting-started/01-quick-start.md
@@ -48,7 +48,7 @@ This tutorial will not assume the following:
 2. You have any experience with Terragrunt.
 3. You have any existing Terragrunt, OpenTofu or Terraform projects.
 
-\* Note that if you have _both_ OpenTofu and Terraform installed, you'll want to read the [terragrunt-tfpath](/docs/reference/cli-options/#terragrunt-tfpath) docs to understand how Terragrunt determines which binary to use.
+\* Note that if you have _both_ OpenTofu and Terraform installed, you'll want to read the [tf-path](/docs/reference/cli-options/#tf-path) docs to understand how Terragrunt determines which binary to use.
 
 If you would like a less gentle introduction geared towards users with an active AWS account, familiarity with OpenTofu/Terraform, and potentially a team actively using Terragrunt, consider starting with the [Overview](/docs/getting-started/overview/).
 
@@ -131,12 +131,12 @@ $ terragrunt apply -auto-approve
 
 You might notice that this is a little more verbose than the output you're used to seeing from running `tofu` or `terraform` directly. This is because Terragrunt does a bit of work behind the scenes to make sure that you can scale your OpenTofu/Terraform usage without running into common problems. As you get more comfortable with using Terragrunt on larger projects, you may find the extra information helpful.
 
-If you would prefer that Terragrunt output look more like the output from `tofu` or `terraform`, you can use the `--terragrunt-log-format bare` flag (or set the environment variable `TERRAGRUNT_LOG_FORMAT=bare`) to reduce the verbosity of the output.
+If you would prefer that Terragrunt output look more like the output from `tofu` or `terraform`, you can use the `--log-format bare` flag (or set the environment variable `TG_LOG_FORMAT=bare`) to reduce the verbosity of the output.
 
 e.g.
 
 ```bash
-$ terragrunt --terragrunt-log-format bare apply
+$ terragrunt --log-format bare apply
 local_file.file: Refreshing state... [id=0a0a9f2a6772942557ab5355d76af442f8f65e01]
 
 No changes. Your infrastructure matches the configuration.
@@ -306,10 +306,10 @@ Are you sure you want to run 'terragrunt apply' in each folder of the stack desc
 
 This is where that additional verbosity in Terragrunt logging is really handy. You can see that Terragrunt concurrently ran `apply -auto-approve` in both the `foo` and `bar` units. The extra logging for Terragrunt also included information on the names of the units that were processed, and disambiguated the output from each unit.
 
-Similar to the `tofu` CLI, there is a prompt to confirm that you are sure you want to run the command in each unit when performing a command that's potentially destructive. You can skip this prompt by using the `--terragrunt-non-interactive` flag, just as you would with `-auto-approve` in OpenTofu.
+Similar to the `tofu` CLI, there is a prompt to confirm that you are sure you want to run the command in each unit when performing a command that's potentially destructive. You can skip this prompt by using the `--non-interactive` flag, just as you would with `-auto-approve` in OpenTofu.
 
 ```bash
-terragrunt run-all --terragrunt-non-interactive apply
+terragrunt run-all --non-interactive apply
 ```
 
 ### Step 6: Use Terragrunt to manage your DAG
@@ -442,7 +442,7 @@ Group 2
 If you're concerned about the `mock_outputs` attribute resulting in invalid configurations, note that during an apply, the outputs of `foo` will be known, and Terragrunt won't use `mock_outputs` to resolve the outputs of `foo`.
 
 ```bash
-$ terragrunt run-all --terragrunt-non-interactive apply
+$ terragrunt run-all --non-interactive apply
 
 ...
 

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -1525,7 +1525,7 @@ This command will exit with an error if terragrunt detects any unused inputs or 
       - [Strict command](#strict-command)
       - [Print command](#print-command)
     - [dag](#dag)
-      - [Print graph](#print-graph)
+      - [dag graph](#dag-graph)
     - [terragrunt-info](#terragrunt-info)
     - [validate-inputs](#validate-inputs)
 - [Flags](#flags)

--- a/test/integration_docs_aws_test.go
+++ b/test/integration_docs_aws_test.go
@@ -35,14 +35,14 @@ func TestAwsDocsOverview(t *testing.T) {
 
 		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
 		defer func() {
-			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt destroy -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt destroy -auto-approve --non-interactive --working-dir "+rootPath)
 			require.NoError(t, err)
 		}()
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 
@@ -59,14 +59,14 @@ func TestAwsDocsOverview(t *testing.T) {
 
 		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
 		defer func() {
-			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all destroy -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all destroy -auto-approve --non-interactive --working-dir "+rootPath)
 			require.NoError(t, err)
 		}()
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -auto-approve --non-interactive --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 
@@ -83,14 +83,14 @@ func TestAwsDocsOverview(t *testing.T) {
 
 		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
 		defer func() {
-			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all destroy -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all destroy -auto-approve --non-interactive --working-dir "+rootPath)
 			require.NoError(t, err)
 		}()
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -auto-approve --non-interactive --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 
@@ -107,14 +107,14 @@ func TestAwsDocsOverview(t *testing.T) {
 
 		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
 		defer func() {
-			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all destroy -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all destroy -auto-approve --non-interactive --working-dir "+rootPath)
 			require.NoError(t, err)
 		}()
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -auto-approve --non-interactive --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 
@@ -131,14 +131,14 @@ func TestAwsDocsOverview(t *testing.T) {
 
 		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
 		defer func() {
-			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all destroy -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all destroy -auto-approve --non-interactive --working-dir "+rootPath)
 			require.NoError(t, err)
 		}()
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -auto-approve --non-interactive --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 }

--- a/test/integration_docs_test.go
+++ b/test/integration_docs_test.go
@@ -25,11 +25,11 @@ func TestDocsQuickStart(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 		assert.Contains(t, stdout, "Plan: 1 to add, 0 to change, 0 to destroy.")
 
-		stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 		assert.Contains(t, stdout, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
 
@@ -44,10 +44,10 @@ func TestDocsQuickStart(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan -var content='Hello, Terragrunt!' --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan -var content='Hello, Terragrunt!' --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 
-		_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve -var content='Hello, Terragrunt!' --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve -var content='Hello, Terragrunt!' --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 
@@ -60,10 +60,10 @@ func TestDocsQuickStart(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan -var content='Hello, Terragrunt!' --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan -var content='Hello, Terragrunt!' --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 
-		_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -var content='Hello, Terragrunt!' --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -var content='Hello, Terragrunt!' --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 
@@ -76,10 +76,10 @@ func TestDocsQuickStart(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan -var content='Hello, Terragrunt!' --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan -var content='Hello, Terragrunt!' --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 
-		_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -var content='Hello, Terragrunt!' --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply -var content='Hello, Terragrunt!' --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 
@@ -92,10 +92,10 @@ func TestDocsQuickStart(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 
-		_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 
@@ -108,10 +108,10 @@ func TestDocsQuickStart(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 
-		_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all apply --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 
@@ -124,7 +124,7 @@ func TestDocsQuickStart(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan --non-interactive --log-level trace --working-dir "+rootPath)
 		require.Error(t, err)
 	})
 
@@ -137,7 +137,7 @@ func TestDocsQuickStart(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 
@@ -150,7 +150,7 @@ func TestDocsQuickStart(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir "+rootPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Description

Avoids usage of deprecated `terragrunt-` prefixed flags.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Removed `terragrunt-` prefixes from flags in the getting started guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect new CLI option and environment variable names, aligning examples and references with the latest Terragrunt flag conventions.
  - Clarified subcommand naming in the CLI options reference for improved accuracy.

- **Tests**
  - Updated test cases to use the new CLI flag formats, ensuring consistency with the latest Terragrunt command-line options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->