### PR TITLE
chore: Deprecating bare includes

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/codegen"
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
@@ -524,6 +525,7 @@ include {
 	opts := &options.TerragruntOptions{
 		TerragruntConfigPath: "../test/fixtures/parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/" + config.DefaultTerragruntConfigPath,
 		NonInteractive:       true,
+		StrictControls:       controls.New(),
 	}
 
 	l := createLogger()
@@ -1358,6 +1360,7 @@ terraform {
 		TerragruntConfigPath: "../test/fixtures/parent-folders/terragrunt-in-root/child/" + config.DefaultTerragruntConfigPath,
 		NonInteractive:       true,
 		MaxFoldersToCheck:    5,
+		StrictControls:       controls.New(),
 	}
 
 	l := createLogger()

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -181,6 +181,7 @@ func New() strict.Controls {
 			Description: "Prevents the use of the `include` block without a label.",
 			Category:    stageCategory,
 			Error:       errors.New("Using an `include` block without a label is deprecated. Please use the `include` block with a label instead."),
+			Warning:     "Using an `include` block without a label is deprecated. Please use the `include` block with a label instead. For more information, see https://terragrunt.gruntwork.io/docs/migrate/bare-include/",
 		},
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fully deprecates bare includes, including a deprecation warning.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated check for bare includes to emit warning when they're used.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved detection and handling of deprecated configuration options, consolidating checks for deprecated usage into a single process.

- **Bug Fixes**
	- Enhanced strict control evaluation to better catch deprecated usage of bare include blocks and inputs.cty.

- **Tests**
	- Updated tests to initialize strict controls for more accurate validation.

- **Documentation**
	- Added warning messages with additional guidance and migration information for deprecated include usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->