### PR TITLE
chore: Re-enabling `TestAwsDocsTerralithToTerragruntGuide` test

### DIFF
--- a/docs-starlight/src/content/docs/02-guides/01-terralith-to-terragrunt/03-setup.mdx
+++ b/docs-starlight/src/content/docs/02-guides/01-terralith-to-terragrunt/03-setup.mdx
@@ -33,8 +33,8 @@ git init
 (Assuming you are using it) Use `mise` to download, install and pin the version of tools you're going to use in this project.
 
 ```bash
-mise use terragrunt@0.83.2
-mise use opentofu@1.10.3
+mise use terragrunt@0.95.0
+mise use opentofu@1.11.1
 mise use aws@2.27.63
 mise use node@22.17.1
 ```

--- a/test/integration_docs_aws_tofu_test.go
+++ b/test/integration_docs_aws_tofu_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestAwsDocsTerralithToTerragruntGuide(t *testing.T) {
-	t.Skip("This test needs to be skipped until we have a new Terragrunt version we can pin in the mise.toml file due to the change to change in unit logging for stacks")
-
 	t.Parallel()
 
 	fixturePath := filepath.Join("..", "docs-starlight", "src", "fixtures", "terralith-to-terragrunt")
@@ -52,7 +50,7 @@ func TestAwsDocsTerralithToTerragruntGuide(t *testing.T) {
 
 		helpers.ExecWithTestLogger(t, repoDir, "git", "init")
 
-		helpers.ExecWithTestLogger(t, repoDir, "mise", "use", "terragrunt@0.83.2")
+		helpers.ExecWithTestLogger(t, repoDir, "mise", "use", "terragrunt@0.95.0")
 		helpers.ExecWithTestLogger(t, repoDir, "mise", "use", "opentofu@1.11.1")
 		helpers.ExecWithTestLogger(t, repoDir, "mise", "use", "aws@2.27.63")
 		helpers.ExecWithTestLogger(t, repoDir, "mise", "use", "node@22.17.1")
@@ -66,7 +64,7 @@ func TestAwsDocsTerralithToTerragruntGuide(t *testing.T) {
 aws = "2.27.63"
 node = "22.17.1"
 opentofu = "1.11.1"
-terragrunt = "0.83.2"
+terragrunt = "0.95.0"
 `)
 
 		// Run a dummy command to check if the tools are installed


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Re-enables the `TestAwsDocsTerralithToTerragruntGuide` test now that we've updated our logging patterns.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guide with latest supported tool versions: Terragrunt 0.95.0 and OpenTofu 1.11.1

* **Tests**
  * Enabled integration test to verify AWS Terralith to Terragrunt documentation guide

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->