### PR TITLE
Fix: allow Terraform backend init when disable_init is true

### DIFF
--- a/internal/remotestate/remote_state.go
+++ b/internal/remotestate/remote_state.go
@@ -118,7 +118,9 @@ func (remote *RemoteState) NeedsBootstrap(ctx context.Context, l log.Logger, opt
 // GetTFInitArgs converts the RemoteState config into the format used by the `tofu init` command.
 func (remote *RemoteState) GetTFInitArgs() []string {
 	if remote.DisableInit {
-		return []string{"-backend=false"}
+		// Don't pass -backend=false anymore; we still want Terraform to init the backend,
+		// but we don't want Terragrunt to manage bucket creation.
+		return []string{}
 	}
 
 	if remote.Generate != nil {
@@ -127,7 +129,6 @@ func (remote *RemoteState) GetTFInitArgs() []string {
 	}
 
 	config := remote.backend.GetTFInitArgs(remote.BackendConfig)
-
 	var backendConfigArgs = make([]string, 0, len(config))
 
 	for key, value := range config {
@@ -137,6 +138,7 @@ func (remote *RemoteState) GetTFInitArgs() []string {
 
 	return backendConfigArgs
 }
+
 
 // GenerateOpenTofuCode generates the OpenTofu/Terraform code for configuring remote state backend.
 func (remote *RemoteState) GenerateOpenTofuCode(l log.Logger, opts *options.TerragruntOptions) error {


### PR DESCRIPTION
When remote_state.disable_init = true, Terragrunt currently passes `-backend=false` to Terraform, which prevents Terraform from initializing the backend and causes an error like:

  Backend reinitialization required. Please run "terraform init".

This PR removes that flag so that Terraform is allowed to initialize the backend normally. Terragrunt still skips creating S3 buckets or DynamoDB tables, as intended by disable_init.

Fixes #1422.


