### PR TITLE
fix: Use a constant for min version of tofu for auto provider cache dir

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -191,6 +191,8 @@ func runAction(cliCtx *cli.Context, l log.Logger, opts *options.TerragruntOption
 	return errGroup.Wait()
 }
 
+const minTofuVersionForAutoProviderCacheDir = "1.10.0"
+
 // setupAutoProviderCacheDir configures native provider caching by setting TF_PLUGIN_CACHE_DIR.
 //
 // Only works with OpenTofu version >= 1.10. Returns error if conditions aren't met.
@@ -222,7 +224,7 @@ func setupAutoProviderCacheDir(ctx context.Context, l log.Logger, opts *options.
 		return errors.New("cannot determine OpenTofu version")
 	}
 
-	requiredVersion, err := version.NewVersion("1.10.0")
+	requiredVersion, err := version.NewVersion(minTofuVersionForAutoProviderCacheDir)
 	if err != nil {
 		return fmt.Errorf("failed to parse required version: %w", err)
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Addresses nit from review feedback.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal version handling for the auto provider cache directory feature. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->