### PR TITLE
fix: Preventing parse errors in stack generation in worktrees

### DIFF
--- a/docs/src/data/changelog/v1.0.1.mdx
+++ b/docs/src/data/changelog/v1.0.1.mdx
@@ -89,6 +89,12 @@ Previously, the run queue display showed units in apply order even for destroy c
 
 Dependents are now correctly discovered when units are discovered in worktrees. Previously, dependent discovery could fail to find related units when operating within a git worktree.
 
+#### Filter exclusions now respected in worktree sub-discoveries
+
+Negated filters (e.g., `!./catalog/**` from `.terragrunt-filters` or `--filter`) are now propagated to worktree sub-discoveries used by git-based filtering (`--filter-affected`, `--filter '[ref...ref]'`).
+
+Previously, excluded source catalog units in worktrees were still discovered and parsed, causing errors when they referenced `values.*` or `dependency.*` variables without the stack generation context.
+
 #### `read_terragrunt_config()` behavior in implicit stacks fixed
 
 A regression introduced in v0.99.4 caused `read_terragrunt_config()` to fail to parse `dependency` blocks in external configurations during stack execution. This is fixed by resetting parsing context fields that prevented proper evaluation of dependencies in configurations read by `read_terragrunt_config()`.

--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -196,8 +196,14 @@ func (p *WorktreePhase) discoverInWorktree(
 		return nil, err
 	}
 
+	// Propagate non-git filters from the parent discovery to the worktree sub-discovery.
+	// Git expressions are excluded to avoid infinite recursion (the worktree phase is
+	// already handling them). All other filters (path, attribute, negation) are included
+	// so that exclusions and type constraints apply within sub-discoveries.
+	allFilters := append(filters, discovery.filters.ExcludingGitFilters()...)
+
 	subDiscovery := NewDiscovery(wt.Path).
-		WithFilters(filters).
+		WithFilters(allFilters).
 		WithDiscoveryContext(discoveryContext).
 		WithNumWorkers(p.numWorkers)
 
@@ -312,10 +318,12 @@ func (p *WorktreePhase) walkChangedStack(
 		errs = make([]error, 0, 2) //nolint:mnd
 	)
 
