### PR TITLE
docs: Cleaning up changelog for `v1.0.3`

### DIFF
--- a/docs/src/data/changelog/v1.0.3/remotestate-nil-config.mdx
+++ b/docs/src/data/changelog/v1.0.3/remotestate-nil-config.mdx
@@ -1,0 +1,14 @@
+---
+version: "v1.0.3"
+category: "bug-fixes"
+---
+
+#### Fixed crash when a `root.hcl` declares no `remote_state` block
+
+A `root.hcl` that only declared `locals` (or otherwise omitted a `remote_state` block) could trigger a nil pointer dereference inside Terragrunt's remote-state initialization. Downstream tools that embed the Terragrunt config parser, such as [`terragrunt-ls`](https://github.com/gruntwork-io/terragrunt-ls), crashed on every such file.
+
+A missing `remote_state` block now initializes an empty remote-state value instead of panicking, so parsing proceeds normally when no backend is configured.
+
+Reported in [terragrunt-ls#134](https://github.com/gruntwork-io/terragrunt-ls/issues/134).
+
+Thanks to [@SAY-5](https://github.com/SAY-5) for contributing this fix!

--- a/docs/src/data/changelog/v1.0.3/stack-dependencies-nested-stack-path.mdx
+++ b/docs/src/data/changelog/v1.0.3/stack-dependencies-nested-stack-path.mdx
@@ -1,0 +1,29 @@
+---
+version: "v1.0.3"
+category: "experiments-updated"
+---
+
+#### `stack-dependencies`: Multi-level nested `stack.<name>.<nested_stack>.path` references
+
+The [`stack-dependencies`](/reference/experiments/active#stack-dependencies) experiment already supported `stack.<name>.path` (a whole stack) and `stack.<name>.<unit_name>.path` (a unit inside a stack). It now also resolves references where the second segment is itself a nested stack, so an `autoinclude` block in a parent stack can target a stack that lives inside another stack:
+
+```hcl
+# live/terragrunt.stack.hcl
+stack "infra" {
+  source = "../catalog/stacks/infra"
+  path   = "infra"
+}
+
+unit "app" {
+  source = "../catalog/units/app"
+  path   = "app"
+
+  autoinclude {
+    dependency "deep" {
+      config_path = stack.infra.deep.path
+    }
+  }
+}
+```
+
+Here `stack.infra.deep.path` resolves to the generated directory of a `stack "deep"` block declared inside `catalog/stacks/infra/terragrunt.stack.hcl`. This makes deeper stack hierarchies addressable from a single dependency expression without flattening the layout.

--- a/docs/src/data/changelog/v1.0.3/stack-generate-target-race.mdx
+++ b/docs/src/data/changelog/v1.0.3/stack-generate-target-race.mdx
@@ -6,3 +6,5 @@ category: "bug-fixes"
 #### Fixed a race condition in `terragrunt stack generate`
 
 Fixed a race condition in `terragrunt stack generate` that could produce non-deterministic file errors on nested stack hierarchies. The same stack file could reach the worker pool twice through different path forms and cause the duplicate writes to conflict with each other. Paths are now normalized before dispatch so each stack file is generated exactly once per invocation.
+
+When a stack file is legitimately claimed by more than one parent during generation, Terragrunt now logs a warning that names the contending parents and records the latest claimant, so the configuration can be corrected before it causes silent overwrites.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crash when `root.hcl` lacks a `remote_state` block; empty remote-state now initializes automatically
  * Enhanced race condition fix in `terragrunt stack generate` to emit warnings when multiple parents claim the same stack file

* **New Features**
  * Stack-dependencies now supports nested stack path resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->