### PR TITLE
feat: Adding `report` package

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -246,7 +246,7 @@ func (s *Summary) TotalDuration() time.Duration {
 	return s.lastRunEnd.Sub(*s.firstRunStart)
 }
 
-// Write to file
+// WriteToFile writes the report to a file.
 func (r *Report) WriteToFile(path string) error {
 	file, err := os.Create(path)
 	if err != nil {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 	"time"
 )
@@ -236,12 +237,25 @@ func (s *Summary) Update(run *Run) {
 	}
 }
 
+// TotalDuration returns the total duration of all runs in the report.
 func (s *Summary) TotalDuration() time.Duration {
 	if s.firstRunStart == nil || s.lastRunEnd == nil {
 		return 0
 	}
 
 	return s.lastRunEnd.Sub(*s.firstRunStart)
+}
+
+// Write to file
+func (r *Report) WriteToFile(path string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	return r.WriteCSV(file)
 }
 
 // WriteCSV writes the report to a writer in CSV format.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,0 +1,299 @@
+// Package report provides a mechanism for collecting data on runs and generating a reports and summaries on that data.
+package report
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// Report captures data for a report/summary.
+type Report struct {
+	runs map[string]*Run
+}
+
+// Run captures data for a run.
+type Run struct {
+	Name    string
+	Started time.Time
+	Ended   time.Time
+	Result  Result
+	Reason  *Reason
+	Cause   *Cause
+
+	mu sync.RWMutex
+}
+
+// Result captures the result of a run.
+type Result string
+
+// Reason captures the reason for a run.
+type Reason string
+
+// Cause captures the cause of a run.
+type Cause string
+
+// Summary formats data from a report for output as a summary.
+type Summary struct {
+	TotalDuration  time.Duration
+	TotalUnits     int
+	UnitsSucceeded int
+	UnitsFailed    int
+	EarlyExits     int
+	Excluded       int
+}
+
+// NewReport creates a new report.
+func NewReport() *Report {
+	return &Report{
+		runs: make(map[string]*Run),
+	}
+}
+
+// NewRun creates a new run.
+func NewRun(name string) *Run {
+	return &Run{
+		Name:    name,
+		Started: time.Now(),
+	}
+}
+
+// ErrRunAlreadyExists is returned when a run already exists in the report.
+var ErrRunAlreadyExists = errors.New("run already exists")
+
+// AddRun adds a run to the report.
+// If the run already exists, it returns the ErrRunAlreadyExists error.
+func (r *Report) AddRun(run *Run) error {
+	_, ok := r.runs[run.Name]
+	if ok {
+		return fmt.Errorf("%w: %s", ErrRunAlreadyExists, run.Name)
+	}
+
+	r.runs[run.Name] = run
+	return nil
+}
+
+// GetRun returns a run from the report.
+func (r *Report) GetRun(name string) *Run {
+	return r.runs[name]
+}
+
+// ErrRunNotFound is returned when a run is not found in the report.
+var ErrRunNotFound = errors.New("run not found")
+
+// EndRun ends a run and adds it to the report.
+// If the run does not exist, it returns the ErrRunNotFound error.
+// By default, the run is assumed to have succeeded. To change this, pass WithResult to the function.
+func (r *Report) EndRun(name string, endOptions ...EndOption) error {
+	run, ok := r.runs[name]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrRunNotFound, name)
+	}
+
+	run.mu.Lock()
+	defer run.mu.Unlock()
+
+	run.Ended = time.Now()
+	run.Result = ResultSucceeded
+
+	for _, endOption := range endOptions {
+		endOption(run)
+	}
+
+	return nil
+}
+
+// EndOption are optional configurations for ending a run.
+type EndOption func(*Run)
+
+const (
+	ResultSucceeded Result = "succeeded"
+	ResultFailed    Result = "failed"
+	ResultEarlyExit Result = "early exit"
+	ResultExcluded  Result = "excluded"
+)
+
+// WithResult sets the result of a run.
+func WithResult(result Result) EndOption {
+	return func(run *Run) {
+		run.Result = result
+	}
+}
+
+const (
+	ReasonRetrySucceeded Reason = "retry succeeded"
+	ReasonErrorIgnored   Reason = "error ignored"
+	ReasonRunError       Reason = "run error"
+	ReasonExcludeDir     Reason = "--exclude-dir"
+	ReasonExcludeBlock   Reason = "exclude block"
+	ReasonEarlyExit      Reason = "early exit"
+)
+
+// WithReason sets the reason of a run.
+func WithReason(reason Reason) EndOption {
+	return func(run *Run) {
+		run.Reason = &reason
+	}
+}
+
+// WithCauseRetryBlock sets the cause of a run to the name of a particular retry block.
+//
+// This function is a wrapper around withCause, just to make sure that authors always use consistent
+// reasons for causes.
+func WithCauseRetryBlock(name string) EndOption {
+	return withCause(name)
+}
+
+// WithCauseIgnoreBlock sets the cause of a run to the name of a particular ignore block.
+//
+// This function is a wrapper around withCause, just to make sure that authors always use consistent
+// reasons for causes.
+func WithCauseIgnoreBlock(name string) EndOption {
+	return withCause(name)
+}
+
+// WithCauseExcludeBlock sets the cause of a run to the name of a particular exclude block.
+//
+// This function is a wrapper around withCause, just to make sure that authors always use consistent
+// reasons for causes.
+func WithCauseExcludeBlock(name string) EndOption {
+	return withCause(name)
+}
+
+// WithCauseAncestorExit sets the cause of a run to the name of a particular ancestor that exited.
+//
+// This function is a wrapper around withCause, just to make sure that authors always use consistent
+// reasons for causes.
+func WithCauseAncestorExit(name string) EndOption {
+	return withCause(name)
+}
+
+// withCause sets the cause of a run to the name of a particular cause.
+func withCause(name string) EndOption {
+	return func(run *Run) {
+		cause := Cause(name)
+		run.Cause = &cause
+	}
+}
+
+// Summarize returns a summary of the report.
+func (r *Report) Summarize() *Summary {
+	summary := &Summary{
+		TotalUnits: len(r.runs),
+	}
+
+	if len(r.runs) == 0 {
+		return summary
+	}
+
+	firstRunStart := time.Time{}
+	lastRunEnd := time.Time{}
+
+	for _, run := range r.runs {
+		run.mu.RLock()
+		defer run.mu.RUnlock()
+
+		switch run.Result {
+		case ResultSucceeded:
+			summary.UnitsSucceeded++
+		case ResultFailed:
+			summary.UnitsFailed++
+		case ResultEarlyExit:
+			summary.EarlyExits++
+		case ResultExcluded:
+			summary.Excluded++
+		}
+
+		if run.Started.Before(firstRunStart) {
+			firstRunStart = run.Started
+		}
+
+		if run.Ended.After(lastRunEnd) {
+			lastRunEnd = run.Ended
+		}
+	}
+
+	summary.TotalDuration = lastRunEnd.Sub(firstRunStart)
+
+	return summary
+}
+
+// WriteCSV writes the report to a writer in CSV format.
+func (r *Report) WriteCSV(w io.Writer) error {
+	csvWriter := csv.NewWriter(w)
+	defer csvWriter.Flush()
+
+	csvWriter.Write([]string{"Name", "Started", "Ended", "Result", "Reason", "Cause"})
+
+	for _, run := range r.runs {
+		run.mu.RLock()
+		defer run.mu.RUnlock()
+
+		name := run.Name
+		started := run.Started.Format(time.RFC3339)
+		ended := run.Ended.Format(time.RFC3339)
+		result := string(run.Result)
+		reason := ""
+
+		if run.Reason != nil {
+			reason = string(*run.Reason)
+		}
+
+		cause := ""
+		if run.Cause != nil {
+			cause = string(*run.Cause)
+		}
+
+		csvWriter.Write([]string{
+			name,
+			started,
+			ended,
+			result,
+			reason,
+			cause,
+		})
+	}
+
+	return nil
+}
+
+// WriteJSON writes the report to a writer in JSON format.
+func (r *Report) WriteJSON(w io.Writer) error {
+	return json.NewEncoder(w).Encode(r)
+}
+
+// WriteSummary writes the summary to a writer.
+func (r *Report) WriteSummary(w io.Writer) error {
+	return r.Summarize().Write(w)
+}
+
+// Write writes the summary to a writer.
+func (s *Summary) Write(w io.Writer) error {
+	fmt.Fprintf(w, "❯❯ Run Summary\n")
+
+	fmt.Fprintf(w, "Total Units: %d\n", s.TotalUnits)
+
+	fmt.Fprintf(w, "Total Duration: %s\n", s.TotalDuration)
+
+	if s.UnitsSucceeded > 0 {
+		fmt.Fprintf(w, "Units Succeeded: %d\n", s.UnitsSucceeded)
+	}
+
+	if s.UnitsFailed > 0 {
+		fmt.Fprintf(w, "Units Failed: %d\n", s.UnitsFailed)
+	}
+
+	if s.EarlyExits > 0 {
+		fmt.Fprintf(w, "Early Exits: %d\n", s.EarlyExits)
+	}
+
+	if s.Excluded > 0 {
+		fmt.Fprintf(w, "Excluded: %d\n", s.Excluded)
+	}
+
+	return nil
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,0 +1,366 @@
+package report
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewReport(t *testing.T) {
+	report := NewReport()
+	assert.NotNil(t, report)
+	assert.NotNil(t, report.runs)
+	assert.Empty(t, report.runs)
+}
+
+func TestNewRun(t *testing.T) {
+	name := "test-run"
+	run := NewRun(name)
+	assert.NotNil(t, run)
+	assert.Equal(t, name, run.Name)
+	assert.False(t, run.Started.IsZero())
+	assert.True(t, run.Ended.IsZero())
+	assert.Empty(t, run.Result)
+	assert.Nil(t, run.Reason)
+	assert.Nil(t, run.Cause)
+}
+
+func TestAddRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		run     *Run
+		wantErr bool
+	}{
+		{
+			name:    "successful add",
+			run:     NewRun("test-run"),
+			wantErr: false,
+		},
+		{
+			name:    "duplicate run",
+			run:     NewRun("test-run"),
+			wantErr: true,
+		},
+	}
+
+	report := NewReport()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := report.AddRun(tt.run)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "run already exists")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetRun(t *testing.T) {
+	report := NewReport()
+	run := NewRun("test-run")
+	report.AddRun(run)
+
+	tests := []struct {
+		name    string
+		runName string
+		wantNil bool
+	}{
+		{
+			name:    "existing run",
+			runName: "test-run",
+			wantNil: false,
+		},
+		{
+			name:    "non-existent run",
+			runName: "non-existent",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := report.GetRun(tt.runName)
+			if tt.wantNil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+				assert.Equal(t, tt.runName, got.Name)
+			}
+		})
+	}
+}
+
+func TestEndRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		runName    string
+		options    []EndOption
+		wantErr    bool
+		wantResult Result
+		wantReason *Reason
+		wantCause  *Cause
+	}{
+		{
+			name:       "successful end",
+			runName:    "test-run",
+			options:    []EndOption{},
+			wantErr:    false,
+			wantResult: ResultSucceeded,
+		},
+		{
+			name:    "non-existent run",
+			runName: "non-existent",
+			options: []EndOption{},
+			wantErr: true,
+		},
+		{
+			name:       "with result",
+			runName:    "test-run-2",
+			options:    []EndOption{WithResult(ResultFailed)},
+			wantErr:    false,
+			wantResult: ResultFailed,
+		},
+		{
+			name:       "with reason",
+			runName:    "test-run-3",
+			options:    []EndOption{WithReason(ReasonRunError)},
+			wantErr:    false,
+			wantResult: ResultSucceeded,
+			wantReason: func() *Reason { r := ReasonRunError; return &r }(),
+		},
+		{
+			name:       "with cause",
+			runName:    "test-run-4",
+			options:    []EndOption{WithCauseRetryBlock("test-block")},
+			wantErr:    false,
+			wantResult: ResultSucceeded,
+			wantCause:  func() *Cause { c := Cause("test-block"); return &c }(),
+		},
+	}
+
+	report := NewReport()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.wantErr {
+				run := NewRun(tt.runName)
+				report.AddRun(run)
+			}
+
+			err := report.EndRun(tt.runName, tt.options...)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				run := report.GetRun(tt.runName)
+				assert.Equal(t, tt.wantResult, run.Result)
+				if tt.wantReason != nil {
+					assert.NotNil(t, run.Reason)
+					assert.Equal(t, *tt.wantReason, *run.Reason)
+				}
+				if tt.wantCause != nil {
+					assert.NotNil(t, run.Cause)
+					assert.Equal(t, *tt.wantCause, *run.Cause)
+				}
+				assert.False(t, run.Ended.IsZero())
+			}
+		})
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	tests := []struct {
+		name string
+		runs []struct {
+			name   string
+			result Result
+		}
+		wantTotalUnits int
+		wantSucceeded  int
+		wantFailed     int
+		wantEarlyExits int
+		wantExcluded   int
+	}{
+		{
+			name: "empty report",
+			runs: []struct {
+				name   string
+				result Result
+			}{},
+			wantTotalUnits: 0,
+		},
+		{
+			name: "single successful run",
+			runs: []struct {
+				name   string
+				result Result
+			}{
+				{"run1", ResultSucceeded},
+			},
+			wantTotalUnits: 1,
+			wantSucceeded:  1,
+		},
+		{
+			name: "mixed results",
+			runs: []struct {
+				name   string
+				result Result
+			}{
+				{"run1", ResultSucceeded},
+				{"run2", ResultFailed},
+				{"run3", ResultEarlyExit},
+				{"run4", ResultExcluded},
+			},
+			wantTotalUnits: 4,
+			wantSucceeded:  1,
+			wantFailed:     1,
+			wantEarlyExits: 1,
+			wantExcluded:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := NewReport()
+			for _, r := range tt.runs {
+				run := NewRun(r.name)
+				report.AddRun(run)
+				report.EndRun(r.name, WithResult(r.result))
+			}
+
+			summary := report.Summarize()
+			assert.Equal(t, tt.wantTotalUnits, summary.TotalUnits)
+			assert.Equal(t, tt.wantSucceeded, summary.UnitsSucceeded)
+			assert.Equal(t, tt.wantFailed, summary.UnitsFailed)
+			assert.Equal(t, tt.wantEarlyExits, summary.EarlyExits)
+			assert.Equal(t, tt.wantExcluded, summary.Excluded)
+		})
+	}
+}
+
+func TestWriteCSV(t *testing.T) {
+	report := NewReport()
+	run := NewRun("test-run")
+	report.AddRun(run)
+	report.EndRun("test-run", WithResult(ResultFailed), WithReason(ReasonRunError))
+
+	var buf bytes.Buffer
+	err := report.WriteCSV(&buf)
+	assert.NoError(t, err)
+
+	output := buf.String()
+	expected := []string{
+		"Name,Started,Ended,Result,Reason,Cause",
+		"test-run,",
+		"failed",
+		"run error",
+		"",
+	}
+
+	for _, exp := range expected {
+		assert.Contains(t, output, exp)
+	}
+}
+
+func TestWriteSummary(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(*Report)
+		expected string
+	}{
+		{
+			name: "single successful run",
+			setup: func(r *Report) {
+				run := NewRun("successful-run")
+				r.AddRun(run)
+				r.EndRun("successful-run")
+			},
+			expected: `
+❯❯ Run Summary
+Total Units: 1
+Total Duration: %s
+Units Succeeded: 1
+`,
+		},
+		{
+			name: "complex mixed results",
+			setup: func(r *Report) {
+				// Add successful runs
+				firstSuccessfulRun := NewRun("first-successful-run")
+				r.AddRun(firstSuccessfulRun)
+				r.EndRun("first-successful-run")
+
+				secondSuccessfulRun := NewRun("second-successful-run")
+				r.AddRun(secondSuccessfulRun)
+				r.EndRun("second-successful-run")
+
+				// Add failed runs
+				firstFailedRun := NewRun("first-failed-run")
+				r.AddRun(firstFailedRun)
+				r.EndRun("first-failed-run", WithResult(ResultFailed))
+
+				secondFailedRun := NewRun("second-failed-run")
+				r.AddRun(secondFailedRun)
+				r.EndRun("second-failed-run", WithResult(ResultFailed))
+
+				// Add excluded runs
+				firstExcludedRun := NewRun("first-excluded-run")
+				r.AddRun(firstExcludedRun)
+				r.EndRun("first-excluded-run", WithResult(ResultExcluded))
+
+				secondExcludedRun := NewRun("second-excluded-run")
+				r.AddRun(secondExcludedRun)
+				r.EndRun("second-excluded-run", WithResult(ResultExcluded))
+
+				// Add early exit runs
+				firstEarlyExitRun := NewRun("first-early-exit-run")
+				r.AddRun(firstEarlyExitRun)
+				r.EndRun("first-early-exit-run", WithResult(ResultEarlyExit))
+
+				secondEarlyExitRun := NewRun("second-early-exit-run")
+				r.AddRun(secondEarlyExitRun)
+				r.EndRun("second-early-exit-run", WithResult(ResultEarlyExit))
+			},
+			expected: `
+❯❯ Run Summary
+Total Units: 8
+Total Duration: %s
+Units Succeeded: 2
+Units Failed: 2
+Early Exits: 2
+Excluded: 2
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := NewReport()
+			tt.setup(report)
+
+			var buf bytes.Buffer
+			err := report.WriteSummary(&buf)
+			assert.NoError(t, err)
+
+			output := buf.String()
+			// Get the first and last run to calculate duration
+			runs := report.runs
+			var firstRun, lastRun *Run
+			for _, run := range runs {
+				if firstRun == nil || run.Started.Before(firstRun.Started) {
+					firstRun = run
+				}
+				if lastRun == nil || run.Ended.After(lastRun.Ended) {
+					lastRun = run
+				}
+			}
+
+			expected := fmt.Sprintf(strings.TrimSpace(tt.expected), lastRun.Ended.Sub(firstRun.Started).String())
+			assert.Equal(t, expected, strings.TrimSpace(output))
+		})
+	}
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -63,6 +63,7 @@ func TestAddRun(t *testing.T) {
 				assert.Contains(t, err.Error(), "run already exists")
 			} else {
 				assert.NoError(t, err)
+				assert.Len(t, report.runs, 1)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Adds report package in preparation for #3628.

Adding work to actually integrate it into runs in #4387.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `report` package in preparation for #3628.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a reporting tool to track and summarize multiple process runs, including their results, reasons, and durations.
  - Added the ability to generate CSV exports and formatted summaries of run data.

- **Tests**
  - Implemented comprehensive tests to ensure correct creation, management, summarization, and export of run reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->