### PR TITLE
docs: correct --no-destroy-dependencies-check flag name

### DIFF
--- a/docs/src/content/docs/08-migrate/03-cli-redesign.md
+++ b/docs/src/content/docs/08-migrate/03-cli-redesign.md
@@ -105,7 +105,7 @@ Below is a comprehensive mapping of old CLI flag names to their modern counterpa
 | `--terragrunt-no-auto-init`                       | `--no-auto-init`                                          |
 | `--terragrunt-no-auto-retry`                      | `--no-auto-retry`                                         |
 | `--terragrunt-no-color`                           | `--no-color`                                              |
-| `--terragrunt-no-destroy-dependencies-check`      | `--destroy-dependencies-check`                            |
+| `--terragrunt-no-destroy-dependencies-check`      | `--no-destroy-dependencies-check`                         |
 | `--terragrunt-out-dir`                            | `--out-dir`                                               |
 | `--terragrunt-parallelism`                        | `--parallelism`                                           |
 | `--terragrunt-provider-cache-dir`                 | `--provider-cache-dir`                                    |


### PR DESCRIPTION
## Description

The CLI migration table incorrectly lists the modern counterpart of `--terragrunt-no-destroy-dependencies-check` as `--destroy-dependencies-check`. Following the documentation leads to the following error:

```text
Error: Failed to parse command-line flags
  │ 
  │ flag provided but not defined: -destroy-dependencies-check
```

This PR corrects the table to reflect the actual flag name: `--no-destroy-dependencies-check`.

## TODOs

Read the Gruntwork contribution guidelines https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e.

[✓] I authored this code entirely myself
[ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
[ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
[✓] Update the docs.
[ ] Run the relevant tests successfully, including pre-commit checks.
[ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated migration guide for CLI redesign to correct the `--no-destroy-dependencies-check` flag name.

### Migration Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected CLI flag migration guide to accurately reflect the modern equivalent of the `--terragrunt-no-destroy-dependencies-check` flag, ensuring users migrating their configurations have the correct mapping reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->