### PR TITLE
fix: Addresses bug #4979

### DIFF
--- a/internal/awshelper/config.go
+++ b/internal/awshelper/config.go
@@ -131,7 +131,7 @@ func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config,
 		return aws.Config{}, errors.Errorf("Error loading AWS config: %w", err)
 	}
 
-	if createCredentialsFromEnv(b.env) != nil {
+	if createCredentialsFromEnv(b.env) != nil && !b.iamRoleOpts.AssumeRoleWithExistingCredentials {
 		return cfg, nil
 	}
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -336,6 +336,25 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		{
 			args: []string{
 				"plan",
+				doubleDashed(run.IAMAssumeRoleWithExistingCredentialsFlagName),
+			},
+			expectedOptions: mockOptionsWithIamAssumeRoleWithExistingCredentials(
+				t,
+				filepath.Join(
+					workingDir,
+					config.DefaultTerragruntConfigPath,
+				),
+				workingDir,
+				[]string{"plan"},
+				false,
+				"",
+				false,
+			),
+		},
+
+		{
+			args: []string{
+				"plan",
 				doubleDashed(run.ConfigFlagName),
 				"/some/path/" + config.DefaultTerragruntConfigPath,
 				"-non-interactive",
@@ -529,6 +548,16 @@ func mockOptionsWithIamWebIdentityToken(t *testing.T, terragruntConfigPath strin
 	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors, false, defaultLogLevel, false)
 	opts.OriginalIAMRoleOptions.WebIdentityToken = webIdentityToken
 	opts.IAMRoleOptions.WebIdentityToken = webIdentityToken
+
+	return opts
+}
+
+func mockOptionsWithIamAssumeRoleWithExistingCredentials(t *testing.T, terragruntConfigPath string, workingDir string, terraformCliArgs []string, nonInteractive bool, terragruntSource string, ignoreDependencyErrors bool) *options.TerragruntOptions {
+	t.Helper()
+
+	opts := mockOptions(t, terragruntConfigPath, workingDir, terraformCliArgs, nonInteractive, terragruntSource, ignoreDependencyErrors, false, defaultLogLevel, false)
+	opts.OriginalIAMRoleOptions.AssumeRoleWithExistingCredentials = true
+	opts.IAMRoleOptions.AssumeRoleWithExistingCredentials = true
 
 	return opts
 }

--- a/internal/cli/commands/run/flags.go
+++ b/internal/cli/commands/run/flags.go
@@ -77,11 +77,12 @@ const (
 	ConfigFlagName = shared.ConfigFlagName
 
 	// Auth and IAM flags - use shared package constants
-	InputsDebugFlagName                   = shared.InputsDebugFlagName
-	IAMAssumeRoleFlagName                 = shared.IAMAssumeRoleFlagName
-	IAMAssumeRoleDurationFlagName         = shared.IAMAssumeRoleDurationFlagName
-	IAMAssumeRoleSessionNameFlagName      = shared.IAMAssumeRoleSessionNameFlagName
-	IAMAssumeRoleWebIdentityTokenFlagName = shared.IAMAssumeRoleWebIdentityTokenFlagName
+	InputsDebugFlagName                          = shared.InputsDebugFlagName
+	IAMAssumeRoleFlagName                        = shared.IAMAssumeRoleFlagName
+	IAMAssumeRoleDurationFlagName                = shared.IAMAssumeRoleDurationFlagName
+	IAMAssumeRoleSessionNameFlagName             = shared.IAMAssumeRoleSessionNameFlagName
+	IAMAssumeRoleWebIdentityTokenFlagName        = shared.IAMAssumeRoleWebIdentityTokenFlagName
+	IAMAssumeRoleWithExistingCredentialsFlagName = shared.IAMAssumeRoleWithExistingCredentialsFlagName
 )
 
 // NewFlags creates and returns global flags.

--- a/internal/cli/flags/shared/iamassumerole.go
+++ b/internal/cli/flags/shared/iamassumerole.go
@@ -7,10 +7,11 @@ import (
 )
 
 const (
-	IAMAssumeRoleFlagName                 = "iam-assume-role"
-	IAMAssumeRoleDurationFlagName         = "iam-assume-role-duration"
-	IAMAssumeRoleSessionNameFlagName      = "iam-assume-role-session-name"
-	IAMAssumeRoleWebIdentityTokenFlagName = "iam-assume-role-web-identity-token"
+	IAMAssumeRoleFlagName                        = "iam-assume-role"
+	IAMAssumeRoleDurationFlagName                = "iam-assume-role-duration"
+	IAMAssumeRoleSessionNameFlagName             = "iam-assume-role-session-name"
+	IAMAssumeRoleWebIdentityTokenFlagName        = "iam-assume-role-web-identity-token"
+	IAMAssumeRoleWithExistingCredentialsFlagName = "iam-assume-role-with-existing-credentials"
 )
 
 // NewIAMAssumeRoleFlags creates flags for IAM assume role configuration.
@@ -70,6 +71,15 @@ func NewIAMAssumeRoleFlags(opts *options.TerragruntOptions, prefix flags.Prefix,
 				),
 				terragruntPrefixControl,
 			),
+		),
+
+		flags.NewFlag(
+			&clihelper.BoolFlag{
+				Name:        IAMAssumeRoleWithExistingCredentialsFlagName,
+				EnvVars:     tgPrefix.EnvVars(IAMAssumeRoleWithExistingCredentialsFlagName),
+				Destination: &opts.IAMRoleOptions.AssumeRoleWithExistingCredentials,
+				Usage:       "When true, assume the configured IAM role even when AWS credentials are already present in the environment, using them as source credentials for role chaining.",
+			},
 		),
 	}
 }

