### PR TITLE
fix: Adding redirect from /docs/reference/experiment-mode to /docs/reference/experiments

### DIFF
--- a/docs-starlight/astro.config.mjs
+++ b/docs-starlight/astro.config.mjs
@@ -102,6 +102,7 @@ export default defineConfig({
 		"/docs/reference/strict-mode/": "/docs/reference/strict-controls/",
 		"/docs/reference/log-formatting/": "/docs/reference/logging/formatting/",
 		"/docs/features/aws-authentication/": "/docs/features/authentication/",
+		"/docs/reference/experiment-mode/": "/docs/reference/experiments/",
 
 		// Support old doc structure paths
 		"/docs/": "/docs/getting-started/quick-start/",

--- a/docs/_docs/04_reference/06-experiments.md
+++ b/docs/_docs/04_reference/06-experiments.md
@@ -10,6 +10,8 @@ order: 406
 nav_title: Documentation
 nav_title_link: /docs/
 slug: experiments
+redirect_from:
+    - /docs/reference/experiment-mode/
 ---
 
 Terragrunt supports operating in a mode referred to as "Experiment Mode".


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes broken link in docs for stacks.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added redirect from `/docs/reference/experiment-mode` to `/docs/reference/experiments`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a redirect so that visits to `/docs/reference/experiment-mode/` are automatically sent to `/docs/reference/experiments/`.
  - Updated the experiments documentation page to recognize `/docs/reference/experiment-mode/` as an alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->