### PR TITLE
fix: Always run CI on push

### DIFF
--- a/.github/workflows/base-test.yml
+++ b/.github/workflows/base-test.yml
@@ -2,10 +2,6 @@ name: Base Tests
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/.github/workflows/build-no-proxy.yml
+++ b/.github/workflows/build-no-proxy.yml
@@ -2,10 +2,6 @@ name: Build Without Go Proxy
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   build-no-proxy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,6 @@ name: Build
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   build:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,10 +2,6 @@ name: Codespell
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   codespell:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,10 +2,6 @@ name: Integration Tests
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -2,10 +2,6 @@ name: License Check
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   license-check:
@@ -39,4 +35,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: license-check-report-ubuntu
-          path: license-check.log 
+          path: license-check.log

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,10 +2,6 @@ name: Lint
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   lint:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -2,10 +2,6 @@ name: Markdown Lint
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   markdownlint:

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -6,10 +6,6 @@ name: OIDC Integration Tests
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 permissions:
   id-token: write

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -2,10 +2,6 @@ name: Pre-commit
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   precommit:

--- a/.github/workflows/strict-lint.yml
+++ b/.github/workflows/strict-lint.yml
@@ -1,8 +1,7 @@
 name: Strict Lint
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  push:
 
 jobs:
   lint:


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This should make it easier to test external PRs, as we can just push our own branch of external PRs to trigger CI.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated GitHub Actions workflow triggers to run on push instead of pull request.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow triggers so that automated jobs now run on all push events, regardless of branch, and no longer run on pull request events.
	- Minor cleanup in workflow configurations, including removal of unnecessary branch filters and event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->