### PR TITLE
feat: Adding `--summary-unit-duration`

### DIFF
--- a/cli/commands/common/graph/graph.go
+++ b/cli/commands/common/graph/graph.go
@@ -60,7 +60,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 			r.WithFormat(opts.ReportFormat)
 		}
 
-		if opts.SummaryUnitTiming {
+		if opts.SummaryUnitDuration {
 			r.WithShowUnitTiming()
 		}
 

--- a/cli/commands/common/graph/graph.go
+++ b/cli/commands/common/graph/graph.go
@@ -60,6 +60,10 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 			r.WithFormat(opts.ReportFormat)
 		}
 
+		if opts.SummaryUnitTiming {
+			r.WithShowUnitTiming()
+		}
+
 		stackOpts = append(stackOpts, configstack.WithReport(r))
 
 		if opts.ReportSchemaFile != "" {

--- a/cli/commands/common/runall/runall.go
+++ b/cli/commands/common/runall/runall.go
@@ -61,7 +61,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 			r.WithFormat(opts.ReportFormat)
 		}
 
-		if opts.SummaryUnitTiming {
+		if opts.SummaryUnitDuration {
 			r.WithShowUnitTiming()
 		}
 

--- a/cli/commands/common/runall/runall.go
+++ b/cli/commands/common/runall/runall.go
@@ -61,6 +61,10 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 			r.WithFormat(opts.ReportFormat)
 		}
 
