### PR TITLE
chore: Expanding `lll` coverage to `list`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/backend/(delete|migrate)/|internal/cli/commands/catalog/tui/command/|internal/cli/commands/exec/|internal/cli/commands/find/|internal/cli/commands/help/|internal/cli/commands/stack/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/amazonsts)/|internal/stacks/(generate|output)/|internal/tf/cache/middleware/|internal/tips/|pkg/log/(format/placeholders|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/amazonsts)/|internal/stacks/(generate|output)/|internal/tf/cache/middleware/|internal/tips/|pkg/log/(format/placeholders|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/cli/commands/list/cli.go
+++ b/internal/cli/commands/list/cli.go
@@ -82,8 +82,9 @@ func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) clihelper.Flags 
 		flags.NewFlag(&clihelper.BoolFlag{
 			Name:    ExternalFlagName,
 			EnvVars: tgPrefix.EnvVars(ExternalFlagName),
-			Usage:   "Discover external dependencies from initial results, and add them to top-level results (implies discovery of dependencies).",
-			Hidden:  true,
+			Usage: "Discover external dependencies from initial results," +
+				" and add them to top-level results (implies discovery of dependencies).",
+			Hidden: true,
 			Action: func(_ context.Context, _ *clihelper.Context, value bool) error {
 				if !value {
 					return nil

--- a/internal/cli/commands/list/list.go
+++ b/internal/cli/commands/list/list.go
@@ -41,7 +41,11 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 	// so that we can defer cleanup in the same context.
 	gitFilters := opts.Filters.UniqueGitFilters()
 
-	worktrees, worktreeErr := worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{WorkingDir: opts.WorkingDir, GitExpressions: gitFilters, Experiments: opts.Experiments})
+	worktrees, worktreeErr := worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{
+		WorkingDir:     opts.WorkingDir,
+		GitExpressions: gitFilters,
+		Experiments:    opts.Experiments,
+	})
 	if worktreeErr != nil {
 		return errors.Errorf("failed to create worktrees: %w", worktreeErr)
 	}

--- a/internal/cli/commands/list/list_test.go
+++ b/internal/cli/commands/list/list_test.go
@@ -131,7 +131,10 @@ func TestHiddenDiscovery(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	expectedPaths := []string{"unit1", "unit2", filepath.Join("nested", "unit4"), "stack1", filepath.Join(".hidden", "unit3")}
+	expectedPaths := []string{
+		"unit1", "unit2", filepath.Join("nested", "unit4"),
+		"stack1", filepath.Join(".hidden", "unit3"),
+	}
 
 	tgOpts := options.NewTerragruntOptions()
 	tgOpts.WorkingDir = tmpDir


### PR DESCRIPTION
## Description

Addressed `lll` findings in `list`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `list`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting by reorganizing multi-line struct and slice literals for enhanced readability.

* **Chores**
  * Updated linter configuration to refine code quality checks and expand path exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->