### PR TITLE
docs: Documenting the relationship between `--external` and `--dependencies`

### DIFF
--- a/cli/commands/find/cli.go
+++ b/cli/commands/find/cli.go
@@ -91,7 +91,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			Name:        External,
 			EnvVars:     tgPrefix.EnvVars(External),
 			Destination: &opts.External,
-			Usage:       "Discover external dependencies from initial results, and add them to top-level results.",
+			Usage:       "Discover external dependencies from initial results, and add them to top-level results (implies discovery of dependencies).",
 		}),
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        QueueConstructAsFlagName,

--- a/cli/commands/find/find_test.go
+++ b/cli/commands/find/find_test.go
@@ -476,6 +476,65 @@ locals {
 				assert.True(t, readingMap["shared.tfvars"], "should contain shared.tfvars")
 			},
 		},
+		{
+			name: "external flag implies dependencies",
+			setup: func(t *testing.T) string {
+				t.Helper()
+
+				tmpDir := t.TempDir()
+
+				internalDir := filepath.Join(tmpDir, "internal")
+				require.NoError(t, os.MkdirAll(internalDir, 0755))
+
+				unitADir := filepath.Join(internalDir, "unitA")
+				require.NoError(t, os.MkdirAll(unitADir, 0755))
+
+				externalDir := filepath.Join(tmpDir, "external")
+				require.NoError(t, os.MkdirAll(externalDir, 0755))
+
+				unitBDir := filepath.Join(externalDir, "unitB")
+				require.NoError(t, os.MkdirAll(unitBDir, 0755))
+
+				require.NoError(t, os.WriteFile(filepath.Join(unitBDir, "terragrunt.hcl"), []byte(""), 0644))
+
+				require.NoError(t, os.WriteFile(filepath.Join(unitADir, "terragrunt.hcl"), []byte(`
+dependency "unitB" {
+  config_path = "../../external/unitB"
+}
+`), 0644))
+
+				return internalDir
+			},
+			expectedPaths: []string{"unitA", "../external/unitB"},
+			format:        "json",
+			mode:          "normal",
+			external:      true,
+			validate: func(t *testing.T, output string, expectedPaths []string) {
+				t.Helper()
+
+				var configs find.FoundComponents
+				err := json.Unmarshal([]byte(output), &configs)
+				require.NoError(t, err)
+
+				assert.Len(t, configs, 2, "should include both internal and external units")
+
+				var (
+					internalUnit *find.FoundComponent
+					externalUnit *find.FoundComponent
+				)
+
+				for _, cfg := range configs {
+					if cfg.Path == "unitA" {
+						internalUnit = cfg
+					} else if strings.Contains(cfg.Path, "external") {
+						externalUnit = cfg
+					}
+				}
+
+				require.NotNil(t, internalUnit, "should find internal unit")
+				require.NotNil(t, externalUnit, "should find external unit")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/commands/list/cli.go
+++ b/cli/commands/list/cli.go
@@ -60,7 +60,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			Name:        ExternalFlagName,
 			EnvVars:     tgPrefix.EnvVars(ExternalFlagName),
 			Destination: &opts.External,
-			Usage:       "Discover external dependencies from initial results, and add them to top-level results.",
+			Usage:       "Discover external dependencies from initial results, and add them to top-level results (implies discovery of dependencies).",
 		}),
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        TreeFlagName,

--- a/cli/commands/list/list_test.go
+++ b/cli/commands/list/list_test.go
@@ -481,6 +481,63 @@ dependency "C" {
 	assert.Less(t, cIndex, fIndex, "C should come before F")
 }
 
+func TestExternalFlagImpliesDependencies(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	internalDir := filepath.Join(tmpDir, "internal")
+	require.NoError(t, os.MkdirAll(internalDir, 0755))
+
+	unitADir := filepath.Join(internalDir, "unitA")
+	require.NoError(t, os.MkdirAll(unitADir, 0755))
+
+	externalDir := filepath.Join(tmpDir, "external")
+	require.NoError(t, os.MkdirAll(externalDir, 0755))
+
+	unitBDir := filepath.Join(externalDir, "unitB")
+	require.NoError(t, os.MkdirAll(unitBDir, 0755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(unitBDir, "terragrunt.hcl"), []byte(""), 0644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(unitADir, "terragrunt.hcl"), []byte(`
+dependency "unitB" {
+  config_path = "../../external/unitB"
+}
+`), 0644))
+
+	tgOpts := options.NewTerragruntOptions()
+	tgOpts.WorkingDir = internalDir
+
+	l := logger.CreateLogger()
+	l.Formatter().SetDisabledColors(true)
+
+	opts := list.NewOptions(tgOpts)
+	opts.Format = "long"
+	opts.External = true
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	opts.Writer = w
+
+	err = list.Run(t.Context(), l, opts)
+	require.NoError(t, err)
+
+	w.Close()
+
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	outputStr := string(output)
+
+	assert.Contains(t, outputStr, "unitA", "should include internal unit")
+	assert.Contains(t, outputStr, "external", "should include external unit")
+
+	lines := strings.Split(strings.TrimSpace(outputStr), "\n")
+	assert.GreaterOrEqual(t, len(lines), 3, "should have at least header and 2 units")
+}
+
 func TestColorizer(t *testing.T) {
 	t.Parallel()
 

--- a/docs-starlight/src/data/commands/find.mdx
+++ b/docs-starlight/src/data/commands/find.mdx
@@ -285,6 +285,21 @@ terragrunt find --dependencies --external --format=json
 ]
 ```
 
+<Aside type="note" title="Automatic Dependency Discovery">
+
+The `--external` flag automatically enables dependency discovery, so you don't need to explicitly pass `--dependencies` when using `--external` unless you want to actually see the dependency information.
+
+The following commands are equivalent:
+
+```bash
+terragrunt find --external
+terragrunt find --dependencies --external
+```
+
+As the default text format of `find` won't display dependency information anyways.
+
+</Aside>
+
 ## Hidden Configurations
 
 By default, hidden directories (those starting with `.`) are excluded from the search. Use the `--hidden` flag to include them:

--- a/docs-starlight/src/data/commands/list.mdx
+++ b/docs-starlight/src/data/commands/list.mdx
@@ -202,6 +202,19 @@ Include dependency information in the output using the `--dependencies` flag. Wh
 
 Use the `--external` flag to discover and include dependencies that exist outside your current working directory. This is particularly useful when working with shared modules or cross-repository dependencies.
 
+<Aside type="note" title="Automatic Dependency Discovery">
+
+The `--external` flag automatically enables dependency discovery, so you don't need to explicitly pass `--dependencies` when using `--external`. The following commands are equivalent:
+
+```bash
+terragrunt list --external
+terragrunt list --dependencies --external
+```
+
+This is because the default text format of `list` won't display dependency information anyways (as opposed to the `long` format, which does).
+
+</Aside>
+
 ### Hidden Configurations
 
 By default, Terragrunt excludes configurations in hidden directories (those starting with a dot). Use the `--hidden` flag to include these configurations in the output.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Makes it clear that `--dependencies` is optional for users when they're using the `--external` flag.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `--external` flag automatically enables dependency discovery for both `find` and `list` commands.
  * Added informational notes documenting that `--external` implies `--dependencies` functionality.
  * Updated flag usage text for improved clarity on command behavior.

* **Tests**
  * Added test cases validating the interaction between `--external` and dependency discovery flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->