### PR TITLE
[WIP] Proof of concept: Add OpenTelemetry trace propagation to OpenTofu/Terraform

### DIFF
--- a/telemetry/context.go
+++ b/telemetry/context.go
@@ -1,6 +1,10 @@
 package telemetry
 
-import "context"
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+)
 
 const (
 	telemeterContextKey ctxKey = iota
@@ -20,4 +24,23 @@ func TelemeterFromContext(ctx context.Context) *Telemeter {
 	}
 
 	return new(Telemeter)
+}
+
+func TraceParentFromContext(ctx context.Context) (string, error) {
+	span := trace.SpanFromContext(ctx)
+	spanContext := span.SpanContext()
+
+	if !spanContext.IsValid() {
+		return "", nil
+	}
+
+	traceID := spanContext.TraceID().String()
+	spanID := spanContext.SpanID().String()
+	flags := "00"
+	if spanContext.TraceFlags().IsSampled() {
+		flags = "01"
+	}
+
+	traceparent := "00-" + traceID + "-" + spanID + "-" + flags
+	return traceparent, nil
 }


### PR DESCRIPTION
## Description

Fixes #4253

Pass TRACEPARENT environment variable from Terragrunt to child processes for end-to-end distributed tracing with OpenTofu's new tracing support.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

