### PR TITLE
fix: Ensure queue entries are still marked as ready if they have dependencies/dependents that are excluded

### DIFF
--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -314,6 +314,17 @@ func NewRunnerPoolStack(
 		return nil, queueErr
 	}
 
+	// Set units map on queue to enable checking dependencies not in queue
+	// (e.g., when using --queue-strict-include or --filter)
+	unitsMap := make(map[string]*component.Unit, len(units))
+	for _, u := range units {
+		if u != nil && u.Path() != "" {
+			unitsMap[u.Path()] = u
+		}
+	}
+
+	q.SetUnitsMap(unitsMap)
+
 	runner.queue = q
 
 	return runner.WithOptions(opts...), nil

--- a/test/fixtures/queue-strict-include/dependency/main.tf
+++ b/test/fixtures/queue-strict-include/dependency/main.tf
@@ -1,0 +1,3 @@
+resource "terraform_data" "test" {
+  input = "test"
+}

--- a/test/fixtures/queue-strict-include/dependency/terragrunt.hcl
+++ b/test/fixtures/queue-strict-include/dependency/terragrunt.hcl
@@ -1,0 +1,10 @@
+terraform {
+  source = "."
+}
+
+dependency "transitive_dep" {
+  config_path = "../transitive-dependency"
+
+  mock_outputs = {}
+}
+

--- a/test/fixtures/queue-strict-include/dependent/main.tf
+++ b/test/fixtures/queue-strict-include/dependent/main.tf
@@ -1,0 +1,3 @@
+resource "terraform_data" "test" {
+  input = "test"
+}

--- a/test/fixtures/queue-strict-include/dependent/terragrunt.hcl
+++ b/test/fixtures/queue-strict-include/dependent/terragrunt.hcl
@@ -1,0 +1,9 @@
+terraform {
+  source = "."
+}
+
+dependency "dep" {
+  config_path = "../dependency"
+
+  mock_outputs = {}
+}

--- a/test/fixtures/queue-strict-include/transitive-dependency/main.tf
+++ b/test/fixtures/queue-strict-include/transitive-dependency/main.tf
@@ -1,0 +1,3 @@
+resource "terraform_data" "test" {
+  input = "test"
+}

