### PR TITLE
fix: Cleaning up legacy `-all` usage

### DIFF
--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -28,14 +28,14 @@ const (
 )
 
 // ModuleStatus represents the status of a module that we are
-// trying to apply as part of the apply-all or destroy-all command
+// trying to apply or destroy as part of the run --all apply or run --all destroy command
 type ModuleStatus int
 
 // DependencyOrder controls in what order dependencies should be enforced between modules.
 type DependencyOrder int
 
 // RunningModule represents a module we are trying to "run" (i.e. apply or destroy)
-// as part of the apply-all or destroy-all command.
+// as part of the run --all apply or run --all destroy command.
 type RunningModule struct {
 	Err            error
 	Module         *TerraformModule

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -659,7 +659,7 @@ func (stack *Stack) resolveTerraformModule(ctx context.Context, terragruntConfig
 
 // resolveDependenciesForModule looks through the dependencies of the given module and resolve the dependency paths listed in the module's config.
 // If `skipExternal` is true, the func returns only dependencies that are inside of the current working directory, which means they are part of the environment the
-// user is trying to apply-all or destroy-all. Note that this method will NOT fill in the Dependencies field of the TerraformModule struct (see the crosslinkDependencies method for that).
+// user is trying to run --all apply or run --all destroy. Note that this method will NOT fill in the Dependencies field of the TerraformModule struct (see the crosslinkDependencies method for that).
 func (stack *Stack) resolveDependenciesForModule(ctx context.Context, module *TerraformModule, modulesMap TerraformModulesMap, skipExternal bool) (TerraformModulesMap, error) {
 	if module.Config.Dependencies == nil || len(module.Config.Dependencies.Paths) == 0 {
 		return TerraformModulesMap{}, nil
@@ -704,7 +704,7 @@ func (stack *Stack) resolveDependenciesForModule(ctx context.Context, module *Te
 // Look through the dependencies of the modules in the given map and resolve the "external" dependency paths listed in
 // each modules config (i.e. those dependencies not in the given list of Terragrunt config canonical file paths).
 // These external dependencies are outside of the current working directory, which means they may not be part of the
-// environment the user is trying to apply-all or destroy-all. Therefore, this method also confirms whether the user wants
+// environment the user is trying to run --all apply or run --all destroy. Therefore, this method also confirms whether the user wants
 // to actually apply those dependencies or just assume they are already applied. Note that this method will NOT fill in
 // the Dependencies field of the TerraformModule struct (see the crosslinkDependencies method for that).
 func (stack *Stack) resolveExternalDependenciesForModules(ctx context.Context, modulesMap, modulesAlreadyProcessed TerraformModulesMap, recursionLevel int) (TerraformModulesMap, error) {

--- a/docs-starlight/src/content/docs/02-features/04-state-backend.mdx
+++ b/docs-starlight/src/content/docs/02-features/04-state-backend.mdx
@@ -165,7 +165,7 @@ When you run `terragrunt` with a `remote_state` configuration, it will automatic
 
 **Note**: If you specify a `profile` key in `remote_state.config`, Terragrunt will automatically use this AWS profile when creating the S3 bucket or DynamoDB table.
 
-**Note**: You can disable automatic remote state initialization by setting `remote_state.disable_init`, this will skip the automatic creation of remote state resources and will execute `terraform init` passing the `backend=false` option. This can be handy when running commands such as `validate-all` as part of a CI process where you do not want to initialize remote state.
+**Note**: You can disable automatic remote state initialization by setting `remote_state.disable_init`, this will skip the automatic creation of remote state resources and will execute `terraform init` passing the `backend=false` option. This can be handy when running commands such as `run --all validate` as part of a CI process where you do not want to initialize remote state.
 
 The following example demonstrates using an environment variable to configure this option:
 

--- a/docs-starlight/src/content/docs/04-reference/01-hcl/03-attributes.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/03-attributes.mdx
@@ -121,7 +121,7 @@ It supports all terragrunt functions, i.e. `path_relative_from_include()`.
 ## prevent_destroy
 
 Terragrunt `prevent_destroy` boolean flag allows you to protect selected OpenTofu/Terraform module. It will prevent `destroy` or
-`destroy-all` command to actually destroy resources of the protected module. This is useful for modules you want to
+`run --all destroy` command from actually destroying resources of the protected module. This is useful for modules you want to
 carefully protect, such as a database, or a module that provides auth.
 
 Example:
@@ -260,7 +260,7 @@ If your Git provider provides the OIDC token as a file, simply pass the file pat
 
 iam_role = "arn:aws:iam::<AWS account number>:role/<IAM role name>"
 
-iam_web_identity_token = "/path/to/token/file" 
+iam_web_identity_token = "/path/to/token/file"
 ```
 
 ## terraform_binary

--- a/docs/_docs/02_features/04-state-backend.md
+++ b/docs/_docs/02_features/04-state-backend.md
@@ -170,7 +170,7 @@ When you run `terragrunt` with a `remote_state` configuration, it will automatic
 
 **Note**: If you specify a `profile` key in `remote_state.config`, Terragrunt will automatically use this AWS profile when creating the S3 bucket or DynamoDB table.
 
-**Note**: You can disable automatic remote state initialization by setting `remote_state.disable_init`, this will skip the automatic creation of remote state resources and will execute `terraform init` passing the `backend=false` option. This can be handy when running commands such as `validate-all` as part of a CI process where you do not want to initialize remote state.
+**Note**: You can disable automatic remote state initialization by setting `remote_state.disable_init`, this will skip the automatic creation of remote state resources and will execute `terraform init` passing the `backend=false` option. This can be handy when running commands such as `run --all validate` as part of a CI process where you do not want to initialize remote state.
 
 The following example demonstrates using an environment variable to configure this option:
 

--- a/docs/_docs/04_reference/04-config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/04-config-blocks-and-attributes.md
@@ -1961,7 +1961,7 @@ It supports all terragrunt functions, i.e. `path_relative_from_include()`.
 ### prevent_destroy
 
 Terragrunt `prevent_destroy` boolean flag allows you to protect selected OpenTofu/Terraform module. It will prevent `destroy` or
-`destroy-all` command to actually destroy resources of the protected module. This is useful for modules you want to
+`run --all destroy` command from actually destroying resources of the protected module. This is useful for modules you want to
 carefully protect, such as a database, or a module that provides auth.
 
 Example:

--- a/test/fixtures/output-from-remote-state/env1/app2/terragrunt.hcl
+++ b/test/fixtures/output-from-remote-state/env1/app2/terragrunt.hcl
@@ -6,7 +6,7 @@ dependency "app1" {
   config_path = "../app1"
 
   mock_outputs = {
-    app1_text = "(known after apply-all)"
+    app1_text = "(known after run --all apply)"
   }
 }
 
@@ -14,7 +14,7 @@ dependency "app3" {
   config_path = "../app3"
 
   mock_outputs = {
-    app3_text = "(known after apply-all)"
+    app3_text = "(known after run --all apply)"
   }
 }
 

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -288,8 +288,8 @@ func RunValidateAllWithIncludeAndGetIncludedModules(t *testing.T, rootModulePath
 		&validateAllStderr,
 	)
 
-	LogBufferContentsLineByLine(t, validateAllStdout, "validate-all stdout")
-	LogBufferContentsLineByLine(t, validateAllStderr, "validate-all stderr")
+	LogBufferContentsLineByLine(t, validateAllStdout, "run --all validate stdout")
+	LogBufferContentsLineByLine(t, validateAllStderr, "run --all validate stderr")
 
 	require.NoError(t, err)
 

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -612,13 +612,13 @@ func TestAwsOutputAllCommand(t *testing.T) {
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, testFixtureOutputAll)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath)
 
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer
 	)
-	helpers.RunTerragruntRedirectOutput(t, "terragrunt output-all --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath, &stdout, &stderr)
+	helpers.RunTerragruntRedirectOutput(t, "terragrunt run --all output --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath, &stdout, &stderr)
 	output := stdout.String()
 
 	assert.Contains(t, output, "app1 output")
@@ -668,7 +668,7 @@ func TestAwsValidateAllCommand(t *testing.T) {
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, testFixtureOutputAll)
 
-	helpers.RunTerragrunt(t, "terragrunt validate-all --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all validate --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath)
 }
 
 func TestAwsOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *testing.T) {
@@ -684,18 +684,18 @@ func TestAwsOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *testing.T)
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, testFixtureOutputAll)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath)
 
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer
 	)
 	// Call helpers.RunTerragruntCommand directly because this command contains failures (which causes helpers.RunTerragruntRedirectOutput to abort) but we don't care.
-	helpers.RunTerragruntCommand(t, "terragrunt output-all app2_text --terragrunt-ignore-dependency-errors --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath, &stdout, &stderr)
+	helpers.RunTerragruntCommand(t, "terragrunt run --all output app2_text --terragrunt-ignore-dependency-errors --terragrunt-non-interactive --terragrunt-working-dir "+environmentPath, &stdout, &stderr)
 	output := stdout.String()
 
-	helpers.LogBufferContentsLineByLine(t, stdout, "output-all stdout")
-	helpers.LogBufferContentsLineByLine(t, stderr, "output-all stderr")
+	helpers.LogBufferContentsLineByLine(t, stdout, "run --all output stdout")
+	helpers.LogBufferContentsLineByLine(t, stderr, "run --all output stderr")
 
 	// Without --terragrunt-ignore-dependency-errors, app2 never runs because its dependencies have "errors" since they don't have the output "app2_text".
 	assert.Contains(t, output, "app2 output")
@@ -722,14 +722,14 @@ func TestAwsStackCommands(t *testing.T) { //nolint paralleltest
 	mgmtEnvironmentPath := util.JoinPath(tmpEnvPath, testFixtureStack, "mgmt")
 	stageEnvironmentPath := util.JoinPath(tmpEnvPath, testFixtureStack, "stage")
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir "+mgmtEnvironmentPath)
-	helpers.RunTerragrunt(t, "terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir "+stageEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --terragrunt-non-interactive --terragrunt-working-dir "+mgmtEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --terragrunt-non-interactive --terragrunt-working-dir "+stageEnvironmentPath)
 
-	helpers.RunTerragrunt(t, "terragrunt output-all --terragrunt-non-interactive --terragrunt-working-dir "+mgmtEnvironmentPath)
-	helpers.RunTerragrunt(t, "terragrunt output-all --terragrunt-non-interactive --terragrunt-working-dir "+stageEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all output --terragrunt-non-interactive --terragrunt-working-dir "+mgmtEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all output --terragrunt-non-interactive --terragrunt-working-dir "+stageEnvironmentPath)
 
-	helpers.RunTerragrunt(t, "terragrunt destroy-all --terragrunt-non-interactive --terragrunt-working-dir "+stageEnvironmentPath)
-	helpers.RunTerragrunt(t, "terragrunt destroy-all --terragrunt-non-interactive --terragrunt-working-dir "+mgmtEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all destroy --terragrunt-non-interactive --terragrunt-working-dir "+stageEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all destroy --terragrunt-non-interactive --terragrunt-working-dir "+mgmtEnvironmentPath)
 }
 
 func TestAwsRemoteWithBackend(t *testing.T) {
@@ -781,7 +781,7 @@ func TestAwsGetAccountAliasFunctions(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAwsAccountAlias)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureAwsAccountAlias)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -820,7 +820,7 @@ func TestAwsGetCallerIdentityFunctions(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAwsGetCallerIdentity)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureAwsGetCallerIdentity)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -901,7 +901,7 @@ func TestAwsDependencyOutputOptimizationDisableTest(t *testing.T) {
 	defer cleanupTableForTest(t, lockTableName, helpers.TerraformRemoteStateS3Region)
 	helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, helpers.TerraformRemoteStateS3Region)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	// We need to bust the output cache that stores the dependency outputs so that the second run pulls the outputs.
 	// This is only a problem during testing, where the process is shared across terragrunt runs.
@@ -1126,7 +1126,7 @@ func TestAwsDependencyOutputSameOutputConcurrencyRegression(t *testing.T) {
 		stderr := bytes.Buffer{}
 		err := helpers.RunTerragruntCommand(
 			t,
-			"terragrunt apply-all --terragrunt-source-update --terragrunt-non-interactive --terragrunt-working-dir "+rootPath,
+			"terragrunt run --all apply --terragrunt-source-update --terragrunt-non-interactive --terragrunt-working-dir "+rootPath,
 			&stdout,
 			&stderr,
 		)
@@ -1533,7 +1533,7 @@ func dependencyOutputOptimizationTest(t *testing.T, moduleName string, forceInit
 	defer cleanupTableForTest(t, lockTableName, helpers.TerraformRemoteStateS3Region)
 	helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, helpers.TerraformRemoteStateS3Region)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
 
 	// We need to bust the output cache that stores the dependency outputs so that the second run pulls the outputs.
 	// This is only a problem during testing, where the process is shared across terragrunt runs.

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -221,9 +221,9 @@ func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {
 		destroyAllStderr bytes.Buffer
 	)
 
-	err = helpers.RunTerragruntCommand(t, "terragrunt destroy-all --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "destroy-all stdout")
-	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "destroy-all stderr")
+	err = helpers.RunTerragruntCommand(t, "terragrunt run --all destroy --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "run --all destroy stdout")
+	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "run --all destroy stderr")
 
 	require.Error(t, err)
 

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -566,9 +566,9 @@ func TestPreventDestroyDependencies(t *testing.T) {
 		destroyAllStderr bytes.Buffer
 	)
 
-	err = helpers.RunTerragruntCommand(t, "terragrunt destroy-all --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalPreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "destroy-all stdout")
-	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "destroy-all stderr")
+	err = helpers.RunTerragruntCommand(t, "terragrunt run --all destroy --terragrunt-non-interactive --terragrunt-working-dir "+testFixtureLocalPreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "run --all destroy stdout")
+	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "run --all destroy stderr")
 
 	require.Error(t, err)
 

--- a/test/integration_serial_aws_test.go
+++ b/test/integration_serial_aws_test.go
@@ -190,7 +190,7 @@ func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules
 	// read the output of all modules 1 by 1 sequence, parallel reads mix outputs and make output complicated to parse
 	outputParallelism := 1
 	// Call helpers.RunTerragruntCommandWithOutput directly because this command contains failures (which causes helpers.RunTerragruntRedirectOutput to abort) but we don't care.
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output-all -no-color --terragrunt-forward-tf-stdout --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-parallelism %d", environmentPath, outputParallelism))
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run --all --terragrunt-forward-tf-stdout --terragrunt-non-interactive --terragrunt-working-dir %s --terragrunt-parallelism %d -- output -no-color", environmentPath, outputParallelism))
 	if err != nil {
 		return "", 0, err
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -870,7 +870,7 @@ func TestTerragruntReportsTerraformErrorsWithPlanAll(t *testing.T) {
 
 	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, "fixtures/failure")
 
-	cmd := "terragrunt plan-all --terragrunt-non-interactive --terragrunt-working-dir " + rootTerragruntConfigPath
+	cmd := "terragrunt run --all plan --terragrunt-non-interactive --terragrunt-working-dir " + rootTerragruntConfigPath
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer
@@ -1938,10 +1938,10 @@ func TestDependencyMockOutputRestricted(t *testing.T) {
 	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
 	helpers.LogBufferContentsLineByLine(t, showStderr, "show stderr")
 
-	// Verify that validate-all works as well.
+	// Verify that run --all validate works as well.
 	showStdout.Reset()
 	showStderr.Reset()
-	err = helpers.RunTerragruntCommand(t, "terragrunt validate-all --terragrunt-non-interactive --terragrunt-working-dir "+dependent2Path, &showStdout, &showStderr)
+	err = helpers.RunTerragruntCommand(t, "terragrunt run --all validate --terragrunt-non-interactive --terragrunt-working-dir "+dependent2Path, &showStdout, &showStderr)
 	require.NoError(t, err)
 
 	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
@@ -1949,7 +1949,7 @@ func TestDependencyMockOutputRestricted(t *testing.T) {
 
 	showStdout.Reset()
 	showStderr.Reset()
-	err = helpers.RunTerragruntCommand(t, "terragrunt validate-all --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &showStdout, &showStderr)
+	err = helpers.RunTerragruntCommand(t, "terragrunt run --all validate --terragrunt-non-interactive --terragrunt-working-dir "+rootPath, &showStdout, &showStderr)
 	require.NoError(t, err)
 
 	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
@@ -2845,7 +2845,7 @@ func TestTerragruntValidateAllWithVersionChecks(t *testing.T) {
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
-	err := helpers.RunTerragruntVersionCommand(t, "v0.23.21", "terragrunt validate-all --terragrunt-non-interactive --terragrunt-working-dir "+tmpEnvPath, &stdout, &stderr)
+	err := helpers.RunTerragruntVersionCommand(t, "v0.23.21", "terragrunt run --all validate --terragrunt-non-interactive --terragrunt-working-dir "+tmpEnvPath, &stdout, &stderr)
 	helpers.LogBufferContentsLineByLine(t, stdout, "stdout")
 	helpers.LogBufferContentsLineByLine(t, stderr, "stderr")
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Removing all uses of legacy `-all` usage in tests.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Removed all usage of legacy `-all` commands.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to use the newer `run --all <command>` syntax instead of deprecated commands like `apply-all`, `destroy-all`, `validate-all`, and `output-all`.
  - Clarified descriptions and examples throughout the docs for improved accuracy and consistency.

- **Tests**
  - Updated all test commands and log labels to use the `run --all <command>` syntax, replacing older command patterns for consistency with current usage.
  - No changes to test logic or assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->