+		if opts.SummaryUnitTiming {
+			r.WithShowUnitTiming()
+		}
+
 		stackOpts = append(stackOpts, configstack.WithReport(r))
 
 		if opts.ReportSchemaFile != "" {

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -29,6 +29,7 @@ const (
 	UnitsThatIncludeFlagName               = "units-that-include"
 	DependencyFetchOutputFromStateFlagName = "dependency-fetch-output-from-state"
 	UsePartialParseConfigCacheFlagName     = "use-partial-parse-config-cache"
+	SummaryUnitTimingFlagName              = "summary-unit-timing"
 
 	BackendBootstrapFlagName        = "backend-bootstrap"
 	BackendRequireBootstrapFlagName = "backend-require-bootstrap"
@@ -546,6 +547,13 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			EnvVars:     tgPrefix.EnvVars(SummaryDisableFlagName),
 			Destination: &opts.SummaryDisable,
 			Usage:       `Disable the summary output at the end of a run.`,
+		}),
+
+		flags.NewFlag(&cli.BoolFlag{
+			Name:        SummaryUnitTimingFlagName,
+			EnvVars:     tgPrefix.EnvVars(SummaryUnitTimingFlagName),
+			Destination: &opts.SummaryUnitTiming,
+			Usage:       `Show timing information for each unit in the summary output.`,
 		}),
 
 		flags.NewFlag(&cli.GenericFlag[string]{

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -29,7 +29,7 @@ const (
 	UnitsThatIncludeFlagName               = "units-that-include"
 	DependencyFetchOutputFromStateFlagName = "dependency-fetch-output-from-state"
 	UsePartialParseConfigCacheFlagName     = "use-partial-parse-config-cache"
-	SummaryUnitTimingFlagName              = "summary-unit-timing"
+	SummaryUnitDurationFlagName            = "summary-unit-duration"
 
 	BackendBootstrapFlagName        = "backend-bootstrap"
 	BackendRequireBootstrapFlagName = "backend-require-bootstrap"
@@ -550,10 +550,10 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 		}),
 
 		flags.NewFlag(&cli.BoolFlag{
-			Name:        SummaryUnitTimingFlagName,
-			EnvVars:     tgPrefix.EnvVars(SummaryUnitTimingFlagName),
-			Destination: &opts.SummaryUnitTiming,
-			Usage:       `Show timing information for each unit in the summary output.`,
+			Name:        SummaryUnitDurationFlagName,
+			EnvVars:     tgPrefix.EnvVars(SummaryUnitDurationFlagName),
+			Destination: &opts.SummaryUnitDuration,
+			Usage:       `Show duration information for each unit in the summary output.`,
 		}),
 
 		flags.NewFlag(&cli.GenericFlag[string]{

--- a/docs-starlight/src/content/docs/02-features/16-run-report.mdx
+++ b/docs-starlight/src/content/docs/02-features/16-run-report.mdx
@@ -40,6 +40,26 @@ This output is called the "Run Summary". It provides at-a-glance information abo
 - Excluded: The number of units that were excluded from the run (if any were).
 - Early Exits: The number of units that exited early, due to a failure in a dependency (if any did).
 
+### Showing Unit Durations
+
+You can enable showing the duration of each unit in the run summary by using the `--summary-unit-duration` flag.
+
+```bash
+$ terragrunt run --all plan --summary-unit-duration
+
+# Omitted for brevity...
+
+❯❯ Run Summary
+   Duration:   62ms
+      long-running-unit:    10m
+      medium-running-unit:  12s
+      short-running-unit:   5ms
+   Units:      3
+   Succeeded:  3
+```
+
+The units are sorted by duration, with the longest-running units shown first.
+
 ### Disabling the summary
 
 You can disable the summary output by using the `--summary-disable` flag.

--- a/docs-starlight/src/data/commands/run.mdx
+++ b/docs-starlight/src/data/commands/run.mdx
@@ -69,6 +69,7 @@ flags:
   - source-map
   - source-update
   - summary-disable
+  - summary-unit-duration
   - tf-forward-stdout
   - tf-path
   - units-that-include

--- a/docs-starlight/src/data/flags/summary-unit-duration.mdx
+++ b/docs-starlight/src/data/flags/summary-unit-duration.mdx
@@ -1,0 +1,11 @@
+---
+name: summary-unit-duration
+description: Shows the duration of each unit in the run summary.
+type: bool
+env:
+  - TG_SUMMARY_UNIT_DURATION
+---
+
+When enabled, Terragrunt will show the duration of each unit in the run summary. The units are sorted by duration, with the longest-running units shown first.
+
+For more information, see the [Run Report](/docs/features/run-report) feature.

--- a/docs/_docs/02_features/16-run-report.md
+++ b/docs/_docs/02_features/16-run-report.md
@@ -41,6 +41,26 @@ This output is called the "Run Summary". It provides at-a-glance information abo
 - Excluded: The number of units that were excluded from the run (if any were).
 - Early Exits: The number of units that exited early, due to a failure in a dependency (if any did).
 
+### Showing Unit Durations
+
+You can enable showing the duration of each unit in the run summary by using the `--summary-unit-duration` flag.
+
+```bash
+$ terragrunt run --all plan --summary-unit-duration
+
+# Omitted for brevity...
+
+❯❯ Run Summary
+   Duration:   62ms
+      long-running-unit:    10m
+      medium-running-unit:  12s
+      short-running-unit:   5ms
+   Units:      3
+   Succeeded:  3
+```
+
+The units are sorted by duration, with the longest-running units shown first.
+
 ### Disabling the summary
 
 You can disable the summary output by using the `--summary-disable` flag.

--- a/docs/_docs/04_reference/02-cli-options.md
+++ b/docs/_docs/04_reference/02-cli-options.md
@@ -1710,6 +1710,15 @@ When passed in, disable the summary output at the end of a run.
 
 For more information, see the [Run Report](/docs/features/run-report#disabling-the-summary) feature.
 
+### summary-unit-duration
+
+**CLI Arg**: `--summary-unit-duration`<br/>
+**Environment Variable**: `TG_SUMMARY_UNIT_DURATION`<br/>
+
+When enabled, Terragrunt will show the duration of each unit in the run summary. The units are sorted by duration, with the longest-running units shown first.
+
+For more information, see the [Run Report](/docs/features/run-report) feature.
+
 ### iam-assume-role
 
 **CLI Arg**: `--iam-assume-role`<br/>

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -774,7 +774,16 @@ func (s *Summary) writeSummaryEntry(w io.Writer, label string, value string) err
 func (s *Summary) writeUnitsTiming(w io.Writer, colorizer *Colorizer) error {
 	errs := []error{}
 
-	for _, run := range s.runs {
+	// Sort the runs by duration, longest first.
+	sortedRuns := slices.Clone(s.runs)
+	slices.SortFunc(sortedRuns, func(a, b *Run) int {
+		aDuration := a.Ended.Sub(a.Started)
+		bDuration := b.Ended.Sub(b.Started)
+
+		return int(bDuration - aDuration)
+	})
+
+	for _, run := range sortedRuns {
 		if err := s.writeUnitTiming(w, run, colorizer); err != nil {
 			errs = append(errs, err)
 		}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -120,6 +120,27 @@ func NewColorizer(shouldColor bool) *Colorizer {
 	}
 }
 
+// colorDuration returns the duration as a string, colored based on the duration.
+func (c *Colorizer) colorDuration(duration time.Duration) string {
+	if duration < time.Microsecond {
+		return c.nanosecondColorizer(fmt.Sprintf("%dns", duration.Nanoseconds()))
+	}
+
+	if duration < time.Millisecond {
+		return c.microsecondColorizer(fmt.Sprintf("%dµs", duration.Microseconds()))
+	}
+
+	if duration < time.Second {
+		return c.millisecondColorizer(fmt.Sprintf("%dms", duration.Milliseconds()))
+	}
+
+	if duration < time.Minute {
+		return c.secondColorizer(fmt.Sprintf("%ds", int(duration.Seconds())))
+	}
+
+	return c.minuteColorizer(fmt.Sprintf("%dm", int(duration.Minutes())))
+}
+
 // NewReport creates a new report.
 func NewReport() *Report {
 	report := &Report{
@@ -424,28 +445,7 @@ func (s *Summary) TotalDuration() time.Duration {
 func (s *Summary) TotalDurationString(colorizer *Colorizer) string {
 	duration := s.TotalDuration()
 
-	return colorDuration(colorizer, duration)
-}
-
-// colorDuration returns the duration as a string, colored based on the duration.
-func colorDuration(colorizer *Colorizer, duration time.Duration) string {
-	if duration < time.Microsecond {
-		return colorizer.nanosecondColorizer(fmt.Sprintf("%dns", duration.Nanoseconds()))
-	}
-
-	if duration < time.Millisecond {
-		return colorizer.microsecondColorizer(fmt.Sprintf("%dµs", duration.Microseconds()))
-	}
-
-	if duration < time.Second {
-		return colorizer.millisecondColorizer(fmt.Sprintf("%dms", duration.Milliseconds()))
-	}
-
-	if duration < time.Minute {
-		return colorizer.secondColorizer(fmt.Sprintf("%ds", int(duration.Seconds())))
-	}
-
-	return colorizer.minuteColorizer(fmt.Sprintf("%dm", int(duration.Minutes())))
+	return colorizer.colorDuration(duration)
 }
 
 // WriteToFile writes the report to a file.
@@ -824,7 +824,7 @@ func (s *Summary) writeUnitTiming(w io.Writer, run *Run, colorizer *Colorizer) e
 		name,
 		separator,
 		s.unitDurationPadding(name),
-		colorDuration(colorizer, duration),
+		colorizer.colorDuration(duration),
 	)
 	if err != nil {
 		return err

--- a/options/options.go
+++ b/options/options.go
@@ -308,6 +308,8 @@ type TerragruntOptions struct {
 	ForceBackendMigrate bool
 	// SummaryDisable disables the summary output at the end of a run.
 	SummaryDisable bool
+	// SummaryUnitTiming enables showing timing information for each unit in the summary.
+	SummaryUnitTiming bool
 }
 
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests

--- a/options/options.go
+++ b/options/options.go
@@ -308,8 +308,8 @@ type TerragruntOptions struct {
 	ForceBackendMigrate bool
 	// SummaryDisable disables the summary output at the end of a run.
 	SummaryDisable bool
-	// SummaryUnitTiming enables showing timing information for each unit in the summary.
-	SummaryUnitTiming bool
+	// SummaryUnitDuration enables showing duration information for each unit in the summary.
+	SummaryUnitDuration bool
 }
 
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests

--- a/test/integration_report_test.go
+++ b/test/integration_report_test.go
@@ -382,7 +382,7 @@ func TestTerragruntReportExperimentWithUnitTiming(t *testing.T) {
 	// Run terragrunt with report experiment enabled and unit timing enabled
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	err := helpers.RunTerragruntCommand(t, "terragrunt run --all apply --experiment report --non-interactive --working-dir "+rootPath+" --summary-unit-timing", &stdout, &stderr)
+	err := helpers.RunTerragruntCommand(t, "terragrunt run --all apply --experiment report --non-interactive --working-dir "+rootPath+" --summary-unit-duration", &stdout, &stderr)
 	require.NoError(t, err)
 
 	// Verify the report output contains expected information


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds a flag that allows users to get at-a-glance unit duration information in their run summaries.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `--summary-unit-duration` flag.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

