### PR TITLE
fix: Fixing log passthrough for `catalog`

### DIFF
--- a/cli/commands/catalog/catalog.go
+++ b/cli/commands/catalog/catalog.go
@@ -28,5 +28,5 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, rep
 		return errors.New("no modules found by the catalog service")
 	}
 
-	return tui.Run(ctx, opts, svc)
+	return tui.Run(ctx, l, opts, svc)
 }

--- a/cli/commands/catalog/tui/model.go
+++ b/cli/commands/catalog/tui/model.go
@@ -67,7 +67,7 @@ type model struct {
 	ready               bool
 }
 
-func newModel(opts *options.TerragruntOptions, svc catalog.CatalogService) model {
+func newModel(l log.Logger, opts *options.TerragruntOptions, svc catalog.CatalogService) model {
 	var (
 		modules      = svc.Modules()
 		items        = make([]list.Item, 0, len(modules))
@@ -112,6 +112,7 @@ func newModel(opts *options.TerragruntOptions, svc catalog.CatalogService) model
 		pagerKeys:         pagerKeys,
 		terragruntOptions: opts,
 		svc:               svc,
+		logger:            l,
 	}
 }
 

--- a/cli/commands/catalog/tui/tui.go
+++ b/cli/commands/catalog/tui/tui.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog"
 	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
-func Run(ctx context.Context, opts *options.TerragruntOptions, svc catalog.CatalogService) error {
-	if _, err := tea.NewProgram(newModel(opts, svc), tea.WithAltScreen(), tea.WithContext(ctx)).Run(); err != nil {
+func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, svc catalog.CatalogService) error {
+	if _, err := tea.NewProgram(newModel(l, opts, svc), tea.WithAltScreen(), tea.WithContext(ctx)).Run(); err != nil {
 		if err := context.Cause(ctx); errors.Is(err, context.Canceled) {
 			return nil
 		} else if err != nil {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

I accidentally didn't pass through the logger to the `tui.Run()` command, and as a result, it tries to log with a nil pointer.

Closes #4422

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added log passthrough on `tui.Run()` command.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal logging support for the catalog command interface to enhance monitoring and diagnostics. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->