### PR TITLE
chore: Add `fast-copy` strict control

### DIFF
--- a/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
+++ b/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
@@ -3,7 +3,7 @@ version: "v1.0.3"
 category: "experiments-added"
 ---
 
-#### `mark-many-as-read`: mark many files as read in one step
+#### `mark-many-as-read` — Mark many files as read in one step
 
 Enable the new [`mark-many-as-read`](/reference/experiments) experiment to turn on two behaviors that each mark many files as read in a single call: automatic marking of files inside a local `terraform { source = "..." }` block, and the new `mark_glob_as_read` HCL function.
 

--- a/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
+++ b/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
@@ -3,7 +3,7 @@ version: "v1.0.3"
 category: "experiments-added"
 ---
 
-#### `mark-many-as-read` — Mark many files as read in one step
+#### `mark-many-as-read`: mark many files as read in one step
 
 Enable the new [`mark-many-as-read`](/reference/experiments) experiment to turn on two behaviors that each mark many files as read in a single call: automatic marking of files inside a local `terraform { source = "..." }` block, and the new `mark_glob_as_read` HCL function.
 

--- a/docs/src/data/changelog/v1.0.4/fast-copy-strict-control.mdx
+++ b/docs/src/data/changelog/v1.0.4/fast-copy-strict-control.mdx
@@ -5,7 +5,7 @@ category: "performance-improvements"
 
 #### `fast-copy` strict control
 
