### PR TITLE
Hide switcher in hamburger menu

### DIFF
--- a/docs/src/styles/starlight-search.css
+++ b/docs/src/styles/starlight-search.css
@@ -175,6 +175,11 @@ input.pagefind-ui__search-input:focus {
   color: #448daf;
 }
 
+/* Hide Light/Dark Mode Toggle in Hamburger Menu */
+div.mobile-preferences {
+  display: none;
+}
+
 /* Fix to site-search button area smaller on mobile */
 @media (width <= 768px) {
   body.tg site-search > button {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced mobile user experience by streamlining the hamburger menu. The Light/Dark Mode toggle has been removed from the mobile navigation to provide a cleaner interface while maintaining full functionality on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->