### PR TITLE
chore: Remove legacy terragrunt flags

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -382,9 +382,7 @@ func TestParseMultiStringArg(t *testing.T) {
 func TestParseMutliStringKeyValueArg(t *testing.T) {
 	t.Parallel()
 
-	terragruntPrefix := flags.Prefix{flags.TerragruntPrefix}
-
-	flagName := doubleDashed(terragruntPrefix.FlagName(awsproviderpatch.OverrideAttrFlagName))
+	flagName := doubleDashed(awsproviderpatch.OverrideAttrFlagName)
 
 	testCases := []struct {
 		expectedErr  error

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -37,8 +37,6 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		t.Skip("Skipping test on Windows")
 	}
 
-	terragruntPrefix := flags.Prefix{flags.TerragruntPrefix}
-
 	workingDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -79,7 +77,7 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		},
 
 		{
-			args:            []string{"apply", doubleDashed(terragruntPrefix.FlagName("include-external-dependencies"))},
+			args:            []string{"apply", doubleDashed(run.QueueIncludeExternalFlagName)},
 			expectedOptions: mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"apply"}, false, "", false, true, defaultLogLevel, false),
 		},
 
@@ -109,12 +107,12 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		},
 
 		{
-			args:            []string{"plan", doubleDashed(terragruntPrefix.FlagName("ignore-external-dependencies"))},
+			args:            []string{"plan", doubleDashed(run.QueueExcludeExternalFlagName)},
 			expectedOptions: mockOptions(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"plan"}, false, "", false, false, defaultLogLevel, false),
 		},
 
 		{
-			args:            []string{"plan", doubleDashed(terragruntPrefix.FlagName("iam-role")), "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"},
+			args:            []string{"plan", doubleDashed(run.IAMAssumeRoleFlagName), "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"},
 			expectedOptions: mockOptionsWithIamRole(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"plan"}, false, "", false, "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"),
 		},
 
@@ -129,7 +127,7 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		},
 
 		{
-			args:            []string{"plan", doubleDashed(terragruntPrefix.FlagName("iam-web-identity-token")), "web-identity-token"},
+			args:            []string{"plan", doubleDashed(run.IAMAssumeRoleWebIdentityTokenFlagName), "web-identity-token"},
 			expectedOptions: mockOptionsWithIamWebIdentityToken(t, util.JoinPath(workingDir, config.DefaultTerragruntConfigPath), workingDir, []string{"plan"}, false, "", false, "web-identity-token"),
 		},
 

--- a/cli/commands/aws-provider-patch/cli.go
+++ b/cli/commands/aws-provider-patch/cli.go
@@ -58,7 +58,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.AwsProviderPatchOverrides,
 			Usage:       "A key=value attribute to override in a provider block as part of the aws-provider-patch command. May be specified multiple times.",
 		},
-			flags.WithDeprecatedName(terragruntPrefix.FlagName("override-attr"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("override-attr"), terragruntPrefixControl)),
 	}
 }
 

--- a/cli/commands/hcl/format/cli.go
+++ b/cli/commands/hcl/format/cli.go
@@ -33,7 +33,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			Usage:       "The path to a single HCL file that the command should run on.",
 		},
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("hclfmt-file"), terragruntPrefixControl),         // `TG_HCLFMT_FILE`
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("hclfmt-file"), terragruntPrefixControl), // `--terragrunt-hclfmt-file`, `TERRAGRUNT_HCLFMT_FILE`
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("hclfmt-file"), terragruntPrefixControl), // `TERRAGRUNT_HCLFMT_FILE`
 		),
 
 		flags.NewFlag(&cli.SliceFlag[string]{
@@ -43,7 +43,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			Usage:       "Skip HCL formatting in given directories.",
 		},
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("hclfmt-exclude-dir"), terragruntPrefixControl),         // `TG_HCLFMT_EXCLUDE_DIR`
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("hclfmt-exclude-dir"), terragruntPrefixControl), // `--terragrunt-hclfmt-exclude-dir`, `TERRAGRUNT_EXCLUDE_DIR`
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("hclfmt-exclude-dir"), terragruntPrefixControl), // `TERRAGRUNT_EXCLUDE_DIR`
 		),
 
 		flags.NewFlag(&cli.BoolFlag{
@@ -53,7 +53,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			Usage:       "Return a status code of zero when all files are formatted correctly, and a status code of one when they aren't.",
 		},
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("hclfmt-check"), terragruntPrefixControl),  // `TG_HCLFMT_CHECK`
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("check"), terragruntPrefixControl), // `--terragrunt-check`, `TERRAGRUNT_CHECK`
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("check"), terragruntPrefixControl), // `TERRAGRUNT_CHECK`
 		),
 
 		flags.NewFlag(&cli.BoolFlag{
@@ -63,7 +63,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			Usage:       "Print diff between original and modified file versions.",
 		},
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("hclfmt-diff"), terragruntPrefixControl),  // `TG_HCLFMT_DIFF`
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("diff"), terragruntPrefixControl), // `--terragrunt-diff`, `TERRAGRUNT_DIFF`
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("diff"), terragruntPrefixControl), // `TERRAGRUNT_DIFF`
 		),
 
 		flags.NewFlag(&cli.BoolFlag{
@@ -73,7 +73,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			Usage:       "Format HCL from stdin and print result to stdout.",
 		},
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("hclfmt-stdin"), terragruntPrefixControl),         // `TG_HCLFMT_STDIN`
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("hclfmt-stdin"), terragruntPrefixControl), // `--terragrunt-hclfmt-stdin`, `TERRAGRUNT_HCLFMT_STDIN`
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("hclfmt-stdin"), terragruntPrefixControl), // `TERRAGRUNT_HCLFMT_STDIN`
 		),
 	}
 

