### PR TITLE
Revert "chore: bump cloud-nuke to v0.49.0"

### DIFF
--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -26,7 +26,7 @@ jobs:
         env:
             # Authenticate to reduce the likelihood of hitting rate limit issues.
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            VERSION: 0.49.0
+            VERSION: 0.40.0
 
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6


### PR DESCRIPTION
Reverts gruntwork-io/terragrunt#5893

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI infrastructure configuration to use a different version of a deployment tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->