### PR TITLE
chore: Expanding `lll` coverage to `discovery`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,7 +121,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/codegen/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/report/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/codegen/|internal/configbridge/|internal/discovery/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/report/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
     paths:
       - docs
       - _ci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/codegen/|internal/configbridge/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/report/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
+        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/codegen/|internal/configbridge/|internal/discovery/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/gcphelper/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/report/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
     paths:
       - docs
       - _ci

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -76,24 +76,26 @@ func (d *Discovery) Discover(
 		components = filtered
 	}
 
-	cycleCheckErr := telemetry.TelemeterFromContext(ctx).Collect(ctx, "discovery_cycle_check", map[string]any{}, func(childCtx context.Context) error {
-		if _, cycleErr := components.CycleCheck(); cycleErr != nil {
-			l.Debugf("Cycle: %v", cycleErr)
+	cycleCheckErr := telemetry.TelemeterFromContext(ctx).Collect(
+		ctx, "discovery_cycle_check", map[string]any{},
+		func(childCtx context.Context) error {
+			if _, cycleErr := components.CycleCheck(); cycleErr != nil {
+				l.Debugf("Cycle: %v", cycleErr)
 
-			if d.breakCycles {
-				l.Warnf("Cycle detected in dependency graph, attempting removal of cycles.")
+				if d.breakCycles {
+					l.Warnf("Cycle detected in dependency graph, attempting removal of cycles.")
 
-				var removeErr error
+					var removeErr error
 
-				components, removeErr = removeCycles(components)
-				if removeErr != nil {
-					return removeErr
+					components, removeErr = removeCycles(components)
+					if removeErr != nil {
+						return removeErr
+					}
 				}
 			}
-		}
 
-		return nil
-	})
+			return nil
+		})
 
 	if cycleCheckErr != nil && !d.suppressParseErrors {
 		return components, cycleCheckErr
@@ -248,10 +250,12 @@ func (d *Discovery) runGraphPhase(
 
 		var buildErrs []error
 
-		telemetry.TelemeterFromContext(ctx).Collect(ctx, "discover_dependents", map[string]any{}, func(childCtx context.Context) error { //nolint:errcheck
-			buildErrs = d.buildDependencyGraph(childCtx, l, opts, allComponents)
-			return errors.Join(buildErrs...)
-		})
+		telemetry.TelemeterFromContext(ctx).Collect( //nolint:errcheck
+			ctx, "discover_dependents", map[string]any{},
+			func(childCtx context.Context) error {
+				buildErrs = d.buildDependencyGraph(childCtx, l, opts, allComponents)
+				return errors.Join(buildErrs...)
+			})
 
 		if len(buildErrs) > 0 && !d.suppressParseErrors {
 			return &PhaseResults{
@@ -268,17 +272,19 @@ func (d *Discovery) runGraphPhase(
 		err    error
 	)
 
-	telemetry.TelemeterFromContext(ctx).Collect(ctx, "discover_dependencies", map[string]any{}, func(childCtx context.Context) error { //nolint:errcheck
-		result, err = phase.Run(childCtx, l, &PhaseInput{
-			Opts:       opts,
-			Components: resultsToComponents(discovered),
-			Candidates: candidates,
-			Classifier: d.classifier,
-			Discovery:  d,
-		})
+	telemetry.TelemeterFromContext(ctx).Collect( //nolint:errcheck
+		ctx, "discover_dependencies", map[string]any{},
+		func(childCtx context.Context) error {
+			result, err = phase.Run(childCtx, l, &PhaseInput{
+				Opts:       opts,
+				Components: resultsToComponents(discovered),
+				Candidates: candidates,
+				Classifier: d.classifier,
+				Discovery:  d,
+			})
 
-		return err
-	})
+			return err
+		})
 
 	allDiscovered := discovered
 	if result != nil {
@@ -571,14 +577,20 @@ func filterByAllowSet(components component.Components, allowed map[string]struct
 
 // applyQueueFilters marks discovered units as excluded or included based on queue-related CLI flags and config.
 // The runner consumes the exclusion markers instead of re-evaluating the filters.
-func (d *Discovery) applyQueueFilters(opts *options.TerragruntOptions, components component.Components) component.Components {
+func (d *Discovery) applyQueueFilters(
+	opts *options.TerragruntOptions,
+	components component.Components,
+) component.Components {
 	components = d.applyExcludeModules(opts, components)
 
 	return components
 }
 
 // applyExcludeModules marks units (and optionally their dependencies) excluded via terragrunt exclude blocks.
-func (d *Discovery) applyExcludeModules(opts *options.TerragruntOptions, components component.Components) component.Components {
+func (d *Discovery) applyExcludeModules(
+	opts *options.TerragruntOptions,
+	components component.Components,
+) component.Components {
 	for _, c := range components {
 		unit, ok := c.(*component.Unit)
 		if !ok {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -168,24 +168,26 @@ func (d *Discovery) Discover(
 		components = filtered
 	}
 
-	cycleCheckErr := telemetry.TelemeterFromContext(ctx).Collect(ctx, "discovery_cycle_check", map[string]any{}, func(childCtx context.Context) error {
-		if _, cycleErr := components.CycleCheck(); cycleErr != nil {
-			l.Debugf("Cycle: %v", cycleErr)
+	cycleCheckErr := telemetry.TelemeterFromContext(ctx).Collect(
+		ctx, "discovery_cycle_check", map[string]any{},
+		func(childCtx context.Context) error {
+			if _, cycleErr := components.CycleCheck(); cycleErr != nil {
+				l.Debugf("Cycle: %v", cycleErr)
 
-			if d.breakCycles {
-				l.Warnf("Cycle detected in dependency graph, attempting removal of cycles.")
+				if d.breakCycles {
+					l.Warnf("Cycle detected in dependency graph, attempting removal of cycles.")
 
-				var removeErr error
+					var removeErr error
 
-				components, removeErr = removeCycles(components)
-				if removeErr != nil {
-					return removeErr
+					components, removeErr = removeCycles(components)
+					if removeErr != nil {
+						return removeErr
+					}
 				}
 			}
-		}
 
-		return nil
-	})
+			return nil
+		})
 
 	if cycleCheckErr != nil && !d.suppressParseErrors {
 		return components, cycleCheckErr
@@ -383,10 +385,12 @@ func (d *Discovery) runGraphPhase(
 
 		var buildErrs []error
 
-		telemetry.TelemeterFromContext(ctx).Collect(ctx, "discover_dependents", map[string]any{}, func(childCtx context.Context) error { //nolint:errcheck
-			buildErrs = d.buildDependencyGraph(childCtx, l, opts, allComponents)
-			return errors.Join(buildErrs...)
-		})
+		telemetry.TelemeterFromContext(ctx).Collect( //nolint:errcheck
+			ctx, "discover_dependents", map[string]any{},
+			func(childCtx context.Context) error {
+				buildErrs = d.buildDependencyGraph(childCtx, l, opts, allComponents)
+				return errors.Join(buildErrs...)
+			})
 
 		if len(buildErrs) > 0 && !d.suppressParseErrors {
 			return &PhaseResults{
@@ -403,17 +407,19 @@ func (d *Discovery) runGraphPhase(
 		err    error
 	)
 
-	telemetry.TelemeterFromContext(ctx).Collect(ctx, "discover_dependencies", map[string]any{}, func(childCtx context.Context) error { //nolint:errcheck
-		result, err = phase.Run(childCtx, l, &PhaseInput{
-			Opts:       opts,
-			Components: resultsToComponents(discovered),
-			Candidates: candidates,
-			Classifier: d.classifier,
-			Discovery:  d,
-		})
+	telemetry.TelemeterFromContext(ctx).Collect( //nolint:errcheck
+		ctx, "discover_dependencies", map[string]any{},
+		func(childCtx context.Context) error {
+			result, err = phase.Run(childCtx, l, &PhaseInput{
+				Opts:       opts,
+				Components: resultsToComponents(discovered),
+				Candidates: candidates,
+				Classifier: d.classifier,
+				Discovery:  d,
+			})
 
-		return err
-	})
+			return err
+		})
 
 	allDiscovered := discovered
 	if result != nil {
@@ -711,14 +717,20 @@ func filterByAllowSet(components component.Components, allowed map[string]struct
 
 // applyQueueFilters marks discovered units as excluded or included based on queue-related CLI flags and config.
 // The runner consumes the exclusion markers instead of re-evaluating the filters.
-func (d *Discovery) applyQueueFilters(opts *options.TerragruntOptions, components component.Components) component.Components {
+func (d *Discovery) applyQueueFilters(
+	opts *options.TerragruntOptions,
+	components component.Components,
+) component.Components {
 	components = d.applyExcludeModules(opts, components)
 
 	return components
 }
 
 // applyExcludeModules marks units (and optionally their dependencies) excluded via terragrunt exclude blocks.
-func (d *Discovery) applyExcludeModules(opts *options.TerragruntOptions, components component.Components) component.Components {
+func (d *Discovery) applyExcludeModules(
+	opts *options.TerragruntOptions,
+	components component.Components,
+) component.Components {
 	for _, c := range components {
 		unit, ok := c.(*component.Unit)
 		if !ok {

--- a/internal/discovery/errors.go
+++ b/internal/discovery/errors.go
@@ -136,7 +136,9 @@ func NewCoexistenceError(a, b component.Component) error {
 	})
 }
 
-// StackDependencyExpansionError indicates that a stack dependency path could not be expanded into its constituent unit paths. Wraps the underlying parse error so callers can extract typed details via errors.As.
+// StackDependencyExpansionError indicates that a stack dependency path could not be expanded into
+// its constituent unit paths. Wraps the underlying parse error so callers can extract typed details
+// via errors.As.
 type StackDependencyExpansionError struct {
 	Wrapped error
 	DepPath string

--- a/internal/discovery/filter_test.go
+++ b/internal/discovery/filter_test.go
@@ -1085,7 +1085,9 @@ dependency "vpc" {
 
 	// Should include vpc (target) and db (direct dependent) and app (transitive dependent)
 	units := components.Filter(component.UnitKind).Paths()
-	assert.ElementsMatch(t, []string{vpcDir, dbDir, appDir}, units, "...vpc should find vpc and all its dependents (db, app)")
+	assert.ElementsMatch(t,
+		[]string{vpcDir, dbDir, appDir}, units,
+		"...vpc should find vpc and all its dependents (db, app)")
 }
 
 // TestDiscovery_DependentDiscovery_ExcludeTarget tests dependent discovery with target exclusion (^...vpc).
@@ -1290,7 +1292,9 @@ dependency "vpc" {
 
 	// Should include: app (dependent), db (target), vpc (dependency)
 	units := components.Filter(component.UnitKind).Paths()
-	assert.ElementsMatch(t, []string{appDir, dbDir, vpcDir}, units, "...db... should find dependents, target, and dependencies")
+	assert.ElementsMatch(t,
+		[]string{appDir, dbDir, vpcDir}, units,
+		"...db... should find dependents, target, and dependencies")
 }
 
 // TestDiscovery_DependentDiscovery_OutsideWorkingDir tests that dependent discovery
@@ -1370,7 +1374,9 @@ dependency "vpc" {
 	units := components.Filter(component.UnitKind).Paths()
 	assert.Contains(t, units, vpcDir, "vpc should be discovered as the target")
 	assert.Contains(t, units, consumerDir, "consumer should be discovered even though it's outside working dir")
-	assert.ElementsMatch(t, []string{vpcDir, consumerDir}, units, "...vpc should find vpc and consumer (outside working dir)")
+	assert.ElementsMatch(t,
+		[]string{vpcDir, consumerDir}, units,
+		"...vpc should find vpc and consumer (outside working dir)")
 }
 
 // TestDiscovery_DependentDiscovery_OutsideWorkingDir_MultipleLevels tests that dependent discovery

--- a/internal/discovery/filter_test.go
+++ b/internal/discovery/filter_test.go
@@ -1084,7 +1084,9 @@ dependency "vpc" {
 
 	// Should include vpc (target) and db (direct dependent) and app (transitive dependent)
 	units := components.Filter(component.UnitKind).Paths()
-	assert.ElementsMatch(t, []string{vpcDir, dbDir, appDir}, units, "...vpc should find vpc and all its dependents (db, app)")
+	assert.ElementsMatch(t,
+		[]string{vpcDir, dbDir, appDir}, units,
+		"...vpc should find vpc and all its dependents (db, app)")
 }
 
 // TestDiscovery_DependentDiscovery_ExcludeTarget tests dependent discovery with target exclusion (^...vpc).
@@ -1289,7 +1291,9 @@ dependency "vpc" {
 
 	// Should include: app (dependent), db (target), vpc (dependency)
 	units := components.Filter(component.UnitKind).Paths()
-	assert.ElementsMatch(t, []string{appDir, dbDir, vpcDir}, units, "...db... should find dependents, target, and dependencies")
+	assert.ElementsMatch(t,
+		[]string{appDir, dbDir, vpcDir}, units,
+		"...db... should find dependents, target, and dependencies")
 }
 
 // TestDiscovery_DependentDiscovery_OutsideWorkingDir tests that dependent discovery
@@ -1369,7 +1373,9 @@ dependency "vpc" {
 	units := components.Filter(component.UnitKind).Paths()
 	assert.Contains(t, units, vpcDir, "vpc should be discovered as the target")
 	assert.Contains(t, units, consumerDir, "consumer should be discovered even though it's outside working dir")
-	assert.ElementsMatch(t, []string{vpcDir, consumerDir}, units, "...vpc should find vpc and consumer (outside working dir)")
+	assert.ElementsMatch(t,
+		[]string{vpcDir, consumerDir}, units,
+		"...vpc should find vpc and consumer (outside working dir)")
 }
 
 // TestDiscovery_DependentDiscovery_OutsideWorkingDir_MultipleLevels tests that dependent discovery

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -240,7 +240,11 @@ func extractDependencyPaths(cfg *config.TerragruntConfig, c component.Component)
 		}
 
 		if !config.IsValidConfigPath(dependency.ConfigPath) {
-			errs = append(errs, errors.Errorf("skipping dependency %q in %q: config_path could not be resolved", dependency.Name, c.Path()))
+			errs = append(errs, errors.Errorf(
+				"skipping dependency %q in %q: "+
+					"config_path could not be resolved",
+				dependency.Name, c.Path()))
+
 			continue
 		}
 

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -253,7 +253,11 @@ func extractDependencyPaths(cfg *config.TerragruntConfig, c component.Component)
 		}
 
 		if !config.IsValidConfigPath(dependency.ConfigPath) {
-			errs = append(errs, errors.Errorf("skipping dependency %q in %q: config_path could not be resolved", dependency.Name, c.Path()))
+			errs = append(errs, errors.Errorf(
+				"skipping dependency %q in %q: "+
+					"config_path could not be resolved",
+				dependency.Name, c.Path()))
+
 			continue
 		}
 
@@ -306,9 +310,12 @@ func stackDependencyPaths(fs vfs.FS, depPaths []string, c component.Component) (
 	expanded := make([]string, 0, len(depPaths))
 
 	for _, depPath := range depPaths {
-		// Stat upfront so a non-directory dep path (e.g. another-name.hcl) is preserved instead of being passed to the parser, which would reject it as ENOTDIR. The duplication of work is intentional.
+		// Stat upfront so a non-directory dep path (e.g. another-name.hcl) is preserved instead of
+		// being passed to the parser, which would reject it as ENOTDIR. The duplication of work is
+		// intentional.
 		info, statErr := fs.Stat(depPath)
-		// Real I/O errors (permission denied, etc.) must surface so a malformed DAG isn't silently produced; only ENOENT is treated as "keep the raw path".
+		// Real I/O errors (permission denied, etc.) must surface so a malformed DAG isn't silently
+		// produced; only ENOENT is treated as "keep the raw path".
 		if statErr != nil && !errors.Is(statErr, iofs.ErrNotExist) {
 			return nil, NewStackDependencyExpansionError(depPath, statErr)
 		}

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -438,7 +438,9 @@ func (p *GraphPhase) discoverDependentsUpstream(
 	boundaryRoot string,
 	depthRemaining int,
 ) error {
-	l.Debugf("discoverDependentsUpstream: target=%s currentDir=%s boundary=%s depth=%d", target.Path(), currentDir, boundaryRoot, depthRemaining)
+	l.Debugf("discoverDependentsUpstream: target=%s"+
+		" currentDir=%s boundary=%s depth=%d",
+		target.Path(), currentDir, boundaryRoot, depthRemaining)
 
 	if depthRemaining <= 0 {
 		l.Debugf("discoverDependentsUpstream: depth limit reached")

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -432,7 +432,9 @@ func (p *GraphPhase) discoverDependentsUpstream(
 	boundaryRoot string,
 	depthRemaining int,
 ) error {
-	l.Debugf("discoverDependentsUpstream: target=%s currentDir=%s boundary=%s depth=%d", target.Path(), currentDir, boundaryRoot, depthRemaining)
+	l.Debugf("discoverDependentsUpstream: target=%s"+
+		" currentDir=%s boundary=%s depth=%d",
+		target.Path(), currentDir, boundaryRoot, depthRemaining)
 
 	if depthRemaining <= 0 {
 		l.Debugf("discoverDependentsUpstream: depth limit reached")

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -230,7 +230,11 @@ func parseComponent(
 	parseOpts.TerragruntConfigPath = filepath.Join(parseOpts.WorkingDir, configFilename)
 	parseOpts.OriginalTerragruntConfigPath = parseOpts.TerragruntConfigPath
 
-	if _, err := creds.ObtainCredsForParsing(ctx, l, parseOpts.AuthProviderCmd, parseOpts.Env, configbridge.ShellRunOptsFromOpts(parseOpts)); err != nil {
+	shellRunOpts := configbridge.ShellRunOptsFromOpts(parseOpts)
+	if _, err := creds.ObtainCredsForParsing(
+		ctx, l, parseOpts.AuthProviderCmd,
+		parseOpts.Env, shellRunOpts,
+	); err != nil {
 		return err
 	}
 

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -177,7 +177,11 @@ func TestWorktreePhase_Integration_CommandArgs(t *testing.T) {
 			// Set up discovery
 			l := logger.CreateLogger()
 
-			w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+			wtOpts := worktrees.WorktreeOpts{
+				WorkingDir:     tmpDir,
+				GitExpressions: gitExpressions,
+			}
+			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -447,7 +451,11 @@ unit "unit_to_be_untouched" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -807,7 +815,11 @@ locals {
 			require.NoError(t, err)
 
 			// Create worktrees
-			w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: filters.UniqueGitFilters()})
+			wtOpts := worktrees.WorktreeOpts{
+				WorkingDir:     tmpDir,
+				GitExpressions: filters.UniqueGitFilters(),
+			}
+			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -901,7 +913,11 @@ locals {
 	require.NoError(t, err)
 
 	// Create worktrees from the subdirectory
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: basicDir, GitExpressions: filters.UniqueGitFilters()})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     basicDir,
+		GitExpressions: filters.UniqueGitFilters(),
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1166,7 +1182,11 @@ locals {
 			require.NoError(t, err)
 
 			// Create worktrees
-			w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: filters.UniqueGitFilters()})
+			wtOpts := worktrees.WorktreeOpts{
+				WorkingDir:     tmpDir,
+				GitExpressions: filters.UniqueGitFilters(),
+			}
+			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -1263,7 +1283,11 @@ func TestWorktreePhase_Integration_FromSubdirectory_MultipleCommits(t *testing.T
 			require.NoError(t, err)
 
 			// Create worktrees from the subdirectory
-			w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: basicDir, GitExpressions: filters.UniqueGitFilters()})
+			wtOpts := worktrees.WorktreeOpts{
+				WorkingDir:     basicDir,
+				GitExpressions: filters.UniqueGitFilters(),
+			}
+			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -1441,7 +1465,11 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1603,7 +1631,11 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1758,7 +1790,11 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1831,7 +1867,8 @@ unit "app" {
 	}
 
 	assert.True(t, foundStack,
-		"Stack with nested read_terragrunt_config reference should be discovered when sidecar changes; got: %v", componentPaths)
+		"Stack with nested read_terragrunt_config reference should be discovered"+
+			" when sidecar changes; got: %v", componentPaths)
 
 	// Verify: stack WITHOUT the reference should NOT be discovered
 	stackNoRefRel, err := filepath.Rel(tmpDir, stackNoRefDir)
@@ -2189,7 +2226,11 @@ func runWorktreeDiscovery(
 
 	l := logger.CreateLogger()
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -176,7 +176,11 @@ func TestWorktreePhase_Integration_CommandArgs(t *testing.T) {
 			// Set up discovery
 			l := logger.CreateLogger()
 
-			w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+			wtOpts := worktrees.WorktreeOpts{
+				WorkingDir:     tmpDir,
+				GitExpressions: gitExpressions,
+			}
+			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -446,7 +450,11 @@ unit "unit_to_be_untouched" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -806,7 +814,11 @@ locals {
 			require.NoError(t, err)
 
 			// Create worktrees
-			w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: filters.UniqueGitFilters()})
+			wtOpts := worktrees.WorktreeOpts{
+				WorkingDir:     tmpDir,
+				GitExpressions: filters.UniqueGitFilters(),
+			}
+			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -900,7 +912,11 @@ locals {
 	require.NoError(t, err)
 
 	// Create worktrees from the subdirectory
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: basicDir, GitExpressions: filters.UniqueGitFilters()})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     basicDir,
+		GitExpressions: filters.UniqueGitFilters(),
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1165,7 +1181,11 @@ locals {
 			require.NoError(t, err)
 
 			// Create worktrees
-			w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: filters.UniqueGitFilters()})
+			wtOpts := worktrees.WorktreeOpts{
+				WorkingDir:     tmpDir,
+				GitExpressions: filters.UniqueGitFilters(),
+			}
+			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -1262,7 +1282,11 @@ func TestWorktreePhase_Integration_FromSubdirectory_MultipleCommits(t *testing.T
 			require.NoError(t, err)
 
 			// Create worktrees from the subdirectory
-			w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: basicDir, GitExpressions: filters.UniqueGitFilters()})
+			wtOpts := worktrees.WorktreeOpts{
+				WorkingDir:     basicDir,
+				GitExpressions: filters.UniqueGitFilters(),
+			}
+			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -1440,7 +1464,11 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1602,7 +1630,11 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1757,7 +1789,11 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1830,7 +1866,8 @@ unit "app" {
 	}
 
 	assert.True(t, foundStack,
-		"Stack with nested read_terragrunt_config reference should be discovered when sidecar changes; got: %v", componentPaths)
+		"Stack with nested read_terragrunt_config reference should be discovered"+
+			" when sidecar changes; got: %v", componentPaths)
 
 	// Verify: stack WITHOUT the reference should NOT be discovered
 	stackNoRefRel, err := filepath.Rel(tmpDir, stackNoRefDir)
@@ -2188,7 +2225,11 @@ func runWorktreeDiscovery(
 
 	l := logger.CreateLogger()
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions})
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/internal/discovery/stack_dependency_expansion_error_test.go
+++ b/internal/discovery/stack_dependency_expansion_error_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Direct typed-error contract test: StackDependencyExpansionError must carry the depPath and unwrap cleanly to the original parser error.
+// Direct typed-error contract test: StackDependencyExpansionError must carry the depPath and
+// unwrap cleanly to the original parser error.
 func TestStackDependencyExpansionError_Unwrap(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Addressed `lll` findings in `discovery`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `lll` linter coverage to include `discovery`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal code restructuring and refactoring of telemetry instrumentation and method signatures for improved maintainability.

* **Tests**
  * Updated test assertions and helper functions with improved formatting and variable handling.

* **Style**
  * Code formatting improvements and reformatted logging statements across internal modules.

* **Documentation**
  * Enhanced comments clarifying error handling and type contracts.

* **Chores**
  * Updated linter configuration exclusions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/5883)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->