### PR TITLE
refactor: call `CleanStacks` before running the `stacks Generate` func.

### DIFF
--- a/cli/commands/run/cli.go
+++ b/cli/commands/run/cli.go
@@ -126,6 +126,21 @@ func wrapWithStackGenerate(l log.Logger, opts *options.TerragruntOptions, cmd *c
 		// Set the stack config path to the default location in the working directory
 		opts.TerragruntStackConfigPath = filepath.Join(opts.WorkingDir, config.DefaultStackFile)
 
+		// Clean stack folders before calling `generate` when the `--source-update` flag is passed
+		if opts.SourceUpdate {
+			errClean := telemetry.TelemeterFromContext(ctx).Collect(ctx, "stack_clean", map[string]any{
+				"stack_config_path": opts.TerragruntStackConfigPath,
+				"working_dir":       opts.WorkingDir,
+			}, func(ctx context.Context) error {
+				l.Debugf("Running stack clean for %s, as part of generate command", opts.WorkingDir)
+				return config.CleanStacks(ctx, l, opts)
+			})
+
+			if errClean != nil {
+				return errors.Errorf("failed to clean stack directories under %q: %w", opts.WorkingDir, errClean)
+			}
+		}
+
 		// Generate the stack configuration with telemetry tracking
 		err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "stack_generate", map[string]any{
 			"stack_config_path": opts.TerragruntStackConfigPath,

--- a/config/stack.go
+++ b/config/stack.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/telemetry"
+	"github.com/gruntwork-io/terragrunt/tf"
 
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/worker"
@@ -967,4 +968,50 @@ func validateTargetDir(kind, name, destDir, expectedFile string) error {
 	}
 
 	return nil
+}
+
+// CleanStacks removes stack directories within the specified working directory, unless the command is "destroy".
+// It returns an error if any issues occur during the deletion process, or nil if successful.
+func CleanStacks(_ context.Context, l log.Logger, opts *options.TerragruntOptions) error {
+	if opts.TerraformCommand == tf.CommandNameDestroy {
+		l.Debugf("Skipping stack clean for %s, as part of delete command", opts.WorkingDir)
+		return nil
+	}
+
+	errs := &errors.MultiError{}
+
+	walkFn := func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			l.Warnf("Error accessing path %s: %v", path, walkErr)
+
+			errs = errs.Append(walkErr)
+
+			return nil
+		}
+
+		if d.IsDir() && d.Name() == StackDir {
+			relPath, relErr := filepath.Rel(opts.WorkingDir, path)
+			if relErr != nil {
+				relPath = path // fallback to absolute if error
+			}
+
+			l.Infof("Deleting stack directory: %s", relPath)
+
+			if rmErr := os.RemoveAll(path); rmErr != nil {
+				l.Errorf("Failed to delete stack directory %s: %v", relPath, rmErr)
+
+				errs = errs.Append(rmErr)
+			}
+
+			return filepath.SkipDir
+		}
+
+		return nil
+	}
+
+	if walkErr := filepath.WalkDir(opts.WorkingDir, walkFn); walkErr != nil {
+		errs = errs.Append(walkErr)
+	}
+
+	return errs.ErrorOrNil()
 }


### PR DESCRIPTION
## Description

refactor: move `stacks.RunClean` logic into `config.CleanStacks` to allow reuse and to call `CleanStacks` before running the `stacks Generate` func when `--source-update` flag is set.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

refactor: move `stacks.RunClean` logic into `config.CleanStacks` to allow reuse and to call `CleanStacks` before running the `stacks Generate` func when `--source-update` flag is set. fix #4381, #4438 

### Migration Guide

n/a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleaning of stack directories before generating stack configurations when using the `--source-update` flag.
  * Introduced a new process to remove all `.terragrunt-stack` directories, improving workspace hygiene.

* **Bug Fixes**
  * Enhanced error handling and logging during the cleaning process to provide clearer feedback if directory removal fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->