### PR TITLE
fix: Fixing integration of `run --all` with `--source`

### DIFF
--- a/test/fixtures/get-output/run-all-source/live/unit1/terragrunt.hcl
+++ b/test/fixtures/get-output/run-all-source/live/unit1/terragrunt.hcl
@@ -1,0 +1,4 @@
+terraform {
+  source = "../../modules-default//module1"
+}
+

--- a/test/fixtures/get-output/run-all-source/live/unit2/terragrunt.hcl
+++ b/test/fixtures/get-output/run-all-source/live/unit2/terragrunt.hcl
@@ -1,0 +1,4 @@
+terraform {
+  source = "../../modules-default//module2"
+}
+

--- a/test/fixtures/get-output/run-all-source/modules-default/module1/main.tf
+++ b/test/fixtures/get-output/run-all-source/modules-default/module1/main.tf
@@ -1,0 +1,8 @@
+variable "test_var" {
+  default = "module1"
+}
+
+output "module_name" {
+  value = var.test_var
+}
+

--- a/test/fixtures/get-output/run-all-source/modules-default/module2/main.tf
+++ b/test/fixtures/get-output/run-all-source/modules-default/module2/main.tf
@@ -1,0 +1,8 @@
+variable "test_var" {
+  default = "module2"
+}
+
+output "module_name" {
+  value = var.test_var
+}
+

--- a/test/fixtures/get-output/run-all-source/modules-marked/module1/MODULE1_MARKER
+++ b/test/fixtures/get-output/run-all-source/modules-marked/module1/MODULE1_MARKER
@@ -1,0 +1,2 @@
+This is a marker file for module1 to verify the correct source path was used.
+

--- a/test/fixtures/get-output/run-all-source/modules-marked/module1/main.tf
+++ b/test/fixtures/get-output/run-all-source/modules-marked/module1/main.tf
@@ -1,0 +1,8 @@
+variable "test_var" {
+  default = "module1"
+}
+
+output "module_name" {
+  value = var.test_var
+}
+

--- a/test/fixtures/get-output/run-all-source/modules-marked/module2/MODULE2_MARKER
+++ b/test/fixtures/get-output/run-all-source/modules-marked/module2/MODULE2_MARKER
@@ -1,0 +1,2 @@
+This is a marker file for module2 to verify the correct source path was used.
+

--- a/test/fixtures/get-output/run-all-source/modules-marked/module2/main.tf
+++ b/test/fixtures/get-output/run-all-source/modules-marked/module2/main.tf
@@ -1,0 +1,8 @@
+variable "test_var" {
+  default = "module2"
+}
+
+output "module_name" {
+  value = var.test_var
+}
+

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -64,6 +64,7 @@ const (
 	testFixtureFindParentWithDeprecatedRoot   = "fixtures/find-parent-with-deprecated-root"
 	testFixtureGetOutput                      = "fixtures/get-output"
 	testFixtureGetTerragruntSourceCli         = "fixtures/get-terragrunt-source-cli"
+	testFixtureRunAllSource                   = "fixtures/get-output/run-all-source"
 	testFixtureGraphDependencies              = "fixtures/graph-dependencies"
 	testFixtureHclfmtDiff                     = "fixtures/hclfmt-diff"
 	testFixtureHclfmtStdin                    = "fixtures/hclfmt-stdin"
@@ -2206,6 +2207,63 @@ func TestDependencyOutputWithTerragruntSource(t *testing.T) {
 	helpers.LogBufferContentsLineByLine(t, stdout, "stdout")
 	helpers.LogBufferContentsLineByLine(t, stderr, "stderr")
 	require.NoError(t, err)
+}
+
+func TestRunAllWithSourceFlag(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureRunAllSource)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRunAllSource)
+	rootPath := util.JoinPath(tmpEnvPath, testFixtureRunAllSource, "live")
+	modulePath := util.JoinPath(tmpEnvPath, testFixtureRunAllSource, "modules-marked")
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		fmt.Sprintf("terragrunt run --all plan --non-interactive --working-dir %s --source %s", rootPath, modulePath),
+	)
+	require.NoError(t, err)
+
+	// When we fail to update the unit source location to the download dir correctly, we get an error about no configuration
+	// files being present.
+	assert.NotContains(t, stderr, "Error: No configuration files")
+
+	unit1Path := util.JoinPath(rootPath, "unit1")
+	unit2Path := util.JoinPath(rootPath, "unit2")
+
+	// Find the cache directories for each unit
+	unit1CacheDir := util.JoinPath(unit1Path, helpers.TerragruntCache)
+	unit2CacheDir := util.JoinPath(unit2Path, helpers.TerragruntCache)
+
+	var unit1MarkerPath, unit2MarkerPath string
+
+	walkErr := filepath.WalkDir(unit1CacheDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.Name() == "MODULE1_MARKER" {
+			unit1MarkerPath = path
+		}
+
+		return nil
+	})
+	require.NoError(t, walkErr)
+
+	walkErr = filepath.WalkDir(unit2CacheDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.Name() == "MODULE2_MARKER" {
+			unit2MarkerPath = path
+		}
+
+		return nil
+	})
+	require.NoError(t, walkErr)
+
+	assert.NotEmpty(t, unit1MarkerPath)
+	assert.NotEmpty(t, unit2MarkerPath)
 }
 
 func TestDependencyOutputWithHooks(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5207

Fixes integration of `run --all` with `--source`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `--source` flag with the `run-all` command, allowing users to specify per-unit Terragrunt module sources by combining base source with unit-specific module paths.

* **Tests**
  * Added integration test and test fixtures to validate source flag functionality and ensure modules are correctly cached and resolved for multiple units.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->