### PR TITLE
docs: Documenting support for `--filter` in `hcl` commands

### DIFF
--- a/docs-starlight/src/content/docs/03-features/18-filter.mdx
+++ b/docs-starlight/src/content/docs/03-features/18-filter.mdx
@@ -20,7 +20,7 @@ terragrunt find --experiment filter-flag --filter 'foo'
 
 Examples below will omit the `--experiment filter-flag` flag for brevity.
 
-Currently, the `--filter` flag is available in the `find`, `list`, and `run` commands.
+The `--filter` flag is available in the `find`, `list`, `run`, `hcl fmt`, and `hcl validate` commands.
 </Aside>
 
 The `--filter` flag provides a sophisticated querying syntax for targeting specific [units](/docs/features/units) and [stacks](/docs/features/stacks) in Terragrunt commands. This unified approach offers powerful filtering capabilities using a flexible query language.
@@ -318,8 +318,8 @@ The following commands all support the `--filter` flag, and use it to filter res
 - [x] [find](/docs/reference/cli/commands/find)
 - [x] [list](/docs/reference/cli/commands/list)
 - [x] [run](/docs/reference/cli/commands/run)
-- [ ] [hcl fmt](/docs/reference/cli/commands/hcl/fmt) (planned for a future release)
-- [ ] [hcl validate](/docs/reference/cli/commands/hcl/validate) (planned for a future release)
+- [x] [hcl fmt](/docs/reference/cli/commands/hcl/fmt)
+- [x] [hcl validate](/docs/reference/cli/commands/hcl/validate)
 
 This flag is intended to be a flexible way to target specific infrastructure that allows you to dry-run infrastructure targeting using discovery commands (like `find` and `list`) before running a command that actually affects infrastructure (like `run`).
 

--- a/docs-starlight/src/data/commands/hcl/fmt.mdx
+++ b/docs-starlight/src/data/commands/hcl/fmt.mdx
@@ -12,6 +12,7 @@ examples:
     code: |
       terragrunt hcl fmt
 flags:
+  - hcl-fmt-filter
   - hcl-fmt-check
   - hcl-fmt-diff
   - hcl-fmt-exclude-dir

--- a/docs-starlight/src/data/commands/hcl/validate.mdx
+++ b/docs-starlight/src/data/commands/hcl/validate.mdx
@@ -12,6 +12,7 @@ examples:
     code: |
       terragrunt hcl validate
 flags:
+  - filter
   - hcl-validate-json
   - hcl-validate-show-config-path
   - hcl-validate-inputs

--- a/docs-starlight/src/data/flags/filter.mdx
+++ b/docs-starlight/src/data/flags/filter.mdx
@@ -16,8 +16,6 @@ terragrunt find --experiment filter-flag --filter 'foo'
 ```
 
 Examples below will omit the `--experiment filter-flag` flag for brevity.
-
-Currently, the `--filter` flag is available in the `find`, `list`, and `run` commands.
 </Aside>
 
 The `--filter` flag provides a sophisticated querying syntax for targeting specific [units](/docs/features/units) and [stacks](/docs/features/stacks) in Terragrunt commands.
@@ -28,6 +26,8 @@ The `--filter` flag provides a sophisticated querying syntax for targeting speci
 terragrunt find --filter 'app*'
 terragrunt list --filter './prod/** | type=unit'
 terragrunt run --all --filter './prod/**' -- plan
+terragrunt hcl fmt --filter './prod/**'
+terragrunt hcl validate --filter 'type=unit'
 ```
 
 ### Name-Based Filtering
@@ -114,10 +114,11 @@ Currently supported in:
 - [find](/docs/reference/cli/commands/find)
 - [list](/docs/reference/cli/commands/list)
 - [run](/docs/reference/cli/commands/run)
-
-Planned for future releases:
 - [hcl fmt](/docs/reference/cli/commands/hcl/fmt)
 - [hcl validate](/docs/reference/cli/commands/hcl/validate)
+
+Planned for future releases:
+- [dag graph](/docs/reference/cli/commands/dag/graph)
 
 ## Learn More
 

--- a/docs-starlight/src/data/flags/hcl-fmt-filter.mdx
+++ b/docs-starlight/src/data/flags/hcl-fmt-filter.mdx
@@ -1,0 +1,87 @@
+---
+name: filter
+description: Filter configurations using a flexible query language
+type: list(string)
+---
+
+import {Aside} from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental Feature">
+This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
+
+Usage of the filter flag requires usage of the `filter-flag` experiment, like so:
+
+```bash
+terragrunt find --experiment filter-flag --filter 'foo'
+```
+
+Examples below will omit the `--experiment filter-flag` flag for brevity.
+</Aside>
+
+<Aside type="note" title="Filter Behavior for HCL Format">
+The `--filter` flag works differently for `hcl fmt` compared to other commands. It filters on individual HCL files rather than units or stacks (which are directories). As a result, only path-based filter expressions are supported. Attribute-based filters like `type=unit` or `name=my-app` are not applicable to file-level operations.
+
+Example:
+```bash
+# Supported: Path-based filtering
+terragrunt hcl fmt --filter './prod/**/*.hcl'
+
+# Not supported: Attribute-based filtering
+terragrunt hcl fmt --filter 'type=unit'  # This will not work
+```
+</Aside>
+
+The `--filter` flag provides a path-based querying syntax for targeting specific HCL files to format.
+
+## Usage
+
+```bash
+terragrunt hcl fmt --filter './prod/**'
+```
+
+### Path-Based Filtering
+Match HCL files by their file system path:
+
+```bash
+# Relative paths with globs
+terragrunt hcl fmt --filter './envs/prod/**'
+
+# Format all HCL files in a specific directory
+terragrunt hcl fmt --filter './modules/**/*.hcl'
+
+# Absolute paths
+terragrunt hcl fmt --filter '/absolute/path/to/envs/dev/apps/*'
+```
+
+### Negation
+Exclude paths using the `!` prefix:
+
+```bash
+# Exclude by path
+terragrunt hcl fmt --filter '!./prod/**'
+
+# Exclude specific directories
+terragrunt hcl fmt --filter '!./test/**'
+```
+
+### Intersection (Refinement)
+Use the `|` operator to refine results:
+
+```bash
+# Format HCL files in prod directory, excluding tests
+terragrunt hcl fmt --filter './prod/** | !./prod/test/**'
+
+# Format specific file patterns
+terragrunt hcl fmt --filter './**/*.hcl | !./**/test/**'
+```
+
+### Union (Multiple Filters)
+Specify multiple `--filter` flags to combine results using OR logic:
+
+```bash
+# Format files in either dev or staging directories
+terragrunt hcl fmt --filter './dev/**' --filter './staging/**'
+```
+
+For comprehensive examples and advanced usage patterns, see the [Filters feature documentation](/docs/features/filter).
+


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Documenting support for `--filter` in `hcl` commands.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Extended `--filter` flag docs to include `hcl fmt` and `hcl validate`
  * Added usage examples for both commands (path-based filter syntax)
  * Introduced an experimental `hcl fmt` filter doc with examples and note about requiring the filter-flag experiment; clarifies only path-based filtering applies
  * Marked `hcl fmt` and `hcl validate` as implemented (previously planned) and updated command reference
  * Updated future-plans list (added `dag graph`)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->