### PR TITLE
chore: Expanding `lll` coverage to `placeholders`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/(delete|migrate)/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/exec/|internal/cli/commands/find/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/stacks/(generate|output)/|internal/tf/cache/middleware/|internal/tips/|pkg/log/writer/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/(delete|migrate)/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/exec/|internal/cli/commands/find/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/stacks/(generate|output)/|internal/tf/cache/middleware/|internal/tips/|pkg/log/(format/placeholders|writer)/)'
     paths:
       - docs
       - _ci

--- a/pkg/log/format/placeholders/placeholder.go
+++ b/pkg/log/format/placeholders/placeholder.go
@@ -33,7 +33,9 @@ func NewPlaceholderRegister() Placeholders {
 		Time(),
 		Level(),
 		Message(),
-		Field(WorkDirKeyName, options.PathFormat(options.NonePath, options.RelativePath, options.ShortRelativePath, options.ShortPath)),
+		Field(WorkDirKeyName, options.PathFormat(
+			options.NonePath, options.RelativePath, options.ShortRelativePath, options.ShortPath,
+		)),
 		Field(TFPathKeyName, options.PathFormat(options.NonePath, options.FilenamePath, options.DirectoryPath)),
 		Field(TFCmdArgsKeyName),
 		Field(TFCmdKeyName),
@@ -181,7 +183,8 @@ func findPlaintextPlaceholder(str string) (Placeholder, string) { //nolint:iretu
 	return nil, str
 }
 
-// isPlaceholderNameCharacter returns true if the given character `c` does not contain any restricted characters for placeholder names.
+// isPlaceholderNameCharacter returns true if the given character `c` does not
+// contain any restricted characters for placeholder names.
 //
 // e.g. "time" return `true`.
 // e.g. "time " return `false`.


### PR DESCRIPTION
## Description

Addressed `lll` findings in `placeholders`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `placeholders`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code formatting and linter configuration adjustments with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->