### PR TITLE
chore: Verify `--filter` results in minimal parsing

### DIFF
--- a/test/fixtures/filter/minimize-parsing-destroy/landmine-unit-1/main.tf
+++ b/test/fixtures/filter/minimize-parsing-destroy/landmine-unit-1/main.tf
@@ -1,0 +1,2 @@
+# Minimal terraform config
+

--- a/test/fixtures/filter/minimize-parsing-destroy/landmine-unit-1/terragrunt.hcl
+++ b/test/fixtures/filter/minimize-parsing-destroy/landmine-unit-1/terragrunt.hcl
@@ -1,0 +1,8 @@
+locals {
+  test = run_cmd("--terragrunt-quiet", "bash", "-c", "exit 1")
+}
+
+terraform {
+  source = "."
+}
+

--- a/test/fixtures/filter/minimize-parsing-destroy/landmine-unit-2/main.tf
+++ b/test/fixtures/filter/minimize-parsing-destroy/landmine-unit-2/main.tf
@@ -1,0 +1,2 @@
+# Minimal terraform config
+

--- a/test/fixtures/filter/minimize-parsing-destroy/landmine-unit-2/terragrunt.hcl
+++ b/test/fixtures/filter/minimize-parsing-destroy/landmine-unit-2/terragrunt.hcl
@@ -1,0 +1,8 @@
+locals {
+  test = run_cmd("--terragrunt-quiet", "bash", "-c", "exit 1")
+}
+
+terraform {
+  source = "."
+}
+

--- a/test/fixtures/filter/minimize-parsing-destroy/unit-a/main.tf
+++ b/test/fixtures/filter/minimize-parsing-destroy/unit-a/main.tf
@@ -1,0 +1,2 @@
+# Minimal terraform config
+

--- a/test/fixtures/filter/minimize-parsing-destroy/unit-a/terragrunt.hcl
+++ b/test/fixtures/filter/minimize-parsing-destroy/unit-a/terragrunt.hcl
@@ -1,0 +1,4 @@
+terraform {
+  source = "."
+}
+

--- a/test/fixtures/filter/minimize-parsing-destroy/unit-b/main.tf
+++ b/test/fixtures/filter/minimize-parsing-destroy/unit-b/main.tf
@@ -1,0 +1,2 @@
+# Minimal terraform config
+

--- a/test/fixtures/filter/minimize-parsing-destroy/unit-b/terragrunt.hcl
+++ b/test/fixtures/filter/minimize-parsing-destroy/unit-b/terragrunt.hcl
@@ -1,0 +1,4 @@
+terraform {
+  source = "."
+}
+

--- a/test/fixtures/filter/minimize-parsing/dependency-unit/main.tf
+++ b/test/fixtures/filter/minimize-parsing/dependency-unit/main.tf
@@ -1,0 +1,2 @@
+# Minimal terraform config
+

--- a/test/fixtures/filter/minimize-parsing/dependency-unit/terragrunt.hcl
+++ b/test/fixtures/filter/minimize-parsing/dependency-unit/terragrunt.hcl
@@ -1,0 +1,4 @@
+terraform {
+  source = "."
+}
+

--- a/test/fixtures/filter/minimize-parsing/excluded-unit-1/main.tf
+++ b/test/fixtures/filter/minimize-parsing/excluded-unit-1/main.tf
@@ -1,0 +1,2 @@
+# Minimal terraform config
+

--- a/test/fixtures/filter/minimize-parsing/excluded-unit-1/terragrunt.hcl
+++ b/test/fixtures/filter/minimize-parsing/excluded-unit-1/terragrunt.hcl
@@ -1,0 +1,8 @@
+locals {
+  test = run_cmd("--terragrunt-quiet", "bash", "-c", "exit 1")
+}
+
+terraform {
+  source = "."
+}
+

--- a/test/fixtures/filter/minimize-parsing/excluded-unit-2/main.tf
+++ b/test/fixtures/filter/minimize-parsing/excluded-unit-2/main.tf
@@ -1,0 +1,2 @@
+# Minimal terraform config
+

--- a/test/fixtures/filter/minimize-parsing/excluded-unit-2/terragrunt.hcl
+++ b/test/fixtures/filter/minimize-parsing/excluded-unit-2/terragrunt.hcl
@@ -1,0 +1,8 @@
+locals {
+  test = run_cmd("--terragrunt-quiet", "bash", "-c", "exit 1")
+}
+
+terraform {
+  source = "."
+}
+

--- a/test/fixtures/filter/minimize-parsing/excluded-unit-3/main.tf
+++ b/test/fixtures/filter/minimize-parsing/excluded-unit-3/main.tf
@@ -1,0 +1,2 @@
+# Minimal terraform config
+

--- a/test/fixtures/filter/minimize-parsing/excluded-unit-3/terragrunt.hcl
+++ b/test/fixtures/filter/minimize-parsing/excluded-unit-3/terragrunt.hcl
@@ -1,0 +1,8 @@
+locals {
+  test = run_cmd("--terragrunt-quiet", "bash", "-c", "exit 1")
+}
+
+terraform {
+  source = "."
+}
+

--- a/test/fixtures/filter/minimize-parsing/target-unit/main.tf
+++ b/test/fixtures/filter/minimize-parsing/target-unit/main.tf
@@ -1,0 +1,2 @@
+# Minimal terraform config
+

--- a/test/fixtures/filter/minimize-parsing/target-unit/terragrunt.hcl
+++ b/test/fixtures/filter/minimize-parsing/target-unit/terragrunt.hcl
@@ -1,0 +1,10 @@
+dependency "dep" {
+  config_path = "../dependency-unit"
+
+  mock_outputs = {}
+}
+
+terraform {
+  source = "."
+}
+

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -71,6 +71,8 @@ const (
 	// Repeated right now, but it might not be later.
 	TestFixtureOutDir = "fixtures/out-dir"
 
+	ReportFile = "report.json"
+
 	readPermissions      = 0444
 	readWritePermissions = 0666
 	allPermissions       = 0777


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adding `--filter` parse minimization test.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test fixtures for parsing minimization filtering scenarios.
  * Introduced integration tests validating filter functionality with single and multiple unit configurations.
  * Added tests for destroy operations with and without graph filtering.
  * Enhanced test report validation to verify correct unit inclusion and exclusion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->