### PR TITLE
perf: More useful benchmark for determining impact of `hcl fmt` optimization

### DIFF
--- a/cli/commands/hcl/format/format_bench_test.go
+++ b/cli/commands/hcl/format/format_bench_test.go
@@ -2,238 +2,100 @@ package format_test
 
 import (
 	"context"
+	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/cli/commands/hcl/format"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	logformat "github.com/gruntwork-io/terragrunt/pkg/log/format"
-	"github.com/gruntwork-io/terratest/modules/files"
 )
 
 func BenchmarkFormat(b *testing.B) {
-	tmpBase, err := files.CopyFolderToTemp("./testdata/fixtures", b.Name(), func(path string) bool { return true })
+	sourceFile := "../../../../test/fixtures/hcl-filter/fmt/needs-formatting/nested/api/terragrunt.hcl"
+
+	pristineContent, err := os.ReadFile(sourceFile)
 	if err != nil {
-		b.Fatalf("Failed to copy fixtures: %v", err)
-	}
-	defer os.RemoveAll(tmpBase)
-
-	if err = duplicateFixtures(tmpBase, 10); err != nil {
-		b.Fatalf("Failed to duplicate fixtures: %v", err)
+		b.Fatalf("Failed to read source file: %v", err)
 	}
 
-	pristineDir := filepath.Join(tmpBase, "pristine")
-	if err = os.MkdirAll(pristineDir, 0755); err != nil {
-		b.Fatalf("Failed to create pristine dir: %v", err)
-	}
+	fileCounts := []int{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024}
 
-	entries, err := os.ReadDir(tmpBase)
-	if err != nil {
-		b.Fatalf("Failed to read tmpBase: %v", err)
-	}
+	for _, fileCount := range fileCounts {
+		b.Run(fmt.Sprintf("files_%d", fileCount), func(b *testing.B) {
+			tmpBase := b.TempDir()
 
-	for _, entry := range entries {
-		if entry.Name() == "pristine" || entry.Name()[0] == '.' {
-			continue
-		}
-
-		src := filepath.Join(tmpBase, entry.Name())
-		dst := filepath.Join(pristineDir, entry.Name())
-
-		if err = filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
+			var excludeList []string
+			for i := 2; i <= fileCount; i += 2 {
+				excludeList = append(excludeList, fmt.Sprintf("dir-%04d", i))
 			}
 
-			relPath, relErr := filepath.Rel(src, path)
-			if relErr != nil {
-				return relErr
-			}
-
-			destPath := filepath.Join(dst, relPath)
-
-			if d.IsDir() {
-				info, infoErr := d.Info()
-				if infoErr != nil {
-					return infoErr
-				}
-				return os.MkdirAll(destPath, info.Mode())
-			}
-
-			content, readErr := os.ReadFile(path)
-			if readErr != nil {
-				return readErr
-			}
-
-			info, infoErr := d.Info()
-			if infoErr != nil {
-				return infoErr
-			}
-			return os.WriteFile(destPath, content, info.Mode())
-		}); err != nil {
-			b.Fatalf("Failed to copy to pristine: %v", err)
-		}
-	}
-
-	workingDir := tmpBase
-
-	tgOptions, err := options.NewTerragruntOptionsForTest("")
-	if err != nil {
-		b.Fatalf("Failed to create options: %v", err)
-	}
-
-	tgOptions.WorkingDir = workingDir
-	tgOptions.HclExclude = []string{".history", "pristine"}
-	tgOptions.FilterQueries = []string{}
-	tgOptions.Experiments = experiment.NewExperiments()
-	tgOptions.Writer = io.Discard
-	tgOptions.ErrWriter = io.Discard
-
-	formatter := logformat.NewFormatter(logformat.NewKeyValueFormatPlaceholders())
-	formatter.SetDisabledColors(true)
-	l := log.New(log.WithOutput(io.Discard), log.WithLevel(log.ErrorLevel), log.WithFormatter(formatter))
-	ctx := context.Background()
-
-	b.ResetTimer()
-
-	for b.Loop() {
-		b.StopTimer()
-
-		if err := resetFixturesToUnformatted(pristineDir, workingDir); err != nil {
-			b.Fatalf("Failed to reset fixtures: %v", err)
-		}
-
-		b.StartTimer()
-
-		if err := format.Run(ctx, l, tgOptions); err != nil {
-			b.Fatalf("format.Run failed: %v", err)
-		}
-	}
-}
-
-// duplicateFixtures creates multiple copies of the fixtures directory structure to increase
-// the number of files for more realistic benchmarking.
-func duplicateFixtures(baseDir string, count int) error {
-	entries, err := os.ReadDir(baseDir)
-	if err != nil {
-		return err
-	}
-
-	var origDirs []string
-
-	for _, entry := range entries {
-		if entry.IsDir() && entry.Name()[0] != '.' {
-			origDirs = append(origDirs, filepath.Join(baseDir, entry.Name()))
-		}
-	}
-
-	for i := 1; i < count; i++ {
-		for _, origDir := range origDirs {
-			newDirName := filepath.Base(origDir) + "-dup-" + string(rune('0'+i/10)) + string(rune('0'+i%10))
-			newDir := filepath.Join(baseDir, newDirName)
-
-			err := filepath.WalkDir(origDir, func(path string, d fs.DirEntry, walkErr error) error {
-				if walkErr != nil {
-					return walkErr
-				}
-
-				relPath, relErr := filepath.Rel(origDir, path)
-				if relErr != nil {
-					return relErr
-				}
-
-				newPath := filepath.Join(newDir, relPath)
-
-				if d.IsDir() {
-					info, infoErr := d.Info()
-					if infoErr != nil {
-						return infoErr
-					}
-
-					return os.MkdirAll(newPath, info.Mode())
-				}
-
-				content, readErr := os.ReadFile(path)
-				if readErr != nil {
-					return readErr
-				}
-
-				info, infoErr := d.Info()
-				if infoErr != nil {
-					return infoErr
-				}
-
-				return os.WriteFile(newPath, content, info.Mode())
-			})
+			tgOptions, err := options.NewTerragruntOptionsForTest("")
 			if err != nil {
-				return err
+				b.Fatalf("Failed to create options: %v", err)
 			}
-		}
-	}
 
-	return nil
+			tgOptions.WorkingDir = tmpBase
+			tgOptions.HclExclude = excludeList
+			tgOptions.Writer = io.Discard
+			tgOptions.ErrWriter = io.Discard
+
+			formatter := logformat.NewFormatter(logformat.NewKeyValueFormatPlaceholders())
+			formatter.SetDisabledColors(true)
+			l := log.New(log.WithOutput(io.Discard), log.WithLevel(log.ErrorLevel), log.WithFormatter(formatter))
+			ctx := context.Background()
+
+			b.ResetTimer()
+
+			for b.Loop() {
+				b.StopTimer()
+
+				if err := createFiles(tmpBase, pristineContent, fileCount); err != nil {
+					b.Fatalf("Failed to create files: %v", err)
+				}
+
+				b.StartTimer()
+
+				if err := format.Run(ctx, l, tgOptions); err != nil {
+					b.Fatalf("format.Run failed: %v", err)
+				}
+			}
+		})
+	}
 }
 
