### PR TITLE
fix: Fixing reference to `relative_path_to_include`

### DIFF
--- a/docs-starlight/src/data/commands/backend/migrate.mdx
+++ b/docs-starlight/src/data/commands/backend/migrate.mdx
@@ -26,7 +26,7 @@ import { FileTree } from '@astrojs/starlight/components';
 
 This command will migrate the OpenTofu/Terraform state backend from one unit to another.
 
-You will typically want to use this command if you are using a `key` attribute for your `remote_state` block that uses the `relative_path_to_include` function, and you want to rename the unit.
+You will typically want to use this command if you are using a `key` attribute for your `remote_state` block that uses the `path_relative_to_include` function, and you want to rename the unit.
 
 For example, given the following filesystem structure:
 

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -480,7 +480,7 @@ terragrunt backend migrate old-unit new-unit
 
 This command will migrate the OpenTofu/Terraform state backend from the old unit to the new unit.
 
-You will typically want to use this command if you are using a `key` attribute for your `remote_state` block that uses the `relative_path_to_include` function, and you want to rename the unit.
+You will typically want to use this command if you are using a `key` attribute for your `remote_state` block that uses the `path_relative_to_include` function, and you want to rename the unit.
 
 For example, given the following filesystem structure:
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4329.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated reference to `relative_path_to_include` so that it correctly uses `path_relative_to_include` instead.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

