### PR TITLE
docs: Updating install docs

### DIFF
--- a/docs/public/install
+++ b/docs/public/install
@@ -12,11 +12,11 @@
 #   - arrays and readonly declarations
 #
 # Usage:
-#   curl -sL https://docs.terragrunt.com/install | bash
-#   curl -sL https://docs.terragrunt.com/install | bash -s -- -v v0.72.5
-#   curl -sL https://docs.terragrunt.com/install | bash -s -- -d ~/bin
-#   curl -sL https://docs.terragrunt.com/install | bash -s -- --tip
-#   curl -sL https://docs.terragrunt.com/install | bash -s -- --test --commit abc123def
+#   curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash
+#   curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- -v v0.72.5
+#   curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- -d ~/bin
+#   curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --tip
+#   curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --test --commit abc123def
 #
 # Options:
 #   -v, --version VERSION    Install specific version (default: latest)
@@ -88,8 +88,8 @@ usage() {
 Terragrunt Installer
 
 Usage:
-  curl -sL https://docs.terragrunt.com/install | bash
-  curl -sL https://docs.terragrunt.com/install | bash -s -- [OPTIONS]
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- [OPTIONS]
 
 Options:
   -v, --version VERSION    Install specific version (default: latest)
@@ -108,28 +108,28 @@ Use --no-verify-sig to skip, or --verify-cosign to use Cosign instead of GPG.
 
 Examples:
   # Install latest version
-  curl -sL https://docs.terragrunt.com/install | bash
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash
 
   # Install specific version
-  curl -sL https://docs.terragrunt.com/install | bash -s -- -v v0.98.0
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- -v v0.98.0
 
   # Install to custom directory
-  curl -sL https://docs.terragrunt.com/install | bash -s -- -d ~/bin
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- -d ~/bin
 
   # Install without signature verification
-  curl -sL https://docs.terragrunt.com/install | bash -s -- --no-verify-sig
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --no-verify-sig
 
   # Install using Cosign instead of GPG
-  curl -sL https://docs.terragrunt.com/install | bash -s -- --verify-cosign
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --verify-cosign
 
   # Install the latest tip build
-  curl -sL https://docs.terragrunt.com/install | bash -s -- --tip
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --tip
 
   # Install a specific tip build by commit
-  curl -sL https://docs.terragrunt.com/install | bash -s -- --tip --commit abc123def
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --tip --commit abc123def
 
   # Install a test build by commit
-  curl -sL https://docs.terragrunt.com/install | bash -s -- --test --commit abc123def
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --test --commit abc123def
 EOF
 }
 
@@ -574,9 +574,9 @@ Use --force to upgrade/downgrade to ${requested_version}"
     # Check write permissions
     [[ ! -w "$install_dir" ]] && abort "Cannot write to $install_dir
 Run with sudo:
-  curl -sL https://docs.terragrunt.com/install | sudo bash
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | sudo bash
 Or specify a different directory:
-  curl -sL https://docs.terragrunt.com/install | bash -s -- -d ~/bin"
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- -d ~/bin"
 
     info "Installing to ${target_path}..."
     install -m 0755 "$binary_path" "$target_path"
@@ -679,7 +679,7 @@ Please install curl and try again."
     [[ "$VERIFY_SHA" == true ]] && ! command -v sha256sum &>/dev/null && ! command -v shasum &>/dev/null &&
         abort "Neither sha256sum nor shasum found.
 Install one of these tools or skip checksum verification with:
-  curl -sL https://docs.terragrunt.com/install | bash -s -- --no-verify"
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --no-verify"
 
     # Tip/test builds require tar for archive extraction
     [[ -n "$BUILD_CHANNEL" ]] && ! command -v tar &>/dev/null &&
@@ -696,9 +696,9 @@ Install one of these tools or skip checksum verification with:
     gpg)
         command -v gpg &>/dev/null || abort "GPG signature verification requires gpg but it is not installed.
 Install gpg or skip signature verification with:
-  curl -sL https://docs.terragrunt.com/install | bash -s -- --no-verify-sig
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --no-verify-sig
 Or use Cosign instead:
-  curl -sL https://docs.terragrunt.com/install | bash -s -- --verify-cosign"
+  curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --verify-cosign"
         ;;
     cosign)
         command -v cosign &>/dev/null || abort "Cosign verification requested but cosign is not installed."

--- a/docs/src/content/docs/01-getting-started/03-install.mdx
+++ b/docs/src/content/docs/01-getting-started/03-install.mdx
@@ -17,12 +17,20 @@ export const version = releaseData?.tag_name || 'v0.99.0';
 The quickest way to install Terragrunt on Linux or macOS:
 
 ```bash
-curl -sL https://docs.terragrunt.com/install | bash
+curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash
 ```
 
-:::tip[Script Options]
-Run `curl -sL https://docs.terragrunt.com/install | bash -s -- --help` to see all options, or [view the script on GitHub](https://github.com/gruntwork-io/terragrunt/blob/main/docs/public/install).
-:::
+<Aside type="tip" title="Script options and inspecting the script">
+  Run `curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --help` to see all options, or [read the script on GitHub](https://github.com/gruntwork-io/terragrunt/blob/main/docs/public/install).
+
+  Piping a remote script directly into `bash` means executing code you haven't read. If you'd rather review the script before running it, download it to your local filesystem, read through it, and then run it:
+
+  ```bash
+  curl -sSfL --proto '=https' --tlsv1.2 -o install.sh https://terragrunt.com/install
+  less install.sh
+  bash install.sh
+  ```
+</Aside>
 
 ## Download from releases page
 
@@ -182,6 +190,30 @@ Tip builds are served via the builds API at `https://builds.terragrunt.com` and 
 <Aside type="caution" title="No retention guarantee">
   Tip and test builds may be reclaimed at any time to reduce hosting costs. Do not rely on a specific build being available indefinitely. Use [official releases](https://github.com/gruntwork-io/terragrunt/releases) for production.
 </Aside>
+
+### Quick install for tip and test builds
+
+The same install script used for official releases supports tip and test builds via flags.
+
+To install the latest tip build:
+
+```bash
+curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --tip
+```
+
+To install a tip build at a specific commit:
+
+```bash
+curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --tip --commit <commit-sha>
+```
+
+To install a test build at a specific commit:
+
+```bash
+curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- --test --commit <commit-sha>
+```
+
+If you prefer to run the install steps manually, the tabs below show the equivalent commands:
 
 <Tabs>
   <TabItem label="Latest tip">


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updating install scripts a bit.

- Updated domain for the install script from docs.terragrunt.com to terragrunt.com just to get it a little shorter.
- Added `-Sf` which improves error handling by having the script fail fast if the curl fails and shows the error message.
- Added `--proto '=https'` to enforce usage of HTTPS, even through redirects.
- Added `--tlsv1.2` to enforce a minimum TLS version of 1.2.
- Added a callout that users might want to download the script, then run it locally.
- Added the convenience scripts for installing tip and test builds.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced installation command security with stricter curl configuration.
  * Updated installation documentation URL references.
  * Added guidance for reviewing and verifying scripts before execution.
  * Introduced quick-install options supporting tip and test builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->