### PR TITLE
chore: Expanding `lll` coverage to `backend-delete`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/configbridge/|internal/errors/|internal/gcphelper/|internal/stacks/generate/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/delete/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/configbridge/|internal/errors/|internal/gcphelper/|internal/stacks/generate/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
     paths:
       - docs
       - _ci

--- a/internal/cli/commands/backend/delete/delete.go
+++ b/internal/cli/commands/backend/delete/delete.go
@@ -39,7 +39,11 @@ func runDelete(ctx context.Context, l log.Logger, opts *options.TerragruntOption
 		}
 
 		if !enabled {
-			return errors.Errorf("bucket is not versioned, refusing to delete backend state. If you are sure you want to delete the backend state anyways, use the --%s flag", ForceBackendDeleteFlagName)
+			return errors.Errorf(
+				"bucket is not versioned, refusing to delete backend state."+
+					" If you are sure you want to delete the backend state anyways, use the --%s flag",
+				ForceBackendDeleteFlagName,
+			)
 		}
 	}
 


### PR DESCRIPTION
## Description

Addressed `lll` findings in `backend-delete`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `backend-delete`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal linting configuration for code quality checks.

* **Style**
  * Improved error message formatting when backend bucket operations encounter versioning issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->