### PR TITLE
fix: Add missing IAM fields to include merge logic (#4812)

### DIFF
--- a/config/include.go
+++ b/config/include.go
@@ -251,6 +251,14 @@ func (cfg *TerragruntConfig) Merge(l log.Logger, sourceConfig *TerragruntConfig,
 		cfg.IamAssumeRoleDuration = sourceConfig.IamAssumeRoleDuration
 	}
 
+	if sourceConfig.IamAssumeRoleSessionName != "" {
+		cfg.IamAssumeRoleSessionName = sourceConfig.IamAssumeRoleSessionName
+	}
+
+	if sourceConfig.IamWebIdentityToken != "" {
+		cfg.IamWebIdentityToken = sourceConfig.IamWebIdentityToken
+	}
+
 	if sourceConfig.TerraformVersionConstraint != "" {
 		cfg.TerraformVersionConstraint = sourceConfig.TerraformVersionConstraint
 	}
@@ -379,6 +387,14 @@ func (cfg *TerragruntConfig) DeepMerge(l log.Logger, sourceConfig *TerragruntCon
 
 	if sourceConfig.IamAssumeRoleDuration != nil {
 		cfg.IamAssumeRoleDuration = sourceConfig.IamAssumeRoleDuration
+	}
+
+	if sourceConfig.IamAssumeRoleSessionName != "" {
+		cfg.IamAssumeRoleSessionName = sourceConfig.IamAssumeRoleSessionName
+	}
+
+	if sourceConfig.IamWebIdentityToken != "" {
+		cfg.IamWebIdentityToken = sourceConfig.IamWebIdentityToken
 	}
 
 	if sourceConfig.TerraformVersionConstraint != "" {

--- a/config/include_test.go
+++ b/config/include_test.go
@@ -141,12 +141,22 @@ func TestMergeConfigIntoIncludedConfig(t *testing.T) {
 		{
 			&config.TerragruntConfig{IamWebIdentityToken: "token"},
 			&config.TerragruntConfig{IamWebIdentityToken: "token2"},
-			&config.TerragruntConfig{IamWebIdentityToken: "token2"},
+			&config.TerragruntConfig{IamWebIdentityToken: "token"},
 		},
 		{
 			&config.TerragruntConfig{},
 			&config.TerragruntConfig{IamWebIdentityToken: "token"},
 			&config.TerragruntConfig{IamWebIdentityToken: "token"},
+		},
+		{
+			&config.TerragruntConfig{IamAssumeRoleSessionName: "session"},
+			&config.TerragruntConfig{IamAssumeRoleSessionName: "session2"},
+			&config.TerragruntConfig{IamAssumeRoleSessionName: "session"},
+		},
+		{
+			&config.TerragruntConfig{},
+			&config.TerragruntConfig{IamAssumeRoleSessionName: "session"},
+			&config.TerragruntConfig{IamAssumeRoleSessionName: "session"},
 		},
 		{
 			&config.TerragruntConfig{Terraform: &config.TerraformConfig{CopyTerraformLockFile: &[]bool{false}[0]}},


### PR DESCRIPTION
## Description

Fixes #4812:

- Add `IamWebIdentityToken` and `IamAssumeRoleSessionName` to both `Merge()` and `DeepMerge()` functions
- Test `IamWebIdentityToken` and `IamAssumeRoleSessionName` are merged into config from included config
- Update test case expectation to match consistent merge behaviour (child overrides parent)

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs. (N/A)
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

- Added `IamWebIdentityToken` and `IamAssumeRoleSessionName` to both `Merge()` and `DeepMerge()` functions

### Migration Guide

N/A

