### PR TITLE
chore: Refactor out usage of `--all` and `--graph` wrappers where they aren't needed

### DIFF
--- a/cli/commands/aws-provider-patch/cli.go
+++ b/cli/commands/aws-provider-patch/cli.go
@@ -30,12 +30,10 @@
 package awsproviderpatch
 
 import (
-	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
-	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	runcmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
+	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -71,7 +69,13 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Name:   CommandName,
 		Usage:  "Overwrite settings on nested AWS providers to work around a Terraform bug (issue #13018).",
 		Hidden: true,
-		Flags:  append(runcmd.NewFlags(l, opts, nil), NewFlags(l, opts, nil)...),
+		Flags: append(
+			append(
+				append(runcmd.NewFlags(l, opts, nil), NewFlags(l, opts, nil)...),
+				shared.NewAllFlag(opts, CommandName, nil),
+			),
+			shared.NewGraphFlag(opts, CommandName, nil),
+		),
 		Before: func(ctx *cli.Context) error {
 			if err := control.Evaluate(ctx); err != nil {
 				return cli.NewExitError(err, cli.ExitCodeGeneralError)
@@ -84,9 +88,6 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		},
 		DisabledErrorOnUndefinedFlag: true,
 	}
-
-	cmd = runall.WrapCommand(l, opts, cmd, run.Run, true)
-	cmd = graph.WrapCommand(l, opts, cmd, run.Run, true)
 
 	return cmd
 }

--- a/cli/commands/backend/bootstrap/bootstrap.go
+++ b/cli/commands/backend/bootstrap/bootstrap.go
@@ -3,17 +3,84 @@ package bootstrap
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
 func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
+	// If --all is set, discover components and iterate
+	if opts.RunAll {
+		return runOnDiscoveredComponents(ctx, l, opts)
+	}
+
+	// Otherwise, run on single component
+	return runBootstrap(ctx, l, opts)
+}
+
+func runBootstrap(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
 	remoteState, err := config.ParseRemoteState(ctx, l, opts)
 	if err != nil || remoteState == nil {
 		return err
 	}
 
 	return remoteState.Bootstrap(ctx, l, opts)
+}
+
+func runOnDiscoveredComponents(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
+	// Create discovery
+	d, err := discovery.NewForDiscoveryCommand(discovery.DiscoveryCommandOptions{
+		WorkingDir:    opts.WorkingDir,
+		FilterQueries: opts.FilterQueries,
+		Experiments:   opts.Experiments,
+		Hidden:        true,
+		Dependencies:  false,
+		External:      false,
+		Exclude:       true,
+		Include:       true,
+	})
+	if err != nil {
+		return errors.New(err)
+	}
+
+	components, err := d.Discover(ctx, l, opts)
+	if err != nil {
+		return errors.New(err)
+	}
+
+	// Run the bootstrap logic on each component
+	var errs []error
+
+	for _, c := range components {
+		if _, ok := c.(*component.Stack); ok {
+			continue // Skip stacks
+		}
+
+		componentOpts := opts.Clone()
+		componentOpts.WorkingDir = c.Path()
+
+		// Determine config path for this component
+		configFilename := config.DefaultTerragruntConfigPath
+		if len(opts.TerragruntConfigPath) > 0 {
+			configFilename = filepath.Base(opts.TerragruntConfigPath)
+		}
+
+		componentOpts.TerragruntConfigPath = filepath.Join(c.Path(), configFilename)
+
+		// Run the bootstrap logic for this component
+		if err := runBootstrap(ctx, l, componentOpts); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
 }

--- a/cli/commands/backend/bootstrap/cli.go
+++ b/cli/commands/backend/bootstrap/cli.go
@@ -1,11 +1,9 @@
 package bootstrap
 
 import (
-	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -19,6 +17,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 	}
 	sharedFlags = append(sharedFlags, shared.NewBackendFlags(opts, prefix)...)
 	sharedFlags = append(sharedFlags, shared.NewFeatureFlags(opts, prefix)...)
+	sharedFlags = append(sharedFlags, shared.NewAllFlag(opts, CommandName, prefix))
 
 	return sharedFlags
 }
