### PR TITLE
chore: Adding some testing for `logs`

### DIFF
--- a/pkg/log/context_test.go
+++ b/pkg/log/context_test.go
@@ -1,0 +1,28 @@
+package log_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextWithLogger(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New()
+	ctx := log.ContextWithLogger(t.Context(), logger)
+
+	retrieved := log.LoggerFromContext(ctx)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, logger, retrieved)
+}
+
+func TestLoggerFromContextEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	retrieved := log.LoggerFromContext(ctx)
+	assert.Nil(t, retrieved)
+}

--- a/pkg/log/external_test.go
+++ b/pkg/log/external_test.go
@@ -1,0 +1,324 @@
+// Tests in this file validate that the pkg/log package can be fully utilized as
+// an external dependency. Every scenario here imports only public packages
+// (pkg/log, pkg/log/format, pkg/log/format/placeholders, pkg/log/writer) and
+// never reaches into internal/ packages. If any of these tests fail to compile,
+// it signals a broken public API contract.
+package log_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
+	"github.com/gruntwork-io/terragrunt/pkg/log/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExternalLoggerLifecycle exercises the core create → configure → log →
+// clone workflow that an external consumer would follow.
+func TestExternalLoggerLifecycle(t *testing.T) {
+	t.Parallel()
+
+	buf := new(bytes.Buffer)
+	logger := log.New(
+		log.WithLevel(log.DebugLevel),
+		log.WithOutput(buf),
+	)
+
+	// Basic logging methods.
+	logger.Info("info message")
+	assert.Contains(t, buf.String(), "info message")
+
+	buf.Reset()
+
+	logger.Debugf("count=%d", 42)
+	assert.Contains(t, buf.String(), "count=42")
+
+	buf.Reset()
+
+	// Clone and change level independently.
+	child := logger.Clone()
+	child.SetOptions(log.WithOutput(buf))
+
+	require.NoError(t, child.SetLevel("trace"))
+	child.Trace("trace message")
+	assert.Contains(t, buf.String(), "trace message")
+}
+
+// TestExternalLevelRoundTrip confirms that an external consumer can parse a
+// level string, inspect its various name forms, and marshal/unmarshal it.
+func TestExternalLevelRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	level, err := log.ParseLevel("warn")
+	require.NoError(t, err)
+	assert.Equal(t, log.WarnLevel, level)
+	assert.Equal(t, "warn", level.String())
+	assert.Equal(t, "wrn", level.ShortName())
+	assert.Equal(t, "w", level.TinyName())
+
+	data, err := level.MarshalText()
+	require.NoError(t, err)
+
+	var restored log.Level
+
+	require.NoError(t, restored.UnmarshalText(data))
+	assert.Equal(t, level, restored)
+}
+
+// TestExternalAllLevelsEnumeration verifies that AllLevels is accessible and
+// that every level can be stringified.
+func TestExternalAllLevelsEnumeration(t *testing.T) {
+	t.Parallel()
+
+	assert.Len(t, log.AllLevels, 7)
+
+	for _, lvl := range log.AllLevels {
+		assert.NotEmpty(t, lvl.String())
+		assert.True(t, log.AllLevels.Contains(lvl))
+	}
+
+	assert.False(t, log.AllLevels.Contains(log.Level(99)))
+}
+
+// TestExternalFieldsAndErrors confirms that WithField, WithFields, and
+// WithError return enriched loggers whose output contains the added metadata.
+func TestExternalFieldsAndErrors(t *testing.T) {
+	t.Parallel()
+
+	buf := new(bytes.Buffer)
+	logger := log.New(log.WithLevel(log.InfoLevel), log.WithOutput(buf))
+
+	logger.WithField("component", "auth").Info("field check")
+	assert.Contains(t, buf.String(), "component")
+
+	buf.Reset()
+
+	logger.WithFields(log.Fields{"a": 1, "b": 2}).Info("fields check")
+
+	output := buf.String()
+	assert.Contains(t, output, "a")
+	assert.Contains(t, output, "b")
+
+	buf.Reset()
+
+	logger.WithError(assert.AnError).Info("error check")
+	assert.Contains(t, buf.String(), assert.AnError.Error())
+}
+
+// TestExternalContextPropagation stores a logger in a context and retrieves it,
+// the way middleware or request handlers would.
+func TestExternalContextPropagation(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New(log.WithLevel(log.InfoLevel))
+	ctx := log.ContextWithLogger(t.Context(), logger)
+
+	retrieved := log.LoggerFromContext(ctx)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, log.InfoLevel, retrieved.Level())
+
+	assert.Nil(t, log.LoggerFromContext(t.Context()))
+}
+
+// TestExternalFormatterIntegration creates a Formatter from the format
+// subpackage, wires it into a logger, and verifies formatted output.
+func TestExternalFormatterIntegration(t *testing.T) {
+	t.Parallel()
+
+	fmtr := format.NewFormatter(format.NewBareFormatPlaceholders())
+	fmtr.SetDisabledColors(true)
+
+	buf := new(bytes.Buffer)
+	logger := log.New(
+		log.WithLevel(log.InfoLevel),
+		log.WithOutput(buf),
+		log.WithFormatter(fmtr),
+	)
+
+	logger.Info("formatted output")
+	assert.Contains(t, buf.String(), "formatted output")
+}
+
+// TestExternalParseFormatPresets confirms all four named format presets are
+// accessible via ParseFormat.
+func TestExternalParseFormatPresets(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		format.BareFormatName,
+		format.PrettyFormatName,
+		format.JSONFormatName,
+		format.KeyValueFormatName,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			phs, err := format.ParseFormat(name)
+			require.NoError(t, err)
+			assert.NotEmpty(t, phs)
+		})
+	}
+}
+
+// TestExternalCustomFormatParsing parses a user-supplied format string through
+// the placeholders subpackage and formats an entry with it.
+func TestExternalCustomFormatParsing(t *testing.T) {
+	t.Parallel()
+
+	fmtr := format.NewFormatter(nil)
+	fmtr.SetDisabledColors(true)
+
+	require.NoError(t, fmtr.SetCustomFormat("%level %msg"))
+
+	buf := new(bytes.Buffer)
+	logger := log.New(
+		log.WithLevel(log.InfoLevel),
+		log.WithOutput(buf),
+		log.WithFormatter(fmtr),
+	)
+
+	logger.Info("custom format test")
+
+	output := buf.String()
+	assert.Contains(t, output, "info")
+	assert.Contains(t, output, "custom format test")
+}
+
+// TestExternalPlaceholderRegistry ensures the placeholder register and its
+// Parse function are accessible to external callers.
+func TestExternalPlaceholderRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := placeholders.NewPlaceholderRegister()
+	assert.NotNil(t, reg.Get("level"))
+	assert.NotNil(t, reg.Get("msg"))
+	assert.NotNil(t, reg.Get("time"))
+	assert.NotNil(t, reg.Get("interval"))
+	assert.Nil(t, reg.Get("nonexistent"))
+
+	phs, err := placeholders.Parse("%level %msg")
+	require.NoError(t, err)
+	assert.NotEmpty(t, phs)
+}
+
+// TestExternalWriterAdapter verifies that the writer subpackage can be used to
+// bridge an io.Writer into the logging system.
+func TestExternalWriterAdapter(t *testing.T) {
+	t.Parallel()
+
+	buf := new(bytes.Buffer)
+	logger := log.New(log.WithLevel(log.InfoLevel), log.WithOutput(buf))
+
+	w := writer.New(
+		writer.WithLogger(logger),
+		writer.WithDefaultLevel(log.InfoLevel),
+		writer.WithMsgSeparator("\n"),
+	)
+
+	n, err := w.Write([]byte("line1\nline2"))
+	require.NoError(t, err)
+	assert.Len(t, "line1\nline2", n)
+	assert.Contains(t, buf.String(), "line1")
+	assert.Contains(t, buf.String(), "line2")
+}
+
+// TestExternalWriterParseFunc confirms that a custom parse function can be
+// supplied to the writer adapter.
+func TestExternalWriterParseFunc(t *testing.T) {
+	t.Parallel()
+
+	buf := new(bytes.Buffer)
+	logger := log.New(log.WithLevel(log.TraceLevel), log.WithOutput(buf))
+	warnLevel := log.WarnLevel
+
+	w := writer.New(
+		writer.WithLogger(logger),
+		writer.WithParseFunc(func(str string) (string, *time.Time, *log.Level, error) {
+			return "wrapped: " + str, nil, &warnLevel, nil
+		}),
+	)
+
+	_, err := w.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "wrapped: hello")
+}
+
+// TestExternalANSIUtilities exercises the ANSI helper functions that external
+// consumers might use when processing coloured log output.
+func TestExternalANSIUtilities(t *testing.T) {
+	t.Parallel()
+
+	coloured := "\033[31mred text\033[0m"
+	assert.Equal(t, "red text", log.RemoveAllASCISeq(coloured))
+
+	partial := "\033[32mgreen"
+	assert.Contains(t, log.ResetASCISeq(partial), "\033[0m")
+
+	assert.Equal(t, "plain", log.RemoveAllASCISeq("plain"))
+	assert.Equal(t, "plain", log.ResetASCISeq("plain"))
+}
+
+// TestExternalPackageLevelFunctions confirms the package-level convenience
+// functions work without creating an explicit logger.
+func TestExternalPackageLevelFunctions(t *testing.T) {
+	t.Parallel()
+
+	logger := log.Default()
+	require.NotNil(t, logger)
+
+	// WithOptions returns a new logger without mutating the default.
+	custom := log.WithOptions(log.WithLevel(log.TraceLevel))
+	assert.Equal(t, log.TraceLevel, custom.Level())
+
+	// WithField / WithFields / WithError return enriched loggers.
+	assert.NotNil(t, log.WithField("k", "v"))
+	assert.NotNil(t, log.WithFields(log.Fields{"a": 1}))
+	assert.NotNil(t, log.WithError(assert.AnError))
+}
+
+// TestExternalForceLogLevelHook verifies that the force-level hook can be
+// created and wired in via WithHooks.
+func TestExternalForceLogLevelHook(t *testing.T) {
+	t.Parallel()
+
+	hook := log.NewForceLogLevelHook(log.WarnLevel)
+	assert.Len(t, hook.Levels(), 7)
+
+	buf := new(bytes.Buffer)
+
+	// The hook can be attached through the public WithHooks option.
+	logger := log.New(
+		log.WithLevel(log.TraceLevel),
+		log.WithOutput(buf),
+		log.WithHooks(hook),
+	)
+
+	logger.Info("hooked message")
+	// The message should still appear (hook changes level, dropper formatter
+	// controls visibility based on logger level which is Trace — most permissive).
+	assert.Contains(t, buf.String(), "hooked message")
+}
+
+// TestExternalConstants ensures exported constants from the package are
+// accessible.
+func TestExternalConstants(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, ".", log.CurDir)
+	assert.NotEmpty(t, log.CurDirWithSeparator)
+
+	assert.Equal(t, "bare", format.BareFormatName)
+	assert.Equal(t, "pretty", format.PrettyFormatName)
+	assert.Equal(t, "json", format.JSONFormatName)
+	assert.Equal(t, "key-value", format.KeyValueFormatName)
+
+	assert.Equal(t, "prefix", placeholders.WorkDirKeyName)
+	assert.Equal(t, "tf-path", placeholders.TFPathKeyName)
+	assert.Equal(t, "tf-command-args", placeholders.TFCmdArgsKeyName)
+	assert.Equal(t, "tf-command", placeholders.TFCmdKeyName)
+}

