### PR TITLE
Improved error handling in AWS docs

### DIFF
--- a/test/integration_docs_aws_test.go
+++ b/test/integration_docs_aws_test.go
@@ -33,11 +33,13 @@ func TestAwsDocsOverview(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
-		defer func() {
+		t.Cleanup(func() {
+			helpers.DeleteS3Bucket(t, region, s3BucketName)
+		})
+		t.Cleanup(func() {
 			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt destroy -auto-approve --non-interactive --working-dir "+rootPath)
 			require.NoError(t, err)
-		}()
+		})
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
@@ -57,11 +59,13 @@ func TestAwsDocsOverview(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
-		defer func() {
+		t.Cleanup(func() {
+			helpers.DeleteS3Bucket(t, region, s3BucketName)
+		})
+		t.Cleanup(func() {
 			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --working-dir "+rootPath+" -- destroy -auto-approve")
 			require.NoError(t, err)
-		}()
+		})
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
@@ -81,11 +85,13 @@ func TestAwsDocsOverview(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
-		defer func() {
+		t.Cleanup(func() {
+			helpers.DeleteS3Bucket(t, region, s3BucketName)
+		})
+		t.Cleanup(func() {
 			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --working-dir "+rootPath+" -- destroy -auto-approve")
 			require.NoError(t, err)
-		}()
+		})
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
@@ -105,11 +111,13 @@ func TestAwsDocsOverview(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
-		defer func() {
+		t.Cleanup(func() {
+			helpers.DeleteS3Bucket(t, region, s3BucketName)
+		})
+		t.Cleanup(func() {
 			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --working-dir "+rootPath+" -- destroy -auto-approve")
 			require.NoError(t, err)
-		}()
+		})
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
@@ -129,11 +137,13 @@ func TestAwsDocsOverview(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
-		defer func() {
+		t.Cleanup(func() {
+			helpers.DeleteS3Bucket(t, region, s3BucketName)
+		})
+		t.Cleanup(func() {
 			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --working-dir "+rootPath+" -- destroy -auto-approve")
 			require.NoError(t, err)
-		}()
+		})
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Moved defer code to cleanup test functions

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test cleanup procedures to use the testing framework's cleanup mechanism for more reliable resource management during integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->