### PR TITLE
chore: Expanding `lll` coverage to `cloner`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/delete/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/configbridge/|internal/errors/|internal/gcphelper/|internal/stacks/generate/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/delete/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/errors/|internal/gcphelper/|internal/stacks/generate/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
     paths:
       - docs
       - _ci

--- a/internal/cloner/cloner.go
+++ b/internal/cloner/cloner.go
@@ -10,7 +10,8 @@ const (
 
 	// fieldTagValueRequired forces to make deep copy of the field even if the field type is disallowed by the option.
 	fieldTagValueRequired = "required"
-	// fieldTagValueShadowCopy specifies that the dst field should be assigned the src field pointer instead of deep copying.
+	// fieldTagValueShadowCopy specifies that the dst field should be assigned
+	// the src field pointer instead of deep copying.
 	fieldTagValueShadowCopy = "shadowcopy"
 	// fieldTagValueSkip specifies that the dst field should have a null value, regardless of the src value.
 	fieldTagValueSkip      = "skip"
@@ -118,7 +119,8 @@ func (cloner *Cloner[T]) cloneValue(src reflect.Value) reflect.Value {
 		return cloner.clonePointer(src)
 	case reflect.Struct:
 		return cloner.cloneStruct(src)
-	case reflect.Invalid, reflect.Uintptr, reflect.Complex64, reflect.Complex128, reflect.Chan, reflect.Func, reflect.Interface:
+	case reflect.Invalid, reflect.Uintptr, reflect.Complex64, reflect.Complex128,
+		reflect.Chan, reflect.Func, reflect.Interface:
 	}
 
 	return src


### PR DESCRIPTION
## Description

Addressed `lll` findings in `cloner`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `cloner`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality linter configuration to improve consistency.
  * Reformatted internal code structure for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->