### PR TITLE
feat: add --disable-dependency-prompt option for scaffold

### DIFF
--- a/cli/commands/scaffold/cli.go
+++ b/cli/commands/scaffold/cli.go
@@ -18,11 +18,12 @@ import (
 const (
 	CommandName = "scaffold"
 
-	RootFileNameFlagName  = "root-file-name"
-	NoIncludeRootFlagName = "no-include-root"
-	OutputFolderFlagName  = "output-folder"
-	VarFlagName           = "var"
-	VarFileFlagName       = "var-file"
+	RootFileNameFlagName    = "root-file-name"
+	NoIncludeRootFlagName   = "no-include-root"
+	OutputFolderFlagName    = "output-folder"
+	VarFlagName             = "var"
+	VarFileFlagName         = "var-file"
+	DisableDependencyPrompt = "disable-dependency-prompt"
 )
 
 func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
@@ -78,6 +79,13 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			EnvVars:     tgPrefix.EnvVars(VarFileFlagName),
 			Destination: &opts.ScaffoldVarFiles,
 			Usage:       "Files with variables to be used in unit scaffolding.",
+		}),
+
+		flags.NewFlag(&cli.BoolFlag{
+			Name:        DisableDependencyPrompt,
+			EnvVars:     tgPrefix.EnvVars(DisableDependencyPrompt),
+			Destination: &opts.DisableDependencyPrompt,
+			Usage:       "Do not prompt for confirmation to include dependencies.",
 		}),
 	}
 }

--- a/cli/commands/scaffold/scaffold.go
+++ b/cli/commands/scaffold/scaffold.go
@@ -196,14 +196,15 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, mod
 
 	l.Infof("Running boilerplate generation to %s", outputDir)
 	boilerplateOpts := &boilerplate_options.BoilerplateOptions{
-		OutputFolder:    outputDir,
-		OnMissingKey:    boilerplate_options.DefaultMissingKeyAction,
-		OnMissingConfig: boilerplate_options.DefaultMissingConfigAction,
-		Vars:            vars,
-		DisableShell:    true,
-		DisableHooks:    true,
-		NonInteractive:  opts.NonInteractive,
-		TemplateFolder:  boilerplateDir,
+		OutputFolder:            outputDir,
+		OnMissingKey:            boilerplate_options.DefaultMissingKeyAction,
+		OnMissingConfig:         boilerplate_options.DefaultMissingConfigAction,
+		Vars:                    vars,
+		DisableShell:            true,
+		DisableHooks:            true,
+		NonInteractive:          opts.NonInteractive,
+		DisableDependencyPrompt: opts.DisableDependencyPrompt,
+		TemplateFolder:          boilerplateDir,
 	}
 
 	emptyDep := variables.Dependency{}

--- a/cli/commands/scaffold/scaffold_test.go
+++ b/cli/commands/scaffold/scaffold_test.go
@@ -62,14 +62,15 @@ func TestDefaultTemplateVariables(t *testing.T) {
 	require.NoError(t, err)
 
 	boilerplateOpts := &boilerplateoptions.BoilerplateOptions{
-		OutputFolder:    outputDir,
-		OnMissingKey:    boilerplateoptions.DefaultMissingKeyAction,
-		OnMissingConfig: boilerplateoptions.DefaultMissingConfigAction,
-		Vars:            vars,
-		DisableShell:    true,
-		DisableHooks:    true,
-		NonInteractive:  true,
-		TemplateFolder:  templateDir,
+		OutputFolder:            outputDir,
+		OnMissingKey:            boilerplateoptions.DefaultMissingKeyAction,
+		OnMissingConfig:         boilerplateoptions.DefaultMissingConfigAction,
+		Vars:                    vars,
+		DisableShell:            true,
+		DisableHooks:            true,
+		NonInteractive:          true,
+		DisableDependencyPrompt: false,
+		TemplateFolder:          templateDir,
 	}
 
 	emptyDep := variables.Dependency{}

--- a/docs/_docs/02_features/07-scaffold.md
+++ b/docs/_docs/02_features/07-scaffold.md
@@ -16,7 +16,7 @@ Terragrunt scaffolding can generate files for you automatically using [boilerpla
 Currently, one boilerplate template is supported out-of-the-box, which you can use to generate a best-practices `terragrunt.hcl` that configures a OpenTofu/Terraform module for deployment:
 
 ```bash
-terragrunt scaffold <MODULE_URL> [TEMPLATE_URL] [--var] [--var-file] [--no-include-root] [--root-file-name]
+terragrunt scaffold <MODULE_URL> [TEMPLATE_URL] [--var] [--var-file] [--no-include-root] [--root-file-name] [--disable-dependency-prompt]
 ```
 
 Description:
@@ -105,6 +105,7 @@ Optional variables which can be passed to `scaffold` command:
 
 - `--no-include-root` - Disable inclusion of the root module in the generated `terragrunt.hcl` file (equivalent to using `--var=EnableRootInclude=false`, and will be overridden if the corresponding `var` value is set).
 - `--root-file-name` - Set the name of the root configuration file to include in the generated `terragrunt.hcl` file (equivalent to using `--var=RootFileName=<name>`, and will be overridden if the corresponding `var` value is set).
+- `--disable-dependency-prompt` - Disable dependency confirmation, but keep the interactive mode enabled (skip asking for confirmation about including dependencies defined in the boilerplate template).
 
 \* **NOTE**: `RootFileName` is set to `terragrunt.hcl` by default to ensure backwards compatibility, but the pattern of using a `terragrunt.hcl` file at the root of Terragrunt projects has since been deprecated.
 

--- a/options/options.go
+++ b/options/options.go
@@ -310,6 +310,8 @@ type TerragruntOptions struct {
 	SummaryDisable bool
 	// SummaryUnitDuration enables showing duration information for each unit in the summary.
 	SummaryUnitDuration bool
+	// DisableDependencyPrompt disables prompt for confirmation to include dependencies when using scaffolding.
+	DisableDependencyPrompt bool
 }
 
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests
@@ -416,6 +418,7 @@ func NewTerragruntOptionsWithWriters(stdout, stderr io.Writer) *TerragruntOption
 		Telemetry:                  new(telemetry.Options),
 		NoStackValidate:            false,
 		NoStackGenerate:            false,
+		DisableDependencyPrompt:    false,
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4419.

This PR introduces the ability to use the `--disable-dependency-prompt` flag which is available in the [boilerplate] package. Using this flag enables skipping the prompt always asking if the user wants to have the dependencies for base and leaf files included or not. For example, the following output:

```
This boilerplate template has a dependency! Run boilerplate on dependency base with template folder ../.boilerplate-files/base-file and output folder {{ .baseFilePath }}? (y/n) : y
```

Will not be shown in the `terragrunt scaffold` command output when `--disable-dependency-prompt` option is set.

## TODOs

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.

## Release Notes (draft)

Updated `terragrunt scaffold` so the `--disable-dependency-prompt` flag can be used.


