### PR TITLE
chore: Clean up of #5559

### DIFF
--- a/internal/discovery/phase_filesystem.go
+++ b/internal/discovery/phase_filesystem.go
@@ -73,7 +73,7 @@ func (p *FilesystemPhase) Run(ctx context.Context, l log.Logger, input *PhaseInp
 		}
 
 		if d.IsDir() {
-			return p.skipDirIfIgnorable(discovery, path)
+			return p.skipDirIfIgnorable(discovery, d.Name())
 		}
 
 		result := p.processFile(l, input, path, filenames)
@@ -97,14 +97,13 @@ func (p *FilesystemPhase) Run(ctx context.Context, l log.Logger, input *PhaseInp
 }
 
 // skipDirIfIgnorable determines if a directory should be skipped during traversal.
-func (p *FilesystemPhase) skipDirIfIgnorable(discovery *Discovery, path string) error {
-	if err := util.SkipDirIfIgnorable(path); err != nil {
+func (p *FilesystemPhase) skipDirIfIgnorable(discovery *Discovery, dir string) error {
+	if err := util.SkipDirIfIgnorable(dir); err != nil {
 		return err
 	}
 
 	if discovery.noHidden {
-		base := filepath.Base(path)
-		if strings.HasPrefix(base, ".") && base != "." && base != ".." {
+		if strings.HasPrefix(dir, ".") && dir != "." && dir != ".." {
 			return filepath.SkipDir
 		}
 	}

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -480,7 +480,7 @@ func (p *GraphPhase) discoverDependentsUpstream(
 				return filepath.SkipDir
 			}
 
-			if err := util.SkipDirIfIgnorable(path); err != nil {
+			if err := util.SkipDirIfIgnorable(d.Name()); err != nil {
 				return err
 			}
 

--- a/internal/tf/source.go
+++ b/internal/tf/source.go
@@ -75,7 +75,7 @@ func (src Source) EncodeSourceVersion(l log.Logger) (string, error) {
 
 			if d.IsDir() {
 				// We don't use any info from directories to calculate our hash
-				return util.SkipDirIfIgnorable(path)
+				return util.SkipDirIfIgnorable(d.Name())
 			}
 			// avoid checking .terraform.lock.hcl file since contents is auto-generated
 			if d.Name() == util.TerraformLockFile {

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -1213,10 +1213,8 @@ func MoveFile(source string, destination string) error {
 
 // SkipDirIfIgnorable checks if an entire directory should be skipped based on the fact that it's
 // in a directory that should never have components discovered in it.
-func SkipDirIfIgnorable(path string) error {
-	base := filepath.Base(path)
-
-	switch base {
+func SkipDirIfIgnorable(dir string) error {
+	switch dir {
 	case GitDir, TerraformCacheDir, TerragruntCacheDir:
 		return filepath.SkipDir
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Cleans up a little detail of #5559.

We don't need to call `filepath.Base` on the paths while we're walking them, as we already get that for free with `d.Name()`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal directory filtering logic for configuration file discovery across the filesystem, improving consistency in how directories are evaluated during the scanning process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->