### PR TITLE
fix: Fixing `TestSopsDecryptOnMissing` test

### DIFF
--- a/pkg/config/hclparse/parser.go
+++ b/pkg/config/hclparse/parser.go
@@ -97,7 +97,11 @@ func (parser *Parser) GetDiagnosticsWriter(writer io.Writer, disableColor bool) 
 
 	termWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
-		termWidth = 80
+		// When not connected to a terminal (e.g., in CI, tests, or piped output),
+		// use width 0 to disable word-wrapping. This prevents error messages from
+		// being split at unpredictable positions based on path lengths, which can
+		// cause issues when parsing or testing error output.
+		termWidth = 0
 	}
 
 	return hcl.NewDiagnosticTextWriter(writer, parser.Files(), uint(termWidth), termColor)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes flake with `TestSopsDecryptOnMissing`. We make assertions in the test on terminal output, and that breaks when there are line breaks. In general, we shouldn't enforce line wraps based on an 80 character width terminal if users aren't running Terragrunt in a terminal.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled automatic word-wrapping for diagnostic output when not attached to a terminal (CI, tests, piped output), preventing inconsistent line wraps and ensuring stable, parseable error messages.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->