### PR TITLE
feat: fixed TestGcpWorksWithImpersonateBackend test

### DIFF
--- a/.github/scripts/setup/generate-secrets.sh
+++ b/.github/scripts/setup/generate-secrets.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 : "${GOOGLE_COMPUTE_ZONE:?GOOGLE_COMPUTE_ZONE is not set}"
 : "${GOOGLE_IDENTITY_EMAIL:?GOOGLE_IDENTITY_EMAIL is not set}"
 : "${GOOGLE_PROJECT_ID:?GOOGLE_PROJECT_ID is not set}"
+: "${GCLOUD_SERVICE_KEY_IMPERSONATOR:?GCLOUD_SERVICE_KEY_IMPERSONATOR is not set}"
 
 # Optional environment variables
 SECRETS="${SECRETS:-}"
@@ -42,6 +43,8 @@ for SECRET in $SECRETS; do
         printf "export GOOGLE_IDENTITY_EMAIL='%s'\n" "${GOOGLE_IDENTITY_EMAIL}" >> "$ENV_FILE"
     elif [[ "$SECRET" == "GOOGLE_PROJECT_ID" && -n "${GOOGLE_PROJECT_ID}" ]]; then
         printf "export GOOGLE_PROJECT_ID='%s'\n" "${GOOGLE_PROJECT_ID}" >> "$ENV_FILE"
+    elif [[ "$SECRET" == "GCLOUD_SERVICE_KEY_IMPERSONATOR" && -n "${GCLOUD_SERVICE_KEY_IMPERSONATOR}" ]]; then
+        printf "export GCLOUD_SERVICE_KEY_IMPERSONATOR='%s'\n" "${GCLOUD_SERVICE_KEY_IMPERSONATOR}" >> "$ENV_FILE"
     fi
 done
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -96,6 +96,7 @@ jobs:
           GOOGLE_COMPUTE_ZONE: ${{ secrets.GOOGLE_COMPUTE_ZONE }}
           GOOGLE_IDENTITY_EMAIL: ${{ secrets.GOOGLE_IDENTITY_EMAIL }}
           GOOGLE_PROJECT_ID: ${{ secrets.GOOGLE_PROJECT_ID }}
+          GCLOUD_SERVICE_KEY_IMPERSONATOR: ${{ secrets.GCLOUD_SERVICE_KEY_IMPERSONATOR }}
         shell: bash
 
       - name: Setup

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -50,7 +50,7 @@ jobs:
               - .github/scripts/setup/gcp.sh
             tags: gcp
             run: '^TestGcp'
-            secrets: [GCLOUD_SERVICE_KEY, GOOGLE_CLOUD_PROJECT, GOOGLE_COMPUTE_ZONE, GOOGLE_IDENTITY_EMAIL, GOOGLE_PROJECT_ID]
+            secrets: [GCLOUD_SERVICE_KEY, GOOGLE_CLOUD_PROJECT, GOOGLE_COMPUTE_ZONE, GOOGLE_IDENTITY_EMAIL, GOOGLE_PROJECT_ID, GCLOUD_SERVICE_KEY_IMPERSONATOR]
           - name: AWS
             os: ubuntu
             target: ./...

--- a/test/integration_serial_gcp_test.go
+++ b/test/integration_serial_gcp_test.go
@@ -41,10 +41,6 @@ func TestGcpCorrectlyMirrorsTerraformGCPAuth(t *testing.T) {
 }
 
 func TestGcpWorksWithImpersonateBackend(t *testing.T) {
-	if os.Getenv("GCLOUD_SERVICE_KEY_IMPERSONATOR") == "" {
-		t.Skip("Skipping test for impersonation, as it requires a specific secret for GCP.")
-		return
-	}
 	impersonatorKey := os.Getenv("GCLOUD_SERVICE_KEY_IMPERSONATOR")
 	if impersonatorKey == "" {
 		t.Fatalf("required environment variable `%s` - not found", "GCLOUD_SERVICE_KEY_IMPERSONATOR")


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Added passing of GCLOUD_SERVICE_KEY_IMPERSONATOR secret
* Disabled logic to skip tests if GCLOUD_SERVICE_KEY_IMPERSONATOR is not defined 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated secret handling to require and validate the presence of the `GCLOUD_SERVICE_KEY_IMPERSONATOR` environment variable during setup and integration testing.
  - Improved integration test workflow to ensure the necessary secret is always provided and surfaced as an environment variable.
- **Tests**
  - Modified integration tests to fail immediately if the required secret is missing, instead of silently skipping the test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->