### PR TITLE
chore: Bumping golang to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gruntwork-io/terragrunt
 
-go 1.23.0
+go 1.24
 
 toolchain go1.23.5
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
-go = "1.23.8"
+go = "1.24.3"
 opentofu = "1.9.0"
 golangci-lint = "1.64.6"


### PR DESCRIPTION
## Description

Upgrading to Golang 1.24.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated to Golang 1.24.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