--- a/cli/commands/hcl/validate/cli.go
+++ b/cli/commands/hcl/validate/cli.go
@@ -31,7 +31,6 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			Destination: &opts.HCLValidateStrict,
 			Usage:       "Enables strict mode. When used in combination with the `--inputs` flag, any inputs defined in Terragrunt that are _not_ used in OpenTofu/Terraform will trigger an error.",
 		},
-			flags.WithDeprecatedFlagName("strict-validate", terragruntPrefixControl), // `--strict-validate`
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars(
 				"strict-validate",             // `TG_STRICT_VALIDATE`
 				"hclvalidate-strict-validate", // `TG_HCLVALIDATE_STRICT_VALIDATE`

--- a/cli/commands/hcl/validate/cli.go
+++ b/cli/commands/hcl/validate/cli.go
@@ -36,7 +36,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 				"strict-validate",             // `TG_STRICT_VALIDATE`
 				"hclvalidate-strict-validate", // `TG_HCLVALIDATE_STRICT_VALIDATE`
 			), terragruntPrefixControl),
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("strict-validate"), terragruntPrefixControl), // `--terragrunt-strict-validate`, `TERRAGRUNT_STRICT_VALIDATE`
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("strict-validate"), terragruntPrefixControl), // `TERRAGRUNT_STRICT_VALIDATE`
 		),
 
 		flags.NewFlag(&cli.BoolFlag{
@@ -53,7 +53,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 		},
 
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("hclvalidate-strict-validate"), terragruntPrefixControl),          // `TG_HCLVALIDATE_STRICT_VALIDATE`
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("hclvalidate-show-config-path"), terragruntPrefixControl), // `--terragrunt-hclvalidate-show-config-path`, `TERRAGRUNT_HCLVALIDATE_SHOW_CONFIG_PATH`
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("hclvalidate-show-config-path"), terragruntPrefixControl), // `TERRAGRUNT_HCLVALIDATE_SHOW_CONFIG_PATH`
 		),
 
 		flags.NewFlag(&cli.BoolFlag{
@@ -63,7 +63,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 			Usage:       "Format results in JSON format.",
 		},
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("hclvalidate-json"), terragruntPrefixControl),         // `TG_HCLVALIDATE_JSON`
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("hclvalidate-json"), terragruntPrefixControl), // `--terragrunt-hclvalidate-json`, `TERRAGRUNT_HCLVALIDATE_JSON`
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("hclvalidate-json"), terragruntPrefixControl), // `TERRAGRUNT_HCLVALIDATE_JSON`
 		),
 	}
 

--- a/cli/commands/render/cli.go
+++ b/cli/commands/render/cli.go
@@ -85,7 +85,6 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			Destination: &opts.OutputPath,
 			Usage:       "The file name that terragrunt should use when rendering the terragrunt.hcl config (next to the unit configuration).",
 		},
-			flags.WithDeprecatedFlagName("json-out", terragruntPrefixControl),                          // `--json-out`
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("render-json-out"), terragruntPrefixControl),  // `TG_RENDER_JSON_OUT`
 			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("json-out"), terragruntPrefixControl), // `TERRAGRUNT_JSON_OUT`
 		),

--- a/cli/commands/render/cli.go
+++ b/cli/commands/render/cli.go
@@ -87,7 +87,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 		},
 			flags.WithDeprecatedFlagName("json-out", terragruntPrefixControl),                          // `--json-out`
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("render-json-out"), terragruntPrefixControl),  // `TG_RENDER_JSON_OUT`
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("json-out"), terragruntPrefixControl), // `--terragrunt-json-out`, `TERRAGRUNT_JSON_OUT`
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("json-out"), terragruntPrefixControl), // `TERRAGRUNT_JSON_OUT`
 		),
 
 		flags.NewFlag(&cli.BoolFlag{
@@ -97,7 +97,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			Usage:       "Add metadata to the rendered output file.",
 		},
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("render-json-with-metadata"), terragruntPrefixControl), // `TG_RENDER_JSON_WITH_METADATA`
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("with-metadata"), terragruntPrefixControl),     // `--terragrunt-with-metadata`, `TERRAGRUNT_WITH_METADATA`
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("with-metadata"), terragruntPrefixControl),     // `TERRAGRUNT_WITH_METADATA`
 		),
 
 		flags.NewFlag(&cli.BoolFlag{
@@ -107,7 +107,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			Usage:       "Disable identification of dependent modules when rendering config.",
 		},
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("render-json-disable-dependent-modules"), terragruntPrefixControl),  // `TG_RENDER_JSON_DISABLE_DEPENDENT_MODULES`
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("json-disable-dependent-modules"), terragruntPrefixControl), // `--terragrunt-json-disable-dependent-modules`, `TERRAGRUNT_JSON_DISABLE_DEPENDENT_MODULES`
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("json-disable-dependent-modules"), terragruntPrefixControl), // `TERRAGRUNT_JSON_DISABLE_DEPENDENT_MODULES`
 		),
 	}
 }

