### PR TITLE
fix coverage compare regarding retries

### DIFF
--- a/.github/workflows/coverage-compare-main.yml
+++ b/.github/workflows/coverage-compare-main.yml
@@ -24,6 +24,8 @@ jobs:
         id: prev
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           mkdir -p previous
 
@@ -31,8 +33,8 @@ jobs:
           echo "Branch: $BRANCH"
 
           # Find last successful CI run on this branch (excluding current)
-          PREV_RUN_ID=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=${BRANCH}&status=success&per_page=5" \
-            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})][0].id")
+          PREV_RUN_ID=$(gh api "repos/${REPO}/actions/workflows/ci.yml/runs?branch=${BRANCH}&status=success&per_page=5" \
+            --jq "[.workflow_runs[] | select(.id != ${RUN_ID})][0].id")
 
           if [[ -z "$PREV_RUN_ID" || "$PREV_RUN_ID" == "null" ]]; then
             echo "No previous successful run found on $BRANCH"
@@ -43,7 +45,7 @@ jobs:
           echo "Previous run: $PREV_RUN_ID"
 
           # Find the coverage-summary.json artifact in that run
-          ARTIFACT_ID=$(gh api "repos/${{ github.repository }}/actions/runs/${PREV_RUN_ID}/artifacts" \
+          ARTIFACT_ID=$(gh api "repos/${REPO}/actions/runs/${PREV_RUN_ID}/artifacts" \
             --jq '[.artifacts[] | select(.name == "coverage-summary.json")][0].id')
 
           if [[ -z "$ARTIFACT_ID" || "$ARTIFACT_ID" == "null" ]]; then
@@ -53,14 +55,16 @@ jobs:
           fi
 
           # Download and extract
-          gh api "repos/${{ github.repository }}/actions/artifacts/${ARTIFACT_ID}/zip" > /tmp/prev-coverage.zip
+          gh api "repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip" > /tmp/prev-coverage.zip
           unzip -o /tmp/prev-coverage.zip -d previous/
           echo "has_previous=true" >> "$GITHUB_OUTPUT"
 
       - name: Compare Coverage
+        env:
+          HAS_PREVIOUS: ${{ steps.prev.outputs.has_previous }}
         run: |
           PREV_FILE="previous/coverage-summary.json"
-          if [[ "${{ steps.prev.outputs.has_previous }}" != "true" ]]; then
+          if [[ "${HAS_PREVIOUS}" != "true" ]]; then
             PREV_FILE="nonexistent"
           fi
           ./.github/scripts/coverage/compare-coverage.sh current/coverage-summary.json "$PREV_FILE" comparison-report.json


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

our coverage comparison workflow errors if there are multiple matching artifacts for the previous run (e.g. if the previous run was retried), [example](https://github.com/gruntwork-io/terragrunt/actions/runs/23920587424/job/69853281965?pr=5608).

This modifies the filter to select the most recent (github returns them ordered), same as the filter for recent runs.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made coverage-comparison workflow more reliable by improving previous-run detection so comparisons target the correct run.
  * Strengthened artifact selection to consistently find the correct coverage summary for comparison.
  * Standardized how comparison targets are chosen and retrieved to reduce intermittent failures during CI coverage checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->