### PR TITLE
Fix missing tags in DynamoDB lock table creation during bootstrap

### DIFF
--- a/internal/hclhelper/wrap.go
+++ b/internal/hclhelper/wrap.go
@@ -4,6 +4,7 @@ package hclhelper
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -33,8 +34,7 @@ func WrapListToSingleLineHcl(values []any) string {
 func FormatValueToSingleLineHcl(value any) string {
 	switch v := value.(type) {
 	case string:
-		escapedValue := strings.ReplaceAll(v, `"`, `\"`)
-		return fmt.Sprintf(`"%s"`, escapedValue)
+		return strconv.Quote(v)
 	case map[string]any:
 		return WrapMapToSingleLineHcl(v)
 	case []any:

--- a/internal/hclhelper/wrap.go
+++ b/internal/hclhelper/wrap.go
@@ -11,7 +11,7 @@ import (
 func WrapMapToSingleLineHcl(m map[string]any) string {
 	var attributes = make([]string, 0, len(m))
 	for key, value := range m {
-		attributes = append(attributes, fmt.Sprintf(`%s=%s`, key, formatHclValue(value)))
+		attributes = append(attributes, fmt.Sprintf(`%s=%s`, key, FormatValueToSingleLineHcl(value)))
 	}
 
 	sort.Strings(attributes)
@@ -19,14 +19,26 @@ func WrapMapToSingleLineHcl(m map[string]any) string {
 	return fmt.Sprintf("{%s}", strings.Join(attributes, ","))
 }
 
-// formatHclValue - Wrap single line HCL values in quotes.
-func formatHclValue(value any) string {
+// WrapListToSingleLineHcl converts a slice to a single-line HCL list expression.
+func WrapListToSingleLineHcl(values []any) string {
+	var items = make([]string, 0, len(values))
+	for _, item := range values {
+		items = append(items, FormatValueToSingleLineHcl(item))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(items, ","))
+}
+
+// FormatValueToSingleLineHcl converts a Go value to a single-line HCL expression.
+func FormatValueToSingleLineHcl(value any) string {
 	switch v := value.(type) {
 	case string:
 		escapedValue := strings.ReplaceAll(v, `"`, `\"`)
 		return fmt.Sprintf(`"%s"`, escapedValue)
 	case map[string]any:
 		return WrapMapToSingleLineHcl(v)
+	case []any:
+		return WrapListToSingleLineHcl(v)
 	default:
 		return fmt.Sprintf(`%v`, v)
 	}

--- a/internal/remotestate/backend/s3/client.go
+++ b/internal/remotestate/backend/s3/client.go
@@ -120,6 +120,18 @@ func NewClient(ctx context.Context, l log.Logger, config *ExtendedRemoteStateCon
 	return client, nil
 }
 
+func convertToDynamoTags(tags map[string]string) []dynamodbtypes.Tag {
+	var Result []dynamodbtypes.Tag
+
+	for k, v := range tags {
+		Result = append(Result, dynamodbtypes.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+	return Result
+}
+
 // CreateS3BucketIfNecessary prompts the user to create the given bucket if it doesn't already exist and if the user
 // confirms, creates the bucket and enables versioning for it.
 func (client *Client) CreateS3BucketIfNecessary(ctx context.Context, l log.Logger, bucketName string, opts *backend.Options) error {
@@ -1439,6 +1451,10 @@ func (client *Client) CreateLockTable(ctx context.Context, l log.Logger, tableNa
 		BillingMode:          dynamodbtypes.BillingMode(DynamodbPayPerRequestBillingMode),
 		AttributeDefinitions: attributeDefinitions,
 		KeySchema:            keySchema,
+	}
+
+	if len(tags) > 0 {
+		input.Tags = convertToDynamoTags(tags)
 	}
 
 	createTableOutput, err := client.dynamoClient.CreateTable(ctx, input)

--- a/internal/remotestate/remote_state.go
+++ b/internal/remotestate/remote_state.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/hclhelper"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend/gcs"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend/s3"
@@ -133,7 +134,20 @@ func (remote *RemoteState) GetTFInitArgs() []string {
 	var backendConfigArgs = make([]string, 0, len(config))
 
 	for key, value := range config {
-		arg := fmt.Sprintf("-backend-config=%s=%v", key, value)
+		var serialized string
+
+		switch v := value.(type) {
+		case string:
+			serialized = v
+		case map[string]any:
+			serialized = hclhelper.WrapMapToSingleLineHcl(v)
+		case []any:
+			serialized = hclhelper.WrapListToSingleLineHcl(v)
+		default:
+			serialized = fmt.Sprintf("%v", value)
+		}
+
+		arg := fmt.Sprintf("-backend-config=%s=%s", key, serialized)
 		backendConfigArgs = append(backendConfigArgs, arg)
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Terragrunt currently creates the DynamoDB lock table without passing user-defined tags. In environments where IAM/SCP policies enforce request tags (e.g. aws:RequestTag), this causes dynamodb:CreateTable to be denied and breaks terragrunt init --backend-bootstrap.

This PR adds support for including tags in the DynamoDB CreateTable request.
Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DynamoDB lock tables now support custom tagging at creation time.

* **Improvements**
  * Backend configuration arguments now properly serialize complex data types (maps and lists) using HCL formatting for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->