### PR TITLE
perf: Deprecating bare includes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -109,7 +109,7 @@ var (
 			hclparse.WithLogger(opts.Logger),
 		}
 
-		strictControl := opts.StrictControls.Find(controls.NakedInclude)
+		strictControl := opts.StrictControls.Find(controls.BareInclude)
 		strictControl.SuppressWarning()
 
 		if err := strictControl.Evaluate(context.Background()); err != nil {
@@ -1394,10 +1394,10 @@ func detectInputsCtyUsage(file *hclparse.File) bool {
 	return false
 }
 
-// detectNakedIncludeUsage detects if an identifier matching include.foo is used in the given HCL file.
+// detectBareIncludeUsage detects if an identifier matching include.foo is used in the given HCL file.
 //
 // This is deprecated functionality, so we look for this to determine if we should throw an error or warning.
-func detectNakedIncludeUsage(file *hclparse.File) bool {
+func detectBareIncludeUsage(file *hclparse.File) bool {
 	body, ok := file.Body.(*hclsyntax.Body)
 	if !ok {
 		return false

--- a/config/config.go
+++ b/config/config.go
@@ -111,10 +111,16 @@ var (
 		}
 
 		strictControl := opts.StrictControls.Find(controls.BareInclude)
-		strictControl.SuppressWarning()
 
-		if err := strictControl.Evaluate(context.Background()); err != nil {
-			return parseOpts
+		// If we can't find the strict control, we're probably in a test
+		// where the option is being hand written. In that case,
+		// we'll assume we're not in strict mode.
+		if strictControl != nil {
+			strictControl.SuppressWarning()
+
+			if err := strictControl.Evaluate(context.Background()); err != nil {
+				return parseOpts
+			}
 		}
 
 		parseOpts = append(parseOpts, hclparse.WithFileUpdate(updateBareIncludeBlock))

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -1398,18 +1399,52 @@ func detectInputsCtyUsage(file *hclparse.File) bool {
 //
 // This is deprecated functionality, so we look for this to determine if we should throw an error or warning.
 func detectBareIncludeUsage(file *hclparse.File) bool {
-	body, ok := file.Body.(*hclsyntax.Body)
-	if !ok {
+	switch filepath.Ext(file.ConfigPath) {
+	case ".json":
+		var data map[string]interface{}
+		if err := json.Unmarshal(file.File.Bytes, &data); err != nil {
+			// If JSON is invalid, it can't be a valid bare include structure.
+			// The main parser will handle the invalid JSON error.
+			return false
+		}
+
+		includeBlockUntyped, exists := data[MetadataInclude]
+		if !exists {
+			return false
+		}
+
+		switch includeBlockTyped := includeBlockUntyped.(type) {
+		case map[string]interface{}:
+			// Delegate to the logic from include.go, which checks if the map
+			// represents a bare include block (e.g., only known include attributes).
+			return jsonIsIncludeBlock(includeBlockTyped)
+		case []interface{}:
+			// A bare include in JSON array form must have exactly one element,
+			// and that element must be an include block.
+			if len(includeBlockTyped) == 1 {
+				if firstElement, ok := includeBlockTyped[0].(map[string]interface{}); ok {
+					return jsonIsIncludeBlock(firstElement)
+				}
+			}
+
+			return false
+		default:
+			return false
+		}
+	default:
+		body, ok := file.Body.(*hclsyntax.Body)
+		if !ok {
+			return false
+		}
+
+		for _, block := range body.Blocks {
+			if block.Type == MetadataInclude && len(block.Labels) == 0 {
+				return true
+			}
+		}
+
 		return false
 	}
-
-	for _, block := range body.Blocks {
-		if block.Type == MetadataInclude && len(block.Labels) == 0 {
-			return true
-		}
-	}
-
-	return false
 }
 
 // iamRoleCache - store for cached values of IAM roles

--- a/config/include.go
+++ b/config/include.go
@@ -806,7 +806,7 @@ func getTrackInclude(ctx *ParsingContext, terragruntIncludeList IncludeConfigs, 
 func updateBareIncludeBlock(file *hclparse.File) error {
 	// To save us from doing a lot of extra work, first going to check to see if the file has a naked include, first.
 	// If it doesn't, we aren't going to bother fully parsing the file.
-	if !detectNakedIncludeUsage(file) {
+	if !detectBareIncludeUsage(file) {
 		return nil
 	}
 

--- a/config/include.go
+++ b/config/include.go
@@ -804,6 +804,12 @@ func getTrackInclude(ctx *ParsingContext, terragruntIncludeList IncludeConfigs, 
 //
 // Returns the updated contents, a boolean indicated whether anything changed, and an error (if any).
 func updateBareIncludeBlock(file *hclparse.File) error {
+	// To save us from doing a lot of extra work, first going to check to see if the file has a naked include, first.
+	// If it doesn't, we aren't going to bother fully parsing the file.
+	if !detectNakedIncludeUsage(file) {
+		return nil
+	}
+
 	var (
 		codeWasUpdated bool
 		content        []byte

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -180,6 +180,7 @@ func New() strict.Controls {
 			Name:        BareInclude,
 			Description: "Prevents the use of the `include` block without a label.",
 			Category:    stageCategory,
+			Error:       errors.New("Using an `include` block without a label is deprecated. Please use the `include` block with a label instead."),
 		},
 	}
 

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -46,6 +46,9 @@ const (
 
 	// CLIRedesign is the control that prevents the use of commands deprecated as part of the CLI Redesign.
 	CLIRedesign = "cli-redesign"
+
+	// NakedInclude is the control that prevents the use of the `include` block without a label.
+	NakedInclude = "naked-include"
 )
 
 //nolint:lll
@@ -171,6 +174,11 @@ func New() strict.Controls {
 		&Control{
 			Name:        "validate-all",
 			Description: "Prevents the deprecated validate-all command from being used.",
+			Category:    stageCategory,
+		},
+		&Control{
+			Name:        NakedInclude,
+			Description: "Prevents the use of the `include` block without a label.",
 			Category:    stageCategory,
 		},
 	}

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -47,8 +47,8 @@ const (
 	// CLIRedesign is the control that prevents the use of commands deprecated as part of the CLI Redesign.
 	CLIRedesign = "cli-redesign"
 
-	// NakedInclude is the control that prevents the use of the `include` block without a label.
-	NakedInclude = "naked-include"
+	// BareInclude is the control that prevents the use of the `include` block without a label.
+	BareInclude = "bare-include"
 )
 
 //nolint:lll
@@ -177,7 +177,7 @@ func New() strict.Controls {
 			Category:    stageCategory,
 		},
 		&Control{
-			Name:        NakedInclude,
+			Name:        BareInclude,
 			Description: "Prevents the use of the `include` block without a label.",
 			Category:    stageCategory,
 		},

--- a/test/fixtures/strict-bare-include/parent.hcl
+++ b/test/fixtures/strict-bare-include/parent.hcl
@@ -1,0 +1,3 @@
+locals {
+  greeting = "hello"
+}

--- a/test/fixtures/strict-bare-include/terragrunt.hcl
+++ b/test/fixtures/strict-bare-include/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = "parent.hcl"
+}

--- a/test/integration_strict_test.go
+++ b/test/integration_strict_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testFixtureStrictBareInclude = "fixtures/strict-bare-include"
+)
+
 // TestStrictMode uses globally mutated state to determine if strict mode has already
 // been triggered, so we don't run it in parallel.
 //
@@ -127,6 +131,65 @@ func TestRootTerragruntHCLStrictMode(t *testing.T) {
 			}
 
 			assert.Contains(t, stderr, tc.expectedStderr)
+		})
+	}
+}
+
+// TestBareIncludeStrictMode uses globally mutated state to determine if strict mode has already
+// been triggered, so we don't run it in parallel.
+//
+//nolint:paralleltest,tparallel
+func TestBareIncludeStrictMode(t *testing.T) {
+	helpers.CleanupTerraformFolder(t, testFixtureStrictBareInclude)
+
+	testCases := []struct {
+		expectedError error
+		name          string
+		controls      []string
+		strictMode    bool
+	}{
+		{
+			name:          "bare include with no strict mode or control",
+			controls:      []string{},
+			strictMode:    false,
+			expectedError: nil,
+		},
+		{
+			name:          "bare include with bare-include strict control",
+			controls:      []string{"bare-include"},
+			strictMode:    false,
+			expectedError: errors.New("Missing name for include; All include blocks must have 1 labels (name)."),
+		},
+		{
+			name:          "bare include with strict mode",
+			controls:      []string{},
+			strictMode:    true,
+			expectedError: errors.New("Missing name for include; All include blocks must have 1 labels (name)."),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStrictBareInclude)
+			rootPath := util.JoinPath(tmpEnvPath, testFixtureStrictBareInclude)
+
+			args := "init --non-interactive --log-level trace --working-dir " + rootPath
+			if tc.strictMode {
+				args = "--strict-mode " + args
+			}
+
+			for _, control := range tc.controls {
+				args = " --strict-control " + control + " " + args
+			}
+
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt "+args)
+
+			if tc.expectedError != nil {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError.Error())
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Deprecates bare includes.

e.g.

```hcl
include {
    path = find_in_parent_folders()
}
```

As part of this change, a check has been added to also exit early from the logic used for backwards compatibility of bare includes, which avoids some expensive work.

Drops memory consumption of `BenchmarkManyEmptyTerragruntInits` by 68% relative to `v0.80.2`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated handling of naked includes to avoid backwards compatibility logic unless absolutely necessary.
Added `naked-include` strict control to allow users to enforce the use of modern `include` blocks.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a strict control to prevent the use of `include` blocks without a label, marking them as deprecated.
- **Bug Fixes**
	- Improved performance by skipping unnecessary processing when deprecated bare `include` blocks are not present.
- **Tests**
	- Added integration tests to verify strict mode behavior for bare `include` blocks.
	- Included new test fixtures for strict mode scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->