### PR TITLE
fix: Fixing HTTPS CAS URLs

### DIFF
--- a/internal/cas/getter.go
+++ b/internal/cas/getter.go
@@ -91,6 +91,13 @@ func (g *CASGetter) Detect(req *getter.Request) (bool, error) {
 		return true, nil
 	}
 
+	if after, ok := strings.CutPrefix(req.Src, "git::"); ok {
+		req.Src = after
+		req.Forced = "git"
+
+		return true, nil
+	}
+
 	for _, detector := range g.Detectors {
 		src, ok, err := detector.Detect(req.Src, req.Pwd)
 		if err != nil {

--- a/internal/cas/getter_test.go
+++ b/internal/cas/getter_test.go
@@ -56,6 +56,11 @@ func TestCASGetterDetect(t *testing.T) {
 			pwd:  tmp,
 		},
 		{
+			name: "HTTPS URL repository",
+			src:  "git::https://github.com/gruntwork-io/terragrunt",
+			pwd:  tmp,
+		},
+		{
 			name:        "Invalid URL",
 			src:         "not-a-valid-url",
 			pwd:         tmp,


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5197.

Updates CAS URL parsing to handle forced `git` protocol usage in `go-getter` URL.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "git::" prefix syntax to explicitly specify git repositories.

* **Tests**
  * Added test coverage for HTTPS repository URLs with git prefix syntax.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->