### PR TITLE
feat: Adding `--filter-affected` flag

### DIFF
--- a/cli/commands/dag/graph/cli.go
+++ b/cli/commands/dag/graph/cli.go
@@ -20,7 +20,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 	sharedFlags := shared.NewQueueFlags(opts, nil)
 	sharedFlags = append(sharedFlags, shared.NewBackendFlags(opts, nil)...)
 	sharedFlags = append(sharedFlags, shared.NewFeatureFlags(opts, nil)...)
-	sharedFlags = append(sharedFlags, shared.NewFilterFlags(opts)...)
+	sharedFlags = append(sharedFlags, shared.NewFilterFlags(l, opts)...)
 
 	return &cli.Command{
 		Name:      CommandName,

--- a/cli/commands/find/cli.go
+++ b/cli/commands/find/cli.go
@@ -32,7 +32,7 @@ const (
 	QueueConstructAsFlagAlias = "as"
 )
 
-func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
+func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) cli.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
 	flags := cli.Flags{
@@ -101,16 +101,14 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 		}),
 	}
 
-	flags = flags.Add(shared.NewFilterFlags(opts.TerragruntOptions)...)
-
-	return flags
+	return append(flags, shared.NewFilterFlags(l, opts.TerragruntOptions)...)
 }
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 	cmdOpts := NewOptions(opts)
 
 	// Base flags for find plus backend/feature flags
-	flags := NewFlags(cmdOpts, nil)
+	flags := NewFlags(l, cmdOpts, nil)
 	flags = append(flags, shared.NewBackendFlags(opts, nil)...)
 	flags = append(flags, shared.NewFeatureFlags(opts, nil)...)
 

--- a/cli/commands/hcl/format/cli.go
+++ b/cli/commands/hcl/format/cli.go
@@ -21,7 +21,7 @@ const (
 	StdinFlagName      = "stdin"
 )
 
-func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
+func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 	terragruntPrefix := flags.Prefix{flags.TerragruntPrefix}
 	terragruntPrefixControl := flags.StrictControlsByCommand(opts.StrictControls, CommandName)
@@ -79,7 +79,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 	}
 
 	flagSet = flagSet.Add(shared.NewQueueFlags(opts, nil)...)
-	flagSet = flagSet.Add(shared.NewFilterFlags(opts)...)
+	flagSet = flagSet.Add(shared.NewFilterFlags(l, opts)...)
 	flagSet = flagSet.Add(shared.NewParallelismFlag(opts))
 
 	return flagSet
@@ -90,7 +90,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Name:    CommandName,
 		Aliases: []string{CommandNameAlias},
 		Usage:   "Recursively find HashiCorp Configuration Language (HCL) files and rewrite them into a canonical format.",
-		Flags:   NewFlags(opts, nil),
+		Flags:   NewFlags(l, opts, nil),
 		Action: func(ctx *cli.Context) error {
 			return Run(ctx, l, opts.OptionsFromContext(ctx))
 		},

--- a/cli/commands/hcl/validate/cli.go
+++ b/cli/commands/hcl/validate/cli.go
@@ -20,7 +20,7 @@ const (
 	JSONFlagName           = "json"
 )
 
-func NewFlags(opts *options.TerragruntOptions) cli.Flags {
+func NewFlags(l log.Logger, opts *options.TerragruntOptions) cli.Flags {
 	tgPrefix := flags.Prefix{flags.TgPrefix}
 	terragruntPrefix := flags.Prefix{flags.TerragruntPrefix}
 	terragruntPrefixControl := flags.StrictControlsByCommand(opts.StrictControls, CommandName)
@@ -76,7 +76,7 @@ func NewFlags(opts *options.TerragruntOptions) cli.Flags {
 	}
 
 	flagSet = flagSet.Add(shared.NewQueueFlags(opts, nil)...)
-	flagSet = flagSet.Add(shared.NewFilterFlags(opts)...)
+	flagSet = flagSet.Add(shared.NewFilterFlags(l, opts)...)
 
 	return flagSet
 }
@@ -85,7 +85,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 	cmd := &cli.Command{
 		Name:                         CommandName,
 		Usage:                        "Recursively find HashiCorp Configuration Language (HCL) files and validate them.",
-		Flags:                        NewFlags(opts),
+		Flags:                        NewFlags(l, opts),
 		DisabledErrorOnUndefinedFlag: true,
 		Action: func(ctx *cli.Context) error {
 			return Run(ctx, l, opts.OptionsFromContext(ctx))

--- a/cli/commands/list/cli.go
+++ b/cli/commands/list/cli.go
@@ -32,7 +32,7 @@ const (
 	QueueConstructAsFlagAlias = "as"
 )
 
-func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
+func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) cli.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
 	flags := cli.Flags{
@@ -90,9 +90,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 		}),
 	}
 
-	flags = flags.Add(shared.NewFilterFlags(opts.TerragruntOptions)...)
-
-	return flags
+	return append(flags, shared.NewFilterFlags(l, opts.TerragruntOptions)...)
 }
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
@@ -100,7 +98,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 	prefix := flags.Prefix{CommandName}
 
 	// Base flags for list plus backend/feature flags
-	flags := NewFlags(cmdOpts, prefix)
+	flags := NewFlags(l, cmdOpts, prefix)
 	flags = append(flags, shared.NewBackendFlags(opts, prefix)...)
 	flags = append(flags, shared.NewFeatureFlags(opts, prefix)...)
 

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -441,7 +441,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 	flags = flags.Add(shared.NewFeatureFlags(opts, prefix)...)
 	flags = flags.Add(shared.NewIAMAssumeRoleFlags(opts, prefix, CommandName)...)
 	flags = flags.Add(shared.NewQueueFlags(opts, prefix)...)
-	flags = flags.Add(shared.NewFilterFlags(opts)...)
+	flags = flags.Add(shared.NewFilterFlags(l, opts)...)
 	flags = flags.Add(shared.NewParallelismFlag(opts))
 
 	return flags.Sort()

--- a/internal/git/gogit.go
+++ b/internal/git/gogit.go
@@ -183,6 +183,29 @@ func (g *GitRunner) GoCommit(message string, opts *git.CommitOptions) error {
 	return nil
 }
 
+// GoCheckout checks out a branch in the Git repository.
+func (g *GitRunner) GoCheckout(opts *git.CheckoutOptions) error {
+	if err := g.RequiresGoRepo(); err != nil {
+		return err
+	}
+
+	if opts == nil {
+		return errors.New("checkout options are required for go checkouts")
+	}
+
+	w, err := g.goRepo.Worktree()
+	if err != nil {
+		return err
+	}
+
+	err = w.Checkout(opts)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // GoOpenRepoHead gets the head of the Git repository.
 func (g *GitRunner) GoOpenRepoHead() (*plumbing.Reference, error) {
 	if err := g.RequiresGoRepo(); err != nil {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds `--filter-affected` flag that is an alias for `--filter [main...HEAD]` (or whatever other branch is detected as the default using `git config init.defaultBranch`).

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--filter-affected` flag that uses Git to identify units affected by changes on a branch, automatically comparing with the detected or configured default branch (defaults to main/HEAD).
  * Flag validates the "filter-flag" experiment is enabled and warns users about uncommitted changes in the repository.

* **Tests**
  * Added integration test for Git-based filtering functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->