### PR TITLE
Update QuickStart documentation with an additional example to control the output directory

### DIFF
--- a/docs-starlight/src/content/docs/01-getting-started/01-quick-start.mdx
+++ b/docs-starlight/src/content/docs/01-getting-started/01-quick-start.mdx
@@ -315,6 +315,42 @@ You can also see what to expect in your filesystem at each step [here](https://g
 
    This is where that additional verbosity in Terragrunt logging is really handy. You can see that Terragrunt concurrently ran `apply -auto-approve` in both the `foo` and `bar` units. The extra logging for Terragrunt also included information on the names of the units that were processed, and disambiguated the output from each unit.
 
+   When Terragrunt runs these commands, it creates a `.terragrunt-cache` directory in each unit's directory. This cache directory serves as Terragrunt's scratch directory where it:
+
+   - Downloads your remote OpenTofu/Terraform configurations
+   - Runs your OpenTofu/Terraform commands
+   - Stores downloaded modules and providers
+   - Stores generated files (in this case, the `hi.txt` file will be created under `.terragrunt-cache/[HASH]/[HASH]/hi.txt` rather than directly in the `foo` or `bar` directories)
+
+   With this configuration, the `hi.txt` files will be created directly in the `foo` and `bar` directories instead of the `.terragrunt-cache` directory. 
+
+   The `.terragrunt-cache` directory is typically added to `.gitignore` files, similar to the `.terraform` directory that OpenTofu generates. You can safely delete this folder at any time, and Terragrunt will recreate it as necessary.
+
+   If you want to control where the files are created, you can modify the module to accept an output directory parameter. For example, you can update the `shared/main.tf` file to:
+
+   ```hcl
+   variable "content" {}
+   variable "output_dir" {}
+
+   resource "local_file" "file" {
+     content  = var.content
+     filename = "${var.output_dir}/hi.txt"
+   }
+   ```
+
+   Then in your `foo/terragrunt.hcl` and `bar/terragrunt.hcl` files, you can use the `get_terragrunt_dir()` built-in function to get the directory where the `terragrunt.hcl` file is located:
+
+   ```hcl
+   terraform {
+     source = "../shared"
+   }
+
+   inputs = {
+     output_dir = get_terragrunt_dir()
+     content = "Hello from bar, Terragrunt!"
+   }
+   ```
+
    Similar to the `tofu` CLI, there is a prompt to confirm that you are sure you want to run the command in each unit when performing a command that's potentially destructive. You can skip this prompt by using the `--non-interactive` flag, just as you would with `-auto-approve` in OpenTofu.
 
    ```bash

--- a/docs/_docs/01_getting-started/01-quick-start.md
+++ b/docs/_docs/01_getting-started/01-quick-start.md
@@ -267,7 +267,7 @@ This saves you some duplicated content, as you no longer need to maintain that e
 
 If you run `terragrunt apply -auto-approve` in the `foo` and `bar` directories, you'll see that the `content` variable is set to the value you defined in the `inputs` block of the `terragrunt.hcl` file. You might also notice that there's now a special `.terragrunt-cache` directory generated for you in each unit directory. This is where Terragrunt copies the contents of modules, and performs any necessary additional code generation to make sure that your OpenTofu/Terraform code is ready to be run.
 
-The `.terragrunt-cache` directory is typically added to `.gitignore` files, similar to the `.terraform` directory that OpenTofu generates.
+The `.terragrunt-cache` directory is typically added to `.gitignore` files, similar to the `.terraform` directory that OpenTofu generates. You can safely delete this folder at any time, and Terragrunt will recreate it as necessary.
 
 ### Step 5: Use Terragrunt to manage your stacks
 
@@ -307,17 +307,13 @@ Are you sure you want to run 'terragrunt apply' in each folder of the stack desc
 This is where that additional verbosity in Terragrunt logging is really handy. You can see that Terragrunt concurrently ran `apply -auto-approve` in both the `foo` and `bar` units. The extra logging for Terragrunt also included information on the names of the units that were processed, and disambiguated the output from each unit.
 
 When Terragrunt runs these commands, it creates a `.terragrunt-cache` directory in each unit's directory. This cache directory serves as Terragrunt's scratch directory where it:
+
 - Downloads your remote OpenTofu/Terraform configurations
 - Runs your OpenTofu/Terraform commands
 - Stores downloaded modules and providers
 - Stores generated files (in this case, the `hi.txt` file will be created under `.terragrunt-cache/[HASH]/[HASH]/hi.txt` rather than directly in the `foo` or `bar` directories)
 
-With this configuration, the `hi.txt` files will be created directly in the `foo` and `bar` directories instead of the `.terragrunt-cache` directory. This is a common pattern when you want to generate files in specific locations relative to your Terragrunt configuration.
-
-Inside the cache directory, Terragrunt automatically converts your `terragrunt.hcl` configuration into standard OpenTofu/Terraform configuration files:
-- Generates `main.tf` with your module source and provider configurations
-- Creates `terraform.tfvars` or `terraform.tfvars.json` with your input variables
-- Sets up any additional files like `outputs.tf` and `variables.tf` based on your Terragrunt configuration
+With this configuration, the `hi.txt` files will be created directly in the `foo` and `bar` directories instead of the `.terragrunt-cache` directory. 
 
 The `.terragrunt-cache` directory is typically added to `.gitignore` files, similar to the `.terraform` directory that OpenTofu generates. You can safely delete this folder at any time, and Terragrunt will recreate it as necessary.
 

--- a/docs/_docs/01_getting-started/01-quick-start.md
+++ b/docs/_docs/01_getting-started/01-quick-start.md
@@ -267,7 +267,7 @@ This saves you some duplicated content, as you no longer need to maintain that e
 
 If you run `terragrunt apply -auto-approve` in the `foo` and `bar` directories, you'll see that the `content` variable is set to the value you defined in the `inputs` block of the `terragrunt.hcl` file. You might also notice that there's now a special `.terragrunt-cache` directory generated for you in each unit directory. This is where Terragrunt copies the contents of modules, and performs any necessary additional code generation to make sure that your OpenTofu/Terraform code is ready to be run.
 
-The `.terragrunt-cache` directory is typically added to `.gitignore` files, similar to the `.terraform` directory that OpenTofu generates. You can safely delete this folder at any time, and Terragrunt will recreate it as necessary.
+The `.terragrunt-cache` directory is typically added to `.gitignore` files, similar to the `.terraform` directory that OpenTofu generates.
 
 ### Step 5: Use Terragrunt to manage your stacks
 
@@ -307,7 +307,6 @@ Are you sure you want to run 'terragrunt apply' in each folder of the stack desc
 This is where that additional verbosity in Terragrunt logging is really handy. You can see that Terragrunt concurrently ran `apply -auto-approve` in both the `foo` and `bar` units. The extra logging for Terragrunt also included information on the names of the units that were processed, and disambiguated the output from each unit.
 
 When Terragrunt runs these commands, it creates a `.terragrunt-cache` directory in each unit's directory. This cache directory serves as Terragrunt's scratch directory where it:
-
 - Downloads your remote OpenTofu/Terraform configurations
 - Runs your OpenTofu/Terraform commands
 - Stores downloaded modules and providers
@@ -315,7 +314,7 @@ When Terragrunt runs these commands, it creates a `.terragrunt-cache` directory 
 
 With this configuration, the `hi.txt` files will be created directly in the `foo` and `bar` directories instead of the `.terragrunt-cache` directory. 
 
-The `.terragrunt-cache` directory is typically added to `.gitignore` files, similar to the `.terraform` directory that OpenTofu generates. You can safely delete this folder at any time, and Terragrunt will recreate it as necessary.
+The `.terragrunt-cache` directory is typically added to `.gitignore` files, similar to the `.terraform` directory that OpenTofu generates.
 
 
 If you want to control where the files are created, you can modify the module to accept an output directory parameter. For example, you can update the `shared/main.tf` file to:

--- a/docs/_docs/01_getting-started/01-quick-start.md
+++ b/docs/_docs/01_getting-started/01-quick-start.md
@@ -307,15 +307,15 @@ Are you sure you want to run 'terragrunt apply' in each folder of the stack desc
 This is where that additional verbosity in Terragrunt logging is really handy. You can see that Terragrunt concurrently ran `apply -auto-approve` in both the `foo` and `bar` units. The extra logging for Terragrunt also included information on the names of the units that were processed, and disambiguated the output from each unit.
 
 When Terragrunt runs these commands, it creates a `.terragrunt-cache` directory in each unit's directory. This cache directory serves as Terragrunt's scratch directory where it:
+
 - Downloads your remote OpenTofu/Terraform configurations
 - Runs your OpenTofu/Terraform commands
 - Stores downloaded modules and providers
 - Stores generated files (in this case, the `hi.txt` file will be created under `.terragrunt-cache/[HASH]/[HASH]/hi.txt` rather than directly in the `foo` or `bar` directories)
 
-With this configuration, the `hi.txt` files will be created directly in the `foo` and `bar` directories instead of the `.terragrunt-cache` directory. 
+With this configuration, the `hi.txt` files will be created directly in the `foo` and `bar` directories instead of the `.terragrunt-cache` directory.
 
 The `.terragrunt-cache` directory is typically added to `.gitignore` files, similar to the `.terraform` directory that OpenTofu generates.
-
 
 If you want to control where the files are created, you can modify the module to accept an output directory parameter. For example, you can update the `shared/main.tf` file to:
 

--- a/test/fixtures/docs/01-quick-start/step-05.1/.gitignore
+++ b/test/fixtures/docs/01-quick-start/step-05.1/.gitignore
@@ -1,0 +1,2 @@
+.terragrunt-cache
+hi.txt 

--- a/test/fixtures/docs/01-quick-start/step-05.1/README.md
+++ b/test/fixtures/docs/01-quick-start/step-05.1/README.md
@@ -1,0 +1,3 @@
+This example demonstrates how to control output file locations using get_terragrunt_dir().
+
+The hi.txt files will be created directly in the foo and bar directories instead of the .terragrunt-cache directory. 

--- a/test/fixtures/docs/01-quick-start/step-05.1/bar/terragrunt.hcl
+++ b/test/fixtures/docs/01-quick-start/step-05.1/bar/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  source = "../shared"
+}
+
+inputs = {
+  output_dir = get_terragrunt_dir()
+  content    = "Hello from bar, Terragrunt!"
+} 

--- a/test/fixtures/docs/01-quick-start/step-05.1/foo/terragrunt.hcl
+++ b/test/fixtures/docs/01-quick-start/step-05.1/foo/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  source = "../shared"
+}
+
+inputs = {
+  output_dir = get_terragrunt_dir()
+  content    = "Hello from foo, Terragrunt!"
+} 

--- a/test/fixtures/docs/01-quick-start/step-05.1/shared/main.tf
+++ b/test/fixtures/docs/01-quick-start/step-05.1/shared/main.tf
@@ -1,0 +1,7 @@
+variable "content" {}
+variable "output_dir" {}
+
+resource "local_file" "file" {
+  content  = var.content
+  filename = "${var.output_dir}/hi.txt"
+} 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/terragrunt/issues/4296.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the quick start guide with detailed explanations of the `.terragrunt-cache` directory, Terragrunt caching behavior, and strategies for controlling output file locations.
  - Added new example configurations and a README to illustrate managing file outputs using the `get_terragrunt_dir()` function.
- **Chores**
  - Updated example directories with `.gitignore` files to exclude cache and generated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->