### PR TITLE
fix: Fixing respect for version constraints when running a stack

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -454,6 +454,7 @@ func Parse(
 		config.ExcludeBlock,
 		config.ErrorsBlock,
 		config.RemoteStateBlock,
+		config.TerragruntVersionConstraints,
 	)
 
 	cfg, err = config.PartialParseConfigFile(ctx, parsingCtx, l, parseOpts.TerragruntConfigPath, nil)

--- a/test/fixtures/stacks/version-constraints/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/version-constraints/live/terragrunt.stack.hcl
@@ -1,0 +1,4 @@
+unit "app" {
+  source = "../unit"
+  path   = "app"
+}

--- a/test/fixtures/stacks/version-constraints/unit/.terraform.lock.hcl
+++ b/test/fixtures/stacks/version-constraints/unit/.terraform.lock.hcl
@@ -1,0 +1,2 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.

--- a/test/fixtures/stacks/version-constraints/unit/main.tf
+++ b/test/fixtures/stacks/version-constraints/unit/main.tf
@@ -1,0 +1,4 @@
+# Empty module - just needed for terraform init
+output "test" {
+  value = "test"
+}

--- a/test/fixtures/stacks/version-constraints/unit/terragrunt.hcl
+++ b/test/fixtures/stacks/version-constraints/unit/terragrunt.hcl
@@ -1,0 +1,6 @@
+# Constraint that will fail with test version
+terragrunt_version_constraint = ">= 99.0.0"
+
+terraform {
+  source = "."
+}

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -1,6 +1,7 @@
 package test_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,17 +12,16 @@ import (
 	"github.com/gruntwork-io/terratest/modules/files"
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
+	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -57,6 +57,7 @@ const (
 	testFixtureStackNoDotTerragruntStackOutput = "fixtures/stacks/no-dot-terragrunt-stack-output"
 	testFixtureStackFindInParentFolders        = "fixtures/stacks/find-in-parent-folders"
 	testFixtureStackOriginalTerragruntDir      = "fixtures/stacks/get-original-terragrunt-dir"
+	testFixtureStackVersionConstraints         = "fixtures/stacks/version-constraints"
 )
 
 func TestStacksGenerateBasicWithQueueIncludeDirFlag(t *testing.T) {
@@ -2021,4 +2022,33 @@ func findStackFiles(t *testing.T, dir string) []string {
 	require.NoError(t, err)
 
 	return stackFiles
+}
+
+// TestStackVersionConstraints verifies that version constraints are respected in stack runs.
+// This test cannot be parallelized as it changes the global version.Version.
+//
+//nolint:paralleltest
+func TestStackVersionConstraints(t *testing.T) {
+	helpers.CleanupTerragruntFolder(t, testFixtureStackVersionConstraints)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackVersionConstraints)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStackVersionConstraints, "live")
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	// Run with a version that doesn't meet the constraint (>= 99.0.0)
+	err := helpers.RunTerragruntVersionCommand(
+		t,
+		"v0.99.0",
+		"terragrunt stack run plan --non-interactive --working-dir "+rootPath,
+		&stdout,
+		&stderr,
+	)
+	helpers.LogBufferContentsLineByLine(t, stdout, "stdout")
+	helpers.LogBufferContentsLineByLine(t, stderr, "stderr")
+
+	require.Error(t, err)
+
+	var invalidVersionError run.InvalidTerragruntVersion
+	assert.ErrorAs(t, err, &invalidVersionError)
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5512.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the discovery mechanism to parse and recognize Terragrunt version constraints from configuration files, enabling version-based validation during stack processing and execution.

* **Tests**
  * Added comprehensive integration tests to verify version constraint handling during stack operations, validating both satisfied version requirements and deliberate version mismatch error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->