### PR TITLE
chore: Avoiding `contextcheck` suppression

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -152,11 +152,11 @@ func removeNoColorFlagDuplicates(args []string) []string {
 }
 
 func beforeAction(_ *options.TerragruntOptions) cli.ActionFunc {
-	return func(ctx *cli.Context) error {
+	return func(ctx context.Context, cliCtx *cli.Context) error {
 		// setting current context to the options
 		// show help if the args are not specified.
-		if !ctx.Args().Present() {
-			err := cli.ShowAppHelp(ctx)
+		if !cliCtx.Args().Present() {
+			err := cli.ShowAppHelp(ctx, cliCtx)
 			// exit the app
 			return cli.NewExitError(err, 0)
 		}
@@ -165,9 +165,9 @@ func beforeAction(_ *options.TerragruntOptions) cli.ActionFunc {
 		// top-level command, fail fast with guidance to use `run --`.
 		// This removes the legacy behavior of implicitly forwarding unknown
 		// commands to OpenTofu/Terraform.
-		cmdName := ctx.Args().CommandName()
+		cmdName := cliCtx.Args().CommandName()
 		if cmdName != "" {
-			if ctx.Command == nil || ctx.Command.Subcommand(cmdName) == nil {
+			if cliCtx.Command == nil || cliCtx.Command.Subcommand(cmdName) == nil {
 				// Show a clear error pointing users to the explicit run form.
 				// Example: `terragrunt workspace ls` -> suggest `terragrunt run -- workspace ls`.
 				return cli.NewExitError(

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -859,7 +860,7 @@ func setCommandAction(action clipkg.ActionFunc, cmds ...*clipkg.Command) {
 }
 
 func runAppTest(l log.Logger, args []string, opts *options.TerragruntOptions) (*options.TerragruntOptions, error) {
-	emptyAction := func(ctx *clipkg.Context) error { return nil }
+	emptyAction := func(ctx context.Context, cliCtx *clipkg.Context) error { return nil }
 
 	terragruntCommands := commands.New(l, opts)
 	setCommandAction(emptyAction, terragruntCommands...)
@@ -871,8 +872,8 @@ func runAppTest(l log.Logger, args []string, opts *options.TerragruntOptions) (*
 	app.Flags = append(global.NewFlags(l, opts, nil), run.NewFlags(l, opts, nil)...)
 	app.Commands = terragruntCommands.WrapAction(commands.WrapWithTelemetry(l, opts))
 	app.OsExiter = cli.OSExiter
-	app.Action = func(ctx *clipkg.Context) error {
-		opts.TerraformCliArgs = append(opts.TerraformCliArgs, ctx.Args()...)
+	app.Action = func(ctx context.Context, cliCtx *clipkg.Context) error {
+		opts.TerraformCliArgs = append(opts.TerraformCliArgs, cliCtx.Args()...)
 		return nil
 	}
 	app.ExitErrHandler = cli.ExitErrHandler

--- a/cli/commands/aws-provider-patch/cli.go
+++ b/cli/commands/aws-provider-patch/cli.go
@@ -30,6 +30,8 @@
 package awsproviderpatch
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	runcmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
@@ -72,14 +74,14 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Usage:  "Overwrite settings on nested AWS providers to work around a Terraform bug (issue #13018).",
 		Hidden: true,
 		Flags:  append(runcmd.NewFlags(l, opts, nil), NewFlags(l, opts, nil)...),
-		Before: func(ctx *cli.Context) error {
+		Before: func(ctx context.Context, _ *cli.Context) error {
 			if err := control.Evaluate(ctx); err != nil {
 				return cli.NewExitError(err, cli.ExitCodeGeneralError)
 			}
 
 			return nil
 		},
-		Action: func(ctx *cli.Context) error {
+		Action: func(ctx context.Context, _ *cli.Context) error {
 			return Run(ctx, l, opts.OptionsFromContext(ctx))
 		},
 		DisabledErrorOnUndefinedFlag: true,

--- a/cli/commands/backend/bootstrap/cli.go
+++ b/cli/commands/backend/bootstrap/cli.go
@@ -1,6 +1,8 @@
 package bootstrap
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
@@ -12,7 +14,9 @@ import (
 
 const CommandName = "bootstrap"
 
-func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
+func NewFlags(opts *options.TerragruntOptions) cli.Flags {
+	prefix := flags.Prefix{flags.TgPrefix}
+
 	sharedFlags := cli.Flags{
 		shared.NewConfigFlag(opts, prefix, CommandName),
 		shared.NewDownloadDirFlag(opts, prefix, CommandName),
@@ -27,8 +31,8 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 	cmd := &cli.Command{
 		Name:  CommandName,
 		Usage: "Bootstrap OpenTofu/Terraform backend infrastructure.",
-		Flags: NewFlags(l, opts, nil),
-		Action: func(ctx *cli.Context) error {
+		Flags: NewFlags(opts),
+		Action: func(ctx context.Context, _ *cli.Context) error {
 			return Run(ctx, l, opts.OptionsFromContext(ctx))
 		},
 	}

--- a/cli/commands/backend/delete/cli.go
+++ b/cli/commands/backend/delete/cli.go
@@ -1,6 +1,8 @@
 package delete
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
@@ -49,7 +51,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Name:  CommandName,
 		Usage: "Delete OpenTofu/Terraform state.",
 		Flags: NewFlags(l, opts, nil),
-		Action: func(ctx *cli.Context) error {
+		Action: func(ctx context.Context, _ *cli.Context) error {
 			return Run(ctx, l, opts.OptionsFromContext(ctx))
 		},
 	}

--- a/cli/commands/backend/migrate/cli.go
+++ b/cli/commands/backend/migrate/cli.go
@@ -1,6 +1,8 @@
 package migrate
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -43,13 +45,13 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Usage:     "Migrate OpenTofu/Terraform state from one location to another.",
 		UsageText: usageText,
 		Flags:     NewFlags(l, opts, nil),
-		Action: func(ctx *cli.Context) error {
-			srcPath := ctx.Args().First()
+		Action: func(ctx context.Context, cliCtx *cli.Context) error {
+			srcPath := cliCtx.Args().First()
 			if srcPath == "" {
 				return errors.New(usageText)
 			}
 
-			dstPath := ctx.Args().Second()
+			dstPath := cliCtx.Args().Second()
 			if dstPath == "" {
 				return errors.New(usageText)
 			}

--- a/cli/commands/catalog/cli.go
+++ b/cli/commands/catalog/cli.go
@@ -3,6 +3,8 @@
 package catalog
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/commands/scaffold"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
@@ -24,10 +26,10 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Name:  CommandName,
 		Usage: "Launch the user interface for searching and managing your module catalog.",
 		Flags: NewFlags(opts, nil),
-		Action: func(ctx *cli.Context) error {
+		Action: func(ctx context.Context, cliCtx *cli.Context) error {
 			var repoPath string
 
-			if val := ctx.Args().Get(0); val != "" {
+			if val := cliCtx.Args().Get(0); val != "" {
 				repoPath = val
 			}
 

--- a/cli/commands/common/graph/cli.go
+++ b/cli/commands/common/graph/cli.go
@@ -15,7 +15,7 @@ import (
 
 const GraphFlagName = "graph"
 
-func NewFlags(opts *options.TerragruntOptions, commandName string, prefix flags.Prefix) cli.Flags {
+func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
 	return cli.Flags{
@@ -24,7 +24,7 @@ func NewFlags(opts *options.TerragruntOptions, commandName string, prefix flags.
 			EnvVars:     tgPrefix.EnvVars(GraphFlagName),
 			Destination: &opts.Graph,
 			Usage:       "Run the specified OpenTofu/Terraform command following the Directed Acyclic Graph (DAG) of dependencies.",
-			Action: func(_ *cli.Context, _ bool) error {
+			Action: func(_ context.Context, _ *cli.Context, _ bool) error {
 				if opts.RunAll {
 					return errors.New(new(common.AllGraphFlagsError))
 				}
@@ -43,29 +43,29 @@ func WrapCommand(
 	runFn func(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, r *report.Report) error,
 	alwaysDisableSummary bool,
 ) *cli.Command {
-	cmd = cmd.WrapAction(func(cliCtx *cli.Context, action cli.ActionFunc) error {
+	cmd = cmd.WrapAction(func(ctx context.Context, cliCtx *cli.Context, action cli.ActionFunc) error {
 		if alwaysDisableSummary {
 			opts.SummaryDisable = true
 		}
 
 		if !opts.Graph {
-			return action(cliCtx)
+			return action(ctx, cliCtx)
 		}
 
-		opts.RunTerragrunt = func(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, r *report.Report) error {
+		opts.RunTerragrunt = func(innerCtx context.Context, l log.Logger, opts *options.TerragruntOptions, r *report.Report) error {
 			if opts.TerraformCommand == cmd.Name {
-				cliCtx := cliCtx.WithValue(options.ContextKey, opts)
+				innerCtx = context.WithValue(innerCtx, options.ContextKey, opts)
 
-				return action(cliCtx)
+				return action(innerCtx, cliCtx)
 			}
 
-			return runFn(ctx, l, opts, r)
+			return runFn(innerCtx, l, opts, r)
 		}
 
-		return Run(cliCtx, l, opts.OptionsFromContext(cliCtx))
+		return Run(ctx, l, opts.OptionsFromContext(ctx))
 	})
 
-	cmd.Flags = append(cmd.Flags, NewFlags(opts, cmd.Name, nil)...)
+	cmd.Flags = append(cmd.Flags, NewFlags(opts, nil)...)
 
 	return cmd
 }

--- a/cli/commands/dag/graph/cli.go
+++ b/cli/commands/dag/graph/cli.go
@@ -5,6 +5,8 @@
 package graph
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/commands/list"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -27,13 +29,13 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Usage:     "Graph the Directed Acyclic Graph (DAG) in DOT language. Alias for 'list --format=dot --dag --dependencies --external'.",
 		UsageText: "terragrunt dag graph",
 		Flags:     sharedFlags,
-		Action: func(ctx *cli.Context) error {
+		Action: func(ctx context.Context, _ *cli.Context) error {
 			return Run(ctx, l, opts)
 		},
 	}
 }
 
-func Run(ctx *cli.Context, l log.Logger, opts *options.TerragruntOptions) error {
+func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
 	listOpts := list.NewOptions(opts)
 	listOpts.Format = list.FormatDot
 	listOpts.Mode = list.ModeDAG

--- a/cli/commands/dag/graph/cli_test.go
+++ b/cli/commands/dag/graph/cli_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/cli/commands/dag/graph"
-	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/require"
@@ -50,8 +49,8 @@ func BenchmarkRunGraphDependencies(b *testing.B) {
 
 			b.ResetTimer()
 			b.StartTimer()
-			ctx := cli.NewAppContext(b.Context(), cli.NewApp(), nil)
-			err = graph.Run(ctx, logger.CreateLogger(), terragruntOptions)
+
+			err = graph.Run(b.Context(), logger.CreateLogger(), terragruntOptions)
 
 			b.StopTimer()
 			require.NoError(b, err)

--- a/cli/commands/exec/cli.go
+++ b/cli/commands/exec/cli.go
@@ -3,6 +3,8 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -54,8 +56,8 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 			"# Inspect `main.tf` file of module for Unit\nterragrunt exec --in-download-dir -- cat main.tf",
 		},
 		Flags: NewFlags(l, opts, cmdOpts, nil),
-		Action: func(ctx *cli.Context) error {
-			tgArgs, cmdArgs := ctx.Args().Split(cli.BuiltinCmdSep)
+		Action: func(ctx context.Context, cliCtx *cli.Context) error {
+			tgArgs, cmdArgs := cliCtx.Args().Split(cli.BuiltinCmdSep)
 
 			// Use unspecified arguments from the terragrunt command if the user
 			// specified the target command without `--`, e.g. `terragrunt exec ls`.
@@ -64,7 +66,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 			}
 
 			if len(cmdArgs) == 0 {
-				return cli.ShowCommandHelp(ctx)
+				return cli.ShowCommandHelp(ctx, cliCtx)
 			}
 
 			return Run(ctx, l, opts, cmdOpts, cmdArgs)

--- a/cli/commands/find/cli.go
+++ b/cli/commands/find/cli.go
@@ -3,6 +3,8 @@
 package find
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -91,7 +93,7 @@ func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) cli.Flags {
 			EnvVars: tgPrefix.EnvVars(External),
 			Hidden:  true,
 			Usage:   "Discover external dependencies from initial results, and add them to top-level results (implies discovery of dependencies).",
-			Action: func(_ *cli.Context, value bool) error {
+			Action: func(_ context.Context, _ *cli.Context, value bool) error {
 				if !value {
 					return nil
 				}
@@ -125,7 +127,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Aliases: []string{CommandAlias},
 		Usage:   "Find relevant Terragrunt configurations.",
 		Flags:   flags,
-		Before: func(ctx *cli.Context) error {
+		Before: func(_ context.Context, _ *cli.Context) error {
 			if cmdOpts.JSON {
 				cmdOpts.Format = FormatJSON
 			}
@@ -146,7 +148,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 
 			return nil
 		},
-		Action: func(ctx *cli.Context) error {
+		Action: func(ctx context.Context, _ *cli.Context) error {
 			return Run(ctx, l, cmdOpts)
 		},
 	}

--- a/cli/commands/hcl/format/cli.go
+++ b/cli/commands/hcl/format/cli.go
@@ -1,6 +1,8 @@
 package format
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
@@ -91,7 +93,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Aliases: []string{CommandNameAlias},
 		Usage:   "Recursively find HashiCorp Configuration Language (HCL) files and rewrite them into a canonical format.",
 		Flags:   NewFlags(l, opts, nil),
-		Action: func(ctx *cli.Context) error {
+		Action: func(ctx context.Context, _ *cli.Context) error {
 			return Run(ctx, l, opts.OptionsFromContext(ctx))
 		},
 	}

--- a/cli/commands/hcl/validate/cli.go
+++ b/cli/commands/hcl/validate/cli.go
@@ -1,6 +1,8 @@
 package validate
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
@@ -87,7 +89,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Usage:                        "Recursively find HashiCorp Configuration Language (HCL) files and validate them.",
 		Flags:                        NewFlags(l, opts),
 		DisabledErrorOnUndefinedFlag: true,
-		Action: func(ctx *cli.Context) error {
+		Action: func(ctx context.Context, _ *cli.Context) error {
 			return Run(ctx, l, opts.OptionsFromContext(ctx))
 		},
 	}

--- a/cli/commands/hcl/validate/validate.go
+++ b/cli/commands/hcl/validate/validate.go
@@ -142,7 +142,9 @@ func RunValidate(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 				parseErrs = append(parseErrs, errors.New(err))
 			}
 
-			parser := config.NewParsingContext(ctx, l, parseOpts).WithParseOption(parseOptions)
+			ctx, parser := config.NewParsingContext(ctx, l, parseOpts)
+
+			parser = parser.WithParseOption(parseOptions)
 			if values != nil {
 				parser = parser.WithValues(values)
 			}
@@ -153,8 +155,7 @@ func RunValidate(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 				continue
 			}
 
-			//nolint:contextcheck
-			if _, err := config.ParseStackConfig(l, parser, parseOpts, file, values); err != nil {
+			if _, err := config.ParseStackConfig(ctx, l, parser, parseOpts, file, values); err != nil {
 				parseErrs = append(parseErrs, errors.New(err))
 			}
 

--- a/cli/commands/help/cli.go
+++ b/cli/commands/help/cli.go
@@ -2,6 +2,7 @@
 package help
 
 import (
+	"context"
 	"os"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -20,16 +21,16 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Usage:                        "Show help.",
 		Hidden:                       true,
 		DisabledErrorOnUndefinedFlag: true,
-		Action: func(ctx *cli.Context) error {
-			return Action(ctx, l, opts)
+		Action: func(ctx context.Context, cliCtx *cli.Context) error {
+			return Action(ctx, cliCtx, l, opts)
 		},
 	}
 }
 
-func Action(ctx *cli.Context, l log.Logger, opts *options.TerragruntOptions) error {
+func Action(ctx context.Context, cliCtx *cli.Context, l log.Logger, _ *options.TerragruntOptions) error {
 	var (
-		args = ctx.Args()
-		cmds = ctx.Commands
+		args = cliCtx.Args()
+		cmds = cliCtx.Commands
 	)
 
 	if l.Level() >= log.DebugLevel {
@@ -40,7 +41,7 @@ func Action(ctx *cli.Context, l log.Logger, opts *options.TerragruntOptions) err
 	}
 
 	if cmdName := args.CommandName(); cmdName == "" || cmds.Get(cmdName) == nil {
-		return cli.ShowAppHelp(ctx)
+		return cli.ShowAppHelp(ctx, cliCtx)
 	}
 
 	const maxCommandDepth = 1000 // Maximum depth of nested subcommands
@@ -55,11 +56,11 @@ func Action(ctx *cli.Context, l log.Logger, opts *options.TerragruntOptions) err
 
 		args = args.Remove(cmdName)
 		cmds = cmd.Subcommands
-		ctx = ctx.NewCommandContext(cmd, args)
+		cliCtx = cliCtx.NewCommandContext(cmd, args)
 	}
 
-	if ctx.Command != nil {
-		return cli.ShowCommandHelp(ctx)
+	if cliCtx.Command != nil {
+		return cli.ShowCommandHelp(ctx, cliCtx)
 	}
 
 	return cli.NewExitError(errors.New(cli.InvalidCommandNameError(args.First())), cli.ExitCodeGeneralError)

--- a/cli/commands/info/print/cli.go
+++ b/cli/commands/info/print/cli.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	runcmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -19,7 +21,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Usage:     "Print out a short description of Terragrunt context.",
 		UsageText: "terragrunt info print",
 		Flags:     runcmd.NewFlags(l, opts, nil),
-		Action: func(ctx *cli.Context) error {
+		Action: func(ctx context.Context, _ *cli.Context) error {
 			return Run(ctx, l, opts)
 		},
 	}

--- a/cli/commands/list/cli.go
+++ b/cli/commands/list/cli.go
@@ -3,6 +3,8 @@
 package list
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -60,7 +62,7 @@ func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) cli.Flags {
 			EnvVars: tgPrefix.EnvVars(ExternalFlagName),
 			Usage:   "Discover external dependencies from initial results, and add them to top-level results (implies discovery of dependencies).",
 			Hidden:  true,
-			Action: func(_ *cli.Context, value bool) error {
+			Action: func(_ context.Context, _ *cli.Context, value bool) error {
 				if !value {
 					return nil
 				}
@@ -115,7 +117,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Aliases: []string{CommandAlias},
 		Usage:   "List relevant Terragrunt configurations.",
 		Flags:   flags,
-		Before: func(ctx *cli.Context) error {
+		Before: func(_ context.Context, _ *cli.Context) error {
 			if cmdOpts.Tree {
 				cmdOpts.Format = FormatTree
 			}
@@ -140,7 +142,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 
 			return nil
 		},
-		Action: func(ctx *cli.Context) error {
+		Action: func(ctx context.Context, _ *cli.Context) error {
 			return Run(ctx, l, cmdOpts)
 		},
 	}

--- a/cli/commands/render/cli.go
+++ b/cli/commands/render/cli.go
@@ -2,6 +2,8 @@
 package render
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/runall"
 	runcmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
@@ -36,7 +38,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			EnvVars:     tgPrefix.EnvVars(FormatFlagName),
 			Destination: &opts.Format,
 			Usage:       "The output format to render the config in. Currently supports: json",
-			Action: func(ctx *cli.Context, value string) error {
+			Action: func(_ context.Context, _ *cli.Context, value string) error {
 				// Set the default output path based on the format.
 				switch value {
 				case FormatJSON:
@@ -61,7 +63,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) cli.Flags {
 			Name:    JSONFlagName,
 			EnvVars: tgPrefix.EnvVars(JSONFlagName),
 			Usage:   "Render the config in JSON format. Equivalent to --format=json.",
-			Action: func(ctx *cli.Context, value bool) error {
+			Action: func(_ context.Context, _ *cli.Context, value bool) error {
 				opts.Format = FormatJSON
 
 				if opts.OutputPath == "" {
@@ -122,7 +124,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Usage:       "Render the final terragrunt config, with all variables, includes, and functions resolved, in the specified format.",
 		Description: "This is useful for enforcing policies using static analysis tools like Open Policy Agent, or for debugging your terragrunt config.",
 		Flags:       append(runcmd.NewFlags(l, opts, nil), NewFlags(renderOpts, prefix)...),
-		Action: func(ctx *cli.Context) error {
+		Action: func(ctx context.Context, _ *cli.Context) error {
 			tgOpts := opts.OptionsFromContext(ctx)
 			renderOpts := renderOpts.Clone()
 			renderOpts.TerragruntOptions = tgOpts

--- a/cli/commands/run/cli.go
+++ b/cli/commands/run/cli.go
@@ -2,6 +2,7 @@
 package run
 
 import (
+	"context"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/cli/commands/common/graph"
@@ -33,12 +34,12 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		},
 		Flags:       NewFlags(l, opts, nil),
 		Subcommands: NewSubcommands(l, opts),
-		Action: func(ctx *cli.Context) error {
-			if len(ctx.Args()) == 0 {
-				return cli.ShowCommandHelp(ctx)
+		Action: func(ctx context.Context, cliCtx *cli.Context) error {
+			if len(cliCtx.Args()) == 0 {
+				return cli.ShowCommandHelp(ctx, cliCtx)
 			}
 
-			return Action(l, opts)(ctx)
+			return Action(l, opts)(ctx, cliCtx)
 		},
 	}
 
@@ -59,8 +60,8 @@ func NewSubcommands(l log.Logger, opts *options.TerragruntOptions) cli.Commands 
 			Usage:      usage,
 			Hidden:     !visible,
 			CustomHelp: ShowTFHelp(l, opts),
-			Action: func(ctx *cli.Context) error {
-				return Action(l, opts)(ctx)
+			Action: func(ctx context.Context, cliCtx *cli.Context) error {
+				return Action(l, opts)(ctx, cliCtx)
 			},
 		}
 		subcommands[i] = subcommand
@@ -70,14 +71,14 @@ func NewSubcommands(l log.Logger, opts *options.TerragruntOptions) cli.Commands 
 }
 
 func Action(l log.Logger, opts *options.TerragruntOptions) cli.ActionFunc {
-	return func(ctx *cli.Context) error {
+	return func(ctx context.Context, _ *cli.Context) error {
 		if opts.TerraformCommand == tf.CommandNameDestroy {
 			opts.CheckDependentModules = opts.DestroyDependenciesCheck
 		}
 
 		r := report.NewReport().WithWorkingDir(opts.WorkingDir)
 
-		return run.Run(ctx.Context, l, opts.OptionsFromContext(ctx), r)
+		return run.Run(ctx, l, opts.OptionsFromContext(ctx), r)
 	}
 }
 

--- a/cli/commands/run/flags.go
+++ b/cli/commands/run/flags.go
@@ -2,6 +2,7 @@
 package run
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -232,7 +233,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Name:    DependencyFetchOutputFromStateFlagName,
 			EnvVars: tgPrefix.EnvVars(DependencyFetchOutputFromStateFlagName),
 			Usage:   "Enable the dependency-fetch-output-from-state experiment to fetch dependency output directly from the state file instead of using tofu/terraform output.",
-			Action: func(_ *cli.Context, val bool) error {
+			Action: func(_ context.Context, _ *cli.Context, val bool) error {
 				if val {
 					return opts.Experiments.EnableExperiment(experiment.DependencyFetchOutputFromState)
 				}
@@ -264,9 +265,9 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			EnvVars: tgPrefix.EnvVars(UnitsThatIncludeFlagName),
 			Usage:   "If flag is set, 'run --all' will only run the command against Terragrunt modules that include the specified file.",
 			Hidden:  true,
-			Action: func(ctx *cli.Context, value []string) error {
+			Action: func(ctx context.Context, _ *cli.Context, value []string) error {
 				if len(value) != 0 {
-					if err := opts.StrictControls.FilterByNames(controls.UnitsThatInclude).Evaluate(ctx.Context); err != nil {
+					if err := opts.StrictControls.FilterByNames(controls.UnitsThatInclude).Evaluate(ctx); err != nil {
 						return err
 					}
 
@@ -288,9 +289,9 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Destination: &opts.DisableCommandValidation,
 			Usage:       "When this flag is set, Terragrunt will not validate the tofu/terraform command.",
 			Hidden:      true,
-			Action: func(ctx *cli.Context, value bool) error {
+			Action: func(ctx context.Context, _ *cli.Context, value bool) error {
 				if value {
-					return opts.StrictControls.FilterByNames(controls.DisableCommandValidation).Evaluate(ctx.Context)
+					return opts.StrictControls.FilterByNames(controls.DisableCommandValidation).Evaluate(ctx)
 				}
 				return nil
 			},
@@ -302,9 +303,9 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			EnvVars: tgPrefix.EnvVars(NoDestroyDependenciesCheckFlagName),
 			Usage:   "When this flag is set, Terragrunt will not check for dependent units when destroying.",
 			Hidden:  true,
-			Action: func(ctx *cli.Context, value bool) error {
+			Action: func(ctx context.Context, _ *cli.Context, value bool) error {
 				if value {
-					return opts.StrictControls.FilterByNames(controls.NoDestroyDependenciesCheck).Evaluate(ctx.Context)
+					return opts.StrictControls.FilterByNames(controls.NoDestroyDependenciesCheck).Evaluate(ctx)
 				}
 				return nil
 			},
@@ -376,7 +377,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			EnvVars: tgPrefix.EnvVars(EngineEnableFlagName),
 			Usage:   "Enable the iac-engine experiment to use IaC engines.",
 			Hidden:  true,
-			Action: func(_ *cli.Context, val bool) error {
+			Action: func(_ context.Context, _ *cli.Context, val bool) error {
 				if val {
 					return opts.Experiments.EnableExperiment(experiment.IacEngine)
 				}

--- a/cli/commands/run/help.go
+++ b/cli/commands/run/help.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -28,22 +29,22 @@ const TFCommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Comman
 {{ $tfHelp }}{{ end }}
 `
 
-// ShowTFHelp prints TF help for the given `ctx.Command` command.
+// ShowTFHelp prints TF help for the given `cliCtx.Command` command.
 func ShowTFHelp(l log.Logger, opts *options.TerragruntOptions) cli.HelpFunc {
-	return func(ctx *cli.Context) error {
-		if err := shared.NewTFPathFlag(opts).Parse(ctx.Args()); err != nil {
+	return func(ctx context.Context, cliCtx *cli.Context) error {
+		if err := shared.NewTFPathFlag(opts).Parse(cliCtx.Args()); err != nil {
 			return err
 		}
 
-		cli.HelpPrinterCustom(ctx, TFCommandHelpTemplate, map[string]any{
+		cli.HelpPrinterCustom(cliCtx, TFCommandHelpTemplate, map[string]any{
 			"isTerraformPath": func() bool {
 				return isTerraformPath(opts)
 			},
 			"runTFHelp": func() string {
-				return runTFHelp(ctx, l, opts)
+				return runTFHelp(ctx, cliCtx, l, opts)
 			},
 			"tfCommand": func() string {
-				return ctx.Command.Name
+				return cliCtx.Command.Name
 			},
 		})
 
@@ -51,11 +52,11 @@ func ShowTFHelp(l log.Logger, opts *options.TerragruntOptions) cli.HelpFunc {
 	}
 }
 
-func runTFHelp(ctx *cli.Context, l log.Logger, opts *options.TerragruntOptions) string {
+func runTFHelp(ctx context.Context, cliCtx *cli.Context, l log.Logger, opts *options.TerragruntOptions) string {
 	opts = opts.Clone()
 	opts.Writer = io.Discard
 
-	terraformHelpCmd := []string{tf.FlagNameHelpLong, ctx.Command.Name}
+	terraformHelpCmd := []string{tf.FlagNameHelpLong, cliCtx.Command.Name}
 
 	out, err := tf.RunCommandWithOutput(ctx, l, opts, terraformHelpCmd...)
 	if err != nil {

--- a/cli/commands/scaffold/cli.go
+++ b/cli/commands/scaffold/cli.go
@@ -73,14 +73,14 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 		Name:  CommandName,
 		Usage: "Scaffold a new Terragrunt module.",
 		Flags: flags,
-		Action: func(ctx *cli.Context) error {
+		Action: func(ctx context.Context, cliCtx *cli.Context) error {
 			var moduleURL, templateURL string
 
-			if val := ctx.Args().Get(0); val != "" {
+			if val := cliCtx.Args().Get(0); val != "" {
 				moduleURL = val
 			}
 
-			if val := ctx.Args().Get(1); val != "" {
+			if val := cliCtx.Args().Get(1); val != "" {
 				templateURL = val
 			}
 

--- a/cli/commands/stack/cli.go
+++ b/cli/commands/stack/cli.go
@@ -2,6 +2,8 @@
 package stack
 
 import (
+	"context"
+
 	runcmd "github.com/gruntwork-io/terragrunt/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli"
@@ -35,36 +37,36 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *cli.Command {
 			&cli.Command{
 				Name:  generateCommandName,
 				Usage: "Generate a stack from a terragrunt.stack.hcl file",
-				Action: func(ctx *cli.Context) error {
-					return RunGenerate(ctx.Context, l, opts.OptionsFromContext(ctx))
+				Action: func(ctx context.Context, _ *cli.Context) error {
+					return RunGenerate(ctx, l, opts.OptionsFromContext(ctx))
 				},
 				Flags: defaultFlags(l, opts, nil),
 			},
 			&cli.Command{
 				Name:  runCommandName,
 				Usage: "Run a command on the stack generated from the current directory",
-				Action: func(ctx *cli.Context) error {
-					return Run(ctx.Context, l, opts.OptionsFromContext(ctx))
+				Action: func(ctx context.Context, _ *cli.Context) error {
+					return Run(ctx, l, opts.OptionsFromContext(ctx))
 				},
 				Flags: defaultFlags(l, opts, nil),
 			},
 			&cli.Command{
 				Name:  outputCommandName,
 				Usage: "Run fetch stack output",
-				Action: func(ctx *cli.Context) error {
+				Action: func(ctx context.Context, cliCtx *cli.Context) error {
 					index := ""
-					if val := ctx.Args().Get(0); val != "" {
+					if val := cliCtx.Args().Get(0); val != "" {
 						index = val
 					}
-					return RunOutput(ctx.Context, l, opts.OptionsFromContext(ctx), index)
+					return RunOutput(ctx, l, opts.OptionsFromContext(ctx), index)
 				},
 				Flags: outputFlags(l, opts, nil),
 			},
 			&cli.Command{
 				Name:  cleanCommandName,
 				Usage: "Clean the stack generated from the current directory",
-				Action: func(ctx *cli.Context) error {
-					return RunClean(ctx.Context, l, opts.OptionsFromContext(ctx))
+				Action: func(ctx context.Context, _ *cli.Context) error {
+					return RunClean(ctx, l, opts.OptionsFromContext(ctx))
 				},
 			},
 		},
@@ -101,7 +103,7 @@ func outputFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Pre
 		flags.NewFlag(&cli.BoolFlag{
 			Name:  RawFormatFlagName,
 			Usage: "Stack output in raw format",
-			Action: func(ctx *cli.Context, value bool) error {
+			Action: func(_ context.Context, _ *cli.Context, value bool) error {
 				opts.StackOutputFormat = rawOutputFormat
 				return nil
 			},
@@ -109,7 +111,7 @@ func outputFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Pre
 		flags.NewFlag(&cli.BoolFlag{
 			Name:  JSONFormatFlagName,
 			Usage: "Stack output in json format",
-			Action: func(ctx *cli.Context, value bool) error {
+			Action: func(_ context.Context, _ *cli.Context, value bool) error {
 				opts.StackOutputFormat = jsonOutputFormat
 				return nil
 			},

--- a/cli/commands/version/cli.go
+++ b/cli/commands/version/cli.go
@@ -2,26 +2,27 @@
 package version
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/internal/cli"
-	"github.com/gruntwork-io/terragrunt/options"
 )
 
 const (
 	CommandName = "version"
 )
 
-func NewCommand(opts *options.TerragruntOptions) *cli.Command {
+func NewCommand() *cli.Command {
 	return &cli.Command{
 		Name:                         CommandName,
 		Usage:                        "Show terragrunt version.",
 		Hidden:                       true,
 		DisabledErrorOnUndefinedFlag: true,
-		Action: func(ctx *cli.Context) error {
-			return cli.NewExitError(Action(ctx), 0)
+		Action: func(ctx context.Context, cliCtx *cli.Context) error {
+			return cli.NewExitError(Action(ctx, cliCtx), 0)
 		},
 	}
 }
 
-func Action(ctx *cli.Context) error {
-	return cli.ShowVersion(ctx)
+func Action(ctx context.Context, cliCtx *cli.Context) error {
+	return cli.ShowVersion(ctx, cliCtx)
 }

--- a/cli/flags/flag.go
+++ b/cli/flags/flag.go
@@ -122,7 +122,7 @@ func (newFlag *Flag) Apply(set *flag.FlagSet) error {
 }
 
 // RunAction implements `cli.Flag` interface.
-func (newFlag *Flag) RunAction(ctx *cli.Context) error {
+func (newFlag *Flag) RunAction(ctx context.Context, cliCtx *cli.Context) error {
 	for _, deprecated := range newFlag.deprecatedFlags {
 		if err := newFlag.evaluateWrapper(ctx, deprecated.Evaluate); err != nil {
 			return err
@@ -132,7 +132,7 @@ func (newFlag *Flag) RunAction(ctx *cli.Context) error {
 			continue
 		}
 
-		if err := deprecated.RunAction(ctx); err != nil {
+		if err := deprecated.RunAction(ctx, cliCtx); err != nil {
 			return err
 		}
 	}
@@ -145,7 +145,7 @@ func (newFlag *Flag) RunAction(ctx *cli.Context) error {
 		}
 	}
 
-	return newFlag.Flag.RunAction(ctx)
+	return newFlag.Flag.RunAction(ctx, cliCtx)
 }
 
 // Parse parses the given `args` for the flag value and env vars values specified in the flag.

--- a/cli/flags/flag_test.go
+++ b/cli/flags/flag_test.go
@@ -147,7 +147,7 @@ func TestFlag_Evaluate(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				err = testFlag.flag.RunAction(cli.NewAppContext(ctx, nil, nil))
+				err = testFlag.flag.RunAction(ctx, cli.NewAppContext(nil, nil))
 				require.NoError(t, err)
 			}
 

--- a/cli/flags/global/flags.go
+++ b/cli/flags/global/flags.go
@@ -2,6 +2,7 @@
 package global
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/gruntwork-io/go-commons/collections"
@@ -130,7 +131,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			EnvVars: tgPrefix.EnvVars(LogFormatFlagName),
 			Usage:   "Set the log format.",
 			Setter:  l.Formatter().SetFormat,
-			Action: func(_ *cli.Context, val string) error {
+			Action: func(_ context.Context, _ *cli.Context, val string) error {
 				switch val {
 				case format.BareFormatName:
 					opts.ForwardTFStdout = true
@@ -185,7 +186,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			EnvVars: tgPrefix.EnvVars(ExperimentFlagName),
 			Usage:   "Enables specific experiments. For a list of available experiments, see https://terragrunt.gruntwork.io/docs/reference/experiment-mode .",
 			Setter:  opts.Experiments.EnableExperiment,
-			Action: func(_ *cli.Context, val []string) error {
+			Action: func(_ context.Context, _ *cli.Context, _ []string) error {
 				opts.Experiments.NotifyCompletedExperiments(l)
 
 				return nil
@@ -204,7 +205,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 
 				return nil
 			},
-			Action: func(_ *cli.Context, _ bool) error {
+			Action: func(_ context.Context, _ *cli.Context, _ bool) error {
 				opts.StrictControls.LogEnabled(l)
 
 				return nil
@@ -219,7 +220,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Setter: func(val string) error {
 				return opts.StrictControls.EnableControl(val)
 			},
-			Action: func(_ *cli.Context, _ []string) error {
+			Action: func(_ context.Context, _ *cli.Context, _ []string) error {
 				opts.StrictControls.LogEnabled(l)
 
 				return nil
@@ -294,7 +295,7 @@ func NewLogLevelFlag(l log.Logger, opts *options.TerragruntOptions, prefix flags
 		DefaultText: l.Level().String(),
 		Setter:      l.SetLevel,
 		Usage:       fmt.Sprintf("Sets the logging level for Terragrunt. Supported levels: %s.", log.AllLevels),
-		Action: func(_ *cli.Context, val string) error {
+		Action: func(_ context.Context, _ *cli.Context, val string) error {
 			// Before the release of v0.67.0, these levels actually disabled logs, since we do not use these levels for logging.
 			// For backward compatibility we simulate the same behavior.
 			removedLevels := []string{
@@ -318,16 +319,16 @@ func NewHelpVersionFlags(l log.Logger, opts *options.TerragruntOptions) cli.Flag
 			Name:    HelpFlagName,  // --help, -help
 			Aliases: []string{"h"}, //  -h
 			Usage:   "Show help.",
-			Action: func(ctx *cli.Context, _ bool) error {
-				return help.Action(ctx, l, opts)
+			Action: func(ctx context.Context, cliCtx *cli.Context, _ bool) error {
+				return help.Action(ctx, cliCtx, l, opts)
 			},
 		},
 		&cli.BoolFlag{
 			Name:    VersionFlagName, // --version, -version
 			Aliases: []string{"v"},   //  -v
 			Usage:   "Show terragrunt version.",
-			Action: func(ctx *cli.Context, _ bool) (err error) {
-				return version.Action(ctx)
+			Action: func(ctx context.Context, cliCtx *cli.Context, _ bool) (err error) {
+				return version.Action(ctx, cliCtx)
 			},
 		},
 	}

--- a/cli/flags/shared/shared.go
+++ b/cli/flags/shared/shared.go
@@ -5,6 +5,7 @@
 package shared
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/gruntwork-io/terragrunt/cli/flags"
@@ -121,9 +122,9 @@ func NewQueueFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Fla
 				EnvVars: tgPrefix.EnvVars(QueueExcludeExternalFlagName),
 				Usage:   "Ignore external dependencies for --all commands.",
 				Hidden:  true,
-				Action: func(ctx *cli.Context, value bool) error {
+				Action: func(ctx context.Context, _ *cli.Context, value bool) error {
 					if value {
-						return opts.StrictControls.FilterByNames(controls.QueueExcludeExternal).Evaluate(ctx.Context)
+						return opts.StrictControls.FilterByNames(controls.QueueExcludeExternal).Evaluate(ctx)
 					}
 					return nil
 				},
@@ -137,7 +138,7 @@ func NewQueueFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Fla
 				EnvVars: tgPrefix.EnvVars(QueueIncludeExternalFlagName),
 				Usage:   "Include external dependencies for --all commands.",
 				Hidden:  true,
-				Action: func(ctx *cli.Context, value bool) error {
+				Action: func(_ context.Context, _ *cli.Context, value bool) error {
 					if !value {
 						return nil
 					}
@@ -166,7 +167,7 @@ func NewQueueFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Fla
 				EnvVars: tgPrefix.EnvVars(QueueExcludeDirFlagName),
 				Hidden:  true,
 				Usage:   "Unix-style glob of directories to exclude from the queue of Units to run.",
-				Action: func(_ *cli.Context, value []string) error {
+				Action: func(_ context.Context, _ *cli.Context, value []string) error {
 					if len(value) == 0 {
 						return nil
 					}
@@ -189,7 +190,7 @@ func NewQueueFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Fla
 				EnvVars: tgPrefix.EnvVars(QueueIncludeDirFlagName),
 				Hidden:  true,
 				Usage:   "Unix-style glob of directories to include from the queue of Units to run.",
-				Action: func(_ *cli.Context, value []string) error {
+				Action: func(_ context.Context, _ *cli.Context, value []string) error {
 					if len(value) == 0 {
 						return nil
 					}
@@ -212,9 +213,9 @@ func NewQueueFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Fla
 				EnvVars: tgPrefix.EnvVars(QueueStrictIncludeFlagName),
 				Usage:   "If flag is set, only modules under the directories passed in with '--queue-include-dir' will be included.",
 				Hidden:  true,
-				Action: func(ctx *cli.Context, value bool) error {
+				Action: func(ctx context.Context, _ *cli.Context, value bool) error {
 					if value {
-						return opts.StrictControls.FilterByNames(controls.QueueStrictInclude).Evaluate(ctx.Context)
+						return opts.StrictControls.FilterByNames(controls.QueueStrictInclude).Evaluate(ctx)
 					}
 					return nil
 				},
@@ -228,7 +229,7 @@ func NewQueueFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.Fla
 				EnvVars: tgPrefix.EnvVars(QueueIncludeUnitsReadingFlagName),
 				Usage:   "If flag is set, 'run --all' will only run the command against units that read the specified file via a Terragrunt HCL function or include.",
 				Hidden:  true,
-				Action: func(ctx *cli.Context, value []string) error {
+				Action: func(_ context.Context, _ *cli.Context, value []string) error {
 					if len(value) == 0 {
 						return nil
 					}
@@ -263,7 +264,7 @@ func NewFilterFlags(l log.Logger, opts *options.TerragruntOptions) cli.Flags {
 				Name:    FilterAffectedFlagName,
 				EnvVars: tgPrefix.EnvVars(FilterAffectedFlagName),
 				Usage:   "Filter components affected by changes between main and HEAD. Equivalent to --filter=[main...HEAD].",
-				Action: func(ctx *cli.Context, val bool) error {
+				Action: func(ctx context.Context, _ *cli.Context, val bool) error {
 					if !val {
 						return nil
 					}
@@ -286,11 +287,11 @@ func NewFilterFlags(l log.Logger, opts *options.TerragruntOptions) cli.Flags {
 
 					gitRunner = gitRunner.WithWorkDir(workDir)
 
-					if gitRunner.HasUncommittedChanges(ctx.Context) {
+					if gitRunner.HasUncommittedChanges(ctx) {
 						l.Warnf("Warning: You have uncommitted changes. The --filter-affected flag may not include all your local modifications.")
 					}
 
-					defaultBranch := gitRunner.GetDefaultBranch(ctx.Context, l)
+					defaultBranch := gitRunner.GetDefaultBranch(ctx, l)
 
 					opts.FilterQueries = append(opts.FilterQueries, fmt.Sprintf("[%s...HEAD]", defaultBranch))
 
@@ -335,7 +336,7 @@ func NewScaffoldingFlags(opts *options.TerragruntOptions, prefix flags.Prefix) c
 			EnvVars:     tgPrefix.EnvVars(RootFileNameFlagName),
 			Destination: &opts.ScaffoldRootFileName,
 			Usage:       "Name of the root Terragrunt configuration file, if used.",
-			Action: func(ctx *cli.Context, value string) error {
+			Action: func(ctx context.Context, _ *cli.Context, value string) error {
 				if value == "" {
 					return cli.NewExitError("root-file-name flag cannot be empty", cli.ExitCodeGeneralError)
 				}
@@ -438,7 +439,7 @@ func NewFeatureFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli.F
 			EnvVars: tgPrefix.EnvVars(FeatureFlagName),
 			Usage:   "Set feature flags for the HCL code.",
 			// Use default splitting behavior with comma separators via MapFlag defaults
-			Action: func(_ *cli.Context, value map[string]string) error {
+			Action: func(_ context.Context, _ *cli.Context, value map[string]string) error {
 				for key, val := range value {
 					opts.FeatureFlags.Store(key, val)
 				}

--- a/cli/help_test.go
+++ b/cli/help_test.go
@@ -79,8 +79,8 @@ func TestCommandHelpTemplate(t *testing.T) {
 
 	app.Writer = &out
 
-	ctx := cli.NewAppContext(t.Context(), app, nil).NewCommandContext(cmd, nil)
-	require.Error(t, cli.ShowCommandHelp(ctx))
+	cliCtx := cli.NewAppContext(app, nil).NewCommandContext(cmd, nil)
+	require.Error(t, cli.ShowCommandHelp(t.Context(), cliCtx))
 
 	expectedOutput := fmt.Sprintf(`Usage: terragrunt run [options] -- <tofu/terraform command>
 

--- a/config/config_as_cty_test.go
+++ b/config/config_as_cty_test.go
@@ -234,8 +234,8 @@ func TestStackUnitCtyReading(t *testing.T) {
 
 	l := logger.CreateLogger()
 	options := terragruntOptionsForTest(t, config.DefaultTerragruntConfigPath)
-	ctx := config.NewParsingContext(t.Context(), l, options)
-	tgConfigCty, err := config.ParseTerragruntConfig(ctx, l, "../test/fixtures/stacks/basic/live/terragrunt.stack.hcl", nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, options)
+	tgConfigCty, err := config.ParseTerragruntConfig(ctx, pctx, l, "../test/fixtures/stacks/basic/live/terragrunt.stack.hcl", nil)
 	require.NoError(t, err)
 	stackMap, err := ctyhelper.ParseCtyValueToMap(tgConfigCty)
 	require.NoError(t, err)
@@ -254,8 +254,8 @@ func TestStackLocalsCtyReading(t *testing.T) {
 
 	l := logger.CreateLogger()
 	options := terragruntOptionsForTest(t, config.DefaultTerragruntConfigPath)
-	ctx := config.NewParsingContext(t.Context(), l, options)
-	tgConfigCty, err := config.ParseTerragruntConfig(ctx, l, "../test/fixtures/stacks/locals/live/terragrunt.stack.hcl", nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, options)
+	tgConfigCty, err := config.ParseTerragruntConfig(ctx, pctx, l, "../test/fixtures/stacks/locals/live/terragrunt.stack.hcl", nil)
 	require.NoError(t, err)
 	stackMap, err := ctyhelper.ParseCtyValueToMap(tgConfigCty)
 	require.NoError(t, err)

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -145,82 +145,82 @@ type TrackInclude struct {
 
 // Create an EvalContext for the HCL2 parser. We can define functions and variables in this ctx that the HCL2 parser
 // will make available to the Terragrunt configuration during parsing.
-func createTerragruntEvalContext(ctx *ParsingContext, l log.Logger, configPath string) (*hcl.EvalContext, error) {
+func createTerragruntEvalContext(ctx context.Context, pctx *ParsingContext, l log.Logger, configPath string) (*hcl.EvalContext, error) {
 	tfscope := tflang.Scope{
 		BaseDir: filepath.Dir(configPath),
 	}
 
 	terragruntFunctions := map[string]function.Function{
-		FuncNameFindInParentFolders:                     wrapStringSliceToStringAsFuncImpl(ctx, l, FindInParentFolders),
-		FuncNamePathRelativeToInclude:                   wrapStringSliceToStringAsFuncImpl(ctx, l, PathRelativeToInclude),
-		FuncNamePathRelativeFromInclude:                 wrapStringSliceToStringAsFuncImpl(ctx, l, PathRelativeFromInclude),
-		FuncNameGetEnv:                                  wrapStringSliceToStringAsFuncImpl(ctx, l, getEnvironmentVariable),
-		FuncNameRunCmd:                                  wrapStringSliceToStringAsFuncImpl(ctx, l, RunCommand),
-		FuncNameReadTerragruntConfig:                    readTerragruntConfigAsFuncImpl(ctx, l),
-		FuncNameGetPlatform:                             wrapVoidToStringAsFuncImpl(ctx, l, getPlatform),
-		FuncNameGetRepoRoot:                             wrapVoidToStringAsFuncImpl(ctx, l, getRepoRoot),
-		FuncNameGetPathFromRepoRoot:                     wrapVoidToStringAsFuncImpl(ctx, l, getPathFromRepoRoot),
-		FuncNameGetPathToRepoRoot:                       wrapVoidToStringAsFuncImpl(ctx, l, getPathToRepoRoot),
-		FuncNameGetTerragruntDir:                        wrapVoidToStringAsFuncImpl(ctx, l, GetTerragruntDir),
-		FuncNameGetOriginalTerragruntDir:                wrapVoidToStringAsFuncImpl(ctx, l, getOriginalTerragruntDir),
-		FuncNameGetTerraformCommand:                     wrapVoidToStringAsFuncImpl(ctx, l, getTerraformCommand),
-		FuncNameGetTerraformCLIArgs:                     wrapVoidToStringSliceAsFuncImpl(ctx, l, getTerraformCliArgs),
-		FuncNameGetParentTerragruntDir:                  wrapStringSliceToStringAsFuncImpl(ctx, l, GetParentTerragruntDir),
-		FuncNameGetAWSAccountAlias:                      wrapVoidToStringAsFuncImpl(ctx, l, getAWSAccountAlias),
-		FuncNameGetAWSAccountID:                         wrapVoidToStringAsFuncImpl(ctx, l, getAWSAccountID),
-		FuncNameGetAWSCallerIdentityArn:                 wrapVoidToStringAsFuncImpl(ctx, l, getAWSCallerIdentityARN),
-		FuncNameGetAWSCallerIdentityUserID:              wrapVoidToStringAsFuncImpl(ctx, l, getAWSCallerIdentityUserID),
+		FuncNameFindInParentFolders:                     wrapStringSliceToStringAsFuncImpl(ctx, pctx, l, FindInParentFolders),
+		FuncNamePathRelativeToInclude:                   wrapStringSliceToStringAsFuncImpl(ctx, pctx, l, PathRelativeToInclude),
+		FuncNamePathRelativeFromInclude:                 wrapStringSliceToStringAsFuncImpl(ctx, pctx, l, PathRelativeFromInclude),
+		FuncNameGetEnv:                                  wrapStringSliceToStringAsFuncImpl(ctx, pctx, l, getEnvironmentVariable),
+		FuncNameRunCmd:                                  wrapStringSliceToStringAsFuncImpl(ctx, pctx, l, RunCommand),
+		FuncNameReadTerragruntConfig:                    readTerragruntConfigAsFuncImpl(ctx, pctx, l),
+		FuncNameGetPlatform:                             wrapVoidToStringAsFuncImpl(ctx, pctx, l, getPlatform),
+		FuncNameGetRepoRoot:                             wrapVoidToStringAsFuncImpl(ctx, pctx, l, getRepoRoot),
+		FuncNameGetPathFromRepoRoot:                     wrapVoidToStringAsFuncImpl(ctx, pctx, l, getPathFromRepoRoot),
+		FuncNameGetPathToRepoRoot:                       wrapVoidToStringAsFuncImpl(ctx, pctx, l, getPathToRepoRoot),
+		FuncNameGetTerragruntDir:                        wrapVoidToStringAsFuncImpl(ctx, pctx, l, GetTerragruntDir),
+		FuncNameGetOriginalTerragruntDir:                wrapVoidToStringAsFuncImpl(ctx, pctx, l, getOriginalTerragruntDir),
+		FuncNameGetTerraformCommand:                     wrapVoidToStringAsFuncImpl(ctx, pctx, l, getTerraformCommand),
+		FuncNameGetTerraformCLIArgs:                     wrapVoidToStringSliceAsFuncImpl(ctx, pctx, l, getTerraformCliArgs),
+		FuncNameGetParentTerragruntDir:                  wrapStringSliceToStringAsFuncImpl(ctx, pctx, l, GetParentTerragruntDir),
+		FuncNameGetAWSAccountAlias:                      wrapVoidToStringAsFuncImpl(ctx, pctx, l, getAWSAccountAlias),
+		FuncNameGetAWSAccountID:                         wrapVoidToStringAsFuncImpl(ctx, pctx, l, getAWSAccountID),
+		FuncNameGetAWSCallerIdentityArn:                 wrapVoidToStringAsFuncImpl(ctx, pctx, l, getAWSCallerIdentityARN),
+		FuncNameGetAWSCallerIdentityUserID:              wrapVoidToStringAsFuncImpl(ctx, pctx, l, getAWSCallerIdentityUserID),
 		FuncNameGetTerraformCommandsThatNeedVars:        wrapStaticValueToStringSliceAsFuncImpl(TerraformCommandsNeedVars),
 		FuncNameGetTerraformCommandsThatNeedLocking:     wrapStaticValueToStringSliceAsFuncImpl(TerraformCommandsNeedLocking),
 		FuncNameGetTerraformCommandsThatNeedInput:       wrapStaticValueToStringSliceAsFuncImpl(TerraformCommandsNeedInput),
 		FuncNameGetTerraformCommandsThatNeedParallelism: wrapStaticValueToStringSliceAsFuncImpl(TerraformCommandsNeedParallelism),
-		FuncNameSopsDecryptFile:                         wrapStringSliceToStringAsFuncImpl(ctx, l, sopsDecryptFile),
-		FuncNameGetTerragruntSourceCLIFlag:              wrapVoidToStringAsFuncImpl(ctx, l, getTerragruntSourceCliFlag),
-		FuncNameGetDefaultRetryableErrors:               wrapVoidToStringSliceAsFuncImpl(ctx, l, getDefaultRetryableErrors),
-		FuncNameReadTfvarsFile:                          wrapStringSliceToStringAsFuncImpl(ctx, l, readTFVarsFile),
-		FuncNameGetWorkingDir:                           wrapVoidToStringAsFuncImpl(ctx, l, getWorkingDir),
-		FuncNameMarkAsRead:                              wrapStringSliceToStringAsFuncImpl(ctx, l, markAsRead),
-		FuncNameConstraintCheck:                         wrapStringSliceToBoolAsFuncImpl(ctx, ConstraintCheck),
+		FuncNameSopsDecryptFile:                         wrapStringSliceToStringAsFuncImpl(ctx, pctx, l, sopsDecryptFile),
+		FuncNameGetTerragruntSourceCLIFlag:              wrapVoidToStringAsFuncImpl(ctx, pctx, l, getTerragruntSourceCliFlag),
+		FuncNameGetDefaultRetryableErrors:               wrapVoidToStringSliceAsFuncImpl(ctx, pctx, l, getDefaultRetryableErrors),
+		FuncNameReadTfvarsFile:                          wrapStringSliceToStringAsFuncImpl(ctx, pctx, l, readTFVarsFile),
+		FuncNameGetWorkingDir:                           wrapVoidToStringAsFuncImpl(ctx, pctx, l, getWorkingDir),
+		FuncNameMarkAsRead:                              wrapStringSliceToStringAsFuncImpl(ctx, pctx, l, markAsRead),
+		FuncNameConstraintCheck:                         wrapStringSliceToBoolAsFuncImpl(ctx, pctx, ConstraintCheck),
 
 		// Map with HCL functions introduced in Terraform after v0.15.3, since upgrade to a later version is not supported
 		// https://github.com/gruntwork-io/terragrunt/blob/master/go.mod#L22
-		FuncNameStartsWith:  wrapStringSliceToBoolAsFuncImpl(ctx, StartsWith),
-		FuncNameEndsWith:    wrapStringSliceToBoolAsFuncImpl(ctx, EndsWith),
-		FuncNameStrContains: wrapStringSliceToBoolAsFuncImpl(ctx, StrContains),
-		FuncNameTimeCmp:     wrapStringSliceToNumberAsFuncImpl(ctx, l, TimeCmp),
+		FuncNameStartsWith:  wrapStringSliceToBoolAsFuncImpl(ctx, pctx, StartsWith),
+		FuncNameEndsWith:    wrapStringSliceToBoolAsFuncImpl(ctx, pctx, EndsWith),
+		FuncNameStrContains: wrapStringSliceToBoolAsFuncImpl(ctx, pctx, StrContains),
+		FuncNameTimeCmp:     wrapStringSliceToNumberAsFuncImpl(ctx, pctx, l, TimeCmp),
 	}
 
 	functions := map[string]function.Function{}
 
 	maps.Copy(functions, tfscope.Functions())
 	maps.Copy(functions, terragruntFunctions)
-	maps.Copy(functions, ctx.PredefinedFunctions)
+	maps.Copy(functions, pctx.PredefinedFunctions)
 
 	evalCtx := &hcl.EvalContext{
 		Functions: functions,
 	}
 
 	evalCtx.Variables = map[string]cty.Value{}
-	if ctx.Locals != nil {
-		evalCtx.Variables[MetadataLocal] = *ctx.Locals
+	if pctx.Locals != nil {
+		evalCtx.Variables[MetadataLocal] = *pctx.Locals
 	}
 
-	if ctx.Features != nil {
-		evalCtx.Variables[MetadataFeatureFlag] = *ctx.Features
+	if pctx.Features != nil {
+		evalCtx.Variables[MetadataFeatureFlag] = *pctx.Features
 	}
 
-	if ctx.Values != nil {
-		evalCtx.Variables[MetadataValues] = *ctx.Values
+	if pctx.Values != nil {
+		evalCtx.Variables[MetadataValues] = *pctx.Values
 	}
 
-	if ctx.DecodedDependencies != nil {
-		evalCtx.Variables[MetadataDependency] = *ctx.DecodedDependencies
+	if pctx.DecodedDependencies != nil {
+		evalCtx.Variables[MetadataDependency] = *pctx.DecodedDependencies
 	}
 
-	if ctx.TrackInclude != nil && len(ctx.TrackInclude.CurrentList) > 0 {
+	if pctx.TrackInclude != nil && len(pctx.TrackInclude.CurrentList) > 0 {
 		// For each include block, check if we want to expose the included config, and if so, add under the include
 		// variable.
-		exposedInclude, err := includeMapAsCtyVal(ctx, l)
+		exposedInclude, err := includeMapAsCtyVal(ctx, pctx, l)
 		if err != nil {
 			return evalCtx, err
 		}
@@ -232,25 +232,23 @@ func createTerragruntEvalContext(ctx *ParsingContext, l log.Logger, configPath s
 }
 
 // Return the OS platform
-func getPlatform(ctx *ParsingContext, l log.Logger) (string, error) {
+func getPlatform(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	return runtime.GOOS, nil
 }
 
 // Return the repository root as an absolute path
-func getRepoRoot(ctx *ParsingContext, l log.Logger) (string, error) {
+func getRepoRoot(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_repo_root", attrs, func(childCtx context.Context) error {
-		childPctx := ctx.WithContext(childCtx)
-
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_repo_root", attrs, func(childCtx context.Context) error {
 		var innerErr error
 
-		result, innerErr = shell.GitTopLevelDir(childPctx, l, ctx.TerragruntOptions, ctx.TerragruntOptions.WorkingDir) //nolint:contextcheck
+		result, innerErr = shell.GitTopLevelDir(childCtx, l, pctx.TerragruntOptions, pctx.TerragruntOptions.WorkingDir)
 
 		return innerErr
 	})
@@ -259,23 +257,21 @@ func getRepoRoot(ctx *ParsingContext, l log.Logger) (string, error) {
 }
 
 // Return the path from the repository root
-func getPathFromRepoRoot(ctx *ParsingContext, l log.Logger) (string, error) {
+func getPathFromRepoRoot(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_path_from_repo_root", attrs, func(childCtx context.Context) error {
-		childPctx := ctx.WithContext(childCtx)
-
-		repoAbsPath, innerErr := shell.GitTopLevelDir(childPctx, l, ctx.TerragruntOptions, ctx.TerragruntOptions.WorkingDir) //nolint:contextcheck
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_path_from_repo_root", attrs, func(childCtx context.Context) error {
+		repoAbsPath, innerErr := shell.GitTopLevelDir(childCtx, l, pctx.TerragruntOptions, pctx.TerragruntOptions.WorkingDir)
 		if innerErr != nil {
 			return errors.New(innerErr)
 		}
 
-		repoRelPath, innerErr := filepath.Rel(repoAbsPath, ctx.TerragruntOptions.WorkingDir)
+		repoRelPath, innerErr := filepath.Rel(repoAbsPath, pctx.TerragruntOptions.WorkingDir)
 		if innerErr != nil {
 			return errors.New(innerErr)
 		}
@@ -289,23 +285,21 @@ func getPathFromRepoRoot(ctx *ParsingContext, l log.Logger) (string, error) {
 }
 
 // Return the path to the repository root
-func getPathToRepoRoot(ctx *ParsingContext, l log.Logger) (string, error) {
+func getPathToRepoRoot(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_path_to_repo_root", attrs, func(childCtx context.Context) error {
-		childPctx := ctx.WithContext(childCtx)
-
-		repoAbsPath, innerErr := shell.GitTopLevelDir(childPctx, l, ctx.TerragruntOptions, ctx.TerragruntOptions.WorkingDir) //nolint:contextcheck
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_path_to_repo_root", attrs, func(childCtx context.Context) error {
+		repoAbsPath, innerErr := shell.GitTopLevelDir(childCtx, l, pctx.TerragruntOptions, pctx.TerragruntOptions.WorkingDir)
 		if innerErr != nil {
 			return errors.New(innerErr)
 		}
 
-		repoRootPathAbs, innerErr := filepath.Rel(ctx.TerragruntOptions.WorkingDir, repoAbsPath)
+		repoRootPathAbs, innerErr := filepath.Rel(pctx.TerragruntOptions.WorkingDir, repoAbsPath)
 		if innerErr != nil {
 			return errors.New(innerErr)
 		}
@@ -319,16 +313,16 @@ func getPathToRepoRoot(ctx *ParsingContext, l log.Logger) (string, error) {
 }
 
 // GetTerragruntDir returns the directory where the Terragrunt configuration file lives.
-func GetTerragruntDir(ctx *ParsingContext, l log.Logger) (string, error) {
+func GetTerragruntDir(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_terragrunt_dir", attrs, func(childCtx context.Context) error {
-		path := ctx.TerragruntOptions.TerragruntConfigPath
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_terragrunt_dir", attrs, func(childCtx context.Context) error {
+		path := pctx.TerragruntOptions.TerragruntConfigPath
 
 		terragruntConfigFileAbsPath, innerErr := filepath.Abs(path)
 		if innerErr != nil {
@@ -347,16 +341,16 @@ func GetTerragruntDir(ctx *ParsingContext, l log.Logger) (string, error) {
 // Terragrunt config is being read from another e.g., if /terraform-code/terragrunt.hcl
 // calls read_terragrunt_config("/foo/bar.hcl"), and within bar.hcl, you call get_original_terragrunt_dir(), you'll
 // get back /terraform-code.
-func getOriginalTerragruntDir(ctx *ParsingContext, l log.Logger) (string, error) {
+func getOriginalTerragruntDir(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_original_terragrunt_dir", attrs, func(childCtx context.Context) error {
-		terragruntConfigFileAbsPath, innerErr := filepath.Abs(ctx.TerragruntOptions.OriginalTerragruntConfigPath)
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_original_terragrunt_dir", attrs, func(childCtx context.Context) error {
+		terragruntConfigFileAbsPath, innerErr := filepath.Abs(pctx.TerragruntOptions.OriginalTerragruntConfigPath)
 		if innerErr != nil {
 			return errors.New(innerErr)
 		}
@@ -370,10 +364,10 @@ func getOriginalTerragruntDir(ctx *ParsingContext, l log.Logger) (string, error)
 }
 
 // GetParentTerragruntDir returns the parent directory where the Terragrunt configuration file lives.
-func GetParentTerragruntDir(ctx *ParsingContext, l log.Logger, params []string) (string, error) {
+func GetParentTerragruntDir(ctx context.Context, pctx *ParsingContext, l log.Logger, params []string) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 	if len(params) > 0 {
 		attrs["include_label"] = params[0]
@@ -381,15 +375,13 @@ func GetParentTerragruntDir(ctx *ParsingContext, l log.Logger, params []string) 
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_parent_terragrunt_dir", attrs, func(childCtx context.Context) error {
-		childPctx := ctx.WithContext(childCtx)
-
-		parentPath, innerErr := PathRelativeFromInclude(childPctx, l, params) //nolint:contextcheck
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_parent_terragrunt_dir", attrs, func(childCtx context.Context) error {
+		parentPath, innerErr := PathRelativeFromInclude(childCtx, pctx, l, params)
 		if innerErr != nil {
 			return errors.New(innerErr)
 		}
 
-		currentPath := filepath.Dir(ctx.TerragruntOptions.TerragruntConfigPath)
+		currentPath := filepath.Dir(pctx.TerragruntOptions.TerragruntConfigPath)
 
 		parentPath, innerErr = filepath.Abs(filepath.Join(currentPath, parentPath))
 		if innerErr != nil {
@@ -428,19 +420,51 @@ func parseGetEnvParameters(parameters []string) (EnvVar, error) {
 // RunCommand is a helper function that runs a command and returns the stdout as the interpolation
 // for each `run_cmd` in locals section, function is called twice
 // result
-func RunCommand(ctx *ParsingContext, l log.Logger, args []string) (string, error) {
+func RunCommand(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) (string, error) {
+	// Capture original args for telemetry before any modifications
+	originalArgs := make([]string, len(args))
+	copy(originalArgs, args)
+
+	// Parse flags for telemetry attributes
+	suppressOutput := false
+	disableCache := false
+	useGlobalCache := false
+
+	for _, arg := range args {
+		switch arg {
+		case "--terragrunt-quiet":
+			suppressOutput = true
+		case "--terragrunt-global-cache":
+			useGlobalCache = true
+		case "--terragrunt-no-cache":
+			disableCache = true
+		}
+	}
+
+	// Extract command name (first non-flag argument)
+	var command string
+
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "--terragrunt-") {
+			command = arg
+			break
+		}
+	}
+
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_run_cmd", map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
-		"args":        args,
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_run_cmd", map[string]any{
+		"config_path":     pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir":     pctx.TerragruntOptions.WorkingDir,
+		"command":         command,
+		"args":            fmt.Sprintf("%v", originalArgs),
+		"suppress_output": suppressOutput,
+		"global_cache":    useGlobalCache,
+		"no_cache":        disableCache,
 	}, func(childCtx context.Context) error {
-		childPctx := ctx.WithContext(childCtx)
-
 		var innerErr error
 
-		result, innerErr = runCommandImpl(childPctx, l, args) //nolint:contextcheck
+		result, innerErr = runCommandImpl(childCtx, pctx, l, args)
 
 		return innerErr
 	})
@@ -449,7 +473,7 @@ func RunCommand(ctx *ParsingContext, l log.Logger, args []string) (string, error
 }
 
 // runCommandImpl contains the actual implementation of RunCommand
-func runCommandImpl(ctx *ParsingContext, l log.Logger, args []string) (string, error) {
+func runCommandImpl(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) (string, error) {
 	// runCommandCache - cache of evaluated `run_cmd` invocations
 	// see: https://github.com/gruntwork-io/terragrunt/issues/1427
 	runCommandCache := cache.ContextCache[string](ctx, RunCmdCacheContextKey)
@@ -461,7 +485,7 @@ func runCommandImpl(ctx *ParsingContext, l log.Logger, args []string) (string, e
 	suppressOutput := false
 	disableCache := false
 	useGlobalCache := false
-	currentPath := filepath.Dir(ctx.TerragruntOptions.TerragruntConfigPath)
+	currentPath := filepath.Dir(pctx.TerragruntOptions.TerragruntConfigPath)
 	cachePath := currentPath
 
 	checkOptions := true
@@ -511,7 +535,7 @@ func runCommandImpl(ctx *ParsingContext, l log.Logger, args []string) (string, e
 		}
 	}
 
-	cmdOutput, err := shell.RunCommandWithOutput(ctx, l, ctx.TerragruntOptions, currentPath, suppressOutput, false, args[0], args[1:]...)
+	cmdOutput, err := shell.RunCommandWithOutput(ctx, l, pctx.TerragruntOptions, currentPath, suppressOutput, false, args[0], args[1:]...)
 	if err != nil {
 		return "", errors.New(err)
 	}
@@ -533,10 +557,10 @@ func runCommandImpl(ctx *ParsingContext, l log.Logger, args []string) (string, e
 	return value, nil
 }
 
-func getEnvironmentVariable(ctx *ParsingContext, l log.Logger, parameters []string) (string, error) {
+func getEnvironmentVariable(ctx context.Context, pctx *ParsingContext, l log.Logger, parameters []string) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	if len(parameters) > 0 {
@@ -549,13 +573,13 @@ func getEnvironmentVariable(ctx *ParsingContext, l log.Logger, parameters []stri
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_env", attrs, func(childCtx context.Context) error {
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_env", attrs, func(childCtx context.Context) error {
 		parameterMap, innerErr := parseGetEnvParameters(parameters)
 		if innerErr != nil {
 			return errors.New(innerErr)
 		}
 
-		envValue, exists := ctx.TerragruntOptions.Env[parameterMap.Name]
+		envValue, exists := pctx.TerragruntOptions.Env[parameterMap.Name]
 
 		if !exists {
 			if parameterMap.IsRequired {
@@ -576,13 +600,14 @@ func getEnvironmentVariable(ctx *ParsingContext, l log.Logger, parameters []stri
 // FindInParentFolders fings a parent Terragrunt configuration file in the parent
 // folders above the current Terragrunt configuration file and return its path.
 func FindInParentFolders(
-	ctx *ParsingContext,
+	ctx context.Context,
+	pctx *ParsingContext,
 	l log.Logger,
 	params []string,
 ) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 	if len(params) > 0 {
 		attrs["file_to_find"] = params[0]
@@ -594,12 +619,10 @@ func FindInParentFolders(
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_find_in_parent_folders", attrs, func(childCtx context.Context) error {
-		childPctx := ctx.WithContext(childCtx)
-
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_find_in_parent_folders", attrs, func(childCtx context.Context) error {
 		var innerErr error
 
-		result, innerErr = findInParentFoldersImpl(childPctx, l, params) //nolint:contextcheck
+		result, innerErr = findInParentFoldersImpl(childCtx, pctx, l, params)
 
 		return innerErr
 	})
@@ -608,7 +631,7 @@ func FindInParentFolders(
 }
 
 // findInParentFoldersImpl contains the actual implementation of FindInParentFolders
-func findInParentFoldersImpl(ctx *ParsingContext, l log.Logger, params []string) (string, error) {
+func findInParentFoldersImpl(ctx context.Context, pctx *ParsingContext, l log.Logger, params []string) (string, error) {
 	numParams := len(params)
 
 	var (
@@ -628,7 +651,7 @@ func findInParentFoldersImpl(ctx *ParsingContext, l log.Logger, params []string)
 		return "", errors.New(WrongNumberOfParamsError{Func: "find_in_parent_folders", Expected: "0, 1, or 2", Actual: numParams})
 	}
 
-	previousDir, err := filepath.Abs(filepath.Dir(ctx.TerragruntOptions.TerragruntConfigPath))
+	previousDir, err := filepath.Abs(filepath.Dir(pctx.TerragruntOptions.TerragruntConfigPath))
 	if err != nil {
 		return "", errors.New(err)
 	}
@@ -636,7 +659,7 @@ func findInParentFoldersImpl(ctx *ParsingContext, l log.Logger, params []string)
 	previousDir = filepath.ToSlash(previousDir)
 
 	if fileToFindParam == "" || fileToFindParam == DefaultTerragruntConfigPath {
-		allControls := ctx.TerragruntOptions.StrictControls
+		allControls := pctx.TerragruntOptions.StrictControls
 		rootTGHCLControl := allControls.FilterByNames(controls.RootTerragruntHCL)
 		logger := log.ContextWithLogger(ctx, l)
 
@@ -656,7 +679,7 @@ func findInParentFoldersImpl(ctx *ParsingContext, l log.Logger, params []string)
 
 	// To avoid getting into an accidental infinite loop (e.g. do to cyclical symlinks), set a max on the number of
 	// parent folders we'll check
-	for range ctx.TerragruntOptions.MaxFoldersToCheck {
+	for range pctx.TerragruntOptions.MaxFoldersToCheck {
 		currentDir := filepath.ToSlash(filepath.Dir(previousDir))
 		if currentDir == previousDir {
 			if numParams == matchedPats {
@@ -664,7 +687,7 @@ func findInParentFoldersImpl(ctx *ParsingContext, l log.Logger, params []string)
 			}
 
 			return "", errors.New(ParentFileNotFoundError{
-				Path:  ctx.TerragruntOptions.TerragruntConfigPath,
+				Path:  pctx.TerragruntOptions.TerragruntConfigPath,
 				File:  fileToFindStr,
 				Cause: "Traversed all the way to the root",
 			})
@@ -683,19 +706,19 @@ func findInParentFoldersImpl(ctx *ParsingContext, l log.Logger, params []string)
 	}
 
 	return "", errors.New(ParentFileNotFoundError{
-		Path:  ctx.TerragruntOptions.TerragruntConfigPath,
+		Path:  pctx.TerragruntOptions.TerragruntConfigPath,
 		File:  fileToFindStr,
-		Cause: fmt.Sprintf("Exceeded maximum folders to check (%d)", ctx.TerragruntOptions.MaxFoldersToCheck),
+		Cause: fmt.Sprintf("Exceeded maximum folders to check (%d)", pctx.TerragruntOptions.MaxFoldersToCheck),
 	})
 }
 
 // PathRelativeToInclude returns the relative path between the included Terragrunt configuration file
 // and the current Terragrunt configuration file. Name param is required and used to lookup the
 // relevant import block when called in a child config with multiple import blocks.
-func PathRelativeToInclude(ctx *ParsingContext, l log.Logger, params []string) (string, error) {
+func PathRelativeToInclude(ctx context.Context, pctx *ParsingContext, l log.Logger, params []string) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 	if len(params) > 0 {
 		attrs["include_label"] = params[0]
@@ -703,8 +726,8 @@ func PathRelativeToInclude(ctx *ParsingContext, l log.Logger, params []string) (
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_path_relative_to_include", attrs, func(childCtx context.Context) error {
-		if ctx.TrackInclude == nil {
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_path_relative_to_include", attrs, func(childCtx context.Context) error {
+		if pctx.TrackInclude == nil {
 			result = "."
 			return nil
 		}
@@ -712,11 +735,11 @@ func PathRelativeToInclude(ctx *ParsingContext, l log.Logger, params []string) (
 		var included IncludeConfig
 
 		switch {
-		case ctx.TrackInclude.Original != nil:
-			included = *ctx.TrackInclude.Original
-		case len(ctx.TrackInclude.CurrentList) > 0:
+		case pctx.TrackInclude.Original != nil:
+			included = *pctx.TrackInclude.Original
+		case len(pctx.TrackInclude.CurrentList) > 0:
 			// Called in child ctx, so we need to select the right include file.
-			selected, innerErr := getSelectedIncludeBlock(*ctx.TrackInclude, params)
+			selected, innerErr := getSelectedIncludeBlock(*pctx.TrackInclude, params)
 			if innerErr != nil {
 				return innerErr
 			}
@@ -727,7 +750,7 @@ func PathRelativeToInclude(ctx *ParsingContext, l log.Logger, params []string) (
 			return nil
 		}
 
-		currentPath := filepath.Dir(ctx.TerragruntOptions.TerragruntConfigPath)
+		currentPath := filepath.Dir(pctx.TerragruntOptions.TerragruntConfigPath)
 		includePath := filepath.Dir(included.Path)
 
 		if !filepath.IsAbs(includePath) {
@@ -745,10 +768,10 @@ func PathRelativeToInclude(ctx *ParsingContext, l log.Logger, params []string) (
 }
 
 // PathRelativeFromInclude returns the relative path from the current Terragrunt configuration to the included Terragrunt configuration file
-func PathRelativeFromInclude(ctx *ParsingContext, l log.Logger, params []string) (string, error) {
+func PathRelativeFromInclude(ctx context.Context, pctx *ParsingContext, l log.Logger, params []string) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 	if len(params) > 0 {
 		attrs["include_label"] = params[0]
@@ -756,13 +779,13 @@ func PathRelativeFromInclude(ctx *ParsingContext, l log.Logger, params []string)
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_path_relative_from_include", attrs, func(childCtx context.Context) error {
-		if ctx.TrackInclude == nil {
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_path_relative_from_include", attrs, func(childCtx context.Context) error {
+		if pctx.TrackInclude == nil {
 			result = "."
 			return nil
 		}
 
-		included, innerErr := getSelectedIncludeBlock(*ctx.TrackInclude, params)
+		included, innerErr := getSelectedIncludeBlock(*pctx.TrackInclude, params)
 		if innerErr != nil {
 			return innerErr
 		} else if included == nil {
@@ -771,7 +794,7 @@ func PathRelativeFromInclude(ctx *ParsingContext, l log.Logger, params []string)
 		}
 
 		includePath := filepath.Dir(included.Path)
-		currentPath := filepath.Dir(ctx.TerragruntOptions.TerragruntConfigPath)
+		currentPath := filepath.Dir(pctx.TerragruntOptions.TerragruntConfigPath)
 
 		if !filepath.IsAbs(includePath) {
 			includePath = filepath.Join(currentPath, includePath)
@@ -786,25 +809,23 @@ func PathRelativeFromInclude(ctx *ParsingContext, l log.Logger, params []string)
 }
 
 // getTerraformCommand returns the current terraform command in execution
-func getTerraformCommand(ctx *ParsingContext, l log.Logger) (string, error) {
-	return ctx.TerragruntOptions.TerraformCommand, nil
+func getTerraformCommand(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
+	return pctx.TerragruntOptions.TerraformCommand, nil
 }
 
 // getWorkingDir returns the current working dir
-func getWorkingDir(ctx *ParsingContext, l log.Logger) (string, error) {
+func getWorkingDir(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_working_dir", attrs, func(childCtx context.Context) error {
-		childPctx := ctx.WithContext(childCtx)
-
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_working_dir", attrs, func(childCtx context.Context) error {
 		var innerErr error
 
-		result, innerErr = getWorkingDirImpl(childPctx, l) //nolint:contextcheck
+		result, innerErr = getWorkingDirImpl(childCtx, pctx, l)
 
 		return innerErr
 	})
@@ -813,37 +834,32 @@ func getWorkingDir(ctx *ParsingContext, l log.Logger) (string, error) {
 }
 
 // getWorkingDirImpl contains the actual implementation of getWorkingDir
-func getWorkingDirImpl(ctx *ParsingContext, l log.Logger) (string, error) {
+func getWorkingDirImpl(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	l.Debugf("Start processing get_working_dir built-in function")
 	defer l.Debugf("Complete processing get_working_dir built-in function")
 
 	// Initialize evaluation ctx extensions from base blocks.
-	ctx.PredefinedFunctions = map[string]function.Function{
+	pctx.PredefinedFunctions = map[string]function.Function{
 		FuncNameGetWorkingDir: wrapVoidToEmptyStringAsFuncImpl(),
 	}
 
-	terragruntConfig, err := PartialParseConfigFile(
-		ctx.WithDecodeList(TerraformSource),
-		l,
-		ctx.TerragruntOptions.TerragruntConfigPath,
-		nil,
-	)
+	terragruntConfig, err := ParseConfigFile(ctx, pctx, l, pctx.TerragruntOptions.TerragruntConfigPath, nil)
 	if err != nil {
 		return "", err
 	}
 
-	sourceURL, err := GetTerraformSourceURL(ctx.TerragruntOptions, terragruntConfig)
+	sourceURL, err := GetTerraformSourceURL(pctx.TerragruntOptions, terragruntConfig)
 	if err != nil {
 		return "", err
 	}
 
 	if sourceURL == "" {
-		return ctx.TerragruntOptions.WorkingDir, nil
+		return pctx.TerragruntOptions.WorkingDir, nil
 	}
 
-	walkWithSymlinks := ctx.TerragruntOptions.Experiments.Evaluate(experiment.Symlinks)
+	walkWithSymlinks := pctx.TerragruntOptions.Experiments.Evaluate(experiment.Symlinks)
 
-	source, err := tf.NewSource(l, sourceURL, ctx.TerragruntOptions.DownloadDir, ctx.TerragruntOptions.WorkingDir, walkWithSymlinks)
+	source, err := tf.NewSource(l, sourceURL, pctx.TerragruntOptions.DownloadDir, pctx.TerragruntOptions.WorkingDir, walkWithSymlinks)
 	if err != nil {
 		return "", err
 	}
@@ -852,16 +868,16 @@ func getWorkingDirImpl(ctx *ParsingContext, l log.Logger) (string, error) {
 }
 
 // getTerraformCliArgs returns cli args for terraform
-func getTerraformCliArgs(ctx *ParsingContext, l log.Logger) ([]string, error) {
+func getTerraformCliArgs(ctx context.Context, pctx *ParsingContext, l log.Logger) ([]string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result []string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_terraform_cli_args", attrs, func(childCtx context.Context) error {
-		result = ctx.TerragruntOptions.TerraformCliArgs
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_terraform_cli_args", attrs, func(childCtx context.Context) error {
+		result = pctx.TerragruntOptions.TerraformCliArgs
 		return nil
 	})
 
@@ -869,15 +885,15 @@ func getTerraformCliArgs(ctx *ParsingContext, l log.Logger) ([]string, error) {
 }
 
 // getDefaultRetryableErrors returns default retryable errors for use in errors.retry blocks
-func getDefaultRetryableErrors(ctx *ParsingContext, l log.Logger) ([]string, error) {
+func getDefaultRetryableErrors(ctx context.Context, pctx *ParsingContext, l log.Logger) ([]string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result []string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_default_retryable_errors", attrs, func(childCtx context.Context) error {
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_default_retryable_errors", attrs, func(childCtx context.Context) error {
 		result = options.DefaultRetryableErrors
 		return nil
 	})
@@ -886,16 +902,16 @@ func getDefaultRetryableErrors(ctx *ParsingContext, l log.Logger) ([]string, err
 }
 
 // Return the AWS account alias
-func getAWSAccountAlias(ctx *ParsingContext, l log.Logger) (string, error) {
+func getAWSAccountAlias(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_aws_account_alias", attrs, func(childCtx context.Context) error {
-		awsConfig, err := awshelper.CreateAwsConfig(childCtx, l, nil, ctx.TerragruntOptions)
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_aws_account_alias", attrs, func(childCtx context.Context) error {
+		awsConfig, err := awshelper.CreateAwsConfig(childCtx, l, nil, pctx.TerragruntOptions)
 		if err != nil {
 			return err
 		}
@@ -914,16 +930,16 @@ func getAWSAccountAlias(ctx *ParsingContext, l log.Logger) (string, error) {
 }
 
 // Return the AWS account id associated to the current set of credentials
-func getAWSAccountID(ctx *ParsingContext, l log.Logger) (string, error) {
+func getAWSAccountID(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_aws_account_id", attrs, func(childCtx context.Context) error {
-		awsConfig, err := awshelper.CreateAwsConfig(childCtx, l, nil, ctx.TerragruntOptions)
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_aws_account_id", attrs, func(childCtx context.Context) error {
+		awsConfig, err := awshelper.CreateAwsConfig(childCtx, l, nil, pctx.TerragruntOptions)
 		if err != nil {
 			return err
 		}
@@ -942,16 +958,16 @@ func getAWSAccountID(ctx *ParsingContext, l log.Logger) (string, error) {
 }
 
 // Return the ARN of the AWS identity associated with the current set of credentials
-func getAWSCallerIdentityARN(ctx *ParsingContext, l log.Logger) (string, error) {
+func getAWSCallerIdentityARN(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_aws_caller_identity_arn", attrs, func(childCtx context.Context) error {
-		awsConfig, err := awshelper.CreateAwsConfig(childCtx, l, nil, ctx.TerragruntOptions)
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_aws_caller_identity_arn", attrs, func(childCtx context.Context) error {
+		awsConfig, err := awshelper.CreateAwsConfig(childCtx, l, nil, pctx.TerragruntOptions)
 		if err != nil {
 			return err
 		}
@@ -970,16 +986,16 @@ func getAWSCallerIdentityARN(ctx *ParsingContext, l log.Logger) (string, error) 
 }
 
 // Return the UserID of the AWS identity associated with the current set of credentials
-func getAWSCallerIdentityUserID(ctx *ParsingContext, l log.Logger) (string, error) {
+func getAWSCallerIdentityUserID(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_aws_caller_identity_user_id", attrs, func(childCtx context.Context) error {
-		awsConfig, err := awshelper.CreateAwsConfig(childCtx, l, nil, ctx.TerragruntOptions)
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_aws_caller_identity_user_id", attrs, func(childCtx context.Context) error {
+		awsConfig, err := awshelper.CreateAwsConfig(childCtx, l, nil, pctx.TerragruntOptions)
 		if err != nil {
 			return err
 		}
@@ -1000,11 +1016,11 @@ func getAWSCallerIdentityUserID(ctx *ParsingContext, l log.Logger) (string, erro
 // ParseTerragruntConfig parses the terragrunt config and return a
 // representation that can be used as a reference. If given a default value,
 // this will return the default if the terragrunt config file does not exist.
-func ParseTerragruntConfig(ctx *ParsingContext, l log.Logger, configPath string, defaultVal *cty.Value) (cty.Value, error) {
+func ParseTerragruntConfig(ctx context.Context, pctx *ParsingContext, l log.Logger, configPath string, defaultVal *cty.Value) (cty.Value, error) {
 	// target config check: make sure the target config exists. If the file does not exist, and there is no default val,
 	// return an error. If the file does not exist but there is a default val, return the default val. Otherwise,
 	// proceed to parse the file as a terragrunt config file.
-	targetConfig := getCleanedTargetConfigPath(configPath, ctx.TerragruntOptions.TerragruntConfigPath)
+	targetConfig := getCleanedTargetConfigPath(configPath, pctx.TerragruntOptions.TerragruntConfigPath)
 
 	targetConfigFileExists := util.FileExists(targetConfig)
 
@@ -1019,20 +1035,20 @@ func ParseTerragruntConfig(ctx *ParsingContext, l log.Logger, configPath string,
 	path := targetConfig
 
 	if !filepath.IsAbs(path) {
-		path = filepath.Join(ctx.TerragruntOptions.WorkingDir, path)
+		path = filepath.Join(pctx.TerragruntOptions.WorkingDir, path)
 		path = filepath.Clean(path)
 	}
 
 	// Track that this file was read during parsing
-	trackFileRead(ctx.FilesRead, path)
+	trackFileRead(pctx.FilesRead, path)
 
 	// We update the ctx of terragruntOptions to the config being read in.
-	l, opts, err := ctx.TerragruntOptions.CloneWithConfigPath(l, targetConfig)
+	l, opts, err := pctx.TerragruntOptions.CloneWithConfigPath(l, targetConfig)
 	if err != nil {
 		return cty.NilVal, err
 	}
 
-	ctx = ctx.WithTerragruntOptions(opts).WithDiagnosticsSuppressed(l)
+	pctx = pctx.WithTerragruntOptions(opts).WithDiagnosticsSuppressed(l)
 
 	// check if file is stack file, decode as stack file
 	if filepath.Base(targetConfig) == DefaultStackFile {
@@ -1053,7 +1069,7 @@ func ParseTerragruntConfig(ctx *ParsingContext, l log.Logger, configPath string,
 
 	// check if file is a values file, decode as values file
 	if strings.HasSuffix(targetConfig, valuesFile) {
-		unitValues, readErr := ReadValues(ctx.Context, l, ctx.TerragruntOptions, filepath.Dir(targetConfig))
+		unitValues, readErr := ReadValues(ctx, l, pctx.TerragruntOptions, filepath.Dir(targetConfig))
 		if readErr != nil {
 			return cty.NilVal, errors.New(readErr)
 		}
@@ -1061,7 +1077,7 @@ func ParseTerragruntConfig(ctx *ParsingContext, l log.Logger, configPath string,
 		return *unitValues, nil
 	}
 
-	config, err := ParseConfigFile(ctx, l, targetConfig, nil)
+	config, err := ParseConfigFile(ctx, pctx, l, targetConfig, nil)
 	if err != nil {
 		return cty.NilVal, err
 	}
@@ -1072,7 +1088,7 @@ func ParseTerragruntConfig(ctx *ParsingContext, l log.Logger, configPath string,
 	// NOTE: this will not call terragrunt output, since all the values are cached from the ParseConfigFile call
 	// NOTE: we don't use range here because range will copy the slice, thereby undoing the set attribute.
 	for i := range len(config.TerragruntDependencies) {
-		err := config.TerragruntDependencies[i].setRenderedOutputs(ctx, l)
+		err := config.TerragruntDependencies[i].setRenderedOutputs(ctx, pctx, l)
 		if err != nil {
 			return cty.NilVal, errors.New(err)
 		}
@@ -1082,7 +1098,7 @@ func ParseTerragruntConfig(ctx *ParsingContext, l log.Logger, configPath string,
 }
 
 // Create a cty Function that can be used to for calling read_terragrunt_config.
-func readTerragruntConfigAsFuncImpl(ctx *ParsingContext, l log.Logger) function.Function {
+func readTerragruntConfigAsFuncImpl(ctx context.Context, pctx *ParsingContext, l log.Logger) function.Function {
 	return function.New(&function.Spec{
 		// Takes one required string param
 		Params: []function.Parameter{{Type: cty.String}},
@@ -1110,19 +1126,17 @@ func readTerragruntConfigAsFuncImpl(ctx *ParsingContext, l log.Logger) function.
 			targetConfigPath := strArgs[0]
 
 			attrs := map[string]any{
-				"config_path":        ctx.TerragruntOptions.TerragruntConfigPath,
-				"working_dir":        ctx.TerragruntOptions.WorkingDir,
+				"config_path":        pctx.TerragruntOptions.TerragruntConfigPath,
+				"working_dir":        pctx.TerragruntOptions.WorkingDir,
 				"target_config_path": targetConfigPath,
 				"has_default":        defaultVal != nil,
 			}
 
 			var result cty.Value
 
-			err = telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_read_terragrunt_config", attrs, func(childCtx context.Context) error {
-				childPctx := ctx.WithContext(childCtx)
-
+			err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_read_terragrunt_config", attrs, func(childCtx context.Context) error {
 				var innerErr error
-				result, innerErr = ParseTerragruntConfig(childPctx, l, targetConfigPath, defaultVal) //nolint:contextcheck
+				result, innerErr = ParseTerragruntConfig(childCtx, pctx, l, targetConfigPath, defaultVal)
 				return innerErr
 			})
 
@@ -1226,34 +1240,25 @@ func getModulePathFromSourceURL(sourceURL string) (string, error) {
 // plain-text result of the decrypt operation.
 var sopsCache = cache.NewCache[string](sopsCacheName)
 
-// collectStringFuncWithFilePathSpan is a helper that wraps a function implementation with telemetry collection,
-// extracting the file path from the first argument for span attributes.
-func collectStringFuncWithFilePathSpan(
-	ctx *ParsingContext,
-	l log.Logger,
-	params []string,
-	spanName string,
-	implFunc func(*ParsingContext, log.Logger, []string) (string, error),
-) (string, error) {
-	var filePath string
+// decrypts and returns sops encrypted utf-8 yaml or json data as a string
+func sopsDecryptFile(ctx context.Context, pctx *ParsingContext, l log.Logger, params []string) (string, error) {
+	var sourceFile string
 	if len(params) > 0 {
-		filePath = params[0]
+		sourceFile = params[0]
 	}
 
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
-		"file_path":   filePath,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
+		"file_path":   sourceFile,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, spanName, attrs, func(childCtx context.Context) error {
-		childPctx := ctx.WithContext(childCtx)
-
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_sops_decrypt_file", attrs, func(childCtx context.Context) error {
 		var innerErr error
 
-		result, innerErr = implFunc(childPctx, l, params) //nolint:contextcheck
+		result, innerErr = sopsDecryptFileImpl(childCtx, pctx, l, params)
 
 		return innerErr
 	})
@@ -1261,13 +1266,8 @@ func collectStringFuncWithFilePathSpan(
 	return result, err
 }
 
-// decrypts and returns sops encrypted utf-8 yaml or json data as a string
-func sopsDecryptFile(ctx *ParsingContext, l log.Logger, params []string) (string, error) {
-	return collectStringFuncWithFilePathSpan(ctx, l, params, "hcl_fn_sops_decrypt_file", sopsDecryptFileImpl)
-}
-
 // sopsDecryptFileImpl contains the actual implementation of sopsDecryptFile
-func sopsDecryptFileImpl(ctx *ParsingContext, _ log.Logger, params []string) (string, error) {
+func sopsDecryptFileImpl(ctx context.Context, pctx *ParsingContext, _ log.Logger, params []string) (string, error) {
 	numParams := len(params)
 
 	var sourceFile string
@@ -1288,12 +1288,12 @@ func sopsDecryptFileImpl(ctx *ParsingContext, _ log.Logger, params []string) (st
 	path := sourceFile
 
 	if !filepath.IsAbs(path) {
-		path = filepath.Join(ctx.TerragruntOptions.WorkingDir, path)
+		path = filepath.Join(pctx.TerragruntOptions.WorkingDir, path)
 		path = filepath.Clean(path)
 	}
 
 	// Track that this file was read during parsing
-	trackFileRead(ctx.FilesRead, path)
+	trackFileRead(pctx.FilesRead, path)
 
 	// Set environment variables from the TerragruntOptions.Env map.
 	// This is especially useful for integrations with things like the `auth-provider` flag,
@@ -1303,7 +1303,7 @@ func sopsDecryptFileImpl(ctx *ParsingContext, _ log.Logger, params []string) (st
 	// for decryption, we have to rely on environment variables to pass these configurations.
 	// This can cause a race condition, so we have to be careful to avoid having anything else
 	// running concurrently that might interfere with the environment variables.
-	env := ctx.TerragruntOptions.Env
+	env := pctx.TerragruntOptions.Env
 	if len(env) > 0 {
 		locks.EnvLock.Lock()
 		defer locks.EnvLock.Unlock()
@@ -1357,16 +1357,16 @@ func getSopsFileFormat(sourceFile string) (string, error) {
 }
 
 // Return the location of the Terraform files provided via --source
-func getTerragruntSourceCliFlag(ctx *ParsingContext, l log.Logger) (string, error) {
+func getTerragruntSourceCliFlag(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_get_terragrunt_source_cli_flag", attrs, func(childCtx context.Context) error {
-		result = ctx.TerragruntOptions.Source
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_terragrunt_source_cli_flag", attrs, func(childCtx context.Context) error {
+		result = pctx.TerragruntOptions.Source
 		return nil
 	})
 
@@ -1414,10 +1414,10 @@ func getSelectedIncludeBlock(trackInclude TrackInclude, params []string) (*Inclu
 // StartsWith Implementation of Terraform's StartsWith function
 //
 //nolint:dupl
-func StartsWith(ctx *ParsingContext, args []string) (bool, error) {
+func StartsWith(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 	if len(args) > 0 {
 		attrs["str"] = args[0]
@@ -1429,7 +1429,7 @@ func StartsWith(ctx *ParsingContext, args []string) (bool, error) {
 
 	var result bool
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_startswith", attrs, func(childCtx context.Context) error {
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_startswith", attrs, func(childCtx context.Context) error {
 		if len(args) == 0 {
 			return errors.New(EmptyStringNotAllowedError("parameter to the startswith function"))
 		}
@@ -1448,10 +1448,10 @@ func StartsWith(ctx *ParsingContext, args []string) (bool, error) {
 // EndsWith Implementation of Terraform's EndsWith function
 //
 //nolint:dupl
-func EndsWith(ctx *ParsingContext, args []string) (bool, error) {
+func EndsWith(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 	if len(args) > 0 {
 		attrs["str"] = args[0]
@@ -1463,7 +1463,7 @@ func EndsWith(ctx *ParsingContext, args []string) (bool, error) {
 
 	var result bool
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_endswith", attrs, func(childCtx context.Context) error {
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_endswith", attrs, func(childCtx context.Context) error {
 		if len(args) == 0 {
 			return errors.New(EmptyStringNotAllowedError("parameter to the endswith function"))
 		}
@@ -1480,10 +1480,10 @@ func EndsWith(ctx *ParsingContext, args []string) (bool, error) {
 }
 
 // TimeCmp implements Terraform's `timecmp` function that compares two timestamps.
-func TimeCmp(ctx *ParsingContext, l log.Logger, args []string) (int64, error) {
+func TimeCmp(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) (int64, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 	if len(args) > 0 {
 		attrs["timestamp_a"] = args[0]
@@ -1495,7 +1495,7 @@ func TimeCmp(ctx *ParsingContext, l log.Logger, args []string) (int64, error) {
 
 	var result int64
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_timecmp", attrs, func(childCtx context.Context) error {
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_timecmp", attrs, func(childCtx context.Context) error {
 		if len(args) != matchedPats {
 			return errors.New(errors.New("function can take only two parameters: timestamp_a and timestamp_b"))
 		}
@@ -1529,10 +1529,10 @@ func TimeCmp(ctx *ParsingContext, l log.Logger, args []string) (int64, error) {
 // StrContains Implementation of Terraform's StrContains function
 //
 //nolint:dupl
-func StrContains(ctx *ParsingContext, args []string) (bool, error) {
+func StrContains(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 	if len(args) > 0 {
 		attrs["str"] = args[0]
@@ -1544,7 +1544,7 @@ func StrContains(ctx *ParsingContext, args []string) (bool, error) {
 
 	var result bool
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_strcontains", attrs, func(childCtx context.Context) error {
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_strcontains", attrs, func(childCtx context.Context) error {
 		if len(args) == 0 {
 			return errors.New(EmptyStringNotAllowedError("parameter to the strcontains function"))
 		}
@@ -1561,12 +1561,33 @@ func StrContains(ctx *ParsingContext, args []string) (bool, error) {
 }
 
 // readTFVarsFile reads a *.tfvars or *.tfvars.json file and returns the contents as a JSON encoded string
-func readTFVarsFile(ctx *ParsingContext, l log.Logger, args []string) (string, error) {
-	return collectStringFuncWithFilePathSpan(ctx, l, args, "hcl_fn_read_tfvars_file", readTFVarsFileImpl)
+func readTFVarsFile(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) (string, error) {
+	var filePath string
+	if len(args) > 0 {
+		filePath = args[0]
+	}
+
+	attrs := map[string]any{
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
+		"file_path":   filePath,
+	}
+
+	var result string
+
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_read_tfvars_file", attrs, func(childCtx context.Context) error {
+		var innerErr error
+
+		result, innerErr = readTFVarsFileImpl(pctx, l, args)
+
+		return innerErr
+	})
+
+	return result, err
 }
 
 // readTFVarsFileImpl contains the actual implementation of readTFVarsFile
-func readTFVarsFileImpl(ctx *ParsingContext, l log.Logger, args []string) (string, error) {
+func readTFVarsFileImpl(pctx *ParsingContext, l log.Logger, args []string) (string, error) {
 	if len(args) != 1 {
 		return "", errors.New(WrongNumberOfParamsError{Func: "read_tfvars_file", Expected: "1", Actual: len(args)})
 	}
@@ -1574,7 +1595,7 @@ func readTFVarsFileImpl(ctx *ParsingContext, l log.Logger, args []string) (strin
 	varFile := args[0]
 
 	if !filepath.IsAbs(varFile) {
-		varFile = filepath.Join(ctx.TerragruntOptions.WorkingDir, varFile)
+		varFile = filepath.Join(pctx.TerragruntOptions.WorkingDir, varFile)
 		varFile = filepath.Clean(varFile)
 	}
 
@@ -1583,7 +1604,7 @@ func readTFVarsFileImpl(ctx *ParsingContext, l log.Logger, args []string) (strin
 	}
 
 	// Track that this file was read during parsing
-	trackFileRead(ctx.FilesRead, varFile)
+	trackFileRead(pctx.FilesRead, varFile)
 
 	fileContents, err := os.ReadFile(varFile)
 	if err != nil {
@@ -1601,7 +1622,7 @@ func readTFVarsFileImpl(ctx *ParsingContext, l log.Logger, args []string) (strin
 	}
 
 	var variables map[string]any
-	if err := ParseAndDecodeVarFile(l, ctx.TerragruntOptions, varFile, fileContents, &variables); err != nil {
+	if err := ParseAndDecodeVarFile(l, pctx.TerragruntOptions, varFile, fileContents, &variables); err != nil {
 		return "", err
 	}
 
@@ -1614,10 +1635,10 @@ func readTFVarsFileImpl(ctx *ParsingContext, l log.Logger, args []string) (strin
 }
 
 // markAsRead marks a file as explicitly read. This is useful for detection via TerragruntUnitsReading flag.
-func markAsRead(ctx *ParsingContext, l log.Logger, args []string) (string, error) {
+func markAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) (string, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 	if len(args) > 0 {
 		attrs["file_path"] = args[0]
@@ -1625,7 +1646,7 @@ func markAsRead(ctx *ParsingContext, l log.Logger, args []string) (string, error
 
 	var result string
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_mark_as_read", attrs, func(childCtx context.Context) error {
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_mark_as_read", attrs, func(childCtx context.Context) error {
 		if len(args) != 1 {
 			return errors.New(WrongNumberOfParamsError{Func: "mark_as_read", Expected: "1", Actual: len(args)})
 		}
@@ -1638,12 +1659,12 @@ func markAsRead(ctx *ParsingContext, l log.Logger, args []string) (string, error
 		path := file
 
 		if !filepath.IsAbs(path) {
-			path = filepath.Join(ctx.TerragruntOptions.WorkingDir, path)
+			path = filepath.Join(pctx.TerragruntOptions.WorkingDir, path)
 			path = filepath.Clean(path)
 		}
 
 		// Track that this file was read during parsing
-		trackFileRead(ctx.FilesRead, path)
+		trackFileRead(pctx.FilesRead, path)
 
 		result = file
 
@@ -1745,10 +1766,10 @@ func extractSopsErrors(err error) *errors.MultiError {
 }
 
 // ConstraintCheck Implementation of Terraform's StartsWith function
-func ConstraintCheck(ctx *ParsingContext, args []string) (bool, error) {
+func ConstraintCheck(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
 	attrs := map[string]any{
-		"config_path": ctx.TerragruntOptions.TerragruntConfigPath,
-		"working_dir": ctx.TerragruntOptions.WorkingDir,
+		"config_path": pctx.TerragruntOptions.TerragruntConfigPath,
+		"working_dir": pctx.TerragruntOptions.WorkingDir,
 	}
 	if len(args) > 0 {
 		attrs["version"] = args[0]
@@ -1760,7 +1781,7 @@ func ConstraintCheck(ctx *ParsingContext, args []string) (bool, error) {
 
 	var result bool
 
-	err := telemetry.TelemeterFromContext(ctx.Context).Collect(ctx.Context, "hcl_fn_constraint_check", attrs, func(childCtx context.Context) error {
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_constraint_check", attrs, func(childCtx context.Context) error {
 		if len(args) != matchedPats {
 			return errors.New(WrongNumberOfParamsError{Func: FuncNameConstraintCheck, Expected: "2", Actual: len(args)})
 		}

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -76,8 +76,9 @@ func TestPathRelativeToInclude(t *testing.T) {
 	for _, tc := range testCases {
 		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params)
 		l := logger.CreateLogger()
-		ctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions).WithTrackInclude(trackInclude)
-		actualPath, actualErr := config.PathRelativeToInclude(ctx, l, tc.params)
+		ctx, pctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
+		pctx = pctx.WithTrackInclude(trackInclude)
+		actualPath, actualErr := config.PathRelativeToInclude(ctx, pctx, l, tc.params)
 		require.NoError(t, actualErr, "For include %v and options %v, unexpected error: %v", tc.include, tc.terragruntOptions, actualErr)
 		assert.Equal(t, tc.expectedPath, actualPath, "For include %v and options %v", tc.include, tc.terragruntOptions)
 	}
@@ -140,8 +141,9 @@ func TestPathRelativeFromInclude(t *testing.T) {
 	for _, tc := range testCases {
 		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params)
 		l := logger.CreateLogger()
-		ctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions).WithTrackInclude(trackInclude)
-		actualPath, actualErr := config.PathRelativeFromInclude(ctx, l, tc.params)
+		ctx, pctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
+		pctx = pctx.WithTrackInclude(trackInclude)
+		actualPath, actualErr := config.PathRelativeFromInclude(ctx, pctx, l, tc.params)
 		require.NoError(t, actualErr, "For include %v and options %v, unexpected error: %v", tc.include, tc.terragruntOptions, actualErr)
 		assert.Equal(t, tc.expectedPath, actualPath, "For include %v and options %v", tc.include, tc.terragruntOptions)
 	}
@@ -232,9 +234,9 @@ func TestRunCommand(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
 
-			actualOutput, actualErr := config.RunCommand(ctx, l, tc.params)
+			actualOutput, actualErr := config.RunCommand(ctx, pctx, l, tc.params)
 			if tc.expectedErr != nil {
 				if assert.Error(t, actualErr) {
 					assert.IsType(t, tc.expectedErr, errors.Unwrap(actualErr))
@@ -344,9 +346,9 @@ func TestFindInParentFolders(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
 
-			actualPath, actualErr := config.FindInParentFolders(ctx, l, tc.params)
+			actualPath, actualErr := config.FindInParentFolders(ctx, pctx, l, tc.params)
 			if tc.expectedErr != nil {
 				if assert.Error(t, actualErr) {
 					assert.IsType(t, tc.expectedErr, errors.Unwrap(actualErr))
@@ -457,9 +459,9 @@ func TestResolveTerragruntInterpolation(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
 
-			actualOut, actualErr := config.ParseConfigString(ctx, l, "mock-path-for-test.hcl", tc.str, tc.include)
+			actualOut, actualErr := config.ParseConfigString(ctx, pctx, l, "mock-path-for-test.hcl", tc.str, tc.include)
 			if tc.expectedErr != "" {
 				require.Error(t, actualErr)
 				assert.Contains(t, actualErr.Error(), tc.expectedErr)
@@ -556,9 +558,9 @@ func TestResolveEnvInterpolationConfigString(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
 
-			actualOut, actualErr := config.ParseConfigString(ctx, l, "mock-path-for-test.hcl", tc.str, tc.include)
+			actualOut, actualErr := config.ParseConfigString(ctx, pctx, l, "mock-path-for-test.hcl", tc.str, tc.include)
 			if tc.expectedErr != "" {
 				require.Error(t, actualErr)
 				assert.Contains(t, actualErr.Error(), tc.expectedErr)
@@ -606,8 +608,8 @@ func TestResolveCommandsInterpolationConfigString(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
-			actualOut, actualErr := config.ParseConfigString(ctx, l, "mock-path-for-test.hcl", tc.str, tc.include)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
+			actualOut, actualErr := config.ParseConfigString(ctx, pctx, l, "mock-path-for-test.hcl", tc.str, tc.include)
 			require.NoError(t, actualErr, "For string '%s' include %v and options %v, unexpected error: %v", tc.str, tc.include, tc.terragruntOptions, actualErr)
 
 			assert.NotNil(t, actualOut)
@@ -653,8 +655,8 @@ func TestResolveCliArgsInterpolationConfigString(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
-			actualOut, actualErr := config.ParseConfigString(ctx, l, "mock-path-for-test.hcl", tc.str, tc.include)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
+			actualOut, actualErr := config.ParseConfigString(ctx, pctx, l, "mock-path-for-test.hcl", tc.str, tc.include)
 			require.NoError(t, actualErr, "For string '%s' include %v and options %v, unexpected error: %v", tc.str, tc.include, tc.terragruntOptions, actualErr)
 
 			assert.NotNil(t, actualOut)
@@ -723,8 +725,8 @@ func testGetTerragruntDir(t *testing.T, configPath string, expectedPath string) 
 	require.NoError(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
 
 	l := logger.CreateLogger()
-	ctx := config.NewParsingContext(t.Context(), l, terragruntOptions)
-	actualPath, err := config.GetTerragruntDir(ctx, l)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, terragruntOptions)
+	actualPath, err := config.GetTerragruntDir(ctx, pctx, l)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
 	assert.Equal(t, expectedPath, actualPath)
@@ -821,8 +823,9 @@ func TestGetParentTerragruntDir(t *testing.T) {
 	for _, tc := range testCases {
 		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params)
 		l := logger.CreateLogger()
-		ctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions).WithTrackInclude(trackInclude)
-		actualPath, actualErr := config.GetParentTerragruntDir(ctx, l, tc.params)
+		ctx, pctx := config.NewParsingContext(t.Context(), l, tc.terragruntOptions)
+		pctx = pctx.WithTrackInclude(trackInclude)
+		actualPath, actualErr := config.GetParentTerragruntDir(ctx, pctx, l, tc.params)
 		require.NoError(t, actualErr, "For include %v and options %v, unexpected error: %v", tc.include, tc.terragruntOptions, actualErr)
 		assert.Equal(t, tc.expectedPath, actualPath, "For include %v and options %v", tc.include, tc.terragruntOptions)
 	}
@@ -876,8 +879,8 @@ func TestTerraformBuiltInFunctions(t *testing.T) {
 			terragruntOptions := terragruntOptionsForTest(t, "../test/fixtures/config-terraform-functions/"+config.DefaultTerragruntConfigPath)
 			configString := fmt.Sprintf("inputs = { test = %s }", tc.input)
 			l := logger.CreateLogger()
-			ctx := config.NewParsingContext(t.Context(), l, terragruntOptions)
-			actual, err := config.ParseConfigString(ctx, l, terragruntOptions.TerragruntConfigPath, configString, nil)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, terragruntOptions)
+			actual, err := config.ParseConfigString(ctx, pctx, l, terragruntOptions.TerragruntConfigPath, configString, nil)
 			require.NoError(t, err, "For hcl '%s' include %v and options %v, unexpected error: %v", tc.input, nil, terragruntOptions, err)
 
 			assert.NotNil(t, actual)
@@ -965,8 +968,8 @@ func TestReadTerragruntConfigInputs(t *testing.T) {
 	options := terragruntOptionsForTest(t, config.DefaultTerragruntConfigPath)
 
 	l := logger.CreateLogger()
-	ctx := config.NewParsingContext(t.Context(), l, options)
-	tgConfigCty, err := config.ParseTerragruntConfig(ctx, l, "../test/fixtures/inputs/terragrunt.hcl", nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, options)
+	tgConfigCty, err := config.ParseTerragruntConfig(ctx, pctx, l, "../test/fixtures/inputs/terragrunt.hcl", nil)
 	require.NoError(t, err)
 
 	tgConfigMap, err := ctyhelper.ParseCtyValueToMap(tgConfigCty)
@@ -1003,8 +1006,8 @@ func TestReadTerragruntConfigRemoteState(t *testing.T) {
 
 	options := terragruntOptionsForTest(t, config.DefaultTerragruntConfigPath)
 	l := logger.CreateLogger()
-	ctx := config.NewParsingContext(t.Context(), l, options)
-	tgConfigCty, err := config.ParseTerragruntConfig(ctx, l, "../test/fixtures/terragrunt/terragrunt.hcl", nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, options)
+	tgConfigCty, err := config.ParseTerragruntConfig(ctx, pctx, l, "../test/fixtures/terragrunt/terragrunt.hcl", nil)
 	require.NoError(t, err)
 
 	tgConfigMap, err := ctyhelper.ParseCtyValueToMap(tgConfigCty)
@@ -1037,8 +1040,8 @@ func TestReadTerragruntConfigHooks(t *testing.T) {
 
 	options := terragruntOptionsForTest(t, config.DefaultTerragruntConfigPath)
 	l := logger.CreateLogger()
-	ctx := config.NewParsingContext(t.Context(), l, options)
-	tgConfigCty, err := config.ParseTerragruntConfig(ctx, l, "../test/fixtures/hooks/before-after-and-on-error/terragrunt.hcl", nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, options)
+	tgConfigCty, err := config.ParseTerragruntConfig(ctx, pctx, l, "../test/fixtures/hooks/before-after-and-on-error/terragrunt.hcl", nil)
 	require.NoError(t, err)
 
 	tgConfigMap, err := ctyhelper.ParseCtyValueToMap(tgConfigCty)
@@ -1081,8 +1084,8 @@ func TestReadTerragruntConfigLocals(t *testing.T) {
 
 	options := terragruntOptionsForTest(t, config.DefaultTerragruntConfigPath)
 	l := logger.CreateLogger()
-	ctx := config.NewParsingContext(t.Context(), l, options)
-	tgConfigCty, err := config.ParseTerragruntConfig(ctx, l, "../test/fixtures/locals/canonical/terragrunt.hcl", nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, options)
+	tgConfigCty, err := config.ParseTerragruntConfig(ctx, pctx, l, "../test/fixtures/locals/canonical/terragrunt.hcl", nil)
 	require.NoError(t, err)
 
 	tgConfigMap, err := ctyhelper.ParseCtyValueToMap(tgConfigCty)
@@ -1149,8 +1152,8 @@ func TestStartsWith(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx := config.NewParsingContext(t.Context(), l, tc.config)
-			actual, err := config.StartsWith(ctx, tc.args)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, tc.config)
+			actual, err := config.StartsWith(ctx, pctx, tc.args)
 			require.NoError(t, err)
 			assert.Equal(t, tc.value, actual)
 		})
@@ -1181,8 +1184,8 @@ func TestEndsWith(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx := config.NewParsingContext(t.Context(), l, tc.config)
-			actual, err := config.EndsWith(ctx, tc.args)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, tc.config)
+			actual, err := config.EndsWith(ctx, pctx, tc.args)
 			require.NoError(t, err)
 			assert.Equal(t, tc.value, actual)
 		})
@@ -1243,9 +1246,9 @@ func TestTimeCmp(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx := config.NewParsingContext(t.Context(), l, tc.config)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, tc.config)
 
-			actual, err := config.TimeCmp(ctx, l, tc.args)
+			actual, err := config.TimeCmp(ctx, pctx, l, tc.args)
 			if tc.err != "" {
 				require.EqualError(t, err, tc.err)
 			} else {
@@ -1292,9 +1295,9 @@ func TestStrContains(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx := config.NewParsingContext(t.Context(), l, tc.config)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, tc.config)
 
-			actual, err := config.StrContains(ctx, tc.args)
+			actual, err := config.StrContains(ctx, pctx, tc.args)
 			if tc.err != "" {
 				require.EqualError(t, err, tc.err)
 			} else {
@@ -1311,8 +1314,8 @@ func TestReadTFVarsFiles(t *testing.T) {
 
 	options := terragruntOptionsForTest(t, config.DefaultTerragruntConfigPath)
 	l := logger.CreateLogger()
-	ctx := config.NewParsingContext(t.Context(), l, options)
-	tgConfigCty, err := config.ParseTerragruntConfig(ctx, l, "../test/fixtures/read-tf-vars/terragrunt.hcl", nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, options)
+	tgConfigCty, err := config.ParseTerragruntConfig(ctx, pctx, l, "../test/fixtures/read-tf-vars/terragrunt.hcl", nil)
 	require.NoError(t, err)
 
 	tgConfigMap, err := ctyhelper.ParseCtyValueToMap(tgConfigCty)
@@ -1415,9 +1418,9 @@ func TestConstraintCheck(t *testing.T) {
 
 			l := logger.CreateLogger()
 
-			ctx := config.NewParsingContext(t.Context(), l, tc.config)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, tc.config)
 
-			actual, err := config.ConstraintCheck(ctx, tc.args)
+			actual, err := config.ConstraintCheck(ctx, pctx, tc.args)
 			if tc.err != "" {
 				require.EqualError(t, err, tc.err)
 			} else {

--- a/config/config_partial.go
+++ b/config/config_partial.go
@@ -120,10 +120,10 @@ type terragruntEngine struct {
 // - locals
 // - features
 // - include
-func DecodeBaseBlocks(ctx *ParsingContext, l log.Logger, file *hclparse.File, includeFromChild *IncludeConfig) (*DecodedBaseBlocks, error) {
+func DecodeBaseBlocks(ctx context.Context, pctx *ParsingContext, l log.Logger, file *hclparse.File, includeFromChild *IncludeConfig) (*DecodedBaseBlocks, error) {
 	errs := &errors.MultiError{}
 
-	evalParsingContext, err := createTerragruntEvalContext(ctx, l, file.ConfigPath)
+	evalParsingContext, err := createTerragruntEvalContext(ctx, pctx, l, file.ConfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func DecodeBaseBlocks(ctx *ParsingContext, l log.Logger, file *hclparse.File, in
 		errs = errs.Append(err)
 	}
 
-	trackInclude, err := getTrackInclude(ctx, terragruntIncludeList, includeFromChild)
+	trackInclude, err := getTrackInclude(pctx, terragruntIncludeList, includeFromChild)
 	if err != nil {
 		errs = errs.Append(err)
 	}
@@ -162,14 +162,14 @@ func DecodeBaseBlocks(ctx *ParsingContext, l log.Logger, file *hclparse.File, in
 		errs = errs.Append(flagErrs)
 	}
 
-	flagsAsCtyVal, err := flagsAsCty(ctx, tgFlags.FeatureFlags)
+	flagsAsCtyVal, err := flagsAsCty(pctx, tgFlags.FeatureFlags)
 	if err != nil {
 		errs = errs.Append(err)
 	}
 
 	// Evaluate all the expressions in the locals block separately and generate the variables list to use in the
 	// evaluation ctx.
-	locals, err := EvaluateLocalsBlock(ctx.WithTrackInclude(trackInclude).WithFeatures(&flagsAsCtyVal), l, file)
+	locals, err := EvaluateLocalsBlock(ctx, pctx.WithTrackInclude(trackInclude).WithFeatures(&flagsAsCtyVal), l, file)
 	if err != nil {
 		errs = errs.Append(err)
 	}
@@ -264,7 +264,7 @@ func cliFlagsToCty(ctx *ParsingContext, flagByName map[string]*FeatureFlag) (map
 	return evaluatedFlags, nil
 }
 
-func PartialParseConfigFile(ctx *ParsingContext, l log.Logger, configPath string, include *IncludeConfig) (*TerragruntConfig, error) {
+func PartialParseConfigFile(ctx context.Context, pctx *ParsingContext, l log.Logger, configPath string, include *IncludeConfig) (*TerragruntConfig, error) {
 	hclCache := cache.ContextCache[*hclparse.File](ctx, HclCacheContextKey)
 
 	fileInfo, err := os.Stat(configPath)
@@ -283,34 +283,33 @@ func PartialParseConfigFile(ctx *ParsingContext, l log.Logger, configPath string
 
 	var config *TerragruntConfig
 
-	// TODO: Remove lint ignore
 	err = TraceParseConfigFile(
 		ctx,
 		configPath,
-		ctx.TerragruntOptions.WorkingDir,
+		pctx.TerragruntOptions.WorkingDir,
 		true, // isPartial
-		ctx.PartialParseDecodeList,
+		pctx.PartialParseDecodeList,
 		include,
 		cacheHit,
-		func(_ context.Context) error {
+		func(ctx context.Context) error {
 			var file *hclparse.File
 
-			if cacheConfig, found := hclCache.Get(ctx, cacheKey); found { //nolint:contextcheck
+			if cacheConfig, found := hclCache.Get(ctx, cacheKey); found {
 				file = cacheConfig
 			} else {
 				var parseErr error
 
-				file, parseErr = hclparse.NewParser(ctx.ParserOptions...).ParseFromFile(configPath)
+				file, parseErr = hclparse.NewParser(pctx.ParserOptions...).ParseFromFile(configPath)
 				if parseErr != nil {
 					return parseErr
 				}
 
-				hclCache.Put(ctx, cacheKey, file) //nolint:contextcheck
+				hclCache.Put(ctx, cacheKey, file)
 			}
 
 			var parseErr error
 
-			config, parseErr = TerragruntConfigFromPartialConfig(ctx, l, file, include) //nolint:contextcheck
+			config, parseErr = TerragruntConfigFromPartialConfig(ctx, pctx, l, file, include)
 
 			return parseErr
 		})
@@ -321,28 +320,28 @@ func PartialParseConfigFile(ctx *ParsingContext, l log.Logger, configPath string
 // TerragruntConfigFromPartialConfig is a wrapper of PartialParseConfigString which checks for cached configs.
 // filename, configString, includeFromChild and decodeList are used for the cache key,
 // by getting the default value (%#v) through fmt.
-func TerragruntConfigFromPartialConfig(ctx *ParsingContext, l log.Logger, file *hclparse.File, includeFromChild *IncludeConfig) (*TerragruntConfig, error) {
-	var cacheKey = fmt.Sprintf("%#v-%#v-%#v-%#v", file.ConfigPath, file.Content(), includeFromChild, ctx.PartialParseDecodeList)
+func TerragruntConfigFromPartialConfig(ctx context.Context, pctx *ParsingContext, l log.Logger, file *hclparse.File, includeFromChild *IncludeConfig) (*TerragruntConfig, error) {
+	var cacheKey = fmt.Sprintf("%#v-%#v-%#v-%#v", file.ConfigPath, file.Content(), includeFromChild, pctx.PartialParseDecodeList)
 
 	terragruntConfigCache := cache.ContextCache[*TerragruntConfig](ctx, TerragruntConfigCacheContextKey)
-	if ctx.TerragruntOptions.UsePartialParseConfigCache {
+	if pctx.TerragruntOptions.UsePartialParseConfigCache {
 		if config, found := terragruntConfigCache.Get(ctx, cacheKey); found {
-			l.Debugf("Cache hit for '%s' (partial parsing), decodeList: '%v'.", ctx.TerragruntOptions.TerragruntConfigPath, ctx.PartialParseDecodeList)
+			l.Debugf("Cache hit for '%s' (partial parsing), decodeList: '%v'.", pctx.TerragruntOptions.TerragruntConfigPath, pctx.PartialParseDecodeList)
 
 			deepCopy := clone.Clone(config).(*TerragruntConfig)
 
 			return deepCopy, nil
 		}
 
-		l.Debugf("Cache miss for '%s' (partial parsing), decodeList: '%v'.", ctx.TerragruntOptions.TerragruntConfigPath, ctx.PartialParseDecodeList)
+		l.Debugf("Cache miss for '%s' (partial parsing), decodeList: '%v'.", pctx.TerragruntOptions.TerragruntConfigPath, pctx.PartialParseDecodeList)
 	}
 
-	config, err := PartialParseConfig(ctx, l, file, includeFromChild)
+	config, err := PartialParseConfig(ctx, pctx, l, file, includeFromChild)
 	if err != nil {
 		return config, err
 	}
 
-	if ctx.TerragruntOptions.UsePartialParseConfigCache {
+	if pctx.TerragruntOptions.UsePartialParseConfigCache {
 		putConfig := clone.Clone(config).(*TerragruntConfig)
 		terragruntConfigCache.Put(ctx, cacheKey, putConfig)
 	}
@@ -369,58 +368,58 @@ func TerragruntConfigFromPartialConfig(ctx *ParsingContext, l log.Logger, file *
 // - include
 // Note also that the following blocks are never decoded in a partial parse:
 // - inputs
-func PartialParseConfigString(ctx *ParsingContext, l log.Logger, configPath, configString string, include *IncludeConfig) (*TerragruntConfig, error) {
-	file, err := hclparse.NewParser(ctx.ParserOptions...).ParseFromString(configString, configPath)
+func PartialParseConfigString(ctx context.Context, pctx *ParsingContext, l log.Logger, configPath, configString string, include *IncludeConfig) (*TerragruntConfig, error) {
+	file, err := hclparse.NewParser(pctx.ParserOptions...).ParseFromString(configString, configPath)
 	if err != nil {
 		return nil, err
 	}
 
-	return PartialParseConfig(ctx, l, file, include)
+	return PartialParseConfig(ctx, pctx, l, file, include)
 }
 
-func PartialParseConfig(ctx *ParsingContext, l log.Logger, file *hclparse.File, includeFromChild *IncludeConfig) (*TerragruntConfig, error) {
+func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger, file *hclparse.File, includeFromChild *IncludeConfig) (*TerragruntConfig, error) {
 	errs := &errors.MultiError{}
 
 	// Detect and block deprecated configurations early, before attempting to parse.
 	// This ensures included configs with deprecated syntax get clear error messages
 	// instead of cryptic "Could not find Terragrunt configuration settings" errors.
 	// See: https://github.com/gruntwork-io/terragrunt/issues/4983
-	if err := DetectDeprecatedConfigurations(ctx, l, file); err != nil {
+	if err := DetectDeprecatedConfigurations(ctx, pctx, l, file); err != nil {
 		return nil, err
 	}
 
-	ctx = ctx.WithTrackInclude(nil)
+	pctx = pctx.WithTrackInclude(nil)
 
 	// read unit files and add to context
-	unitValues, err := ReadValues(ctx.Context, l, ctx.TerragruntOptions, filepath.Dir(file.ConfigPath))
+	unitValues, err := ReadValues(ctx, l, pctx.TerragruntOptions, filepath.Dir(file.ConfigPath))
 	if err != nil {
 		return nil, err
 	}
 
-	ctx = ctx.WithValues(unitValues)
+	pctx = pctx.WithValues(unitValues)
 
 	// Decode just the Base blocks. See the function docs for DecodeBaseBlocks for more info on what base blocks are.
 	// Initialize evaluation ctx extensions from base blocks.
-	baseBlocks, err := DecodeBaseBlocks(ctx, l, file, includeFromChild)
+	baseBlocks, err := DecodeBaseBlocks(ctx, pctx, l, file, includeFromChild)
 	if err != nil {
 		errs = errs.Append(err)
 	}
 
 	if baseBlocks != nil {
-		ctx = ctx.WithTrackInclude(baseBlocks.TrackInclude)
-		ctx = ctx.WithFeatures(baseBlocks.FeatureFlags)
-		ctx = ctx.WithLocals(baseBlocks.Locals)
+		pctx = pctx.WithTrackInclude(baseBlocks.TrackInclude)
+		pctx = pctx.WithFeatures(baseBlocks.FeatureFlags)
+		pctx = pctx.WithLocals(baseBlocks.Locals)
 	}
 
 	// Set parsed Locals on the parsed config
-	output, err := convertToTerragruntConfig(ctx, file.ConfigPath, &terragruntConfigFile{})
+	output, err := convertToTerragruntConfig(ctx, pctx, file.ConfigPath, &terragruntConfigFile{})
 	if err != nil {
 		return nil, err
 	}
 
 	output.IsPartial = true
 
-	evalParsingContext, err := createTerragruntEvalContext(ctx, l, file.ConfigPath)
+	evalParsingContext, err := createTerragruntEvalContext(ctx, pctx, l, file.ConfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +428,7 @@ func PartialParseConfig(ctx *ParsingContext, l log.Logger, file *hclparse.File, 
 	// them into the output TerragruntConfig struct.
 	hasExcludeBlock := false
 
-	for _, decode := range ctx.PartialParseDecodeList {
+	for _, decode := range pctx.PartialParseDecodeList {
 		switch decode {
 		case DependenciesBlock:
 			decoded := terragruntDependencies{}
@@ -535,7 +534,7 @@ func PartialParseConfig(ctx *ParsingContext, l log.Logger, file *hclparse.File, 
 			}
 
 			// If the TFPath is not explicitly set, use the TFPath from the config if it is set.
-			if !ctx.TerragruntOptions.TFPathExplicitlySet && decoded.TerraformBinary != nil {
+			if !pctx.TerragruntOptions.TFPathExplicitlySet && decoded.TerraformBinary != nil {
 				output.TerraformBinary = *decoded.TerraformBinary
 			}
 
@@ -606,11 +605,11 @@ func PartialParseConfig(ctx *ParsingContext, l log.Logger, file *hclparse.File, 
 
 	// If this file includes another, parse and merge the partial blocks. Otherwise, just return this config.
 	// If there have been errors during this parse, don't attempt to parse the included config.
-	if len(ctx.TrackInclude.CurrentList) > 0 && !errsContainsIncludeErr {
-		includeCount := len(ctx.TrackInclude.CurrentList)
+	if len(pctx.TrackInclude.CurrentList) > 0 && !errsContainsIncludeErr {
+		includeCount := len(pctx.TrackInclude.CurrentList)
 		includePaths := make([]string, 0, includeCount)
 
-		for _, inc := range ctx.TrackInclude.CurrentList {
+		for _, inc := range pctx.TrackInclude.CurrentList {
 			if inc.Path != "" {
 				includePaths = append(includePaths, inc.Path)
 			}
@@ -618,12 +617,10 @@ func PartialParseConfig(ctx *ParsingContext, l log.Logger, file *hclparse.File, 
 
 		var config *TerragruntConfig
 
-		// TODO: Remove lint ignore
-		err := TraceParseIncludeMerge(ctx, file.ConfigPath, includeCount, includePaths, func(childCtx context.Context) error {
+		err := TraceParseIncludeMerge(ctx, file.ConfigPath, includeCount, includePaths, func(ctx context.Context) error {
 			var mergeErr error
 
-			// Use the child context for trace propagation so include parsing is a child span
-			config, mergeErr = handleInclude(ctx.WithContext(childCtx), l, output, true) //nolint:contextcheck
+			config, mergeErr = handleInclude(ctx, pctx, l, output, true)
 
 			return mergeErr
 		})
@@ -632,7 +629,7 @@ func PartialParseConfig(ctx *ParsingContext, l log.Logger, file *hclparse.File, 
 		}
 
 		// Saving processed includes into configuration, direct assignment since nested includes aren't supported
-		config.ProcessedIncludes = ctx.TrackInclude.CurrentMap
+		config.ProcessedIncludes = pctx.TrackInclude.CurrentMap
 
 		output = config
 	}
@@ -642,20 +639,20 @@ func PartialParseConfig(ctx *ParsingContext, l log.Logger, file *hclparse.File, 
 	}
 
 	if hasExcludeBlock {
-		return processExcludes(ctx, l, output, file)
+		return processExcludes(ctx, pctx, l, output, file)
 	}
 
 	return output, nil
 }
 
 // processExcludes evaluate exclude blocks and merge them into the config.
-func processExcludes(ctx *ParsingContext, l log.Logger, config *TerragruntConfig, file *hclparse.File) (*TerragruntConfig, error) {
-	flagsAsCtyVal, err := flagsAsCty(ctx, config.FeatureFlags)
+func processExcludes(ctx context.Context, pctx *ParsingContext, l log.Logger, config *TerragruntConfig, file *hclparse.File) (*TerragruntConfig, error) {
+	flagsAsCtyVal, err := flagsAsCty(pctx, config.FeatureFlags)
 	if err != nil {
 		return nil, err
 	}
 
-	excludeConfig, err := evaluateExcludeBlocks(ctx.WithFeatures(&flagsAsCtyVal), l, file)
+	excludeConfig, err := evaluateExcludeBlocks(ctx, pctx.WithFeatures(&flagsAsCtyVal), l, file)
 	if err != nil {
 		return nil, err
 	}
@@ -673,19 +670,20 @@ func processExcludes(ctx *ParsingContext, l log.Logger, config *TerragruntConfig
 	return config, nil
 }
 
-func partialParseIncludedConfig(ctx *ParsingContext, l log.Logger, includedConfig *IncludeConfig) (*TerragruntConfig, error) {
+func partialParseIncludedConfig(ctx context.Context, pctx *ParsingContext, l log.Logger, includedConfig *IncludeConfig) (*TerragruntConfig, error) {
 	if includedConfig.Path == "" {
-		return nil, errors.New(IncludedConfigMissingPathError(ctx.TerragruntOptions.TerragruntConfigPath))
+		return nil, errors.New(IncludedConfigMissingPathError(pctx.TerragruntOptions.TerragruntConfigPath))
 	}
 
 	includePath := includedConfig.Path
 
 	if !filepath.IsAbs(includePath) {
-		includePath = filepath.Join(filepath.Dir(ctx.TerragruntOptions.TerragruntConfigPath), includePath)
+		includePath = filepath.Join(filepath.Dir(pctx.TerragruntOptions.TerragruntConfigPath), includePath)
 	}
 
 	config, err := PartialParseConfigFile(
 		ctx,
+		pctx,
 		l,
 		includePath,
 		includedConfig,
@@ -694,7 +692,7 @@ func partialParseIncludedConfig(ctx *ParsingContext, l log.Logger, includedConfi
 		// Convert generic config not found error to include-specific error
 		var configNotFoundError TerragruntConfigNotFoundError
 		if errors.As(err, &configNotFoundError) {
-			return nil, IncludeConfigNotFoundError{IncludePath: includePath, SourcePath: ctx.TerragruntOptions.TerragruntConfigPath}
+			return nil, IncludeConfigNotFoundError{IncludePath: includePath, SourcePath: pctx.TerragruntOptions.TerragruntConfigPath}
 		}
 
 		return nil, err

--- a/config/config_partial_test.go
+++ b/config/config_partial_test.go
@@ -34,8 +34,9 @@ dependencies {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t)).WithDecodeList(config.DependenciesBlock)
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependenciesBlock)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -64,11 +65,12 @@ prevent_destroy = false
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
-	_, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	_, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 
-	_, err = config.PartialParseConfigString(ctx.WithDecodeList(config.DependenciesBlock), l, config.DefaultTerragruntConfigPath, cfg, nil)
+	pctx = pctx.WithDecodeList(config.DependenciesBlock)
+	_, err = config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	assert.Error(t, err)
 }
 
@@ -86,8 +88,9 @@ skip = true
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t)).WithDecodeList(config.DependenciesBlock, config.TerragruntFlags)
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.TerragruntFlags)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -108,8 +111,9 @@ func TestPartialParseOmittedItems(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t)).WithDecodeList(config.DependenciesBlock, config.TerragruntFlags)
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, "", nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.TerragruntFlags)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, "", nil)
 
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
@@ -128,11 +132,13 @@ func TestPartialParseDoesNotResolveIgnoredBlockEvenInParent(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, opts)
-	_, err := config.PartialParseConfigFile(ctx.WithDecodeList(config.TerragruntFlags), l, opts.TerragruntConfigPath, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
+	pctx = pctx.WithDecodeList(config.TerragruntFlags)
+	_, err := config.PartialParseConfigFile(ctx, pctx, l, opts.TerragruntConfigPath, nil)
 	require.NoError(t, err)
 
-	_, err = config.PartialParseConfigFile(ctx.WithDecodeList(config.DependenciesBlock), l, opts.TerragruntConfigPath, nil)
+	pctx = pctx.WithDecodeList(config.DependenciesBlock)
+	_, err = config.PartialParseConfigFile(ctx, pctx, l, opts.TerragruntConfigPath, nil)
 	assert.Error(t, err)
 }
 
@@ -143,8 +149,9 @@ func TestPartialParseOnlyInheritsSelectedBlocksFlags(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, opts).WithDecodeList(config.TerragruntFlags)
-	terragruntConfig, err := config.PartialParseConfigFile(ctx, l, opts.TerragruntConfigPath, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
+	pctx = pctx.WithDecodeList(config.TerragruntFlags)
+	terragruntConfig, err := config.PartialParseConfigFile(ctx, pctx, l, opts.TerragruntConfigPath, nil)
 	require.NoError(t, err)
 
 	assert.True(t, terragruntConfig.IsPartial)
@@ -163,8 +170,9 @@ func TestPartialParseOnlyInheritsSelectedBlocksDependencies(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, opts).WithDecodeList(config.DependenciesBlock)
-	terragruntConfig, err := config.PartialParseConfigFile(ctx, l, opts.TerragruntConfigPath, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
+	pctx = pctx.WithDecodeList(config.DependenciesBlock)
+	terragruntConfig, err := config.PartialParseConfigFile(ctx, pctx, l, opts.TerragruntConfigPath, nil)
 	require.NoError(t, err)
 
 	assert.True(t, terragruntConfig.IsPartial)
@@ -191,8 +199,9 @@ dependency "vpc" {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t)).WithDecodeList(config.DependencyBlock)
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependencyBlock)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -217,8 +226,9 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t)).WithDecodeList(config.DependencyBlock)
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependencyBlock)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -245,8 +255,9 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t)).WithDecodeList(config.DependencyBlock)
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependencyBlock)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -274,8 +285,9 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t)).WithDecodeList(config.DependenciesBlock, config.DependencyBlock)
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.DependencyBlock)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -303,8 +315,9 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t)).WithDecodeList(config.DependencyBlock, config.DependenciesBlock)
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependencyBlock, config.DependenciesBlock)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -332,8 +345,9 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t)).WithDecodeList(config.DependencyBlock, config.DependenciesBlock)
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependencyBlock, config.DependenciesBlock)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -361,8 +375,9 @@ terraform {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t)).WithDecodeList(config.TerraformSource)
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.TerraformSource)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 	assert.True(t, terragruntConfig.IsPartial)
 
@@ -386,8 +401,9 @@ dependency "ec2" {
 
 	l := logger.CreateLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t)).WithDecodeList(config.DependencyBlock)
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependencyBlock)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 	assert.Len(t, terragruntConfig.Dependencies.Paths, 1)
 }
@@ -411,18 +427,19 @@ func TestPartialParseSavesToHclCache(t *testing.T) {
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	baseCtx := context.WithValue(t.Context(), config.HclCacheContextKey, hclCache)
 	l := logger.CreateLogger()
-	parsingContext := config.NewParsingContext(baseCtx, l, mockOptionsForTest(t)).WithDecodeList(config.DependenciesBlock)
+	ctx, pctx := config.NewParsingContext(baseCtx, l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
 	// Verify cache is empty initially
-	_, found := hclCache.Get(parsingContext, expectedCacheKey)
+	_, found := hclCache.Get(ctx, expectedCacheKey)
 	require.False(t, found, "cache should be empty before parsing")
 
 	// Parse config file (should populate cache)
-	_, err = config.PartialParseConfigFile(parsingContext, l, configPath, nil)
+	_, err = config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
 
 	// Verify file was cached
-	cachedFile, found := hclCache.Get(parsingContext, expectedCacheKey)
+	cachedFile, found := hclCache.Get(ctx, expectedCacheKey)
 	require.True(t, found, "expected file to be in cache after first parse")
 	require.NotNil(t, cachedFile, "cached file should not be nil")
 
@@ -447,18 +464,19 @@ func TestPartialParseCacheHitOnSecondParse(t *testing.T) {
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	baseCtx := context.WithValue(t.Context(), config.HclCacheContextKey, hclCache)
 	l := logger.CreateLogger()
-	parsingContext := config.NewParsingContext(baseCtx, l, mockOptionsForTest(t)).WithDecodeList(config.DependenciesBlock)
+	ctx, pctx := config.NewParsingContext(baseCtx, l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
 	// First parse - should be cache miss
-	_, err = config.PartialParseConfigFile(parsingContext, l, configPath, nil)
+	_, err = config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
 
 	// Verify cache hit on second parse
-	_, err = config.PartialParseConfigFile(parsingContext, l, configPath, nil)
+	_, err = config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
 
 	// Verify same file object is returned from cache
-	cachedFile, found := hclCache.Get(parsingContext, cacheKey)
+	cachedFile, found := hclCache.Get(ctx, cacheKey)
 	require.True(t, found)
 	require.NotNil(t, cachedFile)
 }
@@ -481,14 +499,15 @@ func TestPartialParseCacheInvalidationOnFileModification(t *testing.T) {
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	baseCtx := context.WithValue(t.Context(), config.HclCacheContextKey, hclCache)
 	l := logger.CreateLogger()
-	parsingContext := config.NewParsingContext(baseCtx, l, mockOptionsForTest(t)).WithDecodeList(config.DependenciesBlock)
+	ctx, pctx := config.NewParsingContext(baseCtx, l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
 	// Parse original file
-	_, err = config.PartialParseConfigFile(parsingContext, l, configPath, nil)
+	_, err = config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
 
 	// Verify original file is cached
-	_, found := hclCache.Get(parsingContext, originalCacheKey)
+	_, found := hclCache.Get(ctx, originalCacheKey)
 	require.True(t, found, "original file should be cached")
 
 	// Modify file (this changes mod time)
@@ -496,11 +515,11 @@ func TestPartialParseCacheInvalidationOnFileModification(t *testing.T) {
 	forceModTimeChange(t, configPath, fileInfo.ModTime())
 
 	// Parse modified file - should create new cache entry
-	_, err = config.PartialParseConfigFile(parsingContext, l, configPath, nil)
+	_, err = config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
 
 	// Verify old cache entry is still there but new one exists
-	_, found = hclCache.Get(parsingContext, originalCacheKey)
+	_, found = hclCache.Get(ctx, originalCacheKey)
 	require.True(t, found, "original cache entry should still exist")
 
 	// Get new cache key
@@ -510,7 +529,7 @@ func TestPartialParseCacheInvalidationOnFileModification(t *testing.T) {
 	newCacheKey := fmt.Sprintf("configPath-%v-modTime-%v", configPath, fileInfo.ModTime().UnixMicro())
 
 	// Verify new file is cached with different content
-	newCachedFile, found := hclCache.Get(parsingContext, newCacheKey)
+	newCachedFile, found := hclCache.Get(ctx, newCacheKey)
 	require.True(t, found, "modified file should be cached")
 	require.NotNil(t, newCachedFile)
 	assert.Contains(t, newCachedFile.Content(), "../app2")
@@ -527,10 +546,11 @@ func TestPartialParseCacheWithInvalidFile(t *testing.T) {
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	baseCtx := context.WithValue(t.Context(), config.HclCacheContextKey, hclCache)
 	l := logger.CreateLogger()
-	parsingContext := config.NewParsingContext(baseCtx, l, mockOptionsForTest(t)).WithDecodeList(config.DependenciesBlock)
+	ctx, pctx := config.NewParsingContext(baseCtx, l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
 	// Parse should fail and not cache an invalid file
-	_, err := config.PartialParseConfigFile(parsingContext, l, configPath, nil)
+	_, err := config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.Error(t, err, "parsing invalid HCL should fail")
 
 	// Verify nothing was cached
@@ -539,7 +559,7 @@ func TestPartialParseCacheWithInvalidFile(t *testing.T) {
 
 	cacheKey := fmt.Sprintf("configPath-%v-modTime-%v", configPath, fileInfo.ModTime().UnixMicro())
 
-	_, found := hclCache.Get(parsingContext, cacheKey)
+	_, found := hclCache.Get(ctx, cacheKey)
 	require.False(t, found, "invalid file should not be cached")
 }
 
@@ -559,9 +579,10 @@ func TestPartialParseCacheKeyFormat(t *testing.T) {
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	baseCtx := context.WithValue(t.Context(), config.HclCacheContextKey, hclCache)
 	l := logger.CreateLogger()
-	parsingContext := config.NewParsingContext(baseCtx, l, mockOptionsForTest(t)).WithDecodeList(config.DependenciesBlock)
+	ctx, pctx := config.NewParsingContext(baseCtx, l, mockOptionsForTest(t))
+	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
-	_, err = config.PartialParseConfigFile(parsingContext, l, configPath, nil)
+	_, err = config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
 
 	// Verify cache key format matches the expected pattern
@@ -570,7 +591,7 @@ func TestPartialParseCacheKeyFormat(t *testing.T) {
 	assert.Contains(t, expectedCacheKey, strconv.FormatInt(fileInfo.ModTime().UnixMicro(), 10), "cache key should contain mod time")
 
 	// Verify we can retrieve using the expected key
-	_, found := hclCache.Get(parsingContext, expectedCacheKey)
+	_, found := hclCache.Get(ctx, expectedCacheKey)
 	require.True(t, found, "should be able to retrieve using expected cache key format")
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,8 +43,8 @@ remote_state {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.Terraform)
@@ -70,8 +70,8 @@ remote_state = {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.Terraform)
@@ -98,8 +98,8 @@ func TestParseTerragruntJsonConfigRemoteStateMinimalConfig(t *testing.T) {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntJSONConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntJSONConfigPath, cfg, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.Terraform)
@@ -120,8 +120,8 @@ remote_state {}
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
-	_, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Missing required argument; The argument \"backend\" is required")
 }
@@ -147,9 +147,9 @@ remote_state {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,9 +191,9 @@ func TestParseTerragruntJsonConfigRemoteStateFullConfig(t *testing.T) {
 `
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntJSONConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntJSONConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,8 +222,8 @@ retryable_errors = [".*Error.*"]
 `
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
-	_, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "retryable_errors")
 	assert.Contains(t, err.Error(), "Unsupported argument")
@@ -240,8 +240,8 @@ func TestParseTerragruntJsonConfigRetryConfiguration(t *testing.T) {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
-	_, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntJSONConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntJSONConfigPath, cfg, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "retryable_errors")
 	// JSON config gives a slightly different error message
@@ -255,9 +255,9 @@ func TestParseIamRole(t *testing.T) {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,9 +276,9 @@ func TestParseIamAssumeRoleDuration(t *testing.T) {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,9 +297,9 @@ func TestParseIamAssumeRoleSessionName(t *testing.T) {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,9 +320,9 @@ func TestParseIamWebIdentity(t *testing.T) {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -345,9 +345,9 @@ dependencies {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,9 +373,9 @@ dependencies {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -414,9 +414,9 @@ dependencies {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,9 +465,9 @@ func TestParseTerragruntJsonConfigRemoteStateDynamoDbTerraformConfigAndDependenc
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntJSONConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntJSONConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -509,9 +509,9 @@ include {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, opts)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, opts.TerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, opts.TerragruntConfigPath, cfg, nil)
 	if assert.NoError(t, err, "Unexpected error: %v", errors.New(err)) {
 		assert.Nil(t, terragruntConfig.Terraform)
 
@@ -539,9 +539,9 @@ include {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, opts)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, opts.TerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, opts.TerragruntConfigPath, cfg, nil)
 	if assert.NoError(t, err, "Unexpected error: %v", errors.New(err)) {
 		assert.Nil(t, terragruntConfig.Terraform)
 
@@ -581,9 +581,9 @@ remote_state {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, opts)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, opts.TerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, opts.TerragruntConfigPath, cfg, nil)
 	if assert.NoError(t, err, "Unexpected error: %v", errors.New(err)) {
 		assert.Nil(t, terragruntConfig.Terraform)
 
@@ -631,8 +631,8 @@ dependencies {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, opts)
-	terragruntConfig, err := config.ParseConfigString(ctx, l, opts.TerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, opts.TerragruntConfigPath, cfg, nil)
 	require.NoError(t, err, "Unexpected error: %v", errors.New(err))
 
 	assert.NotNil(t, terragruntConfig.Terraform)
@@ -682,8 +682,8 @@ func TestParseTerragruntJsonConfigIncludeOverrideAll(t *testing.T) {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, opts)
-	terragruntConfig, err := config.ParseConfigString(ctx, l, opts.TerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, opts.TerragruntConfigPath, cfg, nil)
 	require.NoError(t, err, "Unexpected error: %v", errors.New(err))
 
 	assert.NotNil(t, terragruntConfig.Terraform)
@@ -715,9 +715,9 @@ func TestParseTerragruntConfigTwoLevels(t *testing.T) {
 	opts := mockOptionsForTestWithConfigPath(t, configPath)
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, opts)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
 
-	_, actualErr := config.ParseConfigString(ctx, l, configPath, cfg, nil)
+	_, actualErr := config.ParseConfigString(ctx, pctx, l, configPath, cfg, nil)
 
 	errStr := actualErr.Error()
 
@@ -741,9 +741,9 @@ func TestParseTerragruntConfigThreeLevels(t *testing.T) {
 	opts := mockOptionsForTestWithConfigPath(t, configPath)
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, opts)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
 
-	_, actualErr := config.ParseConfigString(ctx, l, configPath, cfg, nil)
+	_, actualErr := config.ParseConfigString(ctx, pctx, l, configPath, cfg, nil)
 
 	// Convert the error paths to forward slashes for cross-platform compatibility
 	errStr := actualErr.Error()
@@ -765,8 +765,8 @@ func TestParseTerragruntConfigEmptyConfig(t *testing.T) {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.Terraform)
@@ -784,9 +784,9 @@ func TestParseTerragruntConfigEmptyConfigOldConfig(t *testing.T) {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	cfg, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfgString, nil)
+	cfg, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfgString, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -803,9 +803,9 @@ terraform {}
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -828,9 +828,9 @@ terraform {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -863,9 +863,9 @@ terraform {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -926,8 +926,8 @@ terraform {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.RemoteState)
@@ -985,8 +985,8 @@ func TestParseTerragruntJsonConfigTerraformWithMultipleExtraArguments(t *testing
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntJSONConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntJSONConfigPath, cfg, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, terragruntConfig.RemoteState)
@@ -1252,9 +1252,9 @@ prevent_destroy = true
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1274,9 +1274,9 @@ prevent_destroy = false
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1296,9 +1296,9 @@ skip = true
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	_, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "skip")
 	assert.Contains(t, err.Error(), "Unsupported argument")
@@ -1313,9 +1313,9 @@ skip = false
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	_, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "skip")
 	assert.Contains(t, err.Error(), "Unsupported argument")
@@ -1341,9 +1341,9 @@ terraform {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, opts)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1536,9 +1536,9 @@ func TestBestEffortParseConfigString(t *testing.T) {
 
 			l := createLogger()
 
-			ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+			ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-			terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, tt.cfg, nil)
+			terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, tt.cfg, nil)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {
@@ -1559,9 +1559,9 @@ func TestParseConfigWithMissingIfExists(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 
 	errStr := err.Error()
@@ -1604,11 +1604,11 @@ dependency "dep" {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
 
-	ctx.TerragruntOptions.WorkingDir = unitPath
+	pctx.TerragruntOptions.WorkingDir = unitPath
 
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 
 	assert.Equal(t, &config.TerragruntConfig{
@@ -1795,8 +1795,8 @@ inputs = {
 
 	l := createLogger()
 
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
-	terragruntConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTest(t))
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 
 	// Write the config to a buffer
@@ -1806,7 +1806,7 @@ inputs = {
 	assert.Positive(t, n)
 
 	// Parse the written config back
-	rereadConfig, err := config.ParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, buf.String(), nil)
+	rereadConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, buf.String(), nil)
 	require.NoError(t, err)
 
 	// Verify the configs match

--- a/config/dependency_inputs_test.go
+++ b/config/dependency_inputs_test.go
@@ -31,7 +31,7 @@ inputs = {
 	require.NoError(t, err)
 
 	// Create a parsing context with strict controls
-	ctx := &config.ParsingContext{
+	pctx := &config.ParsingContext{
 		TerragruntOptions: &options.TerragruntOptions{
 			StrictControls: controls.New(),
 		},
@@ -40,7 +40,7 @@ inputs = {
 	logger := log.New()
 
 	// Test that the deprecated configuration is detected and blocked
-	err = config.DetectDeprecatedConfigurations(ctx, logger, file)
+	err = config.DetectDeprecatedConfigurations(t.Context(), pctx, logger, file)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Reading inputs from dependencies is no longer supported")
 	assert.Contains(t, err.Error(), "use outputs")
@@ -65,7 +65,7 @@ inputs = {
 	require.NoError(t, err)
 
 	// Create a parsing context with strict controls
-	ctx := &config.ParsingContext{
+	pctx := &config.ParsingContext{
 		TerragruntOptions: &options.TerragruntOptions{
 			StrictControls: controls.New(),
 		},
@@ -74,7 +74,7 @@ inputs = {
 	logger := log.New()
 
 	// Test that the dependency outputs are allowed (no error)
-	err = config.DetectDeprecatedConfigurations(ctx, logger, file)
+	err = config.DetectDeprecatedConfigurations(t.Context(), pctx, logger, file)
 	require.NoError(t, err)
 }
 

--- a/config/dependency_test.go
+++ b/config/dependency_test.go
@@ -118,16 +118,16 @@ func TestParseDependencyBlockMultiple(t *testing.T) {
 	t.Parallel()
 
 	filename := "../test/fixtures/regressions/multiple-dependency-load-sync/main/terragrunt.hcl"
-	ctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), mockOptionsForTestWithConfigPath(t, filename))
+	ctx, pctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), mockOptionsForTestWithConfigPath(t, filename))
 	opts, err := options.NewTerragruntOptionsForTest(filename)
 	require.NoError(t, err)
 
-	ctx.TerragruntOptions = opts
-	err = ctx.TerragruntOptions.Experiments.EnableExperiment(experiment.DependencyFetchOutputFromState)
+	pctx.TerragruntOptions = opts
+	err = pctx.TerragruntOptions.Experiments.EnableExperiment(experiment.DependencyFetchOutputFromState)
 	require.NoError(t, err)
 
-	ctx.TerragruntOptions.Env = env.Parse(os.Environ())
-	tfConfig, err := config.ParseConfigFile(ctx, logger.CreateLogger(), filename, nil)
+	pctx.TerragruntOptions.Env = env.Parse(os.Environ())
+	tfConfig, err := config.ParseConfigFile(ctx, pctx, logger.CreateLogger(), filename, nil)
 	require.NoError(t, err)
 	assert.Len(t, tfConfig.TerragruntDependencies, 2)
 	assert.Equal(t, "dependency_1", tfConfig.TerragruntDependencies[0].Name)
@@ -177,10 +177,11 @@ dependency "enabled" {
 }
 `
 	l := logger.CreateLogger()
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTestWithConfigPath(t, config.DefaultTerragruntConfigPath)).WithDecodeList(config.DependencyBlock)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTestWithConfigPath(t, config.DefaultTerragruntConfigPath))
+	pctx = pctx.WithDecodeList(config.DependencyBlock)
 
 	// Should not panic - disabled deps bypass config_path validation
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 
 	// Only enabled dependency should be in the paths
@@ -203,10 +204,11 @@ dependency "enabled" {
 }
 `
 	l := logger.CreateLogger()
-	ctx := config.NewParsingContext(t.Context(), l, mockOptionsForTestWithConfigPath(t, config.DefaultTerragruntConfigPath)).WithDecodeList(config.DependencyBlock)
+	ctx, pctx := config.NewParsingContext(t.Context(), l, mockOptionsForTestWithConfigPath(t, config.DefaultTerragruntConfigPath))
+	pctx = pctx.WithDecodeList(config.DependencyBlock)
 
 	// Should not error - disabled deps bypass config_path validation
-	terragruntConfig, err := config.PartialParseConfigString(ctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	terragruntConfig, err := config.PartialParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 
 	// Only enabled dependency should be in the paths

--- a/config/exclude.go
+++ b/config/exclude.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"strconv"
 	"strings"
 
@@ -78,7 +79,7 @@ func (e *ExcludeConfig) Merge(exclude *ExcludeConfig) {
 }
 
 // evaluateExcludeBlocks evaluates the exclude block in the parsed file.
-func evaluateExcludeBlocks(ctx *ParsingContext, l log.Logger, file *hclparse.File) (*ExcludeConfig, error) {
+func evaluateExcludeBlocks(ctx context.Context, pctx *ParsingContext, l log.Logger, file *hclparse.File) (*ExcludeConfig, error) {
 	excludeBlock, err := file.Blocks(MetadataExclude, false)
 	if err != nil {
 		return nil, err
@@ -99,7 +100,7 @@ func evaluateExcludeBlocks(ctx *ParsingContext, l log.Logger, file *hclparse.Fil
 		return nil, err
 	}
 
-	evalCtx, err := createTerragruntEvalContext(ctx, l, file.ConfigPath)
+	evalCtx, err := createTerragruntEvalContext(ctx, pctx, l, file.ConfigPath)
 	if err != nil {
 		l.Errorf("Failed to create eval context %s", file.ConfigPath)
 		return nil, err

--- a/config/include.go
+++ b/config/include.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -26,15 +27,15 @@ const bareIncludeKey = ""
 var fieldsCopyLocks = util.NewKeyLocks()
 
 // Parse the config of the given include, if one is specified
-func parseIncludedConfig(ctx *ParsingContext, l log.Logger, includedConfig *IncludeConfig) (*TerragruntConfig, error) {
+func parseIncludedConfig(ctx context.Context, pctx *ParsingContext, l log.Logger, includedConfig *IncludeConfig) (*TerragruntConfig, error) {
 	if includedConfig.Path == "" {
-		return nil, errors.New(IncludedConfigMissingPathError(ctx.TerragruntOptions.TerragruntConfigPath))
+		return nil, errors.New(IncludedConfigMissingPathError(pctx.TerragruntOptions.TerragruntConfigPath))
 	}
 
 	includePath := includedConfig.Path
 
 	if !filepath.IsAbs(includePath) {
-		includePath = filepath.Join(filepath.Dir(ctx.TerragruntOptions.TerragruntConfigPath), includePath)
+		includePath = filepath.Join(filepath.Dir(pctx.TerragruntOptions.TerragruntConfigPath), includePath)
 	}
 
 	// These condition are here to specifically handle the `run --all` command. During any `run --all` call, terragrunt
@@ -86,28 +87,28 @@ func parseIncludedConfig(ctx *ParsingContext, l log.Logger, includedConfig *Incl
 		return nil, err
 	}
 
-	if hasDependency && len(ctx.PartialParseDecodeList) > 0 {
+	if hasDependency && len(pctx.PartialParseDecodeList) > 0 {
 		l.Debugf(
 			"Included config %s can only be partially parsed during dependency graph formation for run --all command as it has a dependency block.",
 			includePath,
 		)
 
-		return PartialParseConfigFile(ctx, l, includePath, includedConfig)
+		return PartialParseConfigFile(ctx, pctx, l, includePath, includedConfig)
 	}
 
 	// When included config has dependencies, suppress diagnostics during parsing.
-	parseCtx := ctx
+	parseCtx := pctx
 	if hasDependency {
-		parseCtx = ctx.WithDiagnosticsSuppressed(l)
+		parseCtx = pctx.WithDiagnosticsSuppressed(l)
 	}
 
-	config, err := ParseConfigFile(parseCtx, l, includePath, includedConfig)
+	config, err := ParseConfigFile(ctx, parseCtx, l, includePath, includedConfig)
 	if err != nil {
 		var configNotFoundError TerragruntConfigNotFoundError
 		if errors.As(err, &configNotFoundError) {
 			return nil, IncludeConfigNotFoundError{
 				IncludePath: includePath,
-				SourcePath:  ctx.TerragruntOptions.TerragruntConfigPath,
+				SourcePath:  pctx.TerragruntOptions.TerragruntConfigPath,
 			}
 		}
 
@@ -119,14 +120,14 @@ func parseIncludedConfig(ctx *ParsingContext, l log.Logger, includedConfig *Incl
 
 // handleInclude merges the included config into the current config depending on the merge strategy specified by the
 // user.
-func handleInclude(ctx *ParsingContext, l log.Logger, config *TerragruntConfig, isPartial bool) (*TerragruntConfig, error) {
-	if ctx.TrackInclude == nil {
+func handleInclude(ctx context.Context, pctx *ParsingContext, l log.Logger, config *TerragruntConfig, isPartial bool) (*TerragruntConfig, error) {
+	if pctx.TrackInclude == nil {
 		return nil, errors.New("you reached an impossible condition. This is most likely a bug in terragrunt. Please open an issue at github.com/gruntwork-io/terragrunt with this error message.Code: HANDLE_INCLUDE_NIL_INCLUDE_CONFIG")
 	}
 
 	// We merge in the include blocks in reverse order here. The expectation is that the bottom most elements override
 	// those in earlier includes, so we need to merge bottom up instead of top down to ensure this.
-	includeList := ctx.TrackInclude.CurrentList
+	includeList := pctx.TrackInclude.CurrentList
 	baseConfig := config
 
 	for i := len(includeList) - 1; i >= 0; i-- {
@@ -142,13 +143,13 @@ func handleInclude(ctx *ParsingContext, l log.Logger, config *TerragruntConfig, 
 			logPrefix           string
 		)
 
-		trackFileRead(ctx.FilesRead, includeConfig.Path)
+		trackFileRead(pctx.FilesRead, includeConfig.Path)
 
 		if isPartial {
-			parsedIncludeConfig, err = partialParseIncludedConfig(ctx, l, &includeConfig)
+			parsedIncludeConfig, err = partialParseIncludedConfig(ctx, pctx, l, &includeConfig)
 			logPrefix = "[Partial] "
 		} else {
-			parsedIncludeConfig, err = parseIncludedConfig(ctx, l, &includeConfig)
+			parsedIncludeConfig, err = parseIncludedConfig(ctx, pctx, l, &includeConfig)
 		}
 
 		if err != nil {
@@ -162,7 +163,7 @@ func handleInclude(ctx *ParsingContext, l log.Logger, config *TerragruntConfig, 
 		case ShallowMerge:
 			l.Debugf("%sIncluded config %s has strategy shallow merge: merging config in (shallow).", logPrefix, includeConfig.Path)
 
-			if err := parsedIncludeConfig.Merge(l, baseConfig, ctx.TerragruntOptions); err != nil {
+			if err := parsedIncludeConfig.Merge(l, baseConfig, pctx.TerragruntOptions); err != nil {
 				return nil, err
 			}
 
@@ -170,7 +171,7 @@ func handleInclude(ctx *ParsingContext, l log.Logger, config *TerragruntConfig, 
 		case DeepMerge:
 			l.Debugf("%sIncluded config %s has strategy deep merge: merging config in (deep).", logPrefix, includeConfig.Path)
 
-			if err := parsedIncludeConfig.DeepMerge(l, baseConfig, ctx.TerragruntOptions); err != nil {
+			if err := parsedIncludeConfig.DeepMerge(l, baseConfig, pctx.TerragruntOptions); err != nil {
 				return nil, err
 			}
 
@@ -187,13 +188,13 @@ func handleInclude(ctx *ParsingContext, l log.Logger, config *TerragruntConfig, 
 // dependency block configurations between the included config and the child config. This allows us to merge the two
 // dependencies prior to retrieving the outputs, allowing you to have partial configuration that is overridden by a
 // child.
-func handleIncludeForDependency(ctx *ParsingContext, l log.Logger, childDecodedDependency TerragruntDependency) (*TerragruntDependency, error) {
-	if ctx.TrackInclude == nil {
+func handleIncludeForDependency(ctx context.Context, pctx *ParsingContext, l log.Logger, childDecodedDependency TerragruntDependency) (*TerragruntDependency, error) {
+	if pctx.TrackInclude == nil {
 		return nil, errors.New("you reached an impossible condition. This is most likely a bug in terragrunt. Please open an issue at github.com/gruntwork-io/terragrunt with this error message. Code: HANDLE_INCLUDE_DEPENDENCY_NIL_INCLUDE_CONFIG")
 	}
 	// We merge in the include blocks in reverse order here. The expectation is that the bottom most elements override
 	// those in earlier includes, so we need to merge bottom up instead of top down to ensure this.
-	includeList := ctx.TrackInclude.CurrentList
+	includeList := pctx.TrackInclude.CurrentList
 	baseDependencyBlock := childDecodedDependency.Dependencies
 
 	for i := len(includeList) - 1; i >= 0; i-- {
@@ -205,7 +206,7 @@ func handleIncludeForDependency(ctx *ParsingContext, l log.Logger, childDecodedD
 		}
 
 		includedPartialParse, err := partialParseIncludedConfig(
-			ctx.WithDecodeList(DependencyBlock, FeatureFlagsBlock, ExcludeBlock, ErrorsBlock), l, &includeConfig)
+			ctx, pctx.WithDecodeList(DependencyBlock, FeatureFlagsBlock, ExcludeBlock, ErrorsBlock), l, &includeConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/config/locals_test.go
+++ b/config/locals_test.go
@@ -22,8 +22,8 @@ func TestEvaluateLocalsBlock(t *testing.T) {
 	file, err := hclparse.NewParser().ParseFromString(LocalsTestConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), terragruntOptions)
-	evaluatedLocals, err := config.EvaluateLocalsBlock(ctx, logger.CreateLogger(), file)
+	ctx, pctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), terragruntOptions)
+	evaluatedLocals, err := config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.NoError(t, err)
 
 	var actualRegion string
@@ -66,8 +66,8 @@ func TestEvaluateLocalsBlockMultiDeepReference(t *testing.T) {
 	file, err := hclparse.NewParser().ParseFromString(LocalsTestMultiDeepReferenceConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), terragruntOptions)
-	evaluatedLocals, err := config.EvaluateLocalsBlock(ctx, logger.CreateLogger(), file)
+	ctx, pctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), terragruntOptions)
+	evaluatedLocals, err := config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.NoError(t, err)
 
 	expected := "a"
@@ -104,8 +104,8 @@ func TestEvaluateLocalsBlockImpossibleWillFail(t *testing.T) {
 	file, err := hclparse.NewParser().ParseFromString(LocalsTestImpossibleConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), terragruntOptions)
-	_, err = config.EvaluateLocalsBlock(ctx, logger.CreateLogger(), file)
+	ctx, pctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), terragruntOptions)
+	_, err = config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.Error(t, err)
 
 	switch errors.Unwrap(err).(type) { //nolint:errorlint
@@ -123,8 +123,8 @@ func TestEvaluateLocalsBlockMultipleLocalsBlocksWillFail(t *testing.T) {
 	file, err := hclparse.NewParser().ParseFromString(MultipleLocalsBlockConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), terragruntOptions)
-	_, err = config.EvaluateLocalsBlock(ctx, logger.CreateLogger(), file)
+	ctx, pctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), terragruntOptions)
+	_, err = config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.Error(t, err)
 }
 

--- a/config/stack.go
+++ b/config/stack.go
@@ -375,9 +375,9 @@ func (u *Unit) ReadOutputs(ctx context.Context, l log.Logger, opts *options.Terr
 	configPath := filepath.Join(unitDir, DefaultTerragruntConfigPath)
 	l.Debugf("Getting output from unit %s in %s", u.Name, unitDir)
 
-	parserCtx := NewParsingContext(ctx, l, opts)
+	ctx, parserCtx := NewParsingContext(ctx, l, opts)
 
-	jsonBytes, err := getOutputJSONWithCaching(parserCtx, l, configPath) //nolint: contextcheck
+	jsonBytes, err := getOutputJSONWithCaching(ctx, parserCtx, l, configPath)
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -400,15 +400,14 @@ func ReadStackConfigFile(ctx context.Context, l log.Logger, opts *options.Terrag
 	stackOpts.TerragruntConfigPath = filePath
 	stackOpts.OriginalTerragruntConfigPath = filePath
 
-	parser := NewParsingContext(ctx, l, stackOpts)
+	ctx, parser := NewParsingContext(ctx, l, stackOpts)
 
 	file, err := hclparse.NewParser(parser.ParserOptions...).ParseFromFile(filePath)
 	if err != nil {
 		return nil, errors.New(err)
 	}
 
-	//nolint:contextcheck
-	return ParseStackConfig(l, parser, opts, file, values)
+	return ParseStackConfig(ctx, l, parser, opts, file, values)
 }
 
 // ReadStackConfigString reads and parses a Terragrunt stack configuration from a string.
@@ -420,7 +419,7 @@ func ReadStackConfigString(
 	configString string,
 	values *cty.Value,
 ) (*StackConfig, error) {
-	parser := NewParsingContext(ctx, l, opts)
+	ctx, parser := NewParsingContext(ctx, l, opts)
 
 	if values != nil {
 		parser = parser.WithValues(values)
@@ -431,22 +430,20 @@ func ReadStackConfigString(
 		return nil, errors.New(err)
 	}
 
-	//nolint:contextcheck
-	return ParseStackConfig(l, parser, opts, hclFile, values)
+	return ParseStackConfig(ctx, l, parser, opts, hclFile, values)
 }
 
 // ParseStackConfig parses the stack configuration from the given file and values.
-func ParseStackConfig(l log.Logger, parser *ParsingContext, opts *options.TerragruntOptions, file *hclparse.File, values *cty.Value) (*StackConfig, error) {
+func ParseStackConfig(ctx context.Context, l log.Logger, parser *ParsingContext, opts *options.TerragruntOptions, file *hclparse.File, values *cty.Value) (*StackConfig, error) {
 	if values != nil {
 		parser = parser.WithValues(values)
 	}
 
-	//nolint:contextcheck
-	if err := processLocals(l, parser, opts, file); err != nil {
+	if err := processLocals(ctx, l, parser, opts, file); err != nil {
 		return nil, errors.New(err)
 	}
-	//nolint:contextcheck
-	evalParsingContext, err := createTerragruntEvalContext(parser, l, file.ConfigPath)
+
+	evalParsingContext, err := createTerragruntEvalContext(ctx, parser, l, file.ConfigPath)
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -555,14 +552,14 @@ func ReadValues(ctx context.Context, l log.Logger, opts *options.TerragruntOptio
 	}
 
 	l.Debugf("Reading Terragrunt stack values file at %s", filePath)
-	parser := NewParsingContext(ctx, l, opts)
+	ctx, parser := NewParsingContext(ctx, l, opts)
 
 	file, err := hclparse.NewParser(parser.ParserOptions...).ParseFromFile(filePath)
 	if err != nil {
 		return nil, errors.New(err)
 	}
-	//nolint:contextcheck
-	evalParsingContext, err := createTerragruntEvalContext(parser, l, file.ConfigPath)
+
+	evalParsingContext, err := createTerragruntEvalContext(ctx, parser, l, file.ConfigPath)
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -579,7 +576,7 @@ func ReadValues(ctx context.Context, l log.Logger, opts *options.TerragruntOptio
 }
 
 // processLocals processes the locals block in the stack file.
-func processLocals(l log.Logger, parser *ParsingContext, opts *options.TerragruntOptions, file *hclparse.File) error {
+func processLocals(ctx context.Context, l log.Logger, parser *ParsingContext, opts *options.TerragruntOptions, file *hclparse.File) error {
 	localsBlock, err := file.Blocks(MetadataLocals, false)
 	if err != nil {
 		return errors.New(err)
@@ -611,6 +608,7 @@ func processLocals(l log.Logger, parser *ParsingContext, opts *options.Terragrun
 		var evalErr error
 
 		attrs, evaluatedLocals, evaluated, evalErr = attemptEvaluateLocals(
+			ctx,
 			parser,
 			l,
 			file,

--- a/config/stack_test.go
+++ b/config/stack_test.go
@@ -33,7 +33,7 @@ stack "projects" {
 
 `
 	opts := mockOptionsForTest(t)
-	ctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), opts)
+	ctx, _ := config.NewParsingContext(t.Context(), logger.CreateLogger(), opts)
 	terragruntStackConfig, err := config.ReadStackConfigString(ctx, logger.CreateLogger(), opts, config.DefaultStackFile, cfg, nil)
 	require.NoError(t, err)
 
@@ -106,7 +106,7 @@ stack "network" {
 }
 `
 	opts := mockOptionsForTest(t)
-	ctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), opts)
+	ctx, _ := config.NewParsingContext(t.Context(), logger.CreateLogger(), opts)
 	terragruntStackConfig, err := config.ReadStackConfigString(ctx, logger.CreateLogger(), opts, config.DefaultStackFile, cfg, nil)
 	require.NoError(t, err)
 
@@ -164,7 +164,7 @@ locals {
 }
 `
 	opts := mockOptionsForTest(t)
-	ctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), opts)
+	ctx, _ := config.NewParsingContext(t.Context(), logger.CreateLogger(), opts)
 	_, err := config.ReadStackConfigString(ctx, logger.CreateLogger(), opts, config.DefaultStackFile, invalidCfg, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Invalid multi-line string")

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -133,11 +133,11 @@ func (app *App) RunContext(ctx context.Context, arguments []string) (err error) 
 		cmd := app.NewRootCommand()
 
 		args := Args(parentCtx.Args().Slice())
-		ctx := NewAppContext(parentCtx.Context, app, args)
+		cliCtx := NewAppContext(app, args)
 
 		if app.Autocomplete {
 			if err := app.setupAutocomplete(args); err != nil {
-				return app.handleExitCoder(ctx, err)
+				return app.handleExitCoder(cliCtx, err)
 			}
 
 			if compLine := os.Getenv(envCompleteLine); compLine != "" {
@@ -146,11 +146,11 @@ func (app *App) RunContext(ctx context.Context, arguments []string) (err error) 
 					args = args[1:]
 				}
 
-				ctx.shellComplete = true
+				cliCtx.shellComplete = true
 			}
 		}
 
-		return cmd.Run(ctx, args)
+		return cmd.Run(parentCtx.Context, cliCtx, args)
 	}
 
 	return app.App.RunContext(ctx, arguments)

--- a/internal/cli/bool_flag.go
+++ b/internal/cli/bool_flag.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	libflag "flag"
 	"fmt"
 
@@ -115,14 +116,14 @@ func (flag *BoolFlag) Names() []string {
 }
 
 // RunAction implements ActionableFlag.RunAction
-func (flag *BoolFlag) RunAction(ctx *Context) error {
+func (flag *BoolFlag) RunAction(ctx context.Context, cliCtx *Context) error {
 	dest := flag.Destination
 	if dest == nil {
 		dest = new(bool)
 	}
 
 	if flag.Action != nil {
-		return flag.Action(ctx, *dest)
+		return flag.Action(ctx, cliCtx, *dest)
 	}
 
 	return nil

--- a/internal/cli/command_test.go
+++ b/internal/cli/command_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"testing"
@@ -158,12 +159,12 @@ func TestCommandRun(t *testing.T) {
 			var actualOrder = new(int)
 
 			action := func(expectedOrder int, expectedArgs []string) cli.ActionFunc {
-				return func(ctx *cli.Context) error {
+				return func(ctx context.Context, cliCtx *cli.Context) error {
 					(*actualOrder)++
 					assert.Equal(t, expectedOrder, *actualOrder)
 
 					if expectedArgs != nil {
-						actualArgs := ctx.Args().Slice()
+						actualArgs := cliCtx.Args().Slice()
 						assert.Equal(t, expectedArgs, actualArgs)
 					}
 
@@ -171,7 +172,7 @@ func TestCommandRun(t *testing.T) {
 				}
 			}
 
-			skip := func(ctx *cli.Context) error {
+			skip := func(ctx context.Context, cliCtx *cli.Context) error {
 				assert.Fail(t, "this action must be skipped")
 				return nil
 			}
@@ -179,9 +180,9 @@ func TestCommandRun(t *testing.T) {
 			tc := tcFn(action, skip)
 
 			app := &cli.App{App: &urfaveCli.App{Writer: io.Discard}}
-			ctx := cli.NewAppContext(t.Context(), app, tc.args)
+			cliCtx := cli.NewAppContext(app, tc.args)
 
-			err := tc.command.Run(ctx, tc.args)
+			err := tc.command.Run(t.Context(), cliCtx, tc.args)
 			if tc.expectedErr != nil {
 				require.EqualError(t, err, tc.expectedErr.Error(), tc)
 			} else {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"sort"
 	"strings"
 
@@ -107,7 +108,7 @@ func (commands Commands) Swap(i, j int) {
 	commands[i], commands[j] = commands[j], commands[i]
 }
 
-func (commands Commands) WrapAction(fn func(ctx *Context, action ActionFunc) error) Commands {
+func (commands Commands) WrapAction(fn func(ctx context.Context, cliCtx *Context, action ActionFunc) error) Commands {
 	wrapped := make(Commands, len(commands))
 
 	for i := range commands {

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -1,12 +1,7 @@
 package cli
 
-import (
-	"context"
-)
-
 // Context can be used to retrieve context-specific args and parsed command-line options.
 type Context struct {
-	context.Context
 	*App
 	Command       *Command
 	parent        *Context
@@ -14,17 +9,15 @@ type Context struct {
 	shellComplete bool
 }
 
-func NewAppContext(ctx context.Context, app *App, args Args) *Context {
+func NewAppContext(app *App, args Args) *Context {
 	return &Context{
-		Context: ctx,
-		App:     app,
-		args:    args,
+		App:  app,
+		args: args,
 	}
 }
 
 func (ctx *Context) NewCommandContext(command *Command, args Args) *Context {
 	return &Context{
-		Context:       ctx.Context,
 		App:           ctx.App,
 		Command:       command,
 		parent:        ctx,
@@ -35,17 +28,6 @@ func (ctx *Context) NewCommandContext(command *Command, args Args) *Context {
 
 func (ctx *Context) Parent() *Context {
 	return ctx.parent
-}
-
-func (ctx *Context) WithValue(key, val any) *Context {
-	newCtx := *ctx
-	newCtx.Context = context.WithValue(newCtx.Context, key, val)
-
-	return &newCtx
-}
-
-func (ctx *Context) Value(key any) any {
-	return ctx.Context.Value(key)
 }
 
 // Args returns the command line arguments associated with the context.

--- a/internal/cli/flag.go
+++ b/internal/cli/flag.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	libflag "flag"
 	"fmt"
 	"os"
@@ -33,7 +34,7 @@ type MapFlagSetterFunc[K any, V any] func(key K, value V) error
 
 // FlagActionFunc represents function type that is called when the flag is specified.
 // Executed after flag have been parsed  and assigned to the `Destination` field.
-type FlagActionFunc[T any] func(ctx *Context, value T) error
+type FlagActionFunc[T any] func(ctx context.Context, cliCtx *Context, value T) error
 
 type FlagVariable[T any] interface {
 	libflag.Getter
@@ -84,7 +85,7 @@ type Flag interface {
 	GetHidden() bool
 
 	// RunAction runs the flag action.
-	RunAction(ctx *Context) error
+	RunAction(ctx context.Context, cliCtx *Context) error
 
 	// LookupEnv gets and splits the environment variable depending on the flag type: common, map, slice.
 	LookupEnv(envVar string) []string

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	libflag "flag"
 	"io"
 	"sort"
@@ -104,10 +105,10 @@ func (flags Flags) Swap(i, j int) {
 	flags[i], flags[j] = flags[j], flags[i]
 }
 
-func (flags Flags) RunActions(ctx *Context) error {
+func (flags Flags) RunActions(ctx context.Context, cliCtx *Context) error {
 	for _, flag := range flags {
 		if flag.Value().IsSet() {
-			if err := flag.RunAction(ctx); err != nil {
+			if err := flag.RunAction(ctx, cliCtx); err != nil {
 				return err
 			}
 		}

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"context"
 	libflag "flag"
 	"io"
 	"testing"
@@ -63,7 +64,7 @@ func TestFalgsRunActions(t *testing.T) {
 
 	mockFlags := cli.Flags{
 		&cli.SliceFlag[string]{Name: "bar"},
-		&cli.GenericFlag[string]{Name: "foo", Action: func(ctx *cli.Context, val string) error {
+		&cli.GenericFlag[string]{Name: "foo", Action: func(ctx context.Context, cliCtx *cli.Context, val string) error {
 			actionHasBeenRun = true
 			return nil
 		}},
@@ -82,7 +83,7 @@ func TestFalgsRunActions(t *testing.T) {
 
 	assert.False(t, actionHasBeenRun)
 
-	err := mockFlags.RunActions(nil)
+	err := mockFlags.RunActions(t.Context(), nil)
 	require.NoError(t, err)
 
 	assert.True(t, actionHasBeenRun)

--- a/internal/cli/funcs.go
+++ b/internal/cli/funcs.go
@@ -1,19 +1,21 @@
 package cli
 
+import "context"
+
 // CompleteFunc is an action to execute when the shell completion flag is set
-type CompleteFunc func(ctx *Context) error
+type CompleteFunc func(ctx context.Context, cliCtx *Context) error
 
 // ActionFunc is the action to execute when no commands/subcommands are specified.
-type ActionFunc func(ctx *Context) error
+type ActionFunc func(ctx context.Context, cliCtx *Context) error
 
 // HelpFunc is the action to execute when help needs to be displayed.
 // Example:
 //
-//	func showHelp(ctx *Context) error {
+//	func showHelp(ctx context.Context, cliCtx *Context) error {
 //	  fmt.Println("Usage: ...")
 //	  return nil
 //	}
-type HelpFunc func(ctx *Context) error
+type HelpFunc func(ctx context.Context, cliCtx *Context) error
 
 // SplitterFunc is used to parse flags containing multiple values.
 type SplitterFunc func(s, sep string) []string

--- a/internal/cli/generic_flag.go
+++ b/internal/cli/generic_flag.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	libflag "flag"
 	"fmt"
 	"strconv"
@@ -107,14 +108,14 @@ func (flag *GenericFlag[T]) Names() []string {
 }
 
 // RunAction implements ActionableFlag.RunAction
-func (flag *GenericFlag[T]) RunAction(ctx *Context) error {
+func (flag *GenericFlag[T]) RunAction(ctx context.Context, cliCtx *Context) error {
 	dest := flag.Destination
 	if dest == nil {
 		dest = new(T)
 	}
 
 	if flag.Action != nil {
-		return flag.Action(ctx, *dest)
+		return flag.Action(ctx, cliCtx, *dest)
 	}
 
 	return nil

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"slices"
 	"strings"
 
@@ -22,8 +23,8 @@ var (
 )
 
 // ShowAppHelp prints App help.
-func ShowAppHelp(ctx *Context) error {
-	tpl := ctx.CustomAppHelpTemplate
+func ShowAppHelp(_ context.Context, cliCtx *Context) error {
+	tpl := cliCtx.CustomAppHelpTemplate
 	if tpl == "" {
 		tpl = AppHelpTemplate
 	}
@@ -32,11 +33,11 @@ func ShowAppHelp(ctx *Context) error {
 		return errors.Errorf("app help template not defined")
 	}
 
-	if ctx.HelpName == "" {
-		ctx.HelpName = ctx.Name
+	if cliCtx.HelpName == "" {
+		cliCtx.HelpName = cliCtx.Name
 	}
 
-	cli.HelpPrinterCustom(ctx.Writer, tpl, ctx, map[string]any{
+	cli.HelpPrinterCustom(cliCtx.Writer, tpl, cliCtx, map[string]any{
 		"parentCommands": parentCommands,
 		"offsetCommands": offsetCommands,
 	})
@@ -44,21 +45,21 @@ func ShowAppHelp(ctx *Context) error {
 	return NewExitError(nil, ExitCodeSuccess)
 }
 
-// ShowCommandHelp prints command help for the given `ctx`.
-func ShowCommandHelp(ctx *Context) error {
-	if ctx.Command.HelpName == "" {
-		ctx.Command.HelpName = ctx.Command.Name
+// ShowCommandHelp prints command help for the given `cliCtx`.
+func ShowCommandHelp(ctx context.Context, cliCtx *Context) error {
+	if cliCtx.Command.HelpName == "" {
+		cliCtx.Command.HelpName = cliCtx.Command.Name
 	}
 
-	if ctx.Command.CustomHelp != nil {
-		if err := ctx.Command.CustomHelp(ctx); err != nil {
+	if cliCtx.Command.CustomHelp != nil {
+		if err := cliCtx.Command.CustomHelp(ctx, cliCtx); err != nil {
 			return err
 		}
 
 		return NewExitError(nil, ExitCodeSuccess)
 	}
 
-	tpl := ctx.Command.CustomHelpTemplate
+	tpl := cliCtx.Command.CustomHelpTemplate
 	if tpl == "" {
 		tpl = CommandHelpTemplate
 	}
@@ -67,12 +68,12 @@ func ShowCommandHelp(ctx *Context) error {
 		return errors.Errorf("command help template not defined")
 	}
 
-	HelpPrinterCustom(ctx, tpl, nil)
+	HelpPrinterCustom(cliCtx, tpl, nil)
 
 	return NewExitError(nil, ExitCodeSuccess)
 }
 
-func HelpPrinterCustom(ctx *Context, tpl string, customFuncs map[string]any) {
+func HelpPrinterCustom(cliCtx *Context, tpl string, customFuncs map[string]any) {
 	var funcs = map[string]any{
 		"parentCommands": parentCommands,
 		"offsetCommands": offsetCommands,
@@ -82,11 +83,11 @@ func HelpPrinterCustom(ctx *Context, tpl string, customFuncs map[string]any) {
 		maps.Copy(funcs, customFuncs)
 	}
 
-	cli.HelpPrinterCustom(ctx.Writer, tpl, ctx, funcs)
+	cli.HelpPrinterCustom(cliCtx.Writer, tpl, cliCtx, funcs)
 }
 
-func ShowVersion(ctx *Context) error {
-	tpl := ctx.CustomAppVersionTemplate
+func ShowVersion(_ context.Context, cliCtx *Context) error {
+	tpl := cliCtx.CustomAppVersionTemplate
 	if tpl == "" {
 		tpl = AppVersionTemplate
 	}
@@ -95,7 +96,7 @@ func ShowVersion(ctx *Context) error {
 		return errors.Errorf("app version template not defined")
 	}
 
-	cli.HelpPrinterCustom(ctx.Writer, tpl, ctx, nil)
+	cli.HelpPrinterCustom(cliCtx.Writer, tpl, cliCtx, nil)
 
 	return NewExitError(nil, ExitCodeSuccess)
 }

--- a/internal/cli/map_flag.go
+++ b/internal/cli/map_flag.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	libflag "flag"
 	"os"
 	"strings"
@@ -156,9 +157,9 @@ func (flag *MapFlag[K, V]) Names() []string {
 }
 
 // RunAction implements ActionableFlag.RunAction
-func (flag *MapFlag[K, V]) RunAction(ctx *Context) error {
+func (flag *MapFlag[K, V]) RunAction(ctx context.Context, cliCtx *Context) error {
 	if flag.Action != nil {
-		return flag.Action(ctx, *flag.Destination)
+		return flag.Action(ctx, cliCtx, *flag.Destination)
 	}
 
 	return nil

--- a/internal/cli/slice_flag.go
+++ b/internal/cli/slice_flag.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	libflag "flag"
 	"os"
 	"strings"
@@ -136,9 +137,9 @@ func (flag *SliceFlag[T]) Names() []string {
 }
 
 // RunAction implements ActionableFlag.RunAction
-func (flag *SliceFlag[T]) RunAction(ctx *Context) error {
+func (flag *SliceFlag[T]) RunAction(ctx context.Context, cliCtx *Context) error {
 	if flag.Action != nil {
-		return flag.Action(ctx, *flag.Destination)
+		return flag.Action(ctx, cliCtx, *flag.Destination)
 	}
 
 	return nil

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -406,7 +406,8 @@ func Parse(
 	parseOpts.TerragruntConfigPath = filepath.Join(parseOpts.WorkingDir, configFilename)
 	parseOpts.OriginalTerragruntConfigPath = parseOpts.TerragruntConfigPath
 
-	parsingCtx := config.NewParsingContext(ctx, l, parseOpts).WithDecodeList(
+	ctx, parsingCtx := config.NewParsingContext(ctx, l, parseOpts)
+	parsingCtx = parsingCtx.WithDecodeList(
 		config.TerraformSource,
 		config.DependenciesBlock,
 		config.DependencyBlock,
@@ -453,8 +454,7 @@ func Parse(
 		config.RemoteStateBlock,
 	)
 
-	//nolint: contextcheck
-	cfg, err = config.PartialParseConfigFile(parsingCtx, l, parseOpts.TerragruntConfigPath, nil)
+	cfg, err = config.PartialParseConfigFile(ctx, parsingCtx, l, parseOpts.TerragruntConfigPath, nil)
 	if err != nil {
 		if suppressParseErrors {
 			var notFoundErr config.TerragruntConfigNotFoundError

--- a/internal/remotestate/backend/gcs/backend.go
+++ b/internal/remotestate/backend/gcs/backend.go
@@ -110,8 +110,7 @@ func (backend *Backend) Bootstrap(ctx context.Context, l log.Logger, backendConf
 	}
 	// If bucket is specified and skip_bucket_versioning is false then warn user if versioning is disabled on bucket
 	if !extGCSCfg.SkipBucketVersioning && bucketName != "" {
-		// TODO: Remove lint suppression
-		if _, err := client.CheckIfGCSVersioningEnabled(ctx, l, bucketName); err != nil { //nolint:contextcheck
+		if _, err := client.CheckIfGCSVersioningEnabled(ctx, l, bucketName); err != nil {
 			return err
 		}
 	}

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -879,11 +879,12 @@ func useLegacyNullValues() bool {
 }
 
 func getTerragruntConfig(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) (*config.TerragruntConfig, error) {
-	configCtx := config.NewParsingContext(ctx, l, opts).WithDecodeList(
+	ctx, configCtx := config.NewParsingContext(ctx, l, opts)
+	configCtx = configCtx.WithDecodeList(
 		config.TerragruntVersionConstraints, config.FeatureFlagsBlock)
 
-	// TODO: See if we should be ignore this lint error
-	return config.PartialParseConfigFile( //nolint: contextcheck
+	return config.PartialParseConfigFile(
+		ctx,
 		configCtx,
 		l,
 		opts.TerragruntConfigPath,

--- a/shell/run_cmd.go
+++ b/shell/run_cmd.go
@@ -124,7 +124,7 @@ func RunCommandWithOutput(
 			exec.WithForwardSignalDelay(SignalForwardingDelay),
 		)
 
-		if err := cmd.Start(); err != nil { //nolint:contextcheck
+		if err := cmd.Start(); err != nil { //nolint:contextcheck // context already passed to exec.Command
 			err = util.ProcessExecutionError{
 				Err:            err,
 				Args:           args,

--- a/test/benchmarks/helpers/helpers.go
+++ b/test/benchmarks/helpers/helpers.go
@@ -36,7 +36,7 @@ func RunTerragruntCommand(b *testing.B, args ...string) {
 
 	l := logger.CreateLogger().WithOptions(log.WithOutput(io.Discard))
 
-	app := cli.NewApp(l, opts) //nolint:contextcheck
+	app := cli.NewApp(l, opts)
 
 	ctx := log.ContextWithLogger(b.Context(), l)
 

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -1033,7 +1033,7 @@ func RunTerragruntCommandWithContext(
 		log.WithFormatter(format.NewFormatter(format.NewPrettyFormatPlaceholders())),
 	)
 
-	app := cli.NewApp(l, opts) //nolint:contextcheck
+	app := cli.NewApp(l, opts)
 
 	ctx = log.ContextWithLogger(ctx, l)
 

--- a/test/integration_parse_test.go
+++ b/test/integration_parse_test.go
@@ -62,9 +62,9 @@ func TestParseAllFixtureFiles(t *testing.T) {
 
 			l := logger.CreateLogger()
 
-			ctx := config.NewParsingContext(t.Context(), l, opts)
+			ctx, pctx := config.NewParsingContext(t.Context(), l, opts)
 
-			cfg, _ := config.ParseConfigFile(ctx, l, file, nil)
+			cfg, _ := config.ParseConfigFile(ctx, pctx, l, file, nil)
 
 			if slices.Contains(knownBadFiles, file) {
 				assert.Nil(t, cfg)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Ensures that we stop suppressing `contextcheck` lints when we can. We've run into issues with context propagation failing for OpenTelemetry traces, and this should reduce the likelihood of that, as it should be clearer where ctx is being propagated instead of assuming that we're properly referencing the value from a struct it's embedded in.

As part of these changes, the following structs no longer embed Context:

- `cli.Context`
- `config.ParsingContext`

This required changing quite a lot of function signatures throughout the codebase, as we were implicitly plumbing down `context` as a consequence of sending down one of the two structs above.

I ended up keeping the `nolint:contextcheck` [here](https://github.com/gruntwork-io/terragrunt/pull/5320/changes#diff-a15d78d930c27d1cb22286d6b3387dc64630cb1704c8dbd8c6eca02bde351566R127) because we pass down `exec.Command`, which has context embedded within it, and I don't see a better way to handle that.

I also incidentally updated `TraceParseBaseBlocksResult` to set additional attributes on the existing span rather than emitting a new one, per the recommendation from Travis. I know we can probably do a lot more of that to reduce our span count, but I'm trying to make progress incrementally.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified context propagation across the CLI (commands, flags, help, completion, version) for more reliable cancellation and consistent behavior.
  * Parsing moved to a two-context model for safer, isolated evaluation of includes, locals and partial parses.
  * Engine startup/shutdown made more resilient to parent cancellation.

* **Telemetry**
  * Tracing now emits structured OpenTelemetry attributes directly for richer observability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->