### PR TITLE
fix: Fixing discovery parsing stacks as units

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -353,6 +353,14 @@ func (d *Discovery) Discover(ctx context.Context, l log.Logger, opts *options.Te
 	// e.g. dependencies, exclude, etc.
 	if d.requiresParse {
 		for _, cfg := range cfgs {
+			// Stack configurations don't need to be parsed for discovery purposes.
+			// They don't have exclude blocks or dependencies.
+			//
+			// This might change in the future, but for now we'll just skip parsing.
+			if cfg.Type == ConfigTypeStack {
+				continue
+			}
+
 			err := cfg.Parse(ctx, l, opts, d.suppressParseErrors)
 			if err != nil {
 				errs = append(errs, errors.New(err))


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4614.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `discovery` to avoid attempting to parse `terragrunt.stack.hcl` files as units.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration discovery to prevent parsing errors when stack and unit configurations coexist. Stack configurations are now skipped during parsing, avoiding unnecessary failures.

* **Tests**
  * Added a test to ensure stack configurations are not parsed and do not interfere with unit configuration discovery.
  * Minor variable renaming in existing tests for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->