### PR TITLE
chore: Expanding `lll` coverage to `tflint`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/placeholders|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/placeholders|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/tflint/tflint.go
+++ b/internal/tflint/tflint.go
@@ -37,7 +37,13 @@ const (
 )
 
 // RunTflintWithOpts runs tflint with the given options and returns an error if there are any issues.
-func RunTflintWithOpts(ctx context.Context, l log.Logger, opts *TFLintOptions, cfg *runcfg.RunConfig, hook *runcfg.Hook) error {
+func RunTflintWithOpts(
+	ctx context.Context,
+	l log.Logger,
+	opts *TFLintOptions,
+	cfg *runcfg.RunConfig,
+	hook *runcfg.Hook,
+) error {
 	hookExecute := slices.Clone(hook.Execute)
 	hookExecute = slices.DeleteFunc(hookExecute, func(arg string) bool {
 		return arg == tfExternalTFLint
@@ -49,7 +55,8 @@ func RunTflintWithOpts(ctx context.Context, l log.Logger, opts *TFLintOptions, c
 		return err
 	}
 
-	l.Debugf("Using .tflint.hcl file in %s", util.RelPathForLog(opts.RootWorkingDir, configFile, opts.Writers.LogShowAbsPaths))
+	l.Debugf("Using .tflint.hcl file in %s",
+		util.RelPathForLog(opts.RootWorkingDir, configFile, opts.Writers.LogShowAbsPaths))
 
 	variables, err := InputsToTflintVar(cfg.Inputs)
 	if err != nil {
@@ -235,8 +242,9 @@ func tfArgumentsToTflintVar(l log.Logger, hook *runcfg.Hook,
 	return variables, nil
 }
 
-// findTflintConfigInProject looks for a .tflint.hcl file in the current folder or it's parents.
-// When running from cache, we start searching from the original config directory to find config in the source directory.
+// findTflintConfigInProject looks for a .tflint.hcl file in the current
+// folder or it's parents. When running from cache, we start searching
+// from the original config directory to find config in the source directory.
 func findTflintConfigInProject(l log.Logger, opts *TFLintOptions) (string, error) {
 	startDir := opts.WorkingDir
 	if opts.TerragruntConfigPath != "" {
@@ -259,7 +267,9 @@ func findTflintConfigInProject(l log.Logger, opts *TFLintOptions) (string, error
 
 		fileToFind := filepath.Join(previousDir, ".tflint.hcl")
 		if util.FileExists(fileToFind) {
-			l.Debugf("Found .tflint.hcl in %s", util.RelPathForLog(opts.RootWorkingDir, fileToFind, opts.Writers.LogShowAbsPaths))
+			l.Debugf("Found .tflint.hcl in %s",
+				util.RelPathForLog(opts.RootWorkingDir, fileToFind, opts.Writers.LogShowAbsPaths))
+
 			return fileToFind, nil
 		}
 


### PR DESCRIPTION
## Description

Addressed `lll` findings in `tflint`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `tflint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code formatting standards and linter configuration to maintain consistent code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->