### PR TITLE
chore: Updating language in discovery commands

### DIFF
--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -58,7 +58,7 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 	}
 
 	var (
-		cfgs        component.Components
+		components  component.Components
 		discoverErr error
 	)
 
@@ -70,27 +70,27 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		"mode":         opts.Mode,
 		"exclude":      opts.Exclude,
 	}, func(ctx context.Context) error {
-		cfgs, discoverErr = d.Discover(ctx, l, opts.TerragruntOptions)
+		components, discoverErr = d.Discover(ctx, l, opts.TerragruntOptions)
 		return discoverErr
 	})
 	if telemetryErr != nil {
-		l.Debugf("Errors encountered while discovering configurations:\n%s", telemetryErr)
+		l.Debugf("Errors encountered while discovering components:\n%s", telemetryErr)
 	}
 
 	switch opts.Mode {
 	case ModeNormal:
-		cfgs = cfgs.Sort()
+		components = components.Sort()
 	case ModeDAG:
 		err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "find_mode_dag", map[string]any{
 			"working_dir":  opts.WorkingDir,
-			"config_count": len(cfgs),
+			"config_count": len(components),
 		}, func(ctx context.Context) error {
-			q, queueErr := queue.NewQueue(cfgs)
+			q, queueErr := queue.NewQueue(components)
 			if queueErr != nil {
 				return queueErr
 			}
 
-			cfgs = q.Configs()
+			components = q.Components()
 
 			return nil
 		})
@@ -103,15 +103,15 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		return errors.New("invalid mode: " + opts.Mode)
 	}
 
-	var foundCfgs FoundConfigs
+	var foundComponents FoundComponents
 
 	err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "find_discovered_to_found", map[string]any{
 		"working_dir":  opts.WorkingDir,
-		"config_count": len(cfgs),
+		"config_count": len(components),
 	}, func(ctx context.Context) error {
 		var convErr error
 
-		foundCfgs, convErr = discoveredToFound(cfgs, opts)
+		foundComponents, convErr = discoveredToFound(components, opts)
 
 		return convErr
 	})
@@ -121,9 +121,9 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 
 	switch opts.Format {
 	case FormatText:
-		return outputText(l, opts, foundCfgs)
+		return outputText(l, opts, foundComponents)
 	case FormatJSON:
-		return outputJSON(opts, foundCfgs)
+		return outputJSON(opts, foundComponents)
 	default:
 		// This should never happen, because of validation in the command.
 		// If it happens, we want to throw so we can fix the validation.
@@ -131,9 +131,9 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 	}
 }
 
-type FoundConfigs []*FoundConfig
+type FoundComponents []*FoundComponent
 
