### PR TITLE
fix: Avoiding panic on missing `if_exists`

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1549,6 +1549,27 @@ func TestBestEffortParseConfigString(t *testing.T) {
 	}
 }
 
+func TestParseConfigWithMissingIfExists(t *testing.T) {
+	t.Parallel()
+
+	cfg := `generate "test" {
+  path     = "test.tf"
+  contents = "foo"
+}`
+
+	l := createLogger()
+	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+
+	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	require.Error(t, err)
+
+	errStr := err.Error()
+	hasIfExistsError := strings.Contains(errStr, "if_exists")
+	hasGenerateError := strings.Contains(errStr, "generate") || strings.Contains(errStr, "Missing required argument")
+	assert.True(t, hasIfExistsError || hasGenerateError, "Error message should mention missing if_exists attribute or generate block. Got: %s", errStr)
+	assert.NotNil(t, terragruntConfig)
+}
+
 func TestBestEffortParseConfigStringWDependency(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5071

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential nil pointer issues in configuration file parsing to prevent crashes.
  * Added validation to enforce that required attributes are present in configuration blocks.
  * Improved error handling to collect and report multiple configuration issues simultaneously instead of stopping at the first error.

* **Tests**
  * Expanded test coverage for configuration validation, including scenarios with missing required attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->