### PR TITLE
chore: Refactor `find` & `list` so that they use a single write instead of intermediate writes

### DIFF
--- a/cli/commands/find/find.go
+++ b/cli/commands/find/find.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/telemetry"
@@ -282,16 +283,17 @@ func (c *Colorizer) Colorize(foundComponent *FoundComponent) string {
 
 // outputText outputs the discovered components in text format.
 func outputText(l log.Logger, opts *Options, components FoundComponents) error {
+	var buf strings.Builder
+
 	colorizer := NewColorizer(shouldColor(l))
 
 	for _, c := range components {
-		_, err := opts.Writer.Write([]byte(colorizer.Colorize(c) + "\n"))
-		if err != nil {
-			return errors.New(err)
-		}
+		buf.WriteString(colorizer.Colorize(c) + "\n")
 	}
 
-	return nil
+	_, err := opts.Writer.Write([]byte(buf.String()))
+
+	return errors.New(err)
 }
 
 // shouldColor returns true if the output should be colored.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Refactors `find` & `list` so that they build up the string they're going to write before writing.

Ensures write operation is atomic, and prevents unnecessary syscalls.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced output rendering efficiency in the find and list commands through optimized buffer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->