### PR TITLE
bug: version flag race condition fix

### DIFF
--- a/docs/src/data/changelog/v1.0.3/version-flag-race.mdx
+++ b/docs/src/data/changelog/v1.0.3/version-flag-race.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.3"
+category: "bug-fixes"
+---
+
+#### Fixed data race in `--version` flag parsing under concurrent CLI invocations
+
+When multiple Terragrunt CLI invocations ran concurrently in the same process, urfave/cli/v2's package-level `VersionFlag` singleton was mutated concurrently by each invocation's flag-parsing path, producing a `WARNING: DATA RACE` on shared flag state.
+
+Terragrunt now sets `cli.App.HideVersion = true` at construction, which prevents urfave from auto-appending its shared `VersionFlag` into each App's flag set. The `--version` / `-v` flag is unchanged from the user's perspective — it is handled by Terragrunt's own flag registered in `internal/cli/flags/global.NewHelpVersionFlags`.

--- a/internal/clihelper/app.go
+++ b/internal/clihelper/app.go
@@ -89,6 +89,13 @@ func NewApp() *App {
 	cliApp.ExitErrHandler = func(_ *cli.Context, _ error) {}
 	cliApp.HideHelp = true
 	cliApp.HideHelpCommand = true
+	// urfave/cli/v2 exposes VersionFlag as a package-level *BoolFlag singleton
+	// that App.Setup() auto-appends to every App's flag set. Two App instances
+	// running concurrently in the same process (parallel integration tests
+	// under -race) race on that shared flag when flag-parsing calls Apply().
+	// Terragrunt owns --version via flags/global.NewHelpVersionFlags, so
+	// hiding urfave's flag has no user-visible effect.
+	cliApp.HideVersion = true
 
 	return &App{
 		App:          cliApp,


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* fixed data race in `--version` flag parsing

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a data race condition that occurred when running multiple Terragrunt CLI invocations concurrently in the same process. The `--version`/`-v` flag functionality remains available and unchanged.

* **Documentation**
  * Added changelog entry documenting the concurrent invocation data race fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->