### PR TITLE
fix: Fixing bad link to `stack output` command

### DIFF
--- a/docs/_docs/02_features/02-stacks.md
+++ b/docs/_docs/02_features/02-stacks.md
@@ -553,7 +553,7 @@ If real outputs only contain `vpc_id`, `dependency.outputs` will contain a real 
 
 When defining a stack using a `terragrunt.stack.hcl` file, you also have the ability to interact with the aggregated outputs of all the units in the stack.
 
-To do this, use the [`stack output`](/docs/reference/cli/commands/stack/output) command (not the [`stack run output`](/docs/reference/cli/commands/stack/run) command).
+To do this, use the [`stack output`](/docs/reference/cli-options/#stack-output) command (not the [`stack run output`](/docs/reference/cli/commands/stack/run) command).
 
 ```bash
 $ terragrunt stack output


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes bad link to `stack output`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated two references in the Stacks feature documentation to point the stack-output help text to the new CLI options page.
  * Replaced links from the old command reference to /docs/reference/cli-options/#stack-output for improved accuracy and navigation.
  * No functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->