--- a/cli/commands/render/cli.go
+++ b/cli/commands/render/cli.go
@@ -85,6 +85,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			Destination: &opts.OutputPath,
 			Usage:       "The file name that terragrunt should use when rendering the terragrunt.hcl config (next to the unit configuration).",
 		},
+			flags.WithDeprecatedFlagName("json-out", terragruntPrefixControl),                          // `--json-out` (deprecated: use `--out` instead)
 			flags.WithDeprecatedEnvVars(tgPrefix.EnvVars("render-json-out"), terragruntPrefixControl),  // `TG_RENDER_JSON_OUT`
 			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("json-out"), terragruntPrefixControl), // `TERRAGRUNT_JSON_OUT`
 		),

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -117,7 +117,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.OutputFolder,
 			Usage:       "Directory to store plan files.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("out-dir"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("out-dir"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        JSONOutDirFlagName,
@@ -125,7 +125,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.JSONOutputFolder,
 			Usage:       "Directory to store json plan files.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("json-out-dir"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("json-out-dir"), terragruntPrefixControl)),
 
 		// `graph/-grpah` related flags.
 
@@ -154,7 +154,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.TerragruntConfigPath,
 			Usage:       "The path to the Terragrunt config file. Default is terragrunt.hcl.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("config"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("config"), terragruntPrefixControl)),
 
 		NewTFPathFlag(opts, prefix),
 
@@ -165,7 +165,6 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Negative:    true,
 			Destination: &opts.AutoInit,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("no-auto-init"), terragruntPrefixControl),
 			flags.WithDeprecatedFlag(&cli.BoolFlag{
 				EnvVars: terragruntPrefix.EnvVars("auto-init"),
 			}, nil, terragruntPrefixControl)),
@@ -177,7 +176,6 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:       "Don't automatically re-run command in case of transient errors.",
 			Negative:    true,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("no-auto-retry"), terragruntPrefixControl),
 			flags.WithDeprecatedFlag(&cli.BoolFlag{
 				EnvVars: terragruntPrefix.EnvVars("auto-retry"),
 			}, nil, terragruntPrefixControl)),
@@ -189,7 +187,6 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:       "Don't automatically append '-auto-approve' to the underlying OpenTofu/Terraform commands run with 'run --all'.",
 			Negative:    true,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("no-auto-approve"), terragruntPrefixControl),
 			flags.WithDeprecatedFlag(&cli.BoolFlag{
 				EnvVars: terragruntPrefix.EnvVars("auto-approve"),
 			}, nil, terragruntPrefixControl)),
@@ -217,7 +214,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.Source,
 			Usage:       "Download OpenTofu/Terraform configurations from the specified source into a temporary folder, and run Terraform in that temporary folder.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("source"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("source"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        SourceUpdateFlagName,
@@ -225,7 +222,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.SourceUpdate,
 			Usage:       "Delete the contents of the temporary folder to clear out any old, cached source code before downloading new source code into it.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("source-update"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("source-update"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.MapFlag[string, string]{
 			Name:        SourceMapFlagName,
@@ -234,7 +231,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:       "Replace any source URL (including the source URL of a config pulled in with dependency blocks) that has root source with dest.",
 			Splitter:    util.SplitUrls,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("source-map"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("source-map"), terragruntPrefixControl)),
 
 		// Assume IAM Role flags.
 
@@ -244,7 +241,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.IAMRoleOptions.RoleARN,
 			Usage:       "Assume the specified IAM role before executing OpenTofu/Terraform.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("iam-role"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("iam-role"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[int64]{
 			Name:        IAMAssumeRoleDurationFlagName,
@@ -252,7 +249,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.IAMRoleOptions.AssumeRoleDuration,
 			Usage:       "Session duration for IAM Assume Role session.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("iam-assume-role-duration"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("iam-assume-role-duration"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        IAMAssumeRoleSessionNameFlagName,
@@ -260,7 +257,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.IAMRoleOptions.AssumeRoleSessionName,
 			Usage:       "Name for the IAM Assumed Role session.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("iam-assume-role-session-name"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("iam-assume-role-session-name"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        IAMAssumeRoleWebIdentityTokenFlagName,
@@ -279,7 +276,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.IgnoreDependencyErrors,
 			Usage:       "Continue processing Units even if a dependency fails.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("ignore-dependency-errors"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("ignore-dependency-errors"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        QueueIgnoreDAGOrderFlagName,
@@ -287,7 +284,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.IgnoreDependencyOrder,
 			Usage:       "Ignore DAG order for --all commands.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("ignore-dependency-order"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("ignore-dependency-order"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        QueueExcludeExternalFlagName,
@@ -295,7 +292,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.IgnoreExternalDependencies,
 			Usage:       "Ignore external dependencies for --all commands.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("ignore-external-dependencies"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("ignore-external-dependencies"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        QueueIncludeExternalFlagName,
@@ -303,7 +300,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.IncludeExternalDependencies,
 			Usage:       "Include external dependencies for --all commands without asking.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("include-external-dependencies"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("include-external-dependencies"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[int]{
 			Name:        ParallelismFlagName,
@@ -311,7 +308,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.Parallelism,
 			Usage:       "Parallelism for --all commands.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("parallelism"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("parallelism"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        QueueExcludesFileFlagName,
@@ -319,7 +316,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.ExcludesFile,
 			Usage:       "Path to a file with a list of directories that need to be excluded when running *-all commands.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("excludes-file"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("excludes-file"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.SliceFlag[string]{
 			Name:        QueueExcludeDirFlagName,
