### PR TITLE
fix: surface HTTP 429 rate-limiting errors from provider registry

### DIFF
--- a/internal/tf/cache/helpers/client.go
+++ b/internal/tf/cache/helpers/client.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -51,7 +52,7 @@ func (client *Client) Do(ctx context.Context, method, reqURL string, value any) 
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	bodyBytes, err := decodeResponse(resp)
+	bodyBytes, err := DecodeResponse(resp)
 	if err != nil {
 		return err
 	}
@@ -73,9 +74,14 @@ func unmarshalBody(data []byte, value any) error {
 	return nil
 }
 
-func decodeResponse(resp *http.Response) ([]byte, error) {
+// DecodeResponse reads an HTTP response body, returning an error for non-200 status codes.
+func DecodeResponse(resp *http.Response) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
-		return nil, nil
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("received HTTP 429 Too Many Requests from %s (rate limited by registry)", resp.Request.URL)
+		}
+
+		return nil, fmt.Errorf("received HTTP %d %s from %s", resp.StatusCode, http.StatusText(resp.StatusCode), resp.Request.URL)
 	}
 
 	buffer, err := ResponseBuffer(resp)

--- a/internal/tf/cache/helpers/client_test.go
+++ b/internal/tf/cache/helpers/client_test.go
@@ -1,0 +1,75 @@
+package helpers_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecodeResponse_429ReturnsError verifies that decodeResponse returns an error with rate-limiting details
+// when the HTTP response status is 429 Too Many Requests.
+func TestDecodeResponse_429ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://registry.terraform.io/v1/providers/hashicorp/aws/versions", nil)
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Request:    req,
+	}
+
+	data, err := helpers.DecodeResponse(resp)
+	require.Error(t, err)
+	assert.Nil(t, data)
+	assert.Contains(t, err.Error(), "429")
+	assert.Contains(t, err.Error(), "Too Many Requests")
+	assert.Contains(t, err.Error(), "rate limited")
+}
+
+// TestDecodeResponse_NonOKReturnsError verifies that decodeResponse returns an error with the HTTP status code
+// and status text when the response has a non-200 status code.
+func TestDecodeResponse_NonOKReturnsError(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://registry.terraform.io/v1/providers/hashicorp/aws/versions", nil)
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Request:    req,
+	}
+
+	data, err := helpers.DecodeResponse(resp)
+	require.Error(t, err)
+	assert.Nil(t, data)
+	assert.Contains(t, err.Error(), "500")
+	assert.Contains(t, err.Error(), "Internal Server Error")
+}
+
+// TestDecodeResponse_OKReturnsBody verifies that decodeResponse returns the response body
+// when the HTTP response status is 200 OK.
+func TestDecodeResponse_OKReturnsBody(t *testing.T) {
+	t.Parallel()
+
+	body := `{"versions":["1.0.0"]}`
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://registry.terraform.io/v1/providers/hashicorp/aws/versions", nil)
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+
+	data, err := helpers.DecodeResponse(resp)
+	require.NoError(t, err)
+	assert.Equal(t, body, string(data))
+}

--- a/internal/tf/cache/services/provider_cache.go
+++ b/internal/tf/cache/services/provider_cache.go
@@ -357,7 +357,7 @@ func (cache *ProviderCache) warmUp(ctx context.Context) error {
 	}
 
 	if cache.DownloadURL == "" {
-		return errors.New("not found provider download url")
+		return fmt.Errorf("unable to find download URL for provider %s (this may be caused by a rate limit or network issue when querying the registry)", cache.Provider)
 	}
 
 	downloadURLIsLocalFile, err := cache.isLocalFile(fs, cache.DownloadURL)


### PR DESCRIPTION
## Description

This PR fixes misleading error messages when the Terraform provider registry returns HTTP 429 (Too Many Requests) during provider caching. Previously, rate-limiting responses were silently swallowed, producing a confusing "not found provider download url" error with no indication of the actual cause.

## Problem

When running Terragrunt with provider caching enabled (`TERRAGRUNT_PROVIDER_CACHE=1`) at scale (e.g., many concurrent `terragrunt plan` invocations), the Terraform registry may return HTTP 429 to rate-limit requests. The resulting error appears as:

```
ERROR 3 errors occurred:
* unable to cache provider: registry.terraform.io/hashicorp/external v2.3.4, err: not found provider download url
* unable to cache provider: registry.terraform.io/hashicorp/local v2.5.2, err: not found provider download url
* unable to cache provider: registry.terraform.io/hashicorp/null v3.2.3, err: not found provider download url
```

This error message gives no indication that rate-limiting is the cause, making it extremely difficult to diagnose without contacting HashiCorp support.

## Root Cause

In [`internal/tf/cache/helpers/client.go`](internal/tf/cache/helpers/client.go), the `decodeResponse()` function silently returned `(nil, nil)` for **all** non-200 HTTP status codes:

```go
func decodeResponse(resp *http.Response) ([]byte, error) {
    if resp.StatusCode != http.StatusOK {
        return nil, nil  // ← Silent swallow of ALL non-200 responses
    }
    // ...
}
```

This caused a cascade:
1. Registry returns HTTP 429 → `decodeResponse` returns `(nil, nil)`
2. `Client.Do` returns no error → empty provider response is cached
3. `DownloadURL` field is empty
4. `warmUp()` sees empty URL → logs generic "not found provider download url"

## Fix

### 1. Surface HTTP errors from `decodeResponse()`

Non-200 responses now return proper errors with the status code, with a specific message for 429:

```go
func decodeResponse(resp *http.Response) ([]byte, error) {
    if resp.StatusCode != http.StatusOK {
        if resp.StatusCode == http.StatusTooManyRequests {
            return nil, errors.Errorf("received HTTP 429 Too Many Requests from %s (rate limited by registry)", resp.Request.URL)
        }
        return nil, errors.Errorf("received HTTP %d %s from %s", resp.StatusCode, http.StatusText(resp.StatusCode), resp.Request.URL)
    }
    // ...
}
```

### 2. Improved `warmUp()` error message

```go
// Before:
"not found provider download url"

// After:
"unable to find download URL for provider %s (this may be caused by a rate limit or network issue when querying the registry)"
``` 

### Result

After this fix, users will see clear errors:

```
ERROR Failed to get provider platform from "direct": received HTTP 429 Too Many Requests from
https://registry.terraform.io/v1/providers/hashicorp/null/3.2.3/download/linux/amd64 (rate limited by registry)
```

## Additional Benefits

- Non-200 responses are no longer cached as nil (preventing corrupted cache entries)
- All HTTP error status codes (500, 403, etc.) are now surfaced, not just 429
- Follows the same pattern as `helpers.Fetch()` which already returns errors for non-200

## Testing

- Added unit tests for `decodeResponse` covering 429 and 500 status codes
- All existing cache tests pass
- Verified compilation succeeds

Fixes #3932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages when encountering registry rate limits with clearer indication of the issue and affected provider
  * Improved error reporting during provider cache operations with better context about potential rate limiting or network issues

* **Tests**
  * Added comprehensive test coverage for HTTP response handling across various status codes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/5803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->