### PR TITLE
chore: Adding test to verify that the Provider Cache Server is used when fetching outputs from dependencies

### DIFF
--- a/test/fixtures/provider-cache/dependency/.gitignore
+++ b/test/fixtures/provider-cache/dependency/.gitignore
@@ -1,0 +1,2 @@
+# Ignore lock files to allow tests to run with both Terraform and OpenTofu
+.terraform.lock.hcl

--- a/test/fixtures/provider-cache/dependency/app/main.tf
+++ b/test/fixtures/provider-cache/dependency/app/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.4"
+    }
+  }
+}

--- a/test/fixtures/provider-cache/dependency/app/terragrunt.hcl
+++ b/test/fixtures/provider-cache/dependency/app/terragrunt.hcl
@@ -1,0 +1,11 @@
+dependency "dep" {
+  config_path = "../dep"
+
+  mock_outputs = {
+    result = "mock"
+  }
+}
+
+inputs = {
+  dep_value = dependency.dep.outputs.result
+}

--- a/test/fixtures/provider-cache/dependency/dep/main.tf
+++ b/test/fixtures/provider-cache/dependency/dep/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.7.0"
+    }
+  }
+}
+
+output "result" {
+  value = "hello"
+}

--- a/test/fixtures/provider-cache/dependency/dep/terragrunt.hcl
+++ b/test/fixtures/provider-cache/dependency/dep/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -805,6 +805,55 @@ func TestTerragruntProviderCache(t *testing.T) {
 	}
 }
 
+// TestTerragruntProviderCacheWithDependency verifies that the provider cache server
+// is used when resolving dependency outputs. Before the fix, ReadTerragruntConfig and
+// NewParsingContext cleared the provider cache hook from the Go context, causing
+// dependency init to bypass the cache server and download providers directly.
+func TestTerragruntProviderCacheWithDependency(t *testing.T) {
+	helpers.CleanupTerraformFolder(t, testFixtureProviderCacheDependency)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureProviderCacheDependency)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureProviderCacheDependency)
+
+	cacheDir := helpers.TmpDirWOSymlinks(t)
+
+	providerCacheDir := filepath.Join(cacheDir, "provider-cache-test-dependency")
+
+	helpers.RunTerragrunt(
+		t,
+		fmt.Sprintf(
+			"terragrunt run --provider-cache --provider-cache-dir %s --non-interactive --working-dir %s -- init",
+			providerCacheDir,
+			filepath.Join(rootPath, "app"),
+		),
+	)
+
+	registryName := "registry.opentofu.org"
+	if isTerraform() {
+		registryName = "registry.terraform.io"
+	}
+
+	// Verify that the provider cache directory contains providers from both units.
+	// dep uses hashicorp/local, app uses hashicorp/null — if both are cached,
+	// the provider cache server was used for both the dependency and the dependent.
+	for _, provider := range []string{
+		"hashicorp/local/2.7.0",
+		"hashicorp/null/3.2.4",
+	} {
+		providerPath := filepath.Join(providerCacheDir, registryName, provider)
+		assert.DirExists(t, providerPath, "Provider cache dir should contain %s at %s", provider, providerPath)
+	}
+
+	// Verify both units have been initialized by checking for .terraform directories
+	for _, unit := range []string{"dep", "app"} {
+		unitPath := filepath.Join(rootPath, unit)
+		cacheWorkingDir := helpers.FindCacheWorkingDir(t, unitPath)
+		require.NotEmpty(t, cacheWorkingDir, "Should find cache working directory for %s", unitPath)
+
+		terraformDir := filepath.Join(cacheWorkingDir, ".terraform")
+		assert.DirExists(t, terraformDir, ".terraform directory should exist in cache for %s", unit)
+	}
+}
+
 func TestParseTFLog(t *testing.T) {
 	t.Setenv("TF_LOG", "info")
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -93,6 +93,7 @@ const (
 	testFixtureParallelism                    = "fixtures/parallelism"
 	testFixturePath                           = "fixtures/terragrunt/"
 	testFixturePlanfileOrder                  = "fixtures/planfile-order-test"
+	testFixtureProviderCacheDependency        = "fixtures/provider-cache/dependency"
 	testFixtureProviderCacheDirect            = "fixtures/provider-cache/direct"
 	testFixtureProviderCacheFilesystemMirror  = "fixtures/provider-cache/filesystem-mirror"
 	testFixtureProviderCacheMultiplePlatforms = "fixtures/provider-cache/multiple-platforms"


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5128.

This was already solved in #5589, but this adds the test that validates it's fixed now.

The core fix involved ensuring proper propagating of parsing context when fetching outputs from dependencies to ensure that provider cache options are used when fetching dependency outputs.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added new test for provider caching with module dependencies
  * Validates correct provider caching and initialization across dependent modules
  * Tests support both Terraform and OpenTofu implementations

* **Chores**
  * Enhanced test fixtures to prevent lock file conflicts between Terraform and OpenTofu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->