### PR TITLE
fix: Fixing panic in telemetry

### DIFF
--- a/docs/src/data/changelog/v1.0.2.mdx
+++ b/docs/src/data/changelog/v1.0.2.mdx
@@ -1,0 +1,18 @@
+---
+version: "v1.0.2"
+---
+
+### 🐛 Bug Fixes
+
+---
+
+#### Panic in `get_repo_root()` when OpenTelemetry tracing is enabled with TRACEPARENT
+
+Running `terragrunt stack generate` (or any command that invoked shell commands like `git rev-parse`) with OpenTelemetry trace exporting enabled (`TG_TELEMETRY_TRACE_EXPORTER=http`) caused a nil pointer panic:
+
+```
+Call to function "get_repo_root" failed: panic in function implementation:
+runtime error: invalid memory address or nil pointer dereference
+```
+
+The root cause of the panic was fixed, and telemetry codepaths have been hardened against future panics.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -94,7 +94,7 @@ func (app *App) RunContext(ctx context.Context, args []string) error {
 		return err
 	}
 
-	telemeter, err := telemetry.NewTelemeter(ctx, app.Name, app.Version, app.Writer, app.opts.Telemetry)
+	telemeter, err := telemetry.NewTelemeter(ctx, app.l, app.Name, app.Version, app.Writer, app.opts.Telemetry)
 	if err != nil {
 		return err
 	}

