### PR TITLE
fix: fall back to mock_outputs when dependency output fetch fails

### DIFF
--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -659,7 +659,7 @@ func getTerragruntOutput(
 
 	jsonBytes, err := getOutputJSONWithCaching(ctx, pctx, l, targetConfigPath)
 	if err != nil {
-		if !isRenderJSONCommand(pctx) && !isRenderCommand(pctx) && !isAwsS3NoSuchKey(err) {
+		if !isRenderJSONCommand(pctx) && !isRenderCommand(pctx) && !isAwsS3NoSuchKey(err) && !dependencyConfig.shouldReturnMockOutputs(pctx) {
 			return nil, true, err
 		}
 


### PR DESCRIPTION
## Description

This PR fixes a bug where Terragrunt fails with `"There is no variable named 'dependency'"` when dependency output fetching fails, even when `mock_outputs` are configured. The fix ensures Terragrunt properly falls back to mock_outputs when the dependency module's backend is unreachable.

## Problem

When a dependency block has `mock_outputs` configured:

```hcl
dependency "a" {
  config_path = "../config-a"
  mock_outputs = {
    powerball = 0
  }
}

inputs = {
  powerball = dependency.a.outputs.powerball
}
```

Running commands like `terragrunt run -- init -backend=false`, `terragrunt validate`, or `terragrunt providers lock` in CI/CD (where the backend is unreachable) produces:

```
Error: Unknown variable
  on ./terragrunt.hcl line 15:
  15:   powerball = dependency.a.outputs.powerball
There is no variable named "dependency".
```

This happens because `getTerragruntOutput()` only falls back to mock_outputs on error for:
- `render-json` / `render` commands
- AWS S3 `NoSuchKey` errors

For all other commands (init, validate, providers lock, etc.), the error propagates directly, bypassing the mock_outputs fallback entirely.

## Root Cause

In [`pkg/config/dependency.go`](pkg/config/dependency.go), the `getTerragruntOutput()` function has this condition:

```go
if err != nil {
    if !isRenderJSONCommand(pctx) && !isRenderCommand(pctx) && !isAwsS3NoSuchKey(err) {
        return nil, true, err  // Returns error without checking mock_outputs
    }
    // ... fallback to mock_outputs ...
}
```

## Fix

Added `!dependencyConfig.shouldReturnMockOutputs(pctx)` to the condition, so mock_outputs are used as fallback when they are configured and the current command is allowed:

```go
if err != nil {
    if !isRenderJSONCommand(pctx) && !isRenderCommand(pctx) && !isAwsS3NoSuchKey(err) && !dependencyConfig.shouldReturnMockOutputs(pctx) {
        return nil, true, err
    }
    // ... fallback to mock_outputs ...
}
```

The `shouldReturnMockOutputs()` method already performs proper validation:
- Checks that `mock_outputs` is not nil
- Checks that the current command is in `mock_outputs_allowed_terraform_commands` (or that the list is empty/nil)

## Impact

Users can now run commands like `validate`, `providers lock`, and `init -backend=false` in CI/CD environments where the backend is not accessible, without needing the workaround of dynamically setting `skip_outputs`:

```hcl
# The workaround is no longer needed
skip_outputs = contains(["init", "providers", "validate"], get_terraform_command())
```

## Testing

- All existing dependency-related tests pass
- The change is minimal (1 line) and follows the existing pattern of the fallback logic

Fixes #4374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for dependency configurations when mock outputs are enabled, allowing the system to gracefully continue execution in additional scenarios where errors would have previously halted processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->