### PR TITLE
fix: pass argument to version flag, e.g. `run -- version -json`

### DIFF
--- a/cli/commands/run/version_command.go
+++ b/cli/commands/run/version_command.go
@@ -18,7 +18,7 @@ func runVersionCommand(ctx context.Context, l log.Logger, opts *options.Terragru
 		}
 	}
 
-	return tf.RunCommand(ctx, l, opts, tf.CommandNameVersion)
+	return tf.RunCommand(ctx, l, opts, opts.TerraformCliArgs...)
 }
 
 func getTfPathFromConfig(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) (string, error) {


### PR DESCRIPTION
## Description

Fixes #4704 pass argument to version flag, e.g. `run -- version -json`

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

fix #4704 : pass argument to version flag, e.g. `run -- version -json`

### Migration Guide

n/a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The run version command now accepts and forwards user-provided Terraform CLI arguments, enabling custom flags and options for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->