### PR TITLE
fix: Updating environment variables for flags

### DIFF
--- a/docs-starlight/src/data/flags/hcl-fmt-check.mdx
+++ b/docs-starlight/src/data/flags/hcl-fmt-check.mdx
@@ -3,7 +3,7 @@ name: check
 description: Enable check mode in the hclfmt command.
 type: bool
 env:
-  - TG_HCLFMT_CHECK
+  - TG_CHECK
 ---
 
 When enabled, Terragrunt will check if HCL files are properly formatted without making any changes. This is useful in CI/CD pipelines to ensure consistent formatting.

--- a/docs-starlight/src/data/flags/hcl-fmt-diff.mdx
+++ b/docs-starlight/src/data/flags/hcl-fmt-diff.mdx
@@ -3,7 +3,7 @@ name: diff
 description: Print diff between original and modified file versions when running with 'hclfmt'.
 type: bool
 env:
-  - TG_HCLFMT_DIFF
+  - TG_DIFF
 ---
 
 When enabled, Terragrunt will show the differences between the original and formatted versions of HCL files. This helps you understand what changes the formatter would make.

--- a/docs-starlight/src/data/flags/hcl-fmt-exclude-dir.mdx
+++ b/docs-starlight/src/data/flags/hcl-fmt-exclude-dir.mdx
@@ -3,7 +3,7 @@ name: exclude-dir
 description: Skip HCL formatting in given directories.
 type: string
 env:
-  - TG_HCLFMT_EXCLUDE_DIR
+  - TG_EXCLUDE_DIR
 ---
 
 Specifies directories to exclude from HCL formatting. This is useful when you want to skip formatting certain parts of your codebase.

--- a/docs-starlight/src/data/flags/hcl-fmt-file.mdx
+++ b/docs-starlight/src/data/flags/hcl-fmt-file.mdx
@@ -3,7 +3,7 @@ name: file
 description: The path to a single hcl file that the hclfmt command should run on.
 type: string
 env:
-  - TG_HCLFMT_FILE
+  - TG_FILE
 ---
 
 Specifies a single HCL file to format instead of recursively searching for files. This is useful when you want to format just one specific file.

--- a/docs-starlight/src/data/flags/hcl-fmt-stdin.mdx
+++ b/docs-starlight/src/data/flags/hcl-fmt-stdin.mdx
@@ -3,7 +3,7 @@ name: stdin
 description: Format HCL from stdin and print result to stdout.
 type: bool
 env:
-  - TG_HCLFMT_STDIN
+  - TG_STDIN
 ---
 
 When enabled, Terragrunt will read HCL content from standard input, format it, and write the result to standard output. This is useful for integrating with text editors or other tools.

--- a/docs-starlight/src/data/flags/hcl-lint-inputs.mdx
+++ b/docs-starlight/src/data/flags/hcl-lint-inputs.mdx
@@ -3,7 +3,7 @@ name: inputs
 description: Validate that all variables are set by the module a unit provisions.
 type: bool
 env:
-  - TG_HCLVALIDATE_INPUTS
+  - TG_INPUTS
 ---
 
 When enabled, Terragrunt will validate that all variables are set by the module a unit provisions.

--- a/docs-starlight/src/data/flags/hcl-lint-strict.mdx
+++ b/docs-starlight/src/data/flags/hcl-lint-strict.mdx
@@ -3,7 +3,7 @@ name: strict
 description: Throw an error if any inputs are set that are not defined in the module that a unit provisions.
 type: bool
 env:
-  - TG_HCLVALIDATE_STRICT
+  - TG_STRICT
 ---
 
 When enabled, Terragrunt will throw an error if any inputs are set that are not defined in the module that a unit provisions.

--- a/docs-starlight/src/data/flags/hcl-validate-json.mdx
+++ b/docs-starlight/src/data/flags/hcl-validate-json.mdx
@@ -3,7 +3,7 @@ name: json
 description: Output the result in JSON format.
 type: bool
 env:
-  - TG_HCLVALIDATE_JSON
+  - TG_JSON
 ---
 
 When enabled, Terragrunt will output the validation results in JSON format, making it easier to parse and process programmatically.

