### PR TITLE
feat: Adding base tests

### DIFF
--- a/.github/workflows/base-test.yml
+++ b/.github/workflows/base-test.yml
@@ -1,0 +1,47 @@
+name: Base Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use mise to install dependencies
+        uses: jdx/mise-action@v2
+        with:
+          version: 2025.4.4
+
+      - id: go-cache-paths
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Go Build Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-test-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-test-${{ hashFiles('**/go.sum') }}
+
+      - name: Run Tests
+        run: go test ./...
+        shell: bash

--- a/.github/workflows/base-test.yml
+++ b/.github/workflows/base-test.yml
@@ -46,3 +46,6 @@ jobs:
       - name: Run Tests
         run: go test ./...
         shell: bash
+        env:
+          # Adding token here to reduce the likelihood of hitting rate limit issues.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/base-test.yml
+++ b/.github/workflows/base-test.yml
@@ -12,6 +12,7 @@ jobs:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
 

--- a/.github/workflows/base-test.yml
+++ b/.github/workflows/base-test.yml
@@ -35,13 +35,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.go-cache-paths.outputs.go-build }}
-          key: ${{ runner.os }}-go-build-test-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-base-test-${{ hashFiles('**/go.sum') }}
 
       - name: Go Mod Cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-mod-test-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-mod-base-test-${{ hashFiles('**/go.sum') }}
 
       - name: Run Tests
         run: go test ./...

--- a/.github/workflows/base-test.yml
+++ b/.github/workflows/base-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu, macos, windows]
 
     steps:
       - name: Checkout code

