### PR TITLE
Changed wording to install external dependency

### DIFF
--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -342,7 +342,7 @@ func TestTerragruntSkipConfirmExternalDependencies(t *testing.T) {
 	captured := <-capturedOutput
 
 	require.NoError(t, err)
-	assert.NotContains(t, captured, "Should Terragrunt install the external dependency?")
+	assert.NotContains(t, captured, "Should Terragrunt run the external dependency?")
 	assert.NotContains(t, captured, tmp)
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4828 .

It was reported that the prompt was misleading in its wording. 'Apply' for external deps has been replaced with 'install'.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated external-dependency prompt wording from "apply" to "run" for consistent user-facing language.
* **Documentation**
  * Adjusted internal docs and comments to reflect "run" terminology.
* **Tests**
  * Updated integration test expectations to match the new "run" prompt wording.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->