### PR TITLE
Fix command reference in CLI redesign documentation

### DIFF
--- a/docs-starlight/src/content/docs/08-migrate/03-cli-redesign.md
+++ b/docs-starlight/src/content/docs/08-migrate/03-cli-redesign.md
@@ -221,12 +221,12 @@ This usually isn't necessary, except when combining a complicated series of flag
 
 In addition to allowing for explicit invocation of OpenTofu/Terraform instead of using shortcuts, the `run` command also takes on the responsibilities of the now deprecated `run-all` and `graph` commands using flags.
 
-For example, if you are currently using the `terragrunt run --all` command, you can switch to the `run` command with the `--all` flag instead.
+For example, if you are currently using the `terragrunt run-all` command, you can switch to the `run` command with the `--all` flag instead.
 
 Before:
 
 ```bash
-terragrunt run --all plan
+terragrunt run-all plan
 ```
 
 After:


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes a typo in the documentation that may confuse readers preparing a migration to a newer version of Terragrunt

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated migration documentation

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guide documentation to reflect accurate command syntax in code examples, ensuring users receive correct guidance when following migration procedures and understanding command usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->