### PR TITLE
feat: Adding `--filter` `source=` support

### DIFF
--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -28,6 +28,7 @@ type Component interface {
 	SetExternal()
 	Reading() []string
 	SetReading(...string)
+	Sources() []string
 	DiscoveryContext() *DiscoveryContext
 	SetDiscoveryContext(*DiscoveryContext)
 	AddDependency(Component)

--- a/internal/component/stack.go
+++ b/internal/component/stack.go
@@ -87,6 +87,13 @@ func (s *Stack) SetReading(files ...string) {
 	s.reading = files
 }
 
+// Sources returns the list of sources for this component.
+//
+// Stacks don't support leveraging sources right now, so we just return an empty list.
+func (s *Stack) Sources() []string {
+	return []string{}
+}
+
 // DiscoveryContext returns the discovery context for this component.
 func (s *Stack) DiscoveryContext() *DiscoveryContext {
 	return s.discoveryContext

--- a/internal/component/unit.go
+++ b/internal/component/unit.go
@@ -92,6 +92,15 @@ func (u *Unit) SetReading(files ...string) {
 	u.reading = files
 }
 
+// Sources returns the list of sources for this component.
+func (u *Unit) Sources() []string {
+	if u.cfg == nil || u.cfg.Terraform == nil || u.cfg.Terraform.Source == nil {
+		return []string{}
+	}
+
+	return []string{*u.cfg.Terraform.Source}
+}
+
 // DiscoveryContext returns the discovery context for this component.
 func (u *Unit) DiscoveryContext() *DiscoveryContext {
 	return u.discoveryContext

--- a/internal/filter/ast.go
+++ b/internal/filter/ast.go
@@ -103,7 +103,7 @@ func (a *AttributeFilter) CompileGlob() (glob.Glob, error) {
 
 // supportsGlob returns true if the attribute filter supports glob patterns.
 func (a *AttributeFilter) supportsGlob() bool {
-	return a.Key == AttributeReading || a.Key == AttributeName
+	return a.Key == AttributeReading || a.Key == AttributeName || a.Key == AttributeSource
 }
 
 func (a *AttributeFilter) expressionNode()                       {}

--- a/internal/filter/evaluator.go
+++ b/internal/filter/evaluator.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"path/filepath"
+	"slices"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -12,6 +13,7 @@ const (
 	AttributeType     = "type"
 	AttributeExternal = "external"
 	AttributeReading  = "reading"
+	AttributeSource   = "source"
 
 	AttributeTypeValueUnit  = string(component.UnitKind)
 	AttributeTypeValueStack = string(component.StackKind)
@@ -146,6 +148,17 @@ func evaluateAttributeFilter(filter *AttributeFilter, components []component.Com
 					result = append(result, c)
 					break
 				}
+			}
+		}
+	case AttributeSource:
+		g, err := filter.CompileGlob()
+		if err != nil {
+			return nil, NewEvaluationErrorWithCause("failed to compile glob pattern for source filter: "+filter.Value, err)
+		}
+
+		for _, c := range components {
+			if slices.ContainsFunc(c.Sources(), g.Match) {
+				result = append(result, c)
 			}
 		}
 	default:

--- a/test/fixtures/filter-source/github-acme-bar/main.tf
+++ b/test/fixtures/filter-source/github-acme-bar/main.tf
@@ -1,0 +1,2 @@
+# Empty module
+

--- a/test/fixtures/filter-source/github-acme-bar/terragrunt.hcl
+++ b/test/fixtures/filter-source/github-acme-bar/terragrunt.hcl
@@ -1,0 +1,4 @@
+terraform {
+  source = "git::git@github.com:acme/bar?ref=v1.0.0"
+}
+

--- a/test/fixtures/filter-source/github-acme-foo/main.tf
+++ b/test/fixtures/filter-source/github-acme-foo/main.tf
@@ -1,0 +1,2 @@
+# Empty module
+

--- a/test/fixtures/filter-source/github-acme-foo/terragrunt.hcl
+++ b/test/fixtures/filter-source/github-acme-foo/terragrunt.hcl
@@ -1,0 +1,4 @@
+terraform {
+  source = "github.com/acme/foo"
+}
+

--- a/test/fixtures/filter-source/gitlab-example-baz/main.tf
+++ b/test/fixtures/filter-source/gitlab-example-baz/main.tf
@@ -1,0 +1,2 @@
+# Empty module
+

--- a/test/fixtures/filter-source/gitlab-example-baz/terragrunt.hcl
+++ b/test/fixtures/filter-source/gitlab-example-baz/terragrunt.hcl
@@ -1,0 +1,4 @@
+terraform {
+  source = "gitlab.com/example/baz"
+}
+

--- a/test/fixtures/filter-source/local-module/module/main.tf
+++ b/test/fixtures/filter-source/local-module/module/main.tf
@@ -1,0 +1,2 @@
+# Empty module
+

--- a/test/fixtures/filter-source/local-module/terragrunt.hcl
+++ b/test/fixtures/filter-source/local-module/terragrunt.hcl
@@ -1,0 +1,4 @@
+terraform {
+  source = "./module"
+}
+

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -98,6 +98,12 @@ func ExecWithTestLogger(t *testing.T, dir, command string, args ...string) {
 	require.NoError(t, err)
 }
 
+// PointerTo returns a pointer to the given parameter.
+// Useful for constructing pointers to primitive types in test tables, etc.
+func PointerTo[T any](v T) *T {
+	return &v
+}
+
 type testLogger struct {
 	t      *testing.T
 	prefix string


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds the ability to filter on the `source=` attribute.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added source-based filtering to component queries with support for glob patterns, enabling users to match components by their Terraform source using exact strings, wildcard patterns, negation, and combined filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->