### PR TITLE
fix: Updating `--auth-provider-cmd` schema in flags docs

### DIFF
--- a/docs-starlight/src/content/docs/03-features/16-run-report.mdx
+++ b/docs-starlight/src/content/docs/03-features/16-run-report.mdx
@@ -6,7 +6,9 @@ sidebar:
   order: 16
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Aside, Code } from '@astrojs/starlight/components';
+
+import runReportSchema from '../../../../public/schemas/run/report/v3/schema.json?raw';
 
 Terragrunt uses an internal data store to track the results of runs when multiple are done at once. You can view this data, both with a high-level summary that is displayed at the end of each run, and via a detailed report that can be requested on-demand (coming soon).
 
@@ -137,74 +139,7 @@ The schema will be generated at the given path in the current working directory.
 
 This generated schema will look like the following:
 
-```json
-{
-  "items": {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://terragrunt.gruntwork.io/schemas/run/report/v3/schema.json",
-    "properties": {
-      "Started": {
-        "type": "string",
-        "format": "date-time"
-      },
-      "Ended": {
-        "type": "string",
-        "format": "date-time"
-      },
-      "Reason": {
-        "type": "string",
-        "enum": [
-          "retry succeeded",
-          "error ignored",
-          "run error",
-          "exclude block",
-          "ancestor error"
-        ]
-      },
-      "Cause": {
-        "type": "string"
-      },
-      "Name": {
-        "type": "string"
-      },
-      "Result": {
-        "type": "string",
-        "enum": [
-          "succeeded",
-          "failed",
-          "early exit",
-          "excluded"
-        ]
-      },
-      "Ref": {
-        "type": "string"
-      },
-      "Cmd": {
-        "type": "string"
-      },
-      "Args": {
-        "items": {
-          "type": "string"
-        },
-        "type": "array"
-      }
-    },
-    "additionalProperties": false,
-    "type": "object",
-    "required": [
-      "Started",
-      "Ended",
-      "Name",
-      "Result"
-    ],
-    "title": "Terragrunt Run Report Schema",
-    "description": "Schema for Terragrunt run report"
-  },
-  "type": "array",
-  "title": "Terragrunt Run Report Schema",
-  "description": "Array of Terragrunt runs"
-}
-```
+<Code title="run/report/v3/schema.json" lang="json" code={runReportSchema} />
 
 Note the `$id` field, which is used to identify the schema. This is useful to quickly determine which version of the schema is being used. You can also fetch the schema remotely from that URL.
 

--- a/docs-starlight/src/data/flags/auth-provider-cmd.mdx
+++ b/docs-starlight/src/data/flags/auth-provider-cmd.mdx
@@ -7,30 +7,15 @@ env:
   - TG_AUTH_PROVIDER_CMD
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Aside, Code } from '@astrojs/starlight/components';
+
+import authProviderCmdSchema from '../../../public/schemas/auth-provider-cmd/v1/schema.json?raw';
 
 The command and arguments used to obtain authentication credentials dynamically. If specified, Terragrunt runs this command whenever it might need authentication. This includes HCL parsing, where it might be useful to authenticate with a cloud provider _before_ running HCL functions like [`get_aws_account_id`](/docs/reference/hcl/functions#get_aws_account_id) where authentication has to already have taken place. It can also be useful for HCL functions like [`run_cmd`](/docs/reference/hcl/functions#run_cmd) where it may be useful to be authenticated before calling the function.
 
 The output must be valid JSON of the following schema:
 
-```json
-{
-  "awsCredentials": {
-    "ACCESS_KEY_ID": "",
-    "SECRET_ACCESS_KEY": "",
-    "SESSION_TOKEN": ""
-  },
-  "awsRole": {
-    "roleARN": "",
-    "sessionName": "",
-    "duration": 0,
-    "webIdentityToken": ""
-  },
-  "envs": {
-    "ANY_KEY": ""
-  }
-}
-```
+<Code title="auth-provider-cmd/v1/schema.json" lang="json" code={authProviderCmdSchema} />
 
 This allows Terragrunt to acquire different credentials at runtime without changing any `terragrunt.hcl` configuration. You can use this flag to set arbitrary credentials for continuous integration, authentication with providers other than AWS and more.
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updates the schema displayed in the `--auth-provider-cmd` flag to match the schema in the authentication docs.

Also ensures that the run report docs reference the schema so that there's a single source of truth for the schema.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced documentation code examples with improved formatting and cleaner schema references across multiple pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->