### PR TITLE
feat: Adding flake test

### DIFF
--- a/.github/workflows/base-test.yml
+++ b/.github/workflows/base-test.yml
@@ -73,4 +73,3 @@ jobs:
           detailed_summary: 'true'
           include_time_in_summary: 'true'
           group_suite: 'true'
-

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -1,0 +1,80 @@
+name: Flake
+on:
+  release:
+    types: [prereleased]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'The tag name of the release'
+        required: true
+
+jobs:
+  test:
+    name: Flake Test (${{ matrix.flake.name }})
+    runs-on: ${{ matrix.flake.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flake:
+          - name: Ubuntu Base tests
+            os: ubuntu
+            count: 10
+            timeout: 45m
+          - name: macOS Base tests
+            os: macos
+            count: 10
+            timeout: 45m
+
+    env:
+      MISE_PROFILE: cicd
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use mise to install dependencies
+        uses: jdx/mise-action@v2
+        with:
+          version: 2025.4.4
+          experimental: true
+        env:
+          # Adding token here to reduce the likelihood of hitting rate limit issues.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: go-cache-paths
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Go Build Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-base-test-${{ hashFiles('**/go.sum') }}
+
+      - name: Run Tests
+        id: run-tests
+        run: |
+          set -o pipefail
+          go test -v ./... -count=${COUNT} -timeout ${TIMEOUT} | tee >(go-junit-report -set-exit-code > result.xml)
+        shell: bash
+        env:
+          # Adding token here to reduce the likelihood of hitting rate limit issues.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COUNT: ${{ matrix.flake.count }}
+          TIMEOUT: ${{ matrix.flake.timeout }}
+
+      - name: Upload Report (${{ matrix.flake.name }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-${{ matrix.flake.name }}
+          path: result.xml
+
+      - name: Display Test Results (${{ matrix.flake.name }})
+        uses: mikepenz/action-junit-report@v5
+        if: always()
+        with:
+          report_paths: result.xml
+          detailed_summary: 'true'
+          include_time_in_summary: 'true'
+          group_suite: 'true'


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adding tests that run on pre-release with `-count` set to repeat tests for flake identification.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added flake tests.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Flake" workflow for enhanced automated testing on Ubuntu and macOS, including test result reporting and artifact uploads.

- **Chores**
  - Minor formatting cleanup in existing workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->