### PR TITLE
fix: Adjusting lockfile handling when modules define constraints

### DIFF
--- a/internal/providercache/provider_cache.go
+++ b/internal/providercache/provider_cache.go
@@ -211,7 +211,40 @@ func (cache *ProviderCache) warmUpCache(
 		return nil, err
 	}
 
+	providerConstraints, err := getproviders.ParseProviderConstraints(opts, filepath.Dir(opts.TerragruntConfigPath))
+	if err != nil {
+		l.Debugf("Failed to parse provider constraints from %s: %v", filepath.Dir(opts.TerragruntConfigPath), err)
+
+		providerConstraints = make(getproviders.ProviderConstraints)
+	}
+
+	for _, provider := range caches {
+		if providerCache, ok := provider.(*services.ProviderCache); ok {
+			providerAddr := provider.Address()
+			if constraint, exists := providerConstraints[providerAddr]; exists {
+				providerCache.Provider.OriginalConstraints = constraint
+				l.Debugf("Applied constraint %s to provider %s", constraint, providerAddr)
+			} else {
+				l.Debugf("No constraint found for provider %s", providerAddr)
+			}
+		}
+	}
+
 	err = getproviders.UpdateLockfile(ctx, opts.WorkingDir, caches)
+	if err != nil {
+		return nil, err
+	}
+
+	// For upgrade scenarios where no providers were newly cached, we still need to update
+	// the lock file if module constraints have changed. This only happens during upgrades.
+	// Check if user passed -upgrade flag to terraform init
+	isUpgrade := util.ListContainsElement(opts.TerraformCliArgs, "-upgrade")
+
+	if len(caches) == 0 && len(providerConstraints) > 0 && isUpgrade {
+		l.Debugf("No new providers cached, but constraints exist. Updating lock file constraints for upgrade scenario.")
+
+		err = getproviders.UpdateLockfileConstraints(ctx, opts.WorkingDir, providerConstraints)
+	}
 
 	return nil, err
 }

--- a/test/fixtures/provider-cache/constraint-issue/app/main.tf
+++ b/test/fixtures/provider-cache/constraint-issue/app/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.10.0"
+    }
+  }
+}