@@ -327,7 +324,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.ExcludeDirs,
 			Usage:       "Unix-style glob of directories to exclude from the queue of Units to run.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("exclude-dir"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("exclude-dir"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.SliceFlag[string]{
 			Name:        QueueIncludeDirFlagName,
@@ -335,7 +332,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.IncludeDirs,
 			Usage:       "Unix-style glob of directories to include from the queue of Units to run.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("include-dir"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("include-dir"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        InputsDebugFlagName,
@@ -343,7 +340,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.Debug,
 			Usage:       "Write debug.tfvars to working folder to help root-cause issues.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("debug"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("debug"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        UsePartialParseConfigCacheFlagName,
@@ -351,7 +348,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.UsePartialParseConfigCache,
 			Usage:       "Enables caching of includes during partial parsing operations. Will also be used for the --iam-role option if provided.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("use-partial-parse-config-cache"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("use-partial-parse-config-cache"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.SliceFlag[string]{
 			Name:        VersionManagerFileNameFlagName,
@@ -366,7 +363,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.FetchDependencyOutputFromState,
 			Usage:       "The option fetches dependency output directly from the state file instead of using tofu/terraform output.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("fetch-dependency-output-from-state"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("fetch-dependency-output-from-state"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        TFForwardStdoutFlagName,
@@ -374,7 +371,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.ForwardTFStdout,
 			Usage:       "If specified, the output of OpenTofu/Terraform commands will be printed as is, without being integrated into the Terragrunt log.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("forward-tf-stdout"), terragruntPrefixControl),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("forward-tf-stdout"), terragruntPrefixControl),
 			flags.WithDeprecatedFlag(&cli.BoolFlag{
 				Name:    terragruntPrefix.FlagName("include-module-prefix"),
 				EnvVars: terragruntPrefix.EnvVars("include-module-prefix"),
@@ -392,7 +389,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.StrictInclude,
 			Usage:       "If flag is set, only modules under the directories passed in with '--include-dir' will be included.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("strict-include"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("strict-include"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.SliceFlag[string]{
 			Name:        UnitsThatIncludeFlagName,
@@ -400,7 +397,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.ModulesThatInclude,
 			Usage:       "If flag is set, 'run --all' will only run the command against Terragrunt modules that include the specified file.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("modules-that-include"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("modules-that-include"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.SliceFlag[string]{
 			Name:        QueueIncludeUnitsReadingFlagName,
@@ -408,7 +405,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.UnitsReading,
 			Usage:       "If flag is set, 'run --all' will only run the command against Terragrunt units that read the specified file via an HCL function or include.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("queue-include-units-reading"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("queue-include-units-reading"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        BackendBootstrapFlagName,
@@ -423,7 +420,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.FailIfBucketCreationRequired,
 			Usage:       "When this flag is set Terragrunt will fail if the remote state bucket needs to be created.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("fail-on-state-bucket-creation"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("fail-on-state-bucket-creation"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        DisableBucketUpdateFlagName,
@@ -431,7 +428,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.DisableBucketUpdate,
 			Usage:       "When this flag is set Terragrunt will not update the remote state bucket.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("disable-bucket-update"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("disable-bucket-update"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        DisableCommandValidationFlagName,
@@ -439,7 +436,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.DisableCommandValidation,
 			Usage:       "When this flag is set, Terragrunt will not validate the tofu/terraform command.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("disable-command-validation"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("disable-command-validation"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        NoDestroyDependenciesCheckFlagName,
@@ -447,7 +444,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.NoDestroyDependenciesCheck,
 			Usage:       "When this flag is set, Terragrunt will not check for dependent units when destroying.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("no-destroy-dependencies-check"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("no-destroy-dependencies-check"), terragruntPrefixControl)),
 
 		// Terragrunt Provider Cache flags.
 
@@ -457,7 +454,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.ProviderCache,
 			Usage:       "Enables Terragrunt's provider caching.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("provider-cache"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("provider-cache"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        ProviderCacheDirFlagName,
@@ -465,7 +462,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.ProviderCacheDir,
 			Usage:       "The path to the Terragrunt provider cache directory. By default, 'terragrunt/providers' folder in the user cache directory.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("provider-cache-dir"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("provider-cache-dir"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        ProviderCacheTokenFlagName,
@@ -473,7 +470,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.ProviderCacheToken,
 			Usage:       "The token for authentication to the Terragrunt Provider Cache server. By default, assigned automatically.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("provider-cache-token"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("provider-cache-token"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        ProviderCacheHostnameFlagName,
@@ -481,7 +478,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.ProviderCacheHostname,
 			Usage:       "The hostname of the Terragrunt Provider Cache server. By default, 'localhost'.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("provider-cache-hostname"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("provider-cache-hostname"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[int]{
 			Name:        ProviderCachePortFlagName,
@@ -489,7 +486,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.ProviderCachePort,
 			Usage:       "The port of the Terragrunt Provider Cache server. By default, assigned automatically.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("provider-cache-port"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("provider-cache-port"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.SliceFlag[string]{
 			Name:        ProviderCacheRegistryNamesFlagName,
@@ -497,7 +494,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.ProviderCacheRegistryNames,
 			Usage:       "The list of remote registries to cached by Terragrunt Provider Cache server. By default, 'registry.terraform.io', 'registry.opentofu.org'.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("provider-cache-registry-names"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("provider-cache-registry-names"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        AuthProviderCmdFlagName,
@@ -505,7 +502,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.AuthProviderCmd,
 			Usage:       "Run the provided command and arguments to authenticate Terragrunt dynamically when necessary.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("auth-provider-cmd"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("auth-provider-cmd"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.MapFlag[string, string]{
 			Name:     FeatureFlagName,
@@ -520,7 +517,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 				return nil
 			},
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("feature"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("feature"), terragruntPrefixControl)),
 
 		// Terragrunt engine flags.
 
