### PR TITLE
fix: Fixing incremental lint issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ clean:
 
 IGNORE_TAGS := windows|linux|darwin|freebsd|openbsd|netbsd|dragonfly|solaris|plan9|js|wasip1|aix|android|illumos|ios|386|amd64|arm|arm64|mips|mips64|mips64le|mipsle|ppc64|ppc64le|riscv64|s390x|wasm
 
-LINT_TAGS := $(shell grep -rh 'go:build' . | \
+LINT_TAGS := $(shell grep -rh --include='*.go' 'go:build' . | \
 	sed 's/.*go:build\s*//' | \
 	tr -cs '[:alnum:]_' '\n' | \
 	grep -vE '^($(IGNORE_TAGS))$$' | \


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Prevents this grep from matching against the Makefile, ensuring no incomplete `s` tag:

```
GOFLAGS="-tags=aws,awsgcp,awsoidc,docker,engine,gcp,mocks,parse,private_registry,s,sops,ssh,tflint,tofu" golangci-lint run -v --timeout=30m --new-from-merge-base=main ./...
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build system linting configuration to improve efficiency in code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->