### PR TITLE
fix: Use `FromSlash` on return of `git rev-parse --show-toplevel`

### DIFF
--- a/internal/shell/git.go
+++ b/internal/shell/git.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
@@ -42,7 +43,10 @@ func GitTopLevelDir(ctx context.Context, l log.Logger, env map[string]string, pa
 		return "", err
 	}
 
-	cmdOutput := strings.TrimSpace(cmd.Stdout.String())
+	// Git on Windows always emits forward slashes from `rev-parse --show-toplevel`,
+	// so normalize to OS-native separators to stay consistent with the other path
+	// HCL functions (get_terragrunt_dir, find_in_parent_folders, etc.).
+	cmdOutput := filepath.FromSlash(strings.TrimSpace(cmd.Stdout.String()))
 
 	if stderrString := strings.TrimSpace(stderr.String()); stderrString != "" {
 		l.Warnf("git rev-parse --show-toplevel resulted in stderr output: \n%v\n", stderrString)

--- a/internal/shell/git_windows_test.go
+++ b/internal/shell/git_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package shell_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cache"
+	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGitTopLevelDirReturnsOSNativePathOnWindows guards against a regression
+// where `git rev-parse --show-toplevel` output (always forward-slashed, even
+// on Windows) leaked through unchanged. The other HCL path functions return
+// OS-native paths, so get_repo_root must too.
+func TestGitTopLevelDirReturnsOSNativePathOnWindows(t *testing.T) {
+	t.Parallel()
+
+	ctx := cache.ContextWithCache(t.Context())
+
+	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+
+	repoRoot, err := shell.GitTopLevelDir(ctx, l, terragruntOptions.Env, ".")
+	require.NoError(t, err)
+	require.NotEmpty(t, repoRoot)
+
+	assert.NotContains(t, repoRoot, "/", "expected OS-native path on Windows, got %q", repoRoot)
+	assert.Contains(t, repoRoot, "\\", "expected backslash separators on Windows, got %q", strings.ReplaceAll(repoRoot, "\\", "\\\\"))
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #5976.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling on Windows to ensure paths are properly formatted using OS-native path separators, preventing forward slashes in results.

* **Tests**
  * Added Windows-specific testing to validate path formatting consistency and ensure cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->