### PR TITLE
fix: Conditionally enable Vercel adapter

### DIFF
--- a/docs-starlight/astro.config.mjs
+++ b/docs-starlight/astro.config.mjs
@@ -8,6 +8,9 @@ import tailwindcss from "@tailwindcss/vite";
 
 import partytown from "@astrojs/partytown";
 
+// Check if we're in Vercel environment
+const isVercel = globalThis.process?.env?.VERCEL;
+
 export const sidebar = [
   {
     label: "Getting Started",
@@ -71,13 +74,13 @@ export const sidebar = [
 // https://astro.build/config
 export default defineConfig({
   site: "https://terragrunt-v1.gruntwork.io",
-  output: "server",
-  adapter: vercel({
+  output: isVercel ? "server" : "static",
+  adapter: isVercel ? vercel({
     imageService: true,
     isr: {
       expiration: 60 * 60 * 24, // 24 hours
     },
-  }),
+  }) : undefined,
   integrations: [starlight({
     title: "Terragrunt",
     customCss: ["./src/styles/global.css"],
@@ -149,7 +152,7 @@ export default defineConfig({
     // It's recommended that we just skip generation in Vercel,
     // and generate diagrams locally:
     // https://astro-d2.vercel.app/guides/how-astro-d2-works/#deployment
-    skipGeneration: !!process.env['VERCEL']
+    skipGeneration: !!isVercel
   }), partytown({
     config: {
       forward: ['dataLayer.push']


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Allows developers to run the preview environment locally so that we can test updates to features like the search bar.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added conditional logic for the `vercel` adapter so that it's not set in preview mode.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

