### PR TITLE
fix: Fixing Git expressions with explicit stacks

### DIFF
--- a/cli/commands/common/runall/runall.go
+++ b/cli/commands/common/runall/runall.go
@@ -129,11 +129,11 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 		}
 
 		// Generate the stack configuration with telemetry tracking
-		err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "stack_generate", map[string]any{
+		err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "stack_generate", map[string]any{
 			"stack_config_path": opts.TerragruntStackConfigPath,
 			"working_dir":       opts.WorkingDir,
 		}, func(ctx context.Context) error {
-			return generate.GenerateStacks(ctx, l, opts)
+			return generate.GenerateStacks(ctx, l, opts, wts)
 		})
 
 		// Handle any errors during stack generation

--- a/cli/commands/stack/stack.go
+++ b/cli/commands/stack/stack.go
@@ -13,8 +13,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/output"
+	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/options"
 )
 
@@ -43,11 +45,34 @@ func RunGenerate(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 		}
 	}
 
+	filters, err := filter.ParseFilterQueries(opts.FilterQueries)
+	if err != nil {
+		return errors.Errorf("failed to parse filters: %w", err)
+	}
+
+	gitFilters := filters.UniqueGitFilters()
+
+	// Only create worktrees when git filter expressions are present
+	var wts *worktrees.Worktrees
+	if len(gitFilters) > 0 {
+		wts, err = worktrees.NewWorktrees(ctx, l, opts.WorkingDir, gitFilters)
+		if err != nil {
+			return errors.Errorf("failed to create worktrees: %w", err)
+		}
+
+		defer func() {
+			cleanupErr := wts.Cleanup(ctx, l)
+			if cleanupErr != nil {
+				l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
+			}
+		}()
+	}
+
 	return telemetry.TelemeterFromContext(ctx).Collect(ctx, "stack_generate", map[string]any{
 		"stack_config_path": opts.TerragruntStackConfigPath,
 		"working_dir":       opts.WorkingDir,
 	}, func(ctx context.Context) error {
-		return generate.GenerateStacks(ctx, l, opts)
+		return generate.GenerateStacks(ctx, l, opts, wts)
 	})
 }
 