-With the new [`fast-copy`](/reference/strict-controls/active#fast-copy) strict control enabled, Terragrunt compiles each `include_in_copy` and `exclude_from_copy` pattern once and evaluates it inline during a single copy walk. This avoids re-walking subdirectories for every pattern, which should result in noticable speed improvements for large source modules.
+With the new [`fast-copy`](/reference/strict-controls/active#fast-copy) strict control enabled, Terragrunt compiles each `include_in_copy` and `exclude_from_copy` pattern once and evaluates it inline during a single copy walk. This avoids re-walking subdirectories for every pattern, which should result in noticeable speed improvements for large source modules.
 
 ```bash
 terragrunt run plan --strict-control fast-copy

--- a/docs/src/data/changelog/v1.0.4/fast-copy-strict-control.mdx
+++ b/docs/src/data/changelog/v1.0.4/fast-copy-strict-control.mdx
@@ -1,0 +1,14 @@
+---
+version: "v1.0.4"
+category: "performance-improvements"
+---
+
+#### `fast-copy` strict control
+
+With the new [`fast-copy`](/reference/strict-controls/active#fast-copy) strict control enabled, Terragrunt compiles each `include_in_copy` and `exclude_from_copy` pattern once and evaluates it inline during a single copy walk. This avoids re-walking subdirectories for every pattern, which should result in noticable speed improvements for large source modules.
+
+```bash
+terragrunt run plan --strict-control fast-copy
+```
+
+The new matcher does not collapse `**` to zero path segments when a neighbor is a wildcard, so `a/**/*.tf` matches `a/sub/main.tf` but not `a/main.tf`. Patterns that relied on the old collapsing behavior should use brace alternation like `{*.tf,**/*.tf}` to cover both depths.

--- a/docs/src/data/strict-controls/fast-copy.mdx
+++ b/docs/src/data/strict-controls/fast-copy.mdx
@@ -1,6 +1,7 @@
 ---
 name: fast-copy
 status: active
+since: "1.0.4"
 ---
 
 Switches `include_in_copy` and `exclude_from_copy` pattern matching from [zglob](https://pkg.go.dev/github.com/mattn/go-zglob) to [gobwas/glob](https://pkg.go.dev/github.com/gobwas/glob) when Terragrunt copies a module's source folder.

--- a/docs/src/data/strict-controls/fast-copy.mdx
+++ b/docs/src/data/strict-controls/fast-copy.mdx
@@ -1,0 +1,14 @@
+---
+name: fast-copy
+status: active
+---
+
+Use a compile-once, single-walk implementation for `include_in_copy` and `exclude_from_copy` expansion when Terragrunt copies a module's source folder. Faster on large module sources because the walk no longer pre-expands every pattern in a separate pass per nested directory.
+
+### `fast-copy` - Reason
+
+`include_in_copy` and `exclude_from_copy` patterns have historically been expanded with [zglob](https://pkg.go.dev/github.com/mattn/go-zglob), once per pattern, with directory matches recursively re-expanded. On large source trees the pre-expansion can dominate the cost of the copy itself.
+
+Enabling `fast-copy` switches pattern matching to [gobwas/glob](https://pkg.go.dev/github.com/gobwas/glob), compiles each pattern once, and evaluates matches inline during the existing copy walk.
+
+The semantics differ from zglob in one place worth knowing: gobwas does not collapse `**` when one of its neighbors is a wildcard. For example, `a/**/*.tf` matches `a/sub/main.tf` but not `a/main.tf`. Patterns that depended on zero-depth `**` collapsing should use brace alternation, for example `{*.tf,**/*.tf}`, to cover both depths.

--- a/docs/src/data/strict-controls/fast-copy.mdx
+++ b/docs/src/data/strict-controls/fast-copy.mdx
@@ -3,12 +3,10 @@ name: fast-copy
 status: active
 ---
 
-Use a compile-once, single-walk implementation for `include_in_copy` and `exclude_from_copy` expansion when Terragrunt copies a module's source folder. Faster on large module sources because the walk no longer pre-expands every pattern in a separate pass per nested directory.
+Switches `include_in_copy` and `exclude_from_copy` pattern matching from [zglob](https://pkg.go.dev/github.com/mattn/go-zglob) to [gobwas/glob](https://pkg.go.dev/github.com/gobwas/glob) when Terragrunt copies a module's source folder.
 
 ### `fast-copy` - Reason
 
-`include_in_copy` and `exclude_from_copy` patterns have historically been expanded with [zglob](https://pkg.go.dev/github.com/mattn/go-zglob), once per pattern, with directory matches recursively re-expanded. On large source trees the pre-expansion can dominate the cost of the copy itself.
+The default implementation runs zglob once per pattern and recursively re-expands every directory match, which can dominate copy time on large module sources. gobwas compiles each pattern once and matches inline during the existing copy walk.
 
-Enabling `fast-copy` switches pattern matching to [gobwas/glob](https://pkg.go.dev/github.com/gobwas/glob), compiles each pattern once, and evaluates matches inline during the existing copy walk.
-
-The semantics differ from zglob in one place worth knowing: gobwas does not collapse `**` when one of its neighbors is a wildcard. For example, `a/**/*.tf` matches `a/sub/main.tf` but not `a/main.tf`. Patterns that depended on zero-depth `**` collapsing should use brace alternation, for example `{*.tf,**/*.tf}`, to cover both depths.
+gobwas does not collapse `**` when a neighbor is a wildcard, so `a/**/*.tf` matches `a/sub/main.tf` but not `a/main.tf`. Patterns that depended on zero-depth `**` collapsing need brace alternation like `{*.tf,**/*.tf}` to cover both depths.

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
 	github.com/aws/smithy-go v1.24.3
+	github.com/charlievieth/fastwalk v1.0.14
 	github.com/charmbracelet/colorprofile v0.4.2
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F9
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/charlievieth/fastwalk v1.0.14 h1:3Eh5uaFGwHZd8EGwTjJnSpBkfwfsak9h6ICgnWlhAyg=
+github.com/charlievieth/fastwalk v1.0.14/go.mod h1:diVcUreiU1aQ4/Wu3NbxxH4/KYdKpLDojrQ1Bb2KgNY=
 github.com/charmbracelet/colorprofile v0.4.2 h1:BdSNuMjRbotnxHSfxy+PCSa4xAmz7szw70ktAtWRYrY=
 github.com/charmbracelet/colorprofile v0.4.2/go.mod h1:0rTi81QpwDElInthtrQ6Ni7cG0sDtwAd4C4le060fT8=
 github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 h1:eyFRbAmexyt43hVfeyBofiGSEmJ7krjLOYt/9CF5NKA=

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -14,8 +14,8 @@
 // literals. With literals on both sides, "a/**/b" matches "a/b" as well as
 // "a/x/b". If either neighbor is a wildcard (for example "a/**/*.tf" or
 // "*/**/b.tf"), "**" does not collapse and a zero-depth match fails. Use
-// brace alternation — for example "{*.tf,**/*.tf}" — to cover both depths
-// when the trailing segment contains a wildcard.
+// brace alternation like "{*.tf,**/*.tf}" to cover both depths when the
+// trailing segment contains a wildcard.
 //
 // # When to use what
 //

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -96,15 +96,15 @@ func DownloadTerraformSource(
 		// Always include the .tflint.hcl file, if it exists
 		includeInCopy := slices.Concat(cfg.Terraform.IncludeInCopy, []string{tfLintConfig})
 
-		err = util.CopyFolderContents(
-			l,
-			opts.WorkingDir,
-			terraformSource.WorkingDir,
-			ModuleManifestName,
-			includeInCopy,
-			cfg.Terraform.ExcludeFromCopy,
-			isFastCopyEnabled(opts.StrictControls),
-		)
+		copyOpts := []util.CopyOption{
+			util.WithIncludeInCopy(includeInCopy...),
+			util.WithExcludeFromCopy(cfg.Terraform.ExcludeFromCopy...),
+		}
+		if isFastCopyEnabled(opts.StrictControls) {
+			copyOpts = append(copyOpts, util.WithFastCopy())
+		}
+
+		err = util.CopyFolderContents(l, opts.WorkingDir, terraformSource.WorkingDir, ModuleManifestName, copyOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -103,6 +103,7 @@ func DownloadTerraformSource(
 			ModuleManifestName,
 			includeInCopy,
 			cfg.Terraform.ExcludeFromCopy,
+			isFastCopyEnabled(opts.StrictControls),
 		)
 		if err != nil {
 			return nil, err
@@ -316,6 +317,7 @@ func UpdateGetters(l log.Logger, opts *Options, cfg *runcfg.RunConfig) func(*get
 			Logger:          l,
 			IncludeInCopy:   cfg.Terraform.IncludeInCopy,
 			ExcludeFromCopy: cfg.Terraform.ExcludeFromCopy,
+			FastCopy:        isFastCopyEnabled(opts.StrictControls),
 		}
 		client.Getters["http"] = &getter.HttpGetter{Netrc: true}
 		client.Getters["https"] = &getter.HttpGetter{Netrc: true}

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -568,6 +568,7 @@ func copyFolder(t *testing.T, src string, dest string) {
 		".terragrunt-test",
 		nil,
 		nil,
+		false,
 	)
 	require.NoError(t, err)
 }

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -566,9 +566,6 @@ func copyFolder(t *testing.T, src string, dest string) {
 		filepath.FromSlash(src),
 		filepath.FromSlash(dest),
 		".terragrunt-test",
-		nil,
-		nil,
-		false,
 	)
 	require.NoError(t, err)
 }

--- a/internal/runner/run/file_copy_getter.go
+++ b/internal/runner/run/file_copy_getter.go
@@ -54,7 +54,15 @@ func (g *FileCopyGetter) Get(dst string, u *url.URL) error {
 		return errors.Errorf("source path must be a directory")
 	}
 
-	return util.CopyFolderContents(g.Logger, path, dst, SourceManifestName, g.IncludeInCopy, g.ExcludeFromCopy, g.FastCopy)
+	copyOpts := []util.CopyOption{
+		util.WithIncludeInCopy(g.IncludeInCopy...),
+		util.WithExcludeFromCopy(g.ExcludeFromCopy...),
+	}
+	if g.FastCopy {
+		copyOpts = append(copyOpts, util.WithFastCopy())
+	}
+
+	return util.CopyFolderContents(g.Logger, path, dst, SourceManifestName, copyOpts...)
 }
 
 // GetFile The original FileGetter already knows how to do file copying so long as we set the Copy flag to true, so just

--- a/internal/runner/run/file_copy_getter.go
+++ b/internal/runner/run/file_copy_getter.go
@@ -5,10 +5,17 @@ import (
 	"os"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/strict"
+	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-getter"
 )
+
+// isFastCopyEnabled reports whether the `fast-copy` strict control is enabled.
+func isFastCopyEnabled(strictControls strict.Controls) bool {
+	return len(strictControls.FilterByNames(controls.FastCopy).FilterByEnabled()) > 0
+}
 
 // SourceManifestName is the manifest for files copied from the URL specified in the terraform { source = "<URL>" } config
 const SourceManifestName = ".terragrunt-source-manifest"
@@ -24,6 +31,11 @@ type FileCopyGetter struct {
 	// Terragrunt, which will skip hidden folders.
 	IncludeInCopy   []string
 	ExcludeFromCopy []string
+
+	// FastCopy opts the underlying [util.CopyFolderContents] call into the
+	// compile-once, single-walk implementation. Set via the `fast-copy`
+	// strict control at construction time.
+	FastCopy bool
 }
 
 // Get replaces the original FileGetter
@@ -42,7 +54,7 @@ func (g *FileCopyGetter) Get(dst string, u *url.URL) error {
 		return errors.Errorf("source path must be a directory")
 	}
 
-	return util.CopyFolderContents(g.Logger, path, dst, SourceManifestName, g.IncludeInCopy, g.ExcludeFromCopy)
+	return util.CopyFolderContents(g.Logger, path, dst, SourceManifestName, g.IncludeInCopy, g.ExcludeFromCopy, g.FastCopy)
 }
 
 // GetFile The original FileGetter already knows how to do file copying so long as we set the Copy flag to true, so just

--- a/internal/runner/run/file_copy_getter.go
+++ b/internal/runner/run/file_copy_getter.go
@@ -32,9 +32,9 @@ type FileCopyGetter struct {
 	IncludeInCopy   []string
 	ExcludeFromCopy []string
 
-	// FastCopy opts the underlying [util.CopyFolderContents] call into the
-	// compile-once, single-walk implementation. Set via the `fast-copy`
-	// strict control at construction time.
+	// FastCopy routes the [util.CopyFolderContents] call through the
+	// fast-copy path. Set at construction time from the `fast-copy`
+	// strict control.
 	FastCopy bool
 }
 

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -80,10 +80,8 @@ const (
 	// DisableDependentModules is the control that prevents the use of the deprecated `--disable-dependent-modules` flag.
 	DisableDependentModules = "disable-dependent-modules"
 
-	// FastCopy opts into a compile-once, single-walk implementation of
-	// `include_in_copy` / `exclude_from_copy` expansion in
-	// `util.CopyFolderContents`. Faster on large module sources, but
-	// switches pattern matching from zglob to gobwas semantics.
+	// FastCopy is the control that switches `include_in_copy` and
+	// `exclude_from_copy` pattern matching from zglob to gobwas.
 	FastCopy = "fast-copy"
 )
 
@@ -298,7 +296,7 @@ func New() strict.Controls {
 		},
 		&Control{
 			Name:        FastCopy,
-			Description: "Switches `include_in_copy` / `exclude_from_copy` expansion in `util.CopyFolderContents` to a compile-once, single-walk implementation. Pattern matching moves from zglob to gobwas semantics, so `**` no longer collapses when adjacent to a wildcard (for example `a/**/*.tf` will not match `a/foo.tf`). Use brace alternation such as `{*.tf,**/*.tf}` to cover both depths.",
+			Description: "Switches `include_in_copy` and `exclude_from_copy` pattern matching from zglob to gobwas. `**` no longer collapses when adjacent to a wildcard, so `a/**/*.tf` will not match `a/foo.tf`. Use brace alternation like `{*.tf,**/*.tf}` to cover both depths.",
 			Category:    stageCategory,
 		},
 	}

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -79,6 +79,12 @@ const (
 
 	// DisableDependentModules is the control that prevents the use of the deprecated `--disable-dependent-modules` flag.
 	DisableDependentModules = "disable-dependent-modules"
+
+	// FastCopy opts into a compile-once, single-walk implementation of
+	// `include_in_copy` / `exclude_from_copy` expansion in
+	// `util.CopyFolderContents`. Faster on large module sources, but
+	// switches pattern matching from zglob to gobwas semantics.
+	FastCopy = "fast-copy"
 )
 
 //nolint:lll
@@ -289,6 +295,11 @@ func New() strict.Controls {
 			Category:    stageCategory,
 			Error:       errors.New("The `--disable-dependent-modules` flag is no longer supported. Dependent modules discovery has been removed from `terragrunt render`."),
 			Warning:     "The `--disable-dependent-modules` flag is deprecated and will be removed in a future version of Terragrunt. Dependent modules discovery has been removed from `terragrunt render`, so this flag has no effect.",
+		},
+		&Control{
+			Name:        FastCopy,
+			Description: "Switches `include_in_copy` / `exclude_from_copy` expansion in `util.CopyFolderContents` to a compile-once, single-walk implementation. Pattern matching moves from zglob to gobwas semantics, so `**` no longer collapses when adjacent to a wildcard (for example `a/**/*.tf` will not match `a/foo.tf`). Use brace alternation such as `{*.tf,**/*.tf}` to cover both depths.",
+			Category:    stageCategory,
 		},
 	}
 

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -345,6 +346,13 @@ func expandGlobPath(source, absoluteGlobPath string) ([]string, error) {
 
 // CopyFolderContents copies the files and folders within the source folder into the destination folder. Note that hidden files and folders
 // (those starting with a dot) will be skipped. Will create a specified manifest file that contains paths of all copied files.
+//
+// When fastCopy is true, `include_in_copy` and `exclude_from_copy` patterns
+// are compiled once via [glob.Compile] (gobwas semantics) and evaluated
+// inside the copy walk, skipping the recursive pre-expansion that the
+// default path runs for each pattern. Callers should gate fastCopy behind
+// the `fast-copy` strict control so the zglob→gobwas semantic change is
+// opt-in.
 func CopyFolderContents(
 	l log.Logger,
 	source,
@@ -352,10 +360,15 @@ func CopyFolderContents(
 	manifestFile string,
 	includeInCopy []string,
 	excludeFromCopy []string,
+	fastCopy bool,
 ) error {
 	// We use filepath.ToSlash because we end up using globs here, and those expect forward slashes.
 	source = filepath.ToSlash(source)
 	destination = filepath.ToSlash(destination)
+
+	if fastCopy {
+		return copyFolderContentsFast(l, source, destination, manifestFile, includeInCopy, excludeFromCopy)
+	}
 
 	// Expand all the includeInCopy glob paths, converting the globbed results to relative paths so that they work in
 	// the copy filter.
@@ -405,6 +418,182 @@ func CopyFolderContents(
 
 		return !TerragruntExcludes(filepath.FromSlash(relativePath))
 	})
+}
+
+// copyFolderContentsFast is the compile-once, single-walk path for
+// [CopyFolderContents]. See the `fast-copy` strict control.
+func copyFolderContentsFast(
+	l log.Logger,
+	source,
+	destination,
+	manifestFile string,
+	includeInCopy []string,
+	excludeFromCopy []string,
+) error {
+	include, err := compileIncludePatterns(includeInCopy)
+	if err != nil {
+		return err
+	}
+
+	exclude, err := compileExcludePattern(excludeFromCopy)
+	if err != nil {
+		return err
+	}
+
+	return CopyFolderContentsWithFilter(l, source, destination, manifestFile, func(absolutePath string) bool {
+		rel, err := GetPathRelativeTo(absolutePath, source)
+		if err != nil {
+			return false
+		}
+
+		rel = filepath.ToSlash(rel)
+
+		// Preserve the cache-dir skip that expandGlobPath enforced at
+		// expansion time. Must run before include matching — otherwise a
+		// user include like "**" would pull .terragrunt-cache back in.
+		if strings.Contains(rel, TerragruntCacheDir) {
+			return false
+		}
+
+		if exclude != nil && exclude.Match(rel) {
+			return false
+		}
+
+		if include.matches(rel) {
+			return true
+		}
+
+		if !TerragruntExcludes(filepath.FromSlash(rel)) {
+			return true
+		}
+
+		// TerragruntExcludes rejects this path (dot-prefix or similar).
+		// Last chance to keep it: mirror the legacy ancestor pass via
+		// `listContainsElementWithPrefix` — a directory on the path
+		// toward a potential include match must be descended into. The
+		// stat only runs on the TerragruntExcludes-rejected tail, which
+		// is a small subset of the walk.
+		return IsDir(absolutePath) && include.isAncestor(rel)
+	})
+}
+
+// includePatterns holds the compiled include matcher plus a cheap
+// "is rel an ancestor of any potential match" predicate. Ancestor
+// acceptance is what makes the walk descend through dot-prefixed parents
+// like `_module/.region3` to reach an include hidden underneath.
+type includePatterns struct {
+	// match is a single combined matcher built by OR-ing every user
+	// pattern as `{<p>,<p>/**}` inside one brace alternation. One
+	// `Match` call per entry replaces N per-pattern checks.
+	match glob.Matcher
+
+	// ancestor is a combined matcher over the strict path prefixes of
+	// each pattern that does not contain `**`. A rel matching this is a
+	// directory on the way to a potential include match.
+	ancestor glob.Matcher
+
+	// descendAny is true if any pattern contains a `**` segment — in that
+	// case any directory could be on the path to a match, so accept all
+	// non-excluded paths as ancestors regardless of `ancestor`.
+	descendAny bool
+}
+
+func (p includePatterns) matches(rel string) bool {
+	return p.match != nil && p.match.Match(rel)
+}
+
+func (p includePatterns) isAncestor(rel string) bool {
+	if rel == "" || rel == "." {
+		return true
+	}
+
+	if p.descendAny {
+		return true
+	}
+
+	return p.ancestor != nil && p.ancestor.Match(rel)
+}
+
+// compileIncludePatterns compiles user `include_in_copy` patterns into one
+// combined matcher that covers each pattern and all its descendants — so a
+// match behaves like the recursive expansion in [expandGlobPath] — plus an
+// ancestor matcher that flags directories on the path toward a potential
+// match.
+func compileIncludePatterns(patterns []string) (includePatterns, error) {
+	out := includePatterns{}
+
+	if len(patterns) == 0 {
+		return out, nil
+	}
+
+	// Each pattern contributes two alternatives: itself and itself/**.
+	const altsPerPattern = 2
+
+	matchParts := make([]string, 0, altsPerPattern*len(patterns))
+
+	var ancestorParts []string
+
+	for _, p := range patterns {
+		normalized := filepath.ToSlash(p)
+
+		matchParts = append(matchParts, normalized, normalized+"/**")
+
+		segments := strings.Split(normalized, "/")
+
+		if slices.Contains(segments, "**") {
+			out.descendAny = true
+			continue
+		}
+
+		for i := 1; i < len(segments); i++ {
+			ancestorParts = append(ancestorParts, strings.Join(segments[:i], "/"))
+		}
+	}
+
+	match, err := glob.Compile("{" + strings.Join(matchParts, ",") + "}")
+	if err != nil {
+		return includePatterns{}, errors.New(err)
+	}
+
+	out.match = match
+
+	if len(ancestorParts) > 0 {
+		ancestor, err := glob.Compile("{" + strings.Join(ancestorParts, ",") + "}")
+		if err != nil {
+			return includePatterns{}, errors.New(err)
+		}
+
+		out.ancestor = ancestor
+	}
+
+	return out, nil
+}
+
+// compileExcludePattern compiles user `exclude_from_copy` patterns into one
+// combined matcher. Each pattern is wrapped as `{<p>,<p>/**}` so excluding a
+// directory excludes everything under it. Returns nil when patterns is
+// empty.
+func compileExcludePattern(patterns []string) (glob.Matcher, error) {
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+
+	// Each pattern contributes two alternatives: itself and itself/**.
+	const altsPerPattern = 2
+
+	parts := make([]string, 0, altsPerPattern*len(patterns))
+
+	for _, p := range patterns {
+		normalized := filepath.ToSlash(p)
+		parts = append(parts, normalized, normalized+"/**")
+	}
+
+	matcher, err := glob.Compile("{" + strings.Join(parts, ",") + "}")
+	if err != nil {
+		return nil, errors.New(err)
+	}
+
+	return matcher, nil
 }
 
 // CopyFolderContentsWithFilter copies the files and folders within the source folder into the destination folder.

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -345,37 +345,65 @@ func expandGlobPath(source, absoluteGlobPath string) ([]string, error) {
 	return includeExpandedGlobs, nil
 }
 
+// CopyOption configures a [CopyFolderContents] call.
+type CopyOption func(*copyConfig)
+
+type copyConfig struct {
+	includeInCopy   []string
+	excludeFromCopy []string
+	fastCopy        bool
+}
+
+// WithIncludeInCopy adds glob patterns that must be copied even when
+// [TerragruntExcludes] would skip them (for example hidden files).
+func WithIncludeInCopy(patterns ...string) CopyOption {
+	return func(c *copyConfig) {
+		c.includeInCopy = append(c.includeInCopy, patterns...)
+	}
+}
+
+// WithExcludeFromCopy adds glob patterns whose matches must be skipped
+// during the copy.
+func WithExcludeFromCopy(patterns ...string) CopyOption {
+	return func(c *copyConfig) {
+		c.excludeFromCopy = append(c.excludeFromCopy, patterns...)
+	}
+}
+
+// WithFastCopy enables the fast-copy path: patterns compile once through
+// [glob.Compile] and the source tree is walked once via
+// [vfs.WalkDirParallel]. See the `fast-copy` strict control for the
+// semantic implications.
+func WithFastCopy() CopyOption {
+	return func(c *copyConfig) {
+		c.fastCopy = true
+	}
+}
+
 // CopyFolderContents copies the files and folders within the source folder into the destination folder. Note that hidden files and folders
 // (those starting with a dot) will be skipped. Will create a specified manifest file that contains paths of all copied files.
 //
-// When fastCopy is true, `include_in_copy` and `exclude_from_copy` patterns
-// are compiled once via [glob.Compile] (gobwas semantics) and evaluated
-// inside the copy walk, skipping the recursive pre-expansion that the
-// default path runs for each pattern. Callers should gate fastCopy behind
-// the `fast-copy` strict control so the zglob→gobwas semantic change is
-// opt-in.
-func CopyFolderContents(
-	l log.Logger,
-	source,
-	destination,
-	manifestFile string,
-	includeInCopy []string,
-	excludeFromCopy []string,
-	fastCopy bool,
-) error {
+// Optional behavior is configured through [CopyOption] values such as
+// [WithIncludeInCopy], [WithExcludeFromCopy], and [WithFastCopy].
+func CopyFolderContents(l log.Logger, source, destination, manifestFile string, opts ...CopyOption) error {
+	var cfg copyConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	// We use filepath.ToSlash because we end up using globs here, and those expect forward slashes.
 	source = filepath.ToSlash(source)
 	destination = filepath.ToSlash(destination)
 
-	if fastCopy {
-		return copyFolderContentsFast(l, source, destination, manifestFile, includeInCopy, excludeFromCopy)
+	if cfg.fastCopy {
+		return copyFolderContentsFast(l, source, destination, manifestFile, cfg.includeInCopy, cfg.excludeFromCopy)
 	}
 
 	// Expand all the includeInCopy glob paths, converting the globbed results to relative paths so that they work in
 	// the copy filter.
 	includeExpandedGlobs := []string{}
 
-	for _, includeGlob := range includeInCopy {
+	for _, includeGlob := range cfg.includeInCopy {
 		globPath := filepath.Join(source, includeGlob)
 
 		expandGlob, err := expandGlobPath(source, globPath)
@@ -388,7 +416,7 @@ func CopyFolderContents(
 
 	excludeExpandedGlobs := []string{}
 
-	for _, excludeGlob := range excludeFromCopy {
+	for _, excludeGlob := range cfg.excludeFromCopy {
 		globPath := filepath.Join(source, excludeGlob)
 
 		expandGlob, err := expandGlobPath(source, globPath)

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -660,7 +660,10 @@ func compileIncludePatterns(patterns []string) (includePatterns, error) {
 	var ancestorParts []string
 
 	for _, p := range patterns {
-		normalized := filepath.ToSlash(p)
+		normalized := strings.TrimRight(filepath.ToSlash(p), "/")
+		if normalized == "" {
+			continue
+		}
 
 		matchParts = append(matchParts, normalized, normalized+"/**")
 
@@ -710,8 +713,16 @@ func compileExcludePattern(patterns []string) (glob.Matcher, error) {
 	parts := make([]string, 0, altsPerPattern*len(patterns))
 
 	for _, p := range patterns {
-		normalized := filepath.ToSlash(p)
+		normalized := strings.TrimRight(filepath.ToSlash(p), "/")
+		if normalized == "" {
+			continue
+		}
+
 		parts = append(parts, normalized, normalized+"/**")
+	}
+
+	if len(parts) == 0 {
+		return nil, nil
 	}
 
 	matcher, err := glob.Compile("{" + strings.Join(parts, ",") + "}")

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"syscall"
 
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
@@ -421,7 +422,9 @@ func CopyFolderContents(
 }
 
 // copyFolderContentsFast is the compile-once, single-walk path for
-// [CopyFolderContents]. See the `fast-copy` strict control.
+// [CopyFolderContents]. See the `fast-copy` strict control. The walk
+// itself runs via [fastwalk.Walk] so directory reads and filter checks
+// proceed in parallel.
 func copyFolderContentsFast(
 	l log.Logger,
 	source,
@@ -440,41 +443,127 @@ func copyFolderContentsFast(
 		return err
 	}
 
-	return CopyFolderContentsWithFilter(l, source, destination, manifestFile, func(absolutePath string) bool {
-		rel, err := GetPathRelativeTo(absolutePath, source)
+	const ownerReadWriteExecutePerms = 0o700
+	if err := os.MkdirAll(destination, ownerReadWriteExecutePerms); err != nil {
+		return errors.New(err)
+	}
+
+	manifest := NewFileManifest(destination, manifestFile)
+	if err := manifest.Clean(l); err != nil {
+		return errors.New(err)
+	}
+
+	if err := manifest.Create(); err != nil {
+		return errors.New(err)
+	}
+
+	defer func() {
+		if err := manifest.Close(); err != nil {
+			l.Warnf("Error closing manifest file: %v", err)
+		}
+	}()
+
+	// fastwalk runs walkFn concurrently across workers; the gob-encoded
+	// manifest is not safe for concurrent writes, so every AddFile is
+	// guarded by this mutex.
+	var manifestMu sync.Mutex
+
+	walkFn := func(absolutePath string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if absolutePath == source {
+			return nil
+		}
+
+		rel, err := filepath.Rel(source, absolutePath)
 		if err != nil {
-			return false
+			return errors.New(err)
 		}
 
 		rel = filepath.ToSlash(rel)
+
+		isDir := d.IsDir()
 
 		// Preserve the cache-dir skip that expandGlobPath enforced at
 		// expansion time. Must run before include matching — otherwise a
 		// user include like "**" would pull .terragrunt-cache back in.
 		if strings.Contains(rel, TerragruntCacheDir) {
-			return false
+			if isDir {
+				return fs.SkipDir
+			}
+
+			return nil
 		}
 
 		if exclude != nil && exclude.Match(rel) {
-			return false
+			if isDir {
+				return fs.SkipDir
+			}
+
+			return nil
 		}
 
-		if include.matches(rel) {
-			return true
+		included := include.matches(rel)
+
+		if !included && TerragruntExcludes(filepath.FromSlash(rel)) {
+			// Mirror the legacy ancestor pass: a directory on the path
+			// toward a potential include match must still be descended
+			// into, even when TerragruntExcludes would reject it.
+			if isDir && include.isAncestor(rel) {
+				return nil
+			}
+
+			if isDir {
+				return fs.SkipDir
+			}
+
+			return nil
 		}
 
-		if !TerragruntExcludes(filepath.FromSlash(rel)) {
-			return true
+		dest := filepath.Join(destination, rel)
+
+		if isDir {
+			info, err := d.Info()
+			if err != nil {
+				return errors.New(err)
+			}
+
+			// MkdirAll may already have created `dest` with default perms
+			// from a sibling file-copy worker racing ahead. Chmod
+			// normalizes the directory to the source's mode.
+			if err := os.MkdirAll(dest, info.Mode().Perm()); err != nil {
+				return errors.New(err)
+			}
+
+			if err := os.Chmod(dest, info.Mode().Perm()); err != nil {
+				return errors.New(err)
+			}
+
+			return nil
 		}
 
-		// TerragruntExcludes rejects this path (dot-prefix or similar).
-		// Last chance to keep it: mirror the legacy ancestor pass via
-		// `listContainsElementWithPrefix` — a directory on the path
-		// toward a potential include match must be descended into. The
-		// stat only runs on the TerragruntExcludes-rejected tail, which
-		// is a small subset of the walk.
-		return IsDir(absolutePath) && include.isAncestor(rel)
-	})
+		parentDir := filepath.Dir(dest)
+		if err := os.MkdirAll(parentDir, ownerReadWriteExecutePerms); err != nil {
+			return errors.New(err)
+		}
+
+		if err := CopyFile(absolutePath, dest); err != nil {
+			return err
+		}
+
+		manifestMu.Lock()
+		defer manifestMu.Unlock()
+
+		return manifest.AddFile(dest)
+	}
+
+	if err := vfs.WalkDirParallel(vfs.NewOSFS(), source, walkFn); err != nil {
+		return errors.New(err)
+	}
+
+	return nil
 }
 
 // includePatterns holds the compiled include matcher plus a cheap

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -529,7 +529,7 @@ func copyFolderContentsFast(
 
 		// Skip .terragrunt-cache before include matching. A user
 		// include like "**" would otherwise pull it back in.
-		if strings.Contains(rel, TerragruntCacheDir) {
+		if slices.Contains(strings.Split(rel, "/"), TerragruntCacheDir) {
 			if isDir {
 				return fs.SkipDir
 			}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -112,7 +112,7 @@ func CanonicalResolvedPath(path, basePath string) (string, error) {
 
 // GrepFilesWithSuffix returns true if regex matches the contents of any file
 // under rootDir whose name ends with suffix. The walk stops as soon as a match
-// is found. A missing rootDir is not an error — the function returns false.
+// is found. A missing rootDir is not an error; the function returns false.
 func GrepFilesWithSuffix(fsys vfs.FS, regex *regexp.Regexp, rootDir, suffix string) (bool, error) {
 	var found bool
 
@@ -449,10 +449,10 @@ func CopyFolderContents(l log.Logger, source, destination, manifestFile string, 
 	})
 }
 
-// copyFolderContentsFast is the compile-once, single-walk path for
-// [CopyFolderContents]. See the `fast-copy` strict control. The walk
-// itself runs via [fastwalk.Walk] so directory reads and filter checks
-// proceed in parallel.
+// copyFolderContentsFast is the [CopyFolderContents] path used when the
+// `fast-copy` strict control is enabled. Include and exclude patterns
+// are compiled once and the source tree is walked once through
+// [vfs.WalkDirParallel].
 func copyFolderContentsFast(
 	l log.Logger,
 	source,
@@ -491,9 +491,8 @@ func copyFolderContentsFast(
 		}
 	}()
 
-	// fastwalk runs walkFn concurrently across workers; the gob-encoded
-	// manifest is not safe for concurrent writes, so every AddFile is
-	// guarded by this mutex.
+	// The walk is parallel. The gob-encoded manifest is not safe for
+	// concurrent writes, so AddFile is guarded.
 	var manifestMu sync.Mutex
 
 	walkFn := func(absolutePath string, d fs.DirEntry, walkErr error) error {
@@ -514,9 +513,8 @@ func copyFolderContentsFast(
 
 		isDir := d.IsDir()
 
-		// Preserve the cache-dir skip that expandGlobPath enforced at
-		// expansion time. Must run before include matching — otherwise a
-		// user include like "**" would pull .terragrunt-cache back in.
+		// Skip .terragrunt-cache before include matching. A user
+		// include like "**" would otherwise pull it back in.
 		if strings.Contains(rel, TerragruntCacheDir) {
 			if isDir {
 				return fs.SkipDir
@@ -536,9 +534,9 @@ func copyFolderContentsFast(
 		included := include.matches(rel)
 
 		if !included && TerragruntExcludes(filepath.FromSlash(rel)) {
-			// Mirror the legacy ancestor pass: a directory on the path
-			// toward a potential include match must still be descended
-			// into, even when TerragruntExcludes would reject it.
+			// A directory on the way to a potential include match must
+			// still be descended into even when TerragruntExcludes
+			// would reject it.
 			if isDir && include.isAncestor(rel) {
 				return nil
 			}
@@ -558,9 +556,9 @@ func copyFolderContentsFast(
 				return errors.New(err)
 			}
 
-			// MkdirAll may already have created `dest` with default perms
-			// from a sibling file-copy worker racing ahead. Chmod
-			// normalizes the directory to the source's mode.
+			// A sibling file-copy worker may have created `dest`
+			// already with default perms. Chmod forces the source's
+			// mode.
 			if err := os.MkdirAll(dest, info.Mode().Perm()); err != nil {
 				return errors.New(err)
 			}
@@ -594,24 +592,22 @@ func copyFolderContentsFast(
 	return nil
 }
 
-// includePatterns holds the compiled include matcher plus a cheap
-// "is rel an ancestor of any potential match" predicate. Ancestor
-// acceptance is what makes the walk descend through dot-prefixed parents
-// like `_module/.region3` to reach an include hidden underneath.
+// includePatterns holds the compiled include matcher and an ancestor
+// predicate. The predicate lets the walk descend through dot-prefixed
+// parents like `_module/.region3` to reach an include below.
 type includePatterns struct {
-	// match is a single combined matcher built by OR-ing every user
-	// pattern as `{<p>,<p>/**}` inside one brace alternation. One
-	// `Match` call per entry replaces N per-pattern checks.
+	// match is a single matcher that OR-s every user pattern as
+	// `{<p>,<p>/**}` so one Match call per entry covers all of them.
 	match glob.Matcher
 
-	// ancestor is a combined matcher over the strict path prefixes of
-	// each pattern that does not contain `**`. A rel matching this is a
-	// directory on the way to a potential include match.
+	// ancestor matches the path prefixes of every pattern that does
+	// not contain `**`. A rel that matches is a directory on the way
+	// to a potential include match.
 	ancestor glob.Matcher
 
-	// descendAny is true if any pattern contains a `**` segment — in that
-	// case any directory could be on the path to a match, so accept all
-	// non-excluded paths as ancestors regardless of `ancestor`.
+	// descendAny is true when any pattern contains a `**` segment. In
+	// that case every directory is a possible ancestor, so `ancestor`
+	// is not consulted.
 	descendAny bool
 }
 
@@ -631,11 +627,10 @@ func (p includePatterns) isAncestor(rel string) bool {
 	return p.ancestor != nil && p.ancestor.Match(rel)
 }
 
-// compileIncludePatterns compiles user `include_in_copy` patterns into one
-// combined matcher that covers each pattern and all its descendants — so a
-// match behaves like the recursive expansion in [expandGlobPath] — plus an
-// ancestor matcher that flags directories on the path toward a potential
-// match.
+// compileIncludePatterns compiles user `include_in_copy` patterns into
+// one combined matcher that covers each pattern and all its descendants,
+// reproducing the recursive expansion in [expandGlobPath], plus an
+// ancestor matcher for directories on the path toward a potential match.
 func compileIncludePatterns(patterns []string) (includePatterns, error) {
 	out := includePatterns{}
 

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -513,6 +513,20 @@ func copyFolderContentsFast(
 
 		isDir := d.IsDir()
 
+		// fastwalk reports the link itself (type = symlink) before
+		// descending into a followed directory symlink, so `d.IsDir()`
+		// is false on the initial visit. Stat the target so the rest of
+		// the walkFn treats a directory symlink as a directory and
+		// matches the legacy copy semantics.
+		if !isDir && d.Type()&fs.ModeSymlink != 0 {
+			targetInfo, err := os.Stat(absolutePath)
+			if err != nil {
+				return errors.New(err)
+			}
+
+			isDir = targetInfo.IsDir()
+		}
+
 		// Skip .terragrunt-cache before include matching. A user
 		// include like "**" would otherwise pull it back in.
 		if strings.Contains(rel, TerragruntCacheDir) {
@@ -585,7 +599,7 @@ func copyFolderContentsFast(
 		return manifest.AddFile(dest)
 	}
 
-	if err := vfs.WalkDirParallel(vfs.NewOSFS(), source, walkFn); err != nil {
+	if err := vfs.WalkDirParallel(vfs.NewOSFS(), source, walkFn, vfs.WithFollowSymlinks()); err != nil {
 		return errors.New(err)
 	}
 

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -258,25 +258,17 @@ func TestHasPathPrefix(t *testing.T) {
 	}
 }
 
-func TestIncludeInCopy(t *testing.T) {
-	t.Parallel()
+// copyCase is one expected include/exclude outcome for a relative path.
+type copyCase struct {
+	path         string
+	copyExpected bool
+}
 
-	includeInCopy := []string{"_module/.region2", "**/app2", "**/.include-me-too"}
-
-	testCases := []struct {
-		path         string
-		copyExpected bool
-	}{
-		{"/app/terragrunt.hcl", true},
-		{"/_module/main.tf", true},
-		{"/_module/.region1/info.txt", false},
-		{"/_module/.region3/project3-1/f1-2-levels.txt", false},
-		{"/_module/.region3/project3-1/app1/.include-me-too/file.txt", true},
-		{"/_module/.region3/project3-2/.f0/f0-3-levels.txt", false},
-		{"/_module/.region2/.project2-1/app2/f2-dot-f2.txt", true},
-		{"/_module/.region2/.project2-1/readme.txt", true},
-		{"/_module/.region2/project2-2/f2-dot-f0.txt", true},
-	}
+// runCopyFolderContentsCase materializes the given test cases as files under
+// a temp source dir, runs [util.CopyFolderContents] with the given include /
+// exclude patterns, and asserts the destination matches `copyExpected`.
+func runCopyFolderContentsCase(t *testing.T, includeInCopy, excludeFromCopy []string, fastCopy bool, cases []copyCase) {
+	t.Helper()
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	source := filepath.Join(tempDir, "source")
@@ -284,15 +276,15 @@ func TestIncludeInCopy(t *testing.T) {
 
 	fileContent := []byte("source file")
 
-	for _, tc := range testCases {
+	for _, tc := range cases {
 		path := filepath.Join(source, tc.path)
 		assert.NoError(t, os.MkdirAll(filepath.Dir(path), os.ModePerm))
 		assert.NoError(t, os.WriteFile(path, fileContent, 0o644))
 	}
 
-	require.NoError(t, util.CopyFolderContents(logger.CreateLogger(), source, destination, ".terragrunt-test", includeInCopy, nil))
+	require.NoError(t, util.CopyFolderContents(logger.CreateLogger(), source, destination, ".terragrunt-test", includeInCopy, excludeFromCopy, fastCopy))
 
-	for i, tc := range testCases {
+	for i, tc := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
@@ -305,15 +297,40 @@ func TestIncludeInCopy(t *testing.T) {
 	}
 }
 
+func TestIncludeInCopy(t *testing.T) {
+	t.Parallel()
+
+	includeInCopy := []string{"_module/.region2", "**/app2", "**/.include-me-too"}
+
+	cases := []copyCase{
+		{"/app/terragrunt.hcl", true},
+		{"/_module/main.tf", true},
+		{"/_module/.region1/info.txt", false},
+		{"/_module/.region3/project3-1/f1-2-levels.txt", false},
+		{"/_module/.region3/project3-1/app1/.include-me-too/file.txt", true},
+		{"/_module/.region3/project3-2/.f0/f0-3-levels.txt", false},
+		{"/_module/.region2/.project2-1/app2/f2-dot-f2.txt", true},
+		{"/_module/.region2/.project2-1/readme.txt", true},
+		{"/_module/.region2/project2-2/f2-dot-f0.txt", true},
+	}
+
+	for _, mode := range []struct {
+		name     string
+		fastCopy bool
+	}{{"slow", false}, {"fast", true}} {
+		t.Run(mode.name, func(t *testing.T) {
+			t.Parallel()
+			runCopyFolderContentsCase(t, includeInCopy, nil, mode.fastCopy, cases)
+		})
+	}
+}
+
 func TestExcludeFromCopy(t *testing.T) {
 	t.Parallel()
 
 	excludeFromCopy := []string{"module/region2", "**/exclude-me-here", "**/app1"}
 
-	testCases := []struct {
-		path         string
-		copyExpected bool
-	}{
+	cases := []copyCase{
 		{"/app/terragrunt.hcl", true},
 		{"/module/main.tf", true},
 		{"/module/region1/info.txt", true},
@@ -326,29 +343,13 @@ func TestExcludeFromCopy(t *testing.T) {
 		{"/module/region2/project2-2/f2-dot-f0.txt", false},
 	}
 
-	tempDir := helpers.TmpDirWOSymlinks(t)
-	source := filepath.Join(tempDir, "source")
-	destination := filepath.Join(tempDir, "destination")
-
-	fileContent := []byte("source file")
-
-	for _, tc := range testCases {
-		path := filepath.Join(source, tc.path)
-		assert.NoError(t, os.MkdirAll(filepath.Dir(path), os.ModePerm))
-		assert.NoError(t, os.WriteFile(path, fileContent, 0o644))
-	}
-
-	require.NoError(t, util.CopyFolderContents(logger.CreateLogger(), source, destination, ".terragrunt-test", nil, excludeFromCopy))
-
-	for i, tc := range testCases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+	for _, mode := range []struct {
+		name     string
+		fastCopy bool
+	}{{"slow", false}, {"fast", true}} {
+		t.Run(mode.name, func(t *testing.T) {
 			t.Parallel()
-
-			_, err := os.Stat(filepath.Join(destination, tc.path))
-			assert.True(t,
-				tc.copyExpected && err == nil ||
-					!tc.copyExpected && errors.Is(err, os.ErrNotExist),
-				"Unexpected copy result for file '%s' (should be copied: '%t') - got error: %s", tc.path, tc.copyExpected, err)
+			runCopyFolderContentsCase(t, nil, excludeFromCopy, mode.fastCopy, cases)
 		})
 	}
 }
@@ -359,39 +360,20 @@ func TestExcludeIncludeBehaviourPriority(t *testing.T) {
 	includeInCopy := []string{"_module/.region2", "_module/.region3"}
 	excludeFromCopy := []string{"**/.project2-2", "_module/.region3"}
 
-	testCases := []struct {
-		path         string
-		copyExpected bool
-	}{
+	cases := []copyCase{
 		{"/_module/.region2/.project2-1/app2/f2-dot-f2.txt", true},
 		{"/_module/.region2/.project2-1/readme.txt", true},
 		{"/_module/.region2/.project2-2/f2-dot-f0.txt", false},
 		{"/_module/.region3/.project2-1/readme.txt", false},
 	}
 
-	tempDir := helpers.TmpDirWOSymlinks(t)
-	source := filepath.Join(tempDir, "source")
-	destination := filepath.Join(tempDir, "destination")
-
-	fileContent := []byte("source file")
-
-	for _, tc := range testCases {
-		path := filepath.Join(source, tc.path)
-		assert.NoError(t, os.MkdirAll(filepath.Dir(path), os.ModePerm))
-		assert.NoError(t, os.WriteFile(path, fileContent, 0o644))
-	}
-
-	require.NoError(t, util.CopyFolderContents(logger.CreateLogger(), source, destination, ".terragrunt-test", includeInCopy, excludeFromCopy))
-
-	for i, tc := range testCases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+	for _, mode := range []struct {
+		name     string
+		fastCopy bool
+	}{{"slow", false}, {"fast", true}} {
+		t.Run(mode.name, func(t *testing.T) {
 			t.Parallel()
-
-			_, err := os.Stat(filepath.Join(destination, tc.path))
-			assert.True(t,
-				tc.copyExpected && err == nil ||
-					!tc.copyExpected && errors.Is(err, os.ErrNotExist),
-				"Unexpected copy result for file '%s' (should be copied: '%t') - got error: %s", tc.path, tc.copyExpected, err)
+			runCopyFolderContentsCase(t, includeInCopy, excludeFromCopy, mode.fastCopy, cases)
 		})
 	}
 }
@@ -770,3 +752,78 @@ func TestRelPathForLog(t *testing.T) {
 		})
 	}
 }
+
+// buildCopyBenchTree lays out a synthetic module source with `topDirs`
+// top-level directories. Each top-level dir gets a deeply nested chain
+// (`chainDepth` levels) with `filesPerLevel` files at every level, so a
+// bare-directory include pattern like the top-level name triggers the
+// legacy expandGlobPath recursion once per nested directory.
+//
+// Returns the tree root and the list of top-level directory names, which
+// become the include-in-copy patterns fed to the benchmark.
+func buildCopyBenchTree(b *testing.B, topDirs, chainDepth, filesPerLevel int) (string, []string) {
+	b.Helper()
+
+	root := b.TempDir()
+	content := []byte("x")
+	names := make([]string, 0, topDirs)
+
+	for i := range topDirs {
+		name := fmt.Sprintf("mod%03d", i)
+		names = append(names, name)
+
+		current := filepath.Join(root, name)
+
+		for depth := range chainDepth {
+			if err := os.MkdirAll(current, 0o755); err != nil {
+				b.Fatalf("mkdir: %v", err)
+			}
+
+			for f := range filesPerLevel {
+				p := filepath.Join(current, fmt.Sprintf("f%02d.tf", f))
+				if err := os.WriteFile(p, content, 0o644); err != nil {
+					b.Fatalf("write: %v", err)
+				}
+			}
+
+			current = filepath.Join(current, fmt.Sprintf("level%02d", depth))
+		}
+	}
+
+	cache := filepath.Join(root, util.TerragruntCacheDir, "should-be-skipped")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		b.Fatalf("mkdir cache: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(cache, "skip.tf"), content, 0o644); err != nil {
+		b.Fatalf("write cache file: %v", err)
+	}
+
+	return root, names
+}
+
+func benchmarkCopyFolderContents(b *testing.B, fastCopy bool) {
+	b.Helper()
+
+	const (
+		topDirs       = 20
+		chainDepth    = 8
+		filesPerLevel = 5
+	)
+
+	source, include := buildCopyBenchTree(b, topDirs, chainDepth, filesPerLevel)
+	exclude := []string{"**/f00.tf"}
+	l := logger.CreateLogger()
+
+	b.ResetTimer()
+
+	for i := range b.N {
+		dest := filepath.Join(b.TempDir(), strconv.Itoa(i))
+		if err := util.CopyFolderContents(l, source, dest, ".terragrunt-test", include, exclude, fastCopy); err != nil {
+			b.Fatalf("CopyFolderContents: %v", err)
+		}
+	}
+}
+
+func BenchmarkCopyFolderContents_Slow(b *testing.B) { benchmarkCopyFolderContents(b, false) }
+func BenchmarkCopyFolderContents_Fast(b *testing.B) { benchmarkCopyFolderContents(b, true) }

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -282,7 +282,15 @@ func runCopyFolderContentsCase(t *testing.T, includeInCopy, excludeFromCopy []st
 		assert.NoError(t, os.WriteFile(path, fileContent, 0o644))
 	}
 
-	require.NoError(t, util.CopyFolderContents(logger.CreateLogger(), source, destination, ".terragrunt-test", includeInCopy, excludeFromCopy, fastCopy))
+	copyOpts := []util.CopyOption{
+		util.WithIncludeInCopy(includeInCopy...),
+		util.WithExcludeFromCopy(excludeFromCopy...),
+	}
+	if fastCopy {
+		copyOpts = append(copyOpts, util.WithFastCopy())
+	}
+
+	require.NoError(t, util.CopyFolderContents(logger.CreateLogger(), source, destination, ".terragrunt-test", copyOpts...))
 
 	for i, tc := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
@@ -812,16 +820,18 @@ func benchmarkCopyFolderContents(b *testing.B, fastCopy bool) {
 	)
 
 	source, include := buildCopyBenchTree(b, topDirs, chainDepth, filesPerLevel)
-	exclude := []string{"**/f00.tf"}
 	l := logger.CreateLogger()
 
-	b.ResetTimer()
+	copyOpts := []util.CopyOption{
+		util.WithIncludeInCopy(include...),
+		util.WithExcludeFromCopy("**/f00.tf"),
+	}
+	if fastCopy {
+		copyOpts = append(copyOpts, util.WithFastCopy())
+	}
 
-	for i := range b.N {
-		dest := filepath.Join(b.TempDir(), strconv.Itoa(i))
-		if err := util.CopyFolderContents(l, source, dest, ".terragrunt-test", include, exclude, fastCopy); err != nil {
-			b.Fatalf("CopyFolderContents: %v", err)
-		}
+	for b.Loop() {
+		require.NoError(b, util.CopyFolderContents(l, source, b.TempDir(), ".terragrunt-test", copyOpts...))
 	}
 }
 

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -761,14 +761,14 @@ func TestRelPathForLog(t *testing.T) {
 	}
 }
 
-// buildCopyBenchTree lays out a synthetic module source with `topDirs`
-// top-level directories. Each top-level dir gets a deeply nested chain
-// (`chainDepth` levels) with `filesPerLevel` files at every level, so a
-// bare-directory include pattern like the top-level name triggers the
-// legacy expandGlobPath recursion once per nested directory.
+// buildCopyBenchTree lays out a synthetic module source: topDirs
+// top-level directories, each a chain chainDepth levels deep with
+// filesPerLevel files at every level. A bare-directory include pattern
+// like the top-level name triggers the legacy expandGlobPath recursion
+// once per nested directory.
 //
-// Returns the tree root and the list of top-level directory names, which
-// become the include-in-copy patterns fed to the benchmark.
+// Returns the tree root and the top-level directory names, which the
+// benchmark uses as include patterns.
 func buildCopyBenchTree(b *testing.B, topDirs, chainDepth, filesPerLevel int) (string, []string) {
 	b.Helper()
 
@@ -783,15 +783,11 @@ func buildCopyBenchTree(b *testing.B, topDirs, chainDepth, filesPerLevel int) (s
 		current := filepath.Join(root, name)
 
 		for depth := range chainDepth {
-			if err := os.MkdirAll(current, 0o755); err != nil {
-				b.Fatalf("mkdir: %v", err)
-			}
+			require.NoError(b, os.MkdirAll(current, 0o755))
 
 			for f := range filesPerLevel {
 				p := filepath.Join(current, fmt.Sprintf("f%02d.tf", f))
-				if err := os.WriteFile(p, content, 0o644); err != nil {
-					b.Fatalf("write: %v", err)
-				}
+				require.NoError(b, os.WriteFile(p, content, 0o644))
 			}
 
 			current = filepath.Join(current, fmt.Sprintf("level%02d", depth))
@@ -799,13 +795,8 @@ func buildCopyBenchTree(b *testing.B, topDirs, chainDepth, filesPerLevel int) (s
 	}
 
 	cache := filepath.Join(root, util.TerragruntCacheDir, "should-be-skipped")
-	if err := os.MkdirAll(cache, 0o755); err != nil {
-		b.Fatalf("mkdir cache: %v", err)
-	}
-
-	if err := os.WriteFile(filepath.Join(cache, "skip.tf"), content, 0o644); err != nil {
-		b.Fatalf("write cache file: %v", err)
-	}
+	require.NoError(b, os.MkdirAll(cache, 0o755))
+	require.NoError(b, os.WriteFile(filepath.Join(cache, "skip.tf"), content, 0o644))
 
 	return root, names
 }

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -311,15 +311,15 @@ func TestIncludeInCopy(t *testing.T) {
 	includeInCopy := []string{"_module/.region2", "**/app2", "**/.include-me-too"}
 
 	cases := []copyCase{
-		{"/app/terragrunt.hcl", true},
-		{"/_module/main.tf", true},
-		{"/_module/.region1/info.txt", false},
-		{"/_module/.region3/project3-1/f1-2-levels.txt", false},
-		{"/_module/.region3/project3-1/app1/.include-me-too/file.txt", true},
-		{"/_module/.region3/project3-2/.f0/f0-3-levels.txt", false},
-		{"/_module/.region2/.project2-1/app2/f2-dot-f2.txt", true},
-		{"/_module/.region2/.project2-1/readme.txt", true},
-		{"/_module/.region2/project2-2/f2-dot-f0.txt", true},
+		{path: "/app/terragrunt.hcl", copyExpected: true},
+		{path: "/_module/main.tf", copyExpected: true},
+		{path: "/_module/.region1/info.txt", copyExpected: false},
+		{path: "/_module/.region3/project3-1/f1-2-levels.txt", copyExpected: false},
+		{path: "/_module/.region3/project3-1/app1/.include-me-too/file.txt", copyExpected: true},
+		{path: "/_module/.region3/project3-2/.f0/f0-3-levels.txt", copyExpected: false},
+		{path: "/_module/.region2/.project2-1/app2/f2-dot-f2.txt", copyExpected: true},
+		{path: "/_module/.region2/.project2-1/readme.txt", copyExpected: true},
+		{path: "/_module/.region2/project2-2/f2-dot-f0.txt", copyExpected: true},
 	}
 
 	for _, mode := range []struct {
@@ -339,16 +339,40 @@ func TestExcludeFromCopy(t *testing.T) {
 	excludeFromCopy := []string{"module/region2", "**/exclude-me-here", "**/app1"}
 
 	cases := []copyCase{
-		{"/app/terragrunt.hcl", true},
-		{"/module/main.tf", true},
-		{"/module/region1/info.txt", true},
-		{"/module/region1/project2-1/app1/f2-dot-f2.txt", false},
-		{"/module/region3/project3-1/f1-2-levels.txt", true},
-		{"/module/region3/project3-1/app1/exclude-me-here/file.txt", false},
-		{"/module/region3/project3-2/f0/f0-3-levels.txt", true},
-		{"/module/region2/project2-1/app2/f2-dot-f2.txt", false},
-		{"/module/region2/project2-1/readme.txt", false},
-		{"/module/region2/project2-2/f2-dot-f0.txt", false},
+		{path: "/app/terragrunt.hcl", copyExpected: true},
+		{path: "/module/main.tf", copyExpected: true},
+		{path: "/module/region1/info.txt", copyExpected: true},
+		{path: "/module/region1/project2-1/app1/f2-dot-f2.txt", copyExpected: false},
+		{path: "/module/region3/project3-1/f1-2-levels.txt", copyExpected: true},
+		{path: "/module/region3/project3-1/app1/exclude-me-here/file.txt", copyExpected: false},
+		{path: "/module/region3/project3-2/f0/f0-3-levels.txt", copyExpected: true},
+		{path: "/module/region2/project2-1/app2/f2-dot-f2.txt", copyExpected: false},
+		{path: "/module/region2/project2-1/readme.txt", copyExpected: false},
+		{path: "/module/region2/project2-2/f2-dot-f0.txt", copyExpected: false},
+	}
+
+	for _, mode := range []struct {
+		name     string
+		fastCopy bool
+	}{{"slow", false}, {"fast", true}} {
+		t.Run(mode.name, func(t *testing.T) {
+			t.Parallel()
+			runCopyFolderContentsCase(t, nil, excludeFromCopy, mode.fastCopy, cases)
+		})
+	}
+}
+
+func TestExcludeFromCopyTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	excludeFromCopy := []string{"module/region2/", "**/app1/"}
+
+	cases := []copyCase{
+		{path: "/app/terragrunt.hcl", copyExpected: true},
+		{path: "/module/region1/info.txt", copyExpected: true},
+		{path: "/module/region1/project2-1/app1/f2-dot-f2.txt", copyExpected: false},
+		{path: "/module/region2/project2-1/readme.txt", copyExpected: false},
+		{path: "/module/region2/project2-2/f2-dot-f0.txt", copyExpected: false},
 	}
 
 	for _, mode := range []struct {
@@ -369,10 +393,10 @@ func TestExcludeIncludeBehaviourPriority(t *testing.T) {
 	excludeFromCopy := []string{"**/.project2-2", "_module/.region3"}
 
 	cases := []copyCase{
-		{"/_module/.region2/.project2-1/app2/f2-dot-f2.txt", true},
-		{"/_module/.region2/.project2-1/readme.txt", true},
-		{"/_module/.region2/.project2-2/f2-dot-f0.txt", false},
-		{"/_module/.region3/.project2-1/readme.txt", false},
+		{path: "/_module/.region2/.project2-1/app2/f2-dot-f2.txt", copyExpected: true},
+		{path: "/_module/.region2/.project2-1/readme.txt", copyExpected: true},
+		{path: "/_module/.region2/.project2-2/f2-dot-f0.txt", copyExpected: false},
+		{path: "/_module/.region3/.project2-1/readme.txt", copyExpected: false},
 	}
 
 	for _, mode := range []struct {

--- a/internal/util/grep_test.go
+++ b/internal/util/grep_test.go
@@ -47,7 +47,7 @@ func TestGrepFilesWithSuffix(t *testing.T) {
 		{
 			name: "no match when suffix differs",
 			files: map[string]string{
-				// .tf, not .tf.json — must be skipped.
+				// .tf, not .tf.json, must be skipped.
 				"/mod/backend.tf": `terraform { backend "s3" {} }`,
 			},
 			root:   "/mod",

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -147,18 +147,15 @@ func TryLock(fs FS, name string) (Unlocker, bool, error) {
 	return locker.TryLock(name)
 }
 
-// WalkDirParallel walks the file tree rooted at root the same way
-// [WalkDir] does, but reads directories in parallel on filesystems where
-// that is safe. On a [NewOSFS] filesystem the walk is driven by
-// [fastwalk.Walk]; on any other FS (for example [NewMemMapFS]) it
-// transparently degrades to the sequential [WalkDir].
+// WalkDirParallel walks the file tree rooted at root like [WalkDir]
+// does. On a [NewOSFS] filesystem it reads directories in parallel via
+// [fastwalk.Walk]. On any other FS, including [NewMemMapFS], it falls
+// back to the sequential [WalkDir].
 //
-// Unlike [WalkDir], the parallel walk does not guarantee any ordering
-// across directories — fn may be called concurrently from multiple
-// goroutines. Callers that care about deterministic order, or that write
-// to shared state from fn, must use [WalkDir] or serialize access
-// themselves. [fs.SkipDir] and [fs.SkipAll] continue to work as with the
-// sequential walk.
+// The parallel walk calls fn concurrently from multiple goroutines and
+// gives no ordering guarantee across directories. Callers that depend
+// on deterministic order, or that write to shared state from fn, must
+// use [WalkDir] or serialize access themselves.
 func WalkDirParallel(fsys FS, root string, fn fs.WalkDirFunc) error {
 	if _, ok := fsys.(*osFS); !ok {
 		return WalkDir(fsys, root, fn)

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/charlievieth/fastwalk"
 	"github.com/gofrs/flock"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/spf13/afero"
@@ -144,6 +145,32 @@ func TryLock(fs FS, name string) (Unlocker, bool, error) {
 	}
 
 	return locker.TryLock(name)
+}
+
+// WalkDirParallel walks the file tree rooted at root the same way
+// [WalkDir] does, but reads directories in parallel on filesystems where
+// that is safe. On a [NewOSFS] filesystem the walk is driven by
+// [fastwalk.Walk]; on any other FS (for example [NewMemMapFS]) it
+// transparently degrades to the sequential [WalkDir].
+//
+// Unlike [WalkDir], the parallel walk does not guarantee any ordering
+// across directories — fn may be called concurrently from multiple
+// goroutines. Callers that care about deterministic order, or that write
+// to shared state from fn, must use [WalkDir] or serialize access
+// themselves. [fs.SkipDir] and [fs.SkipAll] continue to work as with the
+// sequential walk.
+func WalkDirParallel(fsys FS, root string, fn fs.WalkDirFunc) error {
+	if _, ok := fsys.(*osFS); !ok {
+		return WalkDir(fsys, root, fn)
+	}
+
+	err := fastwalk.Walk(nil, root, fn)
+
+	if errors.Is(err, filepath.SkipDir) || errors.Is(err, filepath.SkipAll) {
+		return nil
+	}
+
+	return err
 }
 
 // WalkDir walks the file tree rooted at root, calling fn for each file or

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -147,6 +147,27 @@ func TryLock(fs FS, name string) (Unlocker, bool, error) {
 	return locker.TryLock(name)
 }
 
+// WalkDirParallelOption configures a [WalkDirParallel] call.
+type WalkDirParallelOption func(*walkDirParallelConfig)
+
+type walkDirParallelConfig struct {
+	followSymlinks bool
+}
+
+// WithFollowSymlinks makes [WalkDirParallel] descend into directories
+// reached through symbolic links. The DirEntry passed to fn for a
+// followed symlink reports the target's type, so `d.IsDir()` is true
+// for a symlink that resolves to a directory. Infinite loops are
+// guarded by fastwalk's ancestor-cycle detection.
+//
+// Without this option, symlinked directories are visited as single
+// entries with `d.IsDir() == false`, matching stdlib [fs.WalkDir].
+func WithFollowSymlinks() WalkDirParallelOption {
+	return func(c *walkDirParallelConfig) {
+		c.followSymlinks = true
+	}
+}
+
 // WalkDirParallel walks the file tree rooted at root like [WalkDir]
 // does. On a [NewOSFS] filesystem it reads directories in parallel via
 // [fastwalk.Walk]. On any other FS, including [NewMemMapFS], it falls
@@ -156,12 +177,22 @@ func TryLock(fs FS, name string) (Unlocker, bool, error) {
 // gives no ordering guarantee across directories. Callers that depend
 // on deterministic order, or that write to shared state from fn, must
 // use [WalkDir] or serialize access themselves.
-func WalkDirParallel(fsys FS, root string, fn fs.WalkDirFunc) error {
+func WalkDirParallel(fsys FS, root string, fn fs.WalkDirFunc, opts ...WalkDirParallelOption) error {
 	if _, ok := fsys.(*osFS); !ok {
 		return WalkDir(fsys, root, fn)
 	}
 
-	err := fastwalk.Walk(nil, root, fn)
+	var cfg walkDirParallelConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	var fwCfg *fastwalk.Config
+	if cfg.followSymlinks {
+		fwCfg = &fastwalk.Config{Follow: true}
+	}
+
+	err := fastwalk.Walk(fwCfg, root, fn)
 
 	if errors.Is(err, filepath.SkipDir) || errors.Is(err, filepath.SkipAll) {
 		return nil

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
@@ -1136,4 +1137,106 @@ func createZipArchiveWithNestedSymlink(t *testing.T) []byte {
 	require.NoError(t, w.Close())
 
 	return buf.Bytes()
+}
+
+func TestWalkDirParallel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("degrades to sequential WalkDir on MemMapFS", func(t *testing.T) {
+		t.Parallel()
+
+		memFs := vfs.NewMemMapFS()
+		require.NoError(t, vfs.WriteFile(memFs, "/root/a.txt", []byte("a"), 0644))
+		require.NoError(t, vfs.WriteFile(memFs, "/root/b.txt", []byte("b"), 0644))
+		require.NoError(t, vfs.WriteFile(memFs, "/root/c.txt", []byte("c"), 0644))
+
+		var names []string
+
+		err := vfs.WalkDirParallel(memFs, "/root", func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			names = append(names, d.Name())
+
+			return nil
+		})
+
+		require.NoError(t, err)
+		// Non-OS FS keeps the deterministic lexical ordering from WalkDir.
+		assert.Equal(t, []string{"root", "a.txt", "b.txt", "c.txt"}, names)
+	})
+
+	t.Run("walks every entry on OSFS", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		osFs := vfs.NewOSFS()
+
+		require.NoError(t, osFs.MkdirAll(filepath.Join(root, "dir"), 0o755))
+		require.NoError(t, vfs.WriteFile(osFs, filepath.Join(root, "a.txt"), []byte("a"), 0o644))
+		require.NoError(t, vfs.WriteFile(osFs, filepath.Join(root, "dir", "nested.txt"), []byte("n"), 0o644))
+
+		var mu sync.Mutex
+
+		seen := map[string]struct{}{}
+
+		err := vfs.WalkDirParallel(osFs, root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			mu.Lock()
+			seen[path] = struct{}{}
+			mu.Unlock()
+
+			return nil
+		})
+
+		require.NoError(t, err)
+		// Parallel walk gives no ordering guarantee, but it must visit every
+		// entry exactly once.
+		assert.Equal(t, map[string]struct{}{
+			root:                                     {},
+			filepath.Join(root, "a.txt"):             {},
+			filepath.Join(root, "dir"):               {},
+			filepath.Join(root, "dir", "nested.txt"): {},
+		}, seen)
+	})
+
+	t.Run("SkipDir prunes a subtree on OSFS", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		osFs := vfs.NewOSFS()
+
+		require.NoError(t, osFs.MkdirAll(filepath.Join(root, "keep"), 0o755))
+		require.NoError(t, osFs.MkdirAll(filepath.Join(root, "skip"), 0o755))
+		require.NoError(t, vfs.WriteFile(osFs, filepath.Join(root, "keep", "a.txt"), []byte("a"), 0o644))
+		require.NoError(t, vfs.WriteFile(osFs, filepath.Join(root, "skip", "b.txt"), []byte("b"), 0o644))
+
+		var mu sync.Mutex
+
+		seen := map[string]struct{}{}
+
+		err := vfs.WalkDirParallel(osFs, root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if d.IsDir() && d.Name() == "skip" {
+				return filepath.SkipDir
+			}
+
+			mu.Lock()
+			seen[path] = struct{}{}
+			mu.Unlock()
+
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, seen, filepath.Join(root, "keep", "a.txt"))
+		assert.NotContains(t, seen, filepath.Join(root, "skip", "b.txt"))
+	})
 }

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -113,6 +113,7 @@ func CopyEnvironment(t *testing.T, environmentPath string, includeInCopy ...stri
 			".terragrunt-test",
 			includeInCopy,
 			excludeFromCopy,
+			false,
 		),
 	)
 

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -113,7 +113,7 @@ func CopyEnvironment(t *testing.T, environmentPath string, includeInCopy ...stri
 			".terragrunt-test",
 			includeInCopy,
 			excludeFromCopy,
-			false,
+			true,
 		),
 	)
 

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -111,9 +111,9 @@ func CopyEnvironment(t *testing.T, environmentPath string, includeInCopy ...stri
 			environmentPath,
 			filepath.Join(tmpDir, environmentPath),
 			".terragrunt-test",
-			includeInCopy,
-			excludeFromCopy,
-			true,
+			util.WithIncludeInCopy(includeInCopy...),
+			util.WithExcludeFromCopy(excludeFromCopy...),
+			util.WithFastCopy(),
 		),
 	)
 

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -1789,7 +1789,7 @@ func TestAwsParallelStateInit(t *testing.T) {
 
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 	for i := range 20 {
-		err := util.CopyFolderContents(logger.CreateLogger(), testFixtureParallelStateInit, tmpEnvPath, ".terragrunt-test", nil, nil)
+		err := util.CopyFolderContents(logger.CreateLogger(), testFixtureParallelStateInit, tmpEnvPath, ".terragrunt-test")
 		require.NoError(t, err)
 		err = os.Rename(
 			path.Join(tmpEnvPath, "template"),

--- a/test/integration_gcp_test.go
+++ b/test/integration_gcp_test.go
@@ -395,7 +395,7 @@ func TestGcpParallelStateInit(t *testing.T) {
 	}
 
 	for i := range 20 {
-		err := util.CopyFolderContents(createLogger(), testFixtureGcsParallelStateInit, tmpEnvPath, ".terragrunt-test", nil, nil)
+		err := util.CopyFolderContents(createLogger(), testFixtureGcsParallelStateInit, tmpEnvPath, ".terragrunt-test")
 		require.NoError(t, err)
 
 		err = os.Rename(

--- a/test/integration_serial_aws_test.go
+++ b/test/integration_serial_aws_test.go
@@ -185,7 +185,7 @@ func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules
 	// copy the template `numberOfModules` times into the app
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 	for i := range numberOfModules {
-		err := util.CopyFolderContents(createLogger(), testFixtureParallelism, tmpEnvPath, ".terragrunt-test", nil, nil)
+		err := util.CopyFolderContents(createLogger(), testFixtureParallelism, tmpEnvPath, ".terragrunt-test")
 		if err != nil {
 			return "", 0, err
 		}

--- a/test/integration_tflint_test.go
+++ b/test/integration_tflint_test.go
@@ -110,7 +110,7 @@ func TestTflintInitSameModule(t *testing.T) {
 	// generate multiple "app" modules that will be initialized in parallel
 	for i := 0; i < tflintInitSamples; i++ {
 		appPath := filepath.Join(modulePath, "dev", fmt.Sprintf("app-%d", i))
-		err := util.CopyFolderContents(createLogger(), appTemplate, appPath, ".terragrunt-test", []string{}, []string{})
+		err := util.CopyFolderContents(createLogger(), appTemplate, appPath, ".terragrunt-test")
 		require.NoError(t, err)
 	}
 
@@ -221,7 +221,7 @@ func CopyEnvironmentWithTflint(t *testing.T, environmentPath string) string {
 
 	t.Logf("Copying %s to %s", environmentPath, tmpDir)
 
-	require.NoError(t, util.CopyFolderContents(createLogger(), environmentPath, filepath.Join(tmpDir, environmentPath), ".terragrunt-test", []string{".tflint.hcl"}, []string{}))
+	require.NoError(t, util.CopyFolderContents(createLogger(), environmentPath, filepath.Join(tmpDir, environmentPath), ".terragrunt-test", util.WithIncludeInCopy(".tflint.hcl")))
 
 	return tmpDir
 }

--- a/test/integration_windows_test.go
+++ b/test/integration_windows_test.go
@@ -257,7 +257,7 @@ func CopyEnvironmentToPath(t *testing.T, environmentPath, targetPath string) {
 		t.Fatalf("Failed to create temp dir %s due to error %v", targetPath, err)
 	}
 
-	copyErr := util.CopyFolderContents(createLogger(), environmentPath, filepath.Join(targetPath, environmentPath), ".terragrunt-test", nil, nil)
+	copyErr := util.CopyFolderContents(createLogger(), environmentPath, filepath.Join(targetPath, environmentPath), ".terragrunt-test")
 	require.NoError(t, copyErr)
 }
 
@@ -280,8 +280,7 @@ func CopyEnvironmentWithTflint(t *testing.T, environmentPath string) string {
 			environmentPath,
 			filepath.Join(tmpDir, environmentPath),
 			".terragrunt-test",
-			[]string{".tflint.hcl"},
-			[]string{},
+			util.WithIncludeInCopy(".tflint.hcl"),
 		),
 	)
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds a new strict control `fast-copy` that enables faster copying of directories by bypassing usage of zglob and WalkDir in favor of gobwas and fastwalk.

On my M3 Max, I was seeing directory copying happen roughly 2–2.5× faster, with about 60% fewer allocations and 27% less memory in microbenchmarks.

Closes #5939

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "fast-copy" strict control to speed up module source copying by compiling include/exclude patterns once and performing a single, faster copy traversal for large modules.

* **Documentation**
  * New docs and changelog for fast-copy, including compatibility guidance: when `**` is adjacent to another wildcard use brace alternation (e.g., `{*.tf,**/*.tf}`) to match both zero-depth and deeper-directory files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->