### PR TITLE
Fix --report-file not created due to cross-device link

### DIFF
--- a/internal/report/writer.go
+++ b/internal/report/writer.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/invopop/jsonschema"
 )
 
@@ -61,7 +62,7 @@ func (r *Report) WriteToFile(path string) error {
 		path = filepath.Join(r.workingDir, path)
 	}
 
-	return os.Rename(tmpFile.Name(), path)
+	return util.MoveFile(tmpFile.Name(), path)
 }
 
 // WriteCSV writes the report to a writer in CSV format.
@@ -192,7 +193,7 @@ func (r *Report) WriteSchemaToFile(path string) error {
 		path = filepath.Join(r.workingDir, path)
 	}
 
-	return os.Rename(tmpFile.Name(), path)
+	return util.MoveFile(tmpFile.Name(), path)
 }
 
 // WriteSchema writes a JSON schema for the report to a writer.

--- a/util/file.go
+++ b/util/file.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
 
@@ -1019,4 +1020,24 @@ func SanitizePath(baseDir string, file string) (string, error) {
 	fullPath := baseDir + string(os.PathSeparator) + fileInfo.Name()
 
 	return fullPath, nil
+}
+
+// MoveFile attempts to rename a file from source to destination, if this fails
+// due to invalid cross-device link it falls back to copying the file contents
+// and deleting the original file.
+func MoveFile(source string, destination string) error {
+	if renameErr := os.Rename(source, destination); renameErr != nil {
+		var sysErr syscall.Errno
+		if errors.As(renameErr, &sysErr) && sysErr == syscall.EXDEV {
+			if moveErr := CopyFile(source, destination); moveErr != nil {
+				return moveErr
+			}
+
+			return os.Remove(source)
+		}
+
+		return renameErr
+	}
+
+	return nil
 }

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -724,3 +724,21 @@ func Test_sanitizePath(t *testing.T) {
 		})
 	}
 }
+
+func TestMoveFile(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	src := filepath.Join(tempDir, "src.txt")
+	dst := filepath.Join(tempDir, "dst.txt")
+
+	require.NoError(t, os.WriteFile(src, []byte("test"), 0644))
+	require.NoError(t, util.MoveFile(src, dst))
+
+	// Verify the file was moved
+	_, err := os.Stat(src)
+	require.True(t, os.IsNotExist(err))
+	contents, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "test", string(contents))
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4674.

Fixes cross-device link errors allowing the --report-file to be created. Does not address writer errors being silently ignored in runall.go and graph.go

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Fixed --report-file failing silently on systems where the temporary directory is on a different partition to the --report-file path

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

