### PR TITLE
chore: Verify `--queue-include-external` isn't necessary when using the `--filter` flag

### DIFF
--- a/test/integration_dag_test.go
+++ b/test/integration_dag_test.go
@@ -33,7 +33,22 @@ func TestIncludeExternalInDagGraphCmd(t *testing.T) {
 	workDir, err := filepath.EvalSymlinks(workDir)
 	require.NoError(t, err)
 
-	cmd := "terragrunt dag graph --queue-include-external --working-dir " + workDir
+	cmd := "terragrunt dag graph --working-dir " + workDir
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "unit-a\" ->")
+}
+
+func TestIncludeExternalInDagGraphCmdWithList(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureGraphDAG)
+	workDir := filepath.Join(testFixtureGraphDAG, "region-1")
+	workDir, err := filepath.EvalSymlinks(workDir)
+	require.NoError(t, err)
+
+	cmd := "terragrunt list --format=dot --dependencies --working-dir " + workDir
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
 	require.NoError(t, err)

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -737,6 +737,47 @@ func TestTerragruntExternalDependencies(t *testing.T) {
 	}
 }
 
+func TestTerragruntExternalDependenciesWithFilter(t *testing.T) {
+	t.Parallel()
+
+	if !helpers.IsExperimentMode(t) {
+		t.Skip("Skipping filter flag tests - TG_EXPERIMENT_MODE not enabled")
+	}
+
+	modules := []string{
+		"module-a",
+		"module-b",
+	}
+
+	helpers.CleanupTerraformFolder(t, testFixtureExternalDependence)
+
+	for _, module := range modules {
+		helpers.CleanupTerraformFolder(t, util.JoinPath(testFixtureExternalDependence, module))
+	}
+
+	var (
+		applyAllStdout bytes.Buffer
+		applyAllStderr bytes.Buffer
+	)
+
+	rootPath := helpers.CopyEnvironment(t, testFixtureExternalDependence)
+	modulePath := util.JoinPath(rootPath, testFixtureExternalDependence, "module-b")
+
+	err := helpers.RunTerragruntCommand(t, "terragrunt run --all apply --non-interactive --filter '{./**}...' --tf-forward-stdout --working-dir "+modulePath, &applyAllStdout, &applyAllStderr)
+	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run --all apply stdout")
+	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run --all apply stderr")
+
+	applyAllStdoutString := applyAllStdout.String()
+
+	if err != nil {
+		t.Errorf("Did not expect to get error: %s", err.Error())
+	}
+
+	for _, module := range modules {
+		assert.Contains(t, applyAllStdoutString, "Hello World, "+module)
+	}
+}
+
 func TestPreventDestroy(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration_runner_pool_test.go
+++ b/test/integration_runner_pool_test.go
@@ -102,7 +102,10 @@ func TestRunnerPoolStackConfigIgnored(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	testPath := util.JoinPath(tmpEnvPath, testFixtureMixedConfig)
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --queue-include-external --all --non-interactive --working-dir "+testPath+" -- apply")
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt run --all --non-interactive --working-dir "+testPath+" -- apply",
+	)
 	require.NoError(t, err)
 	require.NotContains(t, stderr, "Error: Unsupported block type")
 	require.NotContains(t, stderr, "Blocks of type \"unit\" are not expected here")


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Takes every test that uses `--queue-include-external` and ensures it's either not necessary or replacable with `--filter '{./**}...'`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Added test coverage for filter functionality with external dependencies across multiple scenarios (DAG graphs, downloads, and includes)
* Updated existing tests by removing deprecated command flags

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->