### PR TITLE
fix: Locking during run ensure calls

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -179,6 +179,9 @@ func (r *Report) EnsureRun(l log.Logger, path string, opts ...EndOption) (*Run, 
 	if err == nil {
 		l.Debugf("Report run %s already exists, returning existing run", path)
 
+		run.mu.Lock()
+		defer run.mu.Unlock()
+
 		for _, opt := range opts {
 			opt(run)
 		}

--- a/internal/runner/common/unit_runner.go
+++ b/internal/runner/common/unit_runner.go
@@ -61,8 +61,8 @@ func (runner *UnitRunner) runTerragrunt(ctx context.Context, opts *options.Terra
 
 		// Pass the discovery working directory for worktree scenarios
 		var ensureOpts []report.EndOption
-		if ctx := runner.Unit.DiscoveryContext(); ctx != nil && ctx.WorkingDir != "" {
-			ensureOpts = append(ensureOpts, report.WithDiscoveryWorkingDir(ctx.WorkingDir))
+		if discoveryCtx := runner.Unit.DiscoveryContext(); discoveryCtx != nil && discoveryCtx.WorkingDir != "" {
+			ensureOpts = append(ensureOpts, report.WithDiscoveryWorkingDir(discoveryCtx.WorkingDir))
 		}
 
 		if _, err := r.EnsureRun(runner.Unit.Execution.Logger, unitPath, ensureOpts...); err != nil {

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -482,8 +482,8 @@ func (r *Runner) Run(ctx context.Context, l log.Logger, opts *options.Terragrunt
 
 				// Pass the discovery working directory for worktree scenarios
 				var ensureOpts []report.EndOption
-				if ctx := u.DiscoveryContext(); ctx != nil && ctx.WorkingDir != "" {
-					ensureOpts = append(ensureOpts, report.WithDiscoveryWorkingDir(ctx.WorkingDir))
+				if discoveryCtx := u.DiscoveryContext(); discoveryCtx != nil && discoveryCtx.WorkingDir != "" {
+					ensureOpts = append(ensureOpts, report.WithDiscoveryWorkingDir(discoveryCtx.WorkingDir))
 				}
 
 				run, err := r.Stack.Execution.Report.EnsureRun(l, unitPath, ensureOpts...)
@@ -577,8 +577,8 @@ func (r *Runner) Run(ctx context.Context, l log.Logger, opts *options.Terragrunt
 
 				// Pass the discovery working directory for worktree scenarios
 				var ensureOpts []report.EndOption
-				if ctx := unit.DiscoveryContext(); ctx != nil && ctx.WorkingDir != "" {
-					ensureOpts = append(ensureOpts, report.WithDiscoveryWorkingDir(ctx.WorkingDir))
+				if discoveryCtx := unit.DiscoveryContext(); discoveryCtx != nil && discoveryCtx.WorkingDir != "" {
+					ensureOpts = append(ensureOpts, report.WithDiscoveryWorkingDir(discoveryCtx.WorkingDir))
 				}
 
 				run, reportErr := r.Stack.Execution.Report.EnsureRun(l, unitPath, ensureOpts...)


### PR DESCRIPTION
## Description

This addresses review coments from #5308

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thread-safety issue in run modification that could have caused data corruption during concurrent operations.

* **Refactor**
  * Improved internal code clarity with variable naming updates to reduce confusion in discovery context handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->