### PR TITLE
fix: Assume any transport errors to discovery URL are a sign that the user is offline

### DIFF
--- a/internal/tf/cache/handlers/provider_test.go
+++ b/internal/tf/cache/handlers/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/url"
 	"syscall"
 	"testing"
 
@@ -23,14 +24,14 @@ func TestIsOfflineError(t *testing.T) {
 		desc     string
 		expected bool
 	}{
-		{err: syscall.ECONNREFUSED, desc: "connection refused", expected: true},
-		{err: syscall.ECONNRESET, desc: "connection reset by peer", expected: true},
-		{err: syscall.ECONNABORTED, desc: "connection aborted", expected: true},
-		{err: syscall.ENETUNREACH, desc: "network is unreachable", expected: true},
-		{err: errors.New("get \"https://registry.terraform.io/.well-known/terraform.json\": dial tcp: lookup registry.terraform.io on 185.12.64.1:53: dial udp 185.12.64.1:53: connect: network is unreachable"), desc: "network is unreachable", expected: true},
-		{err: errors.New("get \"https://registry.terraform.io/.well-known/terraform.json\": read tcp 10.10.230.10:58328->10.245.10.15:443: read: connection reset by peer"), desc: "network is unreachable", expected: true},
-		{err: &net.DNSError{Err: "no such host", Name: "registry.terraform.io", IsNotFound: true}, desc: "DNS not found", expected: true},
-		{err: &net.DNSError{Err: "server misbehaving", Name: "blocked-registry.invalid", IsTemporary: true}, desc: "DNS temporary failure", expected: true},
+		// *url.Error wrapping various transport failures — all caught by the single *url.Error check.
+		{err: &url.Error{Op: "Get", URL: "https://registry.terraform.io/.well-known/terraform.json", Err: syscall.ECONNREFUSED}, desc: "connection refused", expected: true},
+		{err: &url.Error{Op: "Get", URL: "https://registry.terraform.io/.well-known/terraform.json", Err: syscall.ECONNRESET}, desc: "connection reset", expected: true},
+		{err: &url.Error{Op: "Get", URL: "https://registry.terraform.io/.well-known/terraform.json", Err: syscall.ENETUNREACH}, desc: "network unreachable", expected: true},
+		{err: &url.Error{Op: "Get", URL: "https://registry.terraform.io/.well-known/terraform.json", Err: &net.DNSError{Err: "no such host", Name: "registry.terraform.io", IsNotFound: true}}, desc: "DNS not found", expected: true},
+		{err: &url.Error{Op: "Get", URL: "https://registry.terraform.io/.well-known/terraform.json", Err: &net.DNSError{Err: "server misbehaving", Name: "blocked-registry.invalid"}}, desc: "DNS temporary failure", expected: true},
+		{err: &url.Error{Op: "Get", URL: "https://registry.terraform.io/.well-known/terraform.json", Err: errors.New("tls: failed to verify certificate")}, desc: "TLS error", expected: true},
+		// Non-transport errors — should NOT be treated as offline.
 		{err: errors.New("random error"), desc: "a random error that should not be offline", expected: false},
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5613.

Ensures that failed network requests to registries due to DNS errors, etc. are considered a sign that users are offline. Helps to support air-gapped environments.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced testing for offline and network error scenarios, including DNS and TLS connectivity failures.
  * Added validation for network mirror fallback when registry access is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->