### PR TITLE
docs: Documenting support for `--filter` in the `run` command

### DIFF
--- a/docs-starlight/src/content/docs/03-features/18-filter.mdx
+++ b/docs-starlight/src/content/docs/03-features/18-filter.mdx
@@ -20,7 +20,7 @@ terragrunt find --experiment filter-flag --filter 'foo'
 
 Examples below will omit the `--experiment filter-flag` flag for brevity.
 
-Currently, the `--filter` flag is only available in the `find` and `list` commands. Support for the `run` command is planned for a future release.
+Currently, the `--filter` flag is available in the `find`, `list`, and `run` commands.
 </Aside>
 
 The `--filter` flag provides a sophisticated querying syntax for targeting specific [units](/docs/features/units) and [stacks](/docs/features/stacks) in Terragrunt commands. This unified approach offers powerful filtering capabilities using a flexible query language.
@@ -317,7 +317,7 @@ The following commands all support the `--filter` flag, and use it to filter res
 
 - [x] [find](/docs/reference/cli/commands/find)
 - [x] [list](/docs/reference/cli/commands/list)
-- [ ] [run](/docs/reference/cli/commands/run) (planned for a future release)
+- [x] [run](/docs/reference/cli/commands/run)
 - [ ] [hcl fmt](/docs/reference/cli/commands/hcl/fmt) (planned for a future release)
 - [ ] [hcl validate](/docs/reference/cli/commands/hcl/validate) (planned for a future release)
 

--- a/docs-starlight/src/content/docs/04-reference/04-experiments.md
+++ b/docs-starlight/src/content/docs/04-reference/04-experiments.md
@@ -128,8 +128,7 @@ The `--filter` flag provides a sophisticated querying syntax for targeting units
 
 **Current Support Status:**
 
-- ✅ Available in `find` and `list` commands
-- ❌ **Not yet available in `run` command** - this is planned for future implementation
+- ✅ Available in `find`, `list`, and `run` commands
 
 **Supported Filtering Types:**
 
@@ -147,7 +146,6 @@ The `--filter` flag provides a sophisticated querying syntax for targeting units
 
 - Git-based filtering (`[ref...ref]` syntax)
 - Dependency/dependent traversal (`...` syntax)
-- Integration with `run` command
 
 #### `filter-flag` - How to provide feedback
 
@@ -165,7 +163,7 @@ To transition the `filter-flag` feature to a stable release, the following must 
 - [x] Add support for multiple filters (union/OR semantics)
 - [x] Integrate with the `find` command
 - [x] Integrate with the `list` command
-- [ ] Integrate with the `run` command
+- [x] Integrate with the `run` command
 - [ ] Add support for git-based filtering ([ref...ref] syntax)
 - [ ] Add support for dependency/dependent traversal (... syntax)
 - [ ] Add support for `--filters-file` flag

--- a/docs-starlight/src/data/commands/run.mdx
+++ b/docs-starlight/src/data/commands/run.mdx
@@ -37,6 +37,7 @@ flags:
   - engine-skip-check
   - experimental-engine
   - feature
+  - filter
   - graph
   - iam-assume-role
   - iam-assume-role-duration
@@ -89,6 +90,57 @@ The `run` command also supports the following flags that can be used to drive ru
 
 - `--all`: Run the provided OpenTofu/Terraform command against all units in the current stack.
 - `--graph`: Run the provided OpenTofu/Terraform command against the graph of dependencies for the unit in the current working directory.
+
+## Filtering Units
+
+<Aside type="tip" title="Experimental Feature">
+This feature requires the `filter-flag` experiment to be enabled. Use `--experiment filter-flag` to enable it:
+
+```bash
+terragrunt run --all --experiment filter-flag --filter 'prod/**' -- plan
+```
+
+Examples below will omit the `--experiment filter-flag` flag for brevity.
+</Aside>
+
+The `run` command supports the `--filter` flag to target specific units using a flexible query language. This is particularly useful when running commands across multiple units with `--all`.
+
+### Basic Filtering Examples
+
+```bash
+# Filter by path with glob patterns
+terragrunt run --all --filter 'prod/**' -- plan
+
+# Filter by name
+terragrunt run --all --filter 'app*' -- apply
+
+# Filter by type
+terragrunt run --all --filter 'type=unit' -- plan
+```
+
+### Advanced Filtering
+
+The filter syntax supports negation, intersection, and complex queries:
+
+```bash
+# Exclude specific configurations
+terragrunt run --all --filter '!./test/**' -- plan
+
+# Combine filters with intersection (refinement)
+terragrunt run --all --filter './prod/** | type=unit' -- apply
+
+# Complex queries with chaining
+terragrunt run --all --filter './prod/** | type=unit | !name=legacy' -- plan
+
+# Multiple filters (OR logic)
+terragrunt run --all --filter 'app1' --filter 'app2' -- plan
+```
+
+<Aside type="tip" title="Learn More About Filtering">
+
+For comprehensive examples and advanced usage patterns, see the [Filters feature documentation](/docs/features/filter).
+
+</Aside>
 
 ## Separating Arguments
 

--- a/docs-starlight/src/data/flags/filter.mdx
+++ b/docs-starlight/src/data/flags/filter.mdx
@@ -17,7 +17,7 @@ terragrunt find --experiment filter-flag --filter 'foo'
 
 Examples below will omit the `--experiment filter-flag` flag for brevity.
 
-Currently, the `--filter` flag is only available in the `find` and `list` commands. Support for the `run` command is planned for a future release.
+Currently, the `--filter` flag is available in the `find`, `list`, and `run` commands.
 </Aside>
 
 The `--filter` flag provides a sophisticated querying syntax for targeting specific [units](/docs/features/units) and [stacks](/docs/features/stacks) in Terragrunt commands.
@@ -113,7 +113,7 @@ terragrunt find --filter unit1 --filter stack1
 Currently supported in:
 - [find](/docs/reference/cli/commands/find)
 - [list](/docs/reference/cli/commands/list)
-- [run](/docs/reference/cli/commands/run) (with `--all` flag)
+- [run](/docs/reference/cli/commands/run)
 
 Planned for future releases:
 - [hcl fmt](/docs/reference/cli/commands/hcl/fmt)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Documents support for the `--filter` flag in the `run` command.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added docs for `--filter` support in `run`.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect `--filter` flag support in the `run` command (now available in find, list, and run).
  * Added comprehensive "Filtering Units" section with basic and advanced filtering examples for the `run` command.
  * Marked filter-flag integration with `run` command as completed.
  * Updated command support tables and flag availability across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->