### PR TITLE
Docs fix: --source-map explanation

### DIFF
--- a/docs-starlight/src/data/flags/source-map.mdx
+++ b/docs-starlight/src/data/flags/source-map.mdx
@@ -18,7 +18,7 @@ For example:
 terragrunt run plan --source-map "git::ssh://git@github.com/org/repo.git=../local/repo"
 ```
 
-This will replace any source URL that matches `github.com/example/infrastructure//modules/vpc` with `github.com/example/infrastructure//modules/vpc-new`.
+This will replace any source URL that matches `git::ssh://git@github.com/org/repo.git` with `../local/repo`.
 
 <Aside type="caution">
 Source mapping only performs literal matches on the URL portion. For example, a map key of `ssh://git@github.com/org/repo.git` will not match sources of the form `git::ssh://git@github.com/org/repo.git`. The latter requires a map key of `git::ssh://git@github.com/org/repo.git`.


### PR DESCRIPTION
I was looking at --source-map in docs here https://terragrunt.gruntwork.io/docs/reference/cli/commands/run/#source-map. This note made no sense to me, I assume the way I have corrected it is what was intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated source map flag documentation with a revised example demonstrating how to replace git-based source URLs with local path alternatives. This improvement provides clearer implementation guidance for users working with source mapping configurations across different environments while maintaining existing security considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->