@@ -531,7 +528,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:       "Enable Terragrunt experimental engine.",
 			Hidden:      true,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("experimental-engine"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("experimental-engine"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        EngineCachePathFlagName,
@@ -540,7 +537,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:       "Cache path for Terragrunt engine files.",
 			Hidden:      true,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("engine-cache-path"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("engine-cache-path"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        EngineSkipCheckFlagName,
@@ -549,7 +546,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:       "Skip checksum check for Terragrunt engine files.",
 			Hidden:      true,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("engine-skip-check"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("engine-skip-check"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        EngineLogLevelFlagName,
@@ -558,7 +555,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:       "Terragrunt engine log level.",
 			Hidden:      true,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("engine-log-level"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("engine-log-level"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        SummaryDisableFlagName,
@@ -661,6 +658,6 @@ func NewTFPathFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.
 				return nil
 			},
 		},
-		flags.WithDeprecatedNames(terragruntPrefix.FlagNames("tfpath"), terragruntPrefixControl),
+		flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("tfpath"), terragruntPrefixControl),
 	)
 }

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -4,7 +4,6 @@ package run
 import (
 	"fmt"
 	"path/filepath"
-	"strconv"
 
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -135,7 +134,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.GraphRoot,
 			Usage:       "Root directory from where to build graph dependencies.",
 		},
-			flags.WithDeprecatedName(terragruntPrefix.FlagName("graph-root"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("graph-root"), terragruntPrefixControl)),
 
 		// `--all` and `--graph` related flags.
 
@@ -203,9 +202,11 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			EnvVars:     tgPrefix.EnvVars(DownloadDirFlagName),
 			Destination: &opts.DownloadDir,
 			Usage:       "The path to download OpenTofu/Terraform modules into. Default is .terragrunt-cache in the working directory.",
-		}, flags.WithDeprecatedNamesEnvVars(
-			terragruntPrefix.FlagNames("download-dir"),
-			terragruntPrefix.EnvVars("download"),
+		}, flags.WithDeprecatedEnvVars(
+			append(
+				terragruntPrefix.EnvVars("download"),
+				terragruntPrefix.EnvVars("download-dir")...,
+			),
 			terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
@@ -265,10 +266,14 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.IAMRoleOptions.WebIdentityToken,
 			Usage:       "For AssumeRoleWithWebIdentity, the WebIdentity token.",
 		},
-			flags.WithDeprecatedNamesEnvVars(
-				terragruntPrefix.FlagNames("iam-web-identity-token"),
-				terragruntPrefix.EnvVars("iam-assume-role-web-identity-token"),
-				terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(
+				append(
+					terragruntPrefix.EnvVars("iam-web-identity-token"),
+					terragruntPrefix.EnvVars("iam-assume-role-web-identity-token")...,
+				),
+				terragruntPrefixControl,
+			),
+		),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        QueueIgnoreErrorsFlagName,
@@ -372,16 +377,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:       "If specified, the output of OpenTofu/Terraform commands will be printed as is, without being integrated into the Terragrunt log.",
 		},
 			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("forward-tf-stdout"), terragruntPrefixControl),
-			flags.WithDeprecatedFlag(&cli.BoolFlag{
-				Name:    terragruntPrefix.FlagName("include-module-prefix"),
-				EnvVars: terragruntPrefix.EnvVars("include-module-prefix"),
-				Usage:   "When this flag is set output from Terraform sub-commands is prefixed with module path.",
-				Action: func(_ *cli.Context, _ bool) error {
-					l.Warnf("The --include-module-prefix flag is deprecated. Use the functionality-inverted --%s flag instead. By default, Terraform/OpenTofu output is integrated into the Terragrunt log, which prepends additional data, such as timestamps and prefixes, to log entries.", TFForwardStdoutFlagName)
-
-					return nil
-				},
-			}, flags.NewValue(strconv.FormatBool(false)), legacyLogsControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("include-module-prefix"), legacyLogsControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        QueueStrictIncludeFlagName,

--- a/cli/flags/global/flags.go
+++ b/cli/flags/global/flags.go
@@ -200,23 +200,9 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			},
 		},
 			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedLogFormatFlagName), terragruntPrefixControl),
