### PR TITLE
Updating button destination

### DIFF
--- a/docs-starlight/src/components/TSHero.astro
+++ b/docs-starlight/src/components/TSHero.astro
@@ -71,7 +71,7 @@ import TerragruntIcon from '@assets/icons/terragrunt-icon.svg';
               </div>
           </div>
           <div class="flex gap-5 w-full pb-28 md:pb-20 z-10">
-              <a href="#view-plans">
+              <a href="/contact-tgs">
                   <button class="primary-button">Get Demo</button>
               </a>
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Documentation
  - Updated the “Get Demo” call-to-action on the docs hero to navigate to the Contact TGS page (/contact-tgs) instead of the in-page #view-plans section. Clicking the button now takes users to a dedicated contact page. No other UI or behavior was modified.

- Bug Fixes
  - None

- Chores
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->