### PR TITLE
fix: Cleaning up addition of `--include` on `find`

### DIFF
--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -168,7 +168,7 @@ func discoveredToFound(configs discovery.DiscoveredConfigs, opts *Options) (Foun
 		}
 
 		if opts.Include && config.Parsed != nil && config.Parsed.ProcessedIncludes != nil {
-			foundCfg.Include = map[string]string{}
+			foundCfg.Include = make(map[string]string, len(config.Parsed.ProcessedIncludes))
 			for _, v := range config.Parsed.ProcessedIncludes {
 				foundCfg.Include[v.Name], err = util.GetPathRelativeTo(v.Path, opts.RootWorkingDir)
 				if err != nil {

--- a/docs-starlight/src/data/commands/find.mdx
+++ b/docs-starlight/src/data/commands/find.mdx
@@ -79,6 +79,7 @@ flags:
   - find-hidden
   - find-dependencies
   - find-exclude
+  - find-include
   - find-external
   - queue-construct-as
 ---

--- a/docs-starlight/src/data/flags/find-exclude.mdx
+++ b/docs-starlight/src/data/flags/find-exclude.mdx
@@ -3,7 +3,7 @@ name: find-exclude
 description: Include exclude configuration in the output
 type: boolean
 env:
-  - TG_FIND_EXCLUDE
+  - TG_EXCLUDE
 ---
 
 Include exclude configuration in the output. When enabled, the JSON output will include the configurations of the `exclude` block in the discovered units.

--- a/docs-starlight/src/data/flags/find-exclude.mdx
+++ b/docs-starlight/src/data/flags/find-exclude.mdx
@@ -1,5 +1,5 @@
 ---
-name: find-exclude
+name: exclude
 description: Include exclude configuration in the output
 type: boolean
 env:

--- a/docs-starlight/src/data/flags/find-include.mdx
+++ b/docs-starlight/src/data/flags/find-include.mdx
@@ -1,0 +1,41 @@
+---
+name: find-include
+description: Include `include` configuration in the output.
+type: boolean
+env:
+  - TG_INCLUDE
+---
+
+When enabled, JSON output will include the configurations of the `include` block of discovered units.
+
+```bash
+$ terragrunt find --include --format=json | jq
+[
+  {
+    "type": "unit",
+    "path": "bar",
+    "include": {
+      "cloud": "cloud.hcl"
+    }
+  },
+  {
+    "type": "unit",
+    "path": "foo"
+  }
+]
+```
+
+You can use tools like `jq` to filter the output and get all the units that include a specific configuration.
+
+```bash
+$ terragrunt find --include --format=json | jq '[.[] | select(.include.cloud == "cloud.hcl")]'
+[
+  {
+    "type": "unit",
+    "path": "bar",
+    "include": {
+      "cloud": "cloud.hcl"
+    }
+  }
+]
+```

--- a/docs-starlight/src/data/flags/find-include.mdx
+++ b/docs-starlight/src/data/flags/find-include.mdx
@@ -1,5 +1,5 @@
 ---
-name: find-include
+name: include
 description: Include `include` configuration in the output.
 type: boolean
 env:

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -799,6 +799,42 @@ $ terragrunt find --dependencies --format=json | jq
 ]
 ```
 
+##### Find Include
+
+You can also include include configuration in the output using the `--include` flag. When enabled, the JSON output will include the configurations of the `include` block in the discovered units.
+
+```bash
+$ terragrunt find --include --format=json | jq
+[
+  {
+    "type": "unit",
+    "path": "bar",
+    "include": {
+      "cloud": "cloud.hcl"
+    }
+  },
+  {
+    "type": "unit",
+    "path": "foo"
+  }
+]
+```
+
+You can use tools like `jq` to filter the output and get all the units that include a specific configuration.
+
+```bash
+$ terragrunt find --include --format=json | jq '[.[] | select(.include.cloud == "cloud.hcl")]'
+[
+  {
+    "type": "unit",
+    "path": "bar",
+    "include": {
+      "cloud": "cloud.hcl"
+    }
+  }
+]
+```
+
 ##### Find Exclude
 
 You can also include exclude configuration in the output using the `--exclude` flag. When enabled, the JSON output will include the configurations of the `exclude` block in the discovered units.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds a small optimization for the allocation in the includes for the JSON output and adds docs for the `--include` flag.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated implementation of the JSON render of `find` output to pre-allocate the associated map.
Added docs for the new `--include` flag.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation for a new --include flag for the find command, enabling users to include configuration details in JSON output.

- **Documentation**
  - Updated the list of recognized flags for the find command to include find-include.
  - Added detailed usage instructions and examples for the new include flag.
  - Renamed the find-exclude flag to exclude and updated its associated environment variable.
  - Expanded reference documentation to describe the --include flag and its output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->