### PR TITLE
chore: Expanding `lll` coverage to `runner-creds`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/runner/(common|graph|run/creds/providers/(amazonsts|externalcmd))/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/placeholders|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/placeholders|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/runner/run/creds/getter.go
+++ b/internal/runner/run/creds/getter.go
@@ -22,7 +22,12 @@ func NewGetter() *Getter {
 }
 
 // ObtainAndUpdateEnvIfNecessary obtains credentials through different providers and sets them to the provided env map.
-func (getter *Getter) ObtainAndUpdateEnvIfNecessary(ctx context.Context, l log.Logger, env map[string]string, authProviders ...providers.Provider) error {
+func (getter *Getter) ObtainAndUpdateEnvIfNecessary(
+	ctx context.Context,
+	l log.Logger,
+	env map[string]string,
+	authProviders ...providers.Provider,
+) error {
 	for _, provider := range authProviders {
 		creds, err := provider.GetCredentials(ctx, l)
 		if err != nil {
@@ -35,7 +40,8 @@ func (getter *Getter) ObtainAndUpdateEnvIfNecessary(ctx context.Context, l log.L
 
 		for providerName, prevCreds := range getter.obtainedCreds {
 			if prevCreds.Name == creds.Name {
-				l.Warnf("%s credentials obtained using %s are overwritten by credentials obtained using %s.", creds.Name, providerName, provider.Name())
+				l.Warnf("%s credentials obtained using %s are overwritten by credentials obtained using %s.",
+					creds.Name, providerName, provider.Name())
 			}
 		}
 
@@ -51,9 +57,17 @@ func (getter *Getter) ObtainAndUpdateEnvIfNecessary(ctx context.Context, l log.L
 // credentials, and populates env before HCL parsing.
 // Use when sops_decrypt_file() or get_aws_account_id() may appear in locals.
 // See https://github.com/gruntwork-io/terragrunt/issues/5515
-func ObtainCredsForParsing(ctx context.Context, l log.Logger, authProviderCmd string, env map[string]string, shellOpts *shell.ShellOptions) (*Getter, error) {
+func ObtainCredsForParsing(
+	ctx context.Context,
+	l log.Logger,
+	authProviderCmd string,
+	env map[string]string,
+	shellOpts *shell.ShellOptions,
+) (*Getter, error) {
 	g := NewGetter()
-	if err := g.ObtainAndUpdateEnvIfNecessary(ctx, l, env, externalcmd.NewProvider(l, authProviderCmd, shellOpts)); err != nil {
+
+	provider := externalcmd.NewProvider(l, authProviderCmd, shellOpts)
+	if err := g.ObtainAndUpdateEnvIfNecessary(ctx, l, env, provider); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description

Addressed `lll` findings in `runner-creds`. Also simplified the `path-except` regex by consolidating `run/creds/providers/(amazonsts|externalcmd)` into `run/creds`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `runner-creds`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration to adjust code quality check exclusions.

* **Refactor**
  * Improved code formatting consistency in credential acquisition functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->