--- a/docs-starlight/src/data/flags/hcl-validate-show-config-path.mdx
+++ b/docs-starlight/src/data/flags/hcl-validate-show-config-path.mdx
@@ -3,7 +3,7 @@ name: show-config-path
 description: Show a list of files with invalid configuration.
 type: bool
 env:
-  - TG_HCLVALIDATE_SHOW_CONFIG_PATH
+  - TG_SHOW_CONFIG_PATH
 ---
 
 When enabled, Terragrunt will display the full paths of files that contain invalid HCL configurations. This is particularly useful when validating multiple files to quickly identify which files need attention.

--- a/docs-starlight/src/data/flags/no-auto-approve.mdx
+++ b/docs-starlight/src/data/flags/no-auto-approve.mdx
@@ -2,6 +2,8 @@
 name: no-auto-approve
 description: Don't automatically append '-auto-approve' to the underlying OpenTofu/Terraform commands run with 'run --all'.
 type: bool
+env:
+  - TG_NO_AUTO_APPROVE
 ---
 
 When enabled, Terragrunt will not automatically append the `-auto-approve` flag to destructive commands like `apply` or `destroy` when running with `--all`. This means you'll be prompted for confirmation before making changes.

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -1800,7 +1800,7 @@ To safely access provider cache concurrently, enable the [Provider Cache Server]
 
 **CLI Arg**: `--inputs-debug`<br/>
 **CLI Arg Alias**: `--terragrunt-debug` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
-**Environment Variable**: `TG_DEBUG_INPUTS`<br/>
+**Environment Variable**: `TG_INPUTS_DEBUG`<br/>
 **Environment Variable Alias**: `TERRAGRUNT_DEBUG` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
 
 When passed in, Terragrunt will create a tfvars file that can be used to invoke the terraform module in the same way

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -1887,8 +1887,8 @@ NOTE: This option also disables OpenTofu/Terraform output colors by propagating 
 
 **CLI Arg**: `--check`<br/>
 **CLI Arg Alias**: `--terragrunt-check` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
