### PR TITLE
fix: Fixing `TestAwsS3SSECustomKey`

### DIFF
--- a/test/fixtures/s3-encryption/custom-key/main.tf
+++ b/test/fixtures/s3-encryption/custom-key/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "registry.opentofu.org/hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
+}
+
 resource "null_resource" "main" {}
 
 output "id" {

--- a/test/fixtures/s3-encryption/sse-aes/main.tf
+++ b/test/fixtures/s3-encryption/sse-aes/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "registry.opentofu.org/hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
+}
+
 resource "null_resource" "main" {}
 
 output "id" {

--- a/test/fixtures/s3-encryption/sse-kms/main.tf
+++ b/test/fixtures/s3-encryption/sse-kms/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "registry.opentofu.org/hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
+}
+
 resource "null_resource" "main" {}
 
 output "id" {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5465

These didn't have a `required_providers` block to ensure that the OpenTofu provider registry was used.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test fixture configurations to specify required provider dependencies. These infrastructure updates ensure consistent test environments and support internal testing processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->