### PR TITLE
docs: remove lint meta comment that's getting displayed on the site

### DIFF
--- a/docs-starlight/src/content/docs/03-features/10-hooks.mdx
+++ b/docs-starlight/src/content/docs/03-features/10-hooks.mdx
@@ -303,8 +303,6 @@ terraform {
 
 ### Authentication for tflint rulesets
 
-\<!-- markdownlint-disable MD036 -->
-
 _Public rulesets_
 
 `tflint` works without any authentication for public rulesets (hosted on public repositories).

--- a/docs-starlight/src/content/docs/04-reference/06-lock-files.mdx
+++ b/docs-starlight/src/content/docs/04-reference/06-lock-files.mdx
@@ -6,7 +6,7 @@ sidebar:
   order: 6
 ---
 
-import FileTree from '@components/vendored/starlight/FileTree.astro';
+import FileTree from "@components/vendored/starlight/FileTree.astro";
 
 ## How to use lock files with Terragrunt
 
@@ -23,7 +23,7 @@ Everything else with OpenTofu/Terraform and Terragrunt should work as expected. 
 ### What's a lock file?
 
 [Terraform 0.14 added support for a
-*lock file*](https://www.hashicorp.com/blog/terraform-0-14-introduces-a-dependency-lock-file-for-providers)
+_lock file_](https://www.hashicorp.com/blog/terraform-0-14-introduces-a-dependency-lock-file-for-providers)
 which gets created or updated every time you run `tofu init`/`terraform init`. The file is typically generated into your working
 directory (i.e., the folder in which you ran `tofu init`/`terraform init`) and is called `.terraform.lock.hcl`.
 It captures the versions of all the OpenTofu/Terraform providers you're using. Normally, you want to check this file into
@@ -78,7 +78,6 @@ To solve this problem, since version v0.27.0, Terragrunt implements the followin
    `.terragrunt-cache/xxx/vpc`), it will copy that lock file back to your working directory (e.g., to `/live/stage/vpc`).
    That way, you can commit the lock file (or the changes to the lock file) to version control as usual.
 
-\<!-- markdownlint-disable MD026 -->
 ### Check the lock file in!
 
 After running Terragrunt on each of your modules, you should check your lock files in! That means your folder structure


### PR DESCRIPTION
## Description

These comments are from when these pages were `.md` instead of `.mdx`, making the html comment become a syntax error, but the escaped version displays on the site.

<img width="783" height="564" alt="image" src="https://github.com/user-attachments/assets/eb31d46e-910b-4092-95e0-247c1225027c" />

Turns out markdownlint doesn't run on `.mdx` files anyway 😅 


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation formatting across Hooks and Lock Files reference sections to improve consistency and readability. Updates include standardized quote formatting for import statements and optimized text emphasis styling. These refinements improve visual clarity and align documentation with established style guidelines while maintaining all content integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->