-**Environment Variable**: `TG_HCLFMT_CHECK` (set to `true`)<br/>
-**Environment Variable Alias**: `TERRAGRUNT_CHECK` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
+**Environment Variable**: `TG_CHECK` (set to `true`)<br/>
+**Environment Variable Aliases**: `TERRAGRUNT_CHECK`, `TG_HCLFMT_CHECK` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
 **Commands**:
 
 - [hclfmt](#hclfmt)
@@ -1900,8 +1900,8 @@ command to exit with exit code 1 if there are any files that are not formatted.
 
 **CLI Arg**: `--diff`<br/>
 **CLI Arg Alias**: `--terragrunt-diff` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
-**Environment Variable**: `TG_HCLFMT_DIFF` (set to `true`)<br/>
-**Environment Variable Alias**: `TERRAGRUNT_DIFF` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
+**Environment Variable**: `TG_DIFF` (set to `true`)<br/>
+**Environment Variable Aliases**: `TERRAGRUNT_DIFF`, `TG_HCLFMT_DIFF` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
 **Commands**:
 
 - [hclfmt](#hclfmt)
@@ -1912,8 +1912,8 @@ When passed in, running `hclfmt` will print diff between original and modified f
 
 **CLI Arg**: `--file`<br/>
 **CLI Arg Alias**: `--terragrunt-hclfmt-file` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
-**Environment Variable**: `TG_HCLFMT_FILE` (set to `true`)<br/>
-**Environment Variable Alias**: `TERRAGRUNT_HCLFMT_FILE` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
+**Environment Variable**: `TG_FILE`<br/>
+**Environment Variable Aliases**: `TERRAGRUNT_FILE`, `TG_HCLFMT_FILE` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
 **Requires an argument**: `--file /path/to/terragrunt.hcl`<br/>
 **Commands**:
 
@@ -1925,8 +1925,8 @@ When passed in, run `hclfmt` only on the specified file.
 
 **CLI Arg**: `--exclude-dir`<br/>
 **CLI Arg Alias**: `--terragrunt-hclfmt-exclude-dir` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
-**Environment Variable**: `TG_HCLFMT_EXCLUDE_DIR`<br/>
-**Environment Variable Alias**: `TERRAGRUNT_HCLFMT_EXCLUDE_DIR` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
+**Environment Variable**: `TG_EXCLUDE_DIR`<br/>
+**Environment Variable Aliases**: `TERRAGRUNT_EXCLUDE_DIR`, `TG_HCLFMT_EXCLUDE_DIR` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
 **Requires an argument**: `--exclude-dir /path/to/dir`<br/>
 **Commands**:
 
@@ -1939,8 +1939,8 @@ When passed in, `hclfmt` will ignore files in the specified directories.
 
 **CLI Arg**: `--stdin`<br/>
 **CLI Arg Alias**: `--terragrunt-hclfmt-stdin` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
-**Environment Variable**: `TG_HCLFMT_STDIN` (set to `true`)<br/>
-**Environment Variable Alias**: `TERRAGRUNT_HCLFMT_STDIN` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
+**Environment Variable**: `TG_STDIN` (set to `true`)<br/>
+**Environment Variable Aliases**: `TERRAGRUNT_STDIN`, `TG_HCLFMT_STDIN` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
 **Commands**:
 
 - [hclfmt](#hclfmt)
@@ -1951,8 +1951,8 @@ When passed in, run `hclfmt` only on hcl passed to `stdin`, result is printed to
 
 **CLI Arg**: `--json`<br/>
 **CLI Arg Alias**: `--terragrunt-hclvalidate-json` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
-**Environment Variable**: `TG_HCLVALIDATE_JSON` (set to `true`)<br/>
-**Environment Variable Alias**: `TERRAGRUNT_HCLVALIDATE_JSON` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
+**Environment Variable**: `TG_JSON` (set to `true`)<br/>
+**Environment Variable Aliases**: `TERRAGRUNT_JSON`, `TG_HCLVALIDATE_JSON` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
 **Commands**:
 
 - [hclvalidate](#hclvalidate)
@@ -1963,8 +1963,8 @@ When passed in, render the output in the JSON format.
 
 **CLI Arg**: `--show-config-path`<br/>
 **CLI Arg Alias**: `--terragrunt-hclvalidate-show-config-path` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
-**Environment Variable**: `TG_HCLVALIDATE_SHOW_CONFIG_PATH` (set to `true`)<br/>
-**Environment Variable Alias**: `TERRAGRUNT_HCLVALIDATE_SHOW_CONFIG_PATH` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
+**Environment Variable**: `TG_SHOW_CONFIG_PATH` (set to `true`)<br/>
+**Environment Variable Aliases**: `TERRAGRUNT_SHOW_CONFIG_PATH`, `TG_HCLVALIDATE_SHOW_CONFIG_PATH` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
 **Commands**:
 
 - [hclvalidate](#hclvalidate)
@@ -1988,7 +1988,7 @@ This lead to a faster rendering process, but the output will not include any dep
 
 **CLI Arg**: `--out`<br/>
 **CLI Arg Alias**: `--terragrunt-json-out` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
-**Environment Variable**: `TG_RENDER_JSON_OUT` (set to `true`)<br/>
+**Environment Variable**: `TG_OUT` (set to `true`)<br/>
 **Environment Variable Alias**: `TERRAGRUNT_JSON_OUT` (deprecated: [See migration guide](/docs/migrate/cli-redesign/))<br/>
 **Requires an argument**: `--out /path/to/terragrunt_rendered.json`<br/>
 **Commands**:


### PR DESCRIPTION
## Description

Fixes environment variables that aren't right in the docs.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated environment variables that were mislabelled in the docs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated environment variable names in the documentation for multiple CLI flags to use shorter, standardized forms.
  - Added explicit documentation of environment variable support for the `no-auto-approve` flag.
  - Deprecated environment variable names are still listed as aliases for reference.
  - No changes to command-line flag names, descriptions, or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->