### PR TITLE
fix: Fixing null input passing

### DIFF
--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -5,6 +5,7 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"maps"
@@ -35,6 +36,7 @@ import (
 
 const (
 	CommandNameTerragruntReadConfig = "terragrunt-read-config"
+	NullTFVarsFile                  = ".terragrunt-null-vars.auto.tfvars.json"
 )
 
 var TerraformCommandsThatUseState = []string{
@@ -255,6 +257,20 @@ func runTerragruntWithConfig(
 			return err
 		}
 	}
+
+	// Write null-valued inputs to a tfvars.json file that OpenTofu/Terraform will auto-load.
+	nullVarsFile, err := setTerragruntNullValuesRunCfg(opts, cfg)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if nullVarsFile != "" {
+			if err := os.Remove(nullVarsFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+				l.Debugf("Failed to remove null values file %s: %v", nullVarsFile, err)
+			}
+		}
+	}()
 
 	// Now that we've run 'init' and have all the source code locally, we can finally run the patch command
 	if err := checkProtectedModuleRunCfg(opts, cfg); err != nil {
@@ -715,4 +731,37 @@ func checkProtectedModuleRunCfg(opts *options.TerragruntOptions, cfg *runcfg.Run
 	}
 
 	return nil
+}
+
+// setTerragruntNullValuesRunCfg writes null-valued inputs to a tfvars.json file
+// that OpenTofu/Terraform will auto-load. This is necessary because OpenTofu/Terraform
+// cannot accept null values via environment variables (TF_VAR_*), but it can read them
+// from .auto.tfvars.json files.
+func setTerragruntNullValuesRunCfg(opts *options.TerragruntOptions, cfg *runcfg.RunConfig) (string, error) {
+	jsonEmptyVars := make(map[string]any)
+
+	for varName, varValue := range cfg.Inputs {
+		if varValue == nil {
+			jsonEmptyVars[varName] = nil
+		}
+	}
+
+	if len(jsonEmptyVars) == 0 {
+		return "", nil
+	}
+
+	jsonContents, err := json.MarshalIndent(jsonEmptyVars, "", "  ")
+	if err != nil {
+		return "", errors.New(err)
+	}
+
+	varFile := filepath.Join(opts.WorkingDir, NullTFVarsFile)
+
+	const ownerReadWritePermissions = 0600
+
+	if err := os.WriteFile(varFile, jsonContents, os.FileMode(ownerReadWritePermissions)); err != nil {
+		return "", errors.New(err)
+	}
+
+	return varFile, nil
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4718,3 +4718,31 @@ func TestNoColorDependency(t *testing.T) {
 	assert.NotContains(t, stderr, "\x1b")
 	assert.NotContains(t, stdout, "\x1b")
 }
+
+// TestTerragruntPassNullValues verifies that terragrunt can pass null values to
+// Terraform variables. This is a regression test for:
+// https://github.com/gruntwork-io/terragrunt/issues/5452
+func TestTerragruntPassNullValues(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNullValue)
+	testPath := filepath.Join(tmpEnvPath, testFixtureNullValue)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt apply -auto-approve --non-interactive --working-dir "+testPath,
+	)
+	require.NoError(t, err)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt output -json --non-interactive --working-dir "+testPath,
+	)
+	require.NoError(t, err)
+
+	outputs := map[string]helpers.TerraformOutput{}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &outputs))
+
+	assert.Nil(t, outputs["output1"].Value)
+	assert.Equal(t, "variable 2", outputs["output2"].Value)
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5452.

The PR #5396 accidentally removed too much code as it was inter-mingled with null handling that we actually do need.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terragrunt now supports passing null values to Terraform variables. When null-valued inputs are configured, they are correctly handled and forwarded to Terraform during execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->