### PR TITLE
feat: Mark module sources as read

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "docs",

--- a/docs/src/content/docs/03-features/08-filter/04-attributes.mdx
+++ b/docs/src/content/docs/03-features/08-filter/04-attributes.mdx
@@ -8,6 +8,7 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 import FileTree from '@components/vendored/starlight/FileTree.astro';
+import Since from '@components/Since.astro';
 
 Match units and stacks by their configuration attributes.
 
@@ -104,9 +105,13 @@ Due to how Terragrunt parses configurations during `run --all`, functions will o
 Reading a file directly in the `inputs` attribute will not mark the file as read, as the `inputs` attribute is not parsed until after the queue has already been populated to support rendering of dependency outputs, which are only available after dependencies have been run.
 </Aside>
 
+<Since version="1.0.3">
+
 To mark many files at once, use [`mark_glob_as_read`](/reference/hcl/functions/#mark_glob_as_read), which accepts a glob (with `**` support) and marks every matching file.
 
 If a unit's `terraform` block points at a local module source, enable the [`mark-many-as-read`](/reference/experiments) experiment to have Terragrunt automatically mark that module's `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` files as read. Reading-based filters will then cascade local module changes to every unit that consumes the module. The same experiment also enables the [`mark_glob_as_read`](/reference/hcl/functions/#mark_glob_as_read) HCL function.
+
+</Since>
 
 ## Source-Based Expressions
 

--- a/docs/src/content/docs/03-features/08-filter/04-attributes.mdx
+++ b/docs/src/content/docs/03-features/08-filter/04-attributes.mdx
@@ -104,6 +104,10 @@ Due to how Terragrunt parses configurations during `run --all`, functions will o
 Reading a file directly in the `inputs` attribute will not mark the file as read, as the `inputs` attribute is not parsed until after the queue has already been populated to support rendering of dependency outputs, which are only available after dependencies have been run.
 </Aside>
 
+To mark many files at once, use [`mark_glob_as_read`](/reference/hcl/functions/#mark_glob_as_read), which accepts a glob (with `**` support) and marks every matching file.
+
+If a unit's `terraform` block points at a local module source, enable the [`mark-many-as-read`](/reference/experiments) experiment to have Terragrunt automatically mark that module's `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` files as read. Reading-based filters will then cascade local module changes to every unit that consumes the module. The same experiment also enables the [`mark_glob_as_read`](/reference/hcl/functions/#mark_glob_as_read) HCL function.
+
 ## Source-Based Expressions
 
 Match units and stacks by their Terraform source URL or path specified in the `terraform` block of `terragrunt.hcl` files.

--- a/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -1049,19 +1049,29 @@ block is not evaluated until *after* the queue has been populated with units to 
 `mark_glob_as_read` requires the [`mark-many-as-read`](/reference/experiments) experiment. Calling it without the experiment enabled returns an error.
 </Aside>
 
-`mark_glob_as_read(pattern)` expands the given glob and marks every matching file as read. The glob supports `**` for recursive matches (powered by [`gobwas/glob`](https://github.com/gobwas/glob), the same matcher used elsewhere in Terragrunt's filter expressions). The function returns the list of absolute paths that matched, so it can be composed with other expressions.
+`mark_glob_as_read(pattern)` expands the given glob and marks every matching file as read. It returns the list of absolute paths that matched, so it can be composed with other expressions.
+
+Pattern syntax follows [`gobwas/glob`](https://github.com/gobwas/glob), the same matcher used elsewhere in Terragrunt. `/` is the path separator, `*` matches within a single segment, `**` matches any sequence of characters including separators, `?` matches any single non-separator character, `[abc]` matches a character class, and `{a,b}` matches any of the listed alternatives. A backslash escapes the following metacharacter.
 
 Relative patterns are resolved against the current working directory, the same way `mark_as_read` resolves a relative file path.
 
 <Aside type="caution">
-Glob patterns must use forward slashes (`/`) as the path separator, even on Windows. The underlying matcher treats `\` as a literal character, not a path separator, so a backslash-separated pattern will not match any files.
+Glob patterns must use forward slashes (`/`) as the path separator, even on Windows. The matcher treats `\` as an escape character, not a path separator, so a backslash-separated pattern will not match any files.
+</Aside>
+
+<Aside type="caution">
+`**` does not collapse the separators around it. `config/**/*.yaml` matches files at least one directory below `config/`, but not files directly inside `config/`. Use brace alternation to match at any depth:
+
+```hcl
+mark_glob_as_read("${get_terragrunt_dir()}/config/{*.yaml,**/*.yaml}")
+```
 </Aside>
 
 ```hcl
 # terragrunt.hcl
 
 locals {
-  configs = mark_glob_as_read("${get_terragrunt_dir()}/config/**/*.yaml")
+  configs = mark_glob_as_read("${get_terragrunt_dir()}/config/{*.yaml,**/*.yaml}")
 }
 
 inputs = {
@@ -1069,7 +1079,7 @@ inputs = {
 }
 ```
 
-This is the natural way to mark many files as read in one call. A typical use case is a unit that consumes a directory of configuration files indirectly (for example, through `run_cmd`, `templatefile`, or a shared helper module) and wants changes to any of them to trigger the unit through reading-based filter expressions and the [`queue-include-units-reading`](/reference/cli/commands/run#queue-include-units-reading) flag.
+A typical use case is a unit that consumes a directory of configuration files indirectly (for example, through `run_cmd`, `templatefile`, or a shared helper module) and wants changes to any of them to trigger the unit through reading-based filter expressions and the [`queue-include-units-reading`](/reference/cli/commands/run#queue-include-units-reading) flag.
 
 If the pattern matches nothing, the function returns an empty list without error.
 

--- a/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -1061,6 +1061,10 @@ Coming soon!
 `mark_glob_as_read` requires the [`mark-many-as-read`](/reference/experiments) experiment. Calling it without the experiment enabled returns an error.
 </Aside>
 
+<Aside type="caution">
+`mark_glob_as_read` writes to the same read tracker as [`mark_as_read`](#mark_as_read), so the same evaluation-order caveat applies: during a `run --all`, the queue is populated before `inputs` is evaluated, so a call placed in `inputs` (or any other later-evaluated block) will not influence queue construction. Call `mark_glob_as_read` from `locals` to ensure matched files are considered when the queue is built.
+</Aside>
+
 `mark_glob_as_read(pattern)` expands the given glob and marks every matching file as read. It returns the list of absolute paths that matched, so it can be composed with other expressions.
 
 Pattern syntax follows [`gobwas/glob`](https://github.com/gobwas/glob), the same matcher used elsewhere in Terragrunt. `/` is the path separator, `*` matches within a single segment, `**` matches any sequence of characters including separators, `?` matches any single non-separator character, `[abc]` matches a character class, and `{a,b}` matches any of the listed alternatives. A backslash escapes the following metacharacter.

--- a/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -8,6 +8,8 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 import FileTree from '@components/vendored/starlight/FileTree.astro';
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, just like OpenTofu/Terraform\!
 
@@ -1045,6 +1047,16 @@ block is not evaluated until *after* the queue has been populated with units to 
 
 ## mark_glob_as_read
 
+<Before version="1.0.3">
+
+<Aside type="tip">
+Coming soon!
+</Aside>
+
+</Before>
+
+<Since version="1.0.3">
+
 <Aside type="caution">
 `mark_glob_as_read` requires the [`mark-many-as-read`](/reference/experiments) experiment. Calling it without the experiment enabled returns an error.
 </Aside>
@@ -1060,7 +1072,7 @@ Glob patterns must use forward slashes (`/`) as the path separator, even on Wind
 </Aside>
 
 <Aside type="caution">
-`**` does not collapse the separators around it. `config/**/*.yaml` matches files at least one directory below `config/`, but not files directly inside `config/`. Use brace alternation to match at any depth:
+`**` only collapses the separators around it when the adjacent segments are literals. `config/**/*.yaml` matches files at least one directory below `config/`, but not files directly inside `config/`, because the trailing segment `*.yaml` is a wildcard. Use brace alternation to match at any depth:
 
 ```hcl
 mark_glob_as_read("${get_terragrunt_dir()}/config/{*.yaml,**/*.yaml}")
@@ -1079,9 +1091,11 @@ inputs = {
 }
 ```
 
-A typical use case is a unit that consumes a directory of configuration files indirectly (for example, through `run_cmd`, `templatefile`, or a shared helper module) and wants changes to any of them to trigger the unit through reading-based filter expressions and the [`queue-include-units-reading`](/reference/cli/commands/run#queue-include-units-reading) flag.
+A typical use case is a unit that consumes a directory of configuration files indirectly (for example, through `run_cmd`, `templatefile`, or a shared helper module) and wants changes to any of them to trigger the unit through [reading-based filter expressions](/features/filter/attributes#reading-based-expressions) such as `--filter 'reading=./config/**'`.
 
 If the pattern matches nothing, the function returns an empty list without error.
+
+</Since>
 
 ## constraint_check
 

--- a/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -6,6 +6,7 @@ sidebar:
   order: 4
 ---
 
+import { Aside } from '@astrojs/starlight/components';
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 
 Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, just like OpenTofu/Terraform\!
@@ -1041,6 +1042,36 @@ The same technique can be used to mark a file as read when a file is read using 
 **NOTE**: Due to the way that Terragrunt parses configurations during a `run --all`, functions will only properly mark files as read
 if they are used in the `locals` block. Reading a file directly in the `inputs` block will not mark the file as read, as the `inputs`
 block is not evaluated until *after* the queue has been populated with units to run.
+
+## mark_glob_as_read
+
+<Aside type="caution">
+`mark_glob_as_read` requires the [`mark-many-as-read`](/reference/experiments) experiment. Calling it without the experiment enabled returns an error.
+</Aside>
+
+`mark_glob_as_read(pattern)` expands the given glob and marks every matching file as read. The glob supports `**` for recursive matches (powered by [`gobwas/glob`](https://github.com/gobwas/glob), the same matcher used elsewhere in Terragrunt's filter expressions). The function returns the list of absolute paths that matched, so it can be composed with other expressions.
+
+Relative patterns are resolved against the current working directory, the same way `mark_as_read` resolves a relative file path.
+
+<Aside type="caution">
+Glob patterns must use forward slashes (`/`) as the path separator, even on Windows. The underlying matcher treats `\` as a literal character, not a path separator, so a backslash-separated pattern will not match any files.
+</Aside>
+
+```hcl
+# terragrunt.hcl
+
+locals {
+  configs = mark_glob_as_read("${get_terragrunt_dir()}/config/**/*.yaml")
+}
+
+inputs = {
+  configs = [for f in local.configs : yamldecode(file(f))]
+}
+```
+
+This is the natural way to mark many files as read in one call. A typical use case is a unit that consumes a directory of configuration files indirectly (for example, through `run_cmd`, `templatefile`, or a shared helper module) and wants changes to any of them to trigger the unit through reading-based filter expressions and the [`queue-include-units-reading`](/reference/cli/commands/run#queue-include-units-reading) flag.
+
+If the pattern matches nothing, the function returns an empty list without error.
 
 ## constraint_check
 

--- a/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
+++ b/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
@@ -5,7 +5,7 @@ category: "experiments-added"
 
 #### `mark-many-as-read` — Mark many files as read in one step
 
-Enable the new [`mark-many-as-read`](/reference/experiments) experiment to unlock two behaviors that each mark many files as read at once: automatic marking of files inside a local `terraform { source = "..." }` block, and the new `mark_glob_as_read` HCL function.
+Enable the new [`mark-many-as-read`](/reference/experiments) experiment to turn on two behaviors that each mark many files as read in a single call: automatic marking of files inside a local `terraform { source = "..." }` block, and the new `mark_glob_as_read` HCL function.
 
 With the experiment on, a unit like this:
 
@@ -16,7 +16,7 @@ terraform {
 }
 ```
 
-records every `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` file found under `../../modules/service` (recursively) as read for the unit. Non-source files such as `README.md` are skipped. Reading-based filter expressions (see [Filter Attributes](/features/filter/attributes)) will then match any unit that points at a local module when that module's files change, so `--queue-include-units-reading` cascades module edits to consumers.
+records every `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` file found under `../../modules/service` (recursively) as read for the unit. Non-source files such as `README.md` are skipped. A [reading-based filter expression](/features/filter/attributes#reading-based-expressions) such as `--filter 'reading=../../modules/service/**'` then matches every unit that points at the module, so a change to any file in the module cascades to its consumers.
 
 The same experiment also enables a new HCL function, `mark_glob_as_read(pattern)`, which expands a glob using the same [`gobwas/glob`](https://github.com/gobwas/glob) syntax as filter expressions and marks every matching file as read. It returns the list of absolute paths that matched, so it composes with other expressions:
 
@@ -26,6 +26,6 @@ locals {
 }
 ```
 
-`**` does not collapse the separators around it, so match-at-any-depth is written as `{*.yaml,**/*.yaml}`. See the [HCL reference](/reference/hcl/functions/#mark_glob_as_read) for full pattern syntax.
+`**` only collapses the surrounding separators when the adjacent segments are literals, so match-at-any-depth with a wildcard trailing segment is written as `{*.yaml,**/*.yaml}`. See the [HCL reference](/reference/hcl/functions/#mark_glob_as_read) for full pattern syntax.
 
 This is useful when a unit reads a collection of files indirectly (for example, via `run_cmd` or `templatefile`) and you want changes to any of them to trigger the unit through reading-based filters. Calling `mark_glob_as_read` without the experiment enabled returns an error.

--- a/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
+++ b/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
@@ -1,0 +1,29 @@
+---
+version: "v1.0.3"
+category: "experiments-added"
+---
+
+#### `mark-many-as-read` — Mark many files as read in one step
+
+Enable the new [`mark-many-as-read`](/reference/experiments) experiment to unlock two behaviors that each mark many files as read at once: automatic marking of files inside a local `terraform { source = "..." }` block, and the new `mark_glob_as_read` HCL function.
+
+With the experiment on, a unit like this:
+
+```hcl
+# live/unit/terragrunt.hcl
+terraform {
+  source = "../../modules/service"
+}
+```
+
+records every `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` file found under `../../modules/service` (recursively) as read for the unit. Non-source files such as `README.md` are skipped. Reading-based filter expressions (see [Filter Attributes](/features/filter/attributes)) will then match any unit that points at a local module when that module's files change, so `--queue-include-units-reading` cascades module edits to consumers.
+
+The same experiment also enables a new HCL function, `mark_glob_as_read(pattern)`, which expands a glob (supporting `**`) and marks every matching file as read. It returns the list of absolute paths that matched, so it composes with other expressions:
+
+```hcl
+locals {
+  configs = mark_glob_as_read("${get_terragrunt_dir()}/config/**/*.yaml")
+}
+```
+
+This is useful when a unit reads a collection of files indirectly (for example, via `run_cmd` or `templatefile`) and you want changes to any of them to trigger the unit through reading-based filters. Calling `mark_glob_as_read` without the experiment enabled returns an error.

--- a/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
+++ b/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
@@ -18,12 +18,14 @@ terraform {
 
 records every `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` file found under `../../modules/service` (recursively) as read for the unit. Non-source files such as `README.md` are skipped. Reading-based filter expressions (see [Filter Attributes](/features/filter/attributes)) will then match any unit that points at a local module when that module's files change, so `--queue-include-units-reading` cascades module edits to consumers.
 
-The same experiment also enables a new HCL function, `mark_glob_as_read(pattern)`, which expands a glob (supporting `**`) and marks every matching file as read. It returns the list of absolute paths that matched, so it composes with other expressions:
+The same experiment also enables a new HCL function, `mark_glob_as_read(pattern)`, which expands a glob using the same [`gobwas/glob`](https://github.com/gobwas/glob) syntax as filter expressions and marks every matching file as read. It returns the list of absolute paths that matched, so it composes with other expressions:
 
 ```hcl
 locals {
-  configs = mark_glob_as_read("${get_terragrunt_dir()}/config/**/*.yaml")
+  configs = mark_glob_as_read("${get_terragrunt_dir()}/config/{*.yaml,**/*.yaml}")
 }
 ```
+
+`**` does not collapse the separators around it, so match-at-any-depth is written as `{*.yaml,**/*.yaml}`. See the [HCL reference](/reference/hcl/functions/#mark_glob_as_read) for full pattern syntax.
 
 This is useful when a unit reads a collection of files indirectly (for example, via `run_cmd` or `templatefile`) and you want changes to any of them to trigger the unit through reading-based filters. Calling `mark_glob_as_read` without the experiment enabled returns an error.

--- a/docs/src/data/experiments/mark-many-as-read.mdx
+++ b/docs/src/data/experiments/mark-many-as-read.mdx
@@ -1,0 +1,33 @@
+---
+name: mark-many-as-read
+status: active
+since: "1.0.3"
+---
+
+Mark many files as read in one step, so reading-based filter expressions cascade changes from shared files to the units that consume them.
+
+### `mark-many-as-read` - What it does
+
+Enabling the experiment activates two behaviors:
+
+1. When a unit's `terraform` block points at a local module source, Terragrunt walks that directory and records every `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` file as read for the unit. Non-source files such as `README.md` are skipped. Remote sources (Git, registry, S3, etc.) are not walked.
+2. The `mark_glob_as_read(pattern)` HCL function becomes available. It expands a glob using [`gobwas/glob`](https://github.com/gobwas/glob) syntax and marks every matching file as read, returning the list of absolute paths that matched. Without the experiment enabled, calling the function returns an error. See the [HCL reference](/reference/hcl/functions/#mark_glob_as_read) for pattern syntax and examples.
+
+Both behaviors feed the same reading tracker that powers the [`reading=` filter attribute](/features/filter/attributes#reading-based-expressions), so a change to a local module file or a globbed configuration file is picked up by `--filter 'reading=<path>'` and matches every unit that reads it.
+
+```bash
+terragrunt run --all --experiment mark-many-as-read -- plan
+```
+
+### `mark-many-as-read` - How to provide feedback
+
+Provide your feedback on the [GitHub Discussions](https://github.com/gruntwork-io/terragrunt/discussions) page.
+
+### `mark-many-as-read` - Criteria for stabilization
+
+To transition the `mark-many-as-read` feature to a stable release, the following must be addressed:
+
+- [ ] Confirm local module walking handles nested modules sensibly across macOS, Linux, and Windows.
+- [ ] Confirm glob semantics match user expectations for common patterns, especially `**` with a wildcard trailing segment.
+- [ ] Positive feedback from users relying on reading-based filters in production pipelines.
+- [ ] Integration tests covering the interaction between module walking, `mark_glob_as_read`, and `--filter 'reading=...'`.

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -51,6 +51,11 @@ const (
 	StackDependencies = "stack-dependencies"
 	// CatalogRedesign is the experiment that enables the redesigned catalog experience.
 	CatalogRedesign = "catalog-redesign"
+	// MarkManyAsRead enables behaviors that mark many files as read in one
+	// step: automatic marking of files inside a local terraform module source
+	// (so reading-based filter expressions detect changes to the module) and
+	// the mark_glob_as_read HCL function.
+	MarkManyAsRead = "mark-many-as-read"
 )
 
 const (
@@ -114,6 +119,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: CatalogRedesign,
+		},
+		{
+			Name: MarkManyAsRead,
 		},
 	}
 }

--- a/internal/filter/ast.go
+++ b/internal/filter/ast.go
@@ -4,8 +4,8 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/gobwas/glob"
 	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/glob"
 )
 
 // Expression is the interface that all AST nodes must implement.
@@ -31,7 +31,7 @@ type Expressions []Expression
 
 // PathExpression represents a path or glob filter (e.g., "./path/**/*" or "/absolute/path").
 type PathExpression struct {
-	compiledGlob glob.Glob
+	compiledGlob glob.Matcher
 	Value        string
 }
 
@@ -39,7 +39,7 @@ type PathExpression struct {
 func NewPathFilter(value string) (*PathExpression, error) {
 	pattern := filepath.Clean(filepath.ToSlash(value))
 
-	compiled, err := glob.Compile(pattern, '/')
+	compiled, err := glob.Compile(pattern)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func NewPathFilter(value string) (*PathExpression, error) {
 }
 
 // Glob returns the pre-compiled glob pattern.
-func (p *PathExpression) Glob() glob.Glob {
+func (p *PathExpression) Glob() glob.Matcher {
 	return p.compiledGlob
 }
 
@@ -61,7 +61,7 @@ func (p *PathExpression) Negated() Expression                   { return NewPref
 
 // AttributeExpression represents a key-value attribute filter (e.g., "name=my-app").
 type AttributeExpression struct {
-	compiledGlob glob.Glob
+	compiledGlob glob.Matcher
 	Key          string
 	Value        string
 }
@@ -78,7 +78,7 @@ func NewAttributeExpression(key string, value string) (*AttributeExpression, err
 			pattern = filepath.Clean(filepath.ToSlash(pattern))
 		}
 
-		compiled, err := glob.Compile(pattern, '/')
+		compiled, err := glob.Compile(pattern)
 		if err != nil {
 			return nil, err
 		}
@@ -96,7 +96,7 @@ func NewTypeExpression(kind component.Kind) *AttributeExpression {
 }
 
 // Glob returns the pre-compiled glob pattern.
-func (a *AttributeExpression) Glob() glob.Glob {
+func (a *AttributeExpression) Glob() glob.Matcher {
 	return a.compiledGlob
 }
 

--- a/internal/filter/doc.go
+++ b/internal/filter/doc.go
@@ -210,7 +210,7 @@
 // ## Evaluator
 //
 // The evaluator (evaluator.go) walks the AST and applies the filter logic:
-//   - PathFilter: Uses glob matching (github.com/gobwas/glob) with eager compilation
+//   - PathFilter: Uses glob matching (internal/glob Compile, backed by gobwas) with eager compilation
 //     and caching via sync.Once for performance
 //   - AttributeFilter: Matches attributes by key-value pairs:
 //   - name: Matches filepath.Base(component.Path)

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -1,0 +1,174 @@
+// Package glob consolidates Terragrunt's glob handling behind a single API so
+// callers pick a function that matches their use case rather than picking a
+// library.
+//
+// # Grammar
+//
+// New code uses [gobwas/glob] semantics. Patterns are '/'-separated, '*'
+// matches within a single segment, '**' matches any sequence of characters
+// including separators, '?' matches any single non-separator character,
+// '[...]' matches a character class, and '{a,b}' matches any of the listed
+// alternatives. A backslash escapes the following metacharacter.
+//
+// "**" does not collapse the separators that flank it. A pattern such as
+// "a/**/b" requires at least one intermediate segment and will not match
+// "a/b". Use brace alternation — for example "{a/b,a/**/b}" — when you want
+// zero-or-more behavior.
+//
+// # When to use what
+//
+// Use [Compile] for compile-once-match-many: you hold a single pattern and
+// test it against many strings, for example filter expressions evaluated
+// against every unit in a discovery pass. [Compile] builds a matcher once and
+// matches in constant time.
+//
+// Use [Expand] for compile-then-walk: you hold a single pattern and want to
+// enumerate the matching paths on disk, for example mark_glob_as_read
+// resolving "locals/**/*.yaml" at config evaluation. Pass [WithFilesOnly] to
+// skip directories.
+//
+// Use [LegacyExpand] only for call sites that participate in user-facing
+// configuration surface (for example, include_in_copy and exclude_from_copy
+// expansion). It is backed by [zglob] and retained to avoid a silent behavior
+// change for patterns users have written against zglob for years. Prefer
+// [Expand] for new code.
+//
+// [gobwas/glob]: https://pkg.go.dev/github.com/gobwas/glob
+// [zglob]: https://pkg.go.dev/github.com/mattn/go-zglob
+package glob
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	gobwas "github.com/gobwas/glob"
+	"github.com/mattn/go-zglob"
+)
+
+// Matcher tests whether a string matches a compiled glob pattern. Values are
+// produced by [Compile] and are safe for concurrent use.
+type Matcher interface {
+	Match(s string) bool
+}
+
+// Compile parses pattern as a '/'-separated glob and returns a [Matcher].
+// Intended for testing one pattern against many strings.
+func Compile(pattern string) (Matcher, error) {
+	return gobwas.Compile(pattern, '/')
+}
+
+// ExpandOption configures the behavior of [Expand]. See [WithFilesOnly].
+type ExpandOption func(*expandOptions)
+
+type expandOptions struct {
+	filesOnly bool
+}
+
+// WithFilesOnly causes [Expand] to skip directories, returning only matching
+// files.
+func WithFilesOnly() ExpandOption {
+	return func(o *expandOptions) {
+		o.filesOnly = true
+	}
+}
+
+// Expand returns the absolute paths that match pattern on the local
+// filesystem. The pattern uses '/' as the separator on all platforms and '\'
+// as the escape character. A pattern that matches nothing returns an empty
+// slice and a nil error.
+func Expand(pattern string, opts ...ExpandOption) ([]string, error) {
+	var o expandOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	pattern = path.Clean(pattern)
+
+	root, hasMeta := splitRoot(pattern)
+
+	if !hasMeta {
+		info, err := os.Stat(root)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+
+			return nil, err
+		}
+
+		if o.filesOnly && info.IsDir() {
+			return nil, nil
+		}
+
+		return []string{root}, nil
+	}
+
+	matcher, err := Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []string
+
+	walkErr := filepath.WalkDir(root, func(entry string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+
+		if o.filesOnly && d.IsDir() {
+			return nil
+		}
+
+		if !matcher.Match(filepath.ToSlash(entry)) {
+			return nil
+		}
+
+		matches = append(matches, entry)
+
+		return nil
+	})
+	if walkErr != nil && !os.IsNotExist(walkErr) {
+		return nil, walkErr
+	}
+
+	return matches, nil
+}
+
+// LegacyExpand returns the paths that match pattern using zglob semantics.
+// Prefer [Expand] for new code. LegacyExpand exists only for call sites that
+// interpret patterns written by users in configuration surface where a
+// behavior change between zglob and gobwas would be a breaking change.
+func LegacyExpand(pattern string) ([]string, error) {
+	return zglob.Glob(pattern)
+}
+
+// splitRoot returns the longest leading directory of pattern that contains no
+// glob metacharacters, ready to hand to filepath.WalkDir, and reports whether
+// any metacharacters were found. pattern must use '/' as the separator.
+func splitRoot(pattern string) (string, bool) {
+	metaIdx := strings.IndexAny(pattern, "*?[{\\")
+	if metaIdx < 0 {
+		return filepath.FromSlash(pattern), false
+	}
+
+	prefix := pattern[:metaIdx]
+
+	if i := strings.LastIndex(prefix, "/"); i >= 0 {
+		prefix = prefix[:i]
+	} else {
+		prefix = "."
+	}
+
+	if prefix == "" {
+		prefix = "/"
+	}
+
+	return filepath.FromSlash(prefix), true
+}

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -10,10 +10,12 @@
 // '[...]' matches a character class, and '{a,b}' matches any of the listed
 // alternatives. A backslash escapes the following metacharacter.
 //
-// "**" does not collapse the separators that flank it. A pattern such as
-// "a/**/b" requires at least one intermediate segment and will not match
-// "a/b". Use brace alternation — for example "{a/b,a/**/b}" — when you want
-// zero-or-more behavior.
+// "**" collapses the flanking separators only when the adjacent segments are
+// literals. With literals on both sides, "a/**/b" matches "a/b" as well as
+// "a/x/b". If either neighbor is a wildcard (for example "a/**/*.tf" or
+// "*/**/b.tf"), "**" does not collapse and a zero-depth match fails. Use
+// brace alternation — for example "{*.tf,**/*.tf}" — to cover both depths
+// when the trailing segment contains a wildcard.
 //
 // # When to use what
 //
@@ -38,13 +40,14 @@
 package glob
 
 import (
-	"io/fs"
-	"os"
+	"errors"
+	iofs "io/fs"
 	"path"
 	"path/filepath"
 	"strings"
 
 	gobwas "github.com/gobwas/glob"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/mattn/go-zglob"
 )
 
@@ -75,11 +78,13 @@ func WithFilesOnly() ExpandOption {
 	}
 }
 
-// Expand returns the absolute paths that match pattern on the local
-// filesystem. The pattern uses '/' as the separator on all platforms and '\'
-// as the escape character. A pattern that matches nothing returns an empty
-// slice and a nil error.
-func Expand(pattern string, opts ...ExpandOption) ([]string, error) {
+// Expand returns the absolute paths that match pattern on fs. The pattern
+// uses '/' as the separator on all platforms and '\' as the escape character.
+// A pattern that matches nothing returns an empty slice and a nil error.
+//
+// Most callers pass [vfs.NewOSFS] for fs; tests can pass an in-memory
+// filesystem from [vfs.NewMemMapFS].
+func Expand(fs vfs.FS, pattern string, opts ...ExpandOption) ([]string, error) {
 	var o expandOptions
 	for _, opt := range opts {
 		opt(&o)
@@ -90,9 +95,9 @@ func Expand(pattern string, opts ...ExpandOption) ([]string, error) {
 	root, hasMeta := splitRoot(pattern)
 
 	if !hasMeta {
-		info, err := os.Stat(root)
+		info, err := fs.Stat(root)
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, iofs.ErrNotExist) {
 				return nil, nil
 			}
 
@@ -113,10 +118,10 @@ func Expand(pattern string, opts ...ExpandOption) ([]string, error) {
 
 	var matches []string
 
-	walkErr := filepath.WalkDir(root, func(entry string, d fs.DirEntry, walkErr error) error {
+	walkErr := vfs.WalkDir(fs, root, func(entry string, d iofs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			if d != nil && d.IsDir() {
-				return fs.SkipDir
+				return iofs.SkipDir
 			}
 
 			return nil
@@ -134,7 +139,7 @@ func Expand(pattern string, opts ...ExpandOption) ([]string, error) {
 
 		return nil
 	})
-	if walkErr != nil && !os.IsNotExist(walkErr) {
+	if walkErr != nil && !errors.Is(walkErr, iofs.ErrNotExist) {
 		return nil, walkErr
 	}
 

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -1,0 +1,322 @@
+package glob_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/glob"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pattern string
+		path    string
+		want    bool
+	}{
+		{
+			name:    "star matches within a single segment",
+			pattern: "foo/*.tf",
+			path:    "foo/bar.tf",
+			want:    true,
+		},
+		{
+			name:    "star does not cross a separator",
+			pattern: "foo/*.tf",
+			path:    "foo/bar/baz.tf",
+			want:    false,
+		},
+		{
+			name:    "double-star matches across segments",
+			pattern: "foo/**/bar.tf",
+			path:    "foo/a/b/bar.tf",
+			want:    true,
+		},
+		{
+			name:    "double-star collapses when flanking segments are literals",
+			pattern: "foo/**/bar.tf",
+			path:    "foo/bar.tf",
+			want:    true,
+		},
+		{
+			name:    "double-star does not collapse when trailing segment has a wildcard",
+			pattern: "foo/**/*.tf",
+			path:    "foo/root.tf",
+			want:    false,
+		},
+		{
+			name:    "double-star does not collapse when leading segment has a wildcard",
+			pattern: "*/**/bar.tf",
+			path:    "foo/bar.tf",
+			want:    false,
+		},
+		{
+			name:    "brace alternation is the reliable way to get zero-or-more depth with wildcards",
+			pattern: "foo/{*.tf,**/*.tf}",
+			path:    "foo/bar.tf",
+			want:    true,
+		},
+		{
+			name:    "question mark matches any single non-separator character",
+			pattern: "f?o",
+			path:    "foo",
+			want:    true,
+		},
+		{
+			name:    "question mark does not match the separator",
+			pattern: "f?o",
+			path:    "f/o",
+			want:    false,
+		},
+		{
+			name:    "character class matches listed alternatives",
+			pattern: "[abc].tf",
+			path:    "b.tf",
+			want:    true,
+		},
+		{
+			name:    "character class rejects outside the class",
+			pattern: "[abc].tf",
+			path:    "d.tf",
+			want:    false,
+		},
+		{
+			name:    "backslash escapes a metacharacter to match literally",
+			pattern: `a\*b.tf`,
+			path:    "a*b.tf",
+			want:    true,
+		},
+		{
+			name:    "escaped metacharacter does not match as a wildcard",
+			pattern: `a\*b.tf`,
+			path:    "acb.tf",
+			want:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			matcher, err := glob.Compile(tc.pattern)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.want, matcher.Match(tc.path))
+		})
+	}
+}
+
+func TestCompileRejectsInvalidPattern(t *testing.T) {
+	t.Parallel()
+
+	// An unterminated character class is rejected by the underlying matcher.
+	_, err := glob.Compile("[unterminated")
+	require.Error(t, err)
+}
+
+func TestExpand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		files   []string
+		dirs    []string
+		pattern string
+		opts    []glob.ExpandOption
+		want    []string
+	}{
+		{
+			name:    "static path hits an existing file",
+			files:   []string{"/mod/main.tf"},
+			pattern: "/mod/main.tf",
+			want:    []string{"/mod/main.tf"},
+		},
+		{
+			name:    "static path returns empty when the file is missing",
+			files:   []string{"/mod/main.tf"},
+			pattern: "/mod/absent.tf",
+			want:    nil,
+		},
+		{
+			name:    "static path returns the directory when no files-only",
+			files:   []string{"/mod/keep.txt"},
+			dirs:    []string{"/mod/sub"},
+			pattern: "/mod/sub",
+			want:    []string{"/mod/sub"},
+		},
+		{
+			name:    "static path with files-only drops a directory match",
+			files:   []string{"/mod/keep.txt"},
+			dirs:    []string{"/mod/sub"},
+			pattern: "/mod/sub",
+			opts:    []glob.ExpandOption{glob.WithFilesOnly()},
+			want:    nil,
+		},
+		{
+			name: "star matches files in one directory",
+			files: []string{
+				"/mod/a.tf",
+				"/mod/b.tf",
+				"/mod/nested/c.tf",
+				"/mod/README.md",
+			},
+			pattern: "/mod/*.tf",
+			want:    []string{"/mod/a.tf", "/mod/b.tf"},
+		},
+		{
+			name: "double-star matches nested files but not the root sibling",
+			files: []string{
+				"/mod/root.tf",
+				"/mod/sub/a.tf",
+				"/mod/sub/deep/b.tf",
+			},
+			pattern: "/mod/**/*.tf",
+			want:    []string{"/mod/sub/a.tf", "/mod/sub/deep/b.tf"},
+		},
+		{
+			name: "brace alternation covers root and nested files",
+			files: []string{
+				"/mod/root.tf",
+				"/mod/sub/nested.tf",
+			},
+			pattern: "/mod/{*.tf,**/*.tf}",
+			want:    []string{"/mod/root.tf", "/mod/sub/nested.tf"},
+		},
+		{
+			name: "files-only skips directories matched by the pattern",
+			files: []string{
+				"/mod/keep.tf",
+			},
+			dirs:    []string{"/mod/also"},
+			pattern: "/mod/*",
+			opts:    []glob.ExpandOption{glob.WithFilesOnly()},
+			want:    []string{"/mod/keep.tf"},
+		},
+		{
+			name: "without files-only the same pattern includes the directory",
+			files: []string{
+				"/mod/keep.tf",
+			},
+			dirs:    []string{"/mod/also"},
+			pattern: "/mod/*",
+			want:    []string{"/mod/also", "/mod/keep.tf"},
+		},
+		{
+			name: "backslash escape matches a literal star in a filename",
+			files: []string{
+				"/mod/a*b.tf",
+				"/mod/acb.tf",
+			},
+			pattern: `/mod/a\*b.tf`,
+			want:    []string{"/mod/a*b.tf"},
+		},
+		{
+			name:    "missing root directory returns empty without error",
+			files:   nil,
+			pattern: "/does-not-exist/**/*.tf",
+			want:    nil,
+		},
+		{
+			name: "pattern that matches nothing returns empty",
+			files: []string{
+				"/mod/README.md",
+			},
+			pattern: "/mod/*.tf",
+			want:    nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := vfs.NewMemMapFS()
+			for _, p := range tc.files {
+				require.NoError(t, vfs.WriteFile(fs, p, []byte{}, 0o644))
+			}
+
+			for _, d := range tc.dirs {
+				require.NoError(t, fs.MkdirAll(d, 0o755))
+			}
+
+			got, err := glob.Expand(fs, tc.pattern, tc.opts...)
+			require.NoError(t, err)
+
+			// Sort both sides so the assertion is robust to walker ordering
+			// changes without asserting a specific traversal order.
+			slices.Sort(got)
+
+			want := slices.Clone(tc.want)
+			slices.Sort(want)
+
+			assert.Equal(t, want, got, "pattern %q", tc.pattern)
+		})
+	}
+}
+
+func TestExpandRejectsInvalidPattern(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fs, "/mod/a.tf", []byte{}, 0o644))
+
+	_, err := glob.Expand(fs, "/mod/[unterminated")
+	require.Error(t, err)
+}
+
+// TestLegacyExpandCollapsesGlobstar documents the reason LegacyExpand exists:
+// zglob collapses the separators flanking `**`, whereas Expand (gobwas) does
+// not. Switching the include_in_copy / exclude_from_copy call site from
+// LegacyExpand to Expand would silently change user-facing behavior for
+// patterns like `foo/**/bar.tf`.
+//
+// LegacyExpand reaches the real filesystem, so this test uses t.TempDir()
+// instead of MemMapFS.
+func TestLegacyExpandCollapsesGlobstar(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "root.tf"), nil, 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "sub", "nested.tf"), nil, 0o644))
+
+	pattern := filepath.ToSlash(root) + "/**/*.tf"
+
+	got, err := glob.LegacyExpand(pattern)
+	require.NoError(t, err)
+
+	slices.Sort(got)
+
+	want := []string{
+		filepath.Join(root, "root.tf"),
+		filepath.Join(root, "sub", "nested.tf"),
+	}
+	slices.Sort(want)
+
+	assert.Equal(t, want, got,
+		"zglob collapses `**` so root.tf matches even though it sits alongside sub/")
+}
+
+// TestExpandDivergesFromLegacyOnGlobstar is the counterpart: same pattern
+// shape, same tree, different result under gobwas semantics. Keeps the
+// divergence visible so a future refactor cannot quietly erase it.
+func TestExpandDivergesFromLegacyOnGlobstar(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fs, "/mod/root.tf", nil, 0o644))
+	require.NoError(t, vfs.WriteFile(fs, "/mod/sub/nested.tf", nil, 0o644))
+
+	got, err := glob.Expand(fs, "/mod/**/*.tf")
+	require.NoError(t, err)
+
+	// Only the nested file survives: gobwas does not collapse `**`.
+	assert.Equal(t, []string{"/mod/sub/nested.tf"}, got)
+}

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
@@ -423,7 +424,7 @@ func checkTerraformCodeDefinesBackend(opts *Options, backendType string) error {
 		return errors.New(err)
 	}
 
-	definesJSONBackend, err := util.Grep(terraformJSONBackendRegexp, opts.WorkingDir+"/**/*.tf.json")
+	definesJSONBackend, err := util.GrepFilesWithSuffix(vfs.NewOSFS(), terraformJSONBackendRegexp, opts.WorkingDir, ".tf.json")
 	if err != nil {
 		return err
 	}

--- a/internal/services/catalog/ignore/ignore.go
+++ b/internal/services/catalog/ignore/ignore.go
@@ -13,15 +13,14 @@ import (
 	"strings"
 
 	tgerrors "github.com/gruntwork-io/terragrunt/internal/errors"
-
-	"github.com/gobwas/glob"
+	"github.com/gruntwork-io/terragrunt/internal/glob"
 )
 
 // FileName is the fixed name looked up at the repo root.
 const FileName = ".terragrunt-catalog-ignore"
 
 type rule struct {
-	glob   glob.Glob
+	glob   glob.Matcher
 	raw    string
 	negate bool
 }
@@ -107,7 +106,7 @@ func Parse(r io.Reader) (*Matcher, error) {
 			continue
 		}
 
-		g, err := glob.Compile(line, '/')
+		g, err := glob.Compile(line)
 		if err != nil {
 			return nil, tgerrors.Errorf("%s line %d: invalid pattern %q: %w", FileName, lineNo, line, err)
 		}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -18,6 +18,7 @@ import (
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/mattn/go-zglob"
 	"github.com/mitchellh/go-homedir"
@@ -107,32 +108,46 @@ func CanonicalResolvedPath(path, basePath string) (string, error) {
 	return ResolvePath(canonical), nil
 }
 
-// Grep returns true if the given regex can be found in any of the files matched by the given glob.
-func Grep(regex *regexp.Regexp, glob string) (bool, error) {
-	// Ideally, we'd use a builin Go library like filepath.Glob here, but per https://github.com/golang/go/issues/11862,
-	// the current go implementation doesn't support treating ** as zero or more directories, just zero or one.
-	// So we use a third-party library.
-	matches, err := zglob.Glob(glob)
+// GrepFilesWithSuffix returns true if regex matches the contents of any file
+// under rootDir whose name ends with suffix. The walk stops as soon as a match
+// is found. A missing rootDir is not an error — the function returns false.
+func GrepFilesWithSuffix(fsys vfs.FS, regex *regexp.Regexp, rootDir, suffix string) (bool, error) {
+	var found bool
+
+	err := vfs.WalkDir(fsys, rootDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if errors.Is(walkErr, fs.ErrNotExist) {
+				return fs.SkipAll
+			}
+
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if !strings.HasSuffix(d.Name(), suffix) {
+			return nil
+		}
+
+		contents, err := vfs.ReadFile(fsys, path)
+		if err != nil {
+			return err
+		}
+
+		if regex.Match(contents) {
+			found = true
+			return fs.SkipAll
+		}
+
+		return nil
+	})
 	if err != nil {
 		return false, errors.New(err)
 	}
 
-	for _, match := range matches {
-		if IsDir(match) {
-			continue
-		}
-
-		bytes, err := os.ReadFile(match)
-		if err != nil {
-			return false, errors.New(err)
-		}
-
-		if regex.Match(bytes) {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return found, nil
 }
 
 // FindTFFiles walks through the directory and returns all OpenTofu/Terraform files (.tf, .tofu, .tf.json, .tofu.json)

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -18,9 +18,9 @@ import (
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/glob"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/mattn/go-zglob"
 	"github.com/mitchellh/go-homedir"
 )
 
@@ -312,7 +312,7 @@ func pathContainsPrefix(path string, prefixes []string) bool {
 func expandGlobPath(source, absoluteGlobPath string) ([]string, error) {
 	includeExpandedGlobs := []string{}
 
-	absoluteExpandGlob, err := zglob.Glob(absoluteGlobPath)
+	absoluteExpandGlob, err := glob.LegacyExpand(absoluteGlobPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		// we ignore not exist error as we only care about the globs that exist in the src dir
 		return nil, errors.New(err)

--- a/internal/util/grep_test.go
+++ b/internal/util/grep_test.go
@@ -16,13 +16,12 @@ func TestGrepFilesWithSuffix(t *testing.T) {
 	backendRegex := regexp.MustCompile(`(?m)"backend":[[:space:]]*{[[:space:]]*"s3"`)
 
 	tests := []struct {
-		files     map[string]string
-		regex     *regexp.Regexp
-		name      string
-		root      string
-		suffix    string
-		want      bool
-		expectErr bool
+		files  map[string]string
+		regex  *regexp.Regexp
+		name   string
+		root   string
+		suffix string
+		want   bool
 	}{
 		{
 			name: "matches file at root",
@@ -119,23 +118,19 @@ func TestGrepFilesWithSuffix(t *testing.T) {
 			}
 
 			got, err := util.GrepFilesWithSuffix(fsys, tc.regex, tc.root, tc.suffix)
-			if tc.expectErr {
-				require.Error(t, err)
-				return
-			}
-
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 		})
 	}
 }
 
-func TestGrepFilesWithSuffix_StopsEarly(t *testing.T) {
+func TestGrepFilesWithSuffix_SurvivesUnmatchedSiblings(t *testing.T) {
 	t.Parallel()
 
-	// Writing a sentinel after the expected match; if the walk kept going, we'd still
-	// return true. The key property we can check here is that the function doesn't
-	// crash or error out when there are many files past the first match.
+	// Exercises the case where a matching file sits alongside many non-matching
+	// siblings. Proving that the walk actually short-circuits would require a
+	// counting FS wrapper; this test only asserts that the function still
+	// returns the match without being derailed by the surrounding files.
 	fsys := vfs.NewMemMapFS()
 
 	regex := regexp.MustCompile(`needle`)

--- a/internal/util/grep_test.go
+++ b/internal/util/grep_test.go
@@ -1,0 +1,152 @@
+package util_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrepFilesWithSuffix(t *testing.T) {
+	t.Parallel()
+
+	backendRegex := regexp.MustCompile(`(?m)"backend":[[:space:]]*{[[:space:]]*"s3"`)
+
+	tests := []struct {
+		files     map[string]string
+		regex     *regexp.Regexp
+		name      string
+		root      string
+		suffix    string
+		want      bool
+		expectErr bool
+	}{
+		{
+			name: "matches file at root",
+			files: map[string]string{
+				"/mod/backend.tf.json": `{"terraform": {"backend": {"s3": {}}}}`,
+			},
+			root:   "/mod",
+			suffix: ".tf.json",
+			regex:  backendRegex,
+			want:   true,
+		},
+		{
+			name: "matches nested file",
+			files: map[string]string{
+				"/mod/readme.md":                "hello",
+				"/mod/sub/deep/backend.tf.json": `{"terraform": {"backend": {"s3": {}}}}`,
+			},
+			root:   "/mod",
+			suffix: ".tf.json",
+			regex:  backendRegex,
+			want:   true,
+		},
+		{
+			name: "no match when suffix differs",
+			files: map[string]string{
+				// .tf, not .tf.json — must be skipped.
+				"/mod/backend.tf": `terraform { backend "s3" {} }`,
+			},
+			root:   "/mod",
+			suffix: ".tf.json",
+			regex:  backendRegex,
+			want:   false,
+		},
+		{
+			name: "no match when regex does not hit",
+			files: map[string]string{
+				"/mod/main.tf.json":   `{"resource": {}}`,
+				"/mod/output.tf.json": `{"output": {}}`,
+			},
+			root:   "/mod",
+			suffix: ".tf.json",
+			regex:  backendRegex,
+			want:   false,
+		},
+		{
+			name: "ignores files outside root",
+			files: map[string]string{
+				"/other/backend.tf.json": `{"terraform": {"backend": {"s3": {}}}}`,
+				"/mod/main.tf.json":      `{}`,
+			},
+			root:   "/mod",
+			suffix: ".tf.json",
+			regex:  backendRegex,
+			want:   false,
+		},
+		{
+			name:   "missing root returns false without error",
+			files:  map[string]string{},
+			root:   "/does-not-exist",
+			suffix: ".tf.json",
+			regex:  backendRegex,
+			want:   false,
+		},
+		{
+			name: "empty suffix matches any file",
+			files: map[string]string{
+				"/mod/notes": "has backend s3 annotation",
+			},
+			root:   "/mod",
+			suffix: "",
+			regex:  regexp.MustCompile(`backend s3`),
+			want:   true,
+		},
+		{
+			name: "compound suffix is honored",
+			files: map[string]string{
+				// .json alone should not be enough when suffix is .tf.json.
+				"/mod/config.json": `{"terraform": {"backend": {"s3": {}}}}`,
+			},
+			root:   "/mod",
+			suffix: ".tf.json",
+			regex:  backendRegex,
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fsys := vfs.NewMemMapFS()
+			for path, contents := range tc.files {
+				require.NoError(t, vfs.WriteFile(fsys, path, []byte(contents), 0o644))
+			}
+
+			got, err := util.GrepFilesWithSuffix(fsys, tc.regex, tc.root, tc.suffix)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGrepFilesWithSuffix_StopsEarly(t *testing.T) {
+	t.Parallel()
+
+	// Writing a sentinel after the expected match; if the walk kept going, we'd still
+	// return true. The key property we can check here is that the function doesn't
+	// crash or error out when there are many files past the first match.
+	fsys := vfs.NewMemMapFS()
+
+	regex := regexp.MustCompile(`needle`)
+
+	require.NoError(t, vfs.WriteFile(fsys, "/mod/a.tf.json", []byte(`needle`), 0o644))
+
+	for _, name := range []string{"/mod/b.tf.json", "/mod/c.tf.json", "/mod/sub/d.tf.json"} {
+		require.NoError(t, vfs.WriteFile(fsys, name, []byte(`no match`), 0o644))
+	}
+
+	got, err := util.GrepFilesWithSuffix(fsys, regex, "/mod", ".tf.json")
+	require.NoError(t, err)
+	assert.True(t, got)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1771,6 +1771,10 @@ func convertToTerragruntConfig(ctx context.Context, pctx *ParsingContext, config
 	terragruntConfig.Terraform = terragruntConfigFromFile.Terraform
 	if terragruntConfig.Terraform != nil { // since Terraform is nil each time avoid saving metadata when it is nil
 		terragruntConfig.SetFieldMetadata(MetadataTerraform, defaultMetadata)
+
+		if pctx.Experiments.Evaluate(experiment.MarkManyAsRead) && terragruntConfig.Terraform.Source != nil {
+			markLocalModuleSourceAsRead(pctx, configPath, *terragruntConfig.Terraform.Source)
+		}
 	}
 
 	if err := validateDependencies(pctx, terragruntConfigFromFile.Dependencies); err != nil {
@@ -1956,6 +1960,70 @@ func convertToTerragruntConfig(ctx context.Context, pctx *ParsingContext, config
 	}
 
 	return terragruntConfig, errs.ErrorOrNil()
+}
+
+// moduleSourceReadExtensions lists file extensions within a local terraform module
+// whose changes should propagate to consuming units via reading-based filters.
+var moduleSourceReadExtensions = map[string]struct{}{
+	".tf":        {},
+	".tf.json":   {},
+	".hcl":       {},
+	".tofu":      {},
+	".tofu.json": {},
+}
+
+// markLocalModuleSourceAsRead walks the local terraform module pointed to by
+// rawSource and marks its configuration files as read in pctx.FilesRead. It is a
+// best-effort annotation: non-local sources are skipped and walk errors are
+// swallowed, since a genuinely broken source will surface during download.
+func markLocalModuleSourceAsRead(pctx *ParsingContext, configPath, rawSource string) {
+	sourceWithoutSubdir, subdir := getter.SourceDirSubdir(rawSource)
+
+	sourceURL, err := tf.ToSourceURL(sourceWithoutSubdir, filepath.Dir(configPath))
+	if err != nil || !tf.IsLocalSource(sourceURL) {
+		return
+	}
+
+	moduleDir := filepath.Clean(sourceURL.Path)
+	if subdir != "" {
+		moduleDir = filepath.Clean(filepath.Join(moduleDir, subdir))
+	}
+
+	_ = filepath.WalkDir(moduleDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// Skip unreadable entries rather than aborting the whole walk.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+
+		if d.IsDir() {
+			return util.SkipDirIfIgnorable(d.Name())
+		}
+
+		ext := moduleSourceFileExtension(d.Name())
+		if _, ok := moduleSourceReadExtensions[ext]; !ok {
+			return nil
+		}
+
+		trackFileRead(pctx.FilesRead, path)
+
+		return nil
+	})
+}
+
+// moduleSourceFileExtension returns the extension used for matching module source
+// files, honoring compound extensions like ".tf.json" and ".tofu.json".
+func moduleSourceFileExtension(name string) string {
+	for _, compound := range []string{".tf.json", ".tofu.json"} {
+		if strings.HasSuffix(name, compound) {
+			return compound
+		}
+	}
+
+	return filepath.Ext(name)
 }
 
 // Iterate over dependencies paths and check if directories exists, return error with all missing dependencies

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1989,7 +1989,12 @@ func markLocalModuleSourceAsRead(pctx *ParsingContext, configPath, rawSource str
 		moduleDir = filepath.Clean(filepath.Join(moduleDir, subdir))
 	}
 
-	_ = filepath.WalkDir(moduleDir, func(path string, d fs.DirEntry, walkErr error) error {
+	walkFunc := filepath.WalkDir
+	if pctx.Experiments.Evaluate(experiment.Symlinks) {
+		walkFunc = util.WalkDirWithSymlinks
+	}
+
+	_ = walkFunc(moduleDir, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			// Skip unreadable entries rather than aborting the whole walk.
 			if d != nil && d.IsDir() {

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -1686,10 +1687,10 @@ func markAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []
 // markGlobAsRead expands the given glob pattern and marks each matched file as
 // read. Pattern syntax follows the internal/glob package: '/' is the
 // separator, `**` matches any sequence of characters, `*` matches within a
-// single segment, and '\' escapes the next metacharacter. Note that `**`
-// does not collapse the surrounding separators, so "a/**/b" will not match
-// "a/b"; use "{a/b,a/**/b}" for zero-or-more semantics. Returns the list of
-// absolute file paths that were marked.
+// single segment, and '\' escapes the next metacharacter. `**` only
+// collapses the flanking separators when the adjacent segments are literals,
+// so "a/**/*.tf" will not match "a/b.tf"; use "a/{*.tf,**/*.tf}" to cover
+// both depths. Returns the list of absolute file paths that were marked.
 func markGlobAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) ([]string, error) {
 	attrs := map[string]any{
 		"config_path": pctx.TerragruntConfigPath,
@@ -1731,7 +1732,7 @@ func markGlobAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, arg
 			pattern = path.Clean(filepath.ToSlash(pctx.WorkingDir) + "/" + raw)
 		}
 
-		matches, err := glob.Expand(pattern, glob.WithFilesOnly())
+		matches, err := glob.Expand(vfs.NewOSFS(), pattern, glob.WithFilesOnly())
 		if err != nil {
 			return errors.New(fmt.Errorf("could not expand glob %q: %w", raw, err))
 		}

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -19,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/getsops/sops/v3/cmd/sops/formats"
 	"github.com/getsops/sops/v3/decrypt"
+	"github.com/gobwas/glob"
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -101,6 +103,7 @@ const (
 	FuncNameStrContains                             = "strcontains"
 	FuncNameTimeCmp                                 = "timecmp"
 	FuncNameMarkAsRead                              = "mark_as_read"
+	FuncNameMarkGlobAsRead                          = "mark_glob_as_read"
 	FuncNameConstraintCheck                         = "constraint_check"
 )
 
@@ -199,6 +202,7 @@ func createTerragruntEvalContext(ctx context.Context, pctx *ParsingContext, l lo
 		FuncNameReadTfvarsFile:                          wrapStringSliceToStringAsFuncImpl(ctx, pctx, l, readTFVarsFile),
 		FuncNameGetWorkingDir:                           wrapVoidToStringAsFuncImpl(ctx, pctx, l, getWorkingDir),
 		FuncNameMarkAsRead:                              wrapStringSliceToStringAsFuncImpl(ctx, pctx, l, markAsRead),
+		FuncNameMarkGlobAsRead:                          wrapStringSliceToStringSliceAsFuncImpl(ctx, pctx, l, markGlobAsRead),
 		FuncNameConstraintCheck:                         wrapStringSliceToBoolAsFuncImpl(ctx, pctx, ConstraintCheck),
 
 		// Map with HCL functions introduced in Terraform after v0.15.3, since upgrade to a later version is not supported
@@ -1677,6 +1681,205 @@ func markAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []
 	})
 
 	return result, err
+}
+
+// markGlobAsRead expands the given glob pattern and marks each matched file as
+// read. Pattern syntax is the one implemented by github.com/gobwas/glob using
+// '/' as the path separator, so `**` matches any sequence of path segments and
+// `*` matches within a single segment. Returns the list of absolute file paths
+// that were marked.
+func markGlobAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) ([]string, error) {
+	attrs := map[string]any{
+		"config_path": pctx.TerragruntConfigPath,
+		"working_dir": pctx.WorkingDir,
+	}
+	if len(args) > 0 {
+		attrs["glob"] = args[0]
+	}
+
+	var result []string
+
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_mark_glob_as_read", attrs, func(childCtx context.Context) error {
+		if !pctx.Experiments.Evaluate(experiment.MarkManyAsRead) {
+			pattern := ""
+			if len(args) > 0 {
+				pattern = args[0]
+			}
+
+			return errors.New(MarkGlobAsReadRequiresExperimentError{
+				ConfigPath: pctx.TerragruntConfigPath,
+				Pattern:    pattern,
+			})
+		}
+
+		if len(args) != 1 {
+			return errors.New(WrongNumberOfParamsError{Func: FuncNameMarkGlobAsRead, Expected: "1", Actual: len(args)})
+		}
+
+		raw := args[0]
+
+		pattern := raw
+		if !filepath.IsAbs(pattern) {
+			pattern = filepath.Join(pctx.WorkingDir, pattern)
+		}
+
+		pattern = filepath.ToSlash(filepath.Clean(pattern))
+
+		matchers, err := compileGlobstarVariants(pattern)
+		if err != nil {
+			return errors.New(fmt.Errorf("could not compile glob %q: %w", raw, err))
+		}
+
+		root, hasMeta := splitGlobRoot(pattern)
+
+		if !hasMeta {
+			// Static path — match only if the file exists and is not a directory.
+			if info, statErr := os.Stat(root); statErr == nil && !info.IsDir() {
+				trackFileRead(pctx.FilesRead, root)
+				result = append(result, root)
+			}
+
+			return nil
+		}
+
+		walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				if d != nil && d.IsDir() {
+					return fs.SkipDir
+				}
+
+				return nil
+			}
+
+			if d.IsDir() {
+				return nil
+			}
+
+			slashPath := filepath.ToSlash(path)
+			matched := false
+
+			for _, m := range matchers {
+				if m.Match(slashPath) {
+					matched = true
+					break
+				}
+			}
+
+			if !matched {
+				return nil
+			}
+
+			trackFileRead(pctx.FilesRead, path)
+			result = append(result, path)
+
+			return nil
+		})
+		if walkErr != nil && !os.IsNotExist(walkErr) {
+			return errors.New(fmt.Errorf("could not expand glob %q: %w", raw, walkErr))
+		}
+
+		return nil
+	})
+
+	return result, err
+}
+
+// compileGlobstarVariants compiles the pattern and, for each `/**/` substring,
+// an additional variant where that `/**/` is collapsed to `/`. This reproduces
+// bash's globstar semantics (where `/**/` matches zero or more intermediate
+// directories) on top of github.com/gobwas/glob, which otherwise requires at
+// least one character between the flanking separators.
+func compileGlobstarVariants(pattern string) ([]glob.Glob, error) {
+	variants := globstarVariants(pattern)
+	matchers := make([]glob.Glob, 0, len(variants))
+
+	for _, v := range variants {
+		m, err := glob.Compile(v, '/')
+		if err != nil {
+			return nil, err
+		}
+
+		matchers = append(matchers, m)
+	}
+
+	return matchers, nil
+}
+
+// globstarVariants returns all pattern strings obtained by independently
+// choosing, for each `/**/` substring, whether to keep it or collapse it to `/`.
+// The original pattern is always included. A sentinel caps expansion at a
+// reasonable number of variants to avoid pathological inputs.
+func globstarVariants(pattern string) []string {
+	const maxGlobstars = 4
+
+	positions := make([]int, 0, maxGlobstars)
+	start := 0
+
+	for {
+		idx := strings.Index(pattern[start:], "/**/")
+		if idx < 0 {
+			break
+		}
+
+		positions = append(positions, start+idx)
+		start += idx + 1
+
+		if len(positions) >= maxGlobstars {
+			break
+		}
+	}
+
+	if len(positions) == 0 {
+		return []string{pattern}
+	}
+
+	variants := make([]string, 0, 1<<len(positions))
+
+	for mask := range 1 << len(positions) {
+		var b strings.Builder
+
+		last := 0
+		for i, pos := range positions {
+			b.WriteString(pattern[last:pos])
+
+			if mask&(1<<i) != 0 {
+				b.WriteByte('/')
+			} else {
+				b.WriteString("/**/")
+			}
+
+			last = pos + len("/**/")
+		}
+
+		b.WriteString(pattern[last:])
+		variants = append(variants, b.String())
+	}
+
+	return variants
+}
+
+// splitGlobRoot returns the longest leading directory of pattern that contains
+// no glob metacharacters, and reports whether any metacharacters were found.
+// pattern must use '/' as the separator (filepath.ToSlash has been applied).
+func splitGlobRoot(pattern string) (string, bool) {
+	metaIdx := strings.IndexAny(pattern, "*?[{")
+	if metaIdx < 0 {
+		return pattern, false
+	}
+
+	prefix := pattern[:metaIdx]
+
+	if i := strings.LastIndex(prefix, "/"); i >= 0 {
+		prefix = prefix[:i]
+	} else {
+		prefix = "."
+	}
+
+	if prefix == "" {
+		prefix = "/"
+	}
+
+	return filepath.FromSlash(prefix), true
 }
 
 // warnWhenFileNotMarkedAsRead warns when a file is not being marked as read, even though a user might expect it to be.

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/fs"
 	"maps"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -20,7 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/getsops/sops/v3/cmd/sops/formats"
 	"github.com/getsops/sops/v3/decrypt"
-	"github.com/gobwas/glob"
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -35,6 +34,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/glob"
 	"github.com/gruntwork-io/terragrunt/internal/locks"
 	"github.com/gruntwork-io/terragrunt/internal/retry"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
@@ -1684,10 +1684,12 @@ func markAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []
 }
 
 // markGlobAsRead expands the given glob pattern and marks each matched file as
-// read. Pattern syntax is the one implemented by github.com/gobwas/glob using
-// '/' as the path separator, so `**` matches any sequence of path segments and
-// `*` matches within a single segment. Returns the list of absolute file paths
-// that were marked.
+// read. Pattern syntax follows the internal/glob package: '/' is the
+// separator, `**` matches any sequence of characters, `*` matches within a
+// single segment, and '\' escapes the next metacharacter. Note that `**`
+// does not collapse the surrounding separators, so "a/**/b" will not match
+// "a/b"; use "{a/b,a/**/b}" for zero-or-more semantics. Returns the list of
+// absolute file paths that were marked.
 func markGlobAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) ([]string, error) {
 	attrs := map[string]any{
 		"config_path": pctx.TerragruntConfigPath,
@@ -1718,168 +1720,31 @@ func markGlobAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, arg
 
 		raw := args[0]
 
-		pattern := raw
-		if !filepath.IsAbs(pattern) {
-			pattern = filepath.Join(pctx.WorkingDir, pattern)
+		// Keep the pattern in forward-slash space end-to-end. filepath.Join and
+		// filepath.Clean would rewrite '/' to '\' on Windows, and a subsequent
+		// filepath.ToSlash would then clobber any user-supplied '\' escapes that
+		// gobwas relies on to match literal metacharacters.
+		var pattern string
+		if filepath.IsAbs(raw) {
+			pattern = path.Clean(raw)
+		} else {
+			pattern = path.Clean(filepath.ToSlash(pctx.WorkingDir) + "/" + raw)
 		}
 
-		pattern = filepath.ToSlash(filepath.Clean(pattern))
-
-		matchers, err := compileGlobstarVariants(pattern)
+		matches, err := glob.Expand(pattern, glob.WithFilesOnly())
 		if err != nil {
-			return errors.New(fmt.Errorf("could not compile glob %q: %w", raw, err))
+			return errors.New(fmt.Errorf("could not expand glob %q: %w", raw, err))
 		}
 
-		root, hasMeta := splitGlobRoot(pattern)
-
-		if !hasMeta {
-			// Static path — match only if the file exists and is not a directory.
-			if info, statErr := os.Stat(root); statErr == nil && !info.IsDir() {
-				trackFileRead(pctx.FilesRead, root)
-				result = append(result, root)
-			}
-
-			return nil
-		}
-
-		walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				if d != nil && d.IsDir() {
-					return fs.SkipDir
-				}
-
-				return nil
-			}
-
-			if d.IsDir() {
-				return nil
-			}
-
-			slashPath := filepath.ToSlash(path)
-			matched := false
-
-			for _, m := range matchers {
-				if m.Match(slashPath) {
-					matched = true
-					break
-				}
-			}
-
-			if !matched {
-				return nil
-			}
-
-			trackFileRead(pctx.FilesRead, path)
-			result = append(result, path)
-
-			return nil
-		})
-		if walkErr != nil && !os.IsNotExist(walkErr) {
-			return errors.New(fmt.Errorf("could not expand glob %q: %w", raw, walkErr))
+		for _, match := range matches {
+			trackFileRead(pctx.FilesRead, match)
+			result = append(result, match)
 		}
 
 		return nil
 	})
 
 	return result, err
-}
-
-// compileGlobstarVariants compiles the pattern and, for each `/**/` substring,
-// an additional variant where that `/**/` is collapsed to `/`. This reproduces
-// bash's globstar semantics (where `/**/` matches zero or more intermediate
-// directories) on top of github.com/gobwas/glob, which otherwise requires at
-// least one character between the flanking separators.
-func compileGlobstarVariants(pattern string) ([]glob.Glob, error) {
-	variants := globstarVariants(pattern)
-	matchers := make([]glob.Glob, 0, len(variants))
-
-	for _, v := range variants {
-		m, err := glob.Compile(v, '/')
-		if err != nil {
-			return nil, err
-		}
-
-		matchers = append(matchers, m)
-	}
-
-	return matchers, nil
-}
-
-// globstarVariants returns all pattern strings obtained by independently
-// choosing, for each `/**/` substring, whether to keep it or collapse it to `/`.
-// The original pattern is always included. A sentinel caps expansion at a
-// reasonable number of variants to avoid pathological inputs.
-func globstarVariants(pattern string) []string {
-	const maxGlobstars = 4
-
-	positions := make([]int, 0, maxGlobstars)
-	start := 0
-
-	for {
-		idx := strings.Index(pattern[start:], "/**/")
-		if idx < 0 {
-			break
-		}
-
-		positions = append(positions, start+idx)
-		start += idx + 1
-
-		if len(positions) >= maxGlobstars {
-			break
-		}
-	}
-
-	if len(positions) == 0 {
-		return []string{pattern}
-	}
-
-	variants := make([]string, 0, 1<<len(positions))
-
-	for mask := range 1 << len(positions) {
-		var b strings.Builder
-
-		last := 0
-		for i, pos := range positions {
-			b.WriteString(pattern[last:pos])
-
-			if mask&(1<<i) != 0 {
-				b.WriteByte('/')
-			} else {
-				b.WriteString("/**/")
-			}
-
-			last = pos + len("/**/")
-		}
-
-		b.WriteString(pattern[last:])
-		variants = append(variants, b.String())
-	}
-
-	return variants
-}
-
-// splitGlobRoot returns the longest leading directory of pattern that contains
-// no glob metacharacters, and reports whether any metacharacters were found.
-// pattern must use '/' as the separator (filepath.ToSlash has been applied).
-func splitGlobRoot(pattern string) (string, bool) {
-	metaIdx := strings.IndexAny(pattern, "*?[{")
-	if metaIdx < 0 {
-		return pattern, false
-	}
-
-	prefix := pattern[:metaIdx]
-
-	if i := strings.LastIndex(prefix, "/"); i >= 0 {
-		prefix = prefix[:i]
-	} else {
-		prefix = "."
-	}
-
-	if prefix == "" {
-		prefix = "/"
-	}
-
-	return filepath.FromSlash(prefix), true
 }
 
 // warnWhenFileNotMarkedAsRead warns when a file is not being marked as read, even though a user might expect it to be.

--- a/pkg/config/cty_helpers.go
+++ b/pkg/config/cty_helpers.go
@@ -152,6 +152,38 @@ func wrapVoidToStringSliceAsFuncImpl(
 	})
 }
 
+// Create a cty Function that takes a string slice as input parameters and returns a string slice as output.
+// The implementation of the function calls the given toWrap function.
+func wrapStringSliceToStringSliceAsFuncImpl(
+	ctx context.Context,
+	pctx *ParsingContext,
+	l log.Logger,
+	toWrap func(ctx context.Context, pctx *ParsingContext, l log.Logger, params []string) ([]string, error),
+) function.Function {
+	return function.New(&function.Spec{
+		VarParam: &function.Parameter{Type: cty.String},
+		Type:     function.StaticReturnType(cty.List(cty.String)),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			params, err := ctySliceToStringSlice(args)
+			if err != nil {
+				return cty.ListValEmpty(cty.String), err
+			}
+
+			outVals, err := toWrap(ctx, pctx, l, params)
+			if err != nil || len(outVals) == 0 {
+				return cty.ListValEmpty(cty.String), err
+			}
+
+			outCtyVals := make([]cty.Value, 0, len(outVals))
+			for _, val := range outVals {
+				outCtyVals = append(outCtyVals, cty.StringVal(val))
+			}
+
+			return cty.ListVal(outCtyVals), nil
+		},
+	})
+}
+
 // Create a cty Function that takes no input parameters and returns as output a string slice. The implementation of the
 // function returns the given string slice.
 func wrapStaticValueToStringSliceAsFuncImpl(out []string) function.Function {

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -313,3 +313,14 @@ type MaxParseDepthError struct {
 func (err MaxParseDepthError) Error() string {
 	return fmt.Sprintf("maximum parse depth of %d exceeded (current depth: %d). This usually indicates circular includes or extremely deep config nesting.", err.Max, err.Depth)
 }
+
+// MarkGlobAsReadRequiresExperimentError is returned when the mark_glob_as_read
+// HCL function is called without the mark-many-as-read experiment enabled.
+type MarkGlobAsReadRequiresExperimentError struct {
+	ConfigPath string
+	Pattern    string
+}
+
+func (err MarkGlobAsReadRequiresExperimentError) Error() string {
+	return fmt.Sprintf("mark_glob_as_read(%q) in %s requires the 'mark-many-as-read' experiment to be enabled", err.Pattern, err.ConfigPath)
+}

--- a/pkg/config/mark_as_read_test.go
+++ b/pkg/config/mark_as_read_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
@@ -29,7 +30,9 @@ func TestMarkGlobAsRead(t *testing.T) {
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MarkManyAsRead))
 
 	// Drive the HCL function via a locals block so we exercise the registered cty wrapper.
-	hcl := `locals { matched = mark_glob_as_read("**/*.tf") }`
+	// Brace alternation covers files at the current depth AND deeper, since gobwas's
+	// "**" does not collapse the surrounding separators.
+	hcl := `locals { matched = mark_glob_as_read("{*.tf,**/*.tf}") }`
 
 	out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
 	require.NoError(t, err)
@@ -41,6 +44,41 @@ func TestMarkGlobAsRead(t *testing.T) {
 	assert.Contains(t, read, filepath.Join(dir, "b.tf"))
 	assert.Contains(t, read, filepath.Join(dir, "nested", "c.tf"))
 	assert.NotContains(t, read, filepath.Join(dir, "README.md"))
+}
+
+// TestMarkGlobAsReadEscapesMetacharacter verifies that a backslash-escaped
+// metacharacter in the pattern is treated as a literal, not a wildcard. Windows
+// cannot create files whose names contain '*', so the test is skipped there.
+func TestMarkGlobAsReadEscapesMetacharacter(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("'*' is not a valid character in Windows filenames")
+	}
+
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, "a*b.tf"), "")
+	writeFile(t, filepath.Join(dir, "acb.tf"), "")
+
+	l := logger.CreateLogger()
+	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, configPath)
+	pctx.WorkingDir = dir
+	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MarkManyAsRead))
+
+	// The HCL string literal '"a\\*b.tf"' decodes to 'a\*b.tf', which the glob
+	// engine reads as a literal 'a*b.tf'.
+	hcl := `locals { matched = mark_glob_as_read("a\\*b.tf") }`
+
+	out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	require.NotNil(t, pctx.FilesRead)
+	read := *pctx.FilesRead
+	assert.Contains(t, read, filepath.Join(dir, "a*b.tf"))
+	assert.NotContains(t, read, filepath.Join(dir, "acb.tf"))
 }
 
 func TestMarkGlobAsReadRequiresExperiment(t *testing.T) {

--- a/pkg/config/mark_as_read_test.go
+++ b/pkg/config/mark_as_read_test.go
@@ -1,0 +1,132 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkGlobAsRead(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, "a.tf"), "")
+	writeFile(t, filepath.Join(dir, "b.tf"), "")
+	writeFile(t, filepath.Join(dir, "nested", "c.tf"), "")
+	writeFile(t, filepath.Join(dir, "README.md"), "")
+
+	l := logger.CreateLogger()
+	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, configPath)
+	pctx.WorkingDir = dir
+	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MarkManyAsRead))
+
+	// Drive the HCL function via a locals block so we exercise the registered cty wrapper.
+	hcl := `locals { matched = mark_glob_as_read("**/*.tf") }`
+
+	out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	require.NotNil(t, pctx.FilesRead)
+	read := *pctx.FilesRead
+	assert.Contains(t, read, filepath.Join(dir, "a.tf"))
+	assert.Contains(t, read, filepath.Join(dir, "b.tf"))
+	assert.Contains(t, read, filepath.Join(dir, "nested", "c.tf"))
+	assert.NotContains(t, read, filepath.Join(dir, "README.md"))
+}
+
+func TestMarkGlobAsReadRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.tf"), "")
+
+	l := logger.CreateLogger()
+	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, configPath)
+	pctx.WorkingDir = dir
+
+	hcl := `locals { matched = mark_glob_as_read("**/*.tf") }`
+
+	_, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mark-many-as-read")
+
+	if pctx.FilesRead != nil {
+		assert.NotContains(t, *pctx.FilesRead, filepath.Join(dir, "a.tf"))
+	}
+}
+
+func TestMarkManyAsReadExperiment(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "modules", "foo")
+	unitDir := filepath.Join(root, "units", "bar")
+
+	writeFile(t, filepath.Join(moduleDir, "main.tf"), "")
+	writeFile(t, filepath.Join(moduleDir, "variables.tf.json"), "{}")
+	writeFile(t, filepath.Join(moduleDir, "helpers.hcl"), "")
+	writeFile(t, filepath.Join(moduleDir, "sub", "nested.tf"), "")
+	writeFile(t, filepath.Join(moduleDir, "README.md"), "")
+	writeFile(t, filepath.Join(moduleDir, ".terraform.lock.hcl"), "")
+
+	configPath := filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
+	writeFile(t, configPath, "")
+
+	hcl := `terraform { source = "../../modules/foo" }`
+
+	t.Run("off by default", func(t *testing.T) {
+		t.Parallel()
+
+		l := logger.CreateLogger()
+		ctx, pctx := newTestParsingContext(t, configPath)
+		pctx.WorkingDir = unitDir
+
+		out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+
+		if pctx.FilesRead != nil {
+			for _, f := range *pctx.FilesRead {
+				assert.NotContains(t, f, moduleDir, "module files should not be marked when experiment is off")
+			}
+		}
+	})
+
+	t.Run("on marks source files", func(t *testing.T) {
+		t.Parallel()
+
+		l := logger.CreateLogger()
+		ctx, pctx := newTestParsingContext(t, configPath)
+		pctx.WorkingDir = unitDir
+		require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MarkManyAsRead))
+
+		out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		require.NotNil(t, pctx.FilesRead)
+
+		read := *pctx.FilesRead
+		assert.Contains(t, read, filepath.Join(moduleDir, "main.tf"))
+		assert.Contains(t, read, filepath.Join(moduleDir, "variables.tf.json"))
+		assert.Contains(t, read, filepath.Join(moduleDir, "helpers.hcl"))
+		assert.Contains(t, read, filepath.Join(moduleDir, "sub", "nested.tf"))
+		assert.Contains(t, read, filepath.Join(moduleDir, ".terraform.lock.hcl"))
+		assert.NotContains(t, read, filepath.Join(moduleDir, "README.md"))
+	})
+}
+
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Closes #5956

Adds a new `mark-many-as-read` experiment that marks many files as read for a unit in one step.

When enabled, units with a local `terraform { source = "..." }` automatically mark every source file under that path as read, and a new `mark_glob_as_read` HCL function lets users mark arbitrary globs of files as read.

Reading-based filters (e.g. `--filter 'reading='`) then cascade module edits to consuming units without each unit having to enumerate files by hand. This propagates to Git-based filters as well.

Also consolidates glob handling into one `internal/glob` package shared by the `filter` and the new HCL function, and routes filesystem access through `vfs`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the mark-many-as-read experiment to auto-mark local Terraform/OpenTofu module source files as read and let reading-based filters cascade those changes.
  * Added a new HCL function to mark files by glob patterns and return matched absolute paths.

* **Documentation**
  * Added docs and a v1.0.3 changelog entry explaining the experiment, the new function, glob semantics, and usage notes.

* **Tests**
  * Added tests covering glob expansion, escaped metacharacters, experiment gating, and module-file marking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->