### PR TITLE
chore: Removing `options` from `awshelper`

### DIFF
--- a/internal/awshelper/config.go
+++ b/internal/awshelper/config.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/iam"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
 const (
@@ -255,10 +254,10 @@ func AssumeIamRole(
 
 	roleSessionName := iamRoleOpts.AssumeRoleSessionName
 	if roleSessionName == "" {
-		roleSessionName = options.GetDefaultIAMAssumeRoleSessionName()
+		roleSessionName = iam.GetDefaultAssumeRoleSessionName()
 	}
 
-	duration := time.Duration(options.DefaultIAMAssumeRoleDuration) * time.Second
+	duration := time.Duration(iam.DefaultAssumeRoleDuration) * time.Second
 	if iamRoleOpts.AssumeRoleDuration > 0 {
 		duration = time.Duration(iamRoleOpts.AssumeRoleDuration) * time.Second
 	}
@@ -417,7 +416,7 @@ func getWebIdentityCredentialsFromIAMRoleOptions(
 			return aws.Credentials{}, err
 		}
 
-		duration := time.Duration(options.DefaultIAMAssumeRoleDuration) * time.Second
+		duration := time.Duration(iam.DefaultAssumeRoleDuration) * time.Second
 		if iamRoleOptions.AssumeRoleDuration > 0 {
 			duration = time.Duration(iamRoleOptions.AssumeRoleDuration) * time.Second
 		}
@@ -458,7 +457,7 @@ func getSTSCredentialsFromIAMRoleOptions(
 			roleSessionName = strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
 		}
 
-		duration := time.Duration(options.DefaultIAMAssumeRoleDuration) * time.Second
+		duration := time.Duration(iam.DefaultAssumeRoleDuration) * time.Second
 		if iamRoleOptions.AssumeRoleDuration > 0 {
 			duration = time.Duration(iamRoleOptions.AssumeRoleDuration) * time.Second
 		}

--- a/internal/iam/iam.go
+++ b/internal/iam/iam.go
@@ -2,6 +2,21 @@
 // multiple packages (options, config, awshelper, etc.).
 package iam
 
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	// DefaultAssumeRoleDuration is the default session duration in seconds for IAM role assumption.
+	DefaultAssumeRoleDuration = 3600
+)
+
+// GetDefaultAssumeRoleSessionName returns a unique session name for IAM role assumption.
+func GetDefaultAssumeRoleSessionName() string {
+	return fmt.Sprintf("terragrunt-%d", time.Now().UTC().UnixNano())
+}
+
 // RoleOptions represents options that are used by Terragrunt to assume an IAM role.
 type RoleOptions struct {
 	RoleARN               string

--- a/internal/runner/run/creds/providers/externalcmd/provider.go
+++ b/internal/runner/run/creds/providers/externalcmd/provider.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds/providers/amazonsts"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/mattn/go-shellwords"
 )
 
@@ -143,12 +142,12 @@ func (role *AWSRole) Envs(ctx context.Context, l log.Logger, authProviderCmd str
 
 	sessionName := role.RoleSessionName
 	if sessionName == "" {
-		sessionName = options.GetDefaultIAMAssumeRoleSessionName()
+		sessionName = iam.GetDefaultAssumeRoleSessionName()
 	}
 
 	duration := role.Duration
 	if duration == 0 {
-		duration = options.DefaultIAMAssumeRoleDuration
+		duration = iam.DefaultAssumeRoleDuration
 	}
 
 	iamRoleOpts := iam.RoleOptions{

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -54,8 +54,6 @@ const (
 
 	DefaultTFDataDir = ".terraform"
 
-	DefaultIAMAssumeRoleDuration = 3600
-
 	defaultExcludesFile = ".terragrunt-excludes"
 	defaultFiltersFile  = ".terragrunt-filters"
 
@@ -375,11 +373,6 @@ func NewTerragruntOptionsWithConfigPath(terragruntConfigPath string) (*Terragrun
 	opts.DownloadDir = downloadDir
 
 	return opts, nil
-}
-
-// GetDefaultIAMAssumeRoleSessionName gets the default IAM assume role session name.
-func GetDefaultIAMAssumeRoleSessionName() string {
-	return fmt.Sprintf("terragrunt-%d", time.Now().UTC().UnixNano())
 }
 
 // NewTerragruntOptionsForTest creates a new TerragruntOptions object with reasonable defaults for test usage.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Removes the import of `options` from the `awshelper` package.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal IAM configuration defaults for improved code structure and maintainability. No changes to functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->