-			flags.WithDeprecatedFlag(&cli.BoolFlag{
-				Name:        terragruntPrefix.FlagName(DeprecatedDisableLogFormattingFlagName),
-				EnvVars:     terragruntPrefix.EnvVars(DeprecatedDisableLogFormattingFlagName),
-				Destination: &opts.DisableLogFormatting,
-				Usage:       "If specified, logs will be displayed in key/value format. By default, logs are formatted in a human readable format.",
-			}, flags.NewValue(format.KeyValueFormatName), legacyLogsControl),
-			flags.WithDeprecatedFlag(&cli.BoolFlag{
-				Name:        terragruntPrefix.FlagName(DeprecatedJSONLogFlagName),
-				EnvVars:     terragruntPrefix.EnvVars(DeprecatedJSONLogFlagName),
-				Destination: &opts.JSONLogFormat,
-				Usage:       "If specified, Terragrunt will output its logs in JSON format.",
-			}, flags.NewValue(format.JSONFormatName), legacyLogsControl),
-			flags.WithDeprecatedFlag(&cli.BoolFlag{
-				Name:    terragruntPrefix.FlagName(DeprecatedTfLogJSONFlagName),
-				EnvVars: terragruntPrefix.EnvVars(DeprecatedTfLogJSONFlagName),
-				Usage:   "If specified, Terragrunt will wrap Terraform stdout and stderr in JSON.",
-			}, flags.NewValue(format.JSONFormatName), legacyLogsControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedDisableLogFormattingFlagName), legacyLogsControl),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedJSONLogFlagName), legacyLogsControl),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedTfLogJSONFlagName), legacyLogsControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:    LogCustomFormatFlagName,

--- a/cli/flags/global/flags.go
+++ b/cli/flags/global/flags.go
@@ -150,7 +150,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.WorkingDir,
 			Usage:       "The path to the directory of Terragrunt configurations. Default is current directory.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedWorkingDirFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedWorkingDirFlagName), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:    LogDisableFlagName,
@@ -162,7 +162,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 				return nil
 			},
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedLogDisableFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedLogDisableFlagName), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        ShowLogAbsPathsFlagName,
@@ -170,7 +170,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.LogShowAbsPaths,
 			Usage:       "Show absolute paths in logs.",
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedShowLogAbsPathsFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedShowLogAbsPathsFlagName), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:    NoColorFlagName,
@@ -181,7 +181,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 				return nil
 			},
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedNoColorFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedNoColorFlagName), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:    LogFormatFlagName,
@@ -199,7 +199,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 				return nil
 			},
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedLogFormatFlagName), terragruntPrefixControl),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedLogFormatFlagName), terragruntPrefixControl),
 			flags.WithDeprecatedFlag(&cli.BoolFlag{
 				Name:        terragruntPrefix.FlagName(DeprecatedDisableLogFormattingFlagName),
 				EnvVars:     terragruntPrefix.EnvVars(DeprecatedDisableLogFormattingFlagName),
@@ -224,7 +224,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:   "Set the custom log formatting.",
 			Setter:  l.Formatter().SetCustomFormat,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedLogCustomFormatFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedLogCustomFormatFlagName), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        NonInteractiveFlagName,
@@ -232,7 +232,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.NonInteractive,
 			Usage:       `Assume "yes" for all prompts.`,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedNonInteractiveFlagName), terragruntPrefixControl),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedNonInteractiveFlagName), terragruntPrefixControl),
 			flags.WithDeprecatedFlag(&cli.BoolFlag{
 				Negative: true,
 				EnvVars:  flags.Prefix{}.EnvVars(DeprecatedTFInputFlagName),
@@ -250,7 +250,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 				return nil
 			},
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedExperimentModeFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedExperimentModeFlagName), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.SliceFlag[string]{
 			Name:    ExperimentFlagName,
@@ -263,7 +263,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 				return nil
 			},
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedExperimentFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedExperimentFlagName), terragruntPrefixControl)),
 
 		// Strict Mode flags.
 
@@ -282,7 +282,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 				return nil
 			},
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedStrictModeFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedStrictModeFlagName), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.SliceFlag[string]{
 			Name:    StrictControlFlagName,
@@ -297,7 +297,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 				return nil
 			},
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedStrictControlFlagName), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedStrictControlFlagName), terragruntPrefixControl)),
 	}
 
 	flags = flags.Add(NewTelemetryFlags(opts, nil)...)
@@ -318,22 +318,22 @@ func NewTelemetryFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli
 			EnvVars:     tgPrefix.EnvVars(TelemetryTraceExporterFlagName),
 			Destination: &opts.Telemetry.TraceExporter,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("telemetry-trace-exporter"), terragruntPrefixControl),
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("telemerty-trace-exporter"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("telemetry-trace-exporter"), terragruntPrefixControl),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("telemerty-trace-exporter"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			EnvVars:     tgPrefix.EnvVars(TelemetryTraceExporterInsecureEndpointFlagName),
 			Destination: &opts.Telemetry.TraceExporterInsecureEndpoint,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("telemetry-trace-exporter-insecure-endpoint"), terragruntPrefixControl),
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("telemerty-trace-exporter-insecure-endpoint"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("telemetry-trace-exporter-insecure-endpoint"), terragruntPrefixControl),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("telemerty-trace-exporter-insecure-endpoint"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			EnvVars:     tgPrefix.EnvVars(TelemetryTraceExporterHTTPEndpointFlagName),
 			Destination: &opts.Telemetry.TraceExporterHTTPEndpoint,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("telemetry-trace-exporter-http-endpoint"), terragruntPrefixControl),
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("telemerty-trace-exporter-http-endpoint"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("telemetry-trace-exporter-http-endpoint"), terragruntPrefixControl),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("telemerty-trace-exporter-http-endpoint"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			EnvVars:     flags.Prefix{}.EnvVars(TraceparentFlagName),
@@ -343,15 +343,15 @@ func NewTelemetryFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli
 			EnvVars:     tgPrefix.EnvVars(TelemetryMetricExporterFlagName),
 			Destination: &opts.Telemetry.MetricExporter,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("telemetry-metric-exporter"), terragruntPrefixControl),
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("telemerty-metric-exporter"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("telemetry-metric-exporter"), terragruntPrefixControl),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("telemerty-metric-exporter"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			EnvVars:     tgPrefix.EnvVars(TelemetryMetricExporterInsecureEndpointFlagName),
 			Destination: &opts.Telemetry.MetricExporterInsecureEndpoint,
 		},
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("telemetry-metric-exporter-insecure-endpoint"), terragruntPrefixControl),
-			flags.WithDeprecatedNames(terragruntPrefix.FlagNames("telemerty-metric-exporter-insecure-endpoint"), terragruntPrefixControl)),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("telemetry-metric-exporter-insecure-endpoint"), terragruntPrefixControl),
+			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("telemerty-metric-exporter-insecure-endpoint"), terragruntPrefixControl)),
 	}
 }
 
