### PR TITLE
feat: Use better parsing for `--auth-provider-cmd`

### DIFF
--- a/cli/commands/run/creds/providers/externalcmd/provider.go
+++ b/cli/commands/run/creds/providers/externalcmd/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/shell"
+	"github.com/mattn/go-shellwords"
 )
 
 // Provider runs external command that returns a json string with credentials.
@@ -35,15 +36,20 @@ func (provider *Provider) Name() string {
 
 // GetCredentials implements providers.GetCredentials
 func (provider *Provider) GetCredentials(ctx context.Context, l log.Logger) (*providers.Credentials, error) {
-	command := provider.terragruntOptions.AuthProviderCmd
-	if command == "" {
+	if provider.terragruntOptions.AuthProviderCmd == "" {
 		return nil, nil
 	}
 
-	var args []string
+	parser := shellwords.NewParser()
+	parts, err := parser.Parse(provider.terragruntOptions.AuthProviderCmd)
+	if err != nil {
+		return nil, errors.Errorf("failed to parse auth provider command: %w", err)
+	}
 
-	if parts := strings.Fields(command); len(parts) > 1 {
-		command = parts[0]
+	command := parts[0]
+
+	args := []string{}
+	if len(parts) > 1 {
 		args = parts[1:]
 	}
 
@@ -53,7 +59,10 @@ func (provider *Provider) GetCredentials(ctx context.Context, l log.Logger) (*pr
 	}
 
 	if output.Stdout.String() == "" {
-		return nil, errors.Errorf("command %s completed successfully, but the response does not contain JSON string", command)
+		return nil, errors.Errorf(
+			"command %s completed successfully, but the response does not contain JSON string",
+			provider.terragruntOptions.AuthProviderCmd,
+		)
 	}
 
 	resp := &Response{Envs: make(map[string]string)}

--- a/cli/commands/run/creds/providers/externalcmd/provider.go
+++ b/cli/commands/run/creds/providers/externalcmd/provider.go
@@ -41,6 +41,7 @@ func (provider *Provider) GetCredentials(ctx context.Context, l log.Logger) (*pr
 	}
 
 	parser := shellwords.NewParser()
+
 	parts, err := parser.Parse(provider.terragruntOptions.AuthProviderCmd)
 	if err != nil {
 		return nil, errors.Errorf("failed to parse auth provider command: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -241,6 +241,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -786,6 +786,8 @@ github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.4/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-zglob v0.0.6 h1:mP8RnmCgho4oaUYDIDn6GNxYk+qJGUs8fJLn+twYj2A=
 github.com/mattn/go-zglob v0.0.6/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5wrKakiY=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This gets us support for quoting and whitespace handling when parsing the `--auth-provider-cmd` string.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves parsing of external authentication commands, correctly handling quoted arguments and spaces.
  * Provides clearer errors when a command cannot be parsed or when it runs successfully but returns no output.
  * Treats an empty authentication command as a no-op without error.

* **Chores**
  * Adds a new dependency to support shell-style command parsing, enhancing reliability without changing user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->