### PR TITLE
Add missing `--terragrunt-tfpath` flag to migration list

### DIFF
--- a/docs-starlight/src/content/docs/07-migrate/03-cli-redesign.md
+++ b/docs-starlight/src/content/docs/07-migrate/03-cli-redesign.md
@@ -120,6 +120,7 @@ Below is a comprehensive mapping of old CLI flag names to their modern counterpa
 | `--terragrunt-source`                             | `--source`                                                |
 | `--terragrunt-strict-include`                     | `--queue-strict-include`                                  |
 | `--terragrunt-strict-validate`                    | `--strict-validate`                                       |
+| `--terragrunt-tfpath`                             | `--tf-path`                                               |
 | `--terragrunt-use-partial-parse-config-cache`     | `--use-partial-parse-config-cache`                        |
 | `--terragrunt-working-dir`                        | `--working-dir`                                           |
 | `--terragrunt-non-interactive`                    | `--non-interactive`                                       |


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

The `--terragrunt-tfpath` flag was removed and replaced with the `--tf-path` flag, but that wasn't reflected in the docs. This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI redesign migration guide to include a new mapping in the Flag Migration table: deprecated --terragrunt-tfpath → new --tf-path.
  * Improves clarity for users transitioning to the updated CLI by explicitly documenting the flag change.
  * No functional changes to the product; this is a documentation-only addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->