--- a/internal/iam/iam.go
+++ b/internal/iam/iam.go
@@ -19,10 +19,11 @@ func GetDefaultAssumeRoleSessionName() string {
 
 // RoleOptions represents options that are used by Terragrunt to assume an IAM role.
 type RoleOptions struct {
-	RoleARN               string
-	WebIdentityToken      string
-	AssumeRoleSessionName string
-	AssumeRoleDuration    int64
+	RoleARN                           string
+	WebIdentityToken                  string
+	AssumeRoleSessionName             string
+	AssumeRoleDuration                int64
+	AssumeRoleWithExistingCredentials bool
 }
 
 // MergeRoleOptions merges the source IAM role options into the target, preferring
@@ -44,6 +45,10 @@ func MergeRoleOptions(target RoleOptions, source RoleOptions) RoleOptions {
 
 	if source.WebIdentityToken != "" {
 		out.WebIdentityToken = source.WebIdentityToken
+	}
+
+	if source.AssumeRoleWithExistingCredentials {
+		out.AssumeRoleWithExistingCredentials = true
 	}
 
 	return out

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,35 +57,36 @@ const (
 
 	logMsgSeparator = "\n"
 
-	DefaultEngineType                   = "rpc"
-	MetadataTerraform                   = "terraform"
-	MetadataTerraformBinary             = "terraform_binary"
-	MetadataTerraformVersionConstraint  = "terraform_version_constraint"
-	MetadataTerragruntVersionConstraint = "terragrunt_version_constraint"
-	MetadataRemoteState                 = "remote_state"
-	MetadataDependencies                = "dependencies"
-	MetadataDependency                  = "dependency"
-	MetadataDownloadDir                 = "download_dir"
-	MetadataPreventDestroy              = "prevent_destroy"
-	MetadataIamRole                     = "iam_role"
-	MetadataIamAssumeRoleDuration       = "iam_assume_role_duration"
-	MetadataIamAssumeRoleSessionName    = "iam_assume_role_session_name"
-	MetadataIamWebIdentityToken         = "iam_web_identity_token"
-	MetadataInputs                      = "inputs"
-	MetadataLocals                      = "locals"
-	MetadataLocal                       = "local"
-	MetadataCatalog                     = "catalog"
-	MetadataEngine                      = "engine"
-	MetadataGenerateConfigs             = "generate"
-	MetadataInclude                     = "include"
-	MetadataFeatureFlag                 = "feature"
-	MetadataExclude                     = "exclude"
-	MetadataErrors                      = "errors"
-	MetadataRetry                       = "retry"
-	MetadataIgnore                      = "ignore"
-	MetadataValues                      = "values"
-	MetadataStack                       = "stack"
-	MetadataUnit                        = "unit"
+	DefaultEngineType                            = "rpc"
+	MetadataTerraform                            = "terraform"
+	MetadataTerraformBinary                      = "terraform_binary"
+	MetadataTerraformVersionConstraint           = "terraform_version_constraint"
+	MetadataTerragruntVersionConstraint          = "terragrunt_version_constraint"
+	MetadataRemoteState                          = "remote_state"
+	MetadataDependencies                         = "dependencies"
+	MetadataDependency                           = "dependency"
+	MetadataDownloadDir                          = "download_dir"
+	MetadataPreventDestroy                       = "prevent_destroy"
+	MetadataIamRole                              = "iam_role"
+	MetadataIamAssumeRoleDuration                = "iam_assume_role_duration"
+	MetadataIamAssumeRoleSessionName             = "iam_assume_role_session_name"
+	MetadataIamWebIdentityToken                  = "iam_web_identity_token"
+	MetadataIamAssumeRoleWithExistingCredentials = "iam_assume_role_with_existing_credentials"
+	MetadataInputs                               = "inputs"
+	MetadataLocals                               = "locals"
+	MetadataLocal                                = "local"
+	MetadataCatalog                              = "catalog"
+	MetadataEngine                               = "engine"
+	MetadataGenerateConfigs                      = "generate"
+	MetadataInclude                              = "include"
+	MetadataFeatureFlag                          = "feature"
+	MetadataExclude                              = "exclude"
+	MetadataErrors                               = "errors"
+	MetadataRetry                                = "retry"
+	MetadataIgnore                               = "ignore"
+	MetadataValues                               = "values"
+	MetadataStack                                = "stack"
+	MetadataUnit                                 = "unit"
 )
 
 var (
@@ -139,30 +140,31 @@ type DecodedBaseBlocks struct {
 // TerragruntConfig represents a parsed and expanded configuration
 // NOTE: if any attributes are added, make sure to update terragruntConfigAsCty in config_as_cty.go
 type TerragruntConfig struct {
-	Locals                      map[string]any
-	ProcessedIncludes           IncludeConfigsMap
-	FieldsMetadata              map[string]map[string]any
-	Terraform                   *TerraformConfig
-	Errors                      *ErrorsConfig
-	RemoteState                 *remotestate.RemoteState
-	Dependencies                *ModuleDependencies
-	Exclude                     *ExcludeConfig
-	PreventDestroy              *bool
-	GenerateConfigs             map[string]codegen.GenerateConfig
-	IamAssumeRoleDuration       *int64
-	Inputs                      map[string]any
-	Engine                      *EngineConfig
-	Catalog                     *CatalogConfig
-	IamWebIdentityToken         string
-	IamAssumeRoleSessionName    string
-	IamRole                     string
-	DownloadDir                 string
-	TerragruntVersionConstraint string
-	TerraformVersionConstraint  string
-	TerraformBinary             string
-	TerragruntDependencies      Dependencies
-	FeatureFlags                FeatureFlags
-	IsPartial                   bool
+	Locals                               map[string]any
+	ProcessedIncludes                    IncludeConfigsMap
+	FieldsMetadata                       map[string]map[string]any
+	Terraform                            *TerraformConfig
+	Errors                               *ErrorsConfig
+	RemoteState                          *remotestate.RemoteState
+	Dependencies                         *ModuleDependencies
+	Exclude                              *ExcludeConfig
+	PreventDestroy                       *bool
+	GenerateConfigs                      map[string]codegen.GenerateConfig
+	IamAssumeRoleDuration                *int64
+	Inputs                               map[string]any
+	Engine                               *EngineConfig
+	Catalog                              *CatalogConfig
+	IamWebIdentityToken                  string
+	IamAssumeRoleSessionName             string
+	IamRole                              string
+	DownloadDir                          string
+	TerragruntVersionConstraint          string
+	TerraformVersionConstraint           string
+	TerraformBinary                      string
+	TerragruntDependencies               Dependencies
+	FeatureFlags                         FeatureFlags
+	IsPartial                            bool
+	IamAssumeRoleWithExistingCredentials bool
 }
 
 func (cfg *TerragruntConfig) GetRemoteState(l log.Logger, pctx *ParsingContext) (*remotestate.RemoteState, error) {
@@ -199,9 +201,10 @@ func (cfg *TerragruntConfig) String() string {
 // iam.RoleOptions struct.
 func (cfg *TerragruntConfig) GetIAMRoleOptions() iam.RoleOptions {
 	configIAMRoleOptions := iam.RoleOptions{
-		RoleARN:               cfg.IamRole,
-		AssumeRoleSessionName: cfg.IamAssumeRoleSessionName,
-		WebIdentityToken:      cfg.IamWebIdentityToken,
+		RoleARN:                           cfg.IamRole,
+		AssumeRoleSessionName:             cfg.IamAssumeRoleSessionName,
+		WebIdentityToken:                  cfg.IamWebIdentityToken,
+		AssumeRoleWithExistingCredentials: cfg.IamAssumeRoleWithExistingCredentials,
 	}
 	if cfg.IamAssumeRoleDuration != nil {
 		configIAMRoleOptions.AssumeRoleDuration = *cfg.IamAssumeRoleDuration
@@ -649,17 +652,18 @@ type terragruntConfigFile struct {
 	RemoteState     *remotestate.ConfigFile `hcl:"remote_state,block"`
 	RemoteStateAttr *cty.Value              `hcl:"remote_state,optional"`
 
-	Dependencies             *ModuleDependencies `hcl:"dependencies,block"`
-	DownloadDir              *string             `hcl:"download_dir,attr"`
-	PreventDestroy           *bool               `hcl:"prevent_destroy,attr"`
-	IamRole                  *string             `hcl:"iam_role,attr"`
-	IamAssumeRoleDuration    *int64              `hcl:"iam_assume_role_duration,attr"`
-	IamAssumeRoleSessionName *string             `hcl:"iam_assume_role_session_name,attr"`
-	IamWebIdentityToken      *string             `hcl:"iam_web_identity_token,attr"`
-	TerragruntDependencies   []Dependency        `hcl:"dependency,block"`
-	FeatureFlags             []*FeatureFlag      `hcl:"feature,block"`
-	Exclude                  *ExcludeConfig      `hcl:"exclude,block"`
-	Errors                   *ErrorsConfig       `hcl:"errors,block"`
+	Dependencies                         *ModuleDependencies `hcl:"dependencies,block"`
+	DownloadDir                          *string             `hcl:"download_dir,attr"`
+	PreventDestroy                       *bool               `hcl:"prevent_destroy,attr"`
+	IamRole                              *string             `hcl:"iam_role,attr"`
+	IamAssumeRoleDuration                *int64              `hcl:"iam_assume_role_duration,attr"`
+	IamAssumeRoleSessionName             *string             `hcl:"iam_assume_role_session_name,attr"`
+	IamWebIdentityToken                  *string             `hcl:"iam_web_identity_token,attr"`
+	IamAssumeRoleWithExistingCredentials *bool               `hcl:"iam_assume_role_with_existing_credentials,attr"`
+	TerragruntDependencies               []Dependency        `hcl:"dependency,block"`
+	FeatureFlags                         []*FeatureFlag      `hcl:"feature,block"`
+	Exclude                              *ExcludeConfig      `hcl:"exclude,block"`
+	Errors                               *ErrorsConfig       `hcl:"errors,block"`
 
 	// We allow users to configure code generation via blocks:
 	//
@@ -1772,6 +1776,11 @@ func convertToTerragruntConfig(ctx context.Context, pctx *ParsingContext, config
 	if terragruntConfigFromFile.IamWebIdentityToken != nil {
 		terragruntConfig.IamWebIdentityToken = *terragruntConfigFromFile.IamWebIdentityToken
 		terragruntConfig.SetFieldMetadata(MetadataIamWebIdentityToken, defaultMetadata)
+	}
+
+	if terragruntConfigFromFile.IamAssumeRoleWithExistingCredentials != nil {
+		terragruntConfig.IamAssumeRoleWithExistingCredentials = *terragruntConfigFromFile.IamAssumeRoleWithExistingCredentials
+		terragruntConfig.SetFieldMetadata(MetadataIamAssumeRoleWithExistingCredentials, defaultMetadata)
 	}
 
 	if terragruntConfigFromFile.Engine != nil {

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -27,6 +27,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 	output[MetadataIamRole] = gostringToCty(config.IamRole)
 	output[MetadataIamAssumeRoleSessionName] = gostringToCty(config.IamAssumeRoleSessionName)
 	output[MetadataIamWebIdentityToken] = gostringToCty(config.IamWebIdentityToken)
+	output[MetadataIamAssumeRoleWithExistingCredentials] = goboolToCty(config.IamAssumeRoleWithExistingCredentials)
 
 	catalogConfigCty, err := catalogConfigAsCty(config.Catalog)
 	if err != nil {

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -82,10 +82,11 @@ type terraformConfigSourceOnly struct {
 
 // terragruntFlags is a struct that can be used to only decode the flag attributes (prevent_destroy)
 type terragruntFlags struct {
-	IamRole             *string  `hcl:"iam_role,attr"`
-	IamWebIdentityToken *string  `hcl:"iam_web_identity_token,attr"`
-	PreventDestroy      *bool    `hcl:"prevent_destroy,attr"`
-	Remain              hcl.Body `hcl:",remain"`
+	IamRole                              *string  `hcl:"iam_role,attr"`
+	IamWebIdentityToken                  *string  `hcl:"iam_web_identity_token,attr"`
+	IamAssumeRoleWithExistingCredentials *bool    `hcl:"iam_assume_role_with_existing_credentials,attr"`
+	PreventDestroy                       *bool    `hcl:"prevent_destroy,attr"`
+	Remain                               hcl.Body `hcl:",remain"`
 }
 
 // terragruntVersionConstraints is a struct that can be used to only decode the attributes related to constraining the
@@ -517,6 +518,10 @@ func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger,
 
 			if decoded.IamWebIdentityToken != nil {
 				output.IamWebIdentityToken = *decoded.IamWebIdentityToken
+			}
+
+			if decoded.IamAssumeRoleWithExistingCredentials != nil {
+				output.IamAssumeRoleWithExistingCredentials = *decoded.IamAssumeRoleWithExistingCredentials
 			}
 		case TerragruntVersionConstraints:
 			decoded := terragruntVersionConstraints{}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/codegen"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/iam"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend/s3"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
@@ -482,6 +483,52 @@ func TestParseIamWebIdentity(t *testing.T) {
 	assert.Nil(t, terragruntConfig.Dependencies)
 	assert.Empty(t, terragruntConfig.IamRole)
 	assert.Equal(t, token, terragruntConfig.IamWebIdentityToken)
+}
+
+func TestParseIamAssumeRoleWithExistingCredentials(t *testing.T) {
+	t.Parallel()
+
+	cfg := `iam_assume_role_with_existing_credentials = true`
+
+	l := createLogger()
+
+	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Nil(t, terragruntConfig.RemoteState)
+	assert.Nil(t, terragruntConfig.Terraform)
+	assert.Nil(t, terragruntConfig.Dependencies)
+	assert.True(t, terragruntConfig.IamAssumeRoleWithExistingCredentials)
+
+	// Verify it flows through GetIAMRoleOptions
+	roleOpts := terragruntConfig.GetIAMRoleOptions()
+	assert.True(t, roleOpts.AssumeRoleWithExistingCredentials)
+}
+
+func TestIamAssumeRoleWithExistingCredentialsMerge(t *testing.T) {
+	t.Parallel()
+
+	// HCL sets the flag; CLI does not override it
+	hclOpts := iam.RoleOptions{
+		RoleARN:                           "arn:aws:iam::123456789012:role/BackendRole",
+		AssumeRoleWithExistingCredentials: true,
+	}
+	cliOpts := iam.RoleOptions{} // CLI did not set the flag
+
+	merged := iam.MergeRoleOptions(hclOpts, cliOpts)
+	assert.True(t, merged.AssumeRoleWithExistingCredentials)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/BackendRole", merged.RoleARN)
+
+	// CLI sets the flag; HCL does not — CLI takes precedence
+	hclOpts2 := iam.RoleOptions{RoleARN: "arn:aws:iam::123456789012:role/BackendRole"}
+	cliOpts2 := iam.RoleOptions{AssumeRoleWithExistingCredentials: true}
+
+	merged2 := iam.MergeRoleOptions(hclOpts2, cliOpts2)
+	assert.True(t, merged2.AssumeRoleWithExistingCredentials)
 }
 
 func TestParseTerragruntConfigDependenciesOnePath(t *testing.T) {

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -808,11 +808,6 @@ func getTerragruntOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Lo
 
 	pctx.DownloadDir = downloadDir
 
-	// Clear IAM if changed from original
-	if pctx.IAMRoleOptions != pctx.OriginalIAMRoleOptions {
-		pctx.IAMRoleOptions = iam.RoleOptions{}
-	}
-
 	// Validate and use TerragruntVersionConstraints.TerraformBinary for dependency
 	partialTerragruntConfig, err := PartialParseConfigFile(
 		ctx,

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -299,6 +299,10 @@ func (cfg *TerragruntConfig) Merge(l log.Logger, sourceConfig *TerragruntConfig)
 		cfg.IamWebIdentityToken = sourceConfig.IamWebIdentityToken
 	}
 
+	if sourceConfig.IamAssumeRoleWithExistingCredentials {
+		cfg.IamAssumeRoleWithExistingCredentials = sourceConfig.IamAssumeRoleWithExistingCredentials
+	}
+
 	if sourceConfig.TerraformVersionConstraint != "" {
 		cfg.TerraformVersionConstraint = sourceConfig.TerraformVersionConstraint
 	}

--- a/test/fixtures/assume-role-with-existing-credentials/env1/app1/main.tf
+++ b/test/fixtures/assume-role-with-existing-credentials/env1/app1/main.tf
@@ -1,0 +1,3 @@
+output "app1_text" {
+  value = "app1 output"
+}

--- a/test/fixtures/assume-role-with-existing-credentials/env1/app1/terragrunt.hcl
+++ b/test/fixtures/assume-role-with-existing-credentials/env1/app1/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}

--- a/test/fixtures/assume-role-with-existing-credentials/env1/app2-via-hcl/main.tf
+++ b/test/fixtures/assume-role-with-existing-credentials/env1/app2-via-hcl/main.tf
@@ -1,0 +1,5 @@
+variable "app1_text" {}
+
+output "app2_text" {
+  value = "app2 output: ${var.app1_text}"
+}

--- a/test/fixtures/assume-role-with-existing-credentials/env1/app2-via-hcl/terragrunt.hcl
+++ b/test/fixtures/assume-role-with-existing-credentials/env1/app2-via-hcl/terragrunt.hcl
@@ -1,0 +1,17 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+iam_assume_role_with_existing_credentials = true
+
+dependency "app1" {
+  config_path = "../app1"
+
+  mock_outputs = {
+    app1_text = "(known after apply)"
+  }
+}
+
+inputs = {
+  app1_text = dependency.app1.outputs.app1_text
+}

--- a/test/fixtures/assume-role-with-existing-credentials/env1/app2/main.tf
+++ b/test/fixtures/assume-role-with-existing-credentials/env1/app2/main.tf
@@ -1,0 +1,5 @@
+variable "app1_text" {}
+
+output "app2_text" {
+  value = "app2 output: ${var.app1_text}"
+}

--- a/test/fixtures/assume-role-with-existing-credentials/env1/app2/terragrunt.hcl
+++ b/test/fixtures/assume-role-with-existing-credentials/env1/app2/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+dependency "app1" {
+  config_path = "../app1"
+
+  mock_outputs = {
+    app1_text = "(known after apply)"
+  }
+}
+
+inputs = {
+  app1_text = dependency.app1.outputs.app1_text
+}

--- a/test/fixtures/assume-role-with-existing-credentials/root.hcl
+++ b/test/fixtures/assume-role-with-existing-credentials/root.hcl
@@ -1,0 +1,16 @@
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket  = "__FILL_IN_BUCKET_NAME__"
+    key     = "${path_relative_to_include()}/terraform.tfstate"
+    region  = "__FILL_IN_REGION__"
+    encrypt = true
+    assume_role = {
+      role_arn = "__FILL_IN_ASSUME_ROLE__"
+    }
+  }
+}

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -56,6 +56,7 @@ const (
 	testFixtureS3BackendUseLockfile              = "fixtures/s3-backend/use-lockfile"
 	testFixtureS3BackendDisableInit              = "fixtures/s3-backend-disable-init"
 	testFixtureAssumeRoleWithExternalIDWithComma = "fixtures/assume-role/external-id-with-comma"
+	testFixtureAssumeRoleWithExistingCredentials = "fixtures/assume-role-with-existing-credentials"
 
 	qaMyAppRelPath = "qa/my-app"
 )
@@ -1542,6 +1543,171 @@ func TestAwsAssumeRoleDuration(t *testing.T) {
 	assert.NotContains(t, output, "Initializing the backend...")
 	assert.NotContains(t, output, "has been successfully initialized!")
 	assert.Contains(t, output, "no changes are needed.")
+}
+
+// Regression test for https://github.com/gruntwork-io/terragrunt/issues/4979
+func TestAwsAssumeRoleWithExistingCredentials(t *testing.T) {
+	t.Parallel()
+
+	awsCfg, err := awshelper.NewAWSConfigBuilder().
+		WithSessionConfig(&awshelper.AwsSessionConfig{Region: helpers.TerraformRemoteStateS3Region}).
+		Build(t.Context(), createLogger())
+	require.NoError(t, err, "building AWS config")
+
+	iamClient := iam.NewFromConfig(awsCfg)
+	stsClient := sts.NewFromConfig(awsCfg)
+
+	identity, err := stsClient.GetCallerIdentity(t.Context(), &sts.GetCallerIdentityInput{})
+	require.NoError(t, err, "getting caller identity")
+
+	callerARN := aws.ToString(identity.Arn)
+
+	uniqueID := strings.ToLower(helpers.UniqueID())
+	roleBName := "tg-test-role-b-" + uniqueID
+	s3BucketName := "terragrunt-test-bucket-" + uniqueID
+
+	t.Logf("Creating IAM role %s", roleBName)
+
+	roleBTrustPolicy := fmt.Sprintf(
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":%q},"Action":"sts:AssumeRole"}]}`,
+		callerARN,
+	)
+
+	roleBOut, err := iamClient.CreateRole(t.Context(), &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleBName),
+		AssumeRolePolicyDocument: aws.String(roleBTrustPolicy),
+		Description:              aws.String("Terragrunt integration test: S3 backend role"),
+	})
+	require.NoError(t, err, "creating ROLE_B")
+
+	roleBARN := aws.ToString(roleBOut.Role.Arn)
+
+	t.Cleanup(func() {
+		t.Logf("Deleting IAM role %s", roleBName)
+		iamClient.DeleteRolePolicy(t.Context(), &iam.DeleteRolePolicyInput{ //nolint:errcheck
+			RoleName: aws.String(roleBName), PolicyName: aws.String("s3-access"),
+		})
+		iamClient.DeleteRole(t.Context(), &iam.DeleteRoleInput{RoleName: aws.String(roleBName)}) //nolint:errcheck
+	})
+
+	roleBPolicyDoc := fmt.Sprintf(
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":[%q,%q]}]}`,
+		"arn:aws:s3:::"+s3BucketName,
+		"arn:aws:s3:::"+s3BucketName+"/*",
+	)
+	_, err = iamClient.PutRolePolicy(t.Context(), &iam.PutRolePolicyInput{
+		RoleName:       aws.String(roleBName),
+		PolicyName:     aws.String("s3-access"),
+		PolicyDocument: aws.String(roleBPolicyDoc),
+	})
+	require.NoError(t, err, "attaching S3 policy to ROLE_B")
+
+	t.Cleanup(func() { deleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName) })
+
+	t.Log("Waiting for IAM role propagation...")
+	time.Sleep(10 * time.Second)
+
+	// ── Bootstrap: apply app1 once into S3; its state is shared by both sub-tests ─────────────
+	bootstrapEnvPath := helpers.CopyEnvironment(t, testFixtureAssumeRoleWithExistingCredentials)
+	helpers.CleanupTerraformFolder(t, bootstrapEnvPath)
+
+	bootstrapRootHCL := filepath.Join(bootstrapEnvPath, testFixtureAssumeRoleWithExistingCredentials, "root.hcl")
+	helpers.CopyAndFillMapPlaceholders(t, bootstrapRootHCL, bootstrapRootHCL, map[string]string{
+		"__FILL_IN_BUCKET_NAME__": s3BucketName,
+		"__FILL_IN_REGION__":      helpers.TerraformRemoteStateS3Region,
+		"__FILL_IN_ASSUME_ROLE__": roleBARN,
+	})
+
+	app1BootstrapPath := filepath.Join(bootstrapEnvPath, testFixtureAssumeRoleWithExistingCredentials, "env1", "app1")
+
+	helpers.RunTerragrunt(t, "terragrunt apply --backend-bootstrap --auto-approve --non-interactive --working-dir "+app1BootstrapPath)
+
+	// ── Apply restrictive bucket policy ──────────────────────────────────────────────────────
+	// Deny S3 data operations to every principal except ROLE_B.  This means direct use of the
+	// ambient credentials (which trigger the early-exit bug) will fail with 403.  Only after
+	// assuming ROLE_B (via CLI flag or HCL config) does the access succeed.
+	s3Client := helpers.CreateS3ClientForTest(t, helpers.TerraformRemoteStateS3Region)
+
+	bucketPolicy := fmt.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Deny",
+    "Principal": "*",
+    "Action": ["s3:GetObject","s3:PutObject","s3:DeleteObject","s3:ListBucket","s3:ListBucketVersions","s3:GetObjectVersion"],
+    "Resource": [%q, %q],
+    "Condition": {"ArnNotEquals": {"aws:PrincipalArn": %q}}
+  }]
+}`,
+		"arn:aws:s3:::"+s3BucketName,
+		"arn:aws:s3:::"+s3BucketName+"/*",
+		roleBARN,
+	)
+
+	t.Logf("Setting restrictive bucket policy on %s", s3BucketName)
+
+	_, err = s3Client.PutBucketPolicy(t.Context(), &s3.PutBucketPolicyInput{
+		Bucket: aws.String(s3BucketName),
+		Policy: aws.String(bucketPolicy),
+	})
+	require.NoError(t, err, "setting bucket policy")
+
+	t.Cleanup(func() {
+		t.Logf("Removing bucket policy from %s", s3BucketName)
+		s3Client.DeleteBucketPolicy(t.Context(), &s3.DeleteBucketPolicyInput{Bucket: aws.String(s3BucketName)}) //nolint:errcheck
+	})
+
+	copyFixture := func(t *testing.T, appDir string) string {
+		t.Helper()
+
+		tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAssumeRoleWithExistingCredentials)
+		helpers.CleanupTerraformFolder(t, tmpEnvPath)
+
+		rootHCL := filepath.Join(tmpEnvPath, testFixtureAssumeRoleWithExistingCredentials, "root.hcl")
+		helpers.CopyAndFillMapPlaceholders(t, rootHCL, rootHCL, map[string]string{
+			"__FILL_IN_BUCKET_NAME__": s3BucketName,
+			"__FILL_IN_REGION__":      helpers.TerraformRemoteStateS3Region,
+			"__FILL_IN_ASSUME_ROLE__": roleBARN,
+		})
+
+		return filepath.Join(tmpEnvPath, testFixtureAssumeRoleWithExistingCredentials, "env1", appDir)
+	}
+
+	// ── Sub-test 1: flag supplied on the CLI ─────────────────────────────────────────────────
+	// env1/app2/terragrunt.hcl has no iam_assume_role_with_existing_credentials; the flag is
+	// passed explicitly on the command line.
+	t.Run("via CLI flag", func(t *testing.T) {
+		t.Parallel()
+
+		app2Path := copyFixture(t, "app2")
+
+		helpers.RunTerragrunt(t, "terragrunt apply --auto-approve --non-interactive "+
+			"--experiment dependency-fetch-output-from-state "+
+			"--iam-assume-role-with-existing-credentials "+
+			"--working-dir "+app2Path)
+
+		stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+			"terragrunt output --non-interactive --working-dir "+app2Path)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "app1 output")
+	})
+
+	// ── Sub-test 2: flag set in HCL config, not on the CLI ───────────────────────────────────
+	// env1/app2-via-hcl/terragrunt.hcl carries iam_assume_role_with_existing_credentials = true
+	// directly, so no CLI flag is needed.
+	t.Run("via HCL config", func(t *testing.T) {
+		t.Parallel()
+
+		app2Path := copyFixture(t, "app2-via-hcl")
+
+		helpers.RunTerragrunt(t, "terragrunt apply --auto-approve --non-interactive "+
+			// "--experiment dependency-fetch-output-from-state "+
+			"--working-dir "+app2Path)
+
+		stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+			"terragrunt output --non-interactive --working-dir "+app2Path)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "app1 output")
+	})
 }
 
 // Regression testing for https://github.com/gruntwork-io/terragrunt/issues/906


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4979.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] Run the relevant tests successfully, including pre-commit checks.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated aws-creds-helper logic to return pre [v0.85.1](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.85.1) behavior.
<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AWS credential resolution so role/STS-based credentials take precedence when a Role ARN is configured.
  * Environment credentials are now used only when no Role ARN is present, preserving STS/web-identity flows even if env credentials exist.

* **Tests**
  * Added tests verifying credential selection: role/STS preference when a Role ARN exists.
  * Added tests confirming env credentials are used when no Role ARN is provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->