### PR TITLE
docs: Adding docs for local state to the side with stacks

### DIFF
--- a/docs-starlight/src/content/docs/02-features/02-stacks.mdx
+++ b/docs-starlight/src/content/docs/02-features/02-stacks.mdx
@@ -638,6 +638,155 @@ In addition to using your working directory to control what's included in a [run
 
 There are more flags that control the behavior of the `run` command, which you can find in the [`run` docs](/docs/reference/cli/commands/run).
 
+## Using Local State with Stacks
+
+When using Terragrunt Stacks, you might want to use local state files instead of remote state for development, testing, or specific use cases. However, this presents a challenge because the generated `.terragrunt-stack` directory can be safely deleted and regenerated using `terragrunt stack clean && terragrunt stack generate`, which would normally cause local state files to be lost.
+
+To solve this problem, you can configure your stack to store state files outside of the `.terragrunt-stack` directory, in a persistent location that survives stack regeneration.
+
+### Configuration
+
+Here's how to configure local state that persists across stack regeneration:
+
+**1. Create a `root.hcl` file with local backend configuration:**
+
+```hcl
+# root.hcl
+remote_state {
+  backend = "local"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+
+  config = {
+    path = "${get_parent_terragrunt_dir()}/.terragrunt-local-state/${path_relative_to_include()}/tofu.tfstate"
+  }
+}
+```
+
+**2. Create your stack definition:**
+
+```hcl
+# live/terragrunt.stack.hcl
+unit "vpc" {
+  source = "${find_in_parent_folders("units/vpc")}"
+  path   = "vpc"
+}
+
+unit "database" {
+  source = "${find_in_parent_folders("units/database")}"
+  path   = "database"
+}
+
+unit "app" {
+  source = "${find_in_parent_folders("units/app")}"
+  path   = "app"
+}
+```
+
+**3. Configure your units to include the root configuration:**
+
+```hcl
+# units/vpc/terragrunt.hcl
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "."
+}
+```
+
+**4. Add a `.gitignore` file to exclude state files from version control:**
+
+```gitignore
+# .gitignore
+.terragrunt-local-state
+```
+
+**Important:** Local state files should never be committed to version control as they may contain sensitive information and can cause conflicts when multiple developers work on the same infrastructure.
+
+### How It Works
+
+The key insight is using `path_relative_to_include()` in the state path configuration. This function returns the relative path from each unit to the `root.hcl` file, creating unique state file paths like:
+
+```text
+.terragrunt-local-state/live/.terragrunt-stack/vpc/tofu.tfstate
+.terragrunt-local-state/live/.terragrunt-stack/database/tofu.tfstate
+.terragrunt-local-state/live/.terragrunt-stack/app/tofu.tfstate
+```
+
+Since these state files are stored in `.terragrunt-local-state/` (outside of `.terragrunt-stack/`), they persist when you run:
+
+```bash
+terragrunt stack clean && terragrunt stack generate
+```
+
+### Directory Structure
+
+After running the stack, your directory structure will look like this:
+
+<FileTree>
+
+- .
+  - root.hcl
+  - .gitignore (Excludes .terragrunt-local-state)
+  - .terragrunt-local-state/ (Persistent state files - ignored by git)
+    - live/
+      - .terragrunt-stack/
+        - vpc/
+          - tofu.tfstate
+        - database/
+          - tofu.tfstate
+        - app/
+          - tofu.tfstate
+  - live/
+    - terragrunt.stack.hcl
+    - .terragrunt-stack/ (Generated stack - can be deleted)
+      - vpc/
+        - terragrunt.hcl
+        - main.tf
+      - database/
+        - terragrunt.hcl
+        - main.tf
+      - app/
+        - terragrunt.hcl
+        - main.tf
+  - units/ (Reusable unit definitions)
+    - vpc/
+    - database/
+    - app/
+
+</FileTree>
+
+### Benefits
+
+This approach provides several advantages:
+
+- **State Persistence**: State files survive stack regeneration
+- **Isolation**: Each unit gets its own state file
+- **Consistency**: Directory structure mirrors the stack layout
+- **Flexibility**: You can switch between local and remote state easily by changing the backend configuration
+
+### Example Workflow
+
+```bash
+# Initial setup
+terragrunt stack generate
+terragrunt stack run apply
+
+# Later, regenerate the stack without losing state
+terragrunt stack clean
+terragrunt stack generate
+
+# Verify existing resources are recognized
+terragrunt stack run plan  # Should show "No changes"
+```
+
+This pattern is particularly useful for development environments, testing scenarios, or when you need to maintain local state for compliance or security reasons while still benefiting from Terragrunt's stack management capabilities.
+
 ## Learning more
 
 If you'd like more advanced examples on stacks, check out the [terragrunt-infrastructure-catalog-example repository](https://github.com/gruntwork-io/terragrunt-infrastructure-catalog-example/tree/main/examples/terragrunt/stacks). These have full-featured examples of stacks that deploy real, stateful infrastructure in an AWS account.

