### PR TITLE
perf: Moving logging opts out of TerragruntOptions

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -53,8 +53,8 @@ func NewApp(l log.Logger, opts *options.TerragruntOptions) *App {
 	app.Usage = "Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale.\nFor documentation, see https://terragrunt.gruntwork.io/."
 	app.Author = "Gruntwork <www.gruntwork.io>"
 	app.Version = version.GetVersion()
-	app.Writer = opts.Writer
-	app.ErrWriter = opts.ErrWriter
+	app.Writer = opts.LoggingOptions.Writer
+	app.ErrWriter = opts.LoggingOptions.ErrWriter
 	app.Flags = global.NewFlagsWithDeprecatedMovedFlags(l, opts)
 	app.Commands = terragruntCommands.WrapAction(commands.WrapWithTelemetry(l, opts))
 	app.Before = beforeAction(opts)

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -216,7 +216,7 @@ func assertOptionsEqual(t *testing.T, expected options.TerragruntOptions, actual
 	assert.Equal(t, expected.IgnoreDependencyErrors, actual.IgnoreDependencyErrors, msgAndArgs...)
 	assert.Equal(t, expected.IAMRoleOptions, actual.IAMRoleOptions, msgAndArgs...)
 	assert.Equal(t, expected.OriginalIAMRoleOptions, actual.OriginalIAMRoleOptions, msgAndArgs...)
-	assert.Equal(t, expected.Debug, actual.Debug, msgAndArgs...)
+	assert.Equal(t, expected.LoggingOptions.Debug, actual.LoggingOptions.Debug, msgAndArgs...)
 	assert.Equal(t, expected.SourceMap, actual.SourceMap, msgAndArgs...)
 }
 
@@ -238,7 +238,7 @@ func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, t
 	opts.Source = terragruntSource
 	opts.IgnoreDependencyErrors = ignoreDependencyErrors
 	opts.IncludeExternalDependencies = includeExternalDependencies
-	opts.Debug = debug
+	opts.LoggingOptions.Debug = debug
 
 	return opts
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -240,7 +240,7 @@ func initialSetup(cliCtx *cli.Context, l log.Logger, opts *options.TerragruntOpt
 		return err
 	}
 
-	if opts.LogShowAbsPaths {
+	if opts.LoggingOptions.LogShowAbsPaths {
 		l.Formatter().DisableRelativePaths()
 	}
 

--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -210,7 +210,7 @@ func outputJSON(opts *Options, configs FoundConfigs) error {
 		return errors.New(err)
 	}
 
-	_, err = opts.Writer.Write(append(jsonBytes, []byte("\n")...))
+	_, err = opts.LoggingOptions.Writer.Write(append(jsonBytes, []byte("\n")...))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -278,7 +278,7 @@ func outputText(l log.Logger, opts *Options, configs FoundConfigs) error {
 	colorizer := NewColorizer(shouldColor(l))
 
 	for _, config := range configs {
-		_, err := opts.Writer.Write([]byte(colorizer.Colorize(config) + "\n"))
+		_, err := opts.LoggingOptions.Writer.Write([]byte(colorizer.Colorize(config) + "\n"))
 		if err != nil {
 			return errors.New(err)
 		}

--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/telemetry"
 	"github.com/gruntwork-io/terragrunt/util"
@@ -113,9 +114,9 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 
 	switch opts.Format {
 	case FormatText:
-		return outputText(l, opts, foundCfgs)
+		return outputText(l, opts.LoggingOptions, foundCfgs)
 	case FormatJSON:
-		return outputJSON(opts, foundCfgs)
+		return outputJSON(opts.LoggingOptions, foundCfgs)
 	default:
 		// This should never happen, because of validation in the command.
 		// If it happens, we want to throw so we can fix the validation.
@@ -204,13 +205,13 @@ func discoveredToFound(configs discovery.DiscoveredConfigs, opts *Options) (Foun
 }
 
 // outputJSON outputs the discovered configurations in JSON format.
-func outputJSON(opts *Options, configs FoundConfigs) error {
+func outputJSON(opts *options.LoggingOptions, configs FoundConfigs) error {
 	jsonBytes, err := json.MarshalIndent(configs, "", "  ")
 	if err != nil {
 		return errors.New(err)
 	}
 
-	_, err = opts.LoggingOptions.Writer.Write(append(jsonBytes, []byte("\n")...))
+	_, err = opts.Writer.Write(append(jsonBytes, []byte("\n")...))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -274,11 +275,11 @@ func (c *Colorizer) Colorize(config *FoundConfig) string {
 }
 
 // outputText outputs the discovered configurations in text format.
-func outputText(l log.Logger, opts *Options, configs FoundConfigs) error {
+func outputText(l log.Logger, opts *options.LoggingOptions, configs FoundConfigs) error {
 	colorizer := NewColorizer(shouldColor(l))
 
 	for _, config := range configs {
-		_, err := opts.LoggingOptions.Writer.Write([]byte(colorizer.Colorize(config) + "\n"))
+		_, err := opts.Writer.Write([]byte(colorizer.Colorize(config) + "\n"))
 		if err != nil {
 			return errors.New(err)
 		}

--- a/cli/commands/find/find_test.go
+++ b/cli/commands/find/find_test.go
@@ -434,7 +434,7 @@ dependency "B" {
 			require.NoError(t, err)
 
 			// Set the writer in options
-			opts.Writer = w
+			opts.LoggingOptions.Writer = w
 
 			err = find.Run(t.Context(), l, opts)
 			if tt.format == "invalid" || tt.mode == "invalid" {

--- a/cli/commands/hcl/format/format.go
+++ b/cli/commands/hcl/format/format.go
@@ -124,7 +124,7 @@ func formatFromStdin(l log.Logger, opts *options.TerragruntOptions) error {
 
 	newContents := hclwrite.Format(contents)
 
-	buf := bufio.NewWriter(opts.Writer)
+	buf := bufio.NewWriter(opts.LoggingOptions.Writer)
 
 	if _, err = buf.Write(newContents); err != nil {
 		l.Errorf("Failed to write to stdout")
@@ -177,7 +177,7 @@ func formatTgHCL(l log.Logger, opts *options.TerragruntOptions, tgHclFile string
 			return err
 		}
 
-		_, err = fmt.Fprintf(opts.Writer, "%s\n", diff)
+		_, err = fmt.Fprintf(opts.LoggingOptions.Writer, "%s\n", diff)
 		if err != nil {
 			l.Errorf("Failed to print diff for %s", tgHclFile)
 			return err

--- a/cli/commands/hcl/format/format.go
+++ b/cli/commands/hcl/format/format.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 			return errors.Errorf("both stdin and path flags are specified")
 		}
 
-		return formatFromStdin(l, opts)
+		return formatFromStdin(l, opts.LoggingOptions)
 	}
 
 	// handle when option specifies a particular file
@@ -107,7 +107,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 	return formatErrors.ErrorOrNil()
 }
 
-func formatFromStdin(l log.Logger, opts *options.TerragruntOptions) error {
+func formatFromStdin(l log.Logger, opts *options.LoggingOptions) error {
 	contents, err := io.ReadAll(os.Stdin)
 
 	if err != nil {
@@ -124,7 +124,7 @@ func formatFromStdin(l log.Logger, opts *options.TerragruntOptions) error {
 
 	newContents := hclwrite.Format(contents)
 
-	buf := bufio.NewWriter(opts.LoggingOptions.Writer)
+	buf := bufio.NewWriter(opts.Writer)
 
 	if _, err = buf.Write(newContents); err != nil {
 		l.Errorf("Failed to write to stdout")

--- a/cli/commands/hcl/validate/validate.go
+++ b/cli/commands/hcl/validate/validate.go
@@ -111,7 +111,7 @@ func writeDiagnostics(l log.Logger, opts *options.TerragruntOptions, diags diagn
 		render = view.NewJSONRender()
 	}
 
-	writer := view.NewWriter(opts.Writer, render)
+	writer := view.NewWriter(opts.LoggingOptions.Writer, render)
 
 	if opts.HCLValidateShowConfigPath {
 		return writer.ShowConfigPath(diags)

--- a/cli/commands/info/print/print.go
+++ b/cli/commands/info/print/print.go
@@ -63,7 +63,7 @@ func printTerragruntContext(l log.Logger, opts *options.TerragruntOptions) error
 		return errors.New(err)
 	}
 
-	if _, err := fmt.Fprintf(opts.Writer, "%s\n", b); err != nil {
+	if _, err := fmt.Fprintf(opts.LoggingOptions.Writer, "%s\n", b); err != nil {
 		return errors.New(err)
 	}
 

--- a/cli/commands/list/list.go
+++ b/cli/commands/list/list.go
@@ -335,12 +335,12 @@ func renderLong(opts *Options, configs ListedConfigs, c *Colorizer) error {
 	}
 
 	for _, config := range configs {
-		_, err := opts.Writer.Write([]byte(c.ColorizeType(config.Type)))
+		_, err := opts.LoggingOptions.Writer.Write([]byte(c.ColorizeType(config.Type)))
 		if err != nil {
 			return errors.New(err)
 		}
 
-		_, err = opts.Writer.Write([]byte(" " + c.Colorize(config)))
+		_, err = opts.LoggingOptions.Writer.Write([]byte(" " + c.Colorize(config)))
 		if err != nil {
 			return errors.New(err)
 		}
@@ -356,19 +356,19 @@ func renderLong(opts *Options, configs ListedConfigs, c *Colorizer) error {
 
 			dependenciesPadding := (longestPathLen - len(config.Path)) + extraDependenciesPadding
 			for range dependenciesPadding {
-				_, err := opts.Writer.Write([]byte(" "))
+				_, err := opts.LoggingOptions.Writer.Write([]byte(" "))
 				if err != nil {
 					return errors.New(err)
 				}
 			}
 
-			_, err = opts.Writer.Write([]byte(strings.Join(colorizedDeps, ", ")))
+			_, err = opts.LoggingOptions.Writer.Write([]byte(strings.Join(colorizedDeps, ", ")))
 			if err != nil {
 				return errors.New(err)
 			}
 		}
 
-		_, err = opts.Writer.Write([]byte("\n"))
+		_, err = opts.LoggingOptions.Writer.Write([]byte("\n"))
 		if err != nil {
 			return errors.New(err)
 		}
@@ -379,7 +379,7 @@ func renderLong(opts *Options, configs ListedConfigs, c *Colorizer) error {
 
 // renderLongHeadings renders the headings for the long format.
 func renderLongHeadings(opts *Options, c *Colorizer, longestPathLen int) error {
-	_, err := opts.Writer.Write([]byte(c.ColorizeHeading("Type  Path")))
+	_, err := opts.LoggingOptions.Writer.Write([]byte(c.ColorizeHeading("Type  Path")))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -389,19 +389,19 @@ func renderLongHeadings(opts *Options, c *Colorizer, longestPathLen int) error {
 
 		dependenciesPadding := (longestPathLen - len("Path")) + extraDependenciesPadding
 		for range dependenciesPadding {
-			_, err := opts.Writer.Write([]byte(" "))
+			_, err := opts.LoggingOptions.Writer.Write([]byte(" "))
 			if err != nil {
 				return errors.New(err)
 			}
 		}
 
-		_, err = opts.Writer.Write([]byte(c.ColorizeHeading("Dependencies")))
+		_, err = opts.LoggingOptions.Writer.Write([]byte(c.ColorizeHeading("Dependencies")))
 		if err != nil {
 			return errors.New(err)
 		}
 	}
 
-	_, err = opts.Writer.Write([]byte("\n"))
+	_, err = opts.LoggingOptions.Writer.Write([]byte("\n"))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -415,13 +415,13 @@ func renderTabular(opts *Options, configs ListedConfigs, c *Colorizer) error {
 
 	for i, config := range configs {
 		if i > 0 && i%maxCols == 0 {
-			_, err := opts.Writer.Write([]byte("\n"))
+			_, err := opts.LoggingOptions.Writer.Write([]byte("\n"))
 			if err != nil {
 				return errors.New(err)
 			}
 		}
 
-		_, err := opts.Writer.Write([]byte(c.Colorize(config)))
+		_, err := opts.LoggingOptions.Writer.Write([]byte(c.Colorize(config)))
 		if err != nil {
 			return errors.New(err)
 		}
@@ -429,14 +429,14 @@ func renderTabular(opts *Options, configs ListedConfigs, c *Colorizer) error {
 		// Add padding until the length of maxCols
 		padding := colWidth - len(config.Path)
 		for range padding {
-			_, err := opts.Writer.Write([]byte(" "))
+			_, err := opts.LoggingOptions.Writer.Write([]byte(" "))
 			if err != nil {
 				return errors.New(err)
 			}
 		}
 	}
 
-	_, err := opts.Writer.Write([]byte("\n"))
+	_, err := opts.LoggingOptions.Writer.Write([]byte("\n"))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -624,7 +624,7 @@ func renderTree(opts *Options, configs ListedConfigs, s *TreeStyler, _ string) e
 
 	t = s.Style(t)
 
-	_, err := opts.Writer.Write([]byte(t.String() + "\n"))
+	_, err := opts.LoggingOptions.Writer.Write([]byte(t.String() + "\n"))
 	if err != nil {
 		return errors.New(err)
 	}

--- a/cli/commands/list/list_test.go
+++ b/cli/commands/list/list_test.go
@@ -65,7 +65,7 @@ func TestBasicDiscovery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set the writer in options
-	opts.Writer = w
+	opts.LoggingOptions.Writer = w
 
 	l := logger.CreateLogger()
 
@@ -154,7 +154,7 @@ func TestHiddenDiscovery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set the writer in options
-	opts.Writer = w
+	opts.LoggingOptions.Writer = w
 
 	err = list.Run(t.Context(), l, opts)
 	require.NoError(t, err)
@@ -238,7 +238,7 @@ dependency "unit2" {
 	require.NoError(t, err)
 
 	// Set the writer in options
-	opts.Writer = w
+	opts.LoggingOptions.Writer = w
 
 	err = list.Run(t.Context(), l, opts)
 	require.NoError(t, err)
@@ -317,7 +317,7 @@ dependency "unit3" {
 	require.NoError(t, err)
 
 	// Set the writer in options
-	opts.Writer = w
+	opts.LoggingOptions.Writer = w
 
 	err = list.Run(t.Context(), l, opts)
 	require.NoError(t, err)
@@ -429,7 +429,7 @@ dependency "C" {
 	require.NoError(t, err)
 
 	// Set the writer in options
-	opts.Writer = w
+	opts.LoggingOptions.Writer = w
 
 	err = list.Run(t.Context(), l, opts)
 	require.NoError(t, err)

--- a/cli/commands/output-module-groups/output-module-groups.go
+++ b/cli/commands/output-module-groups/output-module-groups.go
@@ -20,7 +20,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 		return err
 	}
 
-	_, err = fmt.Fprintf(opts.Writer, "%s\n", js)
+	_, err = fmt.Fprintf(opts.LoggingOptions.Writer, "%s\n", js)
 	if err != nil {
 		return err
 	}

--- a/cli/commands/render/render.go
+++ b/cli/commands/render/render.go
@@ -62,7 +62,7 @@ func renderHCL(_ context.Context, l log.Logger, opts *Options, cfg *config.Terra
 
 	l.Infof("Rendering config %s", opts.TerragruntConfigPath)
 
-	_, err := cfg.WriteTo(opts.Writer)
+	_, err := cfg.WriteTo(opts.LoggingOptions.Writer)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func renderJSON(ctx context.Context, l log.Logger, opts *Options, cfg *config.Te
 
 	l.Infof("Rendering config %s", opts.TerragruntConfigPath)
 
-	_, err = opts.Writer.Write(jsonBytes)
+	_, err = opts.LoggingOptions.Writer.Write(jsonBytes)
 	if err != nil {
 		return errors.New(err)
 	}

--- a/cli/commands/render/render_test.go
+++ b/cli/commands/render/render_test.go
@@ -19,7 +19,7 @@ func TestRenderJSON_Basic(t *testing.T) {
 
 	opts, _ := setupTest(t)
 	var outputBuffer bytes.Buffer
-	opts.TerragruntOptions.Writer = &outputBuffer
+	opts.LoggingOptions.Writer = &outputBuffer
 	opts.Format = render.FormatJSON
 	opts.DisableDependentModules = true
 	opts.RenderMetadata = false
@@ -41,7 +41,7 @@ func TestRenderJSON_WithMetadata(t *testing.T) {
 
 	opts, _ := setupTest(t)
 	var outputBuffer bytes.Buffer
-	opts.TerragruntOptions.Writer = &outputBuffer
+	opts.LoggingOptions.Writer = &outputBuffer
 	opts.Format = render.FormatJSON
 	opts.DisableDependentModules = true
 	opts.RenderMetadata = true
@@ -102,7 +102,7 @@ func TestRenderJSON_HCLFormat(t *testing.T) {
 	opts.Format = render.FormatHCL
 
 	var renderedBuffer bytes.Buffer
-	opts.TerragruntOptions.Writer = &renderedBuffer
+	opts.LoggingOptions.Writer = &renderedBuffer
 
 	err := render.Run(t.Context(), logger.CreateLogger(), opts)
 	require.NoError(t, err)

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -318,7 +318,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        InputsDebugFlagName,
 			EnvVars:     tgPrefix.EnvVars(InputsDebugFlagName),
-			Destination: &opts.Debug,
+			Destination: &opts.LoggingOptions.Debug,
 			Usage:       "Write debug.tfvars to working folder to help root-cause issues.",
 		},
 			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("debug"), terragruntPrefixControl)),
@@ -342,7 +342,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        TFForwardStdoutFlagName,
 			EnvVars:     tgPrefix.EnvVars(TFForwardStdoutFlagName),
-			Destination: &opts.ForwardTFStdout,
+			Destination: &opts.LoggingOptions.ForwardTFStdout,
 			Usage:       "If specified, the output of OpenTofu/Terraform commands will be printed as is, without being integrated into the Terragrunt log.",
 		},
 			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("forward-tf-stdout"), terragruntPrefixControl),

--- a/cli/commands/run/help.go
+++ b/cli/commands/run/help.go
@@ -52,7 +52,7 @@ func ShowTFHelp(l log.Logger, opts *options.TerragruntOptions) cli.HelpFunc {
 
 func runTFHelp(ctx *cli.Context, l log.Logger, opts *options.TerragruntOptions) string {
 	opts = opts.Clone()
-	opts.Writer = io.Discard
+	opts.LoggingOptions.Writer = io.Discard
 
 	terraformHelpCmd := []string{tf.FlagNameHelpLong, ctx.Command.Name}
 

--- a/cli/commands/run/run.go
+++ b/cli/commands/run/run.go
@@ -238,7 +238,7 @@ func run(ctx context.Context, l log.Logger, terragruntOptions *options.Terragrun
 
 	// We do the debug file generation here, after all the terragrunt generated terraform files are created so that we
 	// can ensure the tfvars json file only includes the vars that are defined in the module.
-	if updatedTerragruntOptions.Debug {
+	if updatedTerragruntOptions.LoggingOptions.Debug {
 		if err := WriteTerragruntDebugFile(l, updatedTerragruntOptions, terragruntConfig); err != nil {
 			return target.runErrorCallback(l, terragruntOptions, terragruntConfig, err)
 		}
@@ -378,13 +378,13 @@ func runTerragruntWithConfig(
 func confirmActionWithDependentModules(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, cfg *config.TerragruntConfig) bool {
 	modules := configstack.FindWhereWorkingDirIsIncluded(ctx, l, opts, cfg)
 	if len(modules) != 0 {
-		if _, err := opts.ErrWriter.Write([]byte("Detected dependent modules:\n")); err != nil {
+		if _, err := opts.LoggingOptions.ErrWriter.Write([]byte("Detected dependent modules:\n")); err != nil {
 			l.Error(err)
 			return false
 		}
 
 		for _, module := range modules {
-			if _, err := opts.ErrWriter.Write([]byte(module.Path + "\n")); err != nil {
+			if _, err := opts.LoggingOptions.ErrWriter.Write([]byte(module.Path + "\n")); err != nil {
 				l.Error(err)
 				return false
 			}
@@ -724,14 +724,14 @@ func prepareInitOptions(l log.Logger, terragruntOptions *options.TerragruntOptio
 	initOptions.TerraformCliArgs = []string{tf.CommandNameInit}
 	initOptions.WorkingDir = terragruntOptions.WorkingDir
 	initOptions.TerraformCommand = tf.CommandNameInit
-	initOptions.Headless = true
+	initOptions.LoggingOptions.Headless = true
 
 	initOutputForCommands := []string{tf.CommandNamePlan, tf.CommandNameApply}
 	terraformCommand := terragruntOptions.TerraformCliArgs.First()
 
 	if !collections.ListContainsElement(initOutputForCommands, terraformCommand) {
 		// Since some command can return a json string, it is necessary to suppress output to stdout of the `terraform init` command.
-		initOptions.Writer = io.Discard
+		initOptions.LoggingOptions.Writer = io.Discard
 	}
 
 	if collections.ListContainsElement(terragruntOptions.TerraformCliArgs, tf.FlagNameNoColor) {

--- a/cli/commands/run/run_test.go
+++ b/cli/commands/run/run_test.go
@@ -486,7 +486,7 @@ func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, t
 	opts.Source = terragruntSource
 	opts.IgnoreDependencyErrors = ignoreDependencyErrors
 	opts.IncludeExternalDependencies = includeExternalDependencies
-	opts.Debug = debug
+	opts.LoggingOptions.Debug = debug
 
 	return opts
 }

--- a/cli/commands/run/version_check.go
+++ b/cli/commands/run/version_check.go
@@ -122,8 +122,8 @@ func PopulateTerraformVersion(ctx context.Context, l log.Logger, terragruntOptio
 		return l, err
 	}
 
-	terragruntOptionsCopy.Writer = io.Discard
-	terragruntOptionsCopy.ErrWriter = io.Discard
+	terragruntOptionsCopy.LoggingOptions.Writer = io.Discard
+	terragruntOptionsCopy.LoggingOptions.ErrWriter = io.Discard
 
 	for key := range terragruntOptionsCopy.Env {
 		if strings.HasPrefix(key, "TF_CLI_ARGS") {

--- a/cli/commands/stack/stack.go
+++ b/cli/commands/stack/stack.go
@@ -79,7 +79,7 @@ func RunOutput(ctx context.Context, l log.Logger, opts *options.TerragruntOption
 
 	// render outputs
 
-	writer := opts.Writer
+	writer := opts.LoggingOptions.Writer
 
 	switch opts.StackOutputFormat {
 	default:

--- a/cli/flags/global/flags.go
+++ b/cli/flags/global/flags.go
@@ -158,7 +158,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:   "Disable logging.",
 			Setter: func(val bool) error {
 				l.Formatter().SetDisabledOutput(val)
-				opts.ForwardTFStdout = true
+				opts.LoggingOptions.ForwardTFStdout = true
 				return nil
 			},
 		},
@@ -167,7 +167,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        ShowLogAbsPathsFlagName,
 			EnvVars:     tgPrefix.EnvVars(ShowLogAbsPathsFlagName),
-			Destination: &opts.LogShowAbsPaths,
+			Destination: &opts.LoggingOptions.LogShowAbsPaths,
 			Usage:       "Show absolute paths in logs.",
 		},
 			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedShowLogAbsPathsFlagName), terragruntPrefixControl)),
@@ -191,9 +191,9 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Action: func(_ *cli.Context, val string) error {
 				switch val {
 				case format.BareFormatName:
-					opts.ForwardTFStdout = true
+					opts.LoggingOptions.ForwardTFStdout = true
 				case format.JSONFormatName:
-					opts.JSONLogFormat = true
+					opts.LoggingOptions.JSONLogFormat = true
 				}
 
 				return nil
@@ -203,13 +203,13 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			flags.WithDeprecatedFlag(&cli.BoolFlag{
 				Name:        terragruntPrefix.FlagName(DeprecatedDisableLogFormattingFlagName),
 				EnvVars:     terragruntPrefix.EnvVars(DeprecatedDisableLogFormattingFlagName),
-				Destination: &opts.DisableLogFormatting,
+				Destination: &opts.LoggingOptions.DisableLogFormatting,
 				Usage:       "If specified, logs will be displayed in key/value format. By default, logs are formatted in a human readable format.",
 			}, flags.NewValue(format.KeyValueFormatName), legacyLogsControl),
 			flags.WithDeprecatedFlag(&cli.BoolFlag{
 				Name:        terragruntPrefix.FlagName(DeprecatedJSONLogFlagName),
 				EnvVars:     terragruntPrefix.EnvVars(DeprecatedJSONLogFlagName),
-				Destination: &opts.JSONLogFormat,
+				Destination: &opts.LoggingOptions.JSONLogFormat,
 				Usage:       "If specified, Terragrunt will output its logs in JSON format.",
 			}, flags.NewValue(format.JSONFormatName), legacyLogsControl),
 			flags.WithDeprecatedFlag(&cli.BoolFlag{
@@ -375,7 +375,7 @@ func NewLogLevelFlag(l log.Logger, opts *options.TerragruntOptions, prefix flags
 			}
 
 			if collections.ListContainsElement(removedLevels, val) {
-				opts.ForwardTFStdout = true
+				opts.LoggingOptions.ForwardTFStdout = true
 				l.Formatter().SetDisabledOutput(true)
 			}
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -683,7 +683,7 @@ func cloneTerragruntOptionsForDependencyOutput(ctx *ParsingContext, l log.Logger
 		return l, nil, err
 	}
 
-	targetOptions.ForwardTFStdout = false
+	targetOptions.LoggingOptions.ForwardTFStdout = false
 	// just read outputs, so no need to check for dependent modules
 	targetOptions.CheckDependentModules = false
 	targetOptions.TerraformCommand = "output"
@@ -1070,7 +1070,7 @@ func setupTerragruntOptionsForBareTerraform(ctx *ParsingContext, l log.Logger, w
 	}
 
 	targetTGOptions.WorkingDir = workingDir
-	targetTGOptions.Writer = io.Discard
+	targetTGOptions.LoggingOptions.Writer = io.Discard
 	targetTGOptions.Engine = ctx.TerragruntOptions.Engine
 
 	// If the target config has an IAM role directive and it was not set on the command line, set it to
@@ -1097,9 +1097,9 @@ func runTerragruntOutputJSON(ctx *ParsingContext, l log.Logger, targetConfig str
 
 	newOpts := *ctx.TerragruntOptions
 	// explicit disable json formatting and prefixing to read json output
-	newOpts.ForwardTFStdout = false
-	newOpts.JSONLogFormat = false
-	newOpts.Writer = stdoutBufferWriter
+	newOpts.LoggingOptions.ForwardTFStdout = false
+	newOpts.LoggingOptions.JSONLogFormat = false
+	newOpts.LoggingOptions.Writer = stdoutBufferWriter
 	ctx = ctx.WithTerragruntOptions(&newOpts)
 
 	err := ctx.TerragruntOptions.RunTerragrunt(ctx, l, ctx.TerragruntOptions)
@@ -1177,7 +1177,7 @@ func runTerraformInitForDependencyOutput(ctx *ParsingContext, l log.Logger, work
 	}
 
 	initTGOptions.WorkingDir = workingDir
-	initTGOptions.ErrWriter = &stderr
+	initTGOptions.LoggingOptions.ErrWriter = &stderr
 
 	if err = tf.RunCommand(ctx, l, initTGOptions, tf.CommandNameInit, "-get=false"); err != nil {
 		l.Debugf("Ignoring expected error from dependency init call")

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -60,7 +60,7 @@ func (module *TerraformModule) MarshalJSON() ([]byte, error) {
 
 // FlushOutput flushes buffer data to the output writer.
 func (module *TerraformModule) FlushOutput() error {
-	if writer, ok := module.TerragruntOptions.Writer.(*ModuleWriter); ok {
+	if writer, ok := module.TerragruntOptions.LoggingOptions.Writer.(*ModuleWriter); ok {
 		module.outputMu.Lock()
 		defer module.outputMu.Unlock()
 

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -116,7 +116,7 @@ func (module *RunningModule) waitForDependencies() error {
 func (module *RunningModule) runTerragrunt(ctx context.Context, opts *options.TerragruntOptions) error {
 	module.Logger.Debugf("Running %s", module.Module.Path)
 
-	opts.Writer = NewModuleWriter(opts.Writer)
+	opts.LoggingOptions.Writer = NewModuleWriter(opts.LoggingOptions.Writer)
 
 	defer module.Module.FlushOutput() //nolint:errcheck
 
@@ -143,9 +143,9 @@ func (module *RunningModule) runNow(ctx context.Context, rootOptions *options.Te
 			}
 
 			stdout := bytes.Buffer{}
-			jsonOptions.ForwardTFStdout = true
-			jsonOptions.JSONLogFormat = false
-			jsonOptions.Writer = &stdout
+			jsonOptions.LoggingOptions.ForwardTFStdout = true
+			jsonOptions.LoggingOptions.JSONLogFormat = false
+			jsonOptions.LoggingOptions.Writer = &stdout
 			jsonOptions.TerraformCommand = tf.CommandNameShow
 			jsonOptions.TerraformCliArgs = []string{tf.CommandNameShow, "-json", module.Module.planFile(l, rootOptions)}
 

--- a/configstack/stack.go
+++ b/configstack/stack.go
@@ -154,7 +154,7 @@ func (stack *Stack) JSONModuleDeployOrder(terraformCommand string) (string, erro
 
 // Graph creates a graphviz representation of the modules
 func (stack *Stack) Graph(l log.Logger, opts *options.TerragruntOptions) {
-	err := stack.Modules.WriteDot(l, opts.Writer, opts)
+	err := stack.Modules.WriteDot(l, opts.LoggingOptions.Writer, opts)
 	if err != nil {
 		l.Warnf("Failed to graph dot: %v", err)
 	}
@@ -203,7 +203,7 @@ func (stack *Stack) Run(ctx context.Context, l log.Logger, opts *options.Terragr
 		errorStreams := make([]bytes.Buffer, len(stack.Modules))
 
 		for n, module := range stack.Modules {
-			module.TerragruntOptions.ErrWriter = io.MultiWriter(&errorStreams[n], module.TerragruntOptions.ErrWriter)
+			module.TerragruntOptions.LoggingOptions.ErrWriter = io.MultiWriter(&errorStreams[n], module.TerragruntOptions.LoggingOptions.ErrWriter)
 		}
 
 		defer stack.summarizePlanAllErrors(l, errorStreams)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -625,7 +625,7 @@ func invoke(ctx context.Context, l log.Logger, runOptions *ExecutionOptions, cli
 			WorkingDir:     opts.WorkingDir,
 			Command:        runOptions.Command,
 			Args:           runOptions.Args,
-			DisableSummary: opts.LogDisableErrorSummary,
+			DisableSummary: opts.LoggingOptions.LogDisableErrorSummary,
 		}
 
 		return nil, errors.New(err)

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -217,8 +217,8 @@ func (c *DiscoveredConfig) Parse(ctx context.Context, l log.Logger, opts *option
 	parseOpts.WorkingDir = c.Path
 
 	// Suppress logging to avoid cluttering the output.
-	parseOpts.Writer = io.Discard
-	parseOpts.ErrWriter = io.Discard
+	parseOpts.LoggingOptions.Writer = io.Discard
+	parseOpts.LoggingOptions.ErrWriter = io.Discard
 	parseOpts.SkipOutput = true
 
 	filename := config.DefaultTerragruntConfigPath

--- a/internal/providercache/provider_cache.go
+++ b/internal/providercache/provider_cache.go
@@ -311,7 +311,7 @@ func (cache *ProviderCache) createLocalCLIConfig(ctx context.Context, opts *opti
 
 func runTerraformCommand(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, args []string, envs map[string]string) (*util.CmdOutput, error) {
 	// We use custom writer in order to trap the log from `terraform providers lock -platform=provider-cache` command, which terraform considers an error, but to us a success.
-	errWriter := util.NewTrapWriter(opts.ErrWriter)
+	errWriter := util.NewTrapWriter(opts.LoggingOptions.ErrWriter)
 
 	// add -no-color flag to args if it was set in Terragrunt arguments
 	if util.ListContainsElement(opts.TerraformCliArgs, tf.FlagNameNoColor) &&
@@ -324,8 +324,8 @@ func runTerraformCommand(ctx context.Context, l log.Logger, opts *options.Terrag
 		return nil, err
 	}
 
-	cloneOpts.Writer = io.Discard
-	cloneOpts.ErrWriter = errWriter
+	cloneOpts.LoggingOptions.Writer = io.Discard
+	cloneOpts.LoggingOptions.ErrWriter = errWriter
 	cloneOpts.WorkingDir = opts.WorkingDir
 	cloneOpts.TerraformCliArgs = args
 	cloneOpts.Env = envs

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 	opts := options.NewTerragruntOptions()
 
 	l := log.New(
-		log.WithOutput(opts.ErrWriter),
+		log.WithOutput(opts.LoggingOptions.ErrWriter),
 		log.WithLevel(options.DefaultLogLevel),
 		log.WithFormatter(format.NewFormatter(format.NewPrettyFormatPlaceholders())),
 	)

--- a/options/options.go
+++ b/options/options.go
@@ -90,10 +90,8 @@ const (
 
 // TerragruntOptions represents options that configure the behavior of the Terragrunt program
 type TerragruntOptions struct {
-	// If you want stdout to go somewhere other than os.stdout
-	Writer io.Writer
-	// If you want stderr to go somewhere other than os.stderr
-	ErrWriter io.Writer
+	// LoggingOptions defines configuration for logging and output.
+	LoggingOptions *LoggingOptions
 	// Version of terragrunt
 	TerragruntVersion *version.Version `clone:"shadowcopy"`
 	// FeatureFlags is a map of feature flags to enable.
@@ -205,12 +203,6 @@ type TerragruntOptions struct {
 	ProviderCachePort int
 	// The duration in seconds to wait before retrying
 	RetrySleepInterval time.Duration
-	// Output Terragrunt logs in JSON format
-	JSONLogFormat bool
-	// True if terragrunt should run in debug mode
-	Debug bool
-	// Disable TF output formatting
-	ForwardTFStdout bool
 	// Fail execution if is required to create S3 bucket
 	FailIfBucketCreationRequired bool
 	// Controls if s3 bucket should be updated or skipped
@@ -275,14 +267,6 @@ type TerragruntOptions struct {
 	HCLValidateShowConfigPath bool
 	// HCLValidateJSONOutput outputs the hcl validate result as a JSON string.
 	HCLValidateJSONOutput bool
-	// If true, logs will be displayed in formatter key/value, by default logs are formatted in human-readable formatter.
-	DisableLogFormatting bool
-	// Headless is set when Terragrunt is running in headless mode.
-	Headless bool
-	// LogDisableErrorSummary is a flag to skip the error summary
-	LogDisableErrorSummary bool
-	// Disable replacing full paths in logs with short relative paths
-	LogShowAbsPaths bool
 	// NoStackGenerate disable stack generation.
 	NoStackGenerate bool
 	// NoStackValidate disable generated stack validation.
@@ -299,6 +283,28 @@ type TerragruntOptions struct {
 	ForceBackendDelete bool
 	// ForceBackendMigrate forces the backend to be migrated, even if the bucket is not versioned.
 	ForceBackendMigrate bool
+}
+
+// LoggingOptions defines configuration for logging and output.
+type LoggingOptions struct {
+	// If you want stdout to go somewhere other than os.stdout
+	Writer io.Writer
+	// If you want stderr to go somewhere other than os.stderr
+	ErrWriter io.Writer
+	// Output Terragrunt logs in JSON format
+	JSONLogFormat bool
+	// True if terragrunt should run in debug mode
+	Debug bool
+	// Disable TF output formatting
+	ForwardTFStdout bool
+	// If true, logs will be displayed in formatter key/value, by default logs are formatted in human-readable formatter.
+	DisableLogFormatting bool
+	// Headless is set when Terragrunt is running in headless mode.
+	Headless bool
+	// LogDisableErrorSummary is a flag to skip the error summary
+	LogDisableErrorSummary bool
+	// Disable replacing full paths in logs with short relative paths
+	LogShowAbsPaths bool
 }
 
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests
@@ -356,6 +362,7 @@ func NewTerragruntOptions() *TerragruntOptions {
 
 func NewTerragruntOptionsWithWriters(stdout, stderr io.Writer) *TerragruntOptions {
 	return &TerragruntOptions{
+		LoggingOptions:                 &LoggingOptions{Writer: stdout, ErrWriter: stderr},
 		TerraformPath:                  DefaultWrappedPath,
 		ExcludesFile:                   defaultExcludesFile,
 		OriginalTerraformCommand:       "",
@@ -372,8 +379,6 @@ func NewTerragruntOptionsWithWriters(stdout, stderr io.Writer) *TerragruntOption
 		IgnoreDependencyOrder:          false,
 		IgnoreExternalDependencies:     false,
 		IncludeExternalDependencies:    false,
-		Writer:                         stdout,
-		ErrWriter:                      stderr,
 		MaxFoldersToCheck:              DefaultMaxFoldersToCheck,
 		AutoRetry:                      true,
 		RetryMaxAttempts:               DefaultRetryMaxAttempts,
@@ -388,7 +393,6 @@ func NewTerragruntOptionsWithWriters(stdout, stderr io.Writer) *TerragruntOption
 		Diff:                           false,
 		FetchDependencyOutputFromState: false,
 		UsePartialParseConfigCache:     false,
-		ForwardTFStdout:                false,
 		JSONOut:                        DefaultJSONOutName,
 		TerraformImplementation:        UnknownImpl,
 		JSONDisableDependentModules:    false,

--- a/shell/git.go
+++ b/shell/git.go
@@ -38,8 +38,8 @@ func GitTopLevelDir(ctx context.Context, l log.Logger, terragruntOptions *option
 	}
 
 	opts.Env = terragruntOptions.Env
-	opts.Writer = &stdout
-	opts.ErrWriter = &stderr
+	opts.LoggingOptions.Writer = &stdout
+	opts.LoggingOptions.ErrWriter = &stderr
 
 	cmd, err := RunCommandWithOutput(ctx, l, opts, path, true, false, "git", "rev-parse", "--show-toplevel")
 	if err != nil {
@@ -68,8 +68,8 @@ func GitRepoTags(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 	}
 
 	gitOpts.Env = opts.Env
-	gitOpts.Writer = &stdout
-	gitOpts.ErrWriter = &stderr
+	gitOpts.LoggingOptions.Writer = &stdout
+	gitOpts.LoggingOptions.ErrWriter = &stderr
 
 	output, err := RunCommandWithOutput(ctx, l, opts, opts.WorkingDir, true, false, "git", "ls-remote", "--tags", repoPath)
 	if err != nil {

--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -23,7 +23,7 @@ func PromptUserForInput(ctx context.Context, l log.Logger, prompt string, opts *
 		return "yes", nil
 	}
 
-	n, err := opts.ErrWriter.Write([]byte(prompt))
+	n, err := opts.LoggingOptions.ErrWriter.Write([]byte(prompt))
 	if err != nil {
 		l.Error(err)
 

--- a/shell/run_cmd.go
+++ b/shell/run_cmd.go
@@ -67,8 +67,8 @@ func RunCommandWithOutput(
 		l.Debugf("Running command: %s %s", command, strings.Join(args, " "))
 
 		var (
-			cmdStderr = io.MultiWriter(opts.ErrWriter, &output.Stderr)
-			cmdStdout = io.MultiWriter(opts.Writer, &output.Stdout)
+			cmdStderr = io.MultiWriter(opts.LoggingOptions.ErrWriter, &output.Stderr)
+			cmdStdout = io.MultiWriter(opts.LoggingOptions.Writer, &output.Stdout)
 		)
 
 		// Pass the traceparent to the child process if it is available in the context.
@@ -129,7 +129,7 @@ func RunCommandWithOutput(
 				Args:           args,
 				Command:        command,
 				WorkingDir:     cmd.Dir,
-				DisableSummary: opts.LogDisableErrorSummary,
+				DisableSummary: opts.LoggingOptions.LogDisableErrorSummary,
 			}
 
 			return errors.New(err)
@@ -145,7 +145,7 @@ func RunCommandWithOutput(
 				Command:        command,
 				Output:         output,
 				WorkingDir:     cmd.Dir,
-				DisableSummary: opts.LogDisableErrorSummary,
+				DisableSummary: opts.LoggingOptions.LogDisableErrorSummary,
 			}
 
 			return errors.New(err)

--- a/shell/run_cmd_output_test.go
+++ b/shell/run_cmd_output_test.go
@@ -57,8 +57,8 @@ func testCommandOutput(t *testing.T, withOptions func(*options.TerragruntOptions
 	// Specify a single (locking) buffer for both as a way to check that the output is being written in the correct
 	// order
 	var allOutputBuffer BufferWithLocking
-	terragruntOptions.Writer = &allOutputBuffer
-	terragruntOptions.ErrWriter = &allOutputBuffer
+	terragruntOptions.LoggingOptions.Writer = &allOutputBuffer
+	terragruntOptions.LoggingOptions.ErrWriter = &allOutputBuffer
 
 	terragruntOptions.TerraformCliArgs = append(terragruntOptions.TerraformCliArgs, "same")
 

--- a/shell/run_cmd_test.go
+++ b/shell/run_cmd_test.go
@@ -37,8 +37,8 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	terragruntOptions.TerraformCliArgs = append(terragruntOptions.TerraformCliArgs, "--version")
-	terragruntOptions.Writer = stdout
-	terragruntOptions.ErrWriter = stderr
+	terragruntOptions.LoggingOptions.Writer = stdout
+	terragruntOptions.LoggingOptions.ErrWriter = stderr
 
 	l := logger.CreateLogger()
 
@@ -52,8 +52,8 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 	stderr = new(bytes.Buffer)
 
 	terragruntOptions.TerraformCliArgs = []string{}
-	terragruntOptions.Writer = stderr
-	terragruntOptions.ErrWriter = stderr
+	terragruntOptions.LoggingOptions.Writer = stderr
+	terragruntOptions.LoggingOptions.ErrWriter = stderr
 
 	cmd = shell.RunCommand(t.Context(), l, terragruntOptions, "tofu", "--version")
 	require.NoError(t, cmd)

--- a/tf/run_cmd.go
+++ b/tf/run_cmd.go
@@ -58,9 +58,9 @@ func RunCommandWithOutput(ctx context.Context, l log.Logger, opts *options.Terra
 		return nil, err
 	}
 
-	if !opts.ForwardTFStdout {
+	if !opts.LoggingOptions.ForwardTFStdout {
 		opts = opts.Clone()
-		opts.Writer, opts.ErrWriter = logTFOutput(l, opts, args)
+		opts.LoggingOptions.Writer, opts.LoggingOptions.ErrWriter = logTFOutput(l, opts, args)
 	}
 
 	output, err := shell.RunCommandWithOutput(ctx, l, opts, "", false, needsPTY, opts.TerraformPath, args...)
@@ -81,8 +81,8 @@ func RunCommandWithOutput(ctx context.Context, l log.Logger, opts *options.Terra
 
 func logTFOutput(l log.Logger, opts *options.TerragruntOptions, args cli.Args) (io.Writer, io.Writer) {
 	var (
-		outWriter = opts.Writer
-		errWriter = opts.ErrWriter
+		outWriter = opts.LoggingOptions.Writer
+		errWriter = opts.LoggingOptions.ErrWriter
 	)
 
 	logger := l.
@@ -90,7 +90,7 @@ func logTFOutput(l log.Logger, opts *options.TerragruntOptions, args cli.Args) (
 		WithField(placeholders.TFCmdArgsKeyName, args.Slice()).
 		WithField(placeholders.TFCmdKeyName, args.CommandName())
 
-	if opts.JSONLogFormat && !args.Normalize(cli.SingleDashFlag).Contains(FlagNameJSON) {
+	if opts.LoggingOptions.JSONLogFormat && !args.Normalize(cli.SingleDashFlag).Contains(FlagNameJSON) {
 		outWriter = buildOutWriter(
 			opts,
 			logger,
@@ -182,7 +182,7 @@ func shouldForceForwardTFStdout(args cli.Args) bool {
 func buildOutWriter(opts *options.TerragruntOptions, logger log.Logger, outWriter, errWriter io.Writer, writerOptions ...writer.Option) io.Writer {
 	logLevel := log.StdoutLevel
 
-	if opts.Headless {
+	if opts.LoggingOptions.Headless {
 		logLevel = log.InfoLevel
 		outWriter = errWriter
 	}
@@ -206,7 +206,7 @@ func buildOutWriter(opts *options.TerragruntOptions, logger log.Logger, outWrite
 func buildErrWriter(opts *options.TerragruntOptions, logger log.Logger, errWriter io.Writer, writerOptions ...writer.Option) io.Writer {
 	logLevel := log.StderrLevel
 
-	if opts.Headless {
+	if opts.LoggingOptions.Headless {
 		logLevel = log.ErrorLevel
 	}
 

--- a/tf/run_cmd_test.go
+++ b/tf/run_cmd_test.go
@@ -63,8 +63,8 @@ func testCommandOutput(t *testing.T, withOptions func(*options.TerragruntOptions
 	// Specify a single (locking) buffer for both as a way to check that the output is being written in the correct
 	// order
 	var allOutputBuffer BufferWithLocking
-	terragruntOptions.Writer = &allOutputBuffer
-	terragruntOptions.ErrWriter = &allOutputBuffer
+	terragruntOptions.LoggingOptions.Writer = &allOutputBuffer
+	terragruntOptions.LoggingOptions.ErrWriter = &allOutputBuffer
 
 	terragruntOptions.TerraformCliArgs = append(terragruntOptions.TerraformCliArgs, "same")
 	terragruntOptions.TerraformPath = "testdata/test_outputs.sh"

--- a/tflint/tflint.go
+++ b/tflint/tflint.go
@@ -58,7 +58,7 @@ func RunTflintWithOpts(ctx context.Context, l log.Logger, opts *options.Terragru
 
 	l.Debugf("Initializing tflint in directory %s", opts.WorkingDir)
 
-	cli, err := cmd.NewCLI(opts.Writer, opts.ErrWriter)
+	cli, err := cmd.NewCLI(opts.LoggingOptions.Writer, opts.LoggingOptions.ErrWriter)
 	if err != nil {
 		return errors.New(err)
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Breaking down the options used for logging into their own struct, and embedding that into the main TerragruntOptions struct.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `LoggingOptions` struct to `TerragruntOptions` to encapsulate logging-related options.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

