### PR TITLE
Clarify ambiguous documentation on variable precedence

### DIFF
--- a/docs/_docs/04_reference/04-config-blocks-and-attributes.md
+++ b/docs/_docs/04_reference/04-config-blocks-and-attributes.md
@@ -1939,7 +1939,7 @@ tofu apply # or terraform apply
 
 #### Variable Precedence
 
-Variables loaded in OpenTofu/Terraform will consequently use the following precedence order (with the highest precedence being lowest on the list):
+Variables loaded in OpenTofu/Terraform will use the following precedence order from lowest (1) to highest (6):
 
 1. `inputs` set in `terragrunt.hcl` files.
 2. Explicitly set `TF_VAR_` environment variables (these will override the `inputs` set in `terragrunt.hcl` if they conflict).


### PR DESCRIPTION
## Description

Fixes #4316 

Clarify ambiguous documentation on variable precedence

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Clarify ambiguous documentation on variable precedence

### Migration Guide

n/a

