### PR TITLE
fix: Fixing race condition for `TestTerragruntExcludesFile`

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -601,8 +601,6 @@ func TestTerragruntExcludesFile(t *testing.T) {
 			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureExcludesFile, ".terragrunt-excludes")
 			rootPath := util.JoinPath(tmpEnvPath, testFixtureExcludesFile)
 
-			helpers.CleanupTerraformFolder(t, testFixtureExcludesFile)
-
 			helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt run apply --all --non-interactive --working-dir %s %s -- -auto-approve", rootPath, tc.flags))
 
 			stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt run output --all --non-interactive --working-dir %s %s", rootPath, tc.flags))

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -580,9 +580,6 @@ func TestLogRawModuleOutput(t *testing.T) {
 func TestTerragruntExcludesFile(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureExcludesFile, ".terragrunt-excludes")
-	rootPath := util.JoinPath(tmpEnvPath, testFixtureExcludesFile)
-
 	testCases := []struct {
 		flags          string
 		expectedOutput []string
@@ -600,6 +597,9 @@ func TestTerragruntExcludesFile(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
 			t.Parallel()
+
+			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureExcludesFile, ".terragrunt-excludes")
+			rootPath := util.JoinPath(tmpEnvPath, testFixtureExcludesFile)
 
 			helpers.CleanupTerraformFolder(t, testFixtureExcludesFile)
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This test is flaky due to collisions on the same directory here. This mitigates the flake.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Each subtest now runs with its own isolated environment for the Terragrunt excludes-file integration test, improving reliability and parallel-run stability.
  * Reduces flakiness by ensuring fresh setup per case.

* **Refactor**
  * Moved environment setup into individual subtests to simplify test flow.
  * No changes to user-facing behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->