### PR TITLE
4211 - fix: Setting correct exit code for `hcl validate`

### DIFF
--- a/cli/commands/hcl/validate/validate.go
+++ b/cli/commands/hcl/validate/validate.go
@@ -99,6 +99,14 @@ func RunValidate(ctx context.Context, opts *options.TerragruntOptions) error {
 		if err := writeDiagnostics(opts, diags); err != nil {
 			return err
 		}
+
+		// If there were diagnostics and stackErr is currently nil,
+		// create a new error to signal overall validation failure.
+		//
+		// This also ensures a non-zero exit code is returned by Terragrunt.
+		if stackErr == nil {
+			stackErr = errors.Errorf("%d HCL validation error(s) found", len(diags))
+		}
 	}
 
 	return stackErr

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -728,6 +728,24 @@ func TestHclvalidateDiagnostic(t *testing.T) {
 	assert.ElementsMatch(t, expectedDiags, actualDiags)
 }
 
+func TestHclvalidateReturnsNonZeroExitCodeOnError(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureHclvalidate)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureHclvalidate)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureHclvalidate)
+
+	// We expect an error because the fixture has HCL validation issues.
+	// The content of stdout and stderr isn't the primary focus here,
+	// rather the fact that an error (non-zero exit code) is returned.
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt hcl validate --working-dir %s", rootPath))
+	require.Error(t, err, "terragrunt hcl validate should return a non-zero exit code on HCL errors")
+
+	// As an additional check, we can verify that the error message indicates HCL validation errors.
+	// This makes the test more robust.
+	assert.Contains(t, err.Error(), "HCL validation error(s) found")
+}
+
 func TestHclvalidateInvalidConfigPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4211.

Returns a final error for `hcl validate` so that it users can check the overall exit code.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added error for overall exit code to be non-zero if any of the files are invalid in `hcl validate` command.

### Migration Guide

If users were previously using `hcl validate` expecting a zero exit code, they'll need to suppress the exit code using something like `|| true` in their scripts. This is because the command now returns a non-zero exit code if any of the files are invalid.