+	parentFilters := discovery.filters.ExcludingGitFilters()
+
 	discoveryGroup.Go(func() error {
 		fromDiscovery := NewDiscovery(fromStack.Path()).
 			WithDiscoveryContext(fromDiscoveryContext).
-			WithFilters(filter.Filters{}).
+			WithFilters(parentFilters).
 			WithNumWorkers(p.numWorkers)
 
 		var fromDiscoveryErr error
@@ -343,7 +351,7 @@ func (p *WorktreePhase) walkChangedStack(
 	discoveryGroup.Go(func() error {
 		toDiscovery := NewDiscovery(toStack.Path()).
 			WithDiscoveryContext(toDiscoveryContext).
-			WithFilters(filter.Filters{}).
+			WithFilters(parentFilters).
 			WithNumWorkers(p.numWorkers)
 
 		var toDiscoveryErr error

--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -200,7 +200,7 @@ func (p *WorktreePhase) discoverInWorktree(
 	// Git expressions are excluded to avoid infinite recursion (the worktree phase is
 	// already handling them). All other filters (path, attribute, negation) are included
 	// so that exclusions and type constraints apply within sub-discoveries.
-	allFilters := append(filters, discovery.filters.ExcludingGitFilters()...)
+	allFilters := slices.Concat(filters, discovery.filters.ExcludingGitFilters())
 
 	subDiscovery := NewDiscovery(wt.Path).
 		WithFilters(allFilters).

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -2365,3 +2365,93 @@ unit "myapp" {
 		"Expected at least one unit to be discovered when a read file changes, "+
 			"but got no units. All components: %v", componentPaths)
 }
+
+// TestWorktreePhase_Integration_NegatedFiltersAppliedInWorktreeSubDiscoveries tests that
+// negated path filters (e.g., from .terragrunt-filters) are applied within worktree
+// sub-discoveries, not just during the final filter evaluation.
+// This is a regression test for #5821: source catalog units in worktrees were being
+// discovered and parsed despite being excluded by a negated path filter, because the
+// worktree sub-discoveries did not receive the exclusion filters.
+func TestWorktreePhase_Integration_NegatedFiltersAppliedInWorktreeSubDiscoveries(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	// Create two units: one that should be discovered and one that should be excluded.
+	createUnit(t, tmpDir, "app", `# App unit`)
+	// This catalog unit references values.* — it's a template that only works
+	// when generated through a stack. Without the fix, the worktree sub-discovery
+	// tries to parse it and fails with "Unknown variable: values".
+	createUnit(t, tmpDir, "catalog/units/svc", `
+locals {
+  environment = values.environment
+}
+`)
+
+	commitChanges(t, runner, "Initial commit")
+
+	// Modify both units
+	err := os.WriteFile(filepath.Join(tmpDir, "app", "terragrunt.hcl"), []byte(`# Modified app`), 0o644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "catalog", "units", "svc", "terragrunt.hcl"), []byte(`
+locals {
+  environment = values.environment
+  region      = "us-east-1"
+}
+`), 0o644)
+	require.NoError(t, err)
+
+	commitChanges(t, runner, "Modify both units")
+
+	l := logger.CreateLogger()
+
+	// Parse filters: git expression + negated path that excludes catalog
+	filterQueries := []string{"[HEAD~1...HEAD]", "!./catalog/**"}
+	filters, parseErr := filter.ParseFilterQueries(l, filterQueries)
+	require.NoError(t, parseErr)
+
+	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: filters.UniqueGitFilters(),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		require.NoError(t, cleanupErr)
+	})
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+
+	d := discovery.NewDiscovery(tmpDir).
+		WithDiscoveryContext(&component.DiscoveryContext{
+			WorkingDir: tmpDir,
+			Cmd:        "plan",
+		}).
+		WithWorktrees(w).
+		WithRelationships().
+		WithFilters(filters)
+
+	components, err := d.Discover(t.Context(), l, opts)
+	require.NoError(t, err)
+
+	unitPaths := components.Filter(component.UnitKind).Paths()
+
+	worktreePair := w.WorktreePairs["[HEAD~1...HEAD]"]
+	require.NotEmpty(t, worktreePair)
+
+	toWorktree := worktreePair.ToWorktree.Path
+
+	// The app unit should be discovered (it's in the git diff and not excluded)
+	assert.Contains(t, unitPaths, filepath.Join(toWorktree, "app"),
+		"app unit should be discovered")
+
+	// The catalog unit should NOT be discovered (excluded by !./catalog/**)
+	for _, p := range unitPaths {
+		assert.NotContains(t, p, "catalog",
+			"catalog units should be excluded by the negated filter, but found: %s", p)
+	}
+}

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -2455,3 +2455,160 @@ locals {
 			"catalog units should be excluded by the negated filter, but found: %s", p)
 	}
 }
