### PR TITLE
fix(remotestate): survive nil Config passed to New

### DIFF
--- a/internal/remotestate/remote_state.go
+++ b/internal/remotestate/remote_state.go
@@ -33,8 +33,17 @@ type RemoteState struct {
 	backend backend.Backend
 }
 
-// New creates a new `RemoteState` instance.
+// New creates a new `RemoteState` instance. config may be nil when the
+// caller (config.convertToTerragruntConfig) doesn't parse a remote_state
+// block, e.g. a root.hcl that only declares locals — callers used to hit
+// a nil pointer dereference at config.BackendName here and crash.
 func New(config *Config) *RemoteState {
+	if config == nil {
+		return &RemoteState{
+			Config:  &Config{},
+			backend: backend.NewCommonBackend(""),
+		}
+	}
 	remote := &RemoteState{
 		Config:  config,
 		backend: backend.NewCommonBackend(config.BackendName),


### PR DESCRIPTION
Addresses the downstream crash reported in gruntwork-io/terragrunt-ls#134.

## Problem

`config.convertToTerragruntConfig` can call `remotestate.New(nil)` when the parsed configuration doesn't declare a `remote_state` block (e.g. a `root.hcl` that only sets `locals`). The unconditional `config.BackendName` on the next line then panicked:

```
panic: runtime error: invalid memory address or nil pointer dereference
remotestate.New internal/remotestate/remote_state.go:33
config.convertToTerragruntConfig config/config.go:1616
```

That took down `terragrunt-ls` on every `root.hcl` that followed the pattern.

## Fix

Return an empty `RemoteState` backed by a zero-value `*Config` and a no-op common backend when `config` is nil, so callers can continue instead of crashing. The remaining fields already tolerate zero values.

## Test

`go test ./internal/remotestate/...` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability by fixing a crash that could occur during initialization with invalid configuration inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->