### PR TITLE
docs: Cleaning up references to filter as an experiment

### DIFF
--- a/docs-starlight/src/data/commands/find.mdx
+++ b/docs-starlight/src/data/commands/find.mdx
@@ -331,18 +331,6 @@ terragrunt find --working-dir=/path/to/working/dir
 
 ## Filtering Results
 
-<Aside type="tip" title="Experimental Feature">
-This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
-
-Usage of the filter flag requires usage of the `filter-flag` experiment, like so:
-
-```bash
-terragrunt find --experiment filter-flag --filter 'foo'
-```
-
-Examples below will omit the `--experiment filter-flag` flag for brevity.
-</Aside>
-
 The `find` command supports the `--filter` flag to target specific configurations using a flexible query language. This is particularly useful for discovering configurations that match specific criteria before running operations on them.
 
 ### Finding Affected Components
@@ -378,13 +366,13 @@ The filter syntax supports negation, multiple filters, and complex queries:
 
 ```bash
 # Exclude specific configurations
-terragrunt find --experiment filter-flag --filter '!./test/**'
+terragrunt find --filter '!./test/**'
 
 # Multiple filters (OR logic)
-terragrunt find --experiment filter-flag --filter 'app1' --filter 'app2'
+terragrunt find --filter 'app1' --filter 'app2'
 
 # Complex queries with chaining
-terragrunt find --experiment filter-flag --filter './dev/** | type=unit | !name=unit1'
+terragrunt find --filter './dev/** | type=unit | !name=unit1'
 ```
 
 <Aside type="tip" title="Learn More About Filtering">

--- a/docs-starlight/src/data/commands/list.mdx
+++ b/docs-starlight/src/data/commands/list.mdx
@@ -297,16 +297,6 @@ You can disable color output by using the global `--no-color` flag.
 
 ## Filtering Results
 
-<Aside type="tip" title="Experimental Feature">
-This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
-
-Usage of the filter flag requires usage of the `filter-flag` experiment, like so:
-
-```bash
-terragrunt list --experiment filter-flag --filter 'foo'
-```
-</Aside>
-
 The `list` command supports the `--filter` flag to target specific configurations using a flexible query language. This is particularly useful for listing configurations that match specific criteria before running operations on them.
 
 ### Listing Affected Components
@@ -324,16 +314,16 @@ This is equivalent to `terragrunt list --filter '[main...HEAD]'` and automatical
 
 ```bash
 # Filter by name using glob patterns
-terragrunt list --experiment filter-flag --filter 'app*'
+terragrunt list --filter 'app*'
 
 # Filter by path
-terragrunt list --experiment filter-flag --filter './prod/**'
+terragrunt list --filter './prod/**'
 
 # Filter by type
-terragrunt list --experiment filter-flag --filter 'type=unit'
+terragrunt list --filter 'type=unit'
 
 # Combine filters with intersection
-terragrunt list --experiment filter-flag --filter './prod/** | type=unit'
+terragrunt list --filter './prod/** | type=unit'
 ```
 
 ### Advanced Filtering
@@ -342,13 +332,13 @@ The filter syntax supports negation, multiple filters, and complex queries:
 
 ```bash
 # Exclude specific configurations
-terragrunt list --experiment filter-flag --filter '!./test/**'
+terragrunt list --filter '!./test/**'
 
 # Multiple filters (OR logic)
-terragrunt list --experiment filter-flag --filter 'app1' --filter 'app2'
+terragrunt list --filter 'app1' --filter 'app2'
 
 # Complex queries with chaining
-terragrunt list --experiment filter-flag --filter './dev/** | type=unit | !name=unit1'
+terragrunt list --filter './dev/** | type=unit | !name=unit1'
 ```
 
 <Aside type="tip" title="Learn More About Filtering">

--- a/docs-starlight/src/data/commands/run.mdx
+++ b/docs-starlight/src/data/commands/run.mdx
@@ -94,16 +94,6 @@ The `run` command also supports the following flags that can be used to drive ru
 
 ## Filtering Units
 
