### PR TITLE
perf: Moving `RunOptions` out of `TerragruntOptions`

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -210,7 +210,7 @@ func assertOptionsEqual(t *testing.T, expected options.TerragruntOptions, actual
 	assert.Equal(t, expectedConfigPath, actualConfigPath, msgAndArgs...)
 	assert.Equal(t, expected.NonInteractive, actual.NonInteractive, msgAndArgs...)
 	assert.Equal(t, expected.IncludeExternalDependencies, actual.IncludeExternalDependencies, msgAndArgs...)
-	assert.Equal(t, expected.TerraformCliArgs, actual.TerraformCliArgs, msgAndArgs...)
+	assert.Equal(t, expected.RunOptions.TerraformCliArgs, actual.RunOptions.TerraformCliArgs, msgAndArgs...)
 	assert.Equal(t, expectedWorkingDir, actualWorkingDir, msgAndArgs...)
 	assert.Equal(t, expected.Source, actual.Source, msgAndArgs...)
 	assert.Equal(t, expected.IgnoreDependencyErrors, actual.IgnoreDependencyErrors, msgAndArgs...)
@@ -233,7 +233,7 @@ func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, t
 	}
 
 	opts.WorkingDir = workingDir
-	opts.TerraformCliArgs = terraformCliArgs
+	opts.RunOptions.TerraformCliArgs = terraformCliArgs
 	opts.NonInteractive = nonInteractive
 	opts.Source = terragruntSource
 	opts.IgnoreDependencyErrors = ignoreDependencyErrors
@@ -318,7 +318,7 @@ func TestFilterTerragruntArgs(t *testing.T) {
 			)
 			actualOptions, err := runAppTest(l, tc.args, opts)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expected, []string(actualOptions.TerraformCliArgs), "For args %v", tc.args)
+			assert.Equal(t, tc.expected, []string(actualOptions.RunOptions.TerraformCliArgs), "For args %v", tc.args)
 		})
 	}
 }
