### PR TITLE
fix: always fetch dep output from remote state when selected

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -809,7 +809,8 @@ func getTerragruntOutputJSON(ctx *ParsingContext, l log.Logger, targetConfig str
 
 	ctx.TerragruntOptions.Engine = engineOpts
 
-	if isInit {
+	// Do not fetch from init-ed folder if user has explicitly asked to fetch from state.
+	if isInit && !ctx.TerragruntOptions.FetchDependencyOutputFromState {
 		return getTerragruntOutputJSONFromInitFolder(ctx, l, workingDir, remoteStateTGConfig.GetIAMRoleOptions())
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

There are cases where parallelization might affect an init-ed dir during read, such as when using Terragrunt with Atlantis. In these cases, when a user passes the option to fetch dependency output from (remote) state, it should not use output from init-ed dirs.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated: --fetch-dependency-output-from-state now will always pull directly from state, even when dependency dirs are init-ed.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

