### PR TITLE
fix(config): ensure shallow merge respects child values for include_in_copy / exclude_from_copy (#4757)

### DIFF
--- a/config/include.go
+++ b/config/include.go
@@ -307,6 +307,14 @@ func (cfg *TerragruntConfig) Merge(l log.Logger, sourceConfig *TerragruntConfig,
 				cfg.Terraform.CopyTerraformLockFile = sourceConfig.Terraform.CopyTerraformLockFile
 			}
 
+			if sourceConfig.Terraform.IncludeInCopy != nil {
+				cfg.Terraform.IncludeInCopy = sourceConfig.Terraform.IncludeInCopy
+			}
+
+			if sourceConfig.Terraform.ExcludeFromCopy != nil {
+				cfg.Terraform.ExcludeFromCopy = sourceConfig.Terraform.ExcludeFromCopy
+			}
+
 			mergeExtraArgs(l, sourceConfig.Terraform.ExtraArgs, &cfg.Terraform.ExtraArgs)
 
 			mergeHooks(l, sourceConfig.Terraform.BeforeHooks, &cfg.Terraform.BeforeHooks)


### PR DESCRIPTION
## Description

Fixes #4757.

This PR updates the merge logic for `terraform { include_in_copy / exclude_from_copy }` in **shallow include merges**.

### Problem
- Previously, parent values always overrode child values in shallow merges.
- Even when the parent had `nil` lists, the child’s values were dropped.
- This broke expected shallow merge semantics, where **child should win** for simple attributes.

### Solution
- Updated `config/include.go`:
  - Shallow merge: child values now override parent values if non-nil.
  - Parent values are only retained if child does not define them.
- Added unit tests to cover:
  - Parent-only
  - Child-only
  - Both defined → child wins
  - Parent `nil` → child survives
- Deep merge logic is unchanged (already concatenates parent + child correctly).

---

## TODOs

- [x] I authored this code entirely myself  
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)  
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license  
- [x] Update the docs (clarify shallow vs deep merge behavior for copy filters)  
- [x] Run the relevant tests successfully, including pre-commit checks  
- [x] Include release notes  

---

## Release Notes (draft)

Fix: In shallow include merges, child-defined `include_in_copy` / `exclude_from_copy` values in terraform block now override parent values (instead of being ignored).  

### Migration Guide

No breaking changes.  
If you previously had to duplicate `terraform.source` in child configs to make copy filters work, you can now safely define them directly in child configs when using shallow merge.