### PR TITLE
fix: Fixing flake in `TestDeprecatedDefaultCommand_TerraformSubcommandCliArgs`

### DIFF
--- a/test/integration_deprecated_test.go
+++ b/test/integration_deprecated_test.go
@@ -2,6 +2,7 @@ package test_test
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -43,9 +44,12 @@ func TestDeprecatedDefaultCommand_TerraformSubcommandCliArgs(t *testing.T) {
 		t.Run(tofuCmd, func(t *testing.T) {
 			t.Parallel()
 
+			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureExtraArgsPath)
+			rootPath := filepath.Join(tmpEnvPath, testFixtureExtraArgsPath)
+
 			cmd := fmt.Sprintf(
 				"terragrunt --log-level debug --non-interactive --working-dir %s -- %s",
-				testFixtureExtraArgsPath,
+				rootPath,
 				strings.Join(tc.command, " "),
 			)
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

The fixture was polluting the `test/fixtures` directory with temporary files. By creating a temporary clone for the test, we can avoid race conditions between different tests.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test environment setup to use improved fixture handling.

* **Chores**
  * Minor internal test infrastructure improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->