--- a/internal/cas/getter_ssh_test.go
+++ b/internal/cas/getter_ssh_test.go
@@ -44,6 +44,11 @@ func TestSSHCASGetterGet(t *testing.T) {
 		expectRef string
 	}{
 		{
+			name:      "Basic URL without ref",
+			url:       "github.com/gruntwork-io/terragrunt",
+			expectRef: "",
+		},
+		{
 			name:      "URL as SSH",
 			url:       "git@github.com:gruntwork-io/terragrunt.git",
 			expectRef: "",

--- a/internal/cas/getter_ssh_test.go
+++ b/internal/cas/getter_ssh_test.go
@@ -1,0 +1,71 @@
+//go:build ssh
+
+// We don't want contributors to have to install SSH keys to run these tests, so we skip
+// them by default. Contributors need to opt in to run these tests by setting the
+// build flag `ssh` when running the tests. This is done by adding the `-tags ssh` flag
+// to the `go test` command. For example:
+//
+// go test -tags ssh ./...
+
+package cas_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/hashicorp/go-getter/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSHCASGetterGet(t *testing.T) {
+	t.Parallel()
+
+	c, err := cas.New(cas.Options{})
+	require.NoError(t, err)
+
+	opts := &cas.CloneOptions{
+		Branch: "main",
+	}
+
+	l := log.New()
+
+	g := cas.NewCASGetter(&l, c, opts)
+	client := getter.Client{
+		Getters: []getter.Getter{g},
+	}
+
+	tests := []struct {
+		name      string
+		url       string
+		queryRef  string
+		expectRef string
+	}{
+		{
+			name:      "URL as SSH",
+			url:       "git@github.com:gruntwork-io/terragrunt.git",
+			expectRef: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+
+			res, err := client.Get(
+				context.TODO(),
+				&getter.Request{
+					Src: tt.url,
+					Dst: tmpDir,
+				},
+			)
+			require.NoError(t, err)
+
+			assert.Equal(t, tmpDir, res.Dst)
+		})
+	}
+}

--- a/internal/cas/getter_test.go
+++ b/internal/cas/getter_test.go
@@ -95,11 +95,6 @@ func TestCASGetterGet(t *testing.T) {
 		expectRef string
 	}{
 		{
-			name:      "Basic URL without ref",
-			url:       "github.com/gruntwork-io/terragrunt",
-			expectRef: "",
-		},
-		{
 			name:      "URL with ref parameter",
 			url:       "github.com/gruntwork-io/terragrunt?ref=v0.75.0",
 			expectRef: "v0.75.0",

--- a/internal/cas/getter_test.go
+++ b/internal/cas/getter_test.go
@@ -104,11 +104,6 @@ func TestCASGetterGet(t *testing.T) {
 			url:       "github.com/gruntwork-io/terragrunt?ref=v0.75.0",
 			expectRef: "v0.75.0",
 		},
-		{
-			name:      "URL as SSH",
-			url:       "git@github.com:gruntwork-io/terragrunt.git",
-			expectRef: "",
-		},
 	}
 
 	for _, tt := range tests {

--- a/shell/run_cmd_test.go
+++ b/shell/run_cmd_test.go
@@ -19,10 +19,10 @@ func TestRunShellCommand(t *testing.T) {
 	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
 	require.NoError(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
 
-	cmd := shell.RunCommand(context.Background(), terragruntOptions, "terraform", "--version")
+	cmd := shell.RunCommand(context.Background(), terragruntOptions, "tofu", "--version")
 	require.NoError(t, cmd)
 
-	cmd = shell.RunCommand(context.Background(), terragruntOptions, "terraform", "not-a-real-command")
+	cmd = shell.RunCommand(context.Background(), terragruntOptions, "tofu", "not-a-real-command")
 	require.Error(t, cmd)
 }
 
@@ -38,10 +38,10 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 	terragruntOptions.Writer = stdout
 	terragruntOptions.ErrWriter = stderr
 
-	cmd := shell.RunCommand(context.Background(), terragruntOptions, "terraform", "--version")
+	cmd := shell.RunCommand(context.Background(), terragruntOptions, "tofu", "--version")
 	require.NoError(t, cmd)
 
-	assert.Contains(t, stdout.String(), "Terraform", "Output directed to stdout")
+	assert.Contains(t, stdout.String(), "OpenTofu", "Output directed to stdout")
 	assert.Empty(t, stderr.String(), "No output to stderr")
 
 	stdout = new(bytes.Buffer)
@@ -51,10 +51,10 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 	terragruntOptions.Writer = stderr
 	terragruntOptions.ErrWriter = stderr
 
-	cmd = shell.RunCommand(context.Background(), terragruntOptions, "terraform", "--version")
+	cmd = shell.RunCommand(context.Background(), terragruntOptions, "tofu", "--version")
 	require.NoError(t, cmd)
 
-	assert.Contains(t, stderr.String(), "Terraform", "Output directed to stderr")
+	assert.Contains(t, stderr.String(), "OpenTofu", "Output directed to stderr")
 	assert.Empty(t, stdout.String(), "No output to stdout")
 }
 

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -1817,3 +1817,34 @@ func createDynamoDBTable(t *testing.T, awsRegion string, tableName string) {
 	err := createDynamoDBTableE(t, awsRegion, tableName)
 	require.NoError(t, err)
 }
+
+func validateIncludeRemoteStateReflection(t *testing.T, s3BucketName string, keyPath string, configPath string, workingDir string) {
+	t.Helper()
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := helpers.RunTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-config %s --terragrunt-working-dir %s", configPath, workingDir), &stdout, &stderr)
+	require.NoError(t, err)
+
+	outputs := map[string]helpers.TerraformOutput{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
+	remoteStateOut := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(outputs["reflect"].Value.(string)), &remoteStateOut))
+	assert.Equal(
+		t,
+		map[string]any{
+			"backend":                         "s3",
+			"disable_init":                    false,
+			"disable_dependency_optimization": false,
+			"generate":                        nil,
+			"config": map[string]any{
+				"encrypt": true,
+				"bucket":  s3BucketName,
+				"key":     keyPath + "/terraform.tfstate",
+				"region":  "us-west-2",
+			},
+			"encryption": nil,
+		},
+		remoteStateOut,
+	)
+}

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -221,34 +221,3 @@ func validateMultipleIncludeTestOutput(t *testing.T, outputs map[string]helpers.
 		outputs["dep_out"].Value.(map[string]any),
 	)
 }
-
-func validateIncludeRemoteStateReflection(t *testing.T, s3BucketName string, keyPath string, configPath string, workingDir string) {
-	t.Helper()
-
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-	err := helpers.RunTerragruntCommand(t, fmt.Sprintf("terragrunt output -no-color -json --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-config %s --terragrunt-working-dir %s", configPath, workingDir), &stdout, &stderr)
-	require.NoError(t, err)
-
-	outputs := map[string]helpers.TerraformOutput{}
-	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
-	remoteStateOut := map[string]any{}
-	require.NoError(t, json.Unmarshal([]byte(outputs["reflect"].Value.(string)), &remoteStateOut))
-	assert.Equal(
-		t,
-		map[string]any{
-			"backend":                         "s3",
-			"disable_init":                    false,
-			"disable_dependency_optimization": false,
-			"generate":                        nil,
-			"config": map[string]any{
-				"encrypt": true,
-				"bucket":  s3BucketName,
-				"key":     keyPath + "/terraform.tfstate",
-				"region":  "us-west-2",
-			},
-			"encryption": nil,
-		},
-		remoteStateOut,
-	)
-}

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/stretchr/testify/assert"
@@ -59,36 +58,6 @@ func TestTerragruntWorksWithIncludeLocals(t *testing.T) {
 			assert.Equal(t, "us-west-1-test", outputs["region"].Value.(string))
 		})
 	}
