### PR TITLE
chore: Expanding `lll` coverage to `format-options`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,7 +121,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/placeholders|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
     paths:
       - docs
       - _ci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/placeholders|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
     paths:
       - docs
       - _ci

--- a/pkg/log/format/options/color.go
+++ b/pkg/log/format/options/color.go
@@ -190,7 +190,8 @@ func Color(val ColorValue) Option {
 }
 
 var (
-	// defaultAutoColorValues contains ANSI color codes that are assigned sequentially to each unique text in a rotating order
+	// defaultAutoColorValues contains ANSI color codes that are assigned
+	// sequentially to each unique text in a rotating order
 	// https://user-images.githubusercontent.com/995050/47952855-ecb12480-df75-11e8-89d4-ac26c50e80b9.png
 	// https://www.hackitu.de/termcolor256/
 	defaultAutoColorValues = []ColorValue{ //nolint:gochecknoglobals
@@ -211,7 +212,8 @@ var (
 
 type gradientColor struct {
 	// cache stores unique text with their color code.
-	// We use [xsync.MapOf](https://github.com/puzpuzpuz/xsync?tab=readme-ov-file#map) instead of standard `sync.Map` since it's faster and has generic types.
+	// We use [xsync.MapOf](https://github.com/puzpuzpuz/xsync?tab=readme-ov-file#map)
+	// instead of standard `sync.Map` since it's faster and has generic types.
 	cache  *xsync.MapOf[string, ColorValue]
 	values []ColorValue
 	mu     sync.Mutex

--- a/pkg/log/format/options/option.go
+++ b/pkg/log/format/options/option.go
@@ -106,7 +106,8 @@ func (opts Options) Format(data *Data, str any) (string, error) {
 
 // Configure parsers the given `str` to configure the `opts` and returns the rest of the given `str`.
 //
-// e.g. (color=green, case=upper) some-text" sets `color` option to `green`, `case` option to `upper` and returns " some-text".
+// e.g. (color=green, case=upper) some-text" sets `color` option to `green`,
+// `case` option to `upper` and returns " some-text".
 func (opts Options) Configure(str string) (string, error) {
 	if len(str) == 0 || !strings.HasPrefix(str, OptStartSign) {
 		return str, nil

--- a/pkg/log/format/options/path_format.go
+++ b/pkg/log/format/options/path_format.go
@@ -97,7 +97,8 @@ func PathFormat(val PathFormatValue, allowed ...PathFormatValue) Option {
 }
 
 // RelativePather replaces absolute paths with relative ones,
-// For better performance, during instance creation, we creating a cache of relative paths for each subdirectory of baseDir.
+// For better performance, during instance creation, we creating a cache
+// of relative paths for each subdirectory of baseDir.
 //
 // Example of cache:
 // /path/to/dir ./
@@ -133,7 +134,8 @@ func NewRelativePather(baseDir string) (*RelativePather, error) {
 		reversIndex--
 		relPaths[reversIndex] = relPath
 
-		regStr := fmt.Sprintf(`(^|[^%[1]s\w])%[2]s([%[1]s"'\s]|$)`, regexp.QuoteMeta(pathSeparator), regexp.QuoteMeta(absPath))
+		regStr := fmt.Sprintf(`(^|[^%[1]s\w])%[2]s([%[1]s"'\s]|$)`,
+			regexp.QuoteMeta(pathSeparator), regexp.QuoteMeta(absPath))
 		absPathsReg[reversIndex] = regexp.MustCompile(regStr)
 	}
 


### PR DESCRIPTION
## Description

Addressed `lll` findings in `format-options`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `format-options`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration to expand path exclusions for code quality checks.
  * Improved documentation and comment formatting across logging modules for consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->