### PR TITLE
fix: Fixing usage of `dependencies` in discovery

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -511,7 +511,7 @@ func (d *DependencyDiscovery) DiscoverDependencies(ctx context.Context, l log.Lo
 		depPaths = append(depPaths, depPath)
 	}
 
-	if dCfg.Dependencies != nil {
+	if dCfg.Parsed.Dependencies != nil {
 		for _, dependency := range dCfg.Parsed.Dependencies.Paths {
 			if !filepath.IsAbs(dependency) {
 				dependency = filepath.Join(dCfg.Path, dependency)

--- a/test/fixtures/find/dag/c-mixed-deps/terragrunt.hcl
+++ b/test/fixtures/find/dag/c-mixed-deps/terragrunt.hcl
@@ -1,0 +1,8 @@
+# Uses both dependency and dependencies blocks
+dependency "single_dep" {
+    config_path = "../a-dependent"
+}
+
+dependencies {
+    paths = ["../d-dependencies-only"]
+}

--- a/test/fixtures/find/dag/d-dependencies-only/terragrunt.hcl
+++ b/test/fixtures/find/dag/d-dependencies-only/terragrunt.hcl
@@ -1,0 +1,4 @@
+# Uses only dependencies block (plural)
+dependencies {
+    paths = ["../b-dependency"]
+}

--- a/test/fixtures/find/dag/d-dependencies-only/terragrunt.hcl
+++ b/test/fixtures/find/dag/d-dependencies-only/terragrunt.hcl
@@ -1,4 +1,4 @@
 # Uses only dependencies block (plural)
 dependencies {
-    paths = ["../b-dependency"]
+    paths = ["../a-dependent"]
 }

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -96,8 +96,8 @@ func TestFindDAG(t *testing.T) {
 		sort     string
 		expected string
 	}{
-		{name: "alpha", sort: "alpha", expected: "a-dependent\nb-dependency\n"},
-		{name: "dag", sort: "dag", expected: "b-dependency\na-dependent\n"},
+		{name: "alpha", sort: "alpha", expected: "a-dependent\nb-dependency\nc-mixed-deps\nd-dependencies-only\n"},
+		{name: "dag", sort: "dag", expected: "b-dependency\na-dependent\nd-dependencies-only\nc-mixed-deps\n"},
 	}
 
 	for _, tc := range testCases {
@@ -117,6 +117,49 @@ func TestFindDAG(t *testing.T) {
 
 			assert.Empty(t, stderr)
 			assert.Equal(t, tc.expected, stdout)
+		})
+	}
+}
+
+func TestFindDAGWithMixedDependencies(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureFindDAG)
+
+	testCases := []struct {
+		name     string
+		args     string
+		expected string
+	}{
+		{
+			name:     "dag with dependencies output",
+			args:     "--dag --dependencies",
+			expected: "b-dependency\na-dependent\nd-dependencies-only\nc-mixed-deps\n",
+		},
+		{
+			name:     "dag with dependencies json output",
+			args:     "--dag --dependencies --json",
+			expected: `[{"type":"unit","path":"b-dependency"},{"type":"unit","path":"a-dependent","dependencies":["b-dependency"]},{"type":"unit","path":"d-dependencies-only","dependencies":["b-dependency"]},{"type":"unit","path":"c-mixed-deps","dependencies":["a-dependent","d-dependencies-only"]}]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			helpers.CleanupTerraformFolder(t, testFixtureFindDAG)
+
+			cmd := "terragrunt find --no-color --working-dir " + testFixtureFindDAG + " " + tc.args
+
+			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+			require.NoError(t, err)
+
+			assert.Empty(t, stderr)
+			if strings.Contains(tc.args, "--json") {
+				assert.JSONEq(t, tc.expected, stdout)
+			} else {
+				assert.Equal(t, tc.expected, stdout)
+			}
 		})
 	}
 }
@@ -233,7 +276,8 @@ func TestFindQueueConstructAs(t *testing.T) {
 	t.Parallel()
 
 	// I'm using the list fixture here because it's more convenient.
-	helpers.CleanupTerraformFolder(t, testFixtureListDag)
+	testFixtureQueueConstruct := "fixtures/list/dag"
+	helpers.CleanupTerraformFolder(t, testFixtureQueueConstruct)
 
 	testCases := []struct {
 		name           string
@@ -275,9 +319,9 @@ func TestFindQueueConstructAs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			helpers.CleanupTerraformFolder(t, testFixtureListDag)
+			helpers.CleanupTerraformFolder(t, testFixtureQueueConstruct)
 
-			cmd := fmt.Sprintf("terragrunt find --json --no-color --working-dir %s %s", testFixtureListDag, tc.args)
+			cmd := fmt.Sprintf("terragrunt find --json --no-color --working-dir %s %s", testFixtureQueueConstruct, tc.args)
 			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
 			require.NoError(t, err)
 			assert.Empty(t, stderr)

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -139,7 +139,7 @@ func TestFindDAGWithMixedDependencies(t *testing.T) {
 		{
 			name:     "dag with dependencies json output",
 			args:     "--dag --dependencies --json",
-			expected: `[{"type":"unit","path":"b-dependency"},{"type":"unit","path":"a-dependent","dependencies":["b-dependency"]},{"type":"unit","path":"d-dependencies-only","dependencies":["b-dependency"]},{"type":"unit","path":"c-mixed-deps","dependencies":["a-dependent","d-dependencies-only"]}]`,
+			expected: `[{"type":"unit","path":"b-dependency"},{"type":"unit","path":"a-dependent","dependencies":["b-dependency"]},{"type":"unit","path":"d-dependencies-only","dependencies":["a-dependent"]},{"type":"unit","path":"c-mixed-deps","dependencies":["a-dependent","d-dependencies-only"]}]`,
 		},
 	}
 

--- a/test/integration_parse_test.go
+++ b/test/integration_parse_test.go
@@ -143,20 +143,34 @@ func TestParseFindListAllComponentsWithDAG(t *testing.T) {
 
 			fields := strings.Fields(stdout)
 
-			aDepLine := 0
-			bDepLine := 0
+			// Find positions of all fixtures in the output
+			aDepLine := -1
+			bDepLine := -1
+			cMixedLine := -1
+			dDepsLine := -1
 
 			for i, field := range fields {
-				if field == "fixtures/find/dag/a-dependent" {
+				switch field {
+				case "fixtures/find/dag/a-dependent":
 					aDepLine = i
-				}
-
-				if field == "fixtures/find/dag/b-dependency" {
+				case "fixtures/find/dag/b-dependency":
 					bDepLine = i
+				case "fixtures/find/dag/c-mixed-deps":
+					cMixedLine = i
+				case "fixtures/find/dag/d-dependencies-only":
+					dDepsLine = i
 				}
 			}
 
-			assert.Greater(t, aDepLine, bDepLine)
+			// Verify DAG ordering:
+			// b-dependency (no deps) should come first
+			// a-dependent (depends on b) should come after b
+			// d-dependencies-only (depends on b) should come after b
+			// c-mixed-deps (depends on a and d) should come last
+			assert.Greater(t, aDepLine, bDepLine, "a-dependent should come after b-dependency")
+			assert.Greater(t, dDepsLine, bDepLine, "d-dependencies-only should come after b-dependency")
+			assert.Greater(t, cMixedLine, aDepLine, "c-mixed-deps should come after a-dependent")
+			assert.Greater(t, cMixedLine, dDepsLine, "c-mixed-deps should come after d-dependencies-only")
 		})
 	}
 }
@@ -187,20 +201,38 @@ func TestParseFindListAllComponentsWithDAGAndExternal(t *testing.T) {
 
 			fields := strings.Fields(stdout)
 
-			aDepLine := 0
-			bDepLine := 0
+			// Find positions of all fixtures in the output
+			aDepLine := -1
+			bDepLine := -1
+			cMixedLine := -1
+			dDepsLine := -1
 
 			for i, field := range fields {
-				if field == "fixtures/find/dag/a-dependent" {
+				switch field {
+				case "fixtures/find/dag/a-dependent":
 					aDepLine = i
-				}
-
-				if field == "fixtures/find/dag/b-dependency" {
+				case "fixtures/find/dag/b-dependency":
 					bDepLine = i
+				case "fixtures/find/dag/c-mixed-deps":
+					cMixedLine = i
+				case "fixtures/find/dag/d-dependencies-only":
+					dDepsLine = i
 				}
 			}
 
-			assert.Greater(t, aDepLine, bDepLine)
+			// Verify DAG ordering for the core dependencies
+			// The exact ordering may vary with external dependencies included,
+			// but the basic dependency relationship should hold
+			if aDepLine >= 0 && bDepLine >= 0 {
+				assert.Greater(t, aDepLine, bDepLine, "a-dependent should come after b-dependency")
+			}
+			if dDepsLine >= 0 && bDepLine >= 0 {
+				assert.Greater(t, dDepsLine, bDepLine, "d-dependencies-only should come after b-dependency")
+			}
+			if cMixedLine >= 0 && aDepLine >= 0 && dDepsLine >= 0 {
+				assert.Greater(t, cMixedLine, aDepLine, "c-mixed-deps should come after a-dependent")
+				assert.Greater(t, cMixedLine, dDepsLine, "c-mixed-deps should come after d-dependencies-only")
+			}
 		})
 	}
 }

--- a/test/integration_runner_pool_test.go
+++ b/test/integration_runner_pool_test.go
@@ -39,5 +39,5 @@ func TestRunnerPoolTerragruntDestroyOrder(t *testing.T) {
 	// run destroy with runner pool and check the order of the modules
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --experiment runner-pool --all destroy --non-interactive --tf-forward-stdout --working-dir "+rootPath)
 	require.NoError(t, err)
-	assert.Regexp(t, `(?smi)(?:(Module A|Module B|Module C).*){3}(?:(Module D|Module E).*){2}`, stdout)
+	assert.Regexp(t, `(?smi)(?:(Module B|Module D).*){2}(?:(Module A|Module E|Module C).*){3}`, stdout)
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4427.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `discovery` package to respect `dependencies` blocks in addition to `dependency` blocks.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configurations with both single and multiple dependency blocks in Terragrunt files.
  - Introduced new test fixtures demonstrating mixed and dependencies-only configurations.

- **Bug Fixes**
  - Improved dependency discovery logic to ensure accurate detection of dependencies in parsed configurations.

- **Tests**
  - Enhanced and expanded integration tests to validate correct handling and ordering of modules with various dependency structures.
  - Updated test assertions to reflect new module groupings and expected output order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->