### PR TITLE
chore: Expanding `lll` coverage to `generate`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/help/|internal/configbridge/|internal/errors/|internal/gcphelper/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/help/|internal/configbridge/|internal/errors/|internal/gcphelper/|internal/stacks/generate/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
     paths:
       - docs
       - _ci

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -91,7 +91,14 @@ func GenerateStacks(
 }
 
 // generateLevel handles the concurrent generation of all stack files at a given level.
-func generateLevel(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, level int, levelNodes []*StackNode, generatedFiles map[string]bool) error {
+func generateLevel(
+	ctx context.Context,
+	l log.Logger,
+	opts *options.TerragruntOptions,
+	level int,
+	levelNodes []*StackNode,
+	generatedFiles map[string]bool,
+) error {
 	l.Debugf("Generating stack level %d with %d files", level, len(levelNodes))
 
 	wp := worker.NewWorkerPool(opts.Parallelism)


### PR DESCRIPTION
## Description

Addressed `lll` findings in `generate`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `generate`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to exclude additional code paths.
* **Style**
  * Reformatted function signatures for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->