### PR TITLE
perf: Memoizing parsing context creation

### DIFF
--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -136,9 +136,21 @@ type terragruntEngine struct {
 func DecodeBaseBlocks(ctx *ParsingContext, file *hclparse.File, includeFromChild *IncludeConfig) (*DecodedBaseBlocks, error) {
 	errs := &errors.MultiError{}
 
-	evalParsingContext, err := createTerragruntEvalContext(ctx, file.ConfigPath)
-	if err != nil {
-		return nil, err
+	evalCtxCache := cache.ContextCache[*hcl.EvalContext](ctx, EvalCtxCacheContextKey)
+
+	var evalParsingContext *hcl.EvalContext
+
+	if found, ok := evalCtxCache.Get(ctx, file.ConfigPath); ok {
+		evalParsingContext = found
+	} else {
+		var err error
+
+		evalParsingContext, err = createTerragruntEvalContext(ctx, file.ConfigPath)
+		if err != nil {
+			return nil, err
+		}
+
+		evalCtxCache.Put(ctx, file.ConfigPath, evalParsingContext)
 	}
 
 	// Decode just the `include` and `import` blocks, and verify that it's allowed here
@@ -398,9 +410,19 @@ func PartialParseConfig(ctx *ParsingContext, file *hclparse.File, includeFromChi
 
 	output.IsPartial = true
 
-	evalParsingContext, err := createTerragruntEvalContext(ctx, file.ConfigPath)
-	if err != nil {
-		return nil, err
+	evalCtxCache := cache.ContextCache[*hcl.EvalContext](ctx, EvalCtxCacheContextKey)
+
+	var evalParsingContext *hcl.EvalContext
+
+	if found, ok := evalCtxCache.Get(ctx, file.ConfigPath); ok {
+		evalParsingContext = found
+	} else {
+		evalParsingContext, err = createTerragruntEvalContext(ctx, file.ConfigPath)
+		if err != nil {
+			return nil, err
+		}
+
+		evalCtxCache.Put(ctx, file.ConfigPath, evalParsingContext)
 	}
 
 	// Now loop through each requested block / component to decode from the terragrunt config, decode them, and merge

--- a/config/context.go
+++ b/config/context.go
@@ -5,20 +5,25 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/internal/cache"
+	"github.com/hashicorp/hcl/v2"
 )
 
 type configKey byte
 
 const (
-	HclCacheContextKey              configKey = iota
-	TerragruntConfigCacheContextKey configKey = iota
-	RunCmdCacheContextKey           configKey = iota
-	DependencyOutputCacheContextKey configKey = iota
+	HclCacheContextKey configKey = iota
+	TerragruntConfigCacheContextKey
+	RunCmdCacheContextKey
+	DependencyOutputCacheContextKey
+	EvalCtxCacheContextKey
+)
 
+const (
 	hclCacheName              = "hclCache"
 	configCacheName           = "configCache"
 	runCmdCacheName           = "runCmdCache"
 	dependencyOutputCacheName = "dependencyOutputCache"
+	evalCtxCacheName          = "evalCtxCache"
 )
 
 // WithConfigValues add to context default values for configuration.
@@ -27,6 +32,7 @@ func WithConfigValues(ctx context.Context) context.Context {
 	ctx = context.WithValue(ctx, TerragruntConfigCacheContextKey, cache.NewCache[*TerragruntConfig](configCacheName))
 	ctx = context.WithValue(ctx, RunCmdCacheContextKey, cache.NewCache[string](runCmdCacheName))
 	ctx = context.WithValue(ctx, DependencyOutputCacheContextKey, cache.NewCache[*dependencyOutputCache](dependencyOutputCacheName))
+	ctx = context.WithValue(ctx, EvalCtxCacheContextKey, cache.NewCache[*hcl.EvalContext](evalCtxCacheName))
 
 	return ctx
 }

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/go-getter"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
@@ -195,9 +196,21 @@ var outputLocks = sync.Map{}
 //
 //	consider whether or not the implementation of the cyclic dependency detection still makes sense.
 func decodeAndRetrieveOutputs(ctx *ParsingContext, file *hclparse.File) (*cty.Value, error) {
-	evalParsingContext, err := createTerragruntEvalContext(ctx, file.ConfigPath)
-	if err != nil {
-		return nil, err
+	evalCtxCache := cache.ContextCache[*hcl.EvalContext](ctx, EvalCtxCacheContextKey)
+
+	var evalParsingContext *hcl.EvalContext
+
+	if found, ok := evalCtxCache.Get(ctx, file.ConfigPath); ok {
+		evalParsingContext = found
+	} else {
+		var err error
+
+		evalParsingContext, err = createTerragruntEvalContext(ctx, file.ConfigPath)
+		if err != nil {
+			return nil, err
+		}
+
+		evalCtxCache.Put(ctx, file.ConfigPath, evalParsingContext)
 	}
 
 	decodedDependency := TerragruntDependency{}
@@ -652,9 +665,22 @@ func getOutputJSONWithCaching(ctx *ParsingContext, targetConfig string) ([]byte,
 //
 // That way, everything in that dependency happens within its own ctx.
 func cloneTerragruntOptionsForDependency(ctx *ParsingContext, targetConfigPath string) (*options.TerragruntOptions, error) {
-	targetOptions, err := ctx.TerragruntOptions.CloneWithConfigPath(targetConfigPath)
-	if err != nil {
-		return nil, err
+	optsCache := cache.ContextCache[*options.TerragruntOptions](ctx, targetConfigPath)
+
+	var targetOptions *options.TerragruntOptions
+
+	found, ok := optsCache.Get(ctx, targetConfigPath)
+	if ok {
+		targetOptions = found
+	} else {
+		var err error
+
+		targetOptions, err = ctx.TerragruntOptions.CloneWithConfigPath(targetConfigPath)
+		if err != nil {
+			return nil, err
+		}
+
+		optsCache.Put(ctx, targetConfigPath, targetOptions)
 	}
 
 	targetOptions.OriginalTerragruntConfigPath = targetConfigPath

--- a/config/exclude.go
+++ b/config/exclude.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/config/hclparse"
+	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -90,10 +92,22 @@ func evaluateExcludeBlocks(ctx *ParsingContext, file *hclparse.File) (*ExcludeCo
 		return nil, err
 	}
 
-	evalCtx, err := createTerragruntEvalContext(ctx, file.ConfigPath)
-	if err != nil {
-		ctx.TerragruntOptions.Logger.Errorf("Failed to create eval context %s", file.ConfigPath)
-		return nil, err
+	evalCtxCache := cache.ContextCache[*hcl.EvalContext](ctx, EvalCtxCacheContextKey)
+
+	var evalCtx *hcl.EvalContext
+
+	if found, ok := evalCtxCache.Get(ctx, file.ConfigPath); ok {
+		evalCtx = found
+	} else {
+		var err error
+
+		evalCtx, err = createTerragruntEvalContext(ctx, file.ConfigPath)
+		if err != nil {
+			ctx.TerragruntOptions.Logger.Errorf("Failed to create eval context %s", file.ConfigPath)
+			return nil, err
+		}
+
+		evalCtxCache.Put(ctx, file.ConfigPath, evalCtx)
 	}
 
 	evaluatedAttrs := map[string]cty.Value{}

--- a/config/stack.go
+++ b/config/stack.go
@@ -9,12 +9,14 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/telemetry"
 
+	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/worker"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/hashicorp/go-getter/v2"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/gruntwork-io/terragrunt/util"
@@ -708,19 +710,31 @@ func ReadStackConfigString(
 }
 
 // ParseStackConfig parses the stack configuration from the given file and values.
-func ParseStackConfig(parser *ParsingContext, opts *options.TerragruntOptions, file *hclparse.File, values *cty.Value) (*StackConfig, error) {
+func ParseStackConfig(ctx *ParsingContext, opts *options.TerragruntOptions, file *hclparse.File, values *cty.Value) (*StackConfig, error) {
 	if values != nil {
-		parser = parser.WithValues(values)
+		ctx = ctx.WithValues(values)
 	}
 
 	//nolint:contextcheck
-	if err := processLocals(parser, opts, file); err != nil {
+	if err := processLocals(ctx, opts, file); err != nil {
 		return nil, errors.New(err)
 	}
 	//nolint:contextcheck
-	evalParsingContext, err := createTerragruntEvalContext(parser, file.ConfigPath)
-	if err != nil {
-		return nil, errors.New(err)
+	evalCtxCache := cache.ContextCache[*hcl.EvalContext](ctx, EvalCtxCacheContextKey)
+
+	var evalParsingContext *hcl.EvalContext
+
+	if found, ok := evalCtxCache.Get(ctx, file.ConfigPath); ok {
+		evalParsingContext = found
+	} else {
+		var err error
+
+		evalParsingContext, err = createTerragruntEvalContext(ctx, file.ConfigPath)
+		if err != nil {
+			return nil, errors.New(err)
+		}
+
+		evalCtxCache.Put(ctx, file.ConfigPath, evalParsingContext)
 	}
 
 	config := &StackConfigFile{}
@@ -729,8 +743,10 @@ func ParseStackConfig(parser *ParsingContext, opts *options.TerragruntOptions, f
 	}
 
 	localsParsed := map[string]any{}
-	if parser.Locals != nil {
-		localsParsed, err = ctyhelper.ParseCtyValueToMap(*parser.Locals)
+	if ctx.Locals != nil {
+		var err error
+
+		localsParsed, err = ctyhelper.ParseCtyValueToMap(*ctx.Locals)
 		if err != nil {
 			return nil, errors.New(err)
 		}
@@ -806,11 +822,22 @@ func ReadValues(ctx context.Context, opts *options.TerragruntOptions, directory 
 	if err != nil {
 		return nil, errors.New(err)
 	}
-	//nolint:contextcheck
-	evalParsingContext, err := createTerragruntEvalContext(parser, file.ConfigPath)
 
-	if err != nil {
-		return nil, errors.New(err)
+	evalCtxCache := cache.ContextCache[*hcl.EvalContext](ctx, EvalCtxCacheContextKey)
+
+	var evalParsingContext *hcl.EvalContext
+
+	if found, ok := evalCtxCache.Get(ctx, file.ConfigPath); ok {
+		evalParsingContext = found
+	} else {
+		var err error
+
+		evalParsingContext, err = createTerragruntEvalContext(parser, file.ConfigPath)
+		if err != nil {
+			return nil, errors.New(err)
+		}
+
+		evalCtxCache.Put(ctx, file.ConfigPath, evalParsingContext)
 	}
 
 	values := map[string]cty.Value{}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Memoizes `EvalContext` creation to avoid unnecessary allocations from `createTerragruntEvalContext`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added memoization for `EvalContext` creation to avoid unnecessary allocations from `createTerragruntEvalContext`.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

