### PR TITLE
fix: Fixing `remote-relative-with-slash` fixture on ARM tests

### DIFF
--- a/test/fixtures/download/remote-relative-with-slash/terragrunt.hcl
+++ b/test/fixtures/download/remote-relative-with-slash/terragrunt.hcl
@@ -3,5 +3,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git?ref=v0.77.22//test/fixtures/download/relative"
+  source = "github.com/gruntwork-io/terragrunt.git?ref=v0.78.4//test/fixtures/download/relative"
 }

--- a/test/integration_run_test.go
+++ b/test/integration_run_test.go
@@ -106,7 +106,12 @@ func TestRunNoStacksGenerate(t *testing.T) {
 			if tt.shouldFail {
 				require.Error(t, err)
 				assert.Empty(t, stdout)
-				assert.Empty(t, stderr)
+				// We should explicitly avoid asserting on stderr, because information
+				// might be logged to stderr, even if the command succeeds.
+				//
+				// e.g. Usage of the provider cache server.
+				//
+				// assert.Empty(t, stderr)
 			} else {
 				require.NoError(t, err)
 				assert.NotEmpty(t, stdout)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes a busted test.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the referenced version of the remote Terragrunt module in test fixtures.
  - Improved test reliability by adjusting error output expectations to account for informational logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->