### PR TITLE
Update 01-quick-start.mdx

### DIFF
--- a/docs-starlight/src/content/docs/01-getting-started/01-quick-start.mdx
+++ b/docs-starlight/src/content/docs/01-getting-started/01-quick-start.mdx
@@ -322,8 +322,6 @@ You can also see what to expect in your filesystem at each step [here](https://g
    - Stores downloaded modules and providers
    - Stores generated files (in this case, the `hi.txt` file will be created under `.terragrunt-cache/[HASH]/[HASH]/hi.txt` rather than directly in the `foo` or `bar` directories)
 
-   With this configuration, the `hi.txt` files will be created directly in the `foo` and `bar` directories instead of the `.terragrunt-cache` directory.
-
    The `.terragrunt-cache` directory is typically added to `.gitignore` files, similar to the `.terraform` directory that OpenTofu generates. You can safely delete this folder at any time, and Terragrunt will recreate it as necessary.
 
    If you want to control where the files are created, you can modify the module to accept an output directory parameter. For example, you can update the `shared/main.tf` file to:
@@ -350,6 +348,7 @@ You can also see what to expect in your filesystem at each step [here](https://g
      content = "Hello from bar, Terragrunt!"
    }
    ```
+   With this configuration, the `hi.txt` files will be created directly in the `foo` and `bar` directories instead of the `.terragrunt-cache` directory.
 
    Similar to the `tofu` CLI, there is a prompt to confirm that you are sure you want to run the command in each unit when performing a command that's potentially destructive. You can skip this prompt by using the `--non-interactive` flag, just as you would with `-auto-approve` in OpenTofu.
 


### PR DESCRIPTION
moved text 
_With this configuration, the `hi.txt` files will be created directly in the `foo` and `bar` directories instead of the \`.terragrunt-cache\` directory._
 to the proper place, as it makes sense only after the code change is described.

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

- [x] I authored this code entirely myself

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated [X].



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configurable output directory option to direct generated files to the target workspace/project folders instead of the cache.

- Documentation
  - Updated Quick Start to include the new output directory configuration and example usage.
  - Clarified guidance on where generated files are written and how this relates to the cache.
  - Reorganized content to surface the new workflow for creating files in project-specific directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->