### PR TITLE
fix: Correcting `legacy-all` strict control name in docs

### DIFF
--- a/docs-starlight/src/content/docs/04-reference/03-strict-controls.mdx
+++ b/docs-starlight/src/content/docs/04-reference/03-strict-controls.mdx
@@ -253,7 +253,7 @@ Throw an error when using the deprecated Terragrunt configuration.
 
 - [skip-dependencies-inputs](#skip-dependencies-inputs)
 
-### legacy-all-commands
+### legacy-all
 
 Throw an error when using any of the legacy commands replaced by `run-all`.
 

--- a/docs/_docs/04_reference/05-strict-mode.md
+++ b/docs/_docs/04_reference/05-strict-mode.md
@@ -137,7 +137,7 @@ The following strict mode controls are available:
   - [deprecated-flags](#deprecated-flags)
   - [deprecated-env-vars](#deprecated-env-vars)
   - [deprecated-configs](#deprecated-configs)
-  - [legacy-all-commands](#legacy-all-commands)
+  - [legacy-all](#legacy-all)
 
 ### spin-up
 
@@ -286,7 +286,7 @@ Throw an error when using the deprecated Terragrunt configuration.
 
 - [skip-dependencies-inputs](#skip-dependencies-inputs)
 
-### legacy-all-commands
+### legacy-all
 
 Throw an error when using any of the legacy commands replaced by `run --all`.
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4309.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `legacy-all` strict control documentation, as it was mistakenly documented as `legacy-all-commands`.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to rename the strict control category from "legacy-all-commands" to "legacy-all" for improved clarity. No changes to the described functionality or covered commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->