### PR TITLE
chore: Expanding `lll` coverage to `report`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/report/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
     paths:
       - docs
       - _ci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,7 +121,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/report/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
     paths:
       - docs
       - _ci

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1513,7 +1513,8 @@ func TestWriteJSONWithDiscoveryWorkingDir(t *testing.T) {
 
 	// The name should be relative to the worktree dir, not the original repo dir
 	// Without the fix, this would be the full absolute path since unitPath doesn't start with originalRepoDir
-	assert.Equal(t, "module/unit", runs[0].Name, "Run name should be relative to DiscoveryWorkingDir, not report.workingDir")
+	assert.Equal(t, "module/unit", runs[0].Name,
+		"Run name should be relative to DiscoveryWorkingDir, not report.workingDir")
 }
 
 // TestWriteCSVWithDiscoveryWorkingDir verifies that CSV output also uses DiscoveryWorkingDir.
@@ -1554,7 +1555,8 @@ func TestWriteCSVWithDiscoveryWorkingDir(t *testing.T) {
 	require.Len(t, records, 2) // header + 1 data row
 
 	// The name (first column) should be relative to worktree dir
-	assert.Equal(t, "module/unit", records[1][0], "Run name should be relative to DiscoveryWorkingDir, not report.workingDir")
+	assert.Equal(t, "module/unit", records[1][0],
+		"Run name should be relative to DiscoveryWorkingDir, not report.workingDir")
 }
 
 // TestParseJSONRuns verifies that JSON report data can be parsed from bytes.
