### PR TITLE
fix: Enabling disabled tests

### DIFF
--- a/test/fixtures/download/remote-relative/terragrunt.hcl
+++ b/test/fixtures/download/remote-relative/terragrunt.hcl
@@ -3,5 +3,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/relative?ref=v0.77.22"
+  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/relative?ref=v0.79.0"
 }

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -198,8 +198,6 @@ func TestInvalidRemoteDownloadWithRetries(t *testing.T) {
 }
 
 func TestRemoteDownloadWithRelativePath(t *testing.T) {
-	t.Skip("This test needs to be skipped for now, as there's a recursive reference happening on tagged modules that needs to be plumbed out.")
-
 	t.Parallel()
 
 	helpers.CleanupTerraformFolder(t, testFixtureRemoteRelativeDownloadPath)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3165,9 +3165,6 @@ func TestNoMultipleInitsWithoutSourceChange(t *testing.T) {
 }
 
 func TestAutoInitWhenSourceIsChanged(t *testing.T) {
-	// TODO: Resolve this.
-	t.Skip("This test needs to be skipped for now, as there's recursive references happening on tagged modules that needs to be plumbed out.")
-
 	t.Parallel()
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDownload)
@@ -3179,7 +3176,7 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	if err != nil {
 		require.NoError(t, err)
 	}
-	updatedHcl := strings.ReplaceAll(contents, "__TAG_VALUE__", "v0.77.21")
+	updatedHcl := strings.ReplaceAll(contents, "__TAG_VALUE__", "v0.78.4")
 	require.NoError(t, os.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
 
 	stdout := bytes.Buffer{}
@@ -3190,7 +3187,7 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	// providers initialization during first plan
 	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
 
-	updatedHcl = strings.ReplaceAll(contents, "__TAG_VALUE__", "v0.77.22")
+	updatedHcl = strings.ReplaceAll(contents, "__TAG_VALUE__", "v0.79.0")
 	require.NoError(t, os.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
 
 	stdout = bytes.Buffer{}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Enabling tests that were disabled while we were moving to the new repo structure.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Enabled `TestRemoteDownloadWithRelativePath` again.
Enabled `TestAutoInitWhenSourceIsChanged` again.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enabled previously skipped tests related to remote downloads and source version changes.
  - Updated test fixtures to reference the latest module versions.

- **Tests**
  - Improved test coverage by ensuring tests for remote module downloads and source version updates now run as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->