--- a/pkg/log/force_level_hook_test.go
+++ b/pkg/log/force_level_hook_test.go
@@ -1,0 +1,94 @@
+package log_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForceLogLevelHookLevels(t *testing.T) {
+	t.Parallel()
+
+	hook := log.NewForceLogLevelHook(log.WarnLevel)
+	levels := hook.Levels()
+	assert.Len(t, levels, 7)
+}
+
+func TestForceLogLevelHookFire(t *testing.T) {
+	t.Parallel()
+
+	hook := log.NewForceLogLevelHook(log.WarnLevel)
+	logger := logrus.New()
+	logger.SetLevel(logrus.TraceLevel)
+
+	entry := logrus.NewEntry(logger)
+	entry.Level = logrus.InfoLevel
+
+	err := hook.Fire(entry)
+	require.NoError(t, err)
+
+	// Entry level should be changed to the forced level (WarnLevel = 3, + shift 2 = logrus.Level(5))
+	assert.Equal(t, log.WarnLevel.ToLogrusLevel(), entry.Level)
+}
+
+func TestLogEntriesDropperFormatter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		loggerLevel log.Level
+		forcedLevel log.Level
+		expectEmpty bool
+	}{
+		{
+			name:        "entry_at_logger_level_produces_output",
+			loggerLevel: log.InfoLevel,
+			forcedLevel: log.InfoLevel,
+			expectEmpty: false,
+		},
+		{
+			name:        "entry_above_logger_level_produces_output",
+			loggerLevel: log.TraceLevel,
+			forcedLevel: log.InfoLevel,
+			expectEmpty: false,
+		},
+		{
+			name:        "entry_below_logger_level_produces_empty",
+			loggerLevel: log.ErrorLevel,
+			forcedLevel: log.InfoLevel,
+			expectEmpty: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := logrus.New()
+			logger.SetLevel(tc.loggerLevel.ToLogrusLevel())
+
+			hook := log.NewForceLogLevelHook(tc.forcedLevel)
+
+			entry := logrus.NewEntry(logger)
+			entry.Level = logrus.InfoLevel
+			entry.Message = "test message"
+
+			err := hook.Fire(entry)
+			require.NoError(t, err)
+
+			// After Fire, the logger's formatter is a LogEntriesDropperFormatter.
+			// The dropper checks entry.Logger.Level >= entry.Level.
+			output, err := logger.Formatter.Format(entry)
+			require.NoError(t, err)
+
+			if tc.expectEmpty {
+				assert.Empty(t, string(output))
+			} else {
+				assert.NotEmpty(t, string(output))
+			}
+		})
+	}
+}

