### PR TITLE
fix: isolate per-unit feature defaults in run --all

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -403,6 +403,15 @@ func (opts *TerragruntOptions) OptionsFromContext(ctx context.Context) *Terragru
 func (opts *TerragruntOptions) Clone() *TerragruntOptions {
 	newOpts := cloner.Clone(opts)
 
+	if opts.FeatureFlags != nil {
+		clonedFlags := xsync.NewMapOf[string, string]()
+		opts.FeatureFlags.Range(func(key, value string) bool {
+			clonedFlags.Store(key, value)
+			return true
+		})
+		newOpts.FeatureFlags = clonedFlags
+	}
+
 	return newOpts
 }
 

--- a/test/fixtures/feature-flags/run-all-isolated-defaults/catalog/modules/echo-toggle/main.tf
+++ b/test/fixtures/feature-flags/run-all-isolated-defaults/catalog/modules/echo-toggle/main.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.6.0"
+}

--- a/test/fixtures/feature-flags/run-all-isolated-defaults/catalog/modules/echo-toggle/outputs.tf
+++ b/test/fixtures/feature-flags/run-all-isolated-defaults/catalog/modules/echo-toggle/outputs.tf
@@ -1,0 +1,7 @@
+output "effective_toggle" {
+  value = var.effective_toggle
+}
+
+output "raw_toggle" {
+  value = var.raw_toggle
+}

--- a/test/fixtures/feature-flags/run-all-isolated-defaults/catalog/modules/echo-toggle/variables.tf
+++ b/test/fixtures/feature-flags/run-all-isolated-defaults/catalog/modules/echo-toggle/variables.tf
@@ -1,0 +1,7 @@
+variable "effective_toggle" {
+  type = bool
+}
+
+variable "raw_toggle" {
+  type = bool
+}

--- a/test/fixtures/feature-flags/run-all-isolated-defaults/fake-tf.sh
+++ b/test/fixtures/feature-flags/run-all-isolated-defaults/fake-tf.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmd="${1:-}"
+
+case "$cmd" in
+  version|--version|-version)
+    if [[ "${2:-}" == "-json" ]]; then
+      printf '{"terraform_version":"1.14.8"}\n'
+    else
+      printf 'Terraform v1.14.8\n'
+    fi
+    ;;
+  output)
+    if [[ "${2:-}" == "-json" ]]; then
+      printf '{}\n'
+    fi
+    ;;
+  *)
+    ;;
+esac

--- a/test/fixtures/feature-flags/run-all-isolated-defaults/live/bare/peer-service/terragrunt.hcl
+++ b/test/fixtures/feature-flags/run-all-isolated-defaults/live/bare/peer-service/terragrunt.hcl
@@ -1,0 +1,12 @@
+feature "toggle" {
+  default = false
+}
+
+terraform {
+  source = "${find_in_parent_folders("catalog/modules")}//echo-toggle"
+}
+
+inputs = {
+  effective_toggle = feature.toggle.value
+  raw_toggle       = false
+}

--- a/test/fixtures/feature-flags/run-all-isolated-defaults/live/bare/target-service/terragrunt.hcl
+++ b/test/fixtures/feature-flags/run-all-isolated-defaults/live/bare/target-service/terragrunt.hcl
@@ -1,0 +1,12 @@
+feature "toggle" {
+  default = true
+}
+
+terraform {
+  source = "${find_in_parent_folders("catalog/modules")}//echo-toggle"
+}
+
+inputs = {
+  effective_toggle = feature.toggle.value
+  raw_toggle       = true
+}

--- a/test/integration_feature_flags_test.go
+++ b/test/integration_feature_flags_test.go
@@ -3,6 +3,7 @@ package test_test
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -16,6 +17,7 @@ const (
 	testSimpleFlag     = "fixtures/feature-flags/simple-flag"
 	testIncludeFlag    = "fixtures/feature-flags/include-flag"
 	testRunAllFlag     = "fixtures/feature-flags/run-all"
+	testRunAllIsolated = "fixtures/feature-flags/run-all-isolated-defaults"
 	testErrorEmptyFlag = "fixtures/feature-flags/error-empty-flag"
 )
 