@@ -381,7 +381,7 @@ func NewLogLevelFlag(l log.Logger, opts *options.TerragruntOptions, prefix flags
 
 			return nil
 		},
-	}, flags.WithDeprecatedNames(terragruntPrefix.FlagNames(DeprecatedLogLevelFlagName), terragruntPrefixControl))
+	}, flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedLogLevelFlagName), terragruntPrefixControl))
 }
 
 func NewHelpVersionFlags(l log.Logger, opts *options.TerragruntOptions) cli.Flags {

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -163,6 +163,7 @@ func New() strict.Controls {
 			Name:        TerragruntPrefixFlags,
 			Description: "Prevents deprecated flags with `terragrunt-` prefixes from being used.",
 			Category:    stageCategory,
+			Status:      strict.CompletedStatus,
 		},
 		&Control{
 			Name:        TerragruntPrefixEnvVars,

--- a/test/fixtures/destroy-order/hello/main.tf
+++ b/test/fixtures/destroy-order/hello/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "hashicorp/null"
-      version = "3.2.3"
+      version = ">= 3.0.0"
     }
   }
 }

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -311,7 +311,7 @@ func TestRenderJSONConfigWithIncludesDependenciesAndLocals(t *testing.T) {
 
 	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --log-level trace --working-dir "+workDir+" -- apply -auto-approve")
 
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --non-interactive --log-level trace --working-dir %s --json --write --out %s", workDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --non-interactive --log-level trace --working-dir %s --json-out ", workDir)+jsonOut)
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -311,7 +311,7 @@ func TestRenderJSONConfigWithIncludesDependenciesAndLocals(t *testing.T) {
 
 	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --log-level trace --working-dir "+workDir+" -- apply -auto-approve")
 
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --non-interactive --log-level trace --working-dir %s --json-out ", workDir)+jsonOut)
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render --non-interactive --log-level trace --working-dir %s --json --write --out %s", workDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -99,15 +99,12 @@ func TestTerragruntValidateInputs(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, module := range moduleDirs {
-		// capture range var within range scope so it doesn't change as the tests are spun to the background in the
-		// t.Parallel call.
-
 		name := filepath.Base(module)
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
 			nameDashSplit := strings.Split(name, "-")
-			helpers.RunTerragruntValidateInputs(t, module, []string{"--strict-validate"}, nameDashSplit[0] == "success")
+			helpers.RunTerragruntValidateInputs(t, module, []string{"--strict"}, nameDashSplit[0] == "success")
 		})
 	}
 }
@@ -151,7 +148,7 @@ func TestTerragruntValidateInputsWithStrictModeEnabledAndUnusedVar(t *testing.T)
 	t.Parallel()
 
 	moduleDir := filepath.Join("fixtures/validate-inputs", "success-inputs-only")
-	args := []string{"-var=testvariable=testvalue", "--strict-validate"}
+	args := []string{"-var=testvariable=testvalue", "--strict"}
 	helpers.RunTerragruntValidateInputs(t, moduleDir, args, false)
 }
 
@@ -163,7 +160,7 @@ func TestTerragruntValidateInputsWithStrictModeEnabledAndUnusedInputs(t *testing
 	tmpEnvPath, _ := filepath.EvalSymlinks(helpers.CopyEnvironment(t, moduleDir))
 	rootPath := util.JoinPath(tmpEnvPath, moduleDir)
 
-	args := []string{"--strict-validate"}
+	args := []string{"--strict"}
 	helpers.RunTerragruntValidateInputs(t, rootPath, args, false)
 }
 

--- a/test/integration_deprecated_test.go
+++ b/test/integration_deprecated_test.go
@@ -29,7 +29,7 @@ func TestDeprecatedHclvalidateCommand_HclvalidateInvalidConfigPath(t *testing.T)
 		filepath.Join(rootPath, "second/c/terragrunt.hcl"),
 	}
 
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt hclvalidate --terragrunt-working-dir %s --terragrunt-hclvalidate-json --terragrunt-hclvalidate-show-config-path", rootPath))
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt hclvalidate --working-dir %s --json --show-config-path", rootPath))
 	require.Error(t, err)
 
 	var actualPaths []string
