### PR TITLE
docs: Avoid indexing changelog in search

### DIFF
--- a/docs/src/content/docs/07-process/04-changelog.mdx
+++ b/docs/src/content/docs/07-process/04-changelog.mdx
@@ -6,6 +6,7 @@ sidebar:
   order: 4
 tableOfContents:
   maxHeadingLevel: 3
+pagefind: false
 ---
 
 {/* Changelog entries are managed in docs/src/data/changelog/ as individual MDX files.

--- a/docs/src/pages/process/changelog.astro
+++ b/docs/src/pages/process/changelog.astro
@@ -63,9 +63,11 @@ headings.push({ depth: 2, slug: 'prior-releases', text: 'Prior Releases' });
 	headings={headings}
 	sidebar={sidebar}
 >
-	<p>This page tracks notable changes to Terragrunt. For the full list of releases and their assets, see the <a href="https://github.com/gruntwork-io/terragrunt/releases">GitHub Releases Page</a>.</p>
-	<hr />
-	<ChangelogEntries showUnreleased={showUnreleased} />
-	<h2 id="prior-releases">Prior Releases</h2>
-	<p>For all prior releases, see the <a href="https://github.com/gruntwork-io/terragrunt/releases">GitHub Releases Page</a>.</p>
+	<div data-pagefind-ignore>
+		<p>This page tracks notable changes to Terragrunt. For the full list of releases and their assets, see the <a href="https://github.com/gruntwork-io/terragrunt/releases">GitHub Releases Page</a>.</p>
+		<hr />
+		<ChangelogEntries showUnreleased={showUnreleased} />
+		<h2 id="prior-releases">Prior Releases</h2>
+		<p>For all prior releases, see the <a href="https://github.com/gruntwork-io/terragrunt/releases">GitHub Releases Page</a>.</p>
+	</div>
 </StarlightPage>


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Avoids indexing the changelog in the search index to avoid polluting search findings.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search configuration to exclude the changelog page from documentation search indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->