--- a/pkg/log/format/format_test.go
+++ b/pkg/log/format/format_test.go
@@ -1,0 +1,239 @@
+package format_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format/options"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		expectErr bool
+	}{
+		{name: "bare", input: "bare"},
+		{name: "pretty", input: "pretty"},
+		{name: "json", input: "json"},
+		{name: "key-value", input: "key-value"},
+		{name: "nonexistent", input: "nonexistent", expectErr: true},
+		{name: "empty", input: "", expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			phs, err := format.ParseFormat(tc.input)
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.Nil(t, phs)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, phs)
+				assert.NotEmpty(t, phs)
+			}
+		})
+	}
+}
+
+func TestFormatterFormat(t *testing.T) {
+	t.Parallel()
+
+	phs := format.NewBareFormatPlaceholders()
+	fmtr := format.NewFormatter(phs)
+	fmtr.SetDisabledColors(true)
+
+	logrusLogger := logrus.New()
+	logrusEntry := logrus.NewEntry(logrusLogger)
+	logrusEntry.Level = log.InfoLevel.ToLogrusLevel()
+	logrusEntry.Message = "hello formatter"
+
+	entry := &log.Entry{
+		Entry: logrusEntry,
+		Level: log.InfoLevel,
+	}
+
+	output, err := fmtr.Format(entry)
+	require.NoError(t, err)
+	assert.NotEmpty(t, output)
+	assert.Contains(t, string(output), "hello formatter")
+}
+
+func TestFormatterDisabledOutput(t *testing.T) {
+	t.Parallel()
+
+	phs := format.NewBareFormatPlaceholders()
+	fmtr := format.NewFormatter(phs)
+	fmtr.SetDisabledOutput(true)
+
+	logrusLogger := logrus.New()
+	logrusEntry := logrus.NewEntry(logrusLogger)
+	logrusEntry.Level = log.InfoLevel.ToLogrusLevel()
+	logrusEntry.Message = "should not appear"
+
+	entry := &log.Entry{
+		Entry: logrusEntry,
+		Level: log.InfoLevel,
+	}
+
+	output, err := fmtr.Format(entry)
+	require.NoError(t, err)
+	assert.Nil(t, output)
+}
+
+func TestFormatterSetFormat(t *testing.T) {
+	t.Parallel()
+
+	fmtr := format.NewFormatter(nil)
+
+	err := fmtr.SetFormat("bare")
+	require.NoError(t, err)
+
+	logrusLogger := logrus.New()
+	logrusEntry := logrus.NewEntry(logrusLogger)
+	logrusEntry.Level = log.InfoLevel.ToLogrusLevel()
+	logrusEntry.Message = "bare format"
+
+	entry := &log.Entry{
+		Entry: logrusEntry,
+		Level: log.InfoLevel,
+	}
+
+	output, err := fmtr.Format(entry)
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "bare format")
+}
+
+func TestFormatterSetCustomFormat(t *testing.T) {
+	t.Parallel()
+
+	fmtr := format.NewFormatter(nil)
+	fmtr.SetDisabledColors(true)
+
+	err := fmtr.SetCustomFormat("%level %msg")
+	require.NoError(t, err)
+
+	logrusLogger := logrus.New()
+	logrusEntry := logrus.NewEntry(logrusLogger)
+	logrusEntry.Level = log.InfoLevel.ToLogrusLevel()
+	logrusEntry.Message = "custom msg"
+
+	entry := &log.Entry{
+		Entry:  logrusEntry,
+		Level:  log.InfoLevel,
+		Fields: log.Fields{},
+	}
+
+	output, err := fmtr.Format(entry)
+	require.NoError(t, err)
+
+	outputStr := string(output)
+	assert.Contains(t, outputStr, "info")
+	assert.Contains(t, outputStr, "custom msg")
+}
+
+func TestFormatterNilPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	fmtr := format.NewFormatter(nil)
+
+	logrusLogger := logrus.New()
+	logrusEntry := logrus.NewEntry(logrusLogger)
+	logrusEntry.Level = log.InfoLevel.ToLogrusLevel()
+	logrusEntry.Message = "nil placeholders"
+
+	entry := &log.Entry{
+		Entry: logrusEntry,
+		Level: log.InfoLevel,
+	}
+
+	output, err := fmtr.Format(entry)
+	require.NoError(t, err)
+	assert.Nil(t, output)
+}
+
+func TestPlaceholderFormatsAccessible(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bare_format", func(t *testing.T) {
+		t.Parallel()
+
+		phs := format.NewBareFormatPlaceholders()
+		assert.NotEmpty(t, phs)
+
+		// Format should work with minimal data
+		logrusLogger := logrus.New()
+		logrusEntry := logrus.NewEntry(logrusLogger)
+		logrusEntry.Level = log.InfoLevel.ToLogrusLevel()
+		logrusEntry.Message = "test"
+
+		data := &options.Data{
+			Entry: &log.Entry{
+				Entry: logrusEntry,
+				Level: log.InfoLevel,
+			},
+		}
+
+		result, err := phs.Format(data)
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+	})
+
+	t.Run("pretty_format", func(t *testing.T) {
+		t.Parallel()
+
+		phs := format.NewPrettyFormatPlaceholders()
+		assert.NotEmpty(t, phs)
+	})
+
+	t.Run("json_format", func(t *testing.T) {
+		t.Parallel()
+
+		phs := format.NewJSONFormatPlaceholders()
+		assert.NotEmpty(t, phs)
+	})
+
+	t.Run("key_value_format", func(t *testing.T) {
+		t.Parallel()
+
+		phs := format.NewKeyValueFormatPlaceholders()
+		assert.NotEmpty(t, phs)
+	})
+}
+
+func TestFormatterSetFormatInvalid(t *testing.T) {
+	t.Parallel()
+
+	fmtr := format.NewFormatter(nil)
+	err := fmtr.SetFormat("nonexistent")
+	assert.Error(t, err)
+}
+
+func TestFormatterSetCustomFormatInvalid(t *testing.T) {
+	t.Parallel()
+
+	fmtr := format.NewFormatter(nil)
+	err := fmtr.SetCustomFormat("%banana")
+	assert.Error(t, err)
+}
+
+func TestFormatterPlaceholderRegisterNames(t *testing.T) {
+	t.Parallel()
+
+	phs := placeholders.NewPlaceholderRegister()
+	names := phs.Names()
+	assert.NotEmpty(t, names)
+	assert.Contains(t, names, "level")
+	assert.Contains(t, names, "msg")
+	assert.Contains(t, names, "time")
+	assert.Contains(t, names, "interval")
+}

