### PR TITLE
[WIP] feat: Configure CMEK on GCS buckets

### DIFF
--- a/docs-starlight/src/content/docs/02-features/04-state-backend.mdx
+++ b/docs-starlight/src/content/docs/02-features/04-state-backend.mdx
@@ -270,6 +270,7 @@ remote_state {
  enable_bucket_policy_only = false # use only if uniform bucket-level access is needed (https://cloud.google.com/storage/docs/uniform-bucket-level-access)
 
  encryption_key = "GOOGLE_ENCRYPTION_KEY"
+ kms_encryption_key = "projects/${local.project}/locations/${local.location}/keyRings/${local.keyRing}/cryptoKeys/${local.name}"
 }
 ```
 

--- a/docs/_docs/02_features/04-state-backend.md
+++ b/docs/_docs/02_features/04-state-backend.md
@@ -270,6 +270,7 @@ remote_state {
  enable_bucket_policy_only = false # use only if uniform bucket-level access is needed (https://cloud.google.com/storage/docs/uniform-bucket-level-access)
 
  encryption_key = "GOOGLE_ENCRYPTION_KEY"
+ kms_encryption_key = "projects/${local.project}/locations/${local.location}/keyRings/${local.keyRing}/cryptoKeys/${local.name}"
 }
 ```
 

--- a/internal/remotestate/backend/gcs/client.go
+++ b/internal/remotestate/backend/gcs/client.go
@@ -250,6 +250,14 @@ func (client *Client) CreateGCSBucket(ctx context.Context, l log.Logger, bucketN
 		bucketAttrs.BucketPolicyOnly = storage.BucketPolicyOnly{Enabled: true}
 	}
 
+	if client.RemoteStateConfigGCS.KMSEncryptionKey != "" {
+		l.Debugf("Enabling KMS encryption using %s on GCS bucket %s", client.RemoteStateConfigGCS.KMSEncryptionKey, bucketName)
+
+		bucketAttrs.Encryption = &storage.BucketEncryption{
+			DefaultKMSKeyName: client.RemoteStateConfigGCS.KMSEncryptionKey,
+		}
+	}
+
 	if err := bucket.Create(ctx, projectID, bucketAttrs); err != nil {
 		return errors.Errorf("error creating GCS bucket %s: %w", bucketName, err)
 	}

--- a/internal/remotestate/backend/gcs/remote_state_config.go
+++ b/internal/remotestate/backend/gcs/remote_state_config.go
@@ -55,6 +55,7 @@ type RemoteStateConfigGCS struct {
 	Path          string `mapstructure:"path"`
 	EncryptionKey string `mapstructure:"encryption_key"`
 
+	KMSEncryptionKey                   string   `mapstructure:"kms_encryption_key"`
 	ImpersonateServiceAccount          string   `mapstructure:"impersonate_service_account"`
 	ImpersonateServiceAccountDelegates []string `mapstructure:"impersonate_service_account_delegates"`
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4475. Ensures Terragrunt creates GCS buckets with default CMEK when configured for reading and writing state files in the backend.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added default CMEK configuration for Terragrunt-created GCS buckets.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

