### PR TITLE
chore: Expanding `lll` coverage to `errorconfig`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/amazonsts)/|internal/stacks/(generate|output)/|internal/tf/cache/middleware/|internal/tips/|pkg/log/(format/placeholders|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/amazonsts)/|internal/stacks/(generate|output)/|internal/tf/cache/middleware/|internal/tips/|pkg/log/(format/placeholders|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/errorconfig/types_test.go
+++ b/internal/errorconfig/types_test.go
@@ -63,7 +63,8 @@ func TestExtractErrorMessage_DoesNotFalselyMatchTimeout(t *testing.T) {
 	// The timeout pattern should NOT match because the extracted message only
 	// contains stderr and exit error, not the command flags.
 	matched := errorconfig.MatchesAnyRegexpPattern(msg, patterns)
-	assert.False(t, matched, "timeout pattern should NOT match when 'timeout' only appears in command flags; cleaned message: %s", msg)
+	assert.False(t, matched,
+		"timeout pattern should NOT match when 'timeout' only appears in command flags; cleaned message: %s", msg)
 }
 
 func TestExtractErrorMessage_StillMatchesRealTimeout(t *testing.T) {
@@ -88,7 +89,8 @@ func TestExtractErrorMessage_StillMatchesRealTimeout(t *testing.T) {
 
 	msg := errorconfig.ExtractErrorMessage(err)
 	matched := errorconfig.MatchesAnyRegexpPattern(msg, patterns)
-	assert.True(t, matched, "timeout pattern should match when stderr actually contains 'timeout'; cleaned message: %s", msg)
+	assert.True(t, matched,
+		"timeout pattern should match when stderr actually contains 'timeout'; cleaned message: %s", msg)
 }
 
 func TestExtractErrorMessage_StillMatchesTimeoutInStderrWithFlags(t *testing.T) {
@@ -114,7 +116,8 @@ func TestExtractErrorMessage_StillMatchesTimeoutInStderrWithFlags(t *testing.T) 
 
 	msg := errorconfig.ExtractErrorMessage(err)
 	matched := errorconfig.MatchesAnyRegexpPattern(msg, patterns)
-	assert.True(t, matched, "timeout pattern should match when stderr actually contains 'timeout'; cleaned message: %s", msg)
+	assert.True(t, matched,
+		"timeout pattern should match when stderr actually contains 'timeout'; cleaned message: %s", msg)
 }
 
 func TestExtractErrorMessage_NonProcessError(t *testing.T) {


### PR DESCRIPTION
## Description

Addressed `lll` findings in `errorconfig`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `errorconfig`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration to exclude specific internal paths from line-length validation.

* **Tests**
  * Reformatted test assertion statements for improved code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->