### PR TITLE
chore: Moving filters to `opts`

### DIFF
--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gruntwork-io/go-commons/env"
+	"github.com/gruntwork-io/terragrunt/internal/configbridge"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/providercache"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
@@ -215,10 +217,13 @@ func setupAutoProviderCacheDir(ctx context.Context, l log.Logger, opts *options.
 	}
 
 	if opts.TerraformVersion == nil {
-		_, err := run.PopulateTFVersion(ctx, l, opts)
+		_, ver, impl, err := run.PopulateTFVersion(ctx, l, opts.WorkingDir, opts.VersionManagerFileName, configbridge.TFRunOptsFromOpts(opts))
 		if err != nil {
 			return err
 		}
+
+		opts.TerraformVersion = ver
+		opts.TofuImplementation = impl
 	}
 
 	terraformVersion := opts.TerraformVersion
@@ -365,26 +370,50 @@ func initialSetup(cliCtx *clihelper.Context, l log.Logger, opts *options.Terragr
 		opts.TFPath = filepath.Join(opts.WorkingDir, opts.TFPath)
 	}
 
+	var fileFilterStrings []string
+
 	excludeFiltersFromFile, err := util.ExcludeFiltersFromFile(opts.WorkingDir, opts.ExcludesFile)
 	if err != nil {
 		return err
 	}
 
-	opts.FilterQueries = append(opts.FilterQueries, excludeFiltersFromFile...)
+	fileFilterStrings = append(fileFilterStrings, excludeFiltersFromFile...)
 
-	// Process filters file if the filter-flag experiment is enabled and the filters file is not disabled
+	// Process filters file if the filters file is not disabled
 	if !opts.NoFiltersFile {
 		filtersFromFile, filtersFromFileErr := util.GetFiltersFromFile(opts.WorkingDir, opts.FiltersFile)
 		if filtersFromFileErr != nil {
 			return filtersFromFileErr
 		}
 
-		opts.FilterQueries = append(opts.FilterQueries, filtersFromFile...)
+		fileFilterStrings = append(fileFilterStrings, filtersFromFile...)
 	}
 
-	// Sort and compact opts.FilterQueries to make them unique
-	slices.Sort(opts.FilterQueries)
-	opts.FilterQueries = slices.Compact(opts.FilterQueries)
+	if len(fileFilterStrings) > 0 {
+		parsed, parseErr := filter.ParseFilterQueries(l, fileFilterStrings)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		opts.Filters = append(opts.Filters, parsed...)
+	}
+
+	// Deduplicate filters by their string representation
+	seen := make(map[string]struct{}, len(opts.Filters))
+	deduped := make(filter.Filters, 0, len(opts.Filters))
+
+	for _, f := range opts.Filters {
+		key := f.String()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+
+		seen[key] = struct{}{}
+
+		deduped = append(deduped, f)
+	}
+
+	opts.Filters = deduped
 
 	// --- Terragrunt Version
 	terragruntVersion, err := version.NewVersion(cliCtx.Version)

--- a/internal/cli/commands/find/cli.go
+++ b/internal/cli/commands/find/cli.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -115,7 +116,13 @@ func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) clihelper.Flags 
 					return nil
 				}
 
-				opts.FilterQueries = append(opts.FilterQueries, "{./**}...")
+				pathExpr, err := filter.NewPathFilter("./**")
+				if err != nil {
+					return err
+				}
+
+				graphExpr := filter.NewGraphExpression(pathExpr).WithDependencies()
+				opts.Filters = append(opts.Filters, filter.NewFilter(graphExpr, graphExpr.String()))
 
 				return nil
 			},

--- a/internal/cli/commands/find/find.go
+++ b/internal/cli/commands/find/find.go
@@ -3,7 +3,6 @@ package find
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/os/stdout"
 	"github.com/gruntwork-io/terragrunt/internal/queue"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
@@ -33,7 +31,7 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		Exclude:           opts.Exclude,
 		Include:           opts.Include,
 		Reading:           opts.Reading,
