### PR TITLE
docs: Updating documentation around the provider cache server

### DIFF
--- a/docs-starlight/src/content/docs/03-features/13-provider-cache-server.mdx
+++ b/docs-starlight/src/content/docs/03-features/13-provider-cache-server.mdx
@@ -6,6 +6,14 @@ sidebar:
   order: 13
 ---
 
+import { Aside } from '@astrojs/starlight/components'
+
+<Aside type="tip">
+If you're using OpenTofu >= 1.10, you'll use the [Automatic Provider Cache Dir](/docs/features/auto-provider-cache-dir) feature by default on the latest version of Terragrunt.
+
+You might not necessarily get any performance benefits when using this feature if so. Only use this feature if you are using an older version of OpenTofu, if you are using Terraform or if you are reaching a performance bottleneck that is not addressed by the Automatic Provider Cache Dir feature.
+</Aside>
+
 Terragrunt has the ability to cache OpenTofu/Terraform providers across all OpenTofu/Terraform runs. The Provider Cache Server feature ensures that each provider is only ever downloaded and stored on disk exactly once by running a local provider cache server while Terragrunt runs OpenTofu/Terraform commands.
 
 The Provider Cache Server is a performance optimization. For more details on performance optimizations, their tradeoffs, and other performance tips, read the dedicated [Performance documentation](/docs/troubleshooting/performance).
