### PR TITLE
fix: Get way more aggressive with cleanup

### DIFF
--- a/.github/cloud-nuke/config.yml
+++ b/.github/cloud-nuke/config.yml
@@ -1,5 +1,5 @@
 s3:
-  timeout: 10m
+  timeout: 1h
   include:
     names_regex:
       - "^terragrunt-test-bucket-[a-zA-Z0-9]{6}.*"

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -1,4 +1,4 @@
-name: Daily Cloud Nuke
+name: Hourly Cloud Nuke
 on:
   schedule:
     - cron: "0 * * * *" # Runs every hour

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -1,7 +1,7 @@
 name: Daily Cloud Nuke
 on:
   schedule:
-    - cron: "0 0 * * *" # Runs every day at midnight UTC
+    - cron: "0 * * * *" # Runs every hour
   workflow_dispatch:
 
 
@@ -45,5 +45,5 @@ jobs:
                 --resource-type ec2 \
                 --region us-east-1 \
                 --region us-west-2 \
-                --older-than 24h \
+                --older-than 1h \
                 --config .github/cloud-nuke/config.yml


### PR DESCRIPTION
## Description

Updates the cron so that it runs every hour.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated cron for `cloud-nuke` to run every hour.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Increased the timeout for S3 resource cleanup operations.
	- Updated automated cleanup to run every hour instead of once daily, with resources now deleted if older than 1 hour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->