### PR TITLE
chore: Complete CLI Redesign experiment

### DIFF
--- a/cli/commands/backend/cli.go
+++ b/cli/commands/backend/cli.go
@@ -7,8 +7,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/backend/delete"
 	"github.com/gruntwork-io/terragrunt/cli/commands/backend/migrate"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -24,13 +22,6 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 			migrate.NewCommand(opts),
 		},
 		ErrorOnUndefinedFlag: true,
-		Before: func(ctx *cli.Context) error {
-			if !opts.Experiments.Evaluate(experiment.CLIRedesign) {
-				return cli.NewExitError(errors.Errorf("requires that the %[1]s experiment is enabled. e.g. --experiment %[1]s", experiment.CLIRedesign), cli.ExitCodeGeneralError)
-			}
-
-			return nil
-		},
-		Action: cli.ShowCommandHelp,
+		Action:               cli.ShowCommandHelp,
 	}
 }

--- a/cli/commands/exec/cli.go
+++ b/cli/commands/exec/cli.go
@@ -6,8 +6,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -53,13 +51,6 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		},
 		Flags:                NewFlags(opts, cmdOpts, nil),
 		ErrorOnUndefinedFlag: true,
-		Before: func(ctx *cli.Context) error {
-			if !opts.Experiments.Evaluate(experiment.CLIRedesign) {
-				return cli.NewExitError(errors.Errorf("requires that the %[1]s experiment is enabled. e.g. --experiment %[1]s", experiment.CLIRedesign), cli.ExitCodeGeneralError)
-			}
-
-			return nil
-		},
 		Action: func(ctx *cli.Context) error {
 			tgArgs, cmdArgs := ctx.Args().Split(cli.BuiltinCmdSep)
 

--- a/cli/commands/find/cli.go
+++ b/cli/commands/find/cli.go
@@ -5,8 +5,6 @@ package find
 import (
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -98,10 +96,6 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		ErrorOnUndefinedFlag: true,
 		Flags:                NewFlags(cmdOpts, nil),
 		Before: func(ctx *cli.Context) error {
-			if !opts.Experiments.Evaluate(experiment.CLIRedesign) {
-				return cli.NewExitError(errors.Errorf("requires that the %[1]s experiment is enabled. e.g. --experiment %[1]s", experiment.CLIRedesign), cli.ExitCodeGeneralError)
-			}
-
 			if cmdOpts.JSON {
 				cmdOpts.Format = FormatJSON
 			}

--- a/cli/commands/hcl/cli.go
+++ b/cli/commands/hcl/cli.go
@@ -5,8 +5,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/hcl/format"
 	"github.com/gruntwork-io/terragrunt/cli/commands/hcl/validate"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -22,13 +20,6 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 			validate.NewCommand(opts),
 		},
 		ErrorOnUndefinedFlag: true,
-		Before: func(ctx *cli.Context) error {
-			if !opts.Experiments.Evaluate(experiment.CLIRedesign) {
-				return cli.NewExitError(errors.Errorf("requires that the %[1]s experiment is enabled. e.g. --experiment %[1]s", experiment.CLIRedesign), cli.ExitCodeGeneralError)
-			}
-
-			return nil
-		},
-		Action: cli.ShowCommandHelp,
+		Action:               cli.ShowCommandHelp,
 	}
 }

--- a/cli/commands/list/cli.go
+++ b/cli/commands/list/cli.go
@@ -5,8 +5,6 @@ package list
 import (
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -101,10 +99,6 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		ErrorOnUndefinedFlag: true,
 		Flags:                NewFlags(cmdOpts, nil),
 		Before: func(ctx *cli.Context) error {
-			if !opts.Experiments.Evaluate(experiment.CLIRedesign) {
-				return cli.NewExitError(errors.Errorf("requires that the %[1]s experiment is enabled. e.g. --experiment %[1]s", experiment.CLIRedesign), cli.ExitCodeGeneralError)
-			}
-
 			if cmdOpts.Tree {
 				cmdOpts.Format = FormatTree
 			}

--- a/cli/commands/render/cli.go
+++ b/cli/commands/render/cli.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -114,13 +113,6 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 			renderOpts.TerragruntOptions = tgOpts
 
 			return Run(ctx, renderOpts)
-		},
-		Before: func(ctx *cli.Context) error {
-			if !opts.Experiments.Evaluate(experiment.CLIRedesign) {
-				return cli.NewExitError(errors.Errorf("requires that the %[1]s experiment is enabled. e.g. --experiment %[1]s", experiment.CLIRedesign), cli.ExitCodeGeneralError)
-			}
-
-			return nil
 		},
 		ErrorOnUndefinedFlag: true,
 	}

--- a/cli/commands/run/cli.go
+++ b/cli/commands/run/cli.go
@@ -8,8 +8,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/tf"
 )
@@ -34,13 +32,6 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		Flags:                NewFlags(opts, nil),
 		ErrorOnUndefinedFlag: true,
 		Subcommands:          NewSubcommands(opts),
