### PR TITLE
fix: Fixing links at the bottom of Jekyl stacks docs

### DIFF
--- a/docs/_docs/02_features/02-stacks.md
+++ b/docs/_docs/02_features/02-stacks.md
@@ -987,8 +987,8 @@ This pattern is particularly useful for development environments, testing scenar
 
 Now that you understand both implicit and explicit stacks, you can:
 
-- [Learn about the detailed syntax](/docs/reference/hcl/blocks#unit) for `unit` and `stack` blocks
-- [Explore the stack commands](/docs/reference/cli/commands/stack/generate) for generating and managing stacks
+- [Learn about the detailed syntax](/docs/reference/configuration/#stacks) for `unit` and `stack` blocks
+- [Explore the stack commands](/docs/reference/cli-options/#stack-generate) for generating and managing stacks
 - [Understand how to pass values between units](/docs/features/stacks#passing-outputs-between-units)
 
 > **Pro Tip**: Start with implicit stacks to get familiar with the concept, then gradually introduce explicit stacks for reusable patterns as your infrastructure grows.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

The old destinations only exist in the Starlight version of the docs.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated links in the "Next Steps" section to direct users to the latest documentation locations for stack syntax and stack command references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->