+
+// TestWorktreePhase_Integration_GitFilterExclusionPreventsParsingInWorktree verifies that
+// a negated filter prevents excluded units from being parsed inside worktree sub-discoveries.
+// The land-mine unit uses run_cmd("exit 1") which would cause a fatal parse error if evaluated.
+func TestWorktreePhase_Integration_GitFilterExclusionPreventsParsingInWorktree(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	createUnit(t, tmpDir, "app", `# App unit`)
+	createUnit(t, tmpDir, "land-mine", `
+locals {
+  boom = run_cmd("--terragrunt-quiet", "bash", "-c", "exit 1")
+}
+`)
+
+	commitChanges(t, runner, "Initial commit")
+
+	err := os.WriteFile(filepath.Join(tmpDir, "app", "terragrunt.hcl"), []byte(`# Modified app`), 0o644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "land-mine", "terragrunt.hcl"), []byte(`
+locals {
+  boom = run_cmd("--terragrunt-quiet", "bash", "-c", "exit 1")
+  modified = true
+}
+`), 0o644)
+	require.NoError(t, err)
+
+	commitChanges(t, runner, "Modify both units")
+
+	l := logger.CreateLogger()
+	filters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]", "!./land-mine"})
+	require.NoError(t, parseErr)
+
+	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: filters.UniqueGitFilters(),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		require.NoError(t, cleanupErr)
+	})
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+
+	d := discovery.NewDiscovery(tmpDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir, Cmd: "plan"}).
+		WithWorktrees(w).
+		WithRelationships().
+		WithFilters(filters)
+
+	// If the land-mine unit is parsed, run_cmd("exit 1") causes a fatal error.
+	components, err := d.Discover(t.Context(), l, opts)
+	require.NoError(t, err)
+
+	unitPaths := components.Filter(component.UnitKind).Paths()
+
+	toWorktree := w.WorktreePairs["[HEAD~1...HEAD]"].ToWorktree.Path
+	assert.Contains(t, unitPaths, filepath.Join(toWorktree, "app"), "app should be discovered")
+
+	for _, p := range unitPaths {
+		assert.NotContains(t, p, "land-mine", "land-mine should not be discovered: %s", p)
+	}
+}
+
+// TestWorktreePhase_Integration_StackDiscoveryDoesNotParseUnits verifies that
+// discoverStacks (via GenerateStacks) does not parse non-stack components even when
+// reading filters trigger the parse phase. The land-mine unit uses run_cmd("exit 1")
+// which would cause a fatal error if parsed.
+func TestWorktreePhase_Integration_StackDiscoveryDoesNotParseUnits(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	// Create a land-mine unit at the repo root
+	createUnit(t, tmpDir, "land-mine", `
+locals {
+  boom = run_cmd("--terragrunt-quiet", "bash", "-c", "exit 1")
+}
+`)
+
+	// Create a catalog unit for the stack to source
+	catalogDir := filepath.Join(tmpDir, "catalog", "units", "myapp")
+	err := os.MkdirAll(catalogDir, 0o755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(catalogDir, "terragrunt.hcl"), []byte(`# catalog unit`), 0o644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(catalogDir, "main.tf"), []byte(`output "ok" { value = "ok" }`), 0o644)
+	require.NoError(t, err)
+
+	// Create a stack that reads a config file (triggers reading filter path in worktreeStacksToGenerate)
+	stackDir := filepath.Join(tmpDir, "live", "stack")
+	err = os.MkdirAll(stackDir, 0o755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(stackDir, "config.hcl"), []byte(`inputs = { v = "v1" }`), 0o644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(stackDir, "terragrunt.stack.hcl"), []byte(`
+locals {
+  config = read_terragrunt_config("config.hcl")
+}
+
+unit "myapp" {
+  source = "${get_repo_root()}/catalog/units/myapp"
+  path   = "myapp"
+  values = local.config.inputs
+}
+`), 0o644)
+	require.NoError(t, err)
+
+	commitChanges(t, runner, "Initial commit")
+
+	// Change only the config file (triggers reading filter, not a direct stack change)
+	err = os.WriteFile(filepath.Join(stackDir, "config.hcl"), []byte(`inputs = { v = "v2" }`), 0o644)
+	require.NoError(t, err)
+
+	commitChanges(t, runner, "Update config file")
+
+	l := logger.CreateLogger()
+	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
+
+	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		require.NoError(t, cleanupErr)
+	})
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+
+	parsedFilters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]"})
+	require.NoError(t, parseErr)
+
+	opts.Filters = parsedFilters
+	opts.Experiments = experiment.NewExperiments()
+	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
+	require.NoError(t, err)
+
+	// GenerateStacks internally calls discoverStacks with reading filters.
+	// If the land-mine unit is parsed, run_cmd("exit 1") causes a fatal error.
+	err = generate.GenerateStacks(t.Context(), l, opts, w)
+	require.NoError(t, err)
+}

--- a/internal/filter/filters.go
+++ b/internal/filter/filters.go
@@ -93,6 +93,21 @@ func (f Filters) RequiresParse() (Expression, bool) {
 	return nil, false
 }
 
