### PR TITLE
feat: Optional caching for read_terragrunt_config to improve performance

### DIFF
--- a/docs-starlight/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -908,6 +908,50 @@ Notes:
 
 - `read_terragrunt_config` can be also used to read `terragrunt.stack.hcl` and `terragrunt.values.hcl` files.
 
+## read_terragrunt_config_with_cache
+
+`read_terragrunt_config_with_cache(config_path, [default_val])` is similar to `read_terragrunt_config`, but it caches the parsed configuration to avoid re-parsing the same file multiple times during configuration parsing. This can improve performance when the same configuration file is read multiple times.
+
+The function has the same signature and behavior as `read_terragrunt_config`, with the addition of caching:
+
+```hcl
+# terragrunt.hcl
+
+locals {
+  common_vars = read_terragrunt_config_with_cache(find_in_parent_folders("common.hcl"))
+}
+
+inputs = merge(
+  local.common_vars.inputs,
+  {
+    # additional inputs
+  }
+)
+```
+
+Like `read_terragrunt_config`, this function also supports an optional default value:
+
+```hcl
+# terragrunt.hcl
+
+locals {
+  common_vars = read_terragrunt_config_with_cache(find_in_parent_folders("i-dont-exist.hcl"), {inputs = {}})
+}
+```
+
+**When to use `read_terragrunt_config_with_cache` vs `read_terragrunt_config`:**
+
+- Use `read_terragrunt_config_with_cache` when you expect the same configuration file to be read multiple times during parsing, and you want to optimize performance by avoiding redundant parsing.
+- Use `read_terragrunt_config` when you need fresh parsing on each call, or when caching behavior might cause issues with dynamic configuration that changes during parsing.
+
+**Note:** The cached values are preserved from the first time the configuration is parsed, which means that if the same file is read multiple times, subsequent reads will return the cached value from the first read, not a fresh parse. This is expected behavior and proves that the cache is working correctly.
+
+**Warning:** When using `read_terragrunt_config_with_cache`, be aware that functions that depend on the original terragrunt directory context (such as [`get_original_terragrunt_dir()`](#get_original_terragrunt_dir)) will return values from the first time the configuration was parsed, not from the current parsing context.
+
+For example, if a configuration file is first read when called from module A, and then later read when called from module B, the cached version will preserve the `original_terragrunt_dir` value from module A, even when accessed from module B. This is expected caching behavior.
+
+If you need the `original_terragrunt_dir` to reflect the current parsing context, use `read_terragrunt_config` instead of `read_terragrunt_config_with_cache`.
+
 ## sops_decrypt_file
 
 `sops_decrypt_file(file_path)` decrypts a yaml, json, ini, env or "raw text" file encrypted with `sops`.

--- a/docs-starlight/src/data/commands/find.mdx
+++ b/docs-starlight/src/data/commands/find.mdx
@@ -257,6 +257,7 @@ $ terragrunt find --reading --format=json
 
 This includes files read by Terragrunt helper functions such as:
 - [`read_terragrunt_config()`](/docs/reference/hcl/functions/#read_terragrunt_config) - Reading other Terragrunt configuration files
+- [`read_terragrunt_config_with_cache()`](/docs/reference/hcl/functions/#read_terragrunt_config_with_cache) - Reading other Terragrunt configuration files with caching to avoid re-parsing the same file multiple times
 - [`read_tfvars_file()`](/docs/reference/hcl/functions/#read_tfvars_file) - Reading Terraform variable files
 - [`sops_decrypt_file()`](/docs/reference/hcl/functions/#sops_decrypt_file) - Reading encrypted files via SOPS
 - [`mark_as_read()`](/docs/reference/hcl/functions/#mark_as_read) - Explicitly marking a file as read

--- a/docs-starlight/src/data/flags/find-reading.mdx
+++ b/docs-starlight/src/data/flags/find-reading.mdx
@@ -25,6 +25,7 @@ $ terragrunt find --reading --format=json | jq
 
 The `reading` field includes files read by Terragrunt helper functions such as:
 - `read_terragrunt_config()` - Reading other Terragrunt configuration files
+- `read_terragrunt_config_with_cache()` - Reading other Terragrunt configuration files with caching to avoid re-parsing the same file multiple times
 - `read_tfvars_file()` - Reading Terraform variable files
 - `sops_decrypt_file()` - Reading encrypted files via SOPS
 - `mark_as_read()` - Explicitly marking files as read

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -5,25 +5,32 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type configKey byte
 
 const (
-	HclCacheContextKey              configKey = iota
+	// HclCacheContextKey is the context key for the HCL cache.
+	HclCacheContextKey configKey = iota
+	// ReadTerragruntConfigCacheContextKey is the context key for the read terragrunt config cache.
+	ReadTerragruntConfigCacheContextKey configKey = iota
+	// TerragruntConfigCacheContextKey is the context key for the terragrunt config cache.
 	TerragruntConfigCacheContextKey configKey = iota
 	RunCmdCacheContextKey           configKey = iota
 	DependencyOutputCacheContextKey configKey = iota
 
-	hclCacheName              = "hclCache"
-	configCacheName           = "configCache"
-	runCmdCacheName           = "runCmdCache"
-	dependencyOutputCacheName = "dependencyOutputCache"
+	hclCacheName                  = "hclCache"
+	readTerragruntConfigCacheName = "readTerragruntConfigCache"
+	configCacheName               = "configCache"
+	runCmdCacheName               = "runCmdCache"
+	dependencyOutputCacheName     = "dependencyOutputCache"
 )
 
 // WithConfigValues add to context default values for configuration.
 func WithConfigValues(ctx context.Context) context.Context {
 	ctx = context.WithValue(ctx, HclCacheContextKey, cache.NewCache[*hclparse.File](hclCacheName))
+	ctx = context.WithValue(ctx, ReadTerragruntConfigCacheContextKey, cache.NewCache[cty.Value](readTerragruntConfigCacheName))
 	ctx = context.WithValue(ctx, TerragruntConfigCacheContextKey, cache.NewCache[*TerragruntConfig](configCacheName))
 	ctx = context.WithValue(ctx, RunCmdCacheContextKey, cache.NewCache[string](runCmdCacheName))
 	ctx = context.WithValue(ctx, DependencyOutputCacheContextKey, cache.NewCache[*dependencyOutputCache](dependencyOutputCacheName))

--- a/test/fixtures/read-config-with-cache/from_dependency/dep/main.tf
+++ b/test/fixtures/read-config-with-cache/from_dependency/dep/main.tf
@@ -1,0 +1,3 @@
+variable "foo" {}
+
+output "foo" { value = var.foo }

--- a/test/fixtures/read-config-with-cache/from_dependency/dep/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/from_dependency/dep/terragrunt.hcl
@@ -1,0 +1,7 @@
+locals {
+  vars = read_terragrunt_config_with_cache("vars.hcl")
+}
+
+inputs = {
+  foo = local.vars.locals.foo
+}

--- a/test/fixtures/read-config-with-cache/from_dependency/dep/vars.hcl
+++ b/test/fixtures/read-config-with-cache/from_dependency/dep/vars.hcl
@@ -1,0 +1,3 @@
+locals {
+  foo = "hello world"
+}

--- a/test/fixtures/read-config-with-cache/from_dependency/main.tf
+++ b/test/fixtures/read-config-with-cache/from_dependency/main.tf
@@ -1,0 +1,2 @@
+variable "bar" {}
+output "bar" { value = var.bar }

--- a/test/fixtures/read-config-with-cache/from_dependency/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/from_dependency/terragrunt.hcl
@@ -1,0 +1,7 @@
+dependency "dep" {
+  config_path = "./dep/"
+}
+
+inputs = {
+  bar = dependency.dep.outputs.foo
+}

--- a/test/fixtures/read-config-with-cache/full/main.tf
+++ b/test/fixtures/read-config-with-cache/full/main.tf
@@ -1,0 +1,38 @@
+variable "localstg" {}
+output "localstg" { value = var.localstg }
+
+variable "generate" {}
+output "generate" { value = var.generate }
+
+variable "remote_state" {}
+output "remote_state" { value = var.remote_state }
+
+variable "terraformtg" {}
+output "terraformtg" { value = var.terraformtg }
+
+variable "dependencies" {}
+output "dependencies" { value = var.dependencies }
+
+variable "terraform_binary" {}
+output "terraform_binary" { value = var.terraform_binary }
+
+variable "terraform_version_constraint" {}
+output "terraform_version_constraint" { value = var.terraform_version_constraint }
+
+variable "terragrunt_version_constraint" {}
+output "terragrunt_version_constraint" { value = var.terragrunt_version_constraint }
+
+variable "download_dir" {}
+output "download_dir" { value = var.download_dir }
+
+variable "prevent_destroy" {}
+output "prevent_destroy" { value = var.prevent_destroy }
+
+variable "exclude" {}
+output "exclude" { value = var.exclude }
+
+variable "iam_role" {}
+output "iam_role" { value = var.iam_role }
+
+variable "inputs" {}
+output "inputs" { value = var.inputs }

--- a/test/fixtures/read-config-with-cache/full/source.hcl
+++ b/test/fixtures/read-config-with-cache/full/source.hcl
@@ -1,0 +1,76 @@
+locals {
+  the_answer = 42
+}
+
+generate "provider" {
+  path = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents = <<EOF
+provider "aws" {
+  region = "us-east-1"
+}
+EOF
+}
+
+remote_state {
+  backend = "local"
+  generate = {
+    path = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    path = "foo.tfstate"
+  }
+  encryption = {
+    key_provider = "foo"
+  }
+}
+
+terraform {
+  source                   = "./delorean"
+  include_in_copy          = ["time_machine.*"]
+  exclude_from_copy        = ["excluded_time_machine.*"]
+  copy_terraform_lock_file = true
+
+  extra_arguments "var-files" {
+    commands = ["apply", "plan"]
+    required_var_files = ["extra.tfvars"]
+    optional_var_files = ["optional.tfvars"]
+    env_vars = {
+      TF_VAR_custom_var = "I'm set in extra_arguments env_vars"
+    }
+  }
+
+  before_hook "before_hook_1" {
+    commands = ["apply", "plan"]
+    execute = ["touch", "before.out"]
+    run_on_error = true
+  }
+
+  after_hook "after_hook_1" {
+    commands = ["apply", "plan"]
+    execute = ["touch", "after.out"]
+    run_on_error = true
+  }
+}
+
+dependencies {
+  paths = ["../../terragrunt"]
+}
+
+terraform_binary = "terragrunt"
+terraform_version_constraint = "= 0.12.20"
+terragrunt_version_constraint = "= 0.23.18"
+download_dir = ".terragrunt-cache"
+prevent_destroy = true
+iam_role = "TerragruntIAMRole"
+
+exclude {
+  if = true
+  actions = ["all"]
+  no_run = true
+}
+
+inputs = {
+  doc = "Emmett Brown"
+}

--- a/test/fixtures/read-config-with-cache/full/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/full/terragrunt.hcl
@@ -1,0 +1,19 @@
+locals {
+  config = read_terragrunt_config_with_cache("${get_terragrunt_dir()}/source.hcl")
+}
+
+inputs = {
+  localstg                     = local.config.locals
+  generate                     = local.config.generate
+  remote_state                 = local.config.remote_state
+  terraformtg                  = local.config.terraform
+  dependencies                 = local.config.dependencies
+  terraform_binary             = local.config.terraform_binary
+  terraform_version_constraint = local.config.terraform_version_constraint
+  terragrunt_version_constraint = local.config.terragrunt_version_constraint
+  download_dir                 = local.config.download_dir
+  prevent_destroy              = local.config.prevent_destroy
+  exclude                      = local.config.exclude
+  iam_role                     = local.config.iam_role
+  inputs                       = local.config.inputs
+}

--- a/test/fixtures/read-config-with-cache/with_default/main.tf
+++ b/test/fixtures/read-config-with-cache/with_default/main.tf
@@ -1,0 +1,4 @@
+variable "data" {}
+output "data" {
+  value = var.data
+}

--- a/test/fixtures/read-config-with-cache/with_default/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/with_default/terragrunt.hcl
@@ -1,0 +1,5 @@
+locals {
+  config_does_not_exist = read_terragrunt_config_with_cache("${get_terragrunt_dir()}/i-dont-exist.hcl", {data = "default value"})
+}
+
+inputs = local.config_does_not_exist

--- a/test/fixtures/read-config-with-cache/with_dependency/dep/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/with_dependency/dep/terragrunt.hcl
@@ -1,0 +1,3 @@
+dependency "inputs" {
+  config_path = "../../../inputs"
+}

--- a/test/fixtures/read-config-with-cache/with_dependency/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/with_dependency/terragrunt.hcl
@@ -1,0 +1,9 @@
+locals {
+  config_with_dependency = read_terragrunt_config_with_cache("${get_terragrunt_dir()}/dep/terragrunt.hcl")
+}
+
+terraform {
+  source = "${get_terragrunt_dir()}/../../inputs"
+}
+
+inputs = local.config_with_dependency.dependency.inputs.outputs

--- a/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/dep/main.tf
+++ b/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/dep/main.tf
@@ -1,0 +1,31 @@
+variable "terragrunt_dir" {
+  type = string
+}
+
+variable "original_terragrunt_dir" {
+  type = string
+}
+
+variable "bar_terragrunt_dir" {
+  type = string
+}
+
+variable "bar_original_terragrunt_dir" {
+  type = string
+}
+
+output "terragrunt_dir" {
+  value = var.terragrunt_dir
+}
+
+output "original_terragrunt_dir" {
+  value = var.original_terragrunt_dir
+}
+
+output "bar_terragrunt_dir" {
+  value = var.bar_terragrunt_dir
+}
+
+output "bar_original_terragrunt_dir" {
+  value = var.bar_original_terragrunt_dir
+}

--- a/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/dep/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/dep/terragrunt.hcl
@@ -1,0 +1,11 @@
+locals {
+  bar = read_terragrunt_config_with_cache("../foo/bar.hcl")
+}
+
+inputs = {
+  terragrunt_dir          = get_terragrunt_dir()
+  original_terragrunt_dir = get_original_terragrunt_dir()
+
+  bar_terragrunt_dir          = local.bar.locals.terragrunt_dir
+  bar_original_terragrunt_dir = local.bar.locals.original_terragrunt_dir
+}

--- a/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/foo/bar.hcl
+++ b/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/foo/bar.hcl
@@ -1,0 +1,4 @@
+locals {
+  terragrunt_dir          = get_terragrunt_dir()
+  original_terragrunt_dir = get_original_terragrunt_dir()
+}

--- a/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/main.tf
+++ b/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/main.tf
@@ -1,0 +1,47 @@
+variable "terragrunt_dir" {
+  type = string
+}
+
+variable "original_terragrunt_dir" {
+  type = string
+}
+
+variable "dep_terragrunt_dir" {
+  type = string
+}
+
+variable "dep_original_terragrunt_dir" {
+  type = string
+}
+
+variable "dep_bar_terragrunt_dir" {
+  type = string
+}
+
+variable "dep_bar_original_terragrunt_dir" {
+  type = string
+}
+
+output "terragrunt_dir" {
+  value = var.terragrunt_dir
+}
+
+output "original_terragrunt_dir" {
+  value = var.original_terragrunt_dir
+}
+
+output "dep_terragrunt_dir" {
+  value = var.dep_terragrunt_dir
+}
+
+output "dep_original_terragrunt_dir" {
+  value = var.dep_original_terragrunt_dir
+}
+
+output "dep_bar_terragrunt_dir" {
+  value = var.dep_bar_terragrunt_dir
+}
+
+output "dep_bar_original_terragrunt_dir" {
+  value = var.dep_bar_original_terragrunt_dir
+}

--- a/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/terragrunt.hcl
@@ -1,0 +1,18 @@
+locals {
+  bar = read_terragrunt_config_with_cache("foo/bar.hcl")
+}
+
+dependency "dep" {
+  config_path = "./dep"
+}
+
+inputs = {
+  terragrunt_dir          = local.bar.locals.terragrunt_dir
+  original_terragrunt_dir = local.bar.locals.original_terragrunt_dir
+
+  dep_terragrunt_dir          = dependency.dep.outputs.terragrunt_dir
+  dep_original_terragrunt_dir = dependency.dep.outputs.original_terragrunt_dir
+
+  dep_bar_terragrunt_dir          = dependency.dep.outputs.bar_terragrunt_dir
+  dep_bar_original_terragrunt_dir = dependency.dep.outputs.bar_original_terragrunt_dir
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This PR introduces a new function, `read_terragrunt_config_with_cache`, which provides optional, opt-in caching for Terragrunt config parsing. In large Terragrunt infrastructures, shared configuration files (e.g., `global-accounts.hcl`, `global-modules.hcl`, `global-vars.hcl`, etc.) may be parsed thousands of times during a single `run-all` operation. This causes a significant amount of redundant HCL parsing and increases execution time, especially in complex multi-account AWS environments.

This work implements one of the option described in **#4896**, which outlines the motivation, performance impact, and proposed design for optional caching of repeated config reads.

The newly added function behaves like `read_terragrunt_config` but stores the parsed result in an in-memory cache keyed by absolute file path. Subsequent calls for the same file return the cached value, eliminating redundant parsing.

**Key points**

- **Opt-in:** Existing Terragrunt behavior remains unchanged.

- **Performance improvement:** Real-world project tested — 1956 redundant parses reduced to a single parse, producing a ~35% reduction in pipeline runtime.

- **Safe by default:** Caching is not enabled automatically due to compatibility considerations with get_original_terragrunt_dir().

- The caching implementation is isolated to the new function (read_terragrunt_config_with_cache) to avoid breaking existing setups.

**Changes in this PR**

- Introduces read_terragrunt_config_with_cache(path)

- Implements an internal global in-memory cache keyed by canonical absolute path

- Adds tests covering standard caching cases

- Documents behavior, caveats, and usage

- Ensures the default function (read_terragrunt_config) remains unchanged

This feature enables teams with large infrastructures to materially speed up Terragrunt operations without modifying existing configurations.

## TODOs

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

**Added**

- Added a new optional function: read_terragrunt_config_with_cache(path), which caches parsed Terragrunt config files and reuses them across modules.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

Terragrunt now provides an optional caching mechanism for repeated config parsing via a new function:
read_terragrunt_config_with_cache(path).

Caching is **disabled by default** to preserve existing behavior and avoid compatibility issues for users relying on evaluation-context-dependent functions.

#### Who should migrate?

Users with:
- Large Terragrunt mono-repos
- Many modules reusing shared global configuration files
- Slow run-all plan or run-all apply operations
- High numbers of repeated read_terragrunt_config calls

If your infrastructure parses the same *.hcl configuration files hundreds or thousands of times, you are likely to benefit.

#### How to migrate

Simply replace:

```
locals {
  global_accts = read_terragrunt_config(find_in_parent_folders("global-accounts.hcl")).locals
}
```


with:

```
locals {
  global_accts = read_terragrunt_config_with_cache(find_in_parent_folders("global-accounts.hcl")).locals
}

```

No other changes are required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for caching-enabled configuration file reading, including usage examples, best practices, and guidance on cached versus non-cached approaches.
  * Updated reference materials with details on performance benefits and caching behavior.

* **Tests**
  * Added test coverage validating configuration caching across multiple scenarios including dependencies, default values, and directory contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->