### PR TITLE
chore: Updating pin to `v0.93.2` for remote references

### DIFF
--- a/test/fixtures/download/hello-world/main.tf
+++ b/test/fixtures/download/hello-world/main.tf
@@ -29,6 +29,6 @@ output "test" {
 }
 
 module "remote" {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=2ca67fe2dbd3001c4cffa66df9567ca497182cb1"
+  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
   name   = var.name
 }

--- a/test/fixtures/download/remote-ref/terragrunt.hcl
+++ b/test/fixtures/download/remote-ref/terragrunt.hcl
@@ -3,5 +3,5 @@ inputs = {
 }
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=2ca67fe2dbd3001c4cffa66df9567ca497182cb1"
+  source = "git::git@github.com:gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
 }

--- a/test/fixtures/download/remote-relative-with-slash/terragrunt.hcl
+++ b/test/fixtures/download/remote-relative-with-slash/terragrunt.hcl
@@ -3,5 +3,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git?ref=2ca67fe2dbd3001c4cffa66df9567ca497182cb1//test/fixtures/download/relative"
+  source = "github.com/gruntwork-io/terragrunt.git?ref=v0.93.2//test/fixtures/download/relative"
 }

--- a/test/fixtures/download/remote-relative/terragrunt.hcl
+++ b/test/fixtures/download/remote-relative/terragrunt.hcl
@@ -3,5 +3,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/relative?ref=2ca67fe2dbd3001c4cffa66df9567ca497182cb1"
+  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/relative?ref=v0.93.2"
 }

--- a/test/fixtures/download/remote/terragrunt.hcl
+++ b/test/fixtures/download/remote/terragrunt.hcl
@@ -3,5 +3,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=2ca67fe2dbd3001c4cffa66df9567ca497182cb1"
+  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Had to temporarily pin this to a commit before, and this restores it to a tag-based commit:
https://github.com/gruntwork-io/terragrunt/commit/7c30c1b9fd21fd6566cc17215bfdeae1feea2fcb

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated commit-based remote references to tag-based references.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test fixture references to use a tagged release version (v0.93.2) instead of specific commit hashes for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->