### PR TITLE
Clarify that hooks give you control over exit codes.

### DIFF
--- a/docs-starlight/src/content/docs/02-features/10-hooks.md
+++ b/docs-starlight/src/content/docs/02-features/10-hooks.md
@@ -229,6 +229,12 @@ terraform {
 This configuration will cause Terragrunt to output `Will run OpenTofu` and then `Running OpenTofu` before the call
 to OpenTofu/Terraform.
 
+## Hook exit codes
+
+Hooks allow you to apply more control to the exit code returned by the applicable underlying OpenTofu/Terraform command. If any `before_hook` or `after_hook` returns a non-zero exit code, the Terragrunt command you run against the unit will return a non-zero exit code.
+
+For example, suppose you run `terragrunt apply` on a given unit that has no `before_hook`, but has a non-empty `after-hook`. Because there is no `before_hook` defined, Terragrunt will first run `tofu apply`, and let's assume that succeeds and returns an exit code of `0`. Next, Terragrunt will run your `after_hook`. If that fails and returns an exit code of `1`, the ` the entire `terragrunt apply` operation will return an exit code of `1`, even though the underlying `tofu apply` succeeded.
+
 ## Tflint hook
 
 _Before Hooks_ or _After Hooks_ natively support _tflint_, a linter for OpenTofu/Terraform code. It will validate the


### PR DESCRIPTION
## Description

Update https://terragrunt-v1.gruntwork.io/docs/features/hooks/ to clarify that hooks give you control over exit codes. I learned about this today and couldn't find it in the docs, so hopefully this will be helpful to others!

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added docs on hook exit codes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a “Hook exit codes” section to the Hooks documentation, detailing how non-zero exit codes from before_hook or after_hook propagate to the overall Terragrunt exit code.
  - Included an example showing that a failing after_hook results in a non-zero exit code even if tofu/terraform completes successfully, improving clarity on expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->