### PR TITLE
fix: Throwing interrupt signal with `--all` flag

### DIFF
--- a/cli/commands/aws-provider-patch/cli.go
+++ b/cli/commands/aws-provider-patch/cli.go
@@ -69,8 +69,8 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		Action: func(ctx *cli.Context) error { return Run(ctx, opts.OptionsFromContext(ctx)) },
 	}
 
-	cmd = runall.WrapCommand(opts, cmd)
-	cmd = graph.WrapCommand(opts, cmd)
+	cmd = runall.WrapCommand(opts, cmd, run.Run)
+	cmd = graph.WrapCommand(opts, cmd, run.Run)
 
 	return cmd
 }

--- a/cli/commands/backend/bootstrap/cli.go
+++ b/cli/commands/backend/bootstrap/cli.go
@@ -25,7 +25,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		},
 	}
 
-	cmd = runall.WrapCommand(opts, cmd)
+	cmd = runall.WrapCommand(opts, cmd, run.Run)
 
 	return cmd
 }

--- a/cli/commands/backend/delete/cli.go
+++ b/cli/commands/backend/delete/cli.go
@@ -48,7 +48,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		},
 	}
 
-	cmd = runall.WrapCommand(opts, cmd)
+	cmd = runall.WrapCommand(opts, cmd, run.Run)
 
 	return cmd
 }

--- a/cli/commands/common/graph/cli.go
+++ b/cli/commands/common/graph/cli.go
@@ -34,24 +34,26 @@ func NewFlags(opts *options.TerragruntOptions, commandName string, prefix flags.
 }
 
 // WrapCommand appends flags to the given `cmd` and wraps its action.
-func WrapCommand(opts *options.TerragruntOptions, cmd *cli.Command) *cli.Command {
+func WrapCommand(opts *options.TerragruntOptions, cmd *cli.Command, runFn func(ctx context.Context, opts *options.TerragruntOptions) error) *cli.Command {
 	cmd = cmd.WrapAction(func(cliCtx *cli.Context, action cli.ActionFunc) error {
 		if !opts.Graph {
 			return action(cliCtx)
 		}
 
 		opts.RunTerragrunt = func(ctx context.Context, opts *options.TerragruntOptions) error {
-			newCtx := *cliCtx
-			newCtx.Context = opts.ContextWithOptions(ctx)
+			if opts.TerraformCommand == cmd.Name {
+				cliCtx := cliCtx.WithValue(options.ContextKey, opts)
 
-			return action(&newCtx)
+				return action(cliCtx)
+			}
+
+			return runFn(ctx, opts)
 		}
 
 		return Run(cliCtx, opts.OptionsFromContext(cliCtx))
 	})
 
-	flags := append(cmd.Flags, NewFlags(opts, cmd.Name, nil)...)
-	cmd.Flags = flags.Sort()
+	cmd.Flags = append(cmd.Flags, NewFlags(opts, cmd.Name, nil)...)
 
 	return cmd
 }

--- a/cli/commands/dag/graph/cli.go
+++ b/cli/commands/dag/graph/cli.go
@@ -5,6 +5,7 @@ package graph
 import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
+	"github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/configstack"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -26,8 +27,8 @@ func NewCommand(opts *options.TerragruntOptions, _ flags.Prefix) *cli.Command {
 		},
 	}
 
-	cmd = runall.WrapCommand(opts, cmd)
-	cmd = graph.WrapCommand(opts, cmd)
+	cmd = runall.WrapCommand(opts, cmd, run.Run)
+	cmd = graph.WrapCommand(opts, cmd, run.Run)
 
 	return cmd
 }

--- a/cli/commands/graph-dependencies/cli.go
+++ b/cli/commands/graph-dependencies/cli.go
@@ -23,8 +23,8 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		Action: func(ctx *cli.Context) error { return Run(ctx, opts.OptionsFromContext(ctx)) },
 	}
 
-	cmd = runall.WrapCommand(opts, cmd)
-	cmd = graph.WrapCommand(opts, cmd)
+	cmd = runall.WrapCommand(opts, cmd, run.Run)
+	cmd = graph.WrapCommand(opts, cmd, run.Run)
 
 	return cmd
 }

