### PR TITLE
chore: Add support for Terraform 1.12

### DIFF
--- a/.github/scripts/setup/terraform-switch-1-11.sh
+++ b/.github/scripts/setup/terraform-switch-1-11.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-# Install Terraform 1.11 using common script
-.github/scripts/setup/terraform-switch.sh 1.11

--- a/.github/scripts/setup/terraform-switch-1-12.sh
+++ b/.github/scripts/setup/terraform-switch-1-12.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Install Terraform 1.12 using common script
+.github/scripts/setup/terraform-switch.sh 1.12

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,11 +27,11 @@ jobs:
             target: ./test
             setup_scripts:
               - .github/scripts/setup/terraform-switch-1-5.sh
-          - name: Fixtures Terraform 1.11
+          - name: Fixtures Terraform 1.12
             os: ubuntu
             target: ./test
             setup_scripts:
-              - .github/scripts/setup/terraform-switch-1-11.sh
+              - .github/scripts/setup/terraform-switch-1-12.sh
           - name: SSH
             os: ubuntu
             target: ./...
@@ -77,14 +77,14 @@ jobs:
             secrets: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_TEST_S3_ASSUME_ROLE]
             setup_scripts:
               - .github/scripts/setup/terraform-switch-1-5.sh
-          - name: AWS Terraform 1.11
+          - name: AWS Terraform 1.12
             os: ubuntu
             target: ./...
             tags: aws
             run: '^TestAws'
             secrets: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_TEST_S3_ASSUME_ROLE]
             setup_scripts:
-              - .github/scripts/setup/terraform-switch-1-11.sh
+              - .github/scripts/setup/terraform-switch-1-12.sh
           - name: AWSGCP
             os: ubuntu
             target: ./...
@@ -107,12 +107,12 @@ jobs:
               - .github/scripts/setup/windows-setup.ps1
             tags: windows
             run: '^TestWindows'
-          - name: Provider Cache Terraform 1.11
+          - name: Provider Cache Terraform 1.12
             os: ubuntu
             target: ./test
             setup_scripts:
               - .github/scripts/setup/provider-cache.sh
-              - .github/scripts/setup/terraform-switch-1-11.sh
+              - .github/scripts/setup/terraform-switch-1-12.sh
           - name: Provider Cache Tofu
             os: ubuntu
             target: ./test

--- a/docs-starlight/src/content/docs/04-reference/05-supported-versions.md
+++ b/docs-starlight/src/content/docs/04-reference/05-supported-versions.md
@@ -23,6 +23,9 @@ The officially supported versions are:
 
 | Terraform Version | Terragrunt Version                                                                                                                                    |
 |-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.12.x            | >= [0.80.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.80.0)                                                                          |
+| 1.11.x            | >= [0.75.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.75.0)                                                                          |
+| 1.10.x            | >= [0.74.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.74.0)                                                                          |
 | 1.9.x             | >= [0.60.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.60.0)                                                                          |
 | 1.8.x             | >= [0.57.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.57.0)                                                                          |
 | 1.7.x             | >= [0.56.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.56.0)                                                                          |

--- a/docs/_docs/04_reference/07-supported-versions.md
+++ b/docs/_docs/04_reference/07-supported-versions.md
@@ -28,6 +28,7 @@ The officially supported versions are:
 
 | Terraform Version | Terragrunt Version                                                                                                                                    |
 |-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.12.x            | >= [0.80.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.80.0)                                                                          |
 | 1.11.x            | >= [0.75.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.75.0)                                                                          |
 | 1.10.x            | >= [0.74.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.74.0)                                                                          |
 | 1.9.x             | >= [0.60.0](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.60.0)                                                                          |

--- a/mise.cicd.toml
+++ b/mise.cicd.toml
@@ -5,4 +5,4 @@ gcloud = "520.0.0"
 awscli = "2.27.7"
 "go:golang.org/x/tools/cmd/goimports" = "latest"
 tflint = "0.47.0"
-terraform = ["1.5", "1.11"]
+terraform = ["1.5", "1.12"]


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Added support for Terraform 1.12
* Updated tests to track Terraform 1.12 usage
* Updated documentation

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated integration tests and CI configurations to use Terraform version 1.12 instead of 1.11.
  - Removed the setup script for Terraform 1.11 and added a new script for Terraform 1.12.
  - Updated tool version configuration to reference Terraform 1.12.

- **Documentation**
  - Added Terraform 1.12.x to the list of supported versions in the documentation, including compatibility details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->