### PR TITLE
Fix docs flag name

### DIFF
--- a/docs-starlight/src/content/docs/06-troubleshooting/03-performance.mdx
+++ b/docs-starlight/src/content/docs/06-troubleshooting/03-performance.mdx
@@ -64,7 +64,7 @@ Terragrunt dependency blocks allow reading inputs directly from other dependenci
 
 The reason for this is that Terragrunt needs to recursively read inputs from dependencies, and their dependencies, all the way down to the ancestral Terragrunt unit they all have in common to be able to expose the inputs to the dependent unit from its direct dependency (as the inputs from the direct dependency might be derived from a dependency of the direct dependency).
 
-You can mitigate this performance penalty by using the `skip-dependency-inputs` strict control.
+You can mitigate this performance penalty by using the `skip-dependencies-inputs` strict control.
 
 Enabling this strict control will activate a breaking change in Terragrunt behavior, making it so that dependency blocks no longer parse dependencies of dependencies, which is required to read inputs from direct dependencies.
 


### PR DESCRIPTION
It's `dependencies`.

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

* Fix performance doc reference to `skip-dependencies-inputs` flag.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Performance Troubleshooting guide to correct the control name from “skip-dependency-inputs” to “skip-dependencies-inputs,” aligning with the strict control terminology.
  * Clarified guidance on enabling the strict control and its effects.
  * Improves accuracy and reduces confusion so users configure the correct setting.
  * No functional changes to behavior or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->