--- a/test/fixtures/provider-cache/constraint-issue/app/terragrunt.hcl
+++ b/test/fixtures/provider-cache/constraint-issue/app/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/integration_provider_cache_constraint_test.go
+++ b/test/integration_provider_cache_constraint_test.go
@@ -120,6 +120,10 @@ func extractConstraintsFromLockFile(t *testing.T, appPath string, providerName s
 	if strings.Contains(providerName, "/") {
 		// Full name like "cloudflare/cloudflare"
 		providerBlock = lockfile.Body().FirstMatchingBlock("provider", []string{"registry.terraform.io/" + providerName})
+		if providerBlock == nil {
+			// Try OpenTofu registry as well
+			providerBlock = lockfile.Body().FirstMatchingBlock("provider", []string{"registry.opentofu.org/" + providerName})
+		}
 	} else {
 		// Short name - search for matching block
 		for _, block := range lockfile.Body().Blocks() {

--- a/test/integration_provider_cache_constraint_test.go
+++ b/test/integration_provider_cache_constraint_test.go
@@ -1,0 +1,142 @@
+package test_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFixtureProviderCacheConstraintIssue = "fixtures/provider-cache/constraint-issue"
+)
+
+// TestTerragruntProviderCacheConstraintIssue tests that provider cache preserves
+// module constraints instead of pinning exact versions in .terraform.lock.hcl files.
+// Reproduces and validates the fix for GitHub issue #4512.
+//
+//nolint:paralleltest,tparallel
+func TestTerragruntProviderCacheConstraintIssue(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureProviderCacheConstraintIssue)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureProviderCacheConstraintIssue)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureProviderCacheConstraintIssue)
+	appPath := filepath.Join(rootPath, "app")
+
+	providerCacheDir := t.TempDir()
+
+	t.Run("initial_setup_preserves_module_constraints", func(t *testing.T) {
+		helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt init --provider-cache --provider-cache-dir %s --log-level trace --non-interactive --working-dir %s", providerCacheDir, appPath))
+
+		constraintsValue := extractConstraintsFromLockFile(t, appPath, "cloudflare/cloudflare")
+
+		expectedConstraints := "~> 4.0"
+		assert.Equal(t, expectedConstraints, constraintsValue, "Initial lock file should preserve module's required_providers constraints")
+	})
+
+	t.Run("upgrade_updates_constraints_to_match_module", func(t *testing.T) {
+		// Update the main.tf file to change cloudflare version constraint from "~> 4.0" to "~> 4.40"
+		mainTfPath := filepath.Join(appPath, "main.tf")
+		originalContent, err := os.ReadFile(mainTfPath)
+		require.NoError(t, err)
+
+		// Replace the version constraint
+		updatedContent := strings.ReplaceAll(string(originalContent), `version = "~> 4.0"`, `version = "~> 4.40"`)
+		require.NotEqual(t, string(originalContent), updatedContent, "Content should be different after replacement")
+
+		err = os.WriteFile(mainTfPath, []byte(updatedContent), 0644)
+		require.NoError(t, err)
+
+		lockFilePreInit, err := os.ReadFile(filepath.Join(appPath, ".terraform.lock.hcl"))
+		require.NoError(t, err)
+
+		// Run terragrunt init and check that the lock file isn't updated
+		helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt init --provider-cache --provider-cache-dir %s --log-level trace --non-interactive --working-dir %s", providerCacheDir, appPath))
+		lockFilePostInit, err := os.ReadFile(filepath.Join(appPath, ".terraform.lock.hcl"))
+		require.NoError(t, err)
+		assert.Equal(t, string(lockFilePreInit), string(lockFilePostInit), "Lock file should not be updated")
+
+		// Run terragrunt init -upgrade to update the lock file
+		helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt init -upgrade --provider-cache --provider-cache-dir %s --log-level trace --non-interactive --working-dir %s", providerCacheDir, appPath))
+
+		lockFilePostUpgrade, err := os.ReadFile(filepath.Join(appPath, ".terraform.lock.hcl"))
+		require.NoError(t, err)
+		assert.NotEqual(t, string(lockFilePostInit), string(lockFilePostUpgrade), "Lock file should be updated")
+
+		// Verify the lock file constraints are updated to match the module
+		constraintsValue := extractConstraintsFromLockFile(t, appPath, "cloudflare/cloudflare")
+
+		expectedConstraints := "~> 4.40"
+		assert.Equal(t, expectedConstraints, constraintsValue, "Constraints should be updated to match the module's required_providers")
+	})
+
+	t.Run("fresh_start_uses_module_constraints", func(t *testing.T) {
+		// Delete the lock file
+		lockfilePath := filepath.Join(appPath, ".terraform.lock.hcl")
+		err := os.Remove(lockfilePath)
+		require.NoError(t, err)
+
+		// Also clean up .terraform directory to ensure fresh start
+		terraformDir := filepath.Join(appPath, ".terraform")
+		if util.FileExists(terraformDir) {
+			err = os.RemoveAll(terraformDir)
+			require.NoError(t, err)
+		}
+
+		helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt init --provider-cache --provider-cache-dir %s --log-level trace --non-interactive --working-dir %s", providerCacheDir, appPath))
+
+		constraintsValue := extractConstraintsFromLockFile(t, appPath, "cloudflare/cloudflare")
+
+		expectedConstraints := "~> 4.40"
+		assert.Equal(t, expectedConstraints, constraintsValue, "Fresh lock file should use module's required_providers constraints")
+	})
+}
+
+// Helper function to extract constraints value from lock file
+func extractConstraintsFromLockFile(t *testing.T, appPath string, providerName string) string {
+	t.Helper()
+
+	lockfilePath := filepath.Join(appPath, ".terraform.lock.hcl")
+	require.True(t, util.FileExists(lockfilePath), "Lock file should exist")
+
+	// Read and parse the lock file
+	lockfileContent, err := os.ReadFile(lockfilePath)
+	require.NoError(t, err)
+
+	lockfile, diags := hclwrite.ParseConfig(lockfileContent, lockfilePath, hcl.Pos{Line: 1, Column: 1})
+	require.False(t, diags.HasErrors(), "Lock file should be valid HCL")
+
+	// Find the provider block (handle both short and full provider names)
+	var providerBlock *hclwrite.Block
+	if strings.Contains(providerName, "/") {
+		// Full name like "cloudflare/cloudflare"
+		providerBlock = lockfile.Body().FirstMatchingBlock("provider", []string{"registry.terraform.io/" + providerName})
+	} else {
+		// Short name - search for matching block
+		for _, block := range lockfile.Body().Blocks() {
+			if block.Type() == "provider" && len(block.Labels()) > 0 {
+				if strings.Contains(block.Labels()[0], providerName) {
+					providerBlock = block
+					break
+				}
+			}
+		}
+	}
+	require.NotNil(t, providerBlock, "Provider block should exist in lock file")
+
+	// Get the constraints attribute
+	constraintsAttr := providerBlock.Body().GetAttribute("constraints")
+	require.NotNil(t, constraintsAttr, "Constraints attribute should exist")
+
+	constraintsValue := strings.Trim(string(constraintsAttr.Expr().BuildTokens(nil).Bytes()), ` "`)
+	return constraintsValue
+}

