### PR TITLE
fix: Set WaitDelay to prevent SIGKILL on context cancellation (#4839)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -645,8 +645,16 @@ func (g *GitRunner) SetRemoteHeadAuto(ctx context.Context) error {
 	return nil
 }
 
+// waitDelayGit is the time to wait for git to gracefully exit after receiving a signal.
+const waitDelayGit = 30 * time.Second
+
 func (g *GitRunner) prepareCommand(ctx context.Context, name string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, g.GitPath, append([]string{name}, args...)...)
+
+	// Set WaitDelay to give git time to gracefully exit after receiving the signal.
+	// Without this, Go sends SIGKILL immediately after Cancel returns.
+	cmd.WaitDelay = waitDelayGit
+
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return nil

--- a/internal/os/exec/opts.go
+++ b/internal/os/exec/opts.go
@@ -39,3 +39,11 @@ func WithForwardSignalDelay(delay time.Duration) Option {
 		cmd.forwardSignalDelay = delay
 	}
 }
+
+// WithWaitDelay sets the time to wait for the subprocess to gracefully exit
+// after receiving a signal before forcefully killing it with SIGKILL.
+func WithWaitDelay(delay time.Duration) Option {
+	return func(cmd *Cmd) {
+		cmd.WaitDelay = delay
+	}
+}


### PR DESCRIPTION
When using exec.CommandContext, if WaitDelay is not set (defaults to 0), Go immediately sends SIGKILL to the subprocess after the Cancel callback returns. This prevents terraform/tofu from gracefully handling SIGINT and releasing state locks.

This fix sets WaitDelay to 30 seconds in all places that use exec.CommandContext with a custom Cancel function, giving subprocesses time to gracefully exit before being forcefully killed.

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #4839.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commands now gracefully shut down over a configurable grace period (default 30 seconds) after receiving a cancellation signal before terminating, improving reliability and preventing incomplete operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->