@@ -68,7 +68,7 @@ func TestDeprecatedDefaultCommand_TerraformSubcommandCliArgs(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cmd := fmt.Sprintf("terragrunt %s --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s", strings.Join(tc.command, " "), testFixtureExtraArgsPath)
+		cmd := fmt.Sprintf("terragrunt %s --non-interactive --log-level trace --working-dir %s", strings.Join(tc.command, " "), testFixtureExtraArgsPath)
 
 		var (
 			stdout bytes.Buffer
@@ -94,7 +94,7 @@ func TestDeprecatedTerragruntInfoCommand_TerragruntInfoError(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err := helpers.RunTerragruntCommand(t, "terragrunt terragrunt-info --terragrunt-non-interactive --terragrunt-working-dir "+testPath, &stdout, &stderr)
+	err := helpers.RunTerragruntCommand(t, "terragrunt terragrunt-info --non-interactive --working-dir "+testPath, &stdout, &stderr)
 	require.NoError(t, err)
 
 	// parse stdout json as InfoOutput
@@ -111,7 +111,7 @@ func TestDeprecatedRenderJsonCommand_RenderJsonDependentModulesMetadataTerraform
 	tmpDir := util.JoinPath(tmpEnvPath, testFixtureDestroyWarning, "vpc")
 
 	jsonOut := filepath.Join(tmpDir, "terragrunt_rendered.json")
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --terragrunt-non-interactive --terragrunt-log-level trace --terragrunt-working-dir %s  --terragrunt-json-out %s", tmpDir, jsonOut))
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt render-json --with-metadata --non-interactive --log-level trace --working-dir %s  --json-out %s", tmpDir, jsonOut))
 
 	jsonBytes, err := os.ReadFile(jsonOut)
 	require.NoError(t, err)

--- a/test/integration_regressions_test.go
+++ b/test/integration_regressions_test.go
@@ -93,7 +93,7 @@ func TestIncludeError(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRegressions)
 	rootPath := util.JoinPath(tmpEnvPath, testFixtureRegressions, "include-error", "project", "app")
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir "+rootPath)
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --non-interactive --working-dir "+rootPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "include blocks without label")
 }

--- a/test/integration_runner_pool_test.go
+++ b/test/integration_runner_pool_test.go
@@ -67,7 +67,7 @@ func TestRunnerPoolTerragruntDestroyOrder(t *testing.T) {
 	// Parse the destruction order from stdout
 	var destroyOrder []string
 	re := regexp.MustCompile(`Hello, Module ([A-Za-z]+)`)
-	for _, line := range strings.Split(stdout, "\n") {
+	for line := range strings.SplitSeq(stdout, "\n") {
 		if match := re.FindStringSubmatch(line); match != nil {
 			destroyOrder = append(destroyOrder, "module-"+strings.ToLower(match[1]))
 		}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -231,7 +231,7 @@ func TestDetailedExitCodeFailOnFirstRun(t *testing.T) {
 	ctx := t.Context()
 	ctx = tf.ContextWithDetailedExitCode(ctx, &exitCode)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutputWithContext(t, ctx, "terragrunt run-all plan --terragrunt-log-level trace --terragrunt-non-interactive -detailed-exitcode --terragrunt-working-dir "+util.JoinPath(tmpEnvPath, testFixturePath))
+	_, _, err := helpers.RunTerragruntCommandWithOutputWithContext(t, ctx, "terragrunt run --all --log-level trace --non-interactive --working-dir "+util.JoinPath(tmpEnvPath, testFixturePath)+" -- plan -detailed-exitcode")
 	require.NoError(t, err)
 	assert.Equal(t, 0, exitCode.Get())
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -273,7 +273,7 @@ func TestDetailedExitCodeNoChanges(t *testing.T) {
 	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all apply --log-level trace --non-interactive --working-dir "+rootPath)
 	require.NoError(t, err)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutputWithContext(t, ctx, "terragrunt run --all --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir "+rootPath+" -- plan -detailed-exitcode")
+	_, _, err = helpers.RunTerragruntCommandWithOutputWithContext(t, ctx, "terragrunt run --all --log-level trace --non-interactive --working-dir "+rootPath+" -- plan -detailed-exitcode")
 	require.NoError(t, err)
 	assert.Equal(t, 0, exitCode.Get())
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -252,7 +252,7 @@ func TestDetailedExitCodeChangesPresentOne(t *testing.T) {
 	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all apply --log-level trace --non-interactive --working-dir "+filepath.Join(rootPath, "app1"))
 	require.NoError(t, err)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutputWithContext(t, ctx, "terragrunt run --all --terragrunt-log-level trace --terragrunt-non-interactive --terragrunt-working-dir "+rootPath+" -- plan -detailed-exitcode")
+	_, _, err = helpers.RunTerragruntCommandWithOutputWithContext(t, ctx, "terragrunt run --all --log-level trace --non-interactive --working-dir "+rootPath+" -- plan -detailed-exitcode")
 	require.NoError(t, err)
 	assert.Equal(t, 2, exitCode.Get())
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4597.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Removed support for legacy `--terragrunt-` prefixed flags. Only modern flag names are supported going forward.

For more information, see the [migration guide](https://terragrunt.gruntwork.io/docs/migrate/cli-redesign/).

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Deprecation warnings unified to trigger via environment variables (not CLI flag-name aliases) across commands and global options; flag behavior unchanged.
- Bug Fixes
  - Telemetry env vars accept both correct and previously misspelled keys for compatibility.
- Chores
  - Standardized deprecation messaging for many options (auto-init/retry/approve, tfpath, downloads, output/metadata).
  - Tests and examples updated to use current standard CLI flags instead of legacy terragrunt-prefixed names; provider constraint loosened in a test fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->