### PR TITLE
fix: Increasing accuracy of retryable errors match

### DIFF
--- a/pkg/options/error_matching_test.go
+++ b/pkg/options/error_matching_test.go
@@ -26,7 +26,7 @@ func TestExtractErrorMessage_ExcludesCommandFlags(t *testing.T) {
 		Output:     util.CmdOutput{Stderr: stderr},
 	}
 
-	msg := options.ExportExtractErrorMessage(err)
+	msg := options.ExtractErrorMessage(err)
 
 	// The extracted message should only contain stderr and the underlying error,
 	// not the command string with flags.
@@ -58,11 +58,11 @@ func TestExtractErrorMessage_DoesNotFalselyMatchTimeout(t *testing.T) {
 		{Pattern: timeoutPattern},
 	}
 
-	msg := options.ExportExtractErrorMessage(err)
+	msg := options.ExtractErrorMessage(err)
 
 	// The timeout pattern should NOT match because the extracted message only
 	// contains stderr and exit error, not the command flags.
-	matched := options.ExportMatchesAnyRegexpPattern(msg, patterns)
+	matched := options.MatchesAnyRegexpPattern(msg, patterns)
 	assert.False(t, matched, "timeout pattern should NOT match when 'timeout' only appears in command flags; cleaned message: %s", msg)
 }
 
@@ -86,8 +86,8 @@ func TestExtractErrorMessage_StillMatchesRealTimeout(t *testing.T) {
 		{Pattern: timeoutPattern},
 	}
 
-	msg := options.ExportExtractErrorMessage(err)
-	matched := options.ExportMatchesAnyRegexpPattern(msg, patterns)
+	msg := options.ExtractErrorMessage(err)
+	matched := options.MatchesAnyRegexpPattern(msg, patterns)
 	assert.True(t, matched, "timeout pattern should match when stderr actually contains 'timeout'; cleaned message: %s", msg)
 }
 
@@ -112,8 +112,8 @@ func TestExtractErrorMessage_StillMatchesTimeoutInStderrWithFlags(t *testing.T) 
 		{Pattern: timeoutPattern},
 	}
 
-	msg := options.ExportExtractErrorMessage(err)
-	matched := options.ExportMatchesAnyRegexpPattern(msg, patterns)
+	msg := options.ExtractErrorMessage(err)
+	matched := options.MatchesAnyRegexpPattern(msg, patterns)
 	assert.True(t, matched, "timeout pattern should match when stderr actually contains 'timeout'; cleaned message: %s", msg)
 }
 
@@ -123,7 +123,7 @@ func TestExtractErrorMessage_NonProcessError(t *testing.T) {
 	// For non-ProcessExecutionError errors, the full error string is used.
 	err := errors.New("some generic error with timeout in it")
 
-	msg := options.ExportExtractErrorMessage(err)
+	msg := options.ExtractErrorMessage(err)
 	assert.Contains(t, msg, "timeout")
 
 	timeoutPattern := regexp.MustCompile(`(?s).*timeout.*`)
@@ -131,7 +131,7 @@ func TestExtractErrorMessage_NonProcessError(t *testing.T) {
 		{Pattern: timeoutPattern},
 	}
 
-	matched := options.ExportMatchesAnyRegexpPattern(msg, patterns)
+	matched := options.MatchesAnyRegexpPattern(msg, patterns)
 	assert.True(t, matched, "timeout pattern should match for non-ProcessExecutionError; cleaned message: %s", msg)
 }
 
@@ -169,7 +169,7 @@ func TestErrorCleanPattern_PreservesCharacters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := options.ExportErrorCleanPattern.ReplaceAllString(tt.input, " ")
+			result := options.ErrorCleanPattern.ReplaceAllString(tt.input, " ")
 			require.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/options/export_test.go
+++ b/pkg/options/export_test.go
@@ -1,8 +1,0 @@
-package options
-
-// Exported aliases for internal symbols used in external tests.
-var (
-	ExportExtractErrorMessage     = extractErrorMessage
-	ExportMatchesAnyRegexpPattern = matchesAnyRegexpPattern
-	ExportErrorCleanPattern       = errorCleanPattern
-)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -83,7 +83,7 @@ var (
 	}
 
 	// Pattern used to clean error message when looking for retry and ignore patterns.
-	errorCleanPattern = regexp.MustCompile(`[^a-zA-Z0-9./'"():=\- ]+`)
+	ErrorCleanPattern = regexp.MustCompile(`[^a-zA-Z0-9./'"():=\- ]+`)
 )
 
 type ctxKey byte
@@ -790,14 +790,14 @@ func (c *ErrorsConfig) AttemptErrorRecovery(l log.Logger, err error, currentAtte
 		return nil, nil
 	}
 
-	errStr := extractErrorMessage(err)
+	errStr := ExtractErrorMessage(err)
 	action := &ErrorAction{}
 
 	l.Debugf("Attempting error recovery for error: %s", errStr)
 
 	// First check ignore rules
 	for _, ignoreBlock := range c.Ignore {
-		isIgnorable := matchesAnyRegexpPattern(errStr, ignoreBlock.IgnorableErrors)
+		isIgnorable := MatchesAnyRegexpPattern(errStr, ignoreBlock.IgnorableErrors)
 		if !isIgnorable {
 			continue
 		}
@@ -815,7 +815,7 @@ func (c *ErrorsConfig) AttemptErrorRecovery(l log.Logger, err error, currentAtte
 
 	// Then check retry rules
 	for _, retryBlock := range c.Retry {
-		isRetryable := matchesAnyRegexpPattern(errStr, retryBlock.RetryableErrors)
+		isRetryable := MatchesAnyRegexpPattern(errStr, retryBlock.RetryableErrors)
 		if !isRetryable {
 			continue
 		}
@@ -840,7 +840,7 @@ func (c *ErrorsConfig) AttemptErrorRecovery(l log.Logger, err error, currentAtte
 	return nil, nil
 }
 
-func extractErrorMessage(err error) string {
+func ExtractErrorMessage(err error) string {
 	var errText string
 
 	// For ProcessExecutionError, match only against stderr and the underlying error,
@@ -853,13 +853,13 @@ func extractErrorMessage(err error) string {
 	}
 
 	multilineText := log.RemoveAllASCISeq(errText)
-	errorText := errorCleanPattern.ReplaceAllString(multilineText, " ")
+	errorText := ErrorCleanPattern.ReplaceAllString(multilineText, " ")
 
 	return strings.Join(strings.Fields(errorText), " ")
 }
 
-// matchesAnyRegexpPattern checks if the input string matches any of the provided compiled patterns
-func matchesAnyRegexpPattern(input string, patterns []*ErrorsPattern) bool {
+// MatchesAnyRegexpPattern checks if the input string matches any of the provided compiled patterns
+func MatchesAnyRegexpPattern(input string, patterns []*ErrorsPattern) bool {
 	for _, pattern := range patterns {
 		isNegative := pattern.Negative
 		matched := pattern.Pattern.MatchString(input)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5088.

Ensures that we only attempt to match against the stderr and actual
error message of a process error. This prevents things like
matching against the `-timeout` flag when the retryable error is
".*timeout*".

Also preserves dashes and equals in the error message if they exist.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for error message extraction and pattern matching, including handling of timeout detection, command flag exclusion, and special character preservation.

* **Refactor**
  * Made error extraction and pattern matching capabilities available as public APIs; improved error message normalization to properly handle special characters in command flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->