### PR TITLE
fix: correct cloud-nuke config YAML keys and bump to v0.49.0

### DIFF
--- a/.github/cloud-nuke/config.yml
+++ b/.github/cloud-nuke/config.yml
@@ -1,21 +1,21 @@
-s3:
+S3:
   timeout: 1h
   include:
     names_regex:
       - "^terragrunt-test-bucket-[a-zA-Z0-9]{6}.*"
 
-vpc:
+VPC:
   include:
-    name_regex:
+    names_regex:
       - "^vpc-.*"
       - "^step-.*"
 
-ec2:
+EC2:
   include:
-    name_regex:
+    names_regex:
       - "^single-instance$"
 
-dynamodb:
+DynamoDB:
   include:
-    table_names_regex:
+    names_regex:
       - "^terragrunt-test.*"

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -26,7 +26,7 @@ jobs:
         env:
             # Authenticate to reduce the likelihood of hitting rate limit issues.
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            VERSION: 0.40.0
+            VERSION: 0.49.0
 
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6


### PR DESCRIPTION
## Summary
- Fix incorrect YAML field names in `.github/cloud-nuke/config.yml` that cause strict unmarshalling failures in cloud-nuke v0.49.0
- Capitalize top-level resource keys to match cloud-nuke's Config struct tags (`s3`→`S3`, `vpc`→`VPC`, `ec2`→`EC2`, `dynamodb`→`DynamoDB`)
- Fix nested filter keys (`name_regex`→`names_regex`, `table_names_regex`→`names_regex`)
- Bump cloud-nuke from v0.40.0 to v0.49.0

## Context
PR #5893 bumped cloud-nuke to v0.49.0 but the hourly nuke job failed because the config file had wrong YAML keys. It was reverted in #5919. The root cause is that cloud-nuke v0.49.0 uses `yaml.UnmarshalStrict()` which rejects unknown fields.

With the old v0.40.0 (non-strict unmarshalling), the wrong keys were silently ignored — meaning VPC, EC2, and DynamoDB filters were never actually applied. This PR fixes all keys so all four resource filters work correctly.

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` and verify it passes
- [ ] Confirm resources matching the regex patterns are cleaned up on the next hourly run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Cloud-Nuke infrastructure configuration with consistent naming conventions across all resource types.
  * Upgraded Cloud-Nuke to the latest version for improved cloud resource management and cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->