### PR TITLE
Fix issue where global <a> styles applied to some native starlight styles.

### DIFF
--- a/docs-starlight/src/styles/global.css
+++ b/docs-starlight/src/styles/global.css
@@ -398,14 +398,14 @@
   }
 
   /* Global link styling - apply Starlight's link styles everywhere except in sl-markdown-content */
-  a:not(.sl-markdown-content a, .primary-button, .secondary-button) {
+  a:not(.sl-markdown-content a, #starlight__sidebar a, starlight-toc a, .primary-button, .secondary-button) {
     color: var(--color-accent-1);
     text-decoration: underline;
     text-decoration-color: var(--color-accent-1);
     transition: color 0.2s ease, text-decoration-color 0.2s ease;
   }
   
-  a:not(.sl-markdown-content a, .primary-button, .secondary-button):hover {
+  a:not(.sl-markdown-content a, #starlight__sidebar a, starlight-toc a, .primary-button, .secondary-button):hover {
     color: var(--sl-color-accent);
     text-decoration-color: var(--sl-color-accent);
   }


### PR DESCRIPTION
- Fix left sidebar link color and hover:link color
- Fix right table of contents link color

**Before:**
<img width="1897" height="925" alt="image" src="https://github.com/user-attachments/assets/c81f7225-55e4-48d9-9915-cd66992786ff" />

**After:**
<img width="1898" height="922" alt="image" src="https://github.com/user-attachments/assets/2413f60a-669f-4987-bdd4-631589326021" />

This PR is timely because #4787 introduced a regression that this fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated global link styling to exclude links in the documentation sidebar and table of contents. These links now retain their native appearance and no longer inherit the global hover color.
  * Maintains existing styling for all other non-markdown links, improving visual consistency and readability across the docs without affecting primary and secondary button styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->