--- a/pkg/log/format/placeholders/placeholder_test.go
+++ b/pkg/log/format/placeholders/placeholder_test.go
@@ -1,0 +1,294 @@
+package placeholders_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format/options"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        string
+		expectOutput string // if non-empty, format and check output contains this
+		expectCount  int    // expected number of placeholders, -1 to skip
+		expectErr    bool
+	}{
+		{
+			name:        "single_level",
+			input:       "%level",
+			expectCount: 1,
+		},
+		{
+			name:        "single_msg",
+			input:       "%msg",
+			expectCount: 1,
+		},
+		{
+			name:        "single_time",
+			input:       "%time",
+			expectCount: 1,
+		},
+		{
+			name:        "single_interval",
+			input:       "%interval",
+			expectCount: 1,
+		},
+		{
+			name:         "plaintext_only",
+			input:        "just plain text",
+			expectCount:  1,
+			expectOutput: "just plain text",
+		},
+		{
+			name:        "mixed_text_and_placeholder",
+			input:       "level=%level msg=%msg",
+			expectCount: 4, // "level=" + level + " msg=" + msg
+		},
+		{
+			name:        "with_options",
+			input:       "%level(format=short)",
+			expectCount: 1,
+		},
+		{
+			name:         "escaped_percent",
+			input:        "100%%",
+			expectCount:  2, // "100" + "%" (from %%)
+			expectOutput: "100%",
+		},
+		{
+			name:         "tab",
+			input:        "%t",
+			expectCount:  1,
+			expectOutput: "\t",
+		},
+		{
+			name:         "newline",
+			input:        "%n",
+			expectCount:  1,
+			expectOutput: "\n",
+		},
+		{
+			name:        "field_prefix",
+			input:       "%prefix",
+			expectCount: 1,
+		},
+		{
+			name:        "field_tf_path",
+			input:       "%tf-path",
+			expectCount: 1,
+		},
+		{
+			name:        "field_tf_command_args",
+			input:       "%tf-command-args",
+			expectCount: 1,
+		},
+		{
+			name:      "invalid_name_banana",
+			input:     "%banana",
+			expectErr: true,
+		},
+		{
+			name:        "complex_multi_placeholder",
+			input:       "%level %msg [%interval]",
+			expectCount: 6, // level + " " + msg + " [" + interval + "]"
+		},
+		{
+			name:         "empty_string",
+			input:        "",
+			expectCount:  0,
+			expectOutput: "",
+		},
+		{
+			name:        "unnamed_placeholder",
+			input:       "%(content='hello')",
+			expectCount: 1,
+		},
+		{
+			name:        "duplicate_placeholders_different_options",
+			input:       "%level(format=full) %level(format=short)",
+			expectCount: 3, // level(full) + " " + level(short)
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			phs, err := placeholders.Parse(tc.input)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.expectCount >= 0 {
+				assert.Len(t, phs, tc.expectCount)
+			}
+
+			if tc.expectOutput != "" {
+				data := newMinimalData("test", log.InfoLevel)
+				output, err := phs.Format(data)
+				require.NoError(t, err)
+				assert.Contains(t, output, tc.expectOutput)
+			}
+		})
+	}
+}
+
+func TestPlaceholderRegisterNames(t *testing.T) {
+	t.Parallel()
+
+	phs := placeholders.NewPlaceholderRegister()
+	names := phs.Names()
+	assert.NotEmpty(t, names)
+
+	expectedNames := []string{"interval", "time", "level", "msg"}
+	for _, name := range expectedNames {
+		assert.Contains(t, names, name)
+	}
+}
+
+func TestPlaceholdersGet(t *testing.T) {
+	t.Parallel()
+
+	phs := placeholders.NewPlaceholderRegister()
+
+	t.Run("existing_level", func(t *testing.T) {
+		t.Parallel()
+
+		ph := phs.Get("level")
+		assert.NotNil(t, ph)
+		assert.Equal(t, "level", ph.Name())
+	})
+
+	t.Run("existing_msg", func(t *testing.T) {
+		t.Parallel()
+
+		ph := phs.Get("msg")
+		assert.NotNil(t, ph)
+	})
+
+	t.Run("nonexistent", func(t *testing.T) {
+		t.Parallel()
+
+		ph := phs.Get("nonexistent")
+		assert.Nil(t, ph)
+	})
+}
+
+func TestPlaceholdersFormat(t *testing.T) {
+	t.Parallel()
+
+	phs := placeholders.Placeholders{
+		placeholders.PlainText("hello"),
+		placeholders.PlainText(" world"),
+	}
+
+	data := newMinimalData("", log.InfoLevel)
+	output, err := phs.Format(data)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", output)
+}
+
+func TestLevelPlaceholderFormats(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		format   string
+		contains string
+		level    log.Level
+	}{
+		{name: "full_info", format: "%level", contains: "info", level: log.InfoLevel},
+		{name: "full_error", format: "%level", contains: "error", level: log.ErrorLevel},
+		{name: "short_info", format: "%level(format=short)", contains: "inf", level: log.InfoLevel},
+		{name: "tiny_info", format: "%level(format=tiny)", contains: "i", level: log.InfoLevel},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			phs, err := placeholders.Parse(tc.format)
+			require.NoError(t, err)
+
+			data := newMinimalData("msg", tc.level)
+			output, err := phs.Format(data)
+			require.NoError(t, err)
+			assert.Contains(t, output, tc.contains)
+		})
+	}
+}
+
+func TestMessagePlaceholder(t *testing.T) {
+	t.Parallel()
+
+	phs, err := placeholders.Parse("%msg")
+	require.NoError(t, err)
+
+	data := newMinimalData("hello world", log.InfoLevel)
+	output, err := phs.Format(data)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", output)
+}
+
+func FuzzParse(f *testing.F) {
+	seeds := []string{
+		"%level", "%msg", "%time", "%interval",
+		"%level(format=short)", "%level(format=tiny)",
+		"plain text", "%level %msg",
+		"%%", "%t", "%n",
+		"%(content='hello')",
+		"%prefix", "%tf-path", "%tf-command-args",
+		"", "%", "%()", "%(content='unclosed",
+		"%banana",
+		"%level(format=full) some-text %level(format=tiny)",
+	}
+
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		phs, err := placeholders.Parse(input)
+		if err != nil {
+			return
+		}
+
+		// If parsing succeeded, formatting should not panic
+		data := &options.Data{
+			Entry: &log.Entry{
+				Entry: logrus.NewEntry(logrus.New()),
+				Level: log.InfoLevel,
+			},
+			DisabledColors: true,
+		}
+
+		_, _ = phs.Format(data)
+	})
+}
+
+func newMinimalData(msg string, level log.Level) *options.Data {
+	logrusLogger := logrus.New()
+	logrusEntry := logrus.NewEntry(logrusLogger)
+	logrusEntry.Level = level.ToLogrusLevel()
+	logrusEntry.Message = msg
+
+	return &options.Data{
+		Entry: &log.Entry{
+			Entry:  logrusEntry,
+			Level:  level,
+			Fields: log.Fields{},
+		},
+		DisabledColors: true,
+	}
+}

