### PR TITLE
fix: Adding lock files to cache key for provider cache

### DIFF
--- a/.github/workflows/base-test.yml
+++ b/.github/workflows/base-test.yml
@@ -49,7 +49,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ runner.os == 'Linux' && '~/.cache/terragrunt' || '~/Library/Caches/terragrunt' }}
-          key: ${{ runner.os }}-terragrunt-provider-cache
+          key: ${{ runner.os }}-terragrunt-provider-cache-${{ hashFiles('**/.terraform.lock.hcl') }}
+          restore-keys: |
+            ${{ runner.os }}-terragrunt-provider-cache-
 
       - name: Run Tests
         id: run-tests

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -216,7 +216,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/terragrunt
-          key: ${{ runner.os }}-terragrunt-provider-cache
+          key: ${{ runner.os }}-terragrunt-provider-cache-${{ hashFiles('**/.terraform.lock.hcl') }}
+          restore-keys: |
+            ${{ runner.os }}-terragrunt-provider-cache-
 
       - name: Run Tests
         run: |

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -105,7 +105,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/terragrunt
-          key: ${{ runner.os }}-terragrunt-provider-cache
+          key: ${{ runner.os }}-terragrunt-provider-cache-${{ hashFiles('**/.terraform.lock.hcl') }}
+          restore-keys: |
+            ${{ runner.os }}-terragrunt-provider-cache-
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Ensures that we update cache when new `.terraform.lock.hcl` files show up or get updated.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Optimized test workflow caching to improve CI/CD reliability and reduce unnecessary cache misses

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->