-<Aside type="tip" title="Experimental Feature">
-This feature requires the `filter-flag` experiment to be enabled. Use `--experiment filter-flag` to enable it:
-
-```bash
-terragrunt run --all --experiment filter-flag --filter 'prod/**' -- plan
-```
-
-Examples below will omit the `--experiment filter-flag` flag for brevity.
-</Aside>
-
 The `run` command supports the `--filter` flag to target specific units using a flexible query language. This is particularly useful when running commands across multiple units with `--all`.
 
 ### Running Affected Components

--- a/docs-starlight/src/data/flags/filter-affected.mdx
+++ b/docs-starlight/src/data/flags/filter-affected.mdx
@@ -6,18 +6,6 @@ type: bool
 
 import { Aside } from '@astrojs/starlight/components';
 
-<Aside type="tip" title="Experimental Feature">
-This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
-
-Usage of the `--filter-affected` flag requires usage of the `filter-flag` experiment, like so:
-
-```bash
-terragrunt find --experiment filter-flag --filter-affected
-```
-
-Examples below will omit the `--experiment filter-flag` flag for brevity.
-</Aside>
-
 The `--filter-affected` flag is a convenient shorthand for filtering components that have been modified, added, or removed between the default branch (typically `main`) and `HEAD`. It is equivalent to using `--filter '[main...HEAD]'` (or `--filter '[<defaultBranch>...HEAD]'` if your repository uses a different default branch).
 
 ## Usage

--- a/docs-starlight/src/data/flags/filter.mdx
+++ b/docs-starlight/src/data/flags/filter.mdx
@@ -6,18 +6,6 @@ type: list(string)
 
 import {Aside} from '@astrojs/starlight/components';
 
-<Aside type="tip" title="Experimental Feature">
-This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
-
-Usage of the filter flag requires usage of the `filter-flag` experiment, like so:
-
-```bash
-terragrunt find --experiment filter-flag --filter 'foo'
-```
-
-Examples below will omit the `--experiment filter-flag` flag for brevity.
-</Aside>
-
 The `--filter` flag provides a sophisticated querying syntax for targeting specific [units](/docs/features/units) and [stacks](/docs/features/stacks) in Terragrunt commands.
 
 ## Usage
@@ -181,7 +169,7 @@ terragrunt find --filter unit1 --filter stack1
 
 ### The filters file
 
-Instead of specifying filters on the command line, you can store filter queries in a file. By default, Terragrunt automatically reads filter queries from `.terragrunt-filters` in the working directory when the `filter-flag` experiment is enabled.
+Instead of specifying filters on the command line, you can store filter queries in a file. By default, Terragrunt automatically reads filter queries from the `.terragrunt-filters` file in your current working directory if it exists.
 
 ```bash
 # Automatically reads .terragrunt-filters (no flag needed)

--- a/docs-starlight/src/data/flags/filters-file.mdx
+++ b/docs-starlight/src/data/flags/filters-file.mdx
@@ -6,19 +6,7 @@ type: string
 
 import { Aside } from '@astrojs/starlight/components';
 
-<Aside type="tip" title="Experimental Feature">
-This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
-
-Usage of the `--filters-file` flag requires usage of the `filter-flag` experiment, like so:
-
-```bash
-terragrunt find --experiment filter-flag --filters-file custom-filters.txt
-```
-
-Examples below will omit the `--experiment filter-flag` flag for brevity.
-</Aside>
-
-The `--filters-file` flag allows you to specify a custom file path containing filter queries. By default, Terragrunt automatically reads filter queries from `.terragrunt-filters` in the working directory when the `filter-flag` experiment is enabled. Use this flag to specify a different file path.
+The `--filters-file` flag allows you to specify a custom file path containing filter queries. By default, Terragrunt automatically reads filter queries from any `.terragrunt-filters` file in the current working directory. Use this flag to specify a different file path.
 
 ## Usage
 
@@ -31,18 +19,6 @@ terragrunt find --filters-file /path/to/filters.txt
 
 # Use with run --all
 terragrunt run --all --filters-file prod-filters.txt -- plan
-```
-
-## Default Behavior
-
-When the `filter-flag` experiment is enabled, Terragrunt automatically reads filter queries from `.terragrunt-filters` in the working directory. You only need to use `--filters-file` if you want to use a different file path.
-
-```bash
-# Automatically reads .terragrunt-filters (no flag needed)
-terragrunt find --experiment filter-flag
-
-# Explicitly specify the default file (same as above)
-terragrunt find --experiment filter-flag --filters-file .terragrunt-filters
 ```
 
 ## File Format

