### PR TITLE
chore: Backporting #5518 to `v0.99`

### DIFF
--- a/internal/os/exec/cmd_unix_test.go
+++ b/internal/os/exec/cmd_unix_test.go
@@ -4,6 +4,7 @@
 package exec_test
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strconv"
@@ -119,4 +120,44 @@ func TestNewSignalsForwarderMultipleUnix(t *testing.T) {
 	require.NoError(t, err)
 	assert.LessOrEqual(t, retCode, interrupts, "Subprocess received wrong number of signals")
 	assert.Equal(t, expectedInterrupts, retCode, "Subprocess didn't receive multiple signals")
+}
+
+// TestGracefulShutdownOnContextCancelUnix verifies that when the context is cancelled
+// without a signal cause, the Cancel callback sends SIGINT (not SIGKILL) to allow
+// processes like Terraform to gracefully shutdown their child processes.
+// The test script traps SIGINT and exits with code 42, while SIGKILL would terminate
+// it immediately without running the trap handler.
+func TestGracefulShutdownOnContextCancelUnix(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cmd := exec.Command(ctx, "testdata/test_graceful_shutdown.sh")
+
+	cmd.Configure(exec.WithGracefulShutdownDelay(5 * time.Second))
+
+	runChannel := make(chan error)
+
+	go func() {
+		runChannel <- cmd.Run()
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	cancel()
+
+	err := <-runChannel
+	require.Error(t, err)
+
+	retCode, err := util.GetExitCode(err)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		42,
+		retCode,
+		"Expected exit code 42 (SIGINT received), but got %d. "+
+			"This suggests SIGKILL was sent instead of SIGINT.",
+		retCode,
+	)
 }

--- a/internal/os/exec/opts.go
+++ b/internal/os/exec/opts.go
@@ -39,3 +39,12 @@ func WithForwardSignalDelay(delay time.Duration) Option {
 		cmd.forwardSignalDelay = delay
 	}
 }
+
+// WithGracefulShutdownDelay sets the time to wait for a process to exit gracefully
+// after sending an interrupt signal before escalating to SIGKILL.
+// This allows processes like Terraform to clean up child processes (e.g., provider plugins).
+func WithGracefulShutdownDelay(delay time.Duration) Option {
+	return func(cmd *Cmd) {
+		cmd.WaitDelay = delay
+	}
+}

--- a/internal/os/exec/testdata/test_graceful_shutdown.sh
+++ b/internal/os/exec/testdata/test_graceful_shutdown.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+# This script traps SIGINT and exits with code 42 when received.
+# It exits with code 1 if terminated by SIGKILL (or any other unexpected termination).
+# This is used to verify that the graceful shutdown sends SIGINT rather than SIGKILL.
+
+trap 'exit 42' INT
+
+while true; do sleep 0.1; done


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Backports #5518 into the `v0.99` line.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

