### PR TITLE
docs: Updating docs for `--out-dir` and `--json-out-dir`

### DIFF
--- a/docs-starlight/src/data/flags/json-out-dir.mdx
+++ b/docs-starlight/src/data/flags/json-out-dir.mdx
@@ -6,6 +6,24 @@ env:
   - TG_JSON_OUT_DIR
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="note">
+
+This flag only does anything when used with the `--all` flag for stack runs. It does nothing in single-unit runs.
+
+To generate JSON plan files for a single unit run, use the standard OpenTofu/Terraform [-out flag](https://opentofu.org/docs/cli/commands/plan) like so:
+
+```bash
+terragrunt run -- plan -out=/tmp/tfplan
+```
+
+```bash
+terragrunt run -- show -json /tmp/tfplan > /tmp/tfplan.json
+```
+
+</Aside>
+
 Generates machine-readable plan outputs per unit as `tfplan.json` by invoking `show -json` after the plan is created.
 
 - Requires a plan to exist (e.g. created with `--out-dir`).

--- a/docs-starlight/src/data/flags/out-dir.mdx
+++ b/docs-starlight/src/data/flags/out-dir.mdx
@@ -6,6 +6,20 @@ env:
   - TG_OUT_DIR
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="note">
+
+This flag only does anything when used with the `--all` flag for stack runs. It does nothing in single-unit runs.
+
+To generate plan files for a single unit run, use the standard OpenTofu/Terraform [-out flag](https://opentofu.org/docs/cli/commands/plan) like so:
+
+```bash
+terragrunt run -- plan -out=/tmp/tfplan
+```
+
+</Aside>
+
 Specifies where Terragrunt writes native OpenTofu/Terraform plan files for each unit when running stack operations.
 
 - Plans are written as `tfplan.tfplan` per unit.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4952.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified behavior of json-out-dir and out-dir flags, including how they interact with --all.
  * Added prominent callouts with notes, usage guidance, and example commands.
  * Included an example of generating a tfplan with -out and linked to the relevant plan command.
  * Improved readability and discoverability of flag behavior through structured notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->