### PR TITLE
feat: Adding support for `--parallelism` to `hcl fmt`

### DIFF
--- a/cli/commands/hcl/format/cli.go
+++ b/cli/commands/hcl/format/cli.go
@@ -80,6 +80,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 
 	flagSet = flagSet.Add(shared.NewQueueFlags(opts, nil)...)
 	flagSet = flagSet.Add(shared.NewFilterFlag(opts))
+	flagSet = flagSet.Add(shared.NewParallelismFlag(opts))
 
 	return flagSet
 }

--- a/cli/commands/hcl/format/format.go
+++ b/cli/commands/hcl/format/format.go
@@ -125,7 +125,13 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(runtime.NumCPU())
+
+	limit := opts.Parallelism
+	if limit == options.DefaultParallelism {
+		limit = runtime.NumCPU()
+	}
+
+	g.SetLimit(limit)
 
 	// Pre-allocate the errs slice with max possible length
 	// so we don't need to hold a lock to append to it.

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -24,7 +24,6 @@ const (
 	DownloadDirFlagName                    = "download-dir"
 	TFForwardStdoutFlagName                = "tf-forward-stdout"
 	TFPathFlagName                         = "tf-path"
-	ParallelismFlagName                    = "parallelism"
 	InputsDebugFlagName                    = "inputs-debug"
 	UnitsThatIncludeFlagName               = "units-that-include"
 	DependencyFetchOutputFromStateFlagName = "dependency-fetch-output-from-state"
@@ -263,14 +262,6 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 				terragruntPrefixControl,
 			),
 		),
-
-		flags.NewFlag(&cli.GenericFlag[int]{
-			Name:        ParallelismFlagName,
-			EnvVars:     tgPrefix.EnvVars(ParallelismFlagName),
-			Destination: &opts.Parallelism,
-			Usage:       "Parallelism for --all commands.",
-		},
-			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("parallelism"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        InputsDebugFlagName,
@@ -518,6 +509,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 	flags = flags.Add(NewFeatureFlags(l, opts, prefix)...)
 	flags = flags.Add(shared.NewQueueFlags(opts, prefix)...)
 	flags = flags.Add(shared.NewFilterFlag(opts))
+	flags = flags.Add(shared.NewParallelismFlag(opts))
 
 	return flags.Sort()
 }

--- a/cli/flags/shared/shared.go
+++ b/cli/flags/shared/shared.go
@@ -33,6 +33,9 @@ const (
 	NoIncludeRootFlagName = "no-include-root"
 	NoShellFlagName       = "no-shell"
 	NoHooksFlagName       = "no-hooks"
+
+	// Concurrency control flags.
+	ParallelismFlagName = "parallelism"
 )
 
 // NewTFPathFlag creates a flag for specifying the OpenTofu/Terraform binary path.
@@ -226,4 +229,21 @@ func NewScaffoldingFlags(opts *options.TerragruntOptions, prefix flags.Prefix) c
 			Usage:       "Disable hooks when using boilerplate templates.",
 		}),
 	}
+}
+
+// NewParallelismFlag creates a flag for specifying parallelism level.
+func NewParallelismFlag(opts *options.TerragruntOptions) *flags.Flag {
+	tgPrefix := flags.Prefix{flags.TgPrefix}
+	terragruntPrefix := flags.Prefix{flags.TerragruntPrefix}
+	terragruntPrefixControl := flags.StrictControlsByGlobalFlags(opts.StrictControls)
+
+	return flags.NewFlag(
+		&cli.GenericFlag[int]{
+			Name:        ParallelismFlagName,
+			EnvVars:     tgPrefix.EnvVars(ParallelismFlagName),
+			Destination: &opts.Parallelism,
+			Usage:       "Parallelism for --all commands.",
+		},
+		flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("parallelism"), terragruntPrefixControl),
+	)
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Allows users to control parallelism of the `fmt` command.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `--parallelism` flag to `hcl fmt`.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable parallelism flag to control concurrency.

* **Improvements**
  * Formatting now respects the user-provided parallelism limit (falls back to CPU count when using default).
  * Parallelism behavior consolidated for a consistent experience across related commands.

* **Chores**
  * Removed legacy per-command parallelism scaffolding in favor of the unified concurrency flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->