### PR TITLE
fix: Temporarily skipping `TestAwsDocsTerralithToTerragruntGuide` until we get a new release

### DIFF
--- a/test/integration_docs_aws_tofu_test.go
+++ b/test/integration_docs_aws_tofu_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestAwsDocsTerralithToTerragruntGuide(t *testing.T) {
+	t.Skip("This test needs to be skipped until we have a new Terragrunt version we can pin in the mise.toml file due to the change to change in unit logging for stacks")
+
 	t.Parallel()
 
 	fixturePath := filepath.Join("..", "docs-starlight", "src", "fixtures", "terralith-to-terragrunt")


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

We changed how logging is done for units in implicit stacks, removing the leading `./` from paths.

This skips the test until we have a new release that we can pin in the integration test.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily skips `TestAwsDocsTerralithToTerragruntGuide` due to logging changes in stacks until a newer Terragrunt version can be pinned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e2ac2edeb6f14cfded7a977dfeb92234885d86a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Skipped an integration test to bypass execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->