### PR TITLE
feat: Add `dependency-fetch-output-from-state` experiment

### DIFF
--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -17,17 +17,18 @@ import (
 )
 
 const (
-	NoAutoInitFlagName                     = "no-auto-init"
-	NoAutoRetryFlagName                    = "no-auto-retry"
-	NoAutoApproveFlagName                  = "no-auto-approve"
-	NoAutoProviderCacheDirFlagName         = "no-auto-provider-cache-dir"
-	NoEngineFlagName                       = "no-engine"
-	TFForwardStdoutFlagName                = "tf-forward-stdout"
-	UnitsThatIncludeFlagName               = "units-that-include"
-	DependencyFetchOutputFromStateFlagName = "dependency-fetch-output-from-state"
-	UsePartialParseConfigCacheFlagName     = "use-partial-parse-config-cache"
-	SummaryPerUnitFlagName                 = "summary-per-unit"
-	VersionManagerFileNameFlagName         = "version-manager-file-name"
+	NoAutoInitFlagName                       = "no-auto-init"
+	NoAutoRetryFlagName                      = "no-auto-retry"
+	NoAutoApproveFlagName                    = "no-auto-approve"
+	NoAutoProviderCacheDirFlagName           = "no-auto-provider-cache-dir"
+	NoEngineFlagName                         = "no-engine"
+	NoDependencyFetchOutputFromStateFlagName = "no-dependency-fetch-output-from-state"
+	TFForwardStdoutFlagName                  = "tf-forward-stdout"
+	UnitsThatIncludeFlagName                 = "units-that-include"
+	DependencyFetchOutputFromStateFlagName   = "dependency-fetch-output-from-state"
+	UsePartialParseConfigCacheFlagName       = "use-partial-parse-config-cache"
+	SummaryPerUnitFlagName                   = "summary-per-unit"
+	VersionManagerFileNameFlagName           = "version-manager-file-name"
 
 	DisableCommandValidationFlagName   = "disable-command-validation"
 	NoDestroyDependenciesCheckFlagName = "no-destroy-dependencies-check"
@@ -227,12 +228,25 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 		}),
 
 		flags.NewFlag(&cli.BoolFlag{
-			Name:        DependencyFetchOutputFromStateFlagName,
-			EnvVars:     tgPrefix.EnvVars(DependencyFetchOutputFromStateFlagName),
-			Destination: &opts.FetchDependencyOutputFromState,
-			Usage:       "The option fetches dependency output directly from the state file instead of using tofu/terraform output.",
+			Name:    DependencyFetchOutputFromStateFlagName,
+			EnvVars: tgPrefix.EnvVars(DependencyFetchOutputFromStateFlagName),
+			Usage:   "Enable the dependency-fetch-output-from-state experiment to fetch dependency output directly from the state file instead of using tofu/terraform output.",
+			Action: func(_ *cli.Context, val bool) error {
+				if val {
+					return opts.Experiments.EnableExperiment(experiment.DependencyFetchOutputFromState)
+				}
+
+				return nil
+			},
 		},
 			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("fetch-dependency-output-from-state"), terragruntPrefixControl)),
