### PR TITLE
feat: improved `stack clean` to remove recursive stack directories

### DIFF
--- a/test/fixtures/stacks/nested/live-v2/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/nested/live-v2/terragrunt.stack.hcl
@@ -1,0 +1,11 @@
+
+stack "dev" {
+	source = "${get_repo_root()}/stacks/dev"
+	path = "dev"
+}
+
+
+stack "prod" {
+	source = "${get_repo_root()}/stacks/prod"
+	path = "prod"
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Improved `terragrunt stack clean` to remove recursive stack directories
* Added test to track that `clean` command removes .`terragrunt-stack` directories

Example:

![image](https://github.com/user-attachments/assets/c93d17bf-3147-4d0d-a435-027826b18ed7)

Fixes #4279.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The stack cleaning command now removes all stack directories recursively within the working directory, instead of only deleting a single directory.
- **Tests**
  - Added an integration test to verify that stack directories are cleaned recursively across nested locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->