--- a/cli/commands/hcl/format/cli.go
+++ b/cli/commands/hcl/format/cli.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
+	"github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -90,7 +91,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		},
 	}
 
-	cmd = runall.WrapCommand(opts, cmd)
+	cmd = runall.WrapCommand(opts, cmd, run.Run)
 
 	return cmd
 }

--- a/cli/commands/hcl/validate/cli.go
+++ b/cli/commands/hcl/validate/cli.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
+	"github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -78,8 +79,8 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		},
 	}
 
-	cmd = runall.WrapCommand(opts, cmd)
-	cmd = graph.WrapCommand(opts, cmd)
+	cmd = runall.WrapCommand(opts, cmd, run.Run)
+	cmd = graph.WrapCommand(opts, cmd, run.Run)
 
 	return cmd
 }

--- a/cli/commands/render-json/cli.go
+++ b/cli/commands/render-json/cli.go
@@ -62,8 +62,8 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		Action:      func(ctx *cli.Context) error { return Run(ctx, opts.OptionsFromContext(ctx)) },
 	}
 
-	cmd = runall.WrapCommand(opts, cmd)
-	cmd = graph.WrapCommand(opts, cmd)
+	cmd = runall.WrapCommand(opts, cmd, run.Run)
+	cmd = graph.WrapCommand(opts, cmd, run.Run)
 
 	return cmd
 }

--- a/cli/commands/render/cli.go
+++ b/cli/commands/render/cli.go
@@ -117,7 +117,7 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		ErrorOnUndefinedFlag: true,
 	}
 
-	cmd = runall.WrapCommand(opts, cmd)
+	cmd = runall.WrapCommand(opts, cmd, run.Run)
 
 	return cmd
 }

--- a/cli/commands/run/cli.go
+++ b/cli/commands/run/cli.go
@@ -41,8 +41,8 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		},
 	}
 
-	cmd = runall.WrapCommand(opts, cmd)
-	cmd = graph.WrapCommand(opts, cmd)
+	cmd = runall.WrapCommand(opts, cmd, Run)
+	cmd = graph.WrapCommand(opts, cmd, Run)
 
 	return cmd
 }

--- a/cli/commands/terragrunt-info/cli.go
+++ b/cli/commands/terragrunt-info/cli.go
@@ -21,8 +21,8 @@ func NewCommand(opts *options.TerragruntOptions) *cli.Command {
 		Action: func(ctx *cli.Context) error { return Run(ctx, opts.OptionsFromContext(ctx)) },
 	}
 
-	cmd = runall.WrapCommand(opts, cmd)
-	cmd = graph.WrapCommand(opts, cmd)
+	cmd = runall.WrapCommand(opts, cmd, run.Run)
+	cmd = graph.WrapCommand(opts, cmd, run.Run)
 
 	return cmd
 }

--- a/options/options.go
+++ b/options/options.go
@@ -482,11 +482,6 @@ func (opts *TerragruntOptions) OptionsFromContext(ctx context.Context) *Terragru
 	return opts
 }
 
-// ContextWithOptions returns a context containing the value of `TerragruntOptions`.
-func (opts *TerragruntOptions) ContextWithOptions(ctx context.Context) context.Context {
-	return context.WithValue(ctx, ContextKey, opts)
-}
-
 // Clone performs a deep copy of `opts` with shadow copies of: interfaces, and funcs.
 // Fields with "clone" tags can override this behavior.
 func (opts *TerragruntOptions) Clone() *TerragruntOptions {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixing throwing interrupt signal when using `--all` flag, Example of error:

```
signal: interrupt

* Failed to execute "tofu -version" in /var/folders/50/96zp_ztd6ms9cz88hgkl8mhm0000gp/T/TestStorePlanFilesRunAllDestroy1381408063/002/fixtures/out-dir/dependency
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new integration test to verify the correct creation and usage of plan files during the destroy workflow when using the `--all` flag.

- **Refactor**
  - Updated internal command handling to improve flexibility by passing an explicit run function to command wrappers. This may affect how certain commands are executed or extended.

- **Tests**
  - Introduced a new test to ensure plan files are properly managed in shortcut destroy operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->