### PR TITLE
chore: Addressing feedback on #5953 and #5954

### DIFF
--- a/docs/src/data/changelog/v1.0.3/hcl-fmt-diff-no-external-binary.mdx
+++ b/docs/src/data/changelog/v1.0.3/hcl-fmt-diff-no-external-binary.mdx
@@ -8,3 +8,5 @@ category: "bug-fixes"
 Previously, `terragrunt hcl fmt --diff` spawned a `diff` process discovered in `$PATH` to render its output. This made it incompatible with minimal container images and Windows installations where that binary was unavailable.
 
 The flag now produces unified diff output without depending on any external binary.
+
+Note that the output is not byte-identical to GNU `diff -u`. Each file diff is now preceded by a `diff old/<path> new/<path>` header line, and the `---`/`+++` lines no longer include a trailing timestamp. Scripts that parsed the previous output may need small adjustments.

--- a/pkg/config/config_partial_test.go
+++ b/pkg/config/config_partial_test.go
@@ -296,9 +296,8 @@ include "grandparent" {
 			ctx, pctx := newTestParsingContext(t, childPath)
 			pctx = pctx.WithDecodeList(config.TerragruntFlags)
 
-			require.NotPanics(t, func() {
-				_, _ = config.PartialParseConfigFile(ctx, pctx, l, childPath, nil)
-			})
+			_, err := config.PartialParseConfigFile(ctx, pctx, l, childPath, nil)
+			require.Error(t, err, "expected malformed fixture to surface an error rather than silently succeed")
 		})
 	}
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Addresses feedback from #5953 and #5954

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog to document diff output format changes, including a new per-file header format and adjusted line formatting. A compatibility caveat has been added for users parsing previous unified-diff output formats, noting that parser adjustments may be required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->