--- a/pkg/log/level_test.go
+++ b/pkg/log/level_test.go
@@ -1,0 +1,283 @@
+package log_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		expected  log.Level
+		expectErr bool
+	}{
+		{name: "stderr", input: "stderr", expected: log.StderrLevel},
+		{name: "stdout", input: "stdout", expected: log.StdoutLevel},
+		{name: "error", input: "error", expected: log.ErrorLevel},
+		{name: "warn", input: "warn", expected: log.WarnLevel},
+		{name: "info", input: "info", expected: log.InfoLevel},
+		{name: "debug", input: "debug", expected: log.DebugLevel},
+		{name: "trace", input: "trace", expected: log.TraceLevel},
+		{name: "upper_INFO", input: "INFO", expected: log.InfoLevel},
+		{name: "mixed_Debug", input: "Debug", expected: log.DebugLevel},
+		{name: "upper_WARN", input: "WARN", expected: log.WarnLevel},
+		{name: "upper_ERROR", input: "ERROR", expected: log.ErrorLevel},
+		{name: "upper_TRACE", input: "TRACE", expected: log.TraceLevel},
+		{name: "empty", input: "", expectErr: true},
+		{name: "invalid_banana", input: "banana", expectErr: true},
+		{name: "invalid_inf", input: "inf", expectErr: true},
+		{name: "padded_info", input: " info ", expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			level, err := log.ParseLevel(tc.input)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, level)
+			}
+		})
+	}
+}
+
+func TestLevelString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		expected string
+		level    log.Level
+	}{
+		{expected: "stderr", level: log.StderrLevel},
+		{expected: "stdout", level: log.StdoutLevel},
+		{expected: "error", level: log.ErrorLevel},
+		{expected: "warn", level: log.WarnLevel},
+		{expected: "info", level: log.InfoLevel},
+		{expected: "debug", level: log.DebugLevel},
+		{expected: "trace", level: log.TraceLevel},
+		{expected: "", level: log.Level(99)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.expected, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, tc.level.String())
+		})
+	}
+}
+
+func TestLevelShortName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		expected string
+		level    log.Level
+	}{
+		{expected: "std", level: log.StderrLevel},
+		{expected: "std", level: log.StdoutLevel},
+		{expected: "err", level: log.ErrorLevel},
+		{expected: "wrn", level: log.WarnLevel},
+		{expected: "inf", level: log.InfoLevel},
+		{expected: "deb", level: log.DebugLevel},
+		{expected: "trc", level: log.TraceLevel},
+		{expected: "", level: log.Level(99)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.expected, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, tc.level.ShortName())
+		})
+	}
+}
+
+func TestLevelTinyName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		expected string
+		level    log.Level
+	}{
+		{expected: "s", level: log.StderrLevel},
+		{expected: "s", level: log.StdoutLevel},
+		{expected: "e", level: log.ErrorLevel},
+		{expected: "w", level: log.WarnLevel},
+		{expected: "i", level: log.InfoLevel},
+		{expected: "d", level: log.DebugLevel},
+		{expected: "t", level: log.TraceLevel},
+		{expected: "", level: log.Level(99)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.expected, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, tc.level.TinyName())
+		})
+	}
+}
+
+func TestMarshalUnmarshalRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, level := range log.AllLevels {
+		t.Run(level.String(), func(t *testing.T) {
+			t.Parallel()
+
+			data, err := level.MarshalText()
+			require.NoError(t, err)
+			assert.NotEmpty(t, data)
+
+			var unmarshaled log.Level
+
+			err = unmarshaled.UnmarshalText(data)
+			require.NoError(t, err)
+			assert.Equal(t, level, unmarshaled)
+		})
+	}
+
+	t.Run("marshal_unknown_level", func(t *testing.T) {
+		t.Parallel()
+
+		unknown := log.Level(99)
+		_, err := unknown.MarshalText()
+		assert.Error(t, err)
+	})
+
+	t.Run("unmarshal_invalid_text", func(t *testing.T) {
+		t.Parallel()
+
+		var level log.Level
+
+		err := level.UnmarshalText([]byte("banana"))
+		assert.Error(t, err)
+	})
+}
+
+func TestToLogrusLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		level         log.Level
+		expectedShift uint32
+	}{
+		{level: log.StderrLevel, expectedShift: 2},
+		{level: log.StdoutLevel, expectedShift: 3},
+		{level: log.ErrorLevel, expectedShift: 4},
+		{level: log.WarnLevel, expectedShift: 5},
+		{level: log.InfoLevel, expectedShift: 6},
+		{level: log.DebugLevel, expectedShift: 7},
+		{level: log.TraceLevel, expectedShift: 8},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.level.String(), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, logrus.Level(tc.expectedShift), tc.level.ToLogrusLevel())
+		})
+	}
+
+	t.Run("unknown_level", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, logrus.Level(0), log.Level(99).ToLogrusLevel())
+	})
+}
+
+func TestFromLogrusLevel(t *testing.T) {
+	t.Parallel()
+
+	for _, level := range log.AllLevels {
+		t.Run(level.String(), func(t *testing.T) {
+			t.Parallel()
+
+			logrusLevel := level.ToLogrusLevel()
+			roundTripped := log.FromLogrusLevel(logrusLevel)
+			assert.Equal(t, level, roundTripped)
+		})
+	}
+
+	t.Run("unknown_logrus_level", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, log.Level(0), log.FromLogrusLevel(logrus.Level(99)))
+	})
+}
+
+func TestLevelsContains(t *testing.T) {
+	t.Parallel()
+
+	t.Run("contains_known_level", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, log.AllLevels.Contains(log.InfoLevel))
+	})
+
+	t.Run("does_not_contain_unknown_level", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, log.AllLevels.Contains(log.Level(99)))
+	})
+}
+
+func TestLevelsNames(t *testing.T) {
+	t.Parallel()
+
+	names := log.AllLevels.Names()
+	assert.Len(t, names, 7)
+
+	for _, name := range names {
+		assert.NotEmpty(t, name)
+	}
+}
+
+func TestLevelsString(t *testing.T) {
+	t.Parallel()
+
+	str := log.AllLevels.String()
+	assert.Contains(t, str, ",")
+
+	for _, level := range log.AllLevels {
+		assert.Contains(t, str, level.String())
+	}
+}
+
+func TestLevelsToLogrusLevels(t *testing.T) {
+	t.Parallel()
+
+	logrusLevels := log.AllLevels.ToLogrusLevels()
+	assert.Len(t, logrusLevels, 7)
+
+	for i, logrusLevel := range logrusLevels {
+		// Each level should be shifted by 2 from its index
+		assert.Equal(t, logrus.Level(uint32(i)+2), logrusLevel)
+	}
+}
+
+func FuzzParseLevel(f *testing.F) {
+	// Seed with valid names, mixed case, and garbage
+	seeds := []string{
+		"stderr", "stdout", "error", "warn", "info", "debug", "trace",
+		"INFO", "Debug", "WARN", "ERROR", "TRACE",
+		"", "banana", "inf", " info ", "12345",
+	}
+
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		level, err := log.ParseLevel(input)
+		if err == nil {
+			// Valid level: round-trip must produce the same level
+			reparsed, err := log.ParseLevel(level.String())
+			require.NoError(t, err)
+			assert.Equal(t, level, reparsed)
+		}
+	})
+}

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -1,0 +1,156 @@
+package log_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New()
+	assert.NotNil(t, logger)
+}
+
+func TestLoggerLevelFiltering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		loggerLevel log.Level
+		msgLevel    log.Level
+		expectEmpty bool
+	}{
+		{name: "info_at_info_visible", loggerLevel: log.InfoLevel, msgLevel: log.InfoLevel},
+		{name: "debug_at_info_hidden", loggerLevel: log.InfoLevel, msgLevel: log.DebugLevel, expectEmpty: true},
+		{name: "error_at_info_visible", loggerLevel: log.InfoLevel, msgLevel: log.ErrorLevel},
+		{name: "trace_at_trace_visible", loggerLevel: log.TraceLevel, msgLevel: log.TraceLevel},
+		{name: "warn_at_error_hidden", loggerLevel: log.ErrorLevel, msgLevel: log.WarnLevel, expectEmpty: true},
+		{name: "stderr_at_info_visible", loggerLevel: log.InfoLevel, msgLevel: log.StderrLevel},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger, buf := newTestLogger(tc.loggerLevel)
+			logger.Log(tc.msgLevel, "test message")
+
+			if tc.expectEmpty {
+				assert.Empty(t, buf.String())
+			} else {
+				assert.Contains(t, buf.String(), "test message")
+			}
+		})
+	}
+}
+
+func TestLoggerClone(t *testing.T) {
+	t.Parallel()
+
+	original := log.New(log.WithLevel(log.InfoLevel))
+	clone := original.Clone()
+
+	assert.NotNil(t, clone)
+	assert.Equal(t, log.InfoLevel, clone.Level())
+
+	// Clone preserves output independence: writing to clone doesn't affect a separate buffer
+	buf := new(bytes.Buffer)
+	cloneWithBuf := clone.WithOptions(log.WithLevel(log.DebugLevel), log.WithOutput(buf))
+	cloneWithBuf.Debug("clone message")
+	assert.Contains(t, buf.String(), "clone message")
+}
+
+func TestLoggerWithOptions(t *testing.T) {
+	t.Parallel()
+
+	original := log.New(log.WithLevel(log.InfoLevel))
+	modified := original.WithOptions(log.WithLevel(log.DebugLevel))
+
+	assert.NotNil(t, modified)
+	assert.Equal(t, log.DebugLevel, modified.Level())
+}
+
+func TestLoggerSetLevel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid_level", func(t *testing.T) {
+		t.Parallel()
+
+		logger := log.New(log.WithLevel(log.InfoLevel))
+		err := logger.SetLevel("debug")
+		require.NoError(t, err)
+		assert.Equal(t, log.DebugLevel, logger.Level())
+	})
+
+	t.Run("invalid_level", func(t *testing.T) {
+		t.Parallel()
+
+		logger := log.New(log.WithLevel(log.InfoLevel))
+		err := logger.SetLevel("banana")
+		require.Error(t, err)
+		assert.Equal(t, log.InfoLevel, logger.Level())
+	})
+}
+
+func TestLoggerWithField(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newTestLogger(log.InfoLevel)
+	loggerWithField := logger.WithField("key", "value")
+	loggerWithField.Info("field test")
+
+	output := buf.String()
+	assert.Contains(t, output, "field test")
+	assert.Contains(t, output, "key")
+}
+
+func TestLoggerWithFields(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newTestLogger(log.InfoLevel)
+	loggerWithFields := logger.WithFields(log.Fields{"k1": "v1", "k2": "v2"})
+	loggerWithFields.Info("fields test")
+
+	output := buf.String()
+	assert.Contains(t, output, "fields test")
+	assert.Contains(t, output, "k1")
+	assert.Contains(t, output, "k2")
+}
+
+func TestLoggerWithError(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newTestLogger(log.InfoLevel)
+	loggerWithErr := logger.WithError(errors.New("test error"))
+	loggerWithErr.Info("error test")
+
+	output := buf.String()
+	assert.Contains(t, output, "error test")
+	assert.Contains(t, output, "test error")
+}
+
+func TestLoggerFormattedOutput(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newTestLogger(log.InfoLevel)
+	logger.Infof("hello %s", "world")
+
+	assert.Contains(t, buf.String(), "hello world")
+}
+
+// newTestLogger creates a logger that writes to a buffer using the default logrus text formatter.
+func newTestLogger(level log.Level) (log.Logger, *bytes.Buffer) {
+	buf := new(bytes.Buffer)
+	logger := log.New(
+		log.WithLevel(level),
+		log.WithOutput(buf),
+	)
+
+	return logger, buf
+}

