### PR TITLE
chore: Expanding `lll` coverage to `vfs`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/(amazonsts|externalcmd))/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tips/|pkg/log/(format/placeholders|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/(amazonsts|externalcmd))/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tips/|internal/vfs/|pkg/log/(format/placeholders|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -418,7 +418,9 @@ func (z *ZipDecompressor) Unzip(l log.Logger, fs FS, dst, src string, umask os.F
 }
 
 // extractZipFile extracts a single file from a zip archive.
-func (z *ZipDecompressor) extractZipFile(l log.Logger, fs FS, dst string, zipFile *zip.File, umask os.FileMode, totalSize *int64) error {
+func (z *ZipDecompressor) extractZipFile(
+	l log.Logger, fs FS, dst string, zipFile *zip.File, umask os.FileMode, totalSize *int64,
+) error {
 	destPath, err := sanitizeZipPath(dst, zipFile.Name)
 	if err != nil {
 		return err

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -299,7 +299,9 @@ func sanitizeZipPath(dst, name string) (string, error) {
 }
 
 // extractZipFile extracts a single file from a zip archive.
-func (z *ZipDecompressor) extractZipFile(l log.Logger, fs FS, dst string, zipFile *zip.File, umask os.FileMode, totalSize *int64) error {
+func (z *ZipDecompressor) extractZipFile(
+	l log.Logger, fs FS, dst string, zipFile *zip.File, umask os.FileMode, totalSize *int64,
+) error {
 	destPath, err := sanitizeZipPath(dst, zipFile.Name)
 	if err != nil {
 		return err

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -707,7 +707,9 @@ func TestUnzipSymlinkEscape(t *testing.T) {
 		dstPath := filepath.Join(tempDir, "dst")
 
 		// Create symlink pointing outside destination with ..
-		zipData := createZipArchiveWithSymlink(t, "target.txt", []byte("target content"), "evil_link.txt", "../../../etc/passwd")
+		zipData := createZipArchiveWithSymlink(
+			t, "target.txt", []byte("target content"), "evil_link.txt", "../../../etc/passwd",
+		)
 		require.NoError(t, vfs.WriteFile(fs, zipPath, zipData, 0644))
 
 		err := vfs.NewZipDecompressor().Unzip(l, fs, dstPath, zipPath, 0)
@@ -1059,7 +1061,9 @@ func createZipArchiveWithMode(t *testing.T, name string, content []byte, mode os
 }
 
 // createZipArchiveWithSymlink creates a zip archive with a regular file and a symlink to it.
-func createZipArchiveWithSymlink(t *testing.T, targetName string, targetContent []byte, linkName, linkTarget string) []byte {
+func createZipArchiveWithSymlink(
+	t *testing.T, targetName string, targetContent []byte, linkName, linkTarget string,
+) []byte {
 	t.Helper()
 
 	var buf bytes.Buffer

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -553,7 +553,9 @@ func createZipArchiveWithMode(t *testing.T, name string, content []byte, mode os
 }
 
 // createZipArchiveWithSymlink creates a zip archive with a regular file and a symlink to it.
-func createZipArchiveWithSymlink(t *testing.T, targetName string, targetContent []byte, linkName, linkTarget string) []byte {
+func createZipArchiveWithSymlink(
+	t *testing.T, targetName string, targetContent []byte, linkName, linkTarget string,
+) []byte {
 	t.Helper()
 
 	var buf bytes.Buffer
@@ -843,7 +845,9 @@ func TestUnzipSymlinkEscape(t *testing.T) {
 		dstPath := filepath.Join(tempDir, "dst")
 
 		// Create symlink pointing outside destination with ..
-		zipData := createZipArchiveWithSymlink(t, "target.txt", []byte("target content"), "evil_link.txt", "../../../etc/passwd")
+		zipData := createZipArchiveWithSymlink(
+			t, "target.txt", []byte("target content"), "evil_link.txt", "../../../etc/passwd",
+		)
 		require.NoError(t, vfs.WriteFile(fs, zipPath, zipData, 0644))
 
 		err := vfs.NewZipDecompressor().Unzip(l, fs, dstPath, zipPath, 0)


### PR DESCRIPTION
## Description

Addressed `lll` findings in `vfs`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `vfs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted code formatting for improved readability.

* **Chores**
  * Updated code quality tool configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->