### PR TITLE
feat: improve disabled dependency management

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -1387,6 +1387,9 @@ func extractDependencyPaths(cfg *config.TerragruntConfig, component component.Co
 		}
 
 		depPath := dependency.ConfigPath.AsString()
+		if depPath == "" || depPath == "." {
+			continue
+		}
 		if !filepath.IsAbs(depPath) {
 			depPath = filepath.Clean(filepath.Join(component.Path(), depPath))
 		}
@@ -1396,6 +1399,9 @@ func extractDependencyPaths(cfg *config.TerragruntConfig, component component.Co
 
 	if cfg.Dependencies != nil {
 		for _, dependency := range cfg.Dependencies.Paths {
+			if dependency == "" || dependency == "." {
+				continue
+			}
 			if !filepath.IsAbs(dependency) {
 				dependency = filepath.Clean(filepath.Join(component.Path(), dependency))
 			}


### PR DESCRIPTION
## Description

Fixes #2734
Fixes #2927

Fix runner validation to skip disabled dependencies when resolving unit dependencies. Previously, when a dependency block had `enabled = false` but a valid config_path, the path was still validated against discovered units, causing `UnrecognizedDependencyError`. Now getDependenciesForUnit checks TerragruntDependencies for the enabled flag before erroring on missing paths.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated disabled dependency management

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency path validation by skipping empty, current-directory, or disabled dependency paths during resolution instead of causing errors.
  * Enhanced dependency resolution to gracefully handle missing or disabled dependencies, resulting in more tolerant processing.

* **Tests**
  * Added comprehensive test coverage for disabled dependency handling and invalid path skipping scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->