### PR TITLE
fix: validate unique paths for includes and dependencies; validate unique block labels for all blocks.

### DIFF
--- a/config/hclparse/file_test.go
+++ b/config/hclparse/file_test.go
@@ -1,0 +1,103 @@
+package hclparse_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/config/hclparse"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateNoDuplicateBlocks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		hclCode     string
+		expectedErr string
+		expectError bool
+	}{
+		{
+			name: "unique dependency blocks",
+			hclCode: `
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+dependency "database" {
+  config_path = "../database"
+}
+`,
+			expectError: false,
+		},
+		{
+			name: "single dependency block",
+			hclCode: `
+dependency "vpc" {
+  config_path = "../vpc"
+}
+`,
+			expectError: false,
+		},
+		{
+			name:        "empty file",
+			hclCode:     ``,
+			expectError: false,
+		},
+		{
+			name: "duplicate dependency blocks",
+			hclCode: `
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+dependency "vpc" {
+  config_path = "../vpc2"
+}
+`,
+			expectError: true,
+			expectedErr: "Duplicate dependency block with label 'vpc' found",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			file, err := hclparse.NewParser().ParseFromString(test.hclCode, "test.hcl")
+			require.NoError(t, err)
+
+			// Determine which struct to decode into based on content
+			if test.name == "empty file" {
+				var decoded struct{}
+				err = file.Decode(&decoded, &hcl.EvalContext{})
+			} else {
+				var decoded config.TerragruntDependency
+				err = file.Decode(&decoded, &hcl.EvalContext{})
+			}
+
+			if test.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateNoDuplicateBlocks_NonSyntaxBody(t *testing.T) {
+	t.Parallel()
+
+	// Test that non-syntax bodies are handled gracefully
+	parser := hclparse.NewParser(hclparse.WithLogger(logger.CreateLogger()))
+	file, err := parser.ParseFromString("", "empty.hcl")
+	require.NoError(t, err)
+
+	var decoded struct{}
+	err = file.Decode(&decoded, &hcl.EvalContext{})
+	assert.NoError(t, err)
+}

--- a/docs-starlight/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -656,9 +656,9 @@ more about the inheritance properties of Terragrunt in the [Filling in remote st
 section](/docs/features/state-backend/#generating-remote-state-settings-with-terragrunt) of the
 "Keep your remote state configuration DRY" use case overview.
 
-You can have more than one `include` block, but each one must have a unique label. It is recommended to always label
-your `include` blocks. Bare includes (`include` block with no label - e.g., `include {}`) are currently supported for
-backward compatibility, but is deprecated usage and support may be removed in the future.
+You can have more than one `include` block, but each one must have a unique label and a unique path. It is recommended to
+always label your `include` blocks. Bare includes (`include` block with no label - e.g., `include {}`) are currently 
+supported for backward compatibility, but is deprecated usage and support may be removed in the future.
 
 `include` blocks support the following arguments:
 
@@ -666,7 +666,7 @@ backward compatibility, but is deprecated usage and support may be removed in th
   must be labeled with a unique name to differentiate it from the other includes. e.g., if you had a block `include
 "remote" {}`, you can reference the relevant exposed data with the expression `include.remote`.
 - `path` (attribute): Specifies the path to a Terragrunt configuration file (the `parent` config) that should be merged
-  with this configuration (the `child` config).
+  with this configuration (the `child` config). Each include block must have a unique path value.
 - `expose` (attribute, optional): Specifies whether or not the included config should be parsed and exposed as a
   variable. When `true`, you can reference the data of the included config under the variable `include`. Defaults to
   `false`. Note that the `include` variable is a map of `include` labels to the parsed configuration value.
@@ -1202,7 +1202,8 @@ in the [Dependencies between modules
 section](/docs/features/stacks#dependencies-between-units) of the
 "Execute Opentofu/Terraform commands on multiple modules at once" use case overview.
 
-You can define more than one `dependency` block. Each label you provide to the block identifies another `dependency`
+You can define more than one `dependency` block, but each one must have a unique label and a unique `config_path`.
+Each label you provide to the block identifies another `dependency`
 that you can reference in your config.
 
 The `dependency` block supports the following arguments:
@@ -1212,7 +1213,8 @@ The `dependency` block supports the following arguments:
   reference the specific dependency output by the name. E.g if you had a block `dependency "vpc"`, you can reference the
   outputs and inputs of this dependency with the expressions `dependency.vpc.outputs` and `dependency.vpc.inputs`.
 - `config_path` (attribute): Path to a Terragrunt module (folder with a `terragrunt.hcl` file) that should be included
-  as a dependency in this configuration.
+  as a dependency in this configuration. Each dependency block must have a unique config_path value. When using `include`
+  configurations, merged dependencies are also validated for unique `config_path` values.
 - `enabled` (attribute): When `false`, excludes the dependency from execution. Defaults to `true`.
 - `skip_outputs` (attribute): When `true`, skip calling `terragrunt output` when processing this dependency. If
   `mock_outputs` is configured, set `outputs` to the value of `mock_outputs`. Otherwise, `outputs` will be set to an


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4700

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added validation for unique dependency config_path values, unique include path values, and duplicate block labels to prevent configuration conflicts.

### Migration Guide

## Breaking Changes

This release adds stricter validation that may cause existing configurations to fail. The following validation errors may occur:

### Duplicate Dependency Config Paths
**Error**: `duplicate config_path '../vpc' found in dependency blocks`

**Fix**: Ensure each dependency block points to a unique config_path. If multiple dependencies were pointing to the same path, update them to point to different modules or consolidate into a single dependency with a more descriptive name.

### Duplicate Include Paths  
**Error**: `duplicate include path '../../terragrunt.hcl' found in include blocks`

**Fix**: Ensure each include block points to a unique file path. If multiple includes were pointing to the same file, remove the duplicate includes or point them to different configuration files.

### Duplicate Block Labels
**Error**: `Duplicate dependency block with label 'vpc' found`

**Fix**: Ensure all blocks of the same type have unique labels. Rename duplicate labels to be more descriptive (e.g., `vpc_primary`, `vpc_secondary`).

## Validation Scope
These validations apply to:
- Direct configuration parsing
- Include file merging (shallow and deep merge)  
- All Terragrunt commands that parse configuration

## No Action Required
If your configurations already follow best practices with unique paths and labels, no changes are needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enforces unique include paths and unique dependency config_path values with clear, actionable errors.
  - Detects and blocks duplicate labeled blocks in configs before decoding.

- Bug Fixes
  - Prevents ambiguous merges and parsing issues caused by duplicate include/dependency definitions.

- Documentation
  - Clarified uniqueness requirements for include paths and dependency config_path.
  - Added include merge_strategy (no_merge, shallow, deep) guidance.
  - Documented new dependency mock_outputs_merge_strategy_with_state (and deprecation of mock_outputs_merge_with_state).
  - Clarified skip_outputs behavior and how mocks interact with state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->