### PR TITLE
fix: Fixing `TestAwsBootstrapBackendWithAccessLoggingFlake`

### DIFF
--- a/internal/remotestate/backend/s3/client.go
+++ b/internal/remotestate/backend/s3/client.go
@@ -735,16 +735,16 @@ func isBucketAlreadyOwnedByYouError(err error) bool {
 func isBucketErrorRetriable(l log.Logger, err error) bool {
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
-		retriable := apiErr.ErrorCode() == "InternalError" || apiErr.ErrorCode() == "OperationAborted" || apiErr.ErrorCode() == "InvalidParameter"
+		unrecoverable := apiErr.ErrorCode() == "InternalError" || apiErr.ErrorCode() == "OperationAborted" || apiErr.ErrorCode() == "InvalidParameter"
 
-		if !retriable {
+		if !unrecoverable {
 			l.Debugf(
 				"Encountered AWS API error '%s' during bucket creation. Assuming it's retriable and will retry.",
 				apiErr.ErrorCode(),
 			)
 		}
 
-		return retriable
+		return unrecoverable
 	}
 
 	l.Debugf(


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

We have safeguards to protect against concurrent creation and error handling retries of the state logging buckets like we have for the main state bucket.

Results in less flakes for the `TestAwsBootstrapBackendWithAccessLogging` test.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced S3 bucket creation with robust retry logic for transient and concurrent scenarios.
  * Now waits for bucket existence and gracefully handles already-owned cases.
  * Improved detection and logging of retriable vs unretriable errors, and clearer bucket-name-aware messages.
  * Removed silent error suppression so failures are surfaced reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->