### PR TITLE
docs: Adding a `Pull Requests` section to the changelog

### DIFF
--- a/docs/src/components/PullRequests.astro
+++ b/docs/src/components/PullRequests.astro
@@ -1,0 +1,61 @@
+---
+import type { PullRequestGroup } from "@lib/changelog";
+
+interface Props {
+  groups: PullRequestGroup[];
+  slug?: string;
+  label?: string;
+}
+
+const { groups, slug = "pull-requests", label = "Pull Requests" } = Astro.props;
+
+type TitlePart = { code: boolean; text: string };
+
+function splitTitle(title: string): TitlePart[] {
+  const parts: TitlePart[] = [];
+  let last = 0;
+  for (const m of title.matchAll(/`([^`]+)`/g)) {
+    const idx = m.index ?? 0;
+    if (idx > last) parts.push({ code: false, text: title.slice(last, idx) });
+    parts.push({ code: true, text: m[1] });
+    last = idx + m[0].length;
+  }
+  if (last < title.length) parts.push({ code: false, text: title.slice(last) });
+  return parts;
+}
+---
+
+{groups.length > 0 && (
+  <section class="pull-requests">
+    <div class="sl-heading-wrapper level-h2">
+      <h2 id={slug}>{label}</h2>
+      <a class="sl-anchor-link" href={`#${slug}`}>
+        <span aria-hidden="true" class="sl-anchor-icon"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentcolor" d="m12.11 15.39-3.88 3.88a2.52 2.52 0 0 1-3.5 0 2.47 2.47 0 0 1 0-3.5l3.88-3.88a1 1 0 0 0-1.42-1.42l-3.88 3.89a4.48 4.48 0 0 0 6.33 6.33l3.89-3.88a1 1 0 1 0-1.42-1.42Zm8.58-12.08a4.49 4.49 0 0 0-6.33 0l-3.89 3.88a1 1 0 0 0 1.42 1.42l3.88-3.88a2.52 2.52 0 0 1 3.5 0 2.47 2.47 0 0 1 0 3.5l-3.88 3.88a1 1 0 1 0 1.42 1.42l3.88-3.89a4.49 4.49 0 0 0 0-6.33ZM8.83 15.17a1 1 0 0 0 1.1.22 1 1 0 0 0 .32-.22l4.92-4.92a1 1 0 0 0-1.42-1.42l-4.92 4.92a1 1 0 0 0 0 1.42Z"/></svg></span>
+        <span class="sr-only" data-pagefind-ignore>Section titled {label}</span>
+      </a>
+    </div>
+    <hr />
+    {groups.map((group) => (
+      <div class="pull-requests-group">
+        <h3 id={`pull-requests-${group.type.key}`}>{group.type.label}</h3>
+        <ul>
+          {group.items.map((item) => (
+            <li>
+              {splitTitle(item.title).map((part) =>
+                part.code ? <code>{part.text}</code> : <Fragment>{part.text}</Fragment>
+              )}
+              {" by "}
+              <a href={`https://github.com/${item.author}`}>@{item.author}</a>
+              {item.prNumber !== null && (
+                <>
+                  {" in "}
+                  <a href={item.prUrl}>#{item.prNumber}</a>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    ))}
+  </section>
+)}

--- a/docs/src/components/ReleaseEntries.astro
+++ b/docs/src/components/ReleaseEntries.astro
@@ -1,18 +1,14 @@
 ---
 import { render } from "astro:content";
-import CopyReleaseNotes from "./CopyReleaseNotes.astro";
-import { groupByCategory, prepareForGitHub, type ChangelogEntry } from "@lib/changelog";
+import { groupByCategory, type ChangelogEntry } from "@lib/changelog";
 
 interface Props {
-  version: string;
   entries: ChangelogEntry[];
 }
 
-const { version, entries } = Astro.props;
+const { entries } = Astro.props;
 
 const groups = groupByCategory(entries);
-
-const siteUrl = Astro.site?.origin ?? "https://docs.terragrunt.com";
 
 const rendered = await Promise.all(
   groups.map(async (group) => {
@@ -25,18 +21,6 @@ const rendered = await Promise.all(
     return { group, entries };
   })
 );
-
-const githubMarkdown = prepareForGitHub(
-  groups
-    .map((group) => {
-      const bodies = group.entries.map((e) => (e.body ?? "").trim()).join("\n\n");
-      return `### ${group.category.label}\n\n---\n\n${bodies}`;
-    })
-    .join("\n\n"),
-  siteUrl,
-);
-
-const isSemver = version.startsWith("v");
 ---
 
 {rendered.map(({ group, entries }) => (
@@ -52,40 +36,3 @@ const isSemver = version.startsWith("v");
     {entries.map(({ Content }) => <Content />)}
   </section>
 ))}
-
-{isSemver && (
-  <aside class="copy-section">
-    <p class="copy-heading">Copy to GitHub Releases</p>
-    <p class="copy-description">Copy these release notes with absolute URLs and heading levels adjusted for use in a <a href={`https://github.com/gruntwork-io/terragrunt/releases/new?tag=${version}`}>GitHub Release</a>.</p>
-    <CopyReleaseNotes markdown={githubMarkdown} />
-  </aside>
-)}
-
-<style>
-  .copy-section {
-    margin-top: 2rem;
-    padding: 1.25rem;
-    border: 1px solid var(--sl-color-docs-stroke);
-    border-radius: 0.5rem;
-    background: var(--sl-color-bg-nav);
-  }
-
-  .copy-heading {
-    font-size: 0.875rem;
-    font-weight: 600;
-    font-family: var(--font-sans);
-    color: var(--sl-color-white);
-    margin: 0 0 0.375rem;
-  }
-
-  .copy-description {
-    font-size: 0.8125rem;
-    color: var(--sl-color-gray-3);
-    margin: 0 0 0.75rem;
-    line-height: 1.5;
-  }
-
-  .copy-description a {
-    color: var(--sl-color-accent);
-  }
-</style>

--- a/docs/src/lib/changelog.ts
+++ b/docs/src/lib/changelog.ts
@@ -92,6 +92,132 @@ export function categorySlugSort(a: string, b: string): number {
   return ai - bi;
 }
 
+export interface ConventionalType {
+  key: string;
+  label: string;
+}
+
+export const CONVENTIONAL_TYPES: readonly ConventionalType[] = [
+  { key: "breaking", label: "🛠️ Breaking Changes" },
+  { key: "feat", label: "✨ Features" },
+  { key: "fix", label: "🐛 Bug Fixes" },
+  { key: "perf", label: "🏎️ Performance" },
+  { key: "refactor", label: "♻️ Refactors" },
+  { key: "revert", label: "⏪ Reverts" },
+  { key: "docs", label: "📖 Documentation" },
+  { key: "test", label: "✅ Tests" },
+  { key: "build", label: "📦 Build" },
+  { key: "ci", label: "🤖 CI" },
+  { key: "chore", label: "🧹 Chores" },
+  { key: "style", label: "🎨 Style" },
+  { key: "other", label: "📝 Other Changes" },
+] as const;
+
+const CONVENTIONAL_TYPE_KEYS = new Set(CONVENTIONAL_TYPES.map((t) => t.key));
+
+const CONVENTIONAL_TYPE_ALIASES: Record<string, string> = {
+  bug: "fix",
+  doc: "docs",
+};
+
+export interface PullRequestItem {
+  title: string;
+  author: string;
+  prUrl: string;
+  prNumber: number | null;
+  type: string;
+}
+
+export interface PullRequestGroup {
+  type: ConventionalType;
+  items: PullRequestItem[];
+}
+
+const PULL_REQUEST_LINE = /^\*\s+(.+?)\s+by\s+@([\w-]+)\s+in\s+(\S+?)\/?$/;
+const PR_NUMBER = /\/pull\/(\d+)/;
+const CONVENTIONAL_PREFIX = /^([a-z]+)(\([^)]*\))?(!)?:\s*(.*)$/i;
+// Matches the heading GitHub auto-generates in release bodies; the literal
+// text "What's Changed" is GitHub's convention and must stay verbatim.
+const SECTION_HEADING = /^##\s+What's Changed\s*$/i;
+const ANY_H2 = /^##\s+/;
+const FULL_CHANGELOG = /^\*\*Full Changelog\*\*/i;
+const BREAKING_CHANGE = /BREAKING CHANGE:/i;
+
+function classifyTitle(title: string): string {
+  if (BREAKING_CHANGE.test(title)) return "breaking";
+  const match = CONVENTIONAL_PREFIX.exec(title);
+  if (match === null) return "other";
+  const lower = match[1].toLowerCase();
+  const bang = match[3];
+  if (bang === "!") return "breaking";
+  const type = CONVENTIONAL_TYPE_ALIASES[lower] ?? lower;
+  return CONVENTIONAL_TYPE_KEYS.has(type) ? type : "other";
+}
+
+function parsePullRequestLine(line: string): PullRequestItem | null {
+  const match = PULL_REQUEST_LINE.exec(line.trim());
+  if (match === null) return null;
+  const [, title, author, prUrl] = match;
+  const prMatch = PR_NUMBER.exec(prUrl);
+  return {
+    title,
+    author,
+    prUrl,
+    prNumber: prMatch ? Number(prMatch[1]) : null,
+    type: classifyTitle(title),
+  };
+}
+
+function extractPullRequestItems(body: string): PullRequestItem[] {
+  const items: PullRequestItem[] = [];
+  let inSection = false;
+  for (const line of body.split(/\r?\n/)) {
+    if (SECTION_HEADING.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (!inSection) continue;
+    if (ANY_H2.test(line) || FULL_CHANGELOG.test(line)) break;
+    const item = parsePullRequestLine(line);
+    if (item) items.push(item);
+  }
+  return items;
+}
+
+function groupItemsByType(items: PullRequestItem[]): PullRequestGroup[] {
+  const buckets = new Map<string, PullRequestItem[]>();
+  for (const item of items) {
+    const bucket = buckets.get(item.type) ?? [];
+    bucket.push(item);
+    buckets.set(item.type, bucket);
+  }
+  const groups: PullRequestGroup[] = [];
+  for (const type of CONVENTIONAL_TYPES) {
+    const bucket = buckets.get(type.key);
+    if (bucket) groups.push({ type, items: bucket });
+  }
+  return groups;
+}
+
+export function parsePullRequests(body: string | null | undefined): PullRequestGroup[] {
+  if (!body) return [];
+  const items = extractPullRequestItems(body);
+  if (items.length === 0) return [];
+  return groupItemsByType(items);
+}
+
+export function pullRequestsToMarkdown(groups: PullRequestGroup[]): string {
+  if (groups.length === 0) return "";
+  const sections = groups.map((group) => {
+    const lines = group.items.map((item) => {
+      const prRef = item.prNumber === null ? ` in ${item.prUrl}` : ` in [#${item.prNumber}](${item.prUrl})`;
+      return `- ${item.title} by [@${item.author}](https://github.com/${item.author})${prRef}`;
+    });
+    return `### ${group.type.label}\n\n${lines.join("\n")}`;
+  });
+  return `## Pull Requests\n\n${sections.join("\n\n")}`;
+}
+
 export function prepareForGitHub(body: string, siteUrl: string): string {
   let result = body;
 

--- a/docs/src/lib/github.ts
+++ b/docs/src/lib/github.ts
@@ -41,6 +41,7 @@ interface GitHubReleaseResponse {
   name: string;
   html_url: string;
   published_at: string;
+  body?: string;
   [key: string]: unknown;
 }
 
@@ -132,6 +133,55 @@ export async function getLatestRelease(
     });
   } catch (error) {
     console.error(`Error fetching latest release for ${owner}/${repo}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Fetches a specific release by tag with memoization.
+ * Results are cached for 1 hour to avoid rate limiting.
+ */
+export async function getReleaseByTag(
+  owner: string,
+  repo: string,
+  tag: string
+): Promise<GitHubReleaseResponse | null> {
+  const cacheKey = `release-tag:${owner}/${repo}/${tag}`;
+
+  try {
+    return await memoizedFetch(cacheKey, async () => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+      try {
+        const response = await fetch(
+          `https://api.github.com/repos/${owner}/${repo}/releases/tags/${tag}`,
+          {
+            headers: {
+              'User-Agent': 'Terragrunt-Docs',
+            },
+            signal: controller.signal,
+          }
+        );
+
+        if (!response.ok) {
+          if (response.status !== 404) {
+            console.error(
+              `Failed to fetch release ${tag} for ${owner}/${repo}:`,
+              response.status,
+              await response.text()
+            );
+          }
+          return null;
+        }
+
+        return response.json();
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    });
+  } catch (error) {
+    console.error(`Error fetching release ${tag} for ${owner}/${repo}:`, error);
     return null;
   }
 }

--- a/docs/src/pages/process/changelog/[version].astro
+++ b/docs/src/pages/process/changelog/[version].astro
@@ -2,13 +2,18 @@ export const prerender = true;
 ---
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 import ReleaseEntries from '@components/ReleaseEntries.astro';
+import PullRequests from '@components/PullRequests.astro';
+import CopyReleaseNotes from '@components/CopyReleaseNotes.astro';
 import { getCollection } from 'astro:content';
-import { getLatestRelease } from '@lib/github';
+import { getLatestRelease, getReleaseByTag } from '@lib/github';
 import {
   compareVersionsDesc,
   entriesForVersion,
   groupByCategory,
   isReleased,
+  parsePullRequests,
+  prepareForGitHub,
+  pullRequestsToMarkdown,
   uniqueVersions,
 } from '@lib/changelog';
 import { sidebar } from '../../../data/sidebar';
@@ -54,11 +59,35 @@ const older =
     ? visibleVersions[currentIndex + 1]
     : null;
 
-const headings = groups.map((group) => ({
-  depth: 2,
-  slug: group.category.slug,
-  text: group.category.label,
-}));
+const tagName = version.startsWith('v') ? version : `v${version}`;
+const versionRelease = await getReleaseByTag('gruntwork-io', 'terragrunt', tagName);
+const pullRequestGroups = parsePullRequests(versionRelease?.body);
+
+const siteUrl = Astro.site?.origin ?? 'https://docs.terragrunt.com';
+const isSemver = version.startsWith('v');
+
+const releaseEntriesMd = prepareForGitHub(
+  groups
+    .map((group) => {
+      const bodies = group.entries.map((e) => (e.body ?? '').trim()).join('\n\n');
+      return `### ${group.category.label}\n\n---\n\n${bodies}`;
+    })
+    .join('\n\n'),
+  siteUrl,
+);
+const pullRequestsMd = pullRequestsToMarkdown(pullRequestGroups);
+const githubMarkdown = [releaseEntriesMd, pullRequestsMd].filter(Boolean).join('\n\n');
+
+const headings = [
+  ...groups.map((group) => ({
+    depth: 2,
+    slug: group.category.slug,
+    text: group.category.label,
+  })),
+  ...(pullRequestGroups.length > 0
+    ? [{ depth: 2, slug: 'pull-requests', text: 'Pull Requests' }]
+    : []),
+];
 ---
 
 <StarlightPage
@@ -73,6 +102,43 @@ const headings = groups.map((group) => ({
   sidebar={sidebar}
 >
   <div data-pagefind-ignore>
-    <ReleaseEntries version={version} entries={entries} />
+    <ReleaseEntries entries={entries} />
+    <PullRequests groups={pullRequestGroups} />
+    {isSemver && (
+      <aside class="copy-section">
+        <p class="copy-heading">Copy to GitHub Releases</p>
+        <p class="copy-description">Copy these release notes with absolute URLs and heading levels adjusted for use in a <a href={`https://github.com/gruntwork-io/terragrunt/releases/new?tag=${version}`}>GitHub Release</a>.</p>
+        <CopyReleaseNotes markdown={githubMarkdown} />
+      </aside>
+    )}
   </div>
 </StarlightPage>
+
+<style>
+  .copy-section {
+    margin-top: 2rem;
+    padding: 1.25rem;
+    border: 1px solid var(--sl-color-docs-stroke);
+    border-radius: 0.5rem;
+    background: var(--sl-color-bg-nav);
+  }
+
+  .copy-heading {
+    font-size: 0.875rem;
+    font-weight: 600;
+    font-family: var(--font-sans);
+    color: var(--sl-color-white);
+    margin: 0 0 0.375rem;
+  }
+
+  .copy-description {
+    font-size: 0.8125rem;
+    color: var(--sl-color-gray-3);
+    margin: 0 0 0.75rem;
+    line-height: 1.5;
+  }
+
+  .copy-description a {
+    color: var(--sl-color-accent);
+  }
+</style>


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds an automatically updated `Pull Requests` section at the bottom of each release so that we don't have to manually sort these PRs in our release notes anymore.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pull requests are now displayed on changelog pages, grouped by category
  * Release pages now fetch and display PR information directly from GitHub releases

* **Refactor**
  * Reorganized release notes UI to streamline display of changelog entries and pull requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->