### PR TITLE
fix: Fixing `get_original_terragrunt_dir()` interaction with dependencies

### DIFF
--- a/docs/src/data/changelog/v1.0.1.mdx
+++ b/docs/src/data/changelog/v1.0.1.mdx
@@ -93,6 +93,12 @@ Dependents are now correctly discovered when units are discovered in worktrees. 
 
 A regression introduced in v0.99.4 caused `read_terragrunt_config()` to fail to parse `dependency` blocks in external configurations during stack execution. This is fixed by resetting parsing context fields that prevented proper evaluation of dependencies in configurations read by `read_terragrunt_config()`.
 
+#### `get_original_terragrunt_dir()` now resolves correctly during dependency parsing
+
+A regression introduced in `v1.0.0-rc3` caused `get_original_terragrunt_dir()` to return the dependent directory instead of the dependency's directory when parsing dependency configurations from a unit. 
+
+This broke configurations where a dependency's `read_terragrunt_config()` chain relied on `get_original_terragrunt_dir()` to locate sibling files. The fix introduces a dedicated `WithDependencyConfigPath` method that correctly resets the original config path when parsing a dependency as an independent unit.
+
 #### Chained dependency with exposed include conversion fixed
 
 Chaining dependencies with exposed includes no longer produces a spurious "Could not convert include to the execution ctx to evaluate additional locals" error during partial parsing.

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -307,12 +307,11 @@ func decodeDependencies(ctx context.Context, pctx *ParsingContext, l log.Logger,
 			l.Debugf("Reading Terragrunt config file at %s", util.RelPathForLog(pctx.RootWorkingDir, depPath, pctx.Writers.LogShowAbsPaths))
 		}
 
-		_, depCtx, err := pctx.WithConfigPath(l, depPath)
+		_, depCtx, err := pctx.WithDependencyConfigPath(l, depPath)
 		if err != nil {
 			return nil, err
 		}
 
