### PR TITLE
feat: Dependency fetch output from GCS state

### DIFF
--- a/test/fixtures/output-from-remote-state-gcs/env1/app1/main.tf
+++ b/test/fixtures/output-from-remote-state-gcs/env1/app1/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "gcs" {}
+}
+
+output "app1_text" {
+  value = "app1 output"
+}

--- a/test/fixtures/output-from-remote-state-gcs/env1/app1/terragrunt.hcl
+++ b/test/fixtures/output-from-remote-state-gcs/env1/app1/terragrunt.hcl
@@ -1,0 +1,7 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+dependencies {
+  paths = ["../app3"]
+}

--- a/test/fixtures/output-from-remote-state-gcs/env1/app2/main.tf
+++ b/test/fixtures/output-from-remote-state-gcs/env1/app2/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  backend "gcs" {}
+}
+
+output "app1_text" {
+  value = var.app1_text
+}
+
+output "app2_text" {
+  value = "app2 output"
+}
+
+output "app3_text" {
+  value = var.app3_text
+}

--- a/test/fixtures/output-from-remote-state-gcs/env1/app2/terragrunt.hcl
+++ b/test/fixtures/output-from-remote-state-gcs/env1/app2/terragrunt.hcl
@@ -1,0 +1,24 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+dependency "app1" {
+  config_path = "../app1"
+
+  mock_outputs = {
+    app1_text = "(known after run --all apply)"
+  }
+}
+
+dependency "app3" {
+  config_path = "../app3"
+
+  mock_outputs = {
+    app3_text = "(known after run --all apply)"
+  }
+}
+
+inputs = {
+  app1_text = dependency.app1.outputs.app1_text
+  app3_text = dependency.app3.outputs.app3_text
+}

--- a/test/fixtures/output-from-remote-state-gcs/env1/app2/variables.tf
+++ b/test/fixtures/output-from-remote-state-gcs/env1/app2/variables.tf
@@ -1,0 +1,7 @@
+variable "app1_text" {
+  type = string
+}
+
+variable "app3_text" {
+  type = string
+}

--- a/test/fixtures/output-from-remote-state-gcs/env1/app3/main.tf
+++ b/test/fixtures/output-from-remote-state-gcs/env1/app3/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "gcs" {}
+}
+
+output "app3_text" {
+  value = "app3 output"
+}

--- a/test/fixtures/output-from-remote-state-gcs/env1/app3/terragrunt.hcl
+++ b/test/fixtures/output-from-remote-state-gcs/env1/app3/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}

--- a/test/fixtures/output-from-remote-state-gcs/root.hcl
+++ b/test/fixtures/output-from-remote-state-gcs/root.hcl
@@ -1,0 +1,10 @@
+# Configure Terragrunt to automatically store tfstate files in a GCS bucket
+remote_state {
+  backend = "gcs"
+  config = {
+    project  = "__FILL_IN_PROJECT__"
+    location = "__FILL_IN_LOCATION__"
+    bucket   = "__FILL_IN_BUCKET_NAME__"
+    prefix   = "${path_relative_to_include()}"
+  }
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Support fetching dependency output directly from GCS state buckets, currently only S3 is supported.

## Why
We are hitting parallel issues with Terragrunt + Atlantis whereby states that have similar `dependencies` blocks are trying and failing to `init` the dependency in parallel, which looks like it's because dependency outputs are fetched via raw Terraform so don't use the Terragrunt cache? Either way, it would be extremely useful to be able to fetch the dependency states directly from GCS, so no need to `init` and `terraform output` which means users won't hit this contention and it's faster.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] I authored this code entirely myself
- [X] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [X] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [X] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Support fetching dependency output directly from GCS state buckets via `--dependency-fetch-output-from-state`

## Testing
I've built binaries locally using `make build` and successfully tested this functionality:
```
❯ TG_DEPENDENCY_FETCH_OUTPUT_FROM_STATE=true terragrunt plan --log-level debug
DEBU[0000] Terragrunt Version: 0.0.0
DEBU[0000] using cache key for version files: r01AJjVD7VSXCQk1ORuh_no_NRY
DEBU[0000] Running command: terraform -version
DEBU[0000] Engine is not enabled, running command directly in /foo/bar
**SNIP OUTPUT**
DEBU[0000] Fetching outputs directly from gs://$MY_STATE_BUCKET/foo/bar/default.tfstate prefix=[/foo/bar]
DEBU[0001] Retrieved output from foo/bar/terragrunt.hcl as json: {"dns_zone": "bla bla bla"}  using gcs bucket prefix=[/foo/bar]
```

Also added integration tests (didn't see any unit tests for it) which are lifted from the S3 equivalent test files. Should contributors be able to run these integration tests somewhere before raising PRs? 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for fetching dependency outputs from Google Cloud Storage (GCS) remote-state backends.
  * Enables local reading and parsing of GCS-backed Terraform state to resolve dependency outputs and mirror S3 workflow.

* **Tests**
  * Adds integration tests covering GCS remote-state output fetching, no-fetch/fallback scenarios, and mocked-output flows.
  * Adds GCS-based test fixtures modeling dependency chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->