### PR TITLE
fix: Avoid installing D2 in Vercel

### DIFF
--- a/docs-starlight/astro.config.mjs
+++ b/docs-starlight/astro.config.mjs
@@ -134,7 +134,12 @@ export default defineConfig({
         ],
       }),
     ],
-  }), d2(), partytown({
+  }), d2({
+    // It's recommended that we just skip generation in Vercel,
+    // and generate diagrams locally:
+    // https://astro-d2.vercel.app/guides/how-astro-d2-works/#deployment
+    skipGeneration: !!process.env['VERCEL']
+  }), partytown({
     config: {
       forward: ['dataLayer.push']
     }

--- a/docs-starlight/vercel.json
+++ b/docs-starlight/vercel.json
@@ -1,4 +1,0 @@
-{
-    "installCommand": "bun i && curl -fsSL https://d2lang.com/install.sh | sh -s --",
-    "buildCommand": "bun run build"
-}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

The D2 installation keeps failing intermittently, and we don't actually need to install it all the time.

We can just require that folks install D2 themselves and regenerate diagrams when they need to.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Removed `d2` installation in Vercel.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated diagram generation settings to automatically skip diagram creation when deployed on Vercel.
  - Removed the Vercel deployment configuration file, simplifying deployment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->