### PR TITLE
feat: Adding support for CAS in stacks

### DIFF
--- a/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
@@ -8,6 +8,8 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside } from '@astrojs/starlight/components';
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 For an alternate approach (that is more flexible, but not necessarily always the better solution), you can define explicit stacks using `terragrunt.stack.hcl` files. These are **blueprints** that programmatically generate units at runtime.
 
@@ -341,6 +343,139 @@ After running the stack, your directory structure will look like this:
 
 </FileTree>
 
+## CAS Integration
+
+<Before version="1.0.2">
+
+<Aside type="tip">
+Experimental integration between CAS and Stacks is coming soon. Follow the progress in [#5558](https://github.com/gruntwork-io/terragrunt/issues/5558).
+</Aside>
+
+</Before>
+
+<Since version="1.0.2">
+
+<Aside type="tip">
+This functionality is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`. See the [CAS feature documentation](/features/caching/cas) for more details.
+</Aside>
+
+When authoring stacks in a catalog, you can use the `update_source_with_cas` attribute to simplify source management and improve generation performance.
+
+Without CAS, catalog authors need to plumb remote Git URLs through `values` expressions so that generated files reference the correct remote sources:
+
+```hcl
+# stacks/service/terragrunt.stack.hcl
+unit "service" {
+  source = "git::git@github.com:acme/catalog.git//units/service?ref=${values.version}"
+  path   = "service"
+  values = {
+    version = values.version
+  }
+}
+```
+
+This is error-prone and creates unnecessary diffs when the version changes. It also requires a network fetch for every nested source during generation.
+
+With `update_source_with_cas`, you can use relative paths instead:
+
+```hcl
+# stacks/service/terragrunt.stack.hcl
+unit "service" {
+  source = "../..//units/service"
+
+  update_source_with_cas = true
+
+  path = "service"
+}
+```
+
+The `//` separator works the same as with any Terragrunt source. The part before `//` is the base path, and the part after `//` is the subdirectory.
+
+The attribute can also be used in `terragrunt.hcl` files within the `terraform` block:
+
+```hcl
+# units/service/terragrunt.hcl
+terraform {
+  source = "../..//modules/service"
+
+  update_source_with_cas = true
+}
+```
+
+When `update_source_with_cas = true` is set:
+
+1. Terragrunt clones the catalog repository once via CAS and stores the content.
+2. It follows relative source paths within the cloned repository.
+3. At each level, it rewrites the `source` attribute to a `cas::` reference (e.g., `cas::sha1:abc123...`) that points to stored CAS content.
+4. Generated `.terragrunt-stack` files contain deterministic CAS references instead of remote URLs.
+5. Subsequent generation waves resolve `cas::` references directly from the CAS store, with no network access required.
+
+Given the catalog files above, and a consumer stack like:
+
+```hcl
+# live/terragrunt.stack.hcl
+stack "service" {
+  source = "git::git@github.com:acme/catalog.git//stacks/service?ref=v1.0.0"
+
+  update_source_with_cas = true
+
+  path = "service"
+}
+```
+
+Running `terragrunt --experiment cas stack generate` produces:
+
+<FileTree>
+
+- live/
+  - terragrunt.stack.hcl
+  - .terragrunt-stack/
+    - service/
+      - terragrunt.stack.hcl (sources rewritten to cas:: references)
+      - .terragrunt-stack/
+        - service/
+          - terragrunt.hcl (terraform source rewritten to cas:: reference)
+
+</FileTree>
+
+The generated stack file at `.terragrunt-stack/service/terragrunt.stack.hcl` contains the rewritten source:
+
+```hcl
+# .terragrunt-stack/service/terragrunt.stack.hcl
+unit "service" {
+  source = "cas::sha1:a1b2c3d4..."
+
+  update_source_with_cas = true
+
+  path = "service"
+}
+```
+
+And the generated unit file at `.terragrunt-stack/service/.terragrunt-stack/service/terragrunt.hcl` contains:
+
+```hcl
+# .terragrunt-stack/service/.terragrunt-stack/service/terragrunt.hcl
+terraform {
+  source = "cas::sha1:e5f6a7b8...//modules/service"
+
+  update_source_with_cas = true
+}
+```
+
+The first `cas::` reference points to a synthetic tree in the CAS that contains the exact files needed for the unit. The second points to the full repository tree, with `//modules/service` telling Terragrunt which subdirectory to use as the OpenTofu/Terraform module source.
+
+<Aside type="tip">
+The `cas::` reference format includes a hash algorithm prefix (`sha1:` or `sha256:`) to support both SHA-1 and SHA-256 Git repositories.
+</Aside>
+
+Requirements:
+
+- The `cas` experiment must be enabled (`--experiment cas`).
+- The `--no-cas` flag must not be set.
+- Sources using `update_source_with_cas` must be relative paths within the same repository.
+
+</Since>
+
 ## Known Limitations of Explicit Stacks
 
 There are currently some known limitations with explicit stacks that you should be aware of as you start to adopt them.
@@ -355,7 +490,13 @@ As such, if you currently have multiple stacks that need to depend on each other
 
 Every generation of a stack from a `terragrunt.stack.hcl` file can potentially result in network traffic to fetch the source for the stack and filesystem traffic to copy the generated units to the `.terragrunt-stack` directory. This can result in slow stack generation if you have very deeply nested stacks.
 
+<Before version="1.0.2">
 The planned solution for this in the future is to allow for some deduplication in stack generation, but this is not currently implemented.
+</Before>
+
+<Since version="1.0.2">
+To mitigate this, enable the [`cas` experiment](/reference/experiments/active#cas) and use `update_source_with_cas = true` in your catalog's stack and unit files. This deduplicates repository clones and resolves content from the local CAS store instead of fetching from the network on every generation. See [CAS Integration](#cas-integration) for details.
+</Since>
 
 ### Includes are not supported in `terragrunt.stack.hcl` files
 

--- a/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
@@ -345,7 +345,7 @@ After running the stack, your directory structure will look like this:
 
 ## CAS Integration
 
-<Before version="1.0.2">
+<Before version="1.0.3">
 
 <Aside type="tip">
 Experimental integration between CAS and Stacks is coming soon. Follow the progress in [#5558](https://github.com/gruntwork-io/terragrunt/issues/5558).
@@ -353,7 +353,7 @@ Experimental integration between CAS and Stacks is coming soon. Follow the progr
 
 </Before>
 
-<Since version="1.0.2">
+<Since version="1.0.3">
 
 <Aside type="tip">
 This functionality is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`. See the [CAS feature documentation](/features/caching/cas) for more details.
@@ -490,11 +490,11 @@ As such, if you currently have multiple stacks that need to depend on each other
 
 Every generation of a stack from a `terragrunt.stack.hcl` file can potentially result in network traffic to fetch the source for the stack and filesystem traffic to copy the generated units to the `.terragrunt-stack` directory. This can result in slow stack generation if you have very deeply nested stacks.
 
-<Before version="1.0.2">
+<Before version="1.0.3">
 The planned solution for this in the future is to allow for some deduplication in stack generation, but this is not currently implemented.
 </Before>
 
-<Since version="1.0.2">
+<Since version="1.0.3">
 To mitigate this, enable the [`cas` experiment](/reference/experiments/active#cas) and use `update_source_with_cas = true` in your catalog's stack and unit files. This deduplicates repository clones and resolves content from the local CAS store instead of fetching from the network on every generation. See [CAS Integration](#cas-integration) for details.
 </Since>
 

--- a/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
@@ -410,14 +410,14 @@ When `update_source_with_cas = true` is set:
 4. Generated `.terragrunt-stack` files contain deterministic CAS references instead of remote URLs.
 5. Subsequent generation waves resolve `cas::` references directly from the CAS store, with no network access required.
 
-Given the catalog files above, and a consumer stack like:
+Consumers do **not** need to set `update_source_with_cas` themselves. Whenever the `cas` experiment is enabled and the source is remote, Terragrunt automatically takes the CAS path, clones once, and walks the catalog. The attribute is only meaningful inside catalog files, where it tells Terragrunt which nested `source` attributes to rewrite.
+
+Given the catalog files above, and an ordinary consumer stack like:
 
 ```hcl
 # live/terragrunt.stack.hcl
 stack "service" {
   source = "git::git@github.com:acme/catalog.git//stacks/service?ref=v1.0.0"
-
-  update_source_with_cas = true
 
   path = "service"
 }

--- a/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
@@ -359,7 +359,7 @@ Experimental integration between CAS and Stacks is coming soon. Follow the progr
 This functionality is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`. See the [CAS feature documentation](/features/caching/cas) for more details.
 </Aside>
 
-When authoring stacks in a catalog, you can use the `update_source_with_cas` attribute to simplify source management and improve generation performance.
+When authoring stacks in a catalog, you can use the `update_source_with_cas` attribute on nested blocks to replace remote Git URLs with relative paths.
 
 Without CAS, catalog authors need to plumb remote Git URLs through `values` expressions so that generated files reference the correct remote sources:
 
@@ -410,7 +410,7 @@ When `update_source_with_cas = true` is set:
 4. Generated `.terragrunt-stack` files contain deterministic CAS references instead of remote URLs.
 5. Subsequent generation waves resolve `cas::` references directly from the CAS store, with no network access required.
 
-Consumers do **not** need to set `update_source_with_cas` themselves. Whenever the `cas` experiment is enabled and the source is remote, Terragrunt automatically takes the CAS path, clones once, and walks the catalog. The attribute is only meaningful inside catalog files, where it tells Terragrunt which nested `source` attributes to rewrite.
+Consumers do not set `update_source_with_cas` themselves. When the `cas` experiment is enabled and the source is remote, Terragrunt uses the CAS path automatically. The attribute only has effect inside catalog files, where it flags nested `source` attributes for rewriting.
 
 Given the catalog files above, and an ordinary consumer stack like:
 

--- a/docs/src/content/docs/03-features/07-caching/04-cas.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas.mdx
@@ -7,12 +7,20 @@ sidebar:
 ---
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
+import { Aside } from '@astrojs/starlight/components';
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Terragrunt supports a Content Addressable Store (CAS) to deduplicate content across multiple Terragrunt configurations. This feature is still experimental and not recommended for general production usage.
 
-The CAS is used to speed up both catalog cloning and OpenTofu/Terraform source cloning by avoiding redundant downloads of Git repositories.
+The CAS is used to speed up catalog cloning, OpenTofu/Terraform source cloning, and stack generation by avoiding redundant downloads of Git repositories.
 
 To use the CAS, you will need to enable the [cas](/reference/experiments/active#cas) experiment.
+
+
+<Since version="1.0.2">
+You can disable the CAS at any time using the `--no-cas` flag, even when the experiment is enabled. This flag is available on the [`run`](/reference/cli/commands/run), [`stack generate`](/reference/cli/commands/stack/generate), and [`stack run`](/reference/cli/commands/stack/run) commands.
+</Since>
 
 ## Usage
 
@@ -40,6 +48,58 @@ terraform {
 }
 ```
 
+### Stack Usage
+
+<Before version="1.0.2">
+
+<Aside type="tip">
+Experimental integration between CAS and Stacks is coming soon. Follow the progress in [#5558](https://github.com/gruntwork-io/terragrunt/issues/5558).
+</Aside>
+
+</Before>
+
+<Since version="1.0.2">
+
+<Aside type="tip">
+This functionality is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
+</Aside>
+
+When authoring stacks in a catalog, you can use the `update_source_with_cas` attribute to allow relative paths in `source` attributes. This removes the need to plumb remote Git URLs through `values` expressions.
+
+```hcl
+# stacks/my-stack/terragrunt.stack.hcl (in your catalog repository)
+
+unit "service" {
+  source = "../..//units/my-service"
+
+  update_source_with_cas = true
+
+  path = "service"
+}
+```
+
+The referenced unit can also use relative paths:
+
+```hcl
+# units/my-service/terragrunt.hcl (in your catalog repository)
+
+terraform {
+  source = "../..//modules/my-module"
+
+  update_source_with_cas = true
+}
+```
+
+During stack generation, Terragrunt rewrites these relative sources to `cas::` references that point to content stored in the CAS. The repository is cloned once, and subsequent stack generations resolve content from the local store without network access. Generated `.terragrunt-stack` files contain deterministic CAS references instead of version variables, so they do not produce diffs on regeneration.
+
+For more details on using this with stacks, see [Explicit Stacks: CAS Integration](/features/stacks/explicit#cas-integration).
+
+<Aside type="caution">
+Using `update_source_with_cas` requires the `cas` experiment to be enabled. If the experiment is not enabled or `--no-cas` is set, Terragrunt will return an error.
+</Aside>
+
+</Since>
+
 When Terragrunt clones a repository while using the CAS, if the repository is not found in the CAS, Terragrunt will clone the repository from the original URL and store it in the CAS for future use.
 
 When generating a repository from the CAS, Terragrunt will hard link entries from the CAS to the new repository. This allows Terragrunt to deduplicate content across multiple repositories.
@@ -54,18 +114,31 @@ Avoid partial deletions of the CAS directory without care, as that might result 
 
 ## How it works
 
-Terragrunt's CAS uses a content-addressable storage model to deduplicate repository content from Git clones to save disk space and improve performance. Each Git object is identified by its SHA1 hash, allowing identical content to be shared across multiple cloned repositories and repeated clones.
+Terragrunt's CAS uses a content-addressable storage model to deduplicate repository content from Git clones to save disk space and improve performance. Each Git object is identified by its hash, allowing identical content to be shared across multiple cloned repositories and repeated clones.
 
 ### Content Addressing
 
+
+<Before version="1.0.2">
 CAS uses Git's native content addressing scheme where each object is uniquely identified by its SHA1 hash. This means:
 
 - **Identical content** across different repositories shares the same hash
 - **Same commit hash** always represents the same content
 - **Storage is partitioned** by the first two characters of the hash (e.g., `ab/abc123...`)
+</Before>
+
+<Since version="1.0.2">
+CAS uses Git's native content addressing scheme where each object is uniquely identified by its hash. Terragrunt detects the hash algorithm used by the repository (`sha1` or `sha256`) via `git rev-parse --show-object-format`. This means:
+
+- **Identical content** across different repositories shares the same hash
+- **Same commit hash** always represents the same content
+- **Storage is partitioned** by the first two characters of the hash (e.g., `ab/abc123...`)
+- **Both SHA-1 and SHA-256** repositories are supported
+</Since>
 
 ### Storage Structure
 
+<Before version="1.0.2">
 The CAS store is organized in a partitioned structure to optimize file system performance:
 
 <FileTree>
@@ -83,6 +156,34 @@ The CAS store is organized in a partitioned structure to optimize file system pe
 </FileTree>
 
 Each content object is stored at `{hash[:2]}/{hash}`, where the first two characters create a partition directory. This prevents having thousands of files in a single directory, which can degrade file system performance.
+</Before>
+
+<Since version="1.0.2">
+The CAS store is organized into namespaced directories:
+
+<FileTree>
+
+- ~/.cache/terragrunt/cas/store/
+  - blobs/ (file content from Git repositories and synthetic sources)
+    - ab/
+      - abc123...xyz
+      - abc123...xyz.lock
+    - cd/
+      - cd7890...xyz
+  - trees/ (Git-derived tree structures)
+    - f3/
+      - f39ea0...xyz
+  - synth/
+    - trees/ (synthetic trees created during CAS-backed stack generation)
+      - de/
+        - def456...xyz
+
+</FileTree>
+
+The `blobs/` directory stores all file content, identified by hash. Blobs are purely content-addressed, so the same file content always maps to the same hash regardless of origin. The `trees/` directory stores Git-derived tree structures that describe the layout of files in a repository. The `synth/trees/` directory stores synthetic tree structures created during CAS-backed stack generation when `update_source_with_cas` is used. These synthetic trees use a deterministic hash based on the Git reference and path within the repository.
+
+Each content object within a namespace is stored at `{hash[:2]}/{hash}`, where the first two characters create a partition directory to avoid degraded file system performance from large flat directories.
+</Since>
 
 ### Clone Flow
 

--- a/docs/src/content/docs/03-features/07-caching/04-cas.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas.mdx
@@ -18,7 +18,7 @@ The CAS is used to speed up catalog cloning, OpenTofu/Terraform source cloning, 
 To use the CAS, you will need to enable the [cas](/reference/experiments/active#cas) experiment.
 
 
-<Since version="1.0.2">
+<Since version="1.0.3">
 You can disable the CAS at any time using the `--no-cas` flag, even when the experiment is enabled. This flag is available on the [`run`](/reference/cli/commands/run), [`stack generate`](/reference/cli/commands/stack/generate), and [`stack run`](/reference/cli/commands/stack/run) commands.
 </Since>
 
@@ -50,7 +50,7 @@ terraform {
 
 ### Stack Usage
 
-<Before version="1.0.2">
+<Before version="1.0.3">
 
 <Aside type="tip">
 Experimental integration between CAS and Stacks is coming soon. Follow the progress in [#5558](https://github.com/gruntwork-io/terragrunt/issues/5558).
@@ -58,7 +58,7 @@ Experimental integration between CAS and Stacks is coming soon. Follow the progr
 
 </Before>
 
-<Since version="1.0.2">
+<Since version="1.0.3">
 
 <Aside type="tip">
 This functionality is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
@@ -95,7 +95,7 @@ During stack generation, Terragrunt rewrites these relative sources to `cas::` r
 For more details on using this with stacks, see [Explicit Stacks: CAS Integration](/features/stacks/explicit#cas-integration).
 
 <Aside type="caution">
-`update_source_with_cas` only takes effect when the `cas` experiment is enabled and `--no-cas` is not set. Otherwise the attribute is ignored and sources are fetched via the standard getter path.
+Setting `update_source_with_cas = true` requires that the `cas` experiment is enabled and that `--no-cas` is not set. Terragrunt errors out otherwise, since the relative source must be updated to a synthetic tree stored in the CAS.
 </Aside>
 
 </Since>
@@ -119,7 +119,7 @@ Terragrunt's CAS uses a content-addressable storage model to deduplicate reposit
 ### Content Addressing
 
 
-<Before version="1.0.2">
+<Before version="1.0.3">
 CAS uses Git's native content addressing scheme where each object is uniquely identified by its SHA1 hash. This means:
 
 - **Identical content** across different repositories shares the same hash
@@ -127,7 +127,7 @@ CAS uses Git's native content addressing scheme where each object is uniquely id
 - **Storage is partitioned** by the first two characters of the hash (e.g., `ab/abc123...`)
 </Before>
 
-<Since version="1.0.2">
+<Since version="1.0.3">
 CAS uses Git's native content addressing scheme where each object is uniquely identified by its hash. Terragrunt detects the hash algorithm used by the repository (`sha1` or `sha256`) via `git rev-parse --show-object-format`. This means:
 
 - **Identical content** across different repositories shares the same hash
@@ -138,7 +138,7 @@ CAS uses Git's native content addressing scheme where each object is uniquely id
 
 ### Storage Structure
 
-<Before version="1.0.2">
+<Before version="1.0.3">
 The CAS store is organized in a partitioned structure to optimize file system performance:
 
 <FileTree>
@@ -158,7 +158,7 @@ The CAS store is organized in a partitioned structure to optimize file system pe
 Each content object is stored at `{hash[:2]}/{hash}`, where the first two characters create a partition directory. This prevents having thousands of files in a single directory, which can degrade file system performance.
 </Before>
 
-<Since version="1.0.2">
+<Since version="1.0.3">
 The CAS store is organized into namespaced directories:
 
 <FileTree>

--- a/docs/src/content/docs/03-features/07-caching/04-cas.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas.mdx
@@ -95,7 +95,7 @@ During stack generation, Terragrunt rewrites these relative sources to `cas::` r
 For more details on using this with stacks, see [Explicit Stacks: CAS Integration](/features/stacks/explicit#cas-integration).
 
 <Aside type="caution">
-Using `update_source_with_cas` requires the `cas` experiment to be enabled. If the experiment is not enabled or `--no-cas` is set, Terragrunt will return an error.
+`update_source_with_cas` only takes effect when the `cas` experiment is enabled and `--no-cas` is not set. Otherwise the attribute is ignored and sources are fetched via the standard getter path.
 </Aside>
 
 </Since>

--- a/docs/src/data/changelog/v1.0.3/cas-stack-integration.mdx
+++ b/docs/src/data/changelog/v1.0.3/cas-stack-integration.mdx
@@ -1,0 +1,26 @@
+---
+version: "v1.0.3"
+category: "experiments-updated"
+---
+
+#### `cas` — Stack integration via `update_source_with_cas`
+
+The [`cas` experiment](/reference/experiments/active#cas) now integrates with stacks. Units and `terraform` blocks can set `update_source_with_cas = true` to use relative `source` paths in catalog repositories, removing the need to plumb remote Git URLs through `values` expressions.
+
+```hcl
+# stacks/my-stack/terragrunt.stack.hcl (in your catalog repository)
+
+unit "service" {
+  source = "../..//units/my-service"
+
+  update_source_with_cas = true
+
+  path = "service"
+}
+```
+
+During stack generation, Terragrunt rewrites these relative sources to `cas::` references that resolve against content stored in the CAS. The repository is cloned once, and subsequent stack generations resolve content from the local store without network access. Generated `.terragrunt-stack` files contain deterministic CAS references, so regeneration does not produce spurious diffs.
+
+CAS also supports SHA-256 repositories now, detected automatically via `git rev-parse --show-object-format`. The on-disk store layout was reorganized into `blobs/` and `trees/` namespaces under `~/.cache/terragrunt/cas/store/`.
+
+To learn more, see the [CAS documentation](/features/caching/cas) and [Explicit Stacks: CAS Integration](/features/stacks/explicit#cas-integration).

--- a/docs/src/data/changelog/v1.0.3/no-cas-flag.mdx
+++ b/docs/src/data/changelog/v1.0.3/no-cas-flag.mdx
@@ -1,0 +1,16 @@
+---
+version: "v1.0.3"
+category: "new-features"
+---
+
+#### `--no-cas` flag for disabling CAS per command
+
+The new `--no-cas` flag disables the CAS for a single invocation, even when the `cas` experiment is enabled. It is available on [`run`](/reference/cli/commands/run), [`stack generate`](/reference/cli/commands/stack/generate), and [`stack run`](/reference/cli/commands/stack/run).
+
+```bash
+terragrunt stack generate --experiment cas --no-cas
+```
+
+This is useful when you want to fall back to the standard getter path without unwinding experiment configuration.
+
+Generation and runs error when `--no-cas` is combined with `update_source_with_cas = true` on any reachable `unit`, `stack`, or `terraform` block, since relative sources in catalog repositories cannot be resolved without the CAS.

--- a/docs/src/data/commands/run.mdx
+++ b/docs/src/data/commands/run.mdx
@@ -79,6 +79,7 @@ flags:
   - units-that-include
   - use-partial-parse-config-cache
   - version-manager-file-name
+  - no-cas
 ---
 
 import { Aside } from '@astrojs/starlight/components';

--- a/docs/src/data/commands/stack/generate.mdx
+++ b/docs/src/data/commands/stack/generate.mdx
@@ -13,6 +13,7 @@ examples:
       terragrunt stack generate
 flags:
   - stack-generate-filter
+  - no-cas
 ---
 
 import FileTree from "@components/vendored/starlight/FileTree.astro";

--- a/docs/src/data/commands/stack/run.mdx
+++ b/docs/src/data/commands/stack/run.mdx
@@ -22,6 +22,7 @@ examples:
       terragrunt stack run destroy
 flags:
   - no-stack-generate
+  - no-cas
 ---
 
 import { Aside } from '@astrojs/starlight/components';

--- a/docs/src/data/experiments/cas.mdx
+++ b/docs/src/data/experiments/cas.mdx
@@ -8,7 +8,7 @@ Support for Terragrunt Content Addressable Storage (CAS).
 ### `cas` - What it does
 Allow Terragrunt to store and retrieve Git repositories from a Content Addressable Storage (CAS) system.
 
-The CAS is used to speed up both catalog cloning and OpenTofu/Terraform source cloning by avoiding redundant downloads of Git repositories.
+The CAS is used to speed up catalog cloning, OpenTofu/Terraform source cloning, and stack generation by avoiding redundant downloads of Git repositories. When used with stacks, it also allows catalog authors to use relative paths in `source` attributes via the `update_source_with_cas` attribute.
 
 ### `cas` - How to provide feedback
 Share your experience with this feature in the [CAS](https://github.com/gruntwork-io/terragrunt/discussions/3939) Feedback GitHub Discussion.
@@ -22,4 +22,4 @@ To transition the `cas` feature to a stable release, the following must be addre
 
 - [x] Add support for storing and retrieving catalog repositories from the CAS.
 - [x] Add support for storing and retrieving OpenTofu/Terraform modules from the CAS.
-- [ ] Add support for storing and retrieving Unit/Stack configurations from the CAS.
+- [x] Add support for storing and retrieving Unit/Stack configurations from the CAS.

--- a/docs/src/data/flags/no-cas.mdx
+++ b/docs/src/data/flags/no-cas.mdx
@@ -8,4 +8,4 @@ env:
 
 When enabled, Terragrunt skips all CAS operations even if the `cas` experiment is active. Use this to temporarily bypass CAS without removing the experiment flag.
 
-With `--no-cas` set, `update_source_with_cas` in `terragrunt.stack.hcl` or `terragrunt.hcl` files has no effect: sources are fetched via the standard getter path.
+Generation or runs error when `update_source_with_cas = true` is set on any `unit`, `stack`, or `terraform` block reachable from the current invocation, since relative sources rewritten by CAS cannot be resolved without it.

--- a/docs/src/data/flags/no-cas.mdx
+++ b/docs/src/data/flags/no-cas.mdx
@@ -1,0 +1,12 @@
+---
+name: no-cas
+description: Disable the CAS (Content Addressable Storage) feature even when the experiment is enabled.
+type: bool
+env:
+  - TG_NO_CAS
+---
+
+When enabled, Terragrunt will skip all CAS operations even if the `cas` experiment is active.
+This is useful for troubleshooting or when you want to temporarily bypass CAS without removing the experiment flag.
+
+Using `update_source_with_cas` in a `terragrunt.stack.hcl` or `terragrunt.hcl` file while this flag is set will result in an error.

--- a/docs/src/data/flags/no-cas.mdx
+++ b/docs/src/data/flags/no-cas.mdx
@@ -6,7 +6,6 @@ env:
   - TG_NO_CAS
 ---
 
-When enabled, Terragrunt will skip all CAS operations even if the `cas` experiment is active.
-This is useful for troubleshooting or when you want to temporarily bypass CAS without removing the experiment flag.
+When enabled, Terragrunt skips all CAS operations even if the `cas` experiment is active. Use this to temporarily bypass CAS without removing the experiment flag.
 
-Using `update_source_with_cas` in a `terragrunt.stack.hcl` or `terragrunt.hcl` file while this flag is set will result in an error.
+With `--no-cas` set, `update_source_with_cas` in `terragrunt.stack.hcl` or `terragrunt.hcl` files has no effect: sources are fetched via the standard getter path.

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -55,6 +55,7 @@ type CAS struct {
 	synthStore *Store
 	git        *git.GitRunner
 	storePath  string
+	cloneDepth int
 }
 
 // WithStorePath specifies a custom path for the content store.
@@ -62,6 +63,15 @@ type CAS struct {
 func WithStorePath(path string) Option {
 	return func(c *CAS) {
 		c.storePath = path
+	}
+}
+
+// WithCloneDepth overrides the default clone depth.
+// A value of 0 uses the default (shallow clone, depth 1).
+// A negative value (e.g. -1) clones the full history.
+func WithCloneDepth(depth int) Option {
+	return func(c *CAS) {
+		c.cloneDepth = depth
 	}
 }
 

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -49,10 +49,12 @@ type CloneOptions struct {
 
 // CAS clones a git repository using content-addressable storage.
 type CAS struct {
-	fs        vfs.FS
-	store     *Store
-	git       *git.GitRunner
-	storePath string
+	fs         vfs.FS
+	blobStore  *Store
+	treeStore  *Store
+	synthStore *Store
+	git        *git.GitRunner
+	storePath  string
 }
 
 // WithStorePath specifies a custom path for the content store.
@@ -96,7 +98,15 @@ func New(opts ...Option) (*CAS, error) {
 		return nil, fmt.Errorf("failed to create CAS store path: %w", err)
 	}
 
-	c.store = NewStore(c.storePath).WithFS(c.fs)
+	c.blobStore = NewStore(filepath.Join(c.storePath, "blobs")).WithFS(c.fs)
+	c.treeStore = NewStore(filepath.Join(c.storePath, "trees")).WithFS(c.fs)
+	c.synthStore = NewStore(filepath.Join(c.storePath, "synth", "trees")).WithFS(c.fs)
+
+	for _, s := range []*Store{c.blobStore, c.treeStore, c.synthStore} {
+		if err := c.fs.MkdirAll(s.Path(), DefaultDirPerms); err != nil {
+			return nil, fmt.Errorf("failed to create CAS store subdirectory %s: %w", s.Path(), err)
+		}
+	}
 
 	g, err := git.NewGitRunner(vexec.NewOSExec())
 	if err != nil {
@@ -113,17 +123,30 @@ func (c *CAS) FS() vfs.FS {
 	return c.fs
 }
 
+// BlobStore returns the store for blob content.
+func (c *CAS) BlobStore() *Store { return c.blobStore }
+
+// TreeStore returns the store for git-derived tree content.
+func (c *CAS) TreeStore() *Store { return c.treeStore }
+
+// SynthStore returns the store for synthetic tree content.
+func (c *CAS) SynthStore() *Store { return c.synthStore }
+
 // Clone performs the clone operation
 //
 // TODO: Make options optional
 func (c *CAS) Clone(ctx context.Context, l log.Logger, opts *CloneOptions, url string) error {
-	// Ensure the store path exists
-	if err := c.fs.MkdirAll(c.store.Path(), DefaultDirPerms); err != nil {
-		return fmt.Errorf("failed to create store path: %w", err)
+	// Ensure the store paths exist
+	if err := c.fs.MkdirAll(c.blobStore.Path(), DefaultDirPerms); err != nil {
+		return fmt.Errorf("failed to create blob store path: %w", err)
+	}
+
+	if err := c.fs.MkdirAll(c.treeStore.Path(), DefaultDirPerms); err != nil {
+		return fmt.Errorf("failed to create tree store path: %w", err)
 	}
 
 	// Acquire global clone lock to ensure only one clone at a time
-	globalLock, err := vfs.Lock(c.fs, filepath.Join(c.store.Path(), "clone.lock"))
+	globalLock, err := vfs.Lock(c.fs, filepath.Join(c.storePath, "clone.lock"))
 	if err != nil {
 		return fmt.Errorf("failed to acquire global clone lock: %w", err)
 	}
@@ -145,7 +168,7 @@ func (c *CAS) Clone(ctx context.Context, l log.Logger, opts *CloneOptions, url s
 
 		targetDir := c.prepareTargetDirectory(opts.Dir, url)
 
-		if c.store.NeedsWrite(hash) {
+		if c.treeStore.NeedsWrite(hash) {
 			// Create a temporary directory for git operations
 			_, cleanup, createTempDirErr := c.git.CreateTempDir()
 			if createTempDirErr != nil {
@@ -163,9 +186,9 @@ func (c *CAS) Clone(ctx context.Context, l log.Logger, opts *CloneOptions, url s
 			}
 		}
 
-		content := NewContent(c.store)
+		treeContent := NewContent(c.treeStore)
 
-		treeData, err := content.Read(hash)
+		treeData, err := treeContent.Read(hash)
 		if err != nil {
 			return err
 		}
@@ -175,7 +198,7 @@ func (c *CAS) Clone(ctx context.Context, l log.Logger, opts *CloneOptions, url s
 			return err
 		}
 
-		return LinkTree(childCtx, c.store, tree, targetDir)
+		return LinkTree(childCtx, c.blobStore, c.treeStore, tree, targetDir)
 	})
 }
 
@@ -242,9 +265,9 @@ func (c *CAS) storeRootTree(ctx context.Context, l log.Logger, hash string, opts
 		return nil
 	}
 
-	content := NewContent(c.store)
+	treeContent := NewContent(c.treeStore)
 
-	data, err := content.Read(hash)
+	data, err := treeContent.Read(hash)
 	if err != nil {
 		return err
 	}
@@ -266,9 +289,9 @@ func (c *CAS) storeRootTree(ctx context.Context, l log.Logger, hash string, opts
 			return err
 		}
 
-		includedContent := NewContent(c.store)
+		blobContent := NewContent(c.blobStore)
 
-		if err := includedContent.EnsureCopy(l, includedHash, workDirPath); err != nil {
+		if err := blobContent.EnsureCopy(l, includedHash, workDirPath); err != nil {
 			return err
 		}
 
@@ -278,12 +301,12 @@ func (c *CAS) storeRootTree(ctx context.Context, l log.Logger, hash string, opts
 	}
 
 	// Overwrite the root tree with the new data
-	return content.Store(l, hash, data)
+	return treeContent.Store(l, hash, data)
 }
 
 // storeTreeRecursive stores a tree fetched from git ls-tree -r
 func (c *CAS) storeTreeRecursive(ctx context.Context, l log.Logger, hash string, tree *git.Tree) error {
-	if !c.store.NeedsWrite(hash) {
+	if !c.treeStore.NeedsWrite(hash) {
 		return nil
 	}
 
@@ -292,8 +315,8 @@ func (c *CAS) storeTreeRecursive(ctx context.Context, l log.Logger, hash string,
 	}
 
 	// Store the tree object itself
-	content := NewContent(c.store)
-	if err := content.EnsureWithWait(l, hash, tree.Data()); err != nil {
+	treeContent := NewContent(c.treeStore)
+	if err := treeContent.EnsureWithWait(l, hash, tree.Data()); err != nil {
 		return err
 	}
 
@@ -303,7 +326,7 @@ func (c *CAS) storeTreeRecursive(ctx context.Context, l log.Logger, hash string,
 // storeBlobs stores blobs in the CAS
 func (c *CAS) storeBlobs(ctx context.Context, entries []git.TreeEntry) error {
 	for _, entry := range entries {
-		if !c.store.NeedsWrite(entry.Hash) {
+		if !c.blobStore.NeedsWrite(entry.Hash) {
 			continue
 		}
 
@@ -320,7 +343,7 @@ func (c *CAS) storeBlobs(ctx context.Context, entries []git.TreeEntry) error {
 // we want to take advantage of the ability to write to the
 // entry using `git cat-file`.
 func (c *CAS) ensureBlob(ctx context.Context, hash string) error {
-	needsWrite, lock, err := c.store.EnsureWithWait(hash)
+	needsWrite, lock, err := c.blobStore.EnsureWithWait(hash)
 	if err != nil {
 		return err
 	}
@@ -337,7 +360,7 @@ func (c *CAS) ensureBlob(ctx context.Context, hash string) error {
 		}
 	}()
 
-	content := NewContent(c.store)
+	content := NewContent(c.blobStore)
 
 	tmpHandle, err := content.GetTmpHandle(hash)
 	if err != nil {

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -23,7 +23,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
-const defaultCloneDepth = 1
+// DefaultCASCloneDepth is the default shallow clone depth for CAS (git clone --depth).
+const DefaultCASCloneDepth = 1
 
 // Option configures the behavior of CAS.
 type Option func(*CAS)
@@ -42,8 +43,9 @@ type CloneOptions struct {
 	// If empty, does not preserve any files.
 	IncludedGitFiles []string
 
-	// Depth limits the clone history to the given number of commits.
-	// If zero, defaults to 1 (shallow clone). Set to -1 for full history.
+	// Depth limits the clone history to the given number of commits passed to git clone --depth.
+	// If zero, CAS falls back to its configured clone depth (default shallow depth 1).
+	// Set to -1 for full history (Terragrunt omits --depth; git rejects --depth 0).
 	Depth int
 }
 
@@ -66,9 +68,10 @@ func WithStorePath(path string) Option {
 	}
 }
 
-// WithCloneDepth overrides the default clone depth.
-// A value of 0 uses the default (shallow clone, depth 1).
-// A negative value (e.g. -1) clones the full history.
+// WithCloneDepth sets git clone --depth for CAS (positive shallow clone; negative,
+// e.g. -1, means full history with no --depth). Terragrunt validates user-supplied
+// values with ValidateCASCloneDepth (zero is invalid for git). Omit this option to
+// keep cloneDepth unset so per-operation CloneOptions.Depth can fall back to DefaultCASCloneDepth.
 func WithCloneDepth(depth int) Option {
 	return func(c *CAS) {
 		c.cloneDepth = depth
@@ -247,7 +250,11 @@ func (c *CAS) cloneAndStoreContent(
 ) error {
 	depth := opts.Depth
 	if depth == 0 {
-		depth = defaultCloneDepth
+		depth = c.cloneDepth
+	}
+
+	if depth == 0 {
+		depth = DefaultCASCloneDepth
 	}
 
 	if depth < 0 {

--- a/internal/cas/clone_depth.go
+++ b/internal/cas/clone_depth.go
@@ -1,0 +1,20 @@
+package cas
+
+import (
+	"fmt"
+)
+
+// ValidateCASCloneDepth returns an error if depth is not usable for CAS git clones.
+// Git requires a positive integer for --depth; zero is invalid. Negative values
+// mean full history (Terragrunt omits --depth).
+func ValidateCASCloneDepth(depth int) error {
+	if depth == 0 {
+		return fmt.Errorf(
+			"invalid CAS clone depth 0: git clone --depth requires a positive number; "+
+				"use the default (%d) or -1 for full history",
+			DefaultCASCloneDepth,
+		)
+	}
+
+	return nil
+}

--- a/internal/cas/clone_depth_test.go
+++ b/internal/cas/clone_depth_test.go
@@ -1,0 +1,18 @@
+package cas_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCASCloneDepth(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, cas.ValidateCASCloneDepth(1))
+	require.NoError(t, cas.ValidateCASCloneDepth(42))
+	require.NoError(t, cas.ValidateCASCloneDepth(-1))
+	assert.Error(t, cas.ValidateCASCloneDepth(0))
+}

--- a/internal/cas/errors.go
+++ b/internal/cas/errors.go
@@ -34,6 +34,10 @@ const (
 	ErrCASRefEmptyHash Error = "CAS reference has empty hash"
 	// ErrTreeNotFound is returned when a tree hash is not found in any CAS store
 	ErrTreeNotFound Error = "tree not found in CAS store"
+	// ErrAbsoluteSource is returned when an update_source_with_cas source is an absolute path
+	ErrAbsoluteSource Error = "update_source_with_cas does not support absolute sources"
+	// ErrSourceEscapesRepo is returned when an update_source_with_cas source resolves outside the cloned repository
+	ErrSourceEscapesRepo Error = "update_source_with_cas source escapes repository root"
 )
 
 // WrappedError provides additional context for errors

--- a/internal/cas/errors.go
+++ b/internal/cas/errors.go
@@ -75,3 +75,30 @@ func wrapError(op, path string, err error) error {
 		Err:  err,
 	}
 }
+
+// UpdateSourceWithCASRequiresCASError is returned when a block sets
+// update_source_with_cas = true but CAS is unavailable, either because the
+// experiment is not enabled or because --no-cas is set. The relative source
+// has no meaning without CAS, so Terragrunt rejects the configuration rather
+// than silently falling through to the standard getter.
+type UpdateSourceWithCASRequiresCASError struct {
+	// BlockType is the kind of block carrying the attribute: "unit", "stack", or "terraform".
+	BlockType string
+	// Name is the block label. Empty for "terraform" blocks, which are unlabeled.
+	Name string
+	// Path is the file containing the offending block.
+	Path string
+}
+
+func (e *UpdateSourceWithCASRequiresCASError) Error() string {
+	subject := e.BlockType
+	if e.Name != "" {
+		subject = fmt.Sprintf("%s %q", e.BlockType, e.Name)
+	}
+
+	return fmt.Sprintf(
+		"%s in %s sets update_source_with_cas = true, which requires "+
+			"the 'cas' experiment to be enabled and the --no-cas flag to be unset",
+		subject, e.Path,
+	)
+}

--- a/internal/cas/errors.go
+++ b/internal/cas/errors.go
@@ -22,6 +22,18 @@ const (
 	ErrReadFile Error = "failed to read file"
 	// ErrGitClone is returned when the git clone operation fails
 	ErrGitClone Error = "failed to complete git clone"
+	// ErrNoTerraformBlock is returned when a terragrunt.hcl file has no terraform block
+	ErrNoTerraformBlock Error = "no terraform block found"
+	// ErrBlockNotFound is returned when a named block is not found in a stack file
+	ErrBlockNotFound Error = "block not found"
+	// ErrGetFileNotSupported is returned when GetFile is called on the CAS protocol getter
+	ErrGetFileNotSupported Error = "CAS protocol does not support single file downloads"
+	// ErrCASRefMissingPrefix is returned when a CAS reference is missing the expected hash algorithm prefix
+	ErrCASRefMissingPrefix Error = "CAS reference missing expected hash algorithm prefix"
+	// ErrCASRefEmptyHash is returned when a CAS reference has an empty hash
+	ErrCASRefEmptyHash Error = "CAS reference has empty hash"
+	// ErrTreeNotFound is returned when a tree hash is not found in any CAS store
+	ErrTreeNotFound Error = "tree not found in CAS store"
 )
 
 // WrappedError provides additional context for errors

--- a/internal/cas/getter.go
+++ b/internal/cas/getter.go
@@ -45,7 +45,7 @@ func NewCASGetter(l log.Logger, cas *CAS, opts *CloneOptions) *CASGetter {
 
 func (g *CASGetter) Get(ctx context.Context, req *getter.Request) error {
 	if req.Copy {
-		// Handle local directory by persisting to CAS and linking
+		// Handle local directory by persisting to CAS and linking.
 		return g.CAS.StoreLocalDirectory(ctx, g.Logger, req.Src, req.Dst)
 	}
 

--- a/internal/cas/hcl_rewrite.go
+++ b/internal/cas/hcl_rewrite.go
@@ -1,0 +1,165 @@
+package cas
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// RewriteTerraformSource rewrites the `source` attribute inside a `terraform {}` block.
+// Returns the rewritten HCL content.
+func RewriteTerraformSource(content []byte, newSource string) ([]byte, error) {
+	f, diags := hclwrite.ParseConfig(content, "terragrunt.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("failed to parse HCL: %s", diags.Error())
+	}
+
+	for _, block := range f.Body().Blocks() {
+		if block.Type() != "terraform" {
+			continue
+		}
+
+		block.Body().SetAttributeValue("source", cty.StringVal(newSource))
+
+		return f.Bytes(), nil
+	}
+
+	return nil, ErrNoTerraformBlock
+}
+
+// RewriteStackBlockSource rewrites the `source` attribute in a named `unit` or `stack` block.
+// blockType is "unit" or "stack", blockName is the label.
+func RewriteStackBlockSource(content []byte, blockType, blockName, newSource string) ([]byte, error) {
+	f, diags := hclwrite.ParseConfig(content, "terragrunt.stack.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("failed to parse HCL: %s", diags.Error())
+	}
+
+	for _, block := range f.Body().Blocks() {
+		if block.Type() != blockType {
+			continue
+		}
+
+		labels := block.Labels()
+		if len(labels) == 0 || labels[0] != blockName {
+			continue
+		}
+
+		block.Body().SetAttributeValue("source", cty.StringVal(newSource))
+
+		return f.Bytes(), nil
+	}
+
+	return nil, &WrappedError{
+		Op:      blockType,
+		Context: blockName,
+		Err:     ErrBlockNotFound,
+	}
+}
+
+// stackBlockInfo holds parsed information about a unit or stack block in a stack file.
+type stackBlockInfo struct {
+	Name                string
+	Source              string
+	BlockType           string
+	UpdateSourceWithCAS bool
+}
+
+// ReadStackBlocks reads all unit and stack blocks from a stack HCL file,
+// extracting the source and update_source_with_cas attributes.
+func ReadStackBlocks(content []byte) ([]stackBlockInfo, error) {
+	f, diags := hclwrite.ParseConfig(content, "terragrunt.stack.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("failed to parse stack HCL: %s", diags.Error())
+	}
+
+	var blocks []stackBlockInfo
+
+	for _, block := range f.Body().Blocks() {
+		bt := block.Type()
+		if bt != "unit" && bt != "stack" {
+			continue
+		}
+
+		labels := block.Labels()
+		if len(labels) == 0 {
+			continue
+		}
+
+		info := stackBlockInfo{
+			Name:      labels[0],
+			BlockType: bt,
+		}
+
+		if attr := block.Body().GetAttribute("source"); attr != nil {
+			info.Source = extractStringLiteral(attr)
+		}
+
+		if attr := block.Body().GetAttribute("update_source_with_cas"); attr != nil {
+			info.UpdateSourceWithCAS = extractBoolLiteral(attr)
+		}
+
+		blocks = append(blocks, info)
+	}
+
+	return blocks, nil
+}
+
+// ReadTerraformSourceInfo reads the source and update_source_with_cas from a terraform block.
+func ReadTerraformSourceInfo(content []byte) (source string, updateWithCAS bool, err error) {
+	f, diags := hclwrite.ParseConfig(content, "terragrunt.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		return "", false, fmt.Errorf("failed to parse HCL: %s", diags.Error())
+	}
+
+	for _, block := range f.Body().Blocks() {
+		if block.Type() != "terraform" {
+			continue
+		}
+
+		if attr := block.Body().GetAttribute("source"); attr != nil {
+			source = extractStringLiteral(attr)
+		}
+
+		if attr := block.Body().GetAttribute("update_source_with_cas"); attr != nil {
+			updateWithCAS = extractBoolLiteral(attr)
+		}
+
+		return source, updateWithCAS, nil
+	}
+
+	return "", false, nil
+}
+
+// extractStringLiteral extracts a string value from an hclwrite attribute.
+// Returns empty string if the attribute is not a simple string literal.
+func extractStringLiteral(attr *hclwrite.Attribute) string {
+	tokens := attr.Expr().BuildTokens(nil)
+
+	var b strings.Builder
+
+	for _, tok := range tokens {
+		if tok.Type == hclsyntax.TokenQuotedLit {
+			b.Write(tok.Bytes)
+		}
+	}
+
+	return b.String()
+}
+
+// extractBoolLiteral extracts a boolean value from an hclwrite attribute.
+// Returns false if the attribute is not a simple boolean literal.
+func extractBoolLiteral(attr *hclwrite.Attribute) bool {
+	tokens := attr.Expr().BuildTokens(nil)
+	for _, tok := range tokens {
+		if tok.Type == hclsyntax.TokenIdent {
+			return string(tok.Bytes) == "true"
+		}
+	}
+
+	return false
+}

--- a/internal/cas/hcl_rewrite_test.go
+++ b/internal/cas/hcl_rewrite_test.go
@@ -1,0 +1,143 @@
+package cas_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRewriteTerraformSource(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`terraform {
+  source = "../..//modules/ec2-asg-service"
+
+  update_source_with_cas = true
+}
+`)
+
+	result, err := cas.RewriteTerraformSource(input, "cas::sha1:abc123//modules/ec2-asg-service")
+	require.NoError(t, err)
+
+	assert.Contains(t, string(result), `"cas::sha1:abc123//modules/ec2-asg-service"`)
+	assert.Contains(t, string(result), "update_source_with_cas")
+}
+
+func TestRewriteTerraformSource_NoBlock(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`locals {
+  region = "us-east-1"
+}
+`)
+
+	_, err := cas.RewriteTerraformSource(input, "cas::sha1:abc123")
+	require.ErrorIs(t, err, cas.ErrNoTerraformBlock)
+}
+
+func TestRewriteStackBlockSource(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`unit "service" {
+  source = "../..//units/ec2-asg-stateful-service"
+
+  update_source_with_cas = true
+
+  path = "service"
+}
+
+unit "other" {
+  source = "../other"
+  path   = "other"
+}
+`)
+
+	result, err := cas.RewriteStackBlockSource(input, "unit", "service", "cas::sha1:def456")
+	require.NoError(t, err)
+
+	resultStr := string(result)
+	assert.Contains(t, resultStr, `"cas::sha1:def456"`)
+	// "other" unit should remain unchanged
+	assert.Contains(t, resultStr, `"../other"`)
+}
+
+func TestRewriteStackBlockSource_NotFound(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`unit "service" {
+  source = "../../units/service"
+  path   = "service"
+}
+`)
+
+	_, err := cas.RewriteStackBlockSource(input, "unit", "nonexistent", "cas::sha1:abc")
+	require.ErrorIs(t, err, cas.ErrBlockNotFound)
+}
+
+func TestReadStackBlocks(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`unit "service" {
+  source = "../..//units/ec2-asg-stateful-service"
+  update_source_with_cas = true
+  path = "service"
+}
+
+stack "nested" {
+  source = "../stacks/nested"
+  path   = "nested"
+}
+
+unit "plain" {
+  source = "../units/plain"
+  path   = "plain"
+}
+`)
+
+	blocks, err := cas.ReadStackBlocks(input)
+	require.NoError(t, err)
+	require.Len(t, blocks, 3)
+
+	assert.Equal(t, "service", blocks[0].Name)
+	assert.Equal(t, "unit", blocks[0].BlockType)
+	assert.Equal(t, "../..//units/ec2-asg-stateful-service", blocks[0].Source)
+	assert.True(t, blocks[0].UpdateSourceWithCAS)
+
+	assert.Equal(t, "nested", blocks[1].Name)
+	assert.Equal(t, "stack", blocks[1].BlockType)
+	assert.False(t, blocks[1].UpdateSourceWithCAS)
+
+	assert.Equal(t, "plain", blocks[2].Name)
+	assert.False(t, blocks[2].UpdateSourceWithCAS)
+}
+
+func TestReadTerraformSourceInfo(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`terraform {
+  source = "../..//modules/ec2-asg-service"
+  update_source_with_cas = true
+}
+`)
+
+	source, updateWithCAS, err := cas.ReadTerraformSourceInfo(input)
+	require.NoError(t, err)
+	assert.Equal(t, "../..//modules/ec2-asg-service", source)
+	assert.True(t, updateWithCAS)
+}
+
+func TestReadTerraformSourceInfo_NoUpdateFlag(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`terraform {
+  source = "github.com/foo/bar//modules/vpc?ref=v1.0.0"
+}
+`)
+
+	source, updateWithCAS, err := cas.ReadTerraformSourceInfo(input)
+	require.NoError(t, err)
+	assert.Equal(t, "github.com/foo/bar//modules/vpc?ref=v1.0.0", source)
+	assert.False(t, updateWithCAS)
+}

--- a/internal/cas/integration_test.go
+++ b/internal/cas/integration_test.go
@@ -124,14 +124,14 @@ func TestIntegration_TreeStorage(t *testing.T) {
 		require.NotEmpty(t, results)
 		commitHash := results[0].Hash
 
-		// Verify the tree object is stored
-		store := cas.NewStore(storePath)
+		// Verify the tree object is stored in the trees namespace
+		treeStore := cas.NewStore(filepath.Join(storePath, "trees"))
 
 		require.NoError(t, err)
-		assert.False(t, store.NeedsWrite(commitHash), "Tree object should be stored")
+		assert.False(t, treeStore.NeedsWrite(commitHash), "Tree object should be stored")
 
 		// Verify we can read the tree content
-		content := cas.NewContent(store)
+		content := cas.NewContent(treeStore)
 		treeData, err := content.Read(commitHash)
 		require.NoError(t, err)
 

--- a/internal/cas/local.go
+++ b/internal/cas/local.go
@@ -34,7 +34,7 @@ func (c *CAS) StoreLocalDirectory(ctx context.Context, l log.Logger, sourceDir, 
 		return fmt.Errorf("failed to parse local tree: %w", err)
 	}
 
-	return LinkTree(ctx, c.store, tree, targetDir)
+	return LinkTree(ctx, c.blobStore, c.treeStore, tree, targetDir)
 }
 
 // hashDirectory creates a synthetic hash and tree structure for a local directory
@@ -95,10 +95,12 @@ func (c *CAS) hashDirectory(sourceDir string) (string, []byte, error) {
 // storeLocalContent stores all files from a local directory into the CAS
 func (c *CAS) storeLocalContent(l log.Logger, sourceDir, dirHash string, treeData []byte) error {
 	// First store the tree object itself
-	content := NewContent(c.store)
-	if err := content.Ensure(l, dirHash, treeData); err != nil {
+	treeContent := NewContent(c.treeStore)
+	if err := treeContent.Ensure(l, dirHash, treeData); err != nil {
 		return fmt.Errorf("failed to store tree data: %w", err)
 	}
+
+	blobContent := NewContent(c.blobStore)
 
 	// Walk the directory and store all files
 	return vfs.WalkDir(c.fs, sourceDir, func(path string, d fs.DirEntry, err error) error {
@@ -117,7 +119,7 @@ func (c *CAS) storeLocalContent(l log.Logger, sourceDir, dirHash string, treeDat
 			return fmt.Errorf("failed to hash file %s: %w", path, err)
 		}
 
-		if err := content.EnsureCopy(l, fileHash, path); err != nil {
+		if err := blobContent.EnsureCopy(l, fileHash, path); err != nil {
 			return fmt.Errorf("failed to store file %s: %w", path, err)
 		}
 

--- a/internal/cas/materialize_test.go
+++ b/internal/cas/materialize_test.go
@@ -41,7 +41,7 @@ func TestMaterializeTree_FromSynthStore(t *testing.T) {
 	require.NoError(t, synthContent.Store(nil, treeHash, treeData))
 
 	// Build a CAS instance using the same store paths
-	c, err := cas.New(cas.Options{StorePath: storeDir})
+	c, err := cas.New(cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	destDir := helpers.TmpDirWOSymlinks(t)
@@ -81,7 +81,7 @@ func TestMaterializeTree_FromGitTreeStore(t *testing.T) {
 	treeContent := cas.NewContent(treeStore)
 	require.NoError(t, treeContent.Store(nil, treeHash, treeData))
 
-	c, err := cas.New(cas.Options{StorePath: storeDir})
+	c, err := cas.New(cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	destDir := helpers.TmpDirWOSymlinks(t)
@@ -100,7 +100,7 @@ func TestMaterializeTree_NotFound(t *testing.T) {
 
 	storeDir := helpers.TmpDirWOSymlinks(t)
 
-	c, err := cas.New(cas.Options{StorePath: storeDir})
+	c, err := cas.New(cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	destDir := helpers.TmpDirWOSymlinks(t)
@@ -141,7 +141,7 @@ func TestMaterializeTree_SynthTakesPrecedence(t *testing.T) {
 	gitContent := cas.NewContent(treeStore)
 	require.NoError(t, gitContent.Store(nil, hash, []byte("100644 blob blobB\tfile.txt\n")))
 
-	c, err := cas.New(cas.Options{StorePath: storeDir})
+	c, err := cas.New(cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	destDir := helpers.TmpDirWOSymlinks(t)
@@ -201,7 +201,7 @@ func TestCASProtocolGetterGet(t *testing.T) {
 	synthContent := cas.NewContent(synthStore)
 	require.NoError(t, synthContent.Store(nil, treeHash, treeData))
 
-	c, err := cas.New(cas.Options{StorePath: storeDir})
+	c, err := cas.New(cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	l := logger.CreateLogger()
@@ -227,7 +227,7 @@ func TestCASProtocolGetterGet_InvalidRef(t *testing.T) {
 
 	storeDir := helpers.TmpDirWOSymlinks(t)
 
-	c, err := cas.New(cas.Options{StorePath: storeDir})
+	c, err := cas.New(cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	l := logger.CreateLogger()

--- a/internal/cas/materialize_test.go
+++ b/internal/cas/materialize_test.go
@@ -1,0 +1,244 @@
+package cas_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/hashicorp/go-getter/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaterializeTree_FromSynthStore(t *testing.T) {
+	t.Parallel()
+
+	storeDir := helpers.TmpDirWOSymlinks(t)
+
+	blobStore := cas.NewStore(filepath.Join(storeDir, "blobs"))
+	treeStore := cas.NewStore(filepath.Join(storeDir, "trees"))
+	synthStore := cas.NewStore(filepath.Join(storeDir, "synth", "trees"))
+
+	for _, s := range []*cas.Store{blobStore, treeStore, synthStore} {
+		require.NoError(t, os.MkdirAll(s.Path(), 0755))
+	}
+
+	// Store a blob in the blob store
+	blobData := []byte("hello world\n")
+	blobHash := "abc123"
+
+	blobContent := cas.NewContent(blobStore)
+	require.NoError(t, blobContent.Store(nil, blobHash, blobData))
+
+	// Store a synthetic tree that references the blob
+	treeData := []byte("100644 blob abc123\tREADME.md\n")
+	treeHash := "synth999"
+
+	synthContent := cas.NewContent(synthStore)
+	require.NoError(t, synthContent.Store(nil, treeHash, treeData))
+
+	// Build a CAS instance using the same store paths
+	c, err := cas.New(cas.Options{StorePath: storeDir})
+	require.NoError(t, err)
+
+	destDir := helpers.TmpDirWOSymlinks(t)
+	l := logger.CreateLogger()
+
+	err = c.MaterializeTree(t.Context(), l, treeHash, destDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(destDir, "README.md"))
+	require.NoError(t, err)
+	assert.Equal(t, blobData, content)
+}
+
+func TestMaterializeTree_FromGitTreeStore(t *testing.T) {
+	t.Parallel()
+
+	storeDir := helpers.TmpDirWOSymlinks(t)
+
+	blobStore := cas.NewStore(filepath.Join(storeDir, "blobs"))
+	treeStore := cas.NewStore(filepath.Join(storeDir, "trees"))
+	synthStore := cas.NewStore(filepath.Join(storeDir, "synth", "trees"))
+
+	for _, s := range []*cas.Store{blobStore, treeStore, synthStore} {
+		require.NoError(t, os.MkdirAll(s.Path(), 0755))
+	}
+
+	blobData := []byte("module content\n")
+	blobHash := "blob111"
+
+	blobContent := cas.NewContent(blobStore)
+	require.NoError(t, blobContent.Store(nil, blobHash, blobData))
+
+	// Store a tree in the git tree store (not synth)
+	treeData := []byte("100644 blob blob111\tmain.tf\n")
+	treeHash := "tree222"
+
+	treeContent := cas.NewContent(treeStore)
+	require.NoError(t, treeContent.Store(nil, treeHash, treeData))
+
+	c, err := cas.New(cas.Options{StorePath: storeDir})
+	require.NoError(t, err)
+
+	destDir := helpers.TmpDirWOSymlinks(t)
+	l := logger.CreateLogger()
+
+	err = c.MaterializeTree(t.Context(), l, treeHash, destDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(destDir, "main.tf"))
+	require.NoError(t, err)
+	assert.Equal(t, blobData, content)
+}
+
+func TestMaterializeTree_NotFound(t *testing.T) {
+	t.Parallel()
+
+	storeDir := helpers.TmpDirWOSymlinks(t)
+
+	c, err := cas.New(cas.Options{StorePath: storeDir})
+	require.NoError(t, err)
+
+	destDir := helpers.TmpDirWOSymlinks(t)
+	l := logger.CreateLogger()
+
+	err = c.MaterializeTree(t.Context(), l, "nonexistent", destDir)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, cas.ErrTreeNotFound)
+}
+
+func TestMaterializeTree_SynthTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	storeDir := helpers.TmpDirWOSymlinks(t)
+
+	blobStore := cas.NewStore(filepath.Join(storeDir, "blobs"))
+	treeStore := cas.NewStore(filepath.Join(storeDir, "trees"))
+	synthStore := cas.NewStore(filepath.Join(storeDir, "synth", "trees"))
+
+	for _, s := range []*cas.Store{blobStore, treeStore, synthStore} {
+		require.NoError(t, os.MkdirAll(s.Path(), 0755))
+	}
+
+	blobA := []byte("synth version\n")
+	blobB := []byte("git version\n")
+
+	blobContent := cas.NewContent(blobStore)
+	require.NoError(t, blobContent.Store(nil, "blobA", blobA))
+	require.NoError(t, blobContent.Store(nil, "blobB", blobB))
+
+	hash := "samehash"
+
+	// Store in synth store (references blobA)
+	synthContent := cas.NewContent(synthStore)
+	require.NoError(t, synthContent.Store(nil, hash, []byte("100644 blob blobA\tfile.txt\n")))
+
+	// Store in git tree store (references blobB)
+	gitContent := cas.NewContent(treeStore)
+	require.NoError(t, gitContent.Store(nil, hash, []byte("100644 blob blobB\tfile.txt\n")))
+
+	c, err := cas.New(cas.Options{StorePath: storeDir})
+	require.NoError(t, err)
+
+	destDir := helpers.TmpDirWOSymlinks(t)
+	l := logger.CreateLogger()
+
+	err = c.MaterializeTree(t.Context(), l, hash, destDir)
+	require.NoError(t, err)
+
+	// Synth store is checked first, so the synth version should win
+	content, err := os.ReadFile(filepath.Join(destDir, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, blobA, content)
+}
+
+func TestHashAlgorithmSum(t *testing.T) {
+	t.Parallel()
+
+	sha1Result := cas.HashSHA1.Sum([]byte("test"))
+	assert.Len(t, sha1Result, 40)
+
+	sha256Result := cas.HashSHA256.Sum([]byte("test"))
+	assert.Len(t, sha256Result, 64)
+
+	// Same input produces same output
+	assert.Equal(t, sha1Result, cas.HashSHA1.Sum([]byte("test")))
+	assert.Equal(t, sha256Result, cas.HashSHA256.Sum([]byte("test")))
+
+	// Different inputs produce different outputs
+	assert.NotEqual(t, sha1Result, cas.HashSHA1.Sum([]byte("other")))
+}
+
+func TestCASProtocolGetterGet(t *testing.T) {
+	t.Parallel()
+
+	storeDir := helpers.TmpDirWOSymlinks(t)
+
+	blobStore := cas.NewStore(filepath.Join(storeDir, "blobs"))
+	synthStore := cas.NewStore(filepath.Join(storeDir, "synth", "trees"))
+
+	for _, s := range []*cas.Store{
+		blobStore,
+		cas.NewStore(filepath.Join(storeDir, "trees")),
+		synthStore,
+	} {
+		require.NoError(t, os.MkdirAll(s.Path(), 0755))
+	}
+
+	fileContent := []byte("resource {}\n")
+	fileHash := "file123"
+
+	blobContent := cas.NewContent(blobStore)
+	require.NoError(t, blobContent.Store(nil, fileHash, fileContent))
+
+	treeHash := "tree456"
+	treeData := []byte("100644 blob file123\tmain.tf\n")
+
+	synthContent := cas.NewContent(synthStore)
+	require.NoError(t, synthContent.Store(nil, treeHash, treeData))
+
+	c, err := cas.New(cas.Options{StorePath: storeDir})
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+	g := cas.NewCASProtocolGetter(l, c)
+
+	destDir := helpers.TmpDirWOSymlinks(t)
+
+	req := &getter.Request{
+		Src: "sha1:" + treeHash,
+		Dst: destDir,
+	}
+
+	err = g.Get(t.Context(), req)
+	require.NoError(t, err)
+
+	result, err := os.ReadFile(filepath.Join(destDir, "main.tf"))
+	require.NoError(t, err)
+	assert.Equal(t, fileContent, result)
+}
+
+func TestCASProtocolGetterGet_InvalidRef(t *testing.T) {
+	t.Parallel()
+
+	storeDir := helpers.TmpDirWOSymlinks(t)
+
+	c, err := cas.New(cas.Options{StorePath: storeDir})
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+	g := cas.NewCASProtocolGetter(l, c)
+
+	req := &getter.Request{
+		Src: "badprefix:abc123",
+		Dst: t.TempDir(),
+	}
+
+	err = g.Get(t.Context(), req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, cas.ErrCASRefMissingPrefix)
+}

--- a/internal/cas/protocol_getter.go
+++ b/internal/cas/protocol_getter.go
@@ -1,0 +1,195 @@
+package cas
+
+import (
+	"context"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"net/url"
+	"strings"
+
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/hashicorp/go-getter/v2"
+)
+
+// Assert that CASProtocolGetter implements the Getter interface
+var _ getter.Getter = &CASProtocolGetter{}
+
+// CASProtocolPrefix is the go-getter prefix for CAS protocol references.
+const CASProtocolPrefix = "cas::"
+
+// HashAlgorithm identifies the hash algorithm used in a CAS reference.
+type HashAlgorithm string
+
+const (
+	// HashSHA1 is the SHA-1 hash algorithm (40 hex characters).
+	HashSHA1 HashAlgorithm = "sha1"
+	// HashSHA256 is the SHA-256 hash algorithm (64 hex characters).
+	HashSHA256 HashAlgorithm = "sha256"
+)
+
+// validAlgorithms are the hash algorithm prefixes accepted in CAS references.
+var validAlgorithms = []HashAlgorithm{HashSHA1, HashSHA256}
+
+// DetectHashAlgorithm detects the hash algorithm from a hex-encoded hash string.
+func DetectHashAlgorithm(hexHash string) HashAlgorithm {
+	const sha256HexLen = 64
+
+	if len(hexHash) >= sha256HexLen {
+		return HashSHA256
+	}
+
+	return HashSHA1
+}
+
+// NewHash returns a new hash.Hash for the algorithm.
+func (a HashAlgorithm) NewHash() hash.Hash {
+	if a == HashSHA256 {
+		return sha256.New()
+	}
+
+	return sha1.New()
+}
+
+// Sum hashes data and returns the hex-encoded digest.
+func (a HashAlgorithm) Sum(data []byte) string {
+	h := a.NewHash()
+	h.Write(data)
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// CASProtocolGetter is a go-getter Getter implementation that resolves cas::sha1:<hash> references
+// by materializing the referenced tree from the CAS store.
+type CASProtocolGetter struct {
+	CAS    *CAS
+	Logger log.Logger
+}
+
+// NewCASProtocolGetter creates a new CASProtocolGetter.
+func NewCASProtocolGetter(l log.Logger, cas *CAS) *CASProtocolGetter {
+	return &CASProtocolGetter{
+		CAS:    cas,
+		Logger: l,
+	}
+}
+
+func (g *CASProtocolGetter) Get(ctx context.Context, req *getter.Request) error {
+	hash, err := ParseCASRef(req.Src)
+	if err != nil {
+		return fmt.Errorf("failed to parse CAS reference %q: %w", req.Src, err)
+	}
+
+	return g.CAS.MaterializeTree(ctx, g.Logger, hash, req.Dst)
+}
+
+func (g *CASProtocolGetter) GetFile(_ context.Context, _ *getter.Request) error {
+	return ErrGetFileNotSupported
+}
+
+func (g *CASProtocolGetter) Mode(_ context.Context, _ *url.URL) (getter.Mode, error) {
+	return getter.ModeDir, nil
+}
+
+func (g *CASProtocolGetter) Detect(req *getter.Request) (bool, error) {
+	src := req.Src
+
+	if !strings.HasPrefix(src, CASProtocolPrefix) {
+		return false, nil
+	}
+
+	// Strip the cas:: prefix for further processing by go-getter.
+	// go-getter handles //subdir extraction from req.Src.
+	req.Src = strings.TrimPrefix(src, CASProtocolPrefix)
+	req.Forced = "cas"
+
+	return true, nil
+}
+
+// ParseCASRef extracts the hash and algorithm from a CAS reference string.
+// Expected format: "<algorithm>:<hash>" (after cas:: prefix has been stripped by Detect).
+// Accepted algorithms: "sha1", "sha256".
+func ParseCASRef(ref string) (string, error) {
+	for _, alg := range validAlgorithms {
+		prefix := string(alg) + ":"
+
+		after, ok := strings.CutPrefix(ref, prefix)
+		if !ok {
+			continue
+		}
+
+		if after == "" {
+			return "", &WrappedError{
+				Op:      "parse_cas_ref",
+				Context: ref,
+				Err:     ErrCASRefEmptyHash,
+			}
+		}
+
+		return after, nil
+	}
+
+	return "", &WrappedError{
+		Op:      "parse_cas_ref",
+		Context: ref,
+		Err:     ErrCASRefMissingPrefix,
+	}
+}
+
+// FormatCASRef formats a hash into a full CAS reference string, e.g. "cas::sha1:<hash>".
+// The algorithm is detected from the hash length.
+func FormatCASRef(hash string) string {
+	alg := DetectHashAlgorithm(hash)
+
+	return CASProtocolPrefix + string(alg) + ":" + hash
+}
+
+// FormatCASRefWithSubdir formats a hash and subdirectory into a CAS reference,
+// e.g. "cas::sha1:<hash>//subdir". The algorithm is detected from the hash length.
+func FormatCASRefWithSubdir(hash, subdir string) string {
+	return FormatCASRef(hash) + "//" + subdir
+}
+
+// MaterializeTree reads a tree from the CAS store and links its contents to the destination directory.
+// It tries the synth store first, then falls back to the git tree store.
+func (c *CAS) MaterializeTree(ctx context.Context, l log.Logger, hash string, dest string) error {
+	var treeData []byte
+
+	var treeStoreUsed *Store
+
+	// Try synth store first (synthetic trees from stack CAS processing).
+	synthContent := NewContent(c.synthStore)
+
+	data, err := synthContent.Read(hash)
+	if err == nil {
+		treeData = data
+		treeStoreUsed = c.synthStore
+	}
+
+	// Fall back to main tree store (git-derived trees).
+	if treeData == nil {
+		treeContent := NewContent(c.treeStore)
+
+		data, err = treeContent.Read(hash)
+		if err != nil {
+			return &WrappedError{
+				Op:   "materialize_tree",
+				Path: hash,
+				Err:  ErrTreeNotFound,
+			}
+		}
+
+		treeData = data
+		treeStoreUsed = c.treeStore
+	}
+
+	tree, err := git.ParseTree(treeData, dest)
+	if err != nil {
+		return fmt.Errorf("failed to parse CAS tree %s: %w", hash, err)
+	}
+
+	return LinkTree(ctx, c.blobStore, treeStoreUsed, tree, dest)
+}

--- a/internal/cas/protocol_getter.go
+++ b/internal/cas/protocol_getter.go
@@ -78,12 +78,16 @@ func NewCASProtocolGetter(l log.Logger, cas *CAS) *CASProtocolGetter {
 }
 
 func (g *CASProtocolGetter) Get(ctx context.Context, req *getter.Request) error {
-	hash, err := ParseCASRef(req.Src)
+	src := strings.TrimPrefix(req.Src, CASProtocolPrefix)
+
+	hash, err := ParseCASRef(src)
 	if err != nil {
 		return fmt.Errorf("failed to parse CAS reference %q: %w", req.Src, err)
 	}
 
-	return g.CAS.MaterializeTree(ctx, g.Logger, hash, req.Dst)
+	err = g.CAS.MaterializeTree(ctx, g.Logger, hash, req.Dst)
+
+	return err
 }
 
 func (g *CASProtocolGetter) GetFile(_ context.Context, _ *getter.Request) error {
@@ -97,16 +101,22 @@ func (g *CASProtocolGetter) Mode(_ context.Context, _ *url.URL) (getter.Mode, er
 func (g *CASProtocolGetter) Detect(req *getter.Request) (bool, error) {
 	src := req.Src
 
-	if !strings.HasPrefix(src, CASProtocolPrefix) {
+	if req.Forced == "cas" {
+		if _, err := ParseCASRef(src); err == nil {
+			return true, nil
+		}
+
 		return false, nil
 	}
 
-	// Strip the cas:: prefix for further processing by go-getter.
-	// go-getter handles //subdir extraction from req.Src.
-	req.Src = strings.TrimPrefix(src, CASProtocolPrefix)
-	req.Forced = "cas"
+	if strings.HasPrefix(src, CASProtocolPrefix) {
+		// Direct calls to Detect (tests) or sources that did not go through the wrapper.
+		req.Forced = "cas"
 
-	return true, nil
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // ParseCASRef extracts the hash and algorithm from a CAS reference string.

--- a/internal/cas/protocol_getter_test.go
+++ b/internal/cas/protocol_getter_test.go
@@ -1,0 +1,142 @@
+package cas_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/hashicorp/go-getter/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCASRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ref     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid sha1 ref",
+			ref:  "sha1:abc123def456",
+			want: "abc123def456",
+		},
+		{
+			name:    "missing sha1 prefix",
+			ref:     "abc123def456",
+			wantErr: true,
+		},
+		{
+			name:    "empty hash",
+			ref:     "sha1:",
+			wantErr: true,
+		},
+		{
+			name: "valid sha256 ref",
+			ref:  "sha256:abc123def456",
+			want: "abc123def456",
+		},
+		{
+			name:    "unknown algorithm",
+			ref:     "md5:abc123",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := cas.ParseCASRef(tt.ref)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFormatCASRef(t *testing.T) {
+	t.Parallel()
+
+	// Short hash → detected as SHA-1
+	assert.Equal(t, "cas::sha1:abc123", cas.FormatCASRef("abc123"))
+
+	// 40-char hash → SHA-1
+	sha1Hash := "f39ea0ebf891c9954c89d07b73b487ff938ef08b"
+	assert.Equal(t, "cas::sha1:"+sha1Hash, cas.FormatCASRef(sha1Hash))
+
+	// 64-char hash → SHA-256
+	sha256Hash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	assert.Equal(t, "cas::sha256:"+sha256Hash, cas.FormatCASRef(sha256Hash))
+}
+
+func TestFormatCASRefWithSubdir(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "cas::sha1:abc123//modules/vpc", cas.FormatCASRefWithSubdir("abc123", "modules/vpc"))
+}
+
+func TestDetectHashAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, cas.HashSHA1, cas.DetectHashAlgorithm("abc123"))
+	assert.Equal(t, cas.HashSHA1, cas.DetectHashAlgorithm("f39ea0ebf891c9954c89d07b73b487ff938ef08b"))
+
+	sha256Hash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	assert.Equal(t, cas.HashSHA256, cas.DetectHashAlgorithm(sha256Hash))
+}
+
+func TestCASProtocolGetterDetect(t *testing.T) {
+	t.Parallel()
+
+	g := &cas.CASProtocolGetter{}
+
+	tests := []struct {
+		name     string
+		src      string
+		detected bool
+	}{
+		{
+			name:     "cas protocol",
+			src:      "cas::sha1:abc123",
+			detected: true,
+		},
+		{
+			name:     "cas protocol with subdir",
+			src:      "cas::sha1:abc123//modules/vpc",
+			detected: true,
+		},
+		{
+			name:     "git URL",
+			src:      "git::https://github.com/foo/bar.git",
+			detected: false,
+		},
+		{
+			name:     "local path",
+			src:      "../modules/vpc",
+			detected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := &getter.Request{Src: tt.src}
+			detected, err := g.Detect(req)
+			require.NoError(t, err)
+			assert.Equal(t, tt.detected, detected)
+
+			if detected {
+				assert.Equal(t, "cas", req.Forced)
+			}
+		})
+	}
+}

--- a/internal/cas/protocol_getter_test.go
+++ b/internal/cas/protocol_getter_test.go
@@ -101,6 +101,7 @@ func TestCASProtocolGetterDetect(t *testing.T) {
 	tests := []struct {
 		name     string
 		src      string
+		forced   string
 		detected bool
 	}{
 		{
@@ -112,6 +113,18 @@ func TestCASProtocolGetterDetect(t *testing.T) {
 			name:     "cas protocol with subdir",
 			src:      "cas::sha1:abc123//modules/vpc",
 			detected: true,
+		},
+		{
+			name:     "go-getter strips cas:: before Detect",
+			src:      "sha1:f39ea0ebf891c9954c89d07b73b487ff938ef08b",
+			forced:   "cas",
+			detected: true,
+		},
+		{
+			name:     "forced cas with invalid ref",
+			src:      "bogus:xyz",
+			forced:   "cas",
+			detected: false,
 		},
 		{
 			name:     "git URL",
@@ -129,7 +142,7 @@ func TestCASProtocolGetterDetect(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			req := &getter.Request{Src: tt.src}
+			req := &getter.Request{Src: tt.src, Forced: tt.forced}
 			detected, err := g.Detect(req)
 			require.NoError(t, err)
 			assert.Equal(t, tt.detected, detected)

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-getter/v2"
 )
@@ -107,7 +108,7 @@ func (c *CAS) ProcessStackComponent(ctx context.Context, l log.Logger, source, k
 
 // detectRepoHashAlgorithm queries the git object format of a cloned repository.
 func detectRepoHashAlgorithm(ctx context.Context, repoDir string) (HashAlgorithm, error) {
-	g, err := git.NewGitRunner()
+	g, err := git.NewGitRunner(vexec.NewOSExec())
 	if err != nil {
 		return "", fmt.Errorf("failed to create git runner: %w", err)
 	}

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -1,0 +1,336 @@
+package cas
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/hashicorp/go-getter/v2"
+)
+
+// StackCASResult holds the results of CAS processing for a stack component.
+type StackCASResult struct {
+	// Cleanup removes the temporary directory when called.
+	Cleanup func()
+	// ContentDir is the path to the directory containing rewritten content to copy.
+	ContentDir string
+}
+
+// ProcessStackComponent clones a remote source via CAS, resolves update_source_with_cas
+// references, rewrites sources to CAS references, and creates synthetic CAS entries.
+//
+// The source should be a remote URL with an optional //subdir and ?ref= query.
+// The kind should be "unit" or "stack".
+func (c *CAS) ProcessStackComponent(ctx context.Context, l log.Logger, source, kind string) (*StackCASResult, error) {
+	repoURL, subdir := getter.SourceDirSubdir(source)
+
+	parsedURL, err := url.Parse(repoURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse source URL %q: %w", repoURL, err)
+	}
+
+	ref := parsedURL.Query().Get("ref")
+
+	// Remove ref from query so we can clone
+	q := parsedURL.Query()
+	q.Del("ref")
+	parsedURL.RawQuery = q.Encode()
+
+	cleanURL := strings.TrimPrefix(parsedURL.String(), "git::")
+
+	// Resolve ref to commit hash
+	refHash, err := c.resolveReference(ctx, cleanURL, ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve reference %q: %w", ref, err)
+	}
+
+	// Create temp dir for the clone
+	tempDir, err := os.MkdirTemp("", "terragrunt-cas-stack-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+
+	cleanup := func() {
+		_ = os.RemoveAll(tempDir)
+	}
+
+	cloneDir := filepath.Join(tempDir, "repo")
+
+	// Clone the full repo via CAS
+	if err := c.Clone(ctx, l, &CloneOptions{
+		Dir:    cloneDir,
+		Branch: ref,
+	}, cleanURL); err != nil {
+		cleanup()
+
+		return nil, fmt.Errorf("failed to CAS clone %q: %w", cleanURL, err)
+	}
+
+	// Detect the repository's hash algorithm from the cloned content.
+	hashAlg, err := detectRepoHashAlgorithm(ctx, cloneDir)
+	if err != nil {
+		l.Debugf("Failed to detect object format, defaulting to SHA-1: %v", err)
+
+		hashAlg = HashSHA1
+	}
+
+	// Navigate to the subdir within the cloned repo
+	contentDir := cloneDir
+	if subdir != "" {
+		contentDir = filepath.Join(cloneDir, subdir)
+	}
+
+	if _, err := os.Stat(contentDir); err != nil {
+		cleanup()
+
+		return nil, fmt.Errorf("subdir %q not found in cloned repo: %w", subdir, err)
+	}
+
+	// Process the directory: rewrite sources, create synthetic CAS entries
+	if err := c.processDirectory(ctx, l, cloneDir, contentDir, refHash, hashAlg); err != nil {
+		cleanup()
+
+		return nil, fmt.Errorf("failed to process directory for CAS: %w", err)
+	}
+
+	return &StackCASResult{
+		ContentDir: contentDir,
+		Cleanup:    cleanup,
+	}, nil
+}
+
+// detectRepoHashAlgorithm queries the git object format of a cloned repository.
+func detectRepoHashAlgorithm(ctx context.Context, repoDir string) (HashAlgorithm, error) {
+	g, err := git.NewGitRunner()
+	if err != nil {
+		return "", fmt.Errorf("failed to create git runner: %w", err)
+	}
+
+	g.WorkDir = repoDir
+
+	format, err := g.ObjectFormat(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return HashAlgorithm(format), nil
+}
+
+// processDirectory recursively processes a stack or unit directory,
+// rewriting sources and creating synthetic CAS entries.
+func (c *CAS) processDirectory(
+	ctx context.Context, l log.Logger,
+	repoRoot, dirPath, refHash string, hashAlg HashAlgorithm,
+) error {
+	stackFile := filepath.Join(dirPath, "terragrunt.stack.hcl")
+	unitFile := filepath.Join(dirPath, "terragrunt.hcl")
+
+	if _, err := os.Stat(stackFile); err == nil {
+		return c.processStackFile(ctx, l, repoRoot, dirPath, stackFile, refHash, hashAlg)
+	}
+
+	if _, err := os.Stat(unitFile); err == nil {
+		return c.processUnitFile(l, repoRoot, dirPath, unitFile, refHash)
+	}
+
+	return nil
+}
+
+// processStackFile processes a terragrunt.stack.hcl file, rewriting sources for blocks
+// that have update_source_with_cas = true.
+func (c *CAS) processStackFile(
+	ctx context.Context, l log.Logger,
+	repoRoot, dirPath, stackFile, refHash string, hashAlg HashAlgorithm,
+) error {
+	content, err := os.ReadFile(stackFile)
+	if err != nil {
+		return fmt.Errorf("failed to read stack file %s: %w", stackFile, err)
+	}
+
+	blocks, err := ReadStackBlocks(content)
+	if err != nil {
+		return fmt.Errorf("failed to parse stack file %s: %w", stackFile, err)
+	}
+
+	for _, block := range blocks {
+		if !block.UpdateSourceWithCAS {
+			continue
+		}
+
+		l.Debugf("Processing CAS source rewrite for %s %q with source %q", block.BlockType, block.Name, block.Source)
+
+		// Resolve the relative source path
+		sourcePath, sourceSubdir := SplitSourceDoubleSlash(block.Source)
+		resolvedPath := filepath.Clean(filepath.Join(dirPath, sourcePath))
+
+		// Recursively process the resolved directory
+		targetDir := resolvedPath
+		if sourceSubdir != "" {
+			targetDir = filepath.Join(resolvedPath, sourceSubdir)
+		}
+
+		if err := c.processDirectory(ctx, l, repoRoot, targetDir, refHash, hashAlg); err != nil {
+			return fmt.Errorf("failed to process %s %q source: %w", block.BlockType, block.Name, err)
+		}
+
+		// Build a synthetic tree for the target directory
+		synthHash, err := c.buildSyntheticTree(l, targetDir, refHash, repoRoot, hashAlg)
+		if err != nil {
+			return fmt.Errorf("failed to build synthetic tree for %s %q: %w", block.BlockType, block.Name, err)
+		}
+
+		// Rewrite the source in the stack file
+		newSource := FormatCASRef(synthHash)
+
+		content, err = RewriteStackBlockSource(content, block.BlockType, block.Name, newSource)
+		if err != nil {
+			return fmt.Errorf("failed to rewrite source for %s %q: %w", block.BlockType, block.Name, err)
+		}
+
+		l.Debugf("Rewrote %s %q source to %s", block.BlockType, block.Name, newSource)
+	}
+
+	// Write the rewritten stack file back
+	return os.WriteFile(stackFile, content, RegularFilePerms)
+}
+
+// processUnitFile processes a terragrunt.hcl file, rewriting the terraform.source
+// if update_source_with_cas is set.
+func (c *CAS) processUnitFile(l log.Logger, repoRoot, dirPath, unitFile, refHash string) error {
+	content, err := os.ReadFile(unitFile)
+	if err != nil {
+		return fmt.Errorf("failed to read unit file %s: %w", unitFile, err)
+	}
+
+	source, updateWithCAS, err := ReadTerraformSourceInfo(content)
+	if err != nil {
+		return fmt.Errorf("failed to parse unit file %s: %w", unitFile, err)
+	}
+
+	if !updateWithCAS || source == "" {
+		return nil
+	}
+
+	l.Debugf("Processing CAS source rewrite for terraform source %q in %s", source, unitFile)
+
+	// For unit files, the source is a relative path within the repo.
+	// The refHash points to the full repo tree.
+	// We rewrite to: cas::sha1:<refHash>//<subdir>
+	_, sourceSubdir := SplitSourceDoubleSlash(source)
+
+	var newSource string
+
+	if sourceSubdir != "" {
+		newSource = FormatCASRefWithSubdir(refHash, sourceSubdir)
+	} else {
+		// No // separator — the entire source path becomes the subdir
+		// relative to the repo root
+		relPath, err := filepath.Rel(repoRoot, filepath.Clean(filepath.Join(dirPath, source)))
+		if err != nil {
+			return fmt.Errorf("failed to compute relative path: %w", err)
+		}
+
+		newSource = FormatCASRefWithSubdir(refHash, relPath)
+	}
+
+	content, err = RewriteTerraformSource(content, newSource)
+	if err != nil {
+		return fmt.Errorf("failed to rewrite terraform source: %w", err)
+	}
+
+	l.Debugf("Rewrote terraform source to %s", newSource)
+
+	return os.WriteFile(unitFile, content, RegularFilePerms)
+}
+
+// buildSyntheticTree creates a synthetic CAS tree entry for a directory.
+// It hashes all files, stores blobs, and creates a tree entry in the synth store.
+// The tree hash is deterministic: SHA1(refHash + relPathInRepo).
+func (c *CAS) buildSyntheticTree(
+	l log.Logger, dirPath, refHash, repoRoot string, hashAlg HashAlgorithm,
+) (string, error) {
+	var treeData []byte
+
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(dirPath, path)
+		if err != nil {
+			return err
+		}
+
+		// Convert to forward slashes for consistency (git-style paths)
+		relPath = strings.ReplaceAll(relPath, string(filepath.Separator), "/")
+
+		fileHash, err := hashFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to hash file %s: %w", path, err)
+		}
+
+		// Store the blob
+		blobContent := NewContent(c.blobStore)
+		if err := blobContent.EnsureCopy(l, fileHash, path); err != nil {
+			return fmt.Errorf("failed to store blob %s: %w", path, err)
+		}
+
+		mode := fmt.Sprintf("%06o", info.Mode().Perm())
+		treeLine := fmt.Sprintf("%s blob %s\t%s\n", mode, fileHash, relPath)
+		treeData = append(treeData, []byte(treeLine)...)
+
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Compute deterministic hash: SHA1(refHash + relPathInRepo)
+	relPathInRepo, err := filepath.Rel(repoRoot, dirPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to compute relative path for deterministic hash: %w", err)
+	}
+
+	relPathInRepo = strings.ReplaceAll(relPathInRepo, string(filepath.Separator), "/")
+
+	treeHash := hashAlg.Sum([]byte(refHash + relPathInRepo))
+
+	// Store in synth tree store
+	synthContent := NewContent(c.synthStore)
+	if err := synthContent.Ensure(l, treeHash, treeData); err != nil {
+		return "", fmt.Errorf("failed to store synthetic tree: %w", err)
+	}
+
+	return treeHash, nil
+}
+
+// DeterministicTreeHash generates a deterministic hash for a synthetic tree entry
+// by combining the resolved git ref hash with the path within the repository.
+// The hash algorithm is detected from the refHash length to match the repository's object format.
+func DeterministicTreeHash(refHash, pathInRepo string) string {
+	alg := DetectHashAlgorithm(refHash)
+
+	return alg.Sum([]byte(refHash + pathInRepo))
+}
+
+// SplitSourceDoubleSlash splits a source string at the // separator.
+// Returns the base path and the subdirectory (if any).
+// Example: "../..//modules/ec2" -> ("../../", "modules/ec2")
+// Example: "../../modules/ec2"  -> ("../../modules/ec2", "")
+func SplitSourceDoubleSlash(source string) (basePath, subdir string) {
+	idx := strings.Index(source, "//")
+	if idx == -1 {
+		return source, ""
+	}
+
+	return source[:idx], source[idx+2:]
+}

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -61,10 +61,11 @@ func (c *CAS) ProcessStackComponent(ctx context.Context, l log.Logger, source, k
 
 	cloneDir := filepath.Join(tempDir, "repo")
 
-	// Clone the full repo via CAS
+	// Clone the repo via CAS
 	if err := c.Clone(ctx, l, &CloneOptions{
 		Dir:    cloneDir,
 		Branch: ref,
+		Depth:  c.cloneDepth,
 	}, cleanURL); err != nil {
 		cleanup()
 
@@ -195,7 +196,13 @@ func (c *CAS) processStackFile(
 		l.Debugf("Rewrote %s %q source to %s", block.BlockType, block.Name, newSource)
 	}
 
-	// Write the rewritten stack file back
+	// The file may be a read-only hard link from the CAS store, so remove it
+	// before writing the rewritten content to avoid permission errors and to
+	// avoid mutating the stored blob.
+	if err := os.Remove(stackFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove stack file before rewrite %s: %w", stackFile, err)
+	}
+
 	return os.WriteFile(stackFile, content, RegularFilePerms)
 }
 
@@ -244,6 +251,13 @@ func (c *CAS) processUnitFile(l log.Logger, repoRoot, dirPath, unitFile, refHash
 	}
 
 	l.Debugf("Rewrote terraform source to %s", newSource)
+
+	// The file may be a read-only hard link from the CAS store, so remove it
+	// before writing the rewritten content to avoid permission errors and to
+	// avoid mutating the stored blob.
+	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove unit file before rewrite %s: %w", unitFile, err)
+	}
 
 	return os.WriteFile(unitFile, content, RegularFilePerms)
 }

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -136,7 +136,7 @@ func (c *CAS) processDirectory(
 	}
 
 	if _, err := os.Stat(unitFile); err == nil {
-		return c.processUnitFile(l, repoRoot, dirPath, unitFile, refHash)
+		return c.processUnitFile(l, repoRoot, dirPath, unitFile, refHash, hashAlg)
 	}
 
 	return nil
@@ -208,7 +208,7 @@ func (c *CAS) processStackFile(
 
 // processUnitFile processes a terragrunt.hcl file, rewriting the terraform.source
 // if update_source_with_cas is set.
-func (c *CAS) processUnitFile(l log.Logger, repoRoot, dirPath, unitFile, refHash string) error {
+func (c *CAS) processUnitFile(l log.Logger, repoRoot, dirPath, unitFile, refHash string, hashAlg HashAlgorithm) error {
 	content, err := os.ReadFile(unitFile)
 	if err != nil {
 		return fmt.Errorf("failed to read unit file %s: %w", unitFile, err)
@@ -225,25 +225,21 @@ func (c *CAS) processUnitFile(l log.Logger, repoRoot, dirPath, unitFile, refHash
 
 	l.Debugf("Processing CAS source rewrite for terraform source %q in %s", source, unitFile)
 
-	// For unit files, the source is a relative path within the repo.
-	// The refHash points to the full repo tree.
-	// We rewrite to: cas::sha1:<refHash>//<subdir>
-	_, sourceSubdir := SplitSourceDoubleSlash(source)
+	// Resolve the terraform module directory (same pattern as stack blocks).
+	sourcePath, sourceSubdir := SplitSourceDoubleSlash(source)
+	resolvedPath := filepath.Clean(filepath.Join(dirPath, sourcePath))
 
-	var newSource string
-
+	moduleDir := resolvedPath
 	if sourceSubdir != "" {
-		newSource = FormatCASRefWithSubdir(refHash, sourceSubdir)
-	} else {
-		// No // separator — the entire source path becomes the subdir
-		// relative to the repo root
-		relPath, err := filepath.Rel(repoRoot, filepath.Clean(filepath.Join(dirPath, source)))
-		if err != nil {
-			return fmt.Errorf("failed to compute relative path: %w", err)
-		}
-
-		newSource = FormatCASRefWithSubdir(refHash, relPath)
+		moduleDir = filepath.Join(resolvedPath, sourceSubdir)
 	}
+
+	synthHash, err := c.buildSyntheticTree(l, moduleDir, refHash, repoRoot, hashAlg)
+	if err != nil {
+		return fmt.Errorf("failed to build synthetic tree for terraform source %q: %w", source, err)
+	}
+
+	newSource := FormatCASRef(synthHash)
 
 	content, err = RewriteTerraformSource(content, newSource)
 	if err != nil {

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -165,14 +165,9 @@ func (c *CAS) processStackFile(
 
 		l.Debugf("Processing CAS source rewrite for %s %q with source %q", block.BlockType, block.Name, block.Source)
 
-		// Resolve the relative source path
-		sourcePath, sourceSubdir := SplitSourceDoubleSlash(block.Source)
-		resolvedPath := filepath.Clean(filepath.Join(dirPath, sourcePath))
-
-		// Recursively process the resolved directory
-		targetDir := resolvedPath
-		if sourceSubdir != "" {
-			targetDir = filepath.Join(resolvedPath, sourceSubdir)
+		targetDir, err := ResolveInRepoSource(repoRoot, dirPath, block.Source)
+		if err != nil {
+			return fmt.Errorf("failed to resolve source for %s %q: %w", block.BlockType, block.Name, err)
 		}
 
 		if err := c.processDirectory(ctx, l, repoRoot, targetDir, refHash, hashAlg); err != nil {
@@ -225,13 +220,9 @@ func (c *CAS) processUnitFile(l log.Logger, repoRoot, dirPath, unitFile, refHash
 
 	l.Debugf("Processing CAS source rewrite for terraform source %q in %s", source, unitFile)
 
-	// Resolve the terraform module directory (same pattern as stack blocks).
-	sourcePath, sourceSubdir := SplitSourceDoubleSlash(source)
-	resolvedPath := filepath.Clean(filepath.Join(dirPath, sourcePath))
-
-	moduleDir := resolvedPath
-	if sourceSubdir != "" {
-		moduleDir = filepath.Join(resolvedPath, sourceSubdir)
+	moduleDir, err := ResolveInRepoSource(repoRoot, dirPath, source)
+	if err != nil {
+		return fmt.Errorf("failed to resolve terraform source %q: %w", source, err)
 	}
 
 	synthHash, err := c.buildSyntheticTree(l, moduleDir, refHash, repoRoot, hashAlg)
@@ -294,7 +285,7 @@ func (c *CAS) buildSyntheticTree(
 			return fmt.Errorf("failed to store blob %s: %w", path, err)
 		}
 
-		mode := fmt.Sprintf("%06o", info.Mode().Perm())
+		mode := gitTreeMode(info.Mode())
 		treeLine := fmt.Sprintf("%s blob %s\t%s\n", mode, fileHash, relPath)
 		treeData = append(treeData, []byte(treeLine)...)
 
@@ -321,6 +312,43 @@ func (c *CAS) buildSyntheticTree(
 	}
 
 	return treeHash, nil
+}
+
+// ResolveInRepoSource resolves an update_source_with_cas source string relative to
+// dirPath and returns the cleaned absolute path. Absolute sources and sources
+// whose resolved path escapes repoRoot via ".." segments are rejected so CAS
+// materialization stays scoped to the cloned repository.
+func ResolveInRepoSource(repoRoot, dirPath, source string) (string, error) {
+	sourcePath, sourceSubdir := SplitSourceDoubleSlash(source)
+	if filepath.IsAbs(sourcePath) {
+		return "", fmt.Errorf("%w: %q", ErrAbsoluteSource, source)
+	}
+
+	resolved := filepath.Clean(filepath.Join(dirPath, sourcePath))
+	if sourceSubdir != "" {
+		resolved = filepath.Join(resolved, sourceSubdir)
+	}
+
+	rel, err := filepath.Rel(filepath.Clean(repoRoot), resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %q", ErrSourceEscapesRepo, source)
+	}
+
+	return resolved, nil
+}
+
+// gitTreeMode returns the git tree-entry mode string for a file with the given
+// filesystem mode. Directories are handled by the caller, so only the regular
+// file, executable, and symlink cases are covered here.
+func gitTreeMode(mode os.FileMode) string {
+	switch {
+	case mode&os.ModeSymlink != 0:
+		return "120000"
+	case mode&0o111 != 0:
+		return "100755"
+	default:
+		return "100644"
+	}
 }
 
 // DeterministicTreeHash generates a deterministic hash for a synthetic tree entry

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -273,7 +273,7 @@ func (c *CAS) buildSyntheticTree(
 		// Convert to forward slashes for consistency (git-style paths)
 		relPath = strings.ReplaceAll(relPath, string(filepath.Separator), "/")
 
-		fileHash, err := hashFile(path)
+		fileHash, err := hashFile(c.fs, path)
 		if err != nil {
 			return fmt.Errorf("failed to hash file %s: %w", path, err)
 		}

--- a/internal/cas/stacks_test.go
+++ b/internal/cas/stacks_test.go
@@ -1,0 +1,76 @@
+package cas_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitSourceDoubleSlash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		source     string
+		wantBase   string
+		wantSubdir string
+	}{
+		{
+			name:       "with double slash",
+			source:     "../..//modules/ec2-asg-service",
+			wantBase:   "../..",
+			wantSubdir: "modules/ec2-asg-service",
+		},
+		{
+			name:       "without double slash",
+			source:     "../../modules/ec2-asg-service",
+			wantBase:   "../../modules/ec2-asg-service",
+			wantSubdir: "",
+		},
+		{
+			name:       "double slash at start",
+			source:     "//modules/vpc",
+			wantBase:   "",
+			wantSubdir: "modules/vpc",
+		},
+		{
+			name:       "only path",
+			source:     "../units/service",
+			wantBase:   "../units/service",
+			wantSubdir: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			base, subdir := cas.SplitSourceDoubleSlash(tt.source)
+			assert.Equal(t, tt.wantBase, base)
+			assert.Equal(t, tt.wantSubdir, subdir)
+		})
+	}
+}
+
+func TestDeterministicTreeHash(t *testing.T) {
+	t.Parallel()
+
+	// SHA-1 length refHash (40 chars) → produces SHA-1 output (40 chars)
+	sha1Ref := "f39ea0ebf891c9954c89d07b73b487ff938ef08b"
+	hash1 := cas.DeterministicTreeHash(sha1Ref, "stacks/ec2-asg-stateful-service")
+	hash2 := cas.DeterministicTreeHash(sha1Ref, "stacks/ec2-asg-stateful-service")
+	assert.Equal(t, hash1, hash2, "same inputs must produce the same hash")
+	assert.Len(t, hash1, 40, "SHA-1 refHash should produce 40-char output")
+
+	hash3 := cas.DeterministicTreeHash(sha1Ref, "stacks/different")
+	assert.NotEqual(t, hash1, hash3)
+
+	hash4 := cas.DeterministicTreeHash("0000000000000000000000000000000000000000", "stacks/ec2-asg-stateful-service")
+	assert.NotEqual(t, hash1, hash4)
+
+	// SHA-256 length refHash (64 chars) → produces SHA-256 output (64 chars)
+	sha256Ref := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	hash5 := cas.DeterministicTreeHash(sha256Ref, "stacks/ec2-asg-stateful-service")
+	assert.Len(t, hash5, 64, "SHA-256 refHash should produce 64-char output")
+}

--- a/internal/cas/stacks_test.go
+++ b/internal/cas/stacks_test.go
@@ -96,6 +96,7 @@ func TestProcessStackComponent_RewritesStackSources(t *testing.T) {
 
 	result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
 	require.NoError(t, err)
+
 	defer result.Cleanup()
 
 	// The content dir should contain the rewritten terragrunt.stack.hcl
@@ -130,6 +131,7 @@ func TestProcessStackComponent_RewritesUnitSources(t *testing.T) {
 
 	result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
 	require.NoError(t, err)
+
 	defer result.Cleanup()
 
 	// The unit that was recursively processed should have its terraform.source rewritten.
@@ -148,9 +150,14 @@ func TestProcessStackComponent_RewritesUnitSources(t *testing.T) {
 
 	contentStr := string(content)
 
-	// The terraform source should be rewritten to a CAS ref with the modules/vpc subdir.
 	assert.Contains(t, contentStr, "cas::", "unit terraform source should be rewritten to CAS ref")
-	assert.Contains(t, contentStr, "modules/vpc", "CAS ref should include the module subdir")
+	assert.Contains(t, contentStr, "sha1:", "CAS ref should name the hash algorithm")
+	assert.NotContains(
+		t,
+		contentStr,
+		"modules/vpc",
+		"module path should not appear in the cas:: URL when using a synthetic tree",
+	)
 }
 
 func TestProcessStackComponent_CreatesSyntheticTrees(t *testing.T) {
@@ -168,6 +175,7 @@ func TestProcessStackComponent_CreatesSyntheticTrees(t *testing.T) {
 
 	result, err := c.ProcessStackComponent(ctx, l, source, "stack")
 	require.NoError(t, err)
+
 	defer result.Cleanup()
 
 	// Read the rewritten stack file to extract the CAS ref for the "service" unit.
@@ -179,6 +187,7 @@ func TestProcessStackComponent_CreatesSyntheticTrees(t *testing.T) {
 	require.NoError(t, err)
 
 	var serviceSource string
+
 	for _, b := range blocks {
 		if b.Name == "service" {
 			serviceSource = b.Source
@@ -221,6 +230,7 @@ func TestProcessStackComponent_DeterministicOutput(t *testing.T) {
 
 		result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
 		require.NoError(t, err)
+
 		defer result.Cleanup()
 
 		content, err := os.ReadFile(filepath.Join(result.ContentDir, "terragrunt.stack.hcl"))
@@ -253,6 +263,7 @@ func TestProcessStackComponent_MaterializeSynthTree(t *testing.T) {
 
 	result, err := c.ProcessStackComponent(ctx, l, source, "stack")
 	require.NoError(t, err)
+
 	defer result.Cleanup()
 
 	// Extract the CAS hash from the rewritten stack file
@@ -263,6 +274,7 @@ func TestProcessStackComponent_MaterializeSynthTree(t *testing.T) {
 	require.NoError(t, err)
 
 	var serviceSource string
+
 	for _, b := range blocks {
 		if b.Name == "service" {
 			serviceSource = b.Source
@@ -333,6 +345,7 @@ func TestProcessStackComponent_BlobsStoredInCAS(t *testing.T) {
 
 	result, err := c.ProcessStackComponent(ctx, l, source, "stack")
 	require.NoError(t, err)
+
 	defer result.Cleanup()
 
 	// Verify that the blob store has content after processing.

--- a/internal/cas/stacks_test.go
+++ b/internal/cas/stacks_test.go
@@ -59,6 +59,67 @@ func TestSplitSourceDoubleSlash(t *testing.T) {
 	}
 }
 
+func TestResolveInRepoSource(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Join(string(filepath.Separator), "tmp", "repo")
+	dirPath := filepath.Join(repoRoot, "stacks", "app")
+
+	tests := []struct {
+		wantErr error
+		name    string
+		source  string
+		want    string
+	}{
+		{
+			name:   "sibling path within repo",
+			source: "../../units/service",
+			want:   filepath.Join(repoRoot, "units", "service"),
+		},
+		{
+			name:   "double-slash subdir within repo",
+			source: "../..//modules/ec2",
+			want:   filepath.Join(repoRoot, "modules", "ec2"),
+		},
+		{
+			name:   "nested path within dirPath",
+			source: "child",
+			want:   filepath.Join(dirPath, "child"),
+		},
+		{
+			name:    "absolute source rejected",
+			source:  filepath.Join(string(filepath.Separator), "etc", "passwd"),
+			wantErr: cas.ErrAbsoluteSource,
+		},
+		{
+			name:    "parent escape rejected",
+			source:  "../../../../etc",
+			wantErr: cas.ErrSourceEscapesRepo,
+		},
+		{
+			name:    "escape via double-slash subdir",
+			source:  "..//../../../etc",
+			wantErr: cas.ErrSourceEscapesRepo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := cas.ResolveInRepoSource(repoRoot, dirPath, tt.source)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestDeterministicTreeHash(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cas/stacks_test.go
+++ b/internal/cas/stacks_test.go
@@ -1,10 +1,16 @@
 package cas_test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSplitSourceDoubleSlash(t *testing.T) {
@@ -73,4 +79,274 @@ func TestDeterministicTreeHash(t *testing.T) {
 	sha256Ref := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	hash5 := cas.DeterministicTreeHash(sha256Ref, "stacks/ec2-asg-stateful-service")
 	assert.Len(t, hash5, 64, "SHA-256 refHash should produce 64-char output")
+}
+
+func TestProcessStackComponent_RewritesStackSources(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	// Source mimics what a stack generates: <repo-url>//<subdir>?ref=<branch>
+	source := repoURL + "//stacks/my-stack?ref=main"
+
+	result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.NoError(t, err)
+	defer result.Cleanup()
+
+	// The content dir should contain the rewritten terragrunt.stack.hcl
+	stackFile := filepath.Join(result.ContentDir, "terragrunt.stack.hcl")
+	require.FileExists(t, stackFile)
+
+	content, err := os.ReadFile(stackFile)
+	require.NoError(t, err)
+
+	contentStr := string(content)
+
+	// The "service" unit had update_source_with_cas = true, so its source should
+	// be rewritten to a cas:: reference.
+	assert.Contains(t, contentStr, "cas::", "service unit source should be rewritten to CAS ref")
+	assert.Contains(t, contentStr, "update_source_with_cas", "flag should be preserved")
+
+	// The "plain" unit had no update_source_with_cas, so its source must remain unchanged.
+	assert.Contains(t, contentStr, `"../../units/plain-service"`, "plain unit source should be unchanged")
+}
+
+func TestProcessStackComponent_RewritesUnitSources(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	source := repoURL + "//stacks/my-stack?ref=main"
+
+	result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.NoError(t, err)
+	defer result.Cleanup()
+
+	// The unit that was recursively processed should have its terraform.source rewritten.
+	// ProcessStackComponent processes stacks/my-stack, which references units/my-service.
+	// The processDirectory call should reach units/my-service/terragrunt.hcl and rewrite it.
+
+	// First, resolve the path to the cloned unit file.
+	// The contentDir is <tempDir>/repo/stacks/my-stack, and the unit is at
+	// <tempDir>/repo/units/my-service/terragrunt.hcl relative to repo root.
+	repoRoot := filepath.Dir(filepath.Dir(result.ContentDir))
+	unitFile := filepath.Join(repoRoot, "units", "my-service", "terragrunt.hcl")
+	require.FileExists(t, unitFile)
+
+	content, err := os.ReadFile(unitFile)
+	require.NoError(t, err)
+
+	contentStr := string(content)
+
+	// The terraform source should be rewritten to a CAS ref with the modules/vpc subdir.
+	assert.Contains(t, contentStr, "cas::", "unit terraform source should be rewritten to CAS ref")
+	assert.Contains(t, contentStr, "modules/vpc", "CAS ref should include the module subdir")
+}
+
+func TestProcessStackComponent_CreatesSyntheticTrees(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	source := repoURL + "//stacks/my-stack?ref=main"
+
+	result, err := c.ProcessStackComponent(ctx, l, source, "stack")
+	require.NoError(t, err)
+	defer result.Cleanup()
+
+	// Read the rewritten stack file to extract the CAS ref for the "service" unit.
+	stackFile := filepath.Join(result.ContentDir, "terragrunt.stack.hcl")
+	content, err := os.ReadFile(stackFile)
+	require.NoError(t, err)
+
+	blocks, err := cas.ReadStackBlocks(content)
+	require.NoError(t, err)
+
+	var serviceSource string
+	for _, b := range blocks {
+		if b.Name == "service" {
+			serviceSource = b.Source
+
+			break
+		}
+	}
+
+	require.NotEmpty(t, serviceSource, "should find service block in rewritten stack file")
+	assert.True(t, strings.HasPrefix(serviceSource, "cas::"), "source should start with cas:: prefix")
+
+	// Parse the CAS ref to get the hash
+	trimmed := strings.TrimPrefix(serviceSource, "cas::")
+	hash, err := cas.ParseCASRef(trimmed)
+	require.NoError(t, err)
+
+	// The synthetic tree should be stored in the synth store
+	synthStore := cas.NewStore(filepath.Join(storePath, "synth", "trees"))
+	assert.False(t, synthStore.NeedsWrite(hash), "synthetic tree should exist in synth store")
+
+	// Verify the tree can be read and contains entries
+	synthContent := cas.NewContent(synthStore)
+	treeData, err := synthContent.Read(hash)
+	require.NoError(t, err)
+	assert.NotEmpty(t, treeData, "synthetic tree data should not be empty")
+}
+
+func TestProcessStackComponent_DeterministicOutput(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	readStackFile := func() string {
+		storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+		c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+		require.NoError(t, err)
+
+		source := repoURL + "//stacks/my-stack?ref=main"
+
+		result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+		require.NoError(t, err)
+		defer result.Cleanup()
+
+		content, err := os.ReadFile(filepath.Join(result.ContentDir, "terragrunt.stack.hcl"))
+		require.NoError(t, err)
+
+		return string(content)
+	}
+
+	// Process the same source twice with separate CAS stores.
+	first := readStackFile()
+	second := readStackFile()
+
+	// Both runs should produce identical output — the CAS hashes are
+	// deterministic based on ref + path, so regeneration must not produce diffs.
+	assert.Equal(t, first, second, "processing the same source twice should produce identical output")
+}
+
+func TestProcessStackComponent_MaterializeSynthTree(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	source := repoURL + "//stacks/my-stack?ref=main"
+
+	result, err := c.ProcessStackComponent(ctx, l, source, "stack")
+	require.NoError(t, err)
+	defer result.Cleanup()
+
+	// Extract the CAS hash from the rewritten stack file
+	stackContent, err := os.ReadFile(filepath.Join(result.ContentDir, "terragrunt.stack.hcl"))
+	require.NoError(t, err)
+
+	blocks, err := cas.ReadStackBlocks(stackContent)
+	require.NoError(t, err)
+
+	var serviceSource string
+	for _, b := range blocks {
+		if b.Name == "service" {
+			serviceSource = b.Source
+
+			break
+		}
+	}
+
+	require.NotEmpty(t, serviceSource, "should find rewritten service source")
+
+	trimmed := strings.TrimPrefix(serviceSource, "cas::")
+	hash, err := cas.ParseCASRef(trimmed)
+	require.NoError(t, err)
+
+	// Materialize the synthetic tree to a new directory
+	destDir := helpers.TmpDirWOSymlinks(t)
+	err = c.MaterializeTree(ctx, l, hash, destDir)
+	require.NoError(t, err)
+
+	// The materialized tree should contain the unit's terragrunt.hcl
+	assert.FileExists(t, filepath.Join(destDir, "terragrunt.hcl"))
+}
+
+func TestProcessStackComponent_InvalidRefFails(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	source := repoURL + "//stacks/my-stack?ref=nonexistent-tag"
+
+	_, err = c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.Error(t, err, "should fail when ref does not exist")
+}
+
+func TestProcessStackComponent_InvalidSubdirFails(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	source := repoURL + "//nonexistent/path?ref=main"
+
+	_, err = c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.Error(t, err, "should fail when subdir does not exist")
+}
+
+func TestProcessStackComponent_BlobsStoredInCAS(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	source := repoURL + "//stacks/my-stack?ref=main"
+
+	result, err := c.ProcessStackComponent(ctx, l, source, "stack")
+	require.NoError(t, err)
+	defer result.Cleanup()
+
+	// Verify that the blob store has content after processing.
+	// The CAS should have stored blobs for all files in the repo.
+	blobStore := cas.NewStore(filepath.Join(storePath, "blobs"))
+
+	entries, err := os.ReadDir(blobStore.Path())
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries, "blob store should contain entries after processing")
+
+	// Verify the tree store also has content (the root tree from the clone).
+	treeStore := cas.NewStore(filepath.Join(storePath, "trees"))
+
+	entries, err = os.ReadDir(treeStore.Path())
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries, "tree store should contain entries after processing")
 }

--- a/internal/cas/testserver_test.go
+++ b/internal/cas/testserver_test.go
@@ -25,3 +25,67 @@ func startTestServer(t *testing.T) string {
 
 	return url
 }
+
+// startStackTestServer creates a local Git server with a realistic stack
+// repository structure and returns its URL.
+//
+// The repo layout is:
+//
+//	stacks/my-stack/terragrunt.stack.hcl   — stack file with update_source_with_cas
+//	units/my-service/terragrunt.hcl        — unit file with update_source_with_cas
+//	modules/vpc/main.tf                    — plain Terraform module
+func startStackTestServer(t *testing.T) string {
+	t.Helper()
+
+	srv, err := git.NewServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	// Stack file that references a sibling unit via relative path with //.
+	stackHCL := []byte(`unit "service" {
+  source = "../..//units/my-service"
+
+  update_source_with_cas = true
+
+  path = "service"
+}
+
+unit "plain" {
+  source = "../../units/plain-service"
+  path   = "plain"
+}
+`)
+	require.NoError(t, srv.CommitFile("stacks/my-stack/terragrunt.stack.hcl", stackHCL, "add stack file"))
+
+	// Unit file whose terraform.source references a module via relative path.
+	unitHCL := []byte(`terraform {
+  source = "../..//modules/vpc"
+
+  update_source_with_cas = true
+}
+`)
+	require.NoError(t, srv.CommitFile("units/my-service/terragrunt.hcl", unitHCL, "add unit file"))
+
+	// Plain unit (no CAS flag) — should remain unchanged after processing.
+	plainUnitHCL := []byte(`terraform {
+  source = "../../modules/vpc"
+}
+`)
+	require.NoError(t, srv.CommitFile("units/plain-service/terragrunt.hcl", plainUnitHCL, "add plain unit"))
+
+	// Terraform module referenced by the unit.
+	require.NoError(t, srv.CommitFile("modules/vpc/main.tf", []byte(`resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+`), "add vpc module"))
+
+	require.NoError(t, srv.CommitFile("modules/vpc/variables.tf", []byte(`variable "name" {
+  type = string
+}
+`), "add vpc variables"))
+
+	url, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	return url
+}

--- a/internal/cas/tree.go
+++ b/internal/cas/tree.go
@@ -57,7 +57,7 @@ func LinkTree(ctx context.Context, blobStore *Store, treeStore *Store, t *git.Tr
 		}
 	}
 
-	fs := store.FS()
+	fs := blobStore.FS()
 
 	for dirPath := range dirsToCreate {
 		if err := fs.MkdirAll(dirPath, DefaultDirPerms); err != nil {

--- a/internal/cas/tree.go
+++ b/internal/cas/tree.go
@@ -9,9 +9,11 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// LinkTree writes the tree to a target directory
-func LinkTree(ctx context.Context, store *Store, t *git.Tree, targetDir string) error {
-	content := NewContent(store)
+// LinkTree writes the tree to a target directory.
+// blobStore is used to resolve blob entries, treeStore is used to resolve subtree entries.
+func LinkTree(ctx context.Context, blobStore *Store, treeStore *Store, t *git.Tree, targetDir string) error {
+	blobContent := NewContent(blobStore)
+	treeContent := NewContent(treeStore)
 
 	dirsToCreate := make(map[string]struct{}, len(t.Entries()))
 
@@ -76,12 +78,12 @@ func LinkTree(ctx context.Context, store *Store, t *git.Tree, targetDir string) 
 		g.Go(func() error {
 			switch work.itemType {
 			case "link":
-				err := content.Link(ctx, work.entry.Hash, work.path)
+				err := blobContent.Link(ctx, work.entry.Hash, work.path)
 				if err != nil {
 					return wrapError("link_blob", work.path, err)
 				}
 			case "subtree":
-				treeData, err := content.Read(work.entry.Hash)
+				treeData, err := treeContent.Read(work.entry.Hash)
 				if err != nil {
 					return wrapError("read_tree", work.entry.Hash, err)
 				}
@@ -91,7 +93,7 @@ func LinkTree(ctx context.Context, store *Store, t *git.Tree, targetDir string) 
 					return wrapError("parse_tree", work.entry.Hash, err)
 				}
 
-				err = LinkTree(ctx, store, subTree, work.path)
+				err = LinkTree(ctx, blobStore, treeStore, subTree, work.path)
 				if err != nil {
 					return wrapError("link_subtree", work.path, err)
 				}

--- a/internal/cas/tree_test.go
+++ b/internal/cas/tree_test.go
@@ -259,7 +259,7 @@ func TestLinkTree(t *testing.T) {
 			require.NoError(t, memFs.MkdirAll(targetDir, 0755))
 
 			// Link the tree
-			err = cas.LinkTree(t.Context(), store, tree, targetDir)
+			err = cas.LinkTree(t.Context(), store, store, tree, targetDir)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/internal/cli/commands/run/flags.go
+++ b/internal/cli/commands/run/flags.go
@@ -503,6 +503,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 	cmdFlags = cmdFlags.Add(shared.NewFilterFlags(l, opts)...)
 	cmdFlags = cmdFlags.Add(shared.NewParallelismFlag(opts))
 	cmdFlags = cmdFlags.Add(shared.NewNoCASFlag(opts, prefix))
+	cmdFlags = cmdFlags.Add(shared.NewCASCloneDepthFlag(opts, prefix))
 
 	return cmdFlags.Sort()
 }

--- a/internal/cli/commands/run/flags.go
+++ b/internal/cli/commands/run/flags.go
@@ -502,6 +502,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 	cmdFlags = cmdFlags.Add(shared.NewQueueFlags(opts, prefix)...)
 	cmdFlags = cmdFlags.Add(shared.NewFilterFlags(l, opts)...)
 	cmdFlags = cmdFlags.Add(shared.NewParallelismFlag(opts))
+	cmdFlags = cmdFlags.Add(shared.NewNoCASFlag(opts, prefix))
 
 	return cmdFlags.Sort()
 }

--- a/internal/cli/flags/global/flags.go
+++ b/internal/cli/flags/global/flags.go
@@ -39,7 +39,6 @@ const (
 
 	ExperimentModeFlagName = "experiment-mode"
 	ExperimentFlagName     = "experiment"
-	NoCASFlagName          = "no-cas"
 
 	// Tips related flags.
 
@@ -203,13 +202,6 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			},
 		},
 			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedExperimentFlagName), terragruntPrefixControl)),
-
-		flags.NewFlag(&clihelper.BoolFlag{
-			Name:        NoCASFlagName,
-			EnvVars:     tgPrefix.EnvVars(NoCASFlagName),
-			Destination: &opts.NoCAS,
-			Usage:       "Disable the CAS (Content Addressable Storage) feature even when the experiment is enabled.",
-		}),
 
 		// Tips Mode flags.
 

--- a/internal/cli/flags/global/flags.go
+++ b/internal/cli/flags/global/flags.go
@@ -39,6 +39,7 @@ const (
 
 	ExperimentModeFlagName = "experiment-mode"
 	ExperimentFlagName     = "experiment"
+	NoCASFlagName          = "no-cas"
 
 	// Tips related flags.
 
@@ -202,6 +203,13 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 			},
 		},
 			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedExperimentFlagName), terragruntPrefixControl)),
+
+		flags.NewFlag(&clihelper.BoolFlag{
+			Name:        NoCASFlagName,
+			EnvVars:     tgPrefix.EnvVars(NoCASFlagName),
+			Destination: &opts.NoCAS,
+			Usage:       "Disable the CAS (Content Addressable Storage) feature even when the experiment is enabled.",
+		}),
 
 		// Tips Mode flags.
 

--- a/internal/cli/flags/shared/cas.go
+++ b/internal/cli/flags/shared/cas.go
@@ -1,0 +1,23 @@
+package shared
+
+import (
+	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+)
+
+const (
+	NoCASFlagName = "no-cas"
+)
+
+// NewNoCASFlag creates the --no-cas flag for disabling CAS even when the experiment is enabled.
+func NewNoCASFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.Flag {
+	tgPrefix := prefix.Prepend(flags.TgPrefix)
+
+	return flags.NewFlag(&clihelper.BoolFlag{
+		Name:        NoCASFlagName,
+		EnvVars:     tgPrefix.EnvVars(NoCASFlagName),
+		Destination: &opts.NoCAS,
+		Usage:       "Disable the CAS (Content Addressable Storage) feature even when the experiment is enabled.",
+	})
+}

--- a/internal/cli/flags/shared/cas.go
+++ b/internal/cli/flags/shared/cas.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	NoCASFlagName = "no-cas"
+	NoCASFlagName         = "no-cas"
+	CASCloneDepthFlagName = "cas-clone-depth"
 )
 
 // NewNoCASFlag creates the --no-cas flag for disabling CAS even when the experiment is enabled.
@@ -19,5 +20,17 @@ func NewNoCASFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.F
 		EnvVars:     tgPrefix.EnvVars(NoCASFlagName),
 		Destination: &opts.NoCAS,
 		Usage:       "Disable the CAS (Content Addressable Storage) feature even when the experiment is enabled.",
+	})
+}
+
+// NewCASCloneDepthFlag creates the --cas-clone-depth flag for CAS git clone depth.
+func NewCASCloneDepthFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.Flag {
+	tgPrefix := prefix.Prepend(flags.TgPrefix)
+
+	return flags.NewFlag(&clihelper.GenericFlag[int]{
+		Name:        CASCloneDepthFlagName,
+		EnvVars:     tgPrefix.EnvVars(CASCloneDepthFlagName),
+		Destination: &opts.CASCloneDepth,
+		Usage:       "When using CAS, pass this value to git clone --depth (default 1; -1 clones full history). For negative values use --cas-clone-depth=-1 so the dash doesn't result in the value being parsed as a flag.",
 	})
 }

--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -66,6 +66,7 @@ func populateFromOpts(pctx *config.ParsingContext, opts *options.TerragruntOptio
 	pctx.CheckDependentUnits = opts.CheckDependentUnits
 	pctx.Telemetry = opts.Telemetry
 	pctx.NoStackValidate = opts.NoStackValidate
+	pctx.NoCAS = opts.NoCAS
 	pctx.ScaffoldRootFileName = opts.ScaffoldRootFileName
 	pctx.TerragruntStackConfigPath = opts.TerragruntStackConfigPath
 	pctx.ProviderCacheOptions = opts.ProviderCacheOptions

--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -161,5 +161,6 @@ func NewRunOptions(opts *options.TerragruntOptions) *run.Options {
 		DisableBucketUpdate:          opts.DisableBucketUpdate,
 		SourceUpdate:                 opts.SourceUpdate,
 		CASCloneDepth:                opts.CASCloneDepth,
+		NoCAS:                        opts.NoCAS,
 	}
 }

--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -67,6 +67,7 @@ func populateFromOpts(pctx *config.ParsingContext, opts *options.TerragruntOptio
 	pctx.Telemetry = opts.Telemetry
 	pctx.NoStackValidate = opts.NoStackValidate
 	pctx.NoCAS = opts.NoCAS
+	pctx.CASCloneDepth = opts.CASCloneDepth
 	pctx.ScaffoldRootFileName = opts.ScaffoldRootFileName
 	pctx.TerragruntStackConfigPath = opts.TerragruntStackConfigPath
 	pctx.ProviderCacheOptions = opts.ProviderCacheOptions
@@ -159,5 +160,6 @@ func NewRunOptions(opts *options.TerragruntOptions) *run.Options {
 		FailIfBucketCreationRequired: opts.FailIfBucketCreationRequired,
 		DisableBucketUpdate:          opts.DisableBucketUpdate,
 		SourceUpdate:                 opts.SourceUpdate,
+		CASCloneDepth:                opts.CASCloneDepth,
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -696,6 +696,29 @@ func (g *GitRunner) SetRemoteHeadAuto(ctx context.Context) error {
 	return nil
 }
 
+// ObjectFormat returns the object format (hash algorithm) used by the repository in the
+// working directory. Returns "sha1" or "sha256". Requires a working directory with a
+// git repository (bare or non-bare).
+func (g *GitRunner) ObjectFormat(ctx context.Context) (string, error) {
+	if err := g.RequiresWorkDir(); err != nil {
+		return "", err
+	}
+
+	cmd := g.prepareCommand(ctx, "rev-parse", "--show-object-format")
+
+	var stdout, stderr bytes.Buffer
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// Older Git versions don't support --show-object-format; default to sha1.
+		return "sha1", nil //nolint:nilerr
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
 func (g *GitRunner) prepareCommand(ctx context.Context, name string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, g.GitPath, append([]string{name}, args...)...)
 	cmd.Cancel = func() error {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -245,7 +245,7 @@ func (g *GitRunner) Clone(ctx context.Context, repo string, bare bool, depth int
 	}
 
 	if depth > 0 {
-		args = append(args, "--depth", "1", "--single-branch")
+		args = append(args, "--depth", strconv.Itoa(depth), "--single-branch")
 	}
 
 	if branch != "" {

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -373,7 +373,14 @@ func downloadSource(
 		util.RelPathForLog(opts.RootWorkingDir, canonicalSourceURL, opts.Writers.LogShowAbsPaths),
 		util.RelPathForLog(opts.RootWorkingDir, src.DownloadDir, opts.Writers.LogShowAbsPaths))
 
-	allowCAS := opts.Experiments.Evaluate(experiment.CAS)
+	allowCAS := opts.Experiments.Evaluate(experiment.CAS) && !opts.NoCAS
+
+	if cfg.Terraform.UpdateSourceWithCAS && !allowCAS {
+		return errors.New(&cas.UpdateSourceWithCASRequiresCASError{
+			BlockType: "terraform",
+			Path:      opts.TerragruntConfigPath,
+		})
+	}
 
 	isLocalSource := tf.IsLocalSource(src.CanonicalSourceURL)
 
@@ -464,4 +471,8 @@ type DownloadingTerraformSourceErr struct {
 
 func (err DownloadingTerraformSourceErr) Error() string {
 	return fmt.Sprintf("downloading source url %s\n%v", err.URL, err.ErrMsg)
+}
+
+func (err DownloadingTerraformSourceErr) Unwrap() error {
+	return err.ErrMsg
 }

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -390,10 +390,13 @@ func downloadSource(
 			}
 
 			casGetter := cas.NewCASGetter(l, c, &cloneOpts)
+			casProtocol := cas.NewCASProtocolGetter(l, c)
 
-			// Use go-getter v2 Client to properly process the Request
+			// Use go-getter v2 Client to properly process the Request.
+			// CASProtocolGetter handles cas::sha1:<hash> sources (from CAS-rewritten stacks).
+			// CASGetter handles git:: and other remote sources via CAS.
 			client := getterv2.Client{
-				Getters: []getterv2.Getter{casGetter},
+				Getters: []getterv2.Getter{casProtocol, casGetter},
 			}
 
 			// Set Pwd to the working directory so go-getter v2 can resolve relative paths

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -380,7 +380,11 @@ func downloadSource(
 	if allowCAS && !isLocalSource {
 		l.Debugf("CAS experiment enabled: attempting to use Content Addressable Storage for source: %s", canonicalSourceURL)
 
-		c, err := cas.New()
+		if err := cas.ValidateCASCloneDepth(opts.CASCloneDepth); err != nil {
+			return err
+		}
+
+		c, err := cas.New(cas.WithCloneDepth(opts.CASCloneDepth))
 		if err != nil {
 			l.Warnf("Failed to initialize CAS: %v. Falling back to standard getter.", err)
 		} else {

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
@@ -905,6 +906,66 @@ func TestDownloadSourceCASInitializationFailure(t *testing.T) {
 
 	expectedFilePath := filepath.Join(tmpDir, "main.tf")
 	assert.FileExists(t, expectedFilePath)
+}
+
+// TestDownloadSourceUpdateSourceWithCASRequiresCAS verifies that setting
+// update_source_with_cas = true on a terraform block errors when CAS is unavailable,
+// either because the experiment is off or because --no-cas is set.
+func TestDownloadSourceUpdateSourceWithCASRequiresCAS(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		enableCAS bool
+		noCAS     bool
+	}{
+		{name: "experiment off", enableCAS: false, noCAS: false},
+		{name: "experiment on with --no-cas", enableCAS: true, noCAS: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := helpers.TmpDirWOSymlinks(t)
+
+			localSourcePath := absPath(t, "../../../test/fixtures/download-source/hello-world")
+			src := &tf.Source{
+				CanonicalSourceURL: parseURL(t, "file://"+localSourcePath),
+				DownloadDir:        tmpDir,
+				WorkingDir:         tmpDir,
+				VersionFile:        filepath.Join(tmpDir, "version-file.txt"),
+			}
+
+			opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")
+			require.NoError(t, err)
+
+			opts.Experiments = experiment.NewExperiments()
+			if tc.enableCAS {
+				require.NoError(t, opts.Experiments.EnableExperiment(experiment.CAS))
+			}
+
+			opts.NoCAS = tc.noCAS
+			opts.TerragruntConfigPath = "/tmp/terragrunt.hcl"
+
+			cfg := &runcfg.RunConfig{
+				Terraform: runcfg.TerraformConfig{
+					UpdateSourceWithCAS: true,
+				},
+			}
+
+			l := logger.CreateLogger()
+			l.SetOptions(log.WithOutput(io.Discard))
+
+			_, err = run.DownloadTerraformSourceIfNecessary(t.Context(), l, src, configbridge.NewRunOptions(opts), cfg, report.NewReport())
+			require.Error(t, err)
+
+			var target *cas.UpdateSourceWithCASRequiresCASError
+			require.ErrorAs(t, err, &target)
+			assert.Equal(t, "terraform", target.BlockType)
+			assert.Equal(t, opts.TerragruntConfigPath, target.Path)
+		})
+	}
 }
 
 // TestDownloadSourceWithCASMultipleSources tests that CAS works with multiple different sources

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -64,6 +64,7 @@ type Options struct {
 	Experiments                  experiment.Experiments
 	StrictControls               strict.Controls
 	MaxFoldersToCheck            int
+	CASCloneDepth                int
 	AutoRetry                    bool
 	Headless                     bool
 	NonInteractive               bool

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -65,6 +65,7 @@ type Options struct {
 	StrictControls               strict.Controls
 	MaxFoldersToCheck            int
 	CASCloneDepth                int
+	NoCAS                        bool
 	AutoRetry                    bool
 	Headless                     bool
 	NonInteractive               bool

--- a/internal/runner/runcfg/types.go
+++ b/internal/runner/runcfg/types.go
@@ -75,6 +75,12 @@ type TerraformConfig struct {
 	// NoCopyTerraformLockFile specifies whether to skip copying the lock file
 	// Defaults to false (copy the lock file) when not set
 	NoCopyTerraformLockFile bool
+
+	// UpdateSourceWithCAS indicates the terraform.source is a relative path
+	// meant to be rewritten against a cloned repository by CAS. The run path
+	// rejects this when CAS is unavailable, since the relative path has no
+	// meaning without a resolved repo root.
+	UpdateSourceWithCAS bool
 }
 
 // Hook represents a lifecycle hook (before/after).

--- a/internal/services/catalog/catalog.go
+++ b/internal/services/catalog/catalog.go
@@ -175,6 +175,7 @@ func (s *catalogServiceImpl) Load(ctx context.Context, l log.Logger) error {
 			Path:             tempPath,
 			WalkWithSymlinks: walkWithSymlinks,
 			AllowCAS:         allowCAS,
+			CASCloneDepth:    s.opts.CASCloneDepth,
 			SlowReporting:    slowReporting,
 			RootWorkingDir:   s.opts.RootWorkingDir,
 		})

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -57,6 +57,8 @@ type Repo struct {
 	BranchName string
 	LatestTag  string
 
+	casCloneDepth int
+
 	walkWithSymlinks bool
 	allowCAS         bool
 	slowReporting    bool
@@ -67,6 +69,7 @@ type RepoOpts struct {
 	CloneURL         string
 	Path             string
 	RootWorkingDir   string
+	CASCloneDepth    int
 	WalkWithSymlinks bool
 	AllowCAS         bool
 	SlowReporting    bool
@@ -80,6 +83,7 @@ func NewRepo(ctx context.Context, l log.Logger, opts RepoOpts) (*Repo, error) {
 		path:             opts.Path,
 		walkWithSymlinks: opts.WalkWithSymlinks,
 		allowCAS:         opts.AllowCAS,
+		casCloneDepth:    opts.CASCloneDepth,
 		slowReporting:    opts.SlowReporting,
 		rootWorkingDir:   opts.RootWorkingDir,
 	}
@@ -324,7 +328,16 @@ func (repo *Repo) performClone(ctx context.Context, l log.Logger, opts *CloneOpt
 	client := getter.DefaultClient
 
 	if repo.allowCAS {
-		c, err := cas.New()
+		cloneDepth := repo.casCloneDepth
+		if cloneDepth == 0 {
+			cloneDepth = cas.DefaultCASCloneDepth
+		}
+
+		if err := cas.ValidateCASCloneDepth(cloneDepth); err != nil {
+			return err
+		}
+
+		c, err := cas.New(cas.WithCloneDepth(cloneDepth))
 		if err != nil {
 			return err
 		}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -522,15 +522,12 @@ func WriteFileWithSamePermissions(source string, destination string, contents io
 		return errors.New(err)
 	}
 
-	// If destination exists, remove it first to avoid permission issues
-	// This is especially important when CAS creates read-only files
-	if FileExists(destination) {
-		if err := os.Remove(destination); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return errors.New(err)
-		}
+	// CAS may place read-only files at the destination, which would block a plain open.
+	if err := os.Remove(destination); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return errors.New(err)
 	}
 
-	file, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, fileInfo.Mode())
+	file, err := os.OpenFile(destination, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileInfo.Mode())
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -246,6 +246,10 @@ func (cfg *TerragruntConfig) WriteTo(w io.Writer) (int64, error) {
 			terraformBody.SetAttributeValue("source", terraformAsCty.GetAttr("source"))
 		}
 
+		if cfg.Terraform.UpdateSourceWithCAS != nil {
+			terraformBody.SetAttributeValue("update_source_with_cas", terraformAsCty.GetAttr("update_source_with_cas"))
+		}
+
 		// Handle extra_arguments blocks
 		if len(cfg.Terraform.ExtraArgs) > 0 {
 			extraArgsAsCty := terraformAsCty.GetAttr("extra_arguments").AsValueMap()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -848,7 +848,8 @@ func (conf *ErrorHook) String() string {
 // NOTE: If any attributes or blocks are added here, be sure to add it to ctyTerraformConfig in config_as_cty.go as
 // well.
 type TerraformConfig struct {
-	Source *string `hcl:"source,attr"`
+	Source              *string `hcl:"source,attr"`
+	UpdateSourceWithCAS *bool   `hcl:"update_source_with_cas,attr"`
 
 	// Ideally we can avoid the pointer to list slice, but if it is not a pointer, Terraform requires the attribute to
 	// be defined and we want to make this optional.

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -492,6 +492,7 @@ func excludeConfigAsCty(config *ExcludeConfig) (cty.Value, error) {
 type CtyTerraformConfig struct {
 	ExtraArgs             map[string]TerraformExtraArguments `cty:"extra_arguments"`
 	Source                *string                            `cty:"source"`
+	UpdateSourceWithCAS   *bool                              `cty:"update_source_with_cas"`
 	IncludeInCopy         *[]string                          `cty:"include_in_copy"`
 	ExcludeFromCopy       *[]string                          `cty:"exclude_from_copy"`
 	CopyTerraformLockFile *bool                              `cty:"copy_terraform_lock_file"`
@@ -508,6 +509,7 @@ func terraformConfigAsCty(config *TerraformConfig) (cty.Value, error) {
 
 	configCty := CtyTerraformConfig{
 		Source:                config.Source,
+		UpdateSourceWithCAS:   config.UpdateSourceWithCAS,
 		IncludeInCopy:         config.IncludeInCopy,
 		ExcludeFromCopy:       config.ExcludeFromCopy,
 		CopyTerraformLockFile: config.CopyTerraformLockFile,

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -489,10 +489,13 @@ func excludeConfigAsCty(config *ExcludeConfig) (cty.Value, error) {
 
 // CtyTerraformConfig is an alternate representation of TerraformConfig that converts internal blocks into a map that
 // maps the name to the underlying struct, as opposed to a list representation.
+//
+// Fields that should be omitted when nil (rather than serialized as null) must not be included in this struct.
+// Instead, conditionally add them to the cty value in terraformConfigAsCty using ctyObjectAddField.
+// This is necessary because gocty does not support omitempty semantics.
 type CtyTerraformConfig struct {
 	ExtraArgs             map[string]TerraformExtraArguments `cty:"extra_arguments"`
 	Source                *string                            `cty:"source"`
-	UpdateSourceWithCAS   *bool                              `cty:"update_source_with_cas"`
 	IncludeInCopy         *[]string                          `cty:"include_in_copy"`
 	ExcludeFromCopy       *[]string                          `cty:"exclude_from_copy"`
 	CopyTerraformLockFile *bool                              `cty:"copy_terraform_lock_file"`
@@ -509,7 +512,6 @@ func terraformConfigAsCty(config *TerraformConfig) (cty.Value, error) {
 
 	configCty := CtyTerraformConfig{
 		Source:                config.Source,
-		UpdateSourceWithCAS:   config.UpdateSourceWithCAS,
 		IncludeInCopy:         config.IncludeInCopy,
 		ExcludeFromCopy:       config.ExcludeFromCopy,
 		CopyTerraformLockFile: config.CopyTerraformLockFile,
@@ -535,7 +537,18 @@ func terraformConfigAsCty(config *TerraformConfig) (cty.Value, error) {
 		configCty.ErrorHooks[errorHook.Name] = errorHook
 	}
 
-	return GoTypeToCty(configCty)
+	val, err := GoTypeToCty(configCty)
+	if err != nil {
+		return cty.NilVal, err
+	}
+
+	// Only include update_source_with_cas when explicitly set, to avoid
+	// surfacing it as null in outputs for configs that don't use it.
+	if config.UpdateSourceWithCAS != nil {
+		val = ctyObjectAddField(val, "update_source_with_cas", goboolToCty(*config.UpdateSourceWithCAS))
+	}
+
+	return val, nil
 }
 
 // RemoteStateAsCty serializes RemoteState to a cty Value. We can't directly
@@ -838,6 +851,18 @@ func goboolToCty(val bool) cty.Value {
 	}
 
 	return ctyOut
+}
+
+// ctyObjectAddField returns a new cty object value with an additional attribute.
+func ctyObjectAddField(obj cty.Value, name string, val cty.Value) cty.Value {
+	attrs := obj.AsValueMap()
+	if attrs == nil {
+		attrs = map[string]cty.Value{}
+	}
+
+	attrs[name] = val
+
+	return cty.ObjectVal(attrs)
 }
 
 // FormatValue converts a primitive value to its string representation.

--- a/pkg/config/config_as_cty_test.go
+++ b/pkg/config/config_as_cty_test.go
@@ -217,8 +217,24 @@ func TestRemoteStateAsCtyDrift(t *testing.T) {
 func TestTerraformConfigAsCtyDrift(t *testing.T) {
 	t.Parallel()
 
+	// Fields that are intentionally excluded from CtyTerraformConfig because
+	// they use omit-when-nil semantics via ctyObjectAddField.
+	omitWhenNilFields := map[string]bool{
+		"UpdateSourceWithCAS": true,
+	}
+
 	terraformConfigStructInfo := structs.New(config.TerraformConfig{})
-	terraformConfigFields := terraformConfigStructInfo.Names()
+
+	var terraformConfigFields []string
+
+	for _, name := range terraformConfigStructInfo.Names() {
+		if omitWhenNilFields[name] {
+			continue
+		}
+
+		terraformConfigFields = append(terraformConfigFields, name)
+	}
+
 	sort.Strings(terraformConfigFields)
 
 	ctyTerraformConfigStructInfo := structs.New(config.CtyTerraformConfig{})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1729,6 +1729,7 @@ locals {
 
 terraform {
 	source = "git::git@github.com:org/repo.git//modules/test?ref=v0.1.0"
+	update_source_with_cas = true
 
 	extra_arguments "secrets" {
 		commands = ["plan", "apply"]
@@ -1894,6 +1895,7 @@ inputs = {
 	// Verify the configs match
 	assert.Equal(t, terragruntConfig.Locals, rereadConfig.Locals)
 	assert.Equal(t, terragruntConfig.Terraform.Source, rereadConfig.Terraform.Source)
+	assert.Equal(t, terragruntConfig.Terraform.UpdateSourceWithCAS, rereadConfig.Terraform.UpdateSourceWithCAS)
 	assert.Equal(t, terragruntConfig.Terraform.ExtraArgs, rereadConfig.Terraform.ExtraArgs)
 	assert.Equal(t, terragruntConfig.Terraform.BeforeHooks, rereadConfig.Terraform.BeforeHooks)
 	assert.Equal(t, terragruntConfig.Terraform.AfterHooks, rereadConfig.Terraform.AfterHooks)

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1426,6 +1426,7 @@ func runTerragruntOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Lo
 		BackendBootstrap:             pctx.BackendBootstrap,
 		Telemetry:                    pctx.Telemetry,
 		AuthProviderCmd:              pctx.AuthProviderCmd,
+		CASCloneDepth:                pctx.CASCloneDepth,
 	}
 
 	err = run.Run(ctx, l, runOpts, report.NewReport(), runCfg, credsGetter)

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -99,6 +99,7 @@ type ParsingContext struct {
 	UsePartialParseConfigCache       bool
 	SkipOutputsResolution            bool
 	NoStackValidate                  bool
+	NoCAS                            bool
 }
 
 func NewParsingContext(ctx context.Context, l log.Logger, opts ...Option) (context.Context, *ParsingContext) {

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -84,6 +84,7 @@ type ParsingContext struct {
 
 	MaxFoldersToCheck int
 	ParseDepth        int
+	CASCloneDepth     int
 
 	TFPathExplicitlySet bool
 	SkipOutput          bool

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -407,16 +407,17 @@ func generateComponent(ctx context.Context, l log.Logger, opts *generateOpts, cm
 	return generateAutoInclude(l, opts, cmp, dest)
 }
 
-// fetchComponentSource handles the three paths for fetching a component's source:
-//  1. cas:: protocol source: materialize CAS tree directly (must run before the remote-CAS branch
-//     so nested components already rewritten to cas:: are not passed to git clone).
-//  2. Remote source with CAS enabled: CAS-backed clone, rewrite, copy from temp. Triggered
-//     automatically whenever the cas experiment is on and the source is not a local path, so
-//     catalog authors don't need consumers to opt in per-block.
+// fetchComponentSource handles the paths for fetching a component's source:
+//  1. cas:: protocol source: materialize the CAS tree directly. Must run before the remote-CAS
+//     branch so nested components already rewritten to cas:: are not passed to git clone.
+//  2. Remote source with CAS enabled: attempt a CAS-backed clone and copy from a temp dir. This
+//     fires automatically when the cas experiment is on and the source isn't local, so catalog
+//     authors don't need consumers to opt in per-block. On any CAS failure (for example, CAS
+//     can't handle a go-getter query param like depth=1), we fall through to the standard getter.
 //  3. Standard: local copy or remote getter.
 //
-// The update_source_with_cas attribute on a consumer block is a no-op under path 2 — it remains
-// meaningful inside catalog files, where the CAS walk uses it to decide which nested sources to
+// The update_source_with_cas attribute on a consumer block is a no-op under path 2. It only
+// matters inside catalog files, where the CAS walk uses it to decide which nested sources to
 // rewrite to cas:: references.
 func fetchComponentSource(
 	ctx context.Context,
@@ -425,8 +426,7 @@ func fetchComponentSource(
 	cmp *componentToGenerate,
 	kindStr, source, dest string,
 ) error {
-	switch {
-	case isCASProtocol(source):
+	if isCASProtocol(source) {
 		if !opts.casEnabled {
 			return errors.Errorf("cas:: source on %s %q requires the 'cas' experiment to be enabled", kindStr, cmp.name)
 		}
@@ -447,41 +447,60 @@ func fetchComponentSource(
 			return errors.Errorf("Failed to materialize CAS tree for %s %s: %w", kindStr, cmp.name, err)
 		}
 
-	case opts.casEnabled && !isLocal(l, cmp.sourceDir, source):
-		result, err := opts.casInstance.ProcessStackComponent(ctx, l, source, kindStr)
-		if err != nil {
-			return errors.Errorf("CAS processing failed for %s %s: %w", kindStr, cmp.name, err)
+		return nil
+	}
+
+	if opts.casEnabled && !isLocal(l, cmp.sourceDir, source) {
+		casErr := fetchViaCAS(ctx, l, opts, kindStr, source, dest)
+		if casErr == nil {
+			return nil
 		}
 
-		defer result.Cleanup()
+		l.Warnf("CAS processing failed for %s %q: %v. Falling back to standard getter.", kindStr, cmp.name, casErr)
 
-		if err := util.CopyFolderContentsWithFilter(l, result.ContentDir, dest, manifestName, func(_ string) bool {
-			return true
-		}); err != nil {
-			return errors.Errorf("Failed to copy CAS content for %s %s: %w", kindStr, cmp.name, err)
-		}
-
-	default:
-		if err := copyFiles(ctx, l, cmp.name, cmp.sourceDir, source, dest); err != nil {
-			return errors.Errorf(
-				"Failed to fetch %s %s\n"+
-					"  Source:      %s\n"+
-					"  Destination: %s\n\n"+
-					"Troubleshooting:\n"+
-					"  1. Check if your source path is correct relative to the stack file location\n"+
-					"  2. Verify the units or stacks directory exists at the expected location\n"+
-					"  3. Ensure you have proper permissions to read from source and write to destination\n\n"+
-					"Original error: %w",
-				kindStr,
-				cmp.name,
-				source,
-				dest,
-				err,
-			)
+		if cleanupErr := os.RemoveAll(dest); cleanupErr != nil && !os.IsNotExist(cleanupErr) {
+			l.Debugf("Failed to clean partial CAS destination %s: %v", dest, cleanupErr)
 		}
 	}
 
+	if err := copyFiles(ctx, l, cmp.name, cmp.sourceDir, source, dest); err != nil {
+		return errors.Errorf(
+			"Failed to fetch %s %s\n"+
+				"  Source:      %s\n"+
+				"  Destination: %s\n\n"+
+				"Troubleshooting:\n"+
+				"  1. Check if your source path is correct relative to the stack file location\n"+
+				"  2. Verify the units or stacks directory exists at the expected location\n"+
+				"  3. Ensure you have proper permissions to read from source and write to destination\n\n"+
+				"Original error: %w",
+			kindStr,
+			cmp.name,
+			source,
+			dest,
+			err,
+		)
+	}
+
 	return nil
+}
+
+// fetchViaCAS performs the CAS-backed clone, rewrite, and copy for a remote stack component.
+func fetchViaCAS(
+	ctx context.Context,
+	l log.Logger,
+	opts *generateOpts,
+	kindStr, source, dest string,
+) error {
+	result, err := opts.casInstance.ProcessStackComponent(ctx, l, source, kindStr)
+	if err != nil {
+		return err
+	}
+
+	defer result.Cleanup()
+
+	return util.CopyFolderContentsWithFilter(l, result.ContentDir, dest, manifestName, func(_ string) bool {
+		return true
+	})
 }
 
 // isCASProtocol checks if a source string uses the CAS protocol (cas::sha1:<hash>).

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -136,7 +136,11 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 	var casInstance *cas.CAS
 
 	if casEnabled {
-		c, casErr := cas.New()
+		if err := cas.ValidateCASCloneDepth(pctx.CASCloneDepth); err != nil {
+			return err
+		}
+
+		c, casErr := cas.New(cas.WithCloneDepth(pctx.CASCloneDepth))
 		if casErr != nil {
 			l.Warnf("Failed to initialize CAS for stack generation: %v. CAS features disabled.", casErr)
 
@@ -404,29 +408,18 @@ func generateComponent(ctx context.Context, l log.Logger, opts *generateOpts, cm
 }
 
 // fetchComponentSource handles the three paths for fetching a component's source:
-// 1. update_source_with_cas: CAS-backed clone, rewrite, copy from temp
-// 2. cas:: protocol source: materialize CAS tree directly
-// 3. Standard: local copy or remote getter
-func fetchComponentSource(ctx context.Context, l log.Logger, opts generateOpts, cmp *componentToGenerate, kindStr, source, dest string) error {
+//  1. cas:: protocol source: materialize CAS tree directly (must run before update_source_with_cas
+//     so nested components already rewritten to cas:: are not passed to git clone).
+//  2. update_source_with_cas: CAS-backed clone, rewrite, copy from temp
+//  3. Standard: local copy or remote getter
+func fetchComponentSource(
+	ctx context.Context,
+	l log.Logger,
+	opts generateOpts,
+	cmp *componentToGenerate,
+	kindStr, source, dest string,
+) error {
 	switch {
-	case cmp.updateSourceWithCAS:
-		if !opts.casEnabled {
-			return errors.Errorf("update_source_with_cas on %s %q requires the 'cas' experiment to be enabled (use --experiment cas) and --no-cas must not be set", kindStr, cmp.name)
-		}
-
-		result, err := opts.casInstance.ProcessStackComponent(ctx, l, source, kindStr)
-		if err != nil {
-			return errors.Errorf("CAS processing failed for %s %s: %w", kindStr, cmp.name, err)
-		}
-
-		defer result.Cleanup()
-
-		if err := util.CopyFolderContentsWithFilter(l, result.ContentDir, dest, manifestName, func(_ string) bool {
-			return true
-		}); err != nil {
-			return errors.Errorf("Failed to copy CAS content for %s %s: %w", kindStr, cmp.name, err)
-		}
-
 	case isCASProtocol(source):
 		if !opts.casEnabled {
 			return errors.Errorf("cas:: source on %s %q requires the 'cas' experiment to be enabled", kindStr, cmp.name)
@@ -446,6 +439,29 @@ func fetchComponentSource(ctx context.Context, l log.Logger, opts generateOpts, 
 
 		if err := opts.casInstance.MaterializeTree(ctx, l, hash, dest); err != nil {
 			return errors.Errorf("Failed to materialize CAS tree for %s %s: %w", kindStr, cmp.name, err)
+		}
+
+	case cmp.updateSourceWithCAS:
+		if !opts.casEnabled {
+			return errors.Errorf(
+				"update_source_with_cas on %s %q requires the 'cas' experiment to be enabled (use --experiment cas) "+
+					"and --no-cas must not be set",
+				kindStr,
+				cmp.name,
+			)
+		}
+
+		result, err := opts.casInstance.ProcessStackComponent(ctx, l, source, kindStr)
+		if err != nil {
+			return errors.Errorf("CAS processing failed for %s %s: %w", kindStr, cmp.name, err)
+		}
+
+		defer result.Cleanup()
+
+		if err := util.CopyFolderContentsWithFilter(l, result.ContentDir, dest, manifestName, func(_ string) bool {
+			return true
+		}); err != nil {
+			return errors.Errorf("Failed to copy CAS content for %s %s: %w", kindStr, cmp.name, err)
 		}
 
 	default:

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -199,16 +199,15 @@ func generateUnits(ctx context.Context, l log.Logger, opts *generateOpts, pool *
 	for _, unit := range units {
 		pool.Submit(func() error {
 			item := componentToGenerate{
-				sourceDir:           opts.sourceDir,
-				targetDir:           opts.targetDir,
-				name:                unit.Name,
-				path:                unit.Path,
-				source:              unit.Source,
-				values:              unit.Values,
-				noStack:             unit.NoStack != nil && *unit.NoStack,
-				noValidation:        unit.NoValidation != nil && *unit.NoValidation,
-				updateSourceWithCAS: unit.UpdateSourceWithCAS != nil && *unit.UpdateSourceWithCAS,
-				kind:                unitKind,
+				sourceDir:    opts.sourceDir,
+				targetDir:    opts.targetDir,
+				name:         unit.Name,
+				path:         unit.Path,
+				source:       unit.Source,
+				values:       unit.Values,
+				noStack:      unit.NoStack != nil && *unit.NoStack,
+				noValidation: unit.NoValidation != nil && *unit.NoValidation,
+				kind:         unitKind,
 			}
 
 			l.Infof("Generating unit %s from %s", unit.Name, util.RelPathForLog(opts.rootWorkingDir, opts.sourceFile, opts.logShowAbsPaths))
@@ -233,16 +232,15 @@ func generateStacks(ctx context.Context, l log.Logger, opts *generateOpts, pool 
 	for _, stack := range stacks {
 		pool.Submit(func() error {
 			item := componentToGenerate{
-				sourceDir:           opts.sourceDir,
-				targetDir:           opts.targetDir,
-				name:                stack.Name,
-				path:                stack.Path,
-				source:              stack.Source,
-				noStack:             stack.NoStack != nil && *stack.NoStack,
-				noValidation:        stack.NoValidation != nil && *stack.NoValidation,
-				updateSourceWithCAS: stack.UpdateSourceWithCAS != nil && *stack.UpdateSourceWithCAS,
-				values:              stack.Values,
-				kind:                stackKind,
+				sourceDir:    opts.sourceDir,
+				targetDir:    opts.targetDir,
+				name:         stack.Name,
+				path:         stack.Path,
+				source:       stack.Source,
+				noStack:      stack.NoStack != nil && *stack.NoStack,
+				noValidation: stack.NoValidation != nil && *stack.NoValidation,
+				values:       stack.Values,
+				kind:         stackKind,
 			}
 
 			l.Infof("Generating stack %s from %s", stack.Name, util.RelPathForLog(opts.rootWorkingDir, opts.sourceFile, opts.logShowAbsPaths))
@@ -272,16 +270,15 @@ const (
 // It contains information about the source and target directories, the name and path of the item, the source URL or path,
 // and any associated values that need to be generated.
 type componentToGenerate struct {
-	values              *cty.Value
-	sourceDir           string
-	targetDir           string
-	name                string
-	path                string
-	source              string
-	noStack             bool
-	noValidation        bool
-	updateSourceWithCAS bool
-	kind                componentKind
+	values       *cty.Value
+	sourceDir    string
+	targetDir    string
+	name         string
+	path         string
+	source       string
+	noStack      bool
+	noValidation bool
+	kind         componentKind
 }
 
 // resolveDestPath builds and validates the destination path for a generated component.

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -408,10 +408,16 @@ func generateComponent(ctx context.Context, l log.Logger, opts *generateOpts, cm
 }
 
 // fetchComponentSource handles the three paths for fetching a component's source:
-//  1. cas:: protocol source: materialize CAS tree directly (must run before update_source_with_cas
+//  1. cas:: protocol source: materialize CAS tree directly (must run before the remote-CAS branch
 //     so nested components already rewritten to cas:: are not passed to git clone).
-//  2. update_source_with_cas: CAS-backed clone, rewrite, copy from temp
-//  3. Standard: local copy or remote getter
+//  2. Remote source with CAS enabled: CAS-backed clone, rewrite, copy from temp. Triggered
+//     automatically whenever the cas experiment is on and the source is not a local path, so
+//     catalog authors don't need consumers to opt in per-block.
+//  3. Standard: local copy or remote getter.
+//
+// The update_source_with_cas attribute on a consumer block is a no-op under path 2 — it remains
+// meaningful inside catalog files, where the CAS walk uses it to decide which nested sources to
+// rewrite to cas:: references.
 func fetchComponentSource(
 	ctx context.Context,
 	l log.Logger,
@@ -441,16 +447,7 @@ func fetchComponentSource(
 			return errors.Errorf("Failed to materialize CAS tree for %s %s: %w", kindStr, cmp.name, err)
 		}
 
-	case cmp.updateSourceWithCAS:
-		if !opts.casEnabled {
-			return errors.Errorf(
-				"update_source_with_cas on %s %q requires the 'cas' experiment to be enabled (use --experiment cas) "+
-					"and --no-cas must not be set",
-				kindStr,
-				cmp.name,
-			)
-		}
-
+	case opts.casEnabled && !isLocal(l, cmp.sourceDir, source):
 		result, err := opts.casInstance.ProcessStackComponent(ctx, l, source, kindStr)
 		if err != nil {
 			return errors.Errorf("CAS processing failed for %s %s: %w", kindStr, cmp.name, err)

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -133,6 +133,10 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 
 	casEnabled := pctx.Experiments.Evaluate(experiment.CAS) && !pctx.NoCAS
 
+	if err := validateUpdateSourceWithCAS(stackFile, stackFilePath, casEnabled); err != nil {
+		return err
+	}
+
 	var casInstance *cas.CAS
 
 	if casEnabled {
@@ -171,6 +175,38 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 
 	if err := generateStacks(ctx, l, &genOpts, pool, stackFile.Stacks); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// validateUpdateSourceWithCAS rejects stack files that declare update_source_with_cas = true
+// on any unit or stack when CAS is not available. The attribute is meaningless without CAS
+// and would otherwise silently fall through to the standard getter, producing confusing
+// "source not found" failures downstream.
+func validateUpdateSourceWithCAS(stackFile *StackConfig, stackFilePath string, casEnabled bool) error {
+	if casEnabled {
+		return nil
+	}
+
+	for _, unit := range stackFile.Units {
+		if unit.UpdateSourceWithCAS != nil && *unit.UpdateSourceWithCAS {
+			return errors.New(&cas.UpdateSourceWithCASRequiresCASError{
+				BlockType: "unit",
+				Name:      unit.Name,
+				Path:      stackFilePath,
+			})
+		}
+	}
+
+	for _, stack := range stackFile.Stacks {
+		if stack.UpdateSourceWithCAS != nil && *stack.UpdateSourceWithCAS {
+			return errors.New(&cas.UpdateSourceWithCASRequiresCASError{
+				BlockType: "stack",
+				Name:      stack.Name,
+				Path:      stackFilePath,
+			})
+		}
 	}
 
 	return nil

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -415,7 +415,7 @@ func generateComponent(ctx context.Context, l log.Logger, opts *generateOpts, cm
 func fetchComponentSource(
 	ctx context.Context,
 	l log.Logger,
-	opts generateOpts,
+	opts *generateOpts,
 	cmp *componentToGenerate,
 	kindStr, source, dest string,
 ) error {

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -136,7 +136,7 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 	var casInstance *cas.CAS
 
 	if casEnabled {
-		c, casErr := cas.New(cas.Options{})
+		c, casErr := cas.New()
 		if casErr != nil {
 			l.Warnf("Failed to initialize CAS for stack generation: %v. CAS features disabled.", casErr)
 

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
@@ -62,24 +63,26 @@ type StackConfig struct {
 
 // Unit represents unit from a stack file.
 type Unit struct {
-	Remain       hcl.Body   `hcl:",remain"`
-	NoStack      *bool      `hcl:"no_dot_terragrunt_stack,attr"`
-	NoValidation *bool      `hcl:"no_validation,attr"`
-	Values       *cty.Value `hcl:"values,attr"`
-	Name         string     `hcl:",label"`
-	Source       string     `hcl:"source,attr"`
-	Path         string     `hcl:"path,attr"`
+	Remain              hcl.Body   `hcl:",remain"`
+	UpdateSourceWithCAS *bool      `hcl:"update_source_with_cas,attr"`
+	NoStack             *bool      `hcl:"no_dot_terragrunt_stack,attr"`
+	NoValidation        *bool      `hcl:"no_validation,attr"`
+	Values              *cty.Value `hcl:"values,attr"`
+	Name                string     `hcl:",label"`
+	Source              string     `hcl:"source,attr"`
+	Path                string     `hcl:"path,attr"`
 }
 
 // Stack represents the stack block in the configuration.
 type Stack struct {
-	Remain       hcl.Body   `hcl:",remain"`
-	NoStack      *bool      `hcl:"no_dot_terragrunt_stack,attr"`
-	NoValidation *bool      `hcl:"no_validation,attr"`
-	Values       *cty.Value `hcl:"values,attr"`
-	Name         string     `hcl:",label"`
-	Source       string     `hcl:"source,attr"`
-	Path         string     `hcl:"path,attr"`
+	Remain              hcl.Body   `hcl:",remain"`
+	UpdateSourceWithCAS *bool      `hcl:"update_source_with_cas,attr"`
+	NoStack             *bool      `hcl:"no_dot_terragrunt_stack,attr"`
+	NoValidation        *bool      `hcl:"no_validation,attr"`
+	Values              *cty.Value `hcl:"values,attr"`
+	Name                string     `hcl:",label"`
+	Source              string     `hcl:"source,attr"`
+	Path                string     `hcl:"path,attr"`
 }
 
 // GenerateStackFile generates the Terragrunt stack configuration from the given stackFilePath,
@@ -128,6 +131,21 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 		}
 	}
 
+	casEnabled := pctx.Experiments.Evaluate(experiment.CAS) && !pctx.NoCAS
+
+	var casInstance *cas.CAS
+
+	if casEnabled {
+		c, casErr := cas.New(cas.Options{})
+		if casErr != nil {
+			l.Warnf("Failed to initialize CAS for stack generation: %v. CAS features disabled.", casErr)
+
+			casEnabled = false
+		} else {
+			casInstance = c
+		}
+	}
+
 	genOpts := generateOpts{
 		rootWorkingDir:  pctx.RootWorkingDir,
 		logShowAbsPaths: pctx.Writers.LogShowAbsPaths,
@@ -139,6 +157,8 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 		targetDir:       stackTargetDir,
 		autoIncludes:    autoIncludes,
 		stackSrcBytes:   stackSrcBytes,
+		casEnabled:      casEnabled,
+		casInstance:     casInstance,
 	}
 
 	if err := generateUnits(ctx, l, &genOpts, pool, stackFile.Units); err != nil {
@@ -155,6 +175,7 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 // generateOpts holds the subset of options needed for stack/unit generation.
 type generateOpts struct {
 	autoIncludes    map[string]*inthclparse.AutoIncludeResolved
+	casInstance     *cas.CAS
 	sourceMap       map[string]string
 	rootWorkingDir  string
 	stackConfigPath string
@@ -164,6 +185,7 @@ type generateOpts struct {
 	stackSrcBytes   []byte
 	logShowAbsPaths bool
 	noStackValidate bool
+	casEnabled      bool
 }
 
 // generateUnits iterates through a slice of Unit objects, generating each one by copying
@@ -173,15 +195,16 @@ func generateUnits(ctx context.Context, l log.Logger, opts *generateOpts, pool *
 	for _, unit := range units {
 		pool.Submit(func() error {
 			item := componentToGenerate{
-				sourceDir:    opts.sourceDir,
-				targetDir:    opts.targetDir,
-				name:         unit.Name,
-				path:         unit.Path,
-				source:       unit.Source,
-				values:       unit.Values,
-				noStack:      unit.NoStack != nil && *unit.NoStack,
-				noValidation: unit.NoValidation != nil && *unit.NoValidation,
-				kind:         unitKind,
+				sourceDir:           opts.sourceDir,
+				targetDir:           opts.targetDir,
+				name:                unit.Name,
+				path:                unit.Path,
+				source:              unit.Source,
+				values:              unit.Values,
+				noStack:             unit.NoStack != nil && *unit.NoStack,
+				noValidation:        unit.NoValidation != nil && *unit.NoValidation,
+				updateSourceWithCAS: unit.UpdateSourceWithCAS != nil && *unit.UpdateSourceWithCAS,
+				kind:                unitKind,
 			}
 
 			l.Infof("Generating unit %s from %s", unit.Name, util.RelPathForLog(opts.rootWorkingDir, opts.sourceFile, opts.logShowAbsPaths))
@@ -206,15 +229,16 @@ func generateStacks(ctx context.Context, l log.Logger, opts *generateOpts, pool 
 	for _, stack := range stacks {
 		pool.Submit(func() error {
 			item := componentToGenerate{
-				sourceDir:    opts.sourceDir,
-				targetDir:    opts.targetDir,
-				name:         stack.Name,
-				path:         stack.Path,
-				source:       stack.Source,
-				noStack:      stack.NoStack != nil && *stack.NoStack,
-				noValidation: stack.NoValidation != nil && *stack.NoValidation,
-				values:       stack.Values,
-				kind:         stackKind,
+				sourceDir:           opts.sourceDir,
+				targetDir:           opts.targetDir,
+				name:                stack.Name,
+				path:                stack.Path,
+				source:              stack.Source,
+				noStack:             stack.NoStack != nil && *stack.NoStack,
+				noValidation:        stack.NoValidation != nil && *stack.NoValidation,
+				updateSourceWithCAS: stack.UpdateSourceWithCAS != nil && *stack.UpdateSourceWithCAS,
+				values:              stack.Values,
+				kind:                stackKind,
 			}
 
 			l.Infof("Generating stack %s from %s", stack.Name, util.RelPathForLog(opts.rootWorkingDir, opts.sourceFile, opts.logShowAbsPaths))
@@ -244,15 +268,16 @@ const (
 // It contains information about the source and target directories, the name and path of the item, the source URL or path,
 // and any associated values that need to be generated.
 type componentToGenerate struct {
-	values       *cty.Value
-	sourceDir    string
-	targetDir    string
-	name         string
-	path         string
-	source       string
-	noStack      bool
-	noValidation bool
-	kind         componentKind
+	values              *cty.Value
+	sourceDir           string
+	targetDir           string
+	name                string
+	path                string
+	source              string
+	noStack             bool
+	noValidation        bool
+	updateSourceWithCAS bool
+	kind                componentKind
 }
 
 // resolveDestPath builds and validates the destination path for a generated component.
@@ -362,22 +387,8 @@ func generateComponent(ctx context.Context, l log.Logger, opts *generateOpts, cm
 
 	l.Debugf("Generating: %s (%s) to %s", cmp.name, source, dest)
 
-	if err := copyFiles(ctx, l, cmp.name, cmp.sourceDir, source, dest); err != nil {
-		return errors.Errorf(
-			"Failed to fetch %s %s\n"+
-				"  Source:      %s\n"+
-				"  Destination: %s\n\n"+
-				"Troubleshooting:\n"+
-				"  1. Check if your source path is correct relative to the stack file location\n"+
-				"  2. Verify the units or stacks directory exists at the expected location\n"+
-				"  3. Ensure you have proper permissions to read from source and write to destination\n\n"+
-				"Original error: %w",
-			kindStr,
-			cmp.name,
-			source,
-			dest,
-			err,
-		)
+	if err := fetchComponentSource(ctx, l, opts, cmp, kindStr, source, dest); err != nil {
+		return err
 	}
 
 	if err := validateGeneratedComponent(l, cmp, opts, dest); err != nil {
@@ -390,6 +401,79 @@ func generateComponent(ctx context.Context, l log.Logger, opts *generateOpts, cm
 	}
 
 	return generateAutoInclude(l, opts, cmp, dest)
+}
+
+// fetchComponentSource handles the three paths for fetching a component's source:
+// 1. update_source_with_cas: CAS-backed clone, rewrite, copy from temp
+// 2. cas:: protocol source: materialize CAS tree directly
+// 3. Standard: local copy or remote getter
+func fetchComponentSource(ctx context.Context, l log.Logger, opts generateOpts, cmp *componentToGenerate, kindStr, source, dest string) error {
+	switch {
+	case cmp.updateSourceWithCAS:
+		if !opts.casEnabled {
+			return errors.Errorf("update_source_with_cas on %s %q requires the 'cas' experiment to be enabled (use --experiment cas) and --no-cas must not be set", kindStr, cmp.name)
+		}
+
+		result, err := opts.casInstance.ProcessStackComponent(ctx, l, source, kindStr)
+		if err != nil {
+			return errors.Errorf("CAS processing failed for %s %s: %w", kindStr, cmp.name, err)
+		}
+
+		defer result.Cleanup()
+
+		if err := util.CopyFolderContentsWithFilter(l, result.ContentDir, dest, manifestName, func(_ string) bool {
+			return true
+		}); err != nil {
+			return errors.Errorf("Failed to copy CAS content for %s %s: %w", kindStr, cmp.name, err)
+		}
+
+	case isCASProtocol(source):
+		if !opts.casEnabled {
+			return errors.Errorf("cas:: source on %s %q requires the 'cas' experiment to be enabled", kindStr, cmp.name)
+		}
+
+		if err := os.MkdirAll(dest, os.ModePerm); err != nil {
+			return errors.Errorf("Failed to create directory %s for %s %w", dest, cmp.name, err)
+		}
+
+		// Strip the cas:: prefix and parse the hash
+		casRef := strings.TrimPrefix(source, cas.CASProtocolPrefix)
+
+		hash, err := cas.ParseCASRef(casRef)
+		if err != nil {
+			return errors.Errorf("Failed to parse CAS reference for %s %s: %w", kindStr, cmp.name, err)
+		}
+
+		if err := opts.casInstance.MaterializeTree(ctx, l, hash, dest); err != nil {
+			return errors.Errorf("Failed to materialize CAS tree for %s %s: %w", kindStr, cmp.name, err)
+		}
+
+	default:
+		if err := copyFiles(ctx, l, cmp.name, cmp.sourceDir, source, dest); err != nil {
+			return errors.Errorf(
+				"Failed to fetch %s %s\n"+
+					"  Source:      %s\n"+
+					"  Destination: %s\n\n"+
+					"Troubleshooting:\n"+
+					"  1. Check if your source path is correct relative to the stack file location\n"+
+					"  2. Verify the units or stacks directory exists at the expected location\n"+
+					"  3. Ensure you have proper permissions to read from source and write to destination\n\n"+
+					"Original error: %w",
+				kindStr,
+				cmp.name,
+				source,
+				dest,
+				err,
+			)
+		}
+	}
+
+	return nil
+}
+
+// isCASProtocol checks if a source string uses the CAS protocol (cas::sha1:<hash>).
+func isCASProtocol(source string) bool {
+	return strings.HasPrefix(source, cas.CASProtocolPrefix)
 }
 
 // copyFiles copies files or directories from a source to a destination path.

--- a/pkg/config/translate.go
+++ b/pkg/config/translate.go
@@ -62,11 +62,17 @@ func translateTerraformConfig(tf *TerraformConfig, l log.Logger) runcfg.Terrafor
 		noCopyTerraformLockFile = !*tf.CopyTerraformLockFile
 	}
 
+	updateSourceWithCAS := false
+	if tf.UpdateSourceWithCAS != nil {
+		updateSourceWithCAS = *tf.UpdateSourceWithCAS
+	}
+
 	return runcfg.TerraformConfig{
 		Source:                  source,
 		IncludeInCopy:           includeInCopy,
 		ExcludeFromCopy:         excludeFromCopy,
 		NoCopyTerraformLockFile: noCopyTerraformLockFile,
+		UpdateSourceWithCAS:     updateSourceWithCAS,
 		ExtraArgs:               translateExtraArgs(tf.ExtraArgs, l),
 		BeforeHooks:             translateHooks(tf.BeforeHooks),
 		AfterHooks:              translateHooks(tf.AfterHooks),

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -178,6 +178,10 @@ type TerragruntOptions struct {
 	Parallelism int
 	// When searching the directory tree, this is the max folders to check before exiting with an error.
 	MaxFoldersToCheck int
+	// CASCloneDepth is passed to git clone as --depth when CAS clones a remote
+	// repository. Defaults to 1 (see internal/cas.DefaultCASCloneDepth). Values must be
+	// positive (git rejects --depth 0) or negative (e.g. -1) for a full clone without --depth.
+	CASCloneDepth int
 	// Output Terragrunt logs in JSON format
 	JSONLogFormat bool
 	// True if terragrunt should run in debug mode
@@ -324,6 +328,7 @@ func NewTerragruntOptionsWithWriters(stdout, stderr io.Writer) *TerragruntOption
 		Telemetry:              new(telemetry.Options),
 		EngineOptions:          new(engine.EngineOptions),
 		VersionManagerFileName: defaultVersionManagerFileName,
+		CASCloneDepth:          1,
 	}
 }
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -240,6 +240,8 @@ type TerragruntOptions struct {
 	NoStackGenerate bool
 	// NoStackValidate disable generated stack validation.
 	NoStackValidate bool
+	// NoCAS disables the CAS feature even when the experiment is enabled.
+	NoCAS bool
 	// RunAll runs the provided OpenTofu/Terraform command against a stack.
 	RunAll bool
 	// Graph runs the provided OpenTofu/Terraform against the graph of dependencies for the unit in the current working directory.

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -1,8 +1,10 @@
 package options_test
 
 import (
+	"io"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
@@ -75,4 +77,11 @@ func TestInsertTerraformCliArgsNilGuard(t *testing.T) {
 	// Should not panic
 	opts.InsertTerraformCliArgs("plan")
 	assert.Equal(t, []string{"plan"}, opts.TerraformCliArgs.Slice())
+}
+
+func TestNewTerragruntOptionsWithWriters_DefaultCASCloneDepth(t *testing.T) {
+	t.Parallel()
+
+	opts := options.NewTerragruntOptionsWithWriters(io.Discard, io.Discard)
+	assert.Equal(t, cas.DefaultCASCloneDepth, opts.CASCloneDepth)
 }

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -2288,3 +2288,67 @@ func TestCASInStacks(t *testing.T) {
 	assert.Equal(t, wantStack, stackStr)
 	assert.Equal(t, wantUnit, unitStr)
 }
+
+// TestCASInStacksRejectsUpdateSourceWithCASWithNoCAS verifies that stack generation
+// errors when a unit or stack block declares update_source_with_cas = true while
+// --no-cas is set. The "experiment off" branch is covered by the unit tests in
+// internal/runner/run/download_source_test.go; integration-mode here always has the
+// cas experiment enabled via TG_EXPERIMENT_MODE, so --no-cas is the only way to
+// disable CAS for this scenario.
+func TestCASInStacksRejectsUpdateSourceWithCASWithNoCAS(t *testing.T) {
+	t.Parallel()
+
+	if !helpers.IsExperimentMode(t) {
+		t.Skip("Experiment mode is not enabled")
+	}
+
+	testCases := []struct {
+		name        string
+		stackConfig string
+		wantName    string
+	}{
+		{
+			name: "unit block",
+			stackConfig: `unit "bar" {
+  source = "../units/bar"
+  path   = "bar"
+
+  update_source_with_cas = true
+}
+`,
+			wantName: `"bar"`,
+		},
+		{
+			name: "stack block",
+			stackConfig: `stack "nested" {
+  source = "../nested"
+  path   = "nested"
+
+  update_source_with_cas = true
+}
+`,
+			wantName: `"nested"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmp := helpers.TmpDirWOSymlinks(t)
+			liveDir := filepath.Join(tmp, "live")
+			require.NoError(t, os.MkdirAll(liveDir, 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(liveDir, "terragrunt.stack.hcl"), []byte(tc.stackConfig), 0644))
+
+			_, stderr, err := helpers.RunTerragruntCommandWithOutput(
+				t,
+				"terragrunt stack generate --no-cas --non-interactive --working-dir "+liveDir,
+			)
+			require.Error(t, err)
+
+			combined := stderr + err.Error()
+			assert.Contains(t, combined, "update_source_with_cas")
+			assert.Contains(t, combined, tc.wantName)
+		})
+	}
+}

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -1745,12 +1745,12 @@ func TestStackOriginalTerragruntDir(t *testing.T) {
 		content, readErr := os.ReadFile(valuesPath)
 		require.NoError(t, readErr)
 
-		idx := strings.Index(valuesPath, string(os.PathSeparator)+dotStackDirName+string(os.PathSeparator))
-		if idx == -1 {
+		before, _, ok := strings.Cut(valuesPath, string(os.PathSeparator)+dotStackDirName+string(os.PathSeparator))
+		if !ok {
 			continue
 		}
 
-		expected := valuesPath[:idx]
+		expected := before
 
 		isNoLocals := strings.Contains(valuesPath, "no-locals")
 		isNestedReadConfig := strings.Contains(valuesPath, "read-config-nested")
@@ -2165,4 +2165,113 @@ func TestStackOutputWithExclude(t *testing.T) {
 		assert.True(t, util.FileNotExists(tfDir),
 			"excluded unit %s should not have .terraform directory", excluded)
 	}
+}
+
+// TestCASInStacks verifies that CAS works when integrated with stacks.
+func TestCASInStacks(t *testing.T) {
+	t.Parallel()
+
+	if !helpers.IsExperimentMode(t) {
+		t.Skip("Experiment mode is not enabled")
+	}
+
+	srv, err := git.NewServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	bazModule := ``
+	require.NoError(t, srv.CommitFile("modules/baz/main.tf", []byte(bazModule), "commit"))
+
+	require.NoError(t, srv.CommitFile("units/bar/terragrunt.hcl", []byte(`terraform {
+  source = "../..//modules/baz"
+
+  update_source_with_cas = true
+}
+`), "commit"))
+
+	url, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	remoteStack := `unit "bar" {
+  source = "../..//units/bar"
+  path   = "bar"
+
+  update_source_with_cas = true
+}
+`
+	require.NoError(t, srv.CommitFile("stacks/foo/terragrunt.stack.hcl", []byte(remoteStack), "commit"))
+
+	tmp := helpers.TmpDirWOSymlinks(t)
+
+	liveStackPath := filepath.Join(tmp, "live", "terragrunt.stack.hcl")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tmp, "live"), 0755))
+
+	liveStack := fmt.Sprintf(`stack "foo" {
+  source = "git::%s//stacks/foo"
+  path   = "foo"
+
+  update_source_with_cas = true
+}
+`, url)
+	require.NoError(t, os.WriteFile(liveStackPath, []byte(liveStack), 0644))
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack generate --working-dir "+tmp,
+	)
+	require.NoError(t, err)
+
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack run plan --non-interactive --working-dir "+tmp,
+	)
+	require.NoError(t, err)
+
+	runLog := stdout + stderr
+	assert.Contains(t, runLog, ".terragrunt-stack/foo")
+
+	// Generated tree lives next to the stack file: <tmp>/live/.terragrunt-stack/...
+	stackDir := filepath.Join(tmp, "live", ".terragrunt-stack")
+	assert.DirExists(t, stackDir)
+
+	expectedFiles := []string{
+		"foo/terragrunt.stack.hcl",
+		"foo/.terragrunt-stack/bar/terragrunt.hcl",
+		"foo/.terragrunt-stack/bar/main.tf",
+	}
+
+	for _, expectedFile := range expectedFiles {
+		assert.FileExists(t, filepath.Join(stackDir, expectedFile))
+	}
+
+	unitDir := filepath.Join(stackDir, "foo", ".terragrunt-stack", "bar")
+	assert.DirExists(t, unitDir)
+
+	stackConfig := filepath.Join(stackDir, "foo", "terragrunt.stack.hcl")
+	unitConfig := filepath.Join(unitDir, "terragrunt.hcl")
+
+	require.FileExists(t, stackConfig)
+	require.FileExists(t, unitConfig)
+
+	stackConfigContent, err := os.ReadFile(stackConfig)
+	require.NoError(t, err)
+	unitConfigContent, err := os.ReadFile(unitConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, remoteStack, string(stackConfigContent))
+
+	expectedUnitConfigContent := `terraform {
+  source = "."
+}
+`
+	assert.Equal(t, expectedUnitConfigContent, string(unitConfigContent))
+
+	mainTfPath := filepath.Join(unitDir, "main.tf")
+	require.FileExists(t, mainTfPath)
+
+	mainTfContent, err := os.ReadFile(mainTfPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "# empty tf", string(mainTfContent))
 }

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -2218,13 +2219,13 @@ func TestCASInStacks(t *testing.T) {
 
 	_, _, err = helpers.RunTerragruntCommandWithOutput(
 		t,
-		"terragrunt stack generate --working-dir "+tmp,
+		"terragrunt stack generate --cas-clone-depth=-1 --working-dir "+tmp,
 	)
 	require.NoError(t, err)
 
 	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(
 		t,
-		"terragrunt stack run plan --non-interactive --working-dir "+tmp,
+		"terragrunt stack run plan --non-interactive --cas-clone-depth=-1 --working-dir "+tmp,
 	)
 	require.NoError(t, err)
 
@@ -2238,7 +2239,6 @@ func TestCASInStacks(t *testing.T) {
 	expectedFiles := []string{
 		"foo/terragrunt.stack.hcl",
 		"foo/.terragrunt-stack/bar/terragrunt.hcl",
-		"foo/.terragrunt-stack/bar/main.tf",
 	}
 
 	for _, expectedFile := range expectedFiles {
@@ -2259,19 +2259,32 @@ func TestCASInStacks(t *testing.T) {
 	unitConfigContent, err := os.ReadFile(unitConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, remoteStack, string(stackConfigContent))
+	stackStr := string(stackConfigContent)
+	unitStr := string(unitConfigContent)
 
-	expectedUnitConfigContent := `terraform {
-  source = "."
+	// CAS digests depend on the resolved git ref and repo paths; assert exact file shape using the emitted hashes.
+	casSHA1Quoted := regexp.MustCompile(`"cas::sha1:([a-f0-9]{40})"`)
+	stackMatch := casSHA1Quoted.FindStringSubmatch(stackStr)
+	require.Len(t, stackMatch, 2, "generated stack should contain exactly one cas::sha1 reference in a quoted source attribute")
+
+	unitMatch := casSHA1Quoted.FindStringSubmatch(unitStr)
+	require.Len(t, unitMatch, 2, "generated unit terragrunt should contain exactly one cas::sha1 reference in a quoted source attribute")
+
+	wantStack := fmt.Sprintf(`unit "bar" {
+  source = "cas::sha1:%s"
+  path   = "bar"
+
+  update_source_with_cas = true
 }
-`
-	assert.Equal(t, expectedUnitConfigContent, string(unitConfigContent))
+`, stackMatch[1])
 
-	mainTfPath := filepath.Join(unitDir, "main.tf")
-	require.FileExists(t, mainTfPath)
+	wantUnit := fmt.Sprintf(`terraform {
+  source = "cas::sha1:%s"
 
-	mainTfContent, err := os.ReadFile(mainTfPath)
-	require.NoError(t, err)
+  update_source_with_cas = true
+}
+`, unitMatch[1])
 
-	assert.Equal(t, "# empty tf", string(mainTfContent))
+	assert.Equal(t, wantStack, stackStr)
+	assert.Equal(t, wantUnit, unitStr)
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds support for CAS in stacks.

Relates to #5558

This introduces the `update_source_with_cas` attribute on `terraform` blocks  in unit configurations (`terragrunt.hcl` files) and `unit` / `stack` blocks in stack configurations (`terragrunt.stack.hcl`). When set, any unit or stack cloned by a `terragrunt.stack.hcl` containing the attribute set to true on `terraform` blocks or `unit`/`stack` blocks will have their `source` attribute updated to a special `cas::` forced go-getter URL. This allows catalog authors to use relative paths instead of plumbed down remote URLs.

As part of this effort, the `--cas-clone-depth` flag was added. Certain Git providers (like the server provided built into `go-git`, I learned while working on this), don't have support for clones using the `--depth` flag. Instead of using a different Git server provider, I opted to make the depth control optional for the CAS, as users might legitimately integrate with Git providers that don't support setting `--depth`.

This PR also introduces a `--no-cas` flag to disable the CAS feature, even with the experiment active.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --no-cas and --cas-clone-depth flags; support for cas:: sources and deterministic CAS-backed stack/module materialization; new update_source_with_cas attribute to rewrite catalog-authored sources to cas:: references.

* **Documentation**
  * Expanded CAS docs with stack-generation integration, versioned Since/Before notes, hash-algorithm detection, CAS store layout, and guidance for enabling/disabling CAS.

* **Tests**
  * Added comprehensive unit and integration tests covering CAS parsing, rewriting, materialization, and stack workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->