### PR TITLE
fix: configure dependabot to ignore buggy version of charmbracelet/glamour

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
     labels:
       - "go"
       - "dependencies"
+    ignore:
+      - dependency-name: "github.com/charmbracelet/glamour"
+        versions: ["<= 0.10.1"]
 
   - package-ecosystem: "bun"
     directories:


### PR DESCRIPTION
## Description

fix: configure dependabot to ignore buggy version of charmbracelet/glamour

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)
n/a

### Migration Guide
n/a

