### PR TITLE
fix: Fixing cosign

### DIFF
--- a/.github/scripts/release/sign-checksums.sh
+++ b/.github/scripts/release/sign-checksums.sh
@@ -44,20 +44,19 @@ function main {
   # GPG signing
   echo "Signing SHA256SUMS with GPG..."
   gpg --batch --yes -u "${GPG_FINGERPRINT}" \
-      --pinentry-mode loopback \
-      --passphrase "${SIGNING_GPG_PASSPHRASE}" \
-      --output SHA256SUMS.gpgsig \
-      --detach-sign SHA256SUMS
+    --pinentry-mode loopback \
+    --passphrase "${SIGNING_GPG_PASSPHRASE}" \
+    --output SHA256SUMS.gpgsig \
+    --detach-sign SHA256SUMS
 
   echo "GPG signature created: SHA256SUMS.gpgsig"
 
   # Cosign signing (keyless OIDC)
   echo "Signing SHA256SUMS with Cosign..."
   cosign sign-blob SHA256SUMS \
-      --oidc-issuer=https://token.actions.githubusercontent.com \
-      --output-certificate=SHA256SUMS.pem \
-      --output-signature=SHA256SUMS.sig \
-      --yes
+    --output-certificate=SHA256SUMS.pem \
+    --output-signature=SHA256SUMS.sig \
+    --yes
 
   echo "Cosign signature created: SHA256SUMS.sig"
   echo "Cosign certificate created: SHA256SUMS.pem"


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Recent bump of the cosign action broke our signing because cosign no longer allows specifying the configuration and URL at the same time. 

```
  Error: cannot specify service URLs and use signing config
  error during command execution: cannot specify service URLs and use signing config
```

This fixes it.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release signing configuration to modify authentication method for checksum signing operations. Minor formatting adjustments applied to signing scripts with no functional impact on outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->