-}
-
-func TestTerragruntWorksWithIncludeShallowMerge(t *testing.T) {
-	t.Parallel()
-
-	childPath := util.JoinPath(includeFixturePath, includeShallowFixturePath)
-	helpers.CleanupTerraformFolder(t, childPath)
-
-	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
-	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
-
-	tmpTerragruntConfigPath := helpers.CreateTmpTerragruntConfigWithParentAndChild(t, includeFixturePath, includeShallowFixturePath, s3BucketName, "root.hcl", config.DefaultTerragruntConfigPath)
-
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, childPath))
-	validateIncludeRemoteStateReflection(t, s3BucketName, includeShallowFixturePath, tmpTerragruntConfigPath, childPath)
-}
-
-func TestTerragruntWorksWithIncludeNoMerge(t *testing.T) {
-	t.Parallel()
-
-	childPath := util.JoinPath(includeFixturePath, includeNoMergeFixturePath)
-	helpers.CleanupTerraformFolder(t, childPath)
-
-	// We deliberately pick an s3 bucket name that is invalid, as we don't expect to create this s3 bucket.
-	s3BucketName := "__INVALID_NAME__"
-
-	tmpTerragruntConfigPath := helpers.CreateTmpTerragruntConfigWithParentAndChild(t, includeFixturePath, includeNoMergeFixturePath, s3BucketName, "root.hcl", config.DefaultTerragruntConfigPath)
-
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-config %s --terragrunt-working-dir %s", tmpTerragruntConfigPath, childPath))
-	validateIncludeRemoteStateReflection(t, s3BucketName, includeNoMergeFixturePath, tmpTerragruntConfigPath, childPath)
 }
 
 func TestTerragruntRunAllModulesThatIncludeRestrictsSet(t *testing.T) {

--- a/test/integration_scaffold_ssh_test.go
+++ b/test/integration_scaffold_ssh_test.go
@@ -1,0 +1,111 @@
+//go:build ssh
+
+// We don't want contributors to have to install SSH keys to run these tests, so we skip
+// them by default. Contributors need to opt in to run these tests by setting the
+// build flag `ssh` when running the tests. This is done by adding the `-tags ssh` flag
+// to the `go test` command. For example:
+//
+// go test -tags ssh ./...
+
+package test_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/util"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSHScaffoldWithCustomDefaultTemplate(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testScaffoldWithCustomDefaultTemplate)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, testScaffoldWithCustomDefaultTemplate)
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
+		"terragrunt --non-interactive --working-dir %s scaffold %s",
+		filepath.Join(testPath, "unit"),
+		testScaffoldModuleURL,
+	))
+
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "Scaffolding completed")
+
+	assert.FileExists(t, filepath.Join(testPath, "unit", "terragrunt.hcl"))
+	assert.FileExists(t, filepath.Join(testPath, "unit", "external-template.txt"))
+}
+
+func TestSSHScaffoldModuleExternalTemplate(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := t.TempDir()
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --terragrunt-non-interactive --terragrunt-working-dir %s %s %s", tmpEnvPath, testScaffoldModuleGit, testScaffoldExternalTemplateModule))
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "Scaffolding completed")
+	// check that exists file from external template
+	assert.FileExists(t, tmpEnvPath+"/external-template.txt")
+}
+
+func TestSSHScaffoldModuleDifferentRevisionAndSSH(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := t.TempDir()
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --terragrunt-non-interactive --terragrunt-working-dir %s %s --var=Ref=v0.67.4 --var=SourceUrlType=git-ssh", tmpEnvPath, testScaffoldModuleShort))
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.67.4")
+	assert.Contains(t, stderr, "Scaffolding completed")
+}
+
+func TestSSHScaffoldModuleSSH(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := t.TempDir()
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --terragrunt-non-interactive --terragrunt-working-dir %s %s", tmpEnvPath, testScaffoldModuleGit))
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "Scaffolding completed")
+}
+
+func TestSSHScaffoldModuleTemplate(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := t.TempDir()
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --terragrunt-non-interactive --terragrunt-working-dir %s %s", tmpEnvPath, testScaffoldTemplateModule))
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "Scaffolding completed")
+	// check that exists file from .boilerplate dir
+	assert.FileExists(t, tmpEnvPath+"/template-file.txt")
+}
+
+func TestSSHScaffoldModuleVarFile(t *testing.T) {
+	t.Parallel()
+	// generate var file with specific version, without root include and use GIT/SSH to clone module.
+	varFileContent := `
+Ref: v0.67.4
+EnableRootInclude: false
+SourceUrlType: "git-ssh"
+`
+	varFile := filepath.Join(t.TempDir(), "var-file.yaml")
+	err := os.WriteFile(varFile, []byte(varFileContent), 0644)
+	require.NoError(t, err)
+
+	tmpEnvPath := t.TempDir()
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --terragrunt-non-interactive --terragrunt-working-dir %s %s --var-file=%s", tmpEnvPath, testScaffoldModuleShort, varFile))
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.67.4")
+	assert.Contains(t, stderr, "Scaffolding completed")
+	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
+	require.NoError(t, err)
+	assert.NotContains(t, content, "find_in_parent_folders")
+}

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -77,51 +77,6 @@ func TestScaffoldModuleDifferentRevision(t *testing.T) {
 	assert.Contains(t, stderr, "Scaffolding completed")
 }
 
