### PR TITLE
fix: Using cty.DynamicVal to avoid 'Unsupported Attribute' errors

### DIFF
--- a/docs/src/data/changelog/v1.0.1.mdx
+++ b/docs/src/data/changelog/v1.0.1.mdx
@@ -81,6 +81,12 @@ Thank you to the OpenTofu team for introducing this warning to ensure that Windo
 
 ---
 
+#### `hcl validate` no longer fails on `dependency.outputs` references
+
+`terragrunt hcl validate` previously failed with "Unsupported attribute" when a configuration referenced `dependency.<name>.outputs.<key>` without `mock_outputs`. 
+
+During validation, output resolution is skipped, but the `outputs` attribute was never added to the dependency evaluation context, causing any output reference to error. The fix provides a dynamic placeholder for dependency outputs (and inputs) during validation so that attribute access evaluates to unknown rather than failing. Additionally, the dependency resolution pipeline is now more resilient during validation. Dependencies with unresolvable `config_path` values or nonexistent targets no longer cause the entire `dependency` namespace to disappear from the evaluation context.
+
 #### Destroy queue now displays units in correct order
 
 Previously, the run queue display showed units in apply order even for destroy commands. The queue now correctly shows dependents before their dependencies when running destroy, matching the actual execution order.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1345,6 +1345,16 @@ func ParseConfig(
 		retrievedOutputs, err := decodeAndRetrieveOutputs(ctx, pctx, l, file)
 		if err != nil {
 			errs = errs.Append(err)
+
+			// During hcl validate, dependency resolution can fail for many reasons (invalid
+			// config_path, target parse errors, etc.). Use cty.DynamicVal as a fallback so
+			// that the "dependency" variable still exists in the eval context — otherwise every
+			// dependency.x.outputs.y reference cascades into a confusing "dependency is not
+			// defined" error that obscures the real problem.
+			if pctx.SkipOutput && retrievedOutputs == nil {
+				dynamicVal := cty.DynamicVal
+				retrievedOutputs = &dynamicVal
+			}
 		}
 
 		pctx.DecodedDependencies = retrievedOutputs

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -223,6 +223,13 @@ func decodeAndRetrieveOutputs(ctx context.Context, pctx *ParsingContext, l log.L
 		}
 
 		if !IsValidConfigPath(dep.ConfigPath) {
+			// During hcl validate, config_path may be unresolvable (e.g., references an
+			// unavailable local). Skip the invalid dependency instead of aborting — it will
+			// get a cty.DynamicVal placeholder in dependencyBlocksToCtyValue.
+			if pctx.SkipOutput {
+				continue
+			}
+
 			return nil, errors.New(DependencyInvalidConfigPathError{DependencyName: dep.Name})
 		}
 	}
@@ -279,6 +286,11 @@ func decodeDependencies(ctx context.Context, pctx *ParsingContext, l log.Logger,
 		}
 
 		if !IsValidConfigPath(dep.ConfigPath) {
+			if pctx.SkipOutput {
+				updatedDependencies.Dependencies = append(updatedDependencies.Dependencies, dep)
+				continue
+			}
+
 			return &updatedDependencies, errors.New(DependencyInvalidConfigPathError{DependencyName: dep.Name})
 		}
 
@@ -388,10 +400,19 @@ func checkForDependencyBlockCycles(ctx context.Context, pctx *ParsingContext, l 
 		}
 
 		if !IsValidConfigPath(dependency.ConfigPath) {
+			if pctx.SkipOutput {
+				continue
+			}
+
 			return errors.New(DependencyInvalidConfigPathError{DependencyName: dependency.Name})
 		}
 
 		dependencyPath := getCleanedTargetConfigPath(dependency.ConfigPath.AsString(), configPath)
