### PR TITLE
fix: docs build

### DIFF
--- a/docs-starlight/src/content/docs/03-features/10-hooks.mdx
+++ b/docs-starlight/src/content/docs/03-features/10-hooks.mdx
@@ -273,7 +273,7 @@ config {
 
 By default, `tflint` is executed with the internal `tflint` built into Terragrunt, which will evaluate parameters passed in.
 
-<Aside type="warning">
+<Aside type="caution">
     Previous versions of Terragrunt shipped with a version of `tflint` compiled into the binary to allow for more convenient usage without installing `tflint` directly. Due to the adoption of a BUSL license in `tflint` (following Terraform's move), the version included in Terragrunt was frozen.
 
     Use of the internal `tflint` is deprecated, and will be removed in the future. You may opt in ahead of time by adding `--terragrunt-external-tflint` to your hook arguments (see example below), or enabling the [`legacy-internal-tflint` strict control](/docs/reference/strict-controls#legacy-internal-tflint).


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

[Fixes #000.](https://github.com/gruntwork-io/terragrunt/pull/5361) broke the docs build, renaming a .md to .mdx made a markdownlint meta comment into invalid syntax.

This fixes the syntax error. Also a minor nit fix to some docs wording.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised inline aside tone from "warning" to "caution" for clearer guidance.
  * Consolidated the deprecation note into a single, clearer paragraph.
  * Escaped a markdown lint directive to prevent rendering issues and improve source clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->