-// resetFixturesToUnformatted copies the pristine unformatted fixtures back to the working directory
-func resetFixturesToUnformatted(pristineDir, workingDir string) error {
-	pristineDirName := filepath.Base(pristineDir)
-
+func createFiles(workingDir string, content []byte, count int) error {
 	entries, err := os.ReadDir(workingDir)
 	if err != nil {
 		return err
 	}
 
 	for _, entry := range entries {
-		if entry.Name()[0] == '.' || entry.Name() == pristineDirName {
-			continue
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), "dir-") {
+			if err := os.RemoveAll(filepath.Join(workingDir, entry.Name())); err != nil {
+				return err
+			}
+		}
+	}
+
+	for i := 1; i <= count; i++ {
+		dirName := fmt.Sprintf("dir-%04d", i)
+		dirPath := filepath.Join(workingDir, dirName)
+
+		nestedPath := filepath.Join(dirPath, "nested", "deep", "structure")
+		if err := os.MkdirAll(nestedPath, 0755); err != nil {
+			return err
 		}
 
-		path := filepath.Join(workingDir, entry.Name())
-		if err := os.RemoveAll(path); err != nil {
+		filePath := filepath.Join(nestedPath, "terragrunt.hcl")
+		if err := os.WriteFile(filePath, content, 0644); err != nil {
 			return err
 		}
 	}
 
-	return filepath.WalkDir(pristineDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		relPath, relErr := filepath.Rel(pristineDir, path)
-		if relErr != nil {
-			return relErr
-		}
-
-		if relPath == "." {
-			return nil
-		}
-
-		destPath := filepath.Join(workingDir, relPath)
-
-		if d.IsDir() {
-			info, infoErr := d.Info()
-			if infoErr != nil {
-				return infoErr
-			}
-
-			return os.MkdirAll(destPath, info.Mode())
-		}
-
-		content, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
-		}
-
-		info, infoErr := d.Info()
-		if infoErr != nil {
-			return infoErr
-		}
-
-		return os.WriteFile(destPath, content, info.Mode())
-	})
+	return nil
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Makes it a lot easier to compare different implementations of `hcl fmt`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored benchmark test infrastructure to simplify setup and improve efficiency of performance measurements through streamlined configuration and on-demand test data generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->