### PR TITLE
fix(discovery): add `OriginalTerragruntConfigPath` to parse options

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -484,6 +484,7 @@ func Parse(
 	parseOpts.SkipOutput = true
 
 	parseOpts.TerragruntConfigPath = filepath.Join(parseOpts.WorkingDir, configFilename)
+	parseOpts.OriginalTerragruntConfigPath = parseOpts.TerragruntConfigPath
 
 	parsingCtx := config.NewParsingContext(ctx, l, parseOpts).WithDecodeList(
 		config.TerraformSource,


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5029.

<!-- Description of the changes introduced by this PR. -->

Add the `TerragruntConfigPath` as `OriginalTerragruntConfigPath` to the parse options when parsing the discovered configuration, so `get_original_terragrunt_dir()` will return the expected path during discovery.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->

get_original_terragrunt_dir() returns the expected directory path during discovery

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preservation of the original Terragrunt configuration path for enhanced path resolution handling.

* **Tests**
  * Added test coverage for original configuration path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->