### PR TITLE
chore: Expanding `lll` coverage to `exec`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/delete/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/stacks/generate/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/delete/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/exec/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/stacks/generate/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
     paths:
       - docs
       - _ci

--- a/internal/cli/commands/exec/exec.go
+++ b/internal/cli/commands/exec/exec.go
@@ -15,7 +15,13 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
-func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, cmdOpts *Options, args clihelper.Args) error {
+func Run(
+	ctx context.Context,
+	l log.Logger,
+	opts *options.TerragruntOptions,
+	cmdOpts *Options,
+	args clihelper.Args,
+) error {
 	prepared, err := prepare.PrepareConfig(ctx, l, opts)
 	if err != nil {
 		return err
@@ -75,7 +81,9 @@ func runTargetCommand(
 	runOpts := configbridge.NewRunOptions(opts)
 
 	return run.RunActionWithHooks(ctx, l, command, runOpts, cfg, r, func(ctx context.Context) error {
-		_, err := shell.RunCommandWithOutput(ctx, l, configbridge.ShellRunOptsFromOpts(opts), dir, false, false, command, cmdArgs...)
+		_, err := shell.RunCommandWithOutput(
+			ctx, l, configbridge.ShellRunOptsFromOpts(opts), dir, false, false, command, cmdArgs...,
+		)
 		if err != nil {
 			return errors.Errorf("failed to run command in directory %s: %w", dir, err)
 		}


### PR DESCRIPTION
## Description

Addressed `lll` findings in `exec`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `exec`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted function declarations and invocations to multi-line format for improved readability.

* **Chores**
  * Updated linting configuration to exclude an additional directory from code analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->