### PR TITLE
fix: Adding test for `init-from-module` and improving discoverability

### DIFF
--- a/docs-starlight/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs-starlight/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -109,6 +109,7 @@ The `terraform` block supports the following arguments:
   arguments as `before_hook`.
 - `error_hook` (block): Nested blocks used to specify command hooks that run when an error is thrown. The
   error must match one of the expressions listed in the `on_errors` attribute. Error hooks are executed after the before/after hooks.
+  To handle errors during source download (when using the `source` attribute), use `init-from-module` in the `commands` list.
 
 In addition to supporting before and after hooks for all OpenTofu/Terraform commands, the following specialized hooks are also
 supported:
@@ -123,7 +124,8 @@ supported:
   configurations](/docs/features/units) using `go-getter`; the other
   is [Auto-Init](/docs/features/auto-init), which configures the backend and downloads
   provider plugins and modules. If you wish to run a hook when Terragrunt is using `go-getter` to download remote
-  configurations, use `init-from-module` for the command. If you wish to execute a hook when Terragrunt is using
+  configurations, use `init-from-module` for the command. This includes `error_hook` blocks to handle download failures.
+  If you wish to execute a hook when Terragrunt is using
   `tofu init`/`terraform init` for Auto-Init, use `init` for the command. For example, an `after_hook` for the command
   `init-from-module` will run after terragrunt clones the module, while an `after_hook` for the command `init` will run
   after terragrunt runs `tofu init`/`terraform init` on the cloned module.
@@ -204,6 +206,14 @@ terraform {
     on_errors = [
       ".*",
     ]
+  }
+
+  # Handle errors during source download (e.g., when the source URL is invalid or unreachable).
+  # Use "init-from-module" as the command to catch errors during the go-getter download phase.
+  error_hook "source_download_error" {
+    commands  = ["init-from-module"]
+    execute   = ["echo", "Source download failed"]
+    on_errors = [".*"]
   }
 
   # A special after hook to always run after the init-from-module step of the Terragrunt pipeline. In this case, we will

--- a/test/fixtures/hooks/error-hooks-source-download-fail/terragrunt.hcl
+++ b/test/fixtures/hooks/error-hooks-source-download-fail/terragrunt.hcl
@@ -1,0 +1,11 @@
+terraform {
+  # Invalid source URL that will cause download to fail
+  source = "/totallyfakedoesnotexist/notreal"
+
+  # This is the correct way to handle source download errors
+  error_hook "error_on_source_download" {
+    commands  = ["init-from-module"]
+    execute   = ["echo", "ERROR_HOOK_TRIGGERED_ON_INIT_FROM_MODULE"]
+    on_errors = [".*"]
+  }
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5422.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added error hook examples demonstrating how to handle errors during source downloads in module initialization.
- Updated documentation clarifying configuration of error hooks for source download failures, including command execution and error detection.
- Includes sample configurations for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->