### PR TITLE
Fix terraform command generation in different order

### DIFF
--- a/cli/commands/run/run.go
+++ b/cli/commands/run/run.go
@@ -790,7 +790,7 @@ func FilterTerraformExtraArgs(terragruntOptions *options.TerragruntOptions, terr
 	for _, arg := range terragruntConfig.Terraform.ExtraArgs {
 		for _, argCmd := range arg.Commands {
 			if cmd == argCmd {
-				lastArg := terragruntOptions.TerraformCliArgs.Last()
+				lastArg := terragruntOptions.TerraformCliArgs.CommandNameN(1)
 				skipVars := (cmd == tf.CommandNameApply || cmd == tf.CommandNameDestroy) && util.IsFile(lastArg)
 
 				// The following is a fix for GH-493.

--- a/cli/commands/run/run_test.go
+++ b/cli/commands/run/run_test.go
@@ -402,6 +402,12 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
 			[]string{"--foo", "bar", "foo"},
 		},
+		// apply with some parameters, providing a file in a different order => no var files included
+		{
+			mockCmdOptions(t, workingDir, []string{"apply", temporaryFile, "-no-color", "-foo"}),
+			mockExtraArgs([]string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo"}, []string{"plan", "apply"}, []string{"required.tfvars"}, []string{temporaryFile}),
+			[]string{"--foo", "bar", "foo"},
+		},
 		// destroy providing a folder, var files should stay included
 		{
 			mockCmdOptions(t, workingDir, []string{"destroy", workingDir}),


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4220.

<!-- Description of the changes introduced by this PR. -->

When using `-no-color` a var setting and a plan file, the terraform command generated looks like `[...] <file> -no-color` which makes the usage of "Last" wrong.
Since terraform's apply doc says it can take zero or one non-optional parameter, this should do it.

I ran tests and linters as says the doc but the overall tests fail on main, even in the cli package I get failing tests if I run `go test ./cli/...`.
For the linters, `make run-lint` went well, `make run-strict-lint` was failing on main.

<details>

<summary>Test run for  `run_test.go` with the new test, before the fix</summary>

```
> go test ./run_test.go
20:19:30.614 DEBUG  Running command: i-dont-exist
20:19:30.614 DEBUG  Engine is not enabled, running command directly in .
20:19:30.616 ERROR  unknown invocation failed in .
20:19:30.649 DEBUG  Skipping var-file optional.tfvars as it does not exist
--- FAIL: TestFilterTerraformExtraArgs (0.06s)
    run_test.go:451:
                Error Trace:    /home/monkeypac/dev/terragrunt/cli/commands/run/run_test.go:451
                Error:          Not equal:
                                expected: []string{"--foo", "bar", "foo"}
                                actual  : []string{"--foo", "-var-file=test.tfvars", "bar", "-var='key=value'", "foo", "-var-file=required.tfvars", "-var-file=/tmp/TestFilterTerraformExtraArgs3197671377/001/3320748883"}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,5 +1,9 @@
                                -([]string) (len=3) {
                                +([]string) (len=7) {
                                  (string) (len=5) "--foo",
                                + (string) (len=21) "-var-file=test.tfvars",
                                  (string) (len=3) "bar",
                                - (string) (len=3) "foo"
                                + (string) (len=16) "-var='key=value'",
                                + (string) (len=3) "foo",
                                + (string) (len=25) "-var-file=required.tfvars",
                                + (string) (len=68) "-var-file=/tmp/TestFilterTerraformExtraArgs3197671377/001/3320748883"
                                 }
                Test:           TestFilterTerraformExtraArgs
FAIL
FAIL    command-line-arguments  0.095s
FAIL
```

</details>

<details>

<summary>Test run for  `run_test.go` with the new test, after the fix</summary>

```
> go test ./run_test.go
ok      command-line-arguments  0.136s
```

</details>

<details>

<summary>Test run for the whole `cli/commands/run` package after the fix</summary>

```
> go test ./cli/commands/run
ok      github.com/gruntwork-io/terragrunt/cli/commands/run     7.387s
```

</details>

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs. (not concerned)
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated terraform command generation with extra args when using a plan file.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

