### PR TITLE
Add tf-path flag to exec command

### DIFF
--- a/cli/commands/exec/cli.go
+++ b/cli/commands/exec/cli.go
@@ -28,6 +28,7 @@ func NewFlags(opts *options.TerragruntOptions, cmdOpts *Options, prefix flags.Pr
 		run.IAMAssumeRoleDurationFlagName,
 		run.IAMAssumeRoleSessionNameFlagName,
 		run.IAMAssumeRoleWebIdentityTokenFlagName,
+		run.TFPathFlagName,
 	),
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        InDownloadDirFlagName,
@@ -35,23 +36,7 @@ func NewFlags(opts *options.TerragruntOptions, cmdOpts *Options, prefix flags.Pr
 			Destination: &cmdOpts.InDownloadDir,
 			Usage:       "Run the provided command in the download directory.",
 		}),
-		NewTFPathFlag(opts, prefix),
 	)
-}
-
-// NewTFPathFlag creates a flag for specifying the OpenTofu/Terraform binary path.
-func NewTFPathFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.Flag {
-	tgPrefix := prefix.Prepend(flags.TgPrefix)
-	terragruntPrefix := prefix.Prepend(flags.TerragruntPrefix)
-	terragruntPrefixControl := flags.StrictControlsByGlobalFlags(opts.StrictControls)
-
-	return flags.NewFlag(&cli.GenericFlag[string]{
-		Name:        TFPathFlagName,
-		EnvVars:     tgPrefix.EnvVars(TFPathFlagName),
-		Destination: &opts.TerraformPath,
-		Usage:       "Path to the OpenTofu/Terraform binary. Default is tofu (on PATH).",
-	},
-		flags.WithDeprecatedNames(terragruntPrefix.FlagNames("tfpath"), terragruntPrefixControl))
 }
 
 func NewCommand(opts *options.TerragruntOptions) *cli.Command {

--- a/cli/commands/exec/cli.go
+++ b/cli/commands/exec/cli.go
@@ -13,6 +13,7 @@ const (
 	CommandName = "exec"
 
 	InDownloadDirFlagName = "in-download-dir"
+	TFPathFlagName        = "tf-path"
 )
 
 func NewFlags(opts *options.TerragruntOptions, cmdOpts *Options, prefix flags.Prefix) cli.Flags {
@@ -34,7 +35,23 @@ func NewFlags(opts *options.TerragruntOptions, cmdOpts *Options, prefix flags.Pr
 			Destination: &cmdOpts.InDownloadDir,
 			Usage:       "Run the provided command in the download directory.",
 		}),
+		NewTFPathFlag(opts, prefix),
 	)
