### PR TITLE
fix: Adding synchronization controls to protect queue

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -363,6 +363,7 @@ func (q *Queue) GetReadyWithDependencies() []*Entry {
 func (q *Queue) SetEntryStatus(e *Entry, status Status) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
+
 	e.Status = status
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -141,12 +141,11 @@ func (e *Entry) IsUp() bool {
 
 type Queue struct {
 	Entries  Entries
+	mu       sync.RWMutex
 	FailFast bool
 	// IgnoreDependencyOrder, if set to true, causes the queue to ignore dependencies when fetching ready entries.
 	// When enabled, GetReadyWithDependencies will return all entries with StatusReady, regardless of dependency status.
 	IgnoreDependencyOrder bool
-	// mu protects concurrent access to entry status fields
-	mu sync.RWMutex
 }
 
 type Entries []*Entry
@@ -428,7 +427,7 @@ func (q *Queue) earlyExitDependencies(e *Entry) {
 	}
 
 	for _, dep := range e.Config.Dependencies {
-		depEntry := q.EntryByPath(dep.Path)
+		depEntry := q.entryByPathUnsafe(dep.Path)
 		if depEntry == nil {
 			continue
 		}

--- a/internal/runner/runnerpool/controller.go
+++ b/internal/runner/runnerpool/controller.go
@@ -113,7 +113,7 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 			for _, e := range readyEntries {
 				// log debug which entry is running
 				l.Debugf("Runner Pool Controller: running %s", e.Config.Path)
-				e.Status = queue.StatusRunning
+				dr.q.SetEntryStatus(e, queue.StatusRunning)
 
 				sem <- struct{}{}
 
@@ -151,15 +151,12 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 					}
 
 					l.Debugf("Runner Pool Controller: %s succeeded", ent.Config.Path)
-					ent.Status = queue.StatusSucceeded
+					dr.q.SetEntryStatus(ent, queue.StatusSucceeded)
 				}(e)
 			}
 
-			if len(readyEntries) == 0 {
-				// If no goroutines are running, break
-				if len(sem) == 0 {
-					break
-				}
+			if len(readyEntries) == 0 && len(sem) == 0 {
+				break
 			}
 
 			select {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds an RWMutex to the `Queue` struct to synchronize concurrent access to elements of the queue.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added thread-safety to the Queue struct by introducing an RWMutex to synchronize concurrent access.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

