### PR TITLE
fix: Addressing provider cache test flake

### DIFF
--- a/internal/providercache/provider_cache_test.go
+++ b/internal/providercache/provider_cache_test.go
@@ -105,7 +105,10 @@ func TestProviderCache(t *testing.T) {
 		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
 			t.Parallel()
 
-			ctx := t.Context()
+			// Create a new context for each test case to avoid interference
+			//
+			//nolint:usetesting
+			ctx := context.Background()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Hopefully makes the provider cache testing less flaky.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated the provider cache testing to be less flaky.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Updated subtest context handling to use fresh, cancellable contexts per case, improving isolation, determinism, stability, and more predictable CI runs.
  - Added clarifying comments and targeted lint suppressions around test context usage to reduce noise and keep tests clear. No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->