### PR TITLE
docs: Documenting new `--reading` flag for `find`

### DIFF
--- a/docs-starlight/src/data/commands/find.mdx
+++ b/docs-starlight/src/data/commands/find.mdx
@@ -72,6 +72,10 @@ examples:
       Include external dependencies in the output.
     code: |
       terragrunt find --dependencies --external --format 'json'
+  - description: |
+      Include the list of files read by each component in the output.
+    code: |
+      terragrunt find --reading --format 'json'
 flags:
   - find-format
   - find-json
@@ -80,6 +84,7 @@ flags:
   - find-dependencies
   - find-exclude
   - find-include
+  - find-reading
   - find-external
   - queue-construct-as
   - filter
@@ -228,6 +233,32 @@ terragrunt find --exclude --queue-construct-as=plan --format=json
 ```
 
 `find` will remove any units that would match the exclude configuration.
+
+## Reading Files
+
+You can include information about which files are read by each component using the `--reading` flag. This is particularly useful for understanding configuration dependencies and tracking which shared files are consumed by your Terragrunt configurations.
+
+When enabled, the JSON output will include a `reading` field that lists all files that were read during the parsing of each component:
+
+```bash
+$ terragrunt find --reading --format=json
+[
+  {
+    "type": "unit",
+    "path": "app",
+    "reading": [
+      "path/to/shared.hcl",
+      "path/to/shared.tfvars",
+    ]
+  }
+]
+```
+
+This includes files read by Terragrunt helper functions such as:
+- [`read_terragrunt_config()`](/docs/reference/hcl/functions/#read_terragrunt_config) - Reading other Terragrunt configuration files
+- [`read_tfvars_file()`](/docs/reference/hcl/functions/#read_tfvars_file) - Reading Terraform variable files
+- [`sops_decrypt_file()`](/docs/reference/hcl/functions/#sops_decrypt_file) - Reading encrypted files via SOPS
+- [`mark_as_read()`](/docs/reference/hcl/functions/#mark_as_read) - Explicitly marking a file as read
 
 ## External Dependencies
 

--- a/docs-starlight/src/data/flags/find-reading.mdx
+++ b/docs-starlight/src/data/flags/find-reading.mdx
@@ -1,0 +1,47 @@
+---
+name: reading
+description: Include the list of files that are read by components in the output.
+type: boolean
+env:
+  - TG_READING
+---
+
+When enabled, JSON output will include a list of files that were read during the parsing of each component. This is useful for understanding configuration dependencies and tracking which shared files are consumed by your Terragrunt configurations.
+
+```bash
+$ terragrunt find --reading --format=json | jq
+[
+  {
+    "type": "unit",
+    "path": "app",
+    "reading": [
+      "shared.hcl",
+      "shared.tfvars",
+      "common/variables.hcl"
+    ]
+  }
+]
+```
+
+The `reading` field includes files read by Terragrunt helper functions such as:
+- `read_terragrunt_config()` - Reading other Terragrunt configuration files
+- `read_tfvars_file()` - Reading Terraform variable files
+- `sops_decrypt_file()` - Reading encrypted files via SOPS
+- `mark_as_read()` - Explicitly marking files as read
+
+You can use tools like `jq` to analyze which components read specific files:
+
+```bash
+$ terragrunt find --reading --format=json | jq '[.[] | select(.reading[]? | contains("shared.hcl"))]'
+[
+  {
+    "type": "unit",
+    "path": "app",
+    "reading": [
+      "shared.hcl",
+      "shared.tfvars"
+    ]
+  }
+]
+```
+


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Documents the new `--reading` flag for `find`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added new `--reading` flag to `terragrunt find` command that outputs a JSON array of files read during component parsing.
* Updated documentation with comprehensive usage examples, output format specifications, related helper functions, and jq filtering examples for advanced component analysis and dependency tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->