### PR TITLE
fix: Fixing usage of `--tf-path`

### DIFF
--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -575,7 +575,7 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 			// we use the value they set in their configuration.
 			//
 			// Otherwise, we assume that they've explicitly set the path they want to use via the --tf-path flag.
-			if decoded.TerraformBinary != nil && ctx.TerragruntOptions.TerraformPath == options.TofuDefaultPath {
+			if decoded.TerraformBinary != nil && ctx.TerragruntOptions.TerraformPath == options.DefaultWrappedPath {
 				output.TerraformBinary = *decoded.TerraformBinary
 			}
 

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
+	"github.com/gruntwork-io/terragrunt/options"
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/huandu/go-clone"
@@ -567,7 +568,14 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 				output.TerraformVersionConstraint = *decoded.TerraformVersionConstraint
 			}
 
-			if decoded.TerraformBinary != nil {
+			// By default, we use the tofu binary if it's available.
+			//
+			// If we reach this stage, the user has explicitly set a value for the `terraform_binary` attribute,
+			// _and_ the value is the default tofu path (which is what it is if they don't use the --tf-path flag),
+			// we use the value they set in their configuration.
+			//
+			// Otherwise, we assume that they've explicitly set the path they want to use via the --tf-path flag.
+			if decoded.TerraformBinary != nil && ctx.TerragruntOptions.TerraformPath == options.TofuDefaultPath {
 				output.TerraformBinary = *decoded.TerraformBinary
 			}
 

--- a/test/fixtures/tf-path/other-tf.sh
+++ b/test/fixtures/tf-path/other-tf.sh
@@ -2,6 +2,6 @@
 
 tfpath="${TG_TF_PATH:-tofu}"
 
-echo "TF script used!" >&2
+echo "Other TF script used!" >&2
 
 $tfpath "$@"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4129,10 +4129,26 @@ func TestTfPath(t *testing.T) {
 	workingDir, err := filepath.EvalSymlinks(workingDir)
 	require.NoError(t, err)
 
-	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run version --working-dir "+workingDir)
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run version --working-dir "+workingDir)
 	require.NoError(t, err)
 
-	assert.Regexp(t, "(?i)(terraform|opentofu)", stdout+stderr)
+	assert.Contains(t, stderr, "TF script used!")
+}
+
+func TestTfPathOverridesConfig(t *testing.T) {
+	t.Parallel()
+	// Test that the terragrunt run version command correctly identifies and uses
+	// the terraform_binary path configuration if present
+	helpers.CleanupTerraformFolder(t, testFixtureTfPath)
+	rootPath := helpers.CopyEnvironment(t, testFixtureTfPath)
+	workingDir := util.JoinPath(rootPath, testFixtureTfPath)
+	workingDir, err := filepath.EvalSymlinks(workingDir)
+	require.NoError(t, err)
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run version --tf-path ./other-tf.sh --working-dir "+workingDir)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "Other TF script used!")
 }
 
 func TestVersionIsInvokedOnlyOnce(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4331.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated logic for evaluating `terraform_binary` to ensure that `--tf-path` overrides `terraform_binary` if both are defined.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the Terraform binary path, ensuring command-line flags take precedence over configuration settings.
- **New Features**
	- Added a new integration test to verify that overriding the Terraform binary path via command-line works as expected.
- **Tests**
	- Enhanced test scripts with clearer diagnostic messages for easier debugging.
	- Updated existing tests to assert correct script usage based on configuration or CLI override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->