### PR TITLE
chore: Expanding `lll` coverage to `retry`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
     paths:
       - docs
       - _ci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,7 +121,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
     paths:
       - docs
       - _ci

--- a/internal/retry/defaults_test.go
+++ b/internal/retry/defaults_test.go
@@ -17,40 +17,49 @@ func TestDefaultRetryableErrorsMatch(t *testing.T) {
 	}{
 		// OpenTofu provider resolution errors (the CI failures that prompted this change)
 		{
-			name:      "opentofu context deadline on provider resolve",
-			errMsg:    "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/null: could not connect to registry.opentofu.org: failed to request discovery document: Get \"https://registry.opentofu.org/.well-known/terraform.json\": context deadline exceeded",
+			name: "opentofu context deadline on provider resolve",
+			errMsg: "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/null:" +
+				" could not connect to registry.opentofu.org: failed to request discovery document:" +
+				` Get "https://registry.opentofu.org/.well-known/terraform.json": context deadline exceeded`,
 			wantMatch: true,
 		},
 		{
-			name:      "opentofu TLS handshake timeout on provider resolve",
-			errMsg:    "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/aws: could not connect to registry.opentofu.org: TLS handshake timeout",
+			name: "opentofu TLS handshake timeout on provider resolve",
+			errMsg: "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/aws:" +
+				" could not connect to registry.opentofu.org: TLS handshake timeout",
 			wantMatch: true,
 		},
 		{
-			name:      "opentofu tcp timeout on provider resolve",
-			errMsg:    "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/null: could not connect to registry.opentofu.org: tcp connection timeout",
+			name: "opentofu tcp timeout on provider resolve",
+			errMsg: "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/null:" +
+				" could not connect to registry.opentofu.org: tcp connection timeout",
 			wantMatch: true,
 		},
 		{
-			name:      "opentofu tcp connection reset on provider resolve",
-			errMsg:    "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/null: could not connect to registry.opentofu.org: tcp: connection reset by peer",
+			name: "opentofu tcp connection reset on provider resolve",
+			errMsg: "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/null:" +
+				" could not connect to registry.opentofu.org: tcp: connection reset by peer",
 			wantMatch: true,
 		},
 		{
-			name:      "opentofu failed to query available provider packages",
-			errMsg:    "Error: Failed to query available provider packages\nCould not retrieve the list of available versions for provider hashicorp/null: could not connect to registry.opentofu.org: context deadline exceeded",
+			name: "opentofu failed to query available provider packages",
+			errMsg: "Error: Failed to query available provider packages\n" +
+				"Could not retrieve the list of available versions for provider hashicorp/null:" +
+				" could not connect to registry.opentofu.org: context deadline exceeded",
 			wantMatch: true,
 		},
 		{
-			name:      "opentofu discovery document deadline",
-			errMsg:    "failed to request discovery document: Get \"https://registry.opentofu.org/.well-known/terraform.json\": context deadline exceeded",
+			name: "opentofu discovery document deadline",
+			errMsg: `failed to request discovery document: Get "https://registry.opentofu.org/.well-known/terraform.json":` +
+				" context deadline exceeded",
 			wantMatch: true,
 		},
 
 		// Terraform provider installation errors (existing behavior preserved)
 		{
-			name:      "terraform context deadline on provider query",
-			errMsg:    "Error: Failed to install provider\ncould not query provider registry for registry.terraform.io/hashicorp/null: context deadline exceeded",
+			name: "terraform context deadline on provider query",
+			errMsg: "Error: Failed to install provider\ncould not query provider registry for" +
+				" registry.terraform.io/hashicorp/null: context deadline exceeded",
 			wantMatch: true,
 		},
 		{
@@ -76,8 +85,9 @@ func TestDefaultRetryableErrorsMatch(t *testing.T) {
 			wantMatch: true,
 		},
 		{
-			name:      "terraform registry context deadline",
-			errMsg:    "could not query provider registry for registry.terraform.io/hashicorp/template: context deadline exceeded",
+			name: "terraform registry context deadline",
+			errMsg: "could not query provider registry for" +
+				" registry.terraform.io/hashicorp/template: context deadline exceeded",
 			wantMatch: true,
 		},
 
@@ -115,13 +125,15 @@ func TestDefaultRetryableErrorsMatch(t *testing.T) {
 
 		// Permanent errors that must NOT match
 		{
-			name:      "provider not found is permanent",
-			errMsg:    "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/nonexistent: provider registry registry.opentofu.org does not have a provider named hashicorp/nonexistent",
+			name: "provider not found is permanent",
+			errMsg: "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/nonexistent:" +
+				" provider registry registry.opentofu.org does not have a provider named hashicorp/nonexistent",
 			wantMatch: false,
 		},
 		{
-			name:      "version constraint mismatch is permanent",
-			errMsg:    "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/aws: no available releases match the given constraints >= 99.0.0",
+			name: "version constraint mismatch is permanent",
+			errMsg: "Error: Failed to resolve provider packages\nCould not resolve provider hashicorp/aws:" +
+				" no available releases match the given constraints >= 99.0.0",
 			wantMatch: false,
 		},
 		{


### PR DESCRIPTION
## Description

Addressed `lll` findings in `retry`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `retry`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration exclusion patterns.

* **Tests**
  * Reformatted test cases for error-message matching validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->