### PR TITLE
fix: Adjusting tf check so that it's easier to update

### DIFF
--- a/cli/commands/run/run.go
+++ b/cli/commands/run/run.go
@@ -532,6 +532,7 @@ func prepareInitCommand(ctx context.Context, terragruntOptions *options.Terragru
 	return nil
 }
 
+// CheckFolderContainsTerraformCode checks if the folder contains Terraform/OpenTofu code
 func CheckFolderContainsTerraformCode(terragruntOptions *options.TerragruntOptions) error {
 	found := false
 
@@ -544,7 +545,7 @@ func CheckFolderContainsTerraformCode(terragruntOptions *options.TerragruntOptio
 			return nil
 		}
 
-		if strings.HasSuffix(path, ".tf") || strings.HasSuffix(path, ".tofu") || strings.HasSuffix(path, ".tf.json") || strings.HasSuffix(path, ".tofu.json") {
+		if isTofuFile(path) {
 			found = true
 
 			return filepath.SkipAll
@@ -562,6 +563,24 @@ func CheckFolderContainsTerraformCode(terragruntOptions *options.TerragruntOptio
 	}
 
 	return nil
+}
+
+// isTofuFile checks if a given file is an OpenTofu/Terraform file
+func isTofuFile(path string) bool {
+	suffixes := []string{
+		".tf",
+		".tofu",
+		".tf.json",
+		".tofu.json",
+	}
+
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Check that the specified Terraform code defines a backend { ... } block and return an error if doesn't


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Extracts the logic for checking if a file is an OpenTofu/Terraform file so that it's easier to update in the future.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `CheckFolderContainsTerraformCode` check.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal logic for detecting Terraform and OpenTofu files, resulting in more maintainable and readable code. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->