### PR TITLE
chore: Expanding `lll` coverage to `options`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,7 +121,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
     paths:
       - docs
       - _ci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
     paths:
       - docs
       - _ci

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -111,7 +111,8 @@ type TerragruntOptions struct {
 	TerragruntStackConfigPath string
 	// Location of the original Terragrunt config file.
 	OriginalTerragruntConfigPath string
-	// Unlike `WorkingDir`, this path is the same for all dependencies and points to the root working directory specified in the CLI.
+	// Unlike `WorkingDir`, this path is the same for all dependencies and
+	// points to the root working directory specified in the CLI.
 	RootWorkingDir string
 	// Download Terraform configurations from the specified source location into a temporary folder
 	Source string
@@ -223,7 +224,11 @@ type TerragruntOptions struct {
 	RunAllAutoApprove bool
 	// If set to true, delete the contents of the temporary folder before downloading Terraform source code into it
 	SourceUpdate bool
-	// HCLValidateStrict is a strict mode for HCL validation files. When it's set to false the command will only return an error if required inputs are missing from all input sources (env vars, var files, etc). When it's set to true, an error will be returned if required inputs are missing or if unused variables are passed to Terragrunt.",
+	// HCLValidateStrict is a strict mode for HCL validation files. When
+	// it's set to false the command will only return an error if required
+	// inputs are missing from all input sources (env vars, var files, etc).
+	// When it's set to true, an error will be returned if required inputs
+	// are missing or if unused variables are passed to Terragrunt.
 	HCLValidateStrict bool
 	// HCLValidateInputs checks if the terragrunt configured inputs align with the terraform defined variables.
 	HCLValidateInputs bool
@@ -241,7 +246,8 @@ type TerragruntOptions struct {
 	NoStackValidate bool
 	// RunAll runs the provided OpenTofu/Terraform command against a stack.
 	RunAll bool
-	// Graph runs the provided OpenTofu/Terraform against the graph of dependencies for the unit in the current working directory.
+	// Graph runs the provided OpenTofu/Terraform against the graph of
+	// dependencies for the unit in the current working directory.
 	Graph bool
 	// BackendBootstrap automatically bootstraps backend infrastructure before attempting to use it.
 	BackendBootstrap bool
@@ -257,13 +263,16 @@ type TerragruntOptions struct {
 	SummaryPerUnit bool
 	// NoAutoProviderCacheDir disables the auto-provider-cache-dir feature even when the experiment is enabled.
 	NoAutoProviderCacheDir bool
-	// NoDependencyFetchOutputFromState disables the dependency-fetch-output-from-state feature even when the experiment is enabled.
+	// NoDependencyFetchOutputFromState disables the
+	// dependency-fetch-output-from-state feature even when the experiment
+	// is enabled.
 	NoDependencyFetchOutputFromState bool
 	// TFPathExplicitlySet is set to true if the user has explicitly set the TFPath via the --tf-path flag.
 	TFPathExplicitlySet bool
 	// FailFast is a flag to stop execution on the first error in apply of units.
 	FailFast bool
-	// NoDependencyPrompt disables prompt requiring confirmation for base and leaf file dependencies when using scaffolding.
+	// NoDependencyPrompt disables prompt requiring confirmation for base
+	// and leaf file dependencies when using scaffolding.
 	NoDependencyPrompt bool
 	// NoShell disables shell commands when using boilerplate templates in catalog and scaffold commands.
 	NoShell bool
@@ -359,7 +368,9 @@ func GetDefaultIAMAssumeRoleSessionName() string {
 }
 
 // NewTerragruntOptionsForTest creates a new TerragruntOptions object with reasonable defaults for test usage.
-func NewTerragruntOptionsForTest(terragruntConfigPath string, options ...TerragruntOptionsFunc) (*TerragruntOptions, error) {
+func NewTerragruntOptionsForTest(
+	terragruntConfigPath string, options ...TerragruntOptionsFunc,
+) (*TerragruntOptions, error) {
 	formatter := format.NewFormatter(format.NewKeyValueFormatPlaceholders())
 	formatter.SetDisabledColors(true)
 
@@ -398,12 +409,15 @@ func (opts *TerragruntOptions) Clone() *TerragruntOptions {
 	return newOpts
 }
 
-// CloneWithConfigPath creates a copy of this TerragruntOptions, but with different values for the given variables. This is useful for
+// CloneWithConfigPath creates a copy of this TerragruntOptions, but with
+// different values for the given variables. This is useful for
 // creating a TerragruntOptions that behaves the same way, but is used for a Terraform module in a different folder.
 //
 // It also adjusts the given logger, as each cloned option has to use a working directory specific logger to enrich
 // log output correctly.
-func (opts *TerragruntOptions) CloneWithConfigPath(l log.Logger, configPath string) (log.Logger, *TerragruntOptions, error) {
+func (opts *TerragruntOptions) CloneWithConfigPath(
+	l log.Logger, configPath string,
+) (log.Logger, *TerragruntOptions, error) {
 	newOpts := opts.Clone()
 
 	// Ensure configPath is absolute and normalized for consistent path handling
@@ -426,7 +440,8 @@ func (opts *TerragruntOptions) CloneWithConfigPath(l log.Logger, configPath stri
 	return l, newOpts, nil
 }
 
-// InsertTerraformCliArgs inserts the given argsToInsert after the terraform command argument, but before the remaining args.
+// InsertTerraformCliArgs inserts the given argsToInsert after the terraform
+// command argument, but before the remaining args.
 // Uses IacArgs parsing to properly distinguish flags from arguments.
 func (opts *TerragruntOptions) InsertTerraformCliArgs(argsToInsert ...string) {
 	// Ensure TerraformCliArgs is initialized. This allows callers to use

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -112,7 +112,8 @@ type TerragruntOptions struct {
 	TerragruntStackConfigPath string
 	// Location of the original Terragrunt config file.
 	OriginalTerragruntConfigPath string
-	// Unlike `WorkingDir`, this path is the same for all dependencies and points to the root working directory specified in the CLI.
+	// Unlike `WorkingDir`, this path is the same for all dependencies and
+	// points to the root working directory specified in the CLI.
 	RootWorkingDir string
 	// Download Terraform configurations from the specified source location into a temporary folder
 	Source string
@@ -231,7 +232,11 @@ type TerragruntOptions struct {
 	RunAllAutoApprove bool
 	// If set to true, delete the contents of the temporary folder before downloading Terraform source code into it
 	SourceUpdate bool
-	// HCLValidateStrict is a strict mode for HCL validation files. When it's set to false the command will only return an error if required inputs are missing from all input sources (env vars, var files, etc). When it's set to true, an error will be returned if required inputs are missing or if unused variables are passed to Terragrunt.",
+	// HCLValidateStrict is a strict mode for HCL validation files. When
+	// it's set to false the command will only return an error if required
+	// inputs are missing from all input sources (env vars, var files, etc).
+	// When it's set to true, an error will be returned if required inputs
+	// are missing or if unused variables are passed to Terragrunt.
 	HCLValidateStrict bool
 	// HCLValidateInputs checks if the terragrunt configured inputs align with the terraform defined variables.
 	HCLValidateInputs bool
@@ -251,7 +256,8 @@ type TerragruntOptions struct {
 	NoCAS bool
 	// RunAll runs the provided OpenTofu/Terraform command against a stack.
 	RunAll bool
-	// Graph runs the provided OpenTofu/Terraform against the graph of dependencies for the unit in the current working directory.
+	// Graph runs the provided OpenTofu/Terraform against the graph of
+	// dependencies for the unit in the current working directory.
 	Graph bool
 	// BackendBootstrap automatically bootstraps backend infrastructure before attempting to use it.
 	BackendBootstrap bool
@@ -267,13 +273,16 @@ type TerragruntOptions struct {
 	SummaryPerUnit bool
 	// NoAutoProviderCacheDir disables the auto-provider-cache-dir feature even when the experiment is enabled.
 	NoAutoProviderCacheDir bool
-	// NoDependencyFetchOutputFromState disables the dependency-fetch-output-from-state feature even when the experiment is enabled.
+	// NoDependencyFetchOutputFromState disables the
+	// dependency-fetch-output-from-state feature even when the experiment
+	// is enabled.
 	NoDependencyFetchOutputFromState bool
 	// TFPathExplicitlySet is set to true if the user has explicitly set the TFPath via the --tf-path flag.
 	TFPathExplicitlySet bool
 	// FailFast is a flag to stop execution on the first error in apply of units.
 	FailFast bool
-	// NoDependencyPrompt disables prompt requiring confirmation for base and leaf file dependencies when using scaffolding.
+	// NoDependencyPrompt disables prompt requiring confirmation for base
+	// and leaf file dependencies when using scaffolding.
 	NoDependencyPrompt bool
 	// NoShell disables shell commands when using boilerplate templates in catalog and scaffold commands.
 	NoShell bool
@@ -370,7 +379,9 @@ func GetDefaultIAMAssumeRoleSessionName() string {
 }
 
 // NewTerragruntOptionsForTest creates a new TerragruntOptions object with reasonable defaults for test usage.
-func NewTerragruntOptionsForTest(terragruntConfigPath string, options ...TerragruntOptionsFunc) (*TerragruntOptions, error) {
+func NewTerragruntOptionsForTest(
+	terragruntConfigPath string, options ...TerragruntOptionsFunc,
+) (*TerragruntOptions, error) {
 	formatter := format.NewFormatter(format.NewKeyValueFormatPlaceholders())
 	formatter.SetDisabledColors(true)
 
@@ -409,12 +420,15 @@ func (opts *TerragruntOptions) Clone() *TerragruntOptions {
 	return newOpts
 }
 
-// CloneWithConfigPath creates a copy of this TerragruntOptions, but with different values for the given variables. This is useful for
+// CloneWithConfigPath creates a copy of this TerragruntOptions, but with
+// different values for the given variables. This is useful for
 // creating a TerragruntOptions that behaves the same way, but is used for a Terraform module in a different folder.
 //
 // It also adjusts the given logger, as each cloned option has to use a working directory specific logger to enrich
 // log output correctly.
-func (opts *TerragruntOptions) CloneWithConfigPath(l log.Logger, configPath string) (log.Logger, *TerragruntOptions, error) {
+func (opts *TerragruntOptions) CloneWithConfigPath(
+	l log.Logger, configPath string,
+) (log.Logger, *TerragruntOptions, error) {
 	newOpts := opts.Clone()
 
 	// Ensure configPath is absolute and normalized for consistent path handling
@@ -437,7 +451,8 @@ func (opts *TerragruntOptions) CloneWithConfigPath(l log.Logger, configPath stri
 	return l, newOpts, nil
 }
 
-// InsertTerraformCliArgs inserts the given argsToInsert after the terraform command argument, but before the remaining args.
+// InsertTerraformCliArgs inserts the given argsToInsert after the terraform
+// command argument, but before the remaining args.
 // Uses IacArgs parsing to properly distinguish flags from arguments.
 func (opts *TerragruntOptions) InsertTerraformCliArgs(argsToInsert ...string) {
 	// Ensure TerraformCliArgs is initialized. This allows callers to use


### PR DESCRIPTION
## Description

Addressed `lll` findings in `options`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `options`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated and reformatted code documentation for improved clarity.

* **Chores**
  * Refined linter configuration to adjust exclusion patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->