### PR TITLE
feat: Adding `--destroy-dependencies-check`

### DIFF
--- a/cli/commands/run/cli.go
+++ b/cli/commands/run/cli.go
@@ -72,7 +72,7 @@ func NewSubcommands(l log.Logger, opts *options.TerragruntOptions) cli.Commands 
 func Action(l log.Logger, opts *options.TerragruntOptions) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
 		if opts.TerraformCommand == tf.CommandNameDestroy {
-			opts.CheckDependentModules = !opts.NoDestroyDependenciesCheck
+			opts.CheckDependentModules = opts.DestroyDependenciesCheck
 		}
 
 		r := report.NewReport().WithWorkingDir(opts.WorkingDir)

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -31,6 +31,7 @@ const (
 
 	DisableCommandValidationFlagName   = "disable-command-validation"
 	NoDestroyDependenciesCheckFlagName = "no-destroy-dependencies-check"
+	DestroyDependenciesCheckFlagName   = "destroy-dependencies-check"
 
 	SourceFlagName       = "source"
 	SourceMapFlagName    = "source-map"
@@ -266,12 +267,24 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("disable-command-validation"), terragruntPrefixControl)),
 
 		flags.NewFlag(&cli.BoolFlag{
-			Name:        NoDestroyDependenciesCheckFlagName,
-			EnvVars:     tgPrefix.EnvVars(NoDestroyDependenciesCheckFlagName),
-			Destination: &opts.NoDestroyDependenciesCheck,
-			Usage:       "When this flag is set, Terragrunt will not check for dependent units when destroying.",
-		},
-			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("no-destroy-dependencies-check"), terragruntPrefixControl)),
+			Name:    NoDestroyDependenciesCheckFlagName,
+			EnvVars: tgPrefix.EnvVars(NoDestroyDependenciesCheckFlagName),
+			Usage:   "When this flag is set, Terragrunt will not check for dependent units when destroying.",
+			Hidden:  true,
+			Action: func(ctx *cli.Context, value bool) error {
+				if value {
+					return opts.StrictControls.FilterByNames(controls.NoDestroyDependenciesCheck).Evaluate(ctx.Context)
+				}
+				return nil
+			},
+		}),
+
+		flags.NewFlag(&cli.BoolFlag{
+			Name:        DestroyDependenciesCheckFlagName,
+			EnvVars:     tgPrefix.EnvVars(DestroyDependenciesCheckFlagName),
+			Destination: &opts.DestroyDependenciesCheck,
+			Usage:       "When this flag is set, Terragrunt will check for dependent units when destroying.",
+		}),
 
 		// Terragrunt Provider Cache flags.
 

--- a/docs-starlight/src/content/docs/04-reference/03-strict-controls.mdx
+++ b/docs-starlight/src/content/docs/04-reference/03-strict-controls.mdx
@@ -212,6 +212,12 @@ Throw an error when using the deprecated `--disable-command-validation` flag.
 
 **Reason**: Command validation has been removed entirely from Terragrunt. The `run` command now accepts any command and passes it through to the underlying OpenTofu/Terraform binary. The `--disable-command-validation` flag is no longer needed and does nothing.
 
+### no-destroy-dependencies-check
+
+Throw an error when using the deprecated `--no-destroy-dependencies-check` flag.
+
+**Reason**: The `--no-destroy-dependencies-check` flag is deprecated and no longer affects Terragrunt's behavior. Dependency checks are now disabled by default during destroy operations. Use `--destroy-dependencies-check` to explicitly enable dependency checks when needed.
+
 ## Control Categories
 
 Certain strict controls are grouped into categories to make it easier to enable multiple strict controls at once.
