### PR TITLE
docs: Update provider cache documentation to include a valid command

### DIFF
--- a/docs-starlight/src/content/docs/03-features/13-provider-cache-server.mdx
+++ b/docs-starlight/src/content/docs/03-features/13-provider-cache-server.mdx
@@ -118,7 +118,7 @@ OpenTofu/Terraform has an official documented setting [network_mirror](https://d
 If you run `providers lock` with enabled Terragrunt Provider Cache, Terragrunt creates the provider cache and generates the lock file.
 
 ```shell
-terragrunt run --provider-cache providers lock -platform=linux_amd64 -platform=darwin_arm64 -platform=freebsd_amd64
+terragrunt run --provider-cache -- providers lock -platform=linux_amd64 -platform=darwin_arm64 -platform=freebsd_amd64
 ```
 
 ## Configure the Provider Cache Server


### PR DESCRIPTION
Previous command didn't work on the latest version of terragrunt. This updates it to a working command. The docs also indicated that `terraform providers lock` isn't run at all, but I don't believe that is true, so I reworded slightly, but I don't know if there is something more accurate?

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] Update the docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Terragrunt creates the provider cache and generates the lock file as part of the provider-cache workflow, avoiding implication that Terraform’s provider lock is run directly.
  * Updated examples to show the current terragrunt run-based provider-cache workflow and corresponding command usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->