### PR TITLE
fix: Properly sets discovery context so that `plan -destroy` and `apply -destroy` work right

### DIFF
--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/telemetry"
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/mattn/go-shellwords"
 
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
@@ -45,8 +46,23 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 
 	if opts.QueueConstructAs != "" {
 		d = d.WithParseExclude()
+
+		parser := shellwords.NewParser()
+
+		args, err := parser.Parse(opts.QueueConstructAs)
+		if err != nil {
+			return errors.New(err)
+		}
+
+		cmd := args[0]
+
+		if len(args) > 1 {
+			args = args[1:]
+		}
+
 		d = d.WithDiscoveryContext(&discovery.DiscoveryContext{
-			Cmd: opts.QueueConstructAs,
+			Cmd:  cmd,
+			Args: args,
 		})
 	}
 

--- a/cli/commands/list/list.go
+++ b/cli/commands/list/list.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/telemetry"
+	"github.com/mattn/go-shellwords"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/tree"
@@ -41,8 +42,23 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 	if opts.QueueConstructAs != "" {
 		d = d.WithParseExclude()
 		d = d.WithDiscoverDependencies()
+
+		parser := shellwords.NewParser()
+
+		args, err := parser.Parse(opts.QueueConstructAs)
+		if err != nil {
+			return errors.New(err)
+		}
+
+		cmd := args[0]
+
+		if len(args) > 1 {
+			args = args[1:]
+		}
+
 		d = d.WithDiscoveryContext(&discovery.DiscoveryContext{
-			Cmd: opts.QueueConstructAs,
+			Cmd:  cmd,
+			Args: args,
 		})
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -241,6 +241,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -786,6 +786,8 @@ github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.4/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-zglob v0.0.6 h1:mP8RnmCgho4oaUYDIDn6GNxYk+qJGUs8fJLn+twYj2A=
 github.com/mattn/go-zglob v0.0.6/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5wrKakiY=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/internal/runner/runnerpool/builder.go
+++ b/internal/runner/runnerpool/builder.go
@@ -12,7 +12,12 @@ import (
 )
 
 // Build stack runner using discovery and queueing mechanisms.
-func Build(ctx context.Context, l log.Logger, terragruntOptions *options.TerragruntOptions, opts ...common.Option) (common.StackRunner, error) {
+func Build(
+	ctx context.Context,
+	l log.Logger,
+	terragruntOptions *options.TerragruntOptions,
+	opts ...common.Option,
+) (common.StackRunner, error) {
 	// discovery configurations
 	d := discovery.
 		NewDiscovery(terragruntOptions.WorkingDir).
@@ -23,7 +28,10 @@ func Build(ctx context.Context, l log.Logger, terragruntOptions *options.Terragr
 		WithDiscoverDependencies().
 		WithSuppressParseErrors().
 		WithConfigFilenames([]string{filepath.Base(terragruntOptions.TerragruntConfigPath)}).
-		WithDiscoveryContext(&discovery.DiscoveryContext{Cmd: terragruntOptions.TerraformCommand})
+		WithDiscoveryContext(&discovery.DiscoveryContext{
+			Cmd:  terragruntOptions.TerraformCliArgs.First(),
+			Args: terragruntOptions.TerraformCliArgs.Tail(),
+		})
 
 	// Pass include/exclude directory filters
 	if len(terragruntOptions.IncludeDirs) > 0 {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4853 in the `runner-pool` implementation.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - find and list now support shell-like parsing of configured commands, allowing you to specify an executable with arguments (e.g., quoted/space-separated values).
  - Consistent handling of command and arguments across discovery, improving behavior for multi-argument inputs.
  - Clearer error messages when command parsing fails.

- Chores
  - Added a lightweight dependency to enable shell-style argument parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->