@@ -237,6 +243,7 @@ Throw an error when using the deprecated flags.
 
 - [terragrunt-prefix-flags](#terragrunt-prefix-flags)
 - [queue-exclude-external](#queue-exclude-external)
+- [no-destroy-dependencies-check](#no-destroy-dependencies-check)
 
 ### deprecated-env-vars
 

--- a/docs-starlight/src/content/docs/07-migrate/03-cli-redesign.md
+++ b/docs-starlight/src/content/docs/07-migrate/03-cli-redesign.md
@@ -105,7 +105,7 @@ Below is a comprehensive mapping of old CLI flag names to their modern counterpa
 | `--terragrunt-no-auto-init`                       | `--no-auto-init`                                          |
 | `--terragrunt-no-auto-retry`                      | `--no-auto-retry`                                         |
 | `--terragrunt-no-color`                           | `--no-color`                                              |
-| `--terragrunt-no-destroy-dependencies-check`      | `--no-destroy-dependencies-check`                         |
+| `--terragrunt-no-destroy-dependencies-check`      | `--destroy-dependencies-check`                            |
 | `--terragrunt-out-dir`                            | `--out-dir`                                               |
 | `--terragrunt-parallelism`                        | `--parallelism`                                           |
 | `--terragrunt-provider-cache-dir`                 | `--provider-cache-dir`                                    |

--- a/docs-starlight/src/data/commands/run.mdx
+++ b/docs-starlight/src/data/commands/run.mdx
@@ -49,7 +49,7 @@ flags:
   - no-auto-init
   - no-auto-provider-cache-dir
   - no-auto-retry
-  - no-destroy-dependencies-check
+  - destroy-dependencies-check
   - parallelism
   - provider-cache
   - provider-cache-dir

--- a/docs-starlight/src/data/flags/destroy-dependencies-check.mdx
+++ b/docs-starlight/src/data/flags/destroy-dependencies-check.mdx
@@ -1,0 +1,17 @@
+---
+name: destroy-dependencies-check
+description: |
+  Enables Terragrunt's dependency validation during destroy operations.
+type: bool
+env:
+  - TG_DESTROY_DEPENDENCIES_CHECK
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+When enabled, Terragrunt will verify if there are dependent units that would be affected by destroying the current unit and show a warning with the list of dependent modules.
+
+<Aside type="tip">
+Enabling dependency checks during destroy operations helps prevent accidental destruction of infrastructure that other units depend on.
+</Aside>
+

--- a/docs-starlight/src/data/flags/no-destroy-dependencies-check.mdx
+++ b/docs-starlight/src/data/flags/no-destroy-dependencies-check.mdx
@@ -1,7 +1,7 @@
 ---
 name: no-destroy-dependencies-check
 description: |
-  Disables Terragrunt's dependency validation during destroy operations.
+  **Deprecated**: This flag is ignored and no longer affects behavior. Use `--destroy-dependencies-check` to explicitly enable dependency checks during destroy operations.
 type: bool
 env:
   - TG_NO_DESTROY_DEPENDENCIES_CHECK
@@ -9,10 +9,8 @@ env:
 
 import { Aside } from '@astrojs/starlight/components';
 
-When enabled, Terragrunt will not verify if there are dependent units that would be affected by destroying the current unit.
+<Aside type="warning">
+This flag is deprecated and ignored. Dependency checks are disabled by default during destroy operations. Use `--destroy-dependencies-check` to enable them.
 
-This results in faster destroy operations, but may result in orphaned resources.
-
-<Aside type="caution">
-Disabling dependency checks during destroy operations can lead to orphaned resources or broken infrastructure dependencies.
+To enable dependency checks during destroy operations, use the `--destroy-dependencies-check` flag instead.
 </Aside>

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -61,6 +61,9 @@ const (
 
 	// DisableCommandValidation is the control that prevents the use of the deprecated `--disable-command-validation` flag.
 	DisableCommandValidation = "disable-command-validation"
+
+	// NoDestroyDependenciesCheck is the control that prevents the use of the deprecated `--no-destroy-dependencies-check` flag.
+	NoDestroyDependenciesCheck = "no-destroy-dependencies-check"
 )
 
 //nolint:lll
@@ -228,6 +231,13 @@ func New() strict.Controls {
 			Category:    stageCategory,
 			Error:       errors.New("The `--disable-command-validation` flag is no longer supported. Command validation has been removed entirely, and you can pass any command to `terragrunt run`."),
 			Warning:     "The `--disable-command-validation` flag is deprecated and will be removed in a future version of Terragrunt. Command validation has been removed entirely, and you can pass any command to `terragrunt run`.",
+		},
+		&Control{
+			Name:        NoDestroyDependenciesCheck,
+			Description: "Prevents the use of the deprecated `--no-destroy-dependencies-check` flag. This flag is now ignored. Use `--destroy-dependencies-check` to enable dependency checks during destroy operations.",
+			Category:    stageCategory,
+			Error:       errors.New("The `--no-destroy-dependencies-check` flag is no longer supported. Use `--destroy-dependencies-check` to enable dependency checks during destroy operations."),
+			Warning:     "The `--no-destroy-dependencies-check` flag is deprecated and will be removed in a future version of Terragrunt. This flag is now ignored. Use `--destroy-dependencies-check` to enable dependency checks during destroy operations.",
 		},
 	}
 

--- a/options/options.go
+++ b/options/options.go
@@ -255,8 +255,8 @@ type TerragruntOptions struct {
 	FetchDependencyOutputFromState bool
 	// True if is required to show dependent modules and confirm action
 	CheckDependentModules bool
-	// True if is required not to show dependent modules and confirm action
-	NoDestroyDependenciesCheck bool
+	// True if is required to check for dependent modules during destroy operations
+	DestroyDependenciesCheck bool
 	// Include fields metadata in render-json
 	RenderJSONWithMetadata bool
 	// Whether we should automatically retry errored Terraform commands

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -194,7 +194,7 @@ func TestShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
 
-	err = helpers.RunTerragruntCommand(t, "terragrunt destroy --non-interactive --working-dir "+vpcPath, &stdout, &stderr)
+	err = helpers.RunTerragruntCommand(t, "terragrunt destroy --non-interactive --destroy-dependencies-check --working-dir "+vpcPath, &stdout, &stderr)
 	require.NoError(t, err)
 
 	output := stderr.String()
@@ -223,11 +223,11 @@ func TestNoShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
 	err = helpers.RunTerragruntCommand(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath, &stdout, &stderr)
 	require.NoError(t, err)
 
-	// try to destroy vpc module and check if warning is not printed in output
+	// try to destroy vpc module and check if warning is not printed in output (default behavior - checks disabled)
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
 
-	err = helpers.RunTerragruntCommand(t, "terragrunt destroy --non-interactive --no-destroy-dependencies-check --working-dir "+vpcPath, &stdout, &stderr)
+	err = helpers.RunTerragruntCommand(t, "terragrunt destroy --non-interactive --working-dir "+vpcPath, &stdout, &stderr)
 	require.NoError(t, err)
 
 	output := stderr.String()

--- a/test/integration_functions_test.go
+++ b/test/integration_functions_test.go
@@ -344,7 +344,12 @@ func TestPathRelativeFromInclude(t *testing.T) {
 	assert.Equal(t, "something else", val.Value)
 
 	// try to destroy module and check if warning is printed in output, also test `get_parent_terragrunt_dir()` func in the parent terragrunt config.
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt destroy -auto-approve --non-interactive --working-dir "+basePath)
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --non-interactive --working-dir "+basePath+" -- destroy -auto-approve")
+	require.NoError(t, err)
+
+	assert.NotContains(t, stderr, "Detected dependent modules:\n"+clusterPath)
+
+	_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --destroy-dependencies-check --non-interactive --working-dir "+basePath+" -- destroy -auto-approve")
 	require.NoError(t, err)
 
 	assert.Contains(t, stderr, "Detected dependent modules:\n"+clusterPath)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Replaces `--no-destroy-dependencies-check` with `--destroy-dependencies-check`.

This inverts the default behavior of Terragrunt and is a breaking change. Prior to this change, Terragrunt would default to checking all possible configurations that might depend on a unit being destroyed and warn the user that those dependent units might be orphaned. With this change, users need to opt in to the dependency check.

Always checking all configurations that might depend on a unit being destroyed is excessively time-consuming for users with large codebases and can cause errors for users with irrelevant invalid configurations that have nothing to do with the unit being destroyed.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `--destroy-dependencies-check` to opt-in to destroy dependency validation, deprecates/ignores `--no-destroy-dependencies-check`, updates strict controls, wiring, docs, and tests.
> 
> - **CLI/Behavior**:
>   - Add `--destroy-dependencies-check` flag; default destroy skips dependency checks.
>   - Hide/deprecate `--no-destroy-dependencies-check`; enforce via strict control.
>   - Set `opts.CheckDependentModules` based on `opts.DestroyDependenciesCheck` in `run` action.
>   - Replace `options.NoDestroyDependenciesCheck` with `options.DestroyDependenciesCheck`.
> - **Strict Controls**:
>   - New control `no-destroy-dependencies-check` to error on deprecated flag usage.
> - **Docs**:
>   - Update references, flag docs, command listings, and CLI redesign migration table to reflect new flag and deprecation.
> - **Tests**:
>   - Adjust destroy tests to assert default (checks disabled) and opt-in behavior.
>   - Update invocations to use `run` where appropriate and include `--destroy-dependencies-check` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 561795e09ec3abed11fce315b17ecedbeb396359. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --destroy-dependencies-check to explicitly enable dependency validation during destroy operations.
* **Deprecation**
  * --no-destroy-dependencies-check is deprecated/ignored; use --destroy-dependencies-check to enable checks.
* **Documentation**
  * CLI docs, migration table, and flag pages updated to reflect the new flag and deprecation.
* **Tests**
  * Integration tests updated to cover the explicit destroy dependency-check behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->