--- a/test/fixtures/docs/03-stacks-with-local-state/.gitignore
+++ b/test/fixtures/docs/03-stacks-with-local-state/.gitignore
@@ -1,0 +1,1 @@
+.terragrunt-local-state

--- a/test/fixtures/docs/03-stacks-with-local-state/live/terragrunt.stack.hcl
+++ b/test/fixtures/docs/03-stacks-with-local-state/live/terragrunt.stack.hcl
@@ -1,0 +1,14 @@
+unit "foo" {
+  source = "${find_in_parent_folders("units/basic")}"
+  path   = "foo"
+}
+
+unit "bar" {
+  source = "${find_in_parent_folders("units/basic")}"
+  path   = "bar"
+}
+
+unit "baz" {
+  source = "${find_in_parent_folders("units/basic")}"
+  path   = "baz"
+}

--- a/test/fixtures/docs/03-stacks-with-local-state/root.hcl
+++ b/test/fixtures/docs/03-stacks-with-local-state/root.hcl
@@ -1,0 +1,12 @@
+remote_state {
+  backend = "local"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+
+  config = {
+    path = "${get_parent_terragrunt_dir()}/.terragrunt-local-state/${path_relative_to_include()}/tofu.tfstate"
+  }
+}

--- a/test/fixtures/docs/03-stacks-with-local-state/units/basic/main.tf
+++ b/test/fixtures/docs/03-stacks-with-local-state/units/basic/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "basic" {
+  triggers = {
+    hello = "world"
+  }
+}

--- a/test/fixtures/docs/03-stacks-with-local-state/units/basic/terragrunt.hcl
+++ b/test/fixtures/docs/03-stacks-with-local-state/units/basic/terragrunt.hcl
@@ -1,0 +1,7 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "."
+}

--- a/test/integration_docs_test.go
+++ b/test/integration_docs_test.go
@@ -1,6 +1,7 @@
 package test_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -10,7 +11,8 @@ import (
 )
 
 const (
-	testFixtureQuickStart = "fixtures/docs/01-quick-start"
+	testFixtureQuickStart       = "fixtures/docs/01-quick-start"
+	testFixtureStacksLocalState = "fixtures/docs/03-stacks-with-local-state"
 )
 
 func TestDocsQuickStart(t *testing.T) {
@@ -153,4 +155,141 @@ func TestDocsQuickStart(t *testing.T) {
 		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all plan --non-interactive --log-level trace --working-dir "+rootPath)
 		require.NoError(t, err)
 	})
