### PR TITLE
feat: Deprecating default commands

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -92,7 +92,6 @@ func New(opts *options.TerragruntOptions) cli.Commands {
 	)
 
 	configurationCommands := cli.Commands{
-		outputmodulegroups.NewCommand(opts), // output-module-groups
 		hcl.NewCommand(opts),                // hcl
 		info.NewCommand(opts),               // info
 		dag.NewCommand(opts),                // dag
@@ -100,6 +99,7 @@ func New(opts *options.TerragruntOptions) cli.Commands {
 		helpCmd.NewCommand(opts),            // help (hidden)
 		versionCmd.NewCommand(opts),         // version (hidden)
 		awsproviderpatch.NewCommand(opts),   // aws-provider-patch (hidden)
+		outputmodulegroups.NewCommand(opts), // output-module-groups (hidden)
 	}.SetCategory(
 		&cli.Category{
 			Name:  ConfigurationCommandsCategoryName,
@@ -189,10 +189,9 @@ func initialSetup(cliCtx *cli.Context, opts *options.TerragruntOptions) error {
 	args := cliCtx.Args().WithoutBuiltinCmdSep().Normalize(cli.SingleDashFlag)
 	cmdName := cliCtx.Command.Name
 
-	switch {
-	case cmdName == runCmd.CommandName:
+	if cmdName == runCmd.CommandName {
 		cmdName = args.CommandName()
-	default:
+	} else {
 		args = append([]string{cmdName}, args...)
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Deprecating default commands.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a provider cache server to improve provider management during Terraform operations.
  - Added a new command to print a short description of the Terragrunt context.

- **Bug Fixes**
  - Enhanced error handling for flag parsing, including better control over errors for undefined or multiply-set flags.

- **Refactor**
  - Deprecated and removed several commands, including `run-all`, `graph`, `graph-dependencies`, `terragrunt-info`, and `render-json`.
  - Updated command structure to centralize telemetry and option setup.
  - Improved handling and messaging for deprecated commands.
  - Streamlined flag and environment variable handling for backward compatibility.

- **Tests**
  - Added comprehensive tests for the new provider cache server.
  - Updated integration and CLI tests to reflect command changes and improved environment isolation.

- **Chores**
  - Improved internal code organization and modularization for commands and flag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->