### PR TITLE
chore: Adding `--provider-auth-cmd` schema

### DIFF
--- a/docs-starlight/public/schemas/auth-provider-cmd/v1/schema.json
+++ b/docs-starlight/public/schemas/auth-provider-cmd/v1/schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://terragrunt.gruntwork.io/schemas/auth-provider-cmd/v1/schema.json",
+  "title": "Terragrunt Auth Provider Command Response Schema",
+  "description": "Schema for the JSON response expected from an auth provider command",
+  "type": "object",
+  "properties": {
+    "awsCredentials": {
+      "type": "object",
+      "description": "AWS credentials to set as environment variables",
+      "properties": {
+        "ACCESS_KEY_ID": {
+          "type": "string",
+          "description": "AWS access key ID"
+        },
+        "SECRET_ACCESS_KEY": {
+          "type": "string",
+          "description": "AWS secret access key"
+        },
+        "SESSION_TOKEN": {
+          "type": "string",
+          "description": "AWS session token (optional)"
+        }
+      },
+      "required": ["ACCESS_KEY_ID", "SECRET_ACCESS_KEY"],
+      "additionalProperties": false
+    },
+    "awsRole": {
+      "type": "object",
+      "description": "AWS role to assume",
+      "properties": {
+        "roleARN": {
+          "type": "string",
+          "description": "The ARN of the IAM role to assume"
+        },
+        "roleSessionName": {
+          "type": "string",
+          "description": "The session name for the assumed role"
+        },
+        "duration": {
+          "type": "integer",
+          "description": "Duration in seconds for the assumed role session",
+          "minimum": 0
+        },
+        "webIdentityToken": {
+          "type": "string",
+          "description": "Web identity token for OIDC-based role assumption"
+        }
+      },
+      "required": ["roleARN"],
+      "additionalProperties": false
+    },
+    "envs": {
+      "type": "object",
+      "description": "Additional environment variables to set",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs-starlight/src/content/docs/03-features/09-authentication.mdx
+++ b/docs-starlight/src/content/docs/03-features/09-authentication.mdx
@@ -6,6 +6,10 @@ sidebar:
   order: 9
 ---
 
+import { Code } from '@astrojs/starlight/components';
+
+import authProviderCmdSchema from '../../../../public/schemas/auth-provider-cmd/v1/schema.json?raw';
+
 ## Motivation
 
 AWS is by far the most popular OpenTofu/Terraform provider, and most Terragrunt users are using it to manage AWS infrastructure, at least in part. As a consequence, Terragrunt has a number of features that make it easier to work with AWS, especially when you have to manage multiple AWS accounts.
@@ -63,7 +67,7 @@ iam_role = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
 
 Terragrunt will resolve the value of the option by first looking for the cli argument, then looking for the environment variable, then defaulting to the value specified in the config file.
 
-Terragrunt will call the `sts assume-role` API on your behalf and expose the credentials it gets back as environment variables when running OpenTofu/Terraform. The advantage of this approach is that you can store your AWS credentials in a secret store and never write them to disk in plaintext, you get fresh credentials on every run of Terragrunt, without the complexity of calling `assume-role` yourself, and you don’t have to modify your OpenTofu/Terraform code or backend configuration at all.
+Terragrunt will call the `sts assume-role` API on your behalf and expose the credentials it gets back as environment variables when running OpenTofu/Terraform. The advantage of this approach is that you can store your AWS credentials in a secret store and never write them to disk in plaintext, you get fresh credentials on every run of Terragrunt, without the complexity of calling `assume-role` yourself, and you don't have to modify your OpenTofu/Terraform code or backend configuration at all.
 
 ## Leveraging OIDC role assumption
 
@@ -121,29 +125,12 @@ terragrunt apply
 
 When Terragrunt executes this script, it will expect a response in stdout that obeys the following schema:
 
-```json
-{
-  "awsCredentials": {
-    "ACCESS_KEY_ID": "",
-    "SECRET_ACCESS_KEY": "",
-    "SESSION_TOKEN": ""
-  },
-  "awsRole": {
-    "roleARN": "",
-    "sessionName": "",
-    "duration": 0,
-    "webIdentityToken": ""
-  },
-  "envs": {
-    "ANY_KEY": ""
-  }
-}
-```
+<Code title="auth-provider-cmd/v1/schema.json" lang="json" code={authProviderCmdSchema} />
 
 All top-level objects are optional, and you can provide multiple.
 
 - `awsCredentials` is the standard AWS credential object, which can be used to set the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and (optionally) `AWS_SESSION_TOKEN` environment variables before running OpenTofu/Terraform.
-- `awsRole` is the role assumption object, which can be used to dynamically perform role assumption on the `roleARN` role with the `sessionName` session name, for a `duration` of time, and with a `webIdentityToken` if needed. Terragrunt will automatically refresh this role assumption when the duration expires.
+- `awsRole` is the role assumption object, which can be used to dynamically perform role assumption on the `roleARN` role with the `roleSessionName` session name, for a `duration` of time, and with a `webIdentityToken` if needed. Terragrunt will automatically refresh this role assumption when the duration expires.
 - `envs` is a map of environment variables that will be set before running OpenTofu/Terraform.
 
 Given that the working directory of Terragrunt execution is the same as the command, you can author logic in your script to determine which credentials are appropriate to return based on the context of the Terragrunt run.

--- a/internal/runner/run/creds/providers/externalcmd/provider.go
+++ b/internal/runner/run/creds/providers/externalcmd/provider.go
@@ -100,23 +100,36 @@ func (provider *Provider) GetCredentials(ctx context.Context, l log.Logger) (*pr
 	return creds, nil
 }
 
+// Response is the JSON response expected from an auth provider command.
 type Response struct {
-	AWSCredentials *AWSCredentials   `json:"awsCredentials"`
-	AWSRole        *AWSRole          `json:"awsRole"`
-	Envs           map[string]string `json:"envs"`
+	// AWSCredentials contains AWS credentials to set as environment variables.
+	AWSCredentials *AWSCredentials `json:"awsCredentials,omitempty"`
+	// AWSRole contains AWS role information for role assumption.
+	AWSRole *AWSRole `json:"awsRole,omitempty"`
+	// Envs contains additional environment variables to set.
+	Envs map[string]string `json:"envs,omitempty"`
 }
 
+// AWSCredentials is the JSON schema for direct AWS credentials.
 type AWSCredentials struct {
-	AccessKeyID     string `json:"ACCESS_KEY_ID"`
-	SecretAccessKey string `json:"SECRET_ACCESS_KEY"`
-	SessionToken    string `json:"SESSION_TOKEN"`
+	// AccessKeyID is the AWS access key ID.
+	AccessKeyID string `json:"ACCESS_KEY_ID" jsonschema:"required"`
+	// SecretAccessKey is the AWS secret access key.
+	SecretAccessKey string `json:"SECRET_ACCESS_KEY" jsonschema:"required"`
+	// SessionToken is the AWS session token (optional).
+	SessionToken string `json:"SESSION_TOKEN,omitempty"`
 }
 
+// AWSRole is the JSON schema for AWS role assumption.
 type AWSRole struct {
-	RoleARN          string `json:"roleARN"`
-	RoleSessionName  string `json:"roleSessionName"`
-	WebIdentityToken string `json:"webIdentityToken"`
-	Duration         int64  `json:"duration"`
+	// RoleARN is the ARN of the IAM role to assume.
+	RoleARN string `json:"roleARN" jsonschema:"required"`
+	// RoleSessionName is the session name for the assumed role.
+	RoleSessionName string `json:"roleSessionName,omitempty"`
+	// WebIdentityToken is the web identity token for OIDC-based role assumption.
+	WebIdentityToken string `json:"webIdentityToken,omitempty"`
+	// Duration is the duration in seconds for the assumed role session.
+	Duration int64 `json:"duration,omitempty" jsonschema:"minimum=0"`
 }
 
 func (role *AWSRole) Envs(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) map[string]string {

--- a/internal/runner/run/creds/providers/externalcmd/schema.go
+++ b/internal/runner/run/creds/providers/externalcmd/schema.go
@@ -1,0 +1,64 @@
+package externalcmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/invopop/jsonschema"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// SchemaValidationError represents a schema validation error with details.
+type SchemaValidationError struct {
+	Errors []string
+}
+
+func (e *SchemaValidationError) Error() string {
+	return fmt.Sprintf(
+		"Auth provider command response schema validation failed with %d error(s): %v",
+		len(e.Errors),
+		e.Errors,
+	)
+}
+
+// ValidateResponse validates a JSON response against the auth provider command schema.
+// Returns nil if valid, or a SchemaValidationError with details if invalid.
+func ValidateResponse(data []byte) error {
+	schemaBytes, err := json.Marshal(generateResponseSchema())
+	if err != nil {
+		return fmt.Errorf("failed to generate schema: %w", err)
+	}
+
+	schemaLoader := gojsonschema.NewBytesLoader(schemaBytes)
+	documentLoader := gojsonschema.NewBytesLoader(data)
+
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		return fmt.Errorf("failed to validate response: %w", err)
+	}
+
+	if !result.Valid() {
+		errors := make([]string, len(result.Errors()))
+		for i, validationErr := range result.Errors() {
+			errors[i] = validationErr.String()
+		}
+
+		return &SchemaValidationError{Errors: errors}
+	}
+
+	return nil
+}
+
+// generateResponseSchema generates the JSON schema for auth provider command response validation.
+func generateResponseSchema() *jsonschema.Schema {
+	reflector := jsonschema.Reflector{
+		DoNotReference: true,
+	}
+
+	schema := reflector.Reflect(&Response{})
+	schema.Description = "Schema for the JSON response expected from an auth provider command"
+	schema.Title = "Terragrunt Auth Provider Command Response Schema"
+	schema.ID = "https://terragrunt.gruntwork.io/schemas/auth-provider-cmd/v1/schema.json"
+
+	return schema
+}

--- a/internal/runner/run/creds/providers/externalcmd/schema_test.go
+++ b/internal/runner/run/creds/providers/externalcmd/schema_test.go
@@ -1,0 +1,404 @@
+package externalcmd_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds/providers/externalcmd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+		errorCount  int
+	}{
+		{
+			name:        "empty object is valid",
+			input:       `{}`,
+			expectError: false,
+		},
+		{
+			name: "valid awsCredentials",
+			input: `{
+				"awsCredentials": {
+					"ACCESS_KEY_ID": "fake-access-key-id",
+					"SECRET_ACCESS_KEY": "fake-secret-access-key"
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "valid awsCredentials with session token",
+			input: `{
+				"awsCredentials": {
+					"ACCESS_KEY_ID": "fake-access-key-id",
+					"SECRET_ACCESS_KEY": "fake-secret-access-key",
+					"SESSION_TOKEN": "fake-session-token"
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "valid awsRole",
+			input: `{
+				"awsRole": {
+					"roleARN": "arn:aws:iam::123456789012:role/MyRole"
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "valid awsRole with all fields",
+			input: `{
+				"awsRole": {
+					"roleARN": "arn:aws:iam::123456789012:role/MyRole",
+					"roleSessionName": "my-session",
+					"duration": 3600,
+					"webIdentityToken": "fake-web-identity-token"
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "valid envs",
+			input: `{
+				"envs": {
+					"MY_VAR": "my-value",
+					"ANOTHER_VAR": "another-value"
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "valid combined response",
+			input: `{
+				"awsCredentials": {
+					"ACCESS_KEY_ID": "fake-access-key-id",
+					"SECRET_ACCESS_KEY": "fake-secret-access-key"
+				},
+				"envs": {
+					"CUSTOM_VAR": "custom-value"
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "invalid awsCredentials missing ACCESS_KEY_ID",
+			input: `{
+				"awsCredentials": {
+					"SECRET_ACCESS_KEY": "fake-secret-access-key"
+				}
+			}`,
+			expectError: true,
+			errorCount:  1,
+		},
+		{
+			name: "invalid awsCredentials missing SECRET_ACCESS_KEY",
+			input: `{
+				"awsCredentials": {
+					"ACCESS_KEY_ID": "fake-access-key-id"
+				}
+			}`,
+			expectError: true,
+			errorCount:  1,
+		},
+		{
+			name: "invalid awsRole missing roleARN",
+			input: `{
+				"awsRole": {
+					"roleSessionName": "my-session"
+				}
+			}`,
+			expectError: true,
+			errorCount:  1,
+		},
+		{
+			name: "invalid additional property at root",
+			input: `{
+				"unknownField": "value"
+			}`,
+			expectError: true,
+			errorCount:  1,
+		},
+		{
+			name: "invalid additional property in awsCredentials",
+			input: `{
+				"awsCredentials": {
+					"ACCESS_KEY_ID": "fake-access-key-id",
+					"SECRET_ACCESS_KEY": "fake-secret-access-key",
+					"unknownField": "value"
+				}
+			}`,
+			expectError: true,
+			errorCount:  1,
+		},
+		{
+			name: "invalid duration negative",
+			input: `{
+				"awsRole": {
+					"roleARN": "arn:aws:iam::123456789012:role/MyRole",
+					"duration": -1
+				}
+			}`,
+			expectError: true,
+			errorCount:  1,
+		},
+		{
+			name:        "invalid json",
+			input:       `{invalid`,
+			expectError: true,
+		},
+		{
+			name: "awsCredentials with envs",
+			input: `{
+				"awsCredentials": {
+					"ACCESS_KEY_ID": "fake-access-key-id",
+					"SECRET_ACCESS_KEY": "fake-secret-access-key",
+					"SESSION_TOKEN": "session-token-value"
+				},
+				"envs": {
+					"TF_VAR_foo": "bar"
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "awsRole with webIdentityToken",
+			input: `{
+				"awsRole": {
+					"roleARN": "arn:aws:iam::123456789012:role/OIDCRole",
+					"webIdentityToken": "fake-web-identity-token"
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "envs only",
+			input: `{
+				"envs": {
+					"AWS_ACCESS_KEY_ID": "fake-access-key",
+					"AWS_SECRET_ACCESS_KEY": "fake-secret-key",
+					"AWS_SESSION_TOKEN": "fake-session-token"
+				}
+			}`,
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := externalcmd.ValidateResponse([]byte(tc.input))
+
+			if !tc.expectError {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+
+			if tc.errorCount > 0 {
+				var schemaErr *externalcmd.SchemaValidationError
+
+				require.ErrorAs(t, err, &schemaErr)
+
+				assert.Len(t, schemaErr.Errors, tc.errorCount)
+			}
+		})
+	}
+}
+
+func TestSchemaValidationError_Error(t *testing.T) {
+	t.Parallel()
+
+	err := &externalcmd.SchemaValidationError{
+		Errors: []string{"error1", "error2"},
+	}
+
+	assert.Contains(t, err.Error(), "2 error(s)")
+	assert.Contains(t, err.Error(), "error1")
+	assert.Contains(t, err.Error(), "error2")
+}
+
+// TestValidateResponse_NoSensitiveDataInErrors verifies that validation error messages
+// do not leak sensitive credential values to users.
+func TestValidateResponse_NoSensitiveDataInErrors(t *testing.T) {
+	t.Parallel()
+
+	// These are fake sensitive values that should NEVER appear in error messages
+	sensitiveValues := []string{
+		"fake-access-key-id",
+		"fake-secret-key",
+		"fake-session-token",
+		"fake-web-identity-token",
+		"super-secret-env-value-12345",
+	}
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "wrong type for ACCESS_KEY_ID should not leak value",
+			input: `{
+				"awsCredentials": {
+					"ACCESS_KEY_ID": {"nested": "fake-access-key-id"},
+					"SECRET_ACCESS_KEY": "fake-secret-key"
+				}
+			}`,
+		},
+		{
+			name: "wrong type for SECRET_ACCESS_KEY should not leak value",
+			input: `{
+				"awsCredentials": {
+					"ACCESS_KEY_ID": "fake-access-key-id",
+					"SECRET_ACCESS_KEY": ["fake-secret-key"]
+				}
+			}`,
+		},
+		{
+			name: "malformed SECRET_ACCESS_KEY should not leak value",
+			input: `{
+				"awsCredentials": {
+					"ACCESS_KEY_ID": "fake-access-key-id",
+					"SECRET_ACCESS_KEY": ["fake-secret-key
+				}
+			}`,
+		},
+		{
+			name: "wrong type for SESSION_TOKEN should not leak value",
+			input: `{
+				"awsCredentials": {
+					"ACCESS_KEY_ID": "fake-access-key-id",
+					"SECRET_ACCESS_KEY": "fake-secret-key",
+					"SESSION_TOKEN": {"token": "fake-session-token"}
+				}
+			}`,
+		},
+		{
+			name: "wrong type for webIdentityToken should not leak value",
+			input: `{
+				"awsRole": {
+					"roleARN": "arn:aws:iam::123456789012:role/MyRole",
+					"webIdentityToken": ["fake-web-identity-token"]
+				}
+			}`,
+		},
+		{
+			name: "additional property with sensitive value should not leak",
+			input: `{
+				"awsCredentials": {
+					"ACCESS_KEY_ID": "fake-access-key-id",
+					"SECRET_ACCESS_KEY": "fake-secret-key",
+					"SUPER_SECRET_FIELD": "super-secret-env-value-12345"
+				}
+			}`,
+		},
+		{
+			name: "additional property at root with sensitive value should not leak",
+			input: `{
+				"secretField": "super-secret-env-value-12345"
+			}`,
+		},
+		{
+			name: "wrong type for envs value should not leak",
+			input: `{
+				"envs": {
+					"SECRET_VAR": {"secret": "super-secret-env-value-12345"}
+				}
+			}`,
+		},
+		{
+			name: "wrong type for duration with credentials present should not leak credentials",
+			input: `{
+				"awsRole": {
+					"roleARN": "arn:aws:iam::123456789012:role/MyRole",
+					"webIdentityToken": "fake-web-identity-token",
+					"duration": "not-a-number"
+				}
+			}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := externalcmd.ValidateResponse([]byte(tc.input))
+			require.Error(t, err, "expected validation error")
+
+			errMsg := err.Error()
+
+			for _, sensitive := range sensitiveValues {
+				assert.NotContains(t, errMsg, sensitive,
+					"error message should not contain sensitive value")
+			}
+		})
+	}
+}
+
+// TestValidateResponse_ErrorMessagesAreDescriptive verifies that error messages
+// provide useful information about what went wrong without exposing values.
+func TestValidateResponse_ErrorMessagesAreDescriptive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		input           string
+		expectedPhrases []string
+	}{
+		{
+			name: "missing required field mentions field path",
+			input: `{
+				"awsCredentials": {
+					"SECRET_ACCESS_KEY": "secret"
+				}
+			}`,
+			expectedPhrases: []string{"ACCESS_KEY_ID"},
+		},
+		{
+			name: "type error mentions expected type",
+			input: `{
+				"awsRole": {
+					"roleARN": "arn:aws:iam::123456789012:role/MyRole",
+					"duration": "not-a-number"
+				}
+			}`,
+			expectedPhrases: []string{"duration"},
+		},
+		{
+			name: "additional property error mentions the property name but not value",
+			input: `{
+				"unknownField": "secret-value"
+			}`,
+			expectedPhrases: []string{"unknownField"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := externalcmd.ValidateResponse([]byte(tc.input))
+			require.Error(t, err)
+
+			errMsg := err.Error()
+
+			for _, phrase := range tc.expectedPhrases {
+				assert.Contains(
+					t,
+					errMsg,
+					phrase,
+					"error message should mention the field/property name for debugging",
+				)
+			}
+		})
+	}
+}

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/os/signal"
+	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds/providers/externalcmd"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/require"
 )
@@ -288,4 +289,22 @@ func determineToolName(command string) string {
 	}
 
 	return command
+}
+
+// ValidateAuthProviderScript runs the given auth provider script in the specified directory
+// and validates its response against the expected schema.
+func ValidateAuthProviderScript(t *testing.T, dir string, script string) {
+	t.Helper()
+
+	scriptStdout := bytes.Buffer{}
+
+	cmd := exec.CommandContext(t.Context(), script)
+	cmd.Dir = dir
+	cmd.Stdout = &scriptStdout
+
+	err := cmd.Run()
+	require.NoError(t, err)
+
+	err = externalcmd.ValidateResponse(scriptStdout.Bytes())
+	require.NoError(t, err)
 }

--- a/test/integration_aws_oidc_test.go
+++ b/test/integration_aws_oidc_test.go
@@ -128,6 +128,8 @@ func TestAwsReadTerragruntAuthProviderCmdWithOIDC(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, oidcPath)
 	mockAuthCmd := filepath.Join(oidcPath, "mock-auth-cmd.sh")
 
+	helpers.ValidateAuthProviderScript(t, oidcPath, mockAuthCmd)
+
 	helpers.RunTerragrunt(t, fmt.Sprintf(`terragrunt apply -auto-approve --non-interactive --working-dir %s --auth-provider-cmd %s`, oidcPath, mockAuthCmd))
 }
 
@@ -149,6 +151,8 @@ func TestAwsReadTerragruntAuthProviderCmdWithOIDCRemoteState(t *testing.T) {
 	remoteStateOIDCPath := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "remote-state-w-oidc")
 	helpers.CleanupTerraformFolder(t, remoteStateOIDCPath)
 	mockAuthCmd := filepath.Join(remoteStateOIDCPath, "mock-auth-cmd.sh")
+
+	helpers.ValidateAuthProviderScript(t, remoteStateOIDCPath, mockAuthCmd)
 
 	// Create a temporary terragrunt config with actual values
 	tmpTerragruntConfigFile := filepath.Join(remoteStateOIDCPath, "terragrunt.hcl")

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -1776,9 +1776,25 @@ func TestAwsReadTerragruntAuthProviderCmd(t *testing.T) {
 	appPath := filepath.Join(rootPath, "app1")
 	mockAuthCmd := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "mock-auth-cmd.sh")
 
-	helpers.RunTerragrunt(t, fmt.Sprintf(`terragrunt run --all --non-interactive --working-dir %s --auth-provider-cmd %s`, rootPath, mockAuthCmd)+" -- apply -auto-approve")
+	helpers.ValidateAuthProviderScript(t, appPath, mockAuthCmd)
 
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output -json --working-dir %s --auth-provider-cmd %s", appPath, mockAuthCmd))
+	helpers.RunTerragrunt(
+		t,
+		fmt.Sprintf(
+			`terragrunt run --all --non-interactive --working-dir %s --auth-provider-cmd %s -- apply -auto-approve`,
+			rootPath,
+			mockAuthCmd,
+		),
+	)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		fmt.Sprintf(
+			"terragrunt output -json --working-dir %s --auth-provider-cmd %s",
+			appPath,
+			mockAuthCmd,
+		),
+	)
 	require.NoError(t, err)
 
 	outputs := map[string]helpers.TerraformOutput{}
@@ -1797,9 +1813,24 @@ func TestAwsReadTerragruntAuthProviderCmdWithSops(t *testing.T) {
 	sopsPath := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "sops")
 	mockAuthCmd := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "mock-auth-cmd.sh")
 
-	helpers.RunTerragrunt(t, fmt.Sprintf(`terragrunt apply -auto-approve --non-interactive --working-dir %s --auth-provider-cmd %s`, sopsPath, mockAuthCmd))
+	helpers.ValidateAuthProviderScript(t, sopsPath, mockAuthCmd)
 
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output -json --working-dir %s --auth-provider-cmd %s", sopsPath, mockAuthCmd))
+	helpers.RunTerragrunt(
+		t, fmt.Sprintf(
+			`terragrunt apply -auto-approve --non-interactive --working-dir %s --auth-provider-cmd %s`,
+			sopsPath,
+			mockAuthCmd,
+		),
+	)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		fmt.Sprintf(
+			"terragrunt output -json --working-dir %s --auth-provider-cmd %s",
+			sopsPath,
+			mockAuthCmd,
+		),
+	)
 	require.NoError(t, err)
 
 	outputs := map[string]helpers.TerraformOutput{}

--- a/test/integration_runner_pool_test.go
+++ b/test/integration_runner_pool_test.go
@@ -337,4 +337,6 @@ func TestAuthProviderParallelExecution(t *testing.T) {
 	assert.GreaterOrEqual(t, maxConcurrent, 2,
 		"Expected auth commands to detect at least 2 concurrent executions. "+
 			"Detected max concurrent: %d. This proves parallel execution.", maxConcurrent)
+
+	helpers.ValidateAuthProviderScript(t, testPath, authProviderScript)
 }

--- a/test/integration_serial_aws_test.go
+++ b/test/integration_serial_aws_test.go
@@ -52,11 +52,20 @@ func TestReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
 	rootPath := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "remote-state")
 	mockAuthCmd := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "mock-auth-cmd.sh")
 
+	helpers.ValidateAuthProviderScript(t, rootPath, mockAuthCmd)
+
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
 	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
 
 	rootTerragruntConfigPath := filepath.Join(rootPath, config.DefaultTerragruntConfigPath)
-	helpers.CopyTerragruntConfigAndFillPlaceholders(t, rootTerragruntConfigPath, rootTerragruntConfigPath, s3BucketName, "not-used", helpers.TerraformRemoteStateS3Region)
+	helpers.CopyTerragruntConfigAndFillPlaceholders(
+		t,
+		rootTerragruntConfigPath,
+		rootTerragruntConfigPath,
+		s3BucketName,
+		"not-used",
+		helpers.TerraformRemoteStateS3Region,
+	)
 
 	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
@@ -103,7 +112,17 @@ func TestReadTerragruntAuthProviderCmdCredsForDependency(t *testing.T) {
 		"__FILL_AWS_ACCESS_KEY_ID__":     accessKeyID,
 		"__FILL_AWS_SECRET_ACCESS_KEY__": secretAccessKey,
 	})
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt run --all apply --non-interactive --working-dir %s --auth-provider-cmd %s", rootPath, mockAuthCmd))
+
+	helpers.ValidateAuthProviderScript(t, rootPath, mockAuthCmd)
+
+	helpers.RunTerragrunt(
+		t,
+		fmt.Sprintf(
+			"terragrunt run --all apply --non-interactive --working-dir %s --auth-provider-cmd %s",
+			rootPath,
+			mockAuthCmd,
+		),
+	)
 }
 
 // NOTE: the following test asserts precise timing for determining parallelism. As such, it can not be run in parallel

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3219,7 +3219,16 @@ func TestReadTerragruntAuthProviderCmd(t *testing.T) {
 	appPath := filepath.Join(rootPath, "app1")
 	mockAuthCmd := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "mock-auth-cmd.sh")
 
-	helpers.RunTerragrunt(t, fmt.Sprintf(`terragrunt run --all --non-interactive --working-dir %s --auth-provider-cmd %s -- apply -auto-approve`, rootPath, mockAuthCmd))
+	helpers.ValidateAuthProviderScript(t, rootPath, mockAuthCmd)
+
+	helpers.RunTerragrunt(
+		t,
+		fmt.Sprintf(
+			`terragrunt run --all --non-interactive --working-dir %s --auth-provider-cmd %s -- apply -auto-approve`,
+			rootPath,
+			mockAuthCmd,
+		),
+	)
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt output -json --working-dir %s --auth-provider-cmd %s", appPath, mockAuthCmd))
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Publishes an official JSON schema for the expected shape of the `--auth-provider-cmd` stdout payload.

Also updates all usage of `--auth-provider-cmd` in integration tests to validate that they obey the schema.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced schema validation for auth provider command responses to ensure proper structure and prevent invalid configurations.

* **Documentation**
  * Updated authentication documentation with refined field names and structure examples for auth provider responses.

* **Improvements**
  * Enhanced error handling with descriptive, safe validation messages that protect sensitive credential information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->