### PR TITLE
Revert ".github/workflows: Migrate workflows to Blacksmith runners"

### DIFF
--- a/.github/workflows/base-test.yml
+++ b/.github/workflows/base-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [blacksmith-4vcpu-ubuntu-2404, macos]
+        os: [ubuntu, macos]
     env:
       MISE_PROFILE: cicd
 

--- a/.github/workflows/build-no-proxy.yml
+++ b/.github/workflows/build-no-proxy.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-no-proxy:
     name: Build (${{ matrix.os }}/${{ matrix.arch }})
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   detect_release:
     name: Detect if this is a release build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.check.outputs.is_release }}
     steps:
@@ -30,7 +30,7 @@ jobs:
   build:
     name: Build (${{ matrix.os }}/${{ matrix.arch }})
     needs: detect_release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
@@ -120,7 +120,7 @@ jobs:
     name: Merge All Signed Binaries
     if: ${{ needs.detect_release.outputs.is_release == 'true' }}
     needs: [detect_release, sign_macos, sign_windows]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   codespell:
     name: Check Spelling
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/go-mod-tidy-check.yml
+++ b/.github/workflows/go-mod-tidy-check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   go-mod-tidy-check:
     name: Check go.mod and go.sum are tidy
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/gopls.yml
+++ b/.github/workflows/gopls.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   gopls-quickfix:
     name: Gopls Quickfix
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [blacksmith-4vcpu-ubuntu-2404, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         # Windows doesn't get to be linted continuously because it annoyingly requires
         # that all files use \r\n line endings.
         # os: [ubuntu, macos, windows]
-        os: [blacksmith-4vcpu-ubuntu-2404, macos]
+        os: [ubuntu, macos]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         integration:
           - name: GHA AWS
-            os: blacksmith-4vcpu-ubuntu-2404
+            os: ubuntu
             target: ./...
             tags: awsoidc
             run: '^TestAws'

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   precommit:
     name: Run pre-commit hooks
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       MISE_PROFILE: cicd
 


### PR DESCRIPTION
Reverts gruntwork-io/terragrunt#5388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized CI/CD infrastructure by updating all workflows to use standard GitHub Actions runners (ubuntu-latest and macos-latest) instead of custom configurations, ensuring consistency across all automated processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->