### PR TITLE
Fix missing tags in DynamoDB lock table creation during bootstrap

### DIFF
--- a/docs/src/data/changelog/v1.0.5/dynamodb-lock-table-tags.mdx
+++ b/docs/src/data/changelog/v1.0.5/dynamodb-lock-table-tags.mdx
@@ -3,12 +3,26 @@ version: "v1.0.5"
 category: "bug-fixes"
 ---
 
-#### `feature-area`: short user-facing title
+#### `remote_state`: apply tags during DynamoDB lock table creation
 
-Explain the previous broken behavior.
+Terragrunt previously accepted `dynamodb_table_tags` configuration for remote state lock tables, but the tags were not correctly applied during DynamoDB table creation.
 
-Explain impact/error/problem.
+As a result, environments enforcing required AWS resource tags through SCPs or tag policies could fail to create lock tables.
 
-Explain new corrected behavior.
+Terragrunt now correctly converts and applies DynamoDB table tags during lock table creation.
 
-Optional example.
+```hcl
+remote_state {
+  backend = "s3"
+
+  config = {
+    bucket         = "my-state-bucket"
+    dynamodb_table = "terraform-locks"
+
+    dynamodb_table_tags = {
+      Environment = "prod"
+      Team        = "platform"
+    }
+  }
+}
+```

--- a/docs/src/data/changelog/v1.0.5/dynamodb-lock-table-tags.mdx
+++ b/docs/src/data/changelog/v1.0.5/dynamodb-lock-table-tags.mdx
@@ -1,0 +1,14 @@
+---
+version: "v1.0.5"
+category: "bug-fixes"
+---
+
+#### `feature-area`: short user-facing title
+
+Explain the previous broken behavior.
+
+Explain impact/error/problem.
+
+Explain new corrected behavior.
+
+Optional example.

--- a/docs/src/data/changelog/v1.0.5/dynamodb-lock-table-tags.mdx
+++ b/docs/src/data/changelog/v1.0.5/dynamodb-lock-table-tags.mdx
@@ -5,11 +5,11 @@ category: "bug-fixes"
 
 #### `remote_state`: apply tags during DynamoDB lock table creation
 
-Terragrunt previously accepted `dynamodb_table_tags` configuration for remote state lock tables, but the tags were not correctly applied during DynamoDB table creation.
+Terragrunt previously applied `dynamodb_table_tags` to DynamoDB lock tables after table creation rather than during the initial `CreateTable` API request.
 
-As a result, environments enforcing required AWS resource tags through SCPs or tag policies could fail to create lock tables.
+This caused failures in environments enforcing required AWS resource tags through SCPs or tag policies, where tags must be present at resource creation time.
 
