### PR TITLE
chore: Expanding `lll` coverage to `runner-graph`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/(delete|migrate)/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/exec/|internal/cli/commands/find/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/runner/(common|run/creds/providers/amazonsts)/|internal/stacks/(generate|output)/|internal/tf/cache/middleware/|internal/tips/|pkg/log/(format/placeholders|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/(delete|migrate)/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/exec/|internal/cli/commands/find/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/amazonsts)/|internal/stacks/(generate|output)/|internal/tf/cache/middleware/|internal/tips/|pkg/log/(format/placeholders|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/runner/graph/graph.go
+++ b/internal/runner/graph/graph.go
@@ -30,7 +30,8 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 	// *Getter discarded: graph.Run only needs creds in opts.Env for initial config parse.
 	// Per-unit creds are re-fetched in runnerpool task (intentional: each unit may have
 	// different opts after clone).
-	if _, err := creds.ObtainCredsForParsing(ctx, l, opts.AuthProviderCmd, opts.Env, configbridge.ShellRunOptsFromOpts(opts)); err != nil {
+	shellOpts := configbridge.ShellRunOptsFromOpts(opts)
+	if _, err := creds.ObtainCredsForParsing(ctx, l, opts.AuthProviderCmd, opts.Env, shellOpts); err != nil {
 		return err
 	}
 
@@ -42,7 +43,11 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 	}
 
 	if cfg == nil {
-		return errors.New("terragrunt was not able to render the config as json because it received no config. This is almost certainly a bug in Terragrunt. Please open an issue on github.com/gruntwork-io/terragrunt with this message and the contents of your terragrunt.hcl")
+		return errors.New(
+			"terragrunt was not able to render the config as json because it received no config." +
+				" This is almost certainly a bug in Terragrunt. Please open an issue on" +
+				" github.com/gruntwork-io/terragrunt with this message and the contents of your terragrunt.hcl",
+		)
 	}
 	// consider root for graph identification passed destroy-graph-root argument
 	rootDir := opts.GraphRoot


### PR DESCRIPTION
## Description

Addressed `lll` findings in `runner-graph`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `runner-graph`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated linter configuration to exclude additional internal code paths.

* **Refactor**
  * Refactored internal code structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->