### PR TITLE
Add beta releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ workflows:
               only:
                 - /^v.*/
                 - /^alpha.*/
+                - /^beta.*/
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests
@@ -128,6 +129,7 @@ workflows:
               only:
                 - /^v.*/
                 - /^alpha.*/
+                - /^beta.*/
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GCP__automated-tests
@@ -141,6 +143,7 @@ workflows:
               only:
                 - /^v.*/
                 - /^alpha.*/
+                - /^beta.*/
             branches:
               ignore: /.*/
           context:


### PR DESCRIPTION
This release https://github.com/gruntwork-io/terragrunt/releases/tag/beta-2025110302 is missing assets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to support beta release builds and deployments, enabling beta versions to proceed through standard quality checks alongside regular releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->