### PR TITLE
feat: Supporting catalog with no config

### DIFF
--- a/internal/cli/commands/catalog/catalog_redesign.go
+++ b/internal/cli/commands/catalog/catalog_redesign.go
@@ -26,7 +26,7 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 
 	return tui.RunRedesign(ctx, l, opts, func(ctx context.Context) (catalog.CatalogService, error) {
 		// Discover source URLs from terraform.source in terragrunt.hcl files
-		discoveredURLs, err := discoverSourceURLs(opts.RootWorkingDir, opts.Experiments)
+		discoveredURLs, err := DiscoverSourceURLs(opts.RootWorkingDir, opts.Experiments)
 		if err != nil {
 			l.Warnf("Failed to discover source URLs: %v", err)
 		}

--- a/internal/cli/commands/catalog/catalog_redesign.go
+++ b/internal/cli/commands/catalog/catalog_redesign.go
@@ -3,6 +3,11 @@ package catalog
 import (
 	"context"
 
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/internal/configbridge"
+	"github.com/gruntwork-io/terragrunt/internal/services/catalog"
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
@@ -10,9 +15,55 @@ import (
 // runRedesign is the entry point for the redesigned catalog experience.
 // It is invoked when the catalog-redesign experiment is enabled.
 //
-// For now, this delegates to the default implementation. As the redesign
-// evolves, this function will be replaced with a completely different
-// execution path (different service, different TUI, different orchestration).
+// Unlike the default path, it discovers module sources by scanning terraform.source
+// attributes in terragrunt.hcl files across the project tree. It merges these with
+// any catalog block URLs and feeds them into the standard repo/module pipeline.
+// If no sources are found, it shows a welcome screen.
 func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, repoURL string) error {
-	return runDefault(ctx, l, opts, repoURL)
+	// If an explicit URL was passed via CLI, use the default path
+	if repoURL != "" {
+		return runDefault(ctx, l, opts, repoURL)
+	}
+
+	// Discover source URLs from terraform.source in terragrunt.hcl files
+	discoveredURLs, err := discoverSourceURLs(opts.RootWorkingDir, opts.Experiments)
+	if err != nil {
+		l.Warnf("Failed to discover source URLs: %v", err)
+	}
+
+	// Also read catalog config if it exists
+	_, pctx := configbridge.NewParsingContext(ctx, l, opts)
+
+	catalogCfg, catalogErr := config.ReadCatalogConfig(ctx, l, pctx)
+	if catalogErr != nil {
+		l.Debugf("No catalog config found: %v", catalogErr)
+	}
+
+	// Merge: catalog URLs first, then discovered URLs
+	var allURLs []string
+	if catalogCfg != nil {
+		allURLs = append(allURLs, catalogCfg.URLs...)
+	}
+
+	allURLs = append(allURLs, discoveredURLs...)
+	allURLs = util.RemoveDuplicates(allURLs)
+
+	// No sources at all -> welcome screen
+	if len(allURLs) == 0 {
+		return tui.RunWelcome(ctx)
+	}
+
+	// Load modules from all discovered repos
+	svc := catalog.NewCatalogService(opts)
+	svc.WithRepoURLs(allURLs)
+
+	if err := svc.Load(ctx, l); err != nil {
+		l.Error(err)
+	}
+
+	if len(svc.Modules()) == 0 {
+		return tui.RunWelcome(ctx)
+	}
+
+	return tui.Run(ctx, l, opts, svc)
 }

--- a/internal/cli/commands/catalog/catalog_redesign.go
+++ b/internal/cli/commands/catalog/catalog_redesign.go
@@ -28,15 +28,16 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 	return tui.RunRedesign(ctx, l, opts, func(ctx context.Context, status tui.StatusFunc) (catalog.CatalogService, error) {
 		status("Scanning terragrunt.hcl files for module sources...")
 
+		// Create parsing context for source discovery and catalog config
+		ctx, pctx := configbridge.NewParsingContext(ctx, l, opts)
+
 		// Discover source URLs from terraform.source in terragrunt.hcl files
-		discoveredURLs, err := DiscoverSourceURLs(opts.RootWorkingDir, opts.Experiments)
+		discoveredURLs, err := DiscoverSourceURLs(ctx, l, pctx)
 		if err != nil {
 			l.Warnf("Failed to discover source URLs: %v", err)
 		}
 
 		// Also read catalog config if it exists
-		_, pctx := configbridge.NewParsingContext(ctx, l, opts)
-
 		catalogCfg, catalogErr := config.ReadCatalogConfig(ctx, l, pctx)
 		if catalogErr != nil {
 			l.Debugf("No catalog config found: %v", catalogErr)

--- a/internal/cli/commands/catalog/catalog_redesign.go
+++ b/internal/cli/commands/catalog/catalog_redesign.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
@@ -24,7 +25,9 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 		return runDefault(ctx, l, opts, repoURL)
 	}
 
-	return tui.RunRedesign(ctx, l, opts, func(ctx context.Context) (catalog.CatalogService, error) {
+	return tui.RunRedesign(ctx, l, opts, func(ctx context.Context, status tui.StatusFunc) (catalog.CatalogService, error) {
+		status("Scanning terragrunt.hcl files for module sources...")
+
 		// Discover source URLs from terraform.source in terragrunt.hcl files
 		discoveredURLs, err := DiscoverSourceURLs(opts.RootWorkingDir, opts.Experiments)
 		if err != nil {
@@ -52,6 +55,8 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 			return nil, nil
 		}
 
+		status(fmt.Sprintf("Found %d source(s), cloning repositories...", len(allURLs)))
+
 		// Load modules from all discovered repos
 		svc := catalog.NewCatalogService(opts)
 		svc.WithRepoURLs(allURLs)
@@ -59,6 +64,8 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 		if err := svc.Load(ctx, l); err != nil {
 			return svc, err
 		}
+
+		status(fmt.Sprintf("Found %d module(s), loading catalog...", len(svc.Modules())))
 
 		return svc, nil
 	})

--- a/internal/cli/commands/catalog/catalog_redesign.go
+++ b/internal/cli/commands/catalog/catalog_redesign.go
@@ -15,55 +15,51 @@ import (
 // runRedesign is the entry point for the redesigned catalog experience.
 // It is invoked when the catalog-redesign experiment is enabled.
 //
-// Unlike the default path, it discovers module sources by scanning terraform.source
-// attributes in terragrunt.hcl files across the project tree. It merges these with
-// any catalog block URLs and feeds them into the standard repo/module pipeline.
-// If no sources are found, it shows a welcome screen.
+// It launches the TUI immediately with a loading screen, then runs source
+// discovery and module loading in the background. When loading completes,
+// the TUI transitions to the module list or shows a welcome screen.
 func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, repoURL string) error {
 	// If an explicit URL was passed via CLI, use the default path
 	if repoURL != "" {
 		return runDefault(ctx, l, opts, repoURL)
 	}
 
-	// Discover source URLs from terraform.source in terragrunt.hcl files
-	discoveredURLs, err := discoverSourceURLs(opts.RootWorkingDir, opts.Experiments)
-	if err != nil {
-		l.Warnf("Failed to discover source URLs: %v", err)
-	}
+	return tui.RunRedesign(ctx, l, opts, func(ctx context.Context) (catalog.CatalogService, error) {
+		// Discover source URLs from terraform.source in terragrunt.hcl files
+		discoveredURLs, err := discoverSourceURLs(opts.RootWorkingDir, opts.Experiments)
+		if err != nil {
+			l.Warnf("Failed to discover source URLs: %v", err)
+		}
 
-	// Also read catalog config if it exists
-	_, pctx := configbridge.NewParsingContext(ctx, l, opts)
+		// Also read catalog config if it exists
+		_, pctx := configbridge.NewParsingContext(ctx, l, opts)
 
-	catalogCfg, catalogErr := config.ReadCatalogConfig(ctx, l, pctx)
-	if catalogErr != nil {
-		l.Debugf("No catalog config found: %v", catalogErr)
-	}
+		catalogCfg, catalogErr := config.ReadCatalogConfig(ctx, l, pctx)
+		if catalogErr != nil {
+			l.Debugf("No catalog config found: %v", catalogErr)
+		}
 
-	// Merge: catalog URLs first, then discovered URLs
-	var allURLs []string
-	if catalogCfg != nil {
-		allURLs = append(allURLs, catalogCfg.URLs...)
-	}
+		// Merge: catalog URLs first, then discovered URLs
+		var allURLs []string
+		if catalogCfg != nil {
+			allURLs = append(allURLs, catalogCfg.URLs...)
+		}
 
-	allURLs = append(allURLs, discoveredURLs...)
-	allURLs = util.RemoveDuplicates(allURLs)
+		allURLs = append(allURLs, discoveredURLs...)
+		allURLs = util.RemoveDuplicates(allURLs)
 
-	// No sources at all -> welcome screen
-	if len(allURLs) == 0 {
-		return tui.RunWelcome(ctx)
-	}
+		if len(allURLs) == 0 {
+			return nil, nil
+		}
 
-	// Load modules from all discovered repos
-	svc := catalog.NewCatalogService(opts)
-	svc.WithRepoURLs(allURLs)
+		// Load modules from all discovered repos
+		svc := catalog.NewCatalogService(opts)
+		svc.WithRepoURLs(allURLs)
 
-	if err := svc.Load(ctx, l); err != nil {
-		l.Error(err)
-	}
+		if err := svc.Load(ctx, l); err != nil {
+			return svc, err
+		}
 
-	if len(svc.Modules()) == 0 {
-		return tui.RunWelcome(ctx)
-	}
-
-	return tui.Run(ctx, l, opts, svc)
+		return svc, nil
+	})
 }

--- a/internal/cli/commands/catalog/source_discovery.go
+++ b/internal/cli/commands/catalog/source_discovery.go
@@ -1,0 +1,93 @@
+package catalog
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-getter"
+
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+)
+
+// terraformSourceReg matches a terraform block's source attribute with a literal string value.
+// It intentionally excludes interpolated sources (containing $) so that only
+// statically-known URLs are captured.
+var terraformSourceReg = regexp.MustCompile(`(?s)terraform\s*\{[^}]*?source\s*=\s*"([^"$]+)"`)
+
+// discoverSourceURLs walks the project tree starting from rootDir, finds all
+// terragrunt.hcl files, extracts terraform.source URLs, normalizes them to
+// repo-level URLs, and returns a deduplicated list.
+func discoverSourceURLs(rootDir string, experiments experiment.Experiments) ([]string, error) {
+	configFiles, err := config.FindConfigFilesInPath(rootDir, experiments, config.DefaultTerragruntConfigPath, nil, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var repoURLs []string
+
+	for _, configFile := range configFiles {
+		content, err := util.ReadFileAsString(configFile)
+		if err != nil {
+			continue
+		}
+
+		source := extractTerraformSource(content)
+		if source == "" {
+			continue
+		}
+
+		repoURL := extractRepoURL(source)
+		if repoURL == "" {
+			continue
+		}
+
+		repoURLs = append(repoURLs, repoURL)
+	}
+
+	return util.RemoveDuplicates(repoURLs), nil
+}
+
+// extractTerraformSource extracts the terraform.source attribute value from
+// HCL content. Returns an empty string if no literal source is found or if
+// the source uses interpolation.
+func extractTerraformSource(content string) string {
+	matches := terraformSourceReg.FindStringSubmatch(content)
+	if len(matches) < 2 {
+		return ""
+	}
+
+	return matches[1]
+}
+
+// extractRepoURL normalizes a terraform source URL to a repo-level URL by
+// stripping subdirectory paths, query parameters, and getter prefixes.
+// Returns an empty string for local paths and registry sources.
+func extractRepoURL(source string) string {
+	if strings.HasPrefix(source, ".") || strings.HasPrefix(source, "/") {
+		return ""
+	}
+
+	if strings.HasPrefix(source, "tfr:") {
+		return ""
+	}
+
+	// Split at // to separate repo URL from module subdirectory
+	moduleURL, _ := getter.SourceDirSubdir(source)
+	if moduleURL == "" {
+		return ""
+	}
+
+	// Strip query parameters (e.g., ?ref=v1.0.0)
+	if idx := strings.IndexByte(moduleURL, '?'); idx >= 0 {
+		moduleURL = moduleURL[:idx]
+	}
+
+	// Strip getter-specific prefixes (e.g., git::, s3::, gcs::)
+	if idx := strings.Index(moduleURL, "::"); idx >= 0 {
+		moduleURL = moduleURL[idx+2:]
+	}
+
+	return moduleURL
+}

--- a/internal/cli/commands/catalog/source_discovery.go
+++ b/internal/cli/commands/catalog/source_discovery.go
@@ -1,44 +1,47 @@
 package catalog
 
 import (
-	"regexp"
+	"context"
 	"strings"
 
 	"github.com/hashicorp/go-getter"
 
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
-// terraformSourceReg matches a terraform block's source attribute with a literal string value.
-// It intentionally excludes interpolated sources (containing $) so that only
-// statically-known URLs are captured.
-var terraformSourceReg = regexp.MustCompile(`(?s)terraform\s*\{[^}]*?source\s*=\s*"([^"$]+)"`)
-
-// DiscoverSourceURLs walks the project tree starting from rootDir, finds all
-// terragrunt.hcl files, extracts terraform.source URLs, normalizes them to
-// repo-level URLs, and returns a deduplicated list.
-func DiscoverSourceURLs(rootDir string, experiments experiment.Experiments) ([]string, error) {
-	configFiles, err := config.FindConfigFilesInPath(rootDir, experiments, config.DefaultTerragruntConfigPath, nil, "")
+// DiscoverSourceURLs walks the project tree starting from pctx.RootWorkingDir,
+// finds all terragrunt.hcl files, parses them to extract terraform.source URLs,
+// normalizes them to repo-level URLs, and returns a deduplicated list.
+func DiscoverSourceURLs(ctx context.Context, l log.Logger, pctx *config.ParsingContext) ([]string, error) {
+	configFiles, err := config.FindConfigFilesInPath(pctx.RootWorkingDir, pctx.Experiments, config.DefaultTerragruntConfigPath, nil, "")
 	if err != nil {
 		return nil, err
 	}
 
+	sourcePctx := pctx.WithDecodeList(config.TerraformSource).WithDiagnosticsSuppressed(l)
+
 	var repoURLs []string
 
 	for _, configFile := range configFiles {
-		content, err := util.ReadFileAsString(configFile)
+		fileLogger, filePctx, err := sourcePctx.WithConfigPath(l, configFile)
 		if err != nil {
+			l.Debugf("Skipping %s: %v", configFile, err)
 			continue
 		}
 
-		source := ExtractTerraformSource(content)
-		if source == "" {
+		cfg, err := config.PartialParseConfigFile(ctx, filePctx, fileLogger, configFile, nil)
+		if err != nil {
+			l.Debugf("Skipping %s: failed to parse: %v", configFile, err)
 			continue
 		}
 
-		repoURL := ExtractRepoURL(source)
+		if cfg.Terraform == nil || cfg.Terraform.Source == nil {
+			continue
+		}
+
+		repoURL := ExtractRepoURL(*cfg.Terraform.Source)
 		if repoURL == "" {
 			continue
 		}
@@ -47,18 +50,6 @@ func DiscoverSourceURLs(rootDir string, experiments experiment.Experiments) ([]s
 	}
 
 	return util.RemoveDuplicates(repoURLs), nil
-}
-
-// ExtractTerraformSource extracts the terraform.source attribute value from
-// HCL content. Returns an empty string if no literal source is found or if
-// the source uses interpolation.
-func ExtractTerraformSource(content string) string {
-	matches := terraformSourceReg.FindStringSubmatch(content)
-	if len(matches) < 2 { //nolint:mnd
-		return ""
-	}
-
-	return matches[1]
 }
 
 // ExtractRepoURL normalizes a terraform source URL to a repo-level URL by

--- a/internal/cli/commands/catalog/source_discovery.go
+++ b/internal/cli/commands/catalog/source_discovery.go
@@ -16,10 +16,10 @@ import (
 // statically-known URLs are captured.
 var terraformSourceReg = regexp.MustCompile(`(?s)terraform\s*\{[^}]*?source\s*=\s*"([^"$]+)"`)
 
-// discoverSourceURLs walks the project tree starting from rootDir, finds all
+// DiscoverSourceURLs walks the project tree starting from rootDir, finds all
 // terragrunt.hcl files, extracts terraform.source URLs, normalizes them to
 // repo-level URLs, and returns a deduplicated list.
-func discoverSourceURLs(rootDir string, experiments experiment.Experiments) ([]string, error) {
+func DiscoverSourceURLs(rootDir string, experiments experiment.Experiments) ([]string, error) {
 	configFiles, err := config.FindConfigFilesInPath(rootDir, experiments, config.DefaultTerragruntConfigPath, nil, "")
 	if err != nil {
 		return nil, err
@@ -33,12 +33,12 @@ func discoverSourceURLs(rootDir string, experiments experiment.Experiments) ([]s
 			continue
 		}
 
-		source := extractTerraformSource(content)
+		source := ExtractTerraformSource(content)
 		if source == "" {
 			continue
 		}
 
-		repoURL := extractRepoURL(source)
+		repoURL := ExtractRepoURL(source)
 		if repoURL == "" {
 			continue
 		}
@@ -49,22 +49,22 @@ func discoverSourceURLs(rootDir string, experiments experiment.Experiments) ([]s
 	return util.RemoveDuplicates(repoURLs), nil
 }
 
-// extractTerraformSource extracts the terraform.source attribute value from
+// ExtractTerraformSource extracts the terraform.source attribute value from
 // HCL content. Returns an empty string if no literal source is found or if
 // the source uses interpolation.
-func extractTerraformSource(content string) string {
+func ExtractTerraformSource(content string) string {
 	matches := terraformSourceReg.FindStringSubmatch(content)
-	if len(matches) < 2 {
+	if len(matches) < 2 { //nolint:mnd
 		return ""
 	}
 
 	return matches[1]
 }
 
-// extractRepoURL normalizes a terraform source URL to a repo-level URL by
+// ExtractRepoURL normalizes a terraform source URL to a repo-level URL by
 // stripping subdirectory paths, query parameters, and getter prefixes.
 // Returns an empty string for local paths and registry sources.
-func extractRepoURL(source string) string {
+func ExtractRepoURL(source string) string {
 	if strings.HasPrefix(source, ".") || strings.HasPrefix(source, "/") {
 		return ""
 	}

--- a/internal/cli/commands/catalog/source_discovery_test.go
+++ b/internal/cli/commands/catalog/source_discovery_test.go
@@ -1,27 +1,16 @@
-package catalog
+package catalog_test
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// tmpDirResolved returns a temp directory with symlinks resolved.
-// This avoids macOS issues where t.TempDir() returns a symlinked path.
-func tmpDirResolved(t *testing.T) string {
-	t.Helper()
-
-	dir := t.TempDir()
-
-	resolved, err := filepath.EvalSymlinks(dir)
-	require.NoError(t, err)
-
-	return resolved
-}
 
 func TestExtractTerraformSource_Simple(t *testing.T) {
 	t.Parallel()
@@ -31,7 +20,7 @@ terraform {
   source = "github.com/gruntwork-io/terraform-aws-vpc"
 }
 `
-	result := extractTerraformSource(content)
+	result := catalog.ExtractTerraformSource(content)
 	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc", result)
 }
 
@@ -43,7 +32,7 @@ terraform {
   source = "github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0"
 }
 `
-	result := extractTerraformSource(content)
+	result := catalog.ExtractTerraformSource(content)
 	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0", result)
 }
 
@@ -55,7 +44,7 @@ terraform {
   source = "git::https://github.com/gruntwork-io/terraform-aws-vpc.git//modules/vpc?ref=v1.0.0"
 }
 `
-	result := extractTerraformSource(content)
+	result := catalog.ExtractTerraformSource(content)
 	assert.Equal(t, "git::https://github.com/gruntwork-io/terraform-aws-vpc.git//modules/vpc?ref=v1.0.0", result)
 }
 
@@ -67,7 +56,7 @@ terraform {
   source = "${local.base_source_url}?ref=v0.26.0"
 }
 `
-	result := extractTerraformSource(content)
+	result := catalog.ExtractTerraformSource(content)
 	assert.Empty(t, result)
 }
 
@@ -83,7 +72,7 @@ inputs = {
   name = "my-vpc"
 }
 `
-	result := extractTerraformSource(content)
+	result := catalog.ExtractTerraformSource(content)
 	assert.Empty(t, result)
 }
 
@@ -99,64 +88,64 @@ terraform {
   }
 }
 `
-	result := extractTerraformSource(content)
+	result := catalog.ExtractTerraformSource(content)
 	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0", result)
 }
 
 func TestExtractRepoURL_Simple(t *testing.T) {
 	t.Parallel()
 
-	result := extractRepoURL("github.com/gruntwork-io/terraform-aws-vpc")
+	result := catalog.ExtractRepoURL("github.com/gruntwork-io/terraform-aws-vpc")
 	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc", result)
 }
 
 func TestExtractRepoURL_WithSubdirAndRef(t *testing.T) {
 	t.Parallel()
 
-	result := extractRepoURL("github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0")
+	result := catalog.ExtractRepoURL("github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0")
 	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc", result)
 }
 
 func TestExtractRepoURL_GitPrefix(t *testing.T) {
 	t.Parallel()
 
-	result := extractRepoURL("git::https://github.com/gruntwork-io/terraform-aws-vpc.git")
+	result := catalog.ExtractRepoURL("git::https://github.com/gruntwork-io/terraform-aws-vpc.git")
 	assert.Equal(t, "https://github.com/gruntwork-io/terraform-aws-vpc.git", result)
 }
 
 func TestExtractRepoURL_GitPrefixWithSubdir(t *testing.T) {
 	t.Parallel()
 
-	result := extractRepoURL("git::https://github.com/gruntwork-io/terraform-aws-vpc.git//modules/vpc?ref=v1.0.0")
+	result := catalog.ExtractRepoURL("git::https://github.com/gruntwork-io/terraform-aws-vpc.git//modules/vpc?ref=v1.0.0")
 	assert.Equal(t, "https://github.com/gruntwork-io/terraform-aws-vpc.git", result)
 }
 
 func TestExtractRepoURL_LocalPath(t *testing.T) {
 	t.Parallel()
 
-	assert.Empty(t, extractRepoURL("../modules/vpc"))
-	assert.Empty(t, extractRepoURL("./modules/vpc"))
-	assert.Empty(t, extractRepoURL("/absolute/path/to/modules"))
+	assert.Empty(t, catalog.ExtractRepoURL("../modules/vpc"))
+	assert.Empty(t, catalog.ExtractRepoURL("./modules/vpc"))
+	assert.Empty(t, catalog.ExtractRepoURL("/absolute/path/to/modules"))
 }
 
 func TestExtractRepoURL_Registry(t *testing.T) {
 	t.Parallel()
 
-	result := extractRepoURL("tfr:///terraform-aws-modules/vpc/aws?version=3.5.0")
+	result := catalog.ExtractRepoURL("tfr:///terraform-aws-modules/vpc/aws?version=3.5.0")
 	assert.Empty(t, result)
 }
 
 func TestExtractRepoURL_S3Prefix(t *testing.T) {
 	t.Parallel()
 
-	result := extractRepoURL("s3::https://s3-eu-west-1.amazonaws.com/bucket/module.zip")
+	result := catalog.ExtractRepoURL("s3::https://s3-eu-west-1.amazonaws.com/bucket/module.zip")
 	assert.Equal(t, "https://s3-eu-west-1.amazonaws.com/bucket/module.zip", result)
 }
 
 func TestDiscoverSourceURLs(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := tmpDirResolved(t)
+	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	// Create directory structure:
 	// tmpDir/
@@ -210,7 +199,7 @@ inputs = {
 }
 `), 0644))
 
-	urls, err := discoverSourceURLs(tmpDir, experiment.NewExperiments())
+	urls, err := catalog.DiscoverSourceURLs(tmpDir, experiment.NewExperiments())
 	require.NoError(t, err)
 
 	// Should have 2 unique repo URLs (repo-a deduplicated, repo-b, interpolated and no-source skipped)
@@ -222,9 +211,9 @@ inputs = {
 func TestDiscoverSourceURLs_EmptyDir(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := tmpDirResolved(t)
+	tmpDir := helpers.TmpDirWOSymlinks(t)
 
-	urls, err := discoverSourceURLs(tmpDir, experiment.NewExperiments())
+	urls, err := catalog.DiscoverSourceURLs(tmpDir, experiment.NewExperiments())
 	require.NoError(t, err)
 	assert.Empty(t, urls)
 }

--- a/internal/cli/commands/catalog/source_discovery_test.go
+++ b/internal/cli/commands/catalog/source_discovery_test.go
@@ -1,0 +1,230 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tmpDirResolved returns a temp directory with symlinks resolved.
+// This avoids macOS issues where t.TempDir() returns a symlinked path.
+func tmpDirResolved(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	resolved, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+
+	return resolved
+}
+
+func TestExtractTerraformSource_Simple(t *testing.T) {
+	t.Parallel()
+
+	content := `
+terraform {
+  source = "github.com/gruntwork-io/terraform-aws-vpc"
+}
+`
+	result := extractTerraformSource(content)
+	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc", result)
+}
+
+func TestExtractTerraformSource_WithSubdirAndRef(t *testing.T) {
+	t.Parallel()
+
+	content := `
+terraform {
+  source = "github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0"
+}
+`
+	result := extractTerraformSource(content)
+	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0", result)
+}
+
+func TestExtractTerraformSource_GitPrefix(t *testing.T) {
+	t.Parallel()
+
+	content := `
+terraform {
+  source = "git::https://github.com/gruntwork-io/terraform-aws-vpc.git//modules/vpc?ref=v1.0.0"
+}
+`
+	result := extractTerraformSource(content)
+	assert.Equal(t, "git::https://github.com/gruntwork-io/terraform-aws-vpc.git//modules/vpc?ref=v1.0.0", result)
+}
+
+func TestExtractTerraformSource_Interpolated(t *testing.T) {
+	t.Parallel()
+
+	content := `
+terraform {
+  source = "${local.base_source_url}?ref=v0.26.0"
+}
+`
+	result := extractTerraformSource(content)
+	assert.Empty(t, result)
+}
+
+func TestExtractTerraformSource_NoTerraformBlock(t *testing.T) {
+	t.Parallel()
+
+	content := `
+include "root" {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  name = "my-vpc"
+}
+`
+	result := extractTerraformSource(content)
+	assert.Empty(t, result)
+}
+
+func TestExtractTerraformSource_WithOtherAttributes(t *testing.T) {
+	t.Parallel()
+
+	content := `
+terraform {
+  source = "github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0"
+
+  extra_arguments "common" {
+    arguments = ["-var-file=common.tfvars"]
+  }
+}
+`
+	result := extractTerraformSource(content)
+	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0", result)
+}
+
+func TestExtractRepoURL_Simple(t *testing.T) {
+	t.Parallel()
+
+	result := extractRepoURL("github.com/gruntwork-io/terraform-aws-vpc")
+	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc", result)
+}
+
+func TestExtractRepoURL_WithSubdirAndRef(t *testing.T) {
+	t.Parallel()
+
+	result := extractRepoURL("github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0")
+	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc", result)
+}
+
+func TestExtractRepoURL_GitPrefix(t *testing.T) {
+	t.Parallel()
+
+	result := extractRepoURL("git::https://github.com/gruntwork-io/terraform-aws-vpc.git")
+	assert.Equal(t, "https://github.com/gruntwork-io/terraform-aws-vpc.git", result)
+}
+
+func TestExtractRepoURL_GitPrefixWithSubdir(t *testing.T) {
+	t.Parallel()
+
+	result := extractRepoURL("git::https://github.com/gruntwork-io/terraform-aws-vpc.git//modules/vpc?ref=v1.0.0")
+	assert.Equal(t, "https://github.com/gruntwork-io/terraform-aws-vpc.git", result)
+}
+
+func TestExtractRepoURL_LocalPath(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, extractRepoURL("../modules/vpc"))
+	assert.Empty(t, extractRepoURL("./modules/vpc"))
+	assert.Empty(t, extractRepoURL("/absolute/path/to/modules"))
+}
+
+func TestExtractRepoURL_Registry(t *testing.T) {
+	t.Parallel()
+
+	result := extractRepoURL("tfr:///terraform-aws-modules/vpc/aws?version=3.5.0")
+	assert.Empty(t, result)
+}
+
+func TestExtractRepoURL_S3Prefix(t *testing.T) {
+	t.Parallel()
+
+	result := extractRepoURL("s3::https://s3-eu-west-1.amazonaws.com/bucket/module.zip")
+	assert.Equal(t, "https://s3-eu-west-1.amazonaws.com/bucket/module.zip", result)
+}
+
+func TestDiscoverSourceURLs(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := tmpDirResolved(t)
+
+	// Create directory structure:
+	// tmpDir/
+	//   unit-a/terragrunt.hcl  -> source = "github.com/org/repo-a//modules/vpc?ref=v1.0"
+	//   unit-b/terragrunt.hcl  -> source = "github.com/org/repo-b"
+	//   unit-c/terragrunt.hcl  -> source = "github.com/org/repo-a//modules/ecs?ref=v2.0" (same repo as unit-a)
+	//   unit-d/terragrunt.hcl  -> source = "${local.base}?ref=v1" (interpolated, should be skipped)
+	//   unit-e/terragrunt.hcl  -> no terraform block (should be skipped)
+
+	unitA := filepath.Join(tmpDir, "unit-a")
+	unitB := filepath.Join(tmpDir, "unit-b")
+	unitC := filepath.Join(tmpDir, "unit-c")
+	unitD := filepath.Join(tmpDir, "unit-d")
+	unitE := filepath.Join(tmpDir, "unit-e")
+
+	for _, dir := range []string{unitA, unitB, unitC, unitD, unitE} {
+		require.NoError(t, os.MkdirAll(dir, 0755))
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(unitA, "terragrunt.hcl"), []byte(`
+terraform {
+  source = "github.com/org/repo-a//modules/vpc?ref=v1.0"
+}
+`), 0644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(unitB, "terragrunt.hcl"), []byte(`
+terraform {
+  source = "github.com/org/repo-b"
+}
+`), 0644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(unitC, "terragrunt.hcl"), []byte(`
+terraform {
+  source = "github.com/org/repo-a//modules/ecs?ref=v2.0"
+}
+`), 0644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(unitD, "terragrunt.hcl"), []byte(`
+terraform {
+  source = "${local.base_source_url}?ref=v1.0"
+}
+`), 0644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(unitE, "terragrunt.hcl"), []byte(`
+include "root" {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  name = "test"
+}
+`), 0644))
+
+	urls, err := discoverSourceURLs(tmpDir, experiment.NewExperiments())
+	require.NoError(t, err)
+
+	// Should have 2 unique repo URLs (repo-a deduplicated, repo-b, interpolated and no-source skipped)
+	assert.Len(t, urls, 2)
+	assert.Contains(t, urls, "github.com/org/repo-a")
+	assert.Contains(t, urls, "github.com/org/repo-b")
+}
+
+func TestDiscoverSourceURLs_EmptyDir(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := tmpDirResolved(t)
+
+	urls, err := discoverSourceURLs(tmpDir, experiment.NewExperiments())
+	require.NoError(t, err)
+	assert.Empty(t, urls)
+}

--- a/internal/cli/commands/catalog/source_discovery_test.go
+++ b/internal/cli/commands/catalog/source_discovery_test.go
@@ -6,91 +6,13 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestExtractTerraformSource_Simple(t *testing.T) {
-	t.Parallel()
-
-	content := `
-terraform {
-  source = "github.com/gruntwork-io/terraform-aws-vpc"
-}
-`
-	result := catalog.ExtractTerraformSource(content)
-	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc", result)
-}
-
-func TestExtractTerraformSource_WithSubdirAndRef(t *testing.T) {
-	t.Parallel()
-
-	content := `
-terraform {
-  source = "github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0"
-}
-`
-	result := catalog.ExtractTerraformSource(content)
-	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0", result)
-}
-
-func TestExtractTerraformSource_GitPrefix(t *testing.T) {
-	t.Parallel()
-
-	content := `
-terraform {
-  source = "git::https://github.com/gruntwork-io/terraform-aws-vpc.git//modules/vpc?ref=v1.0.0"
-}
-`
-	result := catalog.ExtractTerraformSource(content)
-	assert.Equal(t, "git::https://github.com/gruntwork-io/terraform-aws-vpc.git//modules/vpc?ref=v1.0.0", result)
-}
-
-func TestExtractTerraformSource_Interpolated(t *testing.T) {
-	t.Parallel()
-
-	content := `
-terraform {
-  source = "${local.base_source_url}?ref=v0.26.0"
-}
-`
-	result := catalog.ExtractTerraformSource(content)
-	assert.Empty(t, result)
-}
-
-func TestExtractTerraformSource_NoTerraformBlock(t *testing.T) {
-	t.Parallel()
-
-	content := `
-include "root" {
-  path = find_in_parent_folders()
-}
-
-inputs = {
-  name = "my-vpc"
-}
-`
-	result := catalog.ExtractTerraformSource(content)
-	assert.Empty(t, result)
-}
-
-func TestExtractTerraformSource_WithOtherAttributes(t *testing.T) {
-	t.Parallel()
-
-	content := `
-terraform {
-  source = "github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0"
-
-  extra_arguments "common" {
-    arguments = ["-var-file=common.tfvars"]
-  }
-}
-`
-	result := catalog.ExtractTerraformSource(content)
-	assert.Equal(t, "github.com/gruntwork-io/terraform-aws-vpc//modules/vpc-app?ref=v0.26.0", result)
-}
 
 func TestExtractRepoURL_Simple(t *testing.T) {
 	t.Parallel()
@@ -199,7 +121,11 @@ inputs = {
 }
 `), 0644))
 
-	urls, err := catalog.DiscoverSourceURLs(tmpDir, experiment.NewExperiments())
+	l := logger.CreateLogger()
+	ctx, pctx := config.NewParsingContext(t.Context(), l, config.WithStrictControls(controls.New()))
+	pctx.RootWorkingDir = tmpDir
+
+	urls, err := catalog.DiscoverSourceURLs(ctx, l, pctx)
 	require.NoError(t, err)
 
 	// Should have 2 unique repo URLs (repo-a deduplicated, repo-b, interpolated and no-source skipped)
@@ -213,7 +139,11 @@ func TestDiscoverSourceURLs_EmptyDir(t *testing.T) {
 
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
-	urls, err := catalog.DiscoverSourceURLs(tmpDir, experiment.NewExperiments())
+	l := logger.CreateLogger()
+	ctx, pctx := config.NewParsingContext(t.Context(), l, config.WithStrictControls(controls.New()))
+	pctx.RootWorkingDir = tmpDir
+
+	urls, err := catalog.DiscoverSourceURLs(ctx, l, pctx)
 	require.NoError(t, err)
 	assert.Empty(t, urls)
 }

--- a/internal/cli/commands/catalog/tui/welcome.go
+++ b/internal/cli/commands/catalog/tui/welcome.go
@@ -261,6 +261,9 @@ func (m WelcomeModel) noSourcesView() string { //nolint:gocritic
 // screen immediately while discovery runs in the background, then transitions
 // to the module list if modules are found.
 func RunRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, loadFunc LoadFunc) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	model := NewWelcomeModel(ctx, l, opts, loadFunc)
 
 	if _, err := tea.NewProgram(model, tea.WithContext(ctx)).Run(); err != nil {

--- a/internal/cli/commands/catalog/tui/welcome.go
+++ b/internal/cli/commands/catalog/tui/welcome.go
@@ -23,7 +23,7 @@ type LoadFunc func(ctx context.Context) (catalog.CatalogService, error)
 type welcomeState int
 
 const (
-	welcomeLoading   welcomeState = iota
+	welcomeLoading welcomeState = iota
 	welcomeNoSources
 )
 
@@ -41,7 +41,7 @@ var (
 				Padding(0, 1)
 
 	welcomeBodyStyle = lipgloss.NewStyle().
-				Padding(1, 2)
+				Padding(1, 2) //nolint:mnd
 
 	welcomeCodeStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#8BE9FD"))
@@ -81,11 +81,11 @@ func NewWelcomeModel(ctx context.Context, l log.Logger, opts *options.Terragrunt
 }
 
 // Init implements tea.Model. It starts the spinner and kicks off discovery.
-func (m WelcomeModel) Init() tea.Cmd {
+func (m WelcomeModel) Init() tea.Cmd { //nolint:gocritic
 	return tea.Batch(m.spinner.Tick, m.startDiscovery())
 }
 
-func (m WelcomeModel) startDiscovery() tea.Cmd {
+func (m WelcomeModel) startDiscovery() tea.Cmd { //nolint:gocritic
 	ctx := m.ctx
 	loadFunc := m.loadFunc
 
@@ -117,6 +117,7 @@ func (m WelcomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocrit
 
 	if m.state == welcomeLoading {
 		var cmd tea.Cmd
+
 		m.spinner, cmd = m.spinner.Update(msg)
 
 		return m, cmd
@@ -125,7 +126,7 @@ func (m WelcomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocrit
 	return m, nil
 }
 
-func (m WelcomeModel) handleDiscoveryComplete(msg discoveryCompleteMsg) (tea.Model, tea.Cmd) {
+func (m WelcomeModel) handleDiscoveryComplete(msg discoveryCompleteMsg) (tea.Model, tea.Cmd) { //nolint:gocritic
 	if msg.err != nil {
 		m.logger.Warnf("Discovery error: %v", msg.err)
 	}

--- a/internal/cli/commands/catalog/tui/welcome.go
+++ b/internal/cli/commands/catalog/tui/welcome.go
@@ -16,9 +16,17 @@ import (
 
 const welcomeDocsURL = "https://docs.terragrunt.com/features/catalog/"
 
+// StatusFunc receives progress updates during discovery and loading.
+type StatusFunc func(msg string)
+
 // LoadFunc performs source discovery and module loading in the background.
+// It calls status with human-readable progress updates.
 // It returns a ready CatalogService, or nil if no sources were found.
-type LoadFunc func(ctx context.Context) (catalog.CatalogService, error)
+type LoadFunc func(ctx context.Context, status StatusFunc) (catalog.CatalogService, error)
+
+// OpenURLFunc opens a URL in the user's browser. Injected so tests can
+// substitute a no-op or a recording stub.
+type OpenURLFunc func(url string) error
 
 type welcomeState int
 
@@ -32,6 +40,11 @@ type discoveryCompleteMsg struct {
 	svc catalog.CatalogService
 	err error
 }
+
+// statusUpdateMsg carries a progress update from the LoadFunc.
+type statusUpdateMsg string
+
+const statusChannelSize = 10
 
 var (
 	welcomeTitleStyle = lipgloss.NewStyle().
@@ -50,23 +63,21 @@ var (
 				Foreground(lipgloss.Color("#6272A4"))
 )
 
-// OpenURLFunc opens a URL in the user's browser. Injected so tests can
-// substitute a no-op or a recording stub.
-type OpenURLFunc func(url string) error
-
 // WelcomeModel is a BubbleTea model that shows a loading screen while
 // discovery runs in the background, then either transitions to the module
 // list TUI or settles into a "no sources found" help screen.
 type WelcomeModel struct {
-	ctx       context.Context
-	logger    log.Logger
-	opts      *options.TerragruntOptions
-	loadFunc  LoadFunc
-	openURL   OpenURLFunc
-	spinner   spinner.Model
-	state     welcomeState
-	width     int
-	height    int
+	ctx        context.Context
+	logger     log.Logger
+	opts       *options.TerragruntOptions
+	loadFunc   LoadFunc
+	openURL    OpenURLFunc
+	statusCh   chan string
+	statusText string
+	spinner    spinner.Model
+	state      welcomeState
+	width      int
+	height     int
 }
 
 // NewWelcomeModel creates a WelcomeModel that immediately begins discovery.
@@ -76,13 +87,15 @@ func NewWelcomeModel(ctx context.Context, l log.Logger, opts *options.Terragrunt
 	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B"))
 
 	return WelcomeModel{
-		ctx:      ctx,
-		logger:   l,
-		opts:     opts,
-		loadFunc: loadFunc,
-		openURL:  browser.OpenURL,
-		spinner:  s,
-		state:    welcomeLoading,
+		ctx:        ctx,
+		logger:     l,
+		opts:       opts,
+		loadFunc:   loadFunc,
+		openURL:    browser.OpenURL,
+		statusCh:   make(chan string, statusChannelSize),
+		spinner:    s,
+		statusText: "Discovering modules from your infrastructure...",
+		state:      welcomeLoading,
 	}
 }
 
@@ -95,17 +108,38 @@ func (m WelcomeModel) WithOpenURL(fn OpenURLFunc) WelcomeModel { //nolint:gocrit
 
 // Init implements tea.Model. It starts the spinner and kicks off discovery.
 func (m WelcomeModel) Init() tea.Cmd { //nolint:gocritic
-	return tea.Batch(m.spinner.Tick, m.startDiscovery())
+	return tea.Batch(m.spinner.Tick, m.startDiscovery(), m.listenForStatus())
 }
 
 func (m WelcomeModel) startDiscovery() tea.Cmd { //nolint:gocritic
 	ctx := m.ctx
 	loadFunc := m.loadFunc
+	ch := m.statusCh
 
 	return func() tea.Msg {
-		svc, err := loadFunc(ctx)
+		defer close(ch)
+
+		svc, err := loadFunc(ctx, func(msg string) {
+			select {
+			case ch <- msg:
+			default:
+			}
+		})
 
 		return discoveryCompleteMsg{svc: svc, err: err}
+	}
+}
+
+func (m WelcomeModel) listenForStatus() tea.Cmd { //nolint:gocritic
+	ch := m.statusCh
+
+	return func() tea.Msg {
+		status, ok := <-ch
+		if !ok {
+			return nil
+		}
+
+		return statusUpdateMsg(status)
 	}
 }
 
@@ -114,6 +148,10 @@ func (m WelcomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocrit
 	switch msg := msg.(type) {
 	case discoveryCompleteMsg:
 		return m.handleDiscoveryComplete(msg)
+	case statusUpdateMsg:
+		m.statusText = string(msg)
+
+		return m, m.listenForStatus()
 	case tea.KeyPressMsg:
 		switch msg.String() {
 		case "q", "esc", "ctrl+c":
@@ -189,9 +227,7 @@ func (m WelcomeModel) loadingView() string { //nolint:gocritic
 
 	body := welcomeBodyStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
 		"",
-		m.spinner.View()+" Discovering modules from your infrastructure...",
-		"",
-		welcomeHintStyle.Render("Scanning terragrunt.hcl files for module sources."),
+		m.spinner.View()+" "+m.statusText,
 	))
 
 	return lipgloss.JoinVertical(lipgloss.Center, title, body)

--- a/internal/cli/commands/catalog/tui/welcome.go
+++ b/internal/cli/commands/catalog/tui/welcome.go
@@ -50,18 +50,23 @@ var (
 				Foreground(lipgloss.Color("#6272A4"))
 )
 
+// OpenURLFunc opens a URL in the user's browser. Injected so tests can
+// substitute a no-op or a recording stub.
+type OpenURLFunc func(url string) error
+
 // WelcomeModel is a BubbleTea model that shows a loading screen while
 // discovery runs in the background, then either transitions to the module
 // list TUI or settles into a "no sources found" help screen.
 type WelcomeModel struct {
-	ctx      context.Context
-	logger   log.Logger
-	opts     *options.TerragruntOptions
-	loadFunc LoadFunc
-	spinner  spinner.Model
-	state    welcomeState
-	width    int
-	height   int
+	ctx       context.Context
+	logger    log.Logger
+	opts      *options.TerragruntOptions
+	loadFunc  LoadFunc
+	openURL   OpenURLFunc
+	spinner   spinner.Model
+	state     welcomeState
+	width     int
+	height    int
 }
 
 // NewWelcomeModel creates a WelcomeModel that immediately begins discovery.
@@ -75,9 +80,17 @@ func NewWelcomeModel(ctx context.Context, l log.Logger, opts *options.Terragrunt
 		logger:   l,
 		opts:     opts,
 		loadFunc: loadFunc,
+		openURL:  browser.OpenURL,
 		spinner:  s,
 		state:    welcomeLoading,
 	}
+}
+
+// WithOpenURL replaces the function used to open URLs in the browser.
+func (m WelcomeModel) WithOpenURL(fn OpenURLFunc) WelcomeModel { //nolint:gocritic
+	m.openURL = fn
+
+	return m
 }
 
 // Init implements tea.Model. It starts the spinner and kicks off discovery.
@@ -107,7 +120,7 @@ func (m WelcomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocrit
 			return m, tea.Quit
 		case "h":
 			if m.state == welcomeNoSources {
-				_ = browser.OpenURL(welcomeDocsURL)
+				_ = m.openURL(welcomeDocsURL)
 			}
 		}
 	case tea.WindowSizeMsg:

--- a/internal/cli/commands/catalog/tui/welcome.go
+++ b/internal/cli/commands/catalog/tui/welcome.go
@@ -6,7 +6,10 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/pkg/browser"
 )
+
+const welcomeDocsURL = "https://docs.terragrunt.com/features/catalog/"
 
 var (
 	welcomeTitleStyle = lipgloss.NewStyle().
@@ -53,6 +56,8 @@ func (m WelcomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "q", "esc", "ctrl+c":
 			return m, tea.Quit
+		case "h":
+			_ = browser.OpenURL(welcomeDocsURL)
 		}
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -70,7 +75,7 @@ func (m WelcomeModel) View() tea.View {
 		"",
 		"No module sources were discovered in your infrastructure.",
 		"",
-		"To get started, you can:",
+		"To get started, you can either:",
 		"",
 		"  1. Add a catalog block to your root terragrunt.hcl:",
 		"",
@@ -81,12 +86,15 @@ func (m WelcomeModel) View() tea.View {
 		"  2. Add terraform.source attributes to your unit configurations.",
 		"     The catalog will automatically discover referenced modules.",
 		"",
-		"Learn more: "+welcomeLinkStyle.Render("https://docs.terragrunt.com/features/catalog/"),
-		"",
-		welcomeHintStyle.Render("Press q or Esc to exit."),
+		welcomeHintStyle.Render("h: open docs in browser  q/esc: exit"),
 	))
 
-	content := lipgloss.JoinVertical(lipgloss.Left, title, body)
+	content := lipgloss.JoinVertical(lipgloss.Center, title, body)
+
+	// Center the content in the terminal if dimensions are known
+	if m.width > 0 && m.height > 0 {
+		content = lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+	}
 
 	v := tea.NewView(content)
 	v.AltScreen = true

--- a/internal/cli/commands/catalog/tui/welcome.go
+++ b/internal/cli/commands/catalog/tui/welcome.go
@@ -4,12 +4,34 @@ import (
 	"context"
 	"errors"
 
+	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/pkg/browser"
+
+	"github.com/gruntwork-io/terragrunt/internal/services/catalog"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
 const welcomeDocsURL = "https://docs.terragrunt.com/features/catalog/"
+
+// LoadFunc performs source discovery and module loading in the background.
+// It returns a ready CatalogService, or nil if no sources were found.
+type LoadFunc func(ctx context.Context) (catalog.CatalogService, error)
+
+type welcomeState int
+
+const (
+	welcomeLoading   welcomeState = iota
+	welcomeNoSources
+)
+
+// discoveryCompleteMsg is sent when background discovery finishes.
+type discoveryCompleteMsg struct {
+	svc catalog.CatalogService
+	err error
+}
 
 var (
 	welcomeTitleStyle = lipgloss.NewStyle().
@@ -24,51 +46,144 @@ var (
 	welcomeCodeStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#8BE9FD"))
 
-	welcomeLinkStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#50FA7B")).
-				Underline(true)
-
 	welcomeHintStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#6272A4"))
 )
 
-// WelcomeModel is a simple BubbleTea model that displays a welcome screen
-// when no module sources are discovered and no catalog block exists.
+// WelcomeModel is a BubbleTea model that shows a loading screen while
+// discovery runs in the background, then either transitions to the module
+// list TUI or settles into a "no sources found" help screen.
 type WelcomeModel struct {
-	width  int
-	height int
+	ctx      context.Context
+	logger   log.Logger
+	opts     *options.TerragruntOptions
+	loadFunc LoadFunc
+	spinner  spinner.Model
+	state    welcomeState
+	width    int
+	height   int
 }
 
-// NewWelcomeModel creates a new WelcomeModel.
-func NewWelcomeModel() WelcomeModel {
-	return WelcomeModel{}
+// NewWelcomeModel creates a WelcomeModel that immediately begins discovery.
+func NewWelcomeModel(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, loadFunc LoadFunc) WelcomeModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B"))
+
+	return WelcomeModel{
+		ctx:      ctx,
+		logger:   l,
+		opts:     opts,
+		loadFunc: loadFunc,
+		spinner:  s,
+		state:    welcomeLoading,
+	}
 }
 
-// Init implements tea.Model.
+// Init implements tea.Model. It starts the spinner and kicks off discovery.
 func (m WelcomeModel) Init() tea.Cmd {
-	return nil
+	return tea.Batch(m.spinner.Tick, m.startDiscovery())
+}
+
+func (m WelcomeModel) startDiscovery() tea.Cmd {
+	ctx := m.ctx
+	loadFunc := m.loadFunc
+
+	return func() tea.Msg {
+		svc, err := loadFunc(ctx)
+
+		return discoveryCompleteMsg{svc: svc, err: err}
+	}
 }
 
 // Update implements tea.Model.
-func (m WelcomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m WelcomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocritic
 	switch msg := msg.(type) {
+	case discoveryCompleteMsg:
+		return m.handleDiscoveryComplete(msg)
 	case tea.KeyPressMsg:
 		switch msg.String() {
 		case "q", "esc", "ctrl+c":
 			return m, tea.Quit
 		case "h":
-			_ = browser.OpenURL(welcomeDocsURL)
+			if m.state == welcomeNoSources {
+				_ = browser.OpenURL(welcomeDocsURL)
+			}
 		}
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
 	}
 
+	if m.state == welcomeLoading {
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m WelcomeModel) handleDiscoveryComplete(msg discoveryCompleteMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		m.logger.Warnf("Discovery error: %v", msg.err)
+	}
+
+	if msg.svc != nil && len(msg.svc.Modules()) > 0 {
+		// Transition to the module list TUI
+		newModel := NewModel(m.logger, m.opts, msg.svc)
+		width, height := m.width, m.height
+
+		return newModel, tea.Batch(
+			newModel.Init(),
+			// Forward current dimensions so the new model sizes itself
+			func() tea.Msg {
+				return tea.WindowSizeMsg{Width: width, Height: height}
+			},
+		)
+	}
+
+	m.state = welcomeNoSources
+
 	return m, nil
 }
 
 // View implements tea.Model.
-func (m WelcomeModel) View() tea.View {
+func (m WelcomeModel) View() tea.View { //nolint:gocritic
+	var content string
+
+	switch m.state {
+	case welcomeLoading:
+		content = m.loadingView()
+	case welcomeNoSources:
+		content = m.noSourcesView()
+	}
+
+	if m.width > 0 && m.height > 0 {
+		content = lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+	}
+
+	v := tea.NewView(content)
+	v.AltScreen = true
+
+	return v
+}
+
+func (m WelcomeModel) loadingView() string { //nolint:gocritic
+	title := welcomeTitleStyle.Render(" Terragrunt Catalog ")
+
+	body := welcomeBodyStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
+		"",
+		m.spinner.View()+" Discovering modules from your infrastructure...",
+		"",
+		welcomeHintStyle.Render("Scanning terragrunt.hcl files for module sources."),
+	))
+
+	return lipgloss.JoinVertical(lipgloss.Center, title, body)
+}
+
+func (m WelcomeModel) noSourcesView() string { //nolint:gocritic
 	title := welcomeTitleStyle.Render(" Terragrunt Catalog ")
 
 	body := welcomeBodyStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
@@ -89,22 +204,16 @@ func (m WelcomeModel) View() tea.View {
 		welcomeHintStyle.Render("h: open docs in browser  q/esc: exit"),
 	))
 
-	content := lipgloss.JoinVertical(lipgloss.Center, title, body)
-
-	// Center the content in the terminal if dimensions are known
-	if m.width > 0 && m.height > 0 {
-		content = lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
-	}
-
-	v := tea.NewView(content)
-	v.AltScreen = true
-
-	return v
+	return lipgloss.JoinVertical(lipgloss.Center, title, body)
 }
 
-// RunWelcome launches the welcome screen TUI.
-func RunWelcome(ctx context.Context) error {
-	if _, err := tea.NewProgram(NewWelcomeModel(), tea.WithContext(ctx)).Run(); err != nil {
+// RunRedesign launches the redesigned catalog experience. It shows a loading
+// screen immediately while discovery runs in the background, then transitions
+// to the module list if modules are found.
+func RunRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, loadFunc LoadFunc) error {
+	model := NewWelcomeModel(ctx, l, opts, loadFunc)
+
+	if _, err := tea.NewProgram(model, tea.WithContext(ctx)).Run(); err != nil {
 		if cause := context.Cause(ctx); errors.Is(cause, context.Canceled) {
 			return nil
 		}

--- a/internal/cli/commands/catalog/tui/welcome.go
+++ b/internal/cli/commands/catalog/tui/welcome.go
@@ -1,0 +1,112 @@
+package tui
+
+import (
+	"context"
+	"errors"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+var (
+	welcomeTitleStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("#A8ACB1")).
+				Background(lipgloss.Color("#1D252F")).
+				Padding(0, 1)
+
+	welcomeBodyStyle = lipgloss.NewStyle().
+				Padding(1, 2)
+
+	welcomeCodeStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#8BE9FD"))
+
+	welcomeLinkStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#50FA7B")).
+				Underline(true)
+
+	welcomeHintStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#6272A4"))
+)
+
+// WelcomeModel is a simple BubbleTea model that displays a welcome screen
+// when no module sources are discovered and no catalog block exists.
+type WelcomeModel struct {
+	width  int
+	height int
+}
+
+// NewWelcomeModel creates a new WelcomeModel.
+func NewWelcomeModel() WelcomeModel {
+	return WelcomeModel{}
+}
+
+// Init implements tea.Model.
+func (m WelcomeModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update implements tea.Model.
+func (m WelcomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "q", "esc", "ctrl+c":
+			return m, tea.Quit
+		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	}
+
+	return m, nil
+}
+
+// View implements tea.Model.
+func (m WelcomeModel) View() tea.View {
+	title := welcomeTitleStyle.Render(" Terragrunt Catalog ")
+
+	body := welcomeBodyStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
+		"",
+		"No module sources were discovered in your infrastructure.",
+		"",
+		"To get started, you can:",
+		"",
+		"  1. Add a catalog block to your root terragrunt.hcl:",
+		"",
+		welcomeCodeStyle.Render("     catalog {"),
+		welcomeCodeStyle.Render(`       urls = ["github.com/your-org/your-modules"]`),
+		welcomeCodeStyle.Render("     }"),
+		"",
+		"  2. Add terraform.source attributes to your unit configurations.",
+		"     The catalog will automatically discover referenced modules.",
+		"",
+		"Learn more: "+welcomeLinkStyle.Render("https://docs.terragrunt.com/features/catalog/"),
+		"",
+		welcomeHintStyle.Render("Press q or Esc to exit."),
+	))
+
+	content := lipgloss.JoinVertical(lipgloss.Left, title, body)
+
+	v := tea.NewView(content)
+	v.AltScreen = true
+
+	return v
+}
+
+// RunWelcome launches the welcome screen TUI.
+func RunWelcome(ctx context.Context) error {
+	if _, err := tea.NewProgram(NewWelcomeModel(), tea.WithContext(ctx)).Run(); err != nil {
+		if cause := context.Cause(ctx); errors.Is(cause, context.Canceled) {
+			return nil
+		}
+
+		if cause := context.Cause(ctx); cause != nil {
+			return cause
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/internal/cli/commands/catalog/tui/welcome_test.go
+++ b/internal/cli/commands/catalog/tui/welcome_test.go
@@ -1,0 +1,267 @@
+package tui_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/colorprofile"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/internal/services/catalog"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWelcomeLoadingScreen_NoSources verifies that when discovery finds no
+// module sources, the welcome model stays on the no-sources help screen.
+func TestWelcomeLoadingScreen_NoSources(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+
+	noSourcesLoad := func(_ context.Context) (catalog.CatalogService, error) {
+		return nil, nil
+	}
+
+	m := tui.NewWelcomeModel(t.Context(), l, opts, noSourcesLoad)
+
+	finalModel := runTeaModel(t, m, 120, 40, func(p *tea.Program) {
+		// Wait for discovery to complete and settle into no-sources view
+		time.Sleep(200 * time.Millisecond)
+
+		p.Send(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	})
+
+	// Should still be a WelcomeModel (no transition to module list)
+	_, isWelcome := finalModel.(tui.WelcomeModel)
+	assert.True(t, isWelcome, "should remain on welcome screen when no sources found")
+}
+
+// TestWelcomeLoadingScreen_TransitionsToModuleList verifies that when
+// discovery finds modules, the welcome model transitions to the full
+// module list TUI.
+func TestWelcomeLoadingScreen_TransitionsToModuleList(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+	svc := createMockCatalogService(t, opts)
+
+	withModulesLoad := func(_ context.Context) (catalog.CatalogService, error) {
+		return svc, nil
+	}
+
+	m := tui.NewWelcomeModel(t.Context(), l, opts, withModulesLoad)
+
+	finalModel := runTeaModel(t, m, 120, 40, func(p *tea.Program) {
+		// Wait for discovery and transition to module list
+		time.Sleep(200 * time.Millisecond)
+
+		// Quit from the module list
+		p.Send(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	})
+
+	listModel, isList := finalModel.(tui.Model)
+	require.True(t, isList, "should transition to module list when modules found")
+	assert.Equal(t, tui.ListState, listModel.State)
+	assert.Len(t, listModel.SVC.Modules(), 2, "should have 2 test modules")
+}
+
+// TestWelcomeLoadingScreen_ModuleListNavigation verifies the full flow:
+// loading → module list → select module details → back to list → quit.
+func TestWelcomeLoadingScreen_ModuleListNavigation(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+	svc := createMockCatalogService(t, opts)
+
+	withModulesLoad := func(_ context.Context) (catalog.CatalogService, error) {
+		return svc, nil
+	}
+
+	m := tui.NewWelcomeModel(t.Context(), l, opts, withModulesLoad)
+
+	finalModel := runTeaModel(t, m, 120, 40, func(p *tea.Program) {
+		// Wait for discovery and transition to module list
+		time.Sleep(200 * time.Millisecond)
+
+		// Press Enter to select the first module (navigate to details)
+		p.Send(tea.KeyPressMsg{Code: tea.KeyEnter})
+		time.Sleep(50 * time.Millisecond)
+
+		// Press q to go back to list
+		p.Send(tea.KeyPressMsg{Code: 'q', Text: "q"})
+		time.Sleep(50 * time.Millisecond)
+
+		// Press q again to quit
+		p.Send(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	})
+
+	listModel, isList := finalModel.(tui.Model)
+	require.True(t, isList, "should be on module list after navigating back")
+	assert.Equal(t, tui.ListState, listModel.State)
+}
+
+// TestWelcomeLoadingScreen_QuitDuringLoading verifies that pressing q
+// during the loading phase exits cleanly.
+func TestWelcomeLoadingScreen_QuitDuringLoading(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+
+	slowLoad := func(ctx context.Context) (catalog.CatalogService, error) {
+		// Simulate slow discovery
+		select {
+		case <-time.After(5 * time.Second):
+		case <-ctx.Done():
+		}
+
+		return nil, nil
+	}
+
+	m := tui.NewWelcomeModel(t.Context(), l, opts, slowLoad)
+
+	finalModel := runTeaModel(t, m, 120, 40, func(p *tea.Program) {
+		// Quit immediately while still loading
+		p.Send(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	})
+
+	// Should still be a WelcomeModel (loading was interrupted)
+	_, isWelcome := finalModel.(tui.WelcomeModel)
+	assert.True(t, isWelcome, "should exit as WelcomeModel when quit during loading")
+}
+
+// TestWelcomeNoSourcesScreen_HelpKeyOpensDocs verifies that pressing h on
+// the no-sources screen triggers the open-URL function with the docs URL.
+func TestWelcomeNoSourcesScreen_HelpKeyOpensDocs(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+
+	noSourcesLoad := func(_ context.Context) (catalog.CatalogService, error) {
+		return nil, nil
+	}
+
+	var openedURL string
+
+	m := tui.NewWelcomeModel(t.Context(), l, opts, noSourcesLoad).
+		WithOpenURL(func(url string) error {
+			openedURL = url
+			return nil
+		})
+
+	finalModel := runTeaModel(t, m, 120, 40, func(p *tea.Program) {
+		// Wait for discovery to complete
+		time.Sleep(200 * time.Millisecond)
+
+		// Press h to open docs
+		p.Send(tea.KeyPressMsg{Code: 'h', Text: "h"})
+		time.Sleep(50 * time.Millisecond)
+
+		// Quit
+		p.Send(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	})
+
+	_, isWelcome := finalModel.(tui.WelcomeModel)
+	assert.True(t, isWelcome, "should remain on welcome screen after pressing h")
+	assert.Equal(t, "https://docs.terragrunt.com/features/catalog/", openedURL, "should have opened docs URL")
+}
+
+// TestWelcomeNoSourcesScreen_UnhandledKey verifies that pressing an
+// unrecognized key on the no-sources screen does not crash or change state.
+func TestWelcomeNoSourcesScreen_UnhandledKey(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+
+	noSourcesLoad := func(_ context.Context) (catalog.CatalogService, error) {
+		return nil, nil
+	}
+
+	m := tui.NewWelcomeModel(t.Context(), l, opts, noSourcesLoad)
+
+	finalModel := runTeaModel(t, m, 120, 40, func(p *tea.Program) {
+		// Wait for discovery to complete
+		time.Sleep(200 * time.Millisecond)
+
+		// Press an unhandled key — should be ignored
+		p.Send(tea.KeyPressMsg{Code: 'x', Text: "x"})
+		time.Sleep(50 * time.Millisecond)
+
+		// Quit
+		p.Send(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	})
+
+	_, isWelcome := finalModel.(tui.WelcomeModel)
+	assert.True(t, isWelcome, "should remain on welcome screen after pressing unhandled key")
+}
+
+// runTeaModel starts a tea.Program with any tea.Model, sends messages via
+// the interact callback, and returns the final tea.Model once the program
+// exits. Unlike runModel, this accepts and returns the tea.Model interface
+// so it works with both WelcomeModel and Model.
+func runTeaModel(t *testing.T, m tea.Model, width, height int, interact func(p *tea.Program)) tea.Model {
+	t.Helper()
+
+	var out bytes.Buffer
+
+	pr, pw, err := os.Pipe()
+	require.NoError(t, err)
+
+	defer pr.Close()
+	defer pw.Close()
+
+	p := tea.NewProgram(m,
+		tea.WithInput(pr),
+		tea.WithOutput(&out),
+		tea.WithWindowSize(width, height),
+		tea.WithColorProfile(colorprofile.TrueColor),
+	)
+
+	done := make(chan tea.Model, 1)
+
+	go func() {
+		finalModel, err := p.Run()
+		assert.NoError(t, err)
+
+		done <- finalModel
+	}()
+
+	// Give the program a moment to start and process the initial WindowSizeMsg.
+	time.Sleep(50 * time.Millisecond)
+
+	interact(p)
+
+	select {
+	case fm := <-done:
+		return fm
+	case <-time.After(10 * time.Second):
+		p.Kill()
+		t.Fatal("program did not exit within timeout")
+
+		return nil
+	}
+}

--- a/internal/cli/commands/catalog/tui/welcome_test.go
+++ b/internal/cli/commands/catalog/tui/welcome_test.go
@@ -28,7 +28,7 @@ func TestWelcomeLoadingScreen_NoSources(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	noSourcesLoad := func(_ context.Context) (catalog.CatalogService, error) {
+	noSourcesLoad := func(_ context.Context, _ tui.StatusFunc) (catalog.CatalogService, error) {
 		return nil, nil
 	}
 
@@ -58,7 +58,7 @@ func TestWelcomeLoadingScreen_TransitionsToModuleList(t *testing.T) {
 	l := logger.CreateLogger()
 	svc := createMockCatalogService(t, opts)
 
-	withModulesLoad := func(_ context.Context) (catalog.CatalogService, error) {
+	withModulesLoad := func(_ context.Context, _ tui.StatusFunc) (catalog.CatalogService, error) {
 		return svc, nil
 	}
 
@@ -89,7 +89,7 @@ func TestWelcomeLoadingScreen_ModuleListNavigation(t *testing.T) {
 	l := logger.CreateLogger()
 	svc := createMockCatalogService(t, opts)
 
-	withModulesLoad := func(_ context.Context) (catalog.CatalogService, error) {
+	withModulesLoad := func(_ context.Context, _ tui.StatusFunc) (catalog.CatalogService, error) {
 		return svc, nil
 	}
 
@@ -126,7 +126,7 @@ func TestWelcomeLoadingScreen_QuitDuringLoading(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	slowLoad := func(ctx context.Context) (catalog.CatalogService, error) {
+	slowLoad := func(ctx context.Context, _ tui.StatusFunc) (catalog.CatalogService, error) {
 		// Simulate slow discovery
 		select {
 		case <-time.After(5 * time.Second):
@@ -158,7 +158,7 @@ func TestWelcomeNoSourcesScreen_HelpKeyOpensDocs(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	noSourcesLoad := func(_ context.Context) (catalog.CatalogService, error) {
+	noSourcesLoad := func(_ context.Context, _ tui.StatusFunc) (catalog.CatalogService, error) {
 		return nil, nil
 	}
 
@@ -197,7 +197,7 @@ func TestWelcomeNoSourcesScreen_UnhandledKey(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	noSourcesLoad := func(_ context.Context) (catalog.CatalogService, error) {
+	noSourcesLoad := func(_ context.Context, _ tui.StatusFunc) (catalog.CatalogService, error) {
 		return nil, nil
 	}
 

--- a/internal/services/catalog/catalog.go
+++ b/internal/services/catalog/catalog.go
@@ -54,15 +54,20 @@ type CatalogService interface {
 	// WithRepoURL allows overriding the repository URL.
 	// This is primarily useful for testing.
 	WithRepoURL(repoURL string) CatalogService
+
+	// WithRepoURLs allows setting multiple repository URLs directly.
+	// When set, these URLs take precedence over both WithRepoURL and catalog config.
+	WithRepoURLs(urls []string) CatalogService
 }
 
 // catalogServiceImpl is the concrete implementation of CatalogService.
 // It holds the necessary options and configuration to perform its tasks.
 type catalogServiceImpl struct {
-	opts    *options.TerragruntOptions
-	newRepo NewRepoFunc
-	repoURL string
-	modules module.Modules
+	opts     *options.TerragruntOptions
+	newRepo  NewRepoFunc
+	repoURL  string
+	repoURLs []string
+	modules  module.Modules
 }
 
 // NewCatalogService creates a new instance of catalogServiceImpl with default settings.
@@ -91,13 +96,25 @@ func (s *catalogServiceImpl) WithRepoURL(repoURL string) CatalogService {
 	return s
 }
 
+// WithRepoURLs sets multiple repository URLs directly.
+// When set, these URLs take precedence over both WithRepoURL and catalog config.
+func (s *catalogServiceImpl) WithRepoURLs(urls []string) CatalogService {
+	s.repoURLs = urls
+
+	return s
+}
+
 // Load implements the CatalogService interface.
 // It contains the core logic for cloning/updating repositories and finding Terragrunt modules within them.
 func (s *catalogServiceImpl) Load(ctx context.Context, l log.Logger) error {
-	repoURLs := []string{s.repoURL}
+	var repoURLs []string
 
-	// If no specific repoURL was provided to the service, try to read from catalog config.
-	if s.repoURL == "" {
+	switch {
+	case len(s.repoURLs) > 0:
+		repoURLs = s.repoURLs
+	case s.repoURL != "":
+		repoURLs = []string{s.repoURL}
+	default:
 		_, pctx := configbridge.NewParsingContext(ctx, l, s.opts)
 
 		catalogCfg, err := config.ReadCatalogConfig(ctx, l, pctx)

--- a/internal/services/catalog/catalog.go
+++ b/internal/services/catalog/catalog.go
@@ -185,7 +185,7 @@ func (s *catalogServiceImpl) Load(ctx context.Context, l log.Logger) error {
 			continue
 		}
 
-		l.Infof("Found %d module(s) in repository %q", len(repoModules), currentRepoURL)
+		l.Debugf("Found %d module(s) in repository %q", len(repoModules), currentRepoURL)
 		allModules = append(allModules, repoModules...)
 	}
 
@@ -207,7 +207,7 @@ func (s *catalogServiceImpl) Modules() module.Modules {
 }
 
 func (s *catalogServiceImpl) Scaffold(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, module *module.Module) error {
-	l.Infof("Scaffolding module: %q", module.TerraformSourcePath())
+	l.Debugf("Scaffolding module: %q", module.TerraformSourcePath())
 
 	return scaffold.Run(ctx, l, opts, module.TerraformSourcePath(), "")
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds a welcome screen experience for the catalog TUI in the catalog redesign so that users who don't already have `catalog.urls` configured in their `root.hcl` don't encounter an error. Instead, it offers to load up the Catalog documentation for users and lets them know what they can do to populate the catalog.

In addition, running `terragrunt catalog` now immediately launches the TUI with no delay for discovery and loading of modules. After the initial loading screen is rendered, discovery takes place in the background, with discovered modules populated in the module selection screen afterwards.

Finally, unit `terraform.source` attributes are automatically included in the set of URLs that are used for discovery. It is highly likely that the sources used for units are going to be useful catalogs for more units, so it's a cheap way to get users a working catalog out of the box wihtout additional configuration.

All of these changes are only present when the `catalog-redesign` experiment is active.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic discovery of Terraform module sources from configuration files
  * Introduced interactive TUI experience for catalog workflow with live discovery progress
  * Catalog operations now work without requiring an upfront repository URL input
  * Added quick access to documentation from the catalog interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->