--- a/internal/discovery/worktreediscovery.go
+++ b/internal/discovery/worktreediscovery.go
@@ -87,7 +87,7 @@ func (wd *WorktreeDiscovery) Discover(
 
 			if len(fromFilters) > 0 {
 				fromToG.Go(func() error {
-					components, err := wd.discoverInWorktree(fromToCtx, l, opts, w, pair.FromWorktree, fromFilters, fromWorktreeKind)
+					components, err := wd.discoverInWorktree(fromToCtx, l, opts, pair.FromWorktree, fromFilters, fromWorktreeKind)
 					if err != nil {
 						return err
 					}
@@ -102,7 +102,7 @@ func (wd *WorktreeDiscovery) Discover(
 
 			if len(toFilters) > 0 {
 				fromToG.Go(func() error {
-					components, err := wd.discoverInWorktree(fromToCtx, l, opts, w, pair.ToWorktree, toFilters, toWorktreeKind)
+					components, err := wd.discoverInWorktree(fromToCtx, l, opts, pair.ToWorktree, toFilters, toWorktreeKind)
 					if err != nil {
 						return err
 					}
@@ -145,7 +145,6 @@ func (wd *WorktreeDiscovery) discoverInWorktree(
 	ctx context.Context,
 	l log.Logger,
 	opts *options.TerragruntOptions,
-	w *worktrees.Worktrees,
 	wt worktrees.Worktree,
 	filters filter.Filters,
 	kind worktreeKind,
@@ -172,16 +171,7 @@ func (wd *WorktreeDiscovery) discoverInWorktree(
 		WithDiscoveryContext(&discoveryContext).
 		Discover(ctx, l, opts)
 	if err != nil {
-		return nil, err
-	}
-
-	// Adjust WorkingDir to user's subdirectory for display purposes
-	adjustedWorkingDir := w.WorkingDir(ctx, wt.Path)
-
-	for _, c := range components {
-		if dctx := c.DiscoveryContext(); dctx != nil {
-			dctx.WorkingDir = adjustedWorkingDir
-		}
+		return components, err
 	}
 
 	return components, nil

--- a/test/integration_filter_test.go
+++ b/test/integration_filter_test.go
@@ -983,6 +983,321 @@ func TestFilterFlagWithRunAllGitFilter(t *testing.T) {
 	}
 }
 
+func TestFilterFlagWithExplicitStacksGitFilter(t *testing.T) {
+	t.Parallel()
+
+	// Skip if filter-flag experiment is not enabled
+	if !helpers.IsExperimentMode(t) {
+		t.Skip("Skipping filter flag tests - TG_EXPERIMENT_MODE not enabled")
+	}
+
+	testCases := []struct {
+		name               string
+		filterQuery        string
+		description        string
+		expectedUnits      []string
+		ignoredUnits       []string
+		expectedExcluded   []string
+		filterAllowDestroy bool
+		expectError        bool
+	}{
+		{
+			name:               "git filter discovers units from modified, created, and removed stacks and excludes untouched",
+			filterQuery:        "[HEAD~1...HEAD]",
+			filterAllowDestroy: false,
+			expectedUnits: []string{
+				"unit-to-be-added",
+				"unit-to-be-modified",
+				"unit-to-be-created-1",
+				"unit-to-be-created-2",
+			},
+			ignoredUnits: []string{
+				"unit-to-be-untouched",
+			},
+			expectedExcluded: []string{
+				"unit-to-be-removed-from-stack",
+			},
+			expectError: false,
+			description: "Git filter should discover units from stacks that were created, modified, or removed between commits, and exclude untouched stacks. Units from removed stack should be excluded without --filter-allow-destroy",
+		},
+		{
+			name:               "git filter with --filter-allow-destroy includes units from removed stack",
+			filterQuery:        "[HEAD~1...HEAD]",
+			filterAllowDestroy: true,
+			expectedUnits: []string{
+				"unit-to-be-added",
+				"unit-to-be-modified",
+				"unit-to-be-created-1",
+				"unit-to-be-created-2",
+				"unit-to-be-removed-from-stack",
+			},
+			ignoredUnits: []string{
+				"unit-to-be-untouched",
+			},
+			expectedExcluded: []string{},
+			expectError:      false,
+			description:      "Git filter with --filter-allow-destroy should include units from removed stack for destroy operations",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			tmpDir, err := filepath.EvalSymlinks(tmpDir)
+			require.NoError(t, err)
+
+			runner, err := git.NewGitRunner()
+			require.NoError(t, err)
+
+			runner = runner.WithWorkDir(tmpDir)
+
+			err = runner.Init(t.Context())
+			require.NoError(t, err)
+
+			err = runner.GoOpenRepo()
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				err = runner.GoCloseStorage()
+				require.NoError(t, err)
+			})
+
+			// Create a catalog of units that will be referenced by stacks
+			legacyUnitDir := filepath.Join(tmpDir, "catalog", "units", "legacy")
+			err = os.MkdirAll(legacyUnitDir, 0755)
+			require.NoError(t, err)
+			_ = createTestUnit(t, legacyUnitDir, `# Legacy unit`)
+
+			modernUnitDir := filepath.Join(tmpDir, "catalog", "units", "modern")
+			err = os.MkdirAll(modernUnitDir, 0755)
+			require.NoError(t, err)
+			_ = createTestUnit(t, modernUnitDir, `# Modern unit`)
+
+			// Create initial stacks
+			stackToBeModifiedDir := filepath.Join(tmpDir, "live", "stack-to-be-modified")
+			err = os.MkdirAll(stackToBeModifiedDir, 0755)
+			require.NoError(t, err)
+
+			stackToBeRemovedDir := filepath.Join(tmpDir, "live", "stack-to-be-removed")
+			err = os.MkdirAll(stackToBeRemovedDir, 0755)
+			require.NoError(t, err)
+
+			stackToBeUntouchedDir := filepath.Join(tmpDir, "live", "stack-to-be-untouched")
+			err = os.MkdirAll(stackToBeUntouchedDir, 0755)
+			require.NoError(t, err)
+
+			// Initial stack file contents
+			initialStackContent := `unit "unit-to-be-modified" {
+	source = "${get_repo_root()}/catalog/units/legacy"
+	path   = "unit-to-be-modified"
+}
+
+unit "unit-to-be-removed-from-stack" {
+	source = "${get_repo_root()}/catalog/units/legacy"
+	path   = "unit-to-be-removed-from-stack"
+}
+`
+
+			untouchedStackContent := `unit "unit-to-be-untouched" {
+	source = "${get_repo_root()}/catalog/units/legacy"
+	path   = "unit-to-be-untouched"
+}
+`
+
+			// Write initial stack files
+			err = os.WriteFile(filepath.Join(stackToBeModifiedDir, "terragrunt.stack.hcl"), []byte(initialStackContent), 0644)
+			require.NoError(t, err)
+
+			err = os.WriteFile(filepath.Join(stackToBeRemovedDir, "terragrunt.stack.hcl"), []byte(initialStackContent), 0644)
+			require.NoError(t, err)
+
+			err = os.WriteFile(filepath.Join(stackToBeUntouchedDir, "terragrunt.stack.hcl"), []byte(untouchedStackContent), 0644)
+			require.NoError(t, err)
+
+			// Initial commit
+			err = runner.GoAdd(".")
+			require.NoError(t, err)
+
+			err = runner.GoCommit("Initial commit with stacks", &gogit.CommitOptions{
+				Author: &object.Signature{
+					Name:  "Test User",
+					Email: "test@example.com",
+					When:  time.Now(),
+				},
+			})
+			require.NoError(t, err)
+
+			// Modify the stack-to-be-modified: add a unit, modify a unit, remove a unit
+			modifiedStackContent := `unit "unit-to-be-added" {
+	source = "${get_repo_root()}/catalog/units/modern"
+	path   = "unit-to-be-added"
+}
+
+unit "unit-to-be-modified" {
+	source = "${get_repo_root()}/catalog/units/modern"
+	path   = "unit-to-be-modified"
+}
+`
+			err = os.WriteFile(filepath.Join(stackToBeModifiedDir, "terragrunt.stack.hcl"), []byte(modifiedStackContent), 0644)
+			require.NoError(t, err)
+
+			// Remove the stack-to-be-removed
+			err = os.RemoveAll(stackToBeRemovedDir)
+			require.NoError(t, err)
+
+			// Add a new stack
+			stackToBeCreatedDir := filepath.Join(tmpDir, "live", "stack-to-be-created")
+			err = os.MkdirAll(stackToBeCreatedDir, 0755)
+			require.NoError(t, err)
+
+			newStackContent := `unit "unit-to-be-created-1" {
+	source = "${get_repo_root()}/catalog/units/modern"
+	path   = "unit-to-be-created-1"
+}
+
+unit "unit-to-be-created-2" {
+	source = "${get_repo_root()}/catalog/units/modern"
+	path   = "unit-to-be-created-2"
+}
+`
+			err = os.WriteFile(filepath.Join(stackToBeCreatedDir, "terragrunt.stack.hcl"), []byte(newStackContent), 0644)
+			require.NoError(t, err)
+
+			// Leave stack-to-be-untouched unchanged
+
+			// Commit the changes
+			err = runner.GoAdd(".")
+			require.NoError(t, err)
+
+			err = runner.GoCommit("Modify, create, and remove stacks", &gogit.CommitOptions{
+				Author: &object.Signature{
+					Name:  "Test User",
+					Email: "test@example.com",
+					When:  time.Now(),
+				},
+			})
+			require.NoError(t, err)
+
+			// Run terragrunt run --all --filter with git filter
+			reportFile := "report.json"
+			cmd := "terragrunt run --all --no-color --experiment-mode --working-dir " + tmpDir + " --filter '" + tc.filterQuery + "' --report-file " + reportFile
+
+			if tc.filterAllowDestroy {
+				cmd += " --filter-allow-destroy"
+			}
+
+			cmd += " -- plan"
+
+			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+
+			if tc.expectError {
+				require.Error(t, err, "Expected error for filter query: %s", tc.filterQuery)
+				assert.NotEmpty(t, stderr, "Expected error message in stderr")
+			} else {
+				// For run commands, we expect some output even if terraform isn't fully initialized
+				// The key is that the command should execute and process the filtered units
+				if err != nil {
+					// If there's an error, it might be because terraform isn't initialized
+					// but we should still see that the filter worked (units were discovered)
+					// Let's check if the error is about terraform init or similar
+					if !strings.Contains(stderr, "terraform") && !strings.Contains(stderr, "tofu") {
+						// Unexpected error
+						require.NoError(t, err, "Unexpected error for filter query: %s\nstdout: %s\nstderr: %s", tc.filterQuery, stdout, stderr)
+					}
+				}
+
+				// Verify the report file exists
+				reportFilePath := util.JoinPath(tmpDir, reportFile)
+				assert.FileExists(t, reportFilePath, "Report file should exist")
+
+				// Read and parse the report file
+				content, err := os.ReadFile(reportFilePath)
+				require.NoError(t, err, "Should be able to read report file")
+
+				var records []map[string]string
+
+				err = json.Unmarshal(content, &records)
+				require.NoError(t, err, "Should be able to parse report JSON")
+
+				// Create a map of unit names to records for easier lookup
+				// The report contains full paths, so we extract the unit name from the path
+				recordsByUnit := make(map[string]map[string]string)
+
+				for _, record := range records {
+					fullPath := record["Name"]
+					// Extract unit name from path
+					// Paths might be like: /tmp/.../live/stack-to-be-modified/.terragrunt-stack/unit-to-be-added
+					baseName := filepath.Base(fullPath)
+					recordsByUnit[baseName] = record
+					// Also store by full path for fallback
+					recordsByUnit[fullPath] = record
+					// Store by any part of the path that matches our unit pattern
+					parts := strings.SplitSeq(fullPath, string(filepath.Separator))
+					for part := range parts {
+						if strings.HasPrefix(part, "unit-to-be-") {
+							recordsByUnit[part] = record
+						}
+					}
+				}
+
+				// Verify expected units are in the report and not excluded
+				for _, expectedUnit := range tc.expectedUnits {
+					record, found := recordsByUnit[expectedUnit]
+					if !found {
+						// Try to find by partial match
+						for name, rec := range recordsByUnit {
+							if strings.Contains(name, expectedUnit) {
+								record = rec
+								found = true
+
+								break
+							}
+						}
+					}
+
+					require.True(t, found, "Expected unit '%s' should be in report. Found units: %v", expectedUnit, getUnitNames(recordsByUnit))
+					assert.NotEqual(t, "excluded", record["Result"], "Expected unit '%s' should not be excluded", expectedUnit)
+				}
+
+				// Verify excluded units are NOT in the report
+				for _, excludedUnit := range tc.ignoredUnits {
+					found := false
+
+					for name := range recordsByUnit {
+						if strings.Contains(name, excludedUnit) {
+							found = true
+							break
+						}
+					}
+
+					assert.False(t, found, "Excluded unit '%s' should NOT be in report", excludedUnit)
+				}
+
+				// Verify expected excluded units are in the report but marked as excluded
+				for _, excludedUnit := range tc.expectedExcluded {
+					record, found := recordsByUnit[excludedUnit]
+					if !found {
+						// Try to find by partial match
+						for name, rec := range recordsByUnit {
+							if strings.Contains(name, excludedUnit) {
+								record = rec
+								found = true
+
+								break
+							}
+						}
+					}
+
+					require.True(t, found, "Expected excluded unit '%s' should be in report", excludedUnit)
+					assert.Equal(t, "excluded", record["Result"], "Unit '%s' should be marked as excluded", excludedUnit)
+				}
+			}
+		})
+	}
+}
+
 // getUnitNames extracts unit names from records map for error messages
 func getUnitNames(recordsByUnit map[string]map[string]string) []string {
 	names := make([]string, 0, len(recordsByUnit))


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes issue with stack generation when using Git-based expressions.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved git filter integration for stack generation with optimized worktree initialization and lifecycle handling
  * Enhanced error handling to preserve partial discovery results when filtering stacks
  * Better context handling during filtered stack discovery

* **Tests**
  * Added integration test validating git filter functionality with explicit stacks, including coverage for filter destruction options and various unit scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->