### PR TITLE
feat: Adding `--filter-allow-destroy` flag

### DIFF
--- a/cli/commands/dag/graph/cli.go
+++ b/cli/commands/dag/graph/cli.go
@@ -20,7 +20,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 	sharedFlags := shared.NewQueueFlags(opts, nil)
 	sharedFlags = append(sharedFlags, shared.NewBackendFlags(opts, nil)...)
 	sharedFlags = append(sharedFlags, shared.NewFeatureFlags(opts, nil)...)
-	sharedFlags = append(sharedFlags, shared.NewFilterFlag(opts))
+	sharedFlags = append(sharedFlags, shared.NewFilterFlags(opts)...)
 
 	return &cli.Command{
 		Name:      CommandName,

--- a/cli/commands/find/cli.go
+++ b/cli/commands/find/cli.go
@@ -35,7 +35,7 @@ const (
 func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
-	return cli.Flags{
+	flags := cli.Flags{
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        FormatFlagName,
 			EnvVars:     tgPrefix.EnvVars(FormatFlagName),
@@ -99,8 +99,11 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			Usage:       "Construct the queue as if a specific command was run.",
 			Aliases:     []string{QueueConstructAsFlagAlias},
 		}),
-		shared.NewFilterFlag(opts.TerragruntOptions),
 	}
+
+	flags = flags.Add(shared.NewFilterFlags(opts.TerragruntOptions)...)
+
+	return flags
 }
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {

--- a/cli/commands/hcl/format/cli.go
+++ b/cli/commands/hcl/format/cli.go
@@ -79,7 +79,7 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 	}
 
 	flagSet = flagSet.Add(shared.NewQueueFlags(opts, nil)...)
-	flagSet = flagSet.Add(shared.NewFilterFlag(opts))
+	flagSet = flagSet.Add(shared.NewFilterFlags(opts)...)
 	flagSet = flagSet.Add(shared.NewParallelismFlag(opts))
 
 	return flagSet

--- a/cli/commands/hcl/validate/cli.go
+++ b/cli/commands/hcl/validate/cli.go
@@ -76,7 +76,7 @@ func NewFlags(opts *options.TerragruntOptions) cli.Flags {
 	}
 
 	flagSet = flagSet.Add(shared.NewQueueFlags(opts, nil)...)
-	flagSet = flagSet.Add(shared.NewFilterFlag(opts))
+	flagSet = flagSet.Add(shared.NewFilterFlags(opts)...)
 
 	return flagSet
 }

