### PR TITLE
fix(codegen): fix assume_role parsing failure when transitive_tag_keys or policy_arns arrays are present

### DIFF
--- a/docs/src/data/changelog/v1.0.8/assume-role-list-parsing.mdx
+++ b/docs/src/data/changelog/v1.0.8/assume-role-list-parsing.mdx
@@ -1,0 +1,23 @@
+---
+version: "v1.0.8"
+category: "bug-fixes"
+---
+
+#### `assume_role`: preserve commas inside list expressions
+
+Terragrunt previously failed to correctly parse `assume_role` attributes containing list values such as `transitive_tag_keys` or `policy_arns`. Commas inside nested list expressions were incorrectly treated as top-level separators, causing generated configurations to fail with parsing errors.
+
+```hcl
+assume_role = {
+  role_arn            = "arn:aws:iam::123456789012:role/test-role"
+  transitive_tag_keys = ["Project", "Projects"]
+}
+```
+
+This resulted in errors similar to:
+
+```text
+Missing item separator; Expected a comma to mark the beginning of the next item.
+```
+
+Terragrunt now preserves commas inside nested list and object expressions when parsing `assume_role` blocks, allowing configurations containing array attributes to be processed correctly. 

--- a/internal/codegen/generate.go
+++ b/internal/codegen/generate.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -570,39 +569,56 @@ func convertValue(v any) (ctyjson.SimpleJSONValue, error) {
 	return ctyVal, nil
 }
 
-var (
-	// Regex Explanation:
-	// (          # Start group 1: Match quoted strings
-	//  "         # Match the opening quote
-	//  [^"\\]* # Match zero or more characters that are NOT a quote or backslash
-	//  (?:       # Start non-capturing group (for handling escaped quotes)
-	//    \\.     # Match a backslash followed by ANY character (escaped char)
-	//    [^"\\]* # Match zero or more non-quote/non-backslash chars
-	//  )*        # End non-capturing group, repeat zero or more times
-	//  "         # Match the closing quote
-	// )          # End group 1
-	// |          # OR
-	// (,)        # Start group 2: Match and capture a comma
-	//
-	re = regexp.MustCompile(`("[^"\\]*(?:\\.[^"\\]*)*")|(,)`)
-)
-
 // ReplaceAllCommasOutsideQuotesWithNewLines replaces all commas outside quotes with new lines.
 // This is useful for instances where a single line of HCL content might contain a comma, and we don't
 // want to split the line into multiple lines.
 func ReplaceAllCommasOutsideQuotesWithNewLines(s string) string {
-	output := re.ReplaceAllStringFunc(s, func(match string) string {
-		// Check if the match starts with a quote.
-		// If it does, it's a quoted string (group 1 matched). Return it unchanged.
-		if strings.HasPrefix(match, `"`) {
-			return match
+	var result strings.Builder
+
+	inQuotes := false
+	bracketDepth := 0
+	brackDepth := 0
+
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+
+		switch {
+		case ch == '\\' && inQuotes:
+			result.WriteByte(ch)
+
+			i++
+			if i < len(s) {
+				result.WriteByte(s[i])
+			}
+		case ch == '"':
+			inQuotes = !inQuotes
+
+			result.WriteByte(ch)
+		case ch == '[' && !inQuotes:
+			bracketDepth++
+
+			result.WriteByte(ch)
+		case ch == ']' && !inQuotes:
+			bracketDepth--
+
+			result.WriteByte(ch)
+		case ch == '{' && !inQuotes:
+			brackDepth++
+
+			result.WriteByte(ch)
+		case ch == '}' && !inQuotes:
+			brackDepth--
+
+			result.WriteByte(ch)
+		case ch == ',' && !inQuotes && bracketDepth == 0 && brackDepth == 0:
+			result.WriteByte('\n')
+
+		default:
+			result.WriteByte(ch)
 		}
+	}
 
-		// Otherwise, it must be the comma (group 2 matched). Replace it with a newline.
-		return "\n"
-	})
-
-	return output
+	return result.String()
 }
 
 // GenerateConfigExistsFromString converts a string representation of if_exists into the enum, returning an error if it

