### PR TITLE
perf: Optimizing version constraint check

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = go.mod,go.sum,*.svg,Gemfile.lock,bun.lock
-ignore-words-list = dRan,implementors
+ignore-words-list = dRan,implementors,paln

--- a/cli/commands/run/run.go
+++ b/cli/commands/run/run.go
@@ -480,7 +480,14 @@ func RunTerraformWithRetry(ctx context.Context, terragruntOptions *options.Terra
 	for range terragruntOptions.RetryMaxAttempts {
 		if out, err := tf.RunCommandWithOutput(ctx, terragruntOptions, terragruntOptions.TerraformCliArgs...); err != nil {
 			if out == nil || !IsRetryable(terragruntOptions, out) {
-				terragruntOptions.Logger.Errorf("%s invocation failed in %s", terragruntOptions.TerraformImplementation, terragruntOptions.WorkingDir)
+				implementation := options.DefaultWrappedPath
+
+				parts := strings.Split(terragruntOptions.TerraformPath, string(filepath.Separator))
+				if len(parts) > 0 {
+					implementation = parts[len(parts)-1]
+				}
+
+				terragruntOptions.Logger.Errorf("%s invocation failed in %s", implementation, terragruntOptions.WorkingDir)
 
 				return err
 			} else {

--- a/cli/commands/run/version_check.go
+++ b/cli/commands/run/version_check.go
@@ -17,10 +17,6 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-// DefaultTerraformVersionConstraint uses the constraint syntax from https://github.com/hashicorp/go-version
-// This version of Terragrunt was tested to work with Terraform 0.12.0 and above only
-const DefaultTerraformVersionConstraint = ">= v0.12.0"
-
 // TerraformVersionRegex verifies that terraform --version output is in one of the following formats:
 // - OpenTofu v1.6.0-dev
 // - Terraform v0.9.5-dev (cad024a5fe131a546936674ef85445215bbc4226+CHANGES)

--- a/cli/commands/run/version_check.go
+++ b/cli/commands/run/version_check.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"encoding/hex"
 
@@ -84,8 +85,14 @@ func CheckVersionConstraints(ctx context.Context, terragruntOptions *options.Ter
 	return nil
 }
 
+// TerraformVersionMutex is a global mutex for modifying the TerraformVersion field.
+var TerraformVersionMutex sync.Mutex
+
 // PopulateTerraformVersion populates the currently installed version of Terraform into the given terragruntOptions.
 func PopulateTerraformVersion(ctx context.Context, terragruntOptions *options.TerragruntOptions) error {
+	TerraformVersionMutex.Lock()
+	defer TerraformVersionMutex.Unlock()
+
 	versionCache := GetRunVersionCache(ctx)
 	cacheKey := computeVersionFilesCacheKey(terragruntOptions.WorkingDir)
 

--- a/cli/commands/run/version_check.go
+++ b/cli/commands/run/version_check.go
@@ -33,8 +33,8 @@ const versionParts = 3
 
 var versionFiles = []string{".terraform-version", ".tool-versions", "mise.toml", ".mise.toml"}
 
-// CheckVersionConstraints checks the version constraints of both terragrunt and terraform. Note that as a side effect this will set the
-// following settings on terragruntOptions:
+// CheckVersionConstraints checks the version constraints of both terragrunt and terraform.
+// Note that as a side effect this will set the following settings on terragruntOptions:
 // - TerraformPath
 // - TerraformVersion
 // - FeatureFlags
@@ -51,17 +51,16 @@ func CheckVersionConstraints(ctx context.Context, terragruntOptions *options.Ter
 		terragruntOptions.TerraformPath = partialTerragruntConfig.TerraformBinary
 	}
 
-	if err := PopulateTerraformVersion(ctx, terragruntOptions); err != nil {
-		return err
-	}
-
-	terraformVersionConstraint := DefaultTerraformVersionConstraint
 	if partialTerragruntConfig.TerraformVersionConstraint != "" {
-		terraformVersionConstraint = partialTerragruntConfig.TerraformVersionConstraint
-	}
+		if err := PopulateTerraformVersion(ctx, terragruntOptions); err != nil {
+			return err
+		}
 
-	if err := CheckTerraformVersion(terraformVersionConstraint, terragruntOptions); err != nil {
-		return err
+		terraformVersionConstraint := partialTerragruntConfig.TerraformVersionConstraint
+
+		if err := CheckTerraformVersion(terraformVersionConstraint, terragruntOptions); err != nil {
+			return err
+		}
 	}
 
 	if partialTerragruntConfig.TerragruntVersionConstraint != "" {

--- a/test/fixtures/version-invocation/app/terragrunt.hcl
+++ b/test/fixtures/version-invocation/app/terragrunt.hcl
@@ -1,4 +1,3 @@
-
 dependency "dependency" {
   config_path = "../dependency"
 }
@@ -10,3 +9,5 @@ dependency "dependency-with-custom-version" {
 inputs = {
   input_value = dependency.dependency.outputs.result
 }
+
+terraform_version_constraint = ">= 0.12.0"

--- a/test/fixtures/version-invocation/dependency-with-custom-version/terragrunt.hcl
+++ b/test/fixtures/version-invocation/dependency-with-custom-version/terragrunt.hcl
@@ -1,0 +1,1 @@
+terraform_version_constraint = ">= 0.12.0"

--- a/test/fixtures/version-invocation/dependency/terragrunt.hcl
+++ b/test/fixtures/version-invocation/dependency/terragrunt.hcl
@@ -1,0 +1,1 @@
+terraform_version_constraint = ">= 0.12.0"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1083,60 +1083,73 @@ func TestTerraformCommandCliArgs(t *testing.T) {
 
 	testCases := []struct {
 		expectedErr error
+		name        string
 		expected    string
 		command     []string
 	}{
 		{
+			name:     "version",
 			command:  []string{"version"},
 			expected: wrappedBinary() + " version",
 		},
 		{
+			name:     "version with dash",
 			command:  []string{"--", "version"},
 			expected: wrappedBinary() + " version",
 		},
 		{
+			name:     "version with foo",
 			command:  []string{"--", "version", "foo"},
 			expected: wrappedBinary() + " version",
 		},
 		{
+			name:     "version with foo bar baz",
 			command:  []string{"--", "version", "foo", "bar", "baz"},
 			expected: wrappedBinary() + " version",
 		},
 		{
+			name:     "version with foo bar baz foobar",
 			command:  []string{"--", "version", "foo", "bar", "baz", "foobar"},
 			expected: wrappedBinary() + " version",
 		},
 		{
+			name:     "graph",
 			command:  []string{"--", "graph"},
 			expected: "digraph",
 		},
 		{
+			name:        "paln",
 			command:     []string{"--", "paln"}, //codespell:ignore
 			expected:    "",
 			expectedErr: expectedWrongCommandErr("paln"), //codespell:ignore
 		},
 		{
+			name:     "paln with disable-command-validation",
 			command:  []string{"--disable-command-validation", "--", "paln"}, //codespell:ignore
 			expected: wrappedBinary() + " invocation failed",                 // error caused by running terraform with the wrong command
 		},
 	}
 
 	for _, tc := range testCases {
-		cmd := fmt.Sprintf("terragrunt run --non-interactive --log-level trace --working-dir %s %s", testFixtureExtraArgsPath, strings.Join(tc.command, " "))
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-		var (
-			stdout bytes.Buffer
-			stderr bytes.Buffer
-		)
+			cmd := fmt.Sprintf("terragrunt run --non-interactive --log-level trace --working-dir %s %s", testFixtureExtraArgsPath, strings.Join(tc.command, " "))
 
-		err := helpers.RunTerragruntCommand(t, cmd, &stdout, &stderr)
-		if tc.expectedErr != nil {
-			require.ErrorIs(t, err, tc.expectedErr)
-		}
+			var (
+				stdout bytes.Buffer
+				stderr bytes.Buffer
+			)
 
-		output := stdout.String()
-		errOutput := stderr.String()
-		assert.Contains(t, output+errOutput, tc.expected)
+			err := helpers.RunTerragruntCommand(t, cmd, &stdout, &stderr)
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+			}
+
+			output := stdout.String()
+			errOutput := stderr.String()
+			assert.Contains(t, output+errOutput, tc.expected)
+		})
 	}
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4175,12 +4175,15 @@ func TestVersionIsInvokedOnlyOnce(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	testPath := util.JoinPath(tmpEnvPath, testFixtureVersionCheck)
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --log-level trace --non-interactive --working-dir "+testPath+" -- apply")
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := helpers.RunTerragruntVersionCommand(t, "v0.23.21", "terragrunt run --all --log-level trace --non-interactive --working-dir "+testPath+" -- init", &stdout, &stderr)
 	require.NoError(t, err)
 
 	// check that version command was invoked only once -version
 	versionCmdPattern := regexp.MustCompile(`Running command: ` + regexp.QuoteMeta(wrappedBinary()) + ` -version`)
-	matches := versionCmdPattern.FindAllStringIndex(stderr, -1)
+	matches := versionCmdPattern.FindAllStringIndex(stderr.String(), -1)
 
 	assert.Len(t, matches, 1, "Expected exactly one occurrence of '-version' command, found %d", len(matches))
 }


### PR DESCRIPTION
## Description

Makes it so that the version constraint check is opted into when a user uses a version constraint in their configuration.

Drops memory consumption of `BenchmarkManyEmptyTerragruntInits` by 4% relative to `v0.80.2`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Removed default version constraint check.
