### PR TITLE
chore: Expanding `lll` coverage to `experiment`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/gcphelper/|internal/git/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/amazonsts)/|internal/stacks/(generate|output)/|internal/tf/cache/middleware/|internal/tips/|pkg/log/(format/placeholders|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/amazonsts)/|internal/stacks/(generate|output)/|internal/tf/cache/middleware/|internal/tips/|pkg/log/(format/placeholders|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/experiment/experiment_test.go
+++ b/internal/experiment/experiment_test.go
@@ -90,8 +90,11 @@ func TestValidateExperiments(t *testing.T) {
 				},
 			},
 			experimentNames: []string{testCompletedA},
-			expectedWarning: "The following experiment(s) are already completed: " + testCompletedA + ". Please remove any completed experiments, as setting them no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://docs.terragrunt.com/reference/experiments",
-			expectedError:   nil,
+			expectedWarning: "The following experiment(s) are already completed: " + testCompletedA +
+				". Please remove any completed experiments, as setting them no longer does anything." +
+				" For a list of all ongoing experiments, and the outcomes of previous experiments," +
+				" see https://docs.terragrunt.com/reference/experiments",
+			expectedError: nil,
 		},
 		{
 			name: "invalid and completed experiment",
@@ -105,8 +108,11 @@ func TestValidateExperiments(t *testing.T) {
 				},
 			},
 			experimentNames: []string{"invalid", testCompletedA},
-			expectedWarning: "The following experiment(s) are already completed: " + testCompletedA + ". Please remove any completed experiments, as setting them no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://docs.terragrunt.com/reference/experiments",
-			expectedError:   experiment.NewInvalidExperimentNameError([]string{testOngoingA}),
+			expectedWarning: "The following experiment(s) are already completed: " + testCompletedA +
+				". Please remove any completed experiments, as setting them no longer does anything." +
+				" For a list of all ongoing experiments, and the outcomes of previous experiments," +
+				" see https://docs.terragrunt.com/reference/experiments",
+			expectedError: experiment.NewInvalidExperimentNameError([]string{testOngoingA}),
 		},
 	}
 

--- a/internal/experiment/warnings.go
+++ b/internal/experiment/warnings.go
@@ -16,5 +16,9 @@ func NewCompletedExperimentsWarning(experimentsNames []string) *CompletedExperim
 }
 
 func (w CompletedExperimentsWarning) String() string {
-	return "The following experiment(s) are already completed: " + strings.Join(w.experimentsNames, ", ") + ". Please remove any completed experiments, as setting them no longer does anything. For a list of all ongoing experiments, and the outcomes of previous experiments, see https://docs.terragrunt.com/reference/experiments"
+	return "The following experiment(s) are already completed: " +
+		strings.Join(w.experimentsNames, ", ") +
+		". Please remove any completed experiments, as setting them no longer does anything." +
+		" For a list of all ongoing experiments, and the outcomes of previous experiments," +
+		" see https://docs.terragrunt.com/reference/experiments"
 }


### PR DESCRIPTION
## Description

Addressed `lll` findings in `experiment`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `experiment`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality linting configuration.

* **Tests**
  * Improved test case formatting for warning validation.

* **Refactor**
  * Refactored internal warning message code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->