+
+		// Skip cycle checking for nonexistent dependency targets — there is nothing to traverse.
+		if !util.FileExists(dependencyPath) {
+			continue
+		}
 
 		l, dependencyContext, err := pctx.WithDependencyConfigPath(l, dependencyPath)
 		if err != nil {
@@ -524,6 +545,8 @@ func dependencyBlocksToCtyValue(traceCtx context.Context, pctx *ParsingContext, 
 
 				if dependencyConfig.Inputs != nil {
 					dependencyEncodingMap["inputs"] = *dependencyConfig.Inputs
+				} else if pctx.SkipOutput {
+					dependencyEncodingMap["inputs"] = cty.DynamicVal
 				}
 
 				// Once the dependency is encoded into a map, we need to convert to a cty.Value again so that it can be fed to

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -540,12 +540,16 @@ func dependencyBlocksToCtyValue(traceCtx context.Context, pctx *ParsingContext, 
 					// During hcl validate, output resolution is skipped. Use cty.DynamicVal so that
 					// attribute access on dependency outputs (e.g. dependency.x.outputs.y) evaluates
 					// to unknown rather than producing an "Unsupported attribute" error.
+					l.Debugf("Setting outputs for dependency %s to DynamicVal (output resolution skipped)", dependencyConfig.Name)
+
 					dependencyEncodingMap["outputs"] = cty.DynamicVal
 				}
 
 				if dependencyConfig.Inputs != nil {
 					dependencyEncodingMap["inputs"] = *dependencyConfig.Inputs
 				} else if pctx.SkipOutput {
+					l.Debugf("Setting inputs for dependency %s to DynamicVal (output resolution skipped)", dependencyConfig.Name)
+
 					dependencyEncodingMap["inputs"] = cty.DynamicVal
 				}
 

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -515,6 +515,11 @@ func dependencyBlocksToCtyValue(traceCtx context.Context, pctx *ParsingContext, 
 					lock.Unlock()
 
 					dependencyEncodingMap["outputs"] = *dependencyConfig.RenderedOutputs
+				} else if pctx.SkipOutput {
+					// During hcl validate, output resolution is skipped. Use cty.DynamicVal so that
+					// attribute access on dependency outputs (e.g. dependency.x.outputs.y) evaluates
+					// to unknown rather than producing an "Unsupported attribute" error.
+					dependencyEncodingMap["outputs"] = cty.DynamicVal
 				}
 
 				if dependencyConfig.Inputs != nil {

--- a/test/fixtures/hclvalidate/valid/dependency-output/dep/main.tf
+++ b/test/fixtures/hclvalidate/valid/dependency-output/dep/main.tf
@@ -1,0 +1,3 @@
+output "some_output" {
+  value = "test"
+}

--- a/test/fixtures/hclvalidate/valid/dependency-output/dep/terragrunt.hcl
+++ b/test/fixtures/hclvalidate/valid/dependency-output/dep/terragrunt.hcl
@@ -1,0 +1,1 @@
+// intentionally blank

--- a/test/fixtures/hclvalidate/valid/dependency-output/main.tf
+++ b/test/fixtures/hclvalidate/valid/dependency-output/main.tf
@@ -1,0 +1,3 @@
+variable "my_input" {
+  type = string
+}

--- a/test/fixtures/hclvalidate/valid/dependency-output/terragrunt.hcl
+++ b/test/fixtures/hclvalidate/valid/dependency-output/terragrunt.hcl
@@ -1,0 +1,7 @@
+dependency "dep" {
+  config_path = "./dep"
+}
+
+inputs = {
+  my_input = dependency.dep.outputs.some_output
+}

--- a/test/fixtures/hclvalidate/valid/dependency-unresolvable-path/dep/main.tf
+++ b/test/fixtures/hclvalidate/valid/dependency-unresolvable-path/dep/main.tf
@@ -1,0 +1,3 @@
+output "value" {
+  value = "test"
+}

--- a/test/fixtures/hclvalidate/valid/dependency-unresolvable-path/dep/terragrunt.hcl
+++ b/test/fixtures/hclvalidate/valid/dependency-unresolvable-path/dep/terragrunt.hcl
@@ -1,0 +1,1 @@
+// intentionally blank

--- a/test/fixtures/hclvalidate/valid/dependency-unresolvable-path/main.tf
+++ b/test/fixtures/hclvalidate/valid/dependency-unresolvable-path/main.tf
@@ -1,0 +1,7 @@
+variable "from_valid" {
+  type = string
+}
+
+variable "from_missing" {
+  type = string
+}

--- a/test/fixtures/hclvalidate/valid/dependency-unresolvable-path/terragrunt.hcl
+++ b/test/fixtures/hclvalidate/valid/dependency-unresolvable-path/terragrunt.hcl
@@ -1,0 +1,12 @@
+dependency "missing" {
+  config_path = "../nonexistent-module"
+}
+
+dependency "valid_dep" {
+  config_path = "./dep"
+}
+
+inputs = {
+  from_valid   = dependency.valid_dep.outputs.value
+  from_missing = dependency.missing.outputs.value
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -844,24 +844,6 @@ func TestHclvalidateDiagnostic(t *testing.T) {
 		},
 		&diagnostic.Diagnostic{
 			Severity: diagnostic.DiagnosticSeverity(hcl.DiagError),
-			Summary:  "Unsupported attribute",
-			Detail:   "This object does not have an attribute named \"outputs\".",
-			Range: &diagnostic.Range{
-				Filename: filepath.Join(rootPath, "second/c/terragrunt.hcl"),
-				Start:    diagnostic.Pos{Line: 6, Column: 19, Byte: 86},
-				End:      diagnostic.Pos{Line: 6, Column: 27, Byte: 94},
-			},
-			Snippet: &diagnostic.Snippet{
-				Context:              "",
-				Code:                 "  c = dependency.a.outputs.z",
-				StartLine:            6,
-				HighlightStartOffset: 18,
-				HighlightEndOffset:   26,
-				Values:               []diagnostic.ExpressionValue{{Traversal: "dependency.a", Statement: "is object with no attributes"}},
-			},
-		},
-		&diagnostic.Diagnostic{
-			Severity: diagnostic.DiagnosticSeverity(hcl.DiagError),
 			Summary:  "Missing required argument",
 			Detail:   "The argument \"config_path\" is required, but no definition was found.",
 			Range: &diagnostic.Range{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5811.

`terragrunt hcl validate` previously failed with "Unsupported attribute" when a configuration referenced `dependency.<name>.outputs.<key>` without `mock_outputs`. 

During validation, output resolution is skipped, but the `outputs` attribute was never added to the dependency evaluation context, causing any output reference to error. The fix provides a dynamic placeholder for dependency outputs (and inputs) during validation so that attribute access evaluates to unknown rather than failing. Additionally, the dependency resolution pipeline is now more resilient during validation. Dependencies with unresolvable `config_path` values or nonexistent targets no longer cause the entire `dependency` namespace to disappear from the evaluation context.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation no longer errors for references to dependency outputs when mock outputs are absent; dependency attributes evaluate as unknown instead of failing.
  * Validation is more resilient: unresolved dependency config paths or missing targets no longer remove the dependency namespace.

* **Documentation**
  * Added v1.0.1 changelog entry documenting dependency validation improvements.

* **Tests**
  * Added fixtures covering dependency output and unresolvable-path validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->