### PR TITLE
chore: Adding catalog redesign fork

### DIFF
--- a/internal/cli/commands/catalog/catalog.go
+++ b/internal/cli/commands/catalog/catalog.go
@@ -5,14 +5,26 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
 // Run is the main entry point for the catalog command.
-// It initializes the catalog service, retrieves modules, and then launches the TUI.
+// It dispatches to either the default or redesigned catalog experience
+// based on the catalog-redesign experiment.
 func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, repoURL string) error {
+	if opts.Experiments.Evaluate(experiment.CatalogRedesign) {
+		return runRedesign(ctx, l, opts, repoURL)
+	}
+
+	return runDefault(ctx, l, opts, repoURL)
+}
+
+// runDefault is the default catalog experience.
+// It initializes the catalog service, retrieves modules, and then launches the TUI.
+func runDefault(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, repoURL string) error {
 	svc := catalog.NewCatalogService(opts)
 
 	if repoURL != "" {

--- a/internal/cli/commands/catalog/catalog_redesign.go
+++ b/internal/cli/commands/catalog/catalog_redesign.go
@@ -1,0 +1,18 @@
+package catalog
+
+import (
+	"context"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+)
+
+// runRedesign is the entry point for the redesigned catalog experience.
+// It is invoked when the catalog-redesign experiment is enabled.
+//
+// For now, this delegates to the default implementation. As the redesign
+// evolves, this function will be replaced with a completely different
+// execution path (different service, different TUI, different orchestration).
+func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, repoURL string) error {
+	return runDefault(ctx, l, opts, repoURL)
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds redesign fork so that the redesigned Catalog experience can start to be developed.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added experimental support for an upcoming catalog redesign feature, currently behind a feature flag.

* **Chores**
  * Internal restructuring of catalog command infrastructure to support experiment-driven execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->