### PR TITLE
fix: Fixing `stack run` when there are only units with `no_dot_terragrunt_stack` set

### DIFF
--- a/cli/commands/stack/stack.go
+++ b/cli/commands/stack/stack.go
@@ -2,7 +2,6 @@ package stack
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -15,10 +14,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/options"
-)
-
-const (
-	stackDir = ".terragrunt-stack"
 )
 
 // RunGenerate runs the stack command.
@@ -68,11 +63,6 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 
 	if err != nil {
 		return err
-	}
-
-	opts.WorkingDir = filepath.Join(opts.WorkingDir, stackDir)
-	if _, err := os.Stat(opts.WorkingDir); os.IsNotExist(err) {
-		return errors.Errorf("Stack directory does not exist or is not accessible: %s", opts.WorkingDir)
 	}
 
 	return runall.Run(ctx, l, opts)

--- a/test/fixtures/stacks/all-no-stack-dir/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/all-no-stack-dir/live/terragrunt.stack.hcl
@@ -1,0 +1,12 @@
+unit "foo" {
+  source                  = "../unit"
+  path                    = "foo"
+  no_dot_terragrunt_stack = true
+}
+
+unit "bar" {
+  source                  = "../unit"
+  path                    = "bar"
+  no_dot_terragrunt_stack = true
+}
+

--- a/test/fixtures/stacks/all-no-stack-dir/unit/main.tf
+++ b/test/fixtures/stacks/all-no-stack-dir/unit/main.tf
@@ -1,0 +1,8 @@
+output "test" {
+  value = var.test
+}
+
+variable "test" {
+  type = string
+}
+

--- a/test/fixtures/stacks/all-no-stack-dir/unit/terragrunt.hcl
+++ b/test/fixtures/stacks/all-no-stack-dir/unit/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  test = "value"
+}
+


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Makes it so that `stack run` works even when all the units have `no_dot_terragrunt_stack`.

This is technically breaking, as it adjusts the directory where `stack run` takes place. Logs will include `.terragrunt-stack` and there's a risk that some users might configure their configurations in such a way that this causes issues. However, it's best to be consistent with how this command behaves, and we shouldn't have it not work for users that are using `no_dot_terragrunt_stack` in their configurations while migrating to stacks.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `stack run` to run directly in the directory of the stack, not `.terragrunt-stack`.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

