### PR TITLE
fix: Fixing relative paths in tracked reading files

### DIFF
--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -143,7 +143,12 @@ func handleInclude(ctx context.Context, pctx *ParsingContext, l log.Logger, conf
 			logPrefix           string
 		)
 
-		trackFileRead(pctx.FilesRead, includeConfig.Path)
+		trackedIncludePath := includeConfig.Path
+		if !filepath.IsAbs(trackedIncludePath) {
+			trackedIncludePath = filepath.Clean(filepath.Join(filepath.Dir(pctx.TerragruntConfigPath), trackedIncludePath))
+		}
+
+		trackFileRead(pctx.FilesRead, trackedIncludePath)
 
 		if isPartial {
 			parsedIncludeConfig, err = partialParseIncludedConfig(ctx, pctx, l, &includeConfig)

--- a/test/integration_filter_test.go
+++ b/test/integration_filter_test.go
@@ -886,6 +886,114 @@ func TestFilterFlagWithFindGitFilter(t *testing.T) {
 	}
 }
 
+func TestFilterFlagWithFindGitFilterRelativeInclude(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner()
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(tmpDir)
+
+	err = runner.Init(t.Context())
+	require.NoError(t, err)
+
+	err = runner.GoOpenRepo()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = runner.GoCloseStorage()
+		if err != nil {
+			t.Logf("Error closing storage: %s", err)
+		}
+	})
+
+	// Create a root.hcl at the repo root that the nested unit will include
+	rootHCLPath := filepath.Join(tmpDir, "root.hcl")
+	err = os.WriteFile(rootHCLPath, []byte(`# Root config
+`), 0644)
+	require.NoError(t, err)
+
+	// Create a deeply nested unit that uses get_path_to_repo_root() in its include path
+	nestedUnitDir := filepath.Join(tmpDir, "level1", "level2", "level3", "nested-unit")
+	err = os.MkdirAll(nestedUnitDir, 0755)
+	require.NoError(t, err)
+
+	nestedUnitHCLPath := filepath.Join(nestedUnitDir, "terragrunt.hcl")
+	err = os.WriteFile(nestedUnitHCLPath, []byte(`include "root" {
+  path = "${get_path_to_repo_root()}/root.hcl"
+}
+`), 0644)
+	require.NoError(t, err)
+
+	// Initial commit on main
+	err = runner.GoAdd(".")
+	require.NoError(t, err)
+
+	err = runner.GoCommit("Initial commit", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	head, err := runner.GoOpenRepoHead()
+	require.NoError(t, err)
+
+	// Ensure the main branch exists
+	b, err := runner.Config(t.Context(), "init.defaultBranch")
+	if err != nil || b != "main" {
+		err = runner.GoCheckout(&gogit.CheckoutOptions{
+			Branch: plumbing.ReferenceName("refs/heads/main"),
+			Create: true,
+			Hash:   head.Hash(),
+		})
+		require.NoError(t, err)
+	}
+
+	// Create a feature branch
+	err = runner.GoCheckout(&gogit.CheckoutOptions{
+		Branch: plumbing.ReferenceName("refs/heads/relative-include-test"),
+		Create: true,
+		Hash:   head.Hash(),
+	})
+	require.NoError(t, err)
+
+	// Modify the nested unit
+	err = os.WriteFile(nestedUnitHCLPath, []byte(`include "root" {
+  path = "${get_path_to_repo_root()}/root.hcl"
+}
+
+# Modified on feature branch
+`), 0644)
+	require.NoError(t, err)
+
+	err = runner.GoAdd(".")
+	require.NoError(t, err)
+
+	err = runner.GoCommit("Modify nested unit", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	helpers.CleanupTerraformFolder(t, tmpDir)
+
+	cmd := "terragrunt find --no-color --working-dir " + tmpDir + " --filter '[main...HEAD]'"
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+
+	require.NoError(t, err, "terragrunt find with git filter failed: %s", stderr)
+
+	results := strings.Split(strings.TrimSpace(stdout), "\n")
+	assert.ElementsMatch(t, []string{"level1/level2/level3/nested-unit"}, results)
+}
+
 func TestFilterFlagWithRunAllGitFilter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5650.

Root cause was that the relative path to the include was being stored as the read file in the internal read file tracker. This ensures that the path is stored as an absolute path.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of relative configuration include paths by ensuring they are resolved to absolute paths during file tracking operations.

* **Tests**
  * Added integration test to verify Git-based filtering correctly identifies deeply nested units that utilize relative configuration includes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->