### PR TITLE
chore: Adding `vexec`

### DIFF
--- a/internal/util/shell.go
+++ b/internal/util/shell.go
@@ -10,25 +10,13 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 )
 
-// IsCommandExecutable - returns true if a command can be executed without errors.
-func IsCommandExecutable(ctx context.Context, command string, args ...string) bool {
-	cmd := exec.CommandContext(ctx, command, args...)
-	cmd.Stdin = nil
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-
-	if err := cmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-		if ok := errors.As(err, &exitErr); ok {
-			return exitErr.ExitCode() == 0
-		}
-
-		return false
-	}
-
-	return true
+// IsCommandExecutable returns true if the command can be run to completion
+// without error via the given vexec.Exec.
+func IsCommandExecutable(e vexec.Exec, ctx context.Context, command string, args ...string) bool {
+	return vexec.Run(e, ctx, command, args...) == nil
 }
 
 type CmdOutput struct {

--- a/internal/util/shell_test.go
+++ b/internal/util/shell_test.go
@@ -4,17 +4,18 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestExistingCommand(t *testing.T) {
 	t.Parallel()
 
-	assert.True(t, util.IsCommandExecutable(t.Context(), "pwd"))
+	assert.True(t, util.IsCommandExecutable(vexec.NewOSExec(), t.Context(), "pwd"))
 }
 
 func TestNotExistingCommand(t *testing.T) {
 	t.Parallel()
 
-	assert.False(t, util.IsCommandExecutable(t.Context(), "not-existing-command", "--version"))
+	assert.False(t, util.IsCommandExecutable(vexec.NewOSExec(), t.Context(), "not-existing-command", "--version"))
 }

--- a/internal/util/shell_test.go
+++ b/internal/util/shell_test.go
@@ -1,6 +1,8 @@
 package util_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/util"
@@ -8,14 +10,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExistingCommand(t *testing.T) {
+func TestIsCommandExecutable(t *testing.T) {
 	t.Parallel()
 
-	assert.True(t, util.IsCommandExecutable(vexec.NewOSExec(), t.Context(), "pwd"))
-}
+	testCases := []struct {
+		name   string
+		result vexec.Result
+		want   bool
+	}{
+		{
+			name:   "handler returns clean exit",
+			result: vexec.Result{},
+			want:   true,
+		},
+		{
+			name:   "handler returns non-zero exit",
+			result: vexec.Result{ExitCode: 1},
+			want:   false,
+		},
+		{
+			name:   "handler returns spawn error",
+			result: vexec.Result{Err: errors.New("fork/exec: no such file")},
+			want:   false,
+		},
+		{
+			name:   "handler writes output but exits clean",
+			result: vexec.Result{Stdout: []byte("hello"), Stderr: []byte("warn")},
+			want:   true,
+		},
+	}
 
-func TestNotExistingCommand(t *testing.T) {
-	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	assert.False(t, util.IsCommandExecutable(vexec.NewOSExec(), t.Context(), "not-existing-command", "--version"))
+			e := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+				return tc.result
+			})
+
+			got := util.IsCommandExecutable(e, t.Context(), "whatever", "-version")
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/internal/vexec/fault.go
+++ b/internal/vexec/fault.go
@@ -1,0 +1,24 @@
+package vexec
+
+import (
+	"context"
+	"os/exec"
+)
+
+// NoLookPathExec wraps an Exec and always fails LookPath with exec.ErrNotFound,
+// simulating a system where the requested binary is not on PATH. Command
+// invocations pass through to the wrapped Exec unchanged.
+type NoLookPathExec struct {
+	Exec
+}
+
+// LookPath always returns exec.ErrNotFound.
+func (e *NoLookPathExec) LookPath(file string) (string, error) {
+	return "", &exec.Error{Name: file, Err: exec.ErrNotFound}
+}
+
+// Command delegates to the wrapped Exec so that LookPath fails but direct
+// Command invocations still reach the underlying backend.
+func (e *NoLookPathExec) Command(ctx context.Context, name string, args ...string) Cmd {
+	return e.Exec.Command(ctx, name, args...)
+}

--- a/internal/vexec/vexec.go
+++ b/internal/vexec/vexec.go
@@ -1,0 +1,352 @@
+// Package vexec provides a virtual process-execution abstraction for testing and production use.
+// It wraps os/exec to provide a consistent, injectable interface for running external commands.
+package vexec
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+// Sentinel errors returned by the in-memory backend for misuse of the Cmd
+// lifecycle. All are exported so callers can match them with errors.Is.
+var (
+	// ErrAlreadyStarted is returned when Start is called on a Cmd that has
+	// already been started.
+	ErrAlreadyStarted = errors.New("vexec: command already started")
+	// ErrNotStarted is returned when Wait is called before Start.
+	ErrNotStarted = errors.New("vexec: Wait called before Start")
+	// ErrAlreadyWaited is returned when Wait is called more than once.
+	ErrAlreadyWaited = errors.New("vexec: Wait called more than once")
+	// ErrStdoutAlreadySet is returned from Output or CombinedOutput when
+	// Stdout has been set via SetStdout.
+	ErrStdoutAlreadySet = errors.New("vexec: Stdout already set")
+	// ErrStderrAlreadySet is returned from CombinedOutput when Stderr has
+	// been set via SetStderr.
+	ErrStderrAlreadySet = errors.New("vexec: Stderr already set")
+)
+
+// Exec is the process-execution interface used throughout the codebase.
+// It provides an abstraction over real and in-memory command execution.
+type Exec interface {
+	// Command prepares a command handle bound to ctx. The command is not
+	// started until Run, Start, Output, or CombinedOutput is called.
+	Command(ctx context.Context, name string, args ...string) Cmd
+	// LookPath searches for an executable named file, mirroring exec.LookPath.
+	LookPath(file string) (string, error)
+}
+
+// Cmd is a handle for a single command invocation.
+//
+// A Cmd may only be used once: after Run, Output, CombinedOutput, or Wait
+// returns, subsequent calls to those methods return an error.
+type Cmd interface {
+	SetStdin(r io.Reader)
+	SetStdout(w io.Writer)
+	SetStderr(w io.Writer)
+	SetEnv(env []string)
+	SetDir(dir string)
+
+	Run() error
+	Start() error
+	Wait() error
+	Output() ([]byte, error)
+	CombinedOutput() ([]byte, error)
+
+	// ProcessState returns the post-exit state, or nil if the command has not
+	// finished. The in-memory backend always returns nil; callers that need
+	// exit codes should use ExitCode on the returned error instead.
+	ProcessState() *os.ProcessState
+}
+
+// ExitCoder is implemented by errors that carry a process exit code. The real
+// backend returns *exec.ExitError, which already satisfies this interface;
+// the in-memory backend returns a value that satisfies it too.
+type ExitCoder interface {
+	error
+	ExitCode() int
+}
+
+// ExitCode extracts an exit code from err. It returns 0 if err is nil, or -1
+// if err does not carry an exit code.
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	if ec, ok := errors.AsType[ExitCoder](err); ok {
+		return ec.ExitCode()
+	}
+
+	return -1
+}
+
+// Output runs name with args using e and returns its standard output.
+func Output(e Exec, ctx context.Context, name string, args ...string) ([]byte, error) {
+	return e.Command(ctx, name, args...).Output()
+}
+
+// CombinedOutput runs name with args using e and returns its combined
+// standard output and standard error.
+func CombinedOutput(e Exec, ctx context.Context, name string, args ...string) ([]byte, error) {
+	return e.Command(ctx, name, args...).CombinedOutput()
+}
+
+// Run runs name with args using e and waits for it to complete.
+func Run(e Exec, ctx context.Context, name string, args ...string) error {
+	return e.Command(ctx, name, args...).Run()
+}
+
+// NewOSExec returns an Exec backed by the real operating system via os/exec.
+func NewOSExec() Exec {
+	return &osExec{}
+}
+
+type osExec struct{}
+
+func (osExec) Command(ctx context.Context, name string, args ...string) Cmd {
+	return &osCmd{cmd: exec.CommandContext(ctx, name, args...)}
+}
+
+func (osExec) LookPath(file string) (string, error) {
+	return exec.LookPath(file)
+}
+
+type osCmd struct {
+	cmd *exec.Cmd
+}
+
+func (c *osCmd) SetStdin(r io.Reader)  { c.cmd.Stdin = r }
+func (c *osCmd) SetStdout(w io.Writer) { c.cmd.Stdout = w }
+func (c *osCmd) SetStderr(w io.Writer) { c.cmd.Stderr = w }
+func (c *osCmd) SetEnv(env []string)   { c.cmd.Env = env }
+func (c *osCmd) SetDir(dir string)     { c.cmd.Dir = dir }
+
+func (c *osCmd) Run() error                      { return c.cmd.Run() }
+func (c *osCmd) Start() error                    { return c.cmd.Start() }
+func (c *osCmd) Wait() error                     { return c.cmd.Wait() }
+func (c *osCmd) Output() ([]byte, error)         { return c.cmd.Output() }
+func (c *osCmd) CombinedOutput() ([]byte, error) { return c.cmd.CombinedOutput() }
+func (c *osCmd) ProcessState() *os.ProcessState  { return c.cmd.ProcessState }
+
+// Invocation describes a single command dispatched through the in-memory
+// backend. Handlers inspect it to decide how to respond.
+type Invocation struct {
+	Stdin io.Reader
+	Name  string
+	Dir   string
+	Args  []string
+	Env   []string
+}
+
+// Result is the synthesized outcome of an in-memory command invocation.
+// If Err is non-nil it is returned directly from Run/Start/Wait/Output;
+// otherwise ExitCode is surfaced as an error satisfying ExitCoder when non-zero.
+type Result struct {
+	Err      error
+	Stdout   []byte
+	Stderr   []byte
+	ExitCode int
+}
+
+// Handler processes an Invocation and returns a Result. It is invoked
+// synchronously on the goroutine that calls Run/Start/Wait/Output.
+type Handler func(ctx context.Context, inv Invocation) Result
+
+// PathHandler resolves a binary name to a path for the in-memory backend.
+// Returning a non-nil error causes LookPath to fail with that error.
+type PathHandler func(file string) (string, error)
+
+// MemExecOption configures an in-memory Exec.
+type MemExecOption func(*memExec)
+
+// WithLookPath overrides the default LookPath behavior of NewMemExec.
+// By default, LookPath returns the input name unchanged.
+func WithLookPath(p PathHandler) MemExecOption {
+	return func(e *memExec) {
+		e.lookPath = p
+	}
+}
+
+// NewMemExec returns an Exec whose commands are dispatched to h instead of
+// the operating system. It is intended for tests: h decides how each
+// invocation should behave.
+//
+// h must not be nil. It is invoked synchronously; there is no implicit
+// concurrency. LookPath returns the input name unchanged by default; use
+// WithLookPath to customize.
+func NewMemExec(h Handler, opts ...MemExecOption) Exec {
+	if h == nil {
+		panic("vexec: NewMemExec requires a non-nil Handler")
+	}
+
+	e := &memExec{handler: h}
+
+	for _, opt := range opts {
+		opt(e)
+	}
+
+	return e
+}
+
+type memExec struct {
+	handler  Handler
+	lookPath PathHandler
+}
+
+func (e *memExec) Command(ctx context.Context, name string, args ...string) Cmd {
+	return &memCmd{
+		ctx:     ctx,
+		handler: e.handler,
+		name:    name,
+		args:    args,
+	}
+}
+
+func (e *memExec) LookPath(file string) (string, error) {
+	if e.lookPath != nil {
+		return e.lookPath(file)
+	}
+
+	return file, nil
+}
+
+// memCmd tracks a single in-memory invocation lifecycle.
+type memCmd struct {
+	ctx     context.Context
+	handler Handler
+	stdin   io.Reader
+	stdout  io.Writer
+	stderr  io.Writer
+	name    string
+	dir     string
+	args    []string
+	env     []string
+	result  Result
+	started bool
+	waited  bool
+}
+
+func (c *memCmd) SetStdin(r io.Reader)  { c.stdin = r }
+func (c *memCmd) SetStdout(w io.Writer) { c.stdout = w }
+func (c *memCmd) SetStderr(w io.Writer) { c.stderr = w }
+func (c *memCmd) SetEnv(env []string)   { c.env = env }
+func (c *memCmd) SetDir(dir string)     { c.dir = dir }
+
+func (c *memCmd) ProcessState() *os.ProcessState { return nil }
+
+func (c *memCmd) Run() error {
+	if err := c.Start(); err != nil {
+		return err
+	}
+
+	return c.Wait()
+}
+
+func (c *memCmd) Start() error {
+	if c.started {
+		return ErrAlreadyStarted
+	}
+
+	c.started = true
+	c.result = c.handler(c.ctx, c.invocation())
+
+	return nil
+}
+
+func (c *memCmd) Wait() error {
+	if !c.started {
+		return ErrNotStarted
+	}
+
+	if c.waited {
+		return ErrAlreadyWaited
+	}
+
+	c.waited = true
+
+	if err := writeAll(c.stdout, c.result.Stdout); err != nil {
+		return err
+	}
+
+	if err := writeAll(c.stderr, c.result.Stderr); err != nil {
+		return err
+	}
+
+	if c.result.Err != nil {
+		return c.result.Err
+	}
+
+	if c.result.ExitCode != 0 {
+		return &exitError{code: c.result.ExitCode}
+	}
+
+	return nil
+}
+
+func (c *memCmd) Output() ([]byte, error) {
+	if c.stdout != nil {
+		return nil, ErrStdoutAlreadySet
+	}
+
+	var buf bytes.Buffer
+
+	c.stdout = &buf
+
+	err := c.Run()
+
+	return buf.Bytes(), err
+}
+
+func (c *memCmd) CombinedOutput() ([]byte, error) {
+	if c.stdout != nil {
+		return nil, ErrStdoutAlreadySet
+	}
+
+	if c.stderr != nil {
+		return nil, ErrStderrAlreadySet
+	}
+
+	var buf bytes.Buffer
+
+	c.stdout = &buf
+	c.stderr = &buf
+
+	err := c.Run()
+
+	return buf.Bytes(), err
+}
+
+func (c *memCmd) invocation() Invocation {
+	return Invocation{
+		Name:  c.name,
+		Args:  c.args,
+		Env:   c.env,
+		Dir:   c.dir,
+		Stdin: c.stdin,
+	}
+}
+
+func writeAll(w io.Writer, p []byte) error {
+	if w == nil || len(p) == 0 {
+		return nil
+	}
+
+	_, err := w.Write(p)
+
+	return err
+}
+
+// exitError is returned from memCmd.Run/Wait when the handler reports a
+// non-zero exit code without an explicit Err. It satisfies ExitCoder so
+// callers can recover the exit code via errors.As.
+type exitError struct {
+	code int
+}
+
+func (e *exitError) Error() string { return "exit status " + strconv.Itoa(e.code) }
+func (e *exitError) ExitCode() int { return e.code }