--- a/tf/cache/models/provider.go
+++ b/tf/cache/models/provider.go
@@ -108,6 +108,9 @@ type Provider struct {
 	Version      string
 	OS           string
 	Arch         string
+
+	// OriginalConstraints holds the version constraints from the module's required_providers block
+	OriginalConstraints string
 }
 
 func ParseProvider(str string) *Provider {
@@ -153,6 +156,10 @@ func (provider *Provider) Platform() string {
 
 func (provider *Provider) Address() string {
 	return path.Join(provider.RegistryName, provider.Namespace, provider.Name)
+}
+
+func (provider *Provider) Constraints() string {
+	return provider.OriginalConstraints
 }
 
 // Match returns true if all defined provider properties are matched.

--- a/tf/cache/services/provider_cache.go
+++ b/tf/cache/services/provider_cache.go
@@ -445,7 +445,7 @@ func (service *ProviderService) Run(ctx context.Context) error {
 		return errors.Errorf("provider cache directory not specified")
 	}
 
-	service.logger.Infof("Starting provider cache service with cache dir: %q", service.cacheDir)
+	service.logger.Debugf("Starting provider cache service with cache dir: %q", service.cacheDir)
 
 	if err := os.MkdirAll(service.cacheDir, os.ModePerm); err != nil {
 		return errors.New(err)
@@ -462,7 +462,7 @@ func (service *ProviderService) Run(ctx context.Context) error {
 	errs := &errors.MultiError{}
 	errGroup, ctx := errgroup.WithContext(ctx)
 
-	service.logger.Infof("Provider cache service is ready to process requests")
+	service.logger.Debugf("Provider cache service is ready to process requests")
 
 	for {
 		select {
@@ -479,7 +479,7 @@ func (service *ProviderService) Run(ctx context.Context) error {
 				return nil
 			})
 		case <-ctx.Done():
-			service.logger.Infof("Provider cache service shutting down...")
+			service.logger.Debugf("Provider cache service shutting down...")
 
 			if err := errGroup.Wait(); err != nil {
 				errs = errs.Append(err)
@@ -489,7 +489,7 @@ func (service *ProviderService) Run(ctx context.Context) error {
 				errs = errs.Append(err)
 			}
 
-			service.logger.Infof("Provider cache service shutdown complete")
+			service.logger.Debugf("Provider cache service shutdown complete")
 
 			return errs.ErrorOrNil()
 		}
@@ -522,7 +522,7 @@ func (service *ProviderService) startProviderCaching(ctx context.Context, cache 
 	}
 
 	cache.ready = true
-	service.logger.Infof("Successfully cached provider: %s", cache.Provider)
+	service.logger.Debugf("Successfully cached provider: %s", cache.Provider)
 
 	return nil
 }

--- a/tf/cache/services/provider_cache.go
+++ b/tf/cache/services/provider_cache.go
@@ -140,6 +140,10 @@ func (cache *ProviderCache) Address() string {
 	return cache.Provider.Address()
 }
 
+func (cache *ProviderCache) Constraints() string {
+	return cache.Provider.Constraints()
+}
+
 func (cache *ProviderCache) PackageDir() string {
 	return cache.packageDir
 }

--- a/tf/cache/services/provider_cache.go
+++ b/tf/cache/services/provider_cache.go
@@ -320,13 +320,16 @@ type ProviderService struct {
 }
 
 func NewProviderService(cacheDir, userCacheDir string, credsSource *cliconfig.CredentialsSource, logger log.Logger) *ProviderService {
-	return &ProviderService{
+	service := &ProviderService{
 		cacheDir:              cacheDir,
 		userCacheDir:          userCacheDir,
-		providerCacheWarmUpCh: make(chan *ProviderCache),
+		providerCacheWarmUpCh: make(chan *ProviderCache, 100), // Add buffer to prevent blocking
 		credsSource:           credsSource,
 		logger:                logger,
 	}
+
+	logger.Debugf("Provider service initialized with cache dir: %s, user cache dir: %s", cacheDir, userCacheDir)
+	return service
 }
 
 func (service *ProviderService) Logger() log.Logger {
@@ -344,16 +347,33 @@ func (service *ProviderService) WaitForCacheReady(requestID string) ([]getprovid
 		errs      = &errors.MultiError{}
 	)
 
-	for _, provider := range service.providerCaches.FindByRequestID(requestID) {
+	service.logger.Debugf("Waiting for cache ready with requestID: %s", requestID)
+
+	caches := service.providerCaches.FindByRequestID(requestID)
+	service.logger.Debugf("Found %d caches for requestID: %s", len(caches), requestID)
+
+	// Add debug logging for all provider caches
+	service.logger.Debugf("Total provider caches: %d", len(service.providerCaches))
+	for i, cache := range service.providerCaches {
+		service.logger.Debugf("Cache %d: %s, requestIDs: %v, ready: %v, err: %v",
+			i, cache.Provider, cache.requestIDs, cache.ready, cache.err)
+	}
+
+	for _, provider := range caches {
 		if provider.err != nil {
 			errs = errs.Append(fmt.Errorf("unable to cache provider: %s, err: %w", provider, provider.err))
+			service.logger.Errorf("Provider cache error for %s: %v", provider, provider.err)
 		}
 
 		if provider.ready {
 			providers = append(providers, provider)
+			service.logger.Debugf("Provider %s is ready", provider)
+		} else {
+			service.logger.Debugf("Provider %s is not ready yet", provider)
 		}
 	}
 
+	service.logger.Debugf("Returning %d ready providers for requestID: %s", len(providers), requestID)
 	return providers, errs.ErrorOrNil()
 }
 
@@ -362,7 +382,10 @@ func (service *ProviderService) CacheProvider(ctx context.Context, requestID str
 	service.cacheMu.Lock()
 	defer service.cacheMu.Unlock()
 
+	service.logger.Debugf("CacheProvider called for %s with requestID: %s", provider, requestID)
+
 	if cache := service.providerCaches.Find(provider); cache != nil {
+		service.logger.Debugf("Found existing cache for provider %s", provider)
 		cache.addRequestID(requestID)
 		return cache
 	}
@@ -380,15 +403,20 @@ func (service *ProviderService) CacheProvider(ctx context.Context, requestID str
 		archivePath:     filepath.Join(service.tempDir, packageName+path.Ext(provider.Filename)),
 	}
 
+	service.logger.Debugf("Sending provider %s to warm up channel", provider)
 	select {
 	case service.providerCacheWarmUpCh <- cache:
+		service.logger.Debugf("Successfully sent provider %s to warm up channel", provider)
 		// We need to wait for caching to start and only then release the client (Terraform) requestID. Otherwise, the client may call `WaitForCacheReady()` faster than `service.ReadyMuReady` will be lock.
 		<-cache.started
 		service.providerCaches = append(service.providerCaches, cache)
+		service.logger.Debugf("Added provider %s to provider caches list", provider)
 	case <-ctx.Done():
+		service.logger.Debugf("Context cancelled while trying to cache provider %s", provider)
 	}
 
 	cache.addRequestID(requestID)
+	service.logger.Debugf("Added requestID %s to provider %s", requestID, provider)
 
 	return cache
 }
@@ -411,7 +439,7 @@ func (service *ProviderService) Run(ctx context.Context) error {
 		return errors.Errorf("provider cache directory not specified")
 	}
 
-	service.logger.Debugf("Provider cache dir %q", service.cacheDir)
+	service.logger.Infof("Starting provider cache service with cache dir: %q", service.cacheDir)
 
 	if err := os.MkdirAll(service.cacheDir, os.ModePerm); err != nil {
 		return errors.New(err)
@@ -423,21 +451,29 @@ func (service *ProviderService) Run(ctx context.Context) error {
 	}
 
 	service.tempDir = filepath.Join(tempDir, "providers")
+	service.logger.Debugf("Provider cache service temp dir: %s", service.tempDir)
 
 	errs := &errors.MultiError{}
 	errGroup, ctx := errgroup.WithContext(ctx)
 
+	service.logger.Infof("Provider cache service is ready to process requests")
+
 	for {
 		select {
 		case cache := <-service.providerCacheWarmUpCh:
+			service.logger.Debugf("Received provider cache request for: %s", cache.Provider)
 			errGroup.Go(func() error {
 				if err := service.startProviderCaching(ctx, cache); err != nil {
+					service.logger.Errorf("Failed to start provider caching for %s: %v", cache.Provider, err)
 					errs = errs.Append(err)
+				} else {
+					service.logger.Debugf("Successfully started provider caching for %s", cache.Provider)
 				}
 
 				return nil
 			})
 		case <-ctx.Done():
+			service.logger.Infof("Provider cache service shutting down...")
 			if err := errGroup.Wait(); err != nil {
 				errs = errs.Append(err)
 			}
@@ -446,6 +482,7 @@ func (service *ProviderService) Run(ctx context.Context) error {
 				errs = errs.Append(err)
 			}
 
+			service.logger.Infof("Provider cache service shutdown complete")
 			return errs.ErrorOrNil()
 		}
 	}
@@ -455,16 +492,20 @@ func (service *ProviderService) startProviderCaching(ctx context.Context, cache 
 	service.cacheReadyMu.RLock()
 	defer service.cacheReadyMu.RUnlock()
 
+	service.logger.Debugf("Starting provider caching for: %s", cache.Provider)
 	cache.started <- struct{}{}
 
 	// We need to use a locking mechanism between Terragrunt processes to prevent simultaneous write access to the same provider.
 	lockfile, err := cache.acquireLockFile(ctx)
 	if err != nil {
+		service.logger.Errorf("Failed to acquire lock file for %s: %v", cache.Provider, err)
 		return err
 	}
 	defer lockfile.Unlock() //nolint:errcheck
 
+	service.logger.Debugf("Acquired lock file for %s, starting warm up", cache.Provider)
 	if cache.err = cache.warmUp(ctx); cache.err != nil {
+		service.logger.Errorf("Failed to warm up provider %s: %v", cache.Provider, cache.err)
 		os.Remove(cache.packageDir)  //nolint:errcheck
 		os.Remove(cache.archivePath) //nolint:errcheck
 
@@ -472,6 +513,7 @@ func (service *ProviderService) startProviderCaching(ctx context.Context, cache 
 	}
 
 	cache.ready = true
+	service.logger.Infof("Successfully cached provider: %s", cache.Provider)
 
 	return nil
 }

--- a/tf/getproviders/constraints.go
+++ b/tf/getproviders/constraints.go
@@ -1,0 +1,218 @@
+package getproviders
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/tf"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// ProviderConstraints maps provider addresses to their version constraints from required_providers blocks
+type ProviderConstraints map[string]string
+
+// ParseProviderConstraints parses all .tf and .tofu files in the given directory and extracts required_providers constraints
+func ParseProviderConstraints(opts *options.TerragruntOptions, workingDir string) (ProviderConstraints, error) {
+	constraints := make(ProviderConstraints)
+
+	var allFiles []string
+
+	tfFiles, err := filepath.Glob(filepath.Join(workingDir, "*.tf"))
+	if err != nil {
+		return nil, errors.New(err)
+	}
+
+	allFiles = append(allFiles, tfFiles...)
+
+	tofuFiles, err := filepath.Glob(filepath.Join(workingDir, "*.tofu"))
+	if err != nil {
+		return nil, errors.New(err)
+	}
+
+	allFiles = append(allFiles, tofuFiles...)
+
+	// If no terraform files found, return empty constraints (not an error)
+	if len(allFiles) == 0 {
+		return constraints, nil
+	}
+
+	for _, file := range allFiles {
+		fileConstraints, err := parseProviderConstraintsFromFile(opts, file)
+		if err != nil {
+			// Log parsing errors but continue processing other files
+			// This allows partial success when some files have syntax errors
+			continue
+		}
+
+		// Merge constraints from this file
+		for addr, constraint := range fileConstraints {
+			constraints[addr] = constraint
+		}
+	}
+
+	return constraints, nil
+}
+
+// parseProviderConstraintsFromFile parses a single .tf file and extracts required_providers constraints
+func parseProviderConstraintsFromFile(opts *options.TerragruntOptions, filename string) (ProviderConstraints, error) {
+	constraints := make(ProviderConstraints)
+
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, errors.New(err)
+	}
+
+	// Parse the HCL file
+	file, diags := hclsyntax.ParseConfig(content, filename, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, errors.New(diags)
+	}
+
+	// Walk through the file looking for terraform blocks with required_providers
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil, errors.New("failed to parse HCL body")
+	}
+
+	for _, block := range body.Blocks {
+		if block.Type != "terraform" {
+			continue
+		}
+
+		// Look for required_providers block within terraform block
+		for _, nestedBlock := range block.Body.Blocks {
+			if nestedBlock.Type != "required_providers" {
+				continue
+			}
+
+			// Parse each provider in the required_providers block
+			providerConstraints := parseProvidersFromRequiredProvidersBlock(opts, nestedBlock)
+
+			// Merge constraints from this required_providers block
+			for addr, constraint := range providerConstraints {
+				constraints[addr] = constraint
+			}
+		}
+	}
+
+	return constraints, nil
+}
+
+// parseProvidersFromRequiredProvidersBlock extracts provider constraints from a required_providers block
+func parseProvidersFromRequiredProvidersBlock(opts *options.TerragruntOptions, block *hclsyntax.Block) ProviderConstraints {
+	constraints := make(ProviderConstraints)
+
+	// Parse the attributes in the required_providers block
+	for name, attr := range block.Body.Attributes {
+		// Skip if not an object expression (should be provider configuration)
+		objExpr, ok := attr.Expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			continue
+		}
+
+		var source, version string
+
+		// Extract source and version from the provider configuration
+		for _, item := range objExpr.Items {
+			keyExpr, ok := item.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
+			if !ok {
+				continue
+			}
+
+			// Get the key name
+			keyName := ""
+
+			if keyExpr.Wrapped != nil {
+				// Try different types of key expressions
+				switch expr := keyExpr.Wrapped.(type) {
+				case *hclsyntax.TemplateExpr:
+					if len(expr.Parts) == 1 {
+						if literal, ok := expr.Parts[0].(*hclsyntax.LiteralValueExpr); ok {
+							keyName = literal.Val.AsString()
+						}
+					}
+				case *hclsyntax.ScopeTraversalExpr:
+					// This handles bare identifiers like "source" or "version"
+					if len(expr.Traversal) == 1 {
+						if root, ok := expr.Traversal[0].(hcl.TraverseRoot); ok {
+							keyName = root.Name
+						}
+					}
+				case *hclsyntax.LiteralValueExpr:
+					// Direct literal value
+					if expr.Val.Type() == cty.String {
+						keyName = expr.Val.AsString()
+					}
+				}
+			}
+
+			// Get the value
+			var value string
+
+			if templateExpr, ok := item.ValueExpr.(*hclsyntax.TemplateExpr); ok {
+				if len(templateExpr.Parts) == 1 {
+					if literal, ok := templateExpr.Parts[0].(*hclsyntax.LiteralValueExpr); ok {
+						if literal.Val.Type() == cty.String {
+							value = literal.Val.AsString()
+						}
+					}
+				}
+			}
+
+			// Store source and version attributes
+			switch keyName {
+			case "source":
+				source = value
+			case "version":
+				version = value
+			}
+		}
+
+		// If we have both source and version, create the constraint mapping
+		if source != "" && version != "" {
+			// Normalize the source address to full registry format
+			providerAddr := normalizeProviderAddress(opts, source)
+			constraints[providerAddr] = version
+		} else if source == "" && version != "" {
+			// If only version is specified, assume it's a hashicorp provider
+			registryDomain := tf.GetDefaultRegistryDomain(opts)
+			providerAddr := fmt.Sprintf("%s/hashicorp/%s", registryDomain, name)
+			constraints[providerAddr] = version
+		}
+	}
+
+	return constraints
+}
+
+// normalizeProviderAddress converts provider source to full registry format
+func normalizeProviderAddress(opts *options.TerragruntOptions, source string) string {
+	parts := strings.Split(source, "/")
+	registryDomain := tf.GetDefaultRegistryDomain(opts)
+
+	const (
+		singlePart    = 1
+		twoPartPath   = 2
+		threePartPath = 3
+	)
+
+	switch len(parts) {
+	case singlePart:
+		// "aws" -> "registry.terraform.io/hashicorp/aws" or "registry.opentofu.org/hashicorp/aws"
+		return fmt.Sprintf("%s/hashicorp/%s", registryDomain, parts[0])
+	case twoPartPath:
+		// "hashicorp/aws" -> "registry.terraform.io/hashicorp/aws" or "registry.opentofu.org/hashicorp/aws"
+		return fmt.Sprintf("%s/%s", registryDomain, source)
+	case threePartPath:
+		// "registry.terraform.io/hashicorp/aws" -> keep as is
+		return source
+	default:
+		// Fallback to original if format is unexpected
+		return source
+	}
+}

--- a/tf/getproviders/constraints_test.go
+++ b/tf/getproviders/constraints_test.go
@@ -1,0 +1,210 @@
+package getproviders_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/tf/getproviders"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseProviderConstraints(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory for testing
+	testDir := t.TempDir()
+
+	// Create a test terraform file with required_providers block
+	terraformContent := `
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+`
+
+	err := os.WriteFile(filepath.Join(testDir, "main.tf"), []byte(terraformContent), 0644)
+	require.NoError(t, err)
+
+	// Test parsing with Terraform implementation
+	terraformOpts := &options.TerragruntOptions{
+		TerraformImplementation: options.TerraformImpl,
+	}
+	constraints, err := getproviders.ParseProviderConstraints(terraformOpts, testDir)
+	require.NoError(t, err)
+
+	// Verify the parsed constraints
+	assert.Equal(t, "~> 5.0", constraints["registry.terraform.io/hashicorp/aws"])
+	assert.Equal(t, "~> 4.0", constraints["registry.terraform.io/cloudflare/cloudflare"])
+
+	// Test parsing with OpenTofu implementation
+	openTofuOpts := &options.TerragruntOptions{
+		TerraformImplementation: options.OpenTofuImpl,
+	}
+	constraints, err = getproviders.ParseProviderConstraints(openTofuOpts, testDir)
+	require.NoError(t, err)
+
+	// Verify the parsed constraints use OpenTofu registry
+	assert.Equal(t, "~> 5.0", constraints["registry.opentofu.org/hashicorp/aws"])
+	assert.Equal(t, "~> 4.0", constraints["registry.opentofu.org/cloudflare/cloudflare"])
+}
+
+func TestParseProviderConstraintsWithImplicitProvider(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory for testing
+	testDir := t.TempDir()
+
+	// Create a test terraform file with implicit provider (no source specified)
+	terraformContent := `
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+    }
+  }
+}
+`
+
+	err := os.WriteFile(filepath.Join(testDir, "main.tf"), []byte(terraformContent), 0644)
+	require.NoError(t, err)
+
+	// Test parsing with Terraform implementation
+	terraformOpts := &options.TerragruntOptions{
+		TerraformImplementation: options.TerraformImpl,
+	}
+	constraints, err := getproviders.ParseProviderConstraints(terraformOpts, testDir)
+	require.NoError(t, err)
+
+	// Verify the parsed constraints default to terraform registry
+	assert.Equal(t, "~> 5.0", constraints["registry.terraform.io/hashicorp/aws"])
+
+	// Test parsing with OpenTofu implementation
+	openTofuOpts := &options.TerragruntOptions{
+		TerraformImplementation: options.OpenTofuImpl,
+	}
+	constraints, err = getproviders.ParseProviderConstraints(openTofuOpts, testDir)
+	require.NoError(t, err)
+
+	// Verify the parsed constraints default to OpenTofu registry
+	assert.Equal(t, "~> 5.0", constraints["registry.opentofu.org/hashicorp/aws"])
+}
+
+func TestParseProviderConstraintsWithEnvironmentOverride(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory for testing
+	testDir := t.TempDir()
+
+	// Create a test terraform file with implicit provider (no source specified)
+	terraformContent := `
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+    }
+    custom = {
+      source  = "example/custom"
+      version = "~> 1.0"
+    }
+  }
+}
+`
+
+	err := os.WriteFile(filepath.Join(testDir, "main.tf"), []byte(terraformContent), 0644)
+	require.NoError(t, err)
+
+	// Set the environment variable to override the default registry
+	customRegistry := "custom.registry.example.com"
+	t.Setenv("TG_TF_DEFAULT_REGISTRY_HOST", customRegistry)
+
+	// Test parsing with Terraform implementation - should use custom registry
+	terraformOpts := &options.TerragruntOptions{
+		TerraformImplementation: options.TerraformImpl,
+	}
+	constraints, err := getproviders.ParseProviderConstraints(terraformOpts, testDir)
+	require.NoError(t, err)
+
+	// Verify the parsed constraints use custom registry for implicit providers
+	assert.Equal(t, "~> 5.0", constraints[customRegistry+"/hashicorp/aws"])
+	// Explicit source should use custom registry too
+	assert.Equal(t, "~> 1.0", constraints[customRegistry+"/example/custom"])
+
+	// Test parsing with OpenTofu implementation - should also use custom registry (environment override takes precedence)
+	openTofuOpts := &options.TerragruntOptions{
+		TerraformImplementation: options.OpenTofuImpl,
+	}
+	constraints, err = getproviders.ParseProviderConstraints(openTofuOpts, testDir)
+	require.NoError(t, err)
+
+	// Verify the parsed constraints use custom registry even with OpenTofu
+	assert.Equal(t, "~> 5.0", constraints[customRegistry+"/hashicorp/aws"])
+	assert.Equal(t, "~> 1.0", constraints[customRegistry+"/example/custom"])
+}
+
+func TestParseProviderConstraintsWithTofuFiles(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory for testing
+	testDir := t.TempDir()
+
+	// Create a .tf file with one provider
+	tfContent := `
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+`
+	err := os.WriteFile(filepath.Join(testDir, "main.tf"), []byte(tfContent), 0644)
+	require.NoError(t, err)
+
+	// Create a .tofu file with another provider
+	tofuContent := `
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+`
+	err = os.WriteFile(filepath.Join(testDir, "providers.tofu"), []byte(tofuContent), 0644)
+	require.NoError(t, err)
+
+	// Test parsing with OpenTofu implementation
+	openTofuOpts := &options.TerragruntOptions{
+		TerraformImplementation: options.OpenTofuImpl,
+	}
+	constraints, err := getproviders.ParseProviderConstraints(openTofuOpts, testDir)
+	require.NoError(t, err)
+
+	// Verify constraints from both .tf and .tofu files are parsed
+	assert.Equal(t, "~> 5.0", constraints["registry.opentofu.org/hashicorp/aws"])
+	assert.Equal(t, "~> 3.0", constraints["registry.opentofu.org/hashicorp/azurerm"])
+
+	// Test parsing with Terraform implementation
+	terraformOpts := &options.TerragruntOptions{
+		TerraformImplementation: options.TerraformImpl,
+	}
+	constraints, err = getproviders.ParseProviderConstraints(terraformOpts, testDir)
+	require.NoError(t, err)
+
+	// Verify constraints from both .tf and .tofu files are parsed with Terraform registry
+	assert.Equal(t, "~> 5.0", constraints["registry.terraform.io/hashicorp/aws"])
+	assert.Equal(t, "~> 3.0", constraints["registry.terraform.io/hashicorp/azurerm"])
+}

--- a/tf/getproviders/constraints_test.go
+++ b/tf/getproviders/constraints_test.go
@@ -101,8 +101,6 @@ terraform {
 }
 
 func TestParseProviderConstraintsWithEnvironmentOverride(t *testing.T) {
-	t.Parallel()
-
 	// Create a temporary directory for testing
 	testDir := t.TempDir()
 

--- a/tf/getproviders/lock_test.go
+++ b/tf/getproviders/lock_test.go
@@ -43,6 +43,7 @@ func mockProviderUpdateLock(t *testing.T, ctrl *gomock.Controller, address, vers
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Address().Return(address).AnyTimes()
 	provider.EXPECT().Version().Return(version).AnyTimes()
+	provider.EXPECT().Constraints().Return("").AnyTimes()
 	provider.EXPECT().PackageDir().Return(packageDir).AnyTimes()
 	provider.EXPECT().Logger().Return(logger.CreateLogger()).AnyTimes()
 	provider.EXPECT().DocumentSHA256Sums(gomock.Any()).Return([]byte(document), nil).AnyTimes()
@@ -140,16 +141,16 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:a3366f6b57b0f4b8bf8a5fecf42a834652709a97dd6db1b499c4ab186e33a41f",
   ]
 }
-			
+
 provider "registry.terraform.io/hashicorp/template" {
   version     = "2.1.0"
-  constraints = "<= 2.1.0" 
+  constraints = "<= 2.1.0"
   hashes = [
     "h1:vxE/PD8SWl6Lmh5zRvIW1Y559xfUyuV2T/VeQLXi7f0=",
     "zh:6fc271665ac28c3fee773b9dc2b8066280ba35b7e9a14a6148194a240c43f42a",
     "zh:c19f719c9f7ce6d7449fe9c020100faed0705303c7f95beeef81dfd1e4a2004b",
   ]
-}			
+}
 `,
 			expectedLockfile: `
 provider "registry.terraform.io/hashicorp/aws" {

--- a/tf/getproviders/mocks/mock_provider.go
+++ b/tf/getproviders/mocks/mock_provider.go
@@ -55,6 +55,20 @@ func (mr *MockProviderMockRecorder) Address() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockProvider)(nil).Address))
 }
 
