### PR TITLE
fix: Remove unnecessary `.terragrunt-cache` dir at the stack level

### DIFF
--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -219,12 +219,6 @@ func resolveUnitsFromDiscovery(
 		units = append(units, unit)
 	}
 
-	// Ensure the stack-level default cache directory exists so tests that expect the root cache can find it,
-	// even when per-unit download directories are used.
-	if stackDefaultDownloadDir != "" {
-		_ = os.MkdirAll(stackDefaultDownloadDir, os.ModePerm) // best-effort
-	}
-
 	return units, nil
 }
 

--- a/test/integration_regressions_test.go
+++ b/test/integration_regressions_test.go
@@ -147,11 +147,6 @@ func TestDependencyOutputInGenerateBlock(t *testing.T) {
 		"Should not fail with 'Unsuitable value' error when using dependency outputs in generate blocks")
 	assert.NotContains(t, runAllStderr, "Unsuitable value type",
 		"Should not fail with 'Unsuitable value type' error")
-
-	// Verify the generate block was created successfully
-	// During run --all, the cache is created at the root working directory level
-	generatedFile := util.JoinPath(rootPath, ".terragrunt-cache")
-	assert.DirExists(t, generatedFile, "Terragrunt cache should exist")
 }
 
 // TestDependencyOutputInGenerateBlockDirectRun tests that dependency outputs work when running directly


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5230.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified cache directory management to remove stack-level default cache directory creation.
  
* **Tests**
  * Removed test assertion for default cache directory verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->