### PR TITLE
chore: refactor cache dir exclusion code

### DIFF
--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -121,19 +121,6 @@ func componentFromDependencyPath(path string, components *component.ThreadSafeCo
 	return component.NewUnit(path)
 }
 
-// skipDirIfIgnorable checks if an entire directory should be skipped based on the fact that it's
-// in a directory that should never have components discovered in it.
-func skipDirIfIgnorable(path string) error {
-	base := filepath.Base(path)
-
-	switch base {
-	case ".git", ".terraform", ".terragrunt-cache":
-		return filepath.SkipDir
-	}
-
-	return nil
-}
-
 // createComponentFromPath creates a component from a file path if it matches one of the config filenames.
 // Returns nil if the file doesn't match any of the provided filenames.
 func createComponentFromPath(

--- a/internal/discovery/phase_filesystem.go
+++ b/internal/discovery/phase_filesystem.go
@@ -98,7 +98,7 @@ func (p *FilesystemPhase) Run(ctx context.Context, l log.Logger, input *PhaseInp
 
 // skipDirIfIgnorable determines if a directory should be skipped during traversal.
 func (p *FilesystemPhase) skipDirIfIgnorable(discovery *Discovery, path string) error {
-	if err := skipDirIfIgnorable(path); err != nil {
+	if err := util.SkipDirIfIgnorable(path); err != nil {
 		return err
 	}
 

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -480,7 +480,7 @@ func (p *GraphPhase) discoverDependentsUpstream(
 				return filepath.SkipDir
 			}
 
-			if err := skipDirIfIgnorable(path); err != nil {
+			if err := util.SkipDirIfIgnorable(path); err != nil {
 				return err
 			}
 

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -26,6 +26,8 @@ import (
 const (
 	TerraformLockFile     = ".terraform.lock.hcl"
 	TerragruntCacheDir    = ".terragrunt-cache"
+	TerraformCacheDir     = ".terraform"
+	GitDir                = ".git"
 	DefaultBoilerplateDir = ".boilerplate"
 	TfFileExtension       = ".tf"
 	ChecksumReadBlock     = 8192
@@ -1204,6 +1206,19 @@ func MoveFile(source string, destination string) error {
 		}
 
 		return renameErr
+	}
+
+	return nil
+}
+
+// SkipDirIfIgnorable checks if an entire directory should be skipped based on the fact that it's
+// in a directory that should never have components discovered in it.
+func SkipDirIfIgnorable(path string) error {
+	base := filepath.Base(path)
+
+	switch base {
+	case GitDir, TerraformCacheDir, TerragruntCacheDir:
+		return filepath.SkipDir
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

In https://github.com/gruntwork-io/terragrunt/pull/4533, we skipped recursing through cache directories completely by returning
filepath.SkipDir when hitting one. Previously, we just returned nil which meant we
still had to walk everything in the file tree.

This code change applies the same to `WalkDirWithSymlinks` and refactors the logic
into a single walkDir function. It piggybacks on `util.SkipDirIfIgnorable` which was
migrated from `internal/discovery` and also covers terraform cache dir and git dir.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] I authored this code entirely myself
- [X] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated EncodeSourceVersion to make less stat calls and skip walking cache dirs.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified directory exclusion and traversal behavior across discovery and source encoding so ignorable folders (e.g., .git, .terraform, .terragrunt-cache) are handled consistently.
  * Consolidated file-walking and hashing entry points for more consistent source hashing and error handling during local-source processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->