### PR TITLE
docs: tweak opening wording of `stacks generate`

### DIFF
--- a/docs-starlight/src/data/commands/stack/generate.mdx
+++ b/docs-starlight/src/data/commands/stack/generate.mdx
@@ -8,15 +8,15 @@ usage: |
 sidebar:
   order: 400
 examples:
-  - description: Generate a stack of units using the configurations in a terragrunt.stack.hcl file.
+  - description: Generate stacks of units using the configurations in all terragrunt.stack.hcl files found, starting in the current directory.
     code: |
       terragrunt stack generate
 flags:
   - stack-generate-filter
 ---
 
-import FileTree from '@components/vendored/starlight/FileTree.astro';
-import { Aside } from '@astrojs/starlight/components';
+import FileTree from "@components/vendored/starlight/FileTree.astro";
+import { Aside } from "@astrojs/starlight/components";
 
 ## Generating a stack
 
@@ -87,7 +87,8 @@ terragrunt stack generate --no-stack-validate
 </Aside>
 
 <Aside type="caution">
-Path Restrictions: If an absolute path is provided as an argument, `generate` will throw an error. Only relative paths within the working directory are supported.
+  Path Restrictions: If an absolute path is provided as an argument, `generate` will throw an error. Only relative paths
+  within the working directory are supported.
 </Aside>
 
 <Aside type="caution">
@@ -106,4 +107,5 @@ You can also pass `--source-update` when running commands via `stack run`:
 ```bash
 terragrunt stack run plan --source-update
 ```
+
 </Aside>


### PR DESCRIPTION
## Description

Very minor tweak, later parts of the same page make this clear, but use of the singular form here made the behavior unclear without scrolling down.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the generate command documentation to clarify how it finds and generates stacks from multiple configuration files.
  * Improved formatting and readability of command examples and caution notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->