### PR TITLE
feat: Integrating filters into discovery

### DIFF
--- a/internal/discovery/filter_integration_test.go
+++ b/internal/discovery/filter_integration_test.go
@@ -808,6 +808,8 @@ func TestDiscoveryWithReadingFiltersAndAbsolutePaths(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
+	tmpDir, err := filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, err)
 
 	// Create a shared file with absolute path
 	sharedFile := filepath.Join(tmpDir, "shared.hcl")

--- a/internal/filter/ast.go
+++ b/internal/filter/ast.go
@@ -13,8 +13,8 @@ type Expression interface {
 	expressionNode()
 	// String returns a string representation of the expression for debugging.
 	String() string
-	// RequiresHCLParsing returns true if the expression requires parsing Terragrunt HCL configurations.
-	RequiresHCLParsing() (Expression, bool)
+	// RequiresDiscovery returns true if the expression requires parsing Terragrunt HCL configurations.
+	RequiresDiscovery() (Expression, bool)
 }
 
 // PathFilter represents a path or glob filter (e.g., "./path/**/*" or "/absolute/path").
@@ -48,9 +48,9 @@ func (p *PathFilter) CompileGlob() (glob.Glob, error) {
 	return p.compiledGlob, p.compileErr
 }
 
-func (p *PathFilter) expressionNode()                        {}
-func (p *PathFilter) String() string                         { return p.Value }
-func (p *PathFilter) RequiresHCLParsing() (Expression, bool) { return p, false }
+func (p *PathFilter) expressionNode()                       {}
+func (p *PathFilter) String() string                        { return p.Value }
+func (p *PathFilter) RequiresDiscovery() (Expression, bool) { return p, false }
 
 // AttributeFilter represents a key-value attribute filter (e.g., "name=my-app").
 type AttributeFilter struct {
@@ -93,9 +93,9 @@ func (a *AttributeFilter) supportsGlob() bool {
 	return a.Key == AttributeReading || a.Key == AttributeName
 }
 
-func (a *AttributeFilter) expressionNode()                        {}
-func (a *AttributeFilter) String() string                         { return a.Key + "=" + a.Value }
-func (a *AttributeFilter) RequiresHCLParsing() (Expression, bool) { return a, true }
+func (a *AttributeFilter) expressionNode()                       {}
+func (a *AttributeFilter) String() string                        { return a.Key + "=" + a.Value }
+func (a *AttributeFilter) RequiresDiscovery() (Expression, bool) { return a, true }
 
 // PrefixExpression represents a prefix operator expression (e.g., "!name=foo").
 type PrefixExpression struct {
@@ -105,8 +105,8 @@ type PrefixExpression struct {
 
 func (p *PrefixExpression) expressionNode() {}
 func (p *PrefixExpression) String() string  { return p.Operator + p.Right.String() }
-func (p *PrefixExpression) RequiresHCLParsing() (Expression, bool) {
-	return p.Right.RequiresHCLParsing()
+func (p *PrefixExpression) RequiresDiscovery() (Expression, bool) {
+	return p.Right.RequiresDiscovery()
 }
 
 // InfixExpression represents an infix operator expression (e.g., "./apps/* | name=bar").
@@ -120,12 +120,12 @@ func (i *InfixExpression) expressionNode() {}
 func (i *InfixExpression) String() string {
 	return i.Left.String() + " " + i.Operator + " " + i.Right.String()
 }
-func (i *InfixExpression) RequiresHCLParsing() (Expression, bool) {
-	if _, ok := i.Left.RequiresHCLParsing(); ok {
+func (i *InfixExpression) RequiresDiscovery() (Expression, bool) {
+	if _, ok := i.Left.RequiresDiscovery(); ok {
 		return i, true
 	}
 
-	if _, ok := i.Right.RequiresHCLParsing(); ok {
+	if _, ok := i.Right.RequiresDiscovery(); ok {
 		return i, true
 	}
 

--- a/internal/filter/errors.go
+++ b/internal/filter/errors.go
@@ -45,14 +45,14 @@ func NewEvaluationErrorWithCause(message string, cause error) error {
 	return errors.New(EvaluationError{Message: message, Cause: cause})
 }
 
-// FilterQueryRequiresHCLParsingError is an error that is returned when a filter query requires parsing Terragrunt configurations.
-type FilterQueryRequiresHCLParsingError struct {
+// FilterQueryRequiresDiscoveryError is an error that is returned when a filter query requires discovery of Terragrunt configurations.
+type FilterQueryRequiresDiscoveryError struct {
 	Query string
 }
 
-func (e FilterQueryRequiresHCLParsingError) Error() string {
+func (e FilterQueryRequiresDiscoveryError) Error() string {
 	return fmt.Sprintf(
-		"Filter query '%s' requires parsing Terragrunt configurations, which is not supported when evaluating filters on files",
+		"Filter query '%s' requires discovery of Terragrunt configurations, which is not supported when evaluating filters on generic files",
 		e.Query,
 	)
 }

--- a/internal/filter/filters.go
+++ b/internal/filter/filters.go
@@ -56,10 +56,10 @@ func (f Filters) HasPositiveFilter() bool {
 	return false
 }
 
-// RequiresHCLParsing returns the first expression that requires parsing Terragrunt HCL configurations if any do.
-func (f Filters) RequiresHCLParsing() (Expression, bool) {
+// RequiresDiscovery returns the first expression that requires discovery of Terragrunt components if any do.
+func (f Filters) RequiresDiscovery() (Expression, bool) {
 	for _, filter := range f {
-		if e, ok := filter.expr.RequiresHCLParsing(); ok {
+		if e, ok := filter.expr.RequiresDiscovery(); ok {
 			return e, true
 		}
 	}
@@ -114,8 +114,8 @@ func (f Filters) Evaluate(components component.Components) (component.Components
 // This is useful for the hcl format command, where we want to evaluate filters on files
 // rather than directories, like we do with components.
 func (f Filters) EvaluateOnFiles(files []string) (component.Components, error) {
-	if e, ok := f.RequiresHCLParsing(); ok {
-		return nil, FilterQueryRequiresHCLParsingError{Query: e.String()}
+	if e, ok := f.RequiresDiscovery(); ok {
+		return nil, FilterQueryRequiresDiscoveryError{Query: e.String()}
 	}
 
 	comps := make(component.Components, 0, len(files))

--- a/test/integration_hcl_filter_test.go
+++ b/test/integration_hcl_filter_test.go
@@ -120,31 +120,31 @@ func TestHCLFormatCheckWithFilter(t *testing.T) {
 			name:        "error: name=*.stack.hcl requires HCL parsing",
 			filterArgs:  []string{"name=*.stack.hcl"},
 			expectError: true,
-			errorAs:     filter.FilterQueryRequiresHCLParsingError{Query: "name=*.stack.hcl"},
+			errorAs:     filter.FilterQueryRequiresDiscoveryError{Query: "name=*.stack.hcl"},
 		},
 		{
 			name:        "error: type=unit requires HCL parsing",
 			filterArgs:  []string{"type=unit"},
 			expectError: true,
-			errorAs:     filter.FilterQueryRequiresHCLParsingError{Query: "type=unit"},
+			errorAs:     filter.FilterQueryRequiresDiscoveryError{Query: "type=unit"},
 		},
 		{
 			name:        "error: type=stack requires HCL parsing",
 			filterArgs:  []string{"type=stack"},
 			expectError: true,
-			errorAs:     filter.FilterQueryRequiresHCLParsingError{Query: "type=stack"},
+			errorAs:     filter.FilterQueryRequiresDiscoveryError{Query: "type=stack"},
 		},
 		{
 			name:        "error: external=true requires HCL parsing",
 			filterArgs:  []string{"external=true"},
 			expectError: true,
-			errorAs:     filter.FilterQueryRequiresHCLParsingError{Query: "external=true"},
+			errorAs:     filter.FilterQueryRequiresDiscoveryError{Query: "external=true"},
 		},
 		{
 			name:        "error: intersection with type filter",
 			filterArgs:  []string{"./needs-formatting/** | type=unit"},
 			expectError: true,
-			errorAs:     filter.FilterQueryRequiresHCLParsingError{Query: "./needs-formatting/** | type=unit"},
+			errorAs:     filter.FilterQueryRequiresDiscoveryError{Query: "./needs-formatting/** | type=unit"},
 		},
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Starts integrating filters into the logic for discovery so that we can prevent discovery of components when certain filters are set.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates filter-aware discovery (with experiment flag), refactors constructor, and renames filter parsing requirements to "RequiresDiscovery" with updated errors and tests.
> 
> - **Discovery**:
>   - Enable filter-aware traversal via `WithFilterFlagEnabled` and `WithFilters`; positive filters set `excludeByDefault`.
>   - Skip exclude globs during walk when filter flag is enabled; early file-level filtering and refined hidden-dir handling.
>   - Extract `NewDiscovery` to `constructor.go`; wire filters into `NewForDiscoveryCommand` and `NewForHCLCommand`.
>   - Add `createComponentFromPath` helper; minor concurrency/walk refactors.
> - **Filter Engine**:
>   - Rename `RequiresHCLParsing` → `RequiresDiscovery` across AST and `Filters`.
>   - Replace `FilterQueryRequiresHCLParsingError` with `FilterQueryRequiresDiscoveryError` and update messages.
> - **Tests**:
>   - Add/extend discovery and integration tests for filter behavior (include/exclude defaults, reading file filters incl. absolute paths) and updated error types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cad37ef8d5c4b16ba091f2470e5fd5c4075ffa20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filters are now evaluated during the discovery phase, enabling more efficient filtering of Terragrunt configurations.
  * Added improved handling for symlinked paths in filter-based discovery.

* **Bug Fixes**
  * Enhanced directory exclusion logic to respect filter configurations more accurately.

* **Tests**
  * Added test coverage for filter-driven discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->