@@ -1649,7 +1651,8 @@ func TestParseJSONRunsFromFile(t *testing.T) {
 		t.Parallel()
 
 		reportFile := filepath.Join(tmp, "valid-report.json")
-		content := `[{"Name": "test-unit", "Started": "2024-01-01T10:00:00Z", "Ended": "2024-01-01T10:01:00Z", "Result": "succeeded"}]`
+		content := `[{"Name": "test-unit", "Started": "2024-01-01T10:00:00Z",` +
+			` "Ended": "2024-01-01T10:01:00Z", "Result": "succeeded"}]`
 
 		err := os.WriteFile(reportFile, []byte(content), 0644)
 		require.NoError(t, err)
@@ -1773,9 +1776,15 @@ func TestParseCSVRuns(t *testing.T) {
 			expected: report.CSVRuns{},
 		},
 		{
-			name:     "single run",
-			input:    "Name,Started,Ended,Result,Reason,Cause,Ref,Cmd,Args\nmodule/unit,2024-01-01T10:00:00Z,2024-01-01T10:01:00Z,succeeded,,,,,\n",
-			expected: report.CSVRuns{{Name: "module/unit", Started: "2024-01-01T10:00:00Z", Ended: "2024-01-01T10:01:00Z", Result: "succeeded"}},
+			name: "single run",
+			input: "Name,Started,Ended,Result,Reason,Cause,Ref,Cmd,Args\n" +
+				"module/unit,2024-01-01T10:00:00Z,2024-01-01T10:01:00Z,succeeded,,,,,\n",
+			expected: report.CSVRuns{{
+				Name:    "module/unit",
+				Started: "2024-01-01T10:00:00Z",
+				Ended:   "2024-01-01T10:01:00Z",
+				Result:  "succeeded",
+			}},
 		},
 		{
 			name: "multiple runs with all fields",
@@ -1784,8 +1793,25 @@ unit-a,2024-01-01T10:00:00Z,2024-01-01T10:01:00Z,succeeded,,,HEAD~1,plan,-out=pl
 unit-b,2024-01-01T10:01:00Z,2024-01-01T10:02:00Z,failed,run error,some error,main,apply,
 `,
 			expected: report.CSVRuns{
-				{Name: "unit-a", Started: "2024-01-01T10:00:00Z", Ended: "2024-01-01T10:01:00Z", Result: "succeeded", Ref: "HEAD~1", Cmd: "plan", Args: "-out=plan.tfplan|-var=foo=bar"},
-				{Name: "unit-b", Started: "2024-01-01T10:01:00Z", Ended: "2024-01-01T10:02:00Z", Result: "failed", Reason: "run error", Cause: "some error", Ref: "main", Cmd: "apply"},
+				{
+					Name:    "unit-a",
+					Started: "2024-01-01T10:00:00Z",
+					Ended:   "2024-01-01T10:01:00Z",
+					Result:  "succeeded",
+					Ref:     "HEAD~1",
+					Cmd:     "plan",
+					Args:    "-out=plan.tfplan|-var=foo=bar",
+				},
+				{
+					Name:    "unit-b",
+					Started: "2024-01-01T10:01:00Z",
+					Ended:   "2024-01-01T10:02:00Z",
+					Result:  "failed",
+					Reason:  "run error",
+					Cause:   "some error",
+					Ref:     "main",
+					Cmd:     "apply",
+				},
 			},
 		},
 		{
@@ -1832,7 +1858,8 @@ func TestParseCSVRunsFromFile(t *testing.T) {
 		t.Parallel()
 
 		reportFile := filepath.Join(tmp, "valid-report.csv")
-		content := "Name,Started,Ended,Result,Reason,Cause,Ref,Cmd,Args\ntest-unit,2024-01-01T10:00:00Z,2024-01-01T10:01:00Z,succeeded,,,,,\n"
+		content := "Name,Started,Ended,Result,Reason,Cause,Ref,Cmd,Args\n" +
+			"test-unit,2024-01-01T10:00:00Z,2024-01-01T10:01:00Z,succeeded,,,,,\n"
 
 		err := os.WriteFile(reportFile, []byte(content), 0644)
 		require.NoError(t, err)
@@ -1974,10 +2001,13 @@ func TestParseJSONRunsFromFileValidation(t *testing.T) {
 		},
 		{
 			name: "valid multiple runs",
-			input: `[
-				{"Name": "unit-a", "Started": "2024-01-01T10:00:00Z", "Ended": "2024-01-01T10:01:00Z", "Result": "succeeded"},
-				{"Name": "unit-b", "Started": "2024-01-01T10:01:00Z", "Ended": "2024-01-01T10:02:00Z", "Result": "failed", "Reason": "run error"}
-			]`,
+			input: "[" +
+				`{"Name": "unit-a", "Started": "2024-01-01T10:00:00Z",` +
+				` "Ended": "2024-01-01T10:01:00Z", "Result": "succeeded"},` +
+				`{"Name": "unit-b", "Started": "2024-01-01T10:01:00Z",` +
+				` "Ended": "2024-01-01T10:02:00Z", "Result": "failed",` +
+				` "Reason": "run error"}` +
+				"]",
 			expectError: false,
 		},
 		{

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -336,7 +336,10 @@ func (s *Summary) writeUnitLevelSummary(w io.Writer, colorizer *Colorizer) error
 }
 
 // writeUnitDuration writes unit duration with cleaner formatting
-func (s *Summary) writeUnitDuration(w io.Writer, run *Run, colorizer *Colorizer, unitColorizer func(string) string) error {
+func (s *Summary) writeUnitDuration(
+	w io.Writer, run *Run, colorizer *Colorizer,
+	unitColorizer func(string) string,
+) error {
 	duration := run.Ended.Sub(run.Started)
 
 	name := run.Path

--- a/internal/report/writer.go
+++ b/internal/report/writer.go
@@ -30,6 +30,7 @@ type JSONRun struct {
 	// Ended is the time when the run ended.
 	Ended time.Time `json:"Ended" jsonschema:"required"`
 	// Reason is the reason for the run result, if any.
+	//nolint:lll
 	Reason *string `json:"Reason,omitempty" jsonschema:"enum=retry succeeded,enum=error ignored,enum=run error,enum=exclude block,enum=ancestor error"`
 	// Cause is the cause of the run result, if any.
 	Cause *string `json:"Cause,omitempty"`
@@ -134,7 +135,9 @@ func ParseCSVRuns(data []byte) (CSVRuns, error) {
 
 	for i, record := range records[1:] {
 		if len(record) < csvFieldCount {
-			return nil, fmt.Errorf("invalid CSV record at row %d: expected %d fields, got %d", i+csvRowOffset, csvFieldCount, len(record))
+			return nil, fmt.Errorf(
+				"invalid CSV record at row %d: expected %d fields, got %d",
+				i+csvRowOffset, csvFieldCount, len(record))
 		}
 
 		runs = append(runs, CSVRun{


### PR DESCRIPTION
## Description

Addressed `lll` findings in `report`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `report`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration to exclude additional internal directories from checks.

* **Tests**
  * Reformatted test data construction for improved readability.

* **Refactor**
  * Adjusted code formatting for method signatures and error handling paths to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->