### PR TITLE
Fix wrongly mentionned TG_DOWNLOAD instead of TG_DOWNLOAD_DIR

### DIFF
--- a/docs-starlight/src/content/docs/04-reference/01-hcl/03-attributes.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/03-attributes.mdx
@@ -112,7 +112,7 @@ Variables loaded in OpenTofu/Terraform will consequently use the following prece
 
 The terragrunt `download_dir` string option can be used to override the default download directory.
 
-The precedence is as follows: `--download-dir` command line option → `TG_DOWNLOAD` env variable →
+The precedence is as follows: `--download-dir` command line option → `TG_DOWNLOAD_DIR` env variable →
 `download_dir` attribute of the `terragrunt.hcl` file in the module directory → `download_dir` attribute of the included
 `terragrunt.hcl`.
 

--- a/docs-starlight/src/content/docs/04-reference/08-terragrunt-cache.md
+++ b/docs-starlight/src/content/docs/04-reference/08-terragrunt-cache.md
@@ -28,6 +28,6 @@ If you are **SURE** you want to delete all the folders that come up in the previ
 find . -type d -name ".terragrunt-cache" -prune -exec rm -rf {} \;
 ```
 
-Also consider setting the `TG_DOWNLOAD` environment variable if you wish to place the cache directories somewhere else.
+Also consider setting the `TG_DOWNLOAD_DIR` environment variable if you wish to place the cache directories somewhere else.
 
 If the reason you are clearing out your Terragrunt cache is that you are struggling with running out of disk space, consider using the [Provider Cache](/docs/features/provider-cache-server) feature to store OpenTofu/Terraform provider plugins in a shared location, as those are typically the largest files stored in the `.terragrunt-cache` directory.


### PR DESCRIPTION
## Description

I'm not sure if there was a change and this doc wasn't update or if this was wrong since inception, but this commit makes the doc converge towards already documented string (eg: [https://github.com/gruntwork-io/terragrunt/blob/v0.87.0/docs-starlight/src/data/flags/download-dir.mdx]())

Also I myself spent time finding out that `TG_DOWNLOAD` is incorrect but `TG_DOWNLOAD_DIR` is correct :) 

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)
n/a

### Migration Guide
n/a