--- a/internal/codegen/generate_test.go
+++ b/internal/codegen/generate_test.go
@@ -70,14 +70,14 @@ func TestRemoteStateConfigToTerraformCode(t *testing.T) {
       duration        = "1h30m"
       external_id     = "123456789012"
       policy          = "{}"
-      policy_arns     = ["arn:aws:iam::123456789012:policy/MyPolicy"]
+      policy_arns     = ["arn:aws:iam::123456789012:policy/MyPolicy", "arn:aws:iam::123456789012:policy/MyOtherPolicy"]
       role_arn        = "arn:aws:iam::123456789012:role/MyRole"
       session_name    = "MySession"
       source_identity = "123456789012"
       tags = {
         key = "value"
       }
-      transitive_tag_keys = ["key"]
+      transitive_tag_keys = ["key", "another-key"]
     }
     bucket = "mybucket"
   }
@@ -160,10 +160,10 @@ func TestRemoteStateConfigToTerraformCode(t *testing.T) {
 				"assume_role": "{role_arn=\"arn:aws:iam::123456789012:role/MyRole\"," +
 					"tags={key=\"value\"}, duration=\"1h30m\", " +
 					"external_id=\"123456789012\", policy=\"{}\", " +
-					"policy_arns=[\"arn:aws:iam::123456789012:policy/MyPolicy\"], " +
+					"policy_arns=[\"arn:aws:iam::123456789012:policy/MyPolicy\",\"arn:aws:iam::123456789012:policy/MyOtherPolicy\"], " +
 					"session_name=\"MySession\", " +
 					"source_identity=\"123456789012\", " +
-					"transitive_tag_keys=[\"key\"]}",
+					"transitive_tag_keys=[\"key\",\"another-key\"]}",
 			},
 			map[string]any{},
 			expectedS3WithAssumeRole,