--- a/test/fixtures/queue-strict-include/transitive-dependency/terragrunt.hcl
+++ b/test/fixtures/queue-strict-include/transitive-dependency/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/integration_queue_strict_include_test.go
+++ b/test/integration_queue_strict_include_test.go
@@ -1,0 +1,139 @@
+package test_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFixtureQueueStrictInclude = "fixtures/queue-strict-include"
+)
+
+// TestQueueStrictIncludeWithDependencyNotInQueue tests that when using --queue-strict-include
+// or --filter, units can run even when their dependencies are not in the queue (but have existing state).
+func TestQueueStrictIncludeWithDependencyNotInQueue(t *testing.T) {
+	t.Parallel()
+
+	// Create test fixture with dependency chain: transitive-dependency -> dependency -> dependent
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureQueueStrictInclude)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	testPath := util.JoinPath(tmpEnvPath, testFixtureQueueStrictInclude)
+
+	// First, apply all units to create state
+	// This simulates the scenario where units have been previously applied
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t,
+		fmt.Sprintf("terragrunt run --log-level debug --all --non-interactive --working-dir %s -- apply -auto-approve", testPath))
+	require.NoError(t, err, "Failed to apply all units initially\nstdout: %s\nstderr: %s", stdout, stderr)
+
+	// Verify all units were applied
+	assert.Contains(t, stdout+stderr, "transitive-dependency", "transitive-dependency should be applied")
+	assert.Contains(t, stdout+stderr, "dependency", "dependency should be applied")
+	assert.Contains(t, stdout+stderr, "dependent", "dependent should be applied")
+
+	t.Run("queue-strict-include with queue-include-dir", func(t *testing.T) {
+		t.Parallel()
+
+		helpers.CleanupTerraformFolder(t, testPath)
+
+		// Test with --queue-strict-include and --queue-include-dir to only include dependency
+		// The dependency unit depends on transitive-dependency, which should not be in the queue
+		// but should be considered ready because it has existing state
+		cmd := fmt.Sprintf("terragrunt run --log-level debug --all --non-interactive --working-dir %s --queue-include-dir '**/dependency' --queue-strict-include -- plan", testPath)
+		stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+
+		// The command should succeed
+		require.NoError(t, err, "Command should succeed when dependency has existing state\nstdout: %s\nstderr: %s", stdout, stderr)
+
+		// Verify that dependency unit was processed
+		output := stdout + stderr
+		assert.Contains(t, output, "dependency", "dependency unit should be processed")
+
+		// Verify that transitive-dependency is NOT in the queue (filtered out)
+		// but dependency still runs successfully
+		assert.Contains(t, output, "found 1 readyEntries tasks",
+			"Should show 'found 1 readyEntries tasks' - dependency should run even though transitive-dependency is not in queue")
+	})
+
+	t.Run("queue-strict-include with queue-include-dir and destroy", func(t *testing.T) {
+		t.Parallel()
+
+		helpers.CleanupTerraformFolder(t, testPath)
+
+		// Test with --queue-strict-include and --queue-include-dir to only include dependency
+		// The dependency unit depends on transitive-dependency, which should not be in the queue
+		// but should be considered ready because it has existing state
+		cmd := fmt.Sprintf("terragrunt run --log-level debug --all --non-interactive --working-dir %s --queue-include-dir '**/dependency' --queue-strict-include -- destroy -auto-approve", testPath)
+		stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+
+		// The command should succeed
+		require.NoError(t, err, "Command should succeed when dependency has existing state\nstdout: %s\nstderr: %s", stdout, stderr)
+
+		// Verify that dependency unit was processed
+		output := stdout + stderr
+		assert.Contains(t, output, "dependency", "dependency unit should be processed")
+
+		// Verify that transitive-dependency is NOT in the queue (filtered out)
+		// but dependency still runs successfully
+		assert.Contains(t, output, "found 1 readyEntries tasks",
+			"Should show 'found 1 readyEntries tasks' - dependency should run even though transitive-dependency is not in queue")
+	})
+
+	t.Run("experimental filter flag", func(t *testing.T) {
+		t.Parallel()
+
+		helpers.CleanupTerraformFolder(t, testPath)
+
+		// Skip if filter-flag experiment is not enabled
+		if !helpers.IsExperimentMode(t) {
+			t.Skip("Skipping filter flag tests - TG_EXPERIMENT_MODE not enabled")
+		}
+
+		// Test with experimental --filter to only include dependency
+		cmd := fmt.Sprintf("terragrunt run --log-level debug --all --non-interactive --experiment-mode --working-dir %s --filter './dependency' -- plan", testPath)
+		stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+
+		// The command should succeed
+		require.NoError(t, err, "Command should succeed when dependency has existing state\nstdout: %s\nstderr: %s", stdout, stderr)
+
+		// Verify that dependency unit was processed
+		output := stdout + stderr
+		assert.Contains(t, output, "dependency", "dependency unit should be processed")
+
+		// Verify that transitive-dependency is NOT in the queue (filtered out)
+		// but dependency still runs successfully
+		assert.Contains(t, output, "found 1 readyEntries tasks",
+			"Should show 'found 1 readyEntries tasks' - dependency should run even though transitive-dependency is not in queue")
+	})
+
+	t.Run("experimental filter flag and destroy", func(t *testing.T) {
+		t.Parallel()
+
+		helpers.CleanupTerraformFolder(t, testPath)
+
+		// Skip if filter-flag experiment is not enabled
+		if !helpers.IsExperimentMode(t) {
+			t.Skip("Skipping filter flag tests - TG_EXPERIMENT_MODE not enabled")
+		}
+
+		// Test with experimental --filter to only include dependency
+		cmd := fmt.Sprintf("terragrunt run --log-level debug --all --non-interactive --experiment-mode --working-dir %s --filter './dependency' -- destroy -auto-approve", testPath)
+		stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+
+		// The command should succeed
+		require.NoError(t, err, "Command should succeed when dependency has existing state\nstdout: %s\nstderr: %s", stdout, stderr)
+
+		// Verify that dependency unit was processed
+		output := stdout + stderr
+		assert.Contains(t, output, "dependency", "dependency unit should be processed")
+
+		// Verify that transitive-dependency is NOT in the queue (filtered out)
+		// but dependency still runs successfully
+		assert.Contains(t, output, "found 1 readyEntries tasks",
+			"Should show 'found 1 readyEntries tasks' - dependency should run even though transitive-dependency is not in queue")
+	})
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5192.

Ensures that queue entries are still marked as ready if they have dependencies/dependents that are not in the queue as a consequence of being excluded.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make queue treat dependencies not present in the queue (e.g., due to `--queue-strict-include`/`--filter`) as ready by assuming existing state or `AssumeAlreadyApplied`, wiring a `unitsMap` from the runner and adding integration tests/fixtures.
> 
> - **Queue**
>   - Add `unitsMap` field and `SetUnitsMap` to reference all discovered `*component.Unit` by path.
>   - Update `areDependenciesReadyUnsafe`: if a dependency isn’t in the queue, consider it ready when `AssumeAlreadyApplied` or assume existing state; no longer blocks on absent deps. Honors `IgnoreDependencyErrors` as before.
> - **Runner**
>   - Build a `unitsMap` from resolved units and set it on the queue to enable dependency readiness checks for excluded/not-queued units (e.g., `--queue-strict-include`, `--filter`).
> - **Tests & Fixtures**
>   - Add `test/fixtures/queue-strict-include/*` with a transitive dep chain.
>   - Add `TestQueueStrictIncludeWithDependencyNotInQueue` covering plan/destroy with `--queue-strict-include`/`--queue-include-dir` and experimental `--filter`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8d1ccd7fb94cf6393d79e83c411e277ff51db13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dependency resolution to properly handle filtered queue configurations, enabling strict include/filter options to work correctly with dependent modules.

* **Tests**
  * Added integration tests validating dependency handling behavior with strict include filtering and transitive dependency chains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->