### PR TITLE
feat: Adding cloud-nuke cron

### DIFF
--- a/.github/cloud-nuke/config.yml
+++ b/.github/cloud-nuke/config.yml
@@ -1,0 +1,2 @@
+s3:
+  timeout: 10m

--- a/.github/cloud-nuke/config.yml
+++ b/.github/cloud-nuke/config.yml
@@ -1,2 +1,5 @@
 s3:
   timeout: 10m
+  include:
+    names_regex:
+      - "^terragrunt-test-bucket-[a-zA-Z0-9]{6}.*"

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -1,0 +1,32 @@
+name: Daily Cloud Nuke
+on:
+  schedule:
+    - cron: "0 0 * * *" # Runs every day at midnight UTC
+jobs:
+  run_cloud_nuke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install cloud-nuke
+        run: |
+            wget -O /usr/local/bin/cloud-nuke \
+                --header="Authorization: Bearer ${GITHUB_TOKEN}" \
+                "https://github.com/gruntwork-io/cloud-nuke/releases/download/${VERSION}/cloud-nuke_linux_amd64"
+
+            chmod +x /usr/local/bin/cloud-nuke
+        env:
+            # Authenticate to reduce the likelihood of hitting rate limit issues.
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            VERSION: 0.40.0
+
+      - name: Run cloud-nuke
+        run: |
+            cloud-nuke aws \
+                --dry-run \ # TODO: Remove this after testing, and add --force flag.
+                --log-level debug \
+                --resource-type s3 \
+                --region us-east-1 \
+                --older-than 1d \
+                --config .github/cloud-nuke/config.yml

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -41,5 +41,5 @@ jobs:
                 --log-level debug \
                 --resource-type s3 \
                 --region us-east-1 \
-                --older-than 1d \
+                --older-than 24h \
                 --config .github/cloud-nuke/config.yml

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -36,8 +36,9 @@ jobs:
 
       - name: Run cloud-nuke
         run: |
+            # TODO: After testing, remove --dry-run and add the --force flag.
             cloud-nuke aws \
-                --dry-run \ # TODO: Remove this after testing, and add --force flag.
+                --dry-run \
                 --log-level debug \
                 --resource-type s3 \
                 --region us-east-1 \

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -2,6 +2,13 @@ name: Daily Cloud Nuke
 on:
   schedule:
     - cron: "0 0 * * *" # Runs every day at midnight UTC
+  workflow_dispatch:
+
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   run_cloud_nuke:
     runs-on: ubuntu-latest
@@ -20,6 +27,12 @@ jobs:
             # Authenticate to reduce the likelihood of hitting rate limit issues.
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             VERSION: 0.40.0
+
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CLOUD_NUKE_ROLE }}
+          aws-region: us-east-1
 
       - name: Run cloud-nuke
         run: |


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds daily cloud-nuke cron.

Can't really test this yet. Gonna rely on review to help me determine if this is configured right, then merge it to test off main.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `cloud-nuke` cron.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a daily automated workflow to scan and report on aged S3 resources in AWS using the `cloud-nuke` tool. The workflow runs nightly and can also be triggered manually.
  - Added a configuration file to customize the timeout and filtering of S3 buckets during the scan.

- **Chores**
  - Set up GitHub Actions to automate cloud resource cleanup checks with a dry-run mode for initial testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->