### PR TITLE
feat: Updating styling for summary

### DIFF
--- a/internal/report/colors.go
+++ b/internal/report/colors.go
@@ -10,21 +10,23 @@ import (
 
 // Colorizer is a colorizer for the run summary output.
 type Colorizer struct {
-	headingColorizer     func(string) string
-	successColorizer     func(string) string
-	failureColorizer     func(string) string
-	exitColorizer        func(string) string
-	excludeColorizer     func(string) string
-	successUnitColorizer func(string) string
-	failureUnitColorizer func(string) string
-	exitUnitColorizer    func(string) string
-	excludeUnitColorizer func(string) string
-	nanosecondColorizer  func(string) string
-	microsecondColorizer func(string) string
-	millisecondColorizer func(string) string
-	secondColorizer      func(string) string
-	minuteColorizer      func(string) string
-	defaultColorizer     func(string) string
+	headingTitleColorizer func(string) string
+	headingUnitColorizer  func(string) string
+	successColorizer      func(string) string
+	failureColorizer      func(string) string
+	exitColorizer         func(string) string
+	excludeColorizer      func(string) string
+	successUnitColorizer  func(string) string
+	failureUnitColorizer  func(string) string
+	exitUnitColorizer     func(string) string
+	excludeUnitColorizer  func(string) string
+	nanosecondColorizer   func(string) string
+	microsecondColorizer  func(string) string
+	millisecondColorizer  func(string) string
+	secondColorizer       func(string) string
+	minuteColorizer       func(string) string
+	defaultColorizer      func(string) string
+	paddingColorizer      func(string) string
 }
 
 // NewColorizer creates a new Colorizer.
@@ -34,21 +36,23 @@ func NewColorizer(shouldColor bool) *Colorizer {
 
 	if !shouldColor {
 		return &Colorizer{
-			headingColorizer:     func(s string) string { return s },
-			successColorizer:     func(s string) string { return s },
-			failureColorizer:     func(s string) string { return s },
-			exitColorizer:        func(s string) string { return s },
-			excludeColorizer:     func(s string) string { return s },
-			successUnitColorizer: func(s string) string { return s },
-			failureUnitColorizer: func(s string) string { return s },
-			exitUnitColorizer:    func(s string) string { return s },
-			excludeUnitColorizer: func(s string) string { return s },
-			nanosecondColorizer:  func(s string) string { return s },
-			microsecondColorizer: func(s string) string { return s },
-			millisecondColorizer: func(s string) string { return s },
-			secondColorizer:      func(s string) string { return s },
-			minuteColorizer:      func(s string) string { return s },
-			defaultColorizer:     func(s string) string { return s },
+			headingTitleColorizer: func(s string) string { return s },
+			headingUnitColorizer:  func(s string) string { return s },
+			successColorizer:      func(s string) string { return s },
+			failureColorizer:      func(s string) string { return s },
+			exitColorizer:         func(s string) string { return s },
+			excludeColorizer:      func(s string) string { return s },
+			successUnitColorizer:  func(s string) string { return s },
+			failureUnitColorizer:  func(s string) string { return s },
+			exitUnitColorizer:     func(s string) string { return s },
+			excludeUnitColorizer:  func(s string) string { return s },
+			nanosecondColorizer:   func(s string) string { return s },
+			microsecondColorizer:  func(s string) string { return s },
+			millisecondColorizer:  func(s string) string { return s },
+			secondColorizer:       func(s string) string { return s },
+			minuteColorizer:       func(s string) string { return s },
+			defaultColorizer:      func(s string) string { return s },
+			paddingColorizer:      func(s string) string { return s },
 		}
 	}
 
@@ -67,21 +71,23 @@ func NewColorizer(shouldColor bool) *Colorizer {
 	}
 
 	return &Colorizer{
-		headingColorizer:     ansi.ColorFunc("yellow+bh"),
-		successColorizer:     ansi.ColorFunc("green+bh"),
-		failureColorizer:     ansi.ColorFunc("red+bh"),
-		exitColorizer:        ansi.ColorFunc("yellow+bh"),
-		excludeColorizer:     ansi.ColorFunc("blue+bh"),
-		successUnitColorizer: successUnitColorizer,
-		failureUnitColorizer: failureUnitColorizer,
-		exitUnitColorizer:    exitUnitColorizer,
-		excludeUnitColorizer: excludeUnitColorizer,
-		nanosecondColorizer:  ansi.ColorFunc("cyan+bh"),
-		microsecondColorizer: ansi.ColorFunc("cyan+bh"),
-		millisecondColorizer: ansi.ColorFunc("cyan+bh"),
-		secondColorizer:      ansi.ColorFunc("green+bh"),
-		minuteColorizer:      ansi.ColorFunc("yellow+bh"),
-		defaultColorizer:     ansi.ColorFunc("white+bh"),
+		headingTitleColorizer: ansi.ColorFunc("yellow+bh"),
+		headingUnitColorizer:  ansi.ColorFunc("white+bh"),
+		successColorizer:      ansi.ColorFunc("green+bh"),
+		failureColorizer:      ansi.ColorFunc("red+bh"),
+		exitColorizer:         ansi.ColorFunc("yellow+bh"),
+		excludeColorizer:      ansi.ColorFunc("blue+bh"),
+		successUnitColorizer:  successUnitColorizer,
+		failureUnitColorizer:  failureUnitColorizer,
+		exitUnitColorizer:     exitUnitColorizer,
+		excludeUnitColorizer:  excludeUnitColorizer,
+		nanosecondColorizer:   ansi.ColorFunc("cyan+bh"),
+		microsecondColorizer:  ansi.ColorFunc("cyan+bh"),
+		millisecondColorizer:  ansi.ColorFunc("cyan+bh"),
+		secondColorizer:       ansi.ColorFunc("green+bh"),
+		minuteColorizer:       ansi.ColorFunc("yellow+bh"),
+		defaultColorizer:      ansi.ColorFunc("white+bh"),
+		paddingColorizer:      ansi.ColorFunc("gray"),
 	}
 }
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1072,7 +1072,7 @@ func TestWriteUnitLevelSummary(t *testing.T) {
 ❯❯ Run Summary  1 units  x
    ────────────────────────────
    Succeeded (1)
-      single-run         x
+      single-run ....... x
 `,
 		},
 		{
@@ -1096,9 +1096,9 @@ func TestWriteUnitLevelSummary(t *testing.T) {
 ❯❯ Run Summary  3 units  x
    ────────────────────────────
    Succeeded (3)
-      long-run           x
-      medium-run         x
-      short-run          x
+      long-run ......... x
+      medium-run ....... x
+      short-run ........ x
 `,
 		},
 		{
@@ -1124,12 +1124,12 @@ func TestWriteUnitLevelSummary(t *testing.T) {
 ❯❯ Run Summary  4 units  x
    ────────────────────────────
    Succeeded (2)
-      success-1          x
-      success-2          x
+      success-1 ........ x
+      success-2 ........ x
    Failed (1)
-      fail-run           x
+      fail-run ......... x
    Excluded (1)
-      excluded-run       x
+      excluded-run ..... x
 `,
 		},
 		{
@@ -1152,9 +1152,9 @@ func TestWriteUnitLevelSummary(t *testing.T) {
 ❯❯ Run Summary  3 units  x
    ────────────────────────────
    Succeeded (3)
-      a                  x
-      b                  x
-      c                  x
+      a ................ x
+      b ................ x
+      c ................ x
 `,
 		},
 		{
@@ -1186,7 +1186,7 @@ func TestWriteUnitLevelSummary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 
 			r := report.NewReport().
 				WithDisableColor().
@@ -1201,17 +1201,14 @@ func TestWriteUnitLevelSummary(t *testing.T) {
 
 			// Replace the duration with x since we can't control the actual duration in tests
 			output := buf.String()
-			re := regexp.MustCompile(`Duration:(\s+).*`)
-			output = re.ReplaceAllString(output, "Duration:${1}x")
 
-			// Replace the duration in the header line (e.g., "3 units  8µs" -> "3 units  x")
-			// Updated to handle variable spacing for long unit names
-			re = regexp.MustCompile(`(\d+ units\s+)(\s*)(\d+[µnms]+|\d+[smh]|[^\s]+)`)
-			output = re.ReplaceAllString(output, "${1}${2}x")
+			// Replace the header duration with x
+			re := regexp.MustCompile(`❯❯ Run Summary  (\d+) units(\s+)(\d+.+)`)
+			output = re.ReplaceAllString(output, "❯❯ Run Summary  ${1} units${2}x")
 
-			// Replace the actual durations with x (for the new clean format without colons)
-			re = regexp.MustCompile(`([ ]{6})([^\s]+)(\s+)(\d+[µnms]+|\d+[smh])`)
-			output = re.ReplaceAllString(output, "${1}${2}${3}x")
+			// Replace all the unit level summaries
+			re = regexp.MustCompile(`([ ]{6})([^ ]+)( )([^ ]*)( )(\d+.+)`)
+			output = re.ReplaceAllString(output, "${1}${2}${3}${4}${5}x")
 
 			expected := strings.TrimSpace(tt.expected)
 			assert.Equal(t, expected, strings.TrimSpace(output))

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1186,7 +1186,7 @@ func TestWriteUnitLevelSummary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			r := report.NewReport().
 				WithDisableColor().

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -387,7 +387,9 @@ func (s *Summary) padding(label string, colorizer *Colorizer) string {
 
 	padding := strings.Repeat(s.padder, paddingNeeded)
 
-	if len(padding) < 2 {
+	whitespaceLen := 2
+
+	if len(padding) < whitespaceLen {
 		return "  "
 	}
 
@@ -437,15 +439,13 @@ func (s *Summary) unitDurationPadding(name string, colorizer *Colorizer) string 
 	unitPrefix := strings.Repeat(prefix, unitPrefixMultiplier)
 	currentPosition := len(unitPrefix) + len(name)
 
-	paddingNeeded := headerDurationColumn - currentPosition - durationAlignmentOffset
-
-	if paddingNeeded < 1 {
-		paddingNeeded = 1
-	}
+	paddingNeeded := max(1, headerDurationColumn-currentPosition-durationAlignmentOffset)
 
 	padding := strings.Repeat(s.padder, paddingNeeded)
 
-	if len(padding) < 2 {
+	whitespaceLen := 2
+
+	if len(padding) < whitespaceLen {
 		return "  "
 	}
 

--- a/test/integration_report_test.go
+++ b/test/integration_report_test.go
@@ -438,25 +438,26 @@ func TestTerragruntReportExperimentWithUnitTiming(t *testing.T) {
 	stdoutStr = sortLinesWithinCategories(stdoutStr)
 
 	// The expected format has units grouped by status with timing (sorted alphabetically within categories)
-	expectedOutput := `❯❯ Run Summary  13 units  x
+	expectedOutput := `
+❯❯ Run Summary  13 units  x
    ────────────────────────────
    Succeeded (4)
-      error-ignore        x
-      first-success       x
-      retry-success       x
-      second-success      x
+      error-ignore ...... x
+      first-success ..... x
+      retry-success ..... x
+      second-success .... x
    Failed (3)
-      chain-a             x
-      first-failure       x
-      second-failure      x
+      chain-a ........... x
+      first-failure ..... x
+      second-failure .... x
    Early Exits (4)
-      chain-b             x
-      chain-c             x
-      first-early-exit    x
-      second-early-exit   x
+      chain-b ........... x
+      chain-c ........... x
+      first-early-exit .. x
+      second-early-exit . x
    Excluded (2)
-      first-exclude       x
-      second-exclude      x`
+      first-exclude ..... x
+      second-exclude .... x`
 
 	assert.Equal(t, strings.TrimSpace(expectedOutput), strings.TrimSpace(stdoutStr))
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Addressing styling feedback.

![summary-styling](https://github.com/user-attachments/assets/5ef85e15-29a4-4a8b-98ac-8687b8f6f296)

The dots can be a little hard to see based on terminal backgrounds, but they're meant to be subtle.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated styling on Run Summary.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced summary output with improved colorization, including distinct colors for headings, units, and padding.
  - Introduced a new environment variable to control experimental colorized padding in summaries.

- **Style**
  - Changed the default summary separator from spaces to dots for clearer visual separation in unit-level summaries.

- **Bug Fixes**
  - Improved formatting and alignment of summary entries, ensuring consistent and visually appealing output.

- **Tests**
  - Updated tests to reflect changes in summary formatting and colorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->