### PR TITLE
bug: fixed setting of exit cide

### DIFF
--- a/cli/commands/run/run.go
+++ b/cli/commands/run/run.go
@@ -485,6 +485,10 @@ func RunTerraformWithRetry(ctx context.Context, terragruntOptions *options.Terra
 				return err
 			} else {
 				terragruntOptions.Logger.Infof("Encountered an error eligible for retrying. Sleeping %v before retrying.\n", terragruntOptions.RetrySleepInterval)
+				// Reset the exit code to success so that we can retry the command
+				if exitCode := tf.DetailedExitCodeFromContext(ctx); exitCode != nil {
+					exitCode.ResetSuccess()
+				}
 				select {
 				case <-time.After(terragruntOptions.RetrySleepInterval):
 					// try again

--- a/tf/detailed_exitcode.go
+++ b/tf/detailed_exitcode.go
@@ -4,6 +4,10 @@ import (
 	"sync"
 )
 
+const (
+	DetailedExitCodeError = 1
+)
+
 // DetailedExitCode is the TF detailed exit code. https://opentofu.org/docs/cli/commands/plan/
 type DetailedExitCode struct {
 	Code int
@@ -22,9 +26,18 @@ func (coder *DetailedExitCode) Get() int {
 // - 0 = Success
 // - 1 = Error
 // - 2 = Success with changes pending
+// The method only updates if:
+// - The current code is not 1 (error state)
+// - The new code is greater than current OR equals 1
 func (coder *DetailedExitCode) Set(newCode int) {
 	coder.mu.Lock()
 	defer coder.mu.Unlock()
 
-	coder.Code = newCode
+	if coder.Code == DetailedExitCodeError {
+		return
+	}
+
+	if coder.Code < newCode || newCode == DetailedExitCodeError {
+		coder.Code = newCode
+	}
 }

--- a/tf/detailed_exitcode.go
+++ b/tf/detailed_exitcode.go
@@ -5,7 +5,8 @@ import (
 )
 
 const (
-	DetailedExitCodeError = 1
+	DetailedExitCodeSuccess = 0
+	DetailedExitCodeError   = 1
 )
 
 // DetailedExitCode is the TF detailed exit code. https://opentofu.org/docs/cli/commands/plan/
@@ -14,12 +15,20 @@ type DetailedExitCode struct {
 	mu   sync.RWMutex
 }
 
-// Get returns exit code.
+// Get return exit code.
 func (coder *DetailedExitCode) Get() int {
 	coder.mu.RLock()
 	defer coder.mu.RUnlock()
 
 	return coder.Code
+}
+
+// ResetSuccess resets the exit code to success (0).
+func (coder *DetailedExitCode) ResetSuccess() {
+	coder.mu.Lock()
+	defer coder.mu.Unlock()
+
+	coder.Code = DetailedExitCodeSuccess
 }
 
 // Set updates the exit code following OpenTofu's exit code convention:

--- a/tf/run_cmd.go
+++ b/tf/run_cmd.go
@@ -74,10 +74,6 @@ func RunCommandWithOutput(ctx context.Context, opts *options.TerragruntOptions, 
 		if code != 1 {
 			return output, nil
 		}
-	} else {
-		if exitCode := DetailedExitCodeFromContext(ctx); exitCode != nil {
-			exitCode.Set(0)
-		}
 	}
 
 	return output, err


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Fixed setting of exit code when detailed-exitcode is set
* Updated retry logic to reset exit code when the retry is handled
* Added unit test to track that in case of multiple unit, change in one unit set exit code

Fixes #4292.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