-		Before: func(ctx *cli.Context) error {
-			if !opts.Experiments.Evaluate(experiment.CLIRedesign) {
-				return cli.NewExitError(errors.Errorf("requires that the %[1]s experiment is enabled. e.g. --experiment %[1]s", experiment.CLIRedesign), cli.ExitCodeGeneralError)
-			}
-
-			return nil
-		},
 		Action: func(ctx *cli.Context) error {
 			if len(ctx.Args()) == 0 {
 				return cli.ShowCommandHelp(ctx)

--- a/cli/commands/shortcuts.go
+++ b/cli/commands/shortcuts.go
@@ -4,7 +4,6 @@ import (
 	"slices"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/strict"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -31,8 +30,6 @@ var (
 )
 
 func NewShortcutsCommands(opts *options.TerragruntOptions) cli.Commands {
-	// Note: Some functionality is gated behind the CLIRedesign experiment.
-	// This experiment controls the deprecation warnings for non-shortcut commands.
 	var (
 		runCmd       = run.NewCommand(opts)
 		cmds         = make(cli.Commands, len(runCmd.Subcommands))
@@ -58,7 +55,7 @@ func NewShortcutsCommands(opts *options.TerragruntOptions) cli.Commands {
 			Flags:      runCmd.Flags,
 			CustomHelp: runSubCmd.CustomHelp,
 			Action: func(ctx *cli.Context) error {
-				if isNotShortcutCmd && opts.Experiments.Evaluate(experiment.CLIRedesign) {
+				if isNotShortcutCmd {
 					if err := control.Evaluate(ctx); err != nil {
 						return cli.NewExitError(err, cli.ExitCodeGeneralError)
 					}

--- a/cli/flags/global/flags.go
+++ b/cli/flags/global/flags.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/version"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/strict"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -115,7 +114,7 @@ func NewFlagsWithDeprecatedMovedFlags(opts *options.TerragruntOptions) cli.Flags
 
 			// Disable strcit control evaluation of moves global flags for the experimental `run` command if the `cli-redesign` experiment is not enabled.
 			evaluateWrapper := func(ctx context.Context, evalFn func(ctx context.Context) error) error {
-				if opts.Experiments.Evaluate(experiment.CLIRedesign) && slices.Contains(experimentalCommands, cmd.Name) {
+				if slices.Contains(experimentalCommands, cmd.Name) {
 					return evalFn(ctx)
 				}
 

--- a/docs-starlight/src/content/docs/04-reference/04-experiments.md
+++ b/docs-starlight/src/content/docs/04-reference/04-experiments.md
@@ -119,30 +119,53 @@ To transition the `stacks` feature to a stable release, the following must be ad
 - [x] Confirm compatibility with parallelism flags (e.g., `--parallel`), especially for stacks with dependencies.
 - [x] Ensure that error handling and failure recovery strategies work as intended across large and nested stacks.
 
-### cli-redesign
+### `cas`
 
-Support for the new Terragrunt CLI design.
+Support for Terragrunt Content Addressable Storage (CAS).
 
-#### cli-redesign - What it does
+#### `cas` - What it does
 
-Enable features from the CLI Redesign RFC.
+Allow Terragrunt to store and retrieve state files from a Content Addressable Storage (CAS) system.
 
-This includes:
+At the moment, the CAS is only used to speed up catalog cloning, but in the future, it can be used to store more content.
 
-- Addition of the `run` command.
-- Addition of the `exec` command.
+#### `cas` - How to provide feedback
 
-#### cli-redesign - How to provide feedback
-
-Share your experience with these features in the [CLI Redesign](https://github.com/gruntwork-io/terragrunt/issues/3445) RFC.
+Share your experience with this feature in the [CAS](https://github.com/gruntwork-io/terragrunt/discussions/3939) Feedback GitHub Discussion.
 Feedback is crucial for ensuring the feature meets real-world use cases. Please include:
 
 - Any bugs or issues encountered (including logs or stack traces if possible).
 - Suggestions for additional improvements or enhancements.
 
-#### cli-redesign - Criteria for stabilization
+#### `cas` - Criteria for stabilization
 
-To transition `cli-redesign` features to a stable release, the following must be addressed:
+To transition the `cas` feature to a stable release, the following must be addressed:
+
+- [x] Add support for storing and retrieving catalog repositories from the CAS.
+- [ ] Add support for storing and retrieving OpenTofu/Terraform modules from the CAS.
+- [ ] Add support for storing and retrieving Unit/Stack configurations from the CAS.
+
+## Completed Experiments
+
+- [cli-redesign](#cli-redesign)
+
+### `cli-redesign`
+
+Support for the new Terragrunt CLI design.
+
+#### `cli-redesign` - What it does
+
+Enabled features from the CLI Redesign RFC.
+
+This experiment flag is no longer needed, as the CLI Redesign is now the default.
+
+#### `cli-redesign` - How to provide feedback
+
+Now that the CLI Redesign experiment is complete, please provide feedback in the form of standard [GitHub issues](https://github.com/gruntwork-io/terragrunt/issues).
+
+#### `cli-redesign` - Criteria for stabilization
+
+To transition `cli-redesign` features to a stable the following have been completed:
 
 - [x] Add support for `run` command.
   - [x] Add support for basic usage of the `run` command (e.g., `terragrunt run plan`, `terragrunt run -- plan -no-color`).
@@ -183,29 +206,3 @@ To transition `cli-redesign` features to a stable release, the following must be
   - [x] Add integration with `symlinks` experiment to support listing units/stacks via symlinks.
   - [x] Add handling of broken configurations or configurations requiring authentication.
   - [x] Add integration test for `list` with `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
-
-### `cas`
-
-Support for Terragrunt Content Addressable Storage (CAS).
-
-#### `cas` - What it does
-
-Allow Terragrunt to store and retrieve state files from a Content Addressable Storage (CAS) system.
-
-At the moment, the CAS is only used to speed up catalog cloning, but in the future, it can be used to store more content.
-
-#### `cas` - How to provide feedback
-
-Share your experience with this feature in the [CAS](https://github.com/gruntwork-io/terragrunt/discussions/3939) Feedback GitHub Discussion.
-Feedback is crucial for ensuring the feature meets real-world use cases. Please include:
-
-- Any bugs or issues encountered (including logs or stack traces if possible).
-- Suggestions for additional improvements or enhancements.
-
-#### `cas` - Criteria for stabilization
-
-To transition the `cas` feature to a stable release, the following must be addressed:
-
-- [x] Add support for storing and retrieving catalog repositories from the CAS.
-- [ ] Add support for storing and retrieving OpenTofu/Terraform modules from the CAS.
-- [ ] Add support for storing and retrieving Unit/Stack configurations from the CAS.

--- a/docs-starlight/src/data/commands/backend/bootstrap.mdx
+++ b/docs-starlight/src/data/commands/backend/bootstrap.mdx
@@ -7,9 +7,6 @@ sidebar:
 description: Bootstrap OpenTofu/Terraform backend infrastructure.
 usage: |
   Bootstrap OpenTofu/Terraform backend infrastructure.
-experiment:
-  control: cli-redesign
-  name: cli redesign
 examples:
   - description: |
       Provision backend resources defined in remote_state.

--- a/docs-starlight/src/data/commands/backend/delete.mdx
+++ b/docs-starlight/src/data/commands/backend/delete.mdx
@@ -7,9 +7,6 @@ sidebar:
 description: Delete backend state used by a unit.
 usage: |
   Delete backend state used by a unit.
-experiment:
-  control: cli-redesign
-  name: cli redesign
 examples:
   - description: |
       Delete backend state for the current unit.

--- a/docs-starlight/src/data/commands/backend/migrate.mdx
+++ b/docs-starlight/src/data/commands/backend/migrate.mdx
@@ -7,9 +7,6 @@ sidebar:
 description: Migrate OpenTofu/Terraform state from one unit to another.
 usage: |
   Migrate OpenTofu/Terraform state from one unit to another.
-experiment:
-  control: cli-redesign
-  name: cli redesign
 examples:
   - description: |
       Migrate backend state from `unit` to `unit-renamed`.

--- a/docs-starlight/src/data/commands/dag/graph.mdx
+++ b/docs-starlight/src/data/commands/dag/graph.mdx
@@ -8,9 +8,6 @@ description: Graph the Directed Acyclic Graph (DAG) in DOT language.
 usage: |
   Print a visual representation of the Terragrunt dependency graph in DOT language format.
   This command analyzes your Terragrunt configuration and outputs a directed acyclic graph (DAG) showing the relationships and dependencies between your Terraform modules.
-experiment:
-  control: cli-redesign
-  name: cli redesign
 examples:
   - description: Graph all dependencies in the graph as a DotViz graph.
     code: |

--- a/docs-starlight/src/data/commands/exec.mdx
+++ b/docs-starlight/src/data/commands/exec.mdx
@@ -7,9 +7,6 @@ sidebar:
 description: Execute an arbitrary command, wrapped by Terragrunt.
 usage: |
   Execute an arbitrary command, wrapped by Terragrunt.
-experiment:
-  control: cli-redesign
-  name: CLI Redesign
 examples:
   - description: |
       Execute 'echo "Hello, Terragrunt!"' via Terragrunt.

--- a/docs-starlight/src/data/commands/find.mdx
+++ b/docs-starlight/src/data/commands/find.mdx
@@ -9,9 +9,6 @@ usage: |
   The `find` command helps you discover Terragrunt configurations in your codebase.
 
   It recursively searches for `terragrunt.hcl` and `terragrunt.stack.hcl` files and displays them in formatted output.
-experiment:
-  control: cli-redesign
-  name: CLI Redesign
 examples:
   - description: |
       Find all configurations (units and stacks) in the current directory.

--- a/docs-starlight/src/data/commands/hcl/fmt.mdx
+++ b/docs-starlight/src/data/commands/hcl/fmt.mdx
@@ -7,9 +7,6 @@ sidebar:
 description: Recursively find HashiCorp Configuration Language (HCL) files and rewrite them into a canonical format.
 usage: |
    Recursively find HashiCorp Configuration Language (HCL) files and rewrite them into a canonical format.
-experiment:
-  control: cli-redesign
-  name: cli redesign
 examples:
   - description: Recursively format all HCL files in the current directory.
     code: |

--- a/docs-starlight/src/data/commands/hcl/lint.mdx
+++ b/docs-starlight/src/data/commands/hcl/lint.mdx
@@ -7,9 +7,6 @@ sidebar:
 description: Lint Terragrunt HCL configuration.
 usage: |
    Lint Terragrunt HCL configuration.
-experiment:
-  control: cli-redesign
-  name: cli redesign
 examples:
   - description: Lint all HCL files in the current directory.
     code: |

--- a/docs-starlight/src/data/commands/hcl/validate.mdx
+++ b/docs-starlight/src/data/commands/hcl/validate.mdx
@@ -7,9 +7,6 @@ sidebar:
 description: Recursively find HashiCorp Configuration Language (HCL) files and validate them.
 usage: |
   Recursively find HashiCorp Configuration Language (HCL) files and validate them.
-experiment:
-  control: cli-redesign
-  name: cli redesign
 examples:
   - description: Discover all HCL files in the current directory, and validate them.
     code: |

--- a/docs-starlight/src/data/commands/info/print.mdx
+++ b/docs-starlight/src/data/commands/info/print.mdx
@@ -7,9 +7,6 @@ sidebar:
 description: Print out a short description of Terragrunt context.
 usage: |
   Outputs a JSON object with contextual information such as the configuration file path, current working directory, cache download location, IAM role (if any), the binary used to run Terraform or Tofu, and the command being executed.
-experiment:
-  control: cli-redesign
-  name: CLI Redesign
 examples:
   - description: Print out information about the current context of Terragrunt.
     code: |

--- a/docs-starlight/src/data/commands/list.mdx
+++ b/docs-starlight/src/data/commands/list.mdx
@@ -7,9 +7,6 @@ sidebar:
 description: List Terragrunt configurations in your codebase.
 usage: |
   The list command helps you discover and display Terragrunt configurations in your codebase. It provides various output formats and options to help you understand the structure and dependencies of your Terragrunt configurations.
-experiment:
-  control: cli-redesign
-  name: CLI Redesign
 examples:
   - description: |
       List all units in a typical multi-environment infrastructure setup.

--- a/docs-starlight/src/data/commands/render.mdx
+++ b/docs-starlight/src/data/commands/render.mdx
@@ -8,9 +8,6 @@ description: |
   Render the Terragrunt configuration in the current working directory, with as much work done as possible beforehand (that is, with all includes merged, dependencies resolved/interpolated, function calls executed, etc).
 usage: |
   Generate a simplified version of the Terragrunt configuration with all includes and dependencies resolved.
-experiment:
-  control: cli-redesign
-  name: CLI Redesign
 examples:
   - description: Render the configurations for the current unit in JSON format.
     code: |

--- a/docs-starlight/src/data/commands/run.mdx
+++ b/docs-starlight/src/data/commands/run.mdx
@@ -5,9 +5,6 @@ category: main
 sidebar:
   order: 100
 description: 'Run OpenTofu/Terraform commands.'
-experiment:
-  control: cli-redesign
-  name: CLI Redesign
 usage: |
   Run a command, passing arguments to an orchestrated tofu/terraform binary.
 

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -99,8 +99,6 @@ If you want to run a command that doesn't have a shortcut in Terragrunt, you can
 
 #### run
 
-**[NOTE] The `run` command is experimental, usage requires the [`--experiment cli-redesign` flag](/docs/reference/experiments/#cli-redesign).**
-
 Run the provided OpenTofu/Terraform command against the unit in the current working directory.
 
 Example:
@@ -125,8 +123,6 @@ terragrunt run -- plan -no-color
 ```
 
 #### exec
-
-**[NOTE] The `exec` command is experimental, usage requires the [`--experiment cli-redesign` flag](/docs/reference/experiments/#cli-redesign).**
 
 Execute an arbitrary command orchestrated by Terragrunt.
 
@@ -822,8 +818,6 @@ More details in [scaffold section](https://terragrunt.gruntwork.io/docs/features
 
 #### find
 
-**[NOTE] The `find` command is experimental, usage requires the [`--experiment cli-redesign` flag](/docs/reference/experiments/#cli-redesign).**
-
 Find Terragrunt configurations in your codebase.
 
 ```bash
@@ -1062,8 +1056,6 @@ terragrunt find --hidden
 ```
 
 #### list
-
-**[NOTE] The `list` command is experimental, usage requires the [`--experiment cli-redesign` flag](/docs/reference/experiments/#cli-redesign).**
 
 List Terragrunt configurations in your codebase.
 
@@ -1728,8 +1720,6 @@ This command will exit with an error if terragrunt detects any unused inputs or 
 
 This is equivalent to the soon to be deprecated `run-all` command.
 
-**[NOTE] The `all` flag is experimental, usage requires the [`--experiment cli-redesign` flag](/docs/reference/experiments/#cli-redesign).**
-
 Runs the provided OpenTofu/Terraform command against a [stack](/docs/getting-started/terminology/#stack).
 The command will recursively find terragrunt [units](/docs/getting-started/terminology/#unit) in the current directory
 tree and run the OpenTofu/Terraform command in dependency order (unless the command is destroy,
@@ -1782,8 +1772,6 @@ The algorithm for determining the aggregate exit code is as follows:
 **Environment Variable**: `TG_GRAPH`<br/>
 
 This is equivalent to the soon to be deprecated `graph` command.
-
-**[NOTE] The `graph` command is experimental, usage requires the [`--experiment cli-redesign` flag](/docs/reference/experiments/#cli-redesign).**
 
 Run the provided OpenTofu/Terraform command against the graph of dependencies for the unit in the current working directory. The graph consists of all units that depend on the unit in the current working directory via a `dependency` or `dependencies` blocks, plus all the units that depend on those units, and all the units that depend on those units, and so on, recursively up the tree, up to the Git repository root, or the path specified via the optional `--graph-root` argument.
 

--- a/docs/_docs/04_reference/06-experiments.md
+++ b/docs/_docs/04_reference/06-experiments.md
@@ -121,30 +121,54 @@ To transition the `stacks` feature to a stable release, the following must be ad
 - [x] Confirm compatibility with parallelism flags (e.g., `--parallel`), especially for stacks with dependencies.
 - [x] Ensure that error handling and failure recovery strategies work as intended across large and nested stacks.
 
+
+### `cas`
+
+Support for Terragrunt Content Addressable Storage (CAS).
+
+#### `cas` - What it does
+
+Allow Terragrunt to store and retrieve state files from a Content Addressable Storage (CAS) system.
+
+At the moment, the CAS is only used to speed up catalog cloning, but in the future, it can be used to store more content.
+
+#### `cas` - How to provide feedback
+
+Share your experience with this feature in the [CAS](https://github.com/gruntwork-io/terragrunt/discussions/3939) Feedback GitHub Discussion.
+Feedback is crucial for ensuring the feature meets real-world use cases. Please include:
+
+- Any bugs or issues encountered (including logs or stack traces if possible).
+- Suggestions for additional improvements or enhancements.
+
+#### `cas` - Criteria for stabilization
+
+To transition the `cas` feature to a stable release, the following must be addressed:
+
+- [x] Add support for storing and retrieving catalog repositories from the CAS.
+- [ ] Add support for storing and retrieving OpenTofu/Terraform modules from the CAS.
+- [ ] Add support for storing and retrieving Unit/Stack configurations from the CAS.
+
+## Completed Experiments
+
+- [cli-redesign](#cli-redesign)
+
 ### `cli-redesign`
 
 Support for the new Terragrunt CLI design.
 
 #### `cli-redesign` - What it does
 
-Enable features from the CLI Redesign RFC.
+Enabled features from the CLI Redesign RFC.
 
-This includes:
-
-- Addition of the `run` command.
-- Addition of the `exec` command.
+This experiment flag is no longer needed, as the CLI Redesign is now the default.
 
 #### `cli-redesign` - How to provide feedback
 
-Share your experience with these features in the [CLI Redesign](https://github.com/gruntwork-io/terragrunt/issues/3445) RFC.
-Feedback is crucial for ensuring the feature meets real-world use cases. Please include:
-
-- Any bugs or issues encountered (including logs or stack traces if possible).
-- Suggestions for additional improvements or enhancements.
+Now that the CLI Redesign experiment is complete, please provide feedback in the form of standard [GitHub issues](https://github.com/gruntwork-io/terragrunt/issues).
 
 #### `cli-redesign` - Criteria for stabilization
 
-To transition `cli-redesign` features to a stable release, the following must be addressed:
+To transition `cli-redesign` features to a stable the following have been completed:
 
 - [x] Add support for `run` command.
   - [x] Add support for basic usage of the `run` command (e.g., `terragrunt run plan`, `terragrunt run -- plan -no-color`).
@@ -185,29 +209,3 @@ To transition `cli-redesign` features to a stable release, the following must be
   - [x] Add integration with `symlinks` experiment to support listing units/stacks via symlinks.
   - [x] Add handling of broken configurations or configurations requiring authentication.
   - [x] Add integration test for `list` with `--sort=dag` flag on all the fixtures in the `test/fixtures` directory.
-
-### `cas`
-
-Support for Terragrunt Content Addressable Storage (CAS).
-
-#### `cas` - What it does
-
-Allow Terragrunt to store and retrieve state files from a Content Addressable Storage (CAS) system.
-
-At the moment, the CAS is only used to speed up catalog cloning, but in the future, it can be used to store more content.
-
-#### `cas` - How to provide feedback
-
-Share your experience with this feature in the [CAS](https://github.com/gruntwork-io/terragrunt/discussions/3939) Feedback GitHub Discussion.
-Feedback is crucial for ensuring the feature meets real-world use cases. Please include:
-
-- Any bugs or issues encountered (including logs or stack traces if possible).
-- Suggestions for additional improvements or enhancements.
-
-#### `cas` - Criteria for stabilization
-
-To transition the `cas` feature to a stable release, the following must be addressed:
-
-- [x] Add support for storing and retrieving catalog repositories from the CAS.
-- [ ] Add support for storing and retrieving OpenTofu/Terraform modules from the CAS.
-- [ ] Add support for storing and retrieving Unit/Stack configurations from the CAS.

--- a/docs/_docs/04_reference/06-experiments.md
+++ b/docs/_docs/04_reference/06-experiments.md
@@ -121,7 +121,6 @@ To transition the `stacks` feature to a stable release, the following must be ad
 - [x] Confirm compatibility with parallelism flags (e.g., `--parallel`), especially for stacks with dependencies.
 - [x] Ensure that error handling and failure recovery strategies work as intended across large and nested stacks.
 
-
 ### `cas`
 
 Support for Terragrunt Content Addressable Storage (CAS).

--- a/internal/experiment/errors.go
+++ b/internal/experiment/errors.go
@@ -23,18 +23,3 @@ func (err InvalidExperimentNameError) Is(target error) bool {
 	_, ok := target.(*InvalidExperimentNameError)
 	return ok
 }
-
-// CompletedExperimentsError is an error that is returned when completed experiments are requested.
-type CompletedExperimentsError struct {
-	experimentsNames []string
-}
-
-func NewCompletedExperimentsError(experimentsNames []string) *CompletedExperimentsError {
-	return &CompletedExperimentsError{
-		experimentsNames: experimentsNames,
-	}
-}
-
-func (err CompletedExperimentsError) Error() string {
-	return "The following experiment(s) are already completed: " + strings.Join(err.experimentsNames, ", ") + ". Please remove any completed experiments, as setting them no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://terragrunt.gruntwork.io/docs/reference/experiments"
-}

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -124,7 +124,7 @@ func (exps Experiments) NotifyCompletedExperiments(logger log.Logger) {
 		return
 	}
 
-	logger.Warnf(NewCompletedExperimentsError(completed.Names()).Error())
+	logger.Warnf(NewCompletedExperimentsWarning(completed.Names()).String())
 }
 
 // Evaluate returns true if the experiment is found and enabled otherwise returns false.

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -152,6 +152,8 @@ func (exps Experiment) String() string {
 }
 
 // Evaluate returns true the experiment is enabled.
+//
+// If the experiment is completed, consider it permanently enabled.
 func (exps Experiment) Evaluate() bool {
-	return exps.Enabled
+	return exps.Enabled || exps.Status == StatusCompleted
 }

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -43,7 +43,8 @@ func NewExperiments() Experiments {
 			Name: Symlinks,
 		},
 		{
-			Name: CLIRedesign,
+			Name:   CLIRedesign,
+			Status: StatusCompleted,
 		},
 		{
 			Name: Stacks,

--- a/internal/experiment/warnings.go
+++ b/internal/experiment/warnings.go
@@ -1,0 +1,20 @@
+package experiment
+
+import (
+	"strings"
+)
+
+// CompletedExperimentsWarning is a warning that is returned when completed experiments are requested.
+type CompletedExperimentsWarning struct {
+	experimentsNames []string
+}
+
+func NewCompletedExperimentsWarning(experimentsNames []string) *CompletedExperimentsWarning {
+	return &CompletedExperimentsWarning{
+		experimentsNames: experimentsNames,
+	}
+}
+
+func (w CompletedExperimentsWarning) String() string {
+	return "The following experiment(s) are already completed: " + strings.Join(w.experimentsNames, ", ") + ". Please remove any completed experiments, as setting them no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://terragrunt.gruntwork.io/docs/reference/experiments"
+}

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -130,7 +130,7 @@ func TestAwsBootstrapBackend(t *testing.T) {
 			commonConfigPath := util.JoinPath(rootPath, "common.hcl")
 			helpers.CopyTerragruntConfigAndFillPlaceholders(t, commonConfigPath, commonConfigPath, s3BucketName, dynamoDBName, helpers.TerraformRemoteStateS3Region)
 
-			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt "+tc.args+" --all --non-interactive --log-level debug --strict-control require-explicit-bootstrap --experiment cli-redesign --working-dir "+rootPath)
+			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt "+tc.args+" --all --non-interactive --log-level debug --strict-control require-explicit-bootstrap --working-dir "+rootPath)
 
 			tc.checkExpectedResultFn(t, err, stdout+stderr, s3BucketName, dynamoDBName)
 		})
@@ -157,7 +157,7 @@ func TestAwsBootstrapBackendLegacyBehavior(t *testing.T) {
 	commonConfigPath := util.JoinPath(rootPath, "common.hcl")
 	helpers.CopyTerragruntConfigAndFillPlaceholders(t, commonConfigPath, commonConfigPath, s3BucketName, dynamoDBName, helpers.TerraformRemoteStateS3Region)
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath+" apply")
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --log-level debug --working-dir "+rootPath+" apply")
 	require.NoError(t, err)
 
 	validateS3BucketExistsAndIsTagged(t, helpers.TerraformRemoteStateS3Region, s3BucketName, nil)
@@ -174,7 +174,7 @@ func TestAwsBootstrapBackendLegacyBehavior(t *testing.T) {
 
 	// Users should only see the warning if the backend is actually being
 	// bootstrapped automatically.
-	_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath+" apply")
+	_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --log-level debug --working-dir "+rootPath+" apply")
 	require.NoError(t, err)
 
 	assert.NotContains(t, stderr, "Use the explicit `--backend-bootstrap` flag to automatically provision backend resources before they're needed.")
@@ -200,16 +200,16 @@ func TestAwsBootstrapBackendWithoutVersioning(t *testing.T) {
 	commonConfigPath := util.JoinPath(rootPath, "common.hcl")
 	helpers.CopyTerragruntConfigAndFillPlaceholders(t, commonConfigPath, commonConfigPath, s3BucketName, dynamoDBName, helpers.TerraformRemoteStateS3Region)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --log-level debug --strict-control require-explicit-bootstrap --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true --backend-bootstrap apply")
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --log-level debug --strict-control require-explicit-bootstrap --working-dir "+rootPath+" --feature disable_versioning=true --backend-bootstrap apply")
 	require.NoError(t, err)
 
 	validateS3BucketExistsAndIsTagged(t, helpers.TerraformRemoteStateS3Region, s3BucketName, nil)
 	validateDynamoDBTableExistsAndIsTaggedAndIsSSEncrypted(t, helpers.TerraformRemoteStateS3Region, dynamoDBName, nil, false)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true backend delete --all")
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --working-dir "+rootPath+" --feature disable_versioning=true backend delete --all")
 	require.Error(t, err)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true backend delete --all --force")
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --working-dir "+rootPath+" --feature disable_versioning=true backend delete --all --force")
 	require.NoError(t, err)
 }
 
@@ -234,16 +234,16 @@ func TestAwsMigrateBackendWithoutVersioning(t *testing.T) {
 	commonConfigPath := util.JoinPath(rootPath, "common.hcl")
 	helpers.CopyTerragruntConfigAndFillPlaceholders(t, commonConfigPath, commonConfigPath, s3BucketName, dynamoDBName, helpers.TerraformRemoteStateS3Region)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --non-interactive --log-level debug --strict-control require-explicit-bootstrap --experiment cli-redesign --working-dir "+unitPath+" --feature disable_versioning=true --backend-bootstrap apply -- -auto-approve")
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --non-interactive --log-level debug --strict-control require-explicit-bootstrap --working-dir "+unitPath+" --feature disable_versioning=true --backend-bootstrap apply -- -auto-approve")
 	require.NoError(t, err)
 
 	validateS3BucketExistsAndIsTagged(t, helpers.TerraformRemoteStateS3Region, s3BucketName, nil)
 	validateDynamoDBTableExistsAndIsTaggedAndIsSSEncrypted(t, helpers.TerraformRemoteStateS3Region, dynamoDBName, nil, false)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true backend migrate unit1 unit2")
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --working-dir "+rootPath+" --feature disable_versioning=true backend migrate unit1 unit2")
 	require.Error(t, err)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true backend migrate --force unit1 unit2")
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --working-dir "+rootPath+" --feature disable_versioning=true backend migrate --force unit1 unit2")
 	require.NoError(t, err)
 }
 
@@ -267,7 +267,7 @@ func TestAwsDeleteBackend(t *testing.T) {
 	commonConfigPath := util.JoinPath(rootPath, "common.hcl")
 	helpers.CopyTerragruntConfigAndFillPlaceholders(t, commonConfigPath, commonConfigPath, s3BucketName, dynamoDBName, helpers.TerraformRemoteStateS3Region)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --all --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath)
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --all --non-interactive --log-level debug --working-dir "+rootPath)
 	require.NoError(t, err)
 
 	remoteStateKeys := []string{
@@ -282,7 +282,7 @@ func TestAwsDeleteBackend(t *testing.T) {
 		assert.True(t, doesDynamoDBTableItemExist(t, helpers.TerraformRemoteStateS3Region, dynamoDBName, tableKey), "DynamoDB table key %s must exist", tableKey)
 	}
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt backend delete --all --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath)
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt backend delete --all --non-interactive --log-level debug --working-dir "+rootPath)
 	require.NoError(t, err)
 
 	for _, key := range remoteStateKeys {
@@ -324,7 +324,7 @@ func TestAwsMigrateBackend(t *testing.T) {
 
 	// Bootstrap backend and create remote state for unit1.
 
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --experiment cli-redesign --working-dir "+unit1Path+" -- -auto-approve")
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --working-dir "+unit1Path+" -- -auto-approve")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "Changes to Outputs")
 
@@ -336,7 +336,7 @@ func TestAwsMigrateBackend(t *testing.T) {
 	assert.False(t, doesDynamoDBTableItemExist(t, helpers.TerraformRemoteStateS3Region, dynamoDBName, unit2TableKey), "DynamoDB table key %s must not exist", unit2TableKey)
 
 	// Migrate remote state from unit1 to unit2.
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt backend migrate --log-level debug --experiment cli-redesign --working-dir "+rootPath+" unit1 unit2")
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt backend migrate --log-level debug --working-dir "+rootPath+" unit1 unit2")
 	require.NoError(t, err)
 
 	// Check for remote states after migration.
@@ -347,7 +347,7 @@ func TestAwsMigrateBackend(t *testing.T) {
 
 	// Run `tofu apply` for unit2 with migrated remote state from unit1.
 
-	stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --experiment cli-redesign --working-dir "+unit2Path+" -- -auto-approve")
+	stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --working-dir "+unit2Path+" -- -auto-approve")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "No changes")
 }

--- a/test/integration_awsgcp_test.go
+++ b/test/integration_awsgcp_test.go
@@ -49,21 +49,21 @@ func TestAwsGcpMigrateBetweenDifferentBackends(t *testing.T) {
 
 	// Bootstrap backend and create remote state for unit1.
 
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --experiment cli-redesign --working-dir "+unit1Path+" -- -auto-approve")
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --working-dir "+unit1Path+" -- -auto-approve")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "Changes to Outputs")
 
-	stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run plan --backend-bootstrap --non-interactive --log-level debug --experiment cli-redesign --working-dir "+unit2Path+"")
+	stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run plan --backend-bootstrap --non-interactive --log-level debug --working-dir "+unit2Path+"")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "Changes to Outputs")
 
 	// Migrate remote state from unit1 to unit2.
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt backend migrate --log-level debug --experiment cli-redesign --working-dir "+rootPath+" unit1 unit2")
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt backend migrate --log-level debug --working-dir "+rootPath+" unit1 unit2")
 	require.NoError(t, err)
 
 	// Run `tofu apply` for unit2 with migrated remote state from unit1.
 
-	stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --experiment cli-redesign --working-dir "+unit2Path+" -- -auto-approve")
+	stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --working-dir "+unit2Path+" -- -auto-approve")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "No changes")
 }

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -456,9 +456,9 @@ func TestRenderJSONConfigRunAllWithCLIRedesign(t *testing.T) {
 	defer os.Remove(bazJSONOut)
 	defer os.Remove(rootChildJSONOut)
 
-	helpers.RunTerragrunt(t, "terragrunt run --experiment cli-redesign --all apply --non-interactive --log-level trace --working-dir "+workDir)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --log-level trace --working-dir "+workDir)
 
-	helpers.RunTerragrunt(t, "terragrunt render --experiment cli-redesign --all --json -w --non-interactive --log-level trace --working-dir "+workDir)
+	helpers.RunTerragrunt(t, "terragrunt render --all --json -w --non-interactive --log-level trace --working-dir "+workDir)
 
 	bazJSONBytes, err := os.ReadFile(bazJSONOut)
 	require.NoError(t, err)

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -26,7 +26,7 @@ func TestFindBasic(t *testing.T) {
 
 	helpers.CleanupTerraformFolder(t, testFixtureFindBasic)
 
-	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic)
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --no-color --working-dir "+testFixtureFindBasic)
 	require.NoError(t, err)
 
 	assert.Empty(t, stderr)
@@ -38,7 +38,7 @@ func TestFindBasicJSON(t *testing.T) {
 
 	helpers.CleanupTerraformFolder(t, testFixtureFindBasic)
 
-	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+testFixtureFindBasic+" --json")
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --no-color --working-dir "+testFixtureFindBasic+" --json")
 	require.NoError(t, err)
 
 	assert.Empty(t, stderr)
@@ -70,7 +70,7 @@ func TestFindHidden(t *testing.T) {
 
 			helpers.CleanupTerraformFolder(t, testFixtureFindHidden)
 
-			cmd := "terragrunt find --experiment cli-redesign --no-color --working-dir " + testFixtureFindHidden
+			cmd := "terragrunt find --no-color --working-dir " + testFixtureFindHidden
 
 			if tc.hidden {
 				cmd += " --hidden"
@@ -103,7 +103,7 @@ func TestFindDAG(t *testing.T) {
 
 			helpers.CleanupTerraformFolder(t, testFixtureFindDAG)
 
-			cmd := "terragrunt find --experiment cli-redesign --no-color --working-dir " + testFixtureFindDAG
+			cmd := "terragrunt find --no-color --working-dir " + testFixtureFindDAG
 
 			if tc.sort == "dag" {
 				cmd += " --dag"
@@ -125,13 +125,13 @@ func TestFindExternalDependencies(t *testing.T) {
 
 	internalDir := filepath.Join(testFixtureFindInternalVExternal, "internal")
 
-	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+internalDir+" --dependencies --external")
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --no-color --working-dir "+internalDir+" --dependencies --external")
 	require.NoError(t, err)
 
 	assert.Empty(t, stderr)
 	assert.Equal(t, "../external/c-dependency\na-dependent\nb-dependency\n", stdout)
 
-	stdout, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --experiment cli-redesign --no-color --working-dir "+internalDir+" --dependencies")
+	stdout, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --no-color --working-dir "+internalDir+" --dependencies")
 	require.NoError(t, err)
 
 	assert.Empty(t, stderr)
@@ -175,7 +175,7 @@ func TestFindExclude(t *testing.T) {
 
 			helpers.CleanupTerraformFolder(t, testFixtureFindExclude)
 
-			cmd := fmt.Sprintf("terragrunt find --experiment cli-redesign --no-color --working-dir %s %s", testFixtureFindExclude, tc.args)
+			cmd := fmt.Sprintf("terragrunt find --no-color --working-dir %s %s", testFixtureFindExclude, tc.args)
 			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
 			require.NoError(t, err)
 			assert.Empty(t, stderr)
@@ -258,7 +258,7 @@ func TestFindQueueConstructAs(t *testing.T) {
 
 			helpers.CleanupTerraformFolder(t, testFixtureListDag)
 
-			cmd := fmt.Sprintf("terragrunt find --json --experiment cli-redesign --no-color --working-dir %s %s", testFixtureListDag, tc.args)
+			cmd := fmt.Sprintf("terragrunt find --json --no-color --working-dir %s %s", testFixtureListDag, tc.args)
 			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
 			require.NoError(t, err)
 			assert.Empty(t, stderr)

--- a/test/integration_gcp_test.go
+++ b/test/integration_gcp_test.go
@@ -89,7 +89,7 @@ func TestGcpBootstrapBackend(t *testing.T) {
 			commonConfigPath := util.JoinPath(rootPath, "common.hcl")
 			copyTerragruntGCSConfigAndFillPlaceholders(t, commonConfigPath, commonConfigPath, project, terraformRemoteStateGcpRegion, gcsBucketName)
 
-			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt "+tc.args+" --all --non-interactive --log-level debug --strict-control require-explicit-bootstrap --experiment cli-redesign --working-dir "+rootPath)
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt "+tc.args+" --all --non-interactive --log-level debug --strict-control require-explicit-bootstrap --working-dir "+rootPath)
 
 			tc.checkExpectedResultFn(t, err, gcsBucketName)
 		})
@@ -113,15 +113,15 @@ func TestGcpBootstrapBackendWithoutVersioning(t *testing.T) {
 	commonConfigPath := util.JoinPath(rootPath, "common.hcl")
 	copyTerragruntGCSConfigAndFillPlaceholders(t, commonConfigPath, commonConfigPath, project, terraformRemoteStateGcpRegion, gcsBucketName)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --log-level debug --strict-control require-explicit-bootstrap --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true --backend-bootstrap apply")
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --log-level debug --strict-control require-explicit-bootstrap --working-dir "+rootPath+" --feature disable_versioning=true --backend-bootstrap apply")
 	require.NoError(t, err)
 
 	validateGCSBucketExistsAndIsLabeled(t, terraformRemoteStateGcpRegion, gcsBucketName, nil)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --strict-control require-explicit-bootstrap --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true backend delete --all")
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --strict-control require-explicit-bootstrap --working-dir "+rootPath+" --feature disable_versioning=true backend delete --all")
 	require.Error(t, err)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --strict-control require-explicit-bootstrap --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true backend delete --all --force")
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --strict-control require-explicit-bootstrap --working-dir "+rootPath+" --feature disable_versioning=true backend delete --all --force")
 	require.NoError(t, err)
 }
 
@@ -143,15 +143,15 @@ func TestGcpMigrateBackendWithoutVersioning(t *testing.T) {
 	commonConfigPath := util.JoinPath(rootPath, "common.hcl")
 	copyTerragruntGCSConfigAndFillPlaceholders(t, commonConfigPath, commonConfigPath, project, terraformRemoteStateGcpRegion, gcsBucketName)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --non-interactive --log-level debug --strict-control require-explicit-bootstrap --experiment cli-redesign --working-dir "+unitPath+" --feature disable_versioning=true --backend-bootstrap apply -- -auto-approve")
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --non-interactive --log-level debug --strict-control require-explicit-bootstrap --working-dir "+unitPath+" --feature disable_versioning=true --backend-bootstrap apply -- -auto-approve")
 	require.NoError(t, err)
 
 	validateGCSBucketExistsAndIsLabeled(t, terraformRemoteStateGcpRegion, gcsBucketName, nil)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true backend migrate unit1 unit2")
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --working-dir "+rootPath+" --feature disable_versioning=true backend migrate unit1 unit2")
 	require.Error(t, err)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath+" --feature disable_versioning=true backend migrate --force unit1 unit2")
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt --non-interactive --log-level debug --working-dir "+rootPath+" --feature disable_versioning=true backend migrate --force unit1 unit2")
 	require.NoError(t, err)
 }
 
@@ -172,7 +172,7 @@ func TestGcpDeleteBackend(t *testing.T) {
 	commonConfigPath := util.JoinPath(rootPath, "common.hcl")
 	copyTerragruntGCSConfigAndFillPlaceholders(t, commonConfigPath, commonConfigPath, project, terraformRemoteStateGcpRegion, gcsBucketName)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --all --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath)
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --all --non-interactive --log-level debug --working-dir "+rootPath)
 	require.NoError(t, err)
 
 	remoteStateObjectNames := []string{
@@ -184,7 +184,7 @@ func TestGcpDeleteBackend(t *testing.T) {
 		assert.True(t, doesGCSBucketObjectExist(t, gcsBucketName, objectName), "GCS bucket object %s must exist", objectName)
 	}
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt backend delete --all --non-interactive --log-level debug --experiment cli-redesign --working-dir "+rootPath)
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt backend delete --all --non-interactive --log-level debug --working-dir "+rootPath)
 	require.NoError(t, err)
 
 	for _, objectName := range remoteStateObjectNames {
@@ -217,7 +217,7 @@ func TestGcpMigrateBackend(t *testing.T) {
 
 	// Bootstrap backend and create remote state for unit1.
 
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --experiment cli-redesign --working-dir "+unit1Path+" -- -auto-approve")
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --working-dir "+unit1Path+" -- -auto-approve")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "Changes to Outputs")
 
@@ -227,7 +227,7 @@ func TestGcpMigrateBackend(t *testing.T) {
 	assert.False(t, doesGCSBucketObjectExist(t, gcsBucketName, unit2BackendKey), "GCS bucket object %s must not exist", unit2BackendKey)
 
 	// Migrate remote state from unit1 to unit2.
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt backend migrate --log-level debug --experiment cli-redesign --working-dir "+rootPath+" unit1 unit2")
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt backend migrate --log-level debug --working-dir "+rootPath+" unit1 unit2")
 	require.NoError(t, err)
 
 	// Check for remote states after migration.
@@ -236,7 +236,7 @@ func TestGcpMigrateBackend(t *testing.T) {
 
 	// Run `tofu apply` for unit2 with migrated remote state from unit1.
 
-	stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --experiment cli-redesign --working-dir "+unit2Path+" -- -auto-approve")
+	stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run apply --backend-bootstrap --non-interactive --log-level debug --working-dir "+unit2Path+" -- -auto-approve")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "No changes")
 }

--- a/test/integration_graph_test.go
+++ b/test/integration_graph_test.go
@@ -95,13 +95,13 @@ func TestTerragruntApplyGraph(t *testing.T) {
 			notExpectedModules: []string{"lambda", "eks", "services/eks-service-3"},
 		},
 		{
-			args:               "run --graph apply --experiment cli-redesign --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-graph-root %s",
+			args:               "run --graph apply --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-graph-root %s",
 			path:               "lambda",
 			expectedModules:    []string{"lambda", "services/lambda-service-1", "services/lambda-service-2"},
 			notExpectedModules: []string{"eks", "services/eks-service-1", "services/eks-service-2", "services/eks-service-3"},
 		},
 		{
-			args:               "run apply --graph --experiment cli-redesign --non-interactive --working-dir %s --graph-root %s",
+			args:               "run apply --graph --non-interactive --working-dir %s --graph-root %s",
 			path:               "services/eks-service-5",
 			expectedModules:    []string{"services/eks-service-5"},
 			notExpectedModules: []string{"eks", "lambda", "services/eks-service-1", "services/eks-service-2", "services/eks-service-3"},

--- a/test/integration_json_test.go
+++ b/test/integration_json_test.go
@@ -139,7 +139,7 @@ func TestRenderJsonAttributesMetadataExp(t *testing.T) {
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
 
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -276,7 +276,7 @@ func TestRenderJsonWithInputsNotExistingOutputExp(t *testing.T) {
 	appPath := util.JoinPath(tmpEnvPath, testFixtureRenderJSONInputs, "app")
 
 	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+dependencyPath)
-	helpers.RunTerragrunt(t, "terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir "+appPath)
+	helpers.RunTerragrunt(t, "terragrunt render --json -w --with-metadata --non-interactive --log-level trace --working-dir "+appPath)
 
 	jsonOut := filepath.Join(appPath, "terragrunt.rendered.json")
 
@@ -372,7 +372,7 @@ func TestRenderJsonWithMockOutputsExp(t *testing.T) {
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
 
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -555,7 +555,7 @@ func TestRenderJsonMetadataIncludesExp(t *testing.T) {
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
 
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -725,7 +725,7 @@ func TestRenderJsonMetadataDependencyExp(t *testing.T) {
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
 
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -877,7 +877,7 @@ func TestRenderJsonMetadataTerraformExp(t *testing.T) {
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
 
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -953,7 +953,7 @@ func TestRenderJsonMetadataDependencyModulePrefixExp(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureRenderJSONMetadata, "dependency", "app")
 
-	helpers.RunTerragrunt(t, "terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir "+tmpDir)
+	helpers.RunTerragrunt(t, "terragrunt render --json -w --with-metadata --non-interactive --log-level trace --working-dir "+tmpDir)
 }
 
 func TestRenderJsonDependentModulesMetadataTerraform(t *testing.T) {
@@ -987,7 +987,7 @@ func TestRenderJsonDependentModulesMetadataTerraformExp(t *testing.T) {
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -1033,7 +1033,7 @@ func TestTerragruntRenderJsonHelpExp(t *testing.T) {
 	showStdout := bytes.Buffer{}
 	showStderr := bytes.Buffer{}
 
-	err := helpers.RunTerragruntCommand(t, "terragrunt render --experiment cli-redesign --help --non-interactive --working-dir "+rootPath, &showStdout, &showStderr)
+	err := helpers.RunTerragruntCommand(t, "terragrunt render --help --non-interactive --working-dir "+rootPath, &showStdout, &showStderr)
 	require.NoError(t, err)
 
 	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
@@ -1074,7 +1074,7 @@ func TestRenderJsonDependentModulesTerraformExp(t *testing.T) {
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -1116,7 +1116,7 @@ func TestRenderJsonDisableDependentModulesTerraformExp(t *testing.T) {
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json -w --disable-dependent-modules --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --disable-dependent-modules --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)

--- a/test/integration_list_test.go
+++ b/test/integration_list_test.go
@@ -131,7 +131,7 @@ unit  units/live/prod/vpc
 
 			helpers.CleanupTerraformFolder(t, tc.workingDir)
 
-			args := []string{"terragrunt", "--no-color", "--experiment", "cli-redesign"}
+			args := []string{"terragrunt", "--no-color"}
 			args = append(args, tc.args...)
 			args = append(args, "--working-dir", tc.workingDir)
 
@@ -186,7 +186,7 @@ unit  unit3
 
 			helpers.CleanupTerraformFolder(t, testFixtureFindExclude)
 
-			args := []string{"terragrunt", "--no-color", "--experiment", "cli-redesign"}
+			args := []string{"terragrunt", "--no-color"}
 			args = append(args, tc.args...)
 			args = append(args, "--working-dir", testFixtureFindExclude)
 

--- a/test/integration_parse_test.go
+++ b/test/integration_parse_test.go
@@ -78,8 +78,8 @@ func TestParseFindListAllComponents(t *testing.T) {
 		name    string
 		command string
 	}{
-		{name: "find", command: "terragrunt find --experiment cli-redesign --no-color"},
-		{name: "list", command: "terragrunt list --experiment cli-redesign --no-color"},
+		{name: "find", command: "terragrunt find --no-color"},
+		{name: "list", command: "terragrunt list --no-color"},
 	}
 
 	for _, tt := range tc {
@@ -122,8 +122,8 @@ func TestParseFindListAllComponentsWithDAG(t *testing.T) {
 		name    string
 		command string
 	}{
-		{name: "find", command: "terragrunt find --experiment cli-redesign --no-color --dag"},
-		{name: "list", command: "terragrunt list --experiment cli-redesign --no-color --dag"},
+		{name: "find", command: "terragrunt find --no-color --dag"},
+		{name: "list", command: "terragrunt list --no-color --dag"},
 	}
 
 	for _, tt := range tc {
@@ -166,8 +166,8 @@ func TestParseFindListAllComponentsWithDAGAndExternal(t *testing.T) {
 		name    string
 		command string
 	}{
-		{name: "find", command: "terragrunt find --experiment cli-redesign --no-color --dag --external"},
-		{name: "list", command: "terragrunt list --experiment cli-redesign --no-color --dag --external"},
+		{name: "find", command: "terragrunt find --no-color --dag --external"},
+		{name: "list", command: "terragrunt list --no-color --dag --external"},
 	}
 
 	for _, tt := range tc {

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -527,7 +527,7 @@ func TestTerragruntFindProduceTelemetryTraces(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksBasic)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksBasic)
 
-	output, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --experiment cli-redesign --working-dir "+rootPath)
+	output, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt find --working-dir "+rootPath)
 	require.NoError(t, err)
 
 	// check that output have Telemetry json output
@@ -544,7 +544,7 @@ func TestTerragruntListProduceTelemetryTraces(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksBasic)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksBasic)
 
-	output, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt list --experiment cli-redesign --working-dir "+rootPath)
+	output, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt list --working-dir "+rootPath)
 	require.NoError(t, err)
 
 	// check that output have Telemetry json output

--- a/test/integration_strict_test.go
+++ b/test/integration_strict_test.go
@@ -117,7 +117,7 @@ func TestRootTerragruntHCLStrictMode(t *testing.T) {
 				args = " --strict-control " + control + " " + args
 			}
 
-			_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --experiment cli-redesign "+args+" -- plan")
+			_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run "+args+" -- plan")
 
 			if tc.expectedError != nil {
 				require.Error(t, err)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -169,7 +169,7 @@ func TestGlobalFlagMoveStrictControl(t *testing.T) {
 		},
 		{
 			containsLogMsg: "The global `--tf-path` flag has moved",
-			args:           "--experiment cli-redesign -tf-path=" + tfPath + " init",
+			args:           "-tf-path=" + tfPath + " init",
 		},
 	}
 
@@ -234,7 +234,7 @@ func TestExecCommand(t *testing.T) {
 			err = os.Mkdir(downloadDirPath, os.ModePerm)
 			require.NoError(t, err)
 
-			stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt exec --experiment cli-redesign --working-dir "+rootPath+" "+strings.Join(tc.args, " ")+" -- "+scriptPath)
+			stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt exec --working-dir "+rootPath+" "+strings.Join(tc.args, " ")+" -- "+scriptPath)
 			require.NoError(t, err)
 			assert.Contains(t, stdout, "The first arg is arg1. The second arg is arg2. The script is running in the directory "+util.JoinPath(rootPath, tc.runInDir))
 		})
@@ -1149,7 +1149,7 @@ func TestTerraformCommandCliArgs(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cmd := fmt.Sprintf("terragrunt run --experiment cli-redesign --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s %s", testFixtureExtraArgsPath, strings.Join(tc.command, " "))
+		cmd := fmt.Sprintf("terragrunt run --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s %s", testFixtureExtraArgsPath, strings.Join(tc.command, " "))
 
 		var (
 			stdout bytes.Buffer
@@ -1253,11 +1253,11 @@ func TestRunCommand(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureInputs)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureInputs)
 
-	helpers.RunTerragrunt(t, "terragrunt run --experiment cli-redesign --non-interactive --working-dir "+rootPath+" -- apply -auto-approve")
+	helpers.RunTerragrunt(t, "terragrunt run --non-interactive --working-dir "+rootPath+" -- apply -auto-approve")
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
-	err := helpers.RunTerragruntCommand(t, "terragrunt run --experiment cli-redesign -no-color --non-interactive --working-dir "+rootPath+" -- output -json", &stdout, &stderr)
+	err := helpers.RunTerragruntCommand(t, "terragrunt run -no-color --non-interactive --working-dir "+rootPath+" -- output -json", &stdout, &stderr)
 	require.NoError(t, err)
 
 	outputs := map[string]helpers.TerraformOutput{}
@@ -3867,10 +3867,10 @@ func TestStorePlanFilesJsonRelativePath(t *testing.T) {
 		args string
 	}{
 		{"run-all plan --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s --terragrunt-out-dir test --terragrunt-json-out-dir json"},
-		{"run --all plan --experiment cli-redesign --non-interactive --log-level trace --working-dir %s --out-dir test --json-out-dir json"},
-		{"run plan --all --experiment cli-redesign --non-interactive --log-level trace --working-dir %s --out-dir test --json-out-dir json"},
-		{"run plan -a --experiment cli-redesign --non-interactive --log-level trace --working-dir %s --out-dir test --json-out-dir json"},
-		{"run --all --experiment cli-redesign --non-interactive --log-level trace --working-dir %s --out-dir test --json-out-dir json -- plan"},
+		{"run --all plan --non-interactive --log-level trace --working-dir %s --out-dir test --json-out-dir json"},
+		{"run plan --all --non-interactive --log-level trace --working-dir %s --out-dir test --json-out-dir json"},
+		{"run plan -a --non-interactive --log-level trace --working-dir %s --out-dir test --json-out-dir json"},
+		{"run --all --non-interactive --log-level trace --working-dir %s --out-dir test --json-out-dir json -- plan"},
 	}
 
 	for _, tc := range testCases {
@@ -4234,7 +4234,7 @@ func TestTfPath(t *testing.T) {
 	workingDir, err := filepath.EvalSymlinks(workingDir)
 	require.NoError(t, err)
 
-	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run version --experiment cli-redesign --working-dir "+workingDir)
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run version --working-dir "+workingDir)
 	require.NoError(t, err)
 
 	assert.Regexp(t, "(?i)(terraform|opentofu)", stdout+stderr)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -153,51 +153,6 @@ func TestCLIFlagHints(t *testing.T) {
 	}
 }
 
-func TestGlobalFlagMoveStrictControl(t *testing.T) {
-	t.Parallel()
-
-	tfPath := os.Getenv("TG_TF_PATH")
-
-	testCases := []struct {
-		containsLogMsg    string
-		notContainsLogMsg string
-		args              string
-	}{
-		{
-			notContainsLogMsg: "The global `--tf-path` flag has moved",
-			args:              "-tf-path=" + tfPath + " init",
-		},
-		{
-			containsLogMsg: "The global `--tf-path` flag has moved",
-			args:           "-tf-path=" + tfPath + " init",
-		},
-	}
-
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
-			t.Parallel()
-
-			helpers.CleanupTerraformFolder(t, testFixtureCLIFlagHints)
-			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCLIFlagHints)
-
-			rootPath := util.JoinPath(tmpEnvPath, testFixtureCLIFlagHints)
-			rootPath, err := filepath.EvalSymlinks(rootPath)
-			require.NoError(t, err)
-
-			_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt --working-dir "+rootPath+" "+tc.args)
-			require.NoError(t, err)
-
-			if tc.containsLogMsg != "" {
-				assert.Contains(t, stderr, tc.containsLogMsg)
-			}
-
-			if tc.notContainsLogMsg != "" {
-				assert.NotContains(t, stderr, tc.notContainsLogMsg)
-			}
-		})
-	}
-}
-
 func TestExecCommand(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration_tofu_state_encryption_test.go
+++ b/test/integration_tofu_state_encryption_test.go
@@ -196,7 +196,7 @@ func TestTofuRenderJSONConfigWithEncryptionExp(t *testing.T) {
 	jsonOut := filepath.Join(mainPath, "terragrunt.rendered.json")
 
 	helpers.RunTerragrunt(t, "terragrunt run-all apply -auto-approve --non-interactive --log-level trace --working-dir "+workDir)
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --experiment cli-redesign --json  -w --non-interactive --log-level trace --working-dir %s --out %s", mainPath, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json  -w --non-interactive --log-level trace --working-dir %s --out %s", mainPath, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Completing CLI Redesign experiment.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `cli-redesign` to have a status of completed.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

- If you are currently using `--experiment cli-redesign`, you are now free to remove usage of that flag. To preserve backwards compatibility, it won't cause any issues, but it is no longer needed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The CLI redesign is now the default experience; the experimental flag is no longer required for related commands.
  - Introduced documentation and support for a new "cas" (Content Addressable Storage) experiment.

- **Bug Fixes**
  - Removed unnecessary experimental flag checks from CLI commands, ensuring smoother command execution.

- **Documentation**
  - Updated and reorganized experiment documentation to reflect the completion of the CLI redesign and introduce the new "cas" experiment.
  - Removed experimental status notes and metadata from command documentation for CLI redesign-related commands.

- **Tests**
  - Updated integration tests to remove the deprecated experimental flag and related logic.
  - Adjusted test assertions to expect warnings only when unnecessary experiment flags are provided.
  - Removed obsolete tests related to the CLI redesign experiment flag.

- **Refactor**
  - Cleaned up internal experiment handling by removing obsolete error types and updating experiment evaluation logic.
  - Added new warning types for completed experiments to improve user messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->