### PR TITLE
allow finding credentials for subdomain of terraform registry

### DIFF
--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -273,7 +273,15 @@ func applyHostToken(req *http.Request) (*http.Request, error) {
 		return nil, err
 	}
 
+	// first try to find the exact hostname for the token
+	// then try to match the host suffix for the token
+	// finally fall back to the TG_TF_REGISTRY_TOKEN
 	if creds := cliCfg.CredentialsSource().ForHost(svchost.Hostname(req.URL.Hostname())); creds != nil {
+		creds.PrepareRequest(req)
+		return req, nil
+	}
+
+	if creds := cliCfg.CredentialsSource().ForHostSuffix(svchost.Hostname(req.URL.Hostname())); creds != nil {
 		creds.PrepareRequest(req)
 		return req, nil
 	}

--- a/internal/tf/cliconfig/credentials.go
+++ b/internal/tf/cliconfig/credentials.go
@@ -35,7 +35,7 @@ func (s *CredentialsSource) ForHostSuffix(host svchost.Hostname) svcauth.HostCre
 
 	// Then, any credentials block with the suffix present in the CLI config
 	for key, token := range s.configured {
-		if strings.HasSuffix(host.String(), key.String()) {
+		if strings.HasSuffix(host.String(), "."+key.String()) {
 			return svcauth.HostCredentialsToken(token)
 		}
 	}
@@ -57,7 +57,7 @@ func hostCredentialsFromEnv(host svchost.Hostname) svcauth.HostCredentials {
 
 func hostSuffixCredentialsFromEnv(host svchost.Hostname) svcauth.HostCredentials {
 	for key, token := range collectCredentialsFromEnv() {
-		if strings.HasSuffix(host.String(), key.String()) {
+		if strings.HasSuffix(host.String(), "."+key.String()) {
 			return svcauth.HostCredentialsToken(token)
 		}
 	}

--- a/test/integration_private_registry_test.go
+++ b/test/integration_private_registry_test.go
@@ -65,6 +65,38 @@ func TestPrivateRegistryWithConfgFileToken(t *testing.T) {
 	require.Contains(t, err.Error(), "hashicorp/null", "Error accessing the private registry")
 }
 
+// TestPrivateRegistrySubDomainWithConfigFileToken verifies that a credentials block configured for a parent
+// domain (e.g. "example.com") is used to authenticate requests to a subdomain of that domain (e.g.
+// "app.example.com"). This mirrors registries like Spacelift, where you authenticate against "spacelift.io"
+// but modules are downloaded from "app.spacelift.io". For this test to exercise that path, PRIVATE_REGISTRY_URL
+// must point at a host with a subdomain (at least three labels, e.g. "app.example.com").
+func TestPrivateRegistrySubDomainWithConfigFileToken(t *testing.T) {
+	rootPath, host, token := setupPrivateRegistryTest(t)
+
+	hostParts := strings.Split(host, ".")
+	if len(hostParts) < 3 {
+		t.Skipf("Skipping test because PRIVATE_REGISTRY_URL host %q has no subdomain to test suffix matching against; use a host like \"app.example.com\"", host)
+	}
+
+	// Strip the leftmost label so the credentials block is configured for the parent domain rather than the
+	// exact host used to download the module. Terragrunt should still find these credentials via the
+	// ForHostSuffix fallback.
+	parentHost := strings.Join(hostParts[1:], ".")
+
+	helpers.CopyAndFillMapPlaceholders(t, filepath.Join(privateRegistryFixturePath, "env.tfrc"), filepath.Join(rootPath, "env.tfrc"), map[string]string{
+		"__registry_token__": token,
+		"__registry_host__":  parentHost,
+	})
+
+	t.Setenv("TF_CLI_CONFIG_FILE", filepath.Join(rootPath, "env.tfrc"))
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt init --non-interactive --log-level=trace --working-dir="+rootPath)
+
+	// the hashicorp/null provider errors on install, but that indicates that the private tfr module was downloaded
+	// using credentials matched by suffix against the parent domain, not an exact host match.
+	require.Contains(t, err.Error(), "hashicorp/null", "Error accessing the private registry")
+}
+
 func TestPrivateRegistryWithEnvToken(t *testing.T) {
 	rootPath, host, token := setupPrivateRegistryTest(t)
 


### PR DESCRIPTION
## Description

Fixes #4444.

This allows terraform registries to provide module paths from subdomains where terragrunt will be able to use the token of the original host from the credentials file to still authenticate correctly.

Spacelift is an example of this as they ask you to login into spacelift.io but their registry will have you download from app.spacelift.io. 

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ X] I authored this code entirely myself
- [ X] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [X ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added support for using a terraform registry host token on subdomains for module download.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving credentials using host suffix matching, enabling more flexible authentication for hosts that share common domain endings.  
- **Improvements**
  - Enhanced authentication logic to check for credentials by exact hostname, then by host suffix, and finally by environment variable, providing a more robust credential resolution process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->