### PR TITLE
[WIP] fix: #4094 Add json formatting for map type in remote_state config

### DIFF
--- a/internal/remotestate/remote_state.go
+++ b/internal/remotestate/remote_state.go
@@ -3,8 +3,10 @@ package remotestate
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
@@ -130,7 +132,19 @@ func (remote *RemoteState) GetTFInitArgs() []string {
 	var backendConfigArgs = make([]string, 0, len(config))
 
 	for key, value := range config {
-		arg := fmt.Sprintf("-backend-config=%s=%v", key, value)
+		var sanitizedValue string
+		if reflect.ValueOf(value).Kind() == reflect.Map {
+			jsonValue, err := json.Marshal(value)
+			if err != nil {
+				// TODO: Log error
+				continue
+			}
+			sanitizedValue = string(jsonValue)
+		} else {
+			sanitizedValue = fmt.Sprintf("%v", value)
+		}
+
+		arg := fmt.Sprintf("-backend-config=%s=%s", key, sanitizedValue)
 		backendConfigArgs = append(backendConfigArgs, arg)
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4094.

Introduces the output of json encoded strings for the `-backend-config="endpoints=..."` config option.
Currently, when using `terragrunt` and a custom S3 endpoint the tool just errors out with:

```
  │ Error: Missing close bracket on index
  │
  │   on -backend-config="endpoints=map[s3:https://object.storage.mep.cloud]" line 1:
  │   (source code not available)
  │
  │ The index operator must end with a closing bracket ("]").
```

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of map-type backend configuration values, ensuring they are properly serialized as JSON strings when initializing Terraform. This prevents potential issues with backend configuration containing complex values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->