### PR TITLE
feat: Adding support for local paths in CAS

### DIFF
--- a/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
@@ -474,6 +474,23 @@ Requirements:
 - The `--no-cas` flag must not be set.
 - Sources using `update_source_with_cas` must be relative paths within the same repository.
 
+### Local catalog sources
+
+The consumer stack's `source` can be a local filesystem path in addition to a remote Git URL. Both go through the same CAS-backed rewrite pipeline:
+
+```hcl
+# live/terragrunt.stack.hcl
+stack "service" {
+  source = "../catalog//stacks/service"
+
+  path = "service"
+}
+```
+
+Terragrunt copies the referenced directory into a temporary directory, computes a content-addressed root hash over `(relative path, mode, file content)` triples using SHA-256, and rewrites nested `source` attributes against that copy. The original directory is never modified, so the catalog on disk stays clean even though the rewritten `source` values need somewhere to live.
+
+This is useful when iterating on a catalog before tagging a release: the same `update_source_with_cas = true` attributes in the catalog's `terragrunt.stack.hcl` and `terragrunt.hcl` files apply unchanged, whether consumers pull the catalog over Git or point at a local checkout.
+
 </Since>
 
 ## Known Limitations of Explicit Stacks

--- a/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
@@ -487,7 +487,7 @@ stack "service" {
 }
 ```
 
-Terragrunt copies the referenced directory into a temporary directory, computes a content-addressed root hash over `(relative path, mode, file content)` triples using SHA-256, and rewrites nested `source` attributes against that copy. The original directory is never modified, so the catalog on disk stays clean even though the rewritten `source` values need somewhere to live.
+Terragrunt copies the referenced directory into a temporary directory, computes a content-addressed root hash over `(relative path, mode, file-content hash)` triples using SHA-256, and rewrites nested `source` attributes against that copy. The original directory is never modified, so the catalog on disk stays clean even though the rewritten `source` values need somewhere to live.
 
 This is useful when iterating on a catalog before tagging a release: the same `update_source_with_cas = true` attributes in the catalog's `terragrunt.stack.hcl` and `terragrunt.hcl` files apply unchanged, whether consumers pull the catalog over Git or point at a local checkout.
 

--- a/docs/src/content/docs/03-features/07-caching/04-cas.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas.mdx
@@ -92,6 +92,8 @@ terraform {
 
 During stack generation, Terragrunt rewrites these relative sources to `cas::` references that point to content stored in the CAS. The repository is cloned once, and subsequent stack generations resolve content from the local store without network access. Generated `.terragrunt-stack` files contain deterministic CAS references instead of version variables, so they do not produce diffs on regeneration.
 
+The catalog source can be either a remote Git URL or a local filesystem path (absolute, or relative to the current working directory). Local sources are copied into a temporary directory before rewriting, so the original catalog directory is never modified. This makes the same catalog layout usable against a published Git ref or a local checkout, which is useful when iterating on a catalog before tagging a release.
+
 For more details on using this with stacks, see [Explicit Stacks: CAS Integration](/features/stacks/explicit#cas-integration).
 
 <Aside type="caution">

--- a/docs/src/data/changelog/v1.0.3/cas-local-paths.mdx
+++ b/docs/src/data/changelog/v1.0.3/cas-local-paths.mdx
@@ -1,0 +1,21 @@
+---
+version: "v1.0.3"
+category: "experiments-updated"
+---
+
+#### `cas` — Local paths supported as stack component sources
+
+CAS-backed stack generation now accepts a local filesystem path as the `source` of a consumer `stack` or `unit` block, in addition to a remote Git URL. Terragrunt copies the referenced directory into a temporary directory, computes a content-addressed root hash over the copy, and applies the same `update_source_with_cas` rewriting as the remote flow. The original directory is left untouched.
+
+```hcl
+# live/terragrunt.stack.hcl
+stack "service" {
+  source = "../catalog//stacks/service"
+
+  path = "service"
+}
+```
+
+This makes a catalog usable against a local checkout under the same `update_source_with_cas = true` attributes that already work for Git URLs, which is helpful when iterating on a catalog before tagging a release.
+
+See the [CAS documentation](/features/caching/cas) and [Explicit Stacks: Local catalog sources](/features/stacks/explicit#local-catalog-sources) for details.

--- a/internal/cas/local.go
+++ b/internal/cas/local.go
@@ -68,6 +68,17 @@ func (c *CAS) buildLocalTree(dir string, alg HashAlgorithm) (string, []byte, err
 			return nil
 		}
 
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("failed to stat file %s: %w", path, err)
+		}
+
+		// Skip symlinks and other non-regular entries to keep the synthetic
+		// tree consistent with copyTree, which only copies regular files.
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
 		relPath, err := filepath.Rel(dir, path)
 		if err != nil {
 			return err
@@ -79,11 +90,6 @@ func (c *CAS) buildLocalTree(dir string, alg HashAlgorithm) (string, []byte, err
 		fileHash, err := hashFileAlg(c.fs, path, alg)
 		if err != nil {
 			return fmt.Errorf("failed to hash file %s: %w", path, err)
-		}
-
-		info, err := d.Info()
-		if err != nil {
-			return fmt.Errorf("failed to stat file %s: %w", path, err)
 		}
 
 		mode := fmt.Sprintf("%06o", info.Mode().Perm())
@@ -118,6 +124,15 @@ func (c *CAS) storeLocalContent(l log.Logger, sourceDir, dirHash string, treeDat
 		}
 
 		if d.IsDir() {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("failed to stat file %s: %w", path, err)
+		}
+
+		if !info.Mode().IsRegular() {
 			return nil
 		}
 

--- a/internal/cas/local.go
+++ b/internal/cas/local.go
@@ -2,9 +2,9 @@ package cas
 
 import (
 	"context"
-	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"io/fs"
 	"path/filepath"
 	"strings"
@@ -14,21 +14,23 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
+// DefaultLocalHashAlgorithm is used for content-addressed hashing of local source
+// trees. It is chosen independently of any git repository's object format because
+// local sources have no repository to inherit a format from.
+const DefaultLocalHashAlgorithm = HashSHA256
+
 // StoreLocalDirectory persists all content from a local source directory into the CAS
-// and then links the persisted files to the target directory
+// and then links the persisted files to the target directory.
 func (c *CAS) StoreLocalDirectory(ctx context.Context, l log.Logger, sourceDir, targetDir string) error {
-	// Generate a synthetic hash for the local directory based on its contents
-	hash, treeData, err := c.hashDirectory(sourceDir)
+	hash, treeData, err := c.buildLocalTree(sourceDir, DefaultLocalHashAlgorithm)
 	if err != nil {
 		return fmt.Errorf("failed to hash local directory %s: %w", sourceDir, err)
 	}
 
-	// Store all files from the directory into the CAS
-	if err = c.storeLocalContent(l, sourceDir, hash, treeData); err != nil {
+	if err = c.storeLocalContent(l, sourceDir, hash, treeData, DefaultLocalHashAlgorithm); err != nil {
 		return fmt.Errorf("failed to store local content: %w", err)
 	}
 
-	// Parse the tree data and link to target directory
 	tree, err := git.ParseTree(treeData, targetDir)
 	if err != nil {
 		return fmt.Errorf("failed to parse local tree: %w", err)
@@ -37,31 +39,44 @@ func (c *CAS) StoreLocalDirectory(ctx context.Context, l log.Logger, sourceDir, 
 	return LinkTree(ctx, c.blobStore, c.treeStore, tree, targetDir)
 }
 
-// hashDirectory creates a synthetic hash and tree structure for a local directory
-func (c *CAS) hashDirectory(sourceDir string) (string, []byte, error) {
-	var treeData []byte
+// ComputeLocalRootHash walks dir in deterministic (lexical) order and produces a
+// content-addressed hash over (relpath, mode, file-content-hash) triples. The
+// returned hash plays the same role as a git ref hash does in the remote flow —
+// it is the "root" for DeterministicTreeHash calls when rewriting nested sources.
+// The same file-content hashes are used both inside the root-hash and as blob
+// hashes in the synthetic tree, so blob lookups and tree lookups stay consistent.
+func (c *CAS) ComputeLocalRootHash(dir string, alg HashAlgorithm) (string, error) {
+	hash, _, err := c.buildLocalTree(dir, alg)
+	return hash, err
+}
 
-	var allHashes []string
+// buildLocalTree walks dir and returns (rootHash, treeData). The treeData has
+// the same "<mode> blob <hash>\t<path>\n" format as a git tree, but with
+// file-content hashes taken in the chosen algorithm.
+func (c *CAS) buildLocalTree(dir string, alg HashAlgorithm) (string, []byte, error) {
+	var (
+		treeData []byte
+		rootBuf  []byte
+	)
 
-	err := vfs.WalkDir(c.fs, sourceDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
+	err := vfs.WalkDir(c.fs, dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
 
-		// Implicitly handled by tracking the file hashes.
 		if d.IsDir() {
 			return nil
 		}
 
-		relPath, err := filepath.Rel(sourceDir, path)
+		relPath, err := filepath.Rel(dir, path)
 		if err != nil {
 			return err
 		}
 
-		// Convert to forward slashes for consistency (git-style paths)
+		// Git-style forward slashes in tree entries, regardless of host OS.
 		relPath = strings.ReplaceAll(relPath, string(filepath.Separator), "/")
 
-		fileHash, err := hashFile(c.fs, path)
+		fileHash, err := hashFileAlg(c.fs, path, alg)
 		if err != nil {
 			return fmt.Errorf("failed to hash file %s: %w", path, err)
 		}
@@ -71,13 +86,13 @@ func (c *CAS) hashDirectory(sourceDir string) (string, []byte, error) {
 			return fmt.Errorf("failed to stat file %s: %w", path, err)
 		}
 
-		// Artificially create a tree entry for the file.
 		mode := fmt.Sprintf("%06o", info.Mode().Perm())
-		treeLine := fmt.Sprintf("%s blob %s\t%s\n", mode, fileHash, relPath)
-		treeData = append(treeData, []byte(treeLine)...)
+		treeData = append(treeData, fmt.Appendf(nil, "%s blob %s\t%s\n", mode, fileHash, relPath)...)
 
-		// Collect all hashes for directory hash calculation
-		allHashes = append(allHashes, fileHash)
+		// Root hash input includes path, mode, and content hash so that two
+		// trees with identical files at different relative paths (or different
+		// permissions) get distinct root hashes.
+		rootBuf = append(rootBuf, fmt.Appendf(nil, "%s %s %s\n", relPath, mode, fileHash)...)
 
 		return nil
 	})
@@ -85,16 +100,11 @@ func (c *CAS) hashDirectory(sourceDir string) (string, []byte, error) {
 		return "", nil, err
 	}
 
-	// Create a synthetic hash for the entire directory based on all file hashes
-	// This ensures the same directory contents always get the same hash
-	dirHash := hashString(strings.Join(allHashes, ""))
-
-	return dirHash, treeData, nil
+	return alg.Sum(rootBuf), treeData, nil
 }
 
-// storeLocalContent stores all files from a local directory into the CAS
-func (c *CAS) storeLocalContent(l log.Logger, sourceDir, dirHash string, treeData []byte) error {
-	// First store the tree object itself
+// storeLocalContent stores the tree object and every blob referenced by it.
+func (c *CAS) storeLocalContent(l log.Logger, sourceDir, dirHash string, treeData []byte, alg HashAlgorithm) error {
 	treeContent := NewContent(c.treeStore)
 	if err := treeContent.Ensure(l, dirHash, treeData); err != nil {
 		return fmt.Errorf("failed to store tree data: %w", err)
@@ -102,19 +112,16 @@ func (c *CAS) storeLocalContent(l log.Logger, sourceDir, dirHash string, treeDat
 
 	blobContent := NewContent(c.blobStore)
 
-	// Walk the directory and store all files
 	return vfs.WalkDir(c.fs, sourceDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		// Skip directories and the root directory itself
 		if d.IsDir() {
 			return nil
 		}
 
-		// Hash the file to get its content hash
-		fileHash, err := hashFile(c.fs, path)
+		fileHash, err := hashFileAlg(c.fs, path, alg)
 		if err != nil {
 			return fmt.Errorf("failed to hash file %s: %w", path, err)
 		}
@@ -127,9 +134,26 @@ func (c *CAS) storeLocalContent(l log.Logger, sourceDir, dirHash string, treeDat
 	})
 }
 
-func hashString(s string) string {
-	h := sha1.New()
-	h.Write([]byte(s))
+// hashFileAlg hashes a file's contents using the given algorithm and returns
+// the hex-encoded digest. It exists alongside hashFile (which is hard-coded
+// to SHA-1 for the git remote flow) so the local flow can use SHA-256.
+func hashFileAlg(fsys vfs.FS, path string, alg HashAlgorithm) (string, error) {
+	file, err := fsys.Open(path)
+	if err != nil {
+		return "", err
+	}
 
-	return hex.EncodeToString(h.Sum(nil))
+	h := alg.NewHash()
+
+	if _, err := io.Copy(h, file); err != nil {
+		_ = file.Close()
+
+		return "", err
+	}
+
+	if err := file.Close(); err != nil {
+		return "", fmt.Errorf("closing %s after hashing failed: %w", path, err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/internal/cas/local_test.go
+++ b/internal/cas/local_test.go
@@ -1,0 +1,123 @@
+package cas_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeLocalFixture populates a fresh directory with a small deterministic tree
+// and returns its absolute path.
+func writeLocalFixture(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	dir := helpers.TmpDirWOSymlinks(t)
+	for rel, body := range files {
+		full := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+	}
+
+	return dir
+}
+
+// newCAS constructs a CAS instance backed by a fresh per-test store directory.
+func newCAS(t *testing.T) *cas.CAS {
+	t.Helper()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	return c
+}
+
+func TestComputeLocalRootHash_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	c := newCAS(t)
+	dir := writeLocalFixture(t, map[string]string{
+		"main.tf":          `resource "null_resource" "a" {}`,
+		"subdir/nested.tf": `variable "x" {}` + "\n",
+		"subdir/README.md": "hello",
+	})
+
+	h1, err := c.ComputeLocalRootHash(dir, cas.HashSHA256)
+	require.NoError(t, err)
+
+	h2, err := c.ComputeLocalRootHash(dir, cas.HashSHA256)
+	require.NoError(t, err)
+
+	assert.Equal(t, h1, h2, "same directory must produce the same root hash")
+	assert.Len(t, h1, 64, "SHA-256 hash should be 64 hex chars")
+}
+
+func TestComputeLocalRootHash_DiffersOnContentChange(t *testing.T) {
+	t.Parallel()
+
+	c := newCAS(t)
+	dir := writeLocalFixture(t, map[string]string{
+		"main.tf": "one",
+	})
+
+	before, err := c.ComputeLocalRootHash(dir, cas.HashSHA256)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte("two"), 0o644))
+
+	after, err := c.ComputeLocalRootHash(dir, cas.HashSHA256)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, before, after, "changing a file's contents must change the root hash")
+}
+
+func TestComputeLocalRootHash_DiffersOnModeChange(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode changes are not meaningfully observable on Windows")
+	}
+
+	c := newCAS(t)
+	dir := writeLocalFixture(t, map[string]string{
+		"script.sh": "#!/bin/sh\n",
+	})
+
+	before, err := c.ComputeLocalRootHash(dir, cas.HashSHA256)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chmod(filepath.Join(dir, "script.sh"), 0o755))
+
+	after, err := c.ComputeLocalRootHash(dir, cas.HashSHA256)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, before, after, "changing a file's mode must change the root hash")
+}
+
+func TestComputeLocalRootHash_IgnoresAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	c := newCAS(t)
+
+	files := map[string]string{
+		"main.tf":     `resource "null_resource" "a" {}` + "\n",
+		"lib/util.tf": `locals { x = 1 }` + "\n",
+	}
+
+	dirA := writeLocalFixture(t, files)
+	dirB := writeLocalFixture(t, files)
+
+	hashA, err := c.ComputeLocalRootHash(dirA, cas.HashSHA256)
+	require.NoError(t, err)
+
+	hashB, err := c.ComputeLocalRootHash(dirB, cas.HashSHA256)
+	require.NoError(t, err)
+
+	assert.Equal(t, hashA, hashB, "identical contents at different absolute paths must hash identically")
+}

--- a/internal/cas/race_test.go
+++ b/internal/cas/race_test.go
@@ -3,7 +3,9 @@
 package cas_test
 
 import (
+	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
@@ -63,5 +65,62 @@ func TestCASGetterGetWithRacing(t *testing.T) {
 
 			assert.Equal(t, tmpDir, res.Dst)
 		})
+	}
+}
+
+func TestProcessStackComponentLocalSourceConcurrentWithRacing(t *testing.T) {
+	t.Parallel()
+
+	// Two concurrent ProcessStackComponent calls against the same local source
+	// and the same CAS store must succeed without racing on blob/tree writes,
+	// and must produce identical rewritten stack files.
+	root := buildLocalStackFixture(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	const workers = 4
+
+	results := make([]string, workers)
+	errs := make([]error, workers)
+
+	var wg sync.WaitGroup
+
+	for i := range workers {
+		wg.Add(1)
+
+		go func(idx int) {
+			defer wg.Done()
+
+			source := root + "//stacks/my-stack"
+
+			result, runErr := c.ProcessStackComponent(t.Context(), l, source, "stack")
+			if runErr != nil {
+				errs[idx] = runErr
+				return
+			}
+
+			defer result.Cleanup()
+
+			body, readErr := os.ReadFile(filepath.Join(result.ContentDir, "terragrunt.stack.hcl"))
+			if readErr != nil {
+				errs[idx] = readErr
+				return
+			}
+
+			results[idx] = string(body)
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, e := range errs {
+		require.NoErrorf(t, e, "worker %d failed", i)
+	}
+
+	for i := 1; i < workers; i++ {
+		assert.Equal(t, results[0], results[i], "all concurrent runs must produce identical rewritten output")
 	}
 }

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -3,6 +3,8 @@ package cas
 import (
 	"context"
 	"fmt"
+	"io"
+	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -10,6 +12,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-getter/v2"
 )
@@ -22,13 +25,21 @@ type StackCASResult struct {
 	ContentDir string
 }
 
-// ProcessStackComponent clones a remote source via CAS, resolves update_source_with_cas
-// references, rewrites sources to CAS references, and creates synthetic CAS entries.
+// ProcessStackComponent resolves update_source_with_cas references for a stack
+// component, rewriting nested sources to cas:: references and populating the
+// CAS store with the referenced blobs and synthetic trees.
 //
-// The source should be a remote URL with an optional //subdir and ?ref= query.
-// The kind should be "unit" or "stack".
+// The source may be a remote URL with an optional //subdir and ?ref= query, or
+// a local filesystem path (optionally with a //subdir). Remote sources are
+// cloned into a temp directory; local sources are copied into a temp directory
+// so rewrites do not mutate the caller's working tree. The kind should be
+// "unit" or "stack".
 func (c *CAS) ProcessStackComponent(ctx context.Context, l log.Logger, source, kind string) (*StackCASResult, error) {
 	repoURL, subdir := getter.SourceDirSubdir(source)
+
+	if isLocalPath(repoURL) {
+		return c.processLocalStackComponent(ctx, l, repoURL, subdir)
+	}
 
 	parsedURL, err := url.Parse(repoURL)
 	if err != nil {
@@ -106,6 +117,32 @@ func (c *CAS) ProcessStackComponent(ctx context.Context, l log.Logger, source, k
 	}, nil
 }
 
+// DeterministicTreeHash returns a deterministic tree hash derived from the
+// given root hash and a path within the root. The root hash is a git commit
+// hash for remote sources, or a content-addressed hash of the local tree for
+// local sources; the algorithm is inferred from the root hash's length.
+func DeterministicTreeHash(refHash, pathInRepo string) string {
+	alg := DetectHashAlgorithm(refHash)
+
+	return alg.Sum([]byte(refHash + pathInRepo))
+}
+
+// SplitSourceDoubleSlash splits a source string at the "//" separator and
+// returns the base path and the subdirectory, if any.
+//
+// Examples:
+//
+//	"../..//modules/ec2" -> ("../..", "modules/ec2")
+//	"../../modules/ec2"  -> ("../../modules/ec2", "")
+func SplitSourceDoubleSlash(source string) (basePath, subdir string) {
+	before, after, found := strings.Cut(source, "//")
+	if !found {
+		return source, ""
+	}
+
+	return before, after
+}
+
 // detectRepoHashAlgorithm queries the git object format of a cloned repository.
 func detectRepoHashAlgorithm(ctx context.Context, repoDir string) (HashAlgorithm, error) {
 	g, err := git.NewGitRunner(vexec.NewOSExec())
@@ -123,8 +160,8 @@ func detectRepoHashAlgorithm(ctx context.Context, repoDir string) (HashAlgorithm
 	return HashAlgorithm(format), nil
 }
 
-// processDirectory recursively processes a stack or unit directory,
-// rewriting sources and creating synthetic CAS entries.
+// processDirectory recursively processes a stack or unit directory, rewriting
+// sources and creating synthetic CAS entries.
 func (c *CAS) processDirectory(
 	ctx context.Context, l log.Logger,
 	repoRoot, dirPath, refHash string, hashAlg HashAlgorithm,
@@ -143,8 +180,8 @@ func (c *CAS) processDirectory(
 	return nil
 }
 
-// processStackFile processes a terragrunt.stack.hcl file, rewriting sources for blocks
-// that have update_source_with_cas = true.
+// processStackFile processes a terragrunt.stack.hcl file, rewriting sources
+// for blocks that have update_source_with_cas = true.
 func (c *CAS) processStackFile(
 	ctx context.Context, l log.Logger,
 	repoRoot, dirPath, stackFile, refHash string, hashAlg HashAlgorithm,
@@ -202,8 +239,8 @@ func (c *CAS) processStackFile(
 	return os.WriteFile(stackFile, content, RegularFilePerms)
 }
 
-// processUnitFile processes a terragrunt.hcl file, rewriting the terraform.source
-// if update_source_with_cas is set.
+// processUnitFile processes a terragrunt.hcl file, rewriting the
+// terraform.source if update_source_with_cas is set.
 func (c *CAS) processUnitFile(l log.Logger, repoRoot, dirPath, unitFile, refHash string, hashAlg HashAlgorithm) error {
 	content, err := os.ReadFile(unitFile)
 	if err != nil {
@@ -250,21 +287,28 @@ func (c *CAS) processUnitFile(l log.Logger, repoRoot, dirPath, unitFile, refHash
 	return os.WriteFile(unitFile, content, RegularFilePerms)
 }
 
-// buildSyntheticTree creates a synthetic CAS tree entry for a directory.
-// It hashes all files, stores blobs, and creates a tree entry in the synth store.
-// The tree hash is deterministic: SHA1(refHash + relPathInRepo).
+// buildSyntheticTree creates a synthetic CAS tree entry for a directory. It
+// hashes every file, stores the blobs, and writes a tree object into the synth
+// store. The resulting tree hash is deterministic: hashAlg(refHash + relPathInRepo).
 func (c *CAS) buildSyntheticTree(
 	l log.Logger, dirPath, refHash, repoRoot string, hashAlg HashAlgorithm,
 ) (string, error) {
 	var treeData []byte
 
-	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
+	blobContent := NewContent(c.blobStore)
+
+	err := vfs.WalkDir(c.fs, dirPath, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
 
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
 		}
 
 		relPath, err := filepath.Rel(dirPath, path)
@@ -275,13 +319,11 @@ func (c *CAS) buildSyntheticTree(
 		// Convert to forward slashes for consistency (git-style paths)
 		relPath = strings.ReplaceAll(relPath, string(filepath.Separator), "/")
 
-		fileHash, err := hashFile(c.fs, path)
+		fileHash, err := hashFileAlg(c.fs, path, hashAlg)
 		if err != nil {
 			return fmt.Errorf("failed to hash file %s: %w", path, err)
 		}
 
-		// Store the blob
-		blobContent := NewContent(c.blobStore)
 		if err := blobContent.EnsureCopy(l, fileHash, path); err != nil {
 			return fmt.Errorf("failed to store blob %s: %w", path, err)
 		}
@@ -296,7 +338,7 @@ func (c *CAS) buildSyntheticTree(
 		return "", err
 	}
 
-	// Compute deterministic hash: SHA1(refHash + relPathInRepo)
+	// Compute deterministic hash: hashAlg(refHash + relPathInRepo)
 	relPathInRepo, err := filepath.Rel(repoRoot, dirPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to compute relative path for deterministic hash: %w", err)
@@ -352,24 +394,162 @@ func gitTreeMode(mode os.FileMode) string {
 	}
 }
 
-// DeterministicTreeHash generates a deterministic hash for a synthetic tree entry
-// by combining the resolved git ref hash with the path within the repository.
-// The hash algorithm is detected from the refHash length to match the repository's object format.
-func DeterministicTreeHash(refHash, pathInRepo string) string {
-	alg := DetectHashAlgorithm(refHash)
-
-	return alg.Sum([]byte(refHash + pathInRepo))
-}
-
-// SplitSourceDoubleSlash splits a source string at the // separator.
-// Returns the base path and the subdirectory (if any).
-// Example: "../..//modules/ec2" -> ("../../", "modules/ec2")
-// Example: "../../modules/ec2"  -> ("../../modules/ec2", "")
-func SplitSourceDoubleSlash(source string) (basePath, subdir string) {
-	idx := strings.Index(source, "//")
-	if idx == -1 {
-		return source, ""
+// isLocalPath reports whether source refers to an existing directory on the
+// local filesystem. Remote URLs, go-getter forcers (git::), SSH shorthand
+// (git@host:…), and non-directory paths all return false and fall through to
+// the remote processing flow.
+func isLocalPath(source string) bool {
+	if source == "" {
+		return false
 	}
 
-	return source[:idx], source[idx+2:]
+	if strings.HasPrefix(source, "git::") {
+		return false
+	}
+
+	// SSH shorthand like git@github.com:owner/repo.git — no scheme but not local.
+	if strings.Contains(source, "@") && strings.Contains(source, ":") && !filepath.IsAbs(source) {
+		return false
+	}
+
+	if u, err := url.Parse(source); err == nil && u.Scheme != "" {
+		return false
+	}
+
+	info, err := os.Stat(source)
+	if err != nil {
+		return false
+	}
+
+	return info.IsDir()
+}
+
+// processLocalStackComponent is the local-path analogue of the remote clone
+// flow. It copies the source tree into a temp directory so rewrites do not
+// mutate the caller's working tree, computes a content-addressed root hash,
+// and dispatches through the same processDirectory pipeline as the remote case.
+func (c *CAS) processLocalStackComponent(
+	ctx context.Context, l log.Logger, sourceDir, subdir string,
+) (*StackCASResult, error) {
+	absSource, err := filepath.Abs(sourceDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve local source %q: %w", sourceDir, err)
+	}
+
+	info, err := os.Stat(absSource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat local source %q: %w", absSource, err)
+	}
+
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%w: %s", ErrNotADirectory, absSource)
+	}
+
+	tempDir, err := os.MkdirTemp("", "terragrunt-cas-stack-local-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+
+	cleanup := func() {
+		_ = os.RemoveAll(tempDir)
+	}
+
+	repoRoot := filepath.Join(tempDir, "repo")
+
+	if err := c.copyTree(absSource, repoRoot); err != nil {
+		cleanup()
+
+		return nil, fmt.Errorf("failed to copy local source into temp dir: %w", err)
+	}
+
+	contentDir := repoRoot
+	if subdir != "" {
+		contentDir = filepath.Join(repoRoot, subdir)
+	}
+
+	if _, err := os.Stat(contentDir); err != nil {
+		cleanup()
+
+		return nil, fmt.Errorf("subdir %q not found in local source: %w", subdir, err)
+	}
+
+	rootHash, err := c.ComputeLocalRootHash(repoRoot, DefaultLocalHashAlgorithm)
+	if err != nil {
+		cleanup()
+
+		return nil, fmt.Errorf("failed to compute local root hash: %w", err)
+	}
+
+	if err := c.processDirectory(ctx, l, repoRoot, contentDir, rootHash, DefaultLocalHashAlgorithm); err != nil {
+		cleanup()
+
+		return nil, fmt.Errorf("failed to process local source for CAS: %w", err)
+	}
+
+	return &StackCASResult{
+		ContentDir: contentDir,
+		Cleanup:    cleanup,
+	}, nil
+}
+
+// copyTree copies the directory tree rooted at src into dst using c.fs for all
+// reads and writes, preserving file permissions. Regular files and directories
+// are copied; symlinks and other special files are skipped.
+func (c *CAS) copyTree(src, dst string) error {
+	return vfs.WalkDir(c.fs, src, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(dst, rel)
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return c.fs.MkdirAll(target, DefaultDirPerms)
+		}
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		if err := c.fs.MkdirAll(filepath.Dir(target), DefaultDirPerms); err != nil {
+			return err
+		}
+
+		in, err := c.fs.Open(path)
+		if err != nil {
+			return err
+		}
+
+		out, err := c.fs.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+		if err != nil {
+			_ = in.Close()
+
+			return err
+		}
+
+		if _, err := io.Copy(out, in); err != nil {
+			_ = in.Close()
+			_ = out.Close()
+
+			return err
+		}
+
+		if err := in.Close(); err != nil {
+			_ = out.Close()
+
+			return err
+		}
+
+		return out.Close()
+	})
 }

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -407,8 +407,15 @@ func isLocalPath(source string) bool {
 		return false
 	}
 
+	// Filesystem absolute paths must be classified as local before any URL
+	// parsing. On Windows, "C:\..." would otherwise be read as a URL with
+	// scheme "C" and routed to the remote flow.
+	if filepath.IsAbs(source) {
+		return true
+	}
+
 	// SSH shorthand like git@github.com:owner/repo.git — no scheme but not local.
-	if strings.Contains(source, "@") && strings.Contains(source, ":") && !filepath.IsAbs(source) {
+	if strings.Contains(source, "@") && strings.Contains(source, ":") {
 		return false
 	}
 
@@ -463,8 +470,22 @@ func (c *CAS) processLocalStackComponent(
 	}
 
 	contentDir := repoRoot
+
 	if subdir != "" {
-		contentDir = filepath.Join(repoRoot, subdir)
+		if filepath.IsAbs(subdir) {
+			cleanup()
+
+			return nil, fmt.Errorf("%w: %q", ErrSourceEscapesRepo, subdir)
+		}
+
+		contentDir = filepath.Clean(filepath.Join(repoRoot, subdir))
+
+		rel, err := filepath.Rel(repoRoot, contentDir)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			cleanup()
+
+			return nil, fmt.Errorf("%w: %q", ErrSourceEscapesRepo, subdir)
+		}
 	}
 
 	if _, err := os.Stat(contentDir); err != nil {
@@ -493,8 +514,8 @@ func (c *CAS) processLocalStackComponent(
 }
 
 // copyTree copies the directory tree rooted at src into dst using c.fs for all
-// reads and writes, preserving file permissions. Regular files and directories
-// are copied; symlinks and other special files are skipped.
+// reads and writes, preserving file permissions. Regular files, directories,
+// and symlinks are copied; other special files are skipped.
 func (c *CAS) copyTree(src, dst string) error {
 	return vfs.WalkDir(c.fs, src, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -517,39 +538,58 @@ func (c *CAS) copyTree(src, dst string) error {
 			return c.fs.MkdirAll(target, DefaultDirPerms)
 		}
 
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err := vfs.Readlink(c.fs, path)
+			if err != nil {
+				return err
+			}
+
+			if err := c.fs.MkdirAll(filepath.Dir(target), DefaultDirPerms); err != nil {
+				return err
+			}
+
+			return vfs.Symlink(c.fs, linkTarget, target)
+		}
+
 		if !info.Mode().IsRegular() {
 			return nil
 		}
 
-		if err := c.fs.MkdirAll(filepath.Dir(target), DefaultDirPerms); err != nil {
-			return err
-		}
-
-		in, err := c.fs.Open(path)
-		if err != nil {
-			return err
-		}
-
-		out, err := c.fs.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
-		if err != nil {
-			_ = in.Close()
-
-			return err
-		}
-
-		if _, err := io.Copy(out, in); err != nil {
-			_ = in.Close()
-			_ = out.Close()
-
-			return err
-		}
-
-		if err := in.Close(); err != nil {
-			_ = out.Close()
-
-			return err
-		}
-
-		return out.Close()
+		return c.copyFileInFS(path, target, info.Mode().Perm())
 	})
+}
+
+// copyFileInFS copies a single regular file from srcPath to dstPath through
+// c.fs, creating any missing parent directories with DefaultDirPerms.
+func (c *CAS) copyFileInFS(srcPath, dstPath string, perm fs.FileMode) error {
+	if err := c.fs.MkdirAll(filepath.Dir(dstPath), DefaultDirPerms); err != nil {
+		return err
+	}
+
+	in, err := c.fs.Open(srcPath)
+	if err != nil {
+		return err
+	}
+
+	out, err := c.fs.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		_ = in.Close()
+
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		_ = in.Close()
+		_ = out.Close()
+
+		return err
+	}
+
+	if err := in.Close(); err != nil {
+		_ = out.Close()
+
+		return err
+	}
+
+	return out.Close()
 }

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -544,6 +544,18 @@ func (c *CAS) copyTree(src, dst string) error {
 				return err
 			}
 
+			resolved := linkTarget
+			if !filepath.IsAbs(resolved) {
+				resolved = filepath.Join(filepath.Dir(path), resolved)
+			}
+
+			resolved = filepath.Clean(resolved)
+
+			rel, relErr := filepath.Rel(filepath.Clean(src), resolved)
+			if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				return fmt.Errorf("%w: symlink %q -> %q", ErrSourceEscapesRepo, path, linkTarget)
+			}
+
 			if err := c.fs.MkdirAll(filepath.Dir(target), DefaultDirPerms); err != nil {
 				return err
 			}

--- a/internal/cas/stacks_local_test.go
+++ b/internal/cas/stacks_local_test.go
@@ -331,6 +331,32 @@ func TestProcessStackComponent_LocalSource_MissingSubdir(t *testing.T) {
 	assert.Contains(t, err.Error(), "does-not-exist")
 }
 
+func TestProcessStackComponent_LocalSource_SymlinkEscapesRepo(t *testing.T) {
+	t.Parallel()
+
+	c := newCAS(t)
+	l := logger.CreateLogger()
+
+	tmp := helpers.TmpDirWOSymlinks(t)
+
+	outside := filepath.Join(tmp, "outside")
+	require.NoError(t, os.MkdirAll(outside, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret"), []byte("nope"), 0o644))
+
+	root := filepath.Join(tmp, "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "stacks", "my-stack"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "stacks", "my-stack", "terragrunt.stack.hcl"),
+		[]byte(""),
+		0o644,
+	))
+	require.NoError(t, os.Symlink(outside, filepath.Join(root, "escape")))
+
+	_, err := c.ProcessStackComponent(t.Context(), l, root+"//stacks/my-stack", "stack")
+	require.Error(t, err, "symlink pointing outside the source root must be rejected")
+	require.ErrorIs(t, err, cas.ErrSourceEscapesRepo)
+}
+
 // TestProcessStackComponent_EmptySourceFails exercises the empty-string
 // short-circuit in the local/remote dispatcher. An empty source cannot be a
 // valid local directory or a clonable URL, so it must be rejected.

--- a/internal/cas/stacks_local_test.go
+++ b/internal/cas/stacks_local_test.go
@@ -1,0 +1,434 @@
+package cas_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildLocalStackFixture lays out a directory tree on disk that mirrors the
+// structure used by the remote stack tests so we can exercise the same
+// processing pipeline against a local source. The returned path is the
+// repo-root; callers append "//stacks/my-stack" to target the stack.
+func buildLocalStackFixture(t *testing.T) string {
+	t.Helper()
+
+	root := helpers.TmpDirWOSymlinks(t)
+
+	write := func(rel, body string) {
+		full := filepath.Join(root, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+	}
+
+	write("stacks/my-stack/terragrunt.stack.hcl", `unit "service" {
+  source = "../..//units/my-service"
+
+  update_source_with_cas = true
+
+  path = "service"
+}
+
+unit "plain" {
+  source = "../../units/plain-service"
+  path   = "plain"
+}
+`)
+	write("units/my-service/terragrunt.hcl", `terraform {
+  source = "../..//modules/vpc"
+
+  update_source_with_cas = true
+}
+`)
+	write("units/plain-service/terragrunt.hcl", `terraform {
+  source = "../../modules/vpc"
+}
+`)
+	write("modules/vpc/main.tf", `resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+`)
+	write("modules/vpc/variables.tf", `variable "name" {
+  type = string
+}
+`)
+
+	return root
+}
+
+// snapshotTree reads every regular file under root and returns a sha256 of the
+// sorted (relpath, contents) pairs. Used to prove a run didn't mutate the
+// source tree.
+func snapshotTree(t *testing.T, root string) string {
+	t.Helper()
+
+	h := sha256.New()
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() || !info.Mode().IsRegular() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		h.Write([]byte(rel))
+		h.Write([]byte{0})
+		h.Write(body)
+		h.Write([]byte{0})
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func TestProcessStackComponent_LocalSource_RewritesStackSources(t *testing.T) {
+	t.Parallel()
+
+	root := buildLocalStackFixture(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	source := root + "//stacks/my-stack"
+
+	result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.NoError(t, err)
+
+	defer result.Cleanup()
+
+	stackFile := filepath.Join(result.ContentDir, "terragrunt.stack.hcl")
+	require.FileExists(t, stackFile)
+
+	content, err := os.ReadFile(stackFile)
+	require.NoError(t, err)
+
+	contentStr := string(content)
+
+	assert.Contains(t, contentStr, "cas::sha256:", "service unit source should be rewritten to a SHA-256 CAS ref")
+	assert.Contains(t, contentStr, "update_source_with_cas", "flag should be preserved")
+	assert.Contains(t, contentStr, `"../../units/plain-service"`, "plain unit source should be unchanged")
+}
+
+func TestProcessStackComponent_LocalSource_RewritesUnitSources(t *testing.T) {
+	t.Parallel()
+
+	root := buildLocalStackFixture(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	source := root + "//stacks/my-stack"
+
+	result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.NoError(t, err)
+
+	defer result.Cleanup()
+
+	// contentDir = <tmp>/repo/stacks/my-stack, so repo root is two dirs up.
+	repoCopy := filepath.Dir(filepath.Dir(result.ContentDir))
+	unitFile := filepath.Join(repoCopy, "units", "my-service", "terragrunt.hcl")
+	require.FileExists(t, unitFile)
+
+	content, err := os.ReadFile(unitFile)
+	require.NoError(t, err)
+
+	contentStr := string(content)
+
+	assert.Contains(t, contentStr, "cas::sha256:", "unit terraform source should be rewritten to a SHA-256 CAS ref")
+	assert.NotContains(t, contentStr, "modules/vpc", "module path should not appear in the rewritten source")
+}
+
+func TestProcessStackComponent_LocalSource_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	root := buildLocalStackFixture(t)
+	l := logger.CreateLogger()
+
+	before := snapshotTree(t, root)
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	source := root + "//stacks/my-stack"
+
+	result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.NoError(t, err)
+
+	result.Cleanup()
+
+	after := snapshotTree(t, root)
+	assert.Equal(t, before, after, "processing must not mutate the local source tree")
+}
+
+func TestProcessStackComponent_LocalSource_DeterministicOutput(t *testing.T) {
+	t.Parallel()
+
+	root := buildLocalStackFixture(t)
+	l := logger.CreateLogger()
+
+	readStackFile := func() string {
+		storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+		c, err := cas.New(cas.WithStorePath(storePath))
+		require.NoError(t, err)
+
+		source := root + "//stacks/my-stack"
+
+		result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+		require.NoError(t, err)
+
+		defer result.Cleanup()
+
+		content, err := os.ReadFile(filepath.Join(result.ContentDir, "terragrunt.stack.hcl"))
+		require.NoError(t, err)
+
+		return string(content)
+	}
+
+	first := readStackFile()
+	second := readStackFile()
+
+	assert.Equal(t, first, second, "processing the same local source twice should produce identical output")
+}
+
+func TestProcessStackComponent_LocalSource_ContentAddressedCacheKey(t *testing.T) {
+	t.Parallel()
+
+	// Two fixtures with the same relative layout but different module contents
+	// must yield different synthetic tree hashes — otherwise one source would
+	// poison the cache for the other.
+	rootA := buildLocalStackFixture(t)
+	rootB := buildLocalStackFixture(t)
+
+	// Mutate B's module to make it materially different.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(rootB, "modules", "vpc", "main.tf"),
+		[]byte(`resource "aws_vpc" "different" {
+  cidr_block = "192.168.0.0/16"
+}
+`), 0o644))
+
+	l := logger.CreateLogger()
+
+	runAndExtractServiceRef := func(root string) string {
+		storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+		c, err := cas.New(cas.WithStorePath(storePath))
+		require.NoError(t, err)
+
+		source := root + "//stacks/my-stack"
+
+		result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+		require.NoError(t, err)
+
+		defer result.Cleanup()
+
+		content, err := os.ReadFile(filepath.Join(result.ContentDir, "terragrunt.stack.hcl"))
+		require.NoError(t, err)
+
+		blocks, err := cas.ReadStackBlocks(content)
+		require.NoError(t, err)
+
+		for _, b := range blocks {
+			if b.Name == "service" {
+				return b.Source
+			}
+		}
+
+		t.Fatal("service block not found")
+
+		return ""
+	}
+
+	refA := runAndExtractServiceRef(rootA)
+	refB := runAndExtractServiceRef(rootB)
+
+	require.True(t, strings.HasPrefix(refA, "cas::sha256:"))
+	require.True(t, strings.HasPrefix(refB, "cas::sha256:"))
+	assert.NotEqual(t, refA, refB, "different module contents must produce different CAS refs")
+
+	// And identical content at a fresh path must re-hash to the same ref.
+	rootC := buildLocalStackFixture(t)
+	refC := runAndExtractServiceRef(rootC)
+	assert.Equal(t, refA, refC, "identical content at a different absolute path must hash identically")
+}
+
+func TestProcessStackComponent_LocalSource_NonExistentPath(t *testing.T) {
+	t.Parallel()
+
+	c := newCAS(t)
+	l := logger.CreateLogger()
+
+	// Absolute path that does not exist — must not be misinterpreted as a URL.
+	source := filepath.Join(helpers.TmpDirWOSymlinks(t), "does-not-exist")
+
+	_, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.Error(t, err, "non-existent local path must fail")
+}
+
+func TestProcessStackComponent_LocalSource_RegularFileRejected(t *testing.T) {
+	t.Parallel()
+
+	c := newCAS(t)
+	l := logger.CreateLogger()
+
+	// A regular file is not a valid component source. isLocalPath returns false
+	// for files, so this falls through to the remote flow and fails at URL
+	// parsing / ls-remote — either way, it must return an error rather than
+	// silently succeeding.
+	tmp := helpers.TmpDirWOSymlinks(t)
+	filePath := filepath.Join(tmp, "a-file")
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o644))
+
+	_, err := c.ProcessStackComponent(t.Context(), l, filePath, "stack")
+	require.Error(t, err, "a regular file must not be accepted as a component source")
+}
+
+func TestProcessStackComponent_LocalSource_MissingSubdir(t *testing.T) {
+	t.Parallel()
+
+	c := newCAS(t)
+	l := logger.CreateLogger()
+
+	root := buildLocalStackFixture(t)
+	source := root + "//stacks/does-not-exist"
+
+	_, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.Error(t, err, "missing subdir inside a local source must fail")
+	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+// TestProcessStackComponent_EmptySourceFails exercises the empty-string
+// short-circuit in the local/remote dispatcher. An empty source cannot be a
+// valid local directory or a clonable URL, so it must be rejected.
+func TestProcessStackComponent_EmptySourceFails(t *testing.T) {
+	t.Parallel()
+
+	c := newCAS(t)
+	l := logger.CreateLogger()
+
+	_, err := c.ProcessStackComponent(t.Context(), l, "", "stack")
+	require.Error(t, err, "empty source must be rejected")
+}
+
+// TestProcessStackComponent_GitForcerRoutesRemote confirms that a source with
+// a "git::" forcer is treated as remote even though the rest of the string
+// could parse as a path. The in-process test server stands in for a real
+// remote, so the full remote flow runs end-to-end and must succeed.
+func TestProcessStackComponent_GitForcerRoutesRemote(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	source := "git::" + repoURL + "//stacks/my-stack?ref=main"
+
+	result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.NoError(t, err, "git:: forcer must route through the remote flow and succeed against the test server")
+
+	defer result.Cleanup()
+
+	assert.DirExists(t, result.ContentDir)
+}
+
+// TestProcessStackComponent_SSHShorthandRoutesRemote confirms that SSH
+// shorthand (git@host:path) is treated as remote, not local. The test runs
+// inside a synctest bubble so the context deadline fires on the synthetic
+// clock the moment every bubbled goroutine is idle — no real-time wait, no
+// dependency on DNS or network behavior. All we care about here is which
+// branch of the dispatcher the source was routed through; we assert the
+// error originated in the remote pipeline, not the local one.
+func TestProcessStackComponent_SSHShorthandRoutesRemote(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		c := newCAS(t)
+		l := logger.CreateLogger()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+		defer cancel()
+
+		_, err := c.ProcessStackComponent(ctx, l, "git@unreachable.invalid:owner/repo.git", "stack")
+		require.Error(t, err, "SSH shorthand must route through the remote flow and fail there")
+		assert.NotContains(t, err.Error(), "local source", "error must come from the remote pipeline")
+	})
+}
+
+func TestProcessStackComponent_LocalSource_MaterializeSynthTree(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	root := buildLocalStackFixture(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	source := root + "//stacks/my-stack"
+
+	result, err := c.ProcessStackComponent(ctx, l, source, "stack")
+	require.NoError(t, err)
+
+	defer result.Cleanup()
+
+	stackContent, err := os.ReadFile(filepath.Join(result.ContentDir, "terragrunt.stack.hcl"))
+	require.NoError(t, err)
+
+	blocks, err := cas.ReadStackBlocks(stackContent)
+	require.NoError(t, err)
+
+	var serviceSource string
+
+	for _, b := range blocks {
+		if b.Name == "service" {
+			serviceSource = b.Source
+
+			break
+		}
+	}
+
+	require.NotEmpty(t, serviceSource)
+
+	trimmed := strings.TrimPrefix(serviceSource, "cas::")
+	hash, err := cas.ParseCASRef(trimmed)
+	require.NoError(t, err)
+
+	destDir := helpers.TmpDirWOSymlinks(t)
+	require.NoError(t, c.MaterializeTree(ctx, l, hash, destDir))
+
+	assert.FileExists(t, filepath.Join(destDir, "terragrunt.hcl"))
+}

--- a/internal/cas/stacks_local_test.go
+++ b/internal/cas/stacks_local_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,8 +70,8 @@ unit "plain" {
 }
 
 // snapshotTree reads every regular file under root and returns a sha256 of the
-// sorted (relpath, contents) pairs. Used to prove a run didn't mutate the
-// source tree.
+// (relpath, mode, contents) triples in walk order. Used to prove a run didn't
+// mutate the source tree, including file permissions.
 func snapshotTree(t *testing.T, root string) string {
 	t.Helper()
 
@@ -96,6 +97,8 @@ func snapshotTree(t *testing.T, root string) string {
 		}
 
 		h.Write([]byte(rel))
+		h.Write([]byte{0})
+		h.Write([]byte(info.Mode().String()))
 		h.Write([]byte{0})
 		h.Write(body)
 		h.Write([]byte{0})
@@ -293,6 +296,7 @@ func TestProcessStackComponent_LocalSource_NonExistentPath(t *testing.T) {
 
 	_, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
 	require.Error(t, err, "non-existent local path must fail")
+	require.ErrorIs(t, err, fs.ErrNotExist, "error must be a local file-not-found error")
 }
 
 func TestProcessStackComponent_LocalSource_RegularFileRejected(t *testing.T) {
@@ -301,10 +305,10 @@ func TestProcessStackComponent_LocalSource_RegularFileRejected(t *testing.T) {
 	c := newCAS(t)
 	l := logger.CreateLogger()
 
-	// A regular file is not a valid component source. isLocalPath returns false
-	// for files, so this falls through to the remote flow and fails at URL
-	// parsing / ls-remote — either way, it must return an error rather than
-	// silently succeeding.
+	// A regular file is not a valid component source. The local flow rejects
+	// non-directories with ErrNotADirectory; the remote flow would fail at URL
+	// parsing / ls-remote. Either way, the call must return an error rather
+	// than silently succeeding.
 	tmp := helpers.TmpDirWOSymlinks(t)
 	filePath := filepath.Join(tmp, "a-file")
 	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o644))

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -126,6 +126,18 @@ func Symlink(fs FS, oldname, newname string) error {
 	return linker.SymlinkIfPossible(oldname, newname)
 }
 
+// Readlink reads the target of a symbolic link. It uses afero's
+// ReadlinkIfPossible which is supported by OsFs and any FS implementing
+// afero.Symlinker.
+func Readlink(fs FS, name string) (string, error) {
+	reader, ok := fs.(afero.Symlinker)
+	if !ok {
+		return "", &os.PathError{Op: "readlink", Path: name, Err: afero.ErrNoSymlink}
+	}
+
+	return reader.ReadlinkIfPossible(name)
+}
+
 // Lock acquires a blocking lock for the given name on the filesystem.
 func Lock(fs FS, name string) (Unlocker, error) {
 	locker, ok := fs.(Locker)

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -491,10 +491,6 @@ func fetchComponentSource(
 		}
 
 		l.Warnf("CAS processing failed for %s %q: %v. Falling back to standard getter.", kindStr, cmp.name, casErr)
-
-		if cleanupErr := os.RemoveAll(dest); cleanupErr != nil && !os.IsNotExist(cleanupErr) {
-			l.Debugf("Failed to clean partial CAS destination %s: %v", dest, cleanupErr)
-		}
 	}
 
 	if err := copyFiles(ctx, l, cmp.name, cmp.sourceDir, source, dest); err != nil {
@@ -534,9 +530,20 @@ func fetchViaCAS(
 
 	defer result.Cleanup()
 
-	return util.CopyFolderContentsWithFilter(l, result.ContentDir, dest, manifestName, func(_ string) bool {
+	// A copy failure can leave partial content in dest, so reset it before
+	// falling through to the standard getter. ProcessStackComponent writes only
+	// to its own temp dir, so failures before this point never touch dest.
+	if copyErr := util.CopyFolderContentsWithFilter(l, result.ContentDir, dest, manifestName, func(_ string) bool {
 		return true
-	})
+	}); copyErr != nil {
+		if cleanupErr := os.RemoveAll(dest); cleanupErr != nil && !os.IsNotExist(cleanupErr) {
+			l.Debugf("Failed to clean partial CAS destination %s: %v", dest, cleanupErr)
+		}
+
+		return copyErr
+	}
+
+	return nil
 }
 
 // isCASProtocol checks if a source string uses the CAS protocol (cas::sha1:<hash>).

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -441,12 +441,13 @@ func generateComponent(ctx context.Context, l log.Logger, opts *generateOpts, cm
 }
 
 // fetchComponentSource handles the paths for fetching a component's source:
-//  1. cas:: protocol source: materialize the CAS tree directly. Must run before the remote-CAS
-//     branch so nested components already rewritten to cas:: are not passed to git clone.
-//  2. Remote source with CAS enabled: attempt a CAS-backed clone and copy from a temp dir. This
-//     fires automatically when the cas experiment is on and the source isn't local, so catalog
-//     authors don't need consumers to opt in per-block. On any CAS failure (for example, CAS
-//     can't handle a go-getter query param like depth=1), we fall through to the standard getter.
+//  1. cas:: protocol source: materialize the CAS tree directly. Must run before the CAS-backed
+//     branch so nested components already rewritten to cas:: are not re-fetched.
+//  2. Source with CAS enabled: attempt a CAS-backed fetch (remote clone or local copy into a
+//     temp overlay) and copy from its content dir. This fires automatically whenever the cas
+//     experiment is on, so catalog authors don't need consumers to opt in per-block. On any CAS
+//     failure (for example, CAS can't handle a go-getter query param like depth=1), we fall
+//     through to the standard getter.
 //  3. Standard: local copy or remote getter.
 //
 // The update_source_with_cas attribute on a consumer block is a no-op under path 2. It only
@@ -483,7 +484,7 @@ func fetchComponentSource(
 		return nil
 	}
 
-	if opts.casEnabled && !isLocal(l, cmp.sourceDir, source) {
+	if opts.casEnabled {
 		casErr := fetchViaCAS(ctx, l, opts, kindStr, source, dest)
 		if casErr == nil {
 			return nil
@@ -517,7 +518,9 @@ func fetchComponentSource(
 	return nil
 }
 
-// fetchViaCAS performs the CAS-backed clone, rewrite, and copy for a remote stack component.
+// fetchViaCAS performs the CAS-backed fetch, rewrite, and copy for a stack component.
+// For remote sources the fetch is a CAS-backed git clone; for local sources it is a
+// copy into a temp overlay so rewrites do not mutate the caller's working tree.
 func fetchViaCAS(
 	ctx context.Context,
 	l log.Logger,

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -485,7 +485,7 @@ func fetchComponentSource(
 	}
 
 	if opts.casEnabled {
-		casErr := fetchViaCAS(ctx, l, opts, kindStr, source, dest)
+		casErr := fetchViaCAS(ctx, l, opts, cmp.sourceDir, kindStr, source, dest)
 		if casErr == nil {
 			return nil
 		}
@@ -521,9 +521,11 @@ func fetchViaCAS(
 	ctx context.Context,
 	l log.Logger,
 	opts *generateOpts,
-	kindStr, source, dest string,
+	sourceDir, kindStr, source, dest string,
 ) error {
-	result, err := opts.casInstance.ProcessStackComponent(ctx, l, source, kindStr)
+	resolvedSource := resolveLocalCASSource(l, sourceDir, source)
+
+	result, err := opts.casInstance.ProcessStackComponent(ctx, l, resolvedSource, kindStr)
 	if err != nil {
 		return err
 	}
@@ -544,6 +546,33 @@ func fetchViaCAS(
 	}
 
 	return nil
+}
+
+// resolveLocalCASSource normalizes a relative local source against sourceDir so
+// ProcessStackComponent's filepath.Abs/Stat resolve against the stack file
+// rather than the process CWD. Remote sources, absolute paths, and any source
+// that doesn't look like a local path are returned unchanged. The "//" subdir
+// suffix used by go-getter is preserved.
+func resolveLocalCASSource(l log.Logger, sourceDir, source string) string {
+	if source == "" || sourceDir == "" {
+		return source
+	}
+
+	basePath, subdir := getter.SourceDirSubdir(source)
+	if filepath.IsAbs(basePath) || !isLocal(l, sourceDir, basePath) {
+		return source
+	}
+
+	abs, err := filepath.Abs(filepath.Join(sourceDir, basePath))
+	if err != nil {
+		return source
+	}
+
+	if subdir != "" {
+		return abs + "//" + subdir
+	}
+
+	return abs
 }
 
 // isCASProtocol checks if a source string uses the CAS protocol (cas::sha1:<hash>).

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -2370,3 +2370,119 @@ func TestCASInStacksRejectsUpdateSourceWithCASWithNoCAS(t *testing.T) {
 		})
 	}
 }
+
+// TestCASInStacksLocalSource verifies that CAS processing works end-to-end
+// when the top-level stack source is a local filesystem path rather than a
+// remote git URL. The catalog-like tree lives on disk, the live stack points
+// at it directly, and update_source_with_cas on nested blocks must be
+// rewritten to cas::sha256 references that materialize correctly at run time.
+func TestCASInStacksLocalSource(t *testing.T) {
+	t.Parallel()
+
+	if !helpers.IsExperimentMode(t) {
+		t.Skip("Experiment mode is not enabled")
+	}
+
+	// Keep the catalog on a sibling path outside the live working directory so
+	// terragrunt stack generate doesn't discover the catalog's stack file as a
+	// top-level entry and recurse into it alongside the live stack.
+	catalog := helpers.TmpDirWOSymlinks(t)
+	liveDir := helpers.TmpDirWOSymlinks(t)
+
+	writeFile := func(rel, body string) {
+		full := filepath.Join(catalog, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0644))
+	}
+
+	writeFile("modules/baz/main.tf", ``)
+
+	writeFile("units/bar/terragrunt.hcl", `terraform {
+  source = "../..//modules/baz"
+
+  update_source_with_cas = true
+}
+`)
+
+	writeFile("stacks/foo/terragrunt.stack.hcl", `unit "bar" {
+  source = "../..//units/bar"
+  path   = "bar"
+
+  update_source_with_cas = true
+}
+`)
+
+	liveStack := fmt.Sprintf(`stack "foo" {
+  source = "%s//stacks/foo"
+  path   = "foo"
+
+  update_source_with_cas = true
+}
+`, catalog)
+	require.NoError(t, os.WriteFile(filepath.Join(liveDir, "terragrunt.stack.hcl"), []byte(liveStack), 0644))
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack generate --working-dir "+liveDir,
+	)
+	require.NoError(t, err)
+
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack run plan --non-interactive --working-dir "+liveDir,
+	)
+	require.NoError(t, err)
+
+	runLog := stdout + stderr
+	assert.Contains(t, runLog, ".terragrunt-stack/foo")
+
+	stackDir := filepath.Join(liveDir, ".terragrunt-stack")
+	assert.DirExists(t, stackDir)
+
+	expectedFiles := []string{
+		"foo/terragrunt.stack.hcl",
+		"foo/.terragrunt-stack/bar/terragrunt.hcl",
+	}
+
+	for _, expectedFile := range expectedFiles {
+		assert.FileExists(t, filepath.Join(stackDir, expectedFile))
+	}
+
+	stackConfig := filepath.Join(stackDir, "foo", "terragrunt.stack.hcl")
+	unitConfig := filepath.Join(stackDir, "foo", ".terragrunt-stack", "bar", "terragrunt.hcl")
+
+	stackConfigContent, err := os.ReadFile(stackConfig)
+	require.NoError(t, err)
+	unitConfigContent, err := os.ReadFile(unitConfig)
+	require.NoError(t, err)
+
+	stackStr := string(stackConfigContent)
+	unitStr := string(unitConfigContent)
+
+	// Local sources are content-addressed with SHA-256.
+	casSHA256Quoted := regexp.MustCompile(`"cas::sha256:([a-f0-9]{64})"`)
+
+	stackMatch := casSHA256Quoted.FindStringSubmatch(stackStr)
+	require.Len(t, stackMatch, 2, "generated stack should contain exactly one cas::sha256 reference")
+
+	unitMatch := casSHA256Quoted.FindStringSubmatch(unitStr)
+	require.Len(t, unitMatch, 2, "generated unit terragrunt should contain exactly one cas::sha256 reference")
+
+	wantStack := fmt.Sprintf(`unit "bar" {
+  source = "cas::sha256:%s"
+  path   = "bar"
+
+  update_source_with_cas = true
+}
+`, stackMatch[1])
+
+	wantUnit := fmt.Sprintf(`terraform {
+  source = "cas::sha256:%s"
+
+  update_source_with_cas = true
+}
+`, unitMatch[1])
+
+	assert.Equal(t, wantStack, stackStr)
+	assert.Equal(t, wantUnit, unitStr)
+}

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -2413,12 +2414,12 @@ func TestCASInStacksLocalSource(t *testing.T) {
 `)
 
 	liveStack := fmt.Sprintf(`stack "foo" {
-  source = "%s//stacks/foo"
+  source = %s
   path   = "foo"
 
   update_source_with_cas = true
 }
-`, catalog)
+`, strconv.Quote(filepath.ToSlash(catalog)+"//stacks/foo"))
 	require.NoError(t, os.WriteFile(filepath.Join(liveDir, "terragrunt.stack.hcl"), []byte(liveStack), 0644))
 
 	_, _, err := helpers.RunTerragruntCommandWithOutput(


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds support for local paths in CAS.

Instead of falling back to the existing behavior for local paths, the CAS will now persist the contents of the source, then reproduce the contents from the content store.

This avoid unnecessary disk bloat for users leveraging sources on the local filesystem.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support local filesystem paths as stack sources alongside remote Git URLs; local catalogs are copied to a temp area and rewritten to CAS-backed references.

* **Documentation**
  * Added docs and changelog entries describing local stack-source behavior, temp-directory processing, CAS content-addressing (SHA-256), and preservation of the original catalog.

* **Tests**
  * Added unit, race, and integration tests covering deterministic CAS hashes, non-mutating behavior, concurrency, and local-source processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->