+
+		flags.NewFlag(&cli.BoolFlag{
+			Name:        NoDependencyFetchOutputFromStateFlagName,
+			EnvVars:     tgPrefix.EnvVars(NoDependencyFetchOutputFromStateFlagName),
+			Destination: &opts.NoDependencyFetchOutputFromState,
+			Usage:       "Disable the dependency-fetch-output-from-state feature even when the experiment is enabled.",
+		}),
 
 		flags.NewFlag(&cli.BoolFlag{
 			Name:        TFForwardStdoutFlagName,

--- a/config/dependency.go
+++ b/config/dependency.go
@@ -982,24 +982,24 @@ func getTerragruntOutputJSONFromRemoteState(
 	ctx = ctx.WithTerragruntOptions(targetTGOptions)
 
 	// To speed up dependencies processing it is possible to retrieve its output directly from the backend without init dependencies
-	if ctx.TerragruntOptions.FetchDependencyOutputFromState {
+	if ctx.TerragruntOptions.Experiments.Evaluate(experiment.DependencyFetchOutputFromState) && !ctx.TerragruntOptions.NoDependencyFetchOutputFromState {
 		switch backend := remoteState.BackendName; backend {
 		case s3backend.BackendName:
-			jsonBytes, err := getTerragruntOutputJSONFromRemoteStateS3(
+			jsonBytes, s3GetErr := getTerragruntOutputJSONFromRemoteStateS3(
 				ctx,
 				l,
 				targetTGOptions,
 				remoteState,
 			)
-			if err != nil {
-				return nil, err
+			if s3GetErr != nil {
+				return nil, s3GetErr
 			}
 
 			l.Debugf("Retrieved output from %s as json: %s using s3 bucket", targetTGOptions.TerragruntConfigPath, jsonBytes)
 
 			return jsonBytes, nil
 		default:
-			l.Errorf("FetchDependencyOutputFromState is not supported for backend %s, falling back to normal method", backend)
+			l.Debugf("dependency-fetch-output-from-state experiment is not supported for backend %s, falling back to default output retrieval", backend)
 		}
 	}
 

--- a/config/dependency_test.go
+++ b/config/dependency_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 
@@ -122,7 +123,9 @@ func TestParseDependencyBlockMultiple(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx.TerragruntOptions = opts
-	ctx.TerragruntOptions.FetchDependencyOutputFromState = true
+	err = ctx.TerragruntOptions.Experiments.EnableExperiment(experiment.DependencyFetchOutputFromState)
+	require.NoError(t, err)
+
 	ctx.TerragruntOptions.Env = env.Parse(os.Environ())
 	tfConfig, err := config.ParseConfigFile(ctx, logger.CreateLogger(), filename, nil)
 	require.NoError(t, err)

--- a/docs-starlight/src/content/docs/04-reference/04-experiments.md
+++ b/docs-starlight/src/content/docs/04-reference/04-experiments.md
@@ -71,6 +71,7 @@ The following experiments are available:
 - [cas](#cas)
 - [filter-flag](#filter-flag)
 - [iac-engine](#iac-engine)
+- [dependency-fetch-output-from-state](#dependency-fetch-output-from-state)
 
 ### symlinks
 
@@ -213,6 +214,48 @@ To transition the `iac-engine` feature to a stable release, the following must b
 - [ ] Performance benchmarks and optimization
 - [ ] Security review of engine execution and isolation mechanisms
 - [ ] Community feedback on real-world usage and edge cases
+
+### `dependency-fetch-output-from-state`
+
+Support for fetching dependency outputs directly from state files.
+
+#### `dependency-fetch-output-from-state` - What it does
+
+By default, Terragrunt retrieves dependency outputs by running `tofu output` or `terraform output` commands, which requires initializing the dependency unit and can be slow. When this experiment is enabled, Terragrunt will attempt to fetch dependency outputs directly from the remote state file, bypassing the need to initialize the dependency and significantly speeding up dependency processing.
+
+**Current Backend Support:**
+
+- ✅ S3 backend: Fully supported
+- ⚠️ Other backends: Falls back to the normal method (using `tofu/terraform output`)
+
+When an unsupported backend is encountered, Terragrunt will automatically fall back to the default method of using `tofu/terraform output`.
+
+**Disabling the feature:**
+
+You can disable the dependency-fetch-output-from-state feature using the `--no-dependency-fetch-output-from-state` flag, even when the experiment is enabled:
+
+```bash
+terragrunt run --all --experiment-mode --no-dependency-fetch-output-from-state -- plan
+```
+
+#### `dependency-fetch-output-from-state` - How to provide feedback
+
+Provide your feedback in the dedicated [GitHub discussion](https://github.com/gruntwork-io/terragrunt/discussions/5200) page. When reporting issues or providing feedback, please include:
+
+- The backend type you're using
+- Any performance improvements you've observed
+- Any issues or edge cases you've encountered
+
+#### `dependency-fetch-output-from-state` - Criteria for stabilization
+
+To transition the `dependency-fetch-output-from-state` feature to a stable release, the following must be addressed, at a minimum:
+
+- [ ] Add support for additional backends (e.g., GCS, etc.)
+- [ ] Comprehensive integration testing across different backend types
+- [ ] Performance benchmarking to validate speed improvements
+- [ ] Error handling and edge case testing
+- [ ] Documentation of supported backends and limitations
+- [ ] Community feedback on real-world usage
 
 ## Completed Experiments
 

--- a/docs-starlight/src/data/flags/dependency-fetch-output-from-state.mdx
+++ b/docs-starlight/src/data/flags/dependency-fetch-output-from-state.mdx
@@ -11,6 +11,10 @@ import { Aside } from '@astrojs/starlight/components';
 
 This flag modifies how Terragrunt retrieves output values from dependent units. When enabled, Terragrunt will read the outputs directly from the state file instead of running `terraform output` or `tofu output`.
 
+<Aside type="note">
+This flag is equivalent to enabling the `dependency-fetch-output-from-state` experiment. You can also enable this feature using `--experiment dependency-fetch-output-from-state` or `--experiment-mode`. For more information, see the [Experiments documentation](/docs/reference/experiments#dependency-fetch-output-from-state).
+</Aside>
+
 The main benefit this flag provides is performance. Reading directly from state is typically faster than executing the OpenTofu/Terraform binary to get the same outputs.
 
 The limitation of this approach is that it is only supported by the S3 backend, and OpenTofu/Terraform may change the schema of the state file in the future, breaking this functionality.

--- a/docs-starlight/src/data/flags/no-dependency-fetch-output-from-state.mdx
+++ b/docs-starlight/src/data/flags/no-dependency-fetch-output-from-state.mdx
@@ -1,0 +1,12 @@
+---
+name: no-dependency-fetch-output-from-state
+description: Disable the dependency-fetch-output-from-state feature even when the experiment is enabled.
+type: bool
+env:
+  - TG_NO_DEPENDENCY_FETCH_OUTPUT_FROM_STATE
+---
+
+When enabled, Terragrunt will disable the `dependency-fetch-output-from-state` feature. This flag allows you to selectively opt-out of fetching dependency outputs directly from state files.
+
+This is useful when you want to maintain control over dependency output retrieval in specific environments or scenarios, even when the experiment is enabled globally.
+

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -36,6 +36,9 @@ const (
 	FilterFlag = "filter-flag"
 	// IacEngine is the experiment that enables usage of Terragrunt IaC engines for running IaC operations.
 	IacEngine = "iac-engine"
+	// DependencyFetchOutputFromState is the experiment that enables fetching dependency outputs
+	// directly from state files instead of using terraform/tofu output commands.
+	DependencyFetchOutputFromState = "dependency-fetch-output-from-state"
 )
 
 const (
@@ -83,6 +86,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: IacEngine,
+		},
+		{
+			Name: DependencyFetchOutputFromState,
 		},
 	}
 }

--- a/options/options.go
+++ b/options/options.go
@@ -251,8 +251,6 @@ type TerragruntOptions struct {
 	ProviderCache bool
 	// If set to true, exclude all directories by default when running *-all commands
 	ExcludeByDefault bool
-	// This is an experimental feature, used to speed up dependency processing by getting the output from the state
-	FetchDependencyOutputFromState bool
 	// True if is required to show dependent modules and confirm action
 	CheckDependentModules bool
 	// True if is required not to show dependent modules and confirm action
@@ -321,6 +319,8 @@ type TerragruntOptions struct {
 	NoAutoProviderCacheDir bool
 	// NoEngine disables IaC engines even when the iac-engine experiment is enabled.
 	NoEngine bool
+	// NoDependencyFetchOutputFromState disables the dependency-fetch-output-from-state feature even when the experiment is enabled.
+	NoDependencyFetchOutputFromState bool
 	// TFPathExplicitlySet is set to true if the user has explicitly set the TFPath via the --tf-path flag.
 	TFPathExplicitlySet bool
 	// FailFast is a flag to stop execution on the first error in apply of units.
@@ -390,58 +390,59 @@ func NewTerragruntOptions() *TerragruntOptions {
 
 func NewTerragruntOptionsWithWriters(stdout, stderr io.Writer) *TerragruntOptions {
 	return &TerragruntOptions{
-		TFPath:                         DefaultWrappedPath,
-		ExcludesFile:                   defaultExcludesFile,
-		FiltersFile:                    defaultFiltersFile,
-		OriginalTerraformCommand:       "",
-		TerraformCommand:               "",
-		AutoInit:                       true,
-		RunAllAutoApprove:              true,
-		NonInteractive:                 false,
-		TerraformCliArgs:               []string{},
-		Env:                            map[string]string{},
-		Source:                         "",
-		SourceMap:                      map[string]string{},
-		SourceUpdate:                   false,
-		IgnoreDependencyErrors:         false,
-		IgnoreDependencyOrder:          false,
-		IgnoreExternalDependencies:     false,
-		IncludeExternalDependencies:    false,
-		Writer:                         stdout,
-		ErrWriter:                      stderr,
-		MaxFoldersToCheck:              DefaultMaxFoldersToCheck,
-		AutoRetry:                      true,
-		ExcludeDirs:                    []string{},
-		IncludeDirs:                    []string{},
-		ModulesThatInclude:             []string{},
-		StrictInclude:                  false,
-		Parallelism:                    DefaultParallelism,
-		Check:                          false,
-		Diff:                           false,
-		FetchDependencyOutputFromState: false,
-		UsePartialParseConfigCache:     false,
-		ForwardTFStdout:                false,
-		JSONOut:                        DefaultJSONOutName,
-		TerraformImplementation:        UnknownImpl,
-		JSONDisableDependentModules:    false,
+		TFPath:                      DefaultWrappedPath,
+		ExcludesFile:                defaultExcludesFile,
+		FiltersFile:                 defaultFiltersFile,
+		OriginalTerraformCommand:    "",
+		TerraformCommand:            "",
+		AutoInit:                    true,
+		RunAllAutoApprove:           true,
+		NonInteractive:              false,
+		TerraformCliArgs:            []string{},
+		Env:                         map[string]string{},
+		Source:                      "",
+		SourceMap:                   map[string]string{},
+		SourceUpdate:                false,
+		IgnoreDependencyErrors:      false,
+		IgnoreDependencyOrder:       false,
+		IgnoreExternalDependencies:  false,
+		IncludeExternalDependencies: false,
+		Writer:                      stdout,
+		ErrWriter:                   stderr,
+		MaxFoldersToCheck:           DefaultMaxFoldersToCheck,
+		AutoRetry:                   true,
+		ExcludeDirs:                 []string{},
+		IncludeDirs:                 []string{},
+		ModulesThatInclude:          []string{},
+		StrictInclude:               false,
+		Parallelism:                 DefaultParallelism,
+		Check:                       false,
+		Diff:                        false,
+		UsePartialParseConfigCache:  false,
+		ForwardTFStdout:             false,
+		JSONOut:                     DefaultJSONOutName,
+		TerraformImplementation:     UnknownImpl,
+		JSONDisableDependentModules: false,
 		RunTerragrunt: func(ctx context.Context, l log.Logger, opts *TerragruntOptions, r *report.Report) error {
 			return errors.New(ErrRunTerragruntCommandNotSet)
 		},
-		ProviderCacheRegistryNames: defaultProviderCacheRegistryNames,
-		OutputFolder:               "",
-		JSONOutputFolder:           "",
-		FeatureFlags:               xsync.NewMapOf[string, string](),
-		Errors:                     defaultErrorsConfig(),
-		StrictControls:             controls.New(),
-		Experiments:                experiment.NewExperiments(),
-		Telemetry:                  new(telemetry.Options),
-		NoStackValidate:            false,
-		NoStackGenerate:            false,
-		VersionManagerFileName:     defaultVersionManagerFileName,
-		NoAutoProviderCacheDir:     false,
-		NoDependencyPrompt:         false,
-		NoShell:                    false,
-		NoHooks:                    false,
+		ProviderCacheRegistryNames:       defaultProviderCacheRegistryNames,
+		OutputFolder:                     "",
+		JSONOutputFolder:                 "",
+		FeatureFlags:                     xsync.NewMapOf[string, string](),
+		Errors:                           defaultErrorsConfig(),
+		StrictControls:                   controls.New(),
+		Experiments:                      experiment.NewExperiments(),
+		Telemetry:                        new(telemetry.Options),
+		NoStackValidate:                  false,
+		NoStackGenerate:                  false,
+		VersionManagerFileName:           defaultVersionManagerFileName,
+		NoAutoProviderCacheDir:           false,
+		NoEngine:                         false,
+		NoDependencyFetchOutputFromState: false,
+		NoDependencyPrompt:               false,
+		NoShell:                          false,
+		NoHooks:                          false,
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Moves `--dependency-fetch-output-from-state` to the experiment system.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the experimental dependency-fetch-output-from-state capability, now controlled via the experiments mechanism.
  * Added --no-dependency-fetch-output-from-state to explicitly opt out of dependency output-from-state behavior.

* **Documentation**
  * Added documentation for the experiment and a dedicated flag page with usage and guidance.

* **Tests**
  * Added an integration test validating --no-dependency-fetch-output-from-state behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->