### PR TITLE
fix: Fixing nested spans

### DIFF
--- a/telemetry/tracer.go
+++ b/telemetry/tracer.go
@@ -201,15 +201,18 @@ func (tracer *Tracer) openSpan(ctx context.Context, name string, attrs map[strin
 	}
 
 	if tracer.parentTraceID != nil && tracer.parentSpanID != nil {
-		spanContext := trace.NewSpanContext(trace.SpanContextConfig{
-			TraceID:    *tracer.parentTraceID,
-			SpanID:     *tracer.parentSpanID,
-			Remote:     true,
-			TraceFlags: *tracer.parentTraceFlags,
-		})
+		existingSpan := trace.SpanFromContext(ctx)
+		if !existingSpan.SpanContext().IsValid() {
+			spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+				TraceID:    *tracer.parentTraceID,
+				SpanID:     *tracer.parentSpanID,
+				Remote:     true,
+				TraceFlags: *tracer.parentTraceFlags,
+			})
 
-		// create a new context with the parent span context
-		ctx = trace.ContextWithSpanContext(ctx, spanContext)
+			// create a new context with the parent span context
+			ctx = trace.ContextWithSpanContext(ctx, spanContext)
+		}
 	}
 
 	// This lint is suppressed because we definitely do close the span


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This ensures that spans are still registered with a parent child relationship within Terragrunt, even if a parent span is registered as the ultimate parent span.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures correct span hierarchy when a parent trace is supplied.
> 
> - In `telemetry/tracer.go` `openSpan`, only injects parent `SpanContext` if `SpanFromContext(ctx)` is invalid, avoiding overwriting an existing span context
> - Maintains proper parent-child relationships for nested spans while still honoring externally provided parent trace info
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29275e2594ec33b623695d4716ed63bbcbd450fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry span context handling to prevent conflicts with existing spans. The span context injection logic now validates whether a valid span context already exists before injecting parent context, reducing potential conflicts and ensuring more reliable and consistent tracing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->