### PR TITLE
chore: Expanding `lll` coverage to `dag-graph`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,7 +121,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
     paths:
       - docs
       - _ci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/cli/commands/dag/graph/cli.go
+++ b/internal/cli/commands/dag/graph/cli.go
@@ -25,8 +25,9 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *clihelper.Comman
 	sharedFlags = append(sharedFlags, shared.NewFilterFlags(l, opts)...)
 
 	return &clihelper.Command{
-		Name:      CommandName,
-		Usage:     "Graph the Directed Acyclic Graph (DAG) in DOT language. Alias for 'list --format=dot --dag --dependencies --external'.",
+		Name: CommandName,
+		Usage: "Graph the Directed Acyclic Graph (DAG) in DOT language." +
+			" Alias for 'list --format=dot --dag --dependencies --external'.",
 		UsageText: "terragrunt dag graph",
 		Flags:     sharedFlags,
 		Action: func(ctx context.Context, _ *clihelper.Context) error {

--- a/internal/cli/commands/dag/graph/cli_test.go
+++ b/internal/cli/commands/dag/graph/cli_test.go
@@ -23,10 +23,26 @@ func BenchmarkRunGraphDependencies(b *testing.B) {
 		workingDir           string
 		usePartialParseCache bool
 	}{
-		{"PartialParseBenchmarkRegressionCaching", "regressions/benchmark-parsing/production/deployment-group-1/webserver/terragrunt.hcl", true},
-		{"PartialParseBenchmarkRegressionNoCache", "regressions/benchmark-parsing/production/deployment-group-1/webserver/terragrunt.hcl", false},
-		{"PartialParseBenchmarkRegressionIncludesCaching", "regressions/benchmark-parsing-includes/production/deployment-group-1/webserver/terragrunt.hcl", true},
-		{"PartialParseBenchmarkRegressionIncludesNoCache", "regressions/benchmark-parsing-includes/production/deployment-group-1/webserver/terragrunt.hcl", false},
+		{
+			"PartialParseBenchmarkRegressionCaching",
+			"regressions/benchmark-parsing/production/deployment-group-1/webserver/terragrunt.hcl",
+			true,
+		},
+		{
+			"PartialParseBenchmarkRegressionNoCache",
+			"regressions/benchmark-parsing/production/deployment-group-1/webserver/terragrunt.hcl",
+			false,
+		},
+		{
+			"PartialParseBenchmarkRegressionIncludesCaching",
+			"regressions/benchmark-parsing-includes/production/deployment-group-1/webserver/terragrunt.hcl",
+			true,
+		},
+		{
+			"PartialParseBenchmarkRegressionIncludesNoCache",
+			"regressions/benchmark-parsing-includes/production/deployment-group-1/webserver/terragrunt.hcl",
+			false,
+		},
 	}
 
 	// Run benchmarks


### PR DESCRIPTION
## Description

Addressed `lll` findings in `dag-graph`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `dag-graph`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted command documentation and test fixtures for improved readability.

* **Chores**
  * Updated linter configuration to refine exclusion rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->