### PR TITLE
feat: Adding initial deprecation of `render-json`

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -23,7 +23,6 @@ import (
 	execCmd "github.com/gruntwork-io/terragrunt/cli/commands/exec"
 	graphdependencies "github.com/gruntwork-io/terragrunt/cli/commands/graph-dependencies"
 	outputmodulegroups "github.com/gruntwork-io/terragrunt/cli/commands/output-module-groups"
-	renderjson "github.com/gruntwork-io/terragrunt/cli/commands/render-json"
 	runCmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
 	runall "github.com/gruntwork-io/terragrunt/cli/commands/run-all"
 	terragruntinfo "github.com/gruntwork-io/terragrunt/cli/commands/terragrunt-info"
@@ -88,7 +87,6 @@ func New(opts *options.TerragruntOptions) cli.Commands {
 		info.NewCommand(opts),               // info
 		dag.NewCommand(opts),                // dag
 		terragruntinfo.NewCommand(opts),     // terragrunt-info
-		renderjson.NewCommand(opts),         // render-json
 		render.NewCommand(opts),             // render
 		helpCmd.NewCommand(opts),            // help (hidden)
 		versionCmd.NewCommand(opts),         // version (hidden)

--- a/cli/commands/deprecated.go
+++ b/cli/commands/deprecated.go
@@ -46,7 +46,7 @@ var replaceDeprecatedCommandsFuncs = map[string]replaceDeprecatedCommandFuncType
 	CommandHCLFmtName:         replaceDeprecatedCommandFunc(controls.CLIRedesign, cli.Args{hcl.CommandName, format.CommandName}),
 	CommandHCLValidateName:    replaceDeprecatedCommandFunc(controls.CLIRedesign, cli.Args{hcl.CommandName, validate.CommandName}),
 	CommandValidateInputsName: replaceDeprecatedCommandFunc(controls.CLIRedesign, cli.Args{hcl.CommandName, validate.CommandName, "--" + validate.InputsFlagName}),
-	CommandRenderJSONName:     replaceDeprecatedCommandFunc(controls.CLIRedesign, cli.Args{render.CommandName, render.JSONFlagName, render.WriteFlagName}),
+	CommandRenderJSONName:     replaceDeprecatedCommandFunc(controls.CLIRedesign, cli.Args{render.CommandName, "--" + render.JSONFlagName, "--" + render.WriteFlagName}),
 }
 
 type replaceDeprecatedCommandFuncType func(opts *options.TerragruntOptions, deprecatedCommandName string) cli.ActionFunc
@@ -65,7 +65,6 @@ func replaceDeprecatedCommandFunc(strictControlName string, args cli.Args) repla
 			}
 
 			args := append(args, ctx.Args().Slice()...)
-
 			return ctx.App.NewRootCommand().Run(ctx, args)
 		}
 	}
@@ -76,10 +75,11 @@ func NewDeprecatedCommands(opts *options.TerragruntOptions) cli.Commands {
 
 	for commandName, runFunc := range replaceDeprecatedCommandsFuncs {
 		command := &cli.Command{
-			Name:   commandName,
-			Hidden: true,
-			Action: runFunc(opts, commandName),
-			Flags:  run.NewFlags(opts, nil),
+			Name:       commandName,
+			Hidden:     true,
+			CustomHelp: cli.ShowAppHelp,
+			Action:     runFunc(opts, commandName),
+			Flags:      run.NewFlags(opts, nil),
 		}
 		commands = append(commands, command)
 	}

--- a/cli/commands/deprecated.go
+++ b/cli/commands/deprecated.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/hcl"
 	"github.com/gruntwork-io/terragrunt/cli/commands/hcl/format"
 	"github.com/gruntwork-io/terragrunt/cli/commands/hcl/validate"
+	"github.com/gruntwork-io/terragrunt/cli/commands/render"
 	"github.com/gruntwork-io/terragrunt/cli/commands/run"
 	runall "github.com/gruntwork-io/terragrunt/cli/commands/run-all"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -28,6 +29,7 @@ const (
 	CommandHCLFmtName         = "hclfmt"
 	CommandHCLValidateName    = "hclvalidate"
 	CommandValidateInputsName = "validate-inputs"
+	CommandRenderJSONName     = "render-json"
 )
 
 // deprecatedCommands is a map of deprecated commands to a handler that knows how to convert the command to the known
@@ -44,6 +46,7 @@ var replaceDeprecatedCommandsFuncs = map[string]replaceDeprecatedCommandFuncType
 	CommandHCLFmtName:         replaceDeprecatedCommandFunc(controls.CLIRedesign, cli.Args{hcl.CommandName, format.CommandName}),
 	CommandHCLValidateName:    replaceDeprecatedCommandFunc(controls.CLIRedesign, cli.Args{hcl.CommandName, validate.CommandName}),
 	CommandValidateInputsName: replaceDeprecatedCommandFunc(controls.CLIRedesign, cli.Args{hcl.CommandName, validate.CommandName, "--" + validate.InputsFlagName}),
+	CommandRenderJSONName:     replaceDeprecatedCommandFunc(controls.CLIRedesign, cli.Args{render.CommandName, render.JSONFlagName, render.WriteFlagName}),
 }
 
 type replaceDeprecatedCommandFuncType func(opts *options.TerragruntOptions, deprecatedCommandName string) cli.ActionFunc

--- a/cli/commands/render-json/cli.go
+++ b/cli/commands/render-json/cli.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
+	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -60,6 +61,10 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		Description: "This is useful for enforcing policies using static analysis tools like Open Policy Agent, or for debugging your terragrunt config.",
 		Flags:       append(run.NewFlags(opts, nil), NewFlags(opts, prefix)...),
 		Action:      func(ctx *cli.Context) error { return Run(ctx, opts.OptionsFromContext(ctx)) },
