### PR TITLE
Fixes for terragrunt scale page

### DIFF
--- a/docs-starlight/src/components/TSHero.astro
+++ b/docs-starlight/src/components/TSHero.astro
@@ -36,7 +36,7 @@ import TerragruntIcon from '@assets/icons/terragrunt-icon.svg';
               <h1 class="text-4xl md:text-6xl text-white leading-12 m-0">
                 Terragrunt Scale
               </h1>
-              <p class="max-w-[725px] text-lg text-[var(--color-gray-1)]">
+              <p class="max-w-[650px] text-lg text-[var(--color-gray-1)]">
                   Get best-in-class tooling by the creators of Terragrunt to unlock its full potential, helping you efficiently deploy, and maintain your infrastructure without the grunt work.
               </p>
           </div>
@@ -70,7 +70,7 @@ import TerragruntIcon from '@assets/icons/terragrunt-icon.svg';
                   </div>
               </div>
           </div>
-          <div class="flex gap-5 w-full pb-28 md:pb-52">
+          <div class="flex gap-5 w-full pb-28 md:pb-20">
               <a href="#view-plans">
                   <button class="primary-button">View Plans</button>
               </a>
@@ -80,7 +80,7 @@ import TerragruntIcon from '@assets/icons/terragrunt-icon.svg';
         <ThreeColFeatures>
           <ColFeature color="purple">
             <!-- Grunty Mobile -->
-            <div class="lg:hidden absolute top-[-155px] md:top-[-346px] h-[154px] md:h-[345px] w-[161px] md:w-[361px] right-0 z-10">
+            <div class="lg:hidden absolute top-[-155px] lg:top-[-346px] h-[154px] lg:h-[345px] w-[161px] lg:w-[361px] right-0 z-10">
               <Image
                 alt="Grunty"
                 class="max-w-[100%] h-auto"

--- a/docs-starlight/src/components/TSPricing.astro
+++ b/docs-starlight/src/components/TSPricing.astro
@@ -8,7 +8,7 @@ import IconPricingEnterprise from '@assets/icons/terragrunt-pricing-enterprise.s
 ---
 
 <!-- Section -->
-<section class="relative px-5 pt-10 md:pt-36 w-full" id="view-plans">
+<section class="relative px-5 w-full" id="view-plans">
     <!-- upsell -->
     <div class="relative bg-bg-dark overflow-hidden border-[6px] border-[#E6E6E6] rounded-3xl">
         <Image

--- a/docs-starlight/src/components/TSTerragruntPatcher.astro
+++ b/docs-starlight/src/components/TSTerragruntPatcher.astro
@@ -7,7 +7,7 @@ import Divider from '@components/dv-Divider.astro';
 import IconPatcherEyebrow from '@assets/icons/terragrunt-patcher-eyebrow.svg';
 ---
 
-<section class="flex justify-center items-center pt-10 md:pt-36 px-5 md:px-0">
+<section class="flex justify-center items-center px-5 md:px-0">
     <div class="flex flex-col md:flex-row md:w-[680px] lg:w-[900px] md:pr-6 gap-4 md:gap-8">
         <!-- Header Section -->
         <div class="flex w-full sm:w-1/2 flex-col gap-4 md:gap-8 pb-6 md:pl-12">

--- a/docs-starlight/src/components/TSTerragruntPipelines.astro
+++ b/docs-starlight/src/components/TSTerragruntPipelines.astro
@@ -23,7 +23,8 @@ const scaffoldLink = '/docs/features/scaffold';
         <div class="flex flex-col gap-4 md:gap-8 pb-6 md:pb-[60px] md:pl-12 md:pr-8">
             <Eyebrow text="Terragrunt Pipelines" icon={IconTerragruntEyebrow} />
             <h2 class="text-4xl md:text-[42px] font-sans m-0 text-primary">
-              <span class="text-accent">Deploy</span> infra changes with confidence</h2>
+              <span class="text-accent">Deploy</span> infra changes with confidence
+            </h2>
         </div>
 
         <!-- Content Wrapper -->


### PR DESCRIPTION
Hero

Chop padding in half
Remove pointer from Built for
Check for padding and margin inside components



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Style
  - Refined hero layout: narrower lead paragraph for readability and adjusted action area spacing on medium screens.
  - Updated Grunty image responsiveness so larger screens get appropriate sizing/offset, while smaller screens retain current look.
  - Removed excess top padding in “View plans” and Terragrunt Patcher sections for tighter above‑the‑fold content.
  - Minor header formatting in Terragrunt Pipelines with no visual or functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->