### PR TITLE
chore: Expanding `lll` coverage to `os-exec`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/(amazonsts|externalcmd))/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/placeholders|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/(amazonsts|externalcmd))/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/placeholders|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/os/exec/cmd.go
+++ b/internal/os/exec/cmd.go
@@ -93,13 +93,19 @@ func (cmd *Cmd) Start() error {
 	return nil
 }
 
-// RegisterGracefullyShutdown registers a graceful shutdown for the command in two ways:
-//  1. If the context cancel contains a cause with a signal, this means that Terragrunt received the signal from the OS,
-//     since our executed command may also receive the same signal, we need to give the command time to gracefully shutting down,
-//     to avoid the command receiving this signal twice.
-//     Thus we will send the signal to the executed command with a delay or immediately if Terragrunt receives this same signal again.
-//  2. If the context does not contain any causes, this means that there was some failure and we need to terminate all executed commands,
-//     in this situation we are sure that commands did not receive any signal, so we send them an interrupt signal immediately.
+// RegisterGracefullyShutdown registers a graceful shutdown for the
+// command in two ways:
+//  1. If the context cancel contains a cause with a signal, this means
+//     that Terragrunt received the signal from the OS, since our
+//     executed command may also receive the same signal, we need to
+//     give the command time to gracefully shutting down, to avoid the
+//     command receiving this signal twice. Thus we will send the signal
+//     to the executed command with a delay or immediately if Terragrunt
+//     receives this same signal again.
+//  2. If the context does not contain any causes, this means that there
+//     was some failure and we need to terminate all executed commands,
+//     in this situation we are sure that commands did not receive any
+//     signal, so we send them an interrupt signal immediately.
 func (cmd *Cmd) RegisterGracefullyShutdown(ctx context.Context) func() {
 	cmd.gracefulShutdownRegistered.Store(true)
 


### PR DESCRIPTION
## Description

Addressed `lll` findings in `os-exec`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `os-exec`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance and documentation improvements.

---

**Note:** This release contains only internal improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->