### PR TITLE
chore: Temporarily skipping rustfs test

### DIFF
--- a/test/integration_rustfs_test.go
+++ b/test/integration_rustfs_test.go
@@ -20,20 +20,9 @@ const (
 	testFixtureOutputFromRemoteStateRustFS = "fixtures/output-from-remote-state-rustfs"
 )
 
-func setupRustFS(t *testing.T) string {
-	t.Helper()
-
-	_, addr := helpers.RunContainer(t, "rustfs/rustfs:latest", 9000,
-		testcontainers.WithCmd("/data"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("Starting:"),
-		),
-	)
-
-	return addr
-}
-
 func TestRustFSOutputFromRemoteState(t *testing.T) { //nolint: paralleltest
+	t.Skip("Skipping until integration in CI is resolved")
+
 	rustfsAddr := setupRustFS(t)
 
 	// RustFS default credentials
@@ -100,4 +89,17 @@ func TestRustFSOutputFromRemoteState(t *testing.T) { //nolint: paralleltest
 	assert.Contains(t, stdout, "app3 output")
 	assert.NotContains(t, stderr, "terraform output -json")
 	assert.NotContains(t, stderr, "tofu output -json")
+}
+
+func setupRustFS(t *testing.T) string {
+	t.Helper()
+
+	_, addr := helpers.RunContainer(t, "rustfs/rustfs:latest", 9000,
+		testcontainers.WithCmd("/data"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("Starting:"),
+		),
+	)
+
+	return addr
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Temporarily disabling rustfs test until it's fixed in CI.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified integration test behavior to skip execution in CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->