### PR TITLE
fix: Removing unneecessary input on flake dispatch

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -14,11 +14,11 @@ jobs:
         flake:
           - name: Ubuntu Base tests
             os: ubuntu
-            count: 10
+            count: 3
             timeout: 45m
           - name: macOS Base tests
             os: macos
-            count: 10
+            count: 3
             timeout: 45m
 
     env:

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -3,10 +3,6 @@ on:
   release:
     types: [prereleased]
   workflow_dispatch:
-    inputs:
-      tag_name:
-        description: 'The tag name of the release'
-        required: true
 
 jobs:
   test:


### PR DESCRIPTION
## Description

Accidentally left this in, and it's not necessary.

I also dropped the count to 3. 10 Was taking too long.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Removed unnecessary input from flake workflow dispatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Simplified manual workflow trigger by removing the requirement to enter a tag name when starting the workflow.
  - Reduced the number of test repetitions on Ubuntu and macOS to speed up testing while maintaining test duration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->