### PR TITLE
chore: Expanding `lll` coverage to `stacks-output`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/(delete|migrate)/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/exec/|internal/cli/commands/find/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/stacks/generate/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/(delete|migrate)/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/exec/|internal/cli/commands/find/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/stacks/(generate|output)/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
     paths:
       - docs
       - _ci

--- a/internal/stacks/output/output.go
+++ b/internal/stacks/output/output.go
@@ -143,7 +143,8 @@ func StackOutput(
 
 	unitOutputs := make(map[string]map[string]cty.Value)
 
-	// Build stack list separated by stacks, find all nested stacks, and build a dotted path. If no stack is found, use the unit name.
+	// Build stack list separated by stacks, find all nested stacks, and build
+	// a dotted path. If no stack is found, use the unit name.
 	for path, unit := range declaredUnits {
 		output, found := outputs[path]
 		if !found {
@@ -273,5 +274,9 @@ func buildWorktreesIfNeeded(
 		return nil, nil
 	}
 
-	return worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{WorkingDir: opts.WorkingDir, GitExpressions: gitFilters, Experiments: opts.Experiments})
+	return worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{
+		WorkingDir:     opts.WorkingDir,
+		GitExpressions: gitFilters,
+		Experiments:    opts.Experiments,
+	})
 }

--- a/internal/stacks/output/output.go
+++ b/internal/stacks/output/output.go
@@ -152,7 +152,8 @@ func StackOutput(
 
 	unitOutputs := make(map[string]map[string]cty.Value)
 
-	// Build stack list separated by stacks, find all nested stacks, and build a dotted path. If no stack is found, use the unit name.
+	// Build stack list separated by stacks, find all nested stacks, and build
+	// a dotted path. If no stack is found, use the unit name.
 	for path, unit := range declaredUnits {
 		output, found := outputs[path]
 		if !found {
@@ -310,5 +311,9 @@ func buildWorktreesIfNeeded(
 		return nil, nil
 	}
 
-	return worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{WorkingDir: opts.WorkingDir, GitExpressions: gitFilters, Experiments: opts.Experiments})
+	return worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{
+		WorkingDir:     opts.WorkingDir,
+		GitExpressions: gitFilters,
+		Experiments:    opts.Experiments,
+	})
 }


### PR DESCRIPTION
## Description

Addressed `lll` findings in `stacks-output`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `stacks-output`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal code formatting and configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->