@@ -18,12 +26,15 @@ Let's imagine that your project consists of 50 Terragrunt units, and each of the
 
 OpenTofu/Terraform has a provider caching feature, the [Provider Plugin Cache](https://opentofu.org/docs/cli/config/config-file/#provider-plugin-cache), that does the job well... unless you run multiple OpenTofu/Terraform processes simultaneously, such as when you use `terragrunt run --all`. Then the OpenTofu/Terraform processes begin conflict by overwriting each other’s cache, which causes an error such as `Error: Failed to install provider`. As a result, Terragrunt previously had to disable concurrency for `init` steps in `run --all`, which is significantly slower. If you enable Terragrunt Provider Caching, as described in this section, that will no longer be necessary, and you should see significant performance improvements with `init`, as well as significant savings in terms of bandwidth and disk space usage.
 
+<Aside type="note">
+This isn't necessarily true for the latest version of OpenTofu anymore! For more information, see the [Automatic Provider Cache Dir](/docs/features/auto-provider-cache-dir) feature documentation.
+</Aside>
 ## Usage
 
-Terragrunt Provider Cache is currently considered an experimental feature, so it is disabled by default. To enable it, you need to use the flag [`provider-cache`](https://terragrunt.gruntwork.io/docs/reference/cli/commands/run#provider-cache):
+The Terragrunt Provider Cache Server is disabled by default. To enable it, you need to use the flag [`provider-cache`](https://terragrunt.gruntwork.io/docs/reference/cli/commands/run#provider-cache):
 
 ```shell
-terragrunt run --all apply --provider-cache
+terragrunt run --all --provider-cache apply
 ```
 
 or the environment variable `TG_PROVIDER_CACHE`:

--- a/docs-starlight/src/content/docs/06-troubleshooting/03-performance.mdx
+++ b/docs-starlight/src/content/docs/06-troubleshooting/03-performance.mdx
@@ -12,9 +12,23 @@ Normally, it's best practice to start by measuring performance before making any
 
 However, given the nature of the problems that Terragrunt solves, there are some obvious wins that you can make without measuring performance, if you're aware of the tradeoffs.
 
-### Provider Cache
+### Provider Cache Dir
 
 One of the most expensive things that OpenTofu/Terraform does, from a bandwidth and disk utilization perspective, is download and install providers. These are large binary files that are downloaded from the internet, and not cached across units by default.
+
+If you're using OpenTofu >= 1.10 and the latest version of Terragrunt, you'll use the [Automatic Provider Cache Dir](/docs/features/auto-provider-cache-dir) feature by default.
+
+This feature automatically configures OpenTofu to use its built-in provider caching mechanism by setting the `TF_PLUGIN_CACHE_DIR` environment variable to a central location on the filesystem, allowing reuse of downloaded providers across multiple Terragrunt runs.
+
+For most users at sensible scales, this is an automatic performance win that you don't need to do anything to enable.
+
+### Provider Cache Dir - Gotchas
+
+At very large scales, you might find that the filesystem lock contention between OpenTofu processes to synchronize access to the provider cache directory is a bottleneck. You might also find that you can't use the provider cache directory because you are storing your provider cache in a shared NFS mount or are using Terraform or an older version of OpenTofu.
+
+In these scenarios, you can use the [Provider Cache Server](/docs/features/provider-cache-server) feature to improve performance.
+
+### Provider Cache Server
 
 You can significantly reduce the amount of time taken by Terragrunt runs by enabling the provider cache server, like this:
 
@@ -29,10 +43,6 @@ The provider cache server is a single server that is used by all Terragrunt runs
 When performing individual runs, like `terragrunt plan`, the provider cache server can be a net negative to performance, because starting and stopping the server might add more overhead than just downloading the providers. Whether this is the case depends on many factors, including network speed, the number of providers being downloaded, and whether or not the providers are already cached in the Terragrunt provider cache.
 
 When in doubt, [measure the performance](#measuring-performance) before and after enabling the provider cache server to see if it's a net win for your use case.
-
-We are coordinating with the OpenTofu team to improve the behavior of concurrent access to provider cache, so that this flag will be unnecessary for most users in the future.
-
-See [#1939](https://github.com/opentofu/opentofu/issues/1483) for more details.
 
 ### Fetching Output From State
 
@@ -57,22 +67,6 @@ Next, you should be aware that there is no guarantee that OpenTofu/Terraform wil
 We are coordinating with the OpenTofu team to improve the performance of the `output` command, and we hope that this flag will be unnecessary for most users in the future.
 
 See [#1549](https://github.com/opentofu/opentofu/issues/1549) for more details.
-
-### Skip Dependency Inputs
-
-Terragrunt dependency blocks allow reading inputs directly from other dependencies. However, the mechanism required to support this capability introduces performance overhead during Terragrunt operations. Due to this performance impact, using this feature is heavily discouraged.
-
-The reason for this is that Terragrunt needs to recursively read inputs from dependencies, and their dependencies, all the way down to the ancestral Terragrunt unit they all have in common to be able to expose the inputs to the dependent unit from its direct dependency (as the inputs from the direct dependency might be derived from a dependency of the direct dependency).
-
-You can mitigate this performance penalty by using the `skip-dependencies-inputs` strict control.
-
-Enabling this strict control will activate a breaking change in Terragrunt behavior, making it so that dependency blocks no longer parse dependencies of dependencies, which is required to read inputs from direct dependencies.
-
-In the future, we will be removing this capability from Terragrunt, so you won't need to use this strict control.
-
-### Skip Dependency Inputs - Gotchas
-
-In general, you should use this strict control. The only reason not to use it is if you are using dependency blocks to read inputs from dependencies, which you should stop doing as soon as possible.
 
 ## Measuring Performance
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Documents the current status of the provider cache server.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refresh provider caching docs to emphasize Automatic Provider Cache Dir by default, refine when/how to use Provider Cache Server, and remove outdated guidance (including Skip Dependency Inputs).
> 
> - **Docs – Features (`docs/features/provider-cache-server`)**:
>   - Add tip/note Asides highlighting default use of `Automatic Provider Cache Dir` on OpenTofu >= 1.10 and when to prefer it.
>   - Clarify usage: provider cache server is disabled by default; enable via `--provider-cache` (adjust command order: `terragrunt run --all --provider-cache apply`).
> - **Docs – Troubleshooting (`docs/troubleshooting/performance`)**:
>   - Rename and expand section to **Provider Cache Dir**; document automatic configuration of `TF_PLUGIN_CACHE_DIR` and typical benefits.
>   - Add “Gotchas” for large-scale/unsupported setups; advise using Provider Cache Server in those cases.
>   - Keep provider cache server guidance but move under its own subsection; refine examples.
>   - Remove outdated notes about future coordination and the entire "Skip Dependency Inputs" section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2332167ab2e84cfbcf07fb75ece20c39aa7ea23a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Provider Cache Server documentation with default behavior and enabling instructions
  * Added guidance on automatic provider cache directory for OpenTofu >= 1.10
  * Added sizing and performance considerations for Provider Cache Server
  * Corrected command syntax for enabling provider cache

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->