-type FoundConfig struct {
+type FoundComponent struct {
 	Type component.Kind `json:"type"`
 	Path string         `json:"path"`
 
@@ -143,58 +143,58 @@ type FoundConfig struct {
 	Dependencies []string `json:"dependencies,omitempty"`
 }
 
-func discoveredToFound(configs component.Components, opts *Options) (FoundConfigs, error) {
-	foundCfgs := make(FoundConfigs, 0, len(configs))
+func discoveredToFound(components component.Components, opts *Options) (FoundComponents, error) {
+	foundComponents := make(FoundComponents, 0, len(components))
 	errs := []error{}
 
-	for _, config := range configs {
-		if config.External && !opts.External {
+	for _, c := range components {
+		if c.External && !opts.External {
 			continue
 		}
 
 		if opts.QueueConstructAs != "" {
-			if config.Parsed != nil && config.Parsed.Exclude != nil {
-				if config.Parsed.Exclude.IsActionListed(opts.QueueConstructAs) {
+			if c.Parsed != nil && c.Parsed.Exclude != nil {
+				if c.Parsed.Exclude.IsActionListed(opts.QueueConstructAs) {
 					continue
 				}
 			}
 		}
 
-		relPath, err := filepath.Rel(opts.WorkingDir, config.Path)
+		relPath, err := filepath.Rel(opts.WorkingDir, c.Path)
 		if err != nil {
 			errs = append(errs, errors.New(err))
 
 			continue
 		}
 
-		foundCfg := &FoundConfig{
-			Type: config.Kind,
+		foundComponent := &FoundComponent{
+			Type: c.Kind,
 			Path: relPath,
 		}
 
-		if opts.Exclude && config.Parsed != nil && config.Parsed.Exclude != nil {
-			foundCfg.Exclude = config.Parsed.Exclude.Clone()
+		if opts.Exclude && c.Parsed != nil && c.Parsed.Exclude != nil {
+			foundComponent.Exclude = c.Parsed.Exclude.Clone()
 		}
 
-		if opts.Include && config.Parsed != nil && config.Parsed.ProcessedIncludes != nil {
-			foundCfg.Include = make(map[string]string, len(config.Parsed.ProcessedIncludes))
-			for _, v := range config.Parsed.ProcessedIncludes {
-				foundCfg.Include[v.Name], err = util.GetPathRelativeTo(v.Path, opts.RootWorkingDir)
+		if opts.Include && c.Parsed != nil && c.Parsed.ProcessedIncludes != nil {
+			foundComponent.Include = make(map[string]string, len(c.Parsed.ProcessedIncludes))
+			for _, v := range c.Parsed.ProcessedIncludes {
+				foundComponent.Include[v.Name], err = util.GetPathRelativeTo(v.Path, opts.RootWorkingDir)
 				if err != nil {
 					errs = append(errs, errors.New(err))
 				}
 			}
 		}
 
-		if !opts.Dependencies || len(config.Dependencies()) == 0 {
-			foundCfgs = append(foundCfgs, foundCfg)
+		if !opts.Dependencies || len(c.Dependencies()) == 0 {
+			foundComponents = append(foundComponents, foundComponent)
 
 			continue
 		}
 
-		foundCfg.Dependencies = make([]string, len(config.Dependencies()))
+		foundComponent.Dependencies = make([]string, len(c.Dependencies()))
 
-		for i, dep := range config.Dependencies() {
+		for i, dep := range c.Dependencies() {
 			relDepPath, err := filepath.Rel(opts.WorkingDir, dep.Path)
 			if err != nil {
 				errs = append(errs, errors.New(err))
@@ -202,18 +202,18 @@ func discoveredToFound(configs component.Components, opts *Options) (FoundConfig
 				continue
 			}
 
-			foundCfg.Dependencies[i] = relDepPath
+			foundComponent.Dependencies[i] = relDepPath
 		}
 
-		foundCfgs = append(foundCfgs, foundCfg)
+		foundComponents = append(foundComponents, foundComponent)
 	}
 
-	return foundCfgs, errors.Join(errs...)
+	return foundComponents, errors.Join(errs...)
 }
 
-// outputJSON outputs the discovered configurations in JSON format.
-func outputJSON(opts *Options, configs FoundConfigs) error {
-	jsonBytes, err := json.MarshalIndent(configs, "", "  ")
+// outputJSON outputs the discovered components in JSON format.
+func outputJSON(opts *Options, components FoundComponents) error {
+	jsonBytes, err := json.MarshalIndent(components, "", "  ")
 	if err != nil {
 		return errors.New(err)
 	}
@@ -226,7 +226,7 @@ func outputJSON(opts *Options, configs FoundConfigs) error {
 	return nil
 }
 
-// Colorizer is a colorizer for the discovered configurations.
+// Colorizer is a colorizer for the discovered components.
 type Colorizer struct {
 	unitColorizer  func(string) string
 	stackColorizer func(string) string
@@ -250,15 +250,15 @@ func NewColorizer(shouldColor bool) *Colorizer {
 	}
 }
 
-func (c *Colorizer) Colorize(config *FoundConfig) string {
-	path := config.Path
+func (c *Colorizer) Colorize(foundComponent *FoundComponent) string {
+	path := foundComponent.Path
 
 	// Get the directory and base name using filepath
 	dir, base := filepath.Split(path)
 
 	if dir == "" {
 		// No directory part, color the whole path
-		switch config.Type {
+		switch foundComponent.Type {
 		case component.Unit:
 			return c.unitColorizer(path)
 		case component.Stack:
@@ -271,7 +271,7 @@ func (c *Colorizer) Colorize(config *FoundConfig) string {
 	// Color the components differently
 	coloredPath := c.pathColorizer(dir)
 
-	switch config.Type {
+	switch foundComponent.Type {
 	case component.Unit:
 		return coloredPath + c.unitColorizer(base)
 	case component.Stack:
@@ -281,12 +281,12 @@ func (c *Colorizer) Colorize(config *FoundConfig) string {
 	}
 }
 
-// outputText outputs the discovered configurations in text format.
-func outputText(l log.Logger, opts *Options, configs FoundConfigs) error {
+// outputText outputs the discovered components in text format.
+func outputText(l log.Logger, opts *Options, components FoundComponents) error {
 	colorizer := NewColorizer(shouldColor(l))
 
-	for _, config := range configs {
-		_, err := opts.Writer.Write([]byte(colorizer.Colorize(config) + "\n"))
+	for _, c := range components {
+		_, err := opts.Writer.Write([]byte(colorizer.Colorize(c) + "\n"))
 		if err != nil {
 			return errors.New(err)
 		}

--- a/cli/commands/find/find_test.go
+++ b/cli/commands/find/find_test.go
@@ -139,7 +139,7 @@ func TestRun(t *testing.T) {
 				t.Helper()
 
 				// Verify the output is valid JSON
-				var configs find.FoundConfigs
+				var configs find.FoundComponents
 				err := json.Unmarshal([]byte(output), &configs)
 				require.NoError(t, err)
 
@@ -353,7 +353,7 @@ dependency "B" {
 				t.Helper()
 
 				// Verify the output is valid JSON
-				var configs []find.FoundConfig
+				var configs []find.FoundComponent
 				err := json.Unmarshal([]byte(output), &configs)
 				require.NoError(t, err)
 
@@ -464,14 +464,14 @@ func TestColorizer(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		config *find.FoundConfig
+		config *find.FoundComponent
 		// We can't test exact ANSI codes as they might vary by environment,
 		// so we'll test that different types result in different outputs
 		shouldBeDifferent []component.Kind
 	}{
 		{
 			name: "unit config",
-			config: &find.FoundConfig{
+			config: &find.FoundComponent{
 				Type: component.Unit,
 				Path: "path/to/unit",
 			},
@@ -479,7 +479,7 @@ func TestColorizer(t *testing.T) {
 		},
 		{
 			name: "stack config",
-			config: &find.FoundConfig{
+			config: &find.FoundComponent{
 				Type: component.Stack,
 				Path: "path/to/stack",
 			},
@@ -496,7 +496,7 @@ func TestColorizer(t *testing.T) {
 
 			// Test that different types produce different colorized outputs
 			for _, diffType := range tt.shouldBeDifferent {
-				diffConfig := &find.FoundConfig{
+				diffConfig := &find.FoundComponent{
 					Type: diffType,
 					Path: tt.config.Path,
 				}

--- a/cli/commands/list/list.go
+++ b/cli/commands/list/list.go
@@ -60,7 +60,7 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 	}
 
 	var (
-		cfgs        component.Components
+		components  component.Components
 		discoverErr error
 	)
 
@@ -71,27 +71,27 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		"dependencies": shouldDiscoverDependencies(opts),
 		"external":     opts.External,
 	}, func(ctx context.Context) error {
-		cfgs, discoverErr = d.Discover(ctx, l, opts.TerragruntOptions)
+		components, discoverErr = d.Discover(ctx, l, opts.TerragruntOptions)
 		return discoverErr
 	})
 	if err != nil {
-		l.Debugf("Errors encountered while discovering configurations:\n%s", err)
+		l.Debugf("Errors encountered while discovering components:\n%s", err)
 	}
 
 	switch opts.Mode {
 	case ModeNormal:
-		cfgs = cfgs.Sort()
+		components = components.Sort()
 	case ModeDAG:
 		err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "list_mode_dag", map[string]any{
 			"working_dir":  opts.WorkingDir,
-			"config_count": len(cfgs),
+			"config_count": len(components),
 		}, func(ctx context.Context) error {
-			q, queueErr := queue.NewQueue(cfgs)
+			q, queueErr := queue.NewQueue(components)
 			if queueErr != nil {
 				return queueErr
 			}
 
-			cfgs = q.Configs()
+			components = q.Components()
 
 			return nil
 		})
@@ -104,15 +104,15 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		return errors.New("invalid mode: " + opts.Mode)
 	}
 
-	var listedCfgs ListedConfigs
+	var listedComponents ListedComponents
 
 	err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "list_discovered_to_listed", map[string]any{
 		"working_dir":  opts.WorkingDir,
-		"config_count": len(cfgs),
+		"config_count": len(components),
 	}, func(ctx context.Context) error {
 		var convErr error
 
-		listedCfgs, convErr = discoveredToListed(cfgs, opts)
+		listedComponents, convErr = discoveredToListed(components, opts)
 
 		return convErr
 	})
@@ -122,11 +122,11 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 
 	switch opts.Format {
 	case FormatText:
-		return outputText(l, opts, listedCfgs)
+		return outputText(l, opts, listedComponents)
 	case FormatTree:
-		return outputTree(l, opts, listedCfgs, opts.Mode)
+		return outputTree(l, opts, listedComponents, opts.Mode)
 	case FormatLong:
-		return outputLong(l, opts, listedCfgs)
+		return outputLong(l, opts, listedComponents)
 	default:
 		// This should never happen, because of validation in the command.
 		// If it happens, we want to throw so we can fix the validation.
@@ -151,19 +151,19 @@ func shouldDiscoverDependencies(opts *Options) bool {
 	return false
 }
 
-type ListedConfigs []*ListedConfig
+type ListedComponents []*ListedComponent
 
-type ListedConfig struct {
+type ListedComponent struct {
 	Type component.Kind
 	Path string
 
-	Dependencies []*ListedConfig
+	Dependencies []*ListedComponent
 }
 
-// Contains checks to see if the given path is in the listed configs.
-func (l ListedConfigs) Contains(path string) bool {
-	for _, config := range l {
-		if config.Path == path {
+// Contains checks to see if the given path is in the listed components.
+func (l ListedComponents) Contains(path string) bool {
+	for _, c := range l {
+		if c.Path == path {
 			return true
 		}
 	}
@@ -171,55 +171,55 @@ func (l ListedConfigs) Contains(path string) bool {
 	return false
 }
 
-// Get returns the config with the given path.
-func (l ListedConfigs) Get(path string) *ListedConfig {
-	for _, config := range l {
-		if config.Path == path {
-			return config
+// Get returns the component with the given path.
+func (l ListedComponents) Get(path string) *ListedComponent {
+	for _, c := range l {
+		if c.Path == path {
+			return c
 		}
 	}
 
 	return nil
 }
 
-func discoveredToListed(configs component.Components, opts *Options) (ListedConfigs, error) {
-	listedCfgs := make(ListedConfigs, 0, len(configs))
+func discoveredToListed(components component.Components, opts *Options) (ListedComponents, error) {
+	listedComponents := make(ListedComponents, 0, len(components))
 	errs := []error{}
 
-	for _, config := range configs {
-		if config.External && !opts.External {
+	for _, c := range components {
+		if c.External && !opts.External {
 			continue
 		}
 
 		if opts.QueueConstructAs != "" {
-			if config.Parsed != nil && config.Parsed.Exclude != nil {
-				if config.Parsed.Exclude.IsActionListed(opts.QueueConstructAs) {
+			if c.Parsed != nil && c.Parsed.Exclude != nil {
+				if c.Parsed.Exclude.IsActionListed(opts.QueueConstructAs) {
 					continue
 				}
 			}
 		}
 
-		relPath, err := filepath.Rel(opts.WorkingDir, config.Path)
+		relPath, err := filepath.Rel(opts.WorkingDir, c.Path)
 		if err != nil {
 			errs = append(errs, errors.New(err))
 
 			continue
 		}
 
-		listedCfg := &ListedConfig{
-			Type: config.Kind,
+		listedCfg := &ListedComponent{
+			Type: c.Kind,
 			Path: relPath,
 		}
 
-		if len(config.Dependencies()) == 0 {
-			listedCfgs = append(listedCfgs, listedCfg)
+		if len(c.Dependencies()) == 0 {
+			listedComponents = append(listedComponents, listedCfg)
 
 			continue
 		}
 
-		listedCfg.Dependencies = make([]*ListedConfig, len(config.Dependencies()))
+		listedCfg.Dependencies = make([]*ListedComponent, len(c.Dependencies()))
 
-		for i, dep := range config.Dependencies() {
+		for i, dep := range c.Dependencies() {
 			relDepPath, err := filepath.Rel(opts.WorkingDir, dep.Path)
 			if err != nil {
 				errs = append(errs, errors.New(err))
@@ -227,7 +227,7 @@ func discoveredToListed(configs component.Components, opts *Options) (ListedConf
 				continue
 			}
 
-			listedCfg.Dependencies[i] = &ListedConfig{
+			listedCfg.Dependencies[i] = &ListedComponent{
 				Type: dep.Kind,
 				Path: relDepPath,
 			}
@@ -237,13 +237,13 @@ func discoveredToListed(configs component.Components, opts *Options) (ListedConf
 			return listedCfg.Dependencies[i].Path < listedCfg.Dependencies[j].Path
 		})
 
-		listedCfgs = append(listedCfgs, listedCfg)
+		listedComponents = append(listedComponents, listedCfg)
 	}
 
-	return listedCfgs, errors.Join(errs...)
+	return listedComponents, errors.Join(errs...)
 }
 
-// Colorizer is a colorizer for the discovered configurations.
+// Colorizer is a colorizer for the discovered components.
 type Colorizer struct {
 	unitColorizer    func(string) string
 	stackColorizer   func(string) string
@@ -270,15 +270,15 @@ func NewColorizer(shouldColor bool) *Colorizer {
 	}
 }
 
-func (c *Colorizer) Colorize(config *ListedConfig) string {
-	path := config.Path
+func (c *Colorizer) Colorize(listedComponent *ListedComponent) string {
+	path := listedComponent.Path
 
 	// Get the directory and base name using filepath
 	dir, base := filepath.Split(path)
 
 	if dir == "" {
 		// No directory part, color the whole path
-		switch config.Type {
+		switch listedComponent.Type {
 		case component.Unit:
 			return c.unitColorizer(path)
 		case component.Stack:
@@ -291,7 +291,7 @@ func (c *Colorizer) Colorize(config *ListedConfig) string {
 	// Color the components differently
 	coloredPath := c.pathColorizer(dir)
 
-	switch config.Type {
+	switch listedComponent.Type {
 	case component.Unit:
 		return coloredPath + c.unitColorizer(base)
 	case component.Stack:
@@ -318,18 +318,18 @@ func (c *Colorizer) ColorizeHeading(dep string) string {
 	return c.headingColorizer(dep)
 }
 
-// outputText outputs the discovered configurations in text format.
-func outputText(l log.Logger, opts *Options, configs ListedConfigs) error {
+// outputText outputs the discovered components in text format.
+func outputText(l log.Logger, opts *Options, components ListedComponents) error {
 	colorizer := NewColorizer(shouldColor(l))
 
-	return renderTabular(opts, configs, colorizer)
+	return renderTabular(opts, components, colorizer)
 }
 
-// outputLong outputs the discovered configurations in long format.
-func outputLong(l log.Logger, opts *Options, configs ListedConfigs) error {
+// outputLong outputs the discovered components in long format.
+func outputLong(l log.Logger, opts *Options, components ListedComponents) error {
 	colorizer := NewColorizer(shouldColor(l))
 
-	return renderLong(opts, configs, colorizer)
+	return renderLong(opts, components, colorizer)
 }
 
 // shouldColor returns true if the output should be colored.
@@ -337,36 +337,36 @@ func shouldColor(l log.Logger) bool {
 	return !l.Formatter().DisabledColors() && !stdout.IsRedirected()
 }
 
-// renderLong renders the configurations in a long format.
-func renderLong(opts *Options, configs ListedConfigs, c *Colorizer) error {
-	longestPathLen := getLongestPathLen(configs)
+// renderLong renders the components in a long format.
+func renderLong(opts *Options, components ListedComponents, c *Colorizer) error {
+	longestPathLen := getLongestPathLen(components)
 
 	err := renderLongHeadings(opts, c, longestPathLen)
 	if err != nil {
 		return errors.New(err)
 	}
 
-	for _, config := range configs {
-		_, err := opts.Writer.Write([]byte(c.ColorizeType(config.Type)))
+	for _, component := range components {
+		_, err := opts.Writer.Write([]byte(c.ColorizeType(component.Type)))
 		if err != nil {
 			return errors.New(err)
 		}
 
-		_, err = opts.Writer.Write([]byte(" " + c.Colorize(config)))
+		_, err = opts.Writer.Write([]byte(" " + c.Colorize(component)))
 		if err != nil {
 			return errors.New(err)
 		}
 
-		if opts.Dependencies && len(config.Dependencies) > 0 {
+		if opts.Dependencies && len(component.Dependencies) > 0 {
 			colorizedDeps := []string{}
 
-			for _, dep := range config.Dependencies {
+			for _, dep := range component.Dependencies {
 				colorizedDeps = append(colorizedDeps, c.Colorize(dep))
 			}
 
 			const extraDependenciesPadding = 2
 
-			dependenciesPadding := (longestPathLen - len(config.Path)) + extraDependenciesPadding
+			dependenciesPadding := (longestPathLen - len(component.Path)) + extraDependenciesPadding
 			for range dependenciesPadding {
 				_, err = opts.Writer.Write([]byte(" "))
 				if err != nil {
@@ -421,11 +421,11 @@ func renderLongHeadings(opts *Options, c *Colorizer, longestPathLen int) error {
 	return nil
 }
 
-// renderTabular renders the configurations in a tabular format.
-func renderTabular(opts *Options, configs ListedConfigs, c *Colorizer) error {
-	maxCols, colWidth := getMaxCols(configs)
+// renderTabular renders the components in a tabular format.
+func renderTabular(opts *Options, components ListedComponents, c *Colorizer) error {
+	maxCols, colWidth := getMaxCols(components)
 
-	for i, config := range configs {
+	for i, component := range components {
 		if i > 0 && i%maxCols == 0 {
 			_, err := opts.Writer.Write([]byte("\n"))
 			if err != nil {
@@ -433,13 +433,13 @@ func renderTabular(opts *Options, configs ListedConfigs, c *Colorizer) error {
 			}
 		}
 
-		_, err := opts.Writer.Write([]byte(c.Colorize(config)))
+		_, err := opts.Writer.Write([]byte(c.Colorize(component)))
 		if err != nil {
 			return errors.New(err)
 		}
 
 		// Add padding until the length of maxCols
-		padding := colWidth - len(config.Path)
+		padding := colWidth - len(component.Path)
 		for range padding {
 			_, err := opts.Writer.Write([]byte(" "))
 			if err != nil {
@@ -456,11 +456,11 @@ func renderTabular(opts *Options, configs ListedConfigs, c *Colorizer) error {
 	return nil
 }
 
-// outputTree outputs the discovered configurations in tree format.
-func outputTree(l log.Logger, opts *Options, configs ListedConfigs, sort string) error {
+// outputTree outputs the discovered components in tree format.
+func outputTree(l log.Logger, opts *Options, components ListedComponents, sort string) error {
 	s := NewTreeStyler(shouldColor(l))
 
-	return renderTree(opts, configs, s, sort)
+	return renderTree(opts, components, s, sort)
 }
 
 type TreeStyler struct {
@@ -494,13 +494,13 @@ func (s *TreeStyler) Style(t *tree.Tree) *tree.Tree {
 		RootStyle(s.rootStyle)
 }
 
-// generateTree creates a tree structure from ListedConfigs
-func generateTree(configs ListedConfigs, s *TreeStyler) *tree.Tree {
+// generateTree creates a tree structure from ListedComponents
+func generateTree(components ListedComponents, s *TreeStyler) *tree.Tree {
 	root := tree.Root(".")
 	nodes := make(map[string]*tree.Tree)
 
-	for _, config := range configs {
-		parts := preProcessPath(config.Path)
+	for _, c := range components {
+		parts := preProcessPath(c.Path)
 		if len(parts.segments) == 0 || (len(parts.segments) == 1 && parts.segments[0] == ".") {
 			continue
 		}
@@ -511,14 +511,14 @@ func generateTree(configs ListedConfigs, s *TreeStyler) *tree.Tree {
 		for i, segment := range parts.segments {
 			nextPath := filepath.Join(currentPath, segment)
 			if _, exists := nodes[nextPath]; !exists {
-				configType := component.Stack
+				componentType := component.Stack
 
-				if config.Type == component.Unit && i == len(parts.segments)-1 {
-					configType = component.Unit
+				if c.Type == component.Unit && i == len(parts.segments)-1 {
+					componentType = component.Unit
 				}
 
-				tmpCfg := &ListedConfig{
-					Type: configType,
+				tmpCfg := &ListedComponent{
+					Type: componentType,
 					Path: segment,
 				}
 
@@ -535,37 +535,37 @@ func generateTree(configs ListedConfigs, s *TreeStyler) *tree.Tree {
 	return root
 }
 
-// generateDAGTree creates a tree structure from ListedConfigs.
-// It assumes that the configs are already sorted in DAG order.
-// As such, it will first construct root nodes for each config
-// without a dependency in the listed configs. Then, it will
+// generateDAGTree creates a tree structure from ListedComponents.
+// It assumes that the components are already sorted in DAG order.
+// As such, it will first construct root nodes for each component
+// without a dependency in the listed components. Then, it will
 // connect the remaining nodes to their dependencies, which
-// should be doable in a single pass through the configs.
+// should be doable in a single pass through the components.
 // There may be duplicate entries for dependency nodes, as
-// a node may be a dependency for multiple configs.
+// a node may be a dependency for multiple components.
 // That's OK.
-func generateDAGTree(configs ListedConfigs, s *TreeStyler) *tree.Tree {
+func generateDAGTree(components ListedComponents, s *TreeStyler) *tree.Tree {
 	root := tree.Root(".")
 
 	rootNodes := make(map[string]*tree.Tree)
 	dependencyNodes := make(map[string]*tree.Tree)
 
 	// First pass: create all root nodes
-	for _, config := range configs {
-		if len(config.Dependencies) == 0 || !configs.Contains(config.Path) {
-			rootNodes[config.Path] = tree.New().Root(s.colorizer.Colorize(config))
+	for _, c := range components {
+		if len(c.Dependencies) == 0 || !components.Contains(c.Path) {
+			rootNodes[c.Path] = tree.New().Root(s.colorizer.Colorize(c))
 		}
 	}
 
 	// Second pass: connect dependencies
-	for _, config := range configs {
-		if len(config.Dependencies) == 0 {
+	for _, c := range components {
+		if len(c.Dependencies) == 0 {
 			continue
 		}
 
 		// Sort dependencies to ensure deterministic order
-		sortedDeps := make([]string, len(config.Dependencies))
-		for i, dep := range config.Dependencies {
+		sortedDeps := make([]string, len(c.Dependencies))
+		for i, dep := range c.Dependencies {
 			sortedDeps[i] = dep.Path
 		}
 
@@ -573,17 +573,17 @@ func generateDAGTree(configs ListedConfigs, s *TreeStyler) *tree.Tree {
 
 		for _, dependency := range sortedDeps {
 			if _, exists := rootNodes[dependency]; exists {
-				dependencyNode := tree.New().Root(s.colorizer.Colorize(config))
+				dependencyNode := tree.New().Root(s.colorizer.Colorize(c))
 				rootNodes[dependency].Child(dependencyNode)
-				dependencyNodes[config.Path] = dependencyNode
+				dependencyNodes[c.Path] = dependencyNode
 
 				continue
 			}
 
 			if _, exists := dependencyNodes[dependency]; exists {
-				newDependencyNode := tree.New().Root(s.colorizer.Colorize(config))
+				newDependencyNode := tree.New().Root(s.colorizer.Colorize(c))
 				dependencyNodes[dependency].Child(newDependencyNode)
-				dependencyNodes[config.Path] = newDependencyNode
+				dependencyNodes[c.Path] = newDependencyNode
 			}
 		}
 	}
@@ -604,7 +604,7 @@ func generateDAGTree(configs ListedConfigs, s *TreeStyler) *tree.Tree {
 	return root
 }
 
-// pathParts holds the pre-processed parts of a config path.
+// pathParts holds the pre-processed parts of a component path.
 type pathParts struct {
 	dir      string
 	base     string
@@ -624,14 +624,14 @@ func preProcessPath(path string) pathParts {
 	}
 }
 
-// renderTree renders the configurations in a tree format.
-func renderTree(opts *Options, configs ListedConfigs, s *TreeStyler, _ string) error {
+// renderTree renders the components in a tree format.
+func renderTree(opts *Options, components ListedComponents, s *TreeStyler, _ string) error {
 	var t *tree.Tree
 
 	if opts.Mode == ModeDAG {
-		t = generateDAGTree(configs, s)
+		t = generateDAGTree(components, s)
 	} else {
-		t = generateTree(configs, s)
+		t = generateTree(components, s)
 	}
 
 	t = s.Style(t)
@@ -648,11 +648,11 @@ func renderTree(opts *Options, configs ListedConfigs, s *TreeStyler, _ string) e
 // that can be displayed in the terminal.
 // It also returns the width of each column.
 // The width is the longest path length + 2 for padding.
-func getMaxCols(configs ListedConfigs) (int, int) {
+func getMaxCols(components ListedComponents) (int, int) {
 	maxCols := 0
 
 	terminalWidth := getTerminalWidth()
-	longestPathLen := getLongestPathLen(configs)
+	longestPathLen := getLongestPathLen(components)
 
 	const padding = 2
 
@@ -683,13 +683,13 @@ func getTerminalWidth() int {
 }
 
 // getLongestPathLen returns the length of the
-// longest path in the list of configurations.
-func getLongestPathLen(configs ListedConfigs) int {
+// longest path in the list of components.
+func getLongestPathLen(components ListedComponents) int {
 	longest := 0
 
-	for _, config := range configs {
-		if len(config.Path) > longest {
-			longest = len(config.Path)
+	for _, c := range components {
+		if len(c.Path) > longest {
+			longest = len(c.Path)
 		}
 	}
 

--- a/cli/commands/list/list_test.go
+++ b/cli/commands/list/list_test.go
@@ -488,14 +488,14 @@ func TestColorizer(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		config *list.ListedConfig
+		config *list.ListedComponent
 		// We can't test exact ANSI codes as they might vary by environment,
 		// so we'll test that different types result in different outputs
 		shouldBeDifferent []component.Kind
 	}{
 		{
 			name: "unit config",
-			config: &list.ListedConfig{
+			config: &list.ListedComponent{
 				Type: component.Unit,
 				Path: "path/to/unit",
 			},
@@ -503,7 +503,7 @@ func TestColorizer(t *testing.T) {
 		},
 		{
 			name: "stack config",
-			config: &list.ListedConfig{
+			config: &list.ListedComponent{
 				Type: component.Stack,
 				Path: "path/to/stack",
 			},
@@ -520,7 +520,7 @@ func TestColorizer(t *testing.T) {
 
 			// Test that different types produce different colorized outputs
 			for _, diffType := range tt.shouldBeDifferent {
-				diffConfig := &list.ListedConfig{
+				diffConfig := &list.ListedComponent{
 					Type: diffType,
 					Path: tt.config.Path,
 				}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -164,8 +164,8 @@ func (e Entries) Entry(cfg *component.Component) *Entry {
 	return nil
 }
 
-// Configs returns the queue configs.
-func (q *Queue) Configs() component.Components {
+// Components returns the queue components.
+func (q *Queue) Components() component.Components {
 	result := make(component.Components, 0, len(q.Entries))
 	for _, entry := range q.Entries {
 		result = append(result, entry.Component)

--- a/test/integration_find_test.go
+++ b/test/integration_find_test.go
@@ -257,7 +257,7 @@ func TestFindExclude(t *testing.T) {
 			assert.Empty(t, stderr)
 
 			if strings.Contains(tc.args, "--json") {
-				var configs find.FoundConfigs
+				var configs find.FoundComponents
 
 				err = json.Unmarshal([]byte(stdout), &configs)
 				require.NoError(t, err)
@@ -342,7 +342,7 @@ func TestFindQueueConstructAs(t *testing.T) {
 			require.NoError(t, err)
 			assert.Empty(t, stderr)
 
-			var configs find.FoundConfigs
+			var configs find.FoundComponents
 
 			err = json.Unmarshal([]byte(stdout), &configs)
 			require.NoError(t, err)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updates the language used in discovery commands so that they use "component" instead of "config" when referring to the things we discover.

I'm about to introduce changes to the `find` command related to surfacing `reading`, and I didn't want to confuse things by having all of these changes mixed in.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
- Standardized internal naming conventions throughout the system by replacing "configuration" references with "component" terminology across all modules and operations.
- Component-oriented data structures and APIs now used consistently for discovery, listing, finding, and output processing.
- Updated all output formats, logging messages, telemetry data, and display text to reflect the new component-based nomenclature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->