--- a/internal/vexec/vexec_test.go
+++ b/internal/vexec/vexec_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -16,21 +18,21 @@ import (
 
 func TestOSExec_Output(t *testing.T) {
 	t.Parallel()
+	skipOnWindows(t)
 
-	e := vexec.NewOSExec()
-
-	out, err := vexec.Output(e, t.Context(), "go", "version")
+	out, err := vexec.Output(vexec.NewOSExec(), t.Context(), "echo", "hello")
 
 	require.NoError(t, err)
-	assert.Contains(t, string(out), "go version")
+	assert.Equal(t, "hello\n", string(out))
 }
 
 func TestOSExec_LookPath(t *testing.T) {
 	t.Parallel()
+	skipOnWindows(t)
 
 	e := vexec.NewOSExec()
 
-	path, err := e.LookPath("go")
+	path, err := e.LookPath("sh")
 	require.NoError(t, err)
 	assert.NotEmpty(t, path)
 
@@ -41,13 +43,12 @@ func TestOSExec_LookPath(t *testing.T) {
 
 func TestOSExec_ExitCode(t *testing.T) {
 	t.Parallel()
+	skipOnWindows(t)
 
-	e := vexec.NewOSExec()
-
-	err := vexec.Run(e, t.Context(), "go", "this-is-not-a-go-subcommand")
+	err := vexec.Run(vexec.NewOSExec(), t.Context(), "bash", "-c", "exit 3")
 
 	require.Error(t, err)
-	assert.NotZero(t, vexec.ExitCode(err))
+	assert.Equal(t, 3, vexec.ExitCode(err))
 }
 
 func TestMemExec_HandlerReceivesInvocation(t *testing.T) {
@@ -251,4 +252,410 @@ func TestExitCode(t *testing.T) {
 
 	assert.Equal(t, 0, vexec.ExitCode(nil))
 	assert.Equal(t, -1, vexec.ExitCode(errors.New("plain error")))
+}
+
+func TestMemExec_ExitErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		return vexec.Result{ExitCode: 7}
+	})
+
+	err := vexec.Run(e, t.Context(), "fail")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "7")
+}
+
+func TestMemExec_ProcessStateIsNil(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		return vexec.Result{Stdout: []byte("ok")}
+	})
+
+	cmd := e.Command(t.Context(), "whatever")
+	require.NoError(t, cmd.Run())
+	assert.Nil(t, cmd.ProcessState(), "memCmd must always report nil ProcessState")
+}
+
+// TestOSExec_StartWait exercises the Start/Wait split on the real backend
+// and verifies that stdout/stderr writers are wired up and ProcessState is
+// populated after Wait returns.
+func TestOSExec_StartWait(t *testing.T) {
+	t.Parallel()
+	skipOnWindows(t)
+
+	var stdout, stderr bytes.Buffer
+
+	cmd := vexec.NewOSExec().Command(t.Context(), "echo", "hello")
+	cmd.SetStdout(&stdout)
+	cmd.SetStderr(&stderr)
+
+	require.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Wait())
+
+	assert.Equal(t, "hello\n", stdout.String())
+	assert.Empty(t, stderr.String())
+	assert.NotNil(t, cmd.ProcessState(), "ProcessState must be populated after Wait")
+	assert.True(t, cmd.ProcessState().Success())
+}
+
+// TestOSExec_CombinedOutput exercises CombinedOutput on the real backend
+// against a command that writes to both stdout and stderr and exits non-zero.
+func TestOSExec_CombinedOutput(t *testing.T) {
+	t.Parallel()
+	skipOnWindows(t)
+
+	out, err := vexec.NewOSExec().
+		Command(t.Context(), "bash", "-c", "echo out; echo err >&2; exit 1").
+		CombinedOutput()
+
+	require.Error(t, err)
+	assert.Equal(t, 1, vexec.ExitCode(err))
+	assert.Contains(t, string(out), "out")
+	assert.Contains(t, string(out), "err")
+}
+
+// TestOSExec_SetDir verifies SetDir changes the working directory of the
+// spawned process by comparing bash's `pwd` against a tempdir.
+func TestOSExec_SetDir(t *testing.T) {
+	t.Parallel()
+	skipOnWindows(t)
+
+	tempDir := t.TempDir()
+
+	var buf bytes.Buffer
+
+	cmd := vexec.NewOSExec().Command(t.Context(), "bash", "-c", "pwd")
+	cmd.SetDir(tempDir)
+	cmd.SetStdout(&buf)
+
+	require.NoError(t, cmd.Run())
+
+	// macOS symlinks /tmp to /private/tmp; match via suffix.
+	assert.True(t,
+		strings.HasSuffix(strings.TrimSpace(buf.String()), tempDir),
+		"pwd %q must end with tempdir %q", strings.TrimSpace(buf.String()), tempDir,
+	)
+}
+
+// TestOSExec_SetEnv verifies SetEnv propagates variables to the child process.
+func TestOSExec_SetEnv(t *testing.T) {
+	t.Parallel()
+	skipOnWindows(t)
+
+	var buf bytes.Buffer
+
+	cmd := vexec.NewOSExec().Command(t.Context(), "bash", "-c", `printf %s "$FOO"`)
+	cmd.SetEnv([]string{"FOO=bar"})
+	cmd.SetStdout(&buf)
+
+	require.NoError(t, cmd.Run())
+	assert.Equal(t, "bar", buf.String())
+}
+
+// TestOSExec_SetStdin verifies SetStdin pipes bytes into the child process
+// via cat, which echoes stdin to stdout.
+func TestOSExec_SetStdin(t *testing.T) {
+	t.Parallel()
+	skipOnWindows(t)
+
+	var stdout bytes.Buffer
+
+	cmd := vexec.NewOSExec().Command(t.Context(), "cat")
+	cmd.SetStdin(strings.NewReader("hello from stdin"))
+	cmd.SetStdout(&stdout)
+
+	require.NoError(t, cmd.Run())
+	assert.Equal(t, "hello from stdin", stdout.String())
+}
+
+// TestParity_OSVsMem asserts that osCmd and memCmd are observably
+// interchangeable for the behaviors most callers rely on: success/failure
+// signaling, exit-code extraction, and stdout/stderr wiring. For each case
+// we run the real command first, then replay its captured output through
+// memCmd via a handler — identical observable behavior is the contract.
+//
+// Not asserted: ProcessState parity. osCmd returns a populated *os.ProcessState
+// after Wait; memCmd always returns nil (documented). Callers that need
+// ProcessState should not migrate to memCmd.
+func TestParity_OSVsMem(t *testing.T) {
+	t.Parallel()
+	skipOnWindows(t)
+
+	runParityCases(t, []parityCase{
+		{
+			desc:        "success with stdout",
+			name:        "echo",
+			argv:        []string{"hello"},
+			wantSuccess: true,
+		},
+		{
+			desc:        "success with empty output",
+			name:        "bash",
+			argv:        []string{"-c", "true"},
+			wantSuccess: true,
+		},
+		{
+			desc:        "failure with stderr and non-zero exit",
+			name:        "bash",
+			argv:        []string{"-c", "echo oops >&2; exit 2"},
+			wantSuccess: false,
+		},
+	})
+}
+
+type parityCase struct {
+	desc        string
+	name        string
+	argv        []string
+	wantSuccess bool
+}
+
+func runParityCases(t *testing.T, cases []parityCase) {
+	t.Helper()
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			// Run real command, capture stdout/stderr/exit separately so the
+			// handler can replay them faithfully.
+			var osStdout, osStderr bytes.Buffer
+
+			osCmd := vexec.NewOSExec().Command(t.Context(), tc.name, tc.argv...)
+			osCmd.SetStdout(&osStdout)
+			osCmd.SetStderr(&osStderr)
+			osErr := osCmd.Run()
+
+			capturedOut := osStdout.Bytes()
+			capturedErr := osStderr.Bytes()
+			capturedExit := vexec.ExitCode(osErr)
+
+			// Replay through memCmd.
+			memExec := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+				return vexec.Result{
+					Stdout:   capturedOut,
+					Stderr:   capturedErr,
+					ExitCode: capturedExit,
+				}
+			})
+
+			var memStdout, memStderr bytes.Buffer
+
+			memCmd := memExec.Command(t.Context(), tc.name, tc.argv...)
+			memCmd.SetStdout(&memStdout)
+			memCmd.SetStderr(&memStderr)
+			memErr := memCmd.Run()
+
+			// Success/failure shape must match.
+			assert.Equal(t, tc.wantSuccess, osErr == nil, "os success mismatch")
+			assert.Equal(t, tc.wantSuccess, memErr == nil, "mem success mismatch")
+
+			// Exit codes must be extractable identically.
+			assert.Equal(t, vexec.ExitCode(osErr), vexec.ExitCode(memErr), "exit code mismatch")
+
+			// Stream wiring must match byte-for-byte (compare as strings to
+			// avoid nil-vs-empty []byte distinctions from bytes.Buffer).
+			assert.Equal(t, osStdout.String(), memStdout.String(), "stdout mismatch")
+			assert.Equal(t, osStderr.String(), memStderr.String(), "stderr mismatch")
+
+			// CombinedOutput parity: replay through a fresh pair and compare.
+			osCombined, osCombErr := vexec.NewOSExec().
+				Command(t.Context(), tc.name, tc.argv...).
+				CombinedOutput()
+
+			memCombined, memCombErr := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+				return vexec.Result{
+					Stdout:   capturedOut,
+					Stderr:   capturedErr,
+					ExitCode: capturedExit,
+				}
+			}).Command(t.Context(), tc.name, tc.argv...).CombinedOutput()
+
+			assert.Equal(t, tc.wantSuccess, osCombErr == nil)
+			assert.Equal(t, tc.wantSuccess, memCombErr == nil)
+			assert.Equal(t, vexec.ExitCode(osCombErr), vexec.ExitCode(memCombErr))
+			assert.Equal(t, string(osCombined), string(memCombined), "combined output mismatch")
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Windows-specific tests.
+//
+// These mirror the POSIX osCmd tests above but drive the real backend through
+// cmd.exe, which ships on every Windows installation. The in-memory backend
+// is platform-agnostic, so the memCmd tests above already cover it on Windows.
+// -----------------------------------------------------------------------------
+
+func TestOSExec_Output_Windows(t *testing.T) {
+	t.Parallel()
+	skipNotOnWindows(t)
+
+	out, err := vexec.Output(vexec.NewOSExec(), t.Context(), "cmd", "/C", "echo hello")
+
+	require.NoError(t, err)
+	assert.Equal(t, "hello", strings.TrimSpace(string(out)))
+}
+
+func TestOSExec_LookPath_Windows(t *testing.T) {
+	t.Parallel()
+	skipNotOnWindows(t)
+
+	e := vexec.NewOSExec()
+
+	path, err := e.LookPath("cmd")
+	require.NoError(t, err)
+	assert.NotEmpty(t, path)
+
+	_, err = e.LookPath("definitely-not-a-real-binary-xyz123.exe")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, exec.ErrNotFound)
+}
+
+func TestOSExec_ExitCode_Windows(t *testing.T) {
+	t.Parallel()
+	skipNotOnWindows(t)
+
+	err := vexec.Run(vexec.NewOSExec(), t.Context(), "cmd", "/C", "exit 3")
+
+	require.Error(t, err)
+	assert.Equal(t, 3, vexec.ExitCode(err))
+}
+
+func TestOSExec_StartWait_Windows(t *testing.T) {
+	t.Parallel()
+	skipNotOnWindows(t)
+
+	var stdout, stderr bytes.Buffer
+
+	cmd := vexec.NewOSExec().Command(t.Context(), "cmd", "/C", "echo hello")
+	cmd.SetStdout(&stdout)
+	cmd.SetStderr(&stderr)
+
+	require.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Wait())
+
+	assert.Equal(t, "hello", strings.TrimSpace(stdout.String()))
+	assert.Empty(t, stderr.String())
+	assert.NotNil(t, cmd.ProcessState())
+	assert.True(t, cmd.ProcessState().Success())
+}
+
+func TestOSExec_CombinedOutput_Windows(t *testing.T) {
+	t.Parallel()
+	skipNotOnWindows(t)
+
+	out, err := vexec.NewOSExec().
+		Command(t.Context(), "cmd", "/C", "echo out & echo err 1>&2 & exit 1").
+		CombinedOutput()
+
+	require.Error(t, err)
+	assert.Equal(t, 1, vexec.ExitCode(err))
+	assert.Contains(t, string(out), "out")
+	assert.Contains(t, string(out), "err")
+}
+
+func TestOSExec_SetDir_Windows(t *testing.T) {
+	t.Parallel()
+	skipNotOnWindows(t)
+
+	tempDir := t.TempDir()
+
+	var buf bytes.Buffer
+
+	cmd := vexec.NewOSExec().Command(t.Context(), "cmd", "/C", "cd")
+	cmd.SetDir(tempDir)
+	cmd.SetStdout(&buf)
+
+	require.NoError(t, cmd.Run())
+	assert.True(t,
+		strings.EqualFold(strings.TrimSpace(buf.String()), tempDir),
+		"cwd %q must equal tempdir %q (case-insensitive)", strings.TrimSpace(buf.String()), tempDir,
+	)
+}
+
+func TestOSExec_SetEnv_Windows(t *testing.T) {
+	t.Parallel()
+	skipNotOnWindows(t)
+
+	var buf bytes.Buffer
+
+	// SystemRoot is required for cmd.exe to start on Windows.
+	cmd := vexec.NewOSExec().Command(t.Context(), "cmd", "/C", "echo %FOO%")
+	cmd.SetEnv([]string{"FOO=bar", "SystemRoot=" + windowsSystemRoot()})
+	cmd.SetStdout(&buf)
+
+	require.NoError(t, cmd.Run())
+	assert.Equal(t, "bar", strings.TrimSpace(buf.String()))
+}
+
+func TestOSExec_SetStdin_Windows(t *testing.T) {
+	t.Parallel()
+	skipNotOnWindows(t)
+
+	var stdout bytes.Buffer
+
+	// findstr "^" matches every line and writes it back to stdout.
+	cmd := vexec.NewOSExec().Command(t.Context(), "findstr", "^")
+	cmd.SetStdin(strings.NewReader("hello from stdin\n"))
+	cmd.SetStdout(&stdout)
+
+	require.NoError(t, cmd.Run())
+	assert.Equal(t, "hello from stdin", strings.TrimSpace(stdout.String()))
+}
+
+func TestParity_OSVsMem_Windows(t *testing.T) {
+	t.Parallel()
+	skipNotOnWindows(t)
+
+	runParityCases(t, []parityCase{
+		{
+			desc:        "success with stdout",
+			name:        "cmd",
+			argv:        []string{"/C", "echo hello"},
+			wantSuccess: true,
+		},
+		{
+			desc:        "success with empty output",
+			name:        "cmd",
+			argv:        []string{"/C", "exit 0"},
+			wantSuccess: true,
+		},
+		{
+			desc:        "failure with stderr and non-zero exit",
+			name:        "cmd",
+			argv:        []string{"/C", "echo oops 1>&2 & exit 2"},
+			wantSuccess: false,
+		},
+	})
+}
+
+// windowsSystemRoot returns the value of SystemRoot (e.g. C:\Windows), which
+// cmd.exe requires to start. Falls back to C:\Windows.
+func windowsSystemRoot() string {
+	if v, ok := os.LookupEnv("SystemRoot"); ok {
+		return v
+	}
+
+	return `C:\Windows`
+}
+
+// skipOnWindows skips tests that depend on POSIX binaries (echo, bash, cat).
+func skipOnWindows(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX utilities (echo/bash/cat)")
+	}
+}
+
+// skipNotOnWindows skips tests that depend on Windows binaries (cmd, findstr).
+func skipNotOnWindows(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific test")
+	}
 }

