### PR TITLE
docs: add instructions on bypassing tflint integration behavior

### DIFF
--- a/docs-starlight/src/content/docs/03-features/10-hooks.mdx
+++ b/docs-starlight/src/content/docs/03-features/10-hooks.mdx
@@ -300,6 +300,19 @@ terraform {
 }
 ```
 
+If you need to bypass the integration behavior (auto init or passing in variables), you can specify an absolute path to `tflint`, as this integration works by checking the first value in the `execute` array:
+
+```hcl
+# terragrunt.hcl
+
+terraform {
+  before_hook "before_hook" {
+    commands     = ["apply", "plan"]
+    execute      = ["/usr/local/bin/tflint", "some", "args"]
+  }
+}
+```
+
 ### Authentication for tflint rulesets
 
 \<!-- markdownlint-disable MD036 -->


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Reading through https://github.com/gruntwork-io/terragrunt/issues/3669 it became apparent that there can be valid reasons to bypass the tflint integration behavior (auto init and / or passing in variables).

This PR adds documentation on how one might do this bypassing.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on using absolute paths to bypass integration behavior for tflint hooks, including a configuration example.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->