--- a/docs-starlight/src/data/flags/hcl-fmt-filter.mdx
+++ b/docs-starlight/src/data/flags/hcl-fmt-filter.mdx
@@ -6,18 +6,6 @@ type: list(string)
 
 import {Aside} from '@astrojs/starlight/components';
 
-<Aside type="tip" title="Experimental Feature">
-This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
-
-Usage of the filter flag requires usage of the `filter-flag` experiment, like so:
-
-```bash
-terragrunt find --experiment filter-flag --filter 'foo'
-```
-
-Examples below will omit the `--experiment filter-flag` flag for brevity.
-</Aside>
-
 <Aside type="note" title="Filter Behavior for HCL Format">
 The `--filter` flag works differently for `hcl fmt` compared to other commands. It filters on individual HCL files rather than units or stacks (which are directories). As a result, only path-based filter expressions are supported. Attribute-based filters like `type=unit` or `name=my-app` are not applicable to file-level operations.
 

--- a/docs-starlight/src/data/flags/no-filters-file.mdx
+++ b/docs-starlight/src/data/flags/no-filters-file.mdx
@@ -6,19 +6,7 @@ type: bool
 
 import { Aside } from '@astrojs/starlight/components';
 
-<Aside type="tip" title="Experimental Feature">
-This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
-
-Usage of the `--no-filters-file` flag requires usage of the `filter-flag` experiment, like so:
-
-```bash
-terragrunt find --experiment filter-flag --no-filters-file
-```
-
-Examples below will omit the `--experiment filter-flag` flag for brevity.
-</Aside>
-
-The `--no-filters-file` flag disables automatic reading of the `.terragrunt-filters` file. By default, when the `filter-flag` experiment is enabled, Terragrunt automatically reads filter queries from `.terragrunt-filters` in the working directory. Use this flag to disable that automatic behavior.
+The `--no-filters-file` flag disables automatic reading of the `.terragrunt-filters` file. By default, Terragrunt automatically reads filter queries from any `.terragrunt-filters` file in the current working directory. Use this flag to disable that automatic behavior.
 
 ## Usage
 

--- a/docs-starlight/src/data/flags/stack-generate-filter.mdx
+++ b/docs-starlight/src/data/flags/stack-generate-filter.mdx
@@ -6,18 +6,6 @@ type: list(string)
 
 import {Aside} from '@astrojs/starlight/components';
 
-<Aside type="tip" title="Experimental Feature">
-This feature is currently experimental and not yet complete. See the [filter-flag experiment documentation](/docs/reference/experiments#filter-flag) for details on what is and isn't supported.
-
-Usage of the filter flag requires usage of the `filter-flag` experiment, like so:
-
-```bash
-terragrunt stack generate --experiment filter-flag --filter 'foo | type=stack'
-```
-
-Examples below will omit the `--experiment filter-flag` flag for brevity.
-</Aside>
-
 <Aside type="note" title="Filter Behavior for Stack Generate">
 The `--filter` flag works differently for `stack generate` compared to other commands. It requires that you explicitly target stacks using the `type=stack` attribute.
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

We never cleaned out this call outs that the `--filter` flag was an experiment. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Removed experimental feature notices from filter-related documentation across multiple commands and flags
  * Simplified filter usage examples by eliminating references to experimental prerequisites
  * Updated documentation for find, list, and run commands to reflect cleaner filtering syntax
  * Clarified default filtering behavior without requiring experimental feature flags

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->