--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -69,19 +69,17 @@ func populateFromOpts(pctx *config.ParsingContext, opts *options.TerragruntOptio
 
 // ShellRunOptsFromOpts constructs shell.ShellOptions from TerragruntOptions.
 func ShellRunOptsFromOpts(opts *options.TerragruntOptions) *shell.ShellOptions {
-	return &shell.ShellOptions{
-		Writers:         opts.Writers,
-		EngineOptions:   opts.EngineOptions,
-		WorkingDir:      opts.WorkingDir,
-		Env:             opts.Env,
-		TFPath:          opts.TFPath,
-		EngineConfig:    opts.EngineConfig,
-		Experiments:     opts.Experiments,
-		Telemetry:       opts.Telemetry,
-		RootWorkingDir:  opts.RootWorkingDir,
-		Headless:        opts.Headless,
-		ForwardTFStdout: opts.ForwardTFStdout,
-	}
+	return shell.NewShellOptions().
+		WithWorkingDir(opts.WorkingDir).
+		WithEnv(opts.Env).
+		WithWriters(opts.Writers).
+		WithTelemetry(opts.Telemetry).
+		WithEngine(opts.EngineConfig, opts.EngineOptions).
+		WithTFPath(opts.TFPath).
+		WithRootWorkingDir(opts.RootWorkingDir).
+		WithExperiments(opts.Experiments).
+		WithHeadless(opts.Headless).
+		WithForwardTFStdout(opts.ForwardTFStdout)
 }
 
 // BackendOptsFromOpts constructs backend.Options from TerragruntOptions.

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -179,19 +179,17 @@ func (o *Options) DataDir() string {
 
 // shellRunOptions builds a *shell.ShellOptions from this Options.
 func (o *Options) shellRunOptions() *shell.ShellOptions {
-	return &shell.ShellOptions{
-		Writers:         o.Writers,
-		WorkingDir:      o.WorkingDir,
-		Env:             o.Env,
-		TFPath:          o.TFPath,
-		EngineConfig:    o.EngineConfig,
-		EngineOptions:   o.EngineOptions,
-		Experiments:     o.Experiments,
-		Telemetry:       o.Telemetry,
-		RootWorkingDir:  o.RootWorkingDir,
-		Headless:        o.Headless,
-		ForwardTFStdout: o.ForwardTFStdout,
-	}
+	return shell.NewShellOptions().
+		WithWorkingDir(o.WorkingDir).
+		WithEnv(o.Env).
+		WithWriters(o.Writers).
+		WithTelemetry(o.Telemetry).
+		WithEngine(o.EngineConfig, o.EngineOptions).
+		WithTFPath(o.TFPath).
+		WithRootWorkingDir(o.RootWorkingDir).
+		WithExperiments(o.Experiments).
+		WithHeadless(o.Headless).
+		WithForwardTFStdout(o.ForwardTFStdout)
 }
 
 // tfRunOptions builds a *tf.TFOptions from this Options.

--- a/internal/shell/git.go
+++ b/internal/shell/git.go
@@ -32,11 +32,10 @@ func GitTopLevelDir(ctx context.Context, l log.Logger, env map[string]string, pa
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	gitRunOpts := &ShellOptions{
-		Writers:    writer.Writers{Writer: &stdout, ErrWriter: &stderr},
-		WorkingDir: path,
-		Env:        env,
-	}
+	gitRunOpts := NewShellOptions().
+		WithWorkingDir(path).
+		WithEnv(env).
+		WithWriters(writer.Writers{Writer: &stdout, ErrWriter: &stderr})
 
 	cmd, err := RunCommandWithOutput(ctx, l, gitRunOpts, path, true, false, "git", "rev-parse", "--show-toplevel")
 	if err != nil {
@@ -65,11 +64,10 @@ func GitRepoTags(ctx context.Context, l log.Logger, env map[string]string, worki
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	gitRunOpts := &ShellOptions{
-		Writers:    writer.Writers{Writer: &stdout, ErrWriter: &stderr},
-		WorkingDir: workingDir,
-		Env:        env,
-	}
+	gitRunOpts := NewShellOptions().
+		WithWorkingDir(workingDir).
+		WithEnv(env).
+		WithWriters(writer.Writers{Writer: &stdout, ErrWriter: &stderr})
 
 	output, err := RunCommandWithOutput(ctx, l, gitRunOpts, workingDir, true, false, "git", "ls-remote", "--tags", repoPath)
 	if err != nil {

--- a/internal/shell/run_cmd.go
+++ b/internal/shell/run_cmd.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -43,6 +44,112 @@ type ShellOptions struct {
 	Experiments     experiment.Experiments
 	Headless        bool
 	ForwardTFStdout bool
+}
+
+// NewShellOptions creates ShellOptions with sensible defaults:
+//   - Writers default to os.Stdout / os.Stderr.
+//   - Telemetry is always non-nil; TRACEPARENT is read from the environment when set.
+//
+// Use the With* methods to override any of these.
+func NewShellOptions() *ShellOptions {
+	opts := &ShellOptions{
+		Env: make(map[string]string),
+		Writers: writer.Writers{
+			Writer:    os.Stdout,
+			ErrWriter: os.Stderr,
+		},
+		Telemetry: &telemetry.Options{},
+	}
+
+	if tp := os.Getenv(telemetry.TraceParentEnv); tp != "" {
+		opts.Telemetry.TraceParent = tp
+	}
+
+	return opts
+}
+
+// WithWorkingDir sets the working directory for command execution.
+func (o *ShellOptions) WithWorkingDir(dir string) *ShellOptions {
+	o.WorkingDir = dir
+
+	return o
+}
+
+// WithEnv sets the environment variables for command execution.
+func (o *ShellOptions) WithEnv(env map[string]string) *ShellOptions {
+	o.Env = env
+
+	return o
+}
+
+// WithWriters sets the stdout/stderr writers.
+func (o *ShellOptions) WithWriters(w writer.Writers) *ShellOptions {
+	o.Writers = w
+
+	return o
+}
+
+// SetTraceParent explicitly overrides the TRACEPARENT value used for trace context propagation.
+func (o *ShellOptions) SetTraceParent(tp string) *ShellOptions {
+	if o.Telemetry == nil {
+		o.Telemetry = &telemetry.Options{}
+	}
+
+	o.Telemetry.TraceParent = tp
+
+	return o
+}
+
+// WithTelemetry sets the full telemetry options, replacing the defaults from the constructor.
+func (o *ShellOptions) WithTelemetry(t *telemetry.Options) *ShellOptions {
+	if t != nil {
+		o.Telemetry = t
+	}
+
+	return o
+}
+
+// WithEngine sets the engine configuration and options.
+func (o *ShellOptions) WithEngine(cfg *engine.EngineConfig, opts *engine.EngineOptions) *ShellOptions {
+	o.EngineConfig = cfg
+	o.EngineOptions = opts
+
+	return o
+}
+
+// WithTFPath sets the path to the Terraform/OpenTofu binary.
+func (o *ShellOptions) WithTFPath(path string) *ShellOptions {
+	o.TFPath = path
+
+	return o
+}
+
+// WithRootWorkingDir sets the root working directory used in error messages.
+func (o *ShellOptions) WithRootWorkingDir(dir string) *ShellOptions {
+	o.RootWorkingDir = dir
+
+	return o
+}
+
+// WithExperiments sets the active experiments.
+func (o *ShellOptions) WithExperiments(exp experiment.Experiments) *ShellOptions {
+	o.Experiments = exp
+
+	return o
+}
+
+// WithHeadless sets the headless mode flag.
+func (o *ShellOptions) WithHeadless(h bool) *ShellOptions {
+	o.Headless = h
+
+	return o
+}
+
+// WithForwardTFStdout sets the flag to forward TF stdout.
+func (o *ShellOptions) WithForwardTFStdout(f bool) *ShellOptions {
+	o.ForwardTFStdout = f
+
+	return o
 }
 
 // NoEngine returns true if the user explicitly disabled the engine via --no-engine.
@@ -96,9 +203,7 @@ func RunCommandWithOutput(
 		)
 
 		// Pass the traceparent to the child process if it is available in the context.
-		traceParent := telemetry.TraceParentFromContext(ctx, runOpts.Telemetry)
-
-		if traceParent != "" {
+		if traceParent := telemetry.TraceParentFromContext(ctx, runOpts.Telemetry); traceParent != "" {
 			l.Debugf("Setting trace parent=%q for command %s", traceParent, fmt.Sprintf("%s %v", command, args))
 			runOpts.Env[telemetry.TraceParentEnv] = traceParent
 		}

--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -40,7 +40,7 @@ func TraceParentFromContext(ctx context.Context, telemetry *Options) string {
 		return ""
 	}
 
-	if len(telemetry.TraceParent) > 0 {
+	if telemetry != nil && len(telemetry.TraceParent) > 0 {
 		return telemetry.TraceParent
 	}
 

--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -19,10 +19,11 @@ func ContextWithTelemeter(ctx context.Context, telemeter *Telemeter) context.Con
 	return context.WithValue(ctx, telemeterContextKey, telemeter)
 }
 
-// TelemeterFromContext retrieves the Telemeter from the context, or nil if not present.
+// TelemeterFromContext retrieves the Telemeter from the context.
+// Returns a zero-value Telemeter (safe no-op) if not present or nil.
 func TelemeterFromContext(ctx context.Context) *Telemeter {
 	if val := ctx.Value(telemeterContextKey); val != nil {
-		if telemeter, ok := val.(*Telemeter); ok {
+		if telemeter, ok := val.(*Telemeter); ok && telemeter != nil {
 			return telemeter
 		}
 	}

--- a/internal/telemetry/telemeter.go
+++ b/internal/telemetry/telemeter.go
@@ -4,18 +4,21 @@ package telemetry
 import (
 	"context"
 	"io"
+	"runtime/debug"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
 type Telemeter struct {
 	*Tracer
 	*Meter
+	l log.Logger
 }
 
 // NewTelemeter initializes the telemetry collector.
-func NewTelemeter(ctx context.Context, appName, appVersion string, writer io.Writer, opts *Options) (*Telemeter, error) {
-	tracer, err := NewTracer(ctx, appName, appVersion, writer, opts)
+func NewTelemeter(ctx context.Context, l log.Logger, appName, appVersion string, writer io.Writer, opts *Options) (*Telemeter, error) {
+	tracer, err := NewTracer(ctx, l, appName, appVersion, writer, opts)
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -28,6 +31,7 @@ func NewTelemeter(ctx context.Context, appName, appVersion string, writer io.Wri
 	return &Telemeter{
 		Tracer: tracer,
 		Meter:  meter,
+		l:      l,
 	}, nil
 }
 
@@ -59,6 +63,12 @@ func (tlm *Telemeter) Shutdown(ctx context.Context) error {
 // Collect collects telemetry from function execution metrics and traces.
 func (tlm *Telemeter) Collect(ctx context.Context, name string, attrs map[string]any, fn func(childCtx context.Context) error) error {
 	if tlm == nil {
+		// This should not happen in normal operation. Log a stack trace to help
+		// diagnose if this nil guard is the one preventing a panic.
+		if l := telemeterLoggerFromContext(ctx); l != nil {
+			l.Debugf("Telemeter.Collect called with nil receiver for %q, bypassing telemetry. Stack:\n%s", name, debug.Stack())
+		}
+
 		return fn(ctx)
 	}
 
@@ -66,4 +76,16 @@ func (tlm *Telemeter) Collect(ctx context.Context, name string, attrs map[string
 	return tlm.Trace(ctx, name, attrs, func(ctx context.Context) error {
 		return tlm.Time(ctx, name, attrs, fn)
 	})
+}
+
+// telemeterLoggerFromContext attempts to retrieve the logger from a telemeter
+// stored in the context. Returns nil if no telemeter or logger is available.
+func telemeterLoggerFromContext(ctx context.Context) log.Logger {
+	if val := ctx.Value(telemeterContextKey); val != nil {
+		if tlm, ok := val.(*Telemeter); ok && tlm != nil {
+			return tlm.l
+		}
+	}
+
+	return nil
 }

--- a/internal/telemetry/telemeter.go
+++ b/internal/telemetry/telemeter.go
@@ -33,6 +33,10 @@ func NewTelemeter(ctx context.Context, appName, appVersion string, writer io.Wri
 
 // Shutdown shutdowns the telemetry provider.
 func (tlm *Telemeter) Shutdown(ctx context.Context) error {
+	if tlm == nil {
+		return nil
+	}
+
 	if tlm.Tracer != nil && tlm.Tracer.provider != nil {
 		if err := tlm.Tracer.provider.Shutdown(ctx); err != nil {
 			return errors.New(err)
@@ -54,6 +58,10 @@ func (tlm *Telemeter) Shutdown(ctx context.Context) error {
 
 // Collect collects telemetry from function execution metrics and traces.
 func (tlm *Telemeter) Collect(ctx context.Context, name string, attrs map[string]any, fn func(childCtx context.Context) error) error {
+	if tlm == nil {
+		return fn(ctx)
+	}
+
 	// wrap telemetry collection with trace and time metric
 	return tlm.Trace(ctx, name, attrs, func(ctx context.Context) error {
 		return tlm.Time(ctx, name, attrs, fn)

--- a/internal/telemetry/tracer.go
+++ b/internal/telemetry/tracer.go
@@ -192,6 +192,11 @@ func (tracer *Tracer) Trace(ctx context.Context, name string, attrs map[string]a
 	}
 
 	ctx, span := tracer.openSpan(ctx, name, attrs)
+
+	if span == nil {
+		return fn(ctx)
+	}
+
 	defer span.End()
 
 	if err := fn(ctx); err != nil {

--- a/internal/telemetry/tracer.go
+++ b/internal/telemetry/tracer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -12,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -39,10 +41,11 @@ type Tracer struct {
 	parentTraceID    *trace.TraceID
 	parentSpanID     *trace.SpanID
 	parentTraceFlags *trace.TraceFlags
+	l                log.Logger
 }
 
 // NewTracer creates and configures the traces collection.
-func NewTracer(ctx context.Context, appName, appVersion string, writer io.Writer, opts *Options) (*Tracer, error) {
+func NewTracer(ctx context.Context, l log.Logger, appName, appVersion string, writer io.Writer, opts *Options) (*Tracer, error) {
 	spanExporter, err := NewTraceExporter(ctx, writer, opts)
 	if err != nil {
 		return nil, errors.New(err)
@@ -106,6 +109,7 @@ func NewTracer(ctx context.Context, appName, appVersion string, writer io.Writer
 		parentTraceID:    parentTraceID,
 		parentSpanID:     parentSpanID,
 		parentTraceFlags: parentTraceFlags,
+		l:                l,
 	}
 
 	return tracer, nil
@@ -194,6 +198,10 @@ func (tracer *Tracer) Trace(ctx context.Context, name string, attrs map[string]a
 	ctx, span := tracer.openSpan(ctx, name, attrs)
 
 	if span == nil {
+		if tracer.l != nil {
+			tracer.l.Debugf("openSpan returned nil span for %q (provider may have been shut down), bypassing tracing. Stack:\n%s", name, debug.Stack())
+		}
+
 		return fn(ctx)
 	}
 

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1446,21 +1446,19 @@ func runTerragruntOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Lo
 	return jsonBytes, nil
 }
 
-// shellRunOptsFromPctx builds a *shell.RunOptions from ParsingContext flat fields.
+// shellRunOptsFromPctx builds a *shell.ShellOptions from ParsingContext flat fields.
 func shellRunOptsFromPctx(pctx *ParsingContext) *shell.ShellOptions {
-	return &shell.ShellOptions{
-		Writers:         pctx.Writers,
-		EngineOptions:   pctx.EngineOptions,
-		WorkingDir:      pctx.WorkingDir,
-		Env:             pctx.Env,
-		TFPath:          pctx.TFPath,
-		EngineConfig:    pctx.EngineConfig,
-		Experiments:     pctx.Experiments,
-		Telemetry:       pctx.Telemetry,
-		RootWorkingDir:  pctx.RootWorkingDir,
-		Headless:        pctx.Headless,
-		ForwardTFStdout: pctx.ForwardTFStdout,
-	}
+	return shell.NewShellOptions().
+		WithWorkingDir(pctx.WorkingDir).
+		WithEnv(pctx.Env).
+		WithWriters(pctx.Writers).
+		WithTelemetry(pctx.Telemetry).
+		WithEngine(pctx.EngineConfig, pctx.EngineOptions).
+		WithTFPath(pctx.TFPath).
+		WithRootWorkingDir(pctx.RootWorkingDir).
+		WithExperiments(pctx.Experiments).
+		WithHeadless(pctx.Headless).
+		WithForwardTFStdout(pctx.ForwardTFStdout)
 }
 
 // tfRunOptsFromPctx builds a *tf.RunOptions from ParsingContext flat fields.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This is the change that was actually catching the nil pointer de-reference:
https://github.com/gruntwork-io/terragrunt/pull/5915/changes/8d558fb910ecf2df595a63bad1d0e2dca3a68ef1

The rest is all defensive nil guards and debug stack traces to pinpoint areas where telemetry might be dropped due to un-handled nil pointer de-references elsewhere.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a panic in `get_repo_root()` that occurred when OpenTelemetry tracing was enabled with HTTP exporter (`TG_TELEMETRY_TRACE_EXPORTER=http`) during commands like `terragrunt stack generate`.
  * Hardened telemetry code paths to prevent future nil-pointer panics and improve overall stability when tracing is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->