### PR TITLE
docs: Documenting `--filter` Git support

### DIFF
--- a/docs-starlight/src/content/docs/03-features/18-filter.mdx
+++ b/docs-starlight/src/content/docs/03-features/18-filter.mdx
@@ -84,7 +84,7 @@ There are several different types of filter expressions, and particular ways in 
 | Graph-Based | Filter units based on their dependency relationships using graph traversal operators. |
 | Git-Based | Filter units and stacks based on Git diffs using Git expressions. |
 
-### Name-Based Filtering
+### Name-Based Expressions
 
 Match units and stacks by their name. This is the simplest form of filtering.
 
@@ -110,7 +110,7 @@ terragrunt find --filter 'app*'
 Note that `app1` and `app2` were selected _within_ the `apps` directory. Filtering on names will match _any_ unit/stack that has a name that matches the filter.
 </Aside>
 
-### Path-Based Filtering
+### Path-Based Expressions
 
 Match units and stacks by their file system path.
 
@@ -154,7 +154,7 @@ Note that globs used in path-based filtering will not recursively match nested d
 (That's why `./envs/stage/**` is used above)
 </Aside>
 
-### Attribute-Based Filtering
+### Attribute-Based Expressions
 
 Match units and stacks by their configuration attributes.
 
@@ -183,7 +183,17 @@ terragrunt find --filter 'name=stack*'
         - terragrunt.hcl
 </FileTree>
 
-### Source-Based Filtering
+The following are the attributes supported for attribute-based filtering:
+
+| Attribute | Description |
+|-----------|-------------|
+| name | Match units and stacks by their name. |
+| type | Match units and stacks by their type. |
+| external | Match units and stacks by their external dependency status. |
+| reading | Match units and stacks by the files they read. |
+| source | Match units and stacks by their Terraform source URL or path specified in the `terraform` block of `terragrunt.hcl` files. |
+
+### Source-Based Expressions
 
 Match units and stacks by their Terraform source URL or path specified in the `terraform` block of `terragrunt.hcl` files.
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Documents the ability to filter results by Git-based expressions.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands filter docs with Git-based filtering, clarifies/renames filter expression types, adds attribute and legacy flag mapping tables, usage nuances, and examples.
> 
> - **Docs (Filters)**:
>   - **New**:
>     - Git-based filtering section with examples, behavior notes for `run`, and a "How it works" explanation (worktrees/diffs).
>   - **Refinements**:
>     - Rename headings to "Filter Expressions" (e.g., Name-/Path-/Attribute-/Source-Based Expressions).
>     - Add filter type overview table and supported attribute table (includes `reading`, `source`).
>     - Expand examples (wrapped path syntax `{...}`, intersections/unions, negation semantics) and file trees.
>     - Clarify command support and special interactions:
>       - `hcl fmt`: path-only filtering; attribute filters not supported.
>       - `stack generate`: filters applied only when explicitly targeting stacks.
>     - Update legacy queue flag mappings to equivalent `--filter` expressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81b2862eb63aae1785a6d4a973109ed16d7460b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded filtering documentation with comprehensive overview of all filter types (Name-Based, Path-Based, Attribute-Based, Negation, Intersection, Union, Graph-Based, and Git-Based).
  * Added detailed attributes table clarifying supported filters and descriptions.
  * Enhanced content with practical examples, visual illustrations, and explanations of filter evaluation workflow and command interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->