-Terragrunt now correctly converts and applies DynamoDB table tags during lock table creation.
+Terragrunt now includes `dynamodb_table_tags` in the initial DynamoDB table creation request during remote state bootstrap.
 
 ```hcl
 remote_state {

--- a/internal/remotestate/backend/s3/client.go
+++ b/internal/remotestate/backend/s3/client.go
@@ -120,18 +120,6 @@ func NewClient(ctx context.Context, l log.Logger, config *ExtendedRemoteStateCon
 	return client, nil
 }
 
-func convertToDynamoTags(tags map[string]string) []dynamodbtypes.Tag {
-	var Result []dynamodbtypes.Tag
-
-	for k, v := range tags {
-		Result = append(Result, dynamodbtypes.Tag{
-			Key:   aws.String(k),
-			Value: aws.String(v),
-		})
-	}
-	return Result
-}
-
 // CreateS3BucketIfNecessary prompts the user to create the given bucket if it doesn't already exist and if the user
 // confirms, creates the bucket and enables versioning for it.
 func (client *Client) CreateS3BucketIfNecessary(ctx context.Context, l log.Logger, bucketName string, opts *backend.Options) error {
@@ -654,6 +642,18 @@ func convertTags(tags map[string]string) []types.Tag {
 	}
 
 	return tagsConverted
+}
+
+func convertToDynamoTags(tags map[string]string) []dynamodbtypes.Tag {
+	var Result []dynamodbtypes.Tag
+
+	for k, v := range tags {
+		Result = append(Result, dynamodbtypes.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+	return Result
 }
 
 // WaitUntilS3BucketExists waits until the S3 bucket with the given name exists.

--- a/internal/remotestate/backend/s3/client.go
+++ b/internal/remotestate/backend/s3/client.go
@@ -645,15 +645,15 @@ func convertTags(tags map[string]string) []types.Tag {
 }
 
 func convertToDynamoTags(tags map[string]string) []dynamodbtypes.Tag {
-	var Result []dynamodbtypes.Tag
+	result := make([]dynamodbtypes.Tag, 0, len(tags))
 
 	for k, v := range tags {
-		Result = append(Result, dynamodbtypes.Tag{
+		result = append(result, dynamodbtypes.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v),
 		})
 	}
-	return Result
+	return result
 }
 
 // WaitUntilS3BucketExists waits until the S3 bucket with the given name exists.

--- a/internal/remotestate/backend/s3/client.go
+++ b/internal/remotestate/backend/s3/client.go
@@ -653,6 +653,7 @@ func convertToDynamoTags(tags map[string]string) []dynamodbtypes.Tag {
 			Value: aws.String(v),
 		})
 	}
+
 	return result
 }
 

--- a/internal/remotestate/backend/s3/client.go
+++ b/internal/remotestate/backend/s3/client.go
@@ -120,6 +120,18 @@ func NewClient(ctx context.Context, l log.Logger, config *ExtendedRemoteStateCon
 	return client, nil
 }
 
+func convertToDynamoTags(tags map[string]string) []dynamodbtypes.Tag {
+	var Result []dynamodbtypes.Tag
+
+	for k, v := range tags {
+		Result = append(Result, dynamodbtypes.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+	return Result
+}
+
 // CreateS3BucketIfNecessary prompts the user to create the given bucket if it doesn't already exist and if the user
 // confirms, creates the bucket and enables versioning for it.
 func (client *Client) CreateS3BucketIfNecessary(ctx context.Context, l log.Logger, bucketName string, opts *backend.Options) error {
@@ -1439,6 +1451,10 @@ func (client *Client) CreateLockTable(ctx context.Context, l log.Logger, tableNa
 		BillingMode:          dynamodbtypes.BillingMode(DynamodbPayPerRequestBillingMode),
 		AttributeDefinitions: attributeDefinitions,
 		KeySchema:            keySchema,
+	}
+
+	if len(tags) > 0 {
+		input.Tags = convertToDynamoTags(tags)
 	}
 
 	createTableOutput, err := client.dynamoClient.CreateTable(ctx, input)

--- a/internal/remotestate/backend/s3/client_test.go
+++ b/internal/remotestate/backend/s3/client_test.go
@@ -138,6 +138,37 @@ func TestAwsTableTagging(t *testing.T) {
 	})
 }
 
+// TestAwsCreateLockTableWithTagsAtCreation verifies that
+// DynamoDB lock table tags are applied during the initial
+// CreateTable API request.
+func TestAwsCreateLockTableWithTagsAtCreation(t *testing.T) {
+	t.Parallel()
+
+	client := CreateS3ClientForTest(t)
+	tableName := UniqueTableNameForTest()
+
+	defer CleanupTableForTest(t, tableName, client)
+
+	l := logger.CreateLogger()
+
+	expectedTags := map[string]string{
+		"team": "platform",
+		"env":  "test",
+	}
+
+	err := client.CreateLockTableIfNecessary(
+		t.Context(),
+		l,
+		tableName,
+		expectedTags,
+	)
+
+	require.NoError(t, err)
+
+	// Verify tags are present immediately after creation.
+	assertTags(t, expectedTags, tableName, client)
+}
+
 func assertTags(t *testing.T, expectedTags map[string]string, tableName string, client *s3backend.Client) {
 	t.Helper()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Terragrunt currently creates the DynamoDB lock table without passing user-defined tags. In environments where IAM/SCP policies enforce request tags (e.g. aws:RequestTag), this causes dynamodb:CreateTable to be denied and breaks terragrunt init --backend-bootstrap.

This PR adds support for including tags in the DynamoDB CreateTable request.

Fixes #5792  .

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

## Before fix 
<img width="864" height="132" alt="Screenshot 2026-04-25 at 3 56 41 AM" src="https://github.com/user-attachments/assets/7d0e8a18-e588-436c-beb4-c36df22b9ceb" />

## After fix 
<img width="862" height="265" alt="Screenshot 2026-04-25 at 3 53 21 AM" src="https://github.com/user-attachments/assets/c5e6ae52-a9b9-4efc-bfab-e549f296820c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Backend Improvements**
  * DynamoDB lock table tags are now included in the initial table creation request to improve provisioning in environments enforcing creation-time tags.

* **Bug Fixes**
  * Remote-state lock table tagging now honors configured tags during resource creation.

* **Documentation**
  * Added a v1.0.5 changelog entry describing the fix with usage examples.

* **Tests**
  * Added a test confirming tags are present immediately after table creation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/5974)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->