### PR TITLE
chore: Removing `legacy-all` commands

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -303,8 +303,8 @@ func TestFilterTerragruntArgs(t *testing.T) {
 		{[]string{"plan", doubleDashed(global.NonInteractiveFlagName)}, []string{"plan"}},
 		{[]string{"plan", doubleDashed(run.InputsDebugFlagName)}, []string{"plan"}},
 		{[]string{"plan", doubleDashed(global.NonInteractiveFlagName), "-bar", doubleDashed(global.WorkingDirFlagName), "/some/path", "--baz", doubleDashed(run.ConfigFlagName), "/some/path/" + config.DefaultTerragruntConfigPath}, []string{"plan", "-bar", "-baz"}},
-		{[]string{commands.CommandApplyAllName, "plan", "bar"}, []string{tf.CommandNameApply, "plan", "bar"}},
-		{[]string{commands.CommandDestroyAllName, "plan", "-foo", "--bar"}, []string{tf.CommandNameDestroy, "plan", "-foo", "-bar"}},
+		{[]string{"run", "--all", "apply", "plan", "bar"}, []string{tf.CommandNameApply, "plan", "bar"}},
+		{[]string{"run", "--all", "destroy", "--", "plan", "-foo", "--bar"}, []string{tf.CommandNameDestroy, "plan", "-foo", "-bar"}},
 	}
 
 	for i, tc := range testCases {
@@ -335,22 +335,22 @@ func TestParseMultiStringArg(t *testing.T) {
 		expectedVals []string
 	}{
 		{
-			args:         []string{commands.CommandApplyAllName, flagName, "bar"},
+			args:         []string{"run", "--all", "apply", flagName, "bar"},
 			defaultValue: []string{"default_bar"},
 			expectedVals: []string{"bar"},
 		},
 		{
-			args:         []string{commands.CommandApplyAllName, "--test", "bar"},
+			args:         []string{"run", "--all", "apply", "--", "--test", "bar"},
 			defaultValue: []string{"default_bar"},
 			expectedVals: []string{"default_bar"},
 		},
 		{
-			args:         []string{commands.CommandPlanAllName, "--test", "value", flagName, "bar1", flagName, "bar2"},
+			args:         []string{"run", "--all", "plan", flagName, "bar1", flagName, "bar2", "--", "--test", "value"},
 			defaultValue: []string{"default_bar"},
 			expectedVals: []string{"bar1", "bar2"},
 		},
 		{
-			args:         []string{commands.CommandPlanAllName, "--test", "value", flagName, "bar1", flagName},
+			args:         []string{"run", "--all", "plan", flagName, "bar1", flagName, "--", "--test", "value"},
 			defaultValue: []string{"default_bar"},
 			expectedErr:  argMissingValueError(run.UnitsThatIncludeFlagName),
 		},

--- a/cli/commands/deprecated.go
+++ b/cli/commands/deprecated.go
@@ -25,14 +25,6 @@ import (
 
 // The following commands are DEPRECATED
 const (
-	CommandSpinUpName      = "spin-up"
-	CommandTearDownName    = "tear-down"
-	CommandPlanAllName     = "plan-all"
-	CommandApplyAllName    = "apply-all"
-	CommandDestroyAllName  = "destroy-all"
-	CommandOutputAllName   = "output-all"
-	CommandValidateAllName = "validate-all"
-
 	CommandRunAllName             = "run-all"
 	CommandGraphName              = "graph"
 	CommandHCLFmtName             = "hclfmt"
@@ -47,15 +39,6 @@ const (
 // NewDeprecatedCommands returns a slice of deprecated commands to convert the command to the known alternative.
 func NewDeprecatedCommands(l log.Logger, opts *options.TerragruntOptions) cli.Commands {
 	deprecatedCommands := DeprecatedCommands{
-		// legacy-all commands
-		newDeprecatedLegacyAllCommand(CommandSpinUpName, tf.CommandNameApply),
-		newDeprecatedLegacyAllCommand(CommandTearDownName, tf.CommandNameDestroy),
-		newDeprecatedLegacyAllCommand(CommandPlanAllName, tf.CommandNamePlan),
-		newDeprecatedLegacyAllCommand(CommandApplyAllName, tf.CommandNameApply),
-		newDeprecatedLegacyAllCommand(CommandDestroyAllName, tf.CommandNameDestroy),
-		newDeprecatedLegacyAllCommand(CommandValidateAllName, tf.CommandNameValidate),
-		newDeprecatedLegacyAllCommand(CommandOutputAllName, tf.CommandNameOutput),
-
 		// `hclfmt`
 		newDeprecatedCLIRedesignCommand(CommandHCLFmtName, cli.Args{
 			hcl.CommandName, format.CommandName}),
@@ -145,17 +128,6 @@ func NewDeprecatedCommands(l log.Logger, opts *options.TerragruntOptions) cli.Co
 	deprecatedDefaultCommands := newDeprecatedDefaultCommands(l, opts)
 
 	return append(deprecatedCommands.CLICommands(opts), deprecatedDefaultCommands...)
-}
-
-func newDeprecatedLegacyAllCommand(deprecatedCommandName, tfCommandName string) *DeprecatedCommand {
-	return &DeprecatedCommand{
-		commandName: deprecatedCommandName,
-		// we can't recoomand to use `run --all plan/apply/...` as alternative for `*-all` commands
-		// because `run` command doesn't allow TF flags to be specified before `--` separator.
-		replaceWithArgs: cli.Args{tfCommandName, "--" + runall.AllFlagName},
-		controlName:     controls.LegacyAll,
-		controlCategory: controls.RunAllCommandsCategoryName,
-	}
 }
 
 func newDeprecatedCLIRedesignCommand(deprecatedCommandName string, replaceWithArgs cli.Args, subcommands ...*DeprecatedCommand) *DeprecatedCommand {

--- a/docs-starlight/src/content/docs/04-reference/03-strict-controls.mdx
+++ b/docs-starlight/src/content/docs/04-reference/03-strict-controls.mdx
@@ -32,20 +32,20 @@ The simplest way to enable strict mode is to set the [strict-mode](/docs/referen
 This will enable strict mode for all Terragrunt commands, for all strict mode controls.
 
 ```bash
-$ terragrunt plan-all
-15:26:08.585 WARN   The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all plan` instead.
+$ terragrunt run-all plan
+15:26:08.585 WARN   The `run-all plan` command is deprecated and will be removed in a future version. Use `terragrunt run --all plan` instead.
 ```
 
 ```bash
-$ terragrunt --strict-mode plan-all
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ terragrunt --strict-mode run-all plan
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 ```
 
 You can also use the environment variable, which can be more useful in CI/CD pipelines:
 
 ```bash
-$ TG_STRICT_MODE='true' terragrunt plan-all
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ TG_STRICT_MODE='true' terragrunt run-all plan
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 ```
 
 Instead of enabling strict mode like this, you can also enable specific strict controls by setting the [strict-control](/docs/reference/strict-controls)
@@ -53,98 +53,56 @@ flag to a value that's specific to a particular strict control.
 This can allow you to gradually increase your confidence in the future compatibility of your Terragrunt usage.
 
 ```bash
-$ terragrunt plan-all --strict-control apply-all
-15:26:08.585 WARN   The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all plan` instead.
+$ terragrunt run-all plan --strict-control cli-redesign
+15:26:08.585 WARN   The `run-all plan` command is deprecated and will be removed in a future version. Use `terragrunt run --all plan` instead.
 ```
 
 ```bash
-$ terragrunt plan-all --strict-control plan-all
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ terragrunt run-all plan --strict-control cli-redesign
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 ```
 
 Again, you can also use the environment variable, which might be more useful in CI/CD pipelines:
 
 ```bash
-$ TG_STRICT_CONTROL='plan-all' terragrunt plan-all
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ TG_STRICT_CONTROL='cli-redesign' terragrunt run-all plan
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 ```
 
 You can enable multiple strict controls at once:
 
 ```bash
-$ terragrunt plan-all --strict-control plan-all --strict-control apply-all
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ terragrunt run-all plan --strict-control cli-redesign --strict-control default-command
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 15:26:46.521 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
 ```
 
 ```bash
-$ terragrunt apply-all --strict-control plan-all --strict-control apply-all
-15:26:46.564 ERROR  The `apply-all` command is no longer supported. Use `terragrunt run --all apply` instead.
+$ terragrunt run-all apply --strict-control cli-redesign --strict-control default-command
+15:26:46.564 ERROR  The `run-all apply` command is no longer supported. Use `terragrunt run --all apply` instead.
 15:26:46.564 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
 ```
 
 You can also enable multiple strict controls at once when using the environment variable by using a comma-delimited list.
 
 ```bash
-$ TG_STRICT_CONTROL='plan-all,apply-all' bash -c 'terragrunt plan-all; terragrunt apply-all'
-15:26:46.521 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ TG_STRICT_CONTROL='cli-redesign,default-command' bash -c 'terragrunt run-all plan; terragrunt run-all apply'
+15:26:46.521 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 15:26:46.521 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
-15:26:46.564 ERROR  The `apply-all` command is no longer supported. Use `terragrunt run --all apply` instead.
+15:26:46.564 ERROR  The `run-all apply` command is no longer supported. Use `terragrunt run --all apply` instead.
 15:26:46.564 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
 ```
 
 You can also use [control categories](#control-categories) to enable certain categories of strict controls.
 
 ```bash
-$ terragrunt plan-all --strict-control deprecated-commands
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run-all plan` instead.
+$ terragrunt run-all plan --strict-control deprecated-commands
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 ```
 
 ## Strict Mode Controls
 
 The following strict mode controls are available:
-
-### spin-up
-
-Throw an error when using the `spin-up` command.
-
-**Reason**: The `spin-up` command is deprecated and will be removed in a future version. Use `terragrunt run --all apply` instead.
-
-### tear-down
-
-Throw an error when using the `tear-down` command.
-
-**Reason**: The `tear-down` command is deprecated and will be removed in a future version. Use `terragrunt run --all destroy` instead.
-
-### plan-all
-
-Throw an error when using the `plan-all` command.
-
-**Reason**: The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all plan` instead.
-
-### apply-all
-
-Throw an error when using the `apply-all` command.
-
-**Reason**: The `apply-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all apply` instead.
-
-### destroy-all
-
-Throw an error when using the `destroy-all` command.
-
-**Reason**: The `destroy-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all destroy` instead.
-
-### output-all
-
-Throw an error when using the `output-all` command.
-
-**Reason**: The `output-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all output` instead.
-
-### validate-all
-
-Throw an error when using the `validate-all` command.
-
-**Reason**: The `validate-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all validate` instead.
 
 ### skip-dependencies-inputs
 
@@ -225,15 +183,10 @@ Throw an error when using the deprecated commands.
 
 **Controls**:
 
-- [plan-all](#plan-all)
-- [apply-all](#apply-all)
-- [destroy-all](#destroy-all)
-- [output-all](#output-all)
-- [validate-all](#validate-all)
-- [spin-up](#spin-up)
-- [tear-down](#tear-down)
 - [default-command](#default-command)
 - [cli-redesign](#cli-redesign)
+
+**Note**: The individual `*-all` commands (`plan-all`, `apply-all`, `destroy-all`, `output-all`, `validate-all`, `spin-up`, `tear-down`) have been removed from Terragrunt and are no longer available as strict controls. Use `terragrunt run --all` for the modern equivalent.
 
 ### deprecated-flags
 
@@ -259,16 +212,73 @@ Throw an error when using the deprecated Terragrunt configuration.
 
 - [skip-dependencies-inputs](#skip-dependencies-inputs)
 
-### legacy-all
+## Completed Controls
 
-Throw an error when using any of the legacy commands replaced by `run-all`.
+The following strict controls have been completed and are no longer needed:
 
-**Controls**:
-
+- [legacy-all](#legacy-all)
+- [spin-up](#spin-up)
+- [tear-down](#tear-down)
 - [plan-all](#plan-all)
 - [apply-all](#apply-all)
 - [destroy-all](#destroy-all)
 - [output-all](#output-all)
 - [validate-all](#validate-all)
-- [spin-up](#spin-up)
-- [tear-down](#tear-down)
+
+### legacy-all
+
+**Status**: Completed - The legacy `*-all` commands have been removed from Terragrunt.
+
+This control was previously used to throw an error when using any of the legacy commands that were replaced by `run-all`. These commands have now been completely removed from Terragrunt as part of the deprecation schedule.
+
+**Previously controlled commands** (now removed):
+
+- `plan-all` - Use `terragrunt run --all plan` instead
+- `apply-all` - Use `terragrunt run --all apply` instead
+- `destroy-all` - Use `terragrunt run --all destroy` instead
+- `output-all` - Use `terragrunt run --all output` instead
+- `validate-all` - Use `terragrunt run --all validate` instead
+- `spin-up` - Use `terragrunt run --all apply` instead
+- `tear-down` - Use `terragrunt run --all destroy` instead
+
+### spin-up
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `spin-up` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all apply` instead.
+
+### tear-down
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `tear-down` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all destroy` instead.
+
+### plan-all
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `plan-all` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all plan` instead.
+
+### apply-all
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `apply-all` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all apply` instead.
+
+### destroy-all
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `destroy-all` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all destroy` instead.
+
+### output-all
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `output-all` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all output` instead.
+
+### validate-all
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `validate-all` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all validate` instead.

--- a/docs/_docs/04_reference/05-strict-mode.md
+++ b/docs/_docs/04_reference/05-strict-mode.md
@@ -32,8 +32,8 @@ gradually increase your confidence in the future compatibility of your Terragrun
 For example:
 
 ```bash
-$ terragrunt plan-all --strict-control deprecated-commands
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ terragrunt run-all plan --strict-control deprecated-commands
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 ```
 
 ## Controlling Strict Mode
@@ -43,20 +43,20 @@ The simplest way to enable strict mode is to set the [strict-mode](/docs/referen
 This will enable strict mode for all Terragrunt commands, for all strict mode controls.
 
 ```bash
-$ terragrunt plan-all
-15:26:08.585 WARN   The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all plan` instead.
+$ terragrunt run-all plan
+15:26:08.585 WARN   The `run-all plan` command is deprecated and will be removed in a future version. Use `terragrunt run --all plan` instead.
 ```
 
 ```bash
-$ terragrunt --strict-mode plan-all
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ terragrunt --strict-mode run-all plan
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 ```
 
 You can also use the environment variable, which can be more useful in CI/CD pipelines:
 
 ```bash
-$ TG_STRICT_MODE='true' terragrunt plan-all
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ TG_STRICT_MODE='true' terragrunt run-all plan
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 ```
 
 Instead of enabling strict mode like this, you can also enable specific strict controls by setting the [strict-control](/docs/reference/cli-options/#strict-control)
@@ -65,51 +65,51 @@ flag to a value to a particular strict control.
 This can allow you to gradually increase your confidence in the future compatibility of your Terragrunt usage.
 
 ```bash
-$ terragrunt plan-all
-15:26:08.585 WARN   The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all plan` instead.
+$ terragrunt run-all plan
+15:26:08.585 WARN   The `run-all plan` command is deprecated and will be removed in a future version. Use `terragrunt run --all plan` instead.
 ```
 
 ```bash
-$ terragrunt plan-all --strict-control plan-all
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ terragrunt run-all plan --strict-control cli-redesign
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 ```
 
 Again, you can also use the environment variable, which might be more useful in CI/CD pipelines:
 
 ```bash
-$ TG_STRICT_CONTROL='plan-all' terragrunt plan-all
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ TG_STRICT_CONTROL='cli-redesign' terragrunt run-all plan
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 ```
 
 You can enable multiple strict controls at once:
 
 ```bash
-$ terragrunt plan-all --strict-control plan-all --strict-control apply-all
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ terragrunt run-all plan --strict-control cli-redesign --strict-control default-command
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 15:26:46.521 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
 ```
 
 ```bash
-$ terragrunt apply-all --strict-control plan-all --strict-control apply-all
-15:26:46.564 ERROR  The `apply-all` command is no longer supported. Use `terragrunt run --all apply` instead.
+$ terragrunt run-all apply --strict-control cli-redesign --strict-control default-command
+15:26:46.564 ERROR  The `run-all apply` command is no longer supported. Use `terragrunt run --all apply` instead.
 15:26:46.564 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
 ```
 
 You can also enable multiple strict controls at once when using the environment variable by using a comma delimited list.
 
 ```bash
-$ TG_STRICT_CONTROL='plan-all,apply-all' bash -c 'terragrunt plan-all; terragrunt apply-all'
-15:26:46.521 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ TG_STRICT_CONTROL='cli-redesign,default-command' bash -c 'terragrunt run-all plan; terragrunt run-all apply'
+15:26:46.521 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 15:26:46.521 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
-15:26:46.564 ERROR  The `apply-all` command is no longer supported. Use `terragrunt run --all apply` instead.
+15:26:46.564 ERROR  The `run-all apply` command is no longer supported. Use `terragrunt run --all apply` instead.
 15:26:46.564 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
 ```
 
 You can also use [control categories](#control-categories) to enable certain categories of strict controls.
 
 ```bash
-$ terragrunt plan-all --strict-control deprecated-commands
-15:26:23.685 ERROR  The `plan-all` command is no longer supported. Use `terragrunt run --all plan` instead.
+$ terragrunt run-all plan --strict-control deprecated-commands
+15:26:23.685 ERROR  The `run-all plan` command is no longer supported. Use `terragrunt run --all plan` instead.
 ```
 
 ## Strict Mode Controls
@@ -139,48 +139,6 @@ The following strict mode controls are available:
   - [deprecated-env-vars](#deprecated-env-vars)
   - [deprecated-configs](#deprecated-configs)
   - [legacy-all](#legacy-all)
-
-### spin-up
-
-Throw an error when using the `spin-up` command.
-
-**Reason**: The `spin-up` command is deprecated and will be removed in a future version. Use `terragrunt run --all apply` instead.
-
-### tear-down
-
-Throw an error when using the `tear-down` command.
-
-**Reason**: The `tear-down` command is deprecated and will be removed in a future version. Use `terragrunt run --all destroy` instead.
-
-### plan-all
-
-Throw an error when using the `plan-all` command.
-
-**Reason**: The `plan-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all plan` instead.
-
-### apply-all
-
-Throw an error when using the `apply-all` command.
-
-**Reason**: The `apply-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all apply` instead.
-
-### destroy-all
-
-Throw an error when using the `destroy-all` command.
-
-**Reason**: The `destroy-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all destroy` instead.
-
-### output-all
-
-Throw an error when using the `output-all` command.
-
-**Reason**: The `output-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all output` instead.
-
-### validate-all
-
-Throw an error when using the `validate-all` command.
-
-**Reason**: The `validate-all` command is deprecated and will be removed in a future version. Use `terragrunt run --all validate` instead.
 
 ### skip-dependencies-inputs
 
@@ -259,13 +217,6 @@ Throw an error when using the deprecated commands.
 
 **Controls**:
 
-- [plan-all](#plan-all)
-- [apply-all](#apply-all)
-- [destroy-all](#destroy-all)
-- [output-all](#output-all)
-- [validate-all](#validate-all)
-- [spin-up](#spin-up)
-- [tear-down](#tear-down)
 - [default-command](#default-command)
 - [cli-redesign](#cli-redesign)
 
@@ -293,16 +244,75 @@ Throw an error when using the deprecated Terragrunt configuration.
 
 - [skip-dependencies-inputs](#skip-dependencies-inputs)
 
-### legacy-all
+## Completed Controls
 
-Throw an error when using any of the legacy commands replaced by `run --all`.
+The following strict controls have been completed and are no longer needed:
 
-**Controls**:
-
+- [legacy-all](#legacy-all)
+- [spin-up](#spin-up)
+- [tear-down](#tear-down)
 - [plan-all](#plan-all)
 - [apply-all](#apply-all)
 - [destroy-all](#destroy-all)
 - [output-all](#output-all)
 - [validate-all](#validate-all)
-- [spin-up](#spin-up)
-- [tear-down](#tear-down)
+
+### legacy-all
+
+**Status**: Completed - The legacy `*-all` commands have been removed from Terragrunt.
+
+This control was previously used to throw an error when using any of the legacy commands that were replaced by `run-all`. These commands have now been completely removed from Terragrunt as part of the deprecation schedule.
+
+**Previously controlled commands** (now removed):
+
+- `plan-all` - Use `terragrunt run --all plan` instead
+- `apply-all` - Use `terragrunt run --all apply` instead
+- `destroy-all` - Use `terragrunt run --all destroy` instead
+- `output-all` - Use `terragrunt run --all output` instead
+- `validate-all` - Use `terragrunt run --all validate` instead
+- `spin-up` - Use `terragrunt run --all apply` instead
+- `tear-down` - Use `terragrunt run --all destroy` instead
+
+**Note**: The `run-all` command itself is still deprecated and will be removed in a future version. Use `terragrunt run --all` for the most future-proof syntax.
+
+### spin-up
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `spin-up` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all apply` instead.
+
+### tear-down
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `tear-down` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all destroy` instead.
+
+### plan-all
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `plan-all` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all plan` instead.
+
+### apply-all
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `apply-all` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all apply` instead.
+
+### destroy-all
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `destroy-all` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all destroy` instead.
+
+### output-all
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `output-all` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all output` instead.
+
+### validate-all
+
+**Status**: Completed - This command has been completely removed from Terragrunt.
+
+**Reason**: The `validate-all` command was deprecated and has now been removed as part of the deprecation schedule. Use `terragrunt run --all validate` instead.

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -19,9 +19,6 @@ const (
 	// DeprecatedConfigs is the control that prevents the use of deprecated config fields/section/..., anything related to config syntax.
 	DeprecatedConfigs = "deprecated-configs"
 
-	// LegacyAll is a control group for the legacy *-all commands.
-	LegacyAll = "legacy-all"
-
 	// LegacyLogs is a control group for legacy log flags that were in use before the log was redesign.
 	LegacyLogs = "legacy-logs"
 
@@ -46,6 +43,10 @@ const (
 
 	// CLIRedesign is the control that prevents the use of commands deprecated as part of the CLI Redesign.
 	CLIRedesign = "cli-redesign"
+
+	// LegacyAll is a control group for the legacy *-all commands.
+	// This control is marked as completed since the commands have been removed.
+	LegacyAll = "legacy-all"
 
 	// BareInclude is the control that prevents the use of the `include` block without a label.
 	BareInclude = "bare-include"
@@ -113,7 +114,51 @@ func New() strict.Controls {
 			Name:        LegacyAll,
 			Description: "Prevents old *-all commands such as plan-all from being used.",
 			Category:    stageCategory,
+			Status:      strict.CompletedStatus,
 		},
+		&Control{
+			Name:        "spin-up",
+			Description: "Prevents the deprecated spin-up command from being used.",
+			Category:    stageCategory,
+			Status:      strict.CompletedStatus,
+		},
+		&Control{
+			Name:        "tear-down",
+			Description: "Prevents the deprecated tear-down command from being used.",
+			Category:    stageCategory,
+			Status:      strict.CompletedStatus,
+		},
+		&Control{
+			Name:        "plan-all",
+			Description: "Prevents the deprecated plan-all command from being used.",
+			Category:    stageCategory,
+			Status:      strict.CompletedStatus,
+		},
+		&Control{
+			Name:        "apply-all",
+			Description: "Prevents the deprecated apply-all command from being used.",
+			Category:    stageCategory,
+			Status:      strict.CompletedStatus,
+		},
+		&Control{
+			Name:        "destroy-all",
+			Description: "Prevents the deprecated destroy-all command from being used.",
+			Category:    stageCategory,
+			Status:      strict.CompletedStatus,
+		},
+		&Control{
+			Name:        "output-all",
+			Description: "Prevents the deprecated output-all command from being used.",
+			Category:    stageCategory,
+			Status:      strict.CompletedStatus,
+		},
+		&Control{
+			Name:        "validate-all",
+			Description: "Prevents the deprecated validate-all command from being used.",
+			Category:    stageCategory,
+			Status:      strict.CompletedStatus,
+		},
+
 		&Control{
 			Name:        TerragruntPrefixFlags,
 			Description: "Prevents deprecated flags with `terragrunt-` prefixes from being used.",
@@ -141,41 +186,7 @@ func New() strict.Controls {
 			Warning:     "Using `terragrunt.hcl` as the root of Terragrunt configurations is an anti-pattern, and no longer recommended. In a future version of Terragrunt, this will result in an error. You are advised to use a differently named file like `root.hcl` instead. For more information, see https://terragrunt.gruntwork.io/docs/migrate/migrating-from-root-terragrunt-hcl",
 			Category:    stageCategory,
 		},
-		&Control{
-			Name:        "spin-up",
-			Description: "Prevents the deprecated spin-up command from being used.",
-			Category:    stageCategory,
-		},
-		&Control{
-			Name:        "tear-down",
-			Description: "Prevents the deprecated tear-down command from being used.",
-			Category:    stageCategory,
-		},
-		&Control{
-			Name:        "plan-all",
-			Description: "Prevents the deprecated plan-all command from being used.",
-			Category:    stageCategory,
-		},
-		&Control{
-			Name:        "apply-all",
-			Description: "Prevents the deprecated apply-all command from being used.",
-			Category:    stageCategory,
-		},
-		&Control{
-			Name:        "destroy-all",
-			Description: "Prevents the deprecated destroy-all command from being used.",
-			Category:    stageCategory,
-		},
-		&Control{
-			Name:        "output-all",
-			Description: "Prevents the deprecated output-all command from being used.",
-			Category:    stageCategory,
-		},
-		&Control{
-			Name:        "validate-all",
-			Description: "Prevents the deprecated validate-all command from being used.",
-			Category:    stageCategory,
-		},
+
 		&Control{
 			Name:        BareInclude,
 			Description: "Prevents the use of the `include` block without a label.",

--- a/test/integration_auto_retry_test.go
+++ b/test/integration_auto_retry_test.go
@@ -138,7 +138,7 @@ func TestAutoRetryApplyAllDependentModuleRetries(t *testing.T) {
 	out := new(bytes.Buffer)
 	rootPath := helpers.CopyEnvironment(t, testFixtureAutoRetryApplyAllRetries)
 	modulePath := util.JoinPath(rootPath, testFixtureAutoRetryApplyAllRetries)
-	err := helpers.RunTerragruntCommand(t, "terragrunt apply-all -auto-approve --non-interactive --tf-forward-stdout --working-dir "+modulePath, out, os.Stderr)
+	err := helpers.RunTerragruntCommand(t, "terragrunt run-all apply -auto-approve --non-interactive --tf-forward-stdout --working-dir "+modulePath, out, os.Stderr)
 
 	require.NoError(t, err)
 	s := out.String()

--- a/test/integration_auto_retry_test.go
+++ b/test/integration_auto_retry_test.go
@@ -138,7 +138,7 @@ func TestAutoRetryApplyAllDependentModuleRetries(t *testing.T) {
 	out := new(bytes.Buffer)
 	rootPath := helpers.CopyEnvironment(t, testFixtureAutoRetryApplyAllRetries)
 	modulePath := util.JoinPath(rootPath, testFixtureAutoRetryApplyAllRetries)
-	err := helpers.RunTerragruntCommand(t, "terragrunt run-all apply -auto-approve --non-interactive --tf-forward-stdout --working-dir "+modulePath, out, os.Stderr)
+	err := helpers.RunTerragruntCommand(t, "terragrunt run --all apply --non-interactive --tf-forward-stdout --working-dir "+modulePath, out, os.Stderr)
 
 	require.NoError(t, err)
 	s := out.String()

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -725,13 +725,13 @@ func TestAwsOutputAllCommand(t *testing.T) {
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, testFixtureOutputAll)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+environmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+environmentPath)
 
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer
 	)
-	helpers.RunTerragruntRedirectOutput(t, "terragrunt output-all --non-interactive --working-dir "+environmentPath, &stdout, &stderr)
+	helpers.RunTerragruntRedirectOutput(t, "terragrunt run-all output --non-interactive --working-dir "+environmentPath, &stdout, &stderr)
 	output := stdout.String()
 
 	assert.Contains(t, output, "app1 output")
@@ -781,7 +781,7 @@ func TestAwsValidateAllCommand(t *testing.T) {
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, testFixtureOutputAll)
 
-	helpers.RunTerragrunt(t, "terragrunt validate-all --non-interactive --working-dir "+environmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all validate --non-interactive --working-dir "+environmentPath)
 }
 
 func TestAwsOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *testing.T) {
@@ -797,18 +797,18 @@ func TestAwsOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *testing.T)
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, testFixtureOutputAll)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+environmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+environmentPath)
 
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer
 	)
 	// Call helpers.RunTerragruntCommand directly because this command contains failures (which causes helpers.RunTerragruntRedirectOutput to abort) but we don't care.
-	helpers.RunTerragruntCommand(t, "terragrunt output-all app2_text --queue-ignore-errors --non-interactive --working-dir "+environmentPath, &stdout, &stderr)
+	helpers.RunTerragruntCommand(t, "terragrunt run-all output app2_text --queue-ignore-errors --non-interactive --working-dir "+environmentPath, &stdout, &stderr)
 	output := stdout.String()
 
-	helpers.LogBufferContentsLineByLine(t, stdout, "output-all stdout")
-	helpers.LogBufferContentsLineByLine(t, stderr, "output-all stderr")
+	helpers.LogBufferContentsLineByLine(t, stdout, "run-all output stdout")
+	helpers.LogBufferContentsLineByLine(t, stderr, "run-all output stderr")
 
 	// Without --queue-ignore-errors, app2 never runs because its dependencies have "errors" since they don't have the output "app2_text".
 	assert.Contains(t, output, "app2 output")
@@ -835,14 +835,14 @@ func TestAwsStackCommands(t *testing.T) { //nolint paralleltest
 	mgmtEnvironmentPath := util.JoinPath(tmpEnvPath, testFixtureStack, "mgmt")
 	stageEnvironmentPath := util.JoinPath(tmpEnvPath, testFixtureStack, "stage")
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+mgmtEnvironmentPath)
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+stageEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+mgmtEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+stageEnvironmentPath)
 
-	helpers.RunTerragrunt(t, "terragrunt output-all --non-interactive --working-dir "+mgmtEnvironmentPath)
-	helpers.RunTerragrunt(t, "terragrunt output-all --non-interactive --working-dir "+stageEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all output --non-interactive --working-dir "+mgmtEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all output --non-interactive --working-dir "+stageEnvironmentPath)
 
-	helpers.RunTerragrunt(t, "terragrunt destroy-all --non-interactive --working-dir "+stageEnvironmentPath)
-	helpers.RunTerragrunt(t, "terragrunt destroy-all --non-interactive --working-dir "+mgmtEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all destroy --non-interactive --working-dir "+stageEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all destroy --non-interactive --working-dir "+mgmtEnvironmentPath)
 }
 
 func TestAwsRemoteWithBackend(t *testing.T) {
@@ -894,7 +894,7 @@ func TestAwsGetAccountAliasFunctions(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAwsAccountAlias)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureAwsAccountAlias)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -1014,7 +1014,7 @@ func TestAwsDependencyOutputOptimizationDisableTest(t *testing.T) {
 	defer cleanupTableForTest(t, lockTableName, helpers.TerraformRemoteStateS3Region)
 	helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, helpers.TerraformRemoteStateS3Region)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// We need to bust the output cache that stores the dependency outputs so that the second run pulls the outputs.
 	// This is only a problem during testing, where the process is shared across terragrunt runs.
@@ -1243,7 +1243,7 @@ func TestAwsDependencyOutputSameOutputConcurrencyRegression(t *testing.T) {
 		stderr := bytes.Buffer{}
 		err := helpers.RunTerragruntCommand(
 			t,
-			"terragrunt apply-all --source-update --non-interactive --working-dir "+rootPath,
+			"terragrunt run-all apply --source-update --non-interactive --working-dir "+rootPath,
 			&stdout,
 			&stderr,
 		)
@@ -1641,7 +1641,7 @@ func dependencyOutputOptimizationTest(t *testing.T, moduleName string, forceInit
 	defer cleanupTableForTest(t, lockTableName, helpers.TerraformRemoteStateS3Region)
 	helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, helpers.TerraformRemoteStateS3Region)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --log-level trace --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --log-level trace --non-interactive --working-dir "+rootPath)
 
 	// We need to bust the output cache that stores the dependency outputs so that the second run pulls the outputs.
 	// This is only a problem during testing, where the process is shared across terragrunt runs.

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -725,13 +725,13 @@ func TestAwsOutputAllCommand(t *testing.T) {
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, testFixtureOutputAll)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+environmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+environmentPath)
 
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer
 	)
-	helpers.RunTerragruntRedirectOutput(t, "terragrunt run-all output --non-interactive --working-dir "+environmentPath, &stdout, &stderr)
+	helpers.RunTerragruntRedirectOutput(t, "terragrunt run --all output --non-interactive --working-dir "+environmentPath, &stdout, &stderr)
 	output := stdout.String()
 
 	assert.Contains(t, output, "app1 output")
@@ -781,7 +781,7 @@ func TestAwsValidateAllCommand(t *testing.T) {
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, testFixtureOutputAll)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all validate --non-interactive --working-dir "+environmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all validate --non-interactive --working-dir "+environmentPath)
 }
 
 func TestAwsOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *testing.T) {
@@ -797,18 +797,18 @@ func TestAwsOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *testing.T)
 
 	environmentPath := fmt.Sprintf("%s/%s/env1", tmpEnvPath, testFixtureOutputAll)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+environmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+environmentPath)
 
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer
 	)
 	// Call helpers.RunTerragruntCommand directly because this command contains failures (which causes helpers.RunTerragruntRedirectOutput to abort) but we don't care.
-	helpers.RunTerragruntCommand(t, "terragrunt run-all output app2_text --queue-ignore-errors --non-interactive --working-dir "+environmentPath, &stdout, &stderr)
+	helpers.RunTerragruntCommand(t, "terragrunt run --all output app2_text --queue-ignore-errors --non-interactive --working-dir "+environmentPath, &stdout, &stderr)
 	output := stdout.String()
 
-	helpers.LogBufferContentsLineByLine(t, stdout, "run-all output stdout")
-	helpers.LogBufferContentsLineByLine(t, stderr, "run-all output stderr")
+	helpers.LogBufferContentsLineByLine(t, stdout, "run --all output stdout")
+	helpers.LogBufferContentsLineByLine(t, stderr, "run --all output stderr")
 
 	// Without --queue-ignore-errors, app2 never runs because its dependencies have "errors" since they don't have the output "app2_text".
 	assert.Contains(t, output, "app2 output")
@@ -835,14 +835,14 @@ func TestAwsStackCommands(t *testing.T) { //nolint paralleltest
 	mgmtEnvironmentPath := util.JoinPath(tmpEnvPath, testFixtureStack, "mgmt")
 	stageEnvironmentPath := util.JoinPath(tmpEnvPath, testFixtureStack, "stage")
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+mgmtEnvironmentPath)
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+stageEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+mgmtEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+stageEnvironmentPath)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all output --non-interactive --working-dir "+mgmtEnvironmentPath)
-	helpers.RunTerragrunt(t, "terragrunt run-all output --non-interactive --working-dir "+stageEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all output --non-interactive --working-dir "+mgmtEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all output --non-interactive --working-dir "+stageEnvironmentPath)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all destroy --non-interactive --working-dir "+stageEnvironmentPath)
-	helpers.RunTerragrunt(t, "terragrunt run-all destroy --non-interactive --working-dir "+mgmtEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all destroy --non-interactive --working-dir "+stageEnvironmentPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all destroy --non-interactive --working-dir "+mgmtEnvironmentPath)
 }
 
 func TestAwsRemoteWithBackend(t *testing.T) {
@@ -894,7 +894,7 @@ func TestAwsGetAccountAliasFunctions(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAwsAccountAlias)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureAwsAccountAlias)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -1014,7 +1014,7 @@ func TestAwsDependencyOutputOptimizationDisableTest(t *testing.T) {
 	defer cleanupTableForTest(t, lockTableName, helpers.TerraformRemoteStateS3Region)
 	helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, helpers.TerraformRemoteStateS3Region)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// We need to bust the output cache that stores the dependency outputs so that the second run pulls the outputs.
 	// This is only a problem during testing, where the process is shared across terragrunt runs.
@@ -1243,7 +1243,7 @@ func TestAwsDependencyOutputSameOutputConcurrencyRegression(t *testing.T) {
 		stderr := bytes.Buffer{}
 		err := helpers.RunTerragruntCommand(
 			t,
-			"terragrunt run-all apply --source-update --non-interactive --working-dir "+rootPath,
+			"terragrunt run --all apply --source-update --non-interactive --working-dir "+rootPath,
 			&stdout,
 			&stderr,
 		)
@@ -1641,7 +1641,7 @@ func dependencyOutputOptimizationTest(t *testing.T, moduleName string, forceInit
 	defer cleanupTableForTest(t, lockTableName, helpers.TerraformRemoteStateS3Region)
 	helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, lockTableName, helpers.TerraformRemoteStateS3Region)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --log-level trace --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --log-level trace --non-interactive --working-dir "+rootPath)
 
 	// We need to bust the output cache that stores the dependency outputs so that the second run pulls the outputs.
 	// This is only a problem during testing, where the process is shared across terragrunt runs.

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -933,7 +933,7 @@ func TestAwsGetCallerIdentityFunctions(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAwsGetCallerIdentity)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureAwsGetCallerIdentity)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -941,7 +941,7 @@ func TestAwsGetCallerIdentityFunctions(t *testing.T) {
 
 	require.NoError(
 		t,
-		helpers.RunTerragruntCommand(t, "terragrunt output -no-color -json --non-interactive --working-dir "+rootPath, &stdout, &stderr),
+		helpers.RunTerragruntCommand(t, "terragrunt run --non-interactive --working-dir "+rootPath+" -- output -no-color -json", &stdout, &stderr),
 	)
 
 	// Get values from STS

--- a/test/integration_deprecated_test.go
+++ b/test/integration_deprecated_test.go
@@ -40,43 +40,6 @@ func TestDeprecatedHclvalidateCommand_HclvalidateInvalidConfigPath(t *testing.T)
 	assert.ElementsMatch(t, expectedPaths, actualPaths)
 }
 
-func TestDeprecatedRunAllCommand_TerragruntReportsTerraformErrorsWithPlanAll(t *testing.T) {
-	t.Parallel()
-
-	helpers.CleanupTerraformFolder(t, testFixtureFailedTerraform)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureFailedTerraform)
-
-	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, "fixtures/failure")
-
-	cmd := "terragrunt run-all plan --terragrunt-non-interactive --terragrunt-working-dir " + rootTerragruntConfigPath
-	var (
-		stdout bytes.Buffer
-		stderr bytes.Buffer
-	)
-	// Call helpers.RunTerragruntCommand directly because this command contains failures (which causes helpers.RunTerragruntRedirectOutput to abort) but we don't care.
-	err := helpers.RunTerragruntCommand(t, cmd, &stdout, &stderr)
-	require.NoError(t, err)
-
-	output := stdout.String()
-	errOutput := stderr.String()
-	fmt.Printf("STDERR is %s.\n STDOUT is %s", errOutput, output)
-
-	assert.Contains(t, errOutput, "missingvar1")
-	assert.Contains(t, errOutput, "missingvar2")
-}
-
-func TestDeprecatedLegacyAllCommand_TerragruntStackCommandsWithPlanFile(t *testing.T) {
-	t.Parallel()
-
-	tmpEnvPath, err := filepath.EvalSymlinks(helpers.CopyEnvironment(t, testFixtureDisjoint))
-	require.NoError(t, err)
-	disjointEnvironmentPath := util.JoinPath(tmpEnvPath, testFixtureDisjoint)
-
-	helpers.CleanupTerraformFolder(t, disjointEnvironmentPath)
-	helpers.RunTerragrunt(t, "terragrunt plan-all -out=plan.tfplan --terragrunt-log-level info --terragrunt-non-interactive --terragrunt-working-dir "+disjointEnvironmentPath)
-	helpers.RunTerragrunt(t, "terragrunt run-all apply plan.tfplan --terragrunt-log-level info --terragrunt-non-interactive --terragrunt-working-dir "+disjointEnvironmentPath)
-}
-
 // This tests terragrunt properly passes through terraform commands with sub commands
 // and any number of specified args
 func TestDeprecatedDefaultCommand_TerraformSubcommandCliArgs(t *testing.T) {

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -208,12 +208,12 @@ func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {
 	)
 
 	// Apply and destroy all modules.
-	err := helpers.RunTerragruntCommand(t, "terragrunt run-all apply --non-interactive --working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &applyAllStdout, &applyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run-all apply stdout")
-	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run-all apply stderr")
+	err := helpers.RunTerragruntCommand(t, "terragrunt run --all apply --non-interactive --working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &applyAllStdout, &applyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run --all apply stdout")
+	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run --all apply stderr")
 
 	if err != nil {
-		t.Fatalf("run-all apply in TestPreventDestroyDependenciesIncludedConfig failed with error: %v. Full std", err)
+		t.Fatalf("run --all apply in TestPreventDestroyDependenciesIncludedConfig failed with error: %v. Full std", err)
 	}
 
 	var (
@@ -221,9 +221,9 @@ func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {
 		destroyAllStderr bytes.Buffer
 	)
 
-	err = helpers.RunTerragruntCommand(t, "terragrunt run-all destroy --non-interactive --working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "run-all destroy stdout")
-	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "run-all destroy stderr")
+	err = helpers.RunTerragruntCommand(t, "terragrunt run --all destroy --non-interactive --working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "run --all destroy stdout")
+	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "run --all destroy stderr")
 
 	require.NoError(t, err)
 

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -208,12 +208,12 @@ func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {
 	)
 
 	// Apply and destroy all modules.
-	err := helpers.RunTerragruntCommand(t, "terragrunt apply-all --non-interactive --working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &applyAllStdout, &applyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "apply-all stdout")
-	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "apply-all stderr")
+	err := helpers.RunTerragruntCommand(t, "terragrunt run-all apply --non-interactive --working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &applyAllStdout, &applyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run-all apply stdout")
+	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run-all apply stderr")
 
 	if err != nil {
-		t.Fatalf("apply-all in TestPreventDestroyDependenciesIncludedConfig failed with error: %v. Full std", err)
+		t.Fatalf("run-all apply in TestPreventDestroyDependenciesIncludedConfig failed with error: %v. Full std", err)
 	}
 
 	var (
@@ -221,9 +221,9 @@ func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {
 		destroyAllStderr bytes.Buffer
 	)
 
-	err = helpers.RunTerragruntCommand(t, "terragrunt destroy-all --non-interactive --working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "destroy-all stdout")
-	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "destroy-all stderr")
+	err = helpers.RunTerragruntCommand(t, "terragrunt run-all destroy --non-interactive --working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "run-all destroy stdout")
+	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "run-all destroy stderr")
 
 	require.NoError(t, err)
 

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -308,13 +308,13 @@ func TestExcludeDirs(t *testing.T) {
 		}
 
 		// Apply modules according to test cases
-		err := helpers.RunTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --non-interactive --log-level trace --working-dir %s %s", tc.workingDir, tc.excludeArgs), &applyAllStdout, &applyAllStderr)
+		err := helpers.RunTerragruntCommand(t, fmt.Sprintf("terragrunt run --all apply --non-interactive --log-level trace --working-dir %s %s", tc.workingDir, tc.excludeArgs), &applyAllStdout, &applyAllStderr)
 
-		helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run-all apply stdout")
-		helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run-all apply stderr")
+		helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run --all apply stdout")
+		helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run --all apply stderr")
 
 		if err != nil {
-			t.Fatalf("run-all apply in TestExcludeDirs failed with error: %v. Full std", err)
+			t.Fatalf("run --all apply in TestExcludeDirs failed with error: %v. Full std", err)
 		}
 
 		// Check that the excluded module output is not present
@@ -375,13 +375,13 @@ func TestIncludeDirs(t *testing.T) {
 		}
 
 		// Apply modules according to test cases
-		err := helpers.RunTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --non-interactive  --log-level trace --working-dir %s %s", tc.workingDir, tc.includeArgs), &applyAllStdout, &applyAllStderr)
+		err := helpers.RunTerragruntCommand(t, fmt.Sprintf("terragrunt run --all apply --non-interactive  --log-level trace --working-dir %s %s", tc.workingDir, tc.includeArgs), &applyAllStdout, &applyAllStderr)
 
-		helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run-all apply stdout")
-		helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run-all apply stderr")
+		helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run --all apply stdout")
+		helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run --all apply stderr")
 
 		if err != nil {
-			t.Fatalf("run-all apply in TestIncludeDirs failed with error: %v. Full std", err)
+			t.Fatalf("run --all apply in TestIncludeDirs failed with error: %v. Full std", err)
 		}
 
 		// Check that the included module output is present
@@ -475,9 +475,9 @@ func TestTerragruntExternalDependencies(t *testing.T) {
 	rootPath := helpers.CopyEnvironment(t, testFixtureExternalDependence)
 	modulePath := util.JoinPath(rootPath, testFixtureExternalDependence, "module-b")
 
-	err := helpers.RunTerragruntCommand(t, "terragrunt run-all apply --non-interactive --queue-include-external --tf-forward-stdout --working-dir "+modulePath, &applyAllStdout, &applyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run-all apply stdout")
-	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run-all apply stderr")
+	err := helpers.RunTerragruntCommand(t, "terragrunt run --all apply --non-interactive --queue-include-external --tf-forward-stdout --working-dir "+modulePath, &applyAllStdout, &applyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run --all apply stdout")
+	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run --all apply stderr")
 	applyAllStdoutString := applyAllStdout.String()
 
 	if err != nil {
@@ -549,12 +549,12 @@ func TestPreventDestroyDependencies(t *testing.T) {
 	)
 
 	// Apply and destroy all modules.
-	err := helpers.RunTerragruntCommand(t, "terragrunt run-all apply --non-interactive --working-dir "+testFixtureLocalPreventDestroyDependencies, &applyAllStdout, &applyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run-all apply stdout")
-	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run-all apply stderr")
+	err := helpers.RunTerragruntCommand(t, "terragrunt run --all apply --non-interactive --working-dir "+testFixtureLocalPreventDestroyDependencies, &applyAllStdout, &applyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run --all apply stdout")
+	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run --all apply stderr")
 
 	if err != nil {
-		t.Fatalf("run-all apply in TestPreventDestroyDependencies failed with error: %v. Full std", err)
+		t.Fatalf("run --all apply in TestPreventDestroyDependencies failed with error: %v. Full std", err)
 	}
 
 	var (
@@ -562,9 +562,9 @@ func TestPreventDestroyDependencies(t *testing.T) {
 		destroyAllStderr bytes.Buffer
 	)
 
-	err = helpers.RunTerragruntCommand(t, "terragrunt run-all destroy --non-interactive --working-dir "+testFixtureLocalPreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "run-all destroy stdout")
-	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "run-all destroy stderr")
+	err = helpers.RunTerragruntCommand(t, "terragrunt run --all destroy --non-interactive --working-dir "+testFixtureLocalPreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "run --all destroy stdout")
+	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "run --all destroy stderr")
 
 	require.NoError(t, err)
 

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -308,13 +308,13 @@ func TestExcludeDirs(t *testing.T) {
 		}
 
 		// Apply modules according to test cases
-		err := helpers.RunTerragruntCommand(t, fmt.Sprintf("terragrunt apply-all --non-interactive --log-level trace --working-dir %s %s", tc.workingDir, tc.excludeArgs), &applyAllStdout, &applyAllStderr)
+		err := helpers.RunTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --non-interactive --log-level trace --working-dir %s %s", tc.workingDir, tc.excludeArgs), &applyAllStdout, &applyAllStderr)
 
-		helpers.LogBufferContentsLineByLine(t, applyAllStdout, "apply-all stdout")
-		helpers.LogBufferContentsLineByLine(t, applyAllStderr, "apply-all stderr")
+		helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run-all apply stdout")
+		helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run-all apply stderr")
 
 		if err != nil {
-			t.Fatalf("apply-all in TestExcludeDirs failed with error: %v. Full std", err)
+			t.Fatalf("run-all apply in TestExcludeDirs failed with error: %v. Full std", err)
 		}
 
 		// Check that the excluded module output is not present
@@ -375,13 +375,13 @@ func TestIncludeDirs(t *testing.T) {
 		}
 
 		// Apply modules according to test cases
-		err := helpers.RunTerragruntCommand(t, fmt.Sprintf("terragrunt apply-all --non-interactive  --log-level trace --working-dir %s %s", tc.workingDir, tc.includeArgs), &applyAllStdout, &applyAllStderr)
+		err := helpers.RunTerragruntCommand(t, fmt.Sprintf("terragrunt run-all apply --non-interactive  --log-level trace --working-dir %s %s", tc.workingDir, tc.includeArgs), &applyAllStdout, &applyAllStderr)
 
-		helpers.LogBufferContentsLineByLine(t, applyAllStdout, "apply-all stdout")
-		helpers.LogBufferContentsLineByLine(t, applyAllStderr, "apply-all stderr")
+		helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run-all apply stdout")
+		helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run-all apply stderr")
 
 		if err != nil {
-			t.Fatalf("apply-all in TestExcludeDirs failed with error: %v. Full std", err)
+			t.Fatalf("run-all apply in TestIncludeDirs failed with error: %v. Full std", err)
 		}
 
 		// Check that the included module output is present
@@ -475,9 +475,9 @@ func TestTerragruntExternalDependencies(t *testing.T) {
 	rootPath := helpers.CopyEnvironment(t, testFixtureExternalDependence)
 	modulePath := util.JoinPath(rootPath, testFixtureExternalDependence, "module-b")
 
-	err := helpers.RunTerragruntCommand(t, "terragrunt apply-all --non-interactive --queue-include-external --tf-forward-stdout --working-dir "+modulePath, &applyAllStdout, &applyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "apply-all stdout")
-	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "apply-all stderr")
+	err := helpers.RunTerragruntCommand(t, "terragrunt run-all apply --non-interactive --queue-include-external --tf-forward-stdout --working-dir "+modulePath, &applyAllStdout, &applyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run-all apply stdout")
+	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run-all apply stderr")
 	applyAllStdoutString := applyAllStdout.String()
 
 	if err != nil {
@@ -549,12 +549,12 @@ func TestPreventDestroyDependencies(t *testing.T) {
 	)
 
 	// Apply and destroy all modules.
-	err := helpers.RunTerragruntCommand(t, "terragrunt apply-all --non-interactive --working-dir "+testFixtureLocalPreventDestroyDependencies, &applyAllStdout, &applyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "apply-all stdout")
-	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "apply-all stderr")
+	err := helpers.RunTerragruntCommand(t, "terragrunt run-all apply --non-interactive --working-dir "+testFixtureLocalPreventDestroyDependencies, &applyAllStdout, &applyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run-all apply stdout")
+	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run-all apply stderr")
 
 	if err != nil {
-		t.Fatalf("apply-all in TestPreventDestroyDependencies failed with error: %v. Full std", err)
+		t.Fatalf("run-all apply in TestPreventDestroyDependencies failed with error: %v. Full std", err)
 	}
 
 	var (
@@ -562,9 +562,9 @@ func TestPreventDestroyDependencies(t *testing.T) {
 		destroyAllStderr bytes.Buffer
 	)
 
-	err = helpers.RunTerragruntCommand(t, "terragrunt destroy-all --non-interactive --working-dir "+testFixtureLocalPreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
-	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "destroy-all stdout")
-	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "destroy-all stderr")
+	err = helpers.RunTerragruntCommand(t, "terragrunt run-all destroy --non-interactive --working-dir "+testFixtureLocalPreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "run-all destroy stdout")
+	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "run-all destroy stderr")
 
 	require.NoError(t, err)
 

--- a/test/integration_functions_test.go
+++ b/test/integration_functions_test.go
@@ -39,7 +39,7 @@ func TestStartsWith(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStartswith)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStartswith)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -72,7 +72,7 @@ func TestTimeCmp(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureTimecmp)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureTimecmp)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -119,7 +119,7 @@ func TestEndsWith(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureEndswith)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureEndswith)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -152,7 +152,7 @@ func TestStrContains(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStrcontains)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStrcontains)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -195,7 +195,7 @@ func TestGetRepoRoot(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureGetRepoRoot)
 
 	helpers.CreateGitRepo(t, rootPath)
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -224,7 +224,7 @@ func TestGetWorkingDirBuiltInFunc(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureGetWorkingDir)
 
 	helpers.CreateGitRepo(t, rootPath)
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -290,7 +290,7 @@ func TestPathRelativeFromInclude(t *testing.T) {
 	clusterPath := util.JoinPath(rootPath, "cluster")
 
 	helpers.CreateGitRepo(t, tmpEnvPath)
-	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --working-dir "+rootPath+" -- apply -auto-approve")
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt output -no-color -json --non-interactive --working-dir "+clusterPath)
@@ -318,7 +318,7 @@ func TestGetPathFromRepoRoot(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureGetPathFromRepoRoot)
 
 	helpers.CreateGitRepo(t, tmpEnvPath)
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -347,7 +347,7 @@ func TestGetPathToRepoRoot(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, rootPath)
 
 	helpers.CreateGitRepo(t, tmpEnvPath)
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -383,7 +383,7 @@ func TestGetPlatform(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGetPlatform)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureGetPlatform)
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}

--- a/test/integration_functions_test.go
+++ b/test/integration_functions_test.go
@@ -39,7 +39,7 @@ func TestStartsWith(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStartswith)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStartswith)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -72,7 +72,7 @@ func TestTimeCmp(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureTimecmp)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureTimecmp)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -119,7 +119,7 @@ func TestEndsWith(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureEndswith)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureEndswith)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -152,7 +152,7 @@ func TestStrContains(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStrcontains)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureStrcontains)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -195,7 +195,7 @@ func TestGetRepoRoot(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureGetRepoRoot)
 
 	helpers.CreateGitRepo(t, rootPath)
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -224,7 +224,7 @@ func TestGetWorkingDirBuiltInFunc(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureGetWorkingDir)
 
 	helpers.CreateGitRepo(t, rootPath)
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -290,7 +290,7 @@ func TestPathRelativeFromInclude(t *testing.T) {
 	clusterPath := util.JoinPath(rootPath, "cluster")
 
 	helpers.CreateGitRepo(t, tmpEnvPath)
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt output -no-color -json --non-interactive --working-dir "+clusterPath)
@@ -318,7 +318,7 @@ func TestGetPathFromRepoRoot(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureGetPathFromRepoRoot)
 
 	helpers.CreateGitRepo(t, tmpEnvPath)
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -347,7 +347,7 @@ func TestGetPathToRepoRoot(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, rootPath)
 
 	helpers.CreateGitRepo(t, tmpEnvPath)
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}
@@ -383,7 +383,7 @@ func TestGetPlatform(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGetPlatform)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureGetPlatform)
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath)
 
 	// verify expected outputs are not empty
 	stdout := bytes.Buffer{}

--- a/test/integration_hooks_test.go
+++ b/test/integration_hooks_test.go
@@ -147,7 +147,7 @@ func TestTerragruntHookApplyAll(t *testing.T) {
 	beforeOnlyPath := util.JoinPath(rootPath, "before-only")
 	afterOnlyPath := util.JoinPath(rootPath, "after-only")
 
-	helpers.RunTerragrunt(t, "terragrunt run-all apply -auto-approve --log-level trace --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run --all apply --log-level trace --non-interactive --working-dir "+rootPath)
 
 	_, beforeErr := os.ReadFile(beforeOnlyPath + "/file.out")
 	require.NoError(t, beforeErr)

--- a/test/integration_hooks_test.go
+++ b/test/integration_hooks_test.go
@@ -147,7 +147,7 @@ func TestTerragruntHookApplyAll(t *testing.T) {
 	beforeOnlyPath := util.JoinPath(rootPath, "before-only")
 	afterOnlyPath := util.JoinPath(rootPath, "after-only")
 
-	helpers.RunTerragrunt(t, "terragrunt apply-all -auto-approve --log-level trace --non-interactive --working-dir "+rootPath)
+	helpers.RunTerragrunt(t, "terragrunt run-all apply -auto-approve --log-level trace --non-interactive --working-dir "+rootPath)
 
 	_, beforeErr := os.ReadFile(beforeOnlyPath + "/file.out")
 	require.NoError(t, beforeErr)

--- a/test/integration_serial_aws_test.go
+++ b/test/integration_serial_aws_test.go
@@ -181,17 +181,17 @@ func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules
 	environmentPath := tmpEnvPath
 
 	// forces plugin download & initialization (no parallelism control)
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt plan-all --non-interactive --working-dir %s -var sleep_seconds=%d", environmentPath, timeToDeployEachModule/time.Second))
-	// apply all with parallelism set
-	// NOTE: we can't run just apply-all and not plan-all because the time to initialize the plugins skews the results of the test
-	testStart := int(time.Now().Unix())
-	t.Logf("apply-all start time = %d, %s", testStart, time.Now().Format(time.RFC3339))
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt apply-all --parallelism %d --non-interactive --working-dir %s -var sleep_seconds=%d", parallelism, environmentPath, timeToDeployEachModule/time.Second))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt run-all plan --non-interactive --working-dir %s -var sleep_seconds=%d", environmentPath, timeToDeployEachModule/time.Second))
+
+	// NOTE: we can't run just run-all apply and not run-all plan because the time to initialize the plugins skews the results of the test
+	testStart := time.Now().Unix()
+	t.Logf("run-all apply start time = %d, %s", testStart, time.Now().Format(time.RFC3339))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt run-all apply --parallelism %d --non-interactive --working-dir %s -var sleep_seconds=%d", parallelism, environmentPath, timeToDeployEachModule/time.Second))
 
 	// read the output of all modules 1 by 1 sequence, parallel reads mix outputs and make output complicated to parse
 	outputParallelism := 1
 	// Call helpers.RunTerragruntCommandWithOutput directly because this command contains failures (which causes helpers.RunTerragruntRedirectOutput to abort) but we don't care.
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output-all -no-color --tf-forward-stdout --non-interactive --working-dir %s --parallelism %d", environmentPath, outputParallelism))
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all output -no-color --tf-forward-stdout --non-interactive --working-dir %s --parallelism %d", environmentPath, outputParallelism))
 	if err != nil {
 		return "", 0, err
 	}

--- a/test/integration_serial_aws_test.go
+++ b/test/integration_serial_aws_test.go
@@ -196,5 +196,5 @@ func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules
 		return "", 0, err
 	}
 
-	return stdout, testStart, nil
+	return stdout, int(testStart), nil
 }

--- a/test/integration_serial_aws_test.go
+++ b/test/integration_serial_aws_test.go
@@ -181,17 +181,17 @@ func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules
 	environmentPath := tmpEnvPath
 
 	// forces plugin download & initialization (no parallelism control)
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt run-all plan --non-interactive --working-dir %s -var sleep_seconds=%d", environmentPath, timeToDeployEachModule/time.Second))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt run --all plan --non-interactive --working-dir %s -var sleep_seconds=%d", environmentPath, timeToDeployEachModule/time.Second))
 
-	// NOTE: we can't run just run-all apply and not run-all plan because the time to initialize the plugins skews the results of the test
+	// NOTE: we can't run just run --all apply and not run --all plan because the time to initialize the plugins skews the results of the test
 	testStart := time.Now().Unix()
-	t.Logf("run-all apply start time = %d, %s", testStart, time.Now().Format(time.RFC3339))
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt run-all apply --parallelism %d --non-interactive --working-dir %s -var sleep_seconds=%d", parallelism, environmentPath, timeToDeployEachModule/time.Second))
+	t.Logf("run --all apply start time = %d, %s", testStart, time.Now().Format(time.RFC3339))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt run --all apply --parallelism %d --non-interactive --working-dir %s -var sleep_seconds=%d", parallelism, environmentPath, timeToDeployEachModule/time.Second))
 
 	// read the output of all modules 1 by 1 sequence, parallel reads mix outputs and make output complicated to parse
 	outputParallelism := 1
 	// Call helpers.RunTerragruntCommandWithOutput directly because this command contains failures (which causes helpers.RunTerragruntRedirectOutput to abort) but we don't care.
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run-all output -no-color --tf-forward-stdout --non-interactive --working-dir %s --parallelism %d", environmentPath, outputParallelism))
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run --all output -no-color --tf-forward-stdout --non-interactive --working-dir %s --parallelism %d", environmentPath, outputParallelism))
 	if err != nil {
 		return "", 0, err
 	}

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -386,7 +386,7 @@ func TestPreserveEnvVarApplyAll(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureRegressions, "apply-all-envvar")
 
 	stdout := bytes.Buffer{}
-	helpers.RunTerragruntRedirectOutput(t, "terragrunt apply-all -auto-approve --non-interactive --working-dir "+rootPath, &stdout, os.Stderr)
+	helpers.RunTerragruntRedirectOutput(t, "terragrunt run-all apply -auto-approve --non-interactive --working-dir "+rootPath, &stdout, os.Stderr)
 	t.Log(stdout.String())
 
 	// Check the output of each child module to make sure the inputs were overridden by the env var

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -386,7 +386,7 @@ func TestPreserveEnvVarApplyAll(t *testing.T) {
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureRegressions, "apply-all-envvar")
 
 	stdout := bytes.Buffer{}
-	helpers.RunTerragruntRedirectOutput(t, "terragrunt run-all apply -auto-approve --non-interactive --working-dir "+rootPath, &stdout, os.Stderr)
+	helpers.RunTerragruntRedirectOutput(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath, &stdout, os.Stderr)
 	t.Log(stdout.String())
 
 	// Check the output of each child module to make sure the inputs were overridden by the env var

--- a/test/integration_strict_test.go
+++ b/test/integration_strict_test.go
@@ -29,25 +29,25 @@ func TestStrictMode(t *testing.T) {
 		strictMode     bool
 	}{
 		{
-			name:           "plan-all",
+			name:           "run-all",
 			controls:       []string{},
 			strictMode:     false,
-			expectedStderr: "The `plan-all` command is deprecated and will be removed in a future version of Terragrunt. Use `terragrunt plan --all` instead.",
+			expectedStderr: "The `run-all plan` command is deprecated and will be removed in a future version of Terragrunt. Use `terragrunt plan --all` instead.",
 			expectedError:  nil,
 		},
 		{
-			name:           "plan-all with plan-all strict control",
+			name:           "run-all with deprecated-commands strict control",
 			controls:       []string{"deprecated-commands"},
 			strictMode:     false,
 			expectedStderr: "",
-			expectedError:  errors.New("The `plan-all` command is no longer supported. Use `terragrunt plan --all` instead."),
+			expectedError:  errors.New("The `run-all plan` command is no longer supported. Use `terragrunt plan --all` instead."),
 		},
 		{
-			name:           "plan-all with strict mode",
+			name:           "run-all with strict mode",
 			controls:       []string{},
 			strictMode:     true,
 			expectedStderr: "",
-			expectedError:  errors.New("The `plan-all` command is no longer supported. Use `terragrunt plan --all` instead."),
+			expectedError:  errors.New("The `run-all plan` command is no longer supported. Use `terragrunt plan --all` instead."),
 		},
 	}
 
@@ -65,7 +65,7 @@ func TestStrictMode(t *testing.T) {
 				args = " --strict-control " + control + " " + args
 			}
 
-			_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan-all "+args)
+			_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run-all plan "+args)
 
 			if tc.expectedError != nil {
 				require.Error(t, err)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -891,7 +891,7 @@ func TestTerragruntReportsTerraformErrorsWithPlanAll(t *testing.T) {
 
 	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, "fixtures/failure")
 
-	cmd := "terragrunt run-all plan --non-interactive --working-dir " + rootTerragruntConfigPath
+	cmd := "terragrunt run --all plan --non-interactive --working-dir " + rootTerragruntConfigPath
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer
@@ -1959,10 +1959,10 @@ func TestDependencyMockOutputRestricted(t *testing.T) {
 	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
 	helpers.LogBufferContentsLineByLine(t, showStderr, "show stderr")
 
-	// Verify that run-all validate works as well.
+	// Verify that run --all validate works as well.
 	showStdout.Reset()
 	showStderr.Reset()
-	err = helpers.RunTerragruntCommand(t, "terragrunt run-all validate --non-interactive --working-dir "+rootPath, &showStdout, &showStderr)
+	err = helpers.RunTerragruntCommand(t, "terragrunt run --all validate --non-interactive --working-dir "+rootPath, &showStdout, &showStderr)
 	require.NoError(t, err)
 
 	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
@@ -1970,7 +1970,7 @@ func TestDependencyMockOutputRestricted(t *testing.T) {
 
 	showStdout.Reset()
 	showStderr.Reset()
-	err = helpers.RunTerragruntCommand(t, "terragrunt run-all validate --non-interactive --working-dir "+rootPath, &showStdout, &showStderr)
+	err = helpers.RunTerragruntCommand(t, "terragrunt run --all validate --non-interactive --working-dir "+rootPath, &showStdout, &showStderr)
 	require.NoError(t, err)
 
 	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
@@ -2866,7 +2866,7 @@ func TestTerragruntValidateAllWithVersionChecks(t *testing.T) {
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
-	err := helpers.RunTerragruntVersionCommand(t, "v0.23.21", "terragrunt run-all validate --non-interactive --working-dir "+tmpEnvPath, &stdout, &stderr)
+	err := helpers.RunTerragruntVersionCommand(t, "v0.23.21", "terragrunt run --all validate --non-interactive --working-dir "+tmpEnvPath, &stdout, &stderr)
 	helpers.LogBufferContentsLineByLine(t, stdout, "stdout")
 	helpers.LogBufferContentsLineByLine(t, stderr, "stderr")
 	require.NoError(t, err)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -891,7 +891,7 @@ func TestTerragruntReportsTerraformErrorsWithPlanAll(t *testing.T) {
 
 	rootTerragruntConfigPath := util.JoinPath(tmpEnvPath, "fixtures/failure")
 
-	cmd := "terragrunt plan-all --non-interactive --working-dir " + rootTerragruntConfigPath
+	cmd := "terragrunt run-all plan --non-interactive --working-dir " + rootTerragruntConfigPath
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer
@@ -1959,10 +1959,10 @@ func TestDependencyMockOutputRestricted(t *testing.T) {
 	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
 	helpers.LogBufferContentsLineByLine(t, showStderr, "show stderr")
 
-	// Verify that validate-all works as well.
+	// Verify that run-all validate works as well.
 	showStdout.Reset()
 	showStderr.Reset()
-	err = helpers.RunTerragruntCommand(t, "terragrunt validate-all --non-interactive --working-dir "+rootPath, &showStdout, &showStderr)
+	err = helpers.RunTerragruntCommand(t, "terragrunt run-all validate --non-interactive --working-dir "+rootPath, &showStdout, &showStderr)
 	require.NoError(t, err)
 
 	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
@@ -1970,7 +1970,7 @@ func TestDependencyMockOutputRestricted(t *testing.T) {
 
 	showStdout.Reset()
 	showStderr.Reset()
-	err = helpers.RunTerragruntCommand(t, "terragrunt validate-all --non-interactive --working-dir "+rootPath, &showStdout, &showStderr)
+	err = helpers.RunTerragruntCommand(t, "terragrunt run-all validate --non-interactive --working-dir "+rootPath, &showStdout, &showStderr)
 	require.NoError(t, err)
 
 	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
@@ -2866,7 +2866,7 @@ func TestTerragruntValidateAllWithVersionChecks(t *testing.T) {
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
-	err := helpers.RunTerragruntVersionCommand(t, "v0.23.21", "terragrunt validate-all --non-interactive --working-dir "+tmpEnvPath, &stdout, &stderr)
+	err := helpers.RunTerragruntVersionCommand(t, "v0.23.21", "terragrunt run-all validate --non-interactive --working-dir "+tmpEnvPath, &stdout, &stderr)
 	helpers.LogBufferContentsLineByLine(t, stdout, "stdout")
 	helpers.LogBufferContentsLineByLine(t, stderr, "stderr")
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4548.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Removed `legacy-all` commands.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * None.

* **Bug Fixes**
  * None.

* **Documentation**
  * Updated all documentation to remove references to deprecated legacy commands (e.g., `plan-all`, `apply-all`, etc.) and replace them with the modern `run --all <command>` syntax.
  * Clarified that legacy commands have been fully removed and updated strict mode controls documentation accordingly.

* **Refactor**
  * Removed all internal references and constants for deprecated legacy commands.
  * Updated strict mode controls to explicitly mark legacy commands as completed and reorganized their listing.

* **Tests**
  * Updated all test cases and integration tests to use the new `run --all <command>` syntax instead of legacy commands.
  * Removed tests specifically covering deprecated legacy commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->