### PR TITLE
docs: Fix 'move' to 'moved' block in documentation

### DIFF
--- a/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/05-step-2-refactoring.mdx
+++ b/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/05-step-2-refactoring.mdx
@@ -152,9 +152,9 @@ And introduced resources at addresses the like the following:
 
 The reason for this is that OpenTofu doesn't really have a way of knowing the difference between moving a file like that for the sake of reorganization and completely removing infrastructure in one place and adding it in another without some help from IaC authors.
 
-The way we communicate to OpenTofu that a resource at one address has simply moved to a new address is to introduce `move` blocks.
+The way we communicate to OpenTofu that a resource at one address has simply moved to a new address is to introduce `moved` blocks.
 
-For each resource that we want to move, we'll want to introduce a `move` block with a `from` of the old address (what OpenTofu reports as being destroyed in our plan) and a `to` of the equivalent new address (what OpenTofu reports as being created in our plan).
+For each resource that we want to move, we'll want to introduce a `moved` block with a `from` of the old address (what OpenTofu reports as being destroyed in our plan) and a `to` of the equivalent new address (what OpenTofu reports as being created in our plan).
 
 import liveMovedTf from '../../../../fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/live/moved.tf?raw';
 


### PR DESCRIPTION
## Description

Fix `move` to `moved` block.

Reference: https://opentofu.org/docs/language/modules/develop/refactoring/#moved-block-syntax

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [xI am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Fix `move` to `moved` block


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guide documentation to use correct terminology for describing resource address changes, improving clarity for users following Terraform and OpenTofu migration procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->