### PR TITLE
fix: Use `httptest` in `./internal/tf` to avoid issues from integration in unit tests

### DIFF
--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -321,9 +321,8 @@ func UpdateGetters(l log.Logger, opts *Options, cfg *runcfg.RunConfig) func(*get
 		client.Getters["https"] = &getter.HttpGetter{Netrc: true}
 
 		// Load in custom getters that are only supported in Terragrunt
-		client.Getters["tfr"] = &tf.RegistryGetter{
-			TofuImplementation: opts.TofuImplementation,
-		}
+		client.Getters["tfr"] = tf.NewRegistryGetter(l).
+			WithTofuImplementation(opts.TofuImplementation)
 
 		return nil
 	}

--- a/internal/tf/getter.go
+++ b/internal/tf/getter.go
@@ -24,9 +24,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/util"
 )
 
-// httpClient is the default client to be used by HttpGetters.
-var httpClient = cleanhttp.DefaultClient()
-
 // Constants relevant to the module registry
 const (
 	defaultRegistryDomain   = "registry.terraform.io"
@@ -70,13 +67,82 @@ type RegistryServicePath struct {
 // over the file detector. We deferred the implementation for that to a future release.
 // GH issue: https://github.com/gruntwork-io/terragrunt/issues/1772
 type RegistryGetter struct {
-	client             *getter.Client
-	Logger             log.Logger
+	// client is the [github.com/hashicorp/go-getter.Client] driving the
+	// current download, injected by [github.com/hashicorp/go-getter] via
+	// [RegistryGetter.SetClient]. It is unexported because callers should
+	// not set it directly; go-getter owns its lifecycle. We read its
+	// Options in [RegistryGetter.Get] so downstream
+	// [github.com/hashicorp/go-getter.Get] calls inherit the same
+	// configuration (progress tracking, client mode, etc.) as the top-level
+	// client.
+	client *getter.Client
+	// HTTPClient is the HTTP client used for registry-protocol requests
+	// (service discovery and module download lookup). [NewRegistryGetter]
+	// seeds it with a [github.com/hashicorp/go-cleanhttp.DefaultClient].
+	//
+	// Tests or callers needing a custom transport should swap it via
+	// [RegistryGetter.WithHTTPClient].
+	HTTPClient *http.Client
+	// Logger is stored on the struct because the
+	// [github.com/hashicorp/go-getter.Getter] interface restricts Get to
+	// the signature `Get(string, *url.URL) error`, so there is no way to
+	// pass a logger in per-call. Stashing it here is the only way
+	// downstream code executed from [RegistryGetter.Get] can emit
+	// diagnostic output. [NewRegistryGetter] requires it to guarantee it
+	// is never nil.
+	Logger log.Logger
+	// TofuImplementation selects which default registry domain is used
+	// when the source URL does not specify a host:
+	//
+	// - [github.com/gruntwork-io/terragrunt/internal/tfimpl.OpenTofu]
+	// resolves to registry.opentofu.org
+	//
+	// - [github.com/gruntwork-io/terragrunt/internal/tfimpl.Terraform] to
+	// registry.terraform.io.
+	//
+	// Overridable at runtime via the
+	// TG_TF_DEFAULT_REGISTRY_HOST environment variable (see
+	// [GetDefaultRegistryDomain]).
 	TofuImplementation tfimpl.Type
 }
 
-// SetClient allows the getter to know what getter client (different from the underlying HTTP client) to use for
-// progress tracking.
+// NewRegistryGetter returns a [RegistryGetter] configured with sensible
+// defaults: a [github.com/hashicorp/go-cleanhttp.DefaultClient] for
+// registry-protocol requests, the supplied logger for diagnostic output, and
+// [github.com/gruntwork-io/terragrunt/internal/tfimpl.OpenTofu] as the
+// default implementation. A logger is required because this package does not
+// consistently guard against a nil logger, so requiring one at construction
+// time prevents nil-pointer panics at call time. Use the With* methods to
+// customize other behavior.
+func NewRegistryGetter(l log.Logger) *RegistryGetter {
+	return &RegistryGetter{
+		HTTPClient:         cleanhttp.DefaultClient(),
+		Logger:             l,
+		TofuImplementation: tfimpl.OpenTofu,
+	}
+}
+
+// WithHTTPClient overrides the HTTP client used for registry-protocol
+// requests. Intended for tests that need to route requests through a
+// [net/http/httptest.Server], or for callers that need custom transport
+// configuration.
+func (tfrGetter *RegistryGetter) WithHTTPClient(c *http.Client) *RegistryGetter {
+	tfrGetter.HTTPClient = c
+	return tfrGetter
+}
+
+// WithTofuImplementation selects which default registry domain is used when
+// the source URL does not specify a host. See [RegistryGetter.TofuImplementation].
+func (tfrGetter *RegistryGetter) WithTofuImplementation(impl tfimpl.Type) *RegistryGetter {
+	tfrGetter.TofuImplementation = impl
+	return tfrGetter
+}
+
+// SetClient is part of the [github.com/hashicorp/go-getter.Getter] interface:
+// go-getter calls it to inject the
+// [github.com/hashicorp/go-getter.Client] driving the current download so
+// individual getters can share its options (progress tracking, client mode,
+// etc.).
 func (tfrGetter *RegistryGetter) SetClient(client *getter.Client) {
 	tfrGetter.client = client
 }
@@ -88,11 +154,6 @@ func (tfrGetter *RegistryGetter) Context() context.Context {
 	}
 
 	return tfrGetter.client.Ctx
-}
-
-// registryDomain returns the default registry domain to use for the getter.
-func (tfrGetter *RegistryGetter) registryDomain() string {
-	return GetDefaultRegistryDomain(tfrGetter.TofuImplementation)
 }
 
 // GetDefaultRegistryDomain returns the appropriate registry domain based on the terraform implementation and environment variables.
@@ -142,7 +203,7 @@ func (tfrGetter *RegistryGetter) Get(dstPath string, srcURL *url.URL) error {
 
 	version := versionList[0]
 
-	moduleRegistryBasePath, err := GetModuleRegistryURLBasePath(ctx, tfrGetter.Logger, registryDomain)
+	moduleRegistryBasePath, err := GetModuleRegistryURLBasePath(ctx, tfrGetter.Logger, tfrGetter.HTTPClient, registryDomain)
 	if err != nil {
 		return err
 	}
@@ -152,7 +213,7 @@ func (tfrGetter *RegistryGetter) Get(dstPath string, srcURL *url.URL) error {
 		return err
 	}
 
-	terraformGet, err := GetTerraformGetHeader(ctx, tfrGetter.Logger, moduleURL)
+	terraformGet, err := GetTerraformGetHeader(ctx, tfrGetter.Logger, tfrGetter.HTTPClient, moduleURL)
 	if err != nil {
 		return err
 	}
@@ -251,14 +312,14 @@ func (tfrGetter *RegistryGetter) getSubdir(_ context.Context, l log.Logger, dstP
 // (https://www.terraform.io/docs/internals/remote-service-discovery.html)
 // to figure out where the modules are stored. This will return the base
 // path where the modules can be accessed
-func GetModuleRegistryURLBasePath(ctx context.Context, logger log.Logger, domain string) (string, error) {
+func GetModuleRegistryURLBasePath(ctx context.Context, l log.Logger, httpClient *http.Client, domain string) (string, error) {
 	sdURL := url.URL{
 		Scheme: "https",
 		Host:   domain,
 		Path:   serviceDiscoveryPath,
 	}
 
-	bodyData, _, err := httpGETAndGetResponse(ctx, logger, &sdURL)
+	bodyData, _, err := httpGETAndGetResponse(ctx, l, httpClient, &sdURL)
 	if err != nil {
 		return "", err
 	}
@@ -275,8 +336,8 @@ func GetModuleRegistryURLBasePath(ctx context.Context, logger log.Logger, domain
 
 // GetTerraformGetHeader makes an http GET call to the given registry URL and return the contents of location json
 // body or the header X-Terraform-Get. This function will return an error if the response does not contain the header.
-func GetTerraformGetHeader(ctx context.Context, logger log.Logger, url *url.URL) (string, error) {
-	body, header, err := httpGETAndGetResponse(ctx, logger, url)
+func GetTerraformGetHeader(ctx context.Context, l log.Logger, httpClient *http.Client, url *url.URL) (string, error) {
+	body, header, err := httpGETAndGetResponse(ctx, l, httpClient, url)
 	if err != nil {
 		details := "error receiving HTTP data"
 
@@ -330,6 +391,11 @@ func GetDownloadURLFromHeader(moduleURL *url.URL, terraformGet string) (string, 
 	return terraformGet, nil
 }
 
+// registryDomain returns the default registry domain to use for the getter.
+func (tfrGetter *RegistryGetter) registryDomain() string {
+	return GetDefaultRegistryDomain(tfrGetter.TofuImplementation)
+}
+
 func applyHostToken(req *http.Request) (*http.Request, error) {
 	cliCfg, err := cliconfig.LoadUserConfig()
 	if err != nil {
@@ -351,7 +417,11 @@ func applyHostToken(req *http.Request) (*http.Request, error) {
 
 // httpGETAndGetResponse is a helper function to make a GET request to the given URL using the http client. This
 // function will then read the response and return the contents + the response header.
-func httpGETAndGetResponse(ctx context.Context, logger log.Logger, getURL *url.URL) ([]byte, *http.Header, error) {
+func httpGETAndGetResponse(ctx context.Context, l log.Logger, httpClient *http.Client, getURL *url.URL) ([]byte, *http.Header, error) {
+	if httpClient == nil {
+		httpClient = cleanhttp.DefaultClient()
+	}
+
 	if getURL == nil {
 		return nil, nil, errors.New("httpGETAndGetResponse received nil getURL")
 	}
@@ -376,7 +446,7 @@ func httpGETAndGetResponse(ctx context.Context, logger log.Logger, getURL *url.U
 	defer func() {
 		err := resp.Body.Close()
 		if err != nil {
-			logger.Warnf("Error closing response body: %v", err)
+			l.Warnf("Error closing response body: %v", err)
 		}
 	}()
 

--- a/internal/tf/getter_test.go
+++ b/internal/tf/getter_test.go
@@ -1,6 +1,12 @@
 package tf_test
 
 import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"path/filepath"
 	"testing"
@@ -10,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/hashicorp/go-getter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +24,9 @@ import (
 func TestGetModuleRegistryURLBasePath(t *testing.T) {
 	t.Parallel()
 
-	basePath, err := tf.GetModuleRegistryURLBasePath(t.Context(), logger.CreateLogger(), "registry.terraform.io")
+	server := newRegistryTestServer(t)
+
+	basePath, err := tf.GetModuleRegistryURLBasePath(t.Context(), logger.CreateLogger(), server.Client(), server.Listener.Addr().String())
 	require.NoError(t, err)
 	assert.Equal(t, "/v1/modules/", basePath)
 }
@@ -25,14 +34,16 @@ func TestGetModuleRegistryURLBasePath(t *testing.T) {
 func TestGetTerraformHeader(t *testing.T) {
 	t.Parallel()
 
+	server := newRegistryTestServer(t)
+
 	testModuleURL := url.URL{
 		Scheme: "https",
-		Host:   "registry.terraform.io",
+		Host:   server.Listener.Addr().String(),
 		Path:   "/v1/modules/terraform-aws-modules/vpc/aws/3.3.0/download",
 	}
-	terraformGetHeader, err := tf.GetTerraformGetHeader(t.Context(), logger.CreateLogger(), &testModuleURL)
+	terraformGetHeader, err := tf.GetTerraformGetHeader(t.Context(), logger.CreateLogger(), server.Client(), &testModuleURL)
 	require.NoError(t, err)
-	assert.Contains(t, terraformGetHeader, "github.com/terraform-aws-modules/terraform-aws-vpc")
+	assert.Contains(t, terraformGetHeader, "/download/terraform-aws-vpc.zip")
 }
 
 func TestGetDownloadURLFromHeader(t *testing.T) {
@@ -105,7 +116,9 @@ func TestGetDownloadURLFromHeader(t *testing.T) {
 func TestTFRGetterRootDir(t *testing.T) {
 	t.Parallel()
 
-	testModuleURL, err := url.Parse("tfr://registry.terraform.io/terraform-aws-modules/vpc/aws?version=3.3.0")
+	server := newRegistryTestServer(t)
+
+	testModuleURL, err := url.Parse("tfr://" + server.Listener.Addr().String() + "/terraform-aws-modules/vpc/aws?version=3.3.0")
 	require.NoError(t, err)
 
 	dstPath := helpers.TmpDirWOSymlinks(t)
@@ -114,8 +127,10 @@ func TestTFRGetterRootDir(t *testing.T) {
 	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
 	assert.False(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 
-	tfrGetter := new(tf.RegistryGetter)
-	tfrGetter.TofuImplementation = tfimpl.Terraform
+	tfrGetter := tf.NewRegistryGetter(logger.CreateLogger()).
+		WithTofuImplementation(tfimpl.Terraform).
+		WithHTTPClient(server.Client())
+	tfrGetter.SetClient(newGetterClientWithHTTPClient(t.Context(), server.Client()))
 
 	require.NoError(t, tfrGetter.Get(moduleDestPath, testModuleURL))
 	assert.True(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
@@ -124,7 +139,9 @@ func TestTFRGetterRootDir(t *testing.T) {
 func TestTFRGetterSubModule(t *testing.T) {
 	t.Parallel()
 
-	testModuleURL, err := url.Parse("tfr://registry.terraform.io/terraform-aws-modules/vpc/aws//modules/vpc-endpoints?version=3.3.0")
+	server := newRegistryTestServer(t)
+
+	testModuleURL, err := url.Parse("tfr://" + server.Listener.Addr().String() + "/terraform-aws-modules/vpc/aws//modules/vpc-endpoints?version=3.3.0")
 	require.NoError(t, err)
 
 	dstPath := helpers.TmpDirWOSymlinks(t)
@@ -133,8 +150,10 @@ func TestTFRGetterSubModule(t *testing.T) {
 	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
 	assert.False(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 
-	tfrGetter := new(tf.RegistryGetter)
-	tfrGetter.TofuImplementation = tfimpl.Terraform
+	tfrGetter := tf.NewRegistryGetter(logger.CreateLogger()).
+		WithTofuImplementation(tfimpl.Terraform).
+		WithHTTPClient(server.Client())
+	tfrGetter.SetClient(newGetterClientWithHTTPClient(t.Context(), server.Client()))
 
 	require.NoError(t, tfrGetter.Get(moduleDestPath, testModuleURL))
 	assert.True(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
@@ -154,4 +173,90 @@ func TestBuildRequestUrlRelativePath(t *testing.T) {
 	requestURL, err := tf.BuildRequestURL("gruntwork.io", "/registry/modules/v1", "/tfr-project/terraform-aws-tfr", "6.6.6")
 	require.NoError(t, err)
 	assert.Equal(t, "https://gruntwork.io/registry/modules/v1/tfr-project/terraform-aws-tfr/6.6.6/download", requestURL.String())
+}
+
+// buildModuleZip builds an in-memory zip archive that mirrors the shape of a
+// terraform-aws-vpc module: a root main.tf plus a submodule under
+// modules/vpc-endpoints/main.tf. It is served by the mock registry in place of
+// a real GitHub tarball.
+func buildModuleZip(t *testing.T) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	zw := zip.NewWriter(&buf)
+
+	files := map[string]string{
+		"main.tf":                       "# root module\n",
+		"modules/vpc-endpoints/main.tf": "# vpc-endpoints submodule\n",
+	}
+
+	for name, content := range files {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+
+		n, err := w.Write([]byte(content))
+		require.NoError(t, err)
+
+		require.Equal(t, len(content), n)
+	}
+
+	require.NoError(t, zw.Close())
+
+	return buf.Bytes()
+}
+
+// newRegistryTestServer stands up an httptest TLS server that speaks enough of
+// the Terraform module-registry protocol to satisfy the RegistryGetter: the
+// service-discovery document, a module download endpoint that returns an
+// X-Terraform-Get header, and the zip archive the header points at.
+func newRegistryTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	zipBody := buildModuleZip(t)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/terraform.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"modules.v1":"/v1/modules/"}`)
+	})
+
+	mux.HandleFunc("/v1/modules/terraform-aws-modules/vpc/aws/3.3.0/download", func(w http.ResponseWriter, r *http.Request) {
+		// Resolve against the request host so the downloader hits the same
+		// test server we are about to shut down at end-of-test.
+		w.Header().Set("X-Terraform-Get", "https://"+r.Host+"/download/terraform-aws-vpc.zip")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("/download/terraform-aws-vpc.zip", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+
+		n, err := w.Write(zipBody)
+		assert.NoError(t, err)
+
+		assert.Equal(t, len(zipBody), n)
+	})
+
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+// newGetterClientWithHTTPClient returns a *getter.Client whose Options install
+// a custom HttpGetter that trusts the test server's self-signed cert.
+func newGetterClientWithHTTPClient(ctx context.Context, c *http.Client) *getter.Client {
+	httpGetter := &getter.HttpGetter{Client: c}
+
+	return &getter.Client{
+		Ctx: ctx,
+		Options: []getter.ClientOption{
+			getter.WithGetters(map[string]getter.Getter{
+				"http":  httpGetter,
+				"https": httpGetter,
+				"file":  new(getter.FileGetter),
+			}),
+		},
+	}
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated tests in `./internal/tf` to use `httptest` instead of integrating with live external services.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for Terraform registry getter initialization and configuration.
  * Enhanced getter implementation with refined HTTP client and logger handling.
  * Updated internal test infrastructure for better test isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->