### PR TITLE
chore: enable TestRemoteDownloadWithRelativePathAndSlashInBranch test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -228,7 +228,7 @@ jobs:
           NAME: ${{ matrix.integration.name }}
           TEST_ARGS: ${{ matrix.integration.test_args }}
 
-      - name: Upload Report (${{ matrix.integration.name }}))
+      - name: Upload Report (${{ matrix.integration.name }})
         uses: actions/upload-artifact@v4
         with:
           name: test-report-${{ matrix.integration.name }}

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -211,8 +211,6 @@ func TestRemoteDownloadWithRelativePath(t *testing.T) {
 }
 
 func TestRemoteDownloadWithRelativePathAndSlashInBranch(t *testing.T) {
-	t.Skip("This test needs to be skipped for now, as there's a recursive reference happening on tagged modules that needs to be plumbed out.")
-
 	t.Parallel()
 
 	helpers.CleanupTerraformFolder(t, testFixtureRemoteRelativeDownloadPathWithSlash)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Enabled back TestRemoteDownloadWithRelativePathAndSlashInBranch
* Cleaned GH action step name

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typographical error in the workflow step name for integration tests.

- **Tests**
  - Re-enabled a previously skipped integration test for remote downloads with relative paths and slashes in branch names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->