### PR TITLE
A collection of website polishing

### DIFF
--- a/docs-starlight/src/styles/global.css
+++ b/docs-starlight/src/styles/global.css
@@ -321,6 +321,10 @@ p code {
   margin-bottom: 1.5rem;
 }
 
+.main-pane starlight-file-tree {
+  margin-bottom: 1.8rem;
+}
+
 .main-pane .code {
   font-size: calc(14 / 16 * 1rem);
 }

--- a/docs-starlight/src/styles/global.css
+++ b/docs-starlight/src/styles/global.css
@@ -316,6 +316,11 @@ p code {
   margin-inline: 0;
 }
 
+.main-pane p {
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
 .main-pane .code {
   font-size: calc(14 / 16 * 1rem);
 }

--- a/docs-starlight/src/styles/global.css
+++ b/docs-starlight/src/styles/global.css
@@ -302,6 +302,15 @@ p code {
   padding-left: 0;
 }
 
+#starlight__sidebar details details details {
+  margin-bottom: 0;
+}
+
+#starlight__sidebar details details details summary {
+  margin-top: 0;
+  padding: 0.3em var(--sl-sidebar-item-padding-inline);
+}
+
 .opensourcecard {
   border-left: 0;
 }

--- a/docs-starlight/src/styles/global.css
+++ b/docs-starlight/src/styles/global.css
@@ -1,14 +1,14 @@
-@layer base, starlight, theme, components, utilities;
+@layer base, starlight.base, starlight.reset, starlight.core, starlight.content, starlight.components, starlight.utils, theme, components, utilities;
 @import '@astrojs/starlight-tailwind';
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities);
 
-@import "./buttons.css";
-@import "./contactform.css";
-@import "./lists.css";
+@import "./buttons.css" layer(components);
+@import "./contactform.css" layer(components);
+@import "./lists.css" layer(components);
 
 /* Starlight Fixes */
-@import "./starlight-search.css";
+@import "./starlight-search.css" layer(components);
 
 @font-face {
   font-family: 'Inter';
@@ -308,6 +308,10 @@ p code {
 
 .opensourcecard:last-child {
   border-right: 0;
+}
+
+.main-pane .sl-container {
+  margin-inline: 0;
 }
 
 starlight-toc h2 {

--- a/docs-starlight/src/styles/global.css
+++ b/docs-starlight/src/styles/global.css
@@ -310,8 +310,14 @@ p code {
   border-right: 0;
 }
 
+/* Main pane */
+
 .main-pane .sl-container {
   margin-inline: 0;
+}
+
+.main-pane .code {
+  font-size: calc(14 / 16 * 1rem);
 }
 
 starlight-toc h2 {

--- a/docs-starlight/src/styles/global.css
+++ b/docs-starlight/src/styles/global.css
@@ -282,15 +282,23 @@ p code {
 
 #starlight__sidebar ul li {
   margin: 0;
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
 }
 
 #starlight__sidebar ul li ul li {
   padding-left: 1em;
 }
 
-#starlight__sidebar details summary {
+#starlight__sidebar ul li a {
+  font-size: calc(16 / 16 * 1rem);
+}
+
+#starlight__sidebar details  {
+  padding-left: 0;
+  margin-bottom: 10px;
+}
+
+#starlight__sidebar summary {
+  margin-top: 5px;
   padding-left: 0;
 }
 


### PR DESCRIPTION
This makes a collection of small polish improvements to the Terragrunt website. I have _not_ QA'd this on mobile yet, though I wouldn't expect any of these changes to negatively affect mobile since I'd used `rem` for most changes (which will scale with default font size). 

The changes include:

1. Tighten up the sidebar spacing
2. Standardize the CSS ordering so that dev and prod render the same (previously, there was a large margin to the left of the body text in dev, but not prod)
3. Improve main body formatting



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Refined sidebar layout: adjusted spacing, margins, and link font sizing for clearer navigation.
  - Updated main content styling: improved paragraph line-height, margins, and code font size; standardized container margins.
  - Harmonized component styling via reorganized CSS layers, ensuring consistent appearance across buttons, lists, contact form, and search.
  - Minor padding tweaks for tighter sidebar list items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->