### PR TITLE
fix: Fixing over-warning on strict controls

### DIFF
--- a/internal/cli/flags/global/flags.go
+++ b/internal/cli/flags/global/flags.go
@@ -251,8 +251,9 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			Setter: func(val string) error {
 				return opts.StrictControls.EnableControl(val)
 			},
-			Action: func(_ context.Context, _ *clihelper.Context, _ []string) error {
+			Action: func(_ context.Context, _ *clihelper.Context, vals []string) error {
 				opts.StrictControls.LogEnabled(l)
+				opts.StrictControls.LogCompletedControls(l, vals)
 
 				return nil
 			},

--- a/internal/strict/control.go
+++ b/internal/strict/control.go
@@ -195,15 +195,18 @@ func (ctrls Controls) EnableControl(name string) error {
 	return NewInvalidControlNameError(ctrls.FilterByStatus(ActiveStatus).Names())
 }
 
-// LogEnabled logs the control names that are enabled and have completed Status.
+// LogEnabled logs the control names that are enabled.
 func (ctrls Controls) LogEnabled(logger log.Logger) {
 	enabledControls := ctrls.FilterByEnabled()
 
 	if len(enabledControls) > 0 {
 		logger.Debugf("Enabled strict control(s): %s", enabledControls.Names())
 	}
+}
 
-	completedControls := enabledControls.FilterByStatus(CompletedStatus)
+// LogCompletedControls warns about any completed controls from the given explicitly requested names.
+func (ctrls Controls) LogCompletedControls(logger log.Logger, requestedNames []string) {
+	completedControls := ctrls.FilterByNames(requestedNames...).FilterByStatus(CompletedStatus)
 
 	if len(completedControls) > 0 {
 		logger.Warnf(CompletedControlsFmt, completedControls.Names().String())


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5293.

Strict control completion warnings were firing when users were using strict mode, etc. due to the strict control hierarchy.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Strict control logging now provides targeted warnings when explicitly requested controls are already completed, delivering clearer feedback and helping users understand which controls cannot be re-enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->