### PR TITLE
chore: Expanding `lll` coverage to `runall`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds|runcfg)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
     paths:
       - docs
       - _ci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,7 +121,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds|runcfg)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
     paths:
       - docs
       - _ci

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -27,11 +27,18 @@ import (
 // Known terraform commands that are explicitly not supported in run --all due to the nature of the command. This is
 // tracked as a map that maps the terraform command to the reasoning behind disallowing the command in run --all.
 var runAllDisabledCommands = map[string]string{
-	tf.CommandNameImport:      "terraform import should only be run against a single state representation to avoid injecting the wrong object in the wrong state representation.",
-	tf.CommandNameTaint:       "terraform taint should only be run against a single state representation to avoid using the wrong state address.",
-	tf.CommandNameUntaint:     "terraform untaint should only be run against a single state representation to avoid using the wrong state address.",
-	tf.CommandNameConsole:     "terraform console requires stdin, which is shared across all instances of run --all when multiple modules run concurrently.",
-	tf.CommandNameForceUnlock: "lock IDs are unique per state representation and thus should not be run with run --all.",
+	tf.CommandNameImport: "terraform import should only be run against a single" +
+		" state representation to avoid injecting the wrong object" +
+		" in the wrong state representation.",
+	tf.CommandNameTaint: "terraform taint should only be run against a single" +
+		" state representation to avoid using the wrong state address.",
+	tf.CommandNameUntaint: "terraform untaint should only be run against a single" +
+		" state representation to avoid using the wrong state address.",
+	tf.CommandNameConsole: "terraform console requires stdin, which is shared" +
+		" across all instances of run --all when multiple modules" +
+		" run concurrently.",
+	tf.CommandNameForceUnlock: "lock IDs are unique per state representation" +
+		" and thus should not be run with run --all.",
 }
 
 func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
@@ -90,7 +97,11 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 		err error
 	)
 	if len(gitFilters) > 0 {
-		wts, err = worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{WorkingDir: opts.WorkingDir, GitExpressions: gitFilters, Experiments: opts.Experiments})
+		wts, err = worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{
+			WorkingDir:     opts.WorkingDir,
+			GitExpressions: gitFilters,
+			Experiments:    opts.Experiments,
+		})
 		if err != nil {
 			return errors.Errorf("failed to create worktrees: %w", err)
 		}
@@ -151,7 +162,13 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 	return RunAllOnStack(ctx, l, opts, rnr, r)
 }
 
