### PR TITLE
fix: Addressing panic in `read_terragrunt_config()`

### DIFF
--- a/docs/src/data/changelog/v1.0.3/read-tg-config-panic.mdx
+++ b/docs/src/data/changelog/v1.0.3/read-tg-config-panic.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.3"
+category: "bug-fixes"
+---
+
+#### Fixed crash when `include` and `locals` with `read_terragrunt_config` coexist
+
+A unit that combined an `include` block with a `locals` block calling `read_terragrunt_config(...)` could crash during discovery, surfacing as a misleading `Call to function "read_terragrunt_config" failed` error pointed at the `locals` expression.
+
+Discovery now reports the underlying error instead of crashing.
+
+Reported in [#5949](https://github.com/gruntwork-io/terragrunt/issues/5949).

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -606,7 +606,9 @@ func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger,
 
 	// If this file includes another, parse and merge the partial blocks. Otherwise, just return this config.
 	// If there have been errors during this parse, don't attempt to parse the included config.
-	if len(pctx.TrackInclude.CurrentList) > 0 && !errsContainsIncludeErr {
+	// TrackInclude is nil when DecodeBaseBlocks returned (nil, err), e.g. an invalid feature
+	// default. Skip the merge in that case and let the error surface at the return below.
+	if pctx.TrackInclude != nil && len(pctx.TrackInclude.CurrentList) > 0 && !errsContainsIncludeErr {
 		includeCount := len(pctx.TrackInclude.CurrentList)
 		includePaths := make([]string, 0, includeCount)
 
@@ -629,10 +631,12 @@ func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger,
 			errs = errs.Append(err)
 		}
 
-		// Saving processed includes into configuration, direct assignment since nested includes aren't supported
-		config.ProcessedIncludes = pctx.TrackInclude.CurrentMap
-
-		output = config
+		// handleInclude returns nil when a Merge/DeepMerge fails; keep the pre-include output so the
+		// appended error surfaces below instead of panicking on a nil ProcessedIncludes assignment.
+		if config != nil {
+			config.ProcessedIncludes = pctx.TrackInclude.CurrentMap
+			output = config
+		}
 	}
 
 	if errs.ErrorOrNil() != nil {

--- a/pkg/config/config_partial_test.go
+++ b/pkg/config/config_partial_test.go
@@ -143,6 +143,166 @@ func TestPartialParseDoesNotResolveIgnoredBlockEvenInParent(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// Regression test for https://github.com/gruntwork-io/terragrunt/issues/5949: various invalid
+// include / locals combinations must not panic out of PartialParseConfig.
+func TestPartialParseDoesNotPanicWithIncludeAndReadTerragruntConfigLocals(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]string{
+		"read-target-missing": `
+include "root" {
+  path = find_in_parent_folders("parent.hcl")
+}
+
+locals {
+  env_vars = read_terragrunt_config("this-file-does-not-exist.hcl")
+}
+`,
+		"include-path-empty-string": `
+include "root" {
+  path = ""
+}
+
+locals {
+  env_vars = read_terragrunt_config("this-file-does-not-exist.hcl")
+}
+`,
+		"include-path-undefined-local": `
+include "root" {
+  path = local.undefined
+}
+
+locals {
+  env_vars = read_terragrunt_config("this-file-does-not-exist.hcl")
+}
+`,
+		"include-points-to-missing-file": `
+include "root" {
+  path = find_in_parent_folders("does-not-exist.hcl")
+}
+
+locals {
+  env_vars = read_terragrunt_config("this-file-does-not-exist.hcl")
+}
+`,
+		"include-points-to-malformed-file": `
+include "root" {
+  path = find_in_parent_folders("malformed.hcl")
+}
+
+locals {
+  env_vars = read_terragrunt_config("this-file-does-not-exist.hcl")
+}
+`,
+		"multiple-includes-same-name": `
+include "root" {
+  path = find_in_parent_folders("parent.hcl")
+}
+
+include "root" {
+  path = find_in_parent_folders("parent.hcl")
+}
+
+locals {
+  env_vars = read_terragrunt_config("this-file-does-not-exist.hcl")
+}
+`,
+		"include-parent-also-has-include": `
+include "root" {
+  path = find_in_parent_folders("nested-parent.hcl")
+}
+
+locals {
+  env_vars = read_terragrunt_config("this-file-does-not-exist.hcl")
+}
+`,
+		"bare-include-no-label": `
+include {
+  path = find_in_parent_folders("parent.hcl")
+}
+
+locals {
+  env_vars = read_terragrunt_config("this-file-does-not-exist.hcl")
+}
+`,
+		"include-expression-calling-missing-env": `
+include "root" {
+  path = find_in_parent_folders(get_env("TG_TEST_NONEXISTENT_ENV_VAR_FOR_5949"))
+}
+
+locals {
+  env_vars = read_terragrunt_config(find_in_parent_folders(get_env("TG_TEST_NONEXISTENT_ENV_VAR_FOR_5949")))
+}
+`,
+		"feature-default-undefined-local": `
+include "root" {
+  path = find_in_parent_folders("parent.hcl")
+}
+
+feature "broken" {
+  default = local.never_set
+}
+
+locals {
+  env_vars = read_terragrunt_config("this-file-does-not-exist.hcl")
+}
+`,
+		"feature-default-undefined-function": `
+include "root" {
+  path = find_in_parent_folders("parent.hcl")
+}
+
+feature "broken" {
+  default = not_a_real_function("x")
+}
+
+locals {
+  env_vars = read_terragrunt_config("this-file-does-not-exist.hcl")
+}
+`,
+	}
+
+	for name, childHCL := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := helpers.TmpDirWOSymlinks(t)
+
+			require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "parent.hcl"), []byte(`
+locals {
+  shared = "value"
+}
+`), 0644))
+
+			require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "malformed.hcl"), []byte(`
+locals {
+  broken = {{{
+`), 0644))
+
+			require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "nested-parent.hcl"), []byte(`
+include "grandparent" {
+  path = find_in_parent_folders("parent.hcl")
+}
+`), 0644))
+
+			childDir := filepath.Join(tmpDir, "child")
+			require.NoError(t, os.MkdirAll(childDir, 0755))
+
+			childPath := filepath.Join(childDir, config.DefaultTerragruntConfigPath)
+			require.NoError(t, os.WriteFile(childPath, []byte(childHCL), 0644))
+
+			l := logger.CreateLogger()
+
+			ctx, pctx := newTestParsingContext(t, childPath)
+			pctx = pctx.WithDecodeList(config.TerragruntFlags)
+
+			require.NotPanics(t, func() {
+				_, _ = config.PartialParseConfigFile(ctx, pctx, l, childPath, nil)
+			})
+		})
+	}
+}
+
 func TestPartialParseOnlyInheritsSelectedBlocksFlags(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5949.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)]
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when `include` and `locals` blocks with `read_terragrunt_config()` were combined during configuration discovery. The parser now properly surfaces underlying configuration errors instead of displaying misleading error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->