### PR TITLE
fix: Using a partial parse for `get_working_dir()`

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -854,7 +854,12 @@ func getWorkingDirImpl(ctx *ParsingContext, l log.Logger) (string, error) {
 		FuncNameGetWorkingDir: wrapVoidToEmptyStringAsFuncImpl(),
 	}
 
-	terragruntConfig, err := ParseConfigFile(ctx, l, ctx.TerragruntOptions.TerragruntConfigPath, nil)
+	terragruntConfig, err := PartialParseConfigFile(
+		ctx.WithDecodeList(TerraformSource),
+		l,
+		ctx.TerragruntOptions.TerragruntConfigPath,
+		nil,
+	)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Performs a partial parse of the configuration calling `get_working_dir()` to reduce the overhead of the parse.

It's pretty weird that we parse the file within the `get_working_dir` function, btw. Definitely something we should tackle in the future.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated configuration parsing to ensure Terraform sources are properly decoded during processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->