### PR TITLE
fix: Fixing parsing of external filters

### DIFF
--- a/internal/filter/filters_test.go
+++ b/internal/filter/filters_test.go
@@ -76,6 +76,24 @@ func TestFilters_ParseFilterQueries(t *testing.T) {
 		assert.Contains(t, err.Error(), "filter 0")
 		assert.Contains(t, err.Error(), "filter 1")
 	})
+
+	t.Run("filter in parent directory", func(t *testing.T) {
+		t.Parallel()
+
+		filters, err := filter.ParseFilterQueries([]string{"../apps/*"})
+		require.NoError(t, err)
+		assert.NotNil(t, filters)
+		assert.Equal(t, `["../apps/*"]`, filters.String())
+	})
+
+	t.Run("name filter with slash", func(t *testing.T) {
+		t.Parallel()
+
+		filters, err := filter.ParseFilterQueries([]string{"app/1"})
+		require.NoError(t, err)
+		assert.NotNil(t, filters)
+		assert.Equal(t, `["app/1"]`, filters.String())
+	})
 }
 
 func TestFilters_Evaluate(t *testing.T) {

--- a/internal/filter/lexer.go
+++ b/internal/filter/lexer.go
@@ -61,7 +61,6 @@ func (l *Lexer) NextToken() Token {
 	case 0:
 		tok = NewToken(EOF, "", startPosition)
 	case '.':
-		// Check for ellipsis (three consecutive dots)
 		if l.peekChar() == '.' {
 			if l.readPosition+1 < len(l.input) && l.input[l.readPosition+1] == '.' {
 				l.readChar()
@@ -70,6 +69,13 @@ func (l *Lexer) NextToken() Token {
 				tok = NewToken(ELLIPSIS, "...", startPosition)
 
 				l.readChar()
+
+				return tok
+			}
+
+			// Check if this is .. followed by / (parent directory path)
+			if l.readPosition+1 < len(l.input) && l.input[l.readPosition+1] == '/' {
+				tok = l.readPath(startPosition)
 
 				return tok
 			}
@@ -100,6 +106,13 @@ func (l *Lexer) NextToken() Token {
 		}
 
 		if isIdentifierChar(l.ch) {
+			// Check if this identifier contains a slash - if so, treat it as a path
+			if l.containsSlashBeforeSpecialChar() {
+				tok = l.readPath(startPosition)
+
+				return tok
+			}
+
 			literal := l.readIdentifier()
 			tok = NewToken(IDENT, literal, startPosition)
 
@@ -211,6 +224,26 @@ func (l *Lexer) readPath(startPosition int) Token {
 	literal = strings.TrimSpace(literal)
 
 	return NewToken(PATH, literal, startPosition)
+}
+
+// containsSlashBeforeSpecialChar checks if there's a slash in the input before
+// we encounter a special character, starting from the current position.
+func (l *Lexer) containsSlashBeforeSpecialChar() bool {
+	pos := l.position
+	for pos < len(l.input) {
+		ch := l.input[pos]
+		if ch == '/' {
+			return true
+		}
+
+		if isSpecialChar(ch) {
+			return false
+		}
+
+		pos++
+	}
+
+	return false
 }
 
 // isSpecialChar returns true if the character is a special operator or delimiter.

--- a/internal/filter/lexer_test.go
+++ b/internal/filter/lexer_test.go
@@ -339,10 +339,27 @@ func TestLexer_EdgeCases(t *testing.T) {
 			input: "{my path/file}",
 			expected: []filter.Token{
 				{Type: filter.LBRACE, Literal: "{", Position: 0},
-				{Type: filter.IDENT, Literal: "my path", Position: 1},
-				{Type: filter.PATH, Literal: "/file", Position: 8},
+				{Type: filter.PATH, Literal: "my path/file", Position: 1},
 				{Type: filter.RBRACE, Literal: "}", Position: 13},
 				{Type: filter.EOF, Literal: "", Position: 14},
+			},
+		},
+		{
+			name:  "source filter with slash",
+			input: "source=github.com/acme/foo/bar",
+			expected: []filter.Token{
+				{Type: filter.IDENT, Literal: "source", Position: 0},
+				{Type: filter.EQUAL, Literal: "=", Position: 6},
+				{Type: filter.IDENT, Literal: "github.com/acme/foo/bar", Position: 7},
+				{Type: filter.EOF, Literal: "", Position: 30},
+			},
+		},
+		{
+			name:  "path filter with slash",
+			input: "foo/bar",
+			expected: []filter.Token{
+				{Type: filter.PATH, Literal: "foo/bar", Position: 0},
+				{Type: filter.EOF, Literal: "", Position: 7},
 			},
 		},
 	}

--- a/internal/filter/token.go
+++ b/internal/filter/token.go
@@ -13,7 +13,7 @@ const (
 	// IDENT represents an identifier (e.g., "foo", "name")
 	IDENT
 
-	// PATH represents a path (starts with ./ or /)
+	// PATH represents a path (starts with ./, ../, or /)
 	PATH
 
 	// Operators


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes parsing of paths outside current working directory and paths that don't start with `./` or `/`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Filter syntax now supports parent directory references ("../") in path patterns, enabling users to filter based on ancestor directories.
* Enhanced path recognition in filters to properly handle expressions with slashes, supporting complex multi-segment path filtering across different filter contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->