### PR TITLE
feat: Adding `EnsureRun` method

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -166,6 +166,31 @@ func (r *Report) GetRun(path string) (*Run, error) {
 	return nil, fmt.Errorf("%w: %s", ErrRunNotFound, path)
 }
 
+// EnsureRun tries to get a run from the report.
+// If the run does not exist, it creates a new run and adds it to the report, then returns the run.
+// This is useful when a run is being ended that might not have been started due to exclusion, etc.
+func (r *Report) EnsureRun(path string) (*Run, error) {
+	run, err := r.GetRun(path)
+	if err == nil {
+		return run, err
+	}
+
+	if !errors.Is(err, ErrRunNotFound) {
+		return run, err
+	}
+
+	run, err = NewRun(path)
+	if err != nil {
+		return run, err
+	}
+
+	if err = r.AddRun(run); err != nil {
+		return run, err
+	}
+
+	return run, err
+}
+
 // EndRun ends a run and adds it to the report.
 // If the run does not exist, it returns the ErrRunNotFound error.
 // By default, the run is assumed to have succeeded. To change this, pass WithResult to the function.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -172,7 +172,7 @@ func (r *Report) GetRun(path string) (*Run, error) {
 func (r *Report) EnsureRun(path string) (*Run, error) {
 	run, err := r.GetRun(path)
 	if err == nil {
-		return run, err
+		return run, nil
 	}
 
 	if !errors.Is(err, ErrRunNotFound) {
@@ -188,7 +188,7 @@ func (r *Report) EnsureRun(path string) (*Run, error) {
 		return run, err
 	}
 
-	return run, err
+	return run, nil
 }
 
 // EndRun ends a run and adds it to the report.

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -106,12 +106,12 @@ func TestEnsureRun(t *testing.T) {
 	tmp := t.TempDir()
 
 	tests := []struct {
+		expectedErrIs error
+		setupFunc     func(*report.Report) *report.Run
 		name          string
 		runName       string
 		existingRun   bool
 		expectError   bool
-		expectedErrIs error
-		setupFunc     func(*report.Report) *report.Run
 	}{
 		{
 			name:        "creates new run when run does not exist",
@@ -157,7 +157,7 @@ func TestEnsureRun(t *testing.T) {
 				require.Error(t, err)
 				assert.Nil(t, run)
 				if tt.expectedErrIs != nil {
-					assert.ErrorIs(t, err, tt.expectedErrIs)
+					require.ErrorIs(t, err, tt.expectedErrIs)
 				}
 			} else {
 				require.NoError(t, err)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds a little convenience method that ensures a run exists by trying to grab an existing one, and returning that, or creating a new one if it doesn't exist.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `EnsureRun` method for reports.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new method to ensure a run is present in reports, automatically creating it if missing.

- **Bug Fixes**
  - Improved error handling when retrieving or creating runs in reports.

- **Tests**
  - Introduced tests to verify the new run management functionality and error scenarios.

- **Refactor**
  - Simplified internal logic for handling runs, reducing complexity and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->