### PR TITLE
fix: Fixing `plan -destroy` for `--filter-affected`

### DIFF
--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -13,7 +13,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/gruntwork-io/go-commons/collections"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 
 	"github.com/gruntwork-io/terragrunt/tf"
@@ -206,6 +205,23 @@ func resolveUnitsFromDiscovery(
 
 		if skip {
 			continue
+		}
+
+		// Transfer discovery context command and args to unit options if available
+		if discoveryCtx := unit.DiscoveryContext(); discoveryCtx != nil {
+			if discoveryCtx.Cmd != "" {
+				unitOpts.TerraformCommand = discoveryCtx.Cmd
+			}
+
+			if len(discoveryCtx.Args) > 0 {
+				terraformCliArgs := make([]string, 0, 1+len(discoveryCtx.Args))
+				if discoveryCtx.Cmd != "" {
+					terraformCliArgs = append(terraformCliArgs, discoveryCtx.Cmd)
+				}
+
+				terraformCliArgs = append(terraformCliArgs, discoveryCtx.Args...)
+				unitOpts.TerraformCliArgs = terraformCliArgs
+			}
 		}
 
 		// Initialize execution context
@@ -732,7 +748,24 @@ func (r *Runner) syncTerraformCliArgs(l log.Logger, opts *options.TerragruntOpti
 			continue
 		}
 
-		unit.Execution.TerragruntOptions.TerraformCliArgs = collections.MakeCopyOfList(opts.TerraformCliArgs)
+		discoveryCtx := unit.DiscoveryContext()
+		if discoveryCtx != nil && len(discoveryCtx.Args) > 0 {
+			mergedArgs := slices.Clone(unit.Execution.TerragruntOptions.TerraformCliArgs)
+
+			for _, stackArg := range opts.TerraformCliArgs {
+				if stackArg == opts.TerraformCliArgs.First() {
+					continue
+				}
+
+				if !slices.Contains(mergedArgs, stackArg) {
+					mergedArgs = append(mergedArgs, stackArg)
+				}
+			}
+
+			unit.Execution.TerragruntOptions.TerraformCliArgs = mergedArgs
+		} else {
+			unit.Execution.TerragruntOptions.TerraformCliArgs = slices.Clone(opts.TerraformCliArgs)
+		}
 
 		planFile := unit.PlanFile(opts)
 		if planFile != "" {

--- a/test/integration_filter_test.go
+++ b/test/integration_filter_test.go
@@ -1100,13 +1100,125 @@ func TestFilterFlagWithRunAllGitFilter(t *testing.T) {
 	}
 }
 
-func TestFilterFlagWithRunAllGitFilterLocalStateWarning(t *testing.T) {
+func TestFilterFlagWithRunAllGitFilterRemovedUnitDestroyFlag(t *testing.T) {
 	t.Parallel()
 
-	// Skip if filter-flag experiment is not enabled
-	if !helpers.IsExperimentMode(t) {
-		t.Skip("Skipping filter flag tests - TG_EXPERIMENT_MODE not enabled")
-	}
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner()
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(tmpDir)
+
+	err = runner.Init(t.Context())
+	require.NoError(t, err)
+
+	err = runner.GoOpenRepo()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = runner.GoCloseStorage()
+		require.NoError(t, err)
+	})
+
+	unitToBeRemovedDir := filepath.Join(tmpDir, "unit-to-be-removed")
+	err = os.MkdirAll(unitToBeRemovedDir, 0755)
+	require.NoError(t, err)
+
+	terragruntHCL := `# Unit to be removed
+terraform {
+  source = "."
+}
+`
+	err = os.WriteFile(filepath.Join(unitToBeRemovedDir, "terragrunt.hcl"), []byte(terragruntHCL), 0644)
+	require.NoError(t, err)
+
+	mainTF := `resource "null_resource" "test" {
+  triggers = {
+    test = "value"
+  }
+}
+`
+	err = os.WriteFile(filepath.Join(unitToBeRemovedDir, "main.tf"), []byte(mainTF), 0644)
+	require.NoError(t, err)
+
+	err = runner.GoAdd(".")
+	require.NoError(t, err)
+
+	err = runner.GoCommit("Initial commit with unit", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	// Apply the unit so that it shows up in state first.
+	cmd := "terragrunt run --non-interactive --all --no-color --working-dir " + tmpDir + " -- apply"
+
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err)
+
+	assert.Contains(
+		t,
+		stderr,
+		"Unit unit-to-be-removed",
+		"unit-to-be-removed should be discovered and run",
+	)
+
+	assert.Contains(
+		t,
+		stdout,
+		"Apply complete! Resources: 1 added",
+		"unit-to-be-removed should be applied",
+	)
+
+	err = os.RemoveAll(unitToBeRemovedDir)
+	require.NoError(t, err)
+
+	err = runner.GoAdd(".")
+	require.NoError(t, err)
+
+	err = runner.GoCommit("Remove unit", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	cmd = "terragrunt run --non-interactive --all --no-color --working-dir " + tmpDir +
+		" --filter '[HEAD~1]' --filter-allow-destroy -- plan"
+
+	stdout, stderr, err = helpers.RunTerragruntCommandWithOutput(t, cmd)
+
+	combinedOutput := stdout + stderr
+
+	assert.Contains(
+		t,
+		combinedOutput,
+		"unit-to-be-removed",
+		"Removed unit should be discovered and processed",
+	)
+
+	// Check for destroy-related output. The message "No changes. No objects need to be destroyed"
+	// is what Terraform outputs when plan -destroy is run but there's no state to destroy.
+	// This is expected when using worktrees with local state (state is in original dir, not worktree).
+	// The important thing is that the -destroy flag was passed, which we verify by checking for
+	// this specific message that only appears with -destroy flag.
+	hasDestroyFlag := strings.Contains(combinedOutput, "to destroy") ||
+		strings.Contains(combinedOutput, "No objects need to be destroyed") ||
+		strings.Contains(combinedOutput, "will be destroyed")
+
+	assert.True(t, hasDestroyFlag,
+		"Removed unit should be planned with -destroy flag. Output should contain 'to destroy', 'No objects need to be destroyed', or 'will be destroyed'. "+
+			"Current output:\nstdout: %s\nstderr: %s", stdout, stderr)
+}
+
+func TestFilterFlagWithRunAllGitFilterLocalStateWarning(t *testing.T) {
+	t.Parallel()
 
 	testCases := []struct {
 		name          string
@@ -2003,10 +2115,6 @@ func getUnitNames(recordsByUnit map[string]map[string]string) []string {
 // instead of the specified --out-dir path.
 func TestOutDirWithGitFilter(t *testing.T) {
 	t.Parallel()
-
-	if !helpers.IsExperimentMode(t) {
-		t.Skip("Skipping filter flag tests - TG_EXPERIMENT_MODE not enabled")
-	}
 
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 	outDir := helpers.TmpDirWOSymlinks(t)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -322,8 +322,8 @@ func TestLogCustomFormatOutput(t *testing.T) {
 		{
 			logCustomFormat: "%interval%(content=' plain-text ')%level(case=upper,width=6) %prefix(path=short-relative,suffix=' ')%tf-path(suffix=' ')%tf-command-args(suffix=': ')%msg(path=relative)",
 			expectedStdOutRegs: []*regexp.Regexp{
-				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT dep "+wrappedBinary()+" init -input=false -no-color: Initializing the backend...")),
-				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT app "+wrappedBinary()+" init -input=false -no-color: Initializing the backend...")),
+				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT dep "+wrappedBinary()+" init -no-color -input=false: Initializing the backend...")),
+				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT app "+wrappedBinary()+" init -no-color -input=false: Initializing the backend...")),
 			},
 			expectedStdErrRegs: []*regexp.Regexp{
 				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text DEBUG  Terragrunt Version:")),


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5294.

I think this is a quick fix, but deserves a more thorough update. We shouldn't have multiple sources of truth for the commands and arguments for a run. That refactor can be handled later, though.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discovery context can now override or augment per-unit Terraform commands and CLI arguments for more flexible unit execution.

* **Improvements**
  * Enhanced CLI argument merging to prevent duplicates across discovery-derived and stack-derived arguments.

* **Tests**
  * Added comprehensive test coverage for Git filtering with destroy flag handling.
  * Updated test expectations to reflect CLI argument output changes.
  * Removed experimental gating condition from Git filter test.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->