### PR TITLE
misc testing and lint updates

### DIFF
--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -988,20 +988,16 @@ func CleanupTerragruntFolder(t *testing.T, templatesPath string) {
 func RemoveFile(t *testing.T, path string) {
 	t.Helper()
 
-	if util.FileExists(path) {
-		if err := os.Remove(path); err != nil {
-			t.Fatalf("Error while removing %s: %v", path, err)
-		}
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("Error while removing %s: %v", path, err)
 	}
 }
 
 func RemoveFolder(t *testing.T, path string) {
 	t.Helper()
 
-	if util.FileExists(path) {
-		if err := os.RemoveAll(path); err != nil {
-			t.Fatalf("Error while removing %s: %v", path, err)
-		}
+	if err := os.RemoveAll(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("Error while removing %s: %v", path, err)
 	}
 }
 

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -20,11 +20,14 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/awshelper"
@@ -32,10 +35,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/mattn/go-shellwords"
-
-	"os"
-	"path/filepath"
-	"testing"
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -73,9 +72,9 @@ const (
 
 	ReportFile = "report.json"
 
-	readPermissions      = 0444
-	readWritePermissions = 0666
-	allPermissions       = 0777
+	readPermissions      = 0o444
+	readWritePermissions = 0o666
+	allPermissions       = 0o777
 
 	caKeyBits = 4096
 

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const defaultDirPerms = 0755
+const defaultDirPerms = 0o755
 
 func IsWindows() bool {
 	return runtime.GOOS == "windows"

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -89,6 +89,11 @@ func CreateGitRepo(t *testing.T, path string) {
 	_, err = cmd.CombinedOutput()
 	require.NoError(t, err, "git config user.name failed")
 
+	cmd = exec.CommandContext(ctx, "git", "config", "commit.gpgsign", "false")
+	cmd.Dir = path
+	_, err = cmd.CombinedOutput()
+	require.NoError(t, err, "git config commit.gpgsign failed")
+
 	// Add all files and commit
 	cmd = exec.CommandContext(ctx, "git", "add", "-A")
 	cmd.Dir = path

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -287,8 +287,8 @@ func TestNoShowWarningWithDependentModulesBeforeDestroy(t *testing.T) {
 	appV1Path := filepath.Join(rootPath, "app-v1")
 	appV2Path := filepath.Join(rootPath, "app-v2")
 
-	cleanupTerraformFolder(t, rootPath)
-	cleanupTerraformFolder(t, vpcPath)
+	helpers.CleanupTerraformFolder(t, rootPath)
+	helpers.CleanupTerraformFolder(t, vpcPath)
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}

--- a/test/integration_errors_test.go
+++ b/test/integration_errors_test.go
@@ -29,7 +29,7 @@ const (
 func TestErrorsHandling(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testSimpleErrors)
+	helpers.CleanupTerraformFolder(t, testSimpleErrors)
 	tmpEnvPath := helpers.CopyEnvironment(t, testSimpleErrors)
 	rootPath := filepath.Join(tmpEnvPath, testSimpleErrors)
 
@@ -41,7 +41,7 @@ func TestErrorsHandling(t *testing.T) {
 func TestIgnoreError(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testIgnoreErrors)
+	helpers.CleanupTerraformFolder(t, testIgnoreErrors)
 	tmpEnvPath := helpers.CopyEnvironment(t, testIgnoreErrors)
 	rootPath := filepath.Join(tmpEnvPath, testIgnoreErrors)
 
@@ -55,7 +55,7 @@ func TestIgnoreError(t *testing.T) {
 func TestRunAllIgnoreError(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testRunAllIgnoreErrors)
+	helpers.CleanupTerraformFolder(t, testRunAllIgnoreErrors)
 	tmpEnvPath := helpers.CopyEnvironment(t, testRunAllIgnoreErrors)
 	rootPath := filepath.Join(tmpEnvPath, testRunAllIgnoreErrors)
 
@@ -70,7 +70,7 @@ func TestRunAllIgnoreError(t *testing.T) {
 func TestRetryError(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testRetryErrors)
+	helpers.CleanupTerraformFolder(t, testRetryErrors)
 	tmpEnvPath := helpers.CopyEnvironment(t, testRetryErrors)
 	rootPath := filepath.Join(tmpEnvPath, testRetryErrors)
 
@@ -84,7 +84,7 @@ func TestRetryError(t *testing.T) {
 func TestRetryFailError(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testRetryFailErrors)
+	helpers.CleanupTerraformFolder(t, testRetryFailErrors)
 	tmpEnvPath := helpers.CopyEnvironment(t, testRetryFailErrors)
 	rootPath := filepath.Join(tmpEnvPath, testRetryFailErrors)
 
@@ -97,7 +97,7 @@ func TestRetryFailError(t *testing.T) {
 func TestIgnoreSignal(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testIgnoreSignalErrors)
+	helpers.CleanupTerraformFolder(t, testIgnoreSignalErrors)
 	tmpEnvPath := helpers.CopyEnvironment(t, testIgnoreSignalErrors)
 	rootPath := filepath.Join(tmpEnvPath, testIgnoreSignalErrors)
 
@@ -126,7 +126,7 @@ func TestIgnoreSignal(t *testing.T) {
 func TestRunAllError(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testRunAllErrors)
+	helpers.CleanupTerraformFolder(t, testRunAllErrors)
 	tmpEnvPath := helpers.CopyEnvironment(t, testRunAllErrors)
 	rootPath := filepath.Join(tmpEnvPath, testRunAllErrors)
 
@@ -141,7 +141,7 @@ func TestRunAllError(t *testing.T) {
 func TestRunAllFail(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testRunAllErrors)
+	helpers.CleanupTerraformFolder(t, testRunAllErrors)
 	tmpEnvPath := helpers.CopyEnvironment(t, testRunAllErrors)
 	rootPath := filepath.Join(tmpEnvPath, testRunAllErrors)
 
@@ -155,7 +155,7 @@ func TestRunAllFail(t *testing.T) {
 func TestIgnoreNegativePattern(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testNegativePatternErrors)
+	helpers.CleanupTerraformFolder(t, testNegativePatternErrors)
 	tmpEnvPath := helpers.CopyEnvironment(t, testNegativePatternErrors)
 	rootPath := filepath.Join(tmpEnvPath, testNegativePatternErrors)
 
@@ -168,7 +168,7 @@ func TestIgnoreNegativePattern(t *testing.T) {
 func TestHandleMultiLineErrors(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testMultiLineErrors)
+	helpers.CleanupTerraformFolder(t, testMultiLineErrors)
 	tmpEnvPath := helpers.CopyEnvironment(t, testMultiLineErrors)
 	rootPath := filepath.Join(tmpEnvPath, testMultiLineErrors)
 
@@ -181,7 +181,7 @@ func TestHandleMultiLineErrors(t *testing.T) {
 func TestGetDefaultRetryableErrors(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testGetDefaultErrors)
+	helpers.CleanupTerraformFolder(t, testGetDefaultErrors)
 	tmpEnvPath := helpers.CopyEnvironment(t, testGetDefaultErrors)
 	rootPath := filepath.Join(tmpEnvPath, testGetDefaultErrors)
 
@@ -205,7 +205,7 @@ func TestGetDefaultRetryableErrors(t *testing.T) {
 func TestNoAutoRetryFlag(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testNoAutoRetry)
+	helpers.CleanupTerraformFolder(t, testNoAutoRetry)
 	tmpEnvPath := helpers.CopyEnvironment(t, testNoAutoRetry)
 	rootPath := filepath.Join(tmpEnvPath, testNoAutoRetry)
 
@@ -219,7 +219,7 @@ func TestNoAutoRetryFlag(t *testing.T) {
 	successFile := filepath.Join(cacheDir, "success.txt")
 	err = os.Remove(successFile)
 	require.NoError(t, err)
-	cleanupTerraformFolder(t, testNoAutoRetry)
+	helpers.CleanupTerraformFolder(t, testNoAutoRetry)
 
 	// Test without flag - should succeed with retry
 	_, stderr2, err2 := helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath)

--- a/test/integration_exclude_test.go
+++ b/test/integration_exclude_test.go
@@ -183,7 +183,7 @@ func TestExcludeBlockBehavior(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			cleanupTerraformFolder(t, testExcludeComprehensive)
+			helpers.CleanupTerraformFolder(t, testExcludeComprehensive)
 			tmpEnvPath := helpers.CopyEnvironment(t, testExcludeComprehensive)
 
 			var rootPath string
@@ -316,7 +316,7 @@ func TestExcludeBlockFeatureFlagDefaultInDependency(t *testing.T) {
 	t.Parallel()
 
 	testFixturePath := "fixtures/exclude/dependency-feature-flags"
-	cleanupTerraformFolder(t, testFixturePath)
+	helpers.CleanupTerraformFolder(t, testFixturePath)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixturePath)
 	rootPath := filepath.Join(tmpEnvPath, testFixturePath, "dependent-unit")
 
@@ -336,7 +336,7 @@ func TestExcludeBlockFeatureFlagDefaultRunAll(t *testing.T) {
 	t.Parallel()
 
 	testFixturePath := "fixtures/exclude/dependency-feature-flags"
-	cleanupTerraformFolder(t, testFixturePath)
+	helpers.CleanupTerraformFolder(t, testFixturePath)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixturePath)
 	rootPath := filepath.Join(tmpEnvPath, testFixturePath)
 

--- a/test/integration_feature_flags_test.go
+++ b/test/integration_feature_flags_test.go
@@ -22,7 +22,7 @@ const (
 func TestFeatureFlagDefaults(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testSimpleFlag)
+	helpers.CleanupTerraformFolder(t, testSimpleFlag)
 	tmpEnvPath := helpers.CopyEnvironment(t, testSimpleFlag)
 	rootPath := filepath.Join(tmpEnvPath, testSimpleFlag)
 
@@ -34,7 +34,7 @@ func TestFeatureFlagDefaults(t *testing.T) {
 func TestFeatureFlagCli(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testSimpleFlag)
+	helpers.CleanupTerraformFolder(t, testSimpleFlag)
 	tmpEnvPath := helpers.CopyEnvironment(t, testSimpleFlag)
 	rootPath := filepath.Join(tmpEnvPath, testSimpleFlag)
 
@@ -50,7 +50,7 @@ func TestFeatureFlagCli(t *testing.T) {
 func TestFeatureApplied(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testSimpleFlag)
+	helpers.CleanupTerraformFolder(t, testSimpleFlag)
 	tmpEnvPath := helpers.CopyEnvironment(t, testSimpleFlag)
 	rootPath := filepath.Join(tmpEnvPath, testSimpleFlag)
 
@@ -66,7 +66,7 @@ func TestFeatureApplied(t *testing.T) {
 func TestFeatureFlagEnv(t *testing.T) {
 	t.Setenv("TG_FEATURE", "int_feature_flag=111,bool_feature_flag=true,string_feature_flag=xyz")
 
-	cleanupTerraformFolder(t, testSimpleFlag)
+	helpers.CleanupTerraformFolder(t, testSimpleFlag)
 	tmpEnvPath := helpers.CopyEnvironment(t, testSimpleFlag)
 	rootPath := filepath.Join(tmpEnvPath, testSimpleFlag)
 
@@ -82,7 +82,7 @@ func TestFeatureFlagEnv(t *testing.T) {
 func TestFeatureIncludeFlag(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testIncludeFlag)
+	helpers.CleanupTerraformFolder(t, testIncludeFlag)
 	tmpEnvPath := helpers.CopyEnvironment(t, testIncludeFlag)
 	rootPath := filepath.Join(tmpEnvPath, testIncludeFlag, "app")
 
@@ -94,7 +94,7 @@ func TestFeatureIncludeFlag(t *testing.T) {
 func TestFeatureFlagRunAll(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testRunAllFlag)
+	helpers.CleanupTerraformFolder(t, testRunAllFlag)
 	tmpEnvPath := helpers.CopyEnvironment(t, testRunAllFlag)
 	rootPath := filepath.Join(tmpEnvPath, testRunAllFlag)
 	app1 := filepath.Join(tmpEnvPath, testRunAllFlag, "app1")
@@ -109,7 +109,7 @@ func TestFeatureFlagRunAll(t *testing.T) {
 func TestFailOnEmptyFeatureFlag(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testErrorEmptyFlag)
+	helpers.CleanupTerraformFolder(t, testErrorEmptyFlag)
 	tmpEnvPath := helpers.CopyEnvironment(t, testErrorEmptyFlag)
 	rootPath := filepath.Join(tmpEnvPath, testErrorEmptyFlag)
 

--- a/test/integration_sops_test.go
+++ b/test/integration_sops_test.go
@@ -287,7 +287,7 @@ func TestSOPSTerragruntLogSopsErrors(t *testing.T) {
 func TestSOPSDecryptOnMissing(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testFixtureSopsMissing)
+	helpers.CleanupTerraformFolder(t, testFixtureSopsMissing)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureSopsMissing)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureSopsMissing)
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3516,34 +3516,6 @@ func TestDependenciesOptimisation(t *testing.T) {
 	assert.NotContains(t, stderr, "Retrieved output from ../module-a/terragrunt.hcl")
 }
 
-func cleanupTerraformFolder(t *testing.T, templatesPath string) {
-	t.Helper()
-
-	removeFile(t, filepath.Join(templatesPath, terraformState))
-	removeFile(t, filepath.Join(templatesPath, terraformStateBackup))
-	removeFolder(t, filepath.Join(templatesPath, terraformFolder))
-}
-
-func removeFile(t *testing.T, path string) {
-	t.Helper()
-
-	if util.FileExists(path) {
-		if err := os.Remove(path); err != nil {
-			t.Fatalf("Error while removing %s: %v", path, err)
-		}
-	}
-}
-
-func removeFolder(t *testing.T, path string) {
-	t.Helper()
-
-	if util.FileExists(path) {
-		if err := os.RemoveAll(path); err != nil {
-			t.Fatalf("Error while removing %s: %v", path, err)
-		}
-	}
-}
-
 func TestShowErrorWhenRunAllInvokedWithoutArguments(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1040,7 +1040,7 @@ func TestTerragruntInitOnce(t *testing.T) {
 	cfgPath := filepath.Join(rootPath, "terragrunt.hcl")
 	bytes, err := os.ReadFile(cfgPath)
 	require.NoError(t, err)
-	err = os.WriteFile(cfgPath, bytes, 0644)
+	err = os.WriteFile(cfgPath, bytes, 0o644)
 	require.NoError(t, err)
 
 	stdout, _, err = helpers.RunTerragruntCommandWithOutput(
@@ -3473,7 +3473,7 @@ inputs = {
 `
 
 	configPath := filepath.Join(tmpDir, "terragrunt.hcl")
-	require.NoError(t, os.WriteFile(configPath, []byte(dependencyConfig), 0644))
+	require.NoError(t, os.WriteFile(configPath, []byte(dependencyConfig), 0o644))
 
 	var (
 		stdout bytes.Buffer
@@ -3578,7 +3578,7 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	}
 
 	updatedHcl := strings.ReplaceAll(contents, "__TAG_VALUE__", "v0.78.4")
-	require.NoError(t, os.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
+	require.NoError(t, os.WriteFile(terragruntHcl, []byte(updatedHcl), 0o444))
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
@@ -3589,7 +3589,7 @@ func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"))
 
 	updatedHcl = strings.ReplaceAll(contents, "__TAG_VALUE__", "v0.79.0")
-	require.NoError(t, os.WriteFile(terragruntHcl, []byte(updatedHcl), 0444))
+	require.NoError(t, os.WriteFile(terragruntHcl, []byte(updatedHcl), 0o444))
 
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
@@ -3802,7 +3802,7 @@ func TestInitSkipCache(t *testing.T) {
 
 	// verify that after adding new file, init is executed
 	tfFile := filepath.Join(tmpEnvPath, testFixtureInitCache, "app", "project.tf")
-	if err := os.WriteFile(tfFile, []byte(""), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(""), 0o644); err != nil {
 		t.Fatalf("Error writing new Terraform file to %s: %v", tfFile, err)
 	}
 
@@ -4215,7 +4215,7 @@ func TestLogFormatJSONOutput(t *testing.T) {
 
 	multipeJSONs := bytes.Split(output, []byte("\n"))
 
-	var msgs = make([]string, 0, len(multipeJSONs))
+	msgs := make([]string, 0, len(multipeJSONs))
 
 	for _, jsonBytes := range multipeJSONs {
 		if len(jsonBytes) == 0 {
@@ -4570,11 +4570,11 @@ func TestDiscoveryDoesntResolveOutputs(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	depDir := filepath.Join(tmpDir, "dep")
-	err := os.MkdirAll(depDir, 0755)
+	err := os.MkdirAll(depDir, 0o755)
 	require.NoError(t, err)
 
 	mainDir := filepath.Join(tmpDir, "main")
-	err = os.MkdirAll(mainDir, 0755)
+	err = os.MkdirAll(mainDir, 0o755)
 	require.NoError(t, err)
 
 	depConfig := `
@@ -4582,7 +4582,7 @@ terraform {
   source = "."
 }
 `
-	err = os.WriteFile(filepath.Join(depDir, "terragrunt.hcl"), []byte(depConfig), 0644)
+	err = os.WriteFile(filepath.Join(depDir, "terragrunt.hcl"), []byte(depConfig), 0o644)
 	require.NoError(t, err)
 
 	depTerraform := `
@@ -4590,7 +4590,7 @@ output "value" {
   value = "hello from dependency"
 }
 `
-	err = os.WriteFile(filepath.Join(depDir, "main.tf"), []byte(depTerraform), 0644)
+	err = os.WriteFile(filepath.Join(depDir, "main.tf"), []byte(depTerraform), 0o644)
 	require.NoError(t, err)
 
 	mainConfig := `
@@ -4610,7 +4610,7 @@ inputs = {
   dep_value = dependency.dep.outputs.value
 }
 `
-	err = os.WriteFile(filepath.Join(mainDir, "terragrunt.hcl"), []byte(mainConfig), 0644)
+	err = os.WriteFile(filepath.Join(mainDir, "terragrunt.hcl"), []byte(mainConfig), 0o644)
 	require.NoError(t, err)
 
 	mainTerraform := `
@@ -4622,7 +4622,7 @@ output "result" {
   value = var.dep_value
 }
 `
-	err = os.WriteFile(filepath.Join(mainDir, "main.tf"), []byte(mainTerraform), 0644)
+	err = os.WriteFile(filepath.Join(mainDir, "main.tf"), []byte(mainTerraform), 0o644)
 	require.NoError(t, err)
 
 	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+depDir)
@@ -4652,11 +4652,11 @@ func TestExternalDependenciesAreResolved(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	depDir := filepath.Join(tmpDir, "dep")
-	err := os.MkdirAll(depDir, 0755)
+	err := os.MkdirAll(depDir, 0o755)
 	require.NoError(t, err)
 
 	mainDir := filepath.Join(tmpDir, "main")
-	err = os.MkdirAll(mainDir, 0755)
+	err = os.MkdirAll(mainDir, 0o755)
 	require.NoError(t, err)
 
 	depConfig := `
@@ -4664,7 +4664,7 @@ terraform {
   source = "."
 }
 `
-	err = os.WriteFile(filepath.Join(depDir, "terragrunt.hcl"), []byte(depConfig), 0644)
+	err = os.WriteFile(filepath.Join(depDir, "terragrunt.hcl"), []byte(depConfig), 0o644)
 	require.NoError(t, err)
 
 	depTerraform := `
@@ -4672,7 +4672,7 @@ output "value" {
   value = "hello from dependency"
 }
 `
-	err = os.WriteFile(filepath.Join(depDir, "main.tf"), []byte(depTerraform), 0644)
+	err = os.WriteFile(filepath.Join(depDir, "main.tf"), []byte(depTerraform), 0o644)
 	require.NoError(t, err)
 
 	mainConfig := `
@@ -4692,7 +4692,7 @@ inputs = {
   dep_value = dependency.dep.outputs.value
 }
 `
-	err = os.WriteFile(filepath.Join(mainDir, "terragrunt.hcl"), []byte(mainConfig), 0644)
+	err = os.WriteFile(filepath.Join(mainDir, "terragrunt.hcl"), []byte(mainConfig), 0o644)
 	require.NoError(t, err)
 
 	mainTerraform := `
@@ -4704,7 +4704,7 @@ output "result" {
   value = var.dep_value
 }
 `
-	err = os.WriteFile(filepath.Join(mainDir, "main.tf"), []byte(mainTerraform), 0644)
+	err = os.WriteFile(filepath.Join(mainDir, "main.tf"), []byte(mainTerraform), 0o644)
 	require.NoError(t, err)
 
 	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(

--- a/test/integration_units_reading_test.go
+++ b/test/integration_units_reading_test.go
@@ -27,7 +27,7 @@ const (
 func TestSOPSUnitsReading(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testFixtureUnitsReading)
+	helpers.CleanupTerraformFolder(t, testFixtureUnitsReading)
 
 	testCases := []struct {
 		name           string
@@ -348,7 +348,7 @@ func TestUnitsReadingWithFilter(t *testing.T) {
 func TestQueueStrictIncludeWithUnitsReading(t *testing.T) {
 	t.Parallel()
 
-	cleanupTerraformFolder(t, testFixtureUnitsReading)
+	helpers.CleanupTerraformFolder(t, testFixtureUnitsReading)
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureUnitsReading)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureUnitsReading)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

A few misc things:

- removes redundant functions in test/integration_test.go in favor of existing functions in `helpers` packagae.
- removes unnecessary `FileExists` calls in delete helper functions in favor of `!errors.Is(err, fs.ErrNotExist)`
- disable gpg signing in git repos made by test helper
- accept the lint formatting that my editor keeps doing (mostly adding `o` to octal litearls)

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure by centralizing cleanup helper functions across integration test suite.
  * Improved error handling for resource cleanup operations to gracefully handle missing targets.

* **Chores**
  * Modernized Go code style by updating file permission literals to explicit octal notation (`0o` prefix).
  * Added git configuration step to test setup for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->