### PR TITLE
feat: Adding types, sources and versions to catalog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
 	github.com/aws/smithy-go v1.24.3
 	github.com/charmbracelet/colorprofile v0.4.2
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/docker/go-connections v0.6.0
 	github.com/go-git/go-billy/v6 v6.0.0-20260328065524-593ae452e14d
@@ -162,7 +163,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/internal/cli/commands/catalog/catalog_redesign.go
+++ b/internal/cli/commands/catalog/catalog_redesign.go
@@ -70,8 +70,6 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 				seen[repoURL] = struct{}{}
 
 				loaders.Go(func() error {
-					// Collect modules from this repo so we can resolve the tag once
-					// for the shared Repo, then wrap all modules before sending.
 					var collected []*module.Module
 
 					onModule := func(mod *module.Module) {

--- a/internal/cli/commands/catalog/catalog_redesign.go
+++ b/internal/cli/commands/catalog/catalog_redesign.go
@@ -31,16 +31,9 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 	return redesign.RunRedesign(
 		ctx, l, opts,
 		func(
-			ctx context.Context, status redesign.StatusFunc, moduleCh chan<- *module.Module,
+			ctx context.Context, status redesign.StatusFunc, moduleCh chan<- *redesign.ModuleEntry,
 		) (catalog.CatalogService, error) {
 			svc := catalog.NewCatalogService(opts)
-
-			onModule := func(mod *module.Module) {
-				select {
-				case moduleCh <- mod:
-				case <-ctx.Done():
-				}
-			}
 
 			urlCh := make(chan string, 10) //nolint:mnd
 
@@ -64,7 +57,7 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 
 			maxWorkers := max(1, min(opts.Parallelism, runtime.GOMAXPROCS(0)))
 
-			loaders, loadCtx := errgroup.WithContext(gctx)
+			loaders, loadCtx := errgroup.WithContext(ctx)
 			loaders.SetLimit(maxWorkers)
 
 			seen := make(map[string]struct{})
@@ -77,10 +70,38 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 				seen[repoURL] = struct{}{}
 
 				loaders.Go(func() error {
+					// Collect modules from this repo so we can resolve the tag once
+					// for the shared Repo, then wrap all modules before sending.
+					var collected []*module.Module
+
+					onModule := func(mod *module.Module) {
+						collected = append(collected, mod)
+					}
+
 					if err := svc.LoadStreamingURL(loadCtx, l, repoURL, onModule); err != nil {
-						// Individual repo failures are non-critical — warn and
-						// continue so remaining repos can still load.
-						l.Warnf("Error loading %s: %v", repoURL, err)
+						// Suppress errors from context cancellation (user quit the TUI).
+						if loadCtx.Err() == nil {
+							l.Warnf("Error loading %s: %v", repoURL, err)
+						}
+
+						return nil
+					}
+
+					// All modules from the same repo share a *Repo. Resolve the
+					// latest tag once using the cloned repo on disk.
+					if len(collected) > 0 {
+						collected[0].Repo.ResolveLatestTag(loadCtx)
+					}
+
+					for _, mod := range collected {
+						source := redesign.ExtractRepoURL(mod.TerraformSourcePath())
+						entry := redesign.NewModuleEntry(mod).WithSource(source)
+
+						if mod.Repo.LatestTag != "" {
+							entry = entry.WithVersion(mod.Repo.LatestTag)
+						}
+
+						moduleCh <- entry
 					}
 
 					return nil

--- a/internal/cli/commands/catalog/catalog_redesign.go
+++ b/internal/cli/commands/catalog/catalog_redesign.go
@@ -57,6 +57,8 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 
 			maxWorkers := max(1, min(opts.Parallelism, runtime.GOMAXPROCS(0)))
 
+			// Derive from ctx (not gctx) so loaders survive discovery-group
+			// cancellation. gctx is cancelled automatically when g.Wait returns.
 			loaders, loadCtx := errgroup.WithContext(ctx)
 			loaders.SetLimit(maxWorkers)
 
@@ -99,7 +101,11 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 							entry = entry.WithVersion(mod.Repo.LatestTag)
 						}
 
-						moduleCh <- entry
+						select {
+						case moduleCh <- entry:
+						case <-loadCtx.Done():
+							return nil
+						}
 					}
 
 					return nil

--- a/internal/cli/commands/catalog/tui/redesign/delegate.go
+++ b/internal/cli/commands/catalog/tui/redesign/delegate.go
@@ -29,15 +29,18 @@ const (
 	sourceColorSelected = "#B4DAFF"
 
 	metaMuted = "#6C7086"
+
+	// delegateHeight is the number of lines per catalog item (title + desc + meta).
+	delegateHeight = 3
 )
 
 // catalogDelegate renders catalog modules with a color-coded metadata row
 // (type pill, source, version pill) below the title and description.
 type catalogDelegate struct {
-	styles     list.DefaultItemStyles
-	keys       *tui.DelegateKeyMap
-	shortHelp  func() []key.Binding
-	fullHelp   func() [][]key.Binding
+	styles    list.DefaultItemStyles
+	keys      *tui.DelegateKeyMap
+	shortHelp func() []key.Binding
+	fullHelp  func() [][]key.Binding
 }
 
 func newCatalogDelegate(keys *tui.DelegateKeyMap) catalogDelegate {
@@ -67,22 +70,22 @@ func newCatalogDelegate(keys *tui.DelegateKeyMap) catalogDelegate {
 }
 
 // Height returns the delegate's preferred height (title + desc + meta + spacing).
-func (d catalogDelegate) Height() int {
-	return 3
+func (d catalogDelegate) Height() int { //nolint:gocritic // value receiver required by list.ItemDelegate interface
+	return delegateHeight
 }
 
 // Spacing returns the gap between items.
-func (d catalogDelegate) Spacing() int {
+func (d catalogDelegate) Spacing() int { //nolint:gocritic // value receiver required by list.ItemDelegate interface
 	return 1
 }
 
 // Update is a no-op; input is handled by the model.
-func (d catalogDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd {
+func (d catalogDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { //nolint:gocritic // value receiver required by list.ItemDelegate interface
 	return nil
 }
 
 // ShortHelp returns the delegate's short help bindings.
-func (d catalogDelegate) ShortHelp() []key.Binding {
+func (d catalogDelegate) ShortHelp() []key.Binding { //nolint:gocritic // value receiver required by list.ItemDelegate interface
 	if d.shortHelp != nil {
 		return d.shortHelp()
 	}
@@ -91,7 +94,7 @@ func (d catalogDelegate) ShortHelp() []key.Binding {
 }
 
 // FullHelp returns the delegate's full help bindings.
-func (d catalogDelegate) FullHelp() [][]key.Binding {
+func (d catalogDelegate) FullHelp() [][]key.Binding { //nolint:gocritic // value receiver required by list.ItemDelegate interface
 	if d.fullHelp != nil {
 		return d.fullHelp()
 	}
@@ -100,7 +103,7 @@ func (d catalogDelegate) FullHelp() [][]key.Binding {
 }
 
 // Render prints an item with title, description, and metadata row.
-func (d catalogDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) { //nolint:funlen,cyclop
+func (d catalogDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) { //nolint:funlen,cyclop,gocritic // value receiver required by list.ItemDelegate interface
 	entry, isEntry := item.(*ModuleEntry)
 	if !isEntry {
 		return
@@ -120,6 +123,7 @@ func (d catalogDelegate) Render(w io.Writer, m list.Model, index int, item list.
 
 	// Limit description to a single line
 	var lines []string
+
 	for i, line := range strings.Split(desc, "\n") {
 		if i >= 1 {
 			break
@@ -190,7 +194,7 @@ func (d catalogDelegate) Render(w io.Writer, m list.Model, index int, item list.
 
 	colors := metaPalette(isSelected && m.FilterState() != list.Filtering, emptyFilter)
 	metaLine := lipgloss.NewStyle().Padding(0, padR, 0, padL).Render(
-		buildMetaRow(entry, metaInnerWidth, colors))
+		buildMetaRow(entry, metaInnerWidth, &colors))
 
 	fmt.Fprintf(w, "%s\n%s\n%s", title, desc, metaLine) //nolint:errcheck,gosec
 }

--- a/internal/cli/commands/catalog/tui/redesign/delegate.go
+++ b/internal/cli/commands/catalog/tui/redesign/delegate.go
@@ -16,11 +16,11 @@ import (
 
 // Pill and metadata color constants.
 const (
-	// Module type pill (green-tinted).
-	modulePillBg  = "#2B3D2B"
-	modulePillFg  = "#A6E3A1"
-	modulePillBgS = "#3D5A3D"
-	modulePillFgS = "#C7F5C9"
+	// Module type pill (OpenTofu yellow).
+	modulePillBg  = "#3D3520"
+	modulePillFg  = "#FFDA18"
+	modulePillBgS = "#4D4328"
+	modulePillFgS = "#FFE44D"
 
 	// Stack type pill (blue-tinted).
 	stackPillBg  = "#2B2F3D"
@@ -34,12 +34,12 @@ const (
 	versionBgS = "#45475A"
 	versionFgS = "#CDD6F4"
 
-	// Source URL (muted).
-	sourceColor  = "#7F849C"
-	sourceColorS = "#9399B2"
+	// Source URL (neutral gray, matching the help/controls bar tone).
+	sourceColor  = "#4A4A4A"
+	sourceColorS = "#5A5A5A"
 
-	// Description (blue/link-like, prominent).
-	descForegroundColor = "#89B4FA"
+	// Description (muted blue-gray, readable but secondary to title).
+	descForegroundColor = "#8393A7"
 
 	metaMuted = "#6C7086"
 
@@ -283,6 +283,6 @@ const (
 	selectedTitleForegroundColorDark       = "#63C5DA"
 	selectedTitleBorderForegroundColorDark = "#63C5DA"
 
-	selectedDescForegroundColorDark       = "#89B4FA"
+	selectedDescForegroundColorDark       = "#59788E"
 	selectedDescBorderForegroundColorDark = "#63C5DA"
 )

--- a/internal/cli/commands/catalog/tui/redesign/delegate.go
+++ b/internal/cli/commands/catalog/tui/redesign/delegate.go
@@ -119,7 +119,7 @@ func (d catalogDelegate) FullHelp() [][]key.Binding { //nolint:gocritic // value
 }
 
 // Render prints an item with title, description, and metadata row.
-func (d catalogDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) { //nolint:funlen,cyclop,gocritic // value receiver required by list.ItemDelegate interface
+func (d catalogDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) { //nolint:gocritic // value receiver required by list.ItemDelegate interface
 	entry, isEntry := item.(*ModuleEntry)
 	if !isEntry {
 		return
@@ -131,99 +131,95 @@ func (d catalogDelegate) Render(w io.Writer, m list.Model, index int, item list.
 
 	s := &d.styles
 
-	title := entry.Title()
-	desc := entry.Description()
-
 	textwidth := m.Width() - s.NormalTitle.GetPaddingLeft() - s.NormalTitle.GetPaddingRight()
-	title = ansi.Truncate(title, textwidth, "…")
+	title := ansi.Truncate(entry.Title(), textwidth, "…")
+	desc := truncateFirstLine(entry.Description(), textwidth)
 
-	// Limit description to a single line
-	var lines []string
-
-	for i, line := range strings.Split(desc, "\n") {
-		if i >= 1 {
-			break
-		}
-
-		lines = append(lines, ansi.Truncate(line, textwidth, "…"))
-	}
-
-	desc = strings.Join(lines, "\n")
-
-	isSelected := index == m.Index()
+	selected := index == m.Index() && m.FilterState() != list.Filtering
 	emptyFilter := m.FilterState() == list.Filtering && m.FilterValue() == ""
 	isFiltered := m.FilterState() == list.Filtering || m.FilterState() == list.FilterApplied
 
 	var matchedRunes []int
-
 	if isFiltered {
 		matchedRunes = m.MatchesForItem(index)
 	}
 
-	// Determine padding for the metadata row alignment
-	var padL, padR int
+	padL, padR := metaPadding(s, selected, emptyFilter)
+	title, desc = styleTitleDesc(s, title, desc, selected, emptyFilter, isFiltered, matchedRunes)
 
-	switch {
-	case emptyFilter:
-		padL = s.DimmedTitle.GetPaddingLeft()
-		padR = s.DimmedTitle.GetPaddingRight()
-	case isSelected && m.FilterState() != list.Filtering:
-		padL = s.SelectedTitle.GetPaddingLeft()
-		padR = s.SelectedTitle.GetPaddingRight()
-		// Account for the border on the selected style
-		padL += s.SelectedTitle.GetBorderLeftSize()
-	default:
-		padL = s.NormalTitle.GetPaddingLeft()
-		padR = s.NormalTitle.GetPaddingRight()
+	metaInnerWidth := max(1, m.Width()-padL-padR)
+	colors := metaPalette(entry.ItemType, selected, emptyFilter)
+	metaContent := buildMetaRow(entry, metaInnerWidth, &colors)
+	metaLine := styleMetaLine(s, metaContent, selected, padL, padR)
+
+	fmt.Fprintf(w, "%s\n%s\n%s", title, desc, metaLine) //nolint:errcheck,gosec
+}
+
+// truncateFirstLine returns only the first line of s, truncated to maxWidth.
+func truncateFirstLine(s string, maxWidth int) string {
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		s = s[:idx]
 	}
 
-	// Style title and description based on state
-	switch {
-	case emptyFilter:
-		title = s.DimmedTitle.Render(title)
-		desc = s.DimmedDesc.Render(desc)
-	case isSelected && m.FilterState() != list.Filtering:
+	return ansi.Truncate(s, maxWidth, "…")
+}
+
+// metaPadding returns left/right padding for the metadata row based on
+// the current selection and filter state.
+func metaPadding(s *list.DefaultItemStyles, selected, emptyFilter bool) (int, int) {
+	if emptyFilter {
+		return s.DimmedTitle.GetPaddingLeft(), s.DimmedTitle.GetPaddingRight()
+	}
+
+	if selected {
+		padL := s.SelectedTitle.GetPaddingLeft() + s.SelectedTitle.GetBorderLeftSize()
+		return padL, s.SelectedTitle.GetPaddingRight()
+	}
+
+	return s.NormalTitle.GetPaddingLeft(), s.NormalTitle.GetPaddingRight()
+}
+
+// styleTitleDesc applies the appropriate lipgloss styles to the title and
+// description strings based on selection and filter state.
+func styleTitleDesc(
+	s *list.DefaultItemStyles,
+	title, desc string,
+	selected, emptyFilter, isFiltered bool,
+	matchedRunes []int,
+) (string, string) {
+	if emptyFilter {
+		return s.DimmedTitle.Render(title), s.DimmedDesc.Render(desc)
+	}
+
+	if selected {
 		if isFiltered {
 			unmatched := s.SelectedTitle.Inline(true)
 			matched := unmatched.Inherit(s.FilterMatch)
 			title = lipgloss.StyleRunes(title, matchedRunes, matched, unmatched)
 		}
 
-		title = s.SelectedTitle.Render(title)
-		desc = s.SelectedDesc.Render(desc)
-	default:
-		if isFiltered {
-			unmatched := s.NormalTitle.Inline(true)
-			matched := unmatched.Inherit(s.FilterMatch)
-			title = lipgloss.StyleRunes(title, matchedRunes, matched, unmatched)
-		}
-
-		title = s.NormalTitle.Render(title)
-		desc = s.NormalDesc.Render(desc)
+		return s.SelectedTitle.Render(title), s.SelectedDesc.Render(desc)
 	}
 
-	// Build metadata row
-	metaInnerWidth := m.Width() - padL - padR
-	if metaInnerWidth < 1 {
-		metaInnerWidth = 1
+	if isFiltered {
+		unmatched := s.NormalTitle.Inline(true)
+		matched := unmatched.Inherit(s.FilterMatch)
+		title = lipgloss.StyleRunes(title, matchedRunes, matched, unmatched)
 	}
 
-	selected := isSelected && m.FilterState() != list.Filtering
-	colors := metaPalette(entry.ItemType, selected, emptyFilter)
-	metaContent := buildMetaRow(entry, metaInnerWidth, &colors)
+	return s.NormalTitle.Render(title), s.NormalDesc.Render(desc)
+}
 
-	metaLine := lipgloss.NewStyle().Padding(0, padR, 0, padL).Render(metaContent)
-
+// styleMetaLine wraps the metadata content in the appropriate style. Selected
+// items inherit from SelectedTitle so the left border aligns with the title.
+func styleMetaLine(s *list.DefaultItemStyles, content string, selected bool, padL, padR int) string {
 	if selected {
-		// Derive from SelectedTitle so the border type/color/padding match exactly,
-		// but clear the text foreground so pill colors show through.
-		metaLine = s.SelectedTitle.
+		return s.SelectedTitle.
 			Foreground(lipgloss.NoColor{}).
-			Render(metaContent)
+			Render(content)
 	}
 
-	// Order: title, description, metadata.
-	fmt.Fprintf(w, "%s\n%s\n%s", title, desc, metaLine) //nolint:errcheck,gosec
+	return lipgloss.NewStyle().Padding(0, padR, 0, padL).Render(content)
 }
 
 // metaPalette returns pill/text styles for the metadata row based on item type and selection state.

--- a/internal/cli/commands/catalog/tui/redesign/delegate.go
+++ b/internal/cli/commands/catalog/tui/redesign/delegate.go
@@ -212,7 +212,7 @@ func (d catalogDelegate) Render(w io.Writer, m list.Model, index int, item list.
 	colors := metaPalette(entry.ItemType, selected, emptyFilter)
 	metaContent := buildMetaRow(entry, metaInnerWidth, &colors)
 
-	var metaLine string
+	metaLine := lipgloss.NewStyle().Padding(0, padR, 0, padL).Render(metaContent)
 
 	if selected {
 		// Derive from SelectedTitle so the border type/color/padding match exactly,
@@ -220,8 +220,6 @@ func (d catalogDelegate) Render(w io.Writer, m list.Model, index int, item list.
 		metaLine = s.SelectedTitle.
 			Foreground(lipgloss.NoColor{}).
 			Render(metaContent)
-	} else {
-		metaLine = lipgloss.NewStyle().Padding(0, padR, 0, padL).Render(metaContent)
 	}
 
 	// Order: title, description, metadata.

--- a/internal/cli/commands/catalog/tui/redesign/delegate.go
+++ b/internal/cli/commands/catalog/tui/redesign/delegate.go
@@ -16,17 +16,30 @@ import (
 
 // Pill and metadata color constants.
 const (
-	typePillBg  = "#45475A"
-	typePillFg  = "#CBA6F7"
-	versionBg   = "#313244"
-	versionFg   = "#A6E3A1"
-	sourceColor = "#89B4FA"
+	// Module type pill (green-tinted).
+	modulePillBg  = "#2B3D2B"
+	modulePillFg  = "#A6E3A1"
+	modulePillBgS = "#3D5A3D"
+	modulePillFgS = "#C7F5C9"
 
-	typePillBgSelected  = "#585B70"
-	typePillFgSelected  = "#E4C0FF"
-	versionBgSelected   = "#45475A"
-	versionFgSelected   = "#C7F5C9"
-	sourceColorSelected = "#B4DAFF"
+	// Stack type pill (blue-tinted).
+	stackPillBg  = "#2B2F3D"
+	stackPillFg  = "#89B4FA"
+	stackPillBgS = "#3D4460"
+	stackPillFgS = "#B4DAFF"
+
+	// Version pill (neutral).
+	versionBg  = "#313244"
+	versionFg  = "#BAC2DE"
+	versionBgS = "#45475A"
+	versionFgS = "#CDD6F4"
+
+	// Source URL (muted).
+	sourceColor  = "#7F849C"
+	sourceColorS = "#9399B2"
+
+	// Description (blue/link-like, prominent).
+	descForegroundColor = "#89B4FA"
 
 	metaMuted = "#6C7086"
 
@@ -50,6 +63,9 @@ func newCatalogDelegate(keys *tui.DelegateKeyMap) catalogDelegate {
 	styles.SelectedTitle = styles.SelectedTitle.
 		Foreground(lipgloss.Color(selectedTitleForegroundColorDark)).
 		BorderForeground(lipgloss.Color(selectedTitleBorderForegroundColorDark))
+
+	styles.NormalDesc = styles.NormalDesc.
+		Foreground(lipgloss.Color(descForegroundColor))
 
 	styles.SelectedDesc = styles.SelectedTitle.
 		Foreground(lipgloss.Color(selectedDescForegroundColorDark)).
@@ -192,15 +208,28 @@ func (d catalogDelegate) Render(w io.Writer, m list.Model, index int, item list.
 		metaInnerWidth = 1
 	}
 
-	colors := metaPalette(isSelected && m.FilterState() != list.Filtering, emptyFilter)
-	metaLine := lipgloss.NewStyle().Padding(0, padR, 0, padL).Render(
-		buildMetaRow(entry, metaInnerWidth, &colors))
+	selected := isSelected && m.FilterState() != list.Filtering
+	colors := metaPalette(entry.ItemType, selected, emptyFilter)
+	metaContent := buildMetaRow(entry, metaInnerWidth, &colors)
 
+	var metaLine string
+
+	if selected {
+		// Derive from SelectedTitle so the border type/color/padding match exactly,
+		// but clear the text foreground so pill colors show through.
+		metaLine = s.SelectedTitle.
+			Foreground(lipgloss.NoColor{}).
+			Render(metaContent)
+	} else {
+		metaLine = lipgloss.NewStyle().Padding(0, padR, 0, padL).Render(metaContent)
+	}
+
+	// Order: title, description, metadata.
 	fmt.Fprintf(w, "%s\n%s\n%s", title, desc, metaLine) //nolint:errcheck,gosec
 }
 
-// metaPalette returns pill/text styles for the metadata row based on selection state.
-func metaPalette(selected, dimmed bool) catalogMetaColors {
+// metaPalette returns pill/text styles for the metadata row based on item type and selection state.
+func metaPalette(itemType string, selected, dimmed bool) catalogMetaColors {
 	if dimmed {
 		muted := lipgloss.Color(metaMuted)
 
@@ -211,25 +240,34 @@ func metaPalette(selected, dimmed bool) catalogMetaColors {
 		}
 	}
 
+	// Pick type-pill colors based on item type (module=green, stack=blue).
+	pillBg, pillFg := modulePillBg, modulePillFg
+	pillBgSel, pillFgSel := modulePillBgS, modulePillFgS
+
+	if itemType == "stack" {
+		pillBg, pillFg = stackPillBg, stackPillFg
+		pillBgSel, pillFgSel = stackPillBgS, stackPillFgS
+	}
+
 	if selected {
 		return catalogMetaColors{
 			typePill: lipgloss.NewStyle().
-				Background(lipgloss.Color(typePillBgSelected)).
-				Foreground(lipgloss.Color(typePillFgSelected)).
+				Background(lipgloss.Color(pillBgSel)).
+				Foreground(lipgloss.Color(pillFgSel)).
 				Padding(0, 1),
 			source: lipgloss.NewStyle().
-				Foreground(lipgloss.Color(sourceColorSelected)),
+				Foreground(lipgloss.Color(sourceColorS)),
 			versionPill: lipgloss.NewStyle().
-				Background(lipgloss.Color(versionBgSelected)).
-				Foreground(lipgloss.Color(versionFgSelected)).
+				Background(lipgloss.Color(versionBgS)).
+				Foreground(lipgloss.Color(versionFgS)).
 				Padding(0, 1),
 		}
 	}
 
 	return catalogMetaColors{
 		typePill: lipgloss.NewStyle().
-			Background(lipgloss.Color(typePillBg)).
-			Foreground(lipgloss.Color(typePillFg)).
+			Background(lipgloss.Color(pillBg)).
+			Foreground(lipgloss.Color(pillFg)).
 			Padding(0, 1),
 		source: lipgloss.NewStyle().
 			Foreground(lipgloss.Color(sourceColor)),
@@ -245,6 +283,6 @@ const (
 	selectedTitleForegroundColorDark       = "#63C5DA"
 	selectedTitleBorderForegroundColorDark = "#63C5DA"
 
-	selectedDescForegroundColorDark       = "#59788E"
+	selectedDescForegroundColorDark       = "#89B4FA"
 	selectedDescBorderForegroundColorDark = "#63C5DA"
 )

--- a/internal/cli/commands/catalog/tui/redesign/delegate.go
+++ b/internal/cli/commands/catalog/tui/redesign/delegate.go
@@ -1,0 +1,246 @@
+package redesign
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/list"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+)
+
+// Pill and metadata color constants.
+const (
+	typePillBg  = "#45475A"
+	typePillFg  = "#CBA6F7"
+	versionBg   = "#313244"
+	versionFg   = "#A6E3A1"
+	sourceColor = "#89B4FA"
+
+	typePillBgSelected  = "#585B70"
+	typePillFgSelected  = "#E4C0FF"
+	versionBgSelected   = "#45475A"
+	versionFgSelected   = "#C7F5C9"
+	sourceColorSelected = "#B4DAFF"
+
+	metaMuted = "#6C7086"
+)
+
+// catalogDelegate renders catalog modules with a color-coded metadata row
+// (type pill, source, version pill) below the title and description.
+type catalogDelegate struct {
+	styles     list.DefaultItemStyles
+	keys       *tui.DelegateKeyMap
+	shortHelp  func() []key.Binding
+	fullHelp   func() [][]key.Binding
+}
+
+func newCatalogDelegate(keys *tui.DelegateKeyMap) catalogDelegate {
+	// Use the same default item styles as the production delegate, with our color overrides.
+	styles := list.NewDefaultItemStyles(true)
+
+	styles.SelectedTitle = styles.SelectedTitle.
+		Foreground(lipgloss.Color(selectedTitleForegroundColorDark)).
+		BorderForeground(lipgloss.Color(selectedTitleBorderForegroundColorDark))
+
+	styles.SelectedDesc = styles.SelectedTitle.
+		Foreground(lipgloss.Color(selectedDescForegroundColorDark)).
+		BorderForeground(lipgloss.Color(selectedDescBorderForegroundColorDark))
+
+	help := []key.Binding{keys.Choose, keys.Scaffold}
+
+	return catalogDelegate{
+		styles: styles,
+		keys:   keys,
+		shortHelp: func() []key.Binding {
+			return help
+		},
+		fullHelp: func() [][]key.Binding {
+			return [][]key.Binding{help}
+		},
+	}
+}
+
+// Height returns the delegate's preferred height (title + desc + meta + spacing).
+func (d catalogDelegate) Height() int {
+	return 3
+}
+
+// Spacing returns the gap between items.
+func (d catalogDelegate) Spacing() int {
+	return 1
+}
+
+// Update is a no-op; input is handled by the model.
+func (d catalogDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd {
+	return nil
+}
+
+// ShortHelp returns the delegate's short help bindings.
+func (d catalogDelegate) ShortHelp() []key.Binding {
+	if d.shortHelp != nil {
+		return d.shortHelp()
+	}
+
+	return nil
+}
+
+// FullHelp returns the delegate's full help bindings.
+func (d catalogDelegate) FullHelp() [][]key.Binding {
+	if d.fullHelp != nil {
+		return d.fullHelp()
+	}
+
+	return nil
+}
+
+// Render prints an item with title, description, and metadata row.
+func (d catalogDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) { //nolint:funlen,cyclop
+	entry, isEntry := item.(*ModuleEntry)
+	if !isEntry {
+		return
+	}
+
+	if m.Width() <= 0 {
+		return
+	}
+
+	s := &d.styles
+
+	title := entry.Title()
+	desc := entry.Description()
+
+	textwidth := m.Width() - s.NormalTitle.GetPaddingLeft() - s.NormalTitle.GetPaddingRight()
+	title = ansi.Truncate(title, textwidth, "…")
+
+	// Limit description to a single line
+	var lines []string
+	for i, line := range strings.Split(desc, "\n") {
+		if i >= 1 {
+			break
+		}
+
+		lines = append(lines, ansi.Truncate(line, textwidth, "…"))
+	}
+
+	desc = strings.Join(lines, "\n")
+
+	isSelected := index == m.Index()
+	emptyFilter := m.FilterState() == list.Filtering && m.FilterValue() == ""
+	isFiltered := m.FilterState() == list.Filtering || m.FilterState() == list.FilterApplied
+
+	var matchedRunes []int
+
+	if isFiltered {
+		matchedRunes = m.MatchesForItem(index)
+	}
+
+	// Determine padding for the metadata row alignment
+	var padL, padR int
+
+	switch {
+	case emptyFilter:
+		padL = s.DimmedTitle.GetPaddingLeft()
+		padR = s.DimmedTitle.GetPaddingRight()
+	case isSelected && m.FilterState() != list.Filtering:
+		padL = s.SelectedTitle.GetPaddingLeft()
+		padR = s.SelectedTitle.GetPaddingRight()
+		// Account for the border on the selected style
+		padL += s.SelectedTitle.GetBorderLeftSize()
+	default:
+		padL = s.NormalTitle.GetPaddingLeft()
+		padR = s.NormalTitle.GetPaddingRight()
+	}
+
+	// Style title and description based on state
+	switch {
+	case emptyFilter:
+		title = s.DimmedTitle.Render(title)
+		desc = s.DimmedDesc.Render(desc)
+	case isSelected && m.FilterState() != list.Filtering:
+		if isFiltered {
+			unmatched := s.SelectedTitle.Inline(true)
+			matched := unmatched.Inherit(s.FilterMatch)
+			title = lipgloss.StyleRunes(title, matchedRunes, matched, unmatched)
+		}
+
+		title = s.SelectedTitle.Render(title)
+		desc = s.SelectedDesc.Render(desc)
+	default:
+		if isFiltered {
+			unmatched := s.NormalTitle.Inline(true)
+			matched := unmatched.Inherit(s.FilterMatch)
+			title = lipgloss.StyleRunes(title, matchedRunes, matched, unmatched)
+		}
+
+		title = s.NormalTitle.Render(title)
+		desc = s.NormalDesc.Render(desc)
+	}
+
+	// Build metadata row
+	metaInnerWidth := m.Width() - padL - padR
+	if metaInnerWidth < 1 {
+		metaInnerWidth = 1
+	}
+
+	colors := metaPalette(isSelected && m.FilterState() != list.Filtering, emptyFilter)
+	metaLine := lipgloss.NewStyle().Padding(0, padR, 0, padL).Render(
+		buildMetaRow(entry, metaInnerWidth, colors))
+
+	fmt.Fprintf(w, "%s\n%s\n%s", title, desc, metaLine) //nolint:errcheck,gosec
+}
+
+// metaPalette returns pill/text styles for the metadata row based on selection state.
+func metaPalette(selected, dimmed bool) catalogMetaColors {
+	if dimmed {
+		muted := lipgloss.Color(metaMuted)
+
+		return catalogMetaColors{
+			typePill:    lipgloss.NewStyle().Foreground(muted),
+			source:      lipgloss.NewStyle().Foreground(muted),
+			versionPill: lipgloss.NewStyle().Foreground(muted),
+		}
+	}
+
+	if selected {
+		return catalogMetaColors{
+			typePill: lipgloss.NewStyle().
+				Background(lipgloss.Color(typePillBgSelected)).
+				Foreground(lipgloss.Color(typePillFgSelected)).
+				Padding(0, 1),
+			source: lipgloss.NewStyle().
+				Foreground(lipgloss.Color(sourceColorSelected)),
+			versionPill: lipgloss.NewStyle().
+				Background(lipgloss.Color(versionBgSelected)).
+				Foreground(lipgloss.Color(versionFgSelected)).
+				Padding(0, 1),
+		}
+	}
+
+	return catalogMetaColors{
+		typePill: lipgloss.NewStyle().
+			Background(lipgloss.Color(typePillBg)).
+			Foreground(lipgloss.Color(typePillFg)).
+			Padding(0, 1),
+		source: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(sourceColor)),
+		versionPill: lipgloss.NewStyle().
+			Background(lipgloss.Color(versionBg)).
+			Foreground(lipgloss.Color(versionFg)).
+			Padding(0, 1),
+	}
+}
+
+// Color constants from the production delegate, reused here for consistency.
+const (
+	selectedTitleForegroundColorDark       = "#63C5DA"
+	selectedTitleBorderForegroundColorDark = "#63C5DA"
+
+	selectedDescForegroundColorDark       = "#59788E"
+	selectedDescBorderForegroundColorDark = "#63C5DA"
+)

--- a/internal/cli/commands/catalog/tui/redesign/layout.go
+++ b/internal/cli/commands/catalog/tui/redesign/layout.go
@@ -11,6 +11,7 @@ const (
 	maxVerWidth    = 22
 	metaGap        = 2
 	minSourceWidth = 8
+	halveDivisor   = 2
 )
 
 // catalogMetaColors holds per-column lipgloss styles for the catalog metadata row.
@@ -40,7 +41,7 @@ func abbreviateMiddle(s string, maxWidth int) string {
 	}
 
 	avail := maxWidth - ellW
-	leftW := avail / 2
+	leftW := avail / halveDivisor
 	rightW := avail - leftW
 
 	return takeWidthPrefix(s, leftW) + ell + takeWidthSuffix(s, rightW)
@@ -62,6 +63,7 @@ func takeWidthPrefix(s string, maxW int) string {
 		}
 
 		b.WriteRune(r)
+
 		w += rw
 	}
 
@@ -100,7 +102,7 @@ func takeWidthSuffix(s string, maxW int) string {
 
 // buildMetaRow returns one lipgloss-rendered row: [type]  source  [version].
 // innerWidth is the available width for the metadata content (excluding title padding).
-func buildMetaRow(entry *ModuleEntry, innerWidth int, colors catalogMetaColors) string {
+func buildMetaRow(entry *ModuleEntry, innerWidth int, colors *catalogMetaColors) string {
 	if entry == nil {
 		return ""
 	}
@@ -109,8 +111,10 @@ func buildMetaRow(entry *ModuleEntry, innerWidth int, colors catalogMetaColors) 
 	gapW := metaGap
 
 	// Render type pill
-	var typePart string
-	var typeW int
+	var (
+		typePart string
+		typeW    int
+	)
 
 	if entry.ItemType != "" {
 		typePart = colors.typePill.Render(entry.ItemType)
@@ -118,8 +122,10 @@ func buildMetaRow(entry *ModuleEntry, innerWidth int, colors catalogMetaColors) 
 	}
 
 	// Render version pill
-	var verPart string
-	var verW int
+	var (
+		verPart string
+		verW    int
+	)
 
 	if entry.Version != "" {
 		verDisplay := entry.Version
@@ -178,6 +184,7 @@ func buildMetaRow(entry *ModuleEntry, innerWidth int, colors catalogMetaColors) 
 	}
 
 	leftW := lipgloss.Width(left)
+
 	fill := innerWidth - leftW - verW
 	if fill < metaGap {
 		fill = metaGap

--- a/internal/cli/commands/catalog/tui/redesign/layout.go
+++ b/internal/cli/commands/catalog/tui/redesign/layout.go
@@ -1,0 +1,187 @@
+package redesign
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+const (
+	maxVerWidth    = 22
+	metaGap        = 2
+	minSourceWidth = 8
+)
+
+// catalogMetaColors holds per-column lipgloss styles for the catalog metadata row.
+type catalogMetaColors struct {
+	typePill    lipgloss.Style
+	source      lipgloss.Style
+	versionPill lipgloss.Style
+}
+
+// abbreviateMiddle shortens s to maxWidth cells with an ellipsis in the middle,
+// preserving the prefix (e.g. domain) and suffix (e.g. repo name).
+func abbreviateMiddle(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+
+	w := lipgloss.Width(s)
+	if w <= maxWidth {
+		return s
+	}
+
+	const ell = "…"
+
+	ellW := lipgloss.Width(ell)
+	if maxWidth <= ellW {
+		return ansi.Truncate(s, maxWidth, "")
+	}
+
+	avail := maxWidth - ellW
+	leftW := avail / 2
+	rightW := avail - leftW
+
+	return takeWidthPrefix(s, leftW) + ell + takeWidthSuffix(s, rightW)
+}
+
+func takeWidthPrefix(s string, maxW int) string {
+	if maxW <= 0 {
+		return ""
+	}
+
+	var b strings.Builder
+
+	w := 0
+
+	for _, r := range s {
+		rw := lipgloss.Width(string(r))
+		if w+rw > maxW {
+			break
+		}
+
+		b.WriteRune(r)
+		w += rw
+	}
+
+	return b.String()
+}
+
+func takeWidthSuffix(s string, maxW int) string {
+	if maxW <= 0 {
+		return ""
+	}
+
+	rs := []rune(s)
+
+	var parts []rune
+
+	w := 0
+
+	for i := len(rs) - 1; i >= 0; i-- {
+		r := rs[i]
+		rw := lipgloss.Width(string(r))
+
+		if w+rw > maxW {
+			break
+		}
+
+		parts = append(parts, r)
+		w += rw
+	}
+
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+
+	return string(parts)
+}
+
+// buildMetaRow returns one lipgloss-rendered row: [type]  source  [version].
+// innerWidth is the available width for the metadata content (excluding title padding).
+func buildMetaRow(entry *ModuleEntry, innerWidth int, colors catalogMetaColors) string {
+	if entry == nil {
+		return ""
+	}
+
+	gap := strings.Repeat(" ", metaGap)
+	gapW := metaGap
+
+	// Render type pill
+	var typePart string
+	var typeW int
+
+	if entry.ItemType != "" {
+		typePart = colors.typePill.Render(entry.ItemType)
+		typeW = lipgloss.Width(typePart)
+	}
+
+	// Render version pill
+	var verPart string
+	var verW int
+
+	if entry.Version != "" {
+		verDisplay := entry.Version
+		if lipgloss.Width(verDisplay) > maxVerWidth {
+			verDisplay = ansi.Truncate(verDisplay, maxVerWidth, "…")
+		}
+
+		verPart = colors.versionPill.Render(verDisplay)
+		verW = lipgloss.Width(verPart)
+	}
+
+	// Calculate source column width
+	var srcPart string
+
+	if entry.Source != "" {
+		usedWidth := typeW + verW
+		gaps := 0
+
+		if typeW > 0 {
+			gaps++
+		}
+
+		if verW > 0 {
+			gaps++
+		}
+
+		usedWidth += gaps * gapW
+		srcMax := innerWidth - usedWidth
+
+		if srcMax >= minSourceWidth {
+			srcDisplay := abbreviateMiddle(entry.Source, srcMax)
+			srcPart = colors.source.Render(srcDisplay)
+		}
+	}
+
+	// Assemble left side (type + source)
+	var leftParts []string
+
+	if typePart != "" {
+		leftParts = append(leftParts, typePart)
+	}
+
+	if srcPart != "" {
+		leftParts = append(leftParts, srcPart)
+	}
+
+	if len(leftParts) == 0 && verPart == "" {
+		return ""
+	}
+
+	left := strings.Join(leftParts, gap)
+
+	// Right-align version pill by filling remaining space
+	if verPart == "" {
+		return left
+	}
+
+	leftW := lipgloss.Width(left)
+	fill := innerWidth - leftW - verW
+	if fill < metaGap {
+		fill = metaGap
+	}
+
+	return left + strings.Repeat(" ", fill) + verPart
+}

--- a/internal/cli/commands/catalog/tui/redesign/layout.go
+++ b/internal/cli/commands/catalog/tui/redesign/layout.go
@@ -1,6 +1,7 @@
 package redesign
 
 import (
+	"slices"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -11,7 +12,6 @@ const (
 	maxVerWidth    = 22
 	metaGap        = 2
 	minSourceWidth = 8
-	halveDivisor   = 2
 )
 
 // catalogMetaColors holds per-column lipgloss styles for the catalog metadata row.
@@ -41,7 +41,7 @@ func abbreviateMiddle(s string, maxWidth int) string {
 	}
 
 	avail := maxWidth - ellW
-	leftW := avail / halveDivisor
+	leftW := avail / 2 //nolint:mnd
 	rightW := avail - leftW
 
 	return takeWidthPrefix(s, leftW) + ell + takeWidthSuffix(s, rightW)
@@ -93,9 +93,7 @@ func takeWidthSuffix(s string, maxW int) string {
 		w += rw
 	}
 
-	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
-		parts[i], parts[j] = parts[j], parts[i]
-	}
+	slices.Reverse(parts)
 
 	return string(parts)
 }
@@ -113,14 +111,22 @@ func buildMetaRow(entry *ModuleEntry, innerWidth int, colors *catalogMetaColors)
 
 	usedWidth := 0
 
-	// Type pill.
-	if entry.ItemType != "" {
-		part := colors.typePill.Render(entry.ItemType)
-		parts = append(parts, part)
-		usedWidth += lipgloss.Width(part)
+	remaining := func() int {
+		return innerWidth - usedWidth - len(parts)*metaGap
 	}
 
-	// Version pill (inline, right after type).
+	// Type pill (skip if it won't fit).
+	if entry.ItemType != "" {
+		part := colors.typePill.Render(entry.ItemType)
+		partW := lipgloss.Width(part)
+
+		if partW <= remaining() {
+			parts = append(parts, part)
+			usedWidth += partW
+		}
+	}
+
+	// Version pill (truncate or skip if it won't fit).
 	if entry.Version != "" {
 		verDisplay := entry.Version
 		if lipgloss.Width(verDisplay) > maxVerWidth {
@@ -128,14 +134,17 @@ func buildMetaRow(entry *ModuleEntry, innerWidth int, colors *catalogMetaColors)
 		}
 
 		part := colors.versionPill.Render(verDisplay)
-		parts = append(parts, part)
-		usedWidth += lipgloss.Width(part)
+		partW := lipgloss.Width(part)
+
+		if partW <= remaining() {
+			parts = append(parts, part)
+			usedWidth += partW
+		}
 	}
 
-	// Source URL (gets remaining width).
+	// Source URL (gets remaining width, skip if too narrow).
 	if entry.Source != "" {
-		// Gaps between all parts: if we add source, total gaps = len(parts).
-		srcMax := innerWidth - usedWidth - len(parts)*metaGap
+		srcMax := remaining()
 
 		if srcMax >= minSourceWidth {
 			srcDisplay := abbreviateMiddle(entry.Source, srcMax)

--- a/internal/cli/commands/catalog/tui/redesign/layout.go
+++ b/internal/cli/commands/catalog/tui/redesign/layout.go
@@ -100,95 +100,53 @@ func takeWidthSuffix(s string, maxW int) string {
 	return string(parts)
 }
 
-// buildMetaRow returns one lipgloss-rendered row: [type]  source  [version].
-// innerWidth is the available width for the metadata content (excluding title padding).
+// buildMetaRow returns one lipgloss-rendered row: [type] [version] source.
+// All parts are left-aligned. innerWidth is the available width (excluding padding).
 func buildMetaRow(entry *ModuleEntry, innerWidth int, colors *catalogMetaColors) string {
 	if entry == nil {
 		return ""
 	}
 
 	gap := strings.Repeat(" ", metaGap)
-	gapW := metaGap
 
-	// Render type pill
-	var (
-		typePart string
-		typeW    int
-	)
+	var parts []string
 
+	usedWidth := 0
+
+	// Type pill.
 	if entry.ItemType != "" {
-		typePart = colors.typePill.Render(entry.ItemType)
-		typeW = lipgloss.Width(typePart)
+		part := colors.typePill.Render(entry.ItemType)
+		parts = append(parts, part)
+		usedWidth += lipgloss.Width(part)
 	}
 
-	// Render version pill
-	var (
-		verPart string
-		verW    int
-	)
-
+	// Version pill (inline, right after type).
 	if entry.Version != "" {
 		verDisplay := entry.Version
 		if lipgloss.Width(verDisplay) > maxVerWidth {
 			verDisplay = ansi.Truncate(verDisplay, maxVerWidth, "…")
 		}
 
-		verPart = colors.versionPill.Render(verDisplay)
-		verW = lipgloss.Width(verPart)
+		part := colors.versionPill.Render(verDisplay)
+		parts = append(parts, part)
+		usedWidth += lipgloss.Width(part)
 	}
 
-	// Calculate source column width
-	var srcPart string
-
+	// Source URL (gets remaining width).
 	if entry.Source != "" {
-		usedWidth := typeW + verW
-		gaps := 0
-
-		if typeW > 0 {
-			gaps++
-		}
-
-		if verW > 0 {
-			gaps++
-		}
-
-		usedWidth += gaps * gapW
-		srcMax := innerWidth - usedWidth
+		// Gaps between all parts: if we add source, total gaps = len(parts).
+		srcMax := innerWidth - usedWidth - len(parts)*metaGap
 
 		if srcMax >= minSourceWidth {
 			srcDisplay := abbreviateMiddle(entry.Source, srcMax)
-			srcPart = colors.source.Render(srcDisplay)
+			part := colors.source.Render(srcDisplay)
+			parts = append(parts, part)
 		}
 	}
 
-	// Assemble left side (type + source)
-	var leftParts []string
-
-	if typePart != "" {
-		leftParts = append(leftParts, typePart)
-	}
-
-	if srcPart != "" {
-		leftParts = append(leftParts, srcPart)
-	}
-
-	if len(leftParts) == 0 && verPart == "" {
+	if len(parts) == 0 {
 		return ""
 	}
 
-	left := strings.Join(leftParts, gap)
-
-	// Right-align version pill by filling remaining space
-	if verPart == "" {
-		return left
-	}
-
-	leftW := lipgloss.Width(left)
-
-	fill := innerWidth - leftW - verW
-	if fill < metaGap {
-		fill = metaGap
-	}
-
-	return left + strings.Repeat(" ", fill) + verPart
+	return strings.Join(parts, gap)
 }

--- a/internal/cli/commands/catalog/tui/redesign/model.go
+++ b/internal/cli/commands/catalog/tui/redesign/model.go
@@ -26,7 +26,7 @@ type sessionState int
 type button int
 
 const (
-	title = "List of Modules"
+	title = "All"
 
 	titleForegroundColor = "#A8ACB1"
 	titleBackgroundColor = "#1D252F"

--- a/internal/cli/commands/catalog/tui/redesign/model.go
+++ b/internal/cli/commands/catalog/tui/redesign/model.go
@@ -62,7 +62,7 @@ type Model struct {
 	selectedModule      *module.Module
 	delegateKeys        *tui.DelegateKeyMap
 	buttonBar           *buttonbar.ButtonBar
-	moduleCh            chan *module.Module
+	moduleCh            chan *ModuleEntry
 	pagerKeys           tui.PagerKeyMap
 	listKeys            list.KeyMap
 	currentPagerButtons []button
@@ -81,19 +81,20 @@ func NewModel(l log.Logger, opts *options.TerragruntOptions, svc catalog.Catalog
 	items := make([]list.Item, 0, len(modules))
 
 	for _, mod := range modules {
-		items = append(items, mod)
+		source := ExtractRepoURL(mod.TerraformSourcePath())
+		items = append(items, NewModuleEntry(mod).WithSource(source))
 	}
 
 	sort.Slice(items, func(i, j int) bool {
-		return strings.ToLower(items[i].(*module.Module).Title()) < strings.ToLower(items[j].(*module.Module).Title())
+		return strings.ToLower(items[i].(*ModuleEntry).Title()) < strings.ToLower(items[j].(*ModuleEntry).Title())
 	})
 
 	return newModelWithItems(l, opts, svc, items, nil)
 }
 
-// NewModelStreaming creates a Model with a single initial module and a channel
-// for receiving additional modules as they are discovered.
-func NewModelStreaming(l log.Logger, opts *options.TerragruntOptions, initial *module.Module, moduleCh chan *module.Module) Model {
+// NewModelStreaming creates a Model with a single initial entry and a channel
+// for receiving additional entries as they are discovered.
+func NewModelStreaming(l log.Logger, opts *options.TerragruntOptions, initial *ModuleEntry, moduleCh chan *ModuleEntry) Model {
 	items := []list.Item{initial}
 
 	m := newModelWithItems(l, opts, nil, items, moduleCh)
@@ -102,12 +103,12 @@ func NewModelStreaming(l log.Logger, opts *options.TerragruntOptions, initial *m
 	return m
 }
 
-func newModelWithItems(l log.Logger, opts *options.TerragruntOptions, svc catalog.CatalogService, items []list.Item, moduleCh chan *module.Module) Model {
+func newModelWithItems(l log.Logger, opts *options.TerragruntOptions, svc catalog.CatalogService, items []list.Item, moduleCh chan *ModuleEntry) Model {
 	listKeys := tui.NewListKeyMap()
 	delegateKeys := tui.NewDelegateKeyMap()
 	pagerKeys := tui.NewPagerKeyMap()
 
-	delegate := tui.NewItemDelegate(delegateKeys)
+	delegate := newCatalogDelegate(delegateKeys)
 	lst := list.New(items, delegate, 0, 0)
 	lst.KeyMap = listKeys
 	lst.SetFilteringEnabled(true)
@@ -143,17 +144,17 @@ func newModelWithItems(l log.Logger, opts *options.TerragruntOptions, svc catalo
 // insertModuleSorted inserts a module into the list in alphabetical order,
 // skipping duplicates. If the user has started navigating, the cursor stays
 // on the currently selected item. Otherwise it stays at the top of the list.
-func (m *Model) insertModuleSorted(mod *module.Module) tea.Cmd {
-	if mod == nil {
+func (m *Model) insertModuleSorted(entry *ModuleEntry) tea.Cmd {
+	if entry == nil {
 		return nil
 	}
 
 	items := m.List.Items()
-	modTitle := mod.Title()
+	modTitle := entry.Title()
 
 	// Binary search finds the insertion point by title for sort order.
 	insertIdx := sort.Search(len(items), func(i int) bool {
-		if existing, ok := items[i].(*module.Module); ok {
+		if existing, ok := items[i].(*ModuleEntry); ok {
 			return strings.ToLower(existing.Title()) >= strings.ToLower(modTitle)
 		}
 
@@ -162,13 +163,13 @@ func (m *Model) insertModuleSorted(mod *module.Module) tea.Cmd {
 
 	// De-duplicate by source path, not title, so distinct modules that
 	// share a display name are not collapsed.
-	if isDuplicate(items, mod.TerraformSourcePath()) {
+	if isDuplicate(items, entry.Module.TerraformSourcePath()) {
 		return nil
 	}
 
 	currentIdx := m.List.Index()
 
-	cmd := m.List.InsertItem(insertIdx, mod)
+	cmd := m.List.InsertItem(insertIdx, entry)
 
 	if m.userNavigated {
 		// Preserve cursor: if we inserted before or at the current
@@ -190,8 +191,8 @@ func (m *Model) insertModuleSorted(mod *module.Module) tea.Cmd {
 // incorrectly collapsed.
 func isDuplicate(items []list.Item, sourcePath string) bool {
 	for _, item := range items {
-		if existing, ok := item.(*module.Module); ok {
-			if existing.TerraformSourcePath() == sourcePath {
+		if existing, ok := item.(*ModuleEntry); ok {
+			if existing.Module.TerraformSourcePath() == sourcePath {
 				return true
 			}
 		}
@@ -212,7 +213,7 @@ func (m Model) listenForModule() tea.Cmd { //nolint:gocritic
 			return nil
 		}
 
-		return moduleMsg{module: mod}
+		return moduleMsg{entry: mod}
 	}
 }
 

--- a/internal/cli/commands/catalog/tui/redesign/model_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/model_test.go
@@ -167,13 +167,13 @@ func TestModelStreamingInsertsSorted(t *testing.T) {
 	require.GreaterOrEqual(t, len(modules), 2, "need at least 2 modules")
 
 	// Start with the last module alphabetically
-	moduleCh := make(chan *module.Module, len(modules))
-	m := redesign.NewModelStreaming(l, opts, modules[len(modules)-1], moduleCh)
+	moduleCh := make(chan *redesign.ModuleEntry, len(modules))
+	m := redesign.NewModelStreaming(l, opts, redesign.NewModuleEntry(modules[len(modules)-1]), moduleCh)
 
 	finalModel := runModel(t, m, 120, 40, func(p *tea.Program) {
 		// Send the remaining modules in reverse order
 		for i := len(modules) - 2; i >= 0; i-- {
-			p.Send(redesign.ModuleMsg(modules[i]))
+			p.Send(redesign.ModuleMsg(redesign.NewModuleEntry(modules[i])))
 			time.Sleep(50 * time.Millisecond)
 		}
 
@@ -188,8 +188,8 @@ func TestModelStreamingInsertsSorted(t *testing.T) {
 
 	// Verify sorted order (case-insensitive, matching the sort in model.go)
 	for i := 1; i < len(items); i++ {
-		prev := strings.ToLower(items[i-1].(*module.Module).Title())
-		curr := strings.ToLower(items[i].(*module.Module).Title())
+		prev := strings.ToLower(items[i-1].(*redesign.ModuleEntry).Title())
+		curr := strings.ToLower(items[i].(*redesign.ModuleEntry).Title())
 		assert.LessOrEqual(t, prev, curr, "modules should be in alphabetical order: %q should come before %q", prev, curr)
 	}
 }
@@ -207,12 +207,12 @@ func TestModelStreamingDeduplicates(t *testing.T) {
 	modules := svc.Modules()
 	require.NotEmpty(t, modules)
 
-	moduleCh := make(chan *module.Module, len(modules))
-	m := redesign.NewModelStreaming(l, opts, modules[0], moduleCh)
+	moduleCh := make(chan *redesign.ModuleEntry, len(modules))
+	m := redesign.NewModelStreaming(l, opts, redesign.NewModuleEntry(modules[0]), moduleCh)
 
 	finalModel := runModel(t, m, 120, 40, func(p *tea.Program) {
 		// Send the same module again — should be deduplicated
-		p.Send(redesign.ModuleMsg(modules[0]))
+		p.Send(redesign.ModuleMsg(redesign.NewModuleEntry(modules[0])))
 		time.Sleep(100 * time.Millisecond)
 
 		p.Send(tea.KeyPressMsg{Code: 'q', Text: "q"})

--- a/internal/cli/commands/catalog/tui/redesign/module_entry.go
+++ b/internal/cli/commands/catalog/tui/redesign/module_entry.go
@@ -1,0 +1,44 @@
+package redesign
+
+import "github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
+
+// ModuleEntry wraps a *module.Module with display-only metadata
+// that the redesign TUI needs but that doesn't belong on the shared type.
+type ModuleEntry struct {
+	Module   *module.Module
+	Version  string // resolved semver tag e.g. "v1.2.3", or "" if unknown
+	Source   string // clean repo URL e.g. "github.com/gruntwork-io/repo"
+	ItemType string // "module" for now
+}
+
+// NewModuleEntry creates a ModuleEntry with ItemType set to "module".
+// Use WithVersion and WithSource to attach optional metadata.
+func NewModuleEntry(mod *module.Module) *ModuleEntry {
+	return &ModuleEntry{
+		Module:   mod,
+		ItemType: "module",
+	}
+}
+
+// WithVersion returns the entry with its version set.
+func (e *ModuleEntry) WithVersion(version string) *ModuleEntry {
+	e.Version = version
+
+	return e
+}
+
+// WithSource returns the entry with its source set.
+func (e *ModuleEntry) WithSource(source string) *ModuleEntry {
+	e.Source = source
+
+	return e
+}
+
+// FilterValue implements list.Item by delegating to the inner Module.
+func (e *ModuleEntry) FilterValue() string { return e.Module.FilterValue() }
+
+// Title implements list.DefaultItem by delegating to the inner Module.
+func (e *ModuleEntry) Title() string { return e.Module.Title() }
+
+// Description implements list.DefaultItem by delegating to the inner Module.
+func (e *ModuleEntry) Description() string { return e.Module.Description() }

--- a/internal/cli/commands/catalog/tui/redesign/update.go
+++ b/internal/cli/commands/catalog/tui/redesign/update.go
@@ -36,7 +36,8 @@ func updateList(msg tea.Msg, m Model) (tea.Model, tea.Cmd) { //nolint:gocritic
 
 		switch {
 		case key.Matches(msg, m.delegateKeys.Choose, m.delegateKeys.Scaffold):
-			if selectedModule, ok := m.List.SelectedItem().(*module.Module); ok {
+			if selectedEntry, ok := m.List.SelectedItem().(*ModuleEntry); ok {
+			selectedModule := selectedEntry.Module
 				switch {
 				case key.Matches(msg, m.delegateKeys.Choose):
 					// prepare the viewport
@@ -196,7 +197,7 @@ func updatePager(msg tea.Msg, m Model) (tea.Model, tea.Cmd) { //nolint:gocritic
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocritic
 	switch msg := msg.(type) {
 	case moduleMsg:
-		cmd := m.insertModuleSorted(msg.module)
+		cmd := m.insertModuleSorted(msg.entry)
 
 		return m, tea.Batch(cmd, m.listenForModule())
 	case DiscoveryCompleteMsg:

--- a/internal/cli/commands/catalog/tui/redesign/update.go
+++ b/internal/cli/commands/catalog/tui/redesign/update.go
@@ -37,7 +37,8 @@ func updateList(msg tea.Msg, m Model) (tea.Model, tea.Cmd) { //nolint:gocritic
 		switch {
 		case key.Matches(msg, m.delegateKeys.Choose, m.delegateKeys.Scaffold):
 			if selectedEntry, ok := m.List.SelectedItem().(*ModuleEntry); ok {
-			selectedModule := selectedEntry.Module
+				selectedModule := selectedEntry.Module
+
 				switch {
 				case key.Matches(msg, m.delegateKeys.Choose):
 					// prepare the viewport

--- a/internal/cli/commands/catalog/tui/redesign/view_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/view_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui/redesign"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog"
-	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
@@ -72,7 +71,7 @@ func TestWelcomeNoSourcesView_RendersHelpText(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	noSourcesLoad := func(_ context.Context, _ redesign.StatusFunc, _ chan<- *module.Module) (catalog.CatalogService, error) {
+	noSourcesLoad := func(_ context.Context, _ redesign.StatusFunc, _ chan<- *redesign.ModuleEntry) (catalog.CatalogService, error) {
 		return nil, nil
 	}
 
@@ -108,8 +107,8 @@ func TestModuleListView_LoadingTitle(t *testing.T) {
 	modules := svc.Modules()
 	require.NotEmpty(t, modules)
 
-	moduleCh := make(chan *module.Module, 10)
-	m := redesign.NewModelStreaming(l, opts, modules[0], moduleCh)
+	moduleCh := make(chan *redesign.ModuleEntry, 10)
+	m := redesign.NewModelStreaming(l, opts, redesign.NewModuleEntry(modules[0]), moduleCh)
 
 	updated, _ := m.Update(windowSize)
 	m = updated.(redesign.Model)
@@ -127,6 +126,59 @@ func TestModuleListView_LoadingTitle(t *testing.T) {
 	assert.NotContains(t, content, "(loading...)", "loading indicator should be gone after discovery completes")
 }
 
+func TestModuleListView_MetadataRowRendered(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	svc := createMockCatalogService(t, opts)
+	l := logger.CreateLogger()
+	modules := svc.Modules()
+	require.NotEmpty(t, modules)
+
+	entry := redesign.NewModuleEntry(modules[0]).
+		WithVersion("v1.10.2").
+		WithSource("github.com/gruntwork-io/terragrunt-scale-catalog")
+
+	moduleCh := make(chan *redesign.ModuleEntry, 10)
+	m := redesign.NewModelStreaming(l, opts, entry, moduleCh)
+
+	updated, _ := m.Update(windowSize)
+	m = updated.(redesign.Model)
+
+	content := stripANSI(m.View().Content)
+	assert.Contains(t, content, "module", "metadata row should contain item type")
+	assert.Contains(t, content, "github.com/gruntwork-io/terragrunt-scale-catalog", "metadata row should contain source")
+	assert.Contains(t, content, "v1.10.2", "metadata row should contain version")
+}
+
+func TestModuleListView_NoVersionOmitsVersionPill(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	svc := createMockCatalogService(t, opts)
+	l := logger.CreateLogger()
+	modules := svc.Modules()
+	require.NotEmpty(t, modules)
+
+	entry := redesign.NewModuleEntry(modules[0]).
+		WithSource("github.com/gruntwork-io/terragrunt-scale-catalog")
+
+	moduleCh := make(chan *redesign.ModuleEntry, 10)
+	m := redesign.NewModelStreaming(l, opts, entry, moduleCh)
+
+	updated, _ := m.Update(windowSize)
+	m = updated.(redesign.Model)
+
+	content := stripANSI(m.View().Content)
+	assert.Contains(t, content, "module", "metadata row should contain item type")
+	assert.Contains(t, content, "github.com/gruntwork-io/terragrunt-scale-catalog", "metadata row should contain source")
+	assert.NotContains(t, content, "v1.10.2", "version pill should not appear when version is empty")
+}
+
 // --- synctest: Streaming Flow ---
 
 func TestWelcomeStreamingFlow_Synctest(t *testing.T) {
@@ -141,13 +193,13 @@ func TestWelcomeStreamingFlow_Synctest(t *testing.T) {
 		modules := svc.Modules()
 		require.GreaterOrEqual(t, len(modules), 2, "need at least 2 modules")
 
-		streamingLoad := func(_ context.Context, status redesign.StatusFunc, moduleCh chan<- *module.Module) (catalog.CatalogService, error) {
+		streamingLoad := func(_ context.Context, status redesign.StatusFunc, moduleCh chan<- *redesign.ModuleEntry) (catalog.CatalogService, error) {
 			status("Discovering catalog sources...")
 
 			for _, mod := range modules {
 				time.Sleep(100 * time.Millisecond)
 
-				moduleCh <- mod
+				moduleCh <- redesign.NewModuleEntry(mod)
 			}
 
 			return svc, nil
@@ -240,8 +292,8 @@ func TestWelcomeStreamingFlow_Synctest(t *testing.T) {
 
 			// Verify alphabetical order if multiple items present
 			for i := 1; i < len(items); i++ {
-				prev := items[i-1].(*module.Module).Title()
-				curr := items[i].(*module.Module).Title()
+				prev := items[i-1].(*redesign.ModuleEntry).Title()
+				curr := items[i].(*redesign.ModuleEntry).Title()
 				assert.LessOrEqual(t, strings.ToLower(prev), strings.ToLower(curr),
 					"modules should be in alphabetical order: %q should come before %q", prev, curr)
 			}
@@ -260,7 +312,7 @@ func TestWelcomeLoadingSpinner_Synctest(t *testing.T) {
 
 		l := logger.CreateLogger()
 
-		slowLoad := func(ctx context.Context, _ redesign.StatusFunc, _ chan<- *module.Module) (catalog.CatalogService, error) {
+		slowLoad := func(ctx context.Context, _ redesign.StatusFunc, _ chan<- *redesign.ModuleEntry) (catalog.CatalogService, error) {
 			// Block for a long time (fake time) so we stay in loading state
 			select {
 			case <-time.After(10 * time.Second):
@@ -342,7 +394,7 @@ var windowSize = tea.WindowSizeMsg{Width: 120, Height: 40}
 
 // blockingLoad is a LoadFunc that blocks until the context is cancelled,
 // keeping the WelcomeModel in the loading state.
-func blockingLoad(ctx context.Context, _ redesign.StatusFunc, _ chan<- *module.Module) (catalog.CatalogService, error) {
+func blockingLoad(ctx context.Context, _ redesign.StatusFunc, _ chan<- *redesign.ModuleEntry) (catalog.CatalogService, error) {
 	<-ctx.Done()
 
 	return nil, nil

--- a/internal/cli/commands/catalog/tui/redesign/view_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/view_test.go
@@ -115,14 +115,14 @@ func TestModuleListView_LoadingTitle(t *testing.T) {
 
 	// Should show loading indicator
 	content := stripANSI(m.View().Content)
-	assert.Contains(t, content, "List of Modules (loading...)", "streaming model should show loading indicator")
+	assert.Contains(t, content, "All (loading...)", "streaming model should show loading indicator")
 
 	// Send discoveryComplete to clear loading state
 	updated, _ = m.Update(redesign.DiscoveryCompleteMsg{Svc: svc, Err: nil})
 	m = updated.(redesign.Model)
 
 	content = stripANSI(m.View().Content)
-	assert.Contains(t, content, "List of Modules", "should still have title")
+	assert.Contains(t, content, "All", "should still have title")
 	assert.NotContains(t, content, "(loading...)", "loading indicator should be gone after discovery completes")
 }
 

--- a/internal/cli/commands/catalog/tui/redesign/welcome.go
+++ b/internal/cli/commands/catalog/tui/redesign/welcome.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/browser"
 
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog"
-	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
@@ -22,9 +21,9 @@ type StatusFunc func(msg string)
 
 // LoadFunc performs source discovery and module loading in the background.
 // It calls status with human-readable progress updates and sends each
-// discovered module on moduleCh as it is found. It returns a ready
+// discovered module entry on moduleCh as it is found. It returns a ready
 // CatalogService (for scaffolding), or nil if no sources were found.
-type LoadFunc func(ctx context.Context, status StatusFunc, moduleCh chan<- *module.Module) (catalog.CatalogService, error)
+type LoadFunc func(ctx context.Context, status StatusFunc, moduleCh chan<- *ModuleEntry) (catalog.CatalogService, error)
 
 // OpenURLFunc opens a URL in the user's browser. Injected so tests can
 // substitute a no-op or a recording stub.
@@ -44,14 +43,14 @@ type DiscoveryCompleteMsg struct {
 	Err error
 }
 
-// moduleMsg carries a single newly-discovered module from the LoadFunc.
+// moduleMsg carries a single newly-discovered module entry from the LoadFunc.
 type moduleMsg struct {
-	module *module.Module
+	entry *ModuleEntry
 }
 
 // ModuleMsg creates a moduleMsg for testing.
-func ModuleMsg(mod *module.Module) tea.Msg {
-	return moduleMsg{module: mod}
+func ModuleMsg(entry *ModuleEntry) tea.Msg {
+	return moduleMsg{entry: entry}
 }
 
 // StatusUpdateMsg carries a progress update from the LoadFunc.
@@ -83,11 +82,11 @@ type WelcomeModel struct {
 	ctx              context.Context
 	logger           log.Logger
 	lastDiscoveryErr error
-	moduleCh         chan *module.Module
+	opts             *options.TerragruntOptions
+	loadFunc         LoadFunc
 	openURL          OpenURLFunc
 	statusCh         chan string
-	loadFunc         LoadFunc
-	opts             *options.TerragruntOptions
+	moduleCh         chan *ModuleEntry
 	statusText       string
 	spinner          spinner.Model
 	state            welcomeState
@@ -108,7 +107,7 @@ func NewWelcomeModel(ctx context.Context, l log.Logger, opts *options.Terragrunt
 		loadFunc:   loadFunc,
 		openURL:    browser.OpenURL,
 		statusCh:   make(chan string, statusChannelSize),
-		moduleCh:   make(chan *module.Module, statusChannelSize),
+		moduleCh:   make(chan *ModuleEntry, statusChannelSize),
 		spinner:    s,
 		statusText: "Discovering modules from your infrastructure...",
 		state:      welcomeLoading,
@@ -170,7 +169,7 @@ func (m WelcomeModel) listenForModule() tea.Cmd { //nolint:gocritic
 			return nil
 		}
 
-		return moduleMsg{module: mod}
+		return moduleMsg{entry: mod}
 	}
 }
 
@@ -212,7 +211,7 @@ func (m WelcomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocrit
 
 func (m WelcomeModel) handleModuleMsg(msg moduleMsg) (tea.Model, tea.Cmd) { //nolint:gocritic
 	// First module: transition to the catalog list immediately
-	newModel := NewModelStreaming(m.logger, m.opts, msg.module, m.moduleCh)
+	newModel := NewModelStreaming(m.logger, m.opts, msg.entry, m.moduleCh)
 	width, height := m.width, m.height
 
 	initCmds := []tea.Cmd{newModel.Init()}

--- a/internal/cli/commands/catalog/tui/redesign/welcome_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/welcome_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui/redesign"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog"
-	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +29,7 @@ func TestWelcomeLoadingScreen_NoSources(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	noSourcesLoad := func(_ context.Context, _ redesign.StatusFunc, _ chan<- *module.Module) (catalog.CatalogService, error) {
+	noSourcesLoad := func(_ context.Context, _ redesign.StatusFunc, _ chan<- *redesign.ModuleEntry) (catalog.CatalogService, error) {
 		return nil, nil
 	}
 
@@ -60,9 +59,9 @@ func TestWelcomeLoadingScreen_TransitionsToModuleList(t *testing.T) {
 	l := logger.CreateLogger()
 	svc := createMockCatalogService(t, opts)
 
-	withModulesLoad := func(_ context.Context, _ redesign.StatusFunc, moduleCh chan<- *module.Module) (catalog.CatalogService, error) {
+	withModulesLoad := func(_ context.Context, _ redesign.StatusFunc, moduleCh chan<- *redesign.ModuleEntry) (catalog.CatalogService, error) {
 		for _, mod := range svc.Modules() {
-			moduleCh <- mod
+			moduleCh <- redesign.NewModuleEntry(mod)
 		}
 
 		return svc, nil
@@ -97,9 +96,9 @@ func TestWelcomeLoadingScreen_ModuleListNavigation(t *testing.T) {
 	l := logger.CreateLogger()
 	svc := createMockCatalogService(t, opts)
 
-	withModulesLoad := func(_ context.Context, _ redesign.StatusFunc, moduleCh chan<- *module.Module) (catalog.CatalogService, error) {
+	withModulesLoad := func(_ context.Context, _ redesign.StatusFunc, moduleCh chan<- *redesign.ModuleEntry) (catalog.CatalogService, error) {
 		for _, mod := range svc.Modules() {
-			moduleCh <- mod
+			moduleCh <- redesign.NewModuleEntry(mod)
 		}
 
 		return svc, nil
@@ -138,7 +137,7 @@ func TestWelcomeLoadingScreen_QuitDuringLoading(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	slowLoad := func(ctx context.Context, _ redesign.StatusFunc, _ chan<- *module.Module) (catalog.CatalogService, error) {
+	slowLoad := func(ctx context.Context, _ redesign.StatusFunc, _ chan<- *redesign.ModuleEntry) (catalog.CatalogService, error) {
 		// Simulate slow discovery
 		select {
 		case <-time.After(5 * time.Second):
@@ -170,7 +169,7 @@ func TestWelcomeNoSourcesScreen_HelpKeyOpensDocs(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	noSourcesLoad := func(_ context.Context, _ redesign.StatusFunc, _ chan<- *module.Module) (catalog.CatalogService, error) {
+	noSourcesLoad := func(_ context.Context, _ redesign.StatusFunc, _ chan<- *redesign.ModuleEntry) (catalog.CatalogService, error) {
 		return nil, nil
 	}
 
@@ -209,7 +208,7 @@ func TestWelcomeNoSourcesScreen_UnhandledKey(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	noSourcesLoad := func(_ context.Context, _ redesign.StatusFunc, _ chan<- *module.Module) (catalog.CatalogService, error) {
+	noSourcesLoad := func(_ context.Context, _ redesign.StatusFunc, _ chan<- *redesign.ModuleEntry) (catalog.CatalogService, error) {
 		return nil, nil
 	}
 
@@ -245,10 +244,10 @@ func TestWelcomeStreamingModules(t *testing.T) {
 	modules := svc.Modules()
 	require.GreaterOrEqual(t, len(modules), 2, "need at least 2 modules for streaming test")
 
-	streamingLoad := func(_ context.Context, _ redesign.StatusFunc, moduleCh chan<- *module.Module) (catalog.CatalogService, error) {
+	streamingLoad := func(_ context.Context, _ redesign.StatusFunc, moduleCh chan<- *redesign.ModuleEntry) (catalog.CatalogService, error) {
 		// Stream modules one at a time with a small delay to simulate real discovery
 		for _, mod := range modules {
-			moduleCh <- mod
+			moduleCh <- redesign.NewModuleEntry(mod)
 
 			time.Sleep(20 * time.Millisecond)
 		}
@@ -274,8 +273,8 @@ func TestWelcomeStreamingModules(t *testing.T) {
 	// Verify alphabetical order (case-insensitive, matching the sort in model.go)
 	items := listModel.List.Items()
 	for i := 1; i < len(items); i++ {
-		prev := strings.ToLower(items[i-1].(*module.Module).Title())
-		curr := strings.ToLower(items[i].(*module.Module).Title())
+		prev := strings.ToLower(items[i-1].(*redesign.ModuleEntry).Title())
+		curr := strings.ToLower(items[i].(*redesign.ModuleEntry).Title())
 		assert.LessOrEqual(t, prev, curr, "modules should be in alphabetical order")
 	}
 }

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -178,7 +178,11 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, mod
 		return errors.New(err)
 	}
 
-	// parse module url
+	// Save the original URL before go-getter transformation so the scaffolded
+	// source attribute matches the catalog config format.
+	originalModuleURL := moduleURL
+
+	// parse module url (transforms for go-getter download)
 	moduleURL, err = parseModuleURL(ctx, l, opts, vars, moduleURL)
 	if err != nil {
 		return errors.New(err)
@@ -208,7 +212,8 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, mod
 	vars["requiredVariables"] = requiredVariables
 	vars["optionalVariables"] = optionalVariables
 
-	vars["sourceUrl"] = moduleURL
+	// Build sourceUrl from the original URL with the ref that parseModuleURL resolved.
+	vars["sourceUrl"] = BuildSourceURL(originalModuleURL, moduleURL)
 
 	// Only set these if the `vars` map doesn't already have them set
 	if _, found := vars[enableRootInclude]; !found {
@@ -620,6 +625,47 @@ func addRefToModuleURL(
 	}
 
 	return moduleURL, nil
+}
+
+// BuildSourceURL returns the original module URL with the ref query param
+// from the resolved URL appended, so the scaffolded source preserves the
+// user's original URL format while including the resolved version tag.
+func BuildSourceURL(originalURL, resolvedURL string) string {
+	// Extract ref= value from the resolved (go-getter) URL via string matching,
+	// since the getter prefix (e.g. "git::") confuses url.Parse.
+	refVal := ExtractQueryParam(resolvedURL, refParam)
+
+	// If the original already has a ref, or none was resolved, use it as-is.
+	if refVal == "" || strings.Contains(originalURL, refParam+"=") {
+		return originalURL
+	}
+
+	// Append ?ref= or &ref= depending on whether the original has query params.
+	if strings.Contains(originalURL, "?") {
+		return originalURL + "&" + refParam + "=" + refVal
+	}
+
+	return originalURL + "?" + refParam + "=" + refVal
+}
+
+// ExtractQueryParam extracts a query parameter value from a URL string
+// without relying on url.Parse (which doesn't handle getter prefixes well).
+func ExtractQueryParam(rawURL, param string) string {
+	qIdx := strings.LastIndex(rawURL, "?")
+	if qIdx < 0 {
+		return ""
+	}
+
+	query := rawURL[qIdx+1:]
+
+	for _, kv := range strings.Split(query, "&") {
+		k, v, _ := strings.Cut(kv, "=")
+		if k == param {
+			return v
+		}
+	}
+
+	return ""
 }
 
 // parseURL parses module url to scheme, host and path

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -270,6 +270,52 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, mod
 	return nil
 }
 
+// BuildSourceURL returns the original module URL with the ref query param
+// from the resolved URL appended, so the scaffolded source preserves the
+// user's original URL format while including the resolved version tag.
+func BuildSourceURL(originalURL, resolvedURL string) string {
+	refVal := ExtractQueryParam(resolvedURL, refParam)
+	if refVal == "" {
+		return originalURL
+	}
+
+	base, rawQuery := splitURLQuery(originalURL)
+
+	params, err := url.ParseQuery(rawQuery)
+	if err != nil || params.Has(refParam) {
+		return originalURL
+	}
+
+	params.Set(refParam, refVal)
+
+	return base + "?" + params.Encode()
+}
+
+// ExtractQueryParam extracts a query parameter value from a URL string.
+// It splits on the last "?" to find the query portion, avoiding issues with
+// go-getter prefixes (e.g. "git::") that confuse url.Parse.
+func ExtractQueryParam(rawURL, param string) string {
+	_, rawQuery := splitURLQuery(rawURL)
+
+	params, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return ""
+	}
+
+	return params.Get(param)
+}
+
+// splitURLQuery splits a raw URL at the last "?" into the base and query
+// string. Go-getter URLs may contain "::" prefixes that prevent full URL
+// parsing, but the query string is always after the final "?".
+func splitURLQuery(rawURL string) (string, string) {
+	if idx := strings.LastIndex(rawURL, "?"); idx >= 0 {
+		return rawURL[:idx], rawURL[idx+1:]
+	}
+
+	return rawURL, ""
+}
+
 // applyCatalogConfigToScaffold applies catalog configuration settings to scaffold options.
 // CLI flags take precedence over config file settings.
 func applyCatalogConfigToScaffold(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) {
@@ -625,47 +671,6 @@ func addRefToModuleURL(
 	}
 
 	return moduleURL, nil
-}
-
-// BuildSourceURL returns the original module URL with the ref query param
-// from the resolved URL appended, so the scaffolded source preserves the
-// user's original URL format while including the resolved version tag.
-func BuildSourceURL(originalURL, resolvedURL string) string {
-	// Extract ref= value from the resolved (go-getter) URL via string matching,
-	// since the getter prefix (e.g. "git::") confuses url.Parse.
-	refVal := ExtractQueryParam(resolvedURL, refParam)
-
-	// If the original already has a ref, or none was resolved, use it as-is.
-	if refVal == "" || strings.Contains(originalURL, refParam+"=") {
-		return originalURL
-	}
-
-	// Append ?ref= or &ref= depending on whether the original has query params.
-	if strings.Contains(originalURL, "?") {
-		return originalURL + "&" + refParam + "=" + refVal
-	}
-
-	return originalURL + "?" + refParam + "=" + refVal
-}
-
-// ExtractQueryParam extracts a query parameter value from a URL string
-// without relying on url.Parse (which doesn't handle getter prefixes well).
-func ExtractQueryParam(rawURL, param string) string {
-	qIdx := strings.LastIndex(rawURL, "?")
-	if qIdx < 0 {
-		return ""
-	}
-
-	query := rawURL[qIdx+1:]
-
-	for _, kv := range strings.Split(query, "&") {
-		k, v, _ := strings.Cut(kv, "=")
-		if k == param {
-			return v
-		}
-	}
-
-	return ""
 }
 
 // parseURL parses module url to scheme, host and path

--- a/internal/cli/commands/scaffold/source_url_test.go
+++ b/internal/cli/commands/scaffold/source_url_test.go
@@ -1,0 +1,110 @@
+package scaffold_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/scaffold"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildSourceURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		originalURL string
+		resolvedURL string
+		expected    string
+	}{
+		{
+			name:        "catalog URL gets ref from resolved",
+			originalURL: "github.com/gruntwork-io/terragrunt-scale-catalog//modules/azure/resource-group",
+			resolvedURL: "git::https://github.com/gruntwork-io/terragrunt-scale-catalog.git//modules/azure/resource-group?ref=v1.10.2",
+			expected:    "github.com/gruntwork-io/terragrunt-scale-catalog//modules/azure/resource-group?ref=v1.10.2",
+		},
+		{
+			name:        "original already has ref",
+			originalURL: "github.com/gruntwork-io/repo//modules/foo?ref=v2.0.0",
+			resolvedURL: "git::https://github.com/gruntwork-io/repo.git//modules/foo?ref=v1.0.0",
+			expected:    "github.com/gruntwork-io/repo//modules/foo?ref=v2.0.0",
+		},
+		{
+			name:        "no ref in resolved URL",
+			originalURL: "github.com/gruntwork-io/repo//modules/foo",
+			resolvedURL: "git::https://github.com/gruntwork-io/repo.git//modules/foo",
+			expected:    "github.com/gruntwork-io/repo//modules/foo",
+		},
+		{
+			name:        "original with existing query params gets ref appended",
+			originalURL: "github.com/gruntwork-io/repo//modules/foo?depth=1",
+			resolvedURL: "git::https://github.com/gruntwork-io/repo.git//modules/foo?depth=1&ref=v1.0.0",
+			expected:    "github.com/gruntwork-io/repo//modules/foo?depth=1&ref=v1.0.0",
+		},
+		{
+			name:        "git:: prefixed original preserved",
+			originalURL: "git::https://github.com/gruntwork-io/repo.git//modules/foo",
+			resolvedURL: "git::https://github.com/gruntwork-io/repo.git//modules/foo?ref=v1.0.0",
+			expected:    "git::https://github.com/gruntwork-io/repo.git//modules/foo?ref=v1.0.0",
+		},
+		{
+			name:        "root module without subdirectory",
+			originalURL: "github.com/gruntwork-io/repo",
+			resolvedURL: "git::https://github.com/gruntwork-io/repo.git?ref=v3.0.0",
+			expected:    "github.com/gruntwork-io/repo?ref=v3.0.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := scaffold.BuildSourceURL(tc.originalURL, tc.resolvedURL)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestExtractQueryParam(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		rawURL   string
+		param    string
+		expected string
+	}{
+		{
+			name:     "ref from go-getter URL",
+			rawURL:   "git::https://github.com/org/repo.git//modules/foo?ref=v1.0.0",
+			param:    "ref",
+			expected: "v1.0.0",
+		},
+		{
+			name:     "ref among multiple params",
+			rawURL:   "git::https://github.com/org/repo.git//modules/foo?depth=1&ref=v2.0.0",
+			param:    "ref",
+			expected: "v2.0.0",
+		},
+		{
+			name:     "no query string",
+			rawURL:   "git::https://github.com/org/repo.git//modules/foo",
+			param:    "ref",
+			expected: "",
+		},
+		{
+			name:     "param not present",
+			rawURL:   "git::https://github.com/org/repo.git//modules/foo?depth=1",
+			param:    "ref",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := scaffold.ExtractQueryParam(tc.rawURL, tc.param)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -30,6 +30,7 @@ import (
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/gruntwork-io/terragrunt/internal/os/signal"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/hashicorp/go-version"
 )
 
 const (
@@ -179,6 +180,48 @@ func (g *GitRunner) LsRemote(ctx context.Context, repo, ref string) ([]LsRemoteR
 	}
 
 	return results, nil
+}
+
+const refsTags = "refs/tags/"
+
+// LatestReleaseTag returns the highest semver release tag from the given remote.
+// It uses `git ls-remote --tags` against the named remote (e.g. "origin") and
+// returns the tag with the greatest semantic version, or "" if none exist.
+func (g *GitRunner) LatestReleaseTag(ctx context.Context, remote string) (string, error) {
+	results, err := g.LsRemote(ctx, remote, "refs/tags/*")
+	if err != nil {
+		// No tags is not an error — just means no release tags exist.
+		if errors.Is(err, ErrNoMatchingReference) {
+			return "", nil
+		}
+
+		return "", err
+	}
+
+	var best *version.Version
+
+	for _, r := range results {
+		name := strings.TrimPrefix(r.Ref, refsTags)
+		// Skip dereferenced tag objects (e.g. refs/tags/v1.0.0^{})
+		if strings.HasSuffix(name, "^{}") {
+			continue
+		}
+
+		v, err := version.NewVersion(name)
+		if err != nil {
+			continue
+		}
+
+		if best == nil || v.GreaterThan(best) {
+			best = v
+		}
+	}
+
+	if best == nil {
+		return "", nil
+	}
+
+	return best.Original(), nil
 }
 
 // Clone performs a git clone operation

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -212,6 +212,10 @@ func (g *GitRunner) LatestReleaseTag(ctx context.Context, remote string) (string
 			continue
 		}
 
+		if v.Prerelease() != "" {
+			continue
+		}
+
 		if best == nil || v.GreaterThan(best) {
 			best = v
 		}

--- a/internal/services/catalog/module/module.go
+++ b/internal/services/catalog/module/module.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/go-commons/collections"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/util"
-	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
 const (
@@ -44,11 +43,11 @@ func NewModule(repo *Repo, moduleDir string) (*Module, error) {
 		return nil, err
 	}
 
-	repo.logger.Debugf("Found module in directory %q", moduleDir)
+	repo.Logger.Debugf("Found module in directory %q", moduleDir)
 
 	module.url = repo.ModuleURL(moduleDir)
 
-	repo.logger.Debugf("Module URL: %s", module.url)
+	repo.Logger.Debugf("Module URL: %s", module.url)
 
 	modulePath := filepath.Join(module.repoPath, module.moduleDir)
 
@@ -60,10 +59,6 @@ func NewModule(repo *Repo, moduleDir string) (*Module, error) {
 	module.Doc = doc
 
 	return module, nil
-}
-
-func (module *Module) Logger() log.Logger {
-	return module.logger
 }
 
 // FilterValue implements /github.com/charmbracelet/bubbles.list.Item.FilterValue

--- a/internal/services/catalog/module/module.go
+++ b/internal/services/catalog/module/module.go
@@ -88,15 +88,22 @@ func (module *Module) URL() string {
 	return module.url
 }
 
-// TerraformSourcePath returns the module source URL in the format expected by go-getter:
-// baseURL//moduleDir?query (e.g., git::https://github.com/org/repo.git//modules/foo?ref=v1.0.0)
+// TerraformSourcePath returns the module source URL using the original catalog URL
+// (before go-getter transformation), with the module subdirectory appended:
+// baseURL//moduleDir (e.g., github.com/org/repo//modules/foo)
 func (module *Module) TerraformSourcePath() string {
+	// Prefer the original source URL so scaffolded units match the catalog config.
+	sourceURL := module.cloneURL
+	if module.Repo != nil && module.Repo.SourceURL() != "" {
+		sourceURL = module.Repo.SourceURL()
+	}
+
 	if module.moduleDir == "" {
-		return module.cloneURL
+		return sourceURL
 	}
 
 	// Split on ? to separate base URL from query string
-	base, query, _ := strings.Cut(module.cloneURL, "?")
+	base, query, _ := strings.Cut(sourceURL, "?")
 
 	result := base + "//" + module.moduleDir
 	if query != "" {

--- a/internal/services/catalog/module/module.go
+++ b/internal/services/catalog/module/module.go
@@ -88,22 +88,15 @@ func (module *Module) URL() string {
 	return module.url
 }
 
-// TerraformSourcePath returns the module source URL using the original catalog URL
-// (before go-getter transformation), with the module subdirectory appended:
-// baseURL//moduleDir (e.g., github.com/org/repo//modules/foo)
+// TerraformSourcePath returns the module source URL in the format expected by go-getter:
+// baseURL//moduleDir?query (e.g., git::https://github.com/org/repo.git//modules/foo?ref=v1.0.0)
 func (module *Module) TerraformSourcePath() string {
-	// Prefer the original source URL so scaffolded units match the catalog config.
-	sourceURL := module.cloneURL
-	if module.Repo != nil && module.Repo.SourceURL() != "" {
-		sourceURL = module.Repo.SourceURL()
-	}
-
 	if module.moduleDir == "" {
-		return sourceURL
+		return module.cloneURL
 	}
 
 	// Split on ? to separate base URL from query string
-	base, query, _ := strings.Cut(sourceURL, "?")
+	base, query, _ := strings.Cut(module.cloneURL, "?")
 
 	result := base + "//" + module.moduleDir
 	if query != "" {

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/go-commons/files"
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	gitpkg "github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-getter/v2"
@@ -51,6 +52,7 @@ type Repo struct {
 
 	RemoteURL  string
 	BranchName string
+	LatestTag  string
 
 	walkWithSymlinks bool
 	allowCAS         bool
@@ -412,4 +414,57 @@ func (repo *Repo) parseBranchName() error {
 	}
 
 	return errors.Errorf("could not get branch name for repo %q", repo.path)
+}
+
+// ResolveLatestTag looks up the latest semver release tag from the remote.
+// The result is stored in LatestTag. If the lookup fails or the repo has no
+// semver tags, LatestTag is left empty.
+func (repo *Repo) ResolveLatestTag(ctx context.Context) {
+	remote := repo.remoteForTagLookup()
+	if remote == "" {
+		return
+	}
+
+	runner, err := gitpkg.NewGitRunner()
+	if err != nil {
+		repo.logger.Debugf("catalog: skip tag lookup: %v", err)
+
+		return
+	}
+
+	tag, err := runner.LatestReleaseTag(ctx, remote)
+	if err != nil {
+		repo.logger.Debugf("catalog: failed to resolve latest tag for %q: %v", remote, err)
+
+		return
+	}
+
+	repo.LatestTag = tag
+}
+
+// remoteForTagLookup returns a URL suitable for git ls-remote.
+// It prefers RemoteURL (parsed from .git/config) since that's what git
+// originally used to clone. Falls back to cloneURL with go-getter
+// prefixes and query params stripped.
+func (repo *Repo) remoteForTagLookup() string {
+	if repo.RemoteURL != "" {
+		return repo.RemoteURL
+	}
+
+	u := repo.cloneURL
+	if u == "" {
+		return ""
+	}
+
+	// Strip getter prefix (e.g. "git::", "s3::")
+	if idx := strings.Index(u, "::"); idx >= 0 {
+		u = u[idx+2:]
+	}
+
+	// Strip query parameters (e.g. "?ref=HEAD")
+	if idx := strings.IndexByte(u, '?'); idx >= 0 {
+		u = u[:idx]
+	}
+
+	return u
 }

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -48,6 +48,7 @@ type Repo struct {
 	Logger log.Logger
 
 	cloneURL       string
+	sourceURL      string
 	path           string
 	rootWorkingDir string
 
@@ -74,6 +75,7 @@ func NewRepo(ctx context.Context, l log.Logger, opts RepoOpts) (*Repo, error) {
 	repo := &Repo{
 		Logger:           l,
 		cloneURL:         opts.CloneURL,
+		sourceURL:        opts.CloneURL,
 		path:             opts.Path,
 		walkWithSymlinks: opts.WalkWithSymlinks,
 		allowCAS:         opts.AllowCAS,
@@ -225,6 +227,11 @@ func (repo *Repo) clone(ctx context.Context, l log.Logger) error {
 	}
 
 	return repo.performClone(ctx, l, &opts)
+}
+
+// SourceURL returns the original catalog URL before go-getter transformation.
+func (repo *Repo) SourceURL() string {
+	return repo.sourceURL
 }
 
 func (repo *Repo) resolveCloneURL() string {

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-getter/v2"
+	urlhelper "github.com/hashicorp/go-getter/v2/helper/url"
 	"gopkg.in/ini.v1"
 )
 
@@ -44,7 +45,7 @@ var (
 )
 
 type Repo struct {
-	logger log.Logger
+	Logger log.Logger
 
 	cloneURL       string
 	path           string
@@ -71,7 +72,7 @@ type RepoOpts struct {
 
 func NewRepo(ctx context.Context, l log.Logger, opts RepoOpts) (*Repo, error) {
 	repo := &Repo{
-		logger:           l,
+		Logger:           l,
 		cloneURL:         opts.CloneURL,
 		path:             opts.Path,
 		walkWithSymlinks: opts.WalkWithSymlinks,
@@ -210,7 +211,7 @@ func (repo *Repo) clone(ctx context.Context, l log.Logger) error {
 		SourceURL:  cloneURL,
 		TargetPath: repo.path,
 		Context:    ctx,
-		Logger:     repo.logger,
+		Logger:     repo.Logger,
 	}
 
 	if err := repo.prepareCloneDirectory(); err != nil {
@@ -218,7 +219,7 @@ func (repo *Repo) clone(ctx context.Context, l log.Logger) error {
 	}
 
 	if repo.cloneCompleted() {
-		repo.logger.Debugf("The repo dir exists and %q exists. Skipping cloning.", cloneCompleteSentinel)
+		repo.Logger.Debugf("The repo dir exists and %q exists. Skipping cloning.", cloneCompleteSentinel)
 
 		return nil
 	}
@@ -237,7 +238,7 @@ func (repo *Repo) resolveCloneURL() string {
 func (repo *Repo) handleLocalDir(repoPath string) error {
 	if !filepath.IsAbs(repoPath) {
 		absRepoPath := filepath.Join(repo.rootWorkingDir, repoPath)
-		repo.logger.Debugf("Converting relative path %q to absolute %q", repoPath, absRepoPath)
+		repo.Logger.Debugf("Converting relative path %q to absolute %q", repoPath, absRepoPath)
 		repo.path = absRepoPath
 
 		return nil
@@ -258,7 +259,7 @@ func (repo *Repo) prepareCloneDirectory() error {
 
 	// Clean up incomplete clones
 	if repo.shouldCleanupIncompleteClone() {
-		repo.logger.Debugf("The repo dir exists but %q does not. Removing the repo dir for cloning from the remote source.", cloneCompleteSentinel)
+		repo.Logger.Debugf("The repo dir exists but %q does not. Removing the repo dir for cloning from the remote source.", cloneCompleteSentinel)
 
 		if err := os.RemoveAll(repo.path); err != nil {
 			return errors.New(err)
@@ -364,7 +365,7 @@ func (repo *Repo) parseRemoteURL() error {
 		return errors.Errorf("the specified path %q is not a git repository (no .git/config file found)", repo.path)
 	}
 
-	repo.logger.Debugf("Parsing git config %q", gitConfigPath)
+	repo.Logger.Debugf("Parsing git config %q", gitConfigPath)
 
 	inidata, err := ini.Load(gitConfigPath)
 	if err != nil {
@@ -391,7 +392,7 @@ func (repo *Repo) parseRemoteURL() error {
 	}
 
 	repo.RemoteURL = inidata.Section(sectionName).Key("url").String()
-	repo.logger.Debugf("Remote url: %q for repo: %q", repo.RemoteURL, repo.path)
+	repo.Logger.Debugf("Remote url: %q for repo: %q", repo.RemoteURL, repo.path)
 
 	return nil
 }
@@ -427,14 +428,14 @@ func (repo *Repo) ResolveLatestTag(ctx context.Context) {
 
 	runner, err := gitpkg.NewGitRunner()
 	if err != nil {
-		repo.logger.Debugf("catalog: skip tag lookup: %v", err)
+		repo.Logger.Debugf("catalog: skip tag lookup: %v", err)
 
 		return
 	}
 
 	tag, err := runner.LatestReleaseTag(ctx, remote)
 	if err != nil {
-		repo.logger.Debugf("catalog: failed to resolve latest tag for %q: %v", remote, err)
+		repo.Logger.Debugf("catalog: failed to resolve latest tag for %q: %v", remote, err)
 
 		return
 	}
@@ -445,7 +446,7 @@ func (repo *Repo) ResolveLatestTag(ctx context.Context) {
 // remoteForTagLookup returns a URL suitable for git ls-remote.
 // It prefers RemoteURL (parsed from .git/config) since that's what git
 // originally used to clone. Falls back to cloneURL with go-getter
-// prefixes and query params stripped.
+// prefixes, subdirectory paths, and query params stripped.
 func (repo *Repo) remoteForTagLookup() string {
 	if repo.RemoteURL != "" {
 		return repo.RemoteURL
@@ -456,15 +457,22 @@ func (repo *Repo) remoteForTagLookup() string {
 		return ""
 	}
 
-	// Strip getter prefix (e.g. "git::", "s3::")
-	if idx := strings.Index(u, "::"); idx >= 0 {
-		u = u[idx+2:]
+	// Strip forced getter prefix (e.g. "git::", "s3::")
+	if _, after, ok := strings.Cut(u, "::"); ok {
+		u = after
 	}
 
-	// Strip query parameters (e.g. "?ref=HEAD")
-	if idx := strings.IndexByte(u, '?'); idx >= 0 {
-		u = u[:idx]
+	// Strip //subdir suffix that go-getter uses to select a subdirectory.
+	u, _ = getter.SourceDirSubdir(u)
+
+	// Parse the URL so we can cleanly remove query parameters (e.g. "?ref=HEAD").
+	parsed, err := urlhelper.Parse(u)
+	if err != nil {
+		return u
 	}
 
-	return u
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+
+	return parsed.String()
 }

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -193,6 +193,37 @@ func (repo *Repo) ModuleURL(moduleDir string) string {
 	return ""
 }
 
+// SourceURL returns the original catalog URL before go-getter transformation.
+func (repo *Repo) SourceURL() string {
+	return repo.sourceURL
+}
+
+// ResolveLatestTag looks up the latest semver release tag from the remote.
+// The result is stored in LatestTag. If the lookup fails or the repo has no
+// semver tags, LatestTag is left empty.
+func (repo *Repo) ResolveLatestTag(ctx context.Context) {
+	remote := repo.remoteForTagLookup()
+	if remote == "" {
+		return
+	}
+
+	runner, err := gitpkg.NewGitRunner()
+	if err != nil {
+		repo.Logger.Debugf("catalog: skip tag lookup: %v", err)
+
+		return
+	}
+
+	tag, err := runner.LatestReleaseTag(ctx, remote)
+	if err != nil {
+		repo.Logger.Debugf("catalog: failed to resolve latest tag for %q: %v", remote, err)
+
+		return
+	}
+
+	repo.LatestTag = tag
+}
+
 type CloneOptions struct {
 	Context    context.Context
 	Logger     log.Logger
@@ -227,11 +258,6 @@ func (repo *Repo) clone(ctx context.Context, l log.Logger) error {
 	}
 
 	return repo.performClone(ctx, l, &opts)
-}
-
-// SourceURL returns the original catalog URL before go-getter transformation.
-func (repo *Repo) SourceURL() string {
-	return repo.sourceURL
 }
 
 func (repo *Repo) resolveCloneURL() string {
@@ -422,32 +448,6 @@ func (repo *Repo) parseBranchName() error {
 	}
 
 	return errors.Errorf("could not get branch name for repo %q", repo.path)
-}
-
-// ResolveLatestTag looks up the latest semver release tag from the remote.
-// The result is stored in LatestTag. If the lookup fails or the repo has no
-// semver tags, LatestTag is left empty.
-func (repo *Repo) ResolveLatestTag(ctx context.Context) {
-	remote := repo.remoteForTagLookup()
-	if remote == "" {
-		return
-	}
-
-	runner, err := gitpkg.NewGitRunner()
-	if err != nil {
-		repo.Logger.Debugf("catalog: skip tag lookup: %v", err)
-
-		return
-	}
-
-	tag, err := runner.LatestReleaseTag(ctx, remote)
-	if err != nil {
-		repo.Logger.Debugf("catalog: failed to resolve latest tag for %q: %v", remote, err)
-
-		return
-	}
-
-	repo.LatestTag = tag
 }
 
 // remoteForTagLookup returns a URL suitable for git ls-remote.

--- a/internal/services/catalog/module/repo_tag_test.go
+++ b/internal/services/catalog/module/repo_tag_test.go
@@ -1,4 +1,4 @@
-package module
+package module_test
 
 import (
 	"os"
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,7 @@ func initBareRepoWithTags(t *testing.T, tags []string) string {
 	runIn := func(dir string, args ...string) {
 		t.Helper()
 
-		cmd := exec.Command("git", args...)
+		cmd := exec.CommandContext(t.Context(), "git", args...) //nolint:gosec // test helper, args are hardcoded
 		cmd.Dir = dir
 		cmd.Env = gitEnv
 
@@ -61,8 +62,8 @@ func TestResolveLatestTag_FindsHighestSemver(t *testing.T) {
 	bareDir := initBareRepoWithTags(t, []string{"v1.0.0", "v1.10.2", "v1.5.0", "not-semver"})
 	l := logger.CreateLogger()
 
-	repo := &Repo{
-		logger:    l,
+	repo := &module.Repo{
+		Logger:    l,
 		RemoteURL: bareDir,
 	}
 
@@ -77,8 +78,8 @@ func TestResolveLatestTag_NoTags(t *testing.T) {
 	bareDir := initBareRepoWithTags(t, nil)
 	l := logger.CreateLogger()
 
-	repo := &Repo{
-		logger:    l,
+	repo := &module.Repo{
+		Logger:    l,
 		RemoteURL: bareDir,
 	}
 
@@ -92,8 +93,8 @@ func TestResolveLatestTag_EmptyRemoteURL(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	repo := &Repo{
-		logger: l,
+	repo := &module.Repo{
+		Logger: l,
 	}
 
 	repo.ResolveLatestTag(t.Context())

--- a/internal/services/catalog/module/repo_tag_test.go
+++ b/internal/services/catalog/module/repo_tag_test.go
@@ -38,7 +38,7 @@ func initBareRepoWithTags(t *testing.T, tags []string) string {
 		require.NoError(t, err, "git %v failed: %s", args, out)
 	}
 
-	runIn(bareDir, "init", "--bare")
+	runIn(bareDir, "init", "--bare", "--initial-branch=main")
 
 	workDir := t.TempDir()
 	runIn(workDir, "clone", bareDir, ".")

--- a/internal/services/catalog/module/repo_tag_test.go
+++ b/internal/services/catalog/module/repo_tag_test.go
@@ -1,0 +1,102 @@
+package module
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initBareRepoWithTags creates a bare git repo with the given tags and
+// returns its path.
+func initBareRepoWithTags(t *testing.T, tags []string) string {
+	t.Helper()
+
+	bareDir := filepath.Join(t.TempDir(), "remote.git")
+	require.NoError(t, os.MkdirAll(bareDir, 0755))
+
+	gitEnv := append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+
+	runIn := func(dir string, args ...string) {
+		t.Helper()
+
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = gitEnv
+
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v failed: %s", args, out)
+	}
+
+	runIn(bareDir, "init", "--bare")
+
+	workDir := t.TempDir()
+	runIn(workDir, "clone", bareDir, ".")
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "README.md"), []byte("# Test\nA test module."), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.tf"), []byte("# terraform"), 0644))
+	runIn(workDir, "add", ".")
+	runIn(workDir, "commit", "-m", "init")
+
+	for _, tag := range tags {
+		runIn(workDir, "tag", tag)
+	}
+
+	runIn(workDir, "push", "origin", "main", "--tags")
+
+	return bareDir
+}
+
+func TestResolveLatestTag_FindsHighestSemver(t *testing.T) {
+	t.Parallel()
+
+	bareDir := initBareRepoWithTags(t, []string{"v1.0.0", "v1.10.2", "v1.5.0", "not-semver"})
+	l := logger.CreateLogger()
+
+	repo := &Repo{
+		logger:    l,
+		RemoteURL: bareDir,
+	}
+
+	repo.ResolveLatestTag(t.Context())
+
+	assert.Equal(t, "v1.10.2", repo.LatestTag)
+}
+
+func TestResolveLatestTag_NoTags(t *testing.T) {
+	t.Parallel()
+
+	bareDir := initBareRepoWithTags(t, nil)
+	l := logger.CreateLogger()
+
+	repo := &Repo{
+		logger:    l,
+		RemoteURL: bareDir,
+	}
+
+	repo.ResolveLatestTag(t.Context())
+
+	assert.Empty(t, repo.LatestTag)
+}
+
+func TestResolveLatestTag_EmptyRemoteURL(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	repo := &Repo{
+		logger: l,
+	}
+
+	repo.ResolveLatestTag(t.Context())
+
+	assert.Empty(t, repo.LatestTag)
+}

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -99,7 +99,14 @@ func TestScaffoldGitModuleHttps(t *testing.T) {
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 
-	repo, err := module.NewRepo(ctx, logger.CreateLogger(), module.RepoOpts{CloneURL: "https://github.com/gruntwork-io/terraform-fake-modules", Path: tempDir})
+	repo, err := module.NewRepo(
+		ctx,
+		logger.CreateLogger(),
+		module.RepoOpts{
+			CloneURL: "https://github.com/gruntwork-io/terraform-fake-modules",
+			Path:     tempDir,
+		},
+	)
 	require.NoError(t, err)
 
 	modules, err := repo.FindModules(ctx)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds a "module" pill for each module, a source URL, and a version pill for module.

Sets the catalog list view up to distinguish between modules and other things like templates, units and stacks.

<img width="1590" height="982" alt="image" src="https://github.com/user-attachments/assets/63b0014c-c69c-4911-8c30-2d2739c0eda8" />

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned catalog list with metadata rows showing item type, source and version; improved item rendering, filtering highlights, and layout.
  * Automatic detection of latest release tags for repositories to surface module versions.

* **Bug Fixes**
  * Preserve repository reference parameters when building source URLs in scaffold flows.

* **Tests**
  * Added tests for URL handling, tag resolution, and expanded catalog UI coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->