### PR TITLE
feat: `hcl` commands docs

### DIFF
--- a/cli/commands/hcl/validate/cli.go
+++ b/cli/commands/hcl/validate/cli.go
@@ -12,7 +12,7 @@ const (
 	CommandName = "validate"
 
 	StrictFlagName         = "strict"
-	InputFlagName          = "input"
+	InputsFlagName         = "inputs"
 	ShowConfigPathFlagName = "show-config-path"
 	JSONFlagName           = "json"
 )
@@ -33,9 +33,9 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("strict-validate"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
-			Name:        InputFlagName,
-			EnvVars:     tgPrefix.EnvVars(InputFlagName),
-			Destination: &opts.HCLValidateInput,
+			Name:        InputsFlagName,
+			EnvVars:     tgPrefix.EnvVars(InputsFlagName),
+			Destination: &opts.HCLValidateInputs,
 			Usage:       "Checks if the Terragrunt configured inputs align with OpenTofu/Terraform defined variables.",
 		}),
 		flags.NewFlag(&cli.BoolFlag{

--- a/cli/commands/hcl/validate/validate.go
+++ b/cli/commands/hcl/validate/validate.go
@@ -35,18 +35,18 @@ const splitCount = 2
 func Run(ctx context.Context, opts *options.TerragruntOptions) error {
 	if opts.HCLValidateInputs {
 		if opts.HCLValidateShowConfigPath {
-			return errors.Errorf("specifying both -%s and -%s is invalid", ShowConfigPathFlagName, InputFlagName)
+			return errors.Errorf("specifying both -%s and -%s is invalid", ShowConfigPathFlagName, InputsFlagName)
 		}
 
 		if opts.HCLValidateJSONOutput {
-			return errors.Errorf("specifying both -%s and -%s is invalid", JSONFlagName, InputFlagName)
+			return errors.Errorf("specifying both -%s and -%s is invalid", JSONFlagName, InputsFlagName)
 		}
 
 		return RunValidateInputs(ctx, opts)
 	}
 
 	if opts.HCLValidateStrict {
-		return errors.Errorf("specifying -%s without -%s is invalid", StrictFlagName, InputFlagName)
+		return errors.Errorf("specifying -%s without -%s is invalid", StrictFlagName, InputsFlagName)
 	}
 
 	return RunValidate(ctx, opts)

--- a/cli/commands/hcl/validate/validate.go
+++ b/cli/commands/hcl/validate/validate.go
@@ -33,7 +33,7 @@ import (
 const splitCount = 2
 
 func Run(ctx context.Context, opts *options.TerragruntOptions) error {
-	if opts.HCLValidateInput {
+	if opts.HCLValidateInputs {
 		if opts.HCLValidateShowConfigPath {
 			return errors.Errorf("specifying both -%s and -%s is invalid", ShowConfigPathFlagName, InputFlagName)
 		}

--- a/cli/commands/validate-inputs/cli.go
+++ b/cli/commands/validate-inputs/cli.go
@@ -21,7 +21,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		Usage: "Checks if the terragrunt configured inputs align with the terraform defined variables.",
 		Flags: append(run.NewFlags(opts, nil), validate.NewFlags(opts, nil).Filter(validate.StrictFlagName)...),
 		Action: func(ctx *cli.Context) error {
-			opts.HCLValidateInput = true
+			opts.HCLValidateInputs = true
 
 			return validate.Run(ctx, opts.OptionsFromContext(ctx))
 		},

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -36,6 +36,12 @@ The commands relevant to managing OpenTofu/Terraform state backends are:
   - [backend bootstrap](#backend-bootstrap)
   - [backend delete](#backend-delete)
 
+The commands for interacting with Terragrunt files, written in HashiCorp Configuration Language (HCL):
+
+- [HCL commands](#hcl-commands)
+  - [hcl validate](#hcl-validate)
+  - [hcl format](#hcl-format)
+
 The commands relevant to managing an IaC catalog are:
 
 - [Catalog commands](#catalog-commands)
@@ -697,6 +703,106 @@ Terragrunt performs migrations in one of two ways, depending on the level of sup
 - `--config`: Path to the Terragrunt configuration file to use to migrate the resources.
 - `--download-dir`: Path to download OpenTofu/Terraform modules into. The default is `.terragrunt-cache`.
 - `--force`: Force the migration of the backend state file. By default, Terragrunt will refuse to migrate the backend state file if the source bucket does not have versioning enabled.
+
+### HCL commands
+
+#### hcl validate
+
+Find all hcl files from the configuration stack and validate them.
+
+Example:
+
+```bash
+terragrunt hcl validate
+```
+
+This will search all hcl files from the configuration stack in the current working directory and run the equivalent
+of `tofu validate`/`terraform validate` on them.
+
+For convenience in programmatically parsing these findings, you can also pass the `--json` flag to output the results in JSON format.
+
+Example:
+
+```bash
+terragrunt hcl validate --json
+```
+
+In addition, you can pass the `--show-config-path` flag to only output paths of the invalid config files, delimited by newlines. This can be especially useful when combined with the [queue-excludes-file](#queue-excludes-file) flag.
+
+Example:
+
+```bash
+terragrunt hcl validate --show-config-path
+
+```
+
+Using the `--input` flag helps emit information about the input variables that are
+configured with the given terragrunt configuration. The flag will print out unused
+inputs (inputs that are not defined as an OpenTofu/Terraform variable in the
+corresponding module) and undefined required inputs (required OpenTofu/Terraform
+variables that are not currently being passed in).
+
+Example:
+
+```bash
+> terragrunt hcl validate --inputs
+The following inputs passed in by terragrunt are unused:
+
+    - foo
+    - bar
+
+
+The following required inputs are missing:
+
+    - baz
+
+```
+
+Note that this only checks for variables passed in in the following ways:
+
+- Configured `inputs` attribute.
+
+- var files defined on `terraform.extra_arguments` blocks using `required_var_files` and `optional_var_files`.
+
+- `-var-file` and `-var` CLI arguments defined on `terraform.extra_arguments` using `arguments`.
+
+- `-var-file` and `-var` CLI arguments passed to terragrunt.
+
+- Automatically loaded var files (`terraform.tfvars`, `terraform.tfvars.json`, `*.auto.tfvars`, `*.auto.tfvars.json`)
+
+- `TF_VAR` environment variables defined on `terraform.extra_arguments` blocks.
+
+- `TF_VAR` environment variables defined in the environment.
+
+Be aware that other ways to pass variables to `tofu`/`terraform` are not checked by this command.
+
+Additionally, there are **two modes** in which the `hcl validate --inputs` command can be run: **relaxed** (default) and **strict**.
+
+If you run the `hcl validate --inputs` command without `--strict` flag, relaxed mode will be enabled by default. In relaxed mode, any unused variables
+that are passed, but not used by the underlying OpenTofu/Terraform configuration, will generate a warning, but not an error. Missing required variables will _always_ return an error, whether `hcl validate --inputs` is running in relaxed or strict mode.
+
+To enable strict mode, you can pass the `--strict` flag like so:
+
+```bash
+terragrunt hcl validate --inputs --strict
+```
+
+When running in strict mode, `hcl validate --inputs` will return an error if there are unused inputs.
+
+This command will exit with an error if terragrunt detects any unused inputs or undefined required inputs.
+
+#### hcl format
+
+Recursively find hcl files and rewrite them into a canonical format.
+
+Example:
+
+```bash
+terragrunt hcl fmt
+```
+
+This will recursively search the current working directory for any folders that contain Terragrunt configuration files
+and run the equivalent of `tofu fmt`/`terraform fmt` on them.
 
 ### Catalog commands
 
@@ -1495,6 +1601,9 @@ This command will exit with an error if terragrunt detects any unused inputs or 
     - [backend bootstrap](#backend-bootstrap)
     - [backend delete](#backend-delete)
     - [backend migrate](#backend-migrate)
+  - [HCL commands](#hcl-commands)
+    - [hcl validate](#hcl-validate)
+    - [hcl format](#hcl-format)
   - [Catalog commands](#catalog-commands)
     - [catalog](#catalog)
     - [scaffold](#scaffold)

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -736,7 +736,7 @@ terragrunt hcl validate --show-config-path
 
 ```
 
-Using the `--input` flag helps emit information about the input variables that are
+Using the `--inputs` flag helps emit information about the input variables that are
 configured with the given terragrunt configuration. The flag will print out unused
 inputs (inputs that are not defined as an OpenTofu/Terraform variable in the
 corresponding module) and undefined required inputs (required OpenTofu/Terraform

--- a/options/options.go
+++ b/options/options.go
@@ -271,8 +271,8 @@ type TerragruntOptions struct {
 	SourceUpdate bool
 	// HCLValidateStrict is a strict mode for HCL validation files. When it's set to false the command will only return an error if required inputs are missing from all input sources (env vars, var files, etc). When it's set to true, an error will be returned if required inputs are missing or if unused variables are passed to Terragrunt.",
 	HCLValidateStrict bool
-	// HCLValidateInput checks if the terragrunt configured inputs align with the terraform defined variables.
-	HCLValidateInput bool
+	// HCLValidateInputs checks if the terragrunt configured inputs align with the terraform defined variables.
+	HCLValidateInputs bool
 	// HCLValidateShowConfigPath shows the paths of the hcl invalid configs.
 	HCLValidateShowConfigPath bool
 	// HCLValidateJSONOutput outputs the hcl validate result as a JSON string.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Documentation for the newly implemented `hcl` commands.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated documentation to include new CLI commands: `hcl validate` (with flags for JSON output, input validation, and strict mode) and `hcl format` for recursive HCL file formatting.

- **Style**
  - Improved consistency by renaming related flags and options from singular "input" to plural "inputs" across the CLI and documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->