--- a/pkg/log/util_test.go
+++ b/pkg/log/util_test.go
@@ -1,0 +1,127 @@
+package log_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveAllASCISeq(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no_ansi",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "single_color_code",
+			input:    "\033[31mhello\033[0m",
+			expected: "hello",
+		},
+		{
+			name:     "bold",
+			input:    "\033[1mbold text\033[0m",
+			expected: "bold text",
+		},
+		{
+			name:     "multiple_sequences",
+			input:    "\033[31mred\033[0m and \033[32mgreen\033[0m",
+			expected: "red and green",
+		},
+		{
+			name:     "empty_string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "embedded_mid_string",
+			input:    "before\033[33mmiddle\033[0mafter",
+			expected: "beforemiddleafter",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, log.RemoveAllASCISeq(tc.input))
+		})
+	}
+}
+
+func TestResetASCISeq(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no_ansi_unchanged",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "with_ansi_appends_reset",
+			input:    "\033[31mhello",
+			expected: "\033[31mhello\033[0m",
+		},
+		{
+			name:     "empty_unchanged",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "already_has_reset",
+			input:    "\033[31mhello\033[0m",
+			expected: "\033[31mhello\033[0m\033[0m",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, log.ResetASCISeq(tc.input))
+		})
+	}
+}
+
+func FuzzRemoveAllASCISeq(f *testing.F) {
+	f.Add("")
+	f.Add("hello")
+	f.Add("\033[31mred\033[0m")
+	f.Add("\033[1;32mbold green\033[0m")
+	f.Add("\033[") // bare/incomplete sequence
+
+	f.Fuzz(func(t *testing.T, input string) {
+		// Must never panic
+		result := log.RemoveAllASCISeq(input)
+		// If input had no ANSI start sequence, output equals input
+		if !strings.Contains(input, "\033[") {
+			assert.Equal(t, input, result)
+		}
+	})
+}
+
+func FuzzResetASCISeq(f *testing.F) {
+	f.Add("")
+	f.Add("hello")
+	f.Add("\033[31mred")
+	f.Add("\033[1;32mbold green\033[0m")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		result := log.ResetASCISeq(input)
+		// If input contained ANSI escape, output must end with reset sequence
+		if strings.Contains(input, "\033[") {
+			assert.True(t, strings.HasSuffix(result, "\033[0m"), "output with ANSI sequences should end with reset")
+		}
+	})
+}

