### PR TITLE
docs: Documenting deprecation of `--disable-dependent-modules`

### DIFF
--- a/docs-starlight/src/content/docs/04-reference/03-strict-controls.mdx
+++ b/docs-starlight/src/content/docs/04-reference/03-strict-controls.mdx
@@ -241,6 +241,20 @@ $ terragrunt find --hidden
 WARN  The `--hidden` flag is deprecated and will be removed in a future version of Terragrunt. Hidden directories are now included by default. Use `--no-hidden` to exclude them.
 ```
 
+### disable-dependent-modules
+
+Throw an error when using the deprecated `--disable-dependent-modules` flag.
+
+**Reason**: Dependent modules discovery has been removed from `terragrunt render`. The `--disable-dependent-modules` flag is no longer needed and has no effect.
+
+**Example**:
+
+```bash
+# This will show a warning (or error with strict control enabled)
+$ terragrunt render --format=json --disable-dependent-modules
+WARN  The `--disable-dependent-modules` flag is deprecated and will be removed in a future version of Terragrunt. Dependent modules discovery has been removed from `terragrunt render`, so this flag has no effect.
+```
+
 ## Control Categories
 
 Certain strict controls are grouped into categories to make it easier to enable multiple strict controls at once.

--- a/docs-starlight/src/content/docs/08-migrate/03-cli-redesign.md
+++ b/docs-starlight/src/content/docs/08-migrate/03-cli-redesign.md
@@ -92,7 +92,7 @@ Below is a comprehensive mapping of old CLI flag names to their modern counterpa
 | `--terragrunt-ignore-external-dependencies`       | `--queue-exclude-external`                                |
 | `--terragrunt-include-dir`                        | `--queue-include-dir`                                     |
 | `--terragrunt-include-external-dependencies`      | `--queue-include-external`                                |
-| `--terragrunt-json-disable-dependent-modules`     | `--disable-dependent-modules`                             |
+| `--terragrunt-json-disable-dependent-modules`     | `--disable-dependent-modules` (deprecated)                |
 | `--terragrunt-json-out-dir`                       | `--json-out-dir`                                          |
 | `--terragrunt-json-out`                           | `--out`                                                   |
 | `--terragrunt-log-custom-format`                  | `--log-custom-format`                                     |


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Documents deprecation of `--disable-depedent-modules`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added strict-mode control documentation for the deprecated `--disable-dependent-modules` flag with error handling examples.
  * Updated CLI migration table to mark `--disable-dependent-modules` as deprecated, guiding users on the status of this flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->