### PR TITLE
fix: Use `helpers.CopyEnvironment` wherever there's a test with side-effects

### DIFF
--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -95,6 +95,14 @@ func CopyEnvironment(t *testing.T, environmentPath string, includeInCopy ...stri
 
 	t.Logf("Copying %s to %s", environmentPath, tmpDir)
 
+	// Exclude OpenTofu/Terraform/Terragrunt cache directories
+	// that may have been created when manually running in the fixtures directory.
+	excludeFromCopy := []string{
+		"**/.terraform/**",
+		"**/.terragrunt-cache/**",
+		"**/terragrunt-debug.tfvars.json",
+	}
+
 	require.NoError(
 		t,
 		util.CopyFolderContents(
@@ -103,7 +111,7 @@ func CopyEnvironment(t *testing.T, environmentPath string, includeInCopy ...stri
 			filepath.Join(tmpDir, environmentPath),
 			".terragrunt-test",
 			includeInCopy,
-			nil,
+			excludeFromCopy,
 		),
 	)
 

--- a/test/integration_dag_test.go
+++ b/test/integration_dag_test.go
@@ -25,8 +25,10 @@ func TestDagGraphFlagsRegistration(t *testing.T) {
 func TestIncludeExternalInDagGraphCmd(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureGraphDAG)
-	workDir := filepath.Join(testFixtureGraphDAG, "region-1")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGraphDAG)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureGraphDAG)
+	helpers.CleanupTerraformFolder(t, rootPath)
+	workDir := filepath.Join(rootPath, "region-1")
 	workDir, err := filepath.EvalSymlinks(workDir)
 	require.NoError(t, err)
 
@@ -40,8 +42,10 @@ func TestIncludeExternalInDagGraphCmd(t *testing.T) {
 func TestIncludeExternalInDagGraphCmdWithList(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureGraphDAG)
-	workDir := filepath.Join(testFixtureGraphDAG, "region-1")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGraphDAG)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureGraphDAG)
+	helpers.CleanupTerraformFolder(t, rootPath)
+	workDir := filepath.Join(rootPath, "region-1")
 	workDir, err := filepath.EvalSymlinks(workDir)
 	require.NoError(t, err)
 

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -170,19 +170,23 @@ func TestTerragruntDestroyOrderWithQueueIgnoreErrors(t *testing.T) {
 func TestPreventDestroyOverride(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixturePreventDestroyOverride)
+	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures/prevent-destroy-override")
+	rootPath := filepath.Join(tmpEnvPath, testFixturePreventDestroyOverride)
+	helpers.CleanupTerraformFolder(t, rootPath)
 
-	require.NoError(t, helpers.RunTerragruntCommand(t, "terragrunt apply -auto-approve --working-dir "+testFixturePreventDestroyOverride, os.Stdout, os.Stderr))
-	require.NoError(t, helpers.RunTerragruntCommand(t, "terragrunt destroy -auto-approve --working-dir "+testFixturePreventDestroyOverride, os.Stdout, os.Stderr))
+	require.NoError(t, helpers.RunTerragruntCommand(t, "terragrunt apply -auto-approve --working-dir "+rootPath, os.Stdout, os.Stderr))
+	require.NoError(t, helpers.RunTerragruntCommand(t, "terragrunt destroy -auto-approve --working-dir "+rootPath, os.Stdout, os.Stderr))
 }
 
 func TestPreventDestroyNotSet(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixturePreventDestroyNotSet)
+	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures/prevent-destroy-not-set")
+	rootPath := filepath.Join(tmpEnvPath, testFixturePreventDestroyNotSet)
+	helpers.CleanupTerraformFolder(t, rootPath)
 
