### PR TITLE
chore: Expanding `lll` coverage to `queue`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/placeholders|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/placeholders|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -39,8 +39,10 @@ type Entry struct {
 	// including its path, dependencies, and discovery context (such as the command being run).
 	Component component.Component
 
-	// Status represents the current lifecycle state of this entry in the queue. It tracks whether the entry is pending,
-	// blocked, ready, running, succeeded, or failed. Status is updated as dependencies are resolved and as execution progresses.
+	// Status represents the current lifecycle state of this entry in the
+	// queue. It tracks whether the entry is pending, blocked, ready,
+	// running, succeeded, or failed. Status is updated as dependencies
+	// are resolved and as execution progresses.
 	Status Status
 }
 
@@ -294,7 +296,8 @@ func NewQueue(discovered component.Components) (*Queue, error) {
 	return q, errors.New("cycle detected during queue construction")
 }
 
-// GetReadyWithDependencies returns all entries that are ready to run and have all dependencies completed (or no dependencies).
+// GetReadyWithDependencies returns all entries that are ready to run and
+// have all dependencies completed (or no dependencies).
 func (q *Queue) GetReadyWithDependencies(l log.Logger) []*Entry {
 	q.mu.RLock()
 	defer q.mu.RUnlock()

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -272,7 +272,8 @@ func TestQueue_LinearDependencyExecution(t *testing.T) {
 	// Check that all entries are ready initially and in order A, B, C
 	readyEntries := q.GetReadyWithDependencies(logger.CreateLogger())
 	assert.Len(t, readyEntries, 1, "Initially only A should be ready")
-	assert.Equal(t, queue.StatusReady, readyEntries[0].Status, "Entry %s should have StatusReady", readyEntries[0].Component.Path())
+	assert.Equal(t, queue.StatusReady, readyEntries[0].Status,
+		"Entry %s should have StatusReady", readyEntries[0].Component.Path())
 	assert.Equal(t, "A", readyEntries[0].Component.Path(), "First ready entry should be A")
 
 	// Mark A as running and complete it
@@ -325,7 +326,8 @@ func TestQueue_ParallelExecution(t *testing.T) {
 	// 1. Initially, only A should be ready
 	readyEntries := q.GetReadyWithDependencies(logger.CreateLogger())
 	assert.Len(t, readyEntries, 1, "Initially only A should be ready")
-	assert.Equal(t, queue.StatusReady, readyEntries[0].Status, "Entry %s should have StatusReady", readyEntries[0].Component.Path())
+	assert.Equal(t, queue.StatusReady, readyEntries[0].Status,
+		"Entry %s should have StatusReady", readyEntries[0].Component.Path())
 	assert.Equal(t, "A", readyEntries[0].Component.Path(), "First ready entry should be A")
 
 	// Mark A as running and complete it
@@ -418,7 +420,8 @@ func TestQueue_FailFast(t *testing.T) {
 
 	// All entries should be listed as terminal (A: Failed, B/C: EarlyExit)
 	for _, entry := range q.Entries {
-		assert.True(t, entry.Status == queue.StatusFailed || entry.Status == queue.StatusEarlyExit, "Entry %s should be terminal", entry.Component.Path())
+		assert.True(t, entry.Status == queue.StatusFailed || entry.Status == queue.StatusEarlyExit,
+			"Entry %s should be terminal", entry.Component.Path())
 	}
 
 	// Now all should be terminal


### PR DESCRIPTION
## Description

Addressed `lll` findings in `queue`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `queue`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration for path exclusions.

* **Style**
  * Reformatted comments and test assertions for improved readability.

**Note:** This release contains internal code quality improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->