### PR TITLE
docs: Adding callout for the lack of library compatibility guarantees

### DIFF
--- a/docs-starlight/src/content/docs/07-process/01-1-0-guarantees.mdx
+++ b/docs-starlight/src/content/docs/07-process/01-1-0-guarantees.mdx
@@ -94,6 +94,14 @@ Maintainers will frequently update the build system to use the latest version of
 
 If you are impacted by a Golang version upgrade and would like to request a policy adjustment, please reach out to the maintainers by starting a GitHub discussion or reaching out in the Terragrunt Discord.
 
+### Golang Library Compatibility
+
+Using Terragrunt as a Go library has no backwards compatibility guarantees. Most Go code in the Terragrunt repository lives in [`internal`](https://github.com/gruntwork-io/terragrunt/tree/main/internal), and maintainers don't expect external parties to depend on Terragrunt packages directly.
+
+When packages are generally useful to internal Gruntwork parties, they will be migrated to [`pkg`](https://github.com/gruntwork-io/terragrunt/tree/main/pkg). Breaking changes to packages in `pkg` are still possible at any time, but maintainers will coordinate directly with known consumers to help prevent upgrade issues.
+
+When external parties need a stable dependency on shared code, dedicated libraries will be created in separate, versioned repositories (e.g., [terragrunt-engine-go](https://github.com/gruntwork-io/terragrunt-engine-go)). If you are relying on code in `pkg` or vendoring code from `internal`, you are heavily encouraged to start a conversation with Terragrunt maintainers so that we can plan out a path to an external library that you can rely on to be stable and independently versioned from Terragrunt.
+
 ## Versioning Policy
 
 For the duration of 1.x, only the minor and patch versions of Terragrunt releases will be used in the [semantic versioning scheme](https://semver.org/), just like it was in Terragrunt 0.x.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Calls out that we have no backwards compatibility guarantee when using Terragrunt as a Golang library.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new section documenting Golang library compatibility, clarifying backward compatibility guarantees for external consumers and distinguishing between internal and shared code
  * Updated versioning policy to detail 1.x behavior including breaking change restrictions, minor release features, experimental feature advancement, and patch-level bug fixes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->