### PR TITLE
fix: opts.WorkingDir needs symlinks resolved for later comparisons

### DIFF
--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -450,6 +450,11 @@ func initialSetup(cliCtx *clihelper.Context, l log.Logger, opts *options.Terragr
 		opts.WorkingDir = workingDir
 	}
 
+	// We often want to take paths relative to the working dir like filepath.Rel(opts.WorkingDir, other)
+	// The other path is often a canonical path with symlinks resolved, so opts.WorkingDir needs it as well
+	if resolved, evalErr := filepath.EvalSymlinks(opts.WorkingDir); evalErr == nil {
+		opts.WorkingDir = resolved
+	}
 	opts.WorkingDir = filepath.Clean(opts.WorkingDir)
 
 	l = l.WithField(placeholders.WorkDirKeyName, opts.WorkingDir)

--- a/internal/cli/commands/commands_internal_test.go
+++ b/internal/cli/commands/commands_internal_test.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+
+	runcmd "github.com/gruntwork-io/terragrunt/internal/cli/commands/run"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitialSetupResolvesWorkingDirSymlinks(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "resolve-working-dir-symlink-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("failed to remove temp dir %s: %v", tmpDir, err)
+		}
+	})
+
+	source := filepath.Join(tmpDir, "source")
+	require.NoError(t, os.Mkdir(source, 0o755))
+
+	link := filepath.Join(tmpDir, "link")
+	require.NoError(t, os.Symlink(source, link))
+
+	expectedDir, err := filepath.EvalSymlinks(link)
+	require.NoError(t, err)
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = link // unresolved symlink path
+
+	cliApp := &clihelper.App{App: &cli.App{Version: "0.0.0"}}
+	appCtx := clihelper.NewAppContext(cliApp, clihelper.Args{})
+	cmdCtx := appCtx.NewCommandContext(&clihelper.Command{Name: runcmd.CommandName}, clihelper.Args{})
+
+	formatter := format.NewFormatter(placeholders.Placeholders{placeholders.Message()})
+	l := log.New(log.WithFormatter(formatter))
+	require.NoError(t, initialSetup(cmdCtx, l, opts))
+
+	assert.Equal(t, expectedDir, opts.WorkingDir,
+		"WorkingDir should be resolved to the symlink target, not the symlink path itself")
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Terragrunt discovery could generate duplicate or invalid paths when the working dir path contained a symlink.

If the terragrunt working dir contains a symlink, then opts.WorkingDir would contain the absolute path to this directory, but discovery often needs to compose the working dir with canonical paths to discovered units, so we would mix canonical and non-canonical paths, which could give incorrect results.

When we have a symlink like /link/ -> /Users/user/link/, then the working dir might be for example /link/project/
But during discovery we often resolve symlinks to have canonical paths, which gives paths like /User/user/link/project/a/b/c

This looks like two different absolute paths when we do filepath.Rel(opts.WorkingDir, otherPath) so filepath.Rel will return:

`../../User/user/link/project/a/b/c`

Unfortunately this is subtly wrong! This path does not exist. That's because filePath.Rel() looks at the syntactic WorkingDir path which is /link/project/ and concludes it only needs ../../ to get an absolute path.
But in reality WorkingDir + ../../ is interpreted by the OS as:

`/User/user/link/project/../..` (the real canonical path)

Which resolves to `/User/user/` instead of `/`, because of the symlink. This PR resolve opts.WorkingDir after we make it an absolute path and before we clean it, so that all the symlinks go away and the rest of the code can safely take relative paths to it.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Fixed path issues when Terragrunt's working directory has a symlink in its path.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Working directory handling now resolves symbolic links so paths point to the underlying directory, improving consistency across filesystems.

* **Tests**
  * Added a test to verify working directory symlink resolution to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->