### PR TITLE
fix: Fixing `TestProviderCache` flake

### DIFF
--- a/internal/providercache/provider_cache_test.go
+++ b/internal/providercache/provider_cache_test.go
@@ -154,8 +154,12 @@ func TestProviderCache(t *testing.T) {
 				assert.Regexp(t, tc.expectedBodyReg, string(body))
 			}
 
-			_, err = providerService.WaitForCacheReady("")
-			require.NoError(t, err)
+			// Skip WaitForCacheReady for unauthorized test cases since they don't trigger background operations,
+			// and we cancel context at the end of the test.
+			if tc.expectedStatusCode != http.StatusUnauthorized {
+				_, err = providerService.WaitForCacheReady("")
+				require.NoError(t, err)
+			}
 
 			if tc.expectedCachePath != "" {
 				assert.FileExists(t, filepath.Join(providerCacheDir, tc.expectedCachePath))


### PR DESCRIPTION
## Description

Fixes flake in `TestProviderCache`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `TestProviderCache` to avoid flake.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by skipping unnecessary cache readiness checks for unauthorized scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->