### PR TITLE
feat: Moving `dag graph` command to `list --format=dot`

### DIFF
--- a/cli/commands/dag/cli.go
+++ b/cli/commands/dag/cli.go
@@ -4,7 +4,6 @@ package dag
 
 import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/dag/graph"
-	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -15,13 +14,11 @@ const (
 )
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
-	prefix := flags.Prefix{CommandName}
-
 	return &cli.Command{
 		Name:  CommandName,
 		Usage: "Interact with the Directed Acyclic Graph (DAG).",
 		Subcommands: cli.Commands{
-			graph.NewCommand(l, opts, prefix),
+			graph.NewCommand(l, opts),
 		},
 		Action: cli.ShowCommandHelp,
 	}

--- a/cli/commands/dag/graph/cli.go
+++ b/cli/commands/dag/graph/cli.go
@@ -1,14 +1,14 @@
 // Package graph implements the terragrunt dag graph command which generates a visual
 // representation of the Terragrunt dependency graph in DOT language format.
+//
+// Alias for 'list --format=dot --dag --dependencies --external'.
 package graph
 
 import (
-	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
-	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
-	"github.com/gruntwork-io/terragrunt/cli/commands/run"
-	"github.com/gruntwork-io/terragrunt/cli/flags"
+	"github.com/gruntwork-io/terragrunt/cli/commands/list"
+	runCmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
+	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/runner"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -17,32 +17,39 @@ const (
 	CommandName = "graph"
 )
 
-func NewCommand(l log.Logger, opts *options.TerragruntOptions, _ flags.Prefix) *cli.Command {
-	cmd := &cli.Command{
+func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
+	// Build flags: queue flags + backend/feature flags + filter flag
+	cmdFlags := shared.NewQueueFlags(opts, nil)
+	cmdFlags = append(cmdFlags, runCmd.NewBackendFlags(l, opts, nil)...)
+	cmdFlags = append(cmdFlags, runCmd.NewFeatureFlags(l, opts, nil)...)
+	cmdFlags = append(cmdFlags, shared.NewFilterFlag(opts))
+
+	return &cli.Command{
 		Name:      CommandName,
-		Usage:     "Graph the Directed Acyclic Graph (DAG) in DOT language.",
+		Usage:     "Graph the Directed Acyclic Graph (DAG) in DOT language. Alias for 'list --format=dot --dag --dependencies --external'.",
 		UsageText: "terragrunt dag graph",
+		Flags:     cmdFlags,
 		Action: func(ctx *cli.Context) error {
 			return Run(ctx, l, opts)
 		},
-		Flags: run.NewFlags(l, opts, nil),
 	}
-
-	cmd = runall.WrapCommand(l, opts, cmd, run.Run, true)
-	cmd = graph.WrapCommand(l, opts, cmd, run.Run, true)
-
-	return cmd
 }
 
 func Run(ctx *cli.Context, l log.Logger, opts *options.TerragruntOptions) error {
-	stack, err := runner.FindStackInSubfolders(ctx, l, opts)
-	if err != nil {
-		return err
+	listOpts := list.NewOptions(opts)
+	listOpts.Format = list.FormatDot
+	listOpts.Mode = list.ModeDAG
+	listOpts.Dependencies = true
+	listOpts.Hidden = true
+
+	// By default, graph includes external dependencies.
+	// Respect queue flags to override this behavior.
+	if opts.IgnoreExternalDependencies {
+		listOpts.External = false
+	} else {
+		// Default to true, or explicitly set if --queue-include-external is used
+		listOpts.External = true
 	}
 
-	if err := stack.GetStack().Units.WriteDot(l, opts.Writer, opts); err != nil {
-		l.Warnf("Failed to graph dot: %v", err)
-	}
-
-	return nil
+	return list.Run(ctx, l, listOpts)
 }

--- a/cli/commands/list/cli.go
+++ b/cli/commands/list/cli.go
@@ -41,7 +41,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			Name:        FormatFlagName,
 			EnvVars:     tgPrefix.EnvVars(FormatFlagName),
 			Destination: &opts.Format,
-			Usage:       "Output format for list results. Valid values: text, tree, long.",
+			Usage:       "Output format for list results. Valid values: text, tree, long, dot.",
 			DefaultText: FormatText,
 		}),
 		flags.NewFlag(&cli.BoolFlag{

--- a/cli/commands/list/options.go
+++ b/cli/commands/list/options.go
@@ -15,6 +15,9 @@ const (
 	// FormatLong outputs the discovered configurations in long format.
 	FormatLong = "long"
 
+	// FormatDot outputs the discovered configurations in GraphViz DOT format.
+	FormatDot = "dot"
+
 	// SortAlpha sorts the discovered configurations in alphabetical order.
 	SortAlpha = "alpha"
 
@@ -93,6 +96,8 @@ func (o *Options) validateFormat() error {
 	case FormatTree:
 		return nil
 	case FormatLong:
+		return nil
+	case FormatDot:
 		return nil
 	default:
 		return errors.New("invalid format: " + o.Format)

--- a/internal/runner/common/unit_test.go
+++ b/internal/runner/common/unit_test.go
@@ -135,28 +135,6 @@ func TestUnitsMap_CrossLinkDependencies(t *testing.T) {
 	assert.Equal(t, aPath, units[1].Dependencies[0].Path)
 }
 
-func TestUnits_WriteDot(t *testing.T) {
-	t.Parallel()
-
-	units := common.Units{
-		&common.Unit{Path: "a"},
-		&common.Unit{Path: "b", Dependencies: common.Units{&common.Unit{Path: "a"}}, FlagExcluded: true},
-	}
-
-	var buf bytes.Buffer
-
-	opts := &options.TerragruntOptions{TerragruntConfigPath: "/foo/terragrunt.hcl"}
-	l := logger.CreateLogger()
-	err := units.WriteDot(l, &buf, opts)
-	require.NoError(t, err)
-
-	out := buf.String()
-	assert.Contains(t, out, "digraph {")
-	assert.Contains(t, out, "a")
-	assert.Contains(t, out, "b")
-	assert.Contains(t, out, "[color=red]")
-}
-
 func TestUnits_CheckForCycles(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration_dag_test.go
+++ b/test/integration_dag_test.go
@@ -30,12 +30,13 @@ func TestIncludeExternalInDagGraphCmd(t *testing.T) {
 	t.Parallel()
 
 	helpers.CleanupTerraformFolder(t, testFixtureGraphDAG)
-	workDir := filepath.Join(testFixtureGraphDAG, "region-1", "unit-a")
+	workDir := filepath.Join(testFixtureGraphDAG, "region-1")
+	workDir, err := filepath.EvalSymlinks(workDir)
+	require.NoError(t, err)
 
 	cmd := "terragrunt dag graph --queue-include-external --working-dir " + workDir
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
 	require.NoError(t, err)
-
 	assert.Contains(t, stdout, "unit-a\" ->")
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Moves the logic for `dag graph` to `list --format=dot`.

Relates to https://github.com/gruntwork-io/terragrunt/issues/4745

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `--format=dot` to `list` command to generate DAG graphs in DOT format.
Removed `dag graph` command.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

