### PR TITLE
docs: Documenting `--filter-affected`

### DIFF
--- a/docs-starlight/src/content/docs/03-features/18-filter.mdx
+++ b/docs-starlight/src/content/docs/03-features/18-filter.mdx
@@ -492,6 +492,24 @@ Graph expressions require dependency/dependent discovery to work correctly. When
 
 Match units and stacks based on changes between Git references. This is useful for targeting infrastructure that has been modified, added, or removed between commits, branches, or tags.
 
+#### Shorthand: `--filter-affected`
+
+For the common use case of comparing the default branch (typically `main`) with `HEAD`, you can use the `--filter-affected` flag as a convenient shorthand:
+
+```bash
+# Find components affected by changes between main and HEAD
+terragrunt find --filter-affected
+
+# Equivalent to:
+terragrunt find --filter '[main...HEAD]'
+```
+
+The `--filter-affected` flag automatically detects your repository's default branch and compares it with `HEAD`.
+
+#### Git Filter Expressions
+
+For more control, you can use Git-based filter expressions directly:
+
 ```bash
 # Compare between two references
 terragrunt find --filter '[main...HEAD]'

--- a/docs-starlight/src/data/commands/find.mdx
+++ b/docs-starlight/src/data/commands/find.mdx
@@ -88,6 +88,7 @@ flags:
   - find-external
   - queue-construct-as
   - filter
+  - filter-affected
 ---
 
 import { Aside, Badge } from '@astrojs/starlight/components';
@@ -343,6 +344,17 @@ Examples below will omit the `--experiment filter-flag` flag for brevity.
 </Aside>
 
 The `find` command supports the `--filter` flag to target specific configurations using a flexible query language. This is particularly useful for discovering configurations that match specific criteria before running operations on them.
+
+### Finding Affected Components
+
+For the common use case of finding components affected by changes between the default branch and `HEAD`, you can use the `--filter-affected` flag:
+
+```bash
+# Find all components affected by changes between main and HEAD
+terragrunt find --filter-affected
+```
+
+This is equivalent to `terragrunt find --filter '[main...HEAD]'` and automatically detects your repository's default branch.
 
 ### Basic Filtering Examples
 

--- a/docs-starlight/src/data/commands/list.mdx
+++ b/docs-starlight/src/data/commands/list.mdx
@@ -101,6 +101,7 @@ flags:
   - list-dag
   - queue-construct-as
   - filter
+  - filter-affected
 ---
 
 import { Aside, Badge } from '@astrojs/starlight/components';
@@ -307,6 +308,17 @@ terragrunt list --experiment filter-flag --filter 'foo'
 </Aside>
 
 The `list` command supports the `--filter` flag to target specific configurations using a flexible query language. This is particularly useful for listing configurations that match specific criteria before running operations on them.
+
+### Listing Affected Components
+
+For the common use case of listing components affected by changes between the default branch and `HEAD`, you can use the `--filter-affected` flag:
+
+```bash
+# List all components affected by changes between main and HEAD
+terragrunt list --filter-affected
+```
+
+This is equivalent to `terragrunt list --filter '[main...HEAD]'` and automatically detects your repository's default branch.
 
 ### Basic Filtering Examples
 

--- a/docs-starlight/src/data/commands/run.mdx
+++ b/docs-starlight/src/data/commands/run.mdx
@@ -38,6 +38,7 @@ flags:
   - experimental-engine
   - feature
   - filter
+  - filter-affected
   - graph
   - iam-assume-role
   - iam-assume-role-duration
@@ -104,6 +105,20 @@ Examples below will omit the `--experiment filter-flag` flag for brevity.
 </Aside>
 
 The `run` command supports the `--filter` flag to target specific units using a flexible query language. This is particularly useful when running commands across multiple units with `--all`.
+
+### Running Affected Components
+
+For the common use case of running commands on components affected by changes between the default branch and `HEAD`, you can use the `--filter-affected` flag:
+
+```bash
+# Plan changes for affected components
+terragrunt run --all --filter-affected -- plan
+
+# Apply changes for affected components
+terragrunt run --all --filter-affected -- apply
+```
+
+This is equivalent to `terragrunt run --all --filter '[main...HEAD]' -- plan` and automatically detects your repository's default branch. When using `--filter-affected` with the `run` command, you must use one of the `plan` or `apply` commands, and not the `-destroy` flag.
 
 ### Basic Filtering Examples
 

--- a/docs-starlight/src/data/flags/filter-affected.mdx
+++ b/docs-starlight/src/data/flags/filter-affected.mdx
@@ -1,0 +1,83 @@
+---
+name: filter-affected
+description: Filter components affected by changes between the default branch and HEAD
+type: bool
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental Feature">
+This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
+
+Usage of the `--filter-affected` flag requires usage of the `filter-flag` experiment, like so:
+
+```bash
+terragrunt find --experiment filter-flag --filter-affected
+```
+
+Examples below will omit the `--experiment filter-flag` flag for brevity.
+</Aside>
+
+The `--filter-affected` flag is a convenient shorthand for filtering components that have been modified, added, or removed between the default branch (typically `main`) and `HEAD`. It is equivalent to using `--filter '[main...HEAD]'` (or `--filter '[<defaultBranch>...HEAD]'` if your repository uses a different default branch).
+
+## Usage
+
+```bash
+# Find all components affected by changes between main and HEAD
+terragrunt find --filter-affected
+
+# List affected components
+terragrunt list --filter-affected
+
+# Run plan on affected components
+terragrunt run --all --filter-affected -- plan
+
+# Run apply on affected components
+terragrunt run --all --filter-affected -- apply
+```
+
+## Default Branch Detection
+
+The flag automatically detects your repository's default branch. It checks:
+
+1. Your Git configuration for `init.defaultBranch`
+2. Falls back to `main` if not configured
+
+To use a different branch for comparison, use the `--filter` flag directly with a Git-based filter expression:
+
+```bash
+# Compare against a specific branch
+terragrunt find --filter '[develop...HEAD]'
+
+# Compare between two specific references
+terragrunt find --filter '[v1.0.0...v2.0.0]'
+```
+
+## Uncommitted Changes Warning
+
+If you have uncommitted changes in your working directory, Terragrunt will display a warning:
+
+```
+Warning: You have uncommitted changes. The --filter-affected flag may not include all your local modifications.
+```
+
+This is because `--filter-affected` compares Git references, not your working directory. To include uncommitted changes, you would need to commit them first or use a different filtering approach.
+
+## Equivalent Filter Expression
+
+The `--filter-affected` flag is equivalent to:
+
+```bash
+terragrunt find --filter '[main...HEAD]'
+```
+
+Or, if your default branch is different:
+
+```bash
+terragrunt find --filter '[<defaultBranch>...HEAD]'
+```
+
+## Learn More
+
+For more information about Git-based filtering and advanced usage patterns, see the [Filters feature documentation](/docs/features/filter#git-based-expressions).
+

--- a/docs-starlight/src/data/flags/filter.mdx
+++ b/docs-starlight/src/data/flags/filter.mdx
@@ -100,6 +100,30 @@ terragrunt find --filter './prod/** | type=unit'
 terragrunt find --filter './dev/** | type=unit | !name=unit1'
 ```
 
+### Git-Based Filtering
+
+Filter configurations based on changes between Git references. For the common use case of comparing the default branch with `HEAD`, you can use the `--filter-affected` flag as a convenient shorthand:
+
+```bash
+# Find components affected by changes between main and HEAD
+terragrunt find --filter-affected
+```
+
+For more control, use Git-based filter expressions directly:
+
+```bash
+# Compare between two references
+terragrunt find --filter '[main...HEAD]'
+
+# Shorthand: compare reference to HEAD
+terragrunt find --filter '[main]'
+
+# Compare between specific commits
+terragrunt find --filter '[abc123...def456]'
+```
+
+For more details and examples, see the [Filters feature documentation](/docs/features/filter#git-based-expressions).
+
 ### Graph-Based Filtering
 Filter configurations based on dependency relationships using graph traversal. Use ellipsis (`...`) to traverse the dependency graph and caret (`^`) to exclude the target from results.
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Documents the `--filter-affected` flag.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for the new --filter-affected flag across find, list, and run, including examples for plan/apply usage and a note on experimental status.
  * Documented equivalence to Git-range filter expressions and automatic default-branch detection.
  * Expanded filtering guides with additional Git- and graph-based syntax examples and a warning about uncommitted changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->