### PR TITLE
Docs: Fix bash commands in "Terralith to Terragrunt" guide

### DIFF
--- a/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/05-step-2-refactoring.mdx
+++ b/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/05-step-2-refactoring.mdx
@@ -27,7 +27,7 @@ The Gruntwork recommended best practice for creating reusable IaC is to create a
 To reorganize the resources that we've created so far into reusable modules, we'll create a directory called `catalog/modules` where we can store our modules for reusability. We'll create an OpenTofu module for each piece of high-level functionality that we are provisioning in our current environment (`s3`, `lambda`, `iam` and `ddb`).
 
 ```bash
-mkdir -p catalog/modules/{s3, lambda, iam, ddb}
+mkdir -p catalog/modules/{s3,lambda,iam,ddb}
 ```
 
 Now we can move over the files that were provisioning these independent resources into their own modules so we can establish APIs for them and start reusing some of this code. It's a pretty standard convention to name the core file used in a module `main.tf`. Good modules do one thing, and if you can't figure out what a module does by the name of the module, it's probably indicative that you're making an odd abstraction.

--- a/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/07-step-4-breaking-the-terralith.mdx
+++ b/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/07-step-4-breaking-the-terralith.mdx
@@ -23,7 +23,7 @@ First, let's create a top-level directory for `prod` in `live`.
 
 Next, let's move everything into the `prod` directory (If you're not comfortable with using the `find` command here, you can just drag the content into the `prod` directory).
 
-<Code title="live" lang="bash" frame="terminal" code={`find . -mindepth 1 -maxdepth 1 -not -name 'prod' -exec mv {} prod/ \;`} />
+<Code title="live" lang="bash" frame="terminal" code={`find . -mindepth 1 -maxdepth 1 -not -name 'prod' -exec mv {} prod/ \\;`} />
 
 To complete our new multi-environment setup, let's duplicate that `prod` directory to a new `dev` directory.
 

