### PR TITLE
fix: Fixing warnings for how to reproduce tofu runs

### DIFF
--- a/internal/providercache/provider_cache.go
+++ b/internal/providercache/provider_cache.go
@@ -310,7 +310,7 @@ func (cache *ProviderCache) createLocalCLIConfig(ctx context.Context, opts *opti
 	// Filter registries based on OpenTofu or Terraform implementation to avoid contacting unnecessary registries
 	filteredRegistryNames := filterRegistriesByImplementation(
 		opts.ProviderCacheRegistryNames,
-		opts.TerraformImplementation,
+		opts.TofuImplementation,
 	)
 
 	var providerInstallationIncludes = make([]string, 0, len(filteredRegistryNames))
@@ -394,7 +394,7 @@ func providerCacheEnvironment(opts *options.TerragruntOptions, cliConfigFile str
 	// Filter registries based on OpenTofu or Terraform implementation to avoid setting env vars for unnecessary registries
 	filteredRegistryNames := filterRegistriesByImplementation(
 		opts.ProviderCacheRegistryNames,
-		opts.TerraformImplementation,
+		opts.TofuImplementation,
 	)
 
 	for _, registryName := range filteredRegistryNames {

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -123,7 +123,7 @@ func DownloadTerraformSourceIfNecessary(
 				return err
 			}
 
-			l.Debugf("%s files in %s are up to date. Will not download again.", opts.TerraformImplementation, terraformSource.WorkingDir)
+			l.Debugf("%s files in %s are up to date. Will not download again.", opts.TofuImplementation, terraformSource.WorkingDir)
 
 			return nil
 		}

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -355,7 +355,7 @@ func runTerragruntWithConfig(
 		// If command failed, log a helpful message
 		if runTerraformError != nil {
 			if out == nil {
-				l.Errorf("%s invocation failed in %s", opts.TerraformImplementation, opts.WorkingDir)
+				l.Errorf("%s invocation failed in %s", opts.TofuImplementation, opts.WorkingDir)
 			}
 		}
 

--- a/internal/runner/run/version_check.go
+++ b/internal/runner/run/version_check.go
@@ -102,7 +102,7 @@ func PopulateTFVersion(ctx context.Context, l log.Logger, opts *options.Terragru
 		}
 
 		opts.TerraformVersion = terraformVersion
-		opts.TerraformImplementation = tfImplementation
+		opts.TofuImplementation = tfImplementation
 
 		return l, nil
 	}
@@ -117,7 +117,7 @@ func PopulateTFVersion(ctx context.Context, l log.Logger, opts *options.Terragru
 	versionCache.Put(ctx, cacheKey, cacheData)
 
 	opts.TerraformVersion = terraformVersion
-	opts.TerraformImplementation = tfImplementation
+	opts.TofuImplementation = tfImplementation
 
 	return l, nil
 }

--- a/options/options.go
+++ b/options/options.go
@@ -150,7 +150,7 @@ type TerragruntOptions struct {
 	// Original Terraform command being executed by Terragrunt.
 	OriginalTerraformCommand string
 	// Terraform implementation tool (e.g. terraform, tofu) that terragrunt is wrapping
-	TerraformImplementation TerraformImplementationType
+	TofuImplementation TerraformImplementationType
 	// The file path that terragrunt should use when rendering the terragrunt.hcl config as json.
 	JSONOut string
 	// The path to store unpacked providers.
@@ -421,7 +421,7 @@ func NewTerragruntOptionsWithWriters(stdout, stderr io.Writer) *TerragruntOption
 		UsePartialParseConfigCache:  false,
 		ForwardTFStdout:             false,
 		JSONOut:                     DefaultJSONOutName,
-		TerraformImplementation:     UnknownImpl,
+		TofuImplementation:          UnknownImpl,
 		JSONDisableDependentModules: false,
 		RunTerragrunt: func(ctx context.Context, l log.Logger, opts *TerragruntOptions, r *report.Report) error {
 			return errors.New(ErrRunTerragruntCommandNotSet)

--- a/tf/getproviders/constraints_test.go
+++ b/tf/getproviders/constraints_test.go
@@ -38,7 +38,7 @@ terraform {
 
 	// Test parsing with Terraform implementation
 	terraformOpts := &options.TerragruntOptions{
-		TerraformImplementation: options.TerraformImpl,
+		TofuImplementation: options.TerraformImpl,
 	}
 	constraints, err := getproviders.ParseProviderConstraints(terraformOpts, testDir)
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ terraform {
 
 	// Test parsing with OpenTofu implementation
 	openTofuOpts := &options.TerragruntOptions{
-		TerraformImplementation: options.OpenTofuImpl,
+		TofuImplementation: options.OpenTofuImpl,
 	}
 	constraints, err = getproviders.ParseProviderConstraints(openTofuOpts, testDir)
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ terraform {
 
 	// Test parsing with Terraform implementation
 	terraformOpts := &options.TerragruntOptions{
-		TerraformImplementation: options.TerraformImpl,
+		TofuImplementation: options.TerraformImpl,
 	}
 	constraints, err := getproviders.ParseProviderConstraints(terraformOpts, testDir)
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ terraform {
 
 	// Test parsing with OpenTofu implementation
 	openTofuOpts := &options.TerragruntOptions{
-		TerraformImplementation: options.OpenTofuImpl,
+		TofuImplementation: options.OpenTofuImpl,
 	}
 	constraints, err = getproviders.ParseProviderConstraints(openTofuOpts, testDir)
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ terraform {
 
 	// Test parsing with Terraform implementation - should use custom registry
 	terraformOpts := &options.TerragruntOptions{
-		TerraformImplementation: options.TerraformImpl,
+		TofuImplementation: options.TerraformImpl,
 	}
 	constraints, err := getproviders.ParseProviderConstraints(terraformOpts, testDir)
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ terraform {
 
 	// Test parsing with OpenTofu implementation - should also use custom registry (environment override takes precedence)
 	openTofuOpts := &options.TerragruntOptions{
-		TerraformImplementation: options.OpenTofuImpl,
+		TofuImplementation: options.OpenTofuImpl,
 	}
 	constraints, err = getproviders.ParseProviderConstraints(openTofuOpts, testDir)
 	require.NoError(t, err)
@@ -184,7 +184,7 @@ terraform {
 
 	// Test parsing with OpenTofu implementation
 	openTofuOpts := &options.TerragruntOptions{
-		TerraformImplementation: options.OpenTofuImpl,
+		TofuImplementation: options.OpenTofuImpl,
 	}
 	constraints, err := getproviders.ParseProviderConstraints(openTofuOpts, testDir)
 	require.NoError(t, err)
@@ -195,7 +195,7 @@ terraform {
 
 	// Test parsing with Terraform implementation
 	terraformOpts := &options.TerragruntOptions{
-		TerraformImplementation: options.TerraformImpl,
+		TofuImplementation: options.TerraformImpl,
 	}
 	constraints, err = getproviders.ParseProviderConstraints(terraformOpts, testDir)
 	require.NoError(t, err)
@@ -236,7 +236,7 @@ terraform {
 
 	// Test parsing with Terraform implementation
 	terraformOpts := &options.TerragruntOptions{
-		TerraformImplementation: options.TerraformImpl,
+		TofuImplementation: options.TerraformImpl,
 	}
 	constraints, err := getproviders.ParseProviderConstraints(terraformOpts, testDir)
 	require.NoError(t, err)
@@ -248,7 +248,7 @@ terraform {
 
 	// Test parsing with OpenTofu implementation
 	openTofuOpts := &options.TerragruntOptions{
-		TerraformImplementation: options.OpenTofuImpl,
+		TofuImplementation: options.OpenTofuImpl,
 	}
 	constraints, err = getproviders.ParseProviderConstraints(openTofuOpts, testDir)
 	require.NoError(t, err)
@@ -334,7 +334,7 @@ func TestNormalizeVersionConstraint(t *testing.T) {
 			require.NoError(t, err)
 
 			opts := &options.TerragruntOptions{
-				TerraformImplementation: options.TerraformImpl,
+				TofuImplementation: options.TerraformImpl,
 			}
 			constraints, err := getproviders.ParseProviderConstraints(opts, testDir)
 			require.NoError(t, err)

--- a/tf/getter.go
+++ b/tf/getter.go
@@ -107,7 +107,7 @@ func GetDefaultRegistryDomain(opts *options.TerragruntOptions) string {
 		return defaultRegistry
 	}
 	// if binary is set to use OpenTofu registry, use OpenTofu as default registry
-	if opts.TerraformImplementation == options.OpenTofuImpl {
+	if opts.TofuImplementation == options.OpenTofuImpl {
 		return defaultOtRegistryDomain
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Ensures that users get accurate warnings about how to reproduce runs when debugging.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency for OpenTofu implementation configuration across registry selection, provider caching, and logging operations.
  * Enhanced configuration field naming to better reflect OpenTofu support throughout the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->