### PR TITLE
fix get_terragrunt_dir when using stack

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -271,7 +271,12 @@ func getPathToRepoRoot(ctx *ParsingContext, l log.Logger) (string, error) {
 
 // GetTerragruntDir returns the directory where the Terragrunt configuration file lives.
 func GetTerragruntDir(ctx *ParsingContext, l log.Logger) (string, error) {
-	terragruntConfigFileAbsPath, err := filepath.Abs(ctx.TerragruntOptions.TerragruntConfigPath)
+	path := ctx.TerragruntOptions.TerragruntConfigPath
+	if val, ok := ctx.Context.Value(stackParserContext{}).(stackParserContext); ok {
+		path = val.stackConfigFile
+	}
+
+	terragruntConfigFileAbsPath, err := filepath.Abs(path)
 	if err != nil {
 		return "", errors.New(err)
 	}

--- a/config/stack.go
+++ b/config/stack.go
@@ -72,6 +72,10 @@ type Stack struct {
 	Path         string     `hcl:"path,attr"`
 }
 
+type stackParserContext struct {
+	stackConfigFile string
+}
+
 // GenerateStacks generates the stack files.
 func GenerateStacks(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
 	processedFiles := make(map[string]bool)
@@ -687,6 +691,7 @@ func (u *Unit) ReadOutputs(ctx context.Context, l log.Logger, opts *options.Terr
 func ReadStackConfigFile(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, filePath string, values *cty.Value) (*StackConfig, error) {
 	l.Debugf("Reading Terragrunt stack config file at %s", filePath)
 
+	ctx = context.WithValue(ctx, stackParserContext{}, stackParserContext{stackConfigFile: filePath})
 	parser := NewParsingContext(ctx, l, opts)
 
 	file, err := hclparse.NewParser(parser.ParserOptions...).ParseFromFile(filePath)

--- a/test/fixtures/stacks/terragrunt-dir/live/tennant_1/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/terragrunt-dir/live/tennant_1/terragrunt.stack.hcl
@@ -1,0 +1,7 @@
+unit "unit_a" {
+  source = "../../unit_a"
+  path   = "unit_a"
+  values = {
+    terragrunt_dir = get_terragrunt_dir()
+  }
+}

--- a/test/fixtures/stacks/terragrunt-dir/unit_a/main.tf
+++ b/test/fixtures/stacks/terragrunt-dir/unit_a/main.tf
@@ -1,0 +1,5 @@
+variable "terragrunt_dir" {}
+
+output "terragrunt_dir" {
+  value = var.terragrunt_dir
+}

--- a/test/fixtures/stacks/terragrunt-dir/unit_a/terragrunt.hcl
+++ b/test/fixtures/stacks/terragrunt-dir/unit_a/terragrunt.hcl
@@ -1,0 +1,12 @@
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "."
+}
+
+inputs = {
+  terragrunt_dir = values.terragrunt_dir
+}

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -47,6 +47,7 @@ const (
 	testFixtureStackSelfInclude                = "fixtures/stacks/self-include"
 	testFixtureStackNestedOutputs              = "fixtures/stacks/nested-outputs"
 	testFixtureStackNoValidation               = "fixtures/stacks/no-validation"
+	testFixtureStackTerragruntDir              = "fixtures/stacks/terragrunt-dir"
 )
 
 func TestStacksGenerateBasic(t *testing.T) {
@@ -1295,4 +1296,21 @@ func validateStackDir(t *testing.T, path string) {
 	}
 
 	assert.True(t, hasSubdirectories, "The .terragrunt-stack directory should contain at least one subdirectory")
+}
+
+func TestStackTerragruntDir(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackTerragruntDir)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackTerragruntDir)
+	gitPath := util.JoinPath(tmpEnvPath, testFixtureStackTerragruntDir)
+	helpers.CreateGitRepo(t, gitPath)
+	rootPath := util.JoinPath(gitPath, "live")
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack generate --no-stack-validate --working-dir "+rootPath)
+	require.NoError(t, err)
+
+	out, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply --all --non-interactive --working-dir "+rootPath)
+	require.NoError(t, err)
+	assert.Contains(t, out, `terragrunt_dir = "./tennant_1"`)
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
This pull request addresses [#4255](https://github.com/gruntwork-io/terragrunt/issues/4255): "Inconsistent behavior of get_terragrunt_dir() in terragrunt.stack.hcl".

### Problem
When running terragrunt stack generate and terragrunt apply --all from the root of the live repo, the get_terragrunt_dir() function in terragrunt.stack.hcl incorrectly returns . (the current working directory) rather than the directory where the terragrunt.stack.hcl file is located. This leads to incorrect values being passed to modules, which can cause confusion or unexpected behavior in Terraform outputs.

### Solution
This PR updates the logic for get_terragrunt_dir() so that it correctly resolves the directory of the terragrunt.stack.hcl file, regardless of the execution context. Now, when used within a stack configuration, get_terragrunt_dir() will return the path to the stack file’s directory as expected.

### Testing

- Verified that running terragrunt stack generate and terragrunt apply --all now set terragrunt_dir to the correct directory in all relevant outputs.
- Added/updated tests to cover this scenario.

Fixes #https://github.com/gruntwork-io/terragrunt/issues/4255.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new integration test to verify that the `terragrunt_dir` attribute is correctly set and reflected in stack outputs.
  - Introduced new test fixtures for stack configuration and Terraform files.

- **Chores**
  - Added new example configuration files to support testing of the `terragrunt_dir` attribute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->