--- a/pkg/log/writer/writer_test.go
+++ b/pkg/log/writer/writer_test.go
@@ -1,0 +1,101 @@
+package writer_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/pkg/log/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriterWrite(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newTestLogger(log.InfoLevel)
+	w := writer.New(
+		writer.WithLogger(logger),
+	)
+
+	n, err := w.Write([]byte("hello writer"))
+	require.NoError(t, err)
+	assert.Len(t, "hello writer", n)
+	assert.Contains(t, buf.String(), "hello writer")
+}
+
+func TestWriterWithMsgSeparator(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newTestLogger(log.InfoLevel)
+	w := writer.New(
+		writer.WithLogger(logger),
+		writer.WithMsgSeparator("\n"),
+	)
+
+	_, err := w.Write([]byte("line1\nline2\nline3"))
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "line1")
+	assert.Contains(t, output, "line2")
+	assert.Contains(t, output, "line3")
+}
+
+func TestWriterWithDefaultLevel(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newTestLogger(log.TraceLevel)
+	w := writer.New(
+		writer.WithLogger(logger),
+		writer.WithDefaultLevel(log.DebugLevel),
+	)
+
+	_, err := w.Write([]byte("debug message"))
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "debug message")
+}
+
+func TestWriterWithParseFunc(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newTestLogger(log.TraceLevel)
+	warnLevel := log.WarnLevel
+
+	w := writer.New(
+		writer.WithLogger(logger),
+		writer.WithParseFunc(func(str string) (string, *time.Time, *log.Level, error) {
+			return "parsed: " + str, nil, &warnLevel, nil
+		}),
+	)
+
+	_, err := w.Write([]byte("raw message"))
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "parsed: raw message")
+}
+
+func TestWriterEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newTestLogger(log.InfoLevel)
+	w := writer.New(
+		writer.WithLogger(logger),
+		writer.WithMsgSeparator("\n"),
+	)
+
+	n, err := w.Write([]byte(""))
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+	assert.Empty(t, buf.String())
+}
+
+func newTestLogger(level log.Level) (log.Logger, *bytes.Buffer) {
+	buf := new(bytes.Buffer)
+	logger := log.New(
+		log.WithLevel(level),
+		log.WithOutput(buf),
+	)
+
+	return logger, buf
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds some testing for the `pkg/logs` package.

Starts a new convention where we start to add an explicit `external_test.go` file that uses our `pkg` packages exclusively as black box packages the way that external consumers would.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit and integration tests covering logging context, public API usage, forced-level hooks, level parsing/round-trips, format parsing and placeholders, ANSI escape handling, logger behaviors (cloning, fields, errors, formatting), and writer behaviors (separators, default levels, parse functions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->