--- a/cli/commands/list/cli.go
+++ b/cli/commands/list/cli.go
@@ -35,7 +35,7 @@ const (
 func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
-	return cli.Flags{
+	flags := cli.Flags{
 		flags.NewFlag(&cli.GenericFlag[string]{
 			Name:        FormatFlagName,
 			EnvVars:     tgPrefix.EnvVars(FormatFlagName),
@@ -88,8 +88,11 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			Usage:       "Construct the queue as if a specific command was run.",
 			Aliases:     []string{QueueConstructAsFlagAlias},
 		}),
-		shared.NewFilterFlag(opts.TerragruntOptions),
 	}
+
+	flags = flags.Add(shared.NewFilterFlags(opts.TerragruntOptions)...)
+
+	return flags
 }
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -441,7 +441,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 	flags = flags.Add(shared.NewFeatureFlags(opts, prefix)...)
 	flags = flags.Add(shared.NewIAMAssumeRoleFlags(opts, prefix, CommandName)...)
 	flags = flags.Add(shared.NewQueueFlags(opts, prefix)...)
-	flags = flags.Add(shared.NewFilterFlag(opts))
+	flags = flags.Add(shared.NewFilterFlags(opts)...)
 	flags = flags.Add(shared.NewParallelismFlag(opts))
 
 	return flags.Sort()

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -309,8 +309,13 @@ func NewRunnerPoolStack(
 
 	runner.Stack.Units = units
 
-	if isDestroyCommand(terragruntOptions) {
+	if isDestroyCommand(terragruntOptions.TerraformCommand, terragruntOptions.TerraformCliArgs) {
 		applyPreventDestroyExclusions(l, units)
+	}
+
+	// Apply filter-allow-destroy exclusions for plan and apply commands
+	if terragruntOptions.TerraformCommand == tf.CommandNamePlan || terragruntOptions.TerraformCommand == tf.CommandNameApply {
+		applyFilterAllowDestroyExclusions(l, terragruntOptions, units)
 	}
 
 	// Build queue from resolved units (which have canonical absolute paths).
@@ -623,7 +628,10 @@ func (r *Runner) LogUnitDeployOrder(l log.Logger, terraformCommand string) error
 	// NOTE: This is display-only. The queue scheduler dynamically handles destroy order via
 	// IsUp() checks - dependents must complete before their dependencies are processed.
 	entries := slices.Clone(r.queue.Entries)
-	if r.Stack.Execution != nil && isDestroyCommand(r.Stack.Execution.TerragruntOptions) {
+	if r.Stack.Execution != nil && isDestroyCommand(
+		r.Stack.Execution.TerragruntOptions.TerraformCommand,
+		r.Stack.Execution.TerragruntOptions.TerraformCliArgs,
+	) {
 		slices.Reverse(entries)
 	}
 
@@ -930,9 +938,9 @@ func (r *Runner) SetReport(rpt *report.Report) {
 }
 
 // isDestroyCommand checks if the current command is a destroy operation
-func isDestroyCommand(opts *options.TerragruntOptions) bool {
-	return opts.TerraformCommand == tf.CommandNameDestroy ||
-		util.ListContainsElement(opts.TerraformCliArgs, "-"+tf.CommandNameDestroy)
+func isDestroyCommand(cmd string, args []string) bool {
+	return cmd == tf.CommandNameDestroy ||
+		slices.Contains(args, "-"+tf.CommandNameDestroy)
 }
 
 // applyPreventDestroyExclusions excludes units with prevent_destroy=true and their dependencies
@@ -981,6 +989,30 @@ func applyPreventDestroyExclusions(l log.Logger, units []*component.Unit) {
 
 // maxDependencyTraversalDepth bounds the depth of dependency traversal to prevent excessive recursion.
 const maxDependencyTraversalDepth = 256
+
+// applyFilterAllowDestroyExclusions excludes units with destroy runs from Git-based filters
+// when the --filter-allow-destroy flag is not set. This prevents accidental destruction
+// of infrastructure when using Git-based filters.
+func applyFilterAllowDestroyExclusions(l log.Logger, opts *options.TerragruntOptions, units []*component.Unit) {
+	if opts.FilterAllowDestroy {
+		return
+	}
+
+	for _, unit := range units {
+		discoveryCtx := unit.DiscoveryContext()
+		if discoveryCtx == nil {
+			continue
+		}
+
+		if discoveryCtx.Ref != "" && isDestroyCommand(discoveryCtx.Cmd, discoveryCtx.Args) {
+			if unit.Execution != nil {
+				unit.Execution.FlagExcluded = true
+			}
+
+			l.Warnf("The `%s` unit was removed in the `%s` Git reference, but the `--filter-allow-destroy` flag was not used. The unit will be excluded during applies unless --filter-allow-destroy is used.", unit.DisplayPath(), discoveryCtx.Ref)
+		}
+	}
+}
 
 // collectDependencies collects dependency paths for a unit with a bounded recursion depth.
 func collectDependencies(unit *component.Unit, paths map[string]bool) {

--- a/options/options.go
+++ b/options/options.go
@@ -224,6 +224,8 @@ type TerragruntOptions struct {
 	ForwardTFStdout bool
 	// Fail execution if is required to create S3 bucket
 	FailIfBucketCreationRequired bool
+	// FilterAllowDestroy allows destroy runs when using Git-based filters
+	FilterAllowDestroy bool
 	// Controls if s3 bucket should be updated or skipped
 	DisableBucketUpdate bool
 	// Disables validation terraform command


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds the `--filter-allow-destroy` flag, and excluding destroy runs by default when the flag isn't provided.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds --filter-allow-destroy and updates runner/CLI to exclude Git-filtered destroy runs by default unless explicitly allowed.
> 
> - **CLI/Flags**:
>   - Introduce `--filter-allow-destroy` (and refactor to `shared.NewFilterFlags` returning both `--filter` and `--filter-allow-destroy`).
>   - Wire new filter flags into `run`, `list`, `find`, `hcl format`, `hcl validate`, and `dag graph` commands.
> - **Runner**:
>   - Refactor `isDestroyCommand(cmd, args)` and use it consistently.
>   - Add `applyFilterAllowDestroyExclusions` to exclude units slated for destroy via Git-based filters during `plan`/`apply` unless `--filter-allow-destroy` is set; emit warnings.
>   - Keep existing `prevent_destroy` exclusions; minor queue display tweak for destroy order.
> - **Options**: Add `FilterAllowDestroy` field.
> - **Tests**: Expand integration tests to cover Git filter behavior with/without `--filter-allow-destroy`, validating results via generated reports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df137eb35046db482b72a1e4cb93e44fe2269350. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--filter-allow-destroy` flag to enable destroy operations when using Git-based filters.

* **Bug Fixes**
  * Improved destroy command detection and filtering logic for better Git-ref-based filtering during apply operations.

* **Tests**
  * Refactored filter functionality tests to use JSON report-based validation for comprehensive coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->