### PR TITLE
chore: Adding testing for `RelPathForLog`

### DIFF
--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -714,3 +714,81 @@ func TestMoveFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test", string(contents))
 }
+
+func TestRelPathForLog(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		basePath    string
+		targetPath  string
+		expected    string
+		showAbsPath bool
+	}{
+		{
+			name:        "showAbsPath true returns targetPath unchanged",
+			basePath:    helpers.RootFolder + "base",
+			targetPath:  helpers.RootFolder + "base/child/file.txt",
+			showAbsPath: true,
+			expected:    helpers.RootFolder + "base/child/file.txt",
+		},
+		{
+			name:        "same path returns targetPath",
+			basePath:    helpers.RootFolder + "base",
+			targetPath:  helpers.RootFolder + "base",
+			showAbsPath: false,
+			expected:    helpers.RootFolder + "base",
+		},
+		{
+			name:        "child path gets ./ prefix",
+			basePath:    helpers.RootFolder + "base",
+			targetPath:  helpers.RootFolder + "base/child",
+			showAbsPath: false,
+			expected:    "." + string(filepath.Separator) + "child",
+		},
+		{
+			name:        "nested child path gets ./ prefix",
+			basePath:    helpers.RootFolder + "base",
+			targetPath:  helpers.RootFolder + "base/child/subchild/file.txt",
+			showAbsPath: false,
+			expected:    "." + string(filepath.Separator) + filepath.Join("child", "subchild", "file.txt"),
+		},
+		{
+			name:        "parent path returns relative path with ..",
+			basePath:    helpers.RootFolder + "base/child",
+			targetPath:  helpers.RootFolder + "base",
+			showAbsPath: false,
+			expected:    "..",
+		},
+		{
+			name:        "sibling path returns relative path with ..",
+			basePath:    helpers.RootFolder + "base/child1",
+			targetPath:  helpers.RootFolder + "base/child2",
+			showAbsPath: false,
+			expected:    ".." + string(filepath.Separator) + "child2",
+		},
+		{
+			name:        "deeply nested sibling path",
+			basePath:    helpers.RootFolder + "base/a/b/c",
+			targetPath:  helpers.RootFolder + "base/x/y/z",
+			showAbsPath: false,
+			expected:    ".." + string(filepath.Separator) + ".." + string(filepath.Separator) + ".." + string(filepath.Separator) + filepath.Join("x", "y", "z"),
+		},
+		{
+			name:        "unrelated paths at different roots",
+			basePath:    helpers.RootFolder + "foo",
+			targetPath:  helpers.RootFolder + "bar/baz",
+			showAbsPath: false,
+			expected:    ".." + string(filepath.Separator) + filepath.Join("bar", "baz"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := util.RelPathForLog(tc.basePath, tc.targetPath, tc.showAbsPath)
+			assert.Equal(t, tc.expected, actual, "For basePath %s and targetPath %s", tc.basePath, tc.targetPath)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds testing for `RelPathForLog`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for file path operations to ensure reliability across various path scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->