-		FilterQueries:     opts.FilterQueries,
+		Filters:           opts.Filters,
 		Experiments:       opts.Experiments,
 	})
 	if err != nil {
@@ -42,12 +40,7 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 
 	// We do worktree generation here instead of in the discovery constructor
 	// so that we can defer cleanup in the same context.
-	filters, parseErr := filter.ParseFilterQueries(l, opts.FilterQueries)
-	if parseErr != nil {
-		return fmt.Errorf("failed to parse filters: %w", parseErr)
-	}
-
-	gitFilters := filters.UniqueGitFilters()
+	gitFilters := opts.Filters.UniqueGitFilters()
 
 	worktrees, worktreeErr := worktrees.NewWorktrees(ctx, l, opts.WorkingDir, gitFilters)
 	if worktreeErr != nil {

--- a/internal/cli/commands/hcl/format/format.go
+++ b/internal/cli/commands/hcl/format/format.go
@@ -67,10 +67,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 		err     error
 	)
 
-	filters, err = filter.ParseFilterQueries(l, opts.FilterQueries)
-	if err != nil {
-		return errors.New(err)
-	}
+	filters = opts.Filters
 
 	// We use lightweight discovery here instead of the full discovery used by
 	// the discovery package because we want to find non-comps like includes.

--- a/internal/cli/commands/hcl/format/format_test.go
+++ b/internal/cli/commands/hcl/format/format_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/hcl/format"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -359,7 +360,11 @@ func TestHCLFmtFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	tgOptions.WorkingDir = tmpPath
-	tgOptions.FilterQueries = []string{"./a/b/**"}
+
+	filters, parseErr := filter.ParseFilterQueries(logger.CreateLogger(), []string{"./a/b/**"})
+	require.NoError(t, parseErr)
+
+	tgOptions.Filters = filters
 
 	err = format.Run(t.Context(), logger.CreateLogger(), tgOptions)
 	require.NoError(t, err)
@@ -425,10 +430,13 @@ func TestHCLFmtFilterMultiple(t *testing.T) {
 
 	tgOptions.WorkingDir = tmpPath
 
-	tgOptions.FilterQueries = []string{
+	filters, parseErr := filter.ParseFilterQueries(logger.CreateLogger(), []string{
 		filepath.Join(tmpPath, "terragrunt.hcl"),
 		"./a/b/c/d/e/**",
-	}
+	})
+	require.NoError(t, parseErr)
+
+	tgOptions.Filters = filters
 
 	err = format.Run(t.Context(), logger.CreateLogger(), tgOptions)
 	require.NoError(t, err)
@@ -494,10 +502,13 @@ func TestHCLFmtFilterNegation(t *testing.T) {
 
 	tgOptions.WorkingDir = tmpPath
 
-	tgOptions.FilterQueries = []string{
+	filters, parseErr := filter.ParseFilterQueries(logger.CreateLogger(), []string{
 		"./a/**",
 		"!./a/b/c/d/**",
-	}
+	})
+	require.NoError(t, parseErr)
+
+	tgOptions.Filters = filters
 
 	err = format.Run(t.Context(), logger.CreateLogger(), tgOptions)
 	require.NoError(t, err)

--- a/internal/cli/commands/list/cli.go
+++ b/internal/cli/commands/list/cli.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -84,7 +85,13 @@ func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) clihelper.Flags 
 					return nil
 				}
 
-				opts.FilterQueries = append(opts.FilterQueries, "{./**}...")
+				pathExpr, err := filter.NewPathFilter("./**")
+				if err != nil {
+					return err
+				}
+
+				graphExpr := filter.NewGraphExpression(pathExpr).WithDependencies()
+				opts.Filters = append(opts.Filters, filter.NewFilter(graphExpr, graphExpr.String()))
 
 				return nil
 			},

--- a/internal/cli/commands/list/list.go
+++ b/internal/cli/commands/list/list.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/os/stdout"
 	"github.com/gruntwork-io/terragrunt/internal/queue"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
@@ -32,7 +31,7 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		NoHidden:          opts.NoHidden,
 		WithRequiresParse: opts.Dependencies || opts.Mode == ModeDAG,
 		WithRelationships: opts.Dependencies || opts.Mode == ModeDAG,