@@ -427,6 +427,37 @@ quoted="hello,world"`,
 			name:     "no-commas",
 			input:    `key=value`,
 			expected: `key=value`,
+		},
+		{
+			name:  "comma-inside-list-expression",
+			input: `transitive_tag_keys=["Project","Projects"],role_arn="test-role"`,
+			expected: `transitive_tag_keys=["Project","Projects"]
+role_arn="test-role"`,
+		},
+		{
+			name:  "comma-inside-object-expression",
+			input: `config={env="prod",team="platform"},enabled=true`,
+			expected: `config={env="prod",team="platform"}
+enabled=true`,
+		},
+		{
+			name:  "comma-inside-nested-list-and-object",
+			input: `config={tags=["a","b"],env="prod"},enabled=true`,
+			expected: `config={tags=["a","b"],env="prod"}
+enabled=true`,
+		},
+		{
+			name:  "mixed-quotes-lists-and-top-level-commas",
+			input: `message="hello,world",tags=["a","b"],enabled=true`,
+			expected: `message="hello,world"
+tags=["a","b"]
+enabled=true`,
+		},
+		{
+			name:  "nested-object-containing-list",
+			input: `assume_role={policy_arns=["arn:1","arn:2"],session_name="test"},region="us-east-1"`,
+			expected: `assume_role={policy_arns=["arn:1","arn:2"],session_name="test"}
+region="us-east-1"`,
 		},
 	}
 

--- a/internal/codegen/generate_test.go
+++ b/internal/codegen/generate_test.go
@@ -160,7 +160,8 @@ func TestRemoteStateConfigToTerraformCode(t *testing.T) {
 				"assume_role": "{role_arn=\"arn:aws:iam::123456789012:role/MyRole\"," +
 					"tags={key=\"value\"}, duration=\"1h30m\", " +
 					"external_id=\"123456789012\", policy=\"{}\", " +
-					"policy_arns=[\"arn:aws:iam::123456789012:policy/MyPolicy\",\"arn:aws:iam::123456789012:policy/MyOtherPolicy\"], " +
+					"policy_arns=[\"arn:aws:iam::123456789012:policy/MyPolicy\"," +
+					"\"arn:aws:iam::123456789012:policy/MyOtherPolicy\"], " +
 					"session_name=\"MySession\", " +
 					"source_identity=\"123456789012\", " +
 					"transitive_tag_keys=[\"key\",\"another-key\"]}",

--- a/test/fixtures/codegen/remote-state/s3-assume-role-lists/terragrunt.hcl
+++ b/test/fixtures/codegen/remote-state/s3-assume-role-lists/terragrunt.hcl
@@ -1,0 +1,25 @@
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite"
+  }
+  config = {
+    bucket = "test-bucket"
+    key    = "terraform.tfstate"
+    region = "us-east-1"
+
+    assume_role = {
+      role_arn            = "arn:aws:iam::123456789342:role/test-role"
+      policy_arns         = ["arn:aws:iam::123456789342:policy/test-policy", "arn:aws:iam::123456789342:policy/other-policy"]
+      transitive_tag_keys = ["Project", "ProjectSlug"]
+      tags = {
+        Project = "test-project"
+      }
+    }
+  }
+}
+
+terraform {
+  source = "../../module"
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3165,6 +3165,26 @@ func TestTerragruntRemoteStateCodegenGeneratesBackendBlock(t *testing.T) {
 	assert.True(t, helpers.FileIsInFolder(t, "foo.tfstate", generateTestCase))
 }
 
+func TestTerragruntRemoteStateCodegenPreservesAssumeRoleListCommas(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	generateTestCase := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "remote-state", "s3-assume-role-lists")
+
+	helpers.CleanupTerraformFolder(t, generateTestCase)
+	helpers.CleanupTerragruntFolder(t, generateTestCase)
+
+	helpers.RunTerragrunt(t, "terragrunt init --non-interactive --working-dir "+generateTestCase+" -- -backend=false")
+
+	backendPath := filepath.Join(helpers.FindCacheWorkingDir(t, generateTestCase), "backend.tf")
+	backendBytes, err := os.ReadFile(backendPath)
+	require.NoError(t, err)
+
+	backend := string(backendBytes)
+	assert.Contains(t, backend, `policy_arns = ["arn:aws:iam::123456789342:policy/test-policy", "arn:aws:iam::123456789342:policy/other-policy"]`)
+	assert.Contains(t, backend, `transitive_tag_keys = ["Project", "ProjectSlug"]`)
+}
+
 func TestTerragruntRemoteStateCodegenOverwrites(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION


<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

When `assume_role` blocks contain list attributes like `transitive_tag_keys = ["Project", "ProjectSlug"], terragrunt init` fails with:

> Missing item separator; Expected a comma to mark the beginning of the next item.

Fix : 

Added bracket depth tracking so commas inside `[...]` and `{...}` are preserved, and only top-level argument-separating commas are replaced with newlines.

Fixes #4776 .

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

### Before Fix
<img width="941" height="137" alt="Screenshot 2026-04-26 at 2 37 17 PM" src="https://github.com/user-attachments/assets/85b290fa-ac7a-4326-8e94-55cacf4c56ad" />

### After Fix
<img width="946" height="852" alt="Screenshot 2026-04-26 at 2 37 53 PM" src="https://github.com/user-attachments/assets/7caa0d84-4aba-4c52-9868-7a65a51c4014" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commas inside nested lists/objects or within quoted/escaped text are no longer treated as top-level separators, preventing generated configuration parse errors.

* **Refactor**
  * Parsing logic simplified to a more robust scanner handling quotes, escapes, and nested brackets.

* **Tests**
  * Added cases covering complex comma/quote/bracket scenarios.

* **Documentation**
  * Changelog entry added for v1.0.5 describing the parsing fix.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/5975)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->