### PR TITLE
fix: Adding error handling for engines

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -692,10 +692,10 @@ func initialize(ctx context.Context, l log.Logger, runOptions *ExecutionOptions,
 			return nil, nil
 		}
 
-		if output.ResultCode != 0 {
+		if output.GetResultCode() != 0 {
 			l.Errorf("Engine init failed with error: %s", output.GetStderr())
 
-			return nil, errors.New(fmt.Sprintf("engine init failed with exit code %d", output.ResultCode))
+			return nil, errors.New(fmt.Sprintf("engine init failed with exit code %d", output.GetResultCode()))
 		}
 
 		return &OutputLine{
@@ -734,10 +734,10 @@ func shutdown(ctx context.Context, l log.Logger, runOptions *ExecutionOptions, t
 			return nil, nil
 		}
 
-		if output.ResultCode != 0 {
+		if output.GetResultCode() != 0 {
 			l.Errorf("Engine shutdown failed with error: %s", output.GetStderr())
 
-			return nil, errors.New(fmt.Sprintf("engine shutdown failed with exit code %d", output.ResultCode))
+			return nil, errors.New(fmt.Sprintf("engine shutdown failed with exit code %d", output.GetResultCode()))
 		}
 
 		return &OutputLine{

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -692,6 +692,12 @@ func initialize(ctx context.Context, l log.Logger, runOptions *ExecutionOptions,
 			return nil, nil
 		}
 
+		if output.ResultCode != 0 {
+			l.Errorf("Engine init failed with error: %s", output.GetStderr())
+
+			return nil, errors.New(fmt.Sprintf("engine init failed with exit code %d", output.ResultCode))
+		}
+
 		return &OutputLine{
 			Stderr: output.GetStderr(),
 			Stdout: output.GetStdout(),
@@ -726,6 +732,12 @@ func shutdown(ctx context.Context, l log.Logger, runOptions *ExecutionOptions, t
 
 		if output == nil {
 			return nil, nil
+		}
+
+		if output.ResultCode != 0 {
+			l.Errorf("Engine shutdown failed with error: %s", output.GetStderr())
+
+			return nil, errors.New(fmt.Sprintf("engine shutdown failed with exit code %d", output.ResultCode))
 		}
 
 		return &OutputLine{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds error handling for engines. When the engine fails to initialize or shutdown, it can send back a non-zero status code to indicate that something went wrong.

I don't think I can easily test this right now, but I can add some tests for this once the OpenTofu plugin is updated.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added error handling for engines.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Improved error handling during engine initialization and shutdown to ensure failures are properly detected and reported to the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->