### PR TITLE
chore: Expanding `lll` coverage to `scaffold`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
     paths:
       - docs
       - _ci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,7 +121,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -419,7 +419,8 @@ func downloadTemplate(
 	}
 
 	l.Debugf("Downloading template from %s into %s", baseURL.String(), templateDir)
-	// Downloading baseURL to support boilerplate dependencies and partials. Go-getter discards all but specified folder if one is provided.
+	// Downloading baseURL to support boilerplate dependencies and partials.
+	// Go-getter discards all but specified folder if one is provided.
 	if _, err := getter.GetAny(ctx, templateDir, baseURL.String()); err != nil {
 		return "", errors.New(err)
 	}
@@ -558,7 +559,8 @@ func parseModuleURL(
 }
 
 // rewriteModuleURL rewrites module url to git ssh if required
-// github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs => git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
+// github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
+// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
 func rewriteModuleURL(
 	l log.Logger,
 	opts *options.TerragruntOptions,
@@ -585,7 +587,8 @@ func rewriteModuleURL(
 		return parsedModuleURL, nil
 	}
 	// try to rewrite module url if is https and is requested to be git
-	// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs => git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
+	// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
+	// git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
 	if parsedValue.scheme == "https" && sourceURLType == sourceURLTypeGit {
 		gitUser := sourceGitSSHUser
 		if value, found := vars[sourceGitSSHUserVar]; found {
@@ -606,7 +609,8 @@ func rewriteModuleURL(
 }
 
 // rewriteTemplateURL rewrites template url with reference to tag
-// github.com/denis256/terragrunt-tests.git//scaffold/base-template => github.com/denis256/terragrunt-tests.git//scaffold/base-template?ref=v0.53.8
+// github.com/denis256/terragrunt-tests.git//scaffold/base-template =>
+// github.com/denis256/terragrunt-tests.git//scaffold/base-template?ref=v0.53.8
 func rewriteTemplateURL(
 	ctx context.Context,
 	l log.Logger,
@@ -663,7 +667,8 @@ func addRefToModuleURL(
 	ref := params.Get(refParam)
 	if ref == "" {
 		// if ref is not passed, find last release tag
-		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs => git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8
+		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
+		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8
 		rootSourceURL, _, err := tf.SplitSourceURL(l, moduleURL)
 		if err != nil {
 			return nil, errors.New(err)

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -360,7 +360,8 @@ func downloadTemplate(
 	}
 
 	l.Infof("Downloading template from %s into %s", baseURL.String(), templateDir)
-	// Downloading baseURL to support boilerplate dependencies and partials. Go-getter discards all but specified folder if one is provided.
+	// Downloading baseURL to support boilerplate dependencies and partials.
+	// Go-getter discards all but specified folder if one is provided.
 	if _, err := getter.GetAny(ctx, templateDir, baseURL.String()); err != nil {
 		return "", errors.New(err)
 	}
@@ -499,7 +500,8 @@ func parseModuleURL(
 }
 
 // rewriteModuleURL rewrites module url to git ssh if required
-// github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs => git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
+// github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
+// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
 func rewriteModuleURL(
 	l log.Logger,
 	opts *options.TerragruntOptions,
@@ -526,7 +528,8 @@ func rewriteModuleURL(
 		return parsedModuleURL, nil
 	}
 	// try to rewrite module url if is https and is requested to be git
-	// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs => git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
+	// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
+	// git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
 	if parsedValue.scheme == "https" && sourceURLType == sourceURLTypeGit {
 		gitUser := sourceGitSSHUser
 		if value, found := vars[sourceGitSSHUserVar]; found {
@@ -547,7 +550,8 @@ func rewriteModuleURL(
 }
 
 // rewriteTemplateURL rewrites template url with reference to tag
-// github.com/denis256/terragrunt-tests.git//scaffold/base-template => github.com/denis256/terragrunt-tests.git//scaffold/base-template?ref=v0.53.8
+// github.com/denis256/terragrunt-tests.git//scaffold/base-template =>
+// github.com/denis256/terragrunt-tests.git//scaffold/base-template?ref=v0.53.8
 func rewriteTemplateURL(
 	ctx context.Context,
 	l log.Logger,
@@ -604,7 +608,8 @@ func addRefToModuleURL(
 	ref := params.Get(refParam)
 	if ref == "" {
 		// if ref is not passed, find last release tag
-		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs => git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8
+		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
+		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8
 		rootSourceURL, _, err := tf.SplitSourceURL(l, moduleURL)
 		if err != nil {
 			return nil, errors.New(err)

--- a/internal/cli/commands/scaffold/scaffold_test.go
+++ b/internal/cli/commands/scaffold/scaffold_test.go
@@ -22,7 +22,11 @@ import (
 )
 
 // newTestBoilerplateOptions creates a BoilerplateOptions for testing
-func newTestBoilerplateOptions(templateFolder, outputFolder string, vars map[string]any, noShell, noHooks bool) *boilerplateoptions.BoilerplateOptions {
+func newTestBoilerplateOptions(
+	templateFolder, outputFolder string,
+	vars map[string]any,
+	noShell, noHooks bool,
+) *boilerplateoptions.BoilerplateOptions {
 	return &boilerplateoptions.BoilerplateOptions{
 		TemplateFolder:          templateFolder,
 		OutputFolder:            outputFolder,
@@ -107,7 +111,9 @@ func TestDefaultTemplateVariables(t *testing.T) {
 	assert.Len(t, cfg.Inputs, 1)
 	_, found := cfg.Inputs["required_var_1"]
 	require.True(t, found)
-	require.Equal(t, "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8", *cfg.Terraform.Source)
+	require.Equal(t,
+		"git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8",
+		*cfg.Terraform.Source)
 }
 
 func TestCatalogConfigApplication(t *testing.T) {

--- a/internal/cli/commands/scaffold/source_url_test.go
+++ b/internal/cli/commands/scaffold/source_url_test.go
@@ -20,8 +20,9 @@ func TestBuildSourceURL(t *testing.T) {
 		{
 			name:        "catalog URL gets ref from resolved",
 			originalURL: "github.com/gruntwork-io/terragrunt-scale-catalog//modules/azure/resource-group",
-			resolvedURL: "git::https://github.com/gruntwork-io/terragrunt-scale-catalog.git//modules/azure/resource-group?ref=v1.10.2",
-			expected:    "github.com/gruntwork-io/terragrunt-scale-catalog//modules/azure/resource-group?ref=v1.10.2",
+			resolvedURL: "git::https://github.com/gruntwork-io/terragrunt-scale-catalog.git//" +
+				"modules/azure/resource-group?ref=v1.10.2",
+			expected: "github.com/gruntwork-io/terragrunt-scale-catalog//modules/azure/resource-group?ref=v1.10.2",
 		},
 		{
 			name:        "original already has ref",


### PR DESCRIPTION
## Description

Addressed `lll` findings in `scaffold`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `scaffold`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration to expand exclusion rules for additional internal CLI paths.
* **Documentation**
  * Clarified inline comments for scaffold/template URL handling and examples.
* **Tests**
  * Reformatted several test declarations and assertions for readability without logic changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->