@@ -32,8 +31,6 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 			return Run(ctx, l, opts.OptionsFromContext(ctx))
 		},
 	}
-
-	cmd = runall.WrapCommand(l, opts, cmd, run.Run, true)
 
 	return cmd
 }

--- a/cli/commands/backend/delete/cli.go
+++ b/cli/commands/backend/delete/cli.go
@@ -1,11 +1,9 @@
 package delete
 
 import (
-	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -26,6 +24,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 	}
 	sharedFlags = append(sharedFlags, shared.NewBackendFlags(opts, prefix)...)
 	sharedFlags = append(sharedFlags, shared.NewFeatureFlags(opts, prefix)...)
+	sharedFlags = append(sharedFlags, shared.NewAllFlag(opts, CommandName, prefix))
 
 	return append(sharedFlags,
 		flags.NewFlag(&cli.BoolFlag{
@@ -53,8 +52,6 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 			return Run(ctx, l, opts.OptionsFromContext(ctx))
 		},
 	}
-
-	cmd = runall.WrapCommand(l, opts, cmd, run.Run, true)
 
 	return cmd
 }

--- a/cli/commands/backend/delete/delete.go
+++ b/cli/commands/backend/delete/delete.go
@@ -3,8 +3,11 @@ package delete
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -12,6 +15,16 @@ import (
 )
 
 func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
+	// If --all is set, discover components and iterate
+	if opts.RunAll {
+		return runOnDiscoveredComponents(ctx, l, opts)
+	}
+
+	// Otherwise, run on single component
+	return runDelete(ctx, l, opts)
+}
+
+func runDelete(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
 	remoteState, err := config.ParseRemoteState(ctx, l, opts)
 	if err != nil || remoteState == nil {
 		return err
@@ -34,4 +47,57 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 	}
 
 	return remoteState.Delete(ctx, l, opts)
+}
+
+func runOnDiscoveredComponents(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
+	// Create discovery
+	d, err := discovery.NewForDiscoveryCommand(discovery.DiscoveryCommandOptions{
+		WorkingDir:    opts.WorkingDir,
+		FilterQueries: opts.FilterQueries,
+		Experiments:   opts.Experiments,
+		Hidden:        true,
+		Dependencies:  false,
+		External:      false,
+		Exclude:       true,
+		Include:       true,
+	})
+	if err != nil {
+		return errors.New(err)
+	}
+
+	components, err := d.Discover(ctx, l, opts)
+	if err != nil {
+		return errors.New(err)
+	}
+
+	// Run the delete logic on each component
+	var errs []error
+
+	for _, c := range components {
+		if _, ok := c.(*component.Stack); ok {
+			continue // Skip stacks
+		}
+
+		componentOpts := opts.Clone()
+		componentOpts.WorkingDir = c.Path()
+
+		// Determine config path for this component
+		configFilename := config.DefaultTerragruntConfigPath
+		if len(opts.TerragruntConfigPath) > 0 {
+			configFilename = filepath.Base(opts.TerragruntConfigPath)
+		}
+
+		componentOpts.TerragruntConfigPath = filepath.Join(c.Path(), configFilename)
+
+		// Run the delete logic for this component
+		if err := runDelete(ctx, l, componentOpts); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
 }

--- a/cli/commands/hcl/format/cli.go
+++ b/cli/commands/hcl/format/cli.go
@@ -1,11 +1,9 @@
 package format
 
 import (
-	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -95,8 +93,6 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 			return Run(ctx, l, opts.OptionsFromContext(ctx))
 		},
 	}
-
-	cmd = runall.WrapCommand(l, opts, cmd, run.Run, true)
 
 	return cmd
 }

--- a/cli/commands/hcl/validate/cli.go
+++ b/cli/commands/hcl/validate/cli.go
@@ -1,12 +1,9 @@
 package validate
 
 import (
-	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
-	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -77,6 +74,7 @@ func NewFlags(opts *options.TerragruntOptions) cli.Flags {
 
 	flagSet = flagSet.Add(shared.NewQueueFlags(opts, nil)...)
 	flagSet = flagSet.Add(shared.NewFilterFlag(opts))
+	flagSet = flagSet.Add(shared.NewAllFlag(opts, CommandName, nil))
 
 	return flagSet
 }
@@ -91,9 +89,6 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 			return Run(ctx, l, opts.OptionsFromContext(ctx))
 		},
 	}
