### PR TITLE
bug: handling of errors in parsing base blocks

### DIFF
--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -383,9 +383,11 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 		errs = errs.Append(err)
 	}
 
-	ctx = ctx.WithTrackInclude(baseBlocks.TrackInclude)
-	ctx = ctx.WithFeatures(baseBlocks.FeatureFlags)
-	ctx = ctx.WithLocals(baseBlocks.Locals)
+	if baseBlocks != nil {
+		ctx = ctx.WithTrackInclude(baseBlocks.TrackInclude)
+		ctx = ctx.WithFeatures(baseBlocks.FeatureFlags)
+		ctx = ctx.WithLocals(baseBlocks.Locals)
+	}
 
 	// Set parsed Locals on the parsed config
 	output, err := convertToTerragruntConfig(ctx, file.ConfigPath, &terragruntConfigFile{})

--- a/test/fixtures/regressions/include-error/_envcommon.hcl
+++ b/test/fixtures/regressions/include-error/_envcommon.hcl
@@ -1,0 +1,4 @@
+
+inputs = {
+  common_config = "Common Config"
+}

--- a/test/fixtures/regressions/include-error/project/app/terragrunt.hcl
+++ b/test/fixtures/regressions/include-error/project/app/terragrunt.hcl
@@ -1,0 +1,17 @@
+
+include {
+  path = find_in_parent_folders("eng_teams.hcl")
+}
+
+include {
+  path = find_in_parent_folders("_envcommon.hcl")
+}
+
+inputs = {
+  app = {
+    "kind"      = "deployment",
+    "namespace" = "foobar",
+    "slug"      = "bar-foo",
+    "data"      = "46521694",
+  }
+}

--- a/test/fixtures/regressions/include-error/project/eng_teams.hcl
+++ b/test/fixtures/regressions/include-error/project/eng_teams.hcl
@@ -1,0 +1,4 @@
+
+inputs = {
+  team_name = "Test Team"
+}

--- a/test/integration_regressions_test.go
+++ b/test/integration_regressions_test.go
@@ -85,3 +85,15 @@ func TestMockOutputsMergeWithState(t *testing.T) {
 	helpers.LogBufferContentsLineByLine(t, stdout, "shallow-map-executed")
 	require.NoError(t, err)
 }
+
+func TestIncludeError(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureRegressions)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRegressions)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureRegressions, "include-error", "project", "app")
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "include blocks without label")
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Added handling of errors in parsing base blocks
* Added regression tests to track that parsing works

Fixes #4209.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