-func TestScaffoldModuleDifferentRevisionAndSsh(t *testing.T) {
-	t.Parallel()
-
-	tmpEnvPath := t.TempDir()
-
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --terragrunt-non-interactive --terragrunt-working-dir %s %s --var=Ref=v0.67.4 --var=SourceUrlType=git-ssh", tmpEnvPath, testScaffoldModuleShort))
-	require.NoError(t, err)
-	assert.Contains(t, stderr, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.67.4")
-	assert.Contains(t, stderr, "Scaffolding completed")
-}
-
-func TestScaffoldModuleSsh(t *testing.T) {
-	t.Parallel()
-
-	tmpEnvPath := t.TempDir()
-
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --terragrunt-non-interactive --terragrunt-working-dir %s %s", tmpEnvPath, testScaffoldModuleGit))
-	require.NoError(t, err)
-	assert.Contains(t, stderr, "Scaffolding completed")
-}
-
-func TestScaffoldModuleTemplate(t *testing.T) {
-	t.Parallel()
-
-	tmpEnvPath := t.TempDir()
-
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --terragrunt-non-interactive --terragrunt-working-dir %s %s", tmpEnvPath, testScaffoldTemplateModule))
-	require.NoError(t, err)
-	assert.Contains(t, stderr, "Scaffolding completed")
-	// check that exists file from .boilerplate dir
-	assert.FileExists(t, tmpEnvPath+"/template-file.txt")
-}
-
-func TestScaffoldModuleExternalTemplate(t *testing.T) {
-	t.Parallel()
-
-	tmpEnvPath := t.TempDir()
-
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --terragrunt-non-interactive --terragrunt-working-dir %s %s %s", tmpEnvPath, testScaffoldModuleGit, testScaffoldExternalTemplateModule))
-	require.NoError(t, err)
-	assert.Contains(t, stderr, "Scaffolding completed")
-	// check that exists file from external template
-	assert.FileExists(t, tmpEnvPath+"/external-template.txt")
-}
-
 func TestScaffoldErrorNoModuleUrl(t *testing.T) {
 	t.Parallel()
 
@@ -130,29 +85,6 @@ func TestScaffoldErrorNoModuleUrl(t *testing.T) {
 	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt scaffold --terragrunt-non-interactive --terragrunt-working-dir "+tmpEnvPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "No module URL passed")
-}
-
-func TestScaffoldModuleVarFile(t *testing.T) {
-	t.Parallel()
-	// generate var file with specific version, without root include and use GIT/SSH to clone module.
-	varFileContent := `
-Ref: v0.67.4
-EnableRootInclude: false
-SourceUrlType: "git-ssh"
-`
-	varFile := filepath.Join(t.TempDir(), "var-file.yaml")
-	err := os.WriteFile(varFile, []byte(varFileContent), 0644)
-	require.NoError(t, err)
-
-	tmpEnvPath := t.TempDir()
-
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --terragrunt-non-interactive --terragrunt-working-dir %s %s --var-file=%s", tmpEnvPath, testScaffoldModuleShort, varFile))
-	require.NoError(t, err)
-	assert.Contains(t, stderr, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.67.4")
-	assert.Contains(t, stderr, "Scaffolding completed")
-	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
-	require.NoError(t, err)
-	assert.NotContains(t, content, "find_in_parent_folders")
 }
 
 func TestScaffoldLocalModule(t *testing.T) {
@@ -225,24 +157,4 @@ func TestScaffoldWithRootHCL(t *testing.T) {
 	content, err := util.ReadFileAsString(filepath.Join(testPath, "unit", "terragrunt.hcl"))
 	require.NoError(t, err)
 	assert.Contains(t, content, `path = find_in_parent_folders("root.hcl")`)
-}
-
-func TestScaffoldWithCustomDefaultTemplate(t *testing.T) {
-	t.Parallel()
-
-	tmpEnvPath := helpers.CopyEnvironment(t, testScaffoldWithCustomDefaultTemplate)
-	helpers.CleanupTerraformFolder(t, tmpEnvPath)
-	testPath := util.JoinPath(tmpEnvPath, testScaffoldWithCustomDefaultTemplate)
-
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
-		"terragrunt --non-interactive --working-dir %s scaffold %s",
-		filepath.Join(testPath, "unit"),
-		testScaffoldModuleURL,
-	))
-
-	require.NoError(t, err)
-	assert.Contains(t, stderr, "Scaffolding completed")
-
-	assert.FileExists(t, filepath.Join(testPath, "unit", "terragrunt.hcl"))
-	assert.FileExists(t, filepath.Join(testPath, "unit", "external-template.txt"))
 }

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -700,65 +700,6 @@ func TestTerragruntProviderCache(t *testing.T) {
 	}
 }
 
-func TestReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
-	helpers.CleanupTerraformFolder(t, testFixtureAuthProviderCmd)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAuthProviderCmd)
-	rootPath := util.JoinPath(tmpEnvPath, testFixtureAuthProviderCmd, "remote-state")
-	mockAuthCmd := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "mock-auth-cmd.sh")
-
-	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
-	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
-
-	rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
-	helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", helpers.TerraformRemoteStateS3Region)
-
-	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
-	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-
-	// I'm not sure why, but this test doesn't work with tenv
-	os.Setenv("AWS_ACCESS_KEY_ID", "")     //nolint: tenv,usetesting
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "") //nolint: tenv,usetesting
-
-	defer func() {
-		os.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)         //nolint: tenv,usetesting
-		os.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey) //nolint: tenv,usetesting
-	}()
-
-	credsConfig := util.JoinPath(rootPath, "creds.config")
-
-	helpers.CopyAndFillMapPlaceholders(t, credsConfig, credsConfig, map[string]string{
-		"__FILL_AWS_ACCESS_KEY_ID__":     accessKeyID,
-		"__FILL_AWS_SECRET_ACCESS_KEY__": secretAccessKey,
-	})
-
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-auth-provider-cmd %s", rootPath, mockAuthCmd))
-}
-
-func TestReadTerragruntAuthProviderCmdCredsForDependency(t *testing.T) {
-	helpers.CleanupTerraformFolder(t, testFixtureAuthProviderCmd)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAuthProviderCmd)
-	rootPath := util.JoinPath(tmpEnvPath, testFixtureAuthProviderCmd, "creds-for-dependency")
-	mockAuthCmd := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "mock-auth-cmd.sh")
-
-	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
-	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-	t.Setenv("AWS_ACCESS_KEY_ID", "")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
-
-	dependencyCredsConfig := util.JoinPath(rootPath, "dependency", "creds.config")
-	helpers.CopyAndFillMapPlaceholders(t, dependencyCredsConfig, dependencyCredsConfig, map[string]string{
-		"__FILL_AWS_ACCESS_KEY_ID__":     accessKeyID,
-		"__FILL_AWS_SECRET_ACCESS_KEY__": secretAccessKey,
-	})
-
-	dependentCredsConfig := util.JoinPath(rootPath, "dependent", "creds.config")
-	helpers.CopyAndFillMapPlaceholders(t, dependentCredsConfig, dependentCredsConfig, map[string]string{
-		"__FILL_AWS_ACCESS_KEY_ID__":     accessKeyID,
-		"__FILL_AWS_SECRET_ACCESS_KEY__": secretAccessKey,
-	})
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt run-all apply --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-auth-provider-cmd %s", rootPath, mockAuthCmd))
-}
-
 func TestParseTFLog(t *testing.T) {
 	t.Setenv("TF_LOG", "info")
 

--- a/test/integration_sops_test.go
+++ b/test/integration_sops_test.go
@@ -1,3 +1,13 @@
+//go:build sops
+
+// sops tests assume that you're going to import the test_pgp_key.asc file into your GPG keyring before
+// running the tests. We're not gonna assume that everyone is going to do this, so we're going to skip
+// these tests by default.
+//
+// You can import the key by running the following command:
+//
+//	gpg --import --no-tty --batch --yes ./test/fixtures/sops/test_pgp_key.asc
+
 package test_test
 
 import (

--- a/test/integration_ssh_test.go
+++ b/test/integration_ssh_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSourceMapWithSlashInRef(t *testing.T) {
+func TestSSHSourceMapWithSlashInRef(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureSourceMapSlashes)
@@ -33,7 +33,7 @@ func TestSourceMapWithSlashInRef(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestTerragruntNoWarningRemotePath(t *testing.T) {
+func TestSSHTerragruntNoWarningRemotePath(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNoSubmodules)
@@ -48,7 +48,7 @@ func TestTerragruntNoWarningRemotePath(t *testing.T) {
 	assert.NotContains(t, stderr.String(), "No double-slash (//) found in source URL")
 }
 
-func TestDownloadSourceWithRef(t *testing.T) {
+func TestSSHDownloadSourceWithRef(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRefSource)

--- a/test/integration_ssh_test.go
+++ b/test/integration_ssh_test.go
@@ -1,0 +1,63 @@
+//go:build ssh
+
+// We don't want contributors to have to install SSH keys to run these tests, so we skip
+// them by default. Contributors need to opt in to run these tests by setting the
+// build flag `ssh` when running the tests. This is done by adding the `-tags ssh` flag
+// to the `go test` command. For example:
+//
+// go test -tags ssh ./...
+
+package test_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceMapWithSlashInRef(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureSourceMapSlashes)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, testFixtureSourceMapSlashes)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := helpers.RunTerragruntCommand(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-source-map git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=git::git@github.com:gruntwork-io/terragrunt.git?ref=fixture/test-fixtures --terragrunt-working-dir "+testPath, &stdout, &stderr)
+	require.NoError(t, err)
+}
+
+func TestTerragruntNoWarningRemotePath(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNoSubmodules)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, testFixtureNoSubmodules)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := helpers.RunTerragruntCommand(t, "terragrunt init --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
+	require.NoError(t, err)
+	assert.NotContains(t, stderr.String(), "No double-slash (//) found in source URL")
+}
+
+func TestDownloadSourceWithRef(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRefSource)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, testFixtureRefSource)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := helpers.RunTerragruntCommand(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
+	require.NoError(t, err)
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3464,34 +3464,6 @@ func TestHclFmtStdin(t *testing.T) {
 	assert.Contains(t, stdout, string(expectedDiff))
 }
 
-func TestDownloadSourceWithRef(t *testing.T) {
-	t.Parallel()
-
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRefSource)
-	helpers.CleanupTerraformFolder(t, tmpEnvPath)
-	testPath := util.JoinPath(tmpEnvPath, testFixtureRefSource)
-
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-
-	err := helpers.RunTerragruntCommand(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
-	require.NoError(t, err)
-}
-
-func TestSourceMapWithSlashInRef(t *testing.T) {
-	t.Parallel()
-
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureSourceMapSlashes)
-	helpers.CleanupTerraformFolder(t, tmpEnvPath)
-	testPath := util.JoinPath(tmpEnvPath, testFixtureSourceMapSlashes)
-
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-
-	err := helpers.RunTerragruntCommand(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-source-map git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=git::git@github.com:gruntwork-io/terragrunt.git?ref=fixture/test-fixtures --terragrunt-working-dir "+testPath, &stdout, &stderr)
-	require.NoError(t, err)
-}
-
 func TestInitSkipCache(t *testing.T) {
 	t.Parallel()
 
@@ -3633,21 +3605,6 @@ func TestTerragruntNoWarningLocalPath(t *testing.T) {
 	stderr := bytes.Buffer{}
 
 	err := helpers.RunTerragruntCommand(t, "terragrunt apply --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
-	require.NoError(t, err)
-	assert.NotContains(t, stderr.String(), "No double-slash (//) found in source URL")
-}
-
-func TestTerragruntNoWarningRemotePath(t *testing.T) {
-	t.Parallel()
-
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNoSubmodules)
-	helpers.CleanupTerraformFolder(t, tmpEnvPath)
-	testPath := util.JoinPath(tmpEnvPath, testFixtureNoSubmodules)
-
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-
-	err := helpers.RunTerragruntCommand(t, "terragrunt init --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
 	require.NoError(t, err)
 	assert.NotContains(t, stderr.String(), "No double-slash (//) found in source URL")
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3373,25 +3373,6 @@ func TestDependencyOutputModulePrefix(t *testing.T) {
 	assert.Equal(t, 42, int(outputs["z"].Value.(float64)))
 }
 
-func TestErrorExplaining(t *testing.T) {
-	t.Parallel()
-
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureInitError)
-	initTestCase := util.JoinPath(tmpEnvPath, testFixtureInitError)
-
-	helpers.CleanupTerraformFolder(t, initTestCase)
-	helpers.CleanupTerragruntFolder(t, initTestCase)
-
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-
-	err := helpers.RunTerragruntCommand(t, "terragrunt init -no-color --terragrunt-forward-tf-stdout --terragrunt-non-interactive --terragrunt-working-dir "+initTestCase, &stdout, &stderr)
-	require.Error(t, err)
-
-	explanation := shell.ExplainError(err)
-	assert.Contains(t, explanation, "Check your credentials and permissions")
-}
-
 func TestExplainingMissingCredentials(t *testing.T) {
 	// no parallel because we need to set env vars
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/tmp/not-existing-creds-46521694")
@@ -3717,22 +3698,6 @@ func TestTerragruntHandleEmptyStateFile(t *testing.T) {
 	helpers.CreateEmptyStateFile(t, testPath)
 
 	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --terragrunt-non-interactive --terragrunt-working-dir "+testPath)
-}
-
-func TestTerragruntInvokeTerraformTests(t *testing.T) {
-	t.Parallel()
-	if isTerraform() {
-		t.Skip("Not compatible with Terraform 1.5.x")
-		return
-	}
-
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureTfTest)
-	helpers.CleanupTerraformFolder(t, tmpEnvPath)
-	testPath := util.JoinPath(tmpEnvPath, testFixtureTfTest)
-
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt test --terragrunt-non-interactive --terragrunt-forward-tf-stdout --terragrunt-working-dir "+testPath)
-	require.NoError(t, err)
-	assert.Contains(t, stdout, "1 passed, 0 failed")
 }
 
 func TestTerragruntCommandsThatNeedInput(t *testing.T) {

--- a/test/integration_units_reading_test.go
+++ b/test/integration_units_reading_test.go
@@ -1,3 +1,13 @@
+//go:build sops
+
+// sops tests assume that you're going to import the test_pgp_key.asc file into your GPG keyring before
+// running the tests. We're not gonna assume that everyone is going to do this, so we're going to skip
+// these tests by default.
+//
+// You can import the key by running the following command:
+//
+//	gpg --import --no-tty --batch --yes ./test/fixtures/sops/test_pgp_key.asc
+
 package test_test
 
 import (


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds base tests that simply runs `go test ./...` in each of the following runners:

- `ubuntu-latest`
- `macos-latest`
- `windows-latest`

These tests are meant to validate that the base tests (those that don't require opt-in via special flags) run successfully.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added base tests that just run `go test ./...` in Ubuntu, MacOS, and Windows runners.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new SSH-related integration and unit tests, which are enabled with a special build tag.
  - Added new tests for AWS authentication via external provider commands.
  - Added new integration tests for Terragrunt's include and error explanation features.

- **Bug Fixes**
  - Updated tests to use "tofu" instead of "terraform" where applicable.

- **Chores**
  - Added a new continuous integration workflow to automate testing across multiple operating systems.
  - Improved documentation and build constraints for tests requiring special keys or build tags.

- **Tests**
  - Moved, added, or removed several integration and unit tests to improve coverage and organization, especially for SSH and AWS scenarios. Some tests were relocated to files gated by build tags for optional execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->