### PR TITLE
chore: Refactor direct access of `run` command flags to access in `shared` package

### DIFF
--- a/cli/commands/backend/bootstrap/cli.go
+++ b/cli/commands/backend/bootstrap/cli.go
@@ -2,8 +2,8 @@ package bootstrap
 
 import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
-	runcmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
+	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -13,12 +13,14 @@ import (
 const CommandName = "bootstrap"
 
 func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
-	base := runcmd.NewFlags(l, opts, prefix).Filter(runcmd.ConfigFlagName, runcmd.DownloadDirFlagName)
-	// Also include backend-related and feature flags explicitly for backend commands
-	base = append(base, runcmd.NewBackendFlags(l, opts, prefix)...)
-	base = append(base, runcmd.NewFeatureFlags(l, opts, prefix)...)
+	sharedFlags := cli.Flags{
+		shared.NewConfigFlag(opts, prefix, CommandName),
+		shared.NewDownloadDirFlag(opts, prefix, CommandName),
+	}
+	sharedFlags = append(sharedFlags, shared.NewBackendFlags(opts, prefix)...)
+	sharedFlags = append(sharedFlags, shared.NewFeatureFlags(opts, prefix)...)
 
-	return base
+	return sharedFlags
 }
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {

--- a/cli/commands/backend/delete/cli.go
+++ b/cli/commands/backend/delete/cli.go
@@ -2,8 +2,8 @@ package delete
 
 import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
-	runcmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
+	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -20,7 +20,14 @@ const (
 func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
-	flags := cli.Flags{
+	sharedFlags := cli.Flags{
+		shared.NewConfigFlag(opts, prefix, CommandName),
+		shared.NewDownloadDirFlag(opts, prefix, CommandName),
+	}
+	sharedFlags = append(sharedFlags, shared.NewBackendFlags(opts, prefix)...)
+	sharedFlags = append(sharedFlags, shared.NewFeatureFlags(opts, prefix)...)
+
+	return append(sharedFlags,
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        BucketFlagName,
 			EnvVars:     tgPrefix.EnvVars(BucketFlagName),
@@ -34,13 +41,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:       "Force the backend to be deleted, even if the bucket is not versioned.",
 			Destination: &opts.ForceBackendDelete,
 		}),
-	}
-
-	base := runcmd.NewFlags(l, opts, prefix).Filter(runcmd.ConfigFlagName, runcmd.DownloadDirFlagName)
-	base = append(base, runcmd.NewBackendFlags(l, opts, prefix)...)
-	base = append(base, runcmd.NewFeatureFlags(l, opts, prefix)...)
-
-	return append(flags, base...)
+	)
 }
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {

--- a/cli/commands/backend/migrate/cli.go
+++ b/cli/commands/backend/migrate/cli.go
@@ -1,8 +1,8 @@
 package migrate
 
 import (
-	"github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
+	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -20,20 +20,21 @@ const (
 func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
-	flags := cli.Flags{
+	sharedFlags := cli.Flags{
+		shared.NewConfigFlag(opts, prefix, CommandName),
+		shared.NewDownloadDirFlag(opts, prefix, CommandName),
+	}
+	sharedFlags = append(sharedFlags, shared.NewBackendFlags(opts, prefix)...)
+	sharedFlags = append(sharedFlags, shared.NewFeatureFlags(opts, prefix)...)
+
+	return append(sharedFlags,
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        ForceBackendMigrateFlagName,
 			EnvVars:     tgPrefix.EnvVars(ForceBackendMigrateFlagName),
 			Usage:       "Force the backend to be migrated, even if the bucket is not versioned.",
 			Destination: &opts.ForceBackendMigrate,
 		}),
-	}
-
-	base := run.NewFlags(l, opts, prefix).Filter(run.ConfigFlagName, run.DownloadDirFlagName)
-	base = append(base, run.NewBackendFlags(l, opts, prefix)...)
-	base = append(base, run.NewFeatureFlags(l, opts, prefix)...)
-
-	return append(flags, base...)
+	)
 }
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {

--- a/cli/commands/dag/graph/cli.go
+++ b/cli/commands/dag/graph/cli.go
@@ -6,7 +6,6 @@ package graph
 
 import (
 	"github.com/gruntwork-io/terragrunt/cli/commands/list"
-	runCmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -18,17 +17,16 @@ const (
 )
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
-	// Build flags: queue flags + backend/feature flags + filter flag
-	cmdFlags := shared.NewQueueFlags(opts, nil)
-	cmdFlags = append(cmdFlags, runCmd.NewBackendFlags(l, opts, nil)...)
-	cmdFlags = append(cmdFlags, runCmd.NewFeatureFlags(l, opts, nil)...)
-	cmdFlags = append(cmdFlags, shared.NewFilterFlag(opts))
+	sharedFlags := shared.NewQueueFlags(opts, nil)
+	sharedFlags = append(sharedFlags, shared.NewBackendFlags(opts, nil)...)
+	sharedFlags = append(sharedFlags, shared.NewFeatureFlags(opts, nil)...)
+	sharedFlags = append(sharedFlags, shared.NewFilterFlag(opts))
 
 	return &cli.Command{
 		Name:      CommandName,
 		Usage:     "Graph the Directed Acyclic Graph (DAG) in DOT language. Alias for 'list --format=dot --dag --dependencies --external'.",
 		UsageText: "terragrunt dag graph",
-		Flags:     cmdFlags,
+		Flags:     sharedFlags,
 		Action: func(ctx *cli.Context) error {
 			return Run(ctx, l, opts)
 		},

--- a/cli/commands/exec/cli.go
+++ b/cli/commands/exec/cli.go
@@ -3,8 +3,8 @@
 package exec
 
 import (
-	"github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
+	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -20,17 +20,18 @@ const (
 func NewFlags(l log.Logger, opts *options.TerragruntOptions, cmdOpts *Options, prefix flags.Prefix) cli.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
-	return append(run.NewFlags(l, opts, prefix).Filter(
-		run.AuthProviderCmdFlagName,
-		run.ConfigFlagName,
-		run.DownloadDirFlagName,
-		run.InputsDebugFlagName,
-		run.IAMAssumeRoleFlagName,
-		run.IAMAssumeRoleDurationFlagName,
-		run.IAMAssumeRoleSessionNameFlagName,
-		run.IAMAssumeRoleWebIdentityTokenFlagName,
-		run.TFPathFlagName,
-	),
+	sharedFlags := append(
+		cli.Flags{
+			shared.NewConfigFlag(opts, prefix, CommandName),
+			shared.NewDownloadDirFlag(opts, prefix, CommandName),
+			shared.NewTFPathFlag(opts),
+			shared.NewAuthProviderCmdFlag(opts, prefix, CommandName),
+			shared.NewInputsDebugFlag(opts, prefix, CommandName),
+		},
+		shared.NewIAMAssumeRoleFlags(opts, prefix, CommandName)...,
+	)
+
+	return append(sharedFlags,
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        InDownloadDirFlagName,
 			EnvVars:     tgPrefix.EnvVars(InDownloadDirFlagName),

--- a/cli/commands/find/cli.go
+++ b/cli/commands/find/cli.go
@@ -3,7 +3,6 @@
 package find
 
 import (
-	runCmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -109,8 +108,8 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 
 	// Base flags for find plus backend/feature flags
 	flags := NewFlags(cmdOpts, nil)
-	flags = append(flags, runCmd.NewBackendFlags(l, opts, nil)...)
-	flags = append(flags, runCmd.NewFeatureFlags(l, opts, nil)...)
+	flags = append(flags, shared.NewBackendFlags(opts, nil)...)
+	flags = append(flags, shared.NewFeatureFlags(opts, nil)...)
 
 	return &cli.Command{
 		Name:    CommandName,

--- a/cli/commands/list/cli.go
+++ b/cli/commands/list/cli.go
@@ -3,7 +3,6 @@
 package list
 
 import (
-	runCmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -99,8 +98,8 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 
 	// Base flags for list plus backend/feature flags
 	flags := NewFlags(cmdOpts, prefix)
-	flags = append(flags, runCmd.NewBackendFlags(l, opts, prefix)...)
-	flags = append(flags, runCmd.NewFeatureFlags(l, opts, prefix)...)
+	flags = append(flags, shared.NewBackendFlags(opts, prefix)...)
+	flags = append(flags, shared.NewFeatureFlags(opts, prefix)...)
 
 	return &cli.Command{
 		Name:    CommandName,

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -16,15 +16,11 @@ import (
 )
 
 const (
-	ConfigFlagName                         = "config"
 	NoAutoInitFlagName                     = "no-auto-init"
 	NoAutoRetryFlagName                    = "no-auto-retry"
 	NoAutoApproveFlagName                  = "no-auto-approve"
 	NoAutoProviderCacheDirFlagName         = "no-auto-provider-cache-dir"
-	DownloadDirFlagName                    = "download-dir"
 	TFForwardStdoutFlagName                = "tf-forward-stdout"
-	TFPathFlagName                         = "tf-path"
-	InputsDebugFlagName                    = "inputs-debug"
 	UnitsThatIncludeFlagName               = "units-that-include"
 	DependencyFetchOutputFromStateFlagName = "dependency-fetch-output-from-state"
 	UsePartialParseConfigCacheFlagName     = "use-partial-parse-config-cache"
@@ -32,7 +28,6 @@ const (
 	VersionManagerFileNameFlagName         = "version-manager-file-name"
 
 	DisableCommandValidationFlagName   = "disable-command-validation"
-	AuthProviderCmdFlagName            = "auth-provider-cmd"
 	NoDestroyDependenciesCheckFlagName = "no-destroy-dependencies-check"
 
 	SourceFlagName       = "source"
@@ -40,13 +35,6 @@ const (
 	SourceUpdateFlagName = "source-update"
 
 	NoStackGenerate = "no-stack-generate"
-
-	// Assume IAM Role flags.
-
-	IAMAssumeRoleFlagName                 = "iam-assume-role"
-	IAMAssumeRoleDurationFlagName         = "iam-assume-role-duration"
-	IAMAssumeRoleSessionNameFlagName      = "iam-assume-role-session-name"
-	IAMAssumeRoleWebIdentityTokenFlagName = "iam-assume-role-web-identity-token"
 
 	// Terragrunt Provider Cache related flags.
 
@@ -81,11 +69,23 @@ const (
 
 	FailFastFlagName = "fail-fast"
 
-	// Backend and feature flags (shared with backend commands)
-	BackendBootstrapFlagName        = "backend-bootstrap"
-	BackendRequireBootstrapFlagName = "backend-require-bootstrap"
-	DisableBucketUpdateFlagName     = "disable-bucket-update"
-	FeatureFlagName                 = "feature"
+	// Backend and feature flags (shared with backend commands) - use shared package constants
+	BackendBootstrapFlagName        = shared.BackendBootstrapFlagName
+	BackendRequireBootstrapFlagName = shared.BackendRequireBootstrapFlagName
+	DisableBucketUpdateFlagName     = shared.DisableBucketUpdateFlagName
+	FeatureFlagName                 = shared.FeatureFlagName
+
+	// Config and download flags - use shared package constants
+	ConfigFlagName      = shared.ConfigFlagName
+	DownloadDirFlagName = shared.DownloadDirFlagName
+
+	// Auth and IAM flags - use shared package constants
+	AuthProviderCmdFlagName               = shared.AuthProviderCmdFlagName
+	InputsDebugFlagName                   = shared.InputsDebugFlagName
+	IAMAssumeRoleFlagName                 = shared.IAMAssumeRoleFlagName
+	IAMAssumeRoleDurationFlagName         = shared.IAMAssumeRoleDurationFlagName
+	IAMAssumeRoleSessionNameFlagName      = shared.IAMAssumeRoleSessionNameFlagName
+	IAMAssumeRoleWebIdentityTokenFlagName = shared.IAMAssumeRoleWebIdentityTokenFlagName
 )
 
 // NewFlags creates and returns global flags.
@@ -135,13 +135,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 
 		//  Backward compatibility with `terragrunt-` prefix flags.
 
-		flags.NewFlag(&cli.GenericFlag[string]{
-			Name:        ConfigFlagName,
-			EnvVars:     tgPrefix.EnvVars(ConfigFlagName),
-			Destination: &opts.TerragruntConfigPath,
-			Usage:       "The path to the Terragrunt config file. Default is terragrunt.hcl.",
-		},
-			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("config"), terragruntPrefixControl)),
+		shared.NewConfigFlag(opts, prefix, CommandName),
 
 		shared.NewTFPathFlag(opts),
 
@@ -185,17 +179,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Usage:       "Disable the auto-provider-cache-dir feature even when the experiment is enabled.",
 		}),
 
-		flags.NewFlag(&cli.GenericFlag[string]{
-			Name:        DownloadDirFlagName,
-			EnvVars:     tgPrefix.EnvVars(DownloadDirFlagName),
-			Destination: &opts.DownloadDir,
-			Usage:       "The path to download OpenTofu/Terraform modules into. Default is .terragrunt-cache in the working directory.",
-		}, flags.WithDeprecatedEnvVars(
-			append(
-				terragruntPrefix.EnvVars("download"),
-				terragruntPrefix.EnvVars("download-dir")...,
-			),
-			terragruntPrefixControl)),
+		shared.NewDownloadDirFlag(opts, prefix, CommandName),
 
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        SourceFlagName,
@@ -223,53 +207,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("source-map"), terragruntPrefixControl)),
 
 		// Assume IAM Role flags.
-
-		flags.NewFlag(&cli.GenericFlag[string]{
-			Name:        IAMAssumeRoleFlagName,
-			EnvVars:     tgPrefix.EnvVars(IAMAssumeRoleFlagName),
-			Destination: &opts.IAMRoleOptions.RoleARN,
-			Usage:       "Assume the specified IAM role before executing OpenTofu/Terraform.",
-		},
-			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("iam-role"), terragruntPrefixControl)),
-
-		flags.NewFlag(&cli.GenericFlag[int64]{
-			Name:        IAMAssumeRoleDurationFlagName,
-			EnvVars:     tgPrefix.EnvVars(IAMAssumeRoleDurationFlagName),
-			Destination: &opts.IAMRoleOptions.AssumeRoleDuration,
-			Usage:       "Session duration for IAM Assume Role session.",
-		},
-			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("iam-assume-role-duration"), terragruntPrefixControl)),
-
-		flags.NewFlag(&cli.GenericFlag[string]{
-			Name:        IAMAssumeRoleSessionNameFlagName,
-			EnvVars:     tgPrefix.EnvVars(IAMAssumeRoleSessionNameFlagName),
-			Destination: &opts.IAMRoleOptions.AssumeRoleSessionName,
-			Usage:       "Name for the IAM Assumed Role session.",
-		},
-			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("iam-assume-role-session-name"), terragruntPrefixControl)),
-
-		flags.NewFlag(&cli.GenericFlag[string]{
-			Name:        IAMAssumeRoleWebIdentityTokenFlagName,
-			EnvVars:     tgPrefix.EnvVars(IAMAssumeRoleWebIdentityTokenFlagName),
-			Destination: &opts.IAMRoleOptions.WebIdentityToken,
-			Usage:       "For AssumeRoleWithWebIdentity, the WebIdentity token.",
-		},
-			flags.WithDeprecatedEnvVars(
-				append(
-					terragruntPrefix.EnvVars("iam-web-identity-token"),
-					terragruntPrefix.EnvVars("iam-assume-role-web-identity-token")...,
-				),
-				terragruntPrefixControl,
-			),
-		),
-
-		flags.NewFlag(&cli.BoolFlag{
-			Name:        InputsDebugFlagName,
-			EnvVars:     tgPrefix.EnvVars(InputsDebugFlagName),
-			Destination: &opts.Debug,
-			Usage:       "Write debug.tfvars to working folder to help root-cause issues.",
-		},
-			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("debug"), terragruntPrefixControl)),
+		shared.NewInputsDebugFlag(opts, prefix, CommandName),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        UsePartialParseConfigCacheFlagName,
@@ -377,13 +315,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 		},
 			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("provider-cache-registry-names"), terragruntPrefixControl)),
 
-		flags.NewFlag(&cli.GenericFlag[string]{
-			Name:        AuthProviderCmdFlagName,
-			EnvVars:     tgPrefix.EnvVars(AuthProviderCmdFlagName),
-			Destination: &opts.AuthProviderCmd,
-			Usage:       "Run the provided command and arguments to authenticate Terragrunt dynamically when necessary.",
-		},
-			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("auth-provider-cmd"), terragruntPrefixControl)),
+		shared.NewAuthProviderCmdFlag(opts, prefix, CommandName),
 
 		// Terragrunt engine flags.
 
@@ -505,67 +437,12 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 	}
 
 	// Add shared flags
