### PR TITLE
docs: Documenting `--filters-file` flag

### DIFF
--- a/docs-starlight/src/content/docs/04-reference/04-experiments.md
+++ b/docs-starlight/src/content/docs/04-reference/04-experiments.md
@@ -166,13 +166,13 @@ To transition the `filter-flag` feature to a stable release, the following must 
 - [x] Integrate with the `find` command
 - [x] Integrate with the `list` command
 - [x] Integrate with the `run` command
-- [ ] Add support for git-based filtering ([ref...ref] syntax)
-- [ ] Add support for dependency/dependent traversal (... syntax)
-- [ ] Add support for `--filters-file` flag
+- [x] Add support for git-based filtering ([ref...ref] syntax)
+- [x] Add support for dependency/dependent traversal (... syntax)
+- [x] Add support for `--filters-file` flag
 - [ ] Add support for `--filter-allow-destroy` flag
-- [ ] Add support for `--filter-affected` shorthand
+- [x] Add support for `--filter-affected` shorthand
 - [ ] Comprehensive integration testing across all commands
-- [ ] Deprecate legacy queue control flags (queue-exclude-dir, queue-include-dir, etc.)
+- [ ] Backport legacy queue control flags (queue-exclude-dir, queue-include-dir, etc.) into equivalent filter patterns as aliases.
 
 **Future Deprecations:**
 

--- a/docs-starlight/src/data/flags/filter.mdx
+++ b/docs-starlight/src/data/flags/filter.mdx
@@ -31,6 +31,7 @@ terragrunt hcl validate --filter 'type=unit'
 ```
 
 ### Name-Based Filtering
+
 Match configurations by their name using exact matches or glob patterns:
 
 ```bash
@@ -42,6 +43,7 @@ terragrunt find --filter 'app*'
 ```
 
 ### Path-Based Filtering
+
 Match configurations by their file system path:
 
 ```bash
@@ -53,6 +55,7 @@ terragrunt find --filter '/absolute/path/to/envs/dev/apps/*'
 ```
 
 ### Attribute-Based Filtering
+
 Match configurations by their configuration attributes:
 
 ```bash
@@ -79,6 +82,7 @@ See the [mark_as_read function documentation](/docs/reference/hcl/functions/#mar
 </Aside>
 
 ### Negation
+
 Exclude configurations using the `!` prefix:
 
 ```bash
@@ -90,6 +94,7 @@ terragrunt find --filter '!./prod/**'
 ```
 
 ### Intersection (Refinement)
+
 Use the `|` operator to refine results:
 
 ```bash
@@ -125,6 +130,7 @@ terragrunt find --filter '[abc123...def456]'
 For more details and examples, see the [Filters feature documentation](/docs/features/filter#git-based-expressions).
 
 ### Graph-Based Filtering
+
 Filter configurations based on dependency relationships using graph traversal. Use ellipsis (`...`) to traverse the dependency graph and caret (`^`) to exclude the target from results.
 
 **Syntax variants:**
@@ -165,11 +171,38 @@ For more detailed examples and explanations, see the [Filters feature documentat
 </Aside>
 
 ### Union (Multiple Filters)
+
 Specify multiple `--filter` flags to combine results using OR logic:
 
 ```bash
 # Find components named 'unit1' OR 'stack1'
 terragrunt find --filter unit1 --filter stack1
+```
+
+### The filters file
+
+Instead of specifying filters on the command line, you can store filter queries in a file. By default, Terragrunt automatically reads filter queries from `.terragrunt-filters` in the working directory when the `filter-flag` experiment is enabled.
+
+```bash
+# Automatically reads .terragrunt-filters (no flag needed)
+terragrunt find
+
+# Use a custom filters file
+terragrunt find --filters-file custom-filters.txt
+
+# Disable automatic file reading
+terragrunt find --no-filters-file
+```
+
+The filters file should contain one filter query per line. Empty lines and lines starting with `#` are ignored:
+
+```text
+# Production environment filters
+type=unit
+./prod/**
+
+# Exclude test units
+!name=test-*
 ```
 
 ## Supported Commands

--- a/docs-starlight/src/data/flags/filters-file.mdx
+++ b/docs-starlight/src/data/flags/filters-file.mdx
@@ -1,0 +1,68 @@
+---
+name: filters-file
+description: Path to a file containing filter queries, one per line
+type: string
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental Feature">
+This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
+
+Usage of the `--filters-file` flag requires usage of the `filter-flag` experiment, like so:
+
+```bash
+terragrunt find --experiment filter-flag --filters-file custom-filters.txt
+```
+
+Examples below will omit the `--experiment filter-flag` flag for brevity.
+</Aside>
+
+The `--filters-file` flag allows you to specify a custom file path containing filter queries. By default, Terragrunt automatically reads filter queries from `.terragrunt-filters` in the working directory when the `filter-flag` experiment is enabled. Use this flag to specify a different file path.
+
+## Usage
+
+```bash
+# Use a custom filters file
+terragrunt find --filters-file custom-filters.txt
+
+# Use a filters file in a different directory
+terragrunt find --filters-file /path/to/filters.txt
+
+# Use with run --all
+terragrunt run --all --filters-file prod-filters.txt -- plan
+```
+
+## Default Behavior
+
+When the `filter-flag` experiment is enabled, Terragrunt automatically reads filter queries from `.terragrunt-filters` in the working directory. You only need to use `--filters-file` if you want to use a different file path.
+
+```bash
+# Automatically reads .terragrunt-filters (no flag needed)
+terragrunt find --experiment filter-flag
+
+# Explicitly specify the default file (same as above)
+terragrunt find --experiment filter-flag --filters-file .terragrunt-filters
+```
+
+## File Format
+
+The filters file should contain one filter query per line. Empty lines and lines starting with `#` are ignored:
+
+```text
+# Production environment filters
+type=unit
+./prod/**
+
+# Exclude test units
+!name=test-*
+```
+
+## Disabling Automatic File Reading
+
+To disable automatic reading of `.terragrunt-filters`, use the `--no-filters-file` flag:
+
+```bash
+# Disable automatic .terragrunt-filters reading
+terragrunt find --no-filters-file
+```

--- a/docs-starlight/src/data/flags/no-filters-file.mdx
+++ b/docs-starlight/src/data/flags/no-filters-file.mdx
@@ -1,0 +1,31 @@
+---
+name: no-filters-file
+description: Disable automatic reading of .terragrunt-filters file
+type: bool
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental Feature">
+This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
+
+Usage of the `--no-filters-file` flag requires usage of the `filter-flag` experiment, like so:
+
+```bash
+terragrunt find --experiment filter-flag --no-filters-file
+```
+
+Examples below will omit the `--experiment filter-flag` flag for brevity.
+</Aside>
+
+The `--no-filters-file` flag disables automatic reading of the `.terragrunt-filters` file. By default, when the `filter-flag` experiment is enabled, Terragrunt automatically reads filter queries from `.terragrunt-filters` in the working directory. Use this flag to disable that automatic behavior.
+
+## Usage
+
+```bash
+# Disable automatic .terragrunt-filters reading
+terragrunt find --no-filters-file
+
+# Use with run --all
+terragrunt run --all --no-filters-file -- plan
+```


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Documentes the new `--filters-file` flag.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated filter-flag experiment status tracking.
  * Added documentation for the new filters file feature, enabling storage and automatic loading of filter queries.
  * Documented new --filters-file and --no-filters-file flags for managing filter query files.
  * Updated legacy queue control flag handling to use backward-compatible aliasing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->