### PR TITLE
fix: Avoid using interface pointer

### DIFF
--- a/internal/cas/benchmark_test.go
+++ b/internal/cas/benchmark_test.go
@@ -34,7 +34,7 @@ func BenchmarkClone(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			if err := c.Clone(b.Context(), &l, &cas.CloneOptions{
+			if err := c.Clone(b.Context(), l, &cas.CloneOptions{
 				Dir: targetPath,
 			}, repo); err != nil {
 				b.Fatal(err)
@@ -53,7 +53,7 @@ func BenchmarkClone(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		if err := c.Clone(b.Context(), &l, &cas.CloneOptions{
+		if err := c.Clone(b.Context(), l, &cas.CloneOptions{
 			Dir: filepath.Join(tempDir, "initial"),
 		}, repo); err != nil {
 			b.Fatal(err)
@@ -70,7 +70,7 @@ func BenchmarkClone(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			if err := c.Clone(b.Context(), &l, &cas.CloneOptions{
+			if err := c.Clone(b.Context(), l, &cas.CloneOptions{
 				Dir: targetPath,
 			}, repo); err != nil {
 				b.Fatal(err)
@@ -92,7 +92,7 @@ func BenchmarkContent(b *testing.B) {
 	b.Run("store", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			hash := fmt.Sprintf("benchmark%d", i)
-			if err := content.Store(&l, hash, testData); err != nil {
+			if err := content.Store(l, hash, testData); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -115,7 +115,7 @@ func BenchmarkContent(b *testing.B) {
 				seen[hash] = true
 				mu.Unlock()
 
-				if err := content.Store(&l, hash, testData); err != nil {
+				if err := content.Store(l, hash, testData); err != nil {
 					b.Fatal(err)
 				}
 				i++

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -76,7 +76,7 @@ func New(opts Options) (*CAS, error) {
 // Clone performs the clone operation
 //
 // TODO: Make options optional
-func (c *CAS) Clone(ctx context.Context, l *log.Logger, opts *CloneOptions, url string) error {
+func (c *CAS) Clone(ctx context.Context, l log.Logger, opts *CloneOptions, url string) error {
 	c.cloneStart = time.Now()
 
 	targetDir := c.prepareTargetDirectory(opts.Dir, url)
@@ -89,7 +89,7 @@ func (c *CAS) Clone(ctx context.Context, l *log.Logger, opts *CloneOptions, url 
 
 	defer func() {
 		if cleanupErr := cleanup(); cleanupErr != nil {
-			(*l).Warnf("cleanup error: %v", cleanupErr)
+			l.Warnf("cleanup error: %v", cleanupErr)
 		}
 	}()
 
@@ -152,7 +152,7 @@ func (c *CAS) resolveReference(ctx context.Context, url, branch string) (string,
 	return results[0].Hash, nil
 }
 
-func (c *CAS) cloneAndStoreContent(ctx context.Context, l *log.Logger, opts *CloneOptions, url string, hash string) error {
+func (c *CAS) cloneAndStoreContent(ctx context.Context, l log.Logger, opts *CloneOptions, url string, hash string) error {
 	if err := c.git.Clone(ctx, url, true, 1, opts.Branch); err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func (c *CAS) cloneAndStoreContent(ctx context.Context, l *log.Logger, opts *Clo
 	return c.storeRootTree(ctx, l, hash, opts)
 }
 
-func (c *CAS) storeRootTree(ctx context.Context, l *log.Logger, hash string, opts *CloneOptions) error {
+func (c *CAS) storeRootTree(ctx context.Context, l log.Logger, hash string, opts *CloneOptions) error {
 	if err := c.storeTree(ctx, l, hash, ""); err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func (c *CAS) storeRootTree(ctx context.Context, l *log.Logger, hash string, opt
 	return content.Store(l, hash, data)
 }
 
-func (c *CAS) storeTree(ctx context.Context, l *log.Logger, hash, prefix string) error {
+func (c *CAS) storeTree(ctx context.Context, l log.Logger, hash, prefix string) error {
 	if !c.store.NeedsWrite(hash, c.cloneStart) {
 		return nil
 	}
@@ -340,7 +340,7 @@ func (c *CAS) storeBlobs(ctx context.Context, entries []TreeEntry) error {
 }
 
 // storeTrees concurrently stores trees in the CAS
-func (c *CAS) storeTrees(ctx context.Context, l *log.Logger, entries []TreeEntry, prefix string) error {
+func (c *CAS) storeTrees(ctx context.Context, l log.Logger, entries []TreeEntry, prefix string) error {
 	ch := make(chan error, len(entries))
 
 	var wg sync.WaitGroup

--- a/internal/cas/cas_test.go
+++ b/internal/cas/cas_test.go
@@ -26,7 +26,7 @@ func TestCAS_Clone(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = c.Clone(t.Context(), &l, &cas.CloneOptions{
+		err = c.Clone(t.Context(), l, &cas.CloneOptions{
 			Dir: targetPath,
 		}, "https://github.com/gruntwork-io/terragrunt.git")
 		require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestCAS_Clone(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = c.Clone(t.Context(), &l, &cas.CloneOptions{
+		err = c.Clone(t.Context(), l, &cas.CloneOptions{
 			Dir:    targetPath,
 			Branch: "main",
 		}, "https://github.com/gruntwork-io/terragrunt.git")
@@ -73,7 +73,7 @@ func TestCAS_Clone(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = c.Clone(t.Context(), &l, &cas.CloneOptions{
+		err = c.Clone(t.Context(), l, &cas.CloneOptions{
 			Dir:              targetPath,
 			IncludedGitFiles: []string{"HEAD", "config"},
 		}, "https://github.com/gruntwork-io/terragrunt.git")

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -105,7 +105,7 @@ func (c *Content) ensureTargetDirectory(targetPath string) error {
 
 // Store stores a single content item. This is typically used for trees,
 // As blobs are written directly from git cat-file stdout.
-func (c *Content) Store(l *log.Logger, hash string, data []byte) error {
+func (c *Content) Store(l log.Logger, hash string, data []byte) error {
 	c.store.mapLock.Lock()
 
 	if _, ok := c.store.locks[hash]; !ok {
@@ -141,7 +141,7 @@ func (c *Content) Store(l *log.Logger, hash string, data []byte) error {
 		f.Close()
 
 		if err := os.Remove(tempPath); err != nil {
-			(*l).Warnf("failed to remove temp file %s: %v", tempPath, err)
+			l.Warnf("failed to remove temp file %s: %v", tempPath, err)
 		}
 
 		return wrapError("write_to_store", tempPath, err)
@@ -151,7 +151,7 @@ func (c *Content) Store(l *log.Logger, hash string, data []byte) error {
 		f.Close()
 
 		if err := os.Remove(tempPath); err != nil {
-			(*l).Warnf("failed to remove temp file %s: %v", tempPath, err)
+			l.Warnf("failed to remove temp file %s: %v", tempPath, err)
 		}
 
 		return wrapError("flush_buffer", tempPath, err)
@@ -159,7 +159,7 @@ func (c *Content) Store(l *log.Logger, hash string, data []byte) error {
 
 	if err := f.Close(); err != nil {
 		if err := os.Remove(tempPath); err != nil {
-			(*l).Warnf("failed to remove temp file %s: %v", tempPath, err)
+			l.Warnf("failed to remove temp file %s: %v", tempPath, err)
 		}
 
 		return wrapError("close_file", tempPath, err)
@@ -168,7 +168,7 @@ func (c *Content) Store(l *log.Logger, hash string, data []byte) error {
 	// Set read-only permissions on the temporary file
 	if err := os.Chmod(tempPath, StoredFilePerms); err != nil {
 		if err := os.Remove(tempPath); err != nil {
-			(*l).Warnf("failed to remove temp file %s: %v", tempPath, err)
+			l.Warnf("failed to remove temp file %s: %v", tempPath, err)
 		}
 
 		return wrapError("chmod_temp_file", tempPath, err)
@@ -180,7 +180,7 @@ func (c *Content) Store(l *log.Logger, hash string, data []byte) error {
 		if _, err := os.Stat(path); err == nil {
 			// File exists, make it writable before rename operation
 			if err := os.Chmod(path, RegularFilePerms); err != nil {
-				(*l).Warnf("failed to make destination file writable %s: %v", path, err)
+				l.Warnf("failed to make destination file writable %s: %v", path, err)
 			}
 		}
 	}
@@ -188,7 +188,7 @@ func (c *Content) Store(l *log.Logger, hash string, data []byte) error {
 	// Atomic rename
 	if err := os.Rename(tempPath, path); err != nil {
 		if err := os.Remove(tempPath); err != nil {
-			(*l).Warnf("failed to remove temp file %s: %v", tempPath, err)
+			l.Warnf("failed to remove temp file %s: %v", tempPath, err)
 		}
 
 		return wrapError("finalize_store", path, err)
@@ -206,7 +206,7 @@ func (c *Content) Store(l *log.Logger, hash string, data []byte) error {
 }
 
 // Ensure ensures that a content item exists in the store
-func (c *Content) Ensure(l *log.Logger, hash string, data []byte) error {
+func (c *Content) Ensure(l log.Logger, hash string, data []byte) error {
 	path := c.getPath(hash)
 	if c.store.hasContent(path) {
 		return nil
@@ -216,7 +216,7 @@ func (c *Content) Ensure(l *log.Logger, hash string, data []byte) error {
 }
 
 // EnsureCopy ensures that a content item exists in the store by copying from a file
-func (c *Content) EnsureCopy(l *log.Logger, hash, src string) error {
+func (c *Content) EnsureCopy(l log.Logger, hash, src string) error {
 	path := c.getPath(hash)
 	if c.store.hasContent(path) {
 		return nil

--- a/internal/cas/content_test.go
+++ b/internal/cas/content_test.go
@@ -26,7 +26,7 @@ func TestContent_Store(t *testing.T) {
 		testHash := testHashValue
 		testData := []byte("test content")
 
-		err := content.Store(&l, testHash, testData)
+		err := content.Store(l, testHash, testData)
 		require.NoError(t, err)
 
 		// Verify content was stored
@@ -48,9 +48,9 @@ func TestContent_Store(t *testing.T) {
 		differentData := []byte("different content")
 
 		// Store content twice
-		err := content.Ensure(&l, testHash, testData)
+		err := content.Ensure(l, testHash, testData)
 		require.NoError(t, err)
-		err = content.Ensure(&l, testHash, differentData)
+		err = content.Ensure(l, testHash, differentData)
 		require.NoError(t, err)
 
 		// Verify original content remains
@@ -72,9 +72,9 @@ func TestContent_Store(t *testing.T) {
 		differentData := []byte("different content")
 
 		// Store content twice
-		err := content.Store(&l, testHash, testData)
+		err := content.Store(l, testHash, testData)
 		require.NoError(t, err)
-		err = content.Store(&l, testHash, differentData)
+		err = content.Store(l, testHash, differentData)
 		require.NoError(t, err)
 
 		// Verify original content remains
@@ -101,7 +101,7 @@ func TestContent_Link(t *testing.T) {
 		testData := []byte("test content")
 
 		// First store some content
-		err := content.Store(&l, testHash, testData)
+		err := content.Store(l, testHash, testData)
 		require.NoError(t, err)
 
 		// Then create a link to it
@@ -133,7 +133,7 @@ func TestContent_Link(t *testing.T) {
 		testData := []byte("test content")
 
 		// Store content
-		err := content.Store(&l, testHash, testData)
+		err := content.Store(l, testHash, testData)
 		require.NoError(t, err)
 
 		// Create target file

--- a/internal/cas/getter.go
+++ b/internal/cas/getter.go
@@ -16,12 +16,12 @@ var _ getter.Getter = &CASGetter{}
 // CASGetter is a go-getter Getter implementation.
 type CASGetter struct {
 	CAS       *CAS
-	Logger    *log.Logger
+	Logger    log.Logger
 	Opts      *CloneOptions
 	Detectors []getter.Detector
 }
 
-func NewCASGetter(l *log.Logger, cas *CAS, opts *CloneOptions) *CASGetter {
+func NewCASGetter(l log.Logger, cas *CAS, opts *CloneOptions) *CASGetter {
 	return &CASGetter{
 		Detectors: []getter.Detector{
 			new(getter.GitHubDetector),

--- a/internal/cas/getter_ssh_test.go
+++ b/internal/cas/getter_ssh_test.go
@@ -54,7 +54,7 @@ func TestSSHCASGetterGet(t *testing.T) {
 				Branch: "main",
 			}
 			l := logger.CreateLogger()
-			g := cas.NewCASGetter(&l, c, opts)
+			g := cas.NewCASGetter(l, c, opts)
 			client := getter.Client{
 				Getters: []getter.Getter{g},
 			}

--- a/internal/cas/getter_test.go
+++ b/internal/cas/getter_test.go
@@ -2,6 +2,7 @@ package cas_test
 
 import (
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
@@ -73,7 +74,12 @@ func TestCASGetterDetect(t *testing.T) {
 func TestCASGetterGet(t *testing.T) {
 	t.Parallel()
 
-	c, err := cas.New(cas.Options{})
+	tempDir := t.TempDir()
+	storePath := filepath.Join(tempDir, "store")
+
+	c, err := cas.New(cas.Options{
+		StorePath: storePath,
+	})
 	require.NoError(t, err)
 
 	opts := &cas.CloneOptions{

--- a/internal/cas/getter_test.go
+++ b/internal/cas/getter_test.go
@@ -82,7 +82,7 @@ func TestCASGetterGet(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	g := cas.NewCASGetter(&l, c, opts)
+	g := cas.NewCASGetter(l, c, opts)
 	client := getter.Client{
 		Getters: []getter.Getter{g},
 	}

--- a/internal/cas/integration_test.go
+++ b/internal/cas/integration_test.go
@@ -28,7 +28,7 @@ func TestIntegration_CloneAndReuse(t *testing.T) {
 			StorePath: storePath,
 		})
 		require.NoError(t, err)
-		require.NoError(t, cas1.Clone(t.Context(), &l, &cas.CloneOptions{
+		require.NoError(t, cas1.Clone(t.Context(), l, &cas.CloneOptions{
 			Dir: firstClonePath,
 		}, "https://github.com/gruntwork-io/terragrunt.git"))
 
@@ -43,7 +43,7 @@ func TestIntegration_CloneAndReuse(t *testing.T) {
 			StorePath: storePath,
 		})
 		require.NoError(t, err)
-		require.NoError(t, cas2.Clone(t.Context(), &l, &cas.CloneOptions{
+		require.NoError(t, cas2.Clone(t.Context(), l, &cas.CloneOptions{
 			Dir: secondClonePath,
 		}, "https://github.com/gruntwork-io/terragrunt.git"))
 
@@ -69,7 +69,7 @@ func TestIntegration_CloneAndReuse(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = c.Clone(t.Context(), &l, &cas.CloneOptions{
+		err = c.Clone(t.Context(), l, &cas.CloneOptions{
 			Dir:    filepath.Join(tempDir, "repo"),
 			Branch: "nonexistent-branch",
 		}, "https://github.com/gruntwork-io/terragrunt.git")
@@ -88,7 +88,7 @@ func TestIntegration_CloneAndReuse(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = c.Clone(t.Context(), &l, &cas.CloneOptions{
+		err = c.Clone(t.Context(), l, &cas.CloneOptions{
 			Dir: filepath.Join(tempDir, "repo"),
 		}, "https://github.com/yhakbar/nonexistent-repo.git")
 		require.Error(t, err)
@@ -115,7 +115,7 @@ func TestIntegration_TreeStorage(t *testing.T) {
 			StorePath: storePath,
 		})
 		require.NoError(t, err)
-		require.NoError(t, c.Clone(ctx, &l, &cas.CloneOptions{
+		require.NoError(t, c.Clone(ctx, l, &cas.CloneOptions{
 			Dir: filepath.Join(tempDir, "repo"),
 		}, "https://github.com/gruntwork-io/terragrunt.git"))
 

--- a/internal/cas/race_test.go
+++ b/internal/cas/race_test.go
@@ -3,6 +3,7 @@
 package cas_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
@@ -15,7 +16,12 @@ import (
 func TestCASGetterGetWithRacing(t *testing.T) {
 	t.Parallel()
 
-	c, err := cas.New(cas.Options{})
+	tempDir := t.TempDir()
+	storePath := filepath.Join(tempDir, "store")
+
+	c, err := cas.New(cas.Options{
+		StorePath: storePath,
+	})
 	require.NoError(t, err)
 
 	opts := &cas.CloneOptions{

--- a/internal/cas/race_test.go
+++ b/internal/cas/race_test.go
@@ -24,7 +24,7 @@ func TestCASGetterGetWithRacing(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	g := cas.NewCASGetter(&l, c, opts)
+	g := cas.NewCASGetter(l, c, opts)
 	client := getter.Client{
 		Getters: []getter.Getter{g},
 	}

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -293,7 +293,7 @@ func (repo *Repo) performClone(ctx context.Context, l log.Logger, opts *CloneOpt
 			IncludedGitFiles: includedGitFiles,
 		}
 
-		client.Getters = append([]getter.Getter{cas.NewCASGetter(&l, c, &cloneOpts)}, client.Getters...)
+		client.Getters = append([]getter.Getter{cas.NewCASGetter(l, c, &cloneOpts)}, client.Getters...)
 	}
 
 	sourceURL, err := tf.ToSourceURL(opts.SourceURL, "")


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This was a silly thing I did. We don't need an interface pointer for the logger, we can just use the actual interface.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated CAS usage of the logger to rely on the interface rather than a pointer to the interface.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated logger parameters throughout the application to use value types instead of pointers for improved consistency.
  - Adjusted method and constructor signatures to accept logger values.
  - Updated all related test cases and usage to match the new logger parameter type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->