-	flags = flags.Add(NewBackendFlags(l, opts, prefix)...)
-	flags = flags.Add(NewFeatureFlags(l, opts, prefix)...)
+	flags = flags.Add(shared.NewBackendFlags(opts, prefix)...)
+	flags = flags.Add(shared.NewFeatureFlags(opts, prefix)...)
+	flags = flags.Add(shared.NewIAMAssumeRoleFlags(opts, prefix, CommandName)...)
 	flags = flags.Add(shared.NewQueueFlags(opts, prefix)...)
 	flags = flags.Add(shared.NewFilterFlag(opts))
 	flags = flags.Add(shared.NewParallelismFlag(opts))
 
 	return flags.Sort()
-}
-
-// NewBackendFlags defines backend-related flags that should be available to both `run` and `backend` commands.
-func NewBackendFlags(_ log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
-	tgPrefix := prefix.Prepend(flags.TgPrefix)
-	terragruntPrefix := prefix.Prepend(flags.TerragruntPrefix)
-	terragruntPrefixControl := flags.StrictControlsByGlobalFlags(opts.StrictControls)
-
-	return cli.Flags{
-		flags.NewFlag(&cli.BoolFlag{
-			Name:        BackendBootstrapFlagName,
-			EnvVars:     tgPrefix.EnvVars(BackendBootstrapFlagName),
-			Destination: &opts.BackendBootstrap,
-			Usage:       "Automatically bootstrap backend infrastructure before attempting to use it.",
-		}),
-		flags.NewFlag(&cli.BoolFlag{
-			Name:        BackendRequireBootstrapFlagName,
-			EnvVars:     tgPrefix.EnvVars(BackendRequireBootstrapFlagName),
-			Destination: &opts.FailIfBucketCreationRequired,
-			Usage:       "When this flag is set Terragrunt will fail if the remote state bucket needs to be created.",
-		},
-			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("fail-on-state-bucket-creation"), terragruntPrefixControl),
-		),
-		flags.NewFlag(&cli.BoolFlag{
-			Name:        DisableBucketUpdateFlagName,
-			EnvVars:     tgPrefix.EnvVars(DisableBucketUpdateFlagName),
-			Destination: &opts.DisableBucketUpdate,
-			Usage:       "When this flag is set Terragrunt will not update the remote state bucket.",
-		},
-			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("disable-bucket-update"), terragruntPrefixControl),
-		),
-	}
-}
-
-// NewFeatureFlags defines the feature flag map that should be available to both `run` and `backend` commands.
-func NewFeatureFlags(_ log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
-	tgPrefix := prefix.Prepend(flags.TgPrefix)
-	terragruntPrefix := prefix.Prepend(flags.TerragruntPrefix)
-	terragruntPrefixControl := flags.StrictControlsByGlobalFlags(opts.StrictControls)
-
-	return cli.Flags{
-		flags.NewFlag(&cli.MapFlag[string, string]{
-			Name:    FeatureFlagName,
-			EnvVars: tgPrefix.EnvVars(FeatureFlagName),
-			Usage:   "Set feature flags for the HCL code.",
-			// Use default splitting behavior with comma separators via MapFlag defaults
-			Action: func(_ *cli.Context, value map[string]string) error {
-				for key, val := range value {
-					opts.FeatureFlags.Store(key, val)
-				}
-				return nil
-			},
-		},
-			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("feature"), terragruntPrefixControl),
-		),
-	}
 }