-
-	cmd = runall.WrapCommand(l, opts, cmd, run.Run, true)
-	cmd = graph.WrapCommand(l, opts, cmd, run.Run, true)
 
 	return cmd
 }

--- a/cli/commands/info/print/cli.go
+++ b/cli/commands/info/print/cli.go
@@ -1,10 +1,9 @@
 package print
 
 import (
-	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	runcmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
+	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -18,13 +17,11 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Name:      CommandName,
 		Usage:     "Print out a short description of Terragrunt context.",
 		UsageText: "terragrunt info print",
-		Flags:     runcmd.NewFlags(l, opts, nil),
+		Flags:     append(runcmd.NewFlags(l, opts, nil), shared.NewAllFlag(opts, CommandName, nil)),
 		Action: func(ctx *cli.Context) error {
 			return Run(ctx, l, opts)
 		},
 	}
-
-	cmd = runall.WrapCommand(l, opts, cmd, run.Run, true)
 
 	return cmd
 }

--- a/cli/commands/info/print/print.go
+++ b/cli/commands/info/print/print.go
@@ -8,8 +8,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/report"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
@@ -19,9 +22,69 @@ import (
 )
 
 func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
+	// If --all is set, discover components and iterate
+	if opts.RunAll {
+		return runOnDiscoveredComponents(ctx, l, opts)
+	}
+
+	// Otherwise, run on single component
 	target := run.NewTargetWithErrorHandler(run.TargetPointDownloadSource, handleTerragruntContextPrint, handleTerragruntContextPrintWithError)
 
 	return run.RunWithTarget(ctx, l, opts, report.NewReport(), target)
+}
+
+func runOnDiscoveredComponents(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
+	// Create discovery
+	d, err := discovery.NewForDiscoveryCommand(discovery.DiscoveryCommandOptions{
+		WorkingDir:    opts.WorkingDir,
+		FilterQueries: opts.FilterQueries,
+		Experiments:   opts.Experiments,
+		Hidden:        true,
+		Dependencies:  false,
+		External:      false,
+		Exclude:       true,
+		Include:       true,
+	})
+	if err != nil {
+		return errors.New(err)
+	}
+
+	components, err := d.Discover(ctx, l, opts)
+	if err != nil {
+		return errors.New(err)
+	}
+
+	// Run the print logic on each component
+	var errs []error
+
+	for _, c := range components {
+		if _, ok := c.(*component.Stack); ok {
+			continue // Skip stacks
+		}
+
+		componentOpts := opts.Clone()
+		componentOpts.WorkingDir = c.Path()
+
+		// Determine config path for this component
+		configFilename := config.DefaultTerragruntConfigPath
+		if len(opts.TerragruntConfigPath) > 0 {
+			configFilename = filepath.Base(opts.TerragruntConfigPath)
+		}
+
+		componentOpts.TerragruntConfigPath = filepath.Join(c.Path(), configFilename)
+
+		// Run the print logic for this component
+		target := run.NewTargetWithErrorHandler(run.TargetPointDownloadSource, handleTerragruntContextPrint, handleTerragruntContextPrintWithError)
+		if err := run.RunWithTarget(ctx, l, componentOpts, report.NewReport(), target); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
 }
 
 // InfoOutput represents the structured output of the info command

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -623,7 +623,10 @@ func TestHclvalidateValidConfig(t *testing.T) {
 		tmpEnvPath := helpers.CopyEnvironment(t, testFixtureHclvalidate)
 		rootPath := util.JoinPath(tmpEnvPath, testFixtureHclvalidate)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt hcl validate --all --strict --inputs --working-dir "+filepath.Join(rootPath, "valid"))
+		_, _, err := helpers.RunTerragruntCommandWithOutput(
+			t,
+			"terragrunt hcl validate --all --strict --inputs --working-dir "+filepath.Join(rootPath, "valid"),
+		)
 		require.NoError(t, err)
 	})
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Refactors out usage of the `--all` and `--graph` wrappers in commands besides `run` so that we're not coupling the behavior so tightly.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

