### PR TITLE
chore: Expanding `lll` coverage to `engine`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Fixes #000.
 Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).
 
 - [ ] I authored this code entirely myself
-- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
+- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
 - [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
 - [ ] Update the docs.
 - [ ] Run the relevant tests successfully, including pre-commit checks.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/delete/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/errors/|internal/gcphelper/|internal/stacks/generate/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/delete/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/stacks/generate/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
     paths:
       - docs
       - _ci

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -647,7 +647,12 @@ func createEngine(
 }
 
 // invoke engine for working directory
-func invoke(ctx context.Context, l log.Logger, runOptions *ExecutionOptions, client *proto.EngineClient) (*util.CmdOutput, error) {
+func invoke(
+	ctx context.Context,
+	l log.Logger,
+	runOptions *ExecutionOptions,
+	client *proto.EngineClient,
+) (*util.CmdOutput, error) {
 	l = l.WithField(placeholders.TFPathKeyName, "engine")
 
 	meta, err := ConvertMetaToProtobuf(runOptions.EngineConfig.Meta)
@@ -865,7 +870,12 @@ func initialize(ctx context.Context, l log.Logger, runOptions *ExecutionOptions,
 var ErrEngineShutdownFailed = errors.New("engine shutdown failed")
 
 // shutdown engine for working directory
-func shutdown(ctx context.Context, l log.Logger, runOptions *ExecutionOptions, terragruntEngine *proto.EngineClient) error {
+func shutdown(
+	ctx context.Context,
+	l log.Logger,
+	runOptions *ExecutionOptions,
+	terragruntEngine *proto.EngineClient,
+) error {
 	meta, err := ConvertMetaToProtobuf(runOptions.EngineConfig.Meta)
 	if err != nil {
 		return errors.New(err)


### PR DESCRIPTION
## Description

Addressed `lll` findings in `engine`. Also fixed a trailing `]` typo in `.github/pull_request_template.md`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `engine`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed markdown formatting errors in development workflow templates
  * Refined code quality linter configurations to optimize development environment
  * Improved internal code formatting and organization for maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->