### PR TITLE
fix: Each CAS test gets its own store

### DIFF
--- a/internal/cas/getter_test.go
+++ b/internal/cas/getter_test.go
@@ -2,6 +2,7 @@ package cas_test
 
 import (
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
@@ -73,7 +74,12 @@ func TestCASGetterDetect(t *testing.T) {
 func TestCASGetterGet(t *testing.T) {
 	t.Parallel()
 
-	c, err := cas.New(cas.Options{})
+	tempDir := t.TempDir()
+	storePath := filepath.Join(tempDir, "store")
+
+	c, err := cas.New(cas.Options{
+		StorePath: storePath,
+	})
 	require.NoError(t, err)
 
 	opts := &cas.CloneOptions{

--- a/internal/cas/race_test.go
+++ b/internal/cas/race_test.go
@@ -3,6 +3,7 @@
 package cas_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
@@ -15,7 +16,12 @@ import (
 func TestCASGetterGetWithRacing(t *testing.T) {
 	t.Parallel()
 
-	c, err := cas.New(cas.Options{})
+	tempDir := t.TempDir()
+	storePath := filepath.Join(tempDir, "store")
+
+	c, err := cas.New(cas.Options{
+		StorePath: storePath,
+	})
 	require.NoError(t, err)
 
 	opts := &cas.CloneOptions{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Giving each CAS test its own store, hopefully mitigating race conditions with tests clobering each other.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated CAS tests so that each would get its own store.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

