### PR TITLE
fix [#4613]: register additional flags in the DAG graph subcommand

### DIFF
--- a/cli/commands/dag/graph/cli.go
+++ b/cli/commands/dag/graph/cli.go
@@ -25,6 +25,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, _ flags.Prefix) *
 		Action: func(ctx *cli.Context) error {
 			return Run(ctx, l, opts)
 		},
+		Flags: run.NewFlags(l, opts, nil),
 	}
 
 	cmd = runall.WrapCommand(l, opts, cmd, run.Run, true)


### PR DESCRIPTION
## Description

fix #4613: register additional flags in the DAG graph subcommand

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

fix #4613: register additional flags in the DAG graph subcommand

