### PR TITLE
prevent overwriting Exclude config when not set in current config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1422,7 +1422,11 @@ func ParseConfig(
 		//   original locals for the current config being handled, as that is the locals list that is in scope for this
 		//   config.
 		mergedConfig.Locals = config.Locals
-		mergedConfig.Exclude = config.Exclude
+
+		// preserve included Exclude config when no Exclude config is present in current config
+		if config.Exclude != nil {
+			mergedConfig.Exclude = config.Exclude
+		}
 
 		return mergedConfig, errs.ErrorOrNil()
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5089 

Exclude blocks defined in parent configuration files will be merged in the resulting config even when no exclude block is present in current configuration.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
fixed handling of included exclude blocks

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
n/a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration merging to preserve exclude rules from included configurations when a parent config omits its own exclude block, ensuring exclude settings are consistently retained across configuration hierarchies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->