--- a/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/08-step-5-adding-terragrunt.mdx
+++ b/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/08-step-5-adding-terragrunt.mdx
@@ -27,7 +27,7 @@ Now that we've structured our project to segment environments into their own roo
 
 The process of converting an OpenTofu root module to a Terragrunt unit simply involves adding an empty `terragrunt.hcl` file to each root module (that's all the `find` command below does). This allows Terragrunt to recognize the contents of the directory as a Terragrunt unit, and orchestrate infrastructure updates within it.
 
-<Code title="live" lang="bash" frame="terminal" code={`find . -mindepth 1 -maxdepth 1 -type dir -exec touch {}/terragrunt.hcl \;`} />
+<Code title="live" lang="bash" frame="terminal" code={`find . -mindepth 1 -maxdepth 1 -type dir -exec touch {}/terragrunt.hcl \\;`} />
 
 Now, we can use Terragrunt to orchestrate runs across both of these units.
 

--- a/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/09-step-6-breaking-the-terralith-further.mdx
+++ b/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/09-step-6-breaking-the-terralith-further.mdx
@@ -21,7 +21,7 @@ We're going to follow a very similar process to what we did when breaking apart 
 
 First, we'll create a directory for each of the new units we want to create for all the constituent modules of the `best_cat` megamodule. In each of our environments (`dev` and `prod`).
 
-<Code title="live" lang="bash" frame="terminal" code={`mkdir -p {dev, prod}/{s3, ddb, iam, lambda}`} />
+<Code title="live" lang="bash" frame="terminal" code={`mkdir -p {dev,prod}/{s3,ddb,iam,lambda}`} />
 
 Next, we'll create the `terragrunt.hcl` files in each of these directories.
 
@@ -123,7 +123,7 @@ cd ../s3 && terragrunt state push /tmp/tofu.tfstate
 
 We can now clean up the extraneous files mentioned earlier at the root of the environments.
 
-<Code title="live" lang="bash" frame="terminal" code={`rm -f {dev, prod}/{terragrunt.hcl, moved.tf}`} />
+<Code title="live" lang="bash" frame="terminal" code={`rm -f {dev,prod}/{terragrunt.hcl,moved.tf}`} />
 
 Go ahead and run the following to see very similar plan output to what we've seen in the past when we needed to make state moves & removes.
 

--- a/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/10-step-7-taking-advantage-of-terragrunt-stacks.mdx
+++ b/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/10-step-7-taking-advantage-of-terragrunt-stacks.mdx
@@ -22,11 +22,11 @@ We copy over `.terraform.lock.hcl` files in addition to `terragrunt.hcl` files h
 </Aside>
 
 ```bash
-mkdir -p catalog/units/{ddb, iam, lambda, s3}
-cp live/dev/ddb/{terragrunt.hcl, .terraform.lock.hcl} catalog/units/ddb/
-cp live/dev/iam/{terragrunt.hcl, .terraform.lock.hcl} catalog/units/iam/
-cp live/dev/lambda/{terragrunt.hcl, .terraform.lock.hcl} catalog/units/lambda/
-cp live/dev/s3/{terragrunt.hcl, .terraform.lock.hcl} catalog/units/s3/
+mkdir -p catalog/units/{ddb,iam,lambda,s3}
+cp live/dev/ddb/{terragrunt.hcl,.terraform.lock.hcl}catalog/units/ddb/
+cp live/dev/iam/{terragrunt.hcl,.terraform.lock.hcl}catalog/units/iam/
+cp live/dev/lambda/{terragrunt.hcl,.terraform.lock.hcl}catalog/units/lambda/
+cp live/dev/s3/{terragrunt.hcl,.terraform.lock.hcl}catalog/units/s3/
 ```
 
 You might remember that the unit configurations differed very slightly between `dev` and `prod`. Luckily, Terragrunt has special tooling to handle that via the usage of `values` variables.

--- a/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/10-step-7-taking-advantage-of-terragrunt-stacks.mdx
+++ b/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/10-step-7-taking-advantage-of-terragrunt-stacks.mdx
@@ -23,10 +23,10 @@ We copy over `.terraform.lock.hcl` files in addition to `terragrunt.hcl` files h
 
 ```bash
 mkdir -p catalog/units/{ddb,iam,lambda,s3}
-cp live/dev/ddb/{terragrunt.hcl,.terraform.lock.hcl}catalog/units/ddb/
-cp live/dev/iam/{terragrunt.hcl,.terraform.lock.hcl}catalog/units/iam/
-cp live/dev/lambda/{terragrunt.hcl,.terraform.lock.hcl}catalog/units/lambda/
-cp live/dev/s3/{terragrunt.hcl,.terraform.lock.hcl}catalog/units/s3/
+cp live/dev/ddb/{terragrunt.hcl,.terraform.lock.hcl} catalog/units/ddb/
+cp live/dev/iam/{terragrunt.hcl,.terraform.lock.hcl} catalog/units/iam/
+cp live/dev/lambda/{terragrunt.hcl,.terraform.lock.hcl} catalog/units/lambda/
+cp live/dev/s3/{terragrunt.hcl,.terraform.lock.hcl} catalog/units/s3/
 ```
 
 You might remember that the unit configurations differed very slightly between `dev` and `prod`. Luckily, Terragrunt has special tooling to handle that via the usage of `values` variables.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This fixes a few minor issues with the code/command examples in the "Terralith to Terragrunt" guide:

- Adds backslash escaping --> Fixes ##5898.
- Removes spaces in in `mkdir` and `cp` commands

The code blocks for some `find` commands require an extra backslash (`\`) in order to render the `\;` correctly.


Also, `mkdir` and `cp` commands fail when the directory names have extra spaces, e.g. this will fail:

```bash
mkdir -p catalog/modules/{s3, lambda, iam, ddb}
```

It should be:

```bash
mkdir -p catalog/modules/{s3,lambda,iam,ddb}
```


## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Fixed example bash commands in "Terralith to Terragrunt" guide





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple shell examples in the Terralith-to-Terragrunt migration guide: fixed brace-expansion spacing, adjusted escape sequences for semicolons in inline commands, and normalized path/token spacing in copy/move snippets so command examples render and copy correctly for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->