+// Constraints mocks base method.
+func (m *MockProvider) Constraints() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Constraints")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Constraints indicates an expected call of Constraints.
+func (mr *MockProviderMockRecorder) Constraints() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Constraints", reflect.TypeOf((*MockProvider)(nil).Constraints))
+}
+
 // DocumentSHA256Sums mocks base method.
 func (m *MockProvider) DocumentSHA256Sums(ctx context.Context) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/tf/getproviders/provider.go
+++ b/tf/getproviders/provider.go
@@ -16,6 +16,9 @@ type Provider interface {
 	// Version returns a version of the provider. e.g.: 5.36.0
 	Version() string
 
+	// Constraints returns the version constraints from the module's required_providers block, or empty string if none.
+	Constraints() string
+
 	// DocumentSHA256Sums returns a document with providers hashes for different platforms.
 	DocumentSHA256Sums(ctx context.Context) ([]byte, error)
 

--- a/tf/getter.go
+++ b/tf/getter.go
@@ -92,7 +92,13 @@ func (tfrGetter *RegistryGetter) Context() context.Context {
 
 // registryDomain returns the default registry domain to use for the getter.
 func (tfrGetter *RegistryGetter) registryDomain() string {
-	if tfrGetter.TerragruntOptions == nil {
+	return GetDefaultRegistryDomain(tfrGetter.TerragruntOptions)
+}
+
+// GetDefaultRegistryDomain returns the appropriate registry domain based on the terraform implementation and environment variables.
+// This is the canonical function for determining which registry to use throughout Terragrunt.
+func GetDefaultRegistryDomain(opts *options.TerragruntOptions) string {
+	if opts == nil {
 		return defaultRegistryDomain
 	}
 
@@ -101,7 +107,7 @@ func (tfrGetter *RegistryGetter) registryDomain() string {
 		return defaultRegistry
 	}
 	// if binary is set to use OpenTofu registry, use OpenTofu as default registry
-	if tfrGetter.TerragruntOptions.TerraformImplementation == options.OpenTofuImpl {
+	if opts.TerraformImplementation == options.OpenTofuImpl {
 		return defaultOtRegistryDomain
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4512

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated Provider Cache Server logic to handle existing lock files better, even when modules have version constraints.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of Terraform provider version constraints to ensure module-specified constraints are accurately preserved and updated in lock files, especially during upgrades.
  * Enhanced logging throughout provider caching operations for better traceability and debugging.
  * Added support for parsing provider constraints from both `.tf` and `.tofu` files, including custom registry host overrides.

* **Bug Fixes**
  * Resolved issues where provider version constraints could be incorrectly pinned or not updated in certain upgrade scenarios.

* **Tests**
  * Introduced comprehensive integration and unit tests to verify correct provider constraint handling and lock file updates across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->