+}
+
+// NewTFPathFlag creates a flag for specifying the OpenTofu/Terraform binary path.
+func NewTFPathFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.Flag {
+	tgPrefix := prefix.Prepend(flags.TgPrefix)
+	terragruntPrefix := prefix.Prepend(flags.TerragruntPrefix)
+	terragruntPrefixControl := flags.StrictControlsByGlobalFlags(opts.StrictControls)
+
+	return flags.NewFlag(&cli.GenericFlag[string]{
+		Name:        TFPathFlagName,
+		EnvVars:     tgPrefix.EnvVars(TFPathFlagName),
+		Destination: &opts.TerraformPath,
+		Usage:       "Path to the OpenTofu/Terraform binary. Default is tofu (on PATH).",
+	},
+		flags.WithDeprecatedNames(terragruntPrefix.FlagNames("tfpath"), terragruntPrefixControl))
 }
 
 func NewCommand(opts *options.TerragruntOptions) *cli.Command {

--- a/test/fixtures/exec-cmd-tf-path/app/main.tf
+++ b/test/fixtures/exec-cmd-tf-path/app/main.tf
@@ -1,0 +1,3 @@
+variable "baz" {
+  type = string
+}

--- a/test/fixtures/exec-cmd-tf-path/app/terragrunt.hcl
+++ b/test/fixtures/exec-cmd-tf-path/app/terragrunt.hcl
@@ -1,0 +1,11 @@
+terraform {
+  source = "."
+}
+
+dependency "dep" {
+    config_path = "../dep"
+}
+
+inputs = {
+  baz = dependency.dep.outputs.baz
+}

--- a/test/fixtures/exec-cmd-tf-path/dep/main.tf
+++ b/test/fixtures/exec-cmd-tf-path/dep/main.tf
@@ -1,0 +1,3 @@
+output "baz" {
+  value = "baz"
+}

--- a/test/fixtures/exec-cmd-tf-path/dep/terragrunt.hcl
+++ b/test/fixtures/exec-cmd-tf-path/dep/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/fixtures/exec-cmd-tf-path/script.sh
+++ b/test/fixtures/exec-cmd-tf-path/script.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "baz is ${TF_VAR_baz:-not set}"

--- a/test/fixtures/exec-cmd-tf-path/terraform-output-json.sh
+++ b/test/fixtures/exec-cmd-tf-path/terraform-output-json.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Handle -version
+if [ "$1" = "-version" ]; then
+  echo "Terraform v1.0.0"
+  exit 0
+fi
+
+# Output variable
+cat << 'EOF'
+{
+"baz": {
+  "sensitive": false,
+  "type": "string",
+  "value": "terraform"
+}
+}
+EOF

--- a/test/fixtures/exec-cmd-tf-path/tofu-output-json.sh
+++ b/test/fixtures/exec-cmd-tf-path/tofu-output-json.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Handle -version
+if [ "$1" = "-version" ]; then
+  echo "OpenToFu v1.0.0"
+  exit 0
+fi
+
+# Output variable
+cat << 'EOF'
+{
+"baz": {
+  "sensitive": false,
+  "type": "string",
+  "value": "tofu"
+}
+}
+EOF

--- a/test/integration_exec_test.go
+++ b/test/integration_exec_test.go
@@ -1,0 +1,111 @@
+package test_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecCommand(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		scriptPath string
+		runInDir   string
+		args       []string
+	}{
+		{
+			scriptPath: "./script.sh arg1 arg2",
+			runInDir:   "",
+		},
+		{
+			args:       []string{"--in-download-dir"},
+			scriptPath: "./script.sh arg1 arg2",
+			runInDir:   ".terragrunt-cache",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			helpers.CleanupTerraformFolder(t, testFixtureExecCmd)
+			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureExecCmd)
+
+			rootPath := util.JoinPath(tmpEnvPath, testFixtureExecCmd, "app")
+			rootPath, err := filepath.EvalSymlinks(rootPath)
+			require.NoError(t, err)
+
+			downloadDirPath := util.JoinPath(rootPath, ".terragrunt-cache")
+			scriptPath := util.JoinPath(tmpEnvPath, testFixtureExecCmd, tc.scriptPath)
+
+			err = os.Mkdir(downloadDirPath, os.ModePerm)
+			require.NoError(t, err)
+
+			stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt exec --working-dir "+rootPath+" "+strings.Join(tc.args, " ")+" -- "+scriptPath)
+			require.NoError(t, err)
+			assert.Contains(t, stdout, "The first arg is arg1. The second arg is arg2. The script is running in the directory "+util.JoinPath(rootPath, tc.runInDir))
+		})
+	}
+}
+
+func TestExecCommandTfPath(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		expected string
+		tfPath   string
+	}{
+		{
+			expected: "baz is baz",
+		},
+		{
+			expected: "baz is terraform",
+			tfPath:   "terraform-output-json.sh",
+		},
+		{
+			expected: "baz is tofu",
+			tfPath:   "tofu-output-json.sh",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			helpers.CleanupTerraformFolder(t, testFixtureExecCmdTfPath)
+			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureExecCmdTfPath)
+
+			rootPath := util.JoinPath(tmpEnvPath, testFixtureExecCmdTfPath, "app")
+			rootPath, err := filepath.EvalSymlinks(rootPath)
+			require.NoError(t, err)
+
+			downloadDirPath := util.JoinPath(rootPath, ".terragrunt-cache")
+			scriptPath := util.JoinPath(tmpEnvPath, testFixtureExecCmdTfPath, "./script.sh")
+			tfPath := ""
+			if tc.tfPath != "" {
+				tfPath = "--tf-path " + util.JoinPath(tmpEnvPath, testFixtureExecCmdTfPath, tc.tfPath)
+			}
+
+			err = os.Mkdir(downloadDirPath, os.ModePerm)
+			require.NoError(t, err)
+
+			depPath := util.JoinPath(tmpEnvPath, testFixtureExecCmdTfPath, "dep")
+			depStdout := bytes.Buffer{}
+			depStderr := bytes.Buffer{}
+			require.NoError(t, helpers.RunTerragruntCommand(t, "terragrunt apply -auto-approve --non-interactive -no-color --no-color --log-format=pretty --working-dir "+depPath, &depStdout, &depStderr))
+
+			stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt --log-level debug exec "+tfPath+" --working-dir "+rootPath+"  -- "+scriptPath)
+			require.NoError(t, err)
+			assert.Contains(t, stdout, tc.expected)
+		})
+	}
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -106,6 +106,7 @@ const (
 	testFixtureStdout                         = "fixtures/download/stdout-test"
 	testFixtureTfTest                         = "fixtures/tftest/"
 	testFixtureExecCmd                        = "fixtures/exec-cmd"
+	testFixtureExecCmdTfPath                  = "fixtures/exec-cmd-tf-path"
 	textFixtureDisjointSymlinks               = "fixtures/stack/disjoint-symlinks"
 	testFixtureLogStreaming                   = "fixtures/streaming"
 	testFixtureCLIFlagHints                   = "fixtures/cli-flag-hints"
@@ -149,49 +150,6 @@ func TestCLIFlagHints(t *testing.T) {
 
 			_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt "+tc.args+" --working-dir "+rootPath)
 			assert.EqualError(t, err, tc.expectedError.Error())
-		})
-	}
-}
-
-func TestExecCommand(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		scriptPath string
-		runInDir   string
-		args       []string
-	}{
-		{
-			scriptPath: "./script.sh arg1 arg2",
-			runInDir:   "",
-		},
-		{
-			args:       []string{"--in-download-dir"},
-			scriptPath: "./script.sh arg1 arg2",
-			runInDir:   ".terragrunt-cache",
-		},
-	}
-
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
-			t.Parallel()
-
-			helpers.CleanupTerraformFolder(t, testFixtureExecCmd)
-			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureExecCmd)
-
-			rootPath := util.JoinPath(tmpEnvPath, testFixtureExecCmd, "app")
-			rootPath, err := filepath.EvalSymlinks(rootPath)
-			require.NoError(t, err)
-
-			downloadDirPath := util.JoinPath(rootPath, ".terragrunt-cache")
-			scriptPath := util.JoinPath(tmpEnvPath, testFixtureExecCmd, tc.scriptPath)
-
-			err = os.Mkdir(downloadDirPath, os.ModePerm)
-			require.NoError(t, err)
-
-			stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt exec --working-dir "+rootPath+" "+strings.Join(tc.args, " ")+" -- "+scriptPath)
-			require.NoError(t, err)
-			assert.Contains(t, stdout, "The first arg is arg1. The second arg is arg2. The script is running in the directory "+util.JoinPath(rootPath, tc.runInDir))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->
This change adds the `--tf-path` flag to the `exec` command.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added support for --tf-path in exec command.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new CLI flag to the exec command, allowing users to specify the path to the OpenTofu/Terraform binary.
	- Introduced support for Terraform variable inputs and dependencies in configuration files.
	- Added new scripts to facilitate environment variable handling and output formatting.
- **Tests**
	- Added comprehensive integration tests to validate exec command behavior with new flag and script execution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->