### PR TITLE
fix: Resolving token usage for bucket cleanup

### DIFF
--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -171,11 +171,15 @@ func UniqueID() string {
 }
 
 // CreateS3ClientForTest creates a S3 client we can use at test time. If there are any errors creating the client, fail the test.
-func CreateS3ClientForTest(t *testing.T, awsRegion string) *s3.Client {
+func CreateS3ClientForTest(t *testing.T, awsRegion string, opts ...options.TerragruntOptionsFunc) *s3.Client {
 	t.Helper()
 
 	mockOptions, err := options.NewTerragruntOptionsForTest("aws_s3_test")
 	require.NoError(t, err, "Error creating mockOptions")
+
+	for _, opt := range opts {
+		opt(mockOptions)
+	}
 
 	awsConfig := &awshelper.AwsSessionConfig{Region: awsRegion}
 
@@ -208,7 +212,7 @@ func CreateDynamoDBClientForTest(t *testing.T, awsRegion, awsProfile, iamRoleArn
 func DeleteS3Bucket(t *testing.T, awsRegion string, bucketName string, opts ...options.TerragruntOptionsFunc) error {
 	t.Helper()
 
-	client := CreateS3ClientForTest(t, awsRegion)
+	client := CreateS3ClientForTest(t, awsRegion, opts...)
 
 	t.Logf("Deleting test s3 bucket %s", bucketName)
 

--- a/test/integration_aws_oidc_test.go
+++ b/test/integration_aws_oidc_test.go
@@ -44,9 +44,6 @@ func TestAwsAssumeRoleWebIdentityFile(t *testing.T) {
 
 	token := fetchGitHubOIDCToken(t)
 
-	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
-	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-
 	// These tests need to be run without the static key + secret
 	// used by most AWS tests here.
 	t.Setenv("AWS_ACCESS_KEY_ID", "")
@@ -69,10 +66,13 @@ func TestAwsAssumeRoleWebIdentityFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(tokenFile, []byte(token), 0400))
 
 	defer func() {
-		t.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)
-		t.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey)
-
-		helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName, options.WithIAMRoleARN(role), options.WithIAMWebIdentityToken(token))
+		helpers.DeleteS3Bucket(
+			t,
+			helpers.TerraformRemoteStateS3Region,
+			s3BucketName,
+			options.WithIAMRoleARN(role),
+			options.WithIAMWebIdentityToken(token),
+		)
 	}()
 
 	helpers.CopyAndFillMapPlaceholders(t, originalTerragruntConfigPath, tmpTerragruntConfigFile, map[string]string{
@@ -141,10 +141,6 @@ func TestAwsReadTerragruntAuthProviderCmdWithOIDCRemoteState(t *testing.T) {
 
 	token := fetchGitHubOIDCToken(t)
 
-	// save credentials to restore later
-	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
-	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-
 	// These tests need to be run without the static key + secret
 	// used by most AWS tests here.
 	t.Setenv("AWS_ACCESS_KEY_ID", "")
@@ -167,10 +163,6 @@ func TestAwsReadTerragruntAuthProviderCmdWithOIDCRemoteState(t *testing.T) {
 	require.NotEmpty(t, role)
 
 	defer func() {
-		// set credentials back to original to do removal
-		t.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)
-		t.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey)
-
 		helpers.DeleteS3Bucket(
 			t,
 			helpers.TerraformRemoteStateS3Region,


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes usage of OIDC role assumption in tests for bucket cleanup.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added optional configuration support to the S3 client test helper, enabling more flexible test setups.
  - Propagated test-time options through S3 bucket deletion helpers to ensure consistent configuration.
  - Simplified AWS OIDC integration tests by removing restoration of pre-existing AWS credentials, reducing side effects while preserving test behavior.
  - Minor formatting improvements to test calls for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->