### PR TITLE
fix: Discover dependents in worktrees if units are discovered there

### DIFF
--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -214,19 +214,25 @@ func (p *GraphPhase) processGraphTarget(
 		}
 
 		if state.discovery.gitRoot != "" {
-			// Use the discovery's workingDir as the starting point for dependent discovery.
-			// This is important when the target was discovered from a worktree - dependents
-			// exist in the original working directory, not in the worktree.
 			startDir := state.discovery.workingDir
+			boundaryRoot := state.discovery.gitRoot
+
+			if dCtx := c.DiscoveryContext(); dCtx != nil &&
+				dCtx.WorkingDir != "" &&
+				dCtx.WorkingDir != state.discovery.workingDir {
+				startDir = dCtx.WorkingDir
+				boundaryRoot = dCtx.WorkingDir
+			}
+
 			l.Debugf(
-				"Starting upstream dependent discovery from %s to gitRoot %s",
+				"Starting upstream dependent discovery from %s to boundary %s",
 				startDir,
-				state.discovery.gitRoot,
+				boundaryRoot,
 			)
 
 			visitedDirs := newStringSet()
 
-			err := p.discoverDependentsUpstream(ctx, l, state, c, visitedDirs, startDir, depth)
+			err := p.discoverDependentsUpstream(ctx, l, state, c, visitedDirs, startDir, boundaryRoot, depth)
 			if err != nil {
 				return err
 			}
@@ -422,9 +428,10 @@ func (p *GraphPhase) discoverDependentsUpstream(
 	target component.Component,
 	visitedDirs *stringSet,
 	currentDir string,
+	boundaryRoot string,
 	depthRemaining int,
 ) error {
-	l.Debugf("discoverDependentsUpstream: target=%s currentDir=%s depth=%d", target.Path(), currentDir, depthRemaining)
+	l.Debugf("discoverDependentsUpstream: target=%s currentDir=%s boundary=%s depth=%d", target.Path(), currentDir, boundaryRoot, depthRemaining)
 
 	if depthRemaining <= 0 {
 		l.Debugf("discoverDependentsUpstream: depth limit reached")
@@ -436,9 +443,8 @@ func (p *GraphPhase) discoverDependentsUpstream(
 		return nil
 	}
 
-	gitRoot := state.discovery.gitRoot
-	if gitRoot != "" && currentDir != gitRoot && !strings.HasPrefix(currentDir, gitRoot) {
-		l.Debugf("discoverDependentsUpstream: outside git root boundary (currentDir=%s, gitRoot=%s)", currentDir, gitRoot)
+	if boundaryRoot != "" && currentDir != boundaryRoot && !strings.HasPrefix(currentDir, boundaryRoot) {
+		l.Debugf("discoverDependentsUpstream: outside boundary (currentDir=%s, boundaryRoot=%s)", currentDir, boundaryRoot)
 		return nil
 	}
 
@@ -565,7 +571,7 @@ func (p *GraphPhase) discoverDependentsUpstream(
 
 		err := p.discoverDependentsUpstream(
 			ctx, l, state, dependent, freshVisitedDirs,
-			filepath.Dir(dependent.Path()), depthRemaining-1,
+			filepath.Dir(dependent.Path()), boundaryRoot, depthRemaining-1,
 		)
 		if err != nil {
 			errs = append(errs, err)
@@ -576,7 +582,7 @@ func (p *GraphPhase) discoverDependentsUpstream(
 	if parentDir != currentDir && depthRemaining > 0 {
 		err := p.discoverDependentsUpstream(
 			ctx, l, state, target, visitedDirs,
-			parentDir, depthRemaining-1,
+			parentDir, boundaryRoot, depthRemaining-1,
 		)
 		if err != nil {
 			errs = append(errs, err)

--- a/test/integration_filter_graph_test.go
+++ b/test/integration_filter_graph_test.go
@@ -752,3 +752,111 @@ dependency "vpc" {
 		})
 	}
 }
+
+// TestFilterFlagWithFindNoDuplicateWorktreeEntries tests that when multiple units
+// are both directly changed AND related via dependencies, no duplicates appear.
+// Regression test for https://github.com/gruntwork-io/terragrunt/issues/5748
+func TestFilterFlagWithFindNoDuplicateWorktreeEntries(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner()
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(tmpDir)
+
+	err = runner.Init(t.Context())
+	require.NoError(t, err)
+
+	err = runner.GoOpenRepo()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = runner.GoCloseStorage()
+		if err != nil {
+			t.Logf("Error closing storage: %s", err)
+		}
+	})
+
+	// Create unit-a (no dependencies)
+	unitADir := filepath.Join(tmpDir, "unit-a")
+	err = os.MkdirAll(unitADir, 0755)
+	require.NoError(t, err)
+
+	unitAHCL := `# unit-a - no dependencies
+`
+	err = os.WriteFile(filepath.Join(unitADir, "terragrunt.hcl"), []byte(unitAHCL), 0644)
+	require.NoError(t, err)
+
+	// Create unit-b (depends on unit-a)
+	unitBDir := filepath.Join(tmpDir, "unit-b")
+	err = os.MkdirAll(unitBDir, 0755)
+	require.NoError(t, err)
+
+	unitBHCL := `# unit-b - depends on unit-a
+dependency "unit-a" {
+  config_path = "../unit-a"
+}
+`
+	err = os.WriteFile(filepath.Join(unitBDir, "terragrunt.hcl"), []byte(unitBHCL), 0644)
+	require.NoError(t, err)
+
+	// Initial commit
+	err = runner.GoAdd(".")
+	require.NoError(t, err)
+
+	err = runner.GoCommit("Initial commit with unit-a and unit-b", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	// Modify BOTH units
+	modifiedUnitAHCL := `# unit-a - no dependencies (modified)
+`
+	err = os.WriteFile(filepath.Join(unitADir, "terragrunt.hcl"), []byte(modifiedUnitAHCL), 0644)
+	require.NoError(t, err)
+
+	modifiedUnitBHCL := `# unit-b - depends on unit-a (modified)
+dependency "unit-a" {
+  config_path = "../unit-a"
+}
+`
+	err = os.WriteFile(filepath.Join(unitBDir, "terragrunt.hcl"), []byte(modifiedUnitBHCL), 0644)
+	require.NoError(t, err)
+
+	// Second commit
+	err = runner.GoAdd(".")
+	require.NoError(t, err)
+
+	err = runner.GoCommit("Modify both unit-a and unit-b", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	// Run find with dependents filter
+	cmd := "terragrunt find --no-color --working-dir " + tmpDir + " --filter '...[HEAD~1...HEAD]'"
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err)
+
+	actualUnits := []string{}
+
+	for line := range strings.SplitSeq(strings.TrimSpace(stdout), "\n") {
+		if line != "" {
+			actualUnits = append(actualUnits, filepath.Base(line))
+		}
+	}
+
+	expectedUnits := []string{"unit-a", "unit-b"}
+
+	assert.ElementsMatch(t, expectedUnits, actualUnits)
+	assert.Len(t, actualUnits, len(expectedUnits), "Expected no duplicate entries, but got: %v", actualUnits)
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5748.

Does so by ensuring that dependent discovery starts and is bounded by the worktree where the graph traversal target is discovered.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved upstream dependency discovery to correctly respect workspace boundaries during traversal.
  * Fixed potential duplicate worktree entries when using git-change-based filters.

* **Tests**
  * Added integration test coverage for dependency filtering to ensure accurate results without duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->