@@ -581,7 +581,7 @@ func runAppTest(l log.Logger, args []string, opts *options.TerragruntOptions) (*
 		terragruntCommands...).WrapAction(commands.WrapWithTelemetry(l, opts))
 	app.OsExiter = cli.OSExiter
 	app.Action = func(ctx *clipkg.Context) error {
-		opts.TerraformCliArgs = append(opts.TerraformCliArgs, ctx.Args()...)
+		opts.RunOptions.TerraformCliArgs = append(opts.RunOptions.TerraformCliArgs, ctx.Args()...)
 		return nil
 	}
 	app.ExitErrHandler = cli.ExitErrHandler

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -128,9 +128,9 @@ func New(l log.Logger, opts *options.TerragruntOptions) cli.Commands {
 // WrapWithTelemetry wraps CLI command execution with setting of telemetry context and labels, if telemetry is disabled, just runAction the command.
 func WrapWithTelemetry(l log.Logger, opts *options.TerragruntOptions) func(ctx *cli.Context, action cli.ActionFunc) error {
 	return func(ctx *cli.Context, action cli.ActionFunc) error {
-		return telemetry.TelemeterFromContext(ctx).Collect(ctx.Context, fmt.Sprintf("%s %s", ctx.Command.Name, opts.TerraformCommand), map[string]any{
-			"terraformCommand": opts.TerraformCommand,
-			"args":             opts.TerraformCliArgs,
+		return telemetry.TelemeterFromContext(ctx).Collect(ctx.Context, fmt.Sprintf("%s %s", ctx.Command.Name, opts.RunOptions.TerraformCommand), map[string]any{
+			"terraformCommand": opts.RunOptions.TerraformCommand,
+			"args":             opts.RunOptions.TerraformCliArgs,
 			"dir":              opts.WorkingDir,
 		}, func(childCtx context.Context) error {
 			ctx.Context = childCtx //nolint:fatcontext
@@ -210,8 +210,8 @@ func initialSetup(cliCtx *cli.Context, l log.Logger, opts *options.TerragruntOpt
 		args = append(args, tf.FlagNameNoColor)
 	}
 
-	opts.TerraformCommand = cmdName
-	opts.TerraformCliArgs = args
+	opts.RunOptions.TerraformCommand = cmdName
+	opts.RunOptions.TerraformCliArgs = args
 
 	opts.Env = env.Parse(os.Environ())
 
@@ -269,7 +269,7 @@ func initialSetup(cliCtx *cli.Context, l log.Logger, opts *options.TerragruntOpt
 		return errors.New(err)
 	}
 
-	opts.TerraformPath = filepath.ToSlash(opts.TerraformPath)
+	opts.RunOptions.TerraformPath = filepath.ToSlash(opts.RunOptions.TerraformPath)
 
 	opts.ExcludeDirs, err = util.GlobCanonicalPath(opts.WorkingDir, opts.ExcludeDirs...)
 	if err != nil {
@@ -332,7 +332,7 @@ func initialSetup(cliCtx *cli.Context, l log.Logger, opts *options.TerragruntOpt
 	}
 
 	opts.OriginalTerragruntConfigPath = opts.TerragruntConfigPath
-	opts.OriginalTerraformCommand = opts.TerraformCommand
+	opts.RunOptions.OriginalTerraformCommand = opts.RunOptions.TerraformCommand
 	opts.OriginalIAMRoleOptions = opts.IAMRoleOptions
 
 	opts.RunTerragrunt = runCmd.Run

--- a/cli/commands/common/graph/cli.go
+++ b/cli/commands/common/graph/cli.go
@@ -42,7 +42,7 @@ func WrapCommand(l log.Logger, opts *options.TerragruntOptions, cmd *cli.Command
 		}
 
 		opts.RunTerragrunt = func(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
-			if opts.TerraformCommand == cmd.Name {
+			if opts.RunOptions.TerraformCommand == cmd.Name {
 				cliCtx := cliCtx.WithValue(options.ContextKey, opts)
 
 				return action(cliCtx)

--- a/cli/commands/common/runall/cli.go
+++ b/cli/commands/common/runall/cli.go
@@ -47,7 +47,7 @@ func WrapCommand(l log.Logger, opts *options.TerragruntOptions, cmd *cli.Command
 		}
 
 		opts.RunTerragrunt = func(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
-			if opts.TerraformCommand == cmd.Name {
+			if opts.RunOptions.TerraformCommand == cmd.Name {
 				cliCtx := cliCtx.WithValue(options.ContextKey, opts)
 
 				return action(cliCtx)

--- a/cli/commands/common/runall/runall.go
+++ b/cli/commands/common/runall/runall.go
@@ -31,14 +31,14 @@ var runAllDisabledCommands = map[string]string{
 }
 
 func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
-	if opts.TerraformCommand == "" {
+	if opts.RunOptions.TerraformCommand == "" {
 		return errors.New(MissingCommand{})
 	}
 
-	reason, isDisabled := runAllDisabledCommands[opts.TerraformCommand]
+	reason, isDisabled := runAllDisabledCommands[opts.RunOptions.TerraformCommand]
 	if isDisabled {
 		return RunAllDisabledErr{
-			command: opts.TerraformCommand,
+			command: opts.RunOptions.TerraformCommand,
 			reason:  reason,
 		}
 	}
@@ -54,13 +54,13 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 func RunAllOnStack(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, stack *configstack.Stack) error {
 	l.Debugf("%s", stack.String())
 
-	if err := stack.LogModuleDeployOrder(l, opts.TerraformCommand); err != nil {
+	if err := stack.LogModuleDeployOrder(l, opts.RunOptions.TerraformCommand); err != nil {
 		return err
 	}
 
 	var prompt string
 
-	switch opts.TerraformCommand {
+	switch opts.RunOptions.TerraformCommand {
 	case tf.CommandNameApply:
 		prompt = "Are you sure you want to run 'terragrunt apply' in each folder of the stack described above?"
 	case tf.CommandNameDestroy:
@@ -81,7 +81,7 @@ func RunAllOnStack(ctx context.Context, l log.Logger, opts *options.TerragruntOp
 	}
 
 	return telemetry.TelemeterFromContext(ctx).Collect(ctx, "run_all_on_stack", map[string]any{
-		"terraform_command": opts.TerraformCommand,
+		"terraform_command": opts.RunOptions.TerraformCommand,
 		"working_dir":       opts.WorkingDir,
 	}, func(ctx context.Context) error {
 		return stack.Run(ctx, l, opts)

--- a/cli/commands/common/runall/runall_test.go
+++ b/cli/commands/common/runall/runall_test.go
@@ -18,7 +18,7 @@ func TestMissingRunAllArguments(t *testing.T) {
 	tgOptions, err := options.NewTerragruntOptionsForTest("")
 	require.NoError(t, err)
 
-	tgOptions.TerraformCommand = ""
+	tgOptions.RunOptions.TerraformCommand = ""
 
 	err = runall.Run(t.Context(), logger.CreateLogger(), tgOptions)
 	require.Error(t, err)

--- a/cli/commands/exec/exec.go
+++ b/cli/commands/exec/exec.go
@@ -17,7 +17,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, cmd
 
 	if !cmdOpts.InDownloadDir {
 		targetConfigPoint = run.TargetPointSetInputsAsEnvVars
-		opts.AutoInit = false
+		opts.RunOptions.AutoInit = false
 	}
 
 	target := run.NewTarget(targetConfigPoint, runTargetCommand(cmdOpts, args))

--- a/cli/commands/hcl/validate/validate.go
+++ b/cli/commands/hcl/validate/validate.go
@@ -314,7 +314,7 @@ func getTerraformInputNamesFromVarFiles(l log.Logger, opts *options.TerragruntOp
 // args that are passed in via the configured arguments attribute in the extra_arguments block of the given terragrunt
 // config and those that are directly passed in via the CLI.
 func getTerraformInputNamesFromCLIArgs(l log.Logger, opts *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) ([]string, error) {
-	inputNames, varFiles, err := GetVarFlagsFromArgList(opts.TerraformCliArgs)
+	inputNames, varFiles, err := GetVarFlagsFromArgList(opts.RunOptions.TerraformCliArgs)
 	if err != nil {
 		return inputNames, err
 	}

--- a/cli/commands/info/print/print.go
+++ b/cli/commands/info/print/print.go
@@ -52,8 +52,8 @@ func printTerragruntContext(l log.Logger, opts *options.TerragruntOptions) error
 		ConfigPath:       opts.TerragruntConfigPath,
 		DownloadDir:      opts.DownloadDir,
 		IAMRole:          opts.IAMRoleOptions.RoleARN,
-		TerraformBinary:  opts.TerraformPath,
-		TerraformCommand: opts.TerraformCommand,
+		TerraformBinary:  opts.RunOptions.TerraformPath,
+		TerraformCommand: opts.RunOptions.TerraformCommand,
 		WorkingDir:       opts.WorkingDir,
 	}
 

--- a/cli/commands/output-module-groups/cli.go
+++ b/cli/commands/output-module-groups/cli.go
@@ -49,7 +49,7 @@ func subCommandFunc(l log.Logger, cmd string, opts *options.TerragruntOptions) *
 		Usage:                        "Recursively find terragrunt modules in the current directory tree and output the dependency order as a list of list in JSON for the " + cmd,
 		DisabledErrorOnUndefinedFlag: true,
 		Action: func(ctx *cli.Context) error {
-			opts.TerraformCommand = cmd
+			opts.RunOptions.TerraformCommand = cmd
 			return Run(ctx, l, opts.OptionsFromContext(ctx))
 		},
 	}

--- a/cli/commands/output-module-groups/output-module-groups.go
+++ b/cli/commands/output-module-groups/output-module-groups.go
@@ -15,7 +15,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 		return err
 	}
 
-	js, err := stack.JSONModuleDeployOrder(opts.TerraformCommand)
+	js, err := stack.JSONModuleDeployOrder(opts.RunOptions.TerraformCommand)
 	if err != nil {
 		return err
 	}

--- a/cli/commands/run/cli.go
+++ b/cli/commands/run/cli.go
@@ -76,11 +76,11 @@ func NewSubcommands(l log.Logger, opts *options.TerragruntOptions) cli.Commands 
 
 func Action(l log.Logger, opts *options.TerragruntOptions) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
-		if opts.TerraformCommand == tf.CommandNameDestroy {
-			opts.CheckDependentModules = !opts.NoDestroyDependenciesCheck
+		if opts.RunOptions.TerraformCommand == tf.CommandNameDestroy {
+			opts.RunOptions.CheckDependentModules = !opts.RunOptions.NoDestroyDependenciesCheck
 		}
 
-		if err := validateCommand(opts); err != nil {
+		if err := validateCommand(opts.RunOptions); err != nil {
 			return err
 		}
 
@@ -88,7 +88,7 @@ func Action(l log.Logger, opts *options.TerragruntOptions) cli.ActionFunc {
 	}
 }
 
-func validateCommand(opts *options.TerragruntOptions) error {
+func validateCommand(opts *options.RunOptions) error {
 	if opts.DisableCommandValidation || collections.ListContainsElement(tf.CommandNames, opts.TerraformCommand) {
 		return nil
 	}
@@ -100,7 +100,7 @@ func validateCommand(opts *options.TerragruntOptions) error {
 	return WrongTofuCommand(opts.TerraformCommand)
 }
 
-func isTerraformPath(opts *options.TerragruntOptions) bool {
+func isTerraformPath(opts *options.RunOptions) bool {
 	return strings.HasSuffix(opts.TerraformPath, options.TerraformDefaultPath)
 }
 

--- a/cli/commands/run/cli_test.go
+++ b/cli/commands/run/cli_test.go
@@ -21,16 +21,20 @@ func TestAction(t *testing.T) {
 		{
 			name: "wrong tofu command",
 			opts: &options.TerragruntOptions{
-				TerraformCommand: "foo",
-				TerraformPath:    "tofu",
+				RunOptions: &options.RunOptions{
+					TerraformCommand: "foo",
+					TerraformPath:    "tofu",
+				},
 			},
 			expectedErr: run.WrongTofuCommand("foo"),
 		},
 		{
 			name: "wrong terraform command",
 			opts: &options.TerragruntOptions{
-				TerraformCommand: "foo",
-				TerraformPath:    "terraform",
+				RunOptions: &options.RunOptions{
+					TerraformCommand: "foo",
+					TerraformPath:    "terraform",
+				},
 			},
 			expectedErr: run.WrongTerraformCommand("foo"),
 		},

--- a/cli/commands/run/debug.go
+++ b/cli/commands/run/debug.go
@@ -55,7 +55,7 @@ func WriteTerragruntDebugFile(l log.Logger, opts *options.TerragruntOptions, cfg
 	l.Debugf(
 		"\tterraform -chdir=\"%s\" %s -var-file=\"%s\" ",
 		opts.WorkingDir,
-		strings.Join(opts.TerraformCliArgs, " "),
+		strings.Join(opts.RunOptions.TerraformCliArgs, " "),
 		fileName,
 	)
 

--- a/cli/commands/run/download_source.go
+++ b/cli/commands/run/download_source.go
@@ -111,7 +111,7 @@ func DownloadTerraformSourceIfNecessary(
 			return err
 		}
 
-		l.Debugf("%s files in %s are up to date. Will not download again.", opts.TerraformImplementation, terraformSource.WorkingDir)
+		l.Debugf("%s files in %s are up to date. Will not download again.", opts.RunOptions.TerraformImplementation, terraformSource.WorkingDir)
 
 		return nil
 	}
@@ -134,7 +134,7 @@ func DownloadTerraformSourceIfNecessary(
 		return err
 	}
 
-	terragruntOptionsForDownload.TerraformCommand = tf.CommandNameInitFromModule
+	terragruntOptionsForDownload.RunOptions.TerraformCommand = tf.CommandNameInitFromModule
 	downloadErr := RunActionWithHooks(ctx, l, "download source", terragruntOptionsForDownload, cfg, func(_ context.Context) error {
 		return downloadSource(ctx, l, terraformSource, opts, cfg)
 	})

--- a/cli/commands/run/errors.go
+++ b/cli/commands/run/errors.go
@@ -55,7 +55,7 @@ type MaxRetriesExceeded struct {
 }
 
 func (err MaxRetriesExceeded) Error() string {
-	return fmt.Sprintf("Exhausted retries (%v) for command %v %v", err.Opts.RetryMaxAttempts, err.Opts.TerraformPath, strings.Join(err.Opts.TerraformCliArgs, " "))
+	return fmt.Sprintf("Exhausted retries (%v) for command %v %v", err.Opts.RetryMaxAttempts, err.Opts.RunOptions.TerraformPath, strings.Join(err.Opts.RunOptions.TerraformCliArgs, " "))
 }
 
 type RunAllDisabledErr struct {

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -148,7 +148,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			EnvVars:     tgPrefix.EnvVars(NoAutoInitFlagName),
 			Usage:       "Don't automatically run 'terraform/tofu init' during other terragrunt commands. You must run 'terragrunt init' manually.",
 			Negative:    true,
-			Destination: &opts.AutoInit,
+			Destination: &opts.RunOptions.AutoInit,
 		},
 			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("no-auto-init"), terragruntPrefixControl),
 			flags.WithDeprecatedFlag(&cli.BoolFlag{
@@ -407,7 +407,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        DisableCommandValidationFlagName,
 			EnvVars:     tgPrefix.EnvVars(DisableCommandValidationFlagName),
-			Destination: &opts.DisableCommandValidation,
+			Destination: &opts.RunOptions.DisableCommandValidation,
 			Usage:       "When this flag is set, Terragrunt will not validate the tofu/terraform command.",
 		},
 			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("disable-command-validation"), terragruntPrefixControl)),
@@ -415,7 +415,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        NoDestroyDependenciesCheckFlagName,
 			EnvVars:     tgPrefix.EnvVars(NoDestroyDependenciesCheckFlagName),
-			Destination: &opts.NoDestroyDependenciesCheck,
+			Destination: &opts.RunOptions.NoDestroyDependenciesCheck,
 			Usage:       "When this flag is set, Terragrunt will not check for dependent units when destroying.",
 		},
 			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("no-destroy-dependencies-check"), terragruntPrefixControl)),
@@ -544,7 +544,7 @@ func NewTFPathFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.
 	return flags.NewFlag(&cli.GenericFlag[string]{
 		Name:        TFPathFlagName,
 		EnvVars:     tgPrefix.EnvVars(TFPathFlagName),
-		Destination: &opts.TerraformPath,
+		Destination: &opts.RunOptions.TerraformPath,
 		Usage:       "Path to the OpenTofu/Terraform binary. Default is tofu (on PATH).",
 	},
 		flags.WithDeprecatedNames(terragruntPrefix.FlagNames("tfpath"), terragruntPrefixControl))

--- a/cli/commands/run/help.go
+++ b/cli/commands/run/help.go
@@ -36,7 +36,7 @@ func ShowTFHelp(l log.Logger, opts *options.TerragruntOptions) cli.HelpFunc {
 
 		cli.HelpPrinterCustom(ctx, TFCommandHelpTemplate, map[string]any{
 			"isTerraformPath": func() bool {
-				return isTerraformPath(opts)
+				return isTerraformPath(opts.RunOptions)
 			},
 			"runTFHelp": func() string {
 				return runTFHelp(ctx, l, opts)
@@ -63,7 +63,7 @@ func runTFHelp(ctx *cli.Context, l log.Logger, opts *options.TerragruntOptions) 
 			err = processError.Err
 		}
 
-		return fmt.Sprintf("Failed to execute \"%s %s\": %s", opts.TerraformPath, strings.Join(terraformHelpCmd, " "), err.Error())
+		return fmt.Sprintf("Failed to execute \"%s %s\": %s", opts.RunOptions.TerraformPath, strings.Join(terraformHelpCmd, " "), err.Error())
 	}
 
 	result := out.Stdout.String()

--- a/cli/commands/run/hook.go
+++ b/cli/commands/run/hook.go
@@ -56,7 +56,7 @@ func processErrorHooks(ctx context.Context, l log.Logger, hooks []config.ErrorHo
 	errorMessage := customMultierror.Error()
 
 	for _, curHook := range hooks {
-		if util.MatchesAny(curHook.OnErrors, errorMessage) && util.ListContainsElement(curHook.Commands, terragruntOptions.TerraformCommand) {
+		if util.MatchesAny(curHook.OnErrors, errorMessage) && util.ListContainsElement(curHook.Commands, terragruntOptions.RunOptions.TerraformCommand) {
 			l.Infof("Executing hook: %s", curHook.Name)
 
 			workingDir := ""
@@ -139,7 +139,7 @@ func shouldRunHook(hook config.Hook, terragruntOptions *options.TerragruntOption
 	//
 	// resolves: https://github.com/gruntwork-io/terragrunt/issues/459
 	hasErrors := previousExecErrors.ErrorOrNil() != nil
-	isCommandInHook := util.ListContainsElement(hook.Commands, terragruntOptions.TerraformCommand)
+	isCommandInHook := util.ListContainsElement(hook.Commands, terragruntOptions.RunOptions.TerraformCommand)
 
 	return isCommandInHook && (!hasErrors || (hook.RunOnError != nil && *hook.RunOnError))
 }
@@ -203,8 +203,8 @@ func executeTFLint(ctx context.Context, l log.Logger, opts *options.TerragruntOp
 func terragruntOptionsWithHookEnvs(opts *options.TerragruntOptions, hookName string) *options.TerragruntOptions {
 	newOpts := *opts
 	newOpts.Env = cloner.Clone(opts.Env)
-	newOpts.Env[HookCtxTFPathEnvName] = opts.TerraformPath
-	newOpts.Env[HookCtxCommandEnvName] = opts.TerraformCommand
+	newOpts.Env[HookCtxTFPathEnvName] = opts.RunOptions.TerraformPath
+	newOpts.Env[HookCtxCommandEnvName] = opts.RunOptions.TerraformCommand
 	newOpts.Env[HookCtxHookNameEnvName] = hookName
 
 	return &newOpts

--- a/cli/commands/run/run_test.go
+++ b/cli/commands/run/run_test.go
@@ -264,7 +264,7 @@ func TestTerragruntHandlesCatastrophicTerraformFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use a path that doesn't exist to induce error
-	tgOptions.TerraformPath = "i-dont-exist"
+	tgOptions.RunOptions.TerraformPath = "i-dont-exist"
 	l := logger.CreateLogger()
 	err = run.RunTerraformWithRetry(t.Context(), l, tgOptions)
 	require.Error(t, err)
@@ -481,7 +481,7 @@ func mockOptions(t *testing.T, terragruntConfigPath string, workingDir string, t
 	}
 
 	opts.WorkingDir = workingDir
-	opts.TerraformCliArgs = terraformCliArgs
+	opts.RunOptions.TerraformCliArgs = terraformCliArgs
 	opts.NonInteractive = nonInteractive
 	opts.Source = terragruntSource
 	opts.IgnoreDependencyErrors = ignoreDependencyErrors

--- a/cli/commands/run/version_check.go
+++ b/cli/commands/run/version_check.go
@@ -48,8 +48,8 @@ func CheckVersionConstraints(ctx context.Context, l log.Logger, terragruntOption
 
 	// Change the terraform binary path before checking the version
 	// if the path is not changed from default and set in the config.
-	if terragruntOptions.TerraformPath == options.DefaultWrappedPath && partialTerragruntConfig.TerraformBinary != "" {
-		terragruntOptions.TerraformPath = partialTerragruntConfig.TerraformBinary
+	if terragruntOptions.RunOptions.TerraformPath == options.DefaultWrappedPath && partialTerragruntConfig.TerraformBinary != "" {
+		terragruntOptions.RunOptions.TerraformPath = partialTerragruntConfig.TerraformBinary
 	}
 
 	l, err = PopulateTerraformVersion(ctx, l, terragruntOptions)
@@ -110,9 +110,9 @@ func PopulateTerraformVersion(ctx context.Context, l log.Logger, terragruntOptio
 			return l, err
 		}
 
-		terragruntOptions.TerraformVersion = terraformVersion
+		terragruntOptions.RunOptions.TerraformVersion = terraformVersion
 
-		terragruntOptions.TerraformImplementation = tfImplementation
+		terragruntOptions.RunOptions.TerraformImplementation = tfImplementation
 
 		return l, nil
 	}
@@ -149,11 +149,11 @@ func PopulateTerraformVersion(ctx context.Context, l log.Logger, terragruntOptio
 		return l, err
 	}
 
-	terragruntOptions.TerraformVersion = terraformVersion
-	terragruntOptions.TerraformImplementation = tfImplementation
+	terragruntOptions.RunOptions.TerraformVersion = terraformVersion
+	terragruntOptions.RunOptions.TerraformImplementation = tfImplementation
 
 	if tfImplementation == options.UnknownImpl {
-		terragruntOptions.TerraformImplementation = options.TerraformImpl
+		terragruntOptions.RunOptions.TerraformImplementation = options.TerraformImpl
 
 		l.Warnf("Failed to identify Terraform implementation, fallback to terraform version: %s", terraformVersion)
 	} else {
@@ -166,7 +166,7 @@ func PopulateTerraformVersion(ctx context.Context, l log.Logger, terragruntOptio
 // CheckTerraformVersion checks that the currently installed Terraform version works meets the specified version constraint and return an error
 // if it doesn't
 func CheckTerraformVersion(constraint string, terragruntOptions *options.TerragruntOptions) error {
-	return CheckTerraformVersionMeetsConstraint(terragruntOptions.TerraformVersion, constraint)
+	return CheckTerraformVersionMeetsConstraint(terragruntOptions.RunOptions.TerraformVersion, constraint)
 }
 
 // CheckTerragruntVersion checks that the currently running Terragrunt version meets the specified version constraint and return an error

--- a/cli/commands/run/version_command.go
+++ b/cli/commands/run/version_command.go
@@ -13,7 +13,7 @@ func runVersionCommand(ctx context.Context, l log.Logger, opts *options.Terragru
 	if tfPath, err := getTfPathFromConfig(ctx, l, opts); err != nil {
 		return err
 	} else if tfPath != "" {
-		opts.TerraformPath = tfPath
+		opts.RunOptions.TerraformPath = tfPath
 	}
 
 	return tf.RunCommand(ctx, l, opts, tf.CommandNameVersion)

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -563,7 +563,7 @@ func PathRelativeFromInclude(ctx *ParsingContext, l log.Logger, params []string)
 
 // getTerraformCommand returns the current terraform command in execution
 func getTerraformCommand(ctx *ParsingContext, l log.Logger) (string, error) {
-	return ctx.TerragruntOptions.TerraformCommand, nil
+	return ctx.TerragruntOptions.RunOptions.TerraformCommand, nil
 }
 
 // getWorkingDir returns the current working dir
@@ -602,7 +602,7 @@ func getWorkingDir(ctx *ParsingContext, l log.Logger) (string, error) {
 
 // getTerraformCliArgs returns cli args for terraform
 func getTerraformCliArgs(ctx *ParsingContext, l log.Logger) ([]string, error) {
-	return ctx.TerragruntOptions.TerraformCliArgs, nil
+	return ctx.TerragruntOptions.RunOptions.TerraformCliArgs, nil
 }
 
 // getDefaultRetryableErrors returns default retryable errors

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -565,7 +565,7 @@ func TestResolveCliArgsInterpolationConfigString(t *testing.T) {
 
 	for _, cliArgs := range [][]string{nil, {}, {"apply"}, {"plan", "-out=planfile"}} {
 		opts := terragruntOptionsForTest(t, config.DefaultTerragruntConfigPath)
-		opts.TerraformCliArgs = cliArgs
+		opts.RunOptions.TerraformCliArgs = cliArgs
 		expectedFooInput := cliArgs
 		// Expecting nil to be returned for get_terraform_cli_args() call for
 		// either nil or empty array of input args

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -574,7 +574,7 @@ func PartialParseConfig(ctx *ParsingContext, l log.Logger, file *hclparse.File, 
 			// we use the value they set in their configuration.
 			//
 			// Otherwise, we assume that they've explicitly set the path they want to use via the --tf-path flag.
-			if decoded.TerraformBinary != nil && ctx.TerragruntOptions.TerraformPath == options.DefaultWrappedPath {
+			if decoded.TerraformBinary != nil && ctx.TerragruntOptions.RunOptions.TerraformPath == options.DefaultWrappedPath {
 				output.TerraformBinary = *decoded.TerraformBinary
 			}
 

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -159,7 +159,7 @@ func (dep Dependency) shouldMergeMockOutputsWithState(ctx *ParsingContext) bool 
 	allowedCommand :=
 		dep.MockOutputsAllowedTerraformCommands == nil ||
 			len(*dep.MockOutputsAllowedTerraformCommands) == 0 ||
-			util.ListContainsElement(*dep.MockOutputsAllowedTerraformCommands, ctx.TerragruntOptions.OriginalTerraformCommand)
+			util.ListContainsElement(*dep.MockOutputsAllowedTerraformCommands, ctx.TerragruntOptions.RunOptions.TerraformCommand)
 
 	return allowedCommand && dep.getMockOutputsMergeStrategy() != NoMerge
 }
@@ -544,7 +544,7 @@ func (dep Dependency) shouldReturnMockOutputs(ctx *ParsingContext) bool {
 	allowedCommand :=
 		dep.MockOutputsAllowedTerraformCommands == nil ||
 			len(*dep.MockOutputsAllowedTerraformCommands) == 0 ||
-			util.ListContainsElement(*dep.MockOutputsAllowedTerraformCommands, ctx.TerragruntOptions.OriginalTerraformCommand)
+			util.ListContainsElement(*dep.MockOutputsAllowedTerraformCommands, ctx.TerragruntOptions.RunOptions.TerraformCommand)
 
 	return defaultOutputsSet && allowedCommand || isRenderJSONCommand(ctx) || isRenderCommand(ctx)
 }
@@ -600,12 +600,12 @@ func isAwsS3NoSuchKey(err error) bool {
 
 // isRenderJSONCommand This function will true if terragrunt was invoked with render-json
 func isRenderJSONCommand(ctx *ParsingContext) bool {
-	return util.ListContainsElement(ctx.TerragruntOptions.TerraformCliArgs, renderJSONCommand)
+	return util.ListContainsElement(ctx.TerragruntOptions.RunOptions.TerraformCliArgs, renderJSONCommand)
 }
 
 // isRenderCommand will return true if terragrunt was invoked with render
 func isRenderCommand(ctx *ParsingContext) bool {
-	return util.ListContainsElement(ctx.TerragruntOptions.TerraformCliArgs, renderCommand)
+	return util.ListContainsElement(ctx.TerragruntOptions.RunOptions.TerraformCliArgs, renderCommand)
 }
 
 // getOutputJSONWithCaching will run terragrunt output on the target config if it is not already cached.
@@ -685,9 +685,9 @@ func cloneTerragruntOptionsForDependencyOutput(ctx *ParsingContext, l log.Logger
 
 	targetOptions.LoggingOptions.ForwardTFStdout = false
 	// just read outputs, so no need to check for dependent modules
-	targetOptions.CheckDependentModules = false
-	targetOptions.TerraformCommand = "output"
-	targetOptions.TerraformCliArgs = []string{"output", "-json"}
+	targetOptions.RunOptions.CheckDependentModules = false
+	targetOptions.RunOptions.TerraformCommand = "output"
+	targetOptions.RunOptions.TerraformCliArgs = []string{"output", "-json"}
 
 	// DownloadDir needs to be updated to be in the ctx of the new config, if using default
 	_, originalDefaultDownloadDir, err := options.DefaultWorkingAndDownloadDirs(ctx.TerragruntOptions.TerragruntConfigPath)
@@ -718,7 +718,7 @@ func cloneTerragruntOptionsForDependencyOutput(ctx *ParsingContext, l log.Logger
 	}
 
 	if partialTerragruntConfig.TerraformBinary != "" {
-		targetOptions.TerraformPath = partialTerragruntConfig.TerraformBinary
+		targetOptions.RunOptions.TerraformPath = partialTerragruntConfig.TerraformBinary
 	}
 
 	// If the Source is set, then we need to recompute it in the ctx of the target config.

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -107,7 +107,7 @@ func (module *TerraformModule) planFile(l log.Logger, opts *options.TerragruntOp
 	// set plan file location if output folder is set
 	planFile = module.outputFile(l, opts)
 
-	planCommand := module.TerragruntOptions.TerraformCommand == tf.CommandNamePlan || module.TerragruntOptions.TerraformCommand == tf.CommandNameShow
+	planCommand := module.TerragruntOptions.RunOptions.TerraformCommand == tf.CommandNamePlan || module.TerragruntOptions.RunOptions.TerraformCommand == tf.CommandNameShow
 
 	// in case if JSON output is enabled, and not specified planFile, save plan in working dir
 	if planCommand && planFile == "" && module.TerragruntOptions.JSONOutputFolder != "" {
@@ -168,7 +168,7 @@ func (module *TerraformModule) confirmShouldApplyExternalDependency(ctx context.
 		return false, nil
 	}
 
-	stackCmd := opts.TerraformCommand
+	stackCmd := opts.RunOptions.TerraformCommand
 	if stackCmd == "destroy" {
 		l.Debugf("run --all command called with destroy. To avoid accidentally having destructive effects on external dependencies with run --all command, will not run this command against module %s, which is a dependency of module %s.", dependency.Path, module.Path)
 		return false, nil
@@ -252,7 +252,7 @@ func FindWhereWorkingDirIsIncluded(ctx context.Context, l log.Logger, opts *opti
 
 		cfgOptions.Env = opts.Env
 		cfgOptions.OriginalTerragruntConfigPath = opts.OriginalTerragruntConfigPath
-		cfgOptions.TerraformCommand = opts.TerraformCommand
+		cfgOptions.RunOptions.TerraformCommand = opts.RunOptions.TerraformCommand
 		cfgOptions.NonInteractive = true
 
 		// build stack from config directory
@@ -503,7 +503,7 @@ func (modules TerraformModules) flagUnitsThatAreIncluded(opts *options.Terragrun
 }
 
 // flagExcludedUnits iterates over a module slice and flags all modules that are excluded based on the exclude block.
-func (modules TerraformModules) flagExcludedUnits(l log.Logger, opts *options.TerragruntOptions) TerraformModules {
+func (modules TerraformModules) flagExcludedUnits(l log.Logger, opts *options.RunOptions) TerraformModules {
 	for _, module := range modules {
 		excludeConfig := module.Config.Exclude
 

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -67,7 +67,7 @@ func newRunningModule(module *TerraformModule) *RunningModule {
 func (module *RunningModule) runModuleWhenReady(ctx context.Context, opts *options.TerragruntOptions, semaphore chan struct{}) {
 	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "wait_for_module_ready", map[string]any{
 		"path":             module.Module.Path,
-		"terraformCommand": module.Module.TerragruntOptions.TerraformCommand,
+		"terraformCommand": module.Module.TerragruntOptions.RunOptions.TerraformCommand,
 	}, func(_ context.Context) error {
 		return module.waitForDependencies()
 	})
@@ -80,7 +80,7 @@ func (module *RunningModule) runModuleWhenReady(ctx context.Context, opts *optio
 	if err == nil {
 		err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "run_module", map[string]any{
 			"path":             module.Module.Path,
-			"terraformCommand": module.Module.TerragruntOptions.TerraformCommand,
+			"terraformCommand": module.Module.TerragruntOptions.RunOptions.TerraformCommand,
 		}, func(ctx context.Context) error {
 			return module.runNow(ctx, opts)
 		})
@@ -146,8 +146,8 @@ func (module *RunningModule) runNow(ctx context.Context, rootOptions *options.Te
 			jsonOptions.LoggingOptions.ForwardTFStdout = true
 			jsonOptions.LoggingOptions.JSONLogFormat = false
 			jsonOptions.LoggingOptions.Writer = &stdout
-			jsonOptions.TerraformCommand = tf.CommandNameShow
-			jsonOptions.TerraformCliArgs = []string{tf.CommandNameShow, "-json", module.Module.planFile(l, rootOptions)}
+			jsonOptions.RunOptions.TerraformCommand = tf.CommandNameShow
+			jsonOptions.RunOptions.TerraformCliArgs = []string{tf.CommandNameShow, "-json", module.Module.planFile(l, rootOptions)}
 
 			if err := jsonOptions.RunTerragrunt(ctx, l, jsonOptions); err != nil {
 				return err

--- a/configstack/test_helpers_test.go
+++ b/configstack/test_helpers_test.go
@@ -159,7 +159,7 @@ func assertOptionsEqual(t *testing.T, expected options.TerragruntOptions, actual
 
 	assert.Equal(t, expected.TerragruntConfigPath, actual.TerragruntConfigPath, messageAndArgs...)
 	assert.Equal(t, expected.NonInteractive, actual.NonInteractive, messageAndArgs...)
-	assert.Equal(t, expected.TerraformCliArgs, actual.TerraformCliArgs, messageAndArgs...)
+	assert.Equal(t, expected.RunOptions.TerraformCliArgs, actual.RunOptions.TerraformCliArgs, messageAndArgs...)
 	assert.Equal(t, expected.WorkingDir, actual.WorkingDir, messageAndArgs...)
 }
 

--- a/internal/providercache/provider_cache.go
+++ b/internal/providercache/provider_cache.go
@@ -314,7 +314,7 @@ func runTerraformCommand(ctx context.Context, l log.Logger, opts *options.Terrag
 	errWriter := util.NewTrapWriter(opts.LoggingOptions.ErrWriter)
 
 	// add -no-color flag to args if it was set in Terragrunt arguments
-	if util.ListContainsElement(opts.TerraformCliArgs, tf.FlagNameNoColor) &&
+	if util.ListContainsElement(opts.RunOptions.TerraformCliArgs, tf.FlagNameNoColor) &&
 		!util.ListContainsElement(args, tf.FlagNameNoColor) {
 		args = append(args, tf.FlagNameNoColor)
 	}
@@ -327,10 +327,10 @@ func runTerraformCommand(ctx context.Context, l log.Logger, opts *options.Terrag
 	cloneOpts.LoggingOptions.Writer = io.Discard
 	cloneOpts.LoggingOptions.ErrWriter = errWriter
 	cloneOpts.WorkingDir = opts.WorkingDir
-	cloneOpts.TerraformCliArgs = args
+	cloneOpts.RunOptions.TerraformCliArgs = args
 	cloneOpts.Env = envs
 
-	output, err := tf.RunCommandWithOutput(ctx, l, cloneOpts, cloneOpts.TerraformCliArgs...)
+	output, err := tf.RunCommandWithOutput(ctx, l, cloneOpts, cloneOpts.RunOptions.TerraformCliArgs...)
 	// If the Terraform error matches `httpStatusCacheProviderReg` we ignore it and hide the log from users, otherwise we process the error as is.
 	if err != nil && httpStatusCacheProviderReg.Match(output.Stderr.Bytes()) {
 		return new(util.CmdOutput), nil

--- a/shell/run_cmd.go
+++ b/shell/run_cmd.go
@@ -85,7 +85,7 @@ func RunCommandWithOutput(
 			cmdStdout = io.MultiWriter(&output.Stdout)
 		}
 
-		if command == opts.TerraformPath {
+		if command == opts.RunOptions.TerraformPath {
 			// If the engine is enabled and the command is IaC executable, use the engine to run the command.
 			if opts.Engine != nil && opts.EngineEnabled {
 				l.Debugf("Using engine to run command: %s %s", command, strings.Join(args, " "))

--- a/shell/run_cmd_output_test.go
+++ b/shell/run_cmd_output_test.go
@@ -60,7 +60,7 @@ func testCommandOutput(t *testing.T, withOptions func(*options.TerragruntOptions
 	terragruntOptions.LoggingOptions.Writer = &allOutputBuffer
 	terragruntOptions.LoggingOptions.ErrWriter = &allOutputBuffer
 
-	terragruntOptions.TerraformCliArgs = append(terragruntOptions.TerraformCliArgs, "same")
+	terragruntOptions.RunOptions.TerraformCliArgs = append(terragruntOptions.RunOptions.TerraformCliArgs, "same")
 
 	withOptions(terragruntOptions)
 

--- a/shell/run_cmd_test.go
+++ b/shell/run_cmd_test.go
@@ -36,7 +36,7 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	terragruntOptions.TerraformCliArgs = append(terragruntOptions.TerraformCliArgs, "--version")
+	terragruntOptions.RunOptions.TerraformCliArgs = append(terragruntOptions.RunOptions.TerraformCliArgs, "--version")
 	terragruntOptions.LoggingOptions.Writer = stdout
 	terragruntOptions.LoggingOptions.ErrWriter = stderr
 
@@ -51,7 +51,7 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 	stdout = new(bytes.Buffer)
 	stderr = new(bytes.Buffer)
 
-	terragruntOptions.TerraformCliArgs = []string{}
+	terragruntOptions.RunOptions.TerraformCliArgs = []string{}
 	terragruntOptions.LoggingOptions.Writer = stderr
 	terragruntOptions.LoggingOptions.ErrWriter = stderr
 

--- a/tf/getter.go
+++ b/tf/getter.go
@@ -99,7 +99,7 @@ func (tfrGetter *RegistryGetter) registryDomain() string {
 		return defaultRegistry
 	}
 	// if binary is set to use OpenTofu registry, use OpenTofu as default registry
-	if tfrGetter.TerragruntOptions.TerraformImplementation == options.OpenTofuImpl {
+	if tfrGetter.TerragruntOptions.RunOptions.TerraformImplementation == options.OpenTofuImpl {
 		return defaultOtRegistryDomain
 	}
 

--- a/tf/run_cmd.go
+++ b/tf/run_cmd.go
@@ -63,7 +63,7 @@ func RunCommandWithOutput(ctx context.Context, l log.Logger, opts *options.Terra
 		opts.LoggingOptions.Writer, opts.LoggingOptions.ErrWriter = logTFOutput(l, opts, args)
 	}
 
-	output, err := shell.RunCommandWithOutput(ctx, l, opts, "", false, needsPTY, opts.TerraformPath, args...)
+	output, err := shell.RunCommandWithOutput(ctx, l, opts, "", false, needsPTY, opts.RunOptions.TerraformPath, args...)
 
 	if err != nil && util.ListContainsElement(args, FlagNameDetailedExitCode) {
 		code, _ := util.GetExitCode(err)
@@ -86,7 +86,7 @@ func logTFOutput(l log.Logger, opts *options.TerragruntOptions, args cli.Args) (
 	)
 
 	logger := l.
-		WithField(placeholders.TFPathKeyName, filepath.Base(opts.TerraformPath)).
+		WithField(placeholders.TFPathKeyName, filepath.Base(opts.RunOptions.TerraformPath)).
 		WithField(placeholders.TFCmdArgsKeyName, args.Slice()).
 		WithField(placeholders.TFCmdKeyName, args.CommandName())
 

--- a/tf/run_cmd_test.go
+++ b/tf/run_cmd_test.go
@@ -42,8 +42,7 @@ func TestCommandOutputPrefix(t *testing.T) {
 	logFormatter := format.NewFormatter(format.NewKeyValueFormatPlaceholders())
 
 	testCommandOutput(t, func(terragruntOptions *options.TerragruntOptions) {
-		terragruntOptions.TerraformPath = terraformPath
-
+		terragruntOptions.RunOptions.TerraformPath = terraformPath
 	}, func(l log.Logger) log.Logger {
 		l.SetOptions(log.WithFormatter(logFormatter))
 		return l.WithField(placeholders.WorkDirKeyName, prefix)
@@ -66,8 +65,8 @@ func testCommandOutput(t *testing.T, withOptions func(*options.TerragruntOptions
 	terragruntOptions.LoggingOptions.Writer = &allOutputBuffer
 	terragruntOptions.LoggingOptions.ErrWriter = &allOutputBuffer
 
-	terragruntOptions.TerraformCliArgs = append(terragruntOptions.TerraformCliArgs, "same")
-	terragruntOptions.TerraformPath = "testdata/test_outputs.sh"
+	terragruntOptions.RunOptions.TerraformCliArgs = append(terragruntOptions.RunOptions.TerraformCliArgs, "same")
+	terragruntOptions.RunOptions.TerraformPath = "testdata/test_outputs.sh"
 
 	withOptions(terragruntOptions)
 


### PR DESCRIPTION
## Description

Breaking down the options used for running OpenTofu/Terraform commands into their own struct, and embedding that struct into the main `TerragruntOptions` struct.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