-		depCtx.OriginalTerragruntConfigPath = depPath
 		depCtx.DownloadDir = filepath.Join(filepath.Dir(depPath), util.TerragruntCacheDir)
 
 		if depCtx.IAMRoleOptions != depCtx.OriginalIAMRoleOptions {
@@ -394,12 +393,10 @@ func checkForDependencyBlockCycles(ctx context.Context, pctx *ParsingContext, l 
 
 		dependencyPath := getCleanedTargetConfigPath(dependency.ConfigPath.AsString(), configPath)
 
-		l, dependencyContext, err := pctx.WithConfigPath(l, dependencyPath)
+		l, dependencyContext, err := pctx.WithDependencyConfigPath(l, dependencyPath)
 		if err != nil {
 			return err
 		}
-
-		dependencyContext.OriginalTerragruntConfigPath = dependencyPath
 
 		if err := checkForDependencyBlockCyclesUsingDFS(ctx, dependencyContext, l, dependencyPath, &visitedPaths, &currentTraversalPaths); err != nil {
 			return err
@@ -439,12 +436,10 @@ func checkForDependencyBlockCyclesUsingDFS(
 	for _, dependency := range dependencyPaths {
 		dependencyPath := getCleanedTargetConfigPath(dependency, dependencyPath)
 
-		l, dependencyContext, err := pctx.WithConfigPath(l, dependencyPath)
+		l, dependencyContext, err := pctx.WithDependencyConfigPath(l, dependencyPath)
 		if err != nil {
 			return err
 		}
-
-		dependencyContext.OriginalTerragruntConfigPath = dependencyPath
 
 		if err := checkForDependencyBlockCyclesUsingDFS(ctx, dependencyContext, l, dependencyPath, visitedPaths, currentTraversalPaths); err != nil {
 			return err
@@ -765,14 +760,12 @@ func getOutputJSONWithCaching(ctx context.Context, pctx *ParsingContext, l log.L
 // by directly pulling down the state file. Otherwise, terragrunt will fallback to running `terragrunt output` on the
 // target module.
 func getTerragruntOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Logger, targetConfig string) ([]byte, error) {
-	// Create dependency context using WithConfigPath
-	l, pctx, err := pctx.WithConfigPath(l, targetConfig)
+	l, pctx, err := pctx.WithDependencyConfigPath(l, targetConfig)
 	if err != nil {
 		return nil, err
 	}
 
 	// Set dependency-specific fields
-	pctx.OriginalTerragruntConfigPath = targetConfig
 	pctx.ForwardTFStdout = false
 	pctx.CheckDependentUnits = false
 	pctx.TerraformCommand = "output"

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -312,6 +312,7 @@ func decodeDependencies(ctx context.Context, pctx *ParsingContext, l log.Logger,
 			return nil, err
 		}
 
+		depCtx.OriginalTerragruntConfigPath = depPath
 		depCtx.DownloadDir = filepath.Join(filepath.Dir(depPath), util.TerragruntCacheDir)
 
 		if depCtx.IAMRoleOptions != depCtx.OriginalIAMRoleOptions {
@@ -398,6 +399,8 @@ func checkForDependencyBlockCycles(ctx context.Context, pctx *ParsingContext, l 
 			return err
 		}
 
+		dependencyContext.OriginalTerragruntConfigPath = dependencyPath
+
 		if err := checkForDependencyBlockCyclesUsingDFS(ctx, dependencyContext, l, dependencyPath, &visitedPaths, &currentTraversalPaths); err != nil {
 			return err
 		}
@@ -440,6 +443,8 @@ func checkForDependencyBlockCyclesUsingDFS(
 		if err != nil {
 			return err
 		}
+
+		dependencyContext.OriginalTerragruntConfigPath = dependencyPath
 
 		if err := checkForDependencyBlockCyclesUsingDFS(ctx, dependencyContext, l, dependencyPath, visitedPaths, currentTraversalPaths); err != nil {
 			return err

--- a/pkg/config/dependency_test.go
+++ b/pkg/config/dependency_test.go
@@ -188,6 +188,37 @@ dependency "enabled" {
 
 // TestDisabledDependencyWithEmptyConfigPath verifies that disabled dependencies
 // with empty config_path don't cause errors.
+// TestDependencyOriginalTerragruntDir verifies that when parsing a dependency's
+// config during cycle detection, get_original_terragrunt_dir() returns the
+// dependency's directory, not the caller's directory.
+//
+// Regression test: when unit-a depends on unit-b, and unit-b's config chain
+// calls get_original_terragrunt_dir(), it must resolve to unit-b's directory so
+// that paths constructed from it point to files that exist alongside unit-b.
+func TestDependencyOriginalTerragruntDir(t *testing.T) {
+	t.Parallel()
+
+	filename, err := filepath.Abs(
+		filepath.Join(
+			"../..",
+			"test",
+			"fixtures",
+			"regressions",
+			"dependency-original-terragrunt-dir",
+			"unit-a",
+			"terragrunt.hcl",
+		),
+	)
+	require.NoError(t, err)
+
+	ctx, pctx := newTestParsingContext(t, filename)
+	pctx.OriginalTerragruntConfigPath = filename
+	pctx.SkipOutput = true
+
+	_, err = config.ParseConfigFile(ctx, pctx, logger.CreateLogger(), filename, nil)
+	require.NoError(t, err)
+}
+
 func TestDisabledDependencyWithEmptyConfigPath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -227,6 +227,11 @@ func (ctx *ParsingContext) WithIncrementedDepth() (*ParsingContext, error) {
 // WithConfigPath returns a new ParsingContext with the config path updated.
 // It normalizes the path to an absolute path, updates WorkingDir to the directory
 // containing the config, and adjusts the logger's working directory field if it changed.
+//
+// OriginalTerragruntConfigPath is intentionally NOT updated — this is correct
+// when reading a config from another (e.g. read_terragrunt_config), where the
+// "original" caller should be preserved. For parsing a dependency as a standalone
+// unit, use WithDependencyConfigPath instead.
 func (ctx *ParsingContext) WithConfigPath(l log.Logger, configPath string) (log.Logger, *ParsingContext, error) {
 	configPath = filepath.Clean(configPath)
 	if !filepath.IsAbs(configPath) {
@@ -242,6 +247,21 @@ func (ctx *ParsingContext) WithConfigPath(l log.Logger, configPath string) (log.
 	c := ctx.Clone()
 	c.TerragruntConfigPath = configPath
 	c.WorkingDir = workingDir
+
+	return l, c, nil
+}
+
+// WithDependencyConfigPath returns a new ParsingContext for parsing a dependency
+// as a standalone unit. Unlike WithConfigPath, this also resets
+// OriginalTerragruntConfigPath so that get_original_terragrunt_dir() resolves
+// relative to the dependency, not the caller.
+func (ctx *ParsingContext) WithDependencyConfigPath(l log.Logger, configPath string) (log.Logger, *ParsingContext, error) {
+	l, c, err := ctx.WithConfigPath(l, configPath)
+	if err != nil {
+		return l, nil, err
+	}
+
+	c.OriginalTerragruntConfigPath = c.TerragruntConfigPath
 
 	return l, c, nil
 }

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -224,14 +224,16 @@ func (ctx *ParsingContext) WithIncrementedDepth() (*ParsingContext, error) {
 	return c, nil
 }
 
-// WithConfigPath returns a new ParsingContext with the config path updated.
-// It normalizes the path to an absolute path, updates WorkingDir to the directory
-// containing the config, and adjusts the logger's working directory field if it changed.
+// WithConfigPath returns a new ParsingContext targeting a different config file.
 //
-// OriginalTerragruntConfigPath is intentionally NOT updated — this is correct
-// when reading a config from another (e.g. read_terragrunt_config), where the
-// "original" caller should be preserved. For parsing a dependency as a standalone
-// unit, use WithDependencyConfigPath instead.
+// It normalizes configPath to an absolute path, sets TerragruntConfigPath and
+// WorkingDir accordingly, and updates the logger when the working directory changes.
+//
+// OriginalTerragruntConfigPath is preserved so that get_original_terragrunt_dir()
+// continues to resolve to the caller. This is the correct behavior when one config
+// reads another via read_terragrunt_config.
+//
+// To parse a dependency as an independent unit, use [ParsingContext.WithDependencyConfigPath].
 func (ctx *ParsingContext) WithConfigPath(l log.Logger, configPath string) (log.Logger, *ParsingContext, error) {
 	configPath = filepath.Clean(configPath)
 	if !filepath.IsAbs(configPath) {
@@ -252,9 +254,12 @@ func (ctx *ParsingContext) WithConfigPath(l log.Logger, configPath string) (log.
 }
 
 // WithDependencyConfigPath returns a new ParsingContext for parsing a dependency
-// as a standalone unit. Unlike WithConfigPath, this also resets
-// OriginalTerragruntConfigPath so that get_original_terragrunt_dir() resolves
-// relative to the dependency, not the caller.
+// as an independent unit.
+//
+// It performs the same path and logger updates as [ParsingContext.WithConfigPath],
+// and additionally resets OriginalTerragruntConfigPath to the dependency's path.
+// This ensures that get_original_terragrunt_dir() resolves to the dependency's
+// own directory rather than the caller's.
 func (ctx *ParsingContext) WithDependencyConfigPath(l log.Logger, configPath string) (log.Logger, *ParsingContext, error) {
 	l, c, err := ctx.WithConfigPath(l, configPath)
 	if err != nil {

--- a/test/fixtures/regressions/dependency-original-terragrunt-dir/unit-a/terragrunt.hcl
+++ b/test/fixtures/regressions/dependency-original-terragrunt-dir/unit-a/terragrunt.hcl
@@ -1,0 +1,11 @@
+dependency "unit_b" {
+  config_path  = "../unit-b"
+  skip_outputs = true
+  mock_outputs = {
+    app_name = "mock"
+  }
+}
+
+inputs = {
+  dep_name = dependency.unit_b.outputs.app_name
+}

--- a/test/fixtures/regressions/dependency-original-terragrunt-dir/unit-b/_common.hcl
+++ b/test/fixtures/regressions/dependency-original-terragrunt-dir/unit-b/_common.hcl
@@ -1,0 +1,3 @@
+locals {
+  app_name = "myapp"
+}

--- a/test/fixtures/regressions/dependency-original-terragrunt-dir/unit-b/common.hcl
+++ b/test/fixtures/regressions/dependency-original-terragrunt-dir/unit-b/common.hcl
@@ -1,0 +1,5 @@
+locals {
+  original_dir    = get_original_terragrunt_dir()
+  common_config   = read_terragrunt_config("${local.original_dir}/_common.hcl")
+  app_name        = local.common_config.locals.app_name
+}

--- a/test/fixtures/regressions/dependency-original-terragrunt-dir/unit-b/terragrunt.hcl
+++ b/test/fixtures/regressions/dependency-original-terragrunt-dir/unit-b/terragrunt.hcl
@@ -1,0 +1,8 @@
+locals {
+  common   = read_terragrunt_config("common.hcl")
+  app_name = local.common.locals.app_name
+}
+
+inputs = {
+  app_name = local.app_name
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

During refactors in `v1.0.0-rc3`, a subtle regression was introduced where `OriginalTerragruntConfigPath` was no longer correctly reset when parsing a dependency from a parsing context of a dependent unit. This caused a bug in resolution of `get_original_terragrunt_dir()` where the value of `get_original_terragrunt_dir()` in the unit configuration of the dependency was set to the path of the dependent unit, rather than the dependency being parsed.

This fixes that regression.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a regression where `get_original_terragrunt_dir()` returned incorrect directory references during dependency parsing, affecting proper resolution of sibling files in dependency configuration chains.

* **Tests**
  * Added regression test fixtures to verify correct directory path resolution behavior during dependency configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->