### PR TITLE
optimize "Downloading Terraform configurations" step

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/bmatcuk/doublestar v1.3.4 // indirect
+	github.com/bmatcuk/doublestar v1.3.4
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -310,7 +310,7 @@ func PathOrAncestorMatchesAny(relativePath string, patterns []string) bool {
 	ancestor := relativePath
 	for {
 		ancestor = path.Dir(ancestor)
-		if ancestor == "." || ancestor == "" {
+		if ancestor == "." || ancestor == "" || ancestor == "/" {
 			return false
 		}
 
@@ -384,6 +384,15 @@ func CopyFolderContents(
 		}
 
 		includeExpandedGlobs = append(includeExpandedGlobs, expandGlob...)
+	}
+
+	// Validate exclude patterns early so malformed globs (e.g. unbalanced
+	// brackets) surface as configuration errors rather than silently
+	// matching nothing during the walk.
+	for _, pattern := range excludeFromCopy {
+		if _, err := doublestar.Match(pattern, "."); err != nil {
+			return errors.Errorf("invalid exclude_from_copy pattern %q: %w", pattern, err)
+		}
 	}
 
 	// Exclude patterns are evaluated lazily during the copy walk using

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -10,11 +10,13 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"syscall"
 
+	"github.com/bmatcuk/doublestar"
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
@@ -283,6 +285,43 @@ func pathContainsPrefix(path string, prefixes []string) bool {
 	return false
 }
 
+// PathOrAncestorMatchesAny reports whether relativePath or any of its ancestor
+// directories matches at least one of the given glob patterns. Both patterns
+// and relativePath must use forward slashes.
+//
+// This enables lazy exclude evaluation: instead of pre-expanding every exclude
+// glob into a flat path list (which requires walking the entire source tree
+// once per pattern), we evaluate patterns on-the-fly during the copy walk.
+func PathOrAncestorMatchesAny(relativePath string, patterns []string) bool {
+	if len(patterns) == 0 {
+		return false
+	}
+
+	// Check the full path itself.
+	for _, p := range patterns {
+		if matched, _ := doublestar.Match(p, relativePath); matched {
+			return true
+		}
+	}
+
+	// Walk up the directory tree checking each ancestor. This propagates
+	// directory-level matches to their descendants (e.g. pattern **/.terraform
+	// excludes everything under any .terraform directory).
+	ancestor := relativePath
+	for {
+		ancestor = path.Dir(ancestor)
+		if ancestor == "." || ancestor == "" {
+			return false
+		}
+
+		for _, p := range patterns {
+			if matched, _ := doublestar.Match(p, ancestor); matched {
+				return true
+			}
+		}
+	}
+}
+
 // Takes apbsolute glob path and returns an array of expanded relative paths
 func expandGlobPath(source, absoluteGlobPath string) ([]string, error) {
 	includeExpandedGlobs := []string{}
@@ -347,18 +386,18 @@ func CopyFolderContents(
 		includeExpandedGlobs = append(includeExpandedGlobs, expandGlob...)
 	}
 
-	excludeExpandedGlobs := []string{}
-
-	for _, excludeGlob := range excludeFromCopy {
-		globPath := filepath.Join(source, excludeGlob)
-
-		expandGlob, err := expandGlobPath(source, globPath)
-		if err != nil {
-			return errors.New(err)
-		}
-
-		excludeExpandedGlobs = append(excludeExpandedGlobs, expandGlob...)
-	}
+	// Exclude patterns are evaluated lazily during the copy walk using
+	// PathOrAncestorMatchesAny. This avoids the previous approach of
+	// pre-expanding every exclude glob via zglob.Glob, which walked the
+	// entire source tree once per pattern — including into heavy directories
+	// like .terragrunt-cache and .terraform — before filtering them out.
+	//
+	// For a monorepo where terraform/ is the package root, the old approach
+	// performed O(patterns × tree_size) stat calls upfront (e.g., 7 full
+	// walks of a 2 GB tree). The lazy approach checks each path and its
+	// ancestors against the patterns during the copy walk itself, turning
+	// that into O(files_copied × patterns × depth) glob match operations
+	// with no upfront I/O cost.
 
 	return CopyFolderContentsWithFilter(l, source, destination, manifestFile, func(absolutePath string) bool {
 		relativePath, err := GetPathRelativeTo(absolutePath, source)
@@ -367,14 +406,14 @@ func CopyFolderContents(
 		}
 
 		relativePath = filepath.ToSlash(relativePath)
-		pathHasPrefix := pathContainsPrefix(relativePath, excludeExpandedGlobs)
+		excluded := PathOrAncestorMatchesAny(relativePath, excludeFromCopy)
 
 		listHasElementWithPrefix := listContainsElementWithPrefix(includeExpandedGlobs, relativePath)
-		if listHasElementWithPrefix && !pathHasPrefix {
+		if listHasElementWithPrefix && !excluded {
 			return true
 		}
 
-		if pathHasPrefix {
+		if excluded {
 			return false
 		}
 
@@ -405,27 +444,44 @@ func CopyFolderContentsWithFilter(l log.Logger, source, destination, manifestFil
 		}
 	}(manifest)
 
-	// Why use filepath.Glob here? The original implementation used os.ReadDir, but that method calls lstat on all
-	// the files/folders in the directory, including files/folders you may want to explicitly skip. The next attempt
-	// was to use filepath.Walk, but that doesn't work because it ignores symlinks. So, now we turn to filepath.Glob.
-	files, err := filepath.Glob(source + "/*")
+	// os.ReadDir returns DirEntry values whose Type() method gets the file
+	// type directly from the directory-listing syscall (getdents64 on Linux,
+	// getdirentries on macOS) without an extra lstat per entry.
+	//
+	// Historical note: the original implementation used os.ReadDir, was
+	// switched to filepath.Walk (which ignores symlinks), and then to
+	// filepath.Glob. Since Go 1.16, os.ReadDir returns lightweight DirEntry
+	// values that do NOT call lstat — the earlier concern no longer applies.
+	// Symlinks are handled explicitly below.
+	entries, err := os.ReadDir(source)
 	if err != nil {
 		return errors.New(err)
 	}
 
-	for _, file := range files {
-		fileRelativePath, err := GetPathRelativeTo(file, source)
-		if err != nil {
-			return err
-		}
+	for _, entry := range entries {
+		file := filepath.Join(source, entry.Name())
 
 		if !filter(file) {
 			continue
 		}
 
-		dest := filepath.Join(destination, fileRelativePath)
+		dest := filepath.Join(destination, entry.Name())
 
-		if IsDir(file) {
+		// Determine if this entry is a directory. For symlinks, follow the
+		// link to check the target type — this matches the original behavior
+		// where filepath.Glob returned the path and IsDir (os.Stat) followed
+		// symlinks.
+		isDir := entry.IsDir()
+		if entry.Type()&os.ModeSymlink != 0 {
+			info, err := os.Stat(file)
+			if err != nil {
+				return errors.New(err)
+			}
+
+			isDir = info.IsDir()
+		}
+
+		if isDir {
 			info, err := os.Lstat(file)
 			if err != nil {
 				return errors.New(err)

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -418,6 +418,7 @@ func TestPathOrAncestorMatchesAny(t *testing.T) {
 		{"wildcard no match", "dotcom/dev/output.txt", []string{"**/*.log"}, false},
 		{"multiple patterns first match", "node_modules/foo", []string{"**/dist", "**/node_modules"}, true},
 		{"multiple patterns second match", "build/dist/bundle.js", []string{"**/dist", "**/node_modules"}, true},
+		{"absolute root terminates", "/foo/bar", []string{"baz"}, false},
 	}
 
 	for _, tc := range testCases {
@@ -430,27 +431,24 @@ func TestPathOrAncestorMatchesAny(t *testing.T) {
 	}
 }
 
-func TestExcludeFromCopyLazy(t *testing.T) {
+func TestExcludeFromCopyNoPartialPrefixMatch(t *testing.T) {
 	t.Parallel()
 
-	// Verify that the lazy exclude matching produces the same results as the
-	// pre-expansion approach by reusing the same test structure.
-	excludeFromCopy := []string{"module/region2", "**/exclude-me-here", "**/app1"}
+	// Verify that the lazy exclude matching does not false-positive on paths
+	// that share a common string prefix with an excluded path but are not
+	// actually under it (e.g. "module/region2" must NOT exclude
+	// "module/region2more").
+	excludeFromCopy := []string{"module/region2"}
 
 	testCases := []struct {
 		path         string
 		copyExpected bool
 	}{
-		{"/app/terragrunt.hcl", true},
-		{"/module/main.tf", true},
-		{"/module/region1/info.txt", true},
-		{"/module/region1/project2-1/app1/f2-dot-f2.txt", false},
-		{"/module/region3/project3-1/f1-2-levels.txt", true},
-		{"/module/region3/project3-1/app1/exclude-me-here/file.txt", false},
-		{"/module/region3/project3-2/f0/f0-3-levels.txt", true},
-		{"/module/region2/project2-1/app2/f2-dot-f2.txt", false},
-		{"/module/region2/project2-1/readme.txt", false},
-		{"/module/region2/project2-2/f2-dot-f0.txt", false},
+		{"/module/region2/file.txt", false},
+		{"/module/region2/sub/deep.txt", false},
+		{"/module/region2more/file.txt", true},
+		{"/module/region20/file.txt", true},
+		{"/module/region1/file.txt", true},
 	}
 
 	tempDir := helpers.TmpDirWOSymlinks(t)

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -396,6 +396,145 @@ func TestExcludeIncludeBehaviourPriority(t *testing.T) {
 	}
 }
 
+func TestPathOrAncestorMatchesAny(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		path     string
+		patterns []string
+		expected bool
+	}{
+		{"empty patterns", "foo/bar", nil, false},
+		{"exact match", "module/region2", []string{"module/region2"}, true},
+		{"no match", "module/region1", []string{"module/region2"}, false},
+		{"doublestar exact", ".terraform", []string{"**/.terraform"}, true},
+		{"doublestar nested", "dotcom/dev/myservice/.terraform", []string{"**/.terraform"}, true},
+		{"doublestar child propagation", "dotcom/dev/.terraform/providers/aws", []string{"**/.terraform"}, true},
+		{"doublestar no false positive", "dotcom/dev/.terraformrc", []string{"**/.terraform"}, false},
+		{"concrete child propagation", "module/region2/subdir/file.txt", []string{"module/region2"}, true},
+		{"concrete no partial match", "module/region2more", []string{"module/region2"}, false},
+		{"wildcard pattern", "dotcom/dev/output.log", []string{"**/*.log"}, true},
+		{"wildcard no match", "dotcom/dev/output.txt", []string{"**/*.log"}, false},
+		{"multiple patterns first match", "node_modules/foo", []string{"**/dist", "**/node_modules"}, true},
+		{"multiple patterns second match", "build/dist/bundle.js", []string{"**/dist", "**/node_modules"}, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := util.PathOrAncestorMatchesAny(tc.path, tc.patterns)
+			assert.Equal(t, tc.expected, actual, "For path %s and patterns %v", tc.path, tc.patterns)
+		})
+	}
+}
+
+func TestExcludeFromCopyLazy(t *testing.T) {
+	t.Parallel()
+
+	// Verify that the lazy exclude matching produces the same results as the
+	// pre-expansion approach by reusing the same test structure.
+	excludeFromCopy := []string{"module/region2", "**/exclude-me-here", "**/app1"}
+
+	testCases := []struct {
+		path         string
+		copyExpected bool
+	}{
+		{"/app/terragrunt.hcl", true},
+		{"/module/main.tf", true},
+		{"/module/region1/info.txt", true},
+		{"/module/region1/project2-1/app1/f2-dot-f2.txt", false},
+		{"/module/region3/project3-1/f1-2-levels.txt", true},
+		{"/module/region3/project3-1/app1/exclude-me-here/file.txt", false},
+		{"/module/region3/project3-2/f0/f0-3-levels.txt", true},
+		{"/module/region2/project2-1/app2/f2-dot-f2.txt", false},
+		{"/module/region2/project2-1/readme.txt", false},
+		{"/module/region2/project2-2/f2-dot-f0.txt", false},
+	}
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	source := filepath.Join(tempDir, "source")
+	destination := filepath.Join(tempDir, "destination")
+
+	fileContent := []byte("source file")
+
+	for _, tc := range testCases {
+		path := filepath.Join(source, tc.path)
+		assert.NoError(t, os.MkdirAll(filepath.Dir(path), os.ModePerm))
+		assert.NoError(t, os.WriteFile(path, fileContent, 0o644))
+	}
+
+	require.NoError(t, util.CopyFolderContents(logger.CreateLogger(), source, destination, ".terragrunt-test", nil, excludeFromCopy))
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			_, err := os.Stat(filepath.Join(destination, tc.path))
+			assert.True(t,
+				tc.copyExpected && err == nil ||
+					!tc.copyExpected && errors.Is(err, os.ErrNotExist),
+				"Unexpected copy result for file '%s' (should be copied: '%t') - got error: %s", tc.path, tc.copyExpected, err)
+		})
+	}
+}
+
+// BenchmarkCopyFolderWithDeepExcludes measures the performance of
+// CopyFolderContents when the source tree contains large excluded directories
+// (simulating .terragrunt-cache and .terraform). The lazy exclude matching
+// should be significantly faster than pre-expanding exclude globs.
+func BenchmarkCopyFolderWithDeepExcludes(b *testing.B) {
+	// Create a source tree:
+	// - 50 small module directories (2 files each)
+	// - 5 large .terragrunt-cache directories (100 files each)
+	// - 5 .terraform directories (50 files each)
+	tempDir := b.TempDir()
+	source := filepath.Join(tempDir, "source")
+	fileContent := []byte("module content")
+
+	for i := range 50 {
+		dir := filepath.Join(source, "modules", fmt.Sprintf("mod%d", i))
+		require.NoError(b, os.MkdirAll(dir, os.ModePerm))
+		require.NoError(b, os.WriteFile(filepath.Join(dir, "main.tf"), fileContent, 0o644))
+		require.NoError(b, os.WriteFile(filepath.Join(dir, "variables.tf"), fileContent, 0o644))
+	}
+
+	for i := range 5 {
+		cacheDir := filepath.Join(source, "modules", fmt.Sprintf("mod%d", i), ".terragrunt-cache", "hash1", "hash2")
+		require.NoError(b, os.MkdirAll(cacheDir, os.ModePerm))
+		for j := range 100 {
+			require.NoError(b, os.WriteFile(filepath.Join(cacheDir, fmt.Sprintf("file%d.tf", j)), fileContent, 0o644))
+		}
+	}
+
+	for i := range 5 {
+		tfDir := filepath.Join(source, "modules", fmt.Sprintf("mod%d", i), ".terraform", "providers")
+		require.NoError(b, os.MkdirAll(tfDir, os.ModePerm))
+		for j := range 50 {
+			require.NoError(b, os.WriteFile(filepath.Join(tfDir, fmt.Sprintf("provider%d", j)), fileContent, 0o644))
+		}
+	}
+
+	excludeFromCopy := []string{
+		"**/.terragrunt-cache",
+		"**/.terraform",
+		"**/*.log",
+		"**/.DS_Store",
+		"**/node_modules",
+	}
+
+	l := logger.CreateLogger()
+
+	b.ResetTimer()
+
+	for range b.N {
+		dest := filepath.Join(tempDir, fmt.Sprintf("dest-%d", b.N))
+		require.NoError(b, util.CopyFolderContents(l, source, dest, ".manifest", nil, excludeFromCopy))
+		os.RemoveAll(dest)
+	}
+}
+
 func TestEmptyDir(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

In a large monorepo with hundreds of Terraform modules, the "Downloading Terraform configurations from ... into ./.terragrunt-cache/..." step gets progressively slower as more modules are initialized (`terragrunt init`). Each new `.terragrunt-cache` directory created by a previous `init` increases the time for *all subsequent* `init` runs across the entire repository — even for completely unrelated modules.

The slowdown is triggered any time a file changes anywhere in the package root directory, causing Terragrunt to re-copy the source tree.

### Environment

- Terragrunt v1.0.x
- Monorepo with **433 modules** sharing a common `terraform//` package root via double-slash syntax
- 10 `exclude_from_copy` patterns configured in root `terragrunt.hcl`

Root configuration:

```hcl
terraform {
  source = "${get_repo_root()}/terraform//${path_relative_to_include()}"

  exclude_from_copy = [
    "**/*.log",
    "**/*tfstate*",
    "**/.DS_Store",
    "**/.cache",
    "**/.terraform",
    "**/.terraformrc",
    "**/.terragrunt-cache",
    "**/dist",
    "**/node_modules",
    "**/tmp",
  ]
}
```

### Root Cause

The performance bottleneck is in [`CopyFolderContents`](https://github.com/gruntwork-io/terragrunt/blob/main/internal/util/file.go) which calls `expandGlobPath` for **each** `exclude_from_copy` pattern **before** any file copying begins.

`expandGlobPath` calls [`zglob.Glob()`](https://github.com/mattn/go-zglob), which internally uses `fastwalk` to walk the **entire** source tree for every pattern — including into `.terragrunt-cache` and `.terraform` directories that contain hundreds of megabytes of cached providers and modules. While the results are filtered out afterward (`strings.Contains(path, TerragruntCacheDir)`), the expensive directory walking has already happened.

```go
// internal/util/file.go – expandGlobPath (simplified)
func expandGlobPath(source, absoluteGlobPath string) ([]string, error) {
    // zglob.Glob walks the ENTIRE source tree to find matches,
    // including into .terragrunt-cache (GBs of data)
    absoluteExpandGlob, err := zglob.Glob(absoluteGlobPath)

    for _, path := range absoluteExpandGlob {
        // This filters AFTER walking — too late, the I/O already happened
        if strings.Contains(path, TerragruntCacheDir) {
            continue
        }
        // ...
        if IsDir(path) {
            // Recursive: triggers another full zglob.Glob walk
            expandGlobPath(source, path+"/*")
        }
    }
}
```

**With 10 exclude patterns, this means 10 full walks of the 2.5 GB tree before a single file is copied.** As more modules are initialized and their `.terragrunt-cache` directories grow, each walk takes longer — creating a progressively worsening feedback loop.

Additionally, `CopyFolderContentsWithFilter` uses `filepath.Glob(source + "/*")` which calls `lstat` on every entry in each directory, followed by separate `IsDir()` and `os.Lstat()` calls — resulting in 2-3 redundant stat syscalls per entry.

### Complexity

| | Before (current) | After (proposed) |
|---|---|---|
| **Exclude expansion** | `O(patterns × tree_size)` stat calls upfront | `O(files_copied × patterns × depth)` string matches, no upfront I/O |
| **Directory listing** | `filepath.Glob` → lstat per entry + `IsDir()` + `os.Lstat()` (2-3 stats/entry) | `os.ReadDir` → DirEntry.Type() from syscall (0 extra stats for non-symlinks) |

### Proposed Fix

1. **Lazy exclude matching**: Instead of pre-expanding exclude globs into a flat path list, evaluate patterns on-the-fly during the copy walk using `doublestar.Match` (already an indirect dependency). Each path and its ancestors are checked against the raw patterns. Since `CopyFolderContentsWithFilter` already prunes excluded directories (skips recursion when the filter returns false), the lazy approach never enters the expensive `.terragrunt-cache` or `.terraform` directories.

2. **Replace `filepath.Glob` with `os.ReadDir`**: Since Go 1.16, `os.ReadDir` returns lightweight `DirEntry` values whose `Type()` comes directly from the directory-listing syscall (`getdents64` on Linux, `getdirentries` on macOS) without a separate `lstat` per entry. The earlier concern noted in the code comment ("os.ReadDir calls lstat on all files") no longer applies.

3. **Bonus bug fix**: The current `pathContainsPrefix` uses `strings.HasPrefix` which can match unrelated paths sharing a common prefix (e.g., pattern `module/region2` would incorrectly exclude `module/region2more`). The proposed `doublestar.Match` approach matches on exact path segments.

### Related

- #1390 — Cache construction extremely slow for local modules (closed, workaround: `TF_PLUGIN_CACHE_DIR`)

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

- Updated `CopyFolderContents` to evaluate `exclude_from_copy` glob patterns lazily during the copy walk instead of pre-expanding them via full tree traversals, reducing "Downloading Terraform configurations" time from
  `O(patterns × tree_size)` to `O(files_copied × patterns × depth)` — particularly impactful for large monorepos with accumulated `.terragrunt-cache` directories.   

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * File-copying now evaluates exclude patterns lazily per path instead of pre-expanding lists, simplifying logic.

* **Bug Fix**
  * Improved handling of symbolic links and directory detection during recursive copies to avoid incorrect traversal or exclusions.

* **Performance**
  * Faster behavior when excluding large/deep directory trees during file operations.

* **Tests**
  * Added unit tests and a benchmark covering exclude matching, edge cases, and deep-exclude performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->