### PR TITLE
fix: Reverting to defer on cleanup for docs test

### DIFF
--- a/test/integration_docs_aws_test.go
+++ b/test/integration_docs_aws_test.go
@@ -33,13 +33,11 @@ func TestAwsDocsOverview(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		t.Cleanup(func() {
-			helpers.DeleteS3Bucket(t, region, s3BucketName)
-		})
-		t.Cleanup(func() {
+		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
+		defer func() {
 			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt destroy -auto-approve --non-interactive --working-dir "+rootPath)
 			require.NoError(t, err)
-		})
+		}()
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, config.DefaultTerragruntConfigPath)
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
@@ -59,13 +57,11 @@ func TestAwsDocsOverview(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		t.Cleanup(func() {
-			helpers.DeleteS3Bucket(t, region, s3BucketName)
-		})
-		t.Cleanup(func() {
+		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
+		defer func() {
 			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --working-dir "+rootPath+" -- destroy -auto-approve")
 			require.NoError(t, err)
-		})
+		}()
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
@@ -85,13 +81,11 @@ func TestAwsDocsOverview(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		t.Cleanup(func() {
-			helpers.DeleteS3Bucket(t, region, s3BucketName)
-		})
-		t.Cleanup(func() {
+		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
+		defer func() {
 			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --working-dir "+rootPath+" -- destroy -auto-approve")
 			require.NoError(t, err)
-		})
+		}()
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
@@ -111,13 +105,11 @@ func TestAwsDocsOverview(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		t.Cleanup(func() {
-			helpers.DeleteS3Bucket(t, region, s3BucketName)
-		})
-		t.Cleanup(func() {
+		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
+		defer func() {
 			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --working-dir "+rootPath+" -- destroy -auto-approve")
 			require.NoError(t, err)
-		})
+		}()
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)
@@ -137,13 +129,11 @@ func TestAwsDocsOverview(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, stepPath)
 		rootPath := util.JoinPath(tmpEnvPath, stepPath)
 
-		t.Cleanup(func() {
-			helpers.DeleteS3Bucket(t, region, s3BucketName)
-		})
-		t.Cleanup(func() {
+		defer helpers.DeleteS3Bucket(t, region, s3BucketName)
+		defer func() {
 			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --working-dir "+rootPath+" -- destroy -auto-approve")
 			require.NoError(t, err)
-		})
+		}()
 
 		rootTerragruntConfigPath := util.JoinPath(rootPath, "root.hcl")
 		helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", region)


### PR DESCRIPTION
## Description

Fixes issue with docs test cleanup.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated docs tests to use defer over `t.Cleanup`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test cleanup logic to improve consistency and reliability during integration testing. No changes to test coverage or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->