+}
+
+func TestStacksWithLocalState(t *testing.T) {
+	t.Parallel()
+
+	// Clean up the test fixture
+	helpers.CleanupTerraformFolder(t, testFixtureStacksLocalState)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksLocalState)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksLocalState)
+	livePath := util.JoinPath(rootPath, "live")
+	localStatePath := util.JoinPath(rootPath, ".terragrunt-local-state")
+
+	// Ensure local state directory doesn't exist initially
+	require.NoError(t, os.RemoveAll(localStatePath))
+
+	// Step 1: Generate the stack
+	helpers.RunTerragrunt(t, "terragrunt stack generate --working-dir "+livePath)
+
+	// Verify .terragrunt-stack directory was created
+	stackPath := util.JoinPath(livePath, ".terragrunt-stack")
+	require.DirExists(t, stackPath)
+
+	// Verify individual units were generated
+	fooPath := util.JoinPath(stackPath, "foo")
+	barPath := util.JoinPath(stackPath, "bar")
+	bazPath := util.JoinPath(stackPath, "baz")
+	require.DirExists(t, fooPath)
+	require.DirExists(t, barPath)
+	require.DirExists(t, bazPath)
+
+	// Step 2: Apply the stack to create state files
+	helpers.RunTerragrunt(t, "terragrunt stack run apply --non-interactive --working-dir "+livePath)
+
+	// Verify local state files were created in .terragrunt-local-state
+	// Note: path_relative_to_include() returns "live/.terragrunt-stack/foo" etc.
+	fooStatePath := util.JoinPath(localStatePath, "live", ".terragrunt-stack", "foo", "tofu.tfstate")
+	barStatePath := util.JoinPath(localStatePath, "live", ".terragrunt-stack", "bar", "tofu.tfstate")
+	bazStatePath := util.JoinPath(localStatePath, "live", ".terragrunt-stack", "baz", "tofu.tfstate")
+
+	require.FileExists(t, fooStatePath)
+	require.FileExists(t, barStatePath)
+	require.FileExists(t, bazStatePath)
+
+	// Verify state files contain actual state (not empty)
+	fooStateContent, err := util.ReadFileAsString(fooStatePath)
+	require.NoError(t, err)
+	barStateContent, err := util.ReadFileAsString(barStatePath)
+	require.NoError(t, err)
+	bazStateContent, err := util.ReadFileAsString(bazStatePath)
+	require.NoError(t, err)
+
+	assert.Contains(t, fooStateContent, "null_resource")
+	assert.Contains(t, barStateContent, "null_resource")
+	assert.Contains(t, bazStateContent, "null_resource")
+
+	// Step 3: Clean and regenerate the stack
+	helpers.RunTerragrunt(t, "terragrunt stack clean --working-dir "+livePath)
+
+	// Verify .terragrunt-stack directory was removed
+	require.NoDirExists(t, stackPath)
+
+	// Verify local state files still exist
+	require.FileExists(t, fooStatePath)
+	require.FileExists(t, barStatePath)
+	require.FileExists(t, bazStatePath)
+
+	// Regenerate the stack
+	helpers.RunTerragrunt(t, "terragrunt stack generate --working-dir "+livePath)
+
+	// Verify .terragrunt-stack directory was recreated
+	require.DirExists(t, stackPath)
+	require.DirExists(t, fooPath)
+	require.DirExists(t, barPath)
+	require.DirExists(t, bazPath)
+
+	// Step 4: Verify that existing state is recognized after regeneration
+	// Run plan to make sure it recognizes existing resources
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack run plan --non-interactive --working-dir "+livePath)
+	require.NoError(t, err)
+
+	// The plan output should indicate no changes are needed since resources already exist
+	assert.Contains(t, stdout, "No changes")
+
+	// Step 5: Destroy resources to clean up
+	helpers.RunTerragrunt(t, "terragrunt stack run destroy --non-interactive --working-dir "+livePath)
+
+	// Verify state files still exist but are now empty/clean
+	require.FileExists(t, fooStatePath)
+	require.FileExists(t, barStatePath)
+	require.FileExists(t, bazStatePath)
+}
+
+func TestStacksWithLocalStateFileStructure(t *testing.T) {
+	t.Parallel()
+
+	// Test that verifies the exact file structure created by the local state configuration
+	helpers.CleanupTerraformFolder(t, testFixtureStacksLocalState)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksLocalState)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStacksLocalState)
+	livePath := util.JoinPath(rootPath, "live")
+	localStatePath := util.JoinPath(rootPath, ".terragrunt-local-state")
+
+	// Ensure local state directory doesn't exist initially
+	require.NoError(t, os.RemoveAll(localStatePath))
+
+	// Generate and apply the stack
+	helpers.RunTerragrunt(t, "terragrunt stack generate --working-dir "+livePath)
+	helpers.RunTerragrunt(t, "terragrunt stack run apply --non-interactive --working-dir "+livePath)
+
+	// Test the exact structure of .terragrunt-local-state
+	require.DirExists(t, localStatePath)
+
+	// Check that each unit has its own subdirectory
+	// Note: path structure reflects live/.terragrunt-stack/[unit]
+	fooLocalStateDir := util.JoinPath(localStatePath, "live", ".terragrunt-stack", "foo")
+	barLocalStateDir := util.JoinPath(localStatePath, "live", ".terragrunt-stack", "bar")
+	bazLocalStateDir := util.JoinPath(localStatePath, "live", ".terragrunt-stack", "baz")
+
+	require.DirExists(t, fooLocalStateDir)
+	require.DirExists(t, barLocalStateDir)
+	require.DirExists(t, bazLocalStateDir)
+
+	// Check that state files are in the correct locations
+	require.FileExists(t, util.JoinPath(fooLocalStateDir, "tofu.tfstate"))
+	require.FileExists(t, util.JoinPath(barLocalStateDir, "tofu.tfstate"))
+	require.FileExists(t, util.JoinPath(bazLocalStateDir, "tofu.tfstate"))
+
+	// Since backend.tf is generated in the .terragrunt-cache directory during execution,
+	// we verify the state files exist in the expected .terragrunt-local-state directory structure
+	// This confirms that the backend configuration is working correctly
+
+	// Verify the .terragrunt-local-state directory structure matches path_relative_to_include()
+	liveStateDir := util.JoinPath(localStatePath, "live", ".terragrunt-stack")
+	require.DirExists(t, liveStateDir)
+
+	// Clean up
+	helpers.RunTerragrunt(t, "terragrunt stack run destroy --non-interactive --working-dir "+livePath)
 }


### PR DESCRIPTION
## Description

Adds documentation explaining to users how they can avoid issues with stack regeneration and local state files.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added documentation for state-to-the-side with stack generation.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

