### PR TITLE
fix: Fixes panic in find on files with read_terragrunt_config calls.

### DIFF
--- a/internal/cli/commands/find/find_test.go
+++ b/internal/cli/commands/find/find_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/find"
 	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -533,6 +534,59 @@ locals {
 			tt.validate(t, string(output), tt.expectedPaths)
 		})
 	}
+}
+
+func TestRunWithGraphFilterAndDynamicDependencyConfigPath(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	testDirs := []string{"A"}
+
+	for _, dir := range testDirs {
+		err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755)
+		require.NoError(t, err)
+	}
+
+	testFiles := map[string]string{
+		filepath.Join("A", "terragrunt.hcl"): `
+dependency "target" {
+  config_path = read_terragrunt_config("does-not-exist.hcl").locals.aws_region == "x" ? "../a" : "../b"
+}
+`,
+	}
+
+	for path, content := range testFiles {
+		err := os.WriteFile(filepath.Join(tmpDir, path), []byte(content), 0644)
+		require.NoError(t, err)
+	}
+
+	tgOpts := options.NewTerragruntOptions()
+	tgOpts.WorkingDir = tmpDir
+	tgOpts.RootWorkingDir = tmpDir
+
+	l := logger.CreateLogger()
+	l.Formatter().SetDisabledColors(true)
+
+	filters, err := filter.ParseFilterQueries(l, []string{"...A"})
+	require.NoError(t, err)
+
+	opts := find.NewOptions(tgOpts)
+	opts.Filters = filters
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	opts.Writers.Writer = w
+
+	err = find.Run(t.Context(), l, opts)
+	require.NoError(t, err)
+
+	require.NoError(t, w.Close())
+
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, "A\n", string(output))
 }
 
 func TestColorizer(t *testing.T) {

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -245,6 +245,11 @@ func extractDependencyPaths(cfg *config.TerragruntConfig, c component.Component)
 			continue
 		}
 
+		if !config.IsValidConfigPath(dependency.ConfigPath) {
+			errs = append(errs, errors.New("dependency config path is not a valid known string"))
+			continue
+		}
+
 		depPath := dependency.ConfigPath.AsString()
 		if !filepath.IsAbs(depPath) {
 			depPath = filepath.Clean(filepath.Join(c.Path(), depPath))

--- a/internal/discovery/helpers_test.go
+++ b/internal/discovery/helpers_test.go
@@ -1,0 +1,32 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestExtractDependencyPathsSkipsUnknownDependencyConfigPath(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies that if a dependency config path is not a known string
+	// the function returns an error and does not attempt to resolve the path.
+	cfg := &config.TerragruntConfig{
+		TerragruntDependencies: config.Dependencies{
+			{
+				Name:       "target",
+				ConfigPath: cty.UnknownVal(cty.String),
+			},
+		},
+	}
+
+	component := component.NewUnit("/tmp/live/test")
+
+	depPaths, err := extractDependencyPaths(cfg, component)
+	require.ErrorContains(t, err, "dependency config path is not a valid known string")
+	assert.Empty(t, depPaths)
+}


### PR DESCRIPTION
## Description

Fixes #5726.

This PR fixes a panic in the find commands when it affects units with `read_terragrunt_config` invocations with unknown (during the find command) path.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Fix panic in find command on files with read_terragrunt_config calls with unknown paths.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced validation of dependency configuration paths, including support for dynamic and computed configurations.
  * Improved error handling and reporting for invalid dependency paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->