### PR TITLE
Fix plan output relative

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -134,7 +134,12 @@ func (module *TerraformModule) getPlanFilePath(l log.Logger, opts *options.Terra
 		return ""
 	}
 
-	path, _ := filepath.Rel(opts.WorkingDir, module.Path)
+	// module path will be an absolute path so working dir should absolute too so that Rel() can work
+	wdir, err := filepath.Abs(opts.WorkingDir)
+	if err != nil {
+		wdir = opts.WorkingDir
+	}
+	path, _ := filepath.Rel(wdir, module.Path)
 	dir := filepath.Join(outputFolder, path)
 
 	if !filepath.IsAbs(dir) {

--- a/test/fixtures/plan-output/private-dns-zone/main.tf
+++ b/test/fixtures/plan-output/private-dns-zone/main.tf
@@ -1,0 +1,5 @@
+variable "terragrunt_dir" {}
+
+output "terragrunt_dir" {
+  value = var.terragrunt_dir
+}

--- a/test/fixtures/plan-output/private-dns-zone/terragrunt.hcl
+++ b/test/fixtures/plan-output/private-dns-zone/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  terragrunt_dir = "."
+}

--- a/test/fixtures/plan-output/resource-group/main.tf
+++ b/test/fixtures/plan-output/resource-group/main.tf
@@ -1,0 +1,5 @@
+variable "terragrunt_dir" {}
+
+output "terragrunt_dir" {
+  value = var.terragrunt_dir
+}

--- a/test/fixtures/plan-output/resource-group/terragrunt.hcl
+++ b/test/fixtures/plan-output/resource-group/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  terragrunt_dir = "."
+}

--- a/test/fixtures/plan-output/vnet/main.tf
+++ b/test/fixtures/plan-output/vnet/main.tf
@@ -1,0 +1,5 @@
+variable "terragrunt_dir" {}
+
+output "terragrunt_dir" {
+  value = var.terragrunt_dir
+}

--- a/test/fixtures/plan-output/vnet/terragrunt.hcl
+++ b/test/fixtures/plan-output/vnet/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  terragrunt_dir = "."
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/terragrunt/issues/4430. 

This pull request introduces enhancements to the handling of module paths, adds new test fixtures for validating Terragrunt plans, and implements a new integration test for verifying `terragrunt plan --all` functionality. Below is a summary of the most important changes:

**Enhancements to module path handling:** Updated `getPlanFilePath` in `configstack/module.go` to ensure `opts.WorkingDir` is converted to an absolute path before calling `filepath.Rel`, improving compatibility with absolute module paths.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

