### PR TITLE
perf: Memoizing `get_repo_root()` better

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -7,6 +7,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -125,4 +128,120 @@ func ContextCache[T any](ctx context.Context, key any) *Cache[T] {
 	}
 
 	return cacheInstance
+}
+
+// RepoRootCache stores git repository roots and answers prefix-containment
+// queries. Roots are kept sorted by descending length so Lookup yields the
+// deepest matching root for paths inside nested repositories.
+type RepoRootCache struct {
+	name    string
+	roots   []string
+	mu      sync.RWMutex
+	resolve sync.Mutex
+}
+
+// NewRepoRootCache constructs an empty RepoRootCache. The name is used as a
+// prefix for telemetry counters.
+func NewRepoRootCache(name string) *RepoRootCache {
+	return &RepoRootCache{name: name}
+}
+
+// Lookup returns the deepest cached root that contains path. Containment is
+// component-aware: `/foo` does not match `/foobar`.
+func (c *RepoRootCache) Lookup(ctx context.Context, path string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	telemetry.TelemeterFromContext(ctx).Count(ctx, c.name+"_cache_get", 1)
+
+	for _, root := range c.roots {
+		if pathContainedIn(path, root) {
+			telemetry.TelemeterFromContext(ctx).Count(ctx, c.name+"_cache_hit", 1)
+
+			return root, true
+		}
+	}
+
+	telemetry.TelemeterFromContext(ctx).Count(ctx, c.name+"_cache_miss", 1)
+
+	return "", false
+}
+
+// Add records root as a known repository root. Inserts are ordered by
+// descending length so Lookup's first match is the deepest. Duplicates are
+// ignored.
+func (c *RepoRootCache) Add(ctx context.Context, root string) {
+	if root == "" {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	telemetry.TelemeterFromContext(ctx).Count(ctx, c.name+"_cache_put", 1)
+
+	insertAt := len(c.roots)
+
+	for i, existing := range c.roots {
+		if existing == root {
+			return
+		}
+
+		if insertAt == len(c.roots) && len(root) > len(existing) {
+			insertAt = i
+		}
+	}
+
+	c.roots = slices.Insert(c.roots, insertAt, root)
+}
+
+// BeginResolve serializes callers that are about to perform the external
+// lookup whose result they will Add. Callers must Lookup again after
+// BeginResolve returns so a concurrent populate is observed before running
+// the external resolver. EndResolve releases the lock.
+//
+// The lock is independent of the cache's read/write mutex; it is held across
+// the external call so concurrent misses collapse to a single resolution.
+func (c *RepoRootCache) BeginResolve() {
+	c.resolve.Lock()
+}
+
+// EndResolve releases the lock taken by BeginResolve.
+func (c *RepoRootCache) EndResolve() {
+	c.resolve.Unlock()
+}
+
+// Len returns the number of cached roots.
+func (c *RepoRootCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return len(c.roots)
+}
+
+// pathContainedIn reports whether path equals root or sits beneath it,
+// requiring a separator after root so `/foo` does not match `/foobar`.
+func pathContainedIn(path, root string) bool {
+	if path == root {
+		return true
+	}
+
+	if !strings.HasPrefix(path, root) {
+		return false
+	}
+
+	rest := path[len(root):]
+
+	return len(rest) > 0 && os.IsPathSeparator(rest[0])
+}
+
+// ContextRepoRootCache returns the RepoRootCache stored on the context, or a
+// fresh detached instance if none is present so callers do not need to
+// nil-check.
+func ContextRepoRootCache(ctx context.Context, key any) *RepoRootCache {
+	if c, ok := ctx.Value(key).(*RepoRootCache); ok && c != nil {
+		return c
+	}
+
+	return NewRepoRootCache(fmt.Sprintf("%v", key))
 }

--- a/internal/cache/context.go
+++ b/internal/cache/context.go
@@ -8,13 +8,22 @@ const (
 	// RunCmdCacheContextKey is the context key used to store and retrieve the run command cache
 	RunCmdCacheContextKey ctxKey = iota
 
+	// RepoRootCacheContextKey is the context key for the repo-root cache.
+	RepoRootCacheContextKey
+
 	// runCmdCacheName is the identifier for the run command cache instance
 	runCmdCacheName = "runCmdCache"
+
+	// repoRootCacheName is the identifier for the repo-root cache instance
+	repoRootCacheName = "repoRootCache"
 )
 
 // ctxKey is a type-safe context key type to prevent key collisions
 type ctxKey byte
 
 func ContextWithCache(ctx context.Context) context.Context {
-	return context.WithValue(ctx, RunCmdCacheContextKey, NewCache[string](runCmdCacheName))
+	ctx = context.WithValue(ctx, RunCmdCacheContextKey, NewCache[string](runCmdCacheName))
+	ctx = context.WithValue(ctx, RepoRootCacheContextKey, NewRepoRootCache(repoRootCacheName))
+
+	return ctx
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-git/go-git/v6"
@@ -39,11 +40,14 @@ const (
 
 // GitRunner handles git command execution
 type GitRunner struct {
-	goRepo    *git.Repository
-	goStorage *filesystem.Storage
-	exec      vexec.Exec
-	GitPath   string
-	WorkDir   string
+	goRepo       *git.Repository
+	goStorage    *filesystem.Storage
+	exec         vexec.Exec
+	repoRootOnce *sync.Once
+	repoRootErr  error
+	GitPath      string
+	WorkDir      string
+	repoRoot     string
 }
 
 // NewGitRunner creates a new GitRunner instance. The provided vexec.Exec is
@@ -59,19 +63,24 @@ func NewGitRunner(e vexec.Exec) (*GitRunner, error) {
 	}
 
 	return &GitRunner{
-		GitPath: gitPath,
-		exec:    e,
+		GitPath:      gitPath,
+		exec:         e,
+		repoRootOnce: &sync.Once{},
 	}, nil
 }
 
 // WithWorkDir returns a new GitRunner with the specified working directory
 func (g *GitRunner) WithWorkDir(workDir string) *GitRunner {
 	if g == nil {
-		return &GitRunner{WorkDir: workDir, exec: vexec.NewOSExec()}
+		return &GitRunner{WorkDir: workDir, exec: vexec.NewOSExec(), repoRootOnce: &sync.Once{}}
 	}
 
 	newRunner := *g
 	newRunner.WorkDir = workDir
+	// A different WorkDir may resolve to a different root, so reset the memo.
+	newRunner.repoRootOnce = &sync.Once{}
+	newRunner.repoRoot = ""
+	newRunner.repoRootErr = nil
 
 	return &newRunner
 }
@@ -102,12 +111,24 @@ func (g *GitRunner) RequiresGoRepo() error {
 	return nil
 }
 
-// GetRepoRoot returns the root directory of the git repository.
+// GetRepoRoot returns the root directory of the git repository, memoized
+// per-runner. WithWorkDir clears the memo so a derived runner resolves its
+// own root.
 func (g *GitRunner) GetRepoRoot(ctx context.Context) (string, error) {
 	if err := g.RequiresWorkDir(); err != nil {
 		return "", err
 	}
 
+	g.repoRootOnce.Do(func() {
+		g.repoRoot, g.repoRootErr = g.runRepoRoot(ctx)
+	})
+
+	return g.repoRoot, g.repoRootErr
+}
+
+// runRepoRoot performs the uncached `git rev-parse --show-toplevel`. Use
+// GetRepoRoot for the memoized entry point.
+func (g *GitRunner) runRepoRoot(ctx context.Context) (string, error) {
 	cmd := g.prepareCommand(ctx, "rev-parse", "--show-toplevel")
 
 	var stdout, stderr bytes.Buffer

--- a/internal/shell/git.go
+++ b/internal/shell/git.go
@@ -3,7 +3,9 @@ package shell
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -19,15 +21,47 @@ const (
 	refsTags  = "refs/tags/"
 
 	tagSplitPart = 2
+
+	// maxNestedGitScanDepth caps the nested-repo guard's walk so a path
+	// whose Dir() never reaches a fixed point cannot hang the process.
+	maxNestedGitScanDepth = 1024
 )
 
-// GitTopLevelDir fetches git repository path from passed directory.
-func GitTopLevelDir(ctx context.Context, l log.Logger, env map[string]string, path string) (string, error) {
-	runCache := cache.ContextCache[string](ctx, cache.RunCmdCacheContextKey)
-	cacheKey := "top-level-dir-" + path
+// NestedGitScanDepthExceededError is returned when the nested-repo guard's
+// walk exceeds maxNestedGitScanDepth. Surfacing this as a typed error keeps
+// callers from mistaking an aborted scan for a clean one.
+type NestedGitScanDepthExceededError struct {
+	Path     string
+	Root     string
+	MaxDepth int
+}
 
-	if gitTopLevelDir, found := runCache.Get(ctx, cacheKey); found {
-		return gitTopLevelDir, nil
+func (e *NestedGitScanDepthExceededError) Error() string {
+	return fmt.Sprintf("nested-git scan exceeded depth %d walking from %q to %q", e.MaxDepth, e.Path, e.Root)
+}
+
+// GitTopLevelDir returns the git repository root that contains path,
+// memoized in a run-scoped cache. A `.git` scan between path and any cached
+// ancestor keeps the answer correct when a nested repository sits below an
+// already-cached outer root. Concurrent misses for the same repo collapse to
+// a single fork via the cache's resolve lock and a re-check after acquiring it.
+func GitTopLevelDir(ctx context.Context, l log.Logger, env map[string]string, path string) (string, error) {
+	repoRoots := cache.ContextRepoRootCache(ctx, cache.RepoRootCacheContextKey)
+	normalized := normalizeRepoPath(path)
+
+	if root, ok, err := lookupRepoRoot(ctx, repoRoots, normalized); err != nil {
+		return "", err
+	} else if ok {
+		return root, nil
+	}
+
+	repoRoots.BeginResolve()
+	defer repoRoots.EndResolve()
+
+	if root, ok, err := lookupRepoRoot(ctx, repoRoots, normalized); err != nil {
+		return "", err
+	} else if ok {
+		return root, nil
 	}
 
 	stdout := bytes.Buffer{}
@@ -54,9 +88,81 @@ func GitTopLevelDir(ctx context.Context, l log.Logger, env map[string]string, pa
 
 	l.Debugf("git show-toplevel result: %s", cmdOutput)
 
-	runCache.Put(ctx, cacheKey, cmdOutput)
+	repoRoots.Add(ctx, normalizeRepoPath(cmdOutput))
 
 	return cmdOutput, nil
+}
+
+// lookupRepoRoot returns the cached root for path when the nested-repo guard
+// accepts it. A nested `.git` finding is reported as a miss (false, nil) so
+// the caller falls through to a fresh git resolution.
+func lookupRepoRoot(ctx context.Context, repoRoots *cache.RepoRootCache, path string) (string, bool, error) {
+	cached, ok := repoRoots.Lookup(ctx, path)
+	if !ok {
+		return "", false, nil
+	}
+
+	nested, err := hasNestedGit(path, cached)
+	if err != nil {
+		return "", false, err
+	}
+
+	if nested {
+		return "", false, nil
+	}
+
+	return cached, true, nil
+}
+
+// hasNestedGit reports whether any directory between path and root (exclusive
+// of root) contains a `.git` entry, meaning a nested repository sits below
+// root and would invalidate root as the answer for path.
+func hasNestedGit(path, root string) (bool, error) {
+	if path == root {
+		return false, nil
+	}
+
+	current := path
+	for range maxNestedGitScanDepth {
+		if current == root {
+			return false, nil
+		}
+
+		if _, err := os.Stat(filepath.Join(current, ".git")); err == nil {
+			return true, nil
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return false, nil
+		}
+
+		current = parent
+	}
+
+	return false, &NestedGitScanDepthExceededError{
+		Path:     path,
+		Root:     root,
+		MaxDepth: maxNestedGitScanDepth,
+	}
+}
+
+// normalizeRepoPath canonicalizes a directory path for cache comparison. The
+// EvalSymlinks step is best-effort: failures (e.g. the path does not exist)
+// fall through to the lexical clean so the surrounding git call still
+// produces the real error.
+func normalizeRepoPath(path string) string {
+	if path == "" {
+		return ""
+	}
+
+	cleaned := filepath.Clean(path)
+
+	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
+		return resolved
+	}
+
+	return cleaned
 }
 
 // GitRepoTags fetches git repository tags from passed url.

--- a/internal/shell/run_cmd_test.go
+++ b/internal/shell/run_cmd_test.go
@@ -2,12 +2,15 @@ package shell_test
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -87,9 +90,9 @@ func TestGitLevelTopDirCaching(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	ctx = cache.ContextWithCache(ctx)
-	c := cache.ContextCache[string](ctx, cache.RunCmdCacheContextKey)
+	c := cache.ContextRepoRootCache(ctx, cache.RepoRootCacheContextKey)
 	assert.NotNil(t, c)
-	assert.Empty(t, c.Cache)
+	assert.Equal(t, 0, c.Len())
 
 	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
 	require.NoError(t, err)
@@ -101,5 +104,54 @@ func TestGitLevelTopDirCaching(t *testing.T) {
 	path2, err := shell.GitTopLevelDir(ctx, l, terragruntOptions.Env, path)
 	require.NoError(t, err)
 	assert.Equal(t, path1, path2)
-	assert.Len(t, c.Cache, 1)
+	assert.Equal(t, 1, c.Len())
+}
+
+// TestGitTopLevelDirPrefixHit asserts that a descendant query is served from
+// the cache. The seeded root is synthetic, so a non-cached answer would have
+// to come from `git rev-parse` and would not equal the seeded root.
+func TestGitTopLevelDirPrefixHit(t *testing.T) {
+	t.Parallel()
+
+	root := helpers.TmpDirWOSymlinks(t)
+	subdir := filepath.Join(root, "a", "b", "c")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	ctx := cache.ContextWithCache(t.Context())
+	c := cache.ContextRepoRootCache(ctx, cache.RepoRootCacheContextKey)
+	c.Add(ctx, root)
+
+	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	got, err := shell.GitTopLevelDir(ctx, logger.CreateLogger(), terragruntOptions.Env, subdir)
+	require.NoError(t, err)
+	assert.Equal(t, root, got)
+}
+
+// TestGitTopLevelDirNestedRepoBypass asserts that a `.git` entry between the
+// query path and the cached root forces a fallthrough to `git`. The synthetic
+// outer root is not a real repo, so the test passes whether `git` errors or
+// returns a different root, as long as the outer root is not returned.
+func TestGitTopLevelDirNestedRepoBypass(t *testing.T) {
+	t.Parallel()
+
+	root := helpers.TmpDirWOSymlinks(t)
+	nested := filepath.Join(root, "sub")
+	require.NoError(t, os.MkdirAll(filepath.Join(nested, ".git"), 0o755))
+
+	deep := filepath.Join(nested, "inner")
+	require.NoError(t, os.MkdirAll(deep, 0o755))
+
+	ctx := cache.ContextWithCache(t.Context())
+	c := cache.ContextRepoRootCache(ctx, cache.RepoRootCacheContextKey)
+	c.Add(ctx, root)
+
+	terragruntOptions, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	got, err := shell.GitTopLevelDir(ctx, logger.CreateLogger(), terragruntOptions.Env, deep)
+	if err == nil {
+		assert.NotEqual(t, root, got, "guard should not return the outer root when a nested .git exists")
+	}
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Improves memoization of `get_repo_root()` to more aggressively cache discovered Git repo roots.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Git repository detection now leverages caching for significantly faster lookups across multiple operations.

* **Bug Fixes**
  * Improved handling of nested git repositories to prevent incorrect root directory detection.

* **Tests**
  * Enhanced test coverage for repository caching behavior and nested repository validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->