@@ -106,6 +108,46 @@ func TestFeatureFlagRunAll(t *testing.T) {
 	validateOutputs(t, app2)
 }
 
+func TestFeatureFlagRunAllIsolatesPerUnitDefaults(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testRunAllIsolated)
+	tmpEnvPath := helpers.CopyEnvironment(t, testRunAllIsolated)
+	rootPath := filepath.Join(tmpEnvPath, testRunAllIsolated)
+	livePath := filepath.Join(rootPath, "live", "bare")
+	targetPath := filepath.Join(livePath, "target-service")
+	peerPath := filepath.Join(livePath, "peer-service")
+	tfPath := filepath.Join(rootPath, "fake-tf.sh")
+
+	require.NoError(t, os.Chmod(tfPath, 0o755))
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt plan --non-interactive --no-color --inputs-debug --tf-path "+tfPath+" --working-dir "+targetPath,
+	)
+	require.NoError(t, err)
+
+	targetDirect := readDebugInputs(t, targetPath)
+	assert.EqualValues(t, true, targetDirect["effective_toggle"])
+	assert.EqualValues(t, true, targetDirect["raw_toggle"])
+
+	require.NoError(t, os.Remove(filepath.Join(targetPath, helpers.TerragruntDebugFile)))
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt run --all --non-interactive --no-color --parallelism 1 --inputs-debug --tf-path "+tfPath+" --working-dir "+livePath+" -- plan",
+	)
+	require.NoError(t, err)
+
+	targetRunAll := readDebugInputs(t, targetPath)
+	peerRunAll := readDebugInputs(t, peerPath)
+
+	assert.EqualValues(t, true, targetRunAll["effective_toggle"])
+	assert.EqualValues(t, true, targetRunAll["raw_toggle"])
+	assert.EqualValues(t, false, peerRunAll["effective_toggle"])
+	assert.EqualValues(t, false, peerRunAll["raw_toggle"])
+}
+
 func TestFailOnEmptyFeatureFlag(t *testing.T) {
 	t.Parallel()
 
@@ -152,4 +194,16 @@ func validateOutputsMap(t *testing.T, rootPath string, expected map[string]any) 
 	for key, expected := range expected {
 		assert.EqualValues(t, expected, outputs[key].Value) //nolint:testifylint
 	}
+}
+
+func readDebugInputs(t *testing.T, rootPath string) map[string]any {
+	t.Helper()
+
+	bytes, err := os.ReadFile(filepath.Join(rootPath, helpers.TerragruntDebugFile))
+	require.NoError(t, err)
+
+	outputs := map[string]any{}
+	require.NoError(t, json.Unmarshal(bytes, &outputs))
+
+	return outputs
 }


### PR DESCRIPTION
## Description

Fixes #5810.

`run --all` was cloning `TerragruntOptions` with a shared `FeatureFlags` map, so the first unit that populated a same-named feature default could leak that value into sibling units.

This change deep-copies `FeatureFlags` in `TerragruntOptions.Clone()` so each unit resolves feature defaults independently.

I also added a regression fixture that reproduces the issue with `--inputs-debug` and a fake `--tf-path`: direct `plan` in `target-service` keeps `effective_toggle = true`, and `run --all ... plan` now preserves that value instead of inheriting `peer-service`'s `false` default.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Fixed `run --all` leaking one unit's feature default into sibling units with the same feature name.

### Migration Guide

No migration guide required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for feature flag functionality with isolated defaults, validating toggle behavior across multiple services.
  * Introduced test fixtures and helper utilities to verify feature flags maintain appropriate values in distributed service configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->