-		FilterQueries:     opts.FilterQueries,
+		Filters:           opts.Filters,
 		Experiments:       opts.Experiments,
 	})
 	if err != nil {
@@ -41,12 +40,7 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 
 	// We do worktree generation here instead of in the discovery constructor
 	// so that we can defer cleanup in the same context.
-	filters, parseErr := filter.ParseFilterQueries(l, opts.FilterQueries)
-	if parseErr != nil {
-		return fmt.Errorf("failed to parse filters: %w", parseErr)
-	}
-
-	gitFilters := filters.UniqueGitFilters()
+	gitFilters := opts.Filters.UniqueGitFilters()
 
 	worktrees, worktreeErr := worktrees.NewWorktrees(ctx, l, opts.WorkingDir, gitFilters)
 	if worktreeErr != nil {

--- a/internal/cli/commands/run/flags.go
+++ b/internal/cli/commands/run/flags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/report"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/util"
@@ -262,7 +263,12 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 					}
 
 					for _, v := range value {
-						opts.FilterQueries = append(opts.FilterQueries, "reading="+v)
+						attrExpr, err := filter.NewAttributeExpression(filter.AttributeReading, v)
+						if err != nil {
+							return err
+						}
+
+						opts.Filters = append(opts.Filters, filter.NewFilter(attrExpr, attrExpr.String()))
 					}
 
 					return nil

--- a/internal/cli/commands/run/help.go
+++ b/internal/cli/commands/run/help.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
@@ -58,7 +59,7 @@ func runTFHelp(ctx context.Context, cliCtx *clihelper.Context, l log.Logger, opt
 
 	terraformHelpCmd := []string{tf.FlagNameHelpLong, cliCtx.Command.Name}
 
-	out, err := tf.RunCommandWithOutput(ctx, l, tf.TFOptionsFromOpts(opts), terraformHelpCmd...)
+	out, err := tf.RunCommandWithOutput(ctx, l, configbridge.TFRunOptsFromOpts(opts), terraformHelpCmd...)
 	if err != nil {
 		var processError util.ProcessExecutionError
 		if ok := errors.As(err, &processError); ok {

--- a/internal/cli/commands/run/run.go
+++ b/internal/cli/commands/run/run.go
@@ -158,7 +158,7 @@ func runVersionCommand(ctx context.Context, l log.Logger, opts *options.Terragru
 		}
 	}
 
-	return tf.RunCommand(ctx, l, tf.TFOptionsFromOpts(opts), opts.TerraformCliArgs.Slice()...)
+	return tf.RunCommand(ctx, l, configbridge.TFRunOptsFromOpts(opts), opts.TerraformCliArgs.Slice()...)
 }
 
 func getTFPathFromConfig(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) (string, error) {
@@ -193,22 +193,25 @@ func checkVersionConstraints(ctx context.Context, l log.Logger, opts *options.Te
 		opts.TFPath = partialTerragruntConfig.TerraformBinary
 	}
 
-	l, err = run.PopulateTFVersion(ctx, l, opts)
+	l, ver, impl, err := run.PopulateTFVersion(ctx, l, opts.WorkingDir, opts.VersionManagerFileName, configbridge.TFRunOptsFromOpts(opts))
 	if err != nil {
 		return l, err
 	}
+
+	opts.TerraformVersion = ver
+	opts.TofuImplementation = impl
 
 	terraformVersionConstraint := run.DefaultTerraformVersionConstraint
 	if partialTerragruntConfig.TerraformVersionConstraint != "" {
 		terraformVersionConstraint = partialTerragruntConfig.TerraformVersionConstraint
 	}
 
-	if err := run.CheckTerraformVersion(terraformVersionConstraint, opts); err != nil {
+	if err := run.CheckTerraformVersionMeetsConstraint(opts.TerraformVersion, terraformVersionConstraint); err != nil {
 		return l, err
 	}
 
 	if partialTerragruntConfig.TerragruntVersionConstraint != "" {
-		if err := run.CheckTerragruntVersion(partialTerragruntConfig.TerragruntVersionConstraint, opts); err != nil {
+		if err := run.CheckTerragruntVersionMeetsConstraint(opts.TerragruntVersion, partialTerragruntConfig.TerragruntVersionConstraint); err != nil {
 			return l, err
 		}
 	}

--- a/internal/cli/commands/stack/stack.go
+++ b/internal/cli/commands/stack/stack.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/clean"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/output"
@@ -46,16 +45,16 @@ func RunGenerate(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 		}
 	}
 
-	filters, err := filter.ParseFilterQueries(l, opts.FilterQueries)
-	if err != nil {
-		return errors.Errorf("failed to parse filters: %w", err)
-	}
+	filters := opts.Filters
 
 	gitFilters := filters.UniqueGitFilters()
 
 	// Only create worktrees when git filter expressions are present
 	var wts *worktrees.Worktrees
+
 	if len(gitFilters) > 0 {
+		var err error
+
 		wts, err = worktrees.NewWorktrees(ctx, l, opts.WorkingDir, gitFilters)
 		if err != nil {
 			return errors.Errorf("failed to create worktrees: %w", err)

--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -155,8 +155,6 @@ func NewRunOptions(opts *options.TerragruntOptions) *run.Options {
 		MaxFoldersToCheck:            opts.MaxFoldersToCheck,
 		FailIfBucketCreationRequired: opts.FailIfBucketCreationRequired,
 		DisableBucketUpdate:          opts.DisableBucketUpdate,
-		CheckDependentUnits:          opts.CheckDependentUnits,
-		SkipOutput:                   opts.SkipOutput,
 		SourceUpdate:                 opts.SourceUpdate,
 	}
 }

--- a/internal/discovery/constructor.go
+++ b/internal/discovery/constructor.go
@@ -15,7 +15,7 @@ import (
 type DiscoveryCommandOptions struct {
 	WorkingDir        string
 	QueueConstructAs  string
-	FilterQueries     []string
+	Filters           filter.Filters
 	Experiments       experiment.Experiments
 	NoHidden          bool
 	Exclude           bool
@@ -27,16 +27,16 @@ type DiscoveryCommandOptions struct {
 
 // HCLCommandOptions contains options for HCL commands like hcl validate & format.
 type HCLCommandOptions struct {
-	WorkingDir    string
-	FilterQueries []string
-	Experiments   experiment.Experiments
+	WorkingDir  string
+	Filters     filter.Filters
+	Experiments experiment.Experiments
 }
 
 // StackGenerateOptions contains options for stack generate commands.
 type StackGenerateOptions struct {
-	WorkingDir    string
-	FilterQueries []string
-	Experiments   experiment.Experiments
+	WorkingDir  string
+	Filters     filter.Filters
+	Experiments experiment.Experiments
 }
 
 // NewForDiscoveryCommand creates a Discovery configured for discovery commands (find/list).
@@ -94,13 +94,8 @@ func NewForDiscoveryCommand(l log.Logger, opts *DiscoveryCommandOptions) (*Disco
 		})
 	}
 
-	if len(opts.FilterQueries) > 0 {
-		filters, err := filter.ParseFilterQueries(l, opts.FilterQueries)
-		if err != nil {
-			return nil, err
-		}
-
-		d = d.WithFilters(filters)
+	if len(opts.Filters) > 0 {
+		d = d.WithFilters(opts.Filters)
 	}
 
 	return d, nil
@@ -110,13 +105,8 @@ func NewForDiscoveryCommand(l log.Logger, opts *DiscoveryCommandOptions) (*Disco
 func NewForHCLCommand(l log.Logger, opts HCLCommandOptions) (*Discovery, error) {
 	d := NewDiscovery(opts.WorkingDir)
 
-	if len(opts.FilterQueries) > 0 {
-		filters, err := filter.ParseFilterQueries(l, opts.FilterQueries)
-		if err != nil {
-			return nil, err
-		}
-
-		d = d.WithFilters(filters)
+	if len(opts.Filters) > 0 {
+		d = d.WithFilters(opts.Filters)
 	}
 
 	return d, nil
@@ -126,13 +116,8 @@ func NewForHCLCommand(l log.Logger, opts HCLCommandOptions) (*Discovery, error) 
 func NewForStackGenerate(l log.Logger, opts StackGenerateOptions) (*Discovery, error) {
 	d := NewDiscovery(opts.WorkingDir)
 
-	if len(opts.FilterQueries) > 0 {
-		filters, err := filter.ParseFilterQueries(l, opts.FilterQueries)
-		if err != nil {
-			return nil, err
-		}
-
-		d = d.WithFilters(filters.RestrictToStacks())
+	if len(opts.Filters) > 0 {
+		d = d.WithFilters(opts.Filters.RestrictToStacks())
 	}
 
 	return d, nil

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -24,12 +24,7 @@ func (d *Discovery) Discover(
 	l log.Logger,
 	opts *options.TerragruntOptions,
 ) (component.Components, error) {
-	classifier := filter.NewClassifier()
-	if err := classifier.Analyze(d.filters); err != nil {
-		return nil, err
-	}
-
-	d.classifier = classifier
+	d.classifier = filter.NewClassifier(d.filters)
 
 	results, err := d.runFilesystemPhase(ctx, l, opts)
 	if err != nil && !d.suppressParseErrors {
@@ -38,7 +33,7 @@ func (d *Discovery) Discover(
 
 	discovered, candidates := results.Discovered, results.Candidates
 
-	if d.requiresParse || classifier.HasParseRequiredFilters() {
+	if d.requiresParse || d.classifier.HasParseRequiredFilters() {
 		results, err = d.runParsePhase(ctx, l, opts, discovered, candidates)
 		if err != nil && !d.suppressParseErrors {
 			return nil, err
@@ -47,8 +42,8 @@ func (d *Discovery) Discover(
 		discovered, candidates = results.Discovered, results.Candidates
 	}
 
-	if classifier.HasGraphFilters() {
-		if classifier.HasDependentFilters() && d.gitRoot == "" {
+	if d.classifier.HasGraphFilters() {
+		if d.classifier.HasDependentFilters() && d.gitRoot == "" {
 			if gitRootPath, gitErr := shell.GitTopLevelDir(ctx, l, opts.Env, d.workingDir); gitErr == nil {
 				d.gitRoot = gitRootPath
 				l.Debugf("Set gitRoot for dependent discovery: %s", d.gitRoot)

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -100,9 +100,7 @@ func TestCandidacyClassifier_Analyze(t *testing.T) {
 			filters, err := filter.ParseFilterQueries(l, tt.filterStrings)
 			require.NoError(t, err)
 
-			classifier := filter.NewClassifier()
-			err = classifier.Analyze(filters)
-			require.NoError(t, err)
+			classifier := filter.NewClassifier(filters)
 
 			assert.Equal(t, tt.expectHasPositive, classifier.HasPositiveFilters(), "HasPositiveFilters mismatch")
 			assert.Equal(t, tt.expectHasParseRequired, classifier.HasParseRequiredFilters(), "HasParseRequiredFilters mismatch")
@@ -200,9 +198,7 @@ func TestCandidacyClassifier_ClassifyComponent(t *testing.T) {
 			filters, err := filter.ParseFilterQueries(l, tt.filterStrings)
 			require.NoError(t, err)
 
-			classifier := filter.NewClassifier()
-			err = classifier.Analyze(filters)
-			require.NoError(t, err)
+			classifier := filter.NewClassifier(filters)
 
 			// Create a test component
 			c := component.NewUnit(tt.componentPath)

--- a/internal/discovery/phase_test.go
+++ b/internal/discovery/phase_test.go
@@ -490,9 +490,7 @@ func TestCandidacyClassifier_AnalyzesFiltersCorrectly(t *testing.T) {
 			filters, err := filter.ParseFilterQueries(l, tt.filterStrings)
 			require.NoError(t, err)
 
-			classifier := filter.NewClassifier()
-			err = classifier.Analyze(filters)
-			require.NoError(t, err)
+			classifier := filter.NewClassifier(filters)
 
 			assert.Equal(t, tt.expectHasPositive, classifier.HasPositiveFilters(), "HasPositiveFilters mismatch")
 			assert.Equal(t, tt.expectHasParseRequired, classifier.HasParseRequiredFilters(), "HasParseRequiredFilters mismatch")
@@ -600,9 +598,7 @@ func TestCandidacyClassifier_ClassifiesComponentsCorrectly(t *testing.T) {
 			filters, err := filter.ParseFilterQueries(l, tt.filterStrings)
 			require.NoError(t, err)
 
-			classifier := filter.NewClassifier()
-			err = classifier.Analyze(filters)
-			require.NoError(t, err)
+			classifier := filter.NewClassifier(filters)
 
 			// Create a test component
 			c := component.NewUnit(tt.componentPath)
@@ -628,9 +624,7 @@ func TestClassifier_ParseExpressions(t *testing.T) {
 	filters, err := filter.ParseFilterQueries(l, []string{"reading=config/*", "reading=shared.hcl"})
 	require.NoError(t, err)
 
-	classifier := filter.NewClassifier()
-	err = classifier.Analyze(filters)
-	require.NoError(t, err)
+	classifier := filter.NewClassifier(filters)
 
 	parseExprs := classifier.ParseExpressions()
 	assert.Len(t, parseExprs, 2, "Should have 2 parse expressions")
@@ -645,9 +639,7 @@ func TestClassifier_NegatedExpressions(t *testing.T) {
 	filters, err := filter.ParseFilterQueries(l, []string{"!./foo", "!./bar", "./baz"})
 	require.NoError(t, err)
 
-	classifier := filter.NewClassifier()
-	err = classifier.Analyze(filters)
-	require.NoError(t, err)
+	classifier := filter.NewClassifier(filters)
 
 	negatedExprs := classifier.NegatedExpressions()
 	assert.Len(t, negatedExprs, 2, "Should have 2 negated expressions")
@@ -703,9 +695,7 @@ func TestClassifier_HasDependentFilters(t *testing.T) {
 			filters, err := filter.ParseFilterQueries(l, tt.filterStrings)
 			require.NoError(t, err)
 
-			classifier := filter.NewClassifier()
-			err = classifier.Analyze(filters)
-			require.NoError(t, err)
+			classifier := filter.NewClassifier(filters)
 
 			assert.Equal(t, tt.expectResult, classifier.HasDependentFilters(), "HasDependentFilters mismatch")
 		})

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -456,7 +456,10 @@ unit "unit_to_be_untouched" {
 	opts := options.NewTerragruntOptions()
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
-	opts.FilterQueries = []string{"[HEAD~1...HEAD]"}
+	parsedFilters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]"})
+	require.NoError(t, parseErr)
+
+	opts.Filters = parsedFilters
 	opts.Experiments = experiment.NewExperiments()
 	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
 	require.NoError(t, err)

--- a/internal/filter/ast.go
+++ b/internal/filter/ast.go
@@ -234,19 +234,31 @@ type GraphExpression struct {
 	DependencyDepth     int
 }
 
-// NewGraphExpression creates a new GraphExpression.
-func NewGraphExpression(
-	target Expression,
-	includeDependents bool,
-	includeDependencies bool,
-	excludeTarget bool,
-) *GraphExpression {
+// NewGraphExpression creates a new GraphExpression for the given target.
+// Use the builder methods WithDependents, WithDependencies, and WithExcludeTarget
+// to configure graph traversal behavior.
+func NewGraphExpression(target Expression) *GraphExpression {
 	return &GraphExpression{
-		Target:              target,
-		IncludeDependents:   includeDependents,
-		IncludeDependencies: includeDependencies,
-		ExcludeTarget:       excludeTarget,
+		Target: target,
 	}
+}
+
+// WithDependents includes dependents (reverse dependencies) in the graph traversal.
+func (g *GraphExpression) WithDependents() *GraphExpression {
+	g.IncludeDependents = true
+	return g
+}
+
+// WithDependencies includes dependencies in the graph traversal.
+func (g *GraphExpression) WithDependencies() *GraphExpression {
+	g.IncludeDependencies = true
+	return g
+}
+
+// WithExcludeTarget excludes the target itself from the graph traversal results.
+func (g *GraphExpression) WithExcludeTarget() *GraphExpression {
+	g.ExcludeTarget = true
+	return g
 }
 
 func (g *GraphExpression) expressionNode() {}

--- a/internal/filter/ast_test.go
+++ b/internal/filter/ast_test.go
@@ -84,7 +84,7 @@ func TestRestrictToStacks(t *testing.T) {
 			name: "graph expression",
 			exprFn: func(t *testing.T) filter.Expression {
 				t.Helper()
-				return filter.NewGraphExpression(mustAttr(t, "name", "foo"), true, false, false)
+				return filter.NewGraphExpression(mustAttr(t, "name", "foo")).WithDependents()
 			},
 			expected: false,
 		},

--- a/internal/filter/classifier.go
+++ b/internal/filter/classifier.go
@@ -105,20 +105,11 @@ type Classifier struct {
 	hasPositiveFilters bool
 }
 
-// NewClassifier creates a new Classifier.
-func NewClassifier() *Classifier {
-	return &Classifier{}
-}
-
-// Analyze categorizes all filter expressions for efficient component classification.
+// NewClassifier creates a new Classifier that categorizes all filter expressions
+// for efficient component classification.
 // It separates filters into filesystem-evaluable, parse-required, and graph expressions.
-func (c *Classifier) Analyze(filters Filters) error {
-	c.filesystemExprs = nil
-	c.parseExprs = nil
-	c.graphExprs = nil
-	c.gitExprs = nil
-	c.negatedExprs = nil
-	c.hasPositiveFilters = false
+func NewClassifier(filters Filters) *Classifier {
+	c := &Classifier{}
 
 	for i, f := range filters {
 		expr := f.Expression()
@@ -129,7 +120,7 @@ func (c *Classifier) Analyze(filters Filters) error {
 		c.analyzeExpression(expr, i)
 	}
 
-	return nil
+	return c
 }
 
 // Classify determines whether a component should be discovered, is a candidate,

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -486,8 +486,11 @@ func createConfig(
 		},
 	}
 
-	_, err = run.PopulateTFVersion(t.Context(), logger, opts)
+	_, ver, impl, err := run.PopulateTFVersion(t.Context(), logger, opts.WorkingDir, opts.VersionManagerFileName, configbridge.TFRunOptsFromOpts(opts))
 	require.NoError(t, err)
+
+	opts.TerraformVersion = ver
+	opts.TofuImplementation = impl
 
 	return terraformSource, opts, cfg, err
 }

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -73,8 +73,6 @@ type Options struct {
 	BackendBootstrap             bool
 	FailIfBucketCreationRequired bool
 	DisableBucketUpdate          bool
-	CheckDependentUnits          bool
-	SkipOutput                   bool
 	SourceUpdate                 bool
 	ForwardTFStdout              bool
 }

--- a/internal/runner/run/version_check.go
+++ b/internal/runner/run/version_check.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/hashicorp/go-version"
 )
 
@@ -32,38 +31,33 @@ var TerraformVersionRegex = regexp.MustCompile(`^(\S+)\s(v?\d+\.\d+\.\d+)`)
 
 const versionParts = 3
 
-// PopulateTFVersion populates the currently installed version of OpenTofuTerraform into the given terragruntOptions.
-//
-// The caller also gets a copy of the logger with the config path set.
-func PopulateTFVersion(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) (log.Logger, error) {
+// PopulateTFVersion discovers the currently installed version of OpenTofu/Terraform.
+// It uses a cache keyed by workingDir and versionFiles to avoid repeated invocations.
+// Returns the discovered version and implementation type; the caller is responsible
+// for storing them on *options.TerragruntOptions.
+func PopulateTFVersion(ctx context.Context, l log.Logger, workingDir string, versionFiles []string, tfOpts *tf.TFOptions) (log.Logger, *version.Version, tfimpl.Type, error) {
 	versionCache := GetRunVersionCache(ctx)
-	cacheKey := computeVersionFilesCacheKey(opts.WorkingDir, opts.VersionManagerFileName)
+	cacheKey := computeVersionFilesCacheKey(workingDir, versionFiles)
 	l.Debugf("using cache key for version files: %s", cacheKey)
 
 	if cachedOutput, found := versionCache.Get(ctx, cacheKey); found {
 		tfImplementation, terraformVersion, err := parseVersionFromCache(cachedOutput)
 		if err != nil {
-			return l, err
+			return l, nil, tfimpl.Unknown, err
 		}
 
-		opts.TerraformVersion = terraformVersion
-		opts.TofuImplementation = tfImplementation
-
-		return l, nil
+		return l, terraformVersion, tfImplementation, nil
 	}
 
-	l, terraformVersion, tfImplementation, err := GetTFVersion(ctx, l, opts)
+	l, terraformVersion, tfImplementation, err := GetTFVersion(ctx, l, tfOpts)
 	if err != nil {
-		return l, err
+		return l, nil, tfimpl.Unknown, err
 	}
 
 	cacheData := formatVersionForCache(tfImplementation, terraformVersion)
 	versionCache.Put(ctx, cacheKey, cacheData)
 
-	opts.TerraformVersion = terraformVersion
-	opts.TofuImplementation = tfImplementation
-
-	return l, nil
+	return l, terraformVersion, tfImplementation, nil
 }
 
 // formatVersionForCache formats the implementation and version for the cache
@@ -114,24 +108,29 @@ func parseVersionFromCache(cachedData string) (tfimpl.Type, *version.Version, er
 }
 
 // GetTFVersion checks the OpenTofu/Terraform version directly without using cache.
-// This function can be used independently when you need to check the version without
-// populating or using the version cache.
-func GetTFVersion(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) (log.Logger, *version.Version, tfimpl.Type, error) {
-	_, optsCopy, err := opts.CloneWithConfigPath(l, opts.TerragruntConfigPath)
-	if err != nil {
-		return l, nil, tfimpl.Unknown, err
-	}
+// It takes pre-built *tf.TFOptions and runs "terraform version", discarding output
+// and stripping TF_CLI_ARGS env vars to avoid interference.
+func GetTFVersion(ctx context.Context, l log.Logger, tfOpts *tf.TFOptions) (log.Logger, *version.Version, tfimpl.Type, error) {
+	// Clone to avoid mutating the caller's options.
+	optsCopy := *tfOpts
+	shellCopy := *optsCopy.ShellOptions
+	optsCopy.ShellOptions = &shellCopy
 
-	optsCopy.Writers.Writer = io.Discard
-	optsCopy.Writers.ErrWriter = io.Discard
+	// Discard output — we only need the parsed version string.
+	optsCopy.ShellOptions.Writers.Writer = io.Discard
+	optsCopy.ShellOptions.Writers.ErrWriter = io.Discard
 
-	for key := range optsCopy.Env {
-		if strings.HasPrefix(key, "TF_CLI_ARGS") {
-			delete(optsCopy.Env, key)
+	// Remove TF_CLI_ARGS* so they don't interfere with "--version".
+	envCopy := make(map[string]string, len(shellCopy.Env))
+	for key, val := range shellCopy.Env {
+		if !strings.HasPrefix(key, "TF_CLI_ARGS") {
+			envCopy[key] = val
 		}
 	}
 
-	output, err := tf.RunCommandWithOutput(ctx, l, tf.TFOptionsFromOpts(optsCopy), tf.FlagNameVersion)
+	optsCopy.ShellOptions.Env = envCopy
+
+	output, err := tf.RunCommandWithOutput(ctx, l, &optsCopy, tf.FlagNameVersion)
 	if err != nil {
 		return l, nil, tfimpl.Unknown, err
 	}
@@ -155,18 +154,6 @@ func GetTFVersion(ctx context.Context, l log.Logger, opts *options.TerragruntOpt
 	}
 
 	return l, terraformVersion, tfImplementation, nil
-}
-
-// CheckTerraformVersion checks that the currently installed Terraform version works meets the specified version constraint and return an error
-// if it doesn't
-func CheckTerraformVersion(constraint string, terragruntOptions *options.TerragruntOptions) error {
-	return CheckTerraformVersionMeetsConstraint(terragruntOptions.TerraformVersion, constraint)
-}
-
-// CheckTerragruntVersion checks that the currently running Terragrunt version meets the specified version constraint and return an error
-// if it doesn't
-func CheckTerragruntVersion(constraint string, terragruntOptions *options.TerragruntOptions) error {
-	return CheckTerragruntVersionMeetsConstraint(terragruntOptions.TerragruntVersion, constraint)
 }
 
 // CheckTerragruntVersionMeetsConstraint checks that the current version of Terragrunt meets the specified constraint and return an error if it doesn't

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/runner"
 	"github.com/gruntwork-io/terragrunt/internal/runner/common"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/clean"
@@ -83,15 +82,13 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 		}()
 	}
 
-	filters, err := filter.ParseFilterQueries(l, opts.FilterQueries)
-	if err != nil {
-		return errors.Errorf("failed to parse filters: %w", err)
-	}
-
-	gitFilters := filters.UniqueGitFilters()
+	gitFilters := opts.Filters.UniqueGitFilters()
 
 	// Only create worktrees when git filter expressions are present
-	var wts *worktrees.Worktrees
+	var (
+		wts *worktrees.Worktrees
+		err error
+	)
 	if len(gitFilters) > 0 {
 		wts, err = worktrees.NewWorktrees(ctx, l, opts.WorkingDir, gitFilters)
 		if err != nil {

--- a/internal/runner/runnerpool/builder_helpers.go
+++ b/internal/runner/runnerpool/builder_helpers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/runner/common"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
@@ -55,15 +54,6 @@ func buildConfigFilenames(opts *options.TerragruntOptions) []string {
 	return configFilenames
 }
 
-// parseFilters wraps filter parsing for readability.
-func parseFilters(l log.Logger, queries []string) (filter.Filters, error) {
-	if len(queries) == 0 {
-		return filter.Filters{}, nil
-	}
-
-	return filter.ParseFilterQueries(l, queries)
-}
-
 // extractWorktrees finds WorktreeOption in options and returns worktrees.
 func extractWorktrees(opts []common.Option) *worktrees.Worktrees {
 	for _, opt := range opts {
@@ -103,23 +93,17 @@ func newBaseDiscovery(
 
 // prepareDiscovery constructs a configured discovery instance based on Terragrunt options and flags.
 func prepareDiscovery(
-	l log.Logger,
 	opts *options.TerragruntOptions,
 	runnerOpts ...common.Option,
-) (*discovery.Discovery, error) {
+) *discovery.Discovery {
 	workingDir := resolveWorkingDir(opts)
 	configFilenames := buildConfigFilenames(opts)
 
 	d := newBaseDiscovery(opts, workingDir, configFilenames, runnerOpts...)
 
-	// Apply filter queries when provided
-	if len(opts.FilterQueries) > 0 {
-		filters, err := parseFilters(l, opts.FilterQueries)
-		if err != nil {
-			return nil, errors.Errorf("failed to parse filter queries in %s: %w", workingDir, err)
-		}
-
-		d = d.WithFilters(filters)
+	// Apply pre-parsed filters when provided
+	if len(opts.Filters) > 0 {
+		d = d.WithFilters(opts.Filters)
 	}
 
 	// Apply worktrees for git filter expressions
@@ -127,7 +111,7 @@ func prepareDiscovery(
 		d = d.WithWorktrees(w)
 	}
 
-	return d, nil
+	return d
 }
 
 // discoverWithRetry runs discovery and retries without exclude-by-default if zero results
@@ -139,14 +123,11 @@ func discoverWithRetry(
 	runnerOpts ...common.Option,
 ) (component.Components, error) {
 	// Initial discovery with current excludeByDefault setting
-	d, err := prepareDiscovery(l, opts, runnerOpts...)
-	if err != nil {
-		return nil, err
-	}
+	d := prepareDiscovery(opts, runnerOpts...)
 
 	var discovered component.Components
 
-	err = doWithTelemetry(ctx, telemetryDiscovery, map[string]any{
+	err := doWithTelemetry(ctx, telemetryDiscovery, map[string]any{
 		"working_dir":       opts.WorkingDir,
 		"terraform_command": opts.TerraformCommand,
 	}, func(childCtx context.Context) error {
@@ -267,24 +248,27 @@ func checkUnitVersionConstraints(
 		l = unitLogger
 	}
 
-	_, err := run.PopulateTFVersion(ctx, l, unitOpts)
+	_, ver, impl, err := run.PopulateTFVersion(ctx, l, unitOpts.WorkingDir, unitOpts.VersionManagerFileName, configbridge.TFRunOptsFromOpts(unitOpts))
 	if err != nil {
 		return errors.Errorf("failed to populate Terraform version for unit %s: %w", unit.DisplayPath(), err)
 	}
+
+	unitOpts.TerraformVersion = ver
+	unitOpts.TofuImplementation = impl
 
 	terraformVersionConstraint := run.DefaultTerraformVersionConstraint
 	if unitConfig.TerraformVersionConstraint != "" {
 		terraformVersionConstraint = unitConfig.TerraformVersionConstraint
 	}
 
-	if err := run.CheckTerraformVersion(terraformVersionConstraint, unitOpts); err != nil {
+	if err := run.CheckTerraformVersionMeetsConstraint(unitOpts.TerraformVersion, terraformVersionConstraint); err != nil {
 		return errors.Errorf("Terraform version check failed for unit %s: %w", unit.DisplayPath(), err)
 	}
 
 	if unitConfig.TerragruntVersionConstraint != "" {
-		if err := run.CheckTerragruntVersion(
+		if err := run.CheckTerragruntVersionMeetsConstraint(
+			unitOpts.TerragruntVersion,
 			unitConfig.TerragruntVersionConstraint,
-			unitOpts,
 		); err != nil {
 			return errors.Errorf("Terragrunt version check failed for unit %s: %w", unit.DisplayPath(), err)
 		}

--- a/internal/runner/runnerpool/graph_fallback_test.go
+++ b/internal/runner/runnerpool/graph_fallback_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runnerpool"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -65,7 +66,10 @@ dependency "db" {
 	// Enable the filter-flag experiment
 	require.NoError(t, optsOn.Experiments.EnableExperiment("filter-flag"))
 	// Inject graph filter for dependents of target
-	optsOn.FilterQueries = []string{`...{` + vpcDir + `}`}
+	parsedFilters, parseErr := filter.ParseFilterQueries(l, []string{`...{` + vpcDir + `}`})
+	require.NoError(t, parseErr)
+
+	optsOn.Filters = parsedFilters
 	// Build runner
 	runnerOn, err := runnerpool.Build(ctx, l, optsOn)
 	require.NoError(t, err)

--- a/internal/stacks/output/output.go
+++ b/internal/stacks/output/output.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
@@ -269,12 +268,7 @@ func buildWorktreesIfNeeded(
 	l log.Logger,
 	opts *options.TerragruntOptions,
 ) (*worktrees.Worktrees, error) {
-	filters, err := filter.ParseFilterQueries(l, opts.FilterQueries)
-	if err != nil {
-		return nil, errors.Errorf("failed to parse filters: %w", err)
-	}
-
-	gitFilters := filters.UniqueGitFilters()
+	gitFilters := opts.Filters.UniqueGitFilters()
 	if len(gitFilters) == 0 {
 		return nil, nil
 	}

--- a/internal/tf/run_cmd.go
+++ b/internal/tf/run_cmd.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
 	logwriter "github.com/gruntwork-io/terragrunt/pkg/log/writer"
-	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/mattn/go-isatty"
 )
 
@@ -51,36 +50,6 @@ type TFOptions struct {
 
 	OriginalTerragruntConfigPath string
 	JSONLogFormat                bool
-}
-
-// shellRunOptsFromOpts constructs shell.ShellOptions from TerragruntOptions.
-// This is a local helper to avoid an import cycle with configbridge.
-func shellRunOptsFromOpts(opts *options.TerragruntOptions) *shell.ShellOptions {
-	return &shell.ShellOptions{
-		Writers:         opts.Writers,
-		EngineOptions:   opts.EngineOptions,
-		WorkingDir:      opts.WorkingDir,
-		Env:             opts.Env,
-		TFPath:          opts.TFPath,
-		EngineConfig:    opts.EngineConfig,
-		Experiments:     opts.Experiments,
-		Telemetry:       opts.Telemetry,
-		RootWorkingDir:  opts.RootWorkingDir,
-		Headless:        opts.Headless,
-		ForwardTFStdout: opts.ForwardTFStdout,
-	}
-}
-
-// TFOptionsFromOpts constructs RunOptions from TerragruntOptions.
-func TFOptionsFromOpts(opts *options.TerragruntOptions) *TFOptions {
-	return &TFOptions{
-		JSONLogFormat:                opts.JSONLogFormat,
-		OriginalTerragruntConfigPath: opts.OriginalTerragruntConfigPath,
-		TerragruntConfigPath:         opts.TerragruntConfigPath,
-		TofuImplementation:           opts.TofuImplementation,
-		TerraformCliArgs:             opts.TerraformCliArgs,
-		ShellOptions:                 shellRunOptsFromOpts(opts),
-	}
 }
 
 // RunCommand runs the given Terraform command.

--- a/internal/tf/run_cmd_test.go
+++ b/internal/tf/run_cmd_test.go
@@ -11,17 +11,17 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
 var (
@@ -76,7 +76,7 @@ func testCommandOutput(t *testing.T, withOptions func(*options.TerragruntOptions
 	l := logger.CreateLogger()
 	l = withLogger(l)
 
-	out, err := tf.RunCommandWithOutput(t.Context(), l, tf.TFOptionsFromOpts(terragruntOptions), "same")
+	out, err := tf.RunCommandWithOutput(t.Context(), l, configbridge.TFRunOptsFromOpts(terragruntOptions), "same")
 
 	assert.NotNil(t, out, "Should get output")
 	require.NoError(t, err, "Should have no error")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/errorconfig"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	"github.com/gruntwork-io/terragrunt/internal/iam"
 	pcoptions "github.com/gruntwork-io/terragrunt/internal/providercache/options"
@@ -168,8 +169,8 @@ type TerragruntOptions struct {
 	ScaffoldVars []string
 	// StrictControls is a slice of strict controls.
 	StrictControls strict.Controls `clone:"shadowcopy"`
-	// FilterQueries contains filter query strings for component selection
-	FilterQueries []string
+	// Filters contains parsed filter objects for component selection.
+	Filters filter.Filters `clone:"shadowcopy"`
 	// When set, it will be used to compute the cache key for `-version` checks.
 	VersionManagerFileName []string
 	// Experiments is a map of experiments, and their status.

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -56,7 +57,7 @@ func TestDebugGeneratedInputs(t *testing.T) {
 
 	require.NoError(
 		t,
-		tf.RunCommand(t.Context(), l, tf.TFOptionsFromOpts(mockOptions), "apply", "-auto-approve", "-var-file", debugFile),
+		tf.RunCommand(t.Context(), l, configbridge.TFRunOptsFromOpts(mockOptions), "apply", "-auto-approve", "-var-file", debugFile),
 	)
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Moves filter parsing high enough in the call stack that we don't have to worry about errors related to parsing them deeper down the call stack.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dependency-aware filtering when enabling external discovery and related flags.
  - Stack generation now inherently restricts to stack components.

- Improvements
  - Unified, deduplicated filters for consistent results across commands.
  - Faster, cached Terraform/OpenTofu version detection with clearer logging.
  - More robust version/constraint checks.
  - Consistent filter application in find, list, run, hcl, stack, and run-all.
  - Sanitizes TF_CLI_ARGS during version checks to avoid interference.

- Bug Fixes
  - Better error handling when constructing filters.

- Behavior Changes
  - Certain run options related to dependent units and output are no longer honored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->