### PR TITLE
fix: Removing HTML `font-size`

### DIFF
--- a/docs/assets/css/bootstrap/scss/bootstrap.scss
+++ b/docs/assets/css/bootstrap/scss/bootstrap.scss
@@ -1067,7 +1067,6 @@ th {
   box-sizing: border-box;
 }
 html {
-  font-size: 10px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 body {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

We set `font-size` in the `body` element anyways, so it shouldn't do anything to remove the `font-size` from the `html` element.

It's interfering with proper rending of our "Ask AI" button, so let's remove it to see if it improves things.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Removed `font-size` from top-level `html` element.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated base font size by removing the explicit `font-size` setting from the root HTML element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->