### PR TITLE
fix: Make `stack output` respect `no_dot_terragrunt_stack`

### DIFF
--- a/config/stack.go
+++ b/config/stack.go
@@ -214,7 +214,7 @@ func StackOutput(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 		}
 
 		for _, unit := range stackFile.Units {
-			unitDir := filepath.Join(dir, StackDir, unit.Path)
+			unitDir := getUnitDir(dir, unit)
 
 			var output map[string]cty.Value
 
@@ -1026,4 +1026,13 @@ func CleanStacks(_ context.Context, l log.Logger, opts *options.TerragruntOption
 	}
 
 	return errs.ErrorOrNil()
+}
+
+// getUnitDir returns the directory path for a unit based on its no_dot_terragrunt_stack setting.
+func getUnitDir(dir string, unit *Unit) string {
+	if unit.NoStack != nil && *unit.NoStack {
+		return filepath.Join(dir, unit.Path)
+	}
+
+	return filepath.Join(dir, StackDir, unit.Path)
 }

--- a/test/fixtures/stacks/no-dot-terragrunt-stack-output/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/no-dot-terragrunt-stack-output/live/terragrunt.stack.hcl
@@ -1,0 +1,5 @@
+unit "app1" {
+  source                  = "../units/app1"
+  path                    = "app1"
+  no_dot_terragrunt_stack = true
+}

--- a/test/fixtures/stacks/no-dot-terragrunt-stack-output/units/app1/main.tf
+++ b/test/fixtures/stacks/no-dot-terragrunt-stack-output/units/app1/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 0.13"
+}
+
+variable "name" {
+  description = "Name of the application"
+  type        = string
+}
+
+output "name" {
+  value = var.name
+}

--- a/test/fixtures/stacks/no-dot-terragrunt-stack-output/units/app1/terragrunt.hcl
+++ b/test/fixtures/stacks/no-dot-terragrunt-stack-output/units/app1/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  name = "app1"
+}

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -48,6 +48,7 @@ const (
 	testFixtureStackNestedOutputs              = "fixtures/stacks/nested-outputs"
 	testFixtureStackNoValidation               = "fixtures/stacks/no-validation"
 	testFixtureStackTerragruntDir              = "fixtures/stacks/terragrunt-dir"
+	testFixtureStackNoDotTerragruntStackOutput = "fixtures/stacks/no-dot-terragrunt-stack-output"
 )
 
 func TestStacksGenerateBasic(t *testing.T) {
@@ -1313,4 +1314,25 @@ func TestStackTerragruntDir(t *testing.T) {
 	out, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply --all --non-interactive --working-dir "+rootPath)
 	require.NoError(t, err)
 	assert.Contains(t, out, `terragrunt_dir = "./tennant_1"`)
+}
+
+func TestStackOutputWithNoDotTerragruntStack(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackNoDotTerragruntStackOutput)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackNoDotTerragruntStackOutput)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStackNoDotTerragruntStackOutput, "live")
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --working-dir "+rootPath)
+
+	unitPath := util.JoinPath(rootPath, "app1")
+	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+unitPath)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack output --non-interactive --working-dir "+rootPath,
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "name = \"app1\"")
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/terragrunt/issues/4593.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for units that do not use the `.terragrunt-stack` directory, allowing more flexible stack directory structures.
* **Tests**
  * Introduced a new integration test to verify stack output behavior when the `.terragrunt-stack` directory is omitted.
* **Documentation**
  * Added new example configuration files demonstrating usage without the `.terragrunt-stack` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->