### PR TITLE
Fix broken screenshot in logging page

### DIFF
--- a/docs-starlight/src/content/docs/04-reference/07-logging/02-formatting.md
+++ b/docs-starlight/src/content/docs/04-reference/07-logging/02-formatting.md
@@ -140,7 +140,7 @@ time=12:33:08.513 level=debug msg=Running command: tofu --version
 
 *Unfortunately, it is not possible to display color in a Markdown document, but in the above output, `time=` is colored magenta, `level=` is colored light blue and `msg=` is colored green.*
 
-[![screenshot](/assets/img/screenshots/custom-log-format-1.jpg){: width="50%" }](https://terragrunt.gruntwork.io/assets/img/screenshots/custom-log-format-1.jpg)
+[![screenshot](../../../assets/img/screenshots/custom-log-format-1.jpg){: width="50%" }](https://terragrunt.gruntwork.io/assets/img/screenshots/custom-log-format-1.jpg)
 
 ## Options
 


### PR DESCRIPTION
## Description

Fixes the broken screenshot in [the logging page](https://terragrunt-v1.gruntwork.io/docs/reference/logging/formatting):

<img width="843" height="416" alt="image" src="https://github.com/user-attachments/assets/aef11919-3c0d-43a6-ad24-a2a3d2ad1555" />

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

