### PR TITLE
fix: Fixing issue with ending runs from `--queue-exclude-external`

### DIFF
--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -221,7 +221,34 @@ func (module *RunningModule) moduleFinished(moduleErr error, r *report.Report, r
 
 		if reportExperiment {
 			if err := r.EndRun(module.Module.Path); err != nil {
-				module.Logger.Errorf("Error ending run for module %s: %v", module.Module.Path, err)
+				// If the run is not found in the report, it likely means this module was an external dependency
+				// that was excluded from the queue (e.g., with --queue-exclude-external).
+				if !errors.Is(err, report.ErrRunNotFound) {
+					module.Logger.Errorf("Error ending run for unit %s: %v", module.Module.Path, err)
+
+					return
+				}
+
+				if module.Module.AssumeAlreadyApplied {
+					run, err := report.NewRun(module.Module.Path)
+					if err != nil {
+						module.Logger.Errorf("Error creating run for unit %s: %v", module.Module.Path, err)
+						return
+					}
+
+					if err := r.AddRun(run); err != nil {
+						module.Logger.Errorf("Error adding run for unit %s: %v", module.Module.Path, err)
+						return
+					}
+
+					if err := r.EndRun(
+						run.Path,
+						report.WithResult(report.ResultExcluded),
+						report.WithReason(report.ReasonExcludeExternal),
+					); err != nil {
+						module.Logger.Errorf("Error ending run for unit %s: %v", module.Module.Path, err)
+					}
+				}
 			}
 		}
 	} else {
@@ -234,10 +261,6 @@ func (module *RunningModule) moduleFinished(moduleErr error, r *report.Report, r
 				report.WithReason(report.ReasonRunError),
 				report.WithCauseRunError(moduleErr.Error()),
 			); err != nil {
-				// If we can't find the run, then it never started,
-				// So we should start it and then end it as a failed run.
-				//
-				// Early exit runs should already be ended at this point.
 				if errors.Is(err, report.ErrRunNotFound) {
 					run, err := report.NewRun(module.Module.Path)
 					if err != nil {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -56,12 +56,13 @@ const (
 )
 
 const (
-	ReasonRetrySucceeded Reason = "retry succeeded"
-	ReasonErrorIgnored   Reason = "error ignored"
-	ReasonRunError       Reason = "run error"
-	ReasonExcludeDir     Reason = "--queue-exclude-dir"
-	ReasonExcludeBlock   Reason = "exclude block"
-	ReasonAncestorError  Reason = "ancestor error"
+	ReasonRetrySucceeded  Reason = "retry succeeded"
+	ReasonErrorIgnored    Reason = "error ignored"
+	ReasonRunError        Reason = "run error"
+	ReasonExcludeDir      Reason = "--queue-exclude-dir"
+	ReasonExcludeBlock    Reason = "exclude block"
+	ReasonExcludeExternal Reason = "--queue-exclude-external"
+	ReasonAncestorError   Reason = "ancestor error"
 )
 
 // NewReport creates a new report.

--- a/test/fixtures/external-dependency/terragrunt.hcl
+++ b/test/fixtures/external-dependency/terragrunt.hcl
@@ -1,3 +1,7 @@
+feature "dep" {
+  default = "/tmp/external"
+}
+
 dependencies {
-  paths = ["/tmp/external-46521694"]
+  paths = [feature.dep.value]
 }

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -264,11 +264,6 @@ func TestTerragruntSkipConfirmExternalDependencies(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	testPath := util.JoinPath(tmpEnvPath, testFixtureExternalDependency)
 
-	t.Cleanup(func() {
-		os.RemoveAll(filepath.ToSlash("/tmp/external-46521694"))
-	})
-	require.NoError(t, os.Mkdir(filepath.ToSlash("/tmp/external-46521694"), 0755))
-
 	helpers.CreateGitRepo(t, tmpEnvPath)
 
 	stdout := bytes.Buffer{}
@@ -278,7 +273,18 @@ func TestTerragruntSkipConfirmExternalDependencies(t *testing.T) {
 	oldStdout := os.Stderr
 	os.Stderr = w
 
-	err := helpers.RunTerragruntCommand(t, "terragrunt destroy --working-dir "+testPath, &stdout, &stderr)
+	tmp := t.TempDir()
+
+	err := helpers.RunTerragruntCommand(
+		t,
+		fmt.Sprintf(
+			"terragrunt destroy --feature dep=%s --working-dir %s",
+			tmp,
+			testPath,
+		),
+		&stdout,
+		&stderr,
+	)
 	os.Stderr = oldStdout
 	require.NoError(t, w.Close())
 
@@ -294,7 +300,7 @@ func TestTerragruntSkipConfirmExternalDependencies(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotContains(t, captured, "Should Terragrunt apply the external dependency?")
-	assert.NotContains(t, captured, "/tmp/external1")
+	assert.NotContains(t, captured, tmp)
 }
 
 func TestStorePlanFilesRunAllDestroy(t *testing.T) {

--- a/test/integration_report_test.go
+++ b/test/integration_report_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -459,6 +460,78 @@ func TestTerragruntReportExperimentWithUnitTiming(t *testing.T) {
       second-exclude      x`
 
 	assert.Equal(t, strings.TrimSpace(expectedOutput), strings.TrimSpace(stdoutStr))
+}
+
+func TestReportWithExternalDependenciesExcluded(t *testing.T) {
+	t.Parallel()
+
+	cleanupTerraformFolder(t, testFixtureExternalDependency)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureExternalDependency)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureExternalDependency)
+
+	dep := t.TempDir()
+
+	f, err := os.Create(filepath.Join(dep, "terragrunt.hcl"))
+	require.NoError(t, err)
+	f.Close()
+
+	f, err = os.Create(filepath.Join(dep, "main.tf"))
+	require.NoError(t, err)
+	f.Close()
+
+	reportDir := t.TempDir()
+	reportFile := filepath.Join(reportDir, "report.json")
+
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		fmt.Sprintf(
+			"terragrunt run --all plan --queue-exclude-external --experiment report --feature dep=%s --working-dir %s --report-file %s",
+			dep,
+			rootPath,
+			reportFile,
+		),
+	)
+
+	// The command should succeed without "run not found in report" errors
+	require.NoError(t, err)
+
+	// Verify that no "run not found in report" errors appear in stderr
+	assert.NotContains(t, stderr, "run not found in report")
+	assert.Contains(t, stdout, "Run Summary")
+
+	// Verify that the report file exists
+	assert.FileExists(t, reportFile)
+
+	// Read the report file
+	reportContent, err := os.ReadFile(reportFile)
+	require.NoError(t, err)
+
+	// Verify that the report file contains the expected content
+	var report []map[string]interface{}
+	err = json.Unmarshal(reportContent, &report)
+	require.NoError(t, err)
+
+	// Verify that the report file contains the expected content
+	assert.Len(t, report, 2)
+
+	expected := []struct {
+		name   string
+		result string
+		reason string
+	}{
+		// The first run is always going to be the external dependency,
+		// as it has an instant runtime.
+		{name: dep, result: "excluded", reason: "--queue-exclude-external"},
+		{name: "external-dependency", result: "succeeded"},
+	}
+
+	for i, r := range report {
+		assert.Equal(t, expected[i].name, r["Name"])
+		assert.Equal(t, expected[i].result, r["Result"])
+		if expected[i].reason != "" {
+			assert.Equal(t, expected[i].reason, r["Reason"])
+		}
+	}
 }
 
 // lineType represents the type of line we're processing


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4448.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Fixed bug with `--queue-exclude-external` in `report` experiment.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for marking external dependencies as excluded in reports when using the `--queue-exclude-external` flag.
  - Introduced a new reason label for exclusions in report summaries.

- **Bug Fixes**
  - Improved error handling for external dependencies excluded from the run queue, ensuring accurate reporting.

- **Refactor**
  - Centralized logic for deriving display names from run paths for more consistent reporting.

- **Tests**
  - Added an integration test to verify correct reporting of excluded external dependencies.
  - Updated existing tests to use dynamic temporary directories and feature flags for improved reliability.

- **Chores**
  - Updated test fixtures to use configurable feature values for dependency paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->