### PR TITLE
feat: Adding `--filters-file` flag

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -404,6 +404,16 @@ func initialSetup(cliCtx *cli.Context, l log.Logger, opts *options.TerragruntOpt
 	slices.Sort(opts.ExcludeDirs)
 	opts.ExcludeDirs = slices.Compact(opts.ExcludeDirs)
 
+	// Process filters file if the filter-flag experiment is enabled and the filters file is not disabled
+	if opts.Experiments.Evaluate("filter-flag") && !opts.NoFiltersFile {
+		filtersFromFile, filtersFromFileErr := util.GetFiltersFromFile(opts.WorkingDir, opts.FiltersFile)
+		if filtersFromFileErr != nil {
+			return filtersFromFileErr
+		}
+
+		opts.FilterQueries = append(opts.FilterQueries, filtersFromFile...)
+	}
+
 	if !doubleStarEnabled {
 		opts.ExcludeDirs, err = util.GlobCanonicalPath(l, opts.WorkingDir, opts.ExcludeDirs...)
 		if err != nil {

--- a/cli/flags/shared/shared.go
+++ b/cli/flags/shared/shared.go
@@ -34,6 +34,8 @@ const (
 	FilterFlagName             = "filter"
 	FilterAffectedFlagName     = "filter-affected"
 	FilterAllowDestroyFlagName = "filter-allow-destroy"
+	FilterFileFlagName         = "filters-file"
+	NoFilterFileFlagName       = "no-filters-file"
 
 	// Scaffolding related flags.
 	RootFileNameFlagName  = "root-file-name"
@@ -275,6 +277,40 @@ func NewFilterFlags(l log.Logger, opts *options.TerragruntOptions) cli.Flags {
 					// Check if the filter-flag experiment is enabled
 					if !opts.Experiments.Evaluate("filter-flag") {
 						return cli.NewExitError("the --filter-allow-destroy flag requires the 'filter-flag' experiment to be enabled. Use --experiment=filter-flag or --experiment-mode to enable it", cli.ExitCodeGeneralError)
+					}
+					return nil
+				},
+			},
+		),
+		flags.NewFlag(
+			&cli.GenericFlag[string]{
+				Name:        FilterFileFlagName,
+				EnvVars:     tgPrefix.EnvVars(FilterFileFlagName),
+				Destination: &opts.FiltersFile,
+				Usage:       "Path to a file containing filter queries, one per line. Default is .terragrunt-filters. Requires the 'filter-flag' experiment.",
+				Action: func(_ *cli.Context, val string) error {
+					// Check if the filter-flag experiment is enabled
+					if !opts.Experiments.Evaluate("filter-flag") {
+						return cli.NewExitError("the --filters-file flag requires the 'filter-flag' experiment to be enabled. Use --experiment=filter-flag or --experiment-mode to enable it", cli.ExitCodeGeneralError)
+					}
+					return nil
+				},
+			},
+		),
+		flags.NewFlag(
+			&cli.BoolFlag{
+				Name:        NoFilterFileFlagName,
+				EnvVars:     tgPrefix.EnvVars(NoFilterFileFlagName),
+				Destination: &opts.NoFiltersFile,
+				Usage:       "Disable automatic reading of .terragrunt-filters file. Requires the 'filter-flag' experiment.",
+				Action: func(_ *cli.Context, val bool) error {
+					if !val {
+						return nil
+					}
+
+					// Check if the filter-flag experiment is enabled
+					if !opts.Experiments.Evaluate("filter-flag") {
+						return cli.NewExitError("the --no-filters-file flag requires the 'filter-flag' experiment to be enabled. Use --experiment=filter-flag or --experiment-mode to enable it", cli.ExitCodeGeneralError)
 					}
 					return nil
 				},

--- a/options/options.go
+++ b/options/options.go
@@ -56,6 +56,7 @@ const (
 	minCommandLength = 2
 
 	defaultExcludesFile = ".terragrunt-excludes"
+	defaultFiltersFile  = ".terragrunt-filters"
 
 	DefaultLogLevel = log.InfoLevel
 )
@@ -180,6 +181,8 @@ type TerragruntOptions struct {
 	GraphRoot string
 	// Path to the report file.
 	ReportFile string
+	// Path to a file containing filter queries, one per line. Default is .terragrunt-filters.
+	FiltersFile string
 	// Report format.
 	ReportFormat report.Format
 	// Path to the report schema file.
@@ -328,6 +331,8 @@ type TerragruntOptions struct {
 	NoShell bool
 	// NoHooks disables hooks when using boilerplate templates in catalog and scaffold commands.
 	NoHooks bool
+	// If set, disable automatic reading of .terragrunt-filters file.
+	NoFiltersFile bool
 }
 
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests
@@ -387,6 +392,7 @@ func NewTerragruntOptionsWithWriters(stdout, stderr io.Writer) *TerragruntOption
 	return &TerragruntOptions{
 		TFPath:                         DefaultWrappedPath,
 		ExcludesFile:                   defaultExcludesFile,
+		FiltersFile:                    defaultFiltersFile,
 		OriginalTerraformCommand:       "",
 		TerraformCommand:               "",
 		AutoInit:                       true,

--- a/util/file.go
+++ b/util/file.go
@@ -934,6 +934,39 @@ func GetExcludeDirsFromFile(baseDir, filename string) ([]string, error) {
 	return dirs, nil
 }
 
+// GetFiltersFromFile returns a list of filter queries from the given filename, where each filter query starts on a new line.
+func GetFiltersFromFile(baseDir, filename string) ([]string, error) {
+	filename, err := CanonicalPath(filename, baseDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if !FileExists(filename) || !IsFile(filename) {
+		return nil, nil
+	}
+
+	content, err := ReadFileAsString(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		lines   = strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+		filters = make([]string, 0, len(lines))
+	)
+
+	for _, filter := range lines {
+		filter = strings.TrimSpace(filter)
+		if filter == "" || strings.HasPrefix(filter, "#") {
+			continue
+		}
+
+		filters = append(filters, filter)
+	}
+
+	return filters, nil
+}
+
 // MatchSha256Checksum returns the SHA256 checksum for the given file and filename.
 func MatchSha256Checksum(file, filename []byte) []byte {
 	var checksum []byte


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds the `--filters-file` flag.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for reading filter queries from a file via the `--filters-file` flag
  * Added `--no-filters-file` flag to disable automatic filter file detection
  * Automatic detection of `.terragrunt-filters` file; supports comments and empty lines

* **Tests**
  * Added comprehensive test coverage for filters-file functionality, including experiment mode scenarios and flag combinations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->