### PR TITLE
chore: Getting rid of mockery

### DIFF
--- a/.github/scripts/setup/generate-mocks.sh
+++ b/.github/scripts/setup/generate-mocks.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-make install-mockery
-make generate-mocks

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -124,13 +124,6 @@ jobs:
             target: ./...
             tags: deprecated
             run: '^TestDeprecated'
-          - name: Mock
-            os: ubuntu
-            target: ./...
-            tags: mocks
-            run: '^TestMock'
-            setup_scripts:
-              - .github/scripts/setup/generate-mocks.sh
           - name: Race
             os: ubuntu
             target: ./...

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install-pre-commit-hook:
 # source. See also: .circleci/config.yml
 build: terragrunt
 terragrunt: $(shell find . \( -type d -name 'vendor' -prune \) \
-                        -o \( -type f -name '*.go'   -print \) ) install-mockery generate-mocks
+                        -o \( -type f -name '*.go'   -print \) )
 	set -xe ;\
 	vtag_maybe_extra=$$(git describe --tags --abbrev=12 --dirty --broken) ;\
 	go build -o $@ -ldflags "-X github.com/gruntwork-io/go-commons/version.Version=$${vtag_maybe_extra} -extldflags '-static'" .
@@ -46,11 +46,5 @@ run-lint:
 
 run-strict-lint:
 	golangci-lint run -v --timeout=10m -c .strict.golangci.yml --new-from-rev origin/main ./...
-
-install-mockery:
-	go install github.com/vektra/mockery/v2@v2.44.1
-
-generate-mocks:
-	go generate ./...
 
 .PHONY: help fmtcheck fmt install-fmt-hook clean install-lint run-lint run-strict-lint

--- a/go.mod
+++ b/go.mod
@@ -256,7 +256,6 @@ require (
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/terraform-linters/tflint-plugin-sdk v0.22.0 // indirect
 	github.com/terraform-linters/tflint-ruleset-terraform v0.10.0 // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1647,7 +1647,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/tf/getproviders/lock.go
+++ b/tf/getproviders/lock.go
@@ -1,5 +1,3 @@
-//go:generate mockery --name Provider
-
 package getproviders
 
 import (

--- a/tf/getproviders/mock_provider_test.go
+++ b/tf/getproviders/mock_provider_test.go
@@ -1,0 +1,37 @@
+package getproviders_test
+
+import (
+	"context"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+// manualMockProvider is a manually implemented mock for the Provider interface.
+type manualMockProvider struct {
+	addr             string
+	ver              string
+	pkgDir           string
+	docSHA256Sums    []byte
+	docSHA256SumsErr error
+	logger           log.Logger
+}
+
+func (m *manualMockProvider) Address() string {
+	return m.addr
+}
+
+func (m *manualMockProvider) Version() string {
+	return m.ver
+}
+
+func (m *manualMockProvider) DocumentSHA256Sums(ctx context.Context) ([]byte, error) {
+	return m.docSHA256Sums, m.docSHA256SumsErr
+}
+
+func (m *manualMockProvider) PackageDir() string {
+	return m.pkgDir
+}
+
+func (m *manualMockProvider) Logger() log.Logger {
+	return m.logger
+}

--- a/tf/getproviders/mock_provider_test.go
+++ b/tf/getproviders/mock_provider_test.go
@@ -8,12 +8,12 @@ import (
 
 // manualMockProvider is a manually implemented mock for the Provider interface.
 type manualMockProvider struct {
+	docSHA256SumsErr error
+	logger           log.Logger
 	addr             string
 	ver              string
 	pkgDir           string
 	docSHA256Sums    []byte
-	docSHA256SumsErr error
-	logger           log.Logger
 }
 
 func (m *manualMockProvider) Address() string {

--- a/tf/getproviders/provider.go
+++ b/tf/getproviders/provider.go
@@ -1,5 +1,3 @@
-//go:generate mockery --name Provider
-
 // Package getproviders provides an interface for getting providers.
 package getproviders
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Removes mockery from the codebase, making it easier to ramp up and contribute to the project.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Removed integration with mockery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified test setup by replacing external mocking tools with manual mock implementations.
  - Improved test isolation and resource cleanup in provider-related tests.
  - Removed automatic mock generation instructions and related scripts.

- **Chores**
  - Cleaned up build and test configuration by removing unused scripts, dependencies, and workflow steps related to mock generation.
  - Updated dependency list to remove an unused indirect module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->