-	require.NoError(t, helpers.RunTerragruntCommand(t, "terragrunt apply -auto-approve --working-dir "+testFixturePreventDestroyNotSet, os.Stdout, os.Stderr))
-	err := helpers.RunTerragruntCommand(t, "terragrunt destroy -auto-approve --working-dir "+testFixturePreventDestroyNotSet, os.Stdout, os.Stderr)
+	require.NoError(t, helpers.RunTerragruntCommand(t, "terragrunt apply -auto-approve --working-dir "+rootPath, os.Stdout, os.Stderr))
+	err := helpers.RunTerragruntCommand(t, "terragrunt destroy -auto-approve --working-dir "+rootPath, os.Stdout, os.Stderr)
 
 	if assert.Error(t, err) {
 		var target run.ModuleIsProtected
@@ -309,6 +313,9 @@ func TestNoShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
 func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {
 	t.Parallel()
 
+	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures/download")
+	rootPath := filepath.Join(tmpEnvPath, testFixtureLocalIncludePreventDestroyDependencies)
+
 	// Populate module paths.
 	moduleNames := []string{
 		"module-a",
@@ -318,11 +325,11 @@ func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {
 
 	modulePaths := make(map[string]string, len(moduleNames))
 	for _, moduleName := range moduleNames {
-		modulePaths[moduleName] = filepath.Join(testFixtureLocalIncludePreventDestroyDependencies, moduleName)
+		modulePaths[moduleName] = filepath.Join(rootPath, moduleName)
 	}
 
 	// Cleanup all modules directories.
-	helpers.CleanupTerraformFolder(t, testFixtureLocalIncludePreventDestroyDependencies)
+	helpers.CleanupTerraformFolder(t, rootPath)
 
 	for _, modulePath := range modulePaths {
 		helpers.CleanupTerraformFolder(t, modulePath)
@@ -334,7 +341,7 @@ func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {
 	)
 
 	// Apply and destroy all modules.
-	err := helpers.RunTerragruntCommand(t, "terragrunt run --all apply --non-interactive --working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &applyAllStdout, &applyAllStderr)
+	err := helpers.RunTerragruntCommand(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath, &applyAllStdout, &applyAllStderr)
 	helpers.LogBufferContentsLineByLine(t, applyAllStdout, "run --all apply stdout")
 	helpers.LogBufferContentsLineByLine(t, applyAllStderr, "run --all apply stderr")
 
@@ -347,7 +354,7 @@ func TestPreventDestroyDependenciesIncludedConfig(t *testing.T) {
 		destroyAllStderr bytes.Buffer
 	)
 
-	err = helpers.RunTerragruntCommand(t, "terragrunt run --all destroy --non-interactive --working-dir "+testFixtureLocalIncludePreventDestroyDependencies, &destroyAllStdout, &destroyAllStderr)
+	err = helpers.RunTerragruntCommand(t, "terragrunt run --all destroy --non-interactive --working-dir "+rootPath, &destroyAllStdout, &destroyAllStderr)
 	helpers.LogBufferContentsLineByLine(t, destroyAllStdout, "run --all destroy stdout")
 	helpers.LogBufferContentsLineByLine(t, destroyAllStderr, "run --all destroy stderr")
 

--- a/test/integration_gcp_test.go
+++ b/test/integration_gcp_test.go
@@ -258,8 +258,10 @@ func TestGcpMigrateBackend(t *testing.T) {
 func TestGcpWorksWithBackend(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureGcsPath)
-	helpers.CleanupTerragruntFolder(t, testFixtureGcsPath)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGcsPath)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureGcsPath)
+	helpers.CleanupTerraformFolder(t, rootPath)
+	helpers.CleanupTerragruntFolder(t, rootPath)
 
 	// We need a project to create the bucket in, so we pull one from the recommended environment variable.
 	project := os.Getenv("GOOGLE_CLOUD_PROJECT")
@@ -269,7 +271,7 @@ func TestGcpWorksWithBackend(t *testing.T) {
 
 	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(
 		t,
-		testFixtureGcsPath,
+		rootPath,
 		project,
 		terraformRemoteStateGcpRegion,
 		gcsBucketName,
@@ -280,7 +282,7 @@ func TestGcpWorksWithBackend(t *testing.T) {
 		fmt.Sprintf(
 			"terragrunt apply -auto-approve --non-interactive --backend-bootstrap --config %s --working-dir %s",
 			tmpTerragruntGCSConfigPath,
-			testFixtureGcsPath,
+			rootPath,
 		),
 	)
 
@@ -293,7 +295,9 @@ func TestGcpWorksWithBackend(t *testing.T) {
 func TestGcpWorksWithExistingBucket(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureGcsByoBucketPath)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGcsByoBucketPath)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureGcsByoBucketPath)
+	helpers.CleanupTerraformFolder(t, rootPath)
 
 	// We need a project to create the bucket in, so we pull one from the recommended environment variable.
 	project := os.Getenv("GOOGLE_CLOUD_PROJECT")
@@ -307,7 +311,7 @@ func TestGcpWorksWithExistingBucket(t *testing.T) {
 
 	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(
 		t,
-		testFixtureGcsByoBucketPath,
+		rootPath,
 		project,
 		terraformRemoteStateGcpRegion,
 		gcsBucketName,
@@ -318,7 +322,7 @@ func TestGcpWorksWithExistingBucket(t *testing.T) {
 		fmt.Sprintf(
 			"terragrunt apply -auto-approve --non-interactive --config %s --working-dir %s",
 			tmpTerragruntGCSConfigPath,
-			testFixtureGcsByoBucketPath,
+			rootPath,
 		),
 	)
 
@@ -328,7 +332,9 @@ func TestGcpWorksWithExistingBucket(t *testing.T) {
 func TestGcpCheckMissingBucket(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureGcsNoBucket)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGcsNoBucket)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureGcsNoBucket)
+	helpers.CleanupTerraformFolder(t, rootPath)
 
 	// We need a project to create the bucket in, so we pull one from the recommended environment variable.
 	project := os.Getenv("GOOGLE_CLOUD_PROJECT")
@@ -336,7 +342,7 @@ func TestGcpCheckMissingBucket(t *testing.T) {
 
 	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(
 		t,
-		testFixtureGcsNoBucket,
+		rootPath,
 		project,
 		terraformRemoteStateGcpRegion,
 		gcsBucketName,
@@ -347,7 +353,7 @@ func TestGcpCheckMissingBucket(t *testing.T) {
 		fmt.Sprintf(
 			"terragrunt apply -auto-approve --backend-bootstrap --non-interactive --config %s --working-dir %s",
 			tmpTerragruntGCSConfigPath,
-			testFixtureGcsNoBucket,
+			rootPath,
 		),
 	)
 	require.Error(t, err)
@@ -358,7 +364,9 @@ func TestGcpCheckMissingBucket(t *testing.T) {
 func TestGcpNoPrefixBucket(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureGcsNoPrefix)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGcsNoPrefix)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureGcsNoPrefix)
+	helpers.CleanupTerraformFolder(t, rootPath)
 
 	// We need a project to create the bucket in, so we pull one from the recommended environment variable.
 	project := os.Getenv("GOOGLE_CLOUD_PROJECT")
@@ -366,13 +374,13 @@ func TestGcpNoPrefixBucket(t *testing.T) {
 
 	defer deleteGCSBucket(t, gcsBucketName)
 
-	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, testFixtureGcsNoPrefix, project, terraformRemoteStateGcpRegion, gcsBucketName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, rootPath, project, terraformRemoteStateGcpRegion, gcsBucketName, config.DefaultTerragruntConfigPath)
 	_, _, err := helpers.RunTerragruntCommandWithOutput(
 		t,
 		fmt.Sprintf(
 			"terragrunt apply -auto-approve --backend-bootstrap --non-interactive --config %s --working-dir %s",
 			tmpTerragruntGCSConfigPath,
-			testFixtureGcsNoPrefix,
+			rootPath,
 		),
 	)
 	require.NoError(t, err)

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -173,7 +173,9 @@ func TestTerragruntRunAllModulesWithPrefix(t *testing.T) {
 func TestTerragruntWorksWithIncludeDeepMerge(t *testing.T) {
 	t.Parallel()
 
-	childPath := filepath.Join(includeDeepFixturePath, "child")
+	tmpEnvPath := helpers.CopyEnvironment(t, includeDeepFixturePath)
+	rootPath := filepath.Join(tmpEnvPath, includeDeepFixturePath)
+	childPath := filepath.Join(rootPath, "child")
 	helpers.CleanupTerraformFolder(t, childPath)
 
 	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+childPath)
@@ -211,7 +213,10 @@ func TestTerragruntWorksWithIncludeDeepMerge(t *testing.T) {
 func TestTerragruntWorksWithMultipleInclude(t *testing.T) {
 	t.Parallel()
 
-	files, err := os.ReadDir(includeMultipleFixturePath)
+	tmpEnvPath := helpers.CopyEnvironment(t, includeMultipleFixturePath)
+	rootPath := filepath.Join(tmpEnvPath, includeMultipleFixturePath)
+
+	files, err := os.ReadDir(rootPath)
 	require.NoError(t, err)
 
 	testCases := []string{}
@@ -226,7 +231,7 @@ func TestTerragruntWorksWithMultipleInclude(t *testing.T) {
 		t.Run(filepath.Base(tc), func(t *testing.T) {
 			t.Parallel()
 
-			childPath := filepath.Join(includeMultipleFixturePath, tc, includeDeepFixtureChildPath)
+			childPath := filepath.Join(rootPath, tc, includeDeepFixtureChildPath)
 			helpers.CleanupTerraformFolder(t, childPath)
 			helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+childPath)
 

--- a/test/integration_locals_test.go
+++ b/test/integration_locals_test.go
@@ -28,27 +28,33 @@ const (
 func TestUndefinedLocalsReferenceBreaks(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureLocalsErrorUndefinedLocal)
-	err := helpers.RunTerragruntCommand(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+testFixtureLocalsErrorUndefinedLocal, os.Stdout, os.Stderr)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureLocalsErrorUndefinedLocal)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureLocalsErrorUndefinedLocal)
+	helpers.CleanupTerraformFolder(t, rootPath)
+	err := helpers.RunTerragruntCommand(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath, os.Stdout, os.Stderr)
 	require.Error(t, err)
 }
 
 func TestUndefinedLocalsReferenceToInputsBreaks(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureLocalsErrorUndefinedLocalButInput)
-	err := helpers.RunTerragruntCommand(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+testFixtureLocalsErrorUndefinedLocalButInput, os.Stdout, os.Stderr)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureLocalsErrorUndefinedLocalButInput)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureLocalsErrorUndefinedLocalButInput)
+	helpers.CleanupTerraformFolder(t, rootPath)
+	err := helpers.RunTerragruntCommand(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath, os.Stdout, os.Stderr)
 	require.Error(t, err)
 }
 
 func TestLocalsParsing(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureLocalsCanonical)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureLocalsCanonical)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureLocalsCanonical)
+	helpers.CleanupTerraformFolder(t, rootPath)
 
-	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+testFixtureLocalsCanonical)
+	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath)
 
-	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt output -no-color -json --non-interactive --working-dir "+testFixtureLocalsCanonical)
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt output -no-color -json --non-interactive --working-dir "+rootPath)
 	require.NoError(t, err)
 
 	outputs := map[string]helpers.TerraformOutput{}
@@ -136,12 +142,14 @@ func TestTerragruntInitRunCmd(t *testing.T) {
 func TestTerragruntLocalRunOnce(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureLocalRunOnce)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureLocalRunOnce)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureLocalRunOnce)
+	helpers.CleanupTerraformFolder(t, rootPath)
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err := helpers.RunTerragruntCommand(t, "terragrunt init --working-dir "+testFixtureLocalRunOnce, &stdout, &stderr)
+	err := helpers.RunTerragruntCommand(t, "terragrunt init --working-dir "+rootPath, &stdout, &stderr)
 	require.Error(t, err)
 
 	errout := stdout.String()

--- a/test/integration_s3_encryption_test.go
+++ b/test/integration_s3_encryption_test.go
@@ -127,7 +127,9 @@ func TestAwsS3SSEKeyNotReverted(t *testing.T) {
 	// aws kms create-key --description "Test key for Terragrunt integration tests"
 	// aws kms create-alias --alias-name alias/dedicated-test-key --target-key-id KEY_ID
 
-	helpers.CleanupTerraformFolder(t, s3SSBasicEncryptionFixturePath)
+	tmpEnvPath := helpers.CopyEnvironment(t, s3SSBasicEncryptionFixturePath)
+	rootPath := filepath.Join(tmpEnvPath, s3SSBasicEncryptionFixturePath)
+	helpers.CleanupTerraformFolder(t, rootPath)
 
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
 	lockTableName := "terragrunt-test-locks-" + strings.ToLower(helpers.UniqueID())
@@ -135,7 +137,7 @@ func TestAwsS3SSEKeyNotReverted(t *testing.T) {
 	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, helpers.TerraformRemoteStateS3Region)
 
-	tmpTerragruntConfigPath := helpers.CreateTmpTerragruntConfig(t, s3SSBasicEncryptionFixturePath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath := helpers.CreateTmpTerragruntConfig(t, rootPath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
 	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --backend-bootstrap --non-interactive --working-dir "+filepath.Dir(tmpTerragruntConfigPath))
 	require.NoError(t, err)
 
@@ -144,7 +146,7 @@ func TestAwsS3SSEKeyNotReverted(t *testing.T) {
 	// verify that bucket encryption message is not printed
 	assert.NotContains(t, output, "Bucket Server-Side Encryption")
 
-	tmpTerragruntConfigPath = helpers.CreateTmpTerragruntConfig(t, s3SSBasicEncryptionFixturePath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
+	tmpTerragruntConfigPath = helpers.CreateTmpTerragruntConfig(t, rootPath, s3BucketName, lockTableName, config.DefaultTerragruntConfigPath)
 	stdout, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --backend-bootstrap --non-interactive --working-dir "+filepath.Dir(tmpTerragruntConfigPath))
 	require.NoError(t, err)
 

--- a/test/integration_serial_gcp_test.go
+++ b/test/integration_serial_gcp_test.go
@@ -5,6 +5,7 @@ package test_test
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -24,7 +25,9 @@ func TestGcpCorrectlyMirrorsTerraformGCPAuth(t *testing.T) {
 	os.Unsetenv("GCLOUD_SERVICE_KEY") //nolint:usetesting
 	t.Setenv("GOOGLE_CREDENTIALS", defaultCreds)
 
-	helpers.CleanupTerraformFolder(t, testFixtureGcsPath)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGcsPath)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureGcsPath)
+	helpers.CleanupTerraformFolder(t, rootPath)
 
 	// We need a project to create the bucket in, so we pull one from the recommended environment variable.
 	project := os.Getenv("GOOGLE_CLOUD_PROJECT")
@@ -32,8 +35,8 @@ func TestGcpCorrectlyMirrorsTerraformGCPAuth(t *testing.T) {
 
 	defer deleteGCSBucket(t, gcsBucketName)
 
-	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, testFixtureGcsPath, project, terraformRemoteStateGcpRegion, gcsBucketName, config.DefaultTerragruntConfigPath)
-	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --backend-bootstrap --non-interactive --config %s --working-dir %s", tmpTerragruntGCSConfigPath, testFixtureGcsPath))
+	tmpTerragruntGCSConfigPath := createTmpTerragruntGCSConfig(t, rootPath, project, terraformRemoteStateGcpRegion, gcsBucketName, config.DefaultTerragruntConfigPath)
+	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --backend-bootstrap --non-interactive --config %s --working-dir %s", tmpTerragruntGCSConfigPath, rootPath))
 
 	var expectedGCSLabels = map[string]string{
 		"owner": "terragrunt_test",

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1251,7 +1251,8 @@ func TestTerragruntStackCommandsWithSymlinks(t *testing.T) {
 func TestInvalidSource(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := testFixtureNotExistingSource
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNotExistingSource)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureNotExistingSource)
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -1438,7 +1439,8 @@ func TestRunCommand(t *testing.T) {
 func TestTerragruntMissingDependenciesFail(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := testFixtureMissingDependence
+	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures/missing-dependencies")
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureMissingDependence)
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -2575,8 +2577,9 @@ func TestReadTerragruntConfigFromDependency(t *testing.T) {
 func TestReadTerragruntConfigWithDefault(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureReadConfig)
-	rootPath := filepath.Join(testFixtureReadConfig, "with_default")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureReadConfig)
+	helpers.CleanupTerraformFolder(t, filepath.Join(tmpEnvPath, testFixtureReadConfig))
+	rootPath := filepath.Join(tmpEnvPath, testFixtureReadConfig, "with_default")
 
 	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath)
 
@@ -2598,8 +2601,9 @@ func TestReadTerragruntConfigWithDefault(t *testing.T) {
 func TestReadTerragruntConfigWithOriginalTerragruntDir(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureReadConfig)
-	rootPath := filepath.Join(testFixtureReadConfig, "with_original_terragrunt_dir")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureReadConfig)
+	helpers.CleanupTerraformFolder(t, filepath.Join(tmpEnvPath, testFixtureReadConfig))
+	rootPath := filepath.Join(tmpEnvPath, testFixtureReadConfig, "with_original_terragrunt_dir")
 
 	rootPathAbs, err := filepath.Abs(rootPath)
 	require.NoError(t, err)
@@ -2687,8 +2691,9 @@ func TestReadTerragruntConfigWithOriginalTerragruntDir(t *testing.T) {
 func TestReadTerragruntConfigFull(t *testing.T) {
 	t.Parallel()
 
-	helpers.CleanupTerraformFolder(t, testFixtureReadConfig)
-	rootPath := filepath.Join(testFixtureReadConfig, "full")
+	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures")
+	helpers.CleanupTerraformFolder(t, filepath.Join(tmpEnvPath, testFixtureReadConfig))
+	rootPath := filepath.Join(tmpEnvPath, testFixtureReadConfig, "full")
 
 	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath)
 
@@ -2872,7 +2877,8 @@ func TestTerragruntGenerateBlockRemoveTerragruntFail(t *testing.T) {
 func TestTerragruntGenerateBlockSkip(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "skip")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "skip")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+generateTestCase)
@@ -2882,7 +2888,8 @@ func TestTerragruntGenerateBlockSkip(t *testing.T) {
 func TestTerragruntGenerateBlockOverwrite(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "overwrite")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "overwrite")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -2909,7 +2916,8 @@ func TestTerragruntGenerateAttr(t *testing.T) {
 func TestTerragruntGenerateBlockOverwriteTerragruntSuccess(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "overwrite_terragrunt")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "overwrite_terragrunt")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -2922,7 +2930,8 @@ func TestTerragruntGenerateBlockOverwriteTerragruntSuccess(t *testing.T) {
 func TestTerragruntGenerateBlockOverwriteTerragruntFail(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "overwrite_terragrunt_error")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "overwrite_terragrunt_error")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -2940,7 +2949,8 @@ func TestTerragruntGenerateBlockOverwriteTerragruntFail(t *testing.T) {
 func TestTerragruntGenerateBlockNestedInherit(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "nested", "child_inherit")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "nested", "child_inherit")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -2955,7 +2965,8 @@ func TestTerragruntGenerateBlockNestedInherit(t *testing.T) {
 func TestTerragruntGenerateBlockNestedOverwrite(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "nested", "child_overwrite")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "nested", "child_overwrite")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -2970,7 +2981,8 @@ func TestTerragruntGenerateBlockNestedOverwrite(t *testing.T) {
 func TestTerragruntGenerateBlockDisableSignature(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "disable-signature")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "disable-signature")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -2994,7 +3006,8 @@ func TestTerragruntGenerateBlockDisableSignature(t *testing.T) {
 func TestTerragruntGenerateBlockSameNameFail(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "same_name_error")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "same_name_error")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -3014,7 +3027,8 @@ func TestTerragruntGenerateBlockSameNameFail(t *testing.T) {
 func TestTerragruntGenerateBlockSameNameIncludeFail(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "same_name_includes_error")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "same_name_includes_error")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -3034,7 +3048,8 @@ func TestTerragruntGenerateBlockSameNameIncludeFail(t *testing.T) {
 func TestTerragruntGenerateBlockMultipleSameNameFail(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "same_name_pair_error")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "same_name_pair_error")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -3055,7 +3070,8 @@ func TestTerragruntGenerateBlockMultipleSameNameFail(t *testing.T) {
 func TestTerragruntGenerateBlockDisable(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "disable")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "disable")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -3069,7 +3085,8 @@ func TestTerragruntGenerateBlockDisable(t *testing.T) {
 func TestTerragruntGenerateBlockEnable(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "generate-block", "enable")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "generate-block", "enable")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -3083,7 +3100,8 @@ func TestTerragruntGenerateBlockEnable(t *testing.T) {
 func TestTerragruntRemoteStateCodegenGeneratesBackendBlock(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "remote-state", "base")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "remote-state", "base")
 
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
@@ -3096,7 +3114,8 @@ func TestTerragruntRemoteStateCodegenGeneratesBackendBlock(t *testing.T) {
 func TestTerragruntRemoteStateCodegenOverwrites(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "remote-state", "overwrite")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "remote-state", "overwrite")
 
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
@@ -3110,7 +3129,8 @@ func TestTerragruntRemoteStateCodegenOverwrites(t *testing.T) {
 func TestTerragruntRemoteStateCodegenErrorsIfExists(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "remote-state", "error")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "remote-state", "error")
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
 
@@ -3129,7 +3149,8 @@ func TestTerragruntRemoteStateCodegenErrorsIfExists(t *testing.T) {
 func TestTerragruntRemoteStateCodegenDoesNotGenerateWithSkip(t *testing.T) {
 	t.Parallel()
 
-	generateTestCase := filepath.Join(testFixtureCodegenPath, "remote-state", "skip")
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "remote-state", "skip")
 
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

These are the handful of tests that aren't using `helpers.CopyEnvironment` and run into issues with polluting `test/fixtures` as a consequence. Updating them to use `helpers.CopyEnvironment` to reduce that likelihood. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test isolation by configuring tests to operate on temporary fixture copies instead of direct fixtures
  * Updated test environment setup to exclude cache artifacts during fixture preparation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->