### PR TITLE
feat: Adding markdownlint v2 to GitHub Actions workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,14 +136,6 @@ run_terratest_log_parser: &run_terratest_log_parser
     terratest_log_parser --testlog logs/test-results.log --outputdir logs
   when: always
 
-run_markdownlint: &run_markdownlint
-  name: Run markdownlint
-  command: |
-    markdownlint \
-    --disable MD013 MD024 \
-    -- \
-    docs
-
 codespell: &codespell
   name: Run codespell
   command: |
@@ -635,13 +627,6 @@ jobs:
       - store_test_results:
           path: logs
 
-  run_markdownlint:
-    <<: *defaults
-    steps:
-      - checkout
-      - run:
-          <<: *run_markdownlint
-
   codespell:
     <<: *defaults
     steps:
@@ -966,16 +951,6 @@ workflows:
             - GCP__automated-tests
             - GITHUB__PAT__gruntwork-ci
             - APPLE__OSX__code-signing
-      - run_markdownlint:
-          filters:
-            tags:
-              only:
-                - /^v.*/
-                - /^alpha.*/
-          context:
-            - AWS__PHXDEVOPS__circle-ci-test
-            - GCP__automated-tests
-            - GITHUB__PAT__gruntwork-ci
       - codespell:
           filters:
             tags:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -18,10 +18,5 @@ jobs:
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v15
         with:
-          config: |
-            {
-              "MD013": false,
-              "MD024": false
-            }
           globs: |
             docs/**/*.md

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,27 @@
+name: Markdown Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  markdownlint:
+    name: Run Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v15
+        with:
+          config: |
+            {
+              "MD013": false,
+              "MD024": false
+            }
+          globs: |
+            docs/**/*.md

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,6 @@
+config:
+  # Disable line length limit
+  MD013: false
+
+  # Disable multiple headers with the same content
+  MD024: false


### PR DESCRIPTION
## Description

Adds `markdownlint` to GitHub Actions workflows.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added `markdownlint` to GitHub Actions workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated continuous integration to use GitHub Actions for Markdown linting instead of CircleCI.
	- Introduced a new configuration file to customize Markdown linting rules, allowing longer lines and repeated headers.
	- Markdown linting now applies to files in the docs directory on pushes to main and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->