### PR TITLE
chore: removal of unused AssumeAlreadyApplied field

### DIFF
--- a/internal/component/unit.go
+++ b/internal/component/unit.go
@@ -36,10 +36,9 @@ type Unit struct {
 // UnitExecution holds execution-specific fields for running a unit.
 // This is nil during discovery phase and populated when preparing for execution.
 type UnitExecution struct {
-	TerragruntOptions    *options.TerragruntOptions
-	Logger               log.Logger
-	FlagExcluded         bool
-	AssumeAlreadyApplied bool
+	TerragruntOptions *options.TerragruntOptions
+	Logger            log.Logger
+	FlagExcluded      bool
 }
 
 // NewUnit creates a new Unit component with the given path.
@@ -277,7 +276,6 @@ func (u *Unit) String() string {
 
 	if u.Execution != nil {
 		excluded = u.Execution.FlagExcluded
-		assumeApplied = u.Execution.AssumeAlreadyApplied
 	}
 
 	return fmt.Sprintf(

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -345,20 +345,6 @@ func (q *Queue) areDependenciesReadyUnsafe(l log.Logger, e *Entry) bool {
 	for _, dep := range e.Component.Dependencies() {
 		depEntry := q.entryByPathUnsafe(dep.Path())
 		if depEntry == nil {
-			// Dependency not in queue - check if assumed already applied
-			if q.unitsMap != nil {
-				if unit, ok := q.unitsMap[dep.Path()]; ok {
-					if unit.Execution != nil && unit.Execution.AssumeAlreadyApplied {
-						l.Debugf(
-							"Dependency %s is not in queue, and is assumed to be already applied, considering it ready",
-							dep.Path(),
-						)
-
-						continue
-					}
-				}
-			}
-
 			l.Debugf("Dependency %s is not in queue, considering it ready", dep.Path())
 
 			continue

--- a/internal/runner/common/unit_runner.go
+++ b/internal/runner/common/unit_runner.go
@@ -146,17 +146,6 @@ func (runner *UnitRunner) Run(
 		return nil
 	}
 
-	if runner.Unit.Execution.AssumeAlreadyApplied {
-		if runner.Unit.Execution.Logger != nil {
-			runner.Unit.Execution.Logger.Debugf(
-				"Assuming unit %s has already been applied and skipping it",
-				runner.Unit.Path(),
-			)
-		}
-
-		return nil
-	}
-
 	if err := runner.runTerragrunt(ctx, runner.Unit.Execution.TerragruntOptions, r, cfg, credsGetter); err != nil {
 		return err
 	}

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -367,11 +367,11 @@ func NewRunnerPoolStack(
 // filterUnitsToComponents converts resolved units to Components.
 // Excluded units that are assumed already applied are kept in the queue
 // so their dependents can run (they will be immediately marked as succeeded).
-// Only truly excluded units (FlagExcluded && !AssumeAlreadyApplied) are filtered out.
+// Only truly excluded units with set FlagExcluded are filtered out.
 func filterUnitsToComponents(units []*component.Unit) component.Components {
 	result := make(component.Components, 0, len(units))
 	for _, u := range units {
-		if u.Execution != nil && u.Execution.FlagExcluded && !u.Execution.AssumeAlreadyApplied {
+		if u.Execution != nil && u.Execution.FlagExcluded {
 			// Truly excluded - skip entirely
 			continue
 		}
@@ -452,9 +452,6 @@ func (r *Runner) Run(ctx context.Context, l log.Logger, opts *options.Terragrunt
 					// Determine the reason for exclusion
 					// External dependencies that are assumed already applied are excluded with --queue-exclude-external
 					reason := report.ReasonExcludeBlock
-					if u.Execution.AssumeAlreadyApplied {
-						reason = report.ReasonExcludeExternal
-					}
 
 					if err := r.Stack.Execution.Report.EndRun(
 						l,


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* removed unused field AssumeAlreadyApplied which was only read

Fixes #5412.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated unit execution to always run the complete process, removing logic that could skip executions based on prior application state assumptions.
  * Simplified dependency handling by removing conditional state-based logic, ensuring more consistent behavior across all execution paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->