+// ExcludingGitFilters returns all filters that do not contain a git expression.
+// Git expressions are excluded because they are handled by the worktree phase
+// itself and would cause infinite recursion if propagated to sub-discoveries.
+func (f Filters) ExcludingGitFilters() Filters {
+	result := make(Filters, 0, len(f))
+
+	for _, filter := range f {
+		if !containsGitExpression(filter.expr) {
+			result = append(result, filter)
+		}
+	}
+
+	return result
+}
+
 // DependencyGraphExpressions returns all target expressions from graph expressions that require dependency traversal.
 func (f Filters) DependencyGraphExpressions() []Expression {
 	targets := make([]Expression, 0, len(f))
@@ -139,73 +154,15 @@ func (f Filters) UniqueGitFilters() GitExpressions {
 
 // RestrictToStacks returns a new Filters object with only the filters that are restricted to stacks.
 func (f Filters) RestrictToStacks() Filters {
-	return slices.Collect(func(yield func(*Filter) bool) {
-		for _, filter := range f {
-			if filter.expr.IsRestrictedToStacks() && !yield(filter) {
-				return
-			}
+	result := make(Filters, 0, len(f))
+
+	for _, filter := range f {
+		if filter.expr.IsRestrictedToStacks() {
+			result = append(result, filter)
 		}
-	})
-}
+	}
 
-// collectGraphExpressionTargetsWithDependencies collects target expressions from GraphExpression nodes that have IncludeDependencies set.
-func collectGraphExpressionTargetsWithDependencies(expr Expression) []Expression {
-	var targets []Expression
-
-	WalkExpressions(expr, func(e Expression) bool {
-		if graphExpr, ok := e.(*GraphExpression); ok && graphExpr.IncludeDependencies {
-			targets = append(targets, graphExpr.Target)
-		}
-
-		return true
-	})
-
-	return targets
-}
-
-// collectGraphExpressionTargetsWithDependents collects target expressions from GraphExpression nodes that have IncludeDependents set.
-func collectGraphExpressionTargetsWithDependents(expr Expression) []Expression {
-	var targets []Expression
-
-	WalkExpressions(expr, func(e Expression) bool {
-		if graphExpr, ok := e.(*GraphExpression); ok && graphExpr.IncludeDependents {
-			targets = append(targets, graphExpr.Target)
-		}
-
-		return true
-	})
-
-	return targets
-}
-
-// collectWorktreeExpressions collects worktree expressions from GitExpression nodes.
-func collectWorktreeExpressions(expr Expression) []*GitExpression {
-	var targets []*GitExpression
-
-	WalkExpressions(expr, func(e Expression) bool {
-		if gitExpr, ok := e.(*GitExpression); ok {
-			targets = append(targets, gitExpr)
-		}
-
-		return true
-	})
-
-	return targets
-}
-
-// collectGitReferences collects Git references from GitExpression nodes.
-func collectGitReferences(expr Expression) []string {
-	var refs []string
-
-	WalkExpressions(expr, func(e Expression) bool {
-		if gitExpr, ok := e.(*GitExpression); ok {
-			refs = append(refs, gitExpr.FromRef, gitExpr.ToRef)
-		}
-
-		return true
-	})
-
-	return refs
+	return result
 }
 
 // Evaluate applies all filters with union (OR) semantics in two phases:
@@ -307,6 +264,37 @@ func (f Filters) EvaluateOnFiles(l log.Logger, files []string, workingDir string
 	return f.Evaluate(l, comps)
 }
 
+// String returns a JSON array representation of all filter strings.
+func (f Filters) String() string {
+	filterStrings := make([]string, len(f))
+	for i, filter := range f {
+		filterStrings[i] = filter.String()
+	}
+
+	jsonBytes, err := json.Marshal(filterStrings)
+	if err != nil {
+		return "[]"
+	}
+
+	return string(jsonBytes)
+}
+
+// containsGitExpression returns true if the expression tree contains a GitExpression.
+func containsGitExpression(expr Expression) bool {
+	found := false
+
+	WalkExpressions(expr, func(e Expression) bool {
+		if _, ok := e.(*GitExpression); ok {
+			found = true
+			return false
+		}
+
+		return true
+	})
+
+	return found
+}
+
 func initialComponents(l log.Logger, positiveFilters []*Filter, components component.Components) (component.Components, error) {
 	if len(positiveFilters) == 0 {
 		return components, nil
@@ -333,17 +321,58 @@ func initialComponents(l log.Logger, positiveFilters []*Filter, components compo
 	return remaining, nil
 }
 
-// String returns a JSON array representation of all filter strings.
-func (f Filters) String() string {
-	filterStrings := make([]string, len(f))
-	for i, filter := range f {
-		filterStrings[i] = filter.String()
-	}
+func collectGraphExpressionTargetsWithDependencies(expr Expression) []Expression {
+	var targets []Expression
 
-	jsonBytes, err := json.Marshal(filterStrings)
-	if err != nil {
-		return "[]"
-	}
+	WalkExpressions(expr, func(e Expression) bool {
+		if graphExpr, ok := e.(*GraphExpression); ok && graphExpr.IncludeDependencies {
+			targets = append(targets, graphExpr.Target)
+		}
 
-	return string(jsonBytes)
+		return true
+	})
+
+	return targets
+}
+
+func collectGraphExpressionTargetsWithDependents(expr Expression) []Expression {
+	var targets []Expression
+
+	WalkExpressions(expr, func(e Expression) bool {
+		if graphExpr, ok := e.(*GraphExpression); ok && graphExpr.IncludeDependents {
+			targets = append(targets, graphExpr.Target)
+		}
+
+		return true
+	})
+
+	return targets
+}
+
+func collectGitReferences(expr Expression) []string {
+	var refs []string
+
+	WalkExpressions(expr, func(e Expression) bool {
+		if gitExpr, ok := e.(*GitExpression); ok {
+			refs = append(refs, gitExpr.FromRef, gitExpr.ToRef)
+		}
+
+		return true
+	})
+
+	return refs
+}
+
+func collectWorktreeExpressions(expr Expression) []*GitExpression {
+	var targets []*GitExpression
+
+	WalkExpressions(expr, func(e Expression) bool {
+		if gitExpr, ok := e.(*GitExpression); ok {
+			targets = append(targets, gitExpr)
+		}
+
+		return true
+	})
+
+	return targets
 }

--- a/internal/filter/filters_test.go
+++ b/internal/filter/filters_test.go
@@ -629,6 +629,82 @@ func TestFilters_RestrictToStacks(t *testing.T) {
 	})
 }
 
+func TestFilters_ExcludingGitFilters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty filters", func(t *testing.T) {
+		t.Parallel()
+
+		filters := filter.Filters{}
+		result := filters.ExcludingGitFilters()
+		assert.Empty(t, result)
+	})
+
+	t.Run("only git expression", func(t *testing.T) {
+		t.Parallel()
+
+		filters, err := filter.ParseFilterQueries(testLogger(), []string{"[HEAD~1...HEAD]"})
+		require.NoError(t, err)
+
+		result := filters.ExcludingGitFilters()
+		assert.Empty(t, result)
+	})
+
+	t.Run("no git expressions", func(t *testing.T) {
+		t.Parallel()
+
+		filters, err := filter.ParseFilterQueries(testLogger(), []string{"./live/**", "!./iac/**"})
+		require.NoError(t, err)
+		require.Len(t, filters, 2)
+
+		result := filters.ExcludingGitFilters()
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("mixed git and non-git", func(t *testing.T) {
+		t.Parallel()
+
+		filters, err := filter.ParseFilterQueries(testLogger(), []string{"[HEAD~1...HEAD]", "!./iac/**", "type=unit"})
+		require.NoError(t, err)
+		require.Len(t, filters, 3)
+
+		result := filters.ExcludingGitFilters()
+		assert.Len(t, result, 2)
+
+		// Verify the remaining filters are the non-git ones
+		resultStrs := make([]string, 0, len(result))
+		for _, f := range result {
+			resultStrs = append(resultStrs, f.String())
+		}
+
+		assert.Contains(t, resultStrs, "!./iac/**")
+		assert.Contains(t, resultStrs, "type=unit")
+	})
+
+	t.Run("infix containing git expression is excluded", func(t *testing.T) {
+		t.Parallel()
+
+		filters, err := filter.ParseFilterQueries(testLogger(), []string{"[HEAD~1...HEAD] | !./iac/**"})
+		require.NoError(t, err)
+		require.Len(t, filters, 1)
+
+		result := filters.ExcludingGitFilters()
+		assert.Empty(t, result, "infix filter containing a git expression should be excluded")
+	})
+
+	t.Run("does not modify original", func(t *testing.T) {
+		t.Parallel()
+
+		filters, err := filter.ParseFilterQueries(testLogger(), []string{"[HEAD~1...HEAD]", "./live/**"})
+		require.NoError(t, err)
+		require.Len(t, filters, 2)
+
+		result := filters.ExcludingGitFilters()
+		assert.Len(t, result, 1)
+		assert.Len(t, filters, 2, "original should not be modified")
+	})
+}
+
 func TestFilters_RequiresGitReferences(t *testing.T) {
 	t.Parallel()
 

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -380,7 +380,7 @@ func worktreeStacksToGenerate(
 
 		g.Go(func() error {
 			// Discover all stacks in both worktrees for generation.
-			allFromStacks, err := discoverStacks(ctx, l, opts, pair.FromWorktree, nil)
+			allFromStacks, err := discoverStacks(ctx, l, opts, pair.FromWorktree, false)
 			if err != nil {
 				mu.Lock()
 
@@ -390,12 +390,10 @@ func worktreeStacksToGenerate(
 				return nil
 			}
 
-			// Appending the reading filter to the "to" discovery forces all stacks through
+			// The "to" discovery uses readFiles to force all stacks through
 			// the parse phase (populating Reading()), while still returning every stack
 			// (because they all match type=stack).
-			readingFilters := filter.Filters{filter.NewFilter(parseExpr, parseExpr.String())}
-
-			allToStacks, err := discoverStacks(ctx, l, opts, pair.ToWorktree, readingFilters)
+			allToStacks, err := discoverStacks(ctx, l, opts, pair.ToWorktree, true)
 			if err != nil {
 				mu.Lock()
 
@@ -474,21 +472,27 @@ func worktreeStacksToGenerate(
 	return stacksToGenerate.ToComponents(), nil
 }
 
-// discoverStacks discovers stacks in a worktree using the given additional filters.
+// discoverStacks discovers stacks in a worktree.
 // User-provided filters from opts.Filters are included (restricted to stacks) so that
 // explicit exclusions like --filter '!./land-mine | type=stack' are respected.
+// When readFiles is true, all discovered stacks are parsed to populate their Reading
+// attribute (used by reading-affected detection).
 func discoverStacks(
 	ctx context.Context,
 	l log.Logger,
 	opts *options.TerragruntOptions,
 	wt worktrees.Worktree,
-	additionalFilters filter.Filters,
+	readFiles bool,
 ) (component.Components, error) {
-	allFilters := slices.Concat(stackTypeFilter(), opts.Filters.RestrictToStacks(), additionalFilters)
+	allFilters := slices.Concat(stackTypeFilter(), opts.Filters.RestrictToStacks())
 
 	d := discovery.NewDiscovery(wt.Path).
 		WithSuppressParseErrors().
 		WithFilters(allFilters)
+
+	if readFiles {
+		d = d.WithReadFiles()
+	}
 
 	components, err := d.Discover(ctx, l, opts)
 	if err != nil {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Right now, users with negations in their filter expressions aren't preventing reading parsing from happening in worktrees during stack generation. This is because we aren't properly propagating the non-Git filters from the parent discovery down to child discoveries.

This fix this by properly propagating the non-Git filters from the parent discovery down to child discoveries.

Relates to recommended approach for handling #5821

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filter exclusions are now properly applied during worktree-based filtering operations.
  * Negated filters are now applied consistently in sub-discovery operations.
  * Improved stability by preventing parse errors from excluded catalog units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->