### PR TITLE
chore: Adding tests and docs missing from #5886

### DIFF
--- a/docs/src/data/changelog/v1.0.2.mdx
+++ b/docs/src/data/changelog/v1.0.2.mdx
@@ -127,6 +127,18 @@ runtime error: invalid memory address or nil pointer dereference
 
 The root cause of the panic was fixed, and telemetry codepaths have been hardened against future panics.
 
+#### `shared_credentials_files` and other list/map backend config values were serialized incorrectly
+
+Setting `shared_credentials_files` (or any other list-valued key) in the `remote_state.config` block produced a broken `-backend-config` argument:
+
+```
+-backend-config=shared_credentials_files=[/a/creds /b/creds]
+```
+
+OpenTofu and Terraform both failed to parse this. The same problem affected map-valued keys. Lists and maps are now written as single-line HCL (`["/a/creds","/b/creds"]` and `{key="value"}`), and strings inside them are quoted so embedded quotes, newlines, and tabs survive the round trip.
+
+Thanks to @Rahul-Kumar-prog for contributing this fix!
+
 ### ⚙️ Process Updates
 
 ---

--- a/internal/hclhelper/wrap_test.go
+++ b/internal/hclhelper/wrap_test.go
@@ -24,6 +24,26 @@ func TestWrapMapToSingleLineHcl(t *testing.T) {
 			input:    map[string]any{"key1": "value1", "key2": map[string]any{"nestedKey": "nestedValue"}},
 			expected: `{key1="value1",key2={nestedKey="nestedValue"}}`,
 		},
+		{
+			name:     "StringWithSpecialChars",
+			input:    map[string]any{"key": "a\"b\nc\td"},
+			expected: `{key="a\"b\nc\td"}`,
+		},
+		{
+			name:     "SliceOfStrings",
+			input:    map[string]any{"files": []any{"a", "b"}},
+			expected: `{files=["a","b"]}`,
+		},
+		{
+			name:     "SliceOfMixed",
+			input:    map[string]any{"mixed": []any{"a", 1, true}},
+			expected: `{mixed=["a",1,true]}`,
+		},
+		{
+			name:     "EmptySlice",
+			input:    map[string]any{"files": []any{}},
+			expected: `{files=[]}`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -31,6 +51,89 @@ func TestWrapMapToSingleLineHcl(t *testing.T) {
 			t.Parallel()
 
 			result := hclhelper.WrapMapToSingleLineHcl(tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected %s, but got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestWrapListToSingleLineHcl(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		expected string
+		input    []any
+	}{
+		{
+			name:     "Empty",
+			input:    []any{},
+			expected: `[]`,
+		},
+		{
+			name:     "Strings",
+			input:    []any{"a", "b", "c"},
+			expected: `["a","b","c"]`,
+		},
+		{
+			name:     "StringsWithEscapes",
+			input:    []any{"a\"b", "c\nd"},
+			expected: `["a\"b","c\nd"]`,
+		},
+		{
+			name:     "Mixed",
+			input:    []any{"a", 1, true, 2.5},
+			expected: `["a",1,true,2.5]`,
+		},
+		{
+			name:     "NestedMap",
+			input:    []any{map[string]any{"k": "v"}},
+			expected: `[{k="v"}]`,
+		},
+		{
+			name:     "NestedList",
+			input:    []any{[]any{"a", "b"}, []any{1, 2}},
+			expected: `[["a","b"],[1,2]]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := hclhelper.WrapListToSingleLineHcl(tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected %s, but got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestFormatValueToSingleLineHcl(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{name: "String", input: "hello", expected: `"hello"`},
+		{name: "StringWithQuote", input: `a"b`, expected: `"a\"b"`},
+		{name: "StringWithNewline", input: "a\nb", expected: `"a\nb"`},
+		{name: "StringWithTab", input: "a\tb", expected: `"a\tb"`},
+		{name: "Int", input: 42, expected: `42`},
+		{name: "Bool", input: true, expected: `true`},
+		{name: "Float", input: 2.5, expected: `2.5`},
+		{name: "Map", input: map[string]any{"k": "v"}, expected: `{k="v"}`},
+		{name: "Slice", input: []any{"a", 1}, expected: `["a",1]`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := hclhelper.FormatValueToSingleLineHcl(tc.input)
 			if result != tc.expected {
 				t.Errorf("Expected %s, but got %s", tc.expected, result)
 			}

--- a/internal/remotestate/remote_state_test.go
+++ b/internal/remotestate/remote_state_test.go
@@ -220,6 +220,53 @@ func TestGetTFInitArgs_StringBoolCoercion(t *testing.T) {
 	}
 }
 
+// TestGetTFInitArgs_SharedCredentialsFiles is a regression test for the bug fixed
+// in PR #5886: list-valued backend config (e.g. S3's shared_credentials_files) used
+// to be serialized via fmt.Sprintf("%v", value) producing invalid HCL like "[/a /b]".
+// The s4 unknown-backend fixture is used so terragrunt-specific key filtering does
+// not strip the config before assertions.
+func TestGetTFInitArgs_SharedCredentialsFiles(t *testing.T) {
+	t.Parallel()
+
+	cfg := &remotestate.Config{
+		BackendName: "s4",
+		BackendConfig: map[string]any{
+			"bucket":                   "my-bucket",
+			"shared_credentials_files": []any{"/a/creds", "/b/creds"},
+		},
+	}
+	args := remotestate.New(cfg).GetTFInitArgs()
+
+	assert.ElementsMatch(t, []string{
+		"-backend-config=bucket=my-bucket",
+		`-backend-config=shared_credentials_files=["/a/creds","/b/creds"]`,
+	}, args)
+}
+
+// TestGetTFInitArgs_MapAndListSerialization covers the map, list, and string-escape
+// branches of the GetTFInitArgs value switch added in PR #5886.
+func TestGetTFInitArgs_MapAndListSerialization(t *testing.T) {
+	t.Parallel()
+
+	cfg := &remotestate.Config{
+		BackendName: "s4",
+		BackendConfig: map[string]any{
+			"bucket":      "my-bucket",
+			"assume_role": map[string]any{"role_arn": "arn:aws:iam::123:role/r"},
+			"files":       []any{"/a", "/b"},
+			"note":        "he said \"hi\"\nline2",
+		},
+	}
+	args := remotestate.New(cfg).GetTFInitArgs()
+
+	assert.ElementsMatch(t, []string{
+		"-backend-config=bucket=my-bucket",
+		`-backend-config=assume_role={role_arn="arn:aws:iam::123:role/r"}`,
+		`-backend-config=files=["/a","/b"]`,
+		`-backend-config=note=he said "hi"` + "\nline2",
+	}, args)
+}
+
 func TestNeedsBootstrapDisableInit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds tests and documentation updates that weren't covered in #5886.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backend configuration serialization for list and map values (e.g., shared credentials files) that were previously generating invalid argument formats, causing OpenTofu/Terraform backend parsing to fail. Configuration values now properly serialize into valid single-line HCL syntax with appropriate quote escaping and whitespace preservation to ensure data integrity during parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->