### PR TITLE
fix: Do not parse excluded dirs during discovery phase

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -902,6 +902,27 @@ func (d *Discovery) createComponentFromPath(path string, filenames []string) com
 	return nil
 }
 
+// shouldSkipParsing checks if a component should be skipped during parsing
+// based on exclude directory patterns. Returns true if component matches any exclude pattern.
+func (d *Discovery) shouldSkipParsing(component component.Component) bool {
+	if len(d.compiledExcludePatterns) == 0 {
+		return false
+	}
+
+	canonicalPath, err := util.CanonicalPath(component.Path(), d.workingDir)
+	if err != nil {
+		return false
+	}
+
+	for _, pattern := range d.compiledExcludePatterns {
+		if pattern.Compiled.Match(canonicalPath) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // parseConcurrently parses components concurrently to improve performance using errgroup.
 func (d *Discovery) parseConcurrently(
 	ctx context.Context,
@@ -916,6 +937,13 @@ func (d *Discovery) parseConcurrently(
 		// Stack configurations don't need to be parsed for discovery purposes.
 		// They don't have exclude blocks or dependencies.
 		if _, ok := c.(*component.Stack); ok {
+			continue
+		}
+
+		// Skip parsing components that match exclude patterns
+		// They will still be discovered and reported as excluded
+		if d.shouldSkipParsing(c) {
+			l.Debugf("Skipping parse for excluded component: %s", c.Path())
 			continue
 		}
 

--- a/internal/runner/runnerpool/builder.go
+++ b/internal/runner/runnerpool/builder.go
@@ -65,10 +65,12 @@ func Build(
 		d = d.WithIncludeDirs(terragruntOptions.IncludeDirs)
 	}
 
-	// NOTE: We do NOT pass ExcludeDirs to discovery because excluded units need to be
-	// discovered and reported (for --report-file functionality). The unit resolver will
-	// handle exclusions after discovery, ensuring excluded units appear in reports.
-	//
+	// Pass exclude directory filters to discovery
+	// Discovery will skip parsing (but still discover) excluded units for reporting
+	if len(terragruntOptions.ExcludeDirs) > 0 {
+		d = d.WithExcludeDirs(terragruntOptions.ExcludeDirs)
+	}
+
 	// For now... We can probably use the following once runnerpool has been updated to not expect external
 	// dependencies in the discovery results.
 	//

--- a/test/fixtures/stacks/exclude-template-module/live/project-A/module/main.tf
+++ b/test/fixtures/stacks/exclude-template-module/live/project-A/module/main.tf
@@ -1,0 +1,8 @@
+variable "environment" {
+  type = string
+}
+
+output "environment" {
+  value = var.environment
+}
+

--- a/test/fixtures/stacks/exclude-template-module/live/project-A/module/terragrunt.hcl
+++ b/test/fixtures/stacks/exclude-template-module/live/project-A/module/terragrunt.hcl
@@ -1,0 +1,21 @@
+# Project A dependency on Project B using values
+dependency "project_b" {
+  config_path = "../../../project-B/.terragrunt-stack/${values.env}"
+
+  mock_outputs = {
+    project_b_output = "mock-project-b-output"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+}
+
+terraform {
+  source = "."
+}
+
+# This will fail parsing if module/ isn't excluded from discovery
+# because ${values} only exists in generated stack context, not during standalone parsing
+inputs = {
+  environment = values.env
+}
+

--- a/test/fixtures/stacks/exclude-template-module/live/project-A/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/exclude-template-module/live/project-A/terragrunt.stack.hcl
@@ -1,0 +1,18 @@
+# This stack references a template module that uses stack variables
+# The module/ directory should be excluded to avoid parsing errors
+
+unit "staging" {
+  source = "./module"
+  path   = "staging"
+  values = {
+    env = "staging"
+  }
+}
+
+unit "production" {
+  source = "./module"
+  path   = "production"
+  values = {
+    env = "production"
+  }
+}

--- a/test/fixtures/stacks/exclude-template-module/live/project-B/module/main.tf
+++ b/test/fixtures/stacks/exclude-template-module/live/project-B/module/main.tf
@@ -1,0 +1,8 @@
+variable "environment" {
+  type = string
+}
+
+output "environment" {
+  value = var.environment
+}
+

--- a/test/fixtures/stacks/exclude-template-module/live/project-B/module/terragrunt.hcl
+++ b/test/fixtures/stacks/exclude-template-module/live/project-B/module/terragrunt.hcl
@@ -1,0 +1,10 @@
+terraform {
+  source = "."
+}
+
+# This will fail parsing if module/ isn't excluded from discovery
+# because ${values} only exists in generated stack context, not during standalone parsing
+inputs = {
+  environment = values.env
+}
+

--- a/test/fixtures/stacks/exclude-template-module/live/project-B/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/exclude-template-module/live/project-B/terragrunt.stack.hcl
@@ -1,0 +1,18 @@
+# This stack references a template module that uses stack variables
+# The module/ directory should be excluded to avoid parsing errors
+
+unit "staging" {
+  source = "./module"
+  path   = "staging"
+  values = {
+    env = "staging"
+  }
+}
+
+unit "production" {
+  source = "./module"
+  path   = "production"
+  values = {
+    env = "production"
+  }
+}


### PR DESCRIPTION
## Description

Fixes #5124 .

The `--queue-exclude-dir` flag was not preventing the parsing of excluded directories during dependency discovery. This caused parsing errors when using Terragrunt stacks with template modules whose `terragrunt.hcl` files reference stack-specific values (e.g., `${values.env}`, `${values.project}`).

### Why this was an issue:
- Template modules in stacks often use variables that only exist in the generated stack context
- During discovery, Terragrunt would still parse excluded directories even though they were excluded from execution
- This caused parsing failures because the stack variables weren't available outside their stack context
- Users couldn't effectively exclude template directories to avoid these errors

> Available workarounds were the use of
>   - ` --queue-include-dir` in tandem with `--queue-strict-include`
>   - Adding a mock set of values into a terragrunt.values.hcl in the module to statisfy the parsing during discovery


### Solution
**Commit `f3f7dd7`**: Core Implementation
- Added `shouldSkipParsing()` method to check if a component matches exclude patterns
- Modified `parseConcurrently()` to skip parsing for components that match `--queue-exclude-dir` patterns
- Excluded directories are still discovered (for reporting) but never parsed

**Commit `7f08f13`:** Test Coverage
- Added `TestStacksGenerateExcludeModuleWithStackVariables`integration test
- Created test fixture with template modules using stack variables (`${values.env}`)
- Verifies that `--queue-exclude-dir '**/module'` in tandem with the fix prevents parsing errors while still processing generated stack units

> Note: I reverted the fix after adding the test and validated that it accurately fails prior to commit `f3f7dd7` with expected errors and is resolved after the proposed changes

### Testing
Run the new integration test:
```
go test -v -run TestStacksGenerateExcludeModuleWithStackVariables ./test
```
The test verifies that:
- Template modules with stack variables can be excluded without parsing errors
- Generated stack units are still properly discovered and processed
- The `--queue-exclude-dir` flag works as expected in stack workflows

> All tests defined in `discovery_test.go` pass


## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- N/A: I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- N/A (Bug fix):   Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Discovery phase no longer parses directories matched by `--queue-include-dir` glob mitigating failures from the use of values referenced in generated stacks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory exclusion via --queue-exclude-dir: excluded directories are still discovered/reported but skipped during parsing.

* **Tests**
  * Added an integration test validating exclude-dir behavior with stack/template modules and stack variables.

* **Chores**
  * Added stack/module fixture files demonstrating template modules that should be excluded to avoid parsing errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->