### PR TITLE
fix: Adding auto-retry for provider queries

### DIFF
--- a/pkg/options/auto_retry_options.go
+++ b/pkg/options/auto_retry_options.go
@@ -28,6 +28,7 @@ var DefaultRetryableErrors = []string{
 	"(?s).*Client\\.Timeout exceeded while awaiting headers.*",
 	"(?s).*Could not download module.*The requested URL returned error: 429.*",
 	"(?s).*net/http: TLS.*handshake timeout.*",
+	"(?s).*could not query provider registry.*context deadline exceeded.*",
 }
 
 // defaultErrorsConfig builds a default ErrorsConfig using DefaultRetryableErrors


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

We see provider query errors in CI, and users are likely seeing the same. This adds query timeouts to the set of errors that are automatically retried.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved retry handling for transient provider registry timeout errors, increasing system resilience during temporary service disruptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->