--- a/cli/commands/scaffold/cli.go
+++ b/cli/commands/scaffold/cli.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	runCmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/config"
@@ -67,8 +66,8 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 	flags := NewFlags(opts, nil)
 	// Accept backend and feature flags for scaffold as well
-	flags = append(flags, runCmd.NewBackendFlags(l, opts, nil)...)
-	flags = append(flags, runCmd.NewFeatureFlags(l, opts, nil)...)
+	flags = append(flags, shared.NewBackendFlags(opts, nil)...)
+	flags = append(flags, shared.NewFeatureFlags(opts, nil)...)
 
 	return &cli.Command{
 		Name:  CommandName,

--- a/cli/commands/stack/cli.go
+++ b/cli/commands/stack/cli.go
@@ -2,7 +2,7 @@
 package stack
 
 import (
-	"github.com/gruntwork-io/terragrunt/cli/commands/run"
+	runcmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -85,7 +85,7 @@ func defaultFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Pr
 		}),
 	}
 
-	return append(run.NewFlags(l, opts, nil), flags...)
+	return append(runcmd.NewFlags(l, opts, nil), flags...)
 }
 
 func outputFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Refactors the pattern of using shared access to the `cli/commands/run` package in different commands to instead leverage a dedicated `cli/flags/shared` package.

This keeps the shared flag definitions in one place, which makes it easier to isolate logic related to shared flags, and reduces the risk of circular dependencies.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated CLI command flag management into a centralized shared package, improving code organization across multiple backend, execution, and utility commands while maintaining consistency of command-line interfaces and behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->