### PR TITLE
fix: Fixing `find_in_parent_folders` for `terragrunt.stack.hcl` files

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -272,9 +272,6 @@ func getPathToRepoRoot(ctx *ParsingContext, l log.Logger) (string, error) {
 // GetTerragruntDir returns the directory where the Terragrunt configuration file lives.
 func GetTerragruntDir(ctx *ParsingContext, l log.Logger) (string, error) {
 	path := ctx.TerragruntOptions.TerragruntConfigPath
-	if val, ok := ctx.Context.Value(stackParserContext{}).(stackParserContext); ok {
-		path = val.stackConfigFile
-	}
 
 	terragruntConfigFileAbsPath, err := filepath.Abs(path)
 	if err != nil {

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -368,7 +367,7 @@ unit "test" {
 	require.NoError(t, err)
 	opts.WorkingDir = tempDir
 
-	stackConfig, err := config.ReadStackConfigFile(context.Background(), l, opts, stackHclPath, nil)
+	stackConfig, err := config.ReadStackConfigFile(t.Context(), l, opts, stackHclPath, nil)
 	require.NoError(t, err)
 	require.NotNil(t, stackConfig)
 

--- a/config/stack.go
+++ b/config/stack.go
@@ -74,10 +74,6 @@ type Stack struct {
 	Path         string     `hcl:"path,attr"`
 }
 
-type stackParserContext struct {
-	stackConfigFile string
-}
-
 // GenerateStacks generates the stack files.
 func GenerateStacks(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
 	processedFiles := make(map[string]bool)
@@ -693,8 +689,10 @@ func (u *Unit) ReadOutputs(ctx context.Context, l log.Logger, opts *options.Terr
 func ReadStackConfigFile(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, filePath string, values *cty.Value) (*StackConfig, error) {
 	l.Debugf("Reading Terragrunt stack config file at %s", filePath)
 
-	ctx = context.WithValue(ctx, stackParserContext{}, stackParserContext{stackConfigFile: filePath})
-	parser := NewParsingContext(ctx, l, opts)
+	stackOpts := opts.Clone()
+	stackOpts.TerragruntConfigPath = filePath
+
+	parser := NewParsingContext(ctx, l, stackOpts)
 
 	file, err := hclparse.NewParser(parser.ParserOptions...).ParseFromFile(filePath)
 	if err != nil {

--- a/test/fixtures/stacks/find-in-parent-folders/live/stack/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/find-in-parent-folders/live/stack/terragrunt.stack.hcl
@@ -1,0 +1,13 @@
+locals {
+  mock_vars = read_terragrunt_config(find_in_parent_folders("mock.hcl"))
+  mock       = local.mock_vars.locals.mock
+}
+
+unit "foo" {
+  source = "../../units/foo"
+  path   = "foo"
+
+  values = {
+    mock = local.mock
+  }
+}

--- a/test/fixtures/stacks/find-in-parent-folders/mock.hcl
+++ b/test/fixtures/stacks/find-in-parent-folders/mock.hcl
@@ -1,0 +1,3 @@
+locals {
+  mock = "mock"
+}

--- a/test/fixtures/stacks/find-in-parent-folders/units/foo/main.tf
+++ b/test/fixtures/stacks/find-in-parent-folders/units/foo/main.tf
@@ -1,0 +1,8 @@
+variable "mock" {
+  description = "Mock value to be passed through"
+  type        = string
+}
+
+output "mock" {
+  value = var.mock
+}

--- a/test/fixtures/stacks/find-in-parent-folders/units/foo/terragrunt.hcl
+++ b/test/fixtures/stacks/find-in-parent-folders/units/foo/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  mock = values.mock
+}

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -50,6 +50,7 @@ const (
 	testFixtureStackTerragruntDir              = "fixtures/stacks/terragrunt-dir"
 	testFixtureStacksAllNoStackDir             = "fixtures/stacks/all-no-stack-dir"
 	testFixtureStackNoDotTerragruntStackOutput = "fixtures/stacks/no-dot-terragrunt-stack-output"
+	testFixtureStackFindInParentFolders        = "fixtures/stacks/find-in-parent-folders"
 )
 
 func TestStacksGenerateBasicWithQueueIncludeDirFlag(t *testing.T) {
@@ -1392,4 +1393,48 @@ func TestStackOutputWithNoDotTerragruntStack(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, stdout, "name = \"app1\"")
+}
+
+func TestStackFindInParentFolders(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackFindInParentFolders)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackFindInParentFolders)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureStackFindInParentFolders, "live")
+
+	// Test that stack generation works from the live directory
+	helpers.RunTerragrunt(t, "terragrunt stack generate --working-dir "+rootPath)
+
+	// Verify that the stack directory was created and contains the expected unit
+	stackDir := util.JoinPath(rootPath, "stack", ".terragrunt-stack")
+	validateStackDir(t, stackDir)
+
+	// Verify that the foo unit was generated
+	fooUnitPath := util.JoinPath(stackDir, "foo")
+	assert.True(t, util.FileExists(fooUnitPath), "Expected foo unit to exist in .terragrunt-stack directory")
+	assert.True(t, util.FileExists(util.JoinPath(fooUnitPath, "terragrunt.hcl")), "Expected terragrunt.hcl to exist in foo unit")
+
+	// Test that stack generation works from the parent directory (this tests our fix)
+	parentPath := util.JoinPath(tmpEnvPath, testFixtureStackFindInParentFolders)
+	helpers.RunTerragrunt(t, "terragrunt stack generate --working-dir "+parentPath)
+
+	// Verify that the stack directory was created from the parent directory
+	parentStackDir := util.JoinPath(parentPath, "live", "stack", ".terragrunt-stack")
+	validateStackDir(t, parentStackDir)
+
+	// Verify that the foo unit was generated from the parent directory
+	parentFooUnitPath := util.JoinPath(parentStackDir, "foo")
+	assert.True(t, util.FileExists(parentFooUnitPath), "Expected foo unit to exist when generating from parent directory")
+	assert.True(t, util.FileExists(util.JoinPath(parentFooUnitPath, "terragrunt.hcl")), "Expected terragrunt.hcl to exist in foo unit when generating from parent directory")
+
+	stackPath := util.JoinPath(rootPath, "stack")
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack run apply --non-interactive --working-dir "+stackPath)
+	require.NoError(t, err, "Expected stack run apply to succeed")
+
+	outputStdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack output --raw foo.mock --non-interactive --working-dir "+stackPath)
+	require.NoError(t, err, "Expected stack output to succeed")
+
+	// Verify that the mock value from mock.hcl was correctly passed through
+	assert.Equal(t, "mock", strings.TrimSpace(outputStdout), "Expected raw output to contain just the mock value")
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4655.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated implementation of `find_in_parent_folders` to properly support stacks.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Stacks now correctly resolve configuration files located in parent folders, enabling values to flow from parent configs into stack units.
  - Consistent stack generation from both a stack directory and its parent directory.
  - Reliable propagation of raw outputs from units within stacks.

- Refactor
  - Simplified path resolution for stack configuration, improving reliability and reducing hidden dependencies.

- Tests
  - Added unit and integration tests covering parent-folder config resolution, stack generation from multiple locations, and raw output propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->