-func RunAllOnStack(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, rnr common.StackRunner, r *report.Report) error {
+func RunAllOnStack(
+	ctx context.Context,
+	l log.Logger,
+	opts *options.TerragruntOptions,
+	rnr common.StackRunner,
+	r *report.Report,
+) error {
 	l.Debugf("%s", rnr.GetStack().String())
 
 	isDestroy := opts.TerraformCliArgs.IsDestroyCommand(opts.TerraformCommand)
@@ -165,9 +182,12 @@ func RunAllOnStack(ctx context.Context, l log.Logger, opts *options.TerragruntOp
 	case tf.CommandNameApply:
 		prompt = "Are you sure you want to run 'terragrunt apply' in each unit of the run queue displayed above?"
 	case tf.CommandNameDestroy:
-		prompt = "WARNING: Are you sure you want to run `terragrunt destroy` in each unit of the run queue displayed above? There is no undo!"
+		prompt = "WARNING: Are you sure you want to run `terragrunt destroy`" +
+			" in each unit of the run queue displayed above? There is no undo!"
 	case tf.CommandNameState:
-		prompt = "Are you sure you want to manipulate the state with `terragrunt state` in each unit of the run queue displayed above? Note that absolute paths are shared, while relative paths will be relative to each working directory."
+		prompt = "Are you sure you want to manipulate the state with `terragrunt state`" +
+			" in each unit of the run queue displayed above? Note that absolute paths are shared," +
+			" while relative paths will be relative to each working directory."
 	}
 
 	if prompt != "" {

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -27,11 +27,18 @@ import (
 // Known terraform commands that are explicitly not supported in run --all due to the nature of the command. This is
 // tracked as a map that maps the terraform command to the reasoning behind disallowing the command in run --all.
 var runAllDisabledCommands = map[string]string{
-	tf.CommandNameImport:      "terraform import should only be run against a single state representation to avoid injecting the wrong object in the wrong state representation.",
-	tf.CommandNameTaint:       "terraform taint should only be run against a single state representation to avoid using the wrong state address.",
-	tf.CommandNameUntaint:     "terraform untaint should only be run against a single state representation to avoid using the wrong state address.",
-	tf.CommandNameConsole:     "terraform console requires stdin, which is shared across all instances of run --all when multiple modules run concurrently.",
-	tf.CommandNameForceUnlock: "lock IDs are unique per state representation and thus should not be run with run --all.",
+	tf.CommandNameImport: "terraform import should only be run against a single" +
+		" state representation to avoid injecting the wrong object" +
+		" in the wrong state representation.",
+	tf.CommandNameTaint: "terraform taint should only be run against a single" +
+		" state representation to avoid using the wrong state address.",
+	tf.CommandNameUntaint: "terraform untaint should only be run against a single" +
+		" state representation to avoid using the wrong state address.",
+	tf.CommandNameConsole: "terraform console requires stdin, which is shared" +
+		" across all instances of run --all when multiple modules" +
+		" run concurrently.",
+	tf.CommandNameForceUnlock: "lock IDs are unique per state representation" +
+		" and thus should not be run with run --all.",
 }
 
 func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
@@ -90,7 +97,11 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 		err error
 	)
 	if len(gitFilters) > 0 {
-		wts, err = worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{WorkingDir: opts.WorkingDir, GitExpressions: gitFilters, Experiments: opts.Experiments})
+		wts, err = worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{
+			WorkingDir:     opts.WorkingDir,
+			GitExpressions: gitFilters,
+			Experiments:    opts.Experiments,
+		})
 		if err != nil {
 			return errors.Errorf("failed to create worktrees: %w", err)
 		}
@@ -150,7 +161,13 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 	return RunAllOnStack(ctx, l, opts, rnr, r)
 }
 
-func RunAllOnStack(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, rnr common.StackRunner, r *report.Report) error {
+func RunAllOnStack(
+	ctx context.Context,
+	l log.Logger,
+	opts *options.TerragruntOptions,
+	rnr common.StackRunner,
+	r *report.Report,
+) error {
 	l.Debugf("%s", rnr.GetStack().String())
 
 	isDestroy := opts.TerraformCliArgs.IsDestroyCommand(opts.TerraformCommand)
@@ -164,9 +181,12 @@ func RunAllOnStack(ctx context.Context, l log.Logger, opts *options.TerragruntOp
 	case tf.CommandNameApply:
 		prompt = "Are you sure you want to run 'terragrunt apply' in each unit of the run queue displayed above?"
 	case tf.CommandNameDestroy:
-		prompt = "WARNING: Are you sure you want to run `terragrunt destroy` in each unit of the run queue displayed above? There is no undo!"
+		prompt = "WARNING: Are you sure you want to run `terragrunt destroy`" +
+			" in each unit of the run queue displayed above? There is no undo!"
 	case tf.CommandNameState:
-		prompt = "Are you sure you want to manipulate the state with `terragrunt state` in each unit of the run queue displayed above? Note that absolute paths are shared, while relative paths will be relative to each working directory."
+		prompt = "Are you sure you want to manipulate the state with `terragrunt state`" +
+			" in each unit of the run queue displayed above? Note that absolute paths are shared," +
+			" while relative paths will be relative to each working directory."
 	}
 
 	if prompt != "" {


### PR DESCRIPTION
## Description

Addressed `lll` findings in `runall`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `runall`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal linter configuration for improved code quality checks.
  * Refactored internal code formatting for improved maintainability with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->