+		Before: func(ctx *cli.Context) error {
+			control := opts.StrictControls.Find(controls.CLIRedesign)
+			return control.Evaluate(ctx)
+		},
 	}
 
 	cmd = runall.WrapCommand(opts, cmd)

--- a/cli/commands/render/cli.go
+++ b/cli/commands/render/cli.go
@@ -24,6 +24,8 @@ const (
 
 func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
+	terragruntPrefix := flags.Prefix{flags.TerragruntPrefix}
+	terragruntPrefixControl := flags.StrictControlsByCommand(opts.StrictControls, CommandName)
 
 	return cli.Flags{
 		flags.NewFlag(&cli.GenericFlag[string]{
@@ -80,21 +82,31 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			EnvVars:     tgPrefix.EnvVars(OutFlagName),
 			Destination: &opts.OutputPath,
 			Usage:       "The file name that terragrunt should use when rendering the terragrunt.hcl config (next to the unit configuration).",
-		}),
+		},
+			flags.WithDeprecatedFlagName("json-out", terragruntPrefixControl),                          // `--json-out`
+			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("render-json-out"), terragruntPrefixControl),  // `TG_RENDER_JSON_OUT`
+			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("json-out"), terragruntPrefixControl), // `--terragrunt-json-out`, `TERRAGRUNT_JSON_OUT`
+		),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        WithMetadataFlagName,
 			EnvVars:     tgPrefix.EnvVars(WithMetadataFlagName),
 			Destination: &opts.RenderMetadata,
 			Usage:       "Add metadata to the rendered output file.",
-		}),
+		},
+			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("render-json-with-metadata"), terragruntPrefixControl), // `TG_RENDER_JSON_WITH_METADATA`
+			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("with-metadata"), terragruntPrefixControl),     // `--terragrunt-with-metadata`, `TERRAGRUNT_WITH_METADATA`
+		),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        DisableDependentModulesFlagName,
 			EnvVars:     tgPrefix.EnvVars(DisableDependentModulesFlagName),
 			Destination: &opts.DisableDependentModules,
 			Usage:       "Disable identification of dependent modules when rendering config.",
-		}),
+		},
+			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("render-json-disable-dependent-modules"), terragruntPrefixControl),  // `TG_RENDER_JSON_DISABLE_DEPENDENT_MODULES`
+			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("json-disable-dependent-modules"), terragruntPrefixControl), // `--terragrunt-json-disable-dependent-modules`, `TERRAGRUNT_JSON_DISABLE_DEPENDENT_MODULES`
+		),
 	}
 }
 

--- a/test/integration_json_test.go
+++ b/test/integration_json_test.go
@@ -37,7 +37,7 @@ func TestRenderJsonAttributesMetadata(t *testing.T) {
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
 
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --non-interactive --log-level trace --working-dir %s  --json-out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --non-interactive --log-level trace --working-dir %s --json-out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -964,7 +964,7 @@ func TestRenderJsonDependentModulesMetadataTerraform(t *testing.T) {
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s --terragrunt-json-out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -987,7 +987,7 @@ func TestRenderJsonDependentModulesMetadataTerraformExp(t *testing.T) {
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --with-metadata --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --with-metadata --non-interactive --log-level trace --working-dir %s --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -1000,27 +1000,6 @@ func TestRenderJsonDependentModulesMetadataTerraformExp(t *testing.T) {
 	// check if value list contains app-v1 and app-v2
 	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "app-v1"))
 	assert.Contains(t, dependentModules, util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "app-v2"))
-}
-
-func TestTerragruntRenderJsonHelp(t *testing.T) {
-	t.Parallel()
-
-	helpers.CleanupTerraformFolder(t, testFixtureHooksInitOnceWithSourceNoBackend)
-	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures/hooks/init-once")
-	rootPath := util.JoinPath(tmpEnvPath, testFixtureHooksInitOnceWithSourceNoBackend)
-
-	showStdout := bytes.Buffer{}
-	showStderr := bytes.Buffer{}
-
-	err := helpers.RunTerragruntCommand(t, "terragrunt render-json --help --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &showStdout, &showStderr)
-	require.NoError(t, err)
-
-	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
-
-	output := showStdout.String()
-
-	assert.Contains(t, output, "terragrunt render-json")
-	assert.Contains(t, output, "--with-metadata")
 }
 
 func TestTerragruntRenderJsonHelpExp(t *testing.T) {
@@ -1052,7 +1031,7 @@ func TestRenderJsonDependentModulesTerraform(t *testing.T) {
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s --terragrunt-json-out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -1074,7 +1053,7 @@ func TestRenderJsonDependentModulesTerraformExp(t *testing.T) {
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --non-interactive --log-level trace --working-dir %s --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -1096,7 +1075,7 @@ func TestRenderJsonDisableDependentModulesTerraform(t *testing.T) {
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-json-disable-dependent-modules --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --terragrunt-json-disable-dependent-modules --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s --terragrunt-json-out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)
@@ -1116,7 +1095,7 @@ func TestRenderJsonDisableDependentModulesTerraformExp(t *testing.T) {
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt.rendered.json")
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --disable-dependent-modules --non-interactive --log-level trace --working-dir %s  --out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --json -w --disable-dependent-modules --non-interactive --log-level trace --working-dir %s --out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Deprecates the `render-json` command.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Deprecated the `render-json` command.

### Migration Guide

Use the `render --json -w` command instead. The render command has more features, and is more flexible.

