### PR TITLE
docs: correct --no-destroy-dependencies-check flag name

### DIFF
--- a/docs/src/content/docs/08-migrate/03-cli-redesign.md
+++ b/docs/src/content/docs/08-migrate/03-cli-redesign.md
@@ -105,7 +105,7 @@ Below is a comprehensive mapping of old CLI flag names to their modern counterpa
 | `--terragrunt-no-auto-init`                       | `--no-auto-init`                                          |
 | `--terragrunt-no-auto-retry`                      | `--no-auto-retry`                                         |
 | `--terragrunt-no-color`                           | `--no-color`                                              |
-| `--terragrunt-no-destroy-dependencies-check`      | `--destroy-dependencies-check`                            |
+| `--terragrunt-no-destroy-dependencies-check`      | `--no-destroy-dependencies-check`                         |
 | `--terragrunt-out-dir`                            | `--out-dir`                                               |
 | `--terragrunt-parallelism`                        | `--parallelism`                                           |
 | `--terragrunt-provider-cache-dir`                 | `--provider-cache-dir`                                    |


### PR DESCRIPTION
Updates the CLI migration table to correctly reflect the flag name after removing the 'terragrunt-' prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI migration guide to provide accurate flag mappings for destroy-dependencies configuration options, assisting users in transitioning from legacy command syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->