--- a/internal/vexec/vexec_test.go
+++ b/internal/vexec/vexec_test.go
@@ -1,0 +1,254 @@
+package vexec_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOSExec_Output(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewOSExec()
+
+	out, err := vexec.Output(e, t.Context(), "go", "version")
+
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "go version")
+}
+
+func TestOSExec_LookPath(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewOSExec()
+
+	path, err := e.LookPath("go")
+	require.NoError(t, err)
+	assert.NotEmpty(t, path)
+
+	_, err = e.LookPath("definitely-not-a-real-binary-xyz123")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, exec.ErrNotFound)
+}
+
+func TestOSExec_ExitCode(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewOSExec()
+
+	err := vexec.Run(e, t.Context(), "go", "this-is-not-a-go-subcommand")
+
+	require.Error(t, err)
+	assert.NotZero(t, vexec.ExitCode(err))
+}
+
+func TestMemExec_HandlerReceivesInvocation(t *testing.T) {
+	t.Parallel()
+
+	var got vexec.Invocation
+
+	e := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		got = inv
+		buf, _ := io.ReadAll(inv.Stdin)
+
+		return vexec.Result{Stdout: buf}
+	})
+
+	cmd := e.Command(t.Context(), "tofu", "plan", "-lock=false")
+	cmd.SetEnv([]string{"FOO=bar"})
+	cmd.SetDir("/work")
+	cmd.SetStdin(strings.NewReader("input"))
+
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	assert.Equal(t, "tofu", got.Name)
+	assert.Equal(t, []string{"plan", "-lock=false"}, got.Args)
+	assert.Equal(t, []string{"FOO=bar"}, got.Env)
+	assert.Equal(t, "/work", got.Dir)
+	assert.Equal(t, []byte("input"), out)
+}
+
+func TestMemExec_CombinedOutput(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		return vexec.Result{
+			Stdout: []byte("out-"),
+			Stderr: []byte("err"),
+		}
+	})
+
+	combined, err := vexec.CombinedOutput(e, t.Context(), "whatever")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("out-err"), combined)
+}
+
+func TestMemExec_ExitCode(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		return vexec.Result{ExitCode: 2}
+	})
+
+	err := vexec.Run(e, t.Context(), "fail")
+	require.Error(t, err)
+	assert.Equal(t, 2, vexec.ExitCode(err))
+}
+
+func TestMemExec_ResultErrShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("handler boom")
+
+	e := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		return vexec.Result{Err: sentinel}
+	})
+
+	err := vexec.Run(e, t.Context(), "whatever")
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestMemExec_StartWaitSplit(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+
+	e := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		calls++
+		return vexec.Result{Stdout: []byte("ok")}
+	})
+
+	var buf bytes.Buffer
+
+	cmd := e.Command(t.Context(), "whatever")
+	cmd.SetStdout(&buf)
+
+	require.NoError(t, cmd.Start())
+	require.Equal(t, 1, calls)
+
+	require.NoError(t, cmd.Wait())
+	assert.Equal(t, "ok", buf.String())
+
+	require.ErrorIs(t, cmd.Wait(), vexec.ErrAlreadyWaited)
+	require.ErrorIs(t, cmd.Start(), vexec.ErrAlreadyStarted)
+}
+
+func TestMemExec_WaitBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		return vexec.Result{}
+	})
+
+	cmd := e.Command(t.Context(), "whatever")
+
+	err := cmd.Wait()
+	require.ErrorIs(t, err, vexec.ErrNotStarted)
+}
+
+func TestMemExec_OutputErrorsIfStdoutSet(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		return vexec.Result{}
+	})
+
+	cmd := e.Command(t.Context(), "whatever")
+	cmd.SetStdout(&bytes.Buffer{})
+
+	_, err := cmd.Output()
+	require.ErrorIs(t, err, vexec.ErrStdoutAlreadySet)
+}
+
+func TestMemExec_CombinedOutputErrorsIfStreamsSet(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		return vexec.Result{}
+	})
+
+	cmd := e.Command(t.Context(), "whatever")
+	cmd.SetStderr(&bytes.Buffer{})
+
+	_, err := cmd.CombinedOutput()
+	require.ErrorIs(t, err, vexec.ErrStderrAlreadySet)
+}
+
+func TestMemExec_LookPathDefault(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		return vexec.Result{}
+	})
+
+	path, err := e.LookPath("foo")
+	require.NoError(t, err)
+	assert.Equal(t, "foo", path)
+}
+
+func TestMemExec_LookPathOverride(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewMemExec(
+		func(_ context.Context, _ vexec.Invocation) vexec.Result { return vexec.Result{} },
+		vexec.WithLookPath(func(file string) (string, error) {
+			if file == "tofu" {
+				return "/usr/local/bin/tofu", nil
+			}
+
+			return "", exec.ErrNotFound
+		}),
+	)
+
+	path, err := e.LookPath("tofu")
+	require.NoError(t, err)
+	assert.Equal(t, "/usr/local/bin/tofu", path)
+
+	_, err = e.LookPath("terraform")
+	require.ErrorIs(t, err, exec.ErrNotFound)
+}
+
+func TestMemExec_NilHandlerPanics(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		vexec.NewMemExec(nil)
+	})
+}
+
+func TestNoLookPathExec(t *testing.T) {
+	t.Parallel()
+
+	inner := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		return vexec.Result{Stdout: []byte("hi")}
+	})
+
+	e := &vexec.NoLookPathExec{Exec: inner}
+
+	_, err := e.LookPath("anything")
+	require.Error(t, err)
+
+	var execErr *exec.Error
+	require.ErrorAs(t, err, &execErr)
+	require.ErrorIs(t, execErr.Err, exec.ErrNotFound)
+
+	out, err := vexec.Output(e, t.Context(), "anything")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hi"), out)
+}
+
+func TestExitCode(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 0, vexec.ExitCode(nil))
+	assert.Equal(t, -1, vexec.ExitCode(errors.New("plain error")))
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/tips"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
@@ -528,7 +529,7 @@ func (opts *TerragruntOptions) DataDir() string {
 
 // identifyDefaultWrappedExecutable returns default path used for wrapped executable.
 func identifyDefaultWrappedExecutable(ctx context.Context) string {
-	if util.IsCommandExecutable(ctx, TofuDefaultPath, "-version") {
+	if util.IsCommandExecutable(vexec.NewOSExec(), ctx, TofuDefaultPath, "-version") {
 		return TofuDefaultPath
 	}
 	// fallback to Terraform if tofu is not available

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -47,6 +48,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -841,33 +843,47 @@ func ValidateOutput(t *testing.T, outputs map[string]TerraformOutput, key string
 	assert.Equalf(t, output.Value, value, "Expected output %s to be %t", key, value)
 }
 
-// WrappedBinary - return which binary will be wrapped by Terragrunt, useful in CICD to run same tests against tofu and terraform
-func WrappedBinary() string {
-	value, found := os.LookupEnv("TG_TF_PATH")
-	if !found {
-		// if env variable is not defined, try to check through executing command
-		if util.IsCommandExecutable(context.Background(), TofuBinary, "-version") {
-			return TofuBinary
+// wrappedBinaryOnce memoizes the detected wrapped binary. The result is stable
+// for the lifetime of the process (env vars and installed binaries don't
+// change during a test run), so paying for detection once is enough.
+var (
+	wrappedBinaryOnce   sync.Once
+	wrappedBinaryCached string
+)
+
+// WrappedBinary returns which binary will be wrapped by Terragrunt. The
+// detection runs at most once per process; subsequent calls return the cached
+// value. The ctx is used only on the first call.
+func WrappedBinary(ctx context.Context) string {
+	wrappedBinaryOnce.Do(func() {
+		if value, found := os.LookupEnv("TG_TF_PATH"); found {
+			wrappedBinaryCached = filepath.Base(value)
+			return
 		}
 
-		return TerraformBinary
-	}
+		if util.IsCommandExecutable(vexec.NewOSExec(), ctx, TofuBinary, "-version") {
+			wrappedBinaryCached = TofuBinary
+			return
+		}
 
-	return filepath.Base(value)
+		wrappedBinaryCached = TerraformBinary
+	})
+
+	return wrappedBinaryCached
 }
 
-// ExpectedWrongCommandErr - return expected error message for wrong command
-func ExpectedWrongCommandErr(command string) error {
-	if WrappedBinary() == TofuBinary {
+// ExpectedWrongCommandErr returns the expected error message for a wrong command.
+func ExpectedWrongCommandErr(ctx context.Context, command string) error {
+	if WrappedBinary(ctx) == TofuBinary {
 		return run.WrongTofuCommand(command)
 	}
 
 	return run.WrongTerraformCommand(command)
 }
 
-// IsTerraform checks if the wrapped binary currently in use is the Terraform binary.
-func IsTerraform() bool {
-	return WrappedBinary() == TerraformBinary
+// IsTerraform reports whether the wrapped binary is Terraform.
+func IsTerraform(ctx context.Context) bool {
+	return WrappedBinary(ctx) == TerraformBinary
 }
 
 // IsTerraform110OrHigher checks if the installed Terraform binary is version 1.10.0 or higher.
@@ -879,11 +895,11 @@ func IsTerraform110OrHigher(t *testing.T) bool {
 		requiredMinor = 10
 	)
 
-	if !IsTerraform() {
+	if !IsTerraform(t.Context()) {
 		return false
 	}
 
-	output, err := exec.CommandContext(t.Context(), WrappedBinary(), "-version").Output()
+	output, err := exec.CommandContext(t.Context(), WrappedBinary(t.Context()), "-version").Output()
 	require.NoError(t, err)
 
 	matches := regexp.MustCompile(`Terraform v(\d+)\.(\d+)\.`).FindStringSubmatch(string(output))
@@ -899,13 +915,13 @@ func IsTerraform110OrHigher(t *testing.T) bool {
 }
 
 // IsOpenTofuInstalled checks if OpenTofu is installed.
-func IsOpenTofuInstalled() bool {
-	return util.IsCommandExecutable(context.Background(), TofuBinary, "-version")
+func IsOpenTofuInstalled(ctx context.Context) bool {
+	return util.IsCommandExecutable(vexec.NewOSExec(), ctx, TofuBinary, "-version")
 }
 
 // IsTerraformInstalled checks if Terraform is installed.
-func IsTerraformInstalled() bool {
-	return util.IsCommandExecutable(context.Background(), TerraformBinary, "-version")
+func IsTerraformInstalled(ctx context.Context) bool {
+	return util.IsCommandExecutable(vexec.NewOSExec(), ctx, TerraformBinary, "-version")
 }
 
 // IsNativeS3LockingSupported checks if the installed Terraform binary supports native S3 locking.
@@ -920,7 +936,7 @@ func IsNativeS3LockingSupported(t *testing.T) bool {
 		tofuRequiredMinor      = 10
 	)
 
-	if IsTerraform() {
+	if IsTerraform(t.Context()) {
 		output, err := exec.CommandContext(t.Context(), TerraformBinary, "-version").Output()
 		require.NoError(t, err)
 

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -1277,7 +1277,7 @@ func TestAwsDependencyOutputOptimization(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(reout), &outputs))
 	assert.Equal(t, expectedOutput, outputs["output"].Value)
 
-	for _, logRegexp := range []string{`prefix=../dep .+Running command: ` + wrappedBinary() + ` init -get=false`} {
+	for _, logRegexp := range []string{`prefix=../dep .+Running command: ` + wrappedBinary(t.Context()) + ` init -get=false`} {
 		assert.Regexp(t, logRegexp, reerr)
 	}
 }
@@ -1295,7 +1295,7 @@ func TestAwsDependencyOutputOptimizationNoGenerate(t *testing.T) {
 	t.Parallel()
 
 	expectOutputLogs := []string{
-		`prefix=../dep .+Running command: ` + wrappedBinary() + ` init -get=false`,
+		`prefix=../dep .+Running command: ` + wrappedBinary(t.Context()) + ` init -get=false`,
 	}
 	dependencyOutputOptimizationTest(t, "nested-optimization-nogen", true, expectOutputLogs)
 }
@@ -1495,7 +1495,7 @@ func TestAwsUpdatePolicy(t *testing.T) {
 func TestAwsAssumeRoleDuration(t *testing.T) {
 	t.Parallel()
 
-	if isTerraform() {
+	if isTerraform(t.Context()) {
 		t.Skip("New assume role duration config not supported by Terraform 1.5.x")
 		return
 	}
@@ -2091,7 +2091,7 @@ func TestErrorExplaining(t *testing.T) {
 func TestTerragruntInvokeTerraformTests(t *testing.T) {
 	t.Parallel()
 
-	if isTerraform() {
+	if isTerraform(t.Context()) {
 		t.Skip("Not compatible with Terraform 1.5.x")
 		return
 	}

--- a/test/integration_common_test.go
+++ b/test/integration_common_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -395,23 +397,34 @@ func validateOutput(t *testing.T, outputs map[string]helpers.TerraformOutput, ke
 	assert.Equalf(t, output.Value, value, "Expected output %s to be %t", key, value)
 }
 
-// wrappedBinary - return which binary will be wrapped by Terragrunt, useful in CICD to run same tests against tofu and terraform
-func wrappedBinary() string {
-	value, found := os.LookupEnv("TG_TF_PATH")
-	if !found {
-		// if env variable is not defined, try to check through executing command
-		if util.IsCommandExecutable(context.Background(), helpers.TofuBinary, "-version") {
-			return helpers.TofuBinary
+// wrappedBinaryOnce memoizes the detected wrapped binary for the test process.
+var (
+	wrappedBinaryOnce   sync.Once
+	wrappedBinaryCached string
+)
+
+// wrappedBinary returns which binary will be wrapped by Terragrunt. Detection
+// runs at most once per test process; ctx is used only on the first call.
+func wrappedBinary(ctx context.Context) string {
+	wrappedBinaryOnce.Do(func() {
+		if value, found := os.LookupEnv("TG_TF_PATH"); found {
+			wrappedBinaryCached = filepath.Base(value)
+			return
 		}
 
-		return helpers.TerraformBinary
-	}
+		if util.IsCommandExecutable(vexec.NewOSExec(), ctx, helpers.TofuBinary, "-version") {
+			wrappedBinaryCached = helpers.TofuBinary
+			return
+		}
 
-	return filepath.Base(value)
+		wrappedBinaryCached = helpers.TerraformBinary
+	})
+
+	return wrappedBinaryCached
 }
 
-func isTerraform() bool {
-	return wrappedBinary() == helpers.TerraformBinary
+func isTerraform(ctx context.Context) bool {
+	return wrappedBinary(ctx) == helpers.TerraformBinary
 }
 
 func findFilesWithExtension(dir string, ext string) ([]string, error) {

--- a/test/integration_deprecated_test.go
+++ b/test/integration_deprecated_test.go
@@ -22,19 +22,19 @@ func TestDeprecatedDefaultCommand_TerraformSubcommandCliArgs(t *testing.T) {
 	}{
 		{
 			command:  []string{"force-unlock"},
-			expected: wrappedBinary() + " force-unlock",
+			expected: wrappedBinary(t.Context()) + " force-unlock",
 		},
 		{
 			command:  []string{"force-unlock", "foo"},
-			expected: wrappedBinary() + " force-unlock foo",
+			expected: wrappedBinary(t.Context()) + " force-unlock foo",
 		},
 		{
 			command:  []string{"force-unlock", "foo", "bar", "baz"},
-			expected: wrappedBinary() + " force-unlock foo bar baz",
+			expected: wrappedBinary(t.Context()) + " force-unlock foo bar baz",
 		},
 		{
 			command:  []string{"force-unlock", "foo", "bar", "baz", "foobar"},
-			expected: wrappedBinary() + " force-unlock foo bar baz foobar",
+			expected: wrappedBinary(t.Context()) + " force-unlock foo bar baz foobar",
 		},
 	}
 

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -271,7 +271,7 @@ func TestRemoteWithModuleInRoot(t *testing.T) {
 func TestCustomLockFile(t *testing.T) {
 	t.Parallel()
 
-	path := fmt.Sprintf("%s-%s", testFixtureCustomLockFile, wrappedBinary())
+	path := fmt.Sprintf("%s-%s", testFixtureCustomLockFile, wrappedBinary(t.Context()))
 	tmpEnvPath := helpers.CopyEnvironment(t, filepath.Dir(testFixtureCustomLockFile))
 	rootPath := filepath.Join(tmpEnvPath, path)
 

--- a/test/integration_hooks_test.go
+++ b/test/integration_hooks_test.go
@@ -220,7 +220,7 @@ func TestTerragruntBeforeAndAfterHook(t *testing.T) {
 
 	assert.Equal(t, 1, strings.Count(output, "AFTER_TERRAGRUNT_READ_CONFIG"), "Hooks on terragrunt-read-config command executed more than once")
 
-	expectedHookOutput := fmt.Sprintf("TF_PATH=%s COMMAND=terragrunt-read-config HOOK_NAME=after_hook_3", wrappedBinary())
+	expectedHookOutput := fmt.Sprintf("TF_PATH=%s COMMAND=terragrunt-read-config HOOK_NAME=after_hook_3", wrappedBinary(t.Context()))
 	assert.Equal(t, 1, strings.Count(output, expectedHookOutput))
 
 	require.NoError(t, beforeException)
@@ -438,7 +438,7 @@ func TestTerragruntInfo(t *testing.T) {
 	require.NoError(t, errUnmarshal)
 
 	assert.Equal(t, fmt.Sprintf("%s/%s", rootPath, helpers.TerragruntCache), dat.DownloadDir)
-	assert.Equal(t, wrappedBinary(), dat.TerraformBinary)
+	assert.Equal(t, wrappedBinary(t.Context()), dat.TerraformBinary)
 	assert.Empty(t, dat.IAMRole)
 }
 

--- a/test/integration_json_test.go
+++ b/test/integration_json_test.go
@@ -101,7 +101,7 @@ func TestRenderJsonAttributesMetadata(t *testing.T) {
 
 	expectedTerraformBinary := map[string]any{
 		"metadata": expectedMetadata,
-		"value":    wrappedBinary(),
+		"value":    wrappedBinary(t.Context()),
 	}
 	assert.True(t, reflect.DeepEqual(expectedTerraformBinary, terraformBinary), "expected: %v, got: %v", expectedTerraformBinary, terraformBinary)
 

--- a/test/integration_runner_pool_test.go
+++ b/test/integration_runner_pool_test.go
@@ -223,8 +223,8 @@ func TestRunnerPoolDestroyFailFast(t *testing.T) {
 	// Verify that unit-b failed
 	assert.Contains(t, stderr, "Failed to execute")
 	assert.Contains(t, stderr, "in ./unit-b")
-	assert.NotContains(t, stdout, "unit-b tf-path="+wrappedBinary()+" msg=Destroy complete! Resources: 1 destroyed")
-	assert.NotContains(t, stdout, "unit-a tf-path="+wrappedBinary()+" msg=Destroy complete! Resources: 1 destroyed.")
+	assert.NotContains(t, stdout, "unit-b tf-path="+wrappedBinary(t.Context())+" msg=Destroy complete! Resources: 1 destroyed")
+	assert.NotContains(t, stdout, "unit-a tf-path="+wrappedBinary(t.Context())+" msg=Destroy complete! Resources: 1 destroyed.")
 }
 
 func TestRunnerPoolDestroyDependencies(t *testing.T) {
@@ -241,9 +241,9 @@ func TestRunnerPoolDestroyDependencies(t *testing.T) {
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --fail-fast --working-dir "+testPath+"  -- destroy")
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "unit-b tf-path="+wrappedBinary()+" msg=Destroy complete! Resources: 1 destroyed")
-	assert.Contains(t, stdout, "unit-c tf-path="+wrappedBinary()+" msg=Destroy complete! Resources: 1 destroyed")
-	assert.Contains(t, stdout, "unit-a tf-path="+wrappedBinary()+" msg=Destroy complete! Resources: 1 destroyed.")
+	assert.Contains(t, stdout, "unit-b tf-path="+wrappedBinary(t.Context())+" msg=Destroy complete! Resources: 1 destroyed")
+	assert.Contains(t, stdout, "unit-c tf-path="+wrappedBinary(t.Context())+" msg=Destroy complete! Resources: 1 destroyed")
+	assert.Contains(t, stdout, "unit-a tf-path="+wrappedBinary(t.Context())+" msg=Destroy complete! Resources: 1 destroyed.")
 }
 
 func TestRunnerPoolRemoteSource(t *testing.T) {

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -727,7 +727,7 @@ func TestTerragruntProviderCache(t *testing.T) {
 	}
 
 	registryName := "registry.opentofu.org"
-	if isTerraform() {
+	if isTerraform(t.Context()) {
 		registryName = "registry.terraform.io"
 	}
 
@@ -828,7 +828,7 @@ func TestTerragruntProviderCacheWithDependency(t *testing.T) {
 	)
 
 	registryName := "registry.opentofu.org"
-	if isTerraform() {
+	if isTerraform(t.Context()) {
 		registryName = "registry.terraform.io"
 	}
 
@@ -871,7 +871,7 @@ func TestParseTFLog(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, prefixName := range []string{"app", "dep"} {
-		assert.Contains(t, stderr, "INFO   ["+prefixName+"] "+wrappedBinary()+`: TF_LOG: Go runtime version`)
+		assert.Contains(t, stderr, "INFO   ["+prefixName+"] "+wrappedBinary(t.Context())+`: TF_LOG: Go runtime version`)
 	}
 }
 
@@ -966,7 +966,7 @@ func TestVersionIsInvokedInDifferentDirectory(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	versionCmdPattern := regexp.MustCompile(`Running command: ` + regexp.QuoteMeta(wrappedBinary()) + ` -version`)
+	versionCmdPattern := regexp.MustCompile(`Running command: ` + regexp.QuoteMeta(wrappedBinary(t.Context())) + ` -version`)
 	matches := versionCmdPattern.FindAllStringIndex(stderr, -1)
 
 	// Expected 2 version commands:
@@ -976,7 +976,7 @@ func TestVersionIsInvokedInDifferentDirectory(t *testing.T) {
 	expected := 2
 
 	assert.Len(t, matches, expected, "Expected exactly %d occurrence(s) of '-version' command, found %d", expected, len(matches))
-	assert.Contains(t, stderr, "prefix=dependency-with-custom-version msg=Running command: "+wrappedBinary()+" -version")
+	assert.Contains(t, stderr, "prefix=dependency-with-custom-version msg=Running command: "+wrappedBinary(t.Context())+" -version")
 }
 
 func TestVersionIsInvokedOnlyOnce(t *testing.T) {
@@ -993,7 +993,7 @@ func TestVersionIsInvokedOnlyOnce(t *testing.T) {
 	require.NoError(t, err)
 
 	// check that version command was invoked only once -version
-	versionCmdPattern := regexp.MustCompile(`Running command: ` + regexp.QuoteMeta(wrappedBinary()) + ` -version`)
+	versionCmdPattern := regexp.MustCompile(`Running command: ` + regexp.QuoteMeta(wrappedBinary(t.Context())) + ` -version`)
 	matches := versionCmdPattern.FindAllStringIndex(stderr, -1)
 
 	expected := 1

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -445,8 +445,8 @@ func TestLogCustomFormatOutput(t *testing.T) {
 		{
 			logCustomFormat: "%interval%(content=' plain-text ')%level(case=upper,width=6) %prefix(path=short-relative,suffix=' ')%tf-path(suffix=' ')%tf-command-args(suffix=': ')%msg(path=relative)",
 			expectedStdOutRegs: []*regexp.Regexp{
-				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT dep "+wrappedBinary()+" init -no-color -input=false: Initializing the backend...")),
-				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT app "+wrappedBinary()+" init -no-color -input=false: Initializing the backend...")),
+				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT dep "+wrappedBinary(t.Context())+" init -no-color -input=false: Initializing the backend...")),
+				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT app "+wrappedBinary(t.Context())+" init -no-color -input=false: Initializing the backend...")),
 			},
 			expectedStdErrRegs: []*regexp.Regexp{
 				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text DEBUG  Terragrunt Version:")),
@@ -455,8 +455,8 @@ func TestLogCustomFormatOutput(t *testing.T) {
 		{
 			logCustomFormat: "%interval%(content=' plain-text ')%level(case=upper,width=6) %prefix(path=short-relative,suffix=' ')%tf-path(suffix=' ')%tf-command(suffix=': ')%msg(path=relative)",
 			expectedStdOutRegs: []*regexp.Regexp{
-				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT dep "+wrappedBinary()+" init: Initializing the backend...")),
-				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT app "+wrappedBinary()+" init: Initializing the backend...")),
+				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT dep "+wrappedBinary(t.Context())+" init: Initializing the backend...")),
+				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT app "+wrappedBinary(t.Context())+" init: Initializing the backend...")),
 			},
 			expectedStdErrRegs: []*regexp.Regexp{
 				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text DEBUG  Terragrunt Version:")),
@@ -465,8 +465,8 @@ func TestLogCustomFormatOutput(t *testing.T) {
 		{
 			logCustomFormat: "%interval%(content=' plain-text ')%level(case=upper,width=6) %prefix(path=short-relative,suffix=' ')%tf-path(suffix=' ')%tf-command()-args %msg(path=relative)",
 			expectedStdOutRegs: []*regexp.Regexp{
-				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT dep "+wrappedBinary()+" init-args Initializing the backend...")),
-				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT app "+wrappedBinary()+" init-args Initializing the backend...")),
+				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT dep "+wrappedBinary(t.Context())+" init-args Initializing the backend...")),
+				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT app "+wrappedBinary(t.Context())+" init-args Initializing the backend...")),
 			},
 			expectedStdErrRegs: []*regexp.Regexp{
 				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text DEBUG  -args Terragrunt Version:")),
@@ -475,8 +475,8 @@ func TestLogCustomFormatOutput(t *testing.T) {
 		{
 			logCustomFormat: "%interval%(content=' plain-text ')%level(case=upper,width=6) %prefix(path=short-relative,suffix=' ')%tf-path(suffix=' ')%tf-command()-args % aaa %msg(path=relative) %%bbb % ccc",
 			expectedStdOutRegs: []*regexp.Regexp{
-				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT dep "+wrappedBinary()+" init-args % aaa Initializing the backend... %bbb % ccc")),
-				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT app "+wrappedBinary()+" init-args % aaa Initializing the backend... %bbb % ccc")),
+				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT dep "+wrappedBinary(t.Context())+" init-args % aaa Initializing the backend... %bbb % ccc")),
+				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text STDOUT app "+wrappedBinary(t.Context())+" init-args % aaa Initializing the backend... %bbb % ccc")),
 			},
 			expectedStdErrRegs: []*regexp.Regexp{
 				regexp.MustCompile(`\d{4}` + regexp.QuoteMeta(" plain-text DEBUG  -args % aaa Terragrunt Version:")),
@@ -596,7 +596,7 @@ func TestLogWithAbsPath(t *testing.T) {
 
 	for _, prefixName := range []string{"app", "dep"} {
 		prefixName = filepath.Join(rootPath, prefixName)
-		assert.Contains(t, stdout, "STDOUT ["+prefixName+"] "+wrappedBinary()+": Initializing provider plugins...")
+		assert.Contains(t, stdout, "STDOUT ["+prefixName+"] "+wrappedBinary(t.Context())+": Initializing provider plugins...")
 		assert.Contains(t, stderr, "DEBUG  ["+prefixName+"] Reading Terragrunt config file at "+prefixName+"/terragrunt.hcl")
 	}
 }
@@ -658,7 +658,7 @@ func TestLogFormatPrettyOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, prefixName := range []string{"app", "dep"} {
-		assert.Contains(t, stdout, "STDOUT ["+prefixName+"] "+wrappedBinary()+": Initializing provider plugins...")
+		assert.Contains(t, stdout, "STDOUT ["+prefixName+"] "+wrappedBinary(t.Context())+": Initializing provider plugins...")
 		assert.Contains(t, stderr, "DEBUG  ["+prefixName+"] Reading Terragrunt config file at ./"+prefixName+"/terragrunt.hcl")
 	}
 
@@ -676,12 +676,12 @@ func TestLogStdoutLevel(t *testing.T) {
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --non-interactive -no-color --no-color --log-format=pretty  --working-dir "+rootPath)
 	require.NoError(t, err)
 
-	assert.Contains(t, stdout, "STDOUT "+wrappedBinary()+": Changes to Outputs")
+	assert.Contains(t, stdout, "STDOUT "+wrappedBinary(t.Context())+": Changes to Outputs")
 
 	stdout, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt destroy -auto-approve --non-interactive -no-color --no-color --log-format=pretty  --working-dir "+rootPath)
 	require.NoError(t, err)
 
-	assert.Contains(t, stdout, "STDOUT "+wrappedBinary()+": Changes to Outputs")
+	assert.Contains(t, stdout, "STDOUT "+wrappedBinary(t.Context())+": Changes to Outputs")
 }
 
 func TestLogFormatKeyValueOutput(t *testing.T) {
@@ -705,7 +705,7 @@ func TestLogFormatKeyValueOutput(t *testing.T) {
 				assert.Contains(
 					t,
 					stdout,
-					"level=stdout prefix="+prefixName+" tf-path="+wrappedBinary()+" msg=Initializing provider plugins...\n",
+					"level=stdout prefix="+prefixName+" tf-path="+wrappedBinary(t.Context())+" msg=Initializing provider plugins...\n",
 				)
 				assert.Contains(
 					t,
@@ -984,7 +984,7 @@ func TestTerragruntProviderCacheMultiplePlatforms(t *testing.T) {
 	}
 
 	registryName := "registry.opentofu.org"
-	if isTerraform() {
+	if isTerraform(t.Context()) {
 		registryName = "registry.terraform.io"
 	}
 
@@ -1299,23 +1299,23 @@ func TestTerraformCommandCliArgs(t *testing.T) {
 	}{
 		{
 			command:  []string{"version"},
-			expected: wrappedBinary() + " version",
+			expected: wrappedBinary(t.Context()) + " version",
 		},
 		{
 			command:  []string{"--", "version"},
-			expected: wrappedBinary() + " version",
+			expected: wrappedBinary(t.Context()) + " version",
 		},
 		{
 			command:  []string{"--", "version", "foo"},
-			expected: wrappedBinary() + " version",
+			expected: wrappedBinary(t.Context()) + " version",
 		},
 		{
 			command:  []string{"--", "version", "foo", "bar", "baz"},
-			expected: wrappedBinary() + " version",
+			expected: wrappedBinary(t.Context()) + " version",
 		},
 		{
 			command:  []string{"--", "version", "foo", "bar", "baz", "foobar"},
-			expected: wrappedBinary() + " version",
+			expected: wrappedBinary(t.Context()) + " version",
 		},
 		{
 			command:  []string{"--", "graph"},
@@ -1353,19 +1353,19 @@ func TestTerraformSubcommandCliArgs(t *testing.T) {
 	}{
 		{
 			command:  []string{"force-unlock"},
-			expected: wrappedBinary() + " force-unlock",
+			expected: wrappedBinary(t.Context()) + " force-unlock",
 		},
 		{
 			command:  []string{"force-unlock", "foo"},
-			expected: wrappedBinary() + " force-unlock foo",
+			expected: wrappedBinary(t.Context()) + " force-unlock foo",
 		},
 		{
 			command:  []string{"force-unlock", "foo", "bar", "baz"},
-			expected: wrappedBinary() + " force-unlock foo bar baz",
+			expected: wrappedBinary(t.Context()) + " force-unlock foo bar baz",
 		},
 		{
 			command:  []string{"force-unlock", "foo", "bar", "baz", "foobar"},
-			expected: wrappedBinary() + " force-unlock foo bar baz foobar",
+			expected: wrappedBinary(t.Context()) + " force-unlock foo bar baz foobar",
 		},
 	}
 
@@ -3783,7 +3783,7 @@ func TestInitSkipCache(t *testing.T) {
 
 	// verify that init was invoked
 	assert.Contains(t, stdout, "has been successfully initialized!")
-	assert.Contains(t, stderr, "Running command: "+wrappedBinary()+" init")
+	assert.Contains(t, stderr, "Running command: "+wrappedBinary(t.Context())+" init")
 
 	stdout, stderr, err = helpers.RunTerragruntCommandWithOutput(
 		t, "terragrunt plan --non-interactive --log-level debug --tf-forward-stdout --working-dir "+rootPath,
@@ -3792,7 +3792,7 @@ func TestInitSkipCache(t *testing.T) {
 
 	// verify that init wasn't invoked second time since cache directories are ignored
 	assert.NotContains(t, stdout, "has been successfully initialized!")
-	assert.NotContains(t, stderr, "Running command: "+wrappedBinary()+" init")
+	assert.NotContains(t, stderr, "Running command: "+wrappedBinary(t.Context())+" init")
 
 	// verify that after adding new file, init is executed
 	tfFile := filepath.Join(tmpEnvPath, testFixtureInitCache, "app", "project.tf")
@@ -3808,7 +3808,7 @@ func TestInitSkipCache(t *testing.T) {
 
 	// verify that init was invoked
 	assert.Contains(t, stdout, "has been successfully initialized!")
-	assert.Contains(t, stderr, "Running command: "+wrappedBinary()+" init")
+	assert.Contains(t, stderr, "Running command: "+wrappedBinary(t.Context())+" init")
 }
 
 func TestTerragruntFailIfBucketCreationIsrequired(t *testing.T) {
@@ -4478,7 +4478,7 @@ func TestTfPathOverridesConfigWithTofuTerraform(t *testing.T) {
 	t.Parallel()
 
 	// This test requires that both tofu and terraform are installed.
-	if !helpers.IsTerraformInstalled() || !helpers.IsOpenTofuInstalled() {
+	if !helpers.IsTerraformInstalled(t.Context()) || !helpers.IsOpenTofuInstalled(t.Context()) {
 		t.Skip("This test requires that both OpenTofu and Terraform are installed")
 
 		return


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds a `vexec` package similar to `vfs` to allow for an injectable command execution test double.

It basically provides a handle that lets us swap out actually spawning external processes for internal mocks.

Initially used purely for replacing usage of `exec` in `IsCommandExecutable` tests to keep scope small.

While I was in there, I also updated `WrappedBinary` to get memoized in test helpers. We were repeatedly calling external binaries to check which default we expected, but we can just call it once and memoize the result.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal command execution infrastructure for enhanced testability and maintainability.

* **Tests**
  * Expanded test coverage with deterministic, mockable command execution backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->