### PR TITLE
feat: Adding central Git store for CAS

### DIFF
--- a/docs/src/content/docs/03-features/07-caching/04-cas.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas.mdx
@@ -102,7 +102,7 @@ Setting `update_source_with_cas = true` requires that the `cas` experiment is en
 
 </Since>
 
-When Terragrunt clones a repository while using the CAS, if the repository is not found in the CAS, Terragrunt will clone the repository from the original URL and store it in the CAS for future use.
+When Terragrunt clones a repository while using the CAS, if the repository is not found in the CAS, Terragrunt fetches into the central bare repository for that remote URL and stores the resulting blobs and trees in the CAS for future use. If the central store is unavailable, Terragrunt falls back to cloning the repository from the original URL into a temporary directory.
 
 When generating a repository from the CAS, Terragrunt will hard link entries from the CAS to the new repository. This allows Terragrunt to deduplicate content across multiple repositories.
 
@@ -110,7 +110,15 @@ In the event that hard linking fails due to some operating system / host incompa
 
 ## Storage
 
-The CAS is stored in the `~/.cache/terragrunt/cas` directory. This directory can be safely deleted at any time, as Terragrunt will automatically regenerate the CAS as needed.
+The CAS lives under the platform user cache directory:
+
+| Platform | Path |
+| --- | --- |
+| Linux | `$XDG_CACHE_HOME/terragrunt/cas`, falling back to `~/.cache/terragrunt/cas` |
+| macOS | `~/Library/Caches/terragrunt/cas` |
+| Windows | `%LocalAppData%\terragrunt\cas` |
+
+This directory can be deleted to reclaim disk space when no Terragrunt processes are running against it. Terragrunt will regenerate the CAS on the next run. Avoid deleting it while a Terragrunt operation is in progress, since that can race with in-flight reads, writes, and locks in the store.
 
 Avoid partial deletions of the CAS directory without care, as that might result in partially cloned repositories and unexpected behavior.
 
@@ -179,10 +187,14 @@ The CAS store is organized into namespaced directories:
     - trees/ (synthetic trees created during CAS-backed stack generation)
       - de/
         - def456...xyz
+  - git/ (one bare repository per remote URL, used for incremental fetches)
+    - 1a2b3c4d5e6f7890/
+      - repo/
+      - lock
 
 </FileTree>
 
-The `blobs/` directory stores all file content, identified by hash. Blobs are purely content-addressed, so the same file content always maps to the same hash regardless of origin. The `trees/` directory stores Git-derived tree structures that describe the layout of files in a repository. The `synth/trees/` directory stores synthetic tree structures created during CAS-backed stack generation when `update_source_with_cas` is used. These synthetic trees use a deterministic hash based on the Git reference and path within the repository.
+The `blobs/` directory stores all file content, identified by hash. Blobs are purely content-addressed, so the same file content always maps to the same hash regardless of origin. The `trees/` directory stores Git-derived tree structures that describe the layout of files in a repository. The `synth/trees/` directory stores synthetic tree structures created during CAS-backed stack generation when `update_source_with_cas` is used. These synthetic trees use a deterministic hash based on the Git reference and path within the repository. The `git/` directory holds one bare Git repository per remote URL, keyed by a hash of the URL, so cache misses can fetch only the new objects instead of re-cloning the repository.
 
 Each content object within a namespace is stored at `{hash[:2]}/{hash}`, where the first two characters create a partition directory to avoid degraded file system performance from large flat directories.
 </Since>
@@ -197,10 +209,12 @@ For cold clones, where the content is not already in the CAS:
 
 1. Terragrunt resolves the Git reference (branch/tag) to a commit hash
 2. The tree related to the commit hash is not found in the CAS
-3. Terragrunt clones the repository to a temporary directory
-4. All blobs and trees required to reproduce the repository are extracted
+3. Terragrunt opens the bare repository for the remote URL under `cas/store/git/` (initializing it on first use), takes a per-URL lock, and fetches the requested ref. Subsequent misses against the same URL reuse the existing pack files and only transfer new objects.
+4. All blobs and trees required to reproduce the repository are extracted from the bare repository
 5. Content is stored in the CAS, partitioned by hash prefix
 6. The tree structure is read from the CAS and hard links are created to the target directory
+
+Concurrent units that target the same remote URL share one fetch instead of cloning in parallel, so the objects are typically transferred once and reused. If the shared fetch hangs or fails, Terragrunt logs a warning and falls back to a clone in a temporary directory.
 
 #### Warm Clones
 

--- a/docs/src/data/changelog/v1.0.5/cas-central-git-store.mdx
+++ b/docs/src/data/changelog/v1.0.5/cas-central-git-store.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.0.4"
+version: "v1.0.5"
 category: "experiments-updated"
 ---
 

--- a/docs/src/data/changelog/v1.0.5/cas-central-git-store.mdx
+++ b/docs/src/data/changelog/v1.0.5/cas-central-git-store.mdx
@@ -1,0 +1,16 @@
+---
+version: "v1.0.4"
+category: "experiments-updated"
+---
+
+#### CAS keeps a central Git store for incremental fetches
+
+CAS now keeps one bare Git repository per remote URL inside its store, under `~/.cache/terragrunt/cas/store/git/` on Linux by default. See [Storage](/features/caching/cas#storage) for where this lives on macOS and Windows. On a cache miss, Terragrunt fetches just the requested ref into that repository instead of running a fresh shallow clone into a temporary directory. Repeated misses against the same remote reuse the existing pack files, so fetching a second ref from the same repository transfers only the new objects.
+
+Concurrent Terragrunt runs against the same remote URL share one fetch instead of cloning in parallel; later runs reuse what the first one transferred. If the shared fetch hangs or fails, Terragrunt logs a warning and falls back to a temporary clone so cloning still succeeds.
+
+You can reclaim space at any time by deleting the `git/` subdirectory:
+
+```bash
+rm -rf ~/.cache/terragrunt/cas/store/git
+```

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -55,6 +55,7 @@ type CAS struct {
 	blobStore  *Store
 	treeStore  *Store
 	synthStore *Store
+	gitStore   *GitStore
 	git        *git.GitRunner
 	storePath  string
 	cloneDepth int
@@ -130,6 +131,13 @@ func New(opts ...Option) (*CAS, error) {
 
 	c.git = g
 
+	gs, err := NewGitStore(c.fs, g, filepath.Join(c.storePath, "git"))
+	if err != nil {
+		return nil, err
+	}
+
+	c.gitStore = gs
+
 	return c, nil
 }
 
@@ -160,18 +168,6 @@ func (c *CAS) Clone(ctx context.Context, l log.Logger, opts *CloneOptions, url s
 		return fmt.Errorf("failed to create tree store path: %w", err)
 	}
 
-	// Acquire global clone lock to ensure only one clone at a time
-	globalLock, err := vfs.Lock(c.fs, filepath.Join(c.storePath, "clone.lock"))
-	if err != nil {
-		return fmt.Errorf("failed to acquire global clone lock: %w", err)
-	}
-
-	defer func() {
-		if unlockErr := globalLock.Unlock(); unlockErr != nil {
-			l.Warnf("failed to release global clone lock: %v", unlockErr)
-		}
-	}()
-
 	return telemetry.TelemeterFromContext(ctx).Collect(ctx, "cas_clone", map[string]any{
 		"url":    url,
 		"branch": opts.Branch,
@@ -184,20 +180,8 @@ func (c *CAS) Clone(ctx context.Context, l log.Logger, opts *CloneOptions, url s
 		targetDir := c.prepareTargetDirectory(opts.Dir, url)
 
 		if c.treeStore.NeedsWrite(hash) {
-			// Create a temporary directory for git operations
-			_, cleanup, createTempDirErr := c.git.CreateTempDir()
-			if createTempDirErr != nil {
-				return createTempDirErr
-			}
-
-			defer func() {
-				if cleanupErr := cleanup(); cleanupErr != nil {
-					l.Warnf("cleanup error: %v", cleanupErr)
-				}
-			}()
-
-			if cloneAndStoreErr := c.cloneAndStoreContent(childCtx, l, opts, url, hash); cloneAndStoreErr != nil {
-				return cloneAndStoreErr
+			if err := c.populateTreeFromGit(childCtx, l, opts, url, hash); err != nil {
+				return err
 			}
 		}
 
@@ -215,6 +199,65 @@ func (c *CAS) Clone(ctx context.Context, l log.Logger, opts *CloneOptions, url s
 
 		return LinkTree(childCtx, c.blobStore, c.treeStore, tree, targetDir)
 	})
+}
+
+// populateTreeFromGit fetches the commit at hash and stores its tree and
+// reachable blobs in the CAS. It tries the central git store first. Any
+// error from the central store is logged as a warning, and the function
+// then falls back to a bare clone in a temporary directory.
+func (c *CAS) populateTreeFromGit(ctx context.Context, l log.Logger, opts *CloneOptions, url, hash string) error {
+	depth := resolveCloneDepth(opts.Depth, c.cloneDepth)
+
+	repoPath, unlocker, err := c.gitStore.EnsureRef(ctx, l, c.fs, url, opts.Branch, hash, depth)
+	if err == nil {
+		defer func() {
+			if unlockErr := unlocker.Unlock(); unlockErr != nil {
+				l.Warnf("git store: failed to release lock for %s: %v", url, unlockErr)
+			}
+		}()
+
+		runner := c.git.WithWorkDir(repoPath)
+
+		return c.storeRootTreeFrom(ctx, l, runner, hash, opts)
+	}
+
+	l.Warnf("central git store unavailable for %s, falling back to temporary clone: %v", url, err)
+
+	tempDir, err := vfs.MkdirTemp(c.fs, "", "terragrunt-cas-fallback-*")
+	if err != nil {
+		return fmt.Errorf("create fallback clone dir: %w", errors.Join(ErrFallbackCloneDir, err))
+	}
+
+	defer func() {
+		if rmErr := c.fs.RemoveAll(tempDir); rmErr != nil {
+			l.Warnf("cleanup error: %v", rmErr)
+		}
+	}()
+
+	runner := c.git.WithWorkDir(tempDir)
+
+	if err := runner.Clone(ctx, url, true, depth, opts.Branch); err != nil {
+		return err
+	}
+
+	return c.storeRootTreeFrom(ctx, l, runner, hash, opts)
+}
+
+func resolveCloneDepth(optDepth, casDepth int) int {
+	depth := optDepth
+	if depth == 0 {
+		depth = casDepth
+	}
+
+	if depth == 0 {
+		depth = DefaultCASCloneDepth
+	}
+
+	if depth < 0 {
+		depth = 0
+	}
+
+	return depth
 }
 
 func (c *CAS) prepareTargetDirectory(dir, url string) string {
@@ -243,40 +286,23 @@ func (c *CAS) resolveReference(ctx context.Context, url, branch string) (string,
 	return results[0].Hash, nil
 }
 
-func (c *CAS) cloneAndStoreContent(
+// storeRootTreeFrom reads the recursive tree at hash from the supplied
+// runner's working repository and stores its tree and reachable blobs in
+// the CAS. The runner must already have its WorkDir pointed at a bare repo
+// (or worktree) that contains the requested object.
+func (c *CAS) storeRootTreeFrom(
 	ctx context.Context,
 	l log.Logger,
-	opts *CloneOptions,
-	url,
+	runner *git.GitRunner,
 	hash string,
+	opts *CloneOptions,
 ) error {
-	depth := opts.Depth
-	if depth == 0 {
-		depth = c.cloneDepth
-	}
-
-	if depth == 0 {
-		depth = DefaultCASCloneDepth
-	}
-
-	if depth < 0 {
-		depth = 0
-	}
-
-	if err := c.git.Clone(ctx, url, true, depth, opts.Branch); err != nil {
-		return err
-	}
-
-	return c.storeRootTree(ctx, l, hash, opts)
-}
-
-func (c *CAS) storeRootTree(ctx context.Context, l log.Logger, hash string, opts *CloneOptions) error {
-	tree, err := c.git.LsTreeRecursive(ctx, hash)
+	tree, err := runner.LsTreeRecursive(ctx, hash)
 	if err != nil {
 		return err
 	}
 
-	if err = c.storeTreeRecursive(ctx, l, hash, tree); err != nil {
+	if err = c.storeTreeRecursive(ctx, l, runner, hash, tree); err != nil {
 		return err
 	}
 
@@ -292,7 +318,7 @@ func (c *CAS) storeRootTree(ctx context.Context, l log.Logger, hash string, opts
 	}
 
 	for _, file := range opts.IncludedGitFiles {
-		stat, err := c.fs.Stat(filepath.Join(c.git.WorkDir, file))
+		stat, err := c.fs.Stat(filepath.Join(runner.WorkDir, file))
 		if err != nil {
 			return err
 		}
@@ -301,7 +327,7 @@ func (c *CAS) storeRootTree(ctx context.Context, l log.Logger, hash string, opts
 			continue
 		}
 
-		workDirPath := filepath.Join(c.git.WorkDir, file)
+		workDirPath := filepath.Join(runner.WorkDir, file)
 
 		includedHash, err := hashFile(c.fs, workDirPath)
 		if err != nil {
@@ -324,12 +350,18 @@ func (c *CAS) storeRootTree(ctx context.Context, l log.Logger, hash string, opts
 }
 
 // storeTreeRecursive stores a tree fetched from git ls-tree -r
-func (c *CAS) storeTreeRecursive(ctx context.Context, l log.Logger, hash string, tree *git.Tree) error {
+func (c *CAS) storeTreeRecursive(
+	ctx context.Context,
+	l log.Logger,
+	runner *git.GitRunner,
+	hash string,
+	tree *git.Tree,
+) error {
 	if !c.treeStore.NeedsWrite(hash) {
 		return nil
 	}
 
-	if err := c.storeBlobs(ctx, tree.Entries()); err != nil {
+	if err := c.storeBlobs(ctx, runner, tree.Entries()); err != nil {
 		return err
 	}
 
@@ -343,13 +375,13 @@ func (c *CAS) storeTreeRecursive(ctx context.Context, l log.Logger, hash string,
 }
 
 // storeBlobs stores blobs in the CAS
-func (c *CAS) storeBlobs(ctx context.Context, entries []git.TreeEntry) error {
+func (c *CAS) storeBlobs(ctx context.Context, runner *git.GitRunner, entries []git.TreeEntry) error {
 	for _, entry := range entries {
 		if !c.blobStore.NeedsWrite(entry.Hash) {
 			continue
 		}
 
-		if err := c.ensureBlob(ctx, entry.Hash); err != nil {
+		if err := c.ensureBlob(ctx, runner, entry.Hash); err != nil {
 			return err
 		}
 	}
@@ -361,7 +393,7 @@ func (c *CAS) storeBlobs(ctx context.Context, entries []git.TreeEntry) error {
 // It doesn't use the standard content.Store method because
 // we want to take advantage of the ability to write to the
 // entry using `git cat-file`.
-func (c *CAS) ensureBlob(ctx context.Context, hash string) error {
+func (c *CAS) ensureBlob(ctx context.Context, runner *git.GitRunner, hash string) error {
 	needsWrite, lock, err := c.blobStore.EnsureWithWait(hash)
 	if err != nil {
 		return err
@@ -396,7 +428,7 @@ func (c *CAS) ensureBlob(ctx context.Context, hash string) error {
 		}
 	}()
 
-	err = c.git.CatFile(ctx, hash, tmpHandle)
+	err = runner.CatFile(ctx, hash, tmpHandle)
 	if err != nil {
 		return err
 	}

--- a/internal/cas/cas_test.go
+++ b/internal/cas/cas_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,4 +86,41 @@ func TestCAS_Clone(t *testing.T) {
 		_, err = os.Stat(filepath.Join(targetPath, ".git", "config"))
 		require.NoError(t, err)
 	})
+}
+
+func TestCAS_FallbackWhenGitStoreFails(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startTestServer(t)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+	targetPath := filepath.Join(tempDir, "repo")
+
+	// Occupy the per-URL bare-repo path with a regular file so the central
+	// store cannot create its directory. CAS must still complete the clone via
+	// the temporary fallback path.
+	gitStoreRoot := filepath.Join(storePath, "git")
+	require.NoError(t, os.MkdirAll(gitStoreRoot, 0o755))
+
+	entry := cas.EntryPathForURL(gitStoreRoot, repoURL)
+	require.NoError(t, os.WriteFile(entry, []byte("not a directory"), 0o644))
+
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	err = c.Clone(t.Context(), logger.CreateLogger(), &cas.CloneOptions{
+		Dir:   targetPath,
+		Depth: -1,
+	}, repoURL)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(targetPath, "README.md"))
+	require.NoError(t, err)
+
+	// The blocking file must still be in place. The fallback path is allowed
+	// to bypass the central store, not to repair it.
+	info, err := os.Stat(entry)
+	require.NoError(t, err)
+	assert.False(t, info.IsDir(), "fallback should not have replaced the blocking file")
 }

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -94,7 +95,7 @@ func (c *Content) Link(ctx context.Context, hash, targetPath string) error {
 func (c *Content) Store(l log.Logger, hash string, data []byte) error {
 	lock, err := c.store.AcquireLock(hash)
 	if err != nil {
-		return wrapError("acquire_lock", hash, err)
+		return fmt.Errorf("acquire lock for %s: %w", hash, err)
 	}
 
 	defer func() {
@@ -104,13 +105,13 @@ func (c *Content) Store(l log.Logger, hash string, data []byte) error {
 	}()
 
 	if err = c.fs.MkdirAll(c.store.Path(), DefaultDirPerms); err != nil {
-		return wrapError("create_store_dir", c.store.Path(), ErrCreateDir)
+		return fmt.Errorf("create store dir %s: %w", c.store.Path(), ErrCreateDir)
 	}
 
 	// Ensure partition directory exists
 	partitionDir := c.getPartition(hash)
 	if err = c.fs.MkdirAll(partitionDir, DefaultDirPerms); err != nil {
-		return wrapError("create_partition_dir", partitionDir, ErrCreateDir)
+		return fmt.Errorf("create partition dir %s: %w", partitionDir, ErrCreateDir)
 	}
 
 	return c.writeContentToFile(l, hash, data)
@@ -131,7 +132,7 @@ func (c *Content) Ensure(l log.Logger, hash string, data []byte) error {
 func (c *Content) EnsureWithWait(l log.Logger, hash string, data []byte) error {
 	needsWrite, lock, err := c.store.EnsureWithWait(hash)
 	if err != nil {
-		return wrapError("ensure_with_wait", hash, err)
+		return fmt.Errorf("ensure content for %s: %w", hash, err)
 	}
 
 	// If content already exists or was written by another process, we're done
@@ -147,13 +148,13 @@ func (c *Content) EnsureWithWait(l log.Logger, hash string, data []byte) error {
 	}()
 
 	if err = c.fs.MkdirAll(c.store.Path(), DefaultDirPerms); err != nil {
-		return wrapError("create_store_dir", c.store.Path(), ErrCreateDir)
+		return fmt.Errorf("create store dir %s: %w", c.store.Path(), ErrCreateDir)
 	}
 
 	// Ensure partition directory exists
 	partitionDir := c.getPartition(hash)
 	if err = c.fs.MkdirAll(partitionDir, DefaultDirPerms); err != nil {
-		return wrapError("create_partition_dir", partitionDir, ErrCreateDir)
+		return fmt.Errorf("create partition dir %s: %w", partitionDir, ErrCreateDir)
 	}
 
 	return c.writeContentToFile(l, hash, data)
@@ -168,7 +169,7 @@ func (c *Content) EnsureCopy(l log.Logger, hash, src string) (err error) {
 
 	lock, err := c.store.AcquireLock(hash)
 	if err != nil {
-		return wrapError("acquire_lock", hash, err)
+		return fmt.Errorf("acquire lock for %s: %w", hash, err)
 	}
 
 	defer func() {
@@ -178,12 +179,12 @@ func (c *Content) EnsureCopy(l log.Logger, hash, src string) (err error) {
 	// Ensure partition directory exists
 	partitionDir := c.getPartition(hash)
 	if err = c.fs.MkdirAll(partitionDir, DefaultDirPerms); err != nil {
-		return wrapError("create_partition_dir", partitionDir, ErrCreateDir)
+		return fmt.Errorf("create partition dir %s: %w", partitionDir, ErrCreateDir)
 	}
 
 	f, err := c.fs.Create(path)
 	if err != nil {
-		return wrapError("create_file", path, err)
+		return fmt.Errorf("create file %s: %w", path, err)
 	}
 
 	defer func() {
@@ -192,7 +193,7 @@ func (c *Content) EnsureCopy(l log.Logger, hash, src string) (err error) {
 
 	r, err := c.fs.Open(src)
 	if err != nil {
-		return wrapError("open_source", src, err)
+		return fmt.Errorf("open source %s: %w", src, err)
 	}
 
 	defer func() {
@@ -200,7 +201,7 @@ func (c *Content) EnsureCopy(l log.Logger, hash, src string) (err error) {
 	}()
 
 	if _, err := io.Copy(f, r); err != nil {
-		return wrapError("copy_file", src, err)
+		return fmt.Errorf("copy from %s: %w", src, err)
 	}
 
 	return nil
@@ -210,7 +211,7 @@ func (c *Content) EnsureCopy(l log.Logger, hash, src string) (err error) {
 func (c *Content) GetTmpHandle(hash string) (vfs.File, error) {
 	partitionDir := c.getPartition(hash)
 	if err := c.fs.MkdirAll(partitionDir, DefaultDirPerms); err != nil {
-		return nil, wrapError("create_partition_dir", partitionDir, ErrCreateDir)
+		return nil, fmt.Errorf("create partition dir %s: %w", partitionDir, ErrCreateDir)
 	}
 
 	path := c.getPath(hash)
@@ -218,7 +219,7 @@ func (c *Content) GetTmpHandle(hash string) (vfs.File, error) {
 
 	f, err := c.fs.Create(tempPath)
 	if err != nil {
-		return nil, wrapError("create_temp_file", tempPath, err)
+		return nil, fmt.Errorf("create temp file %s: %w", tempPath, err)
 	}
 
 	return f, err
@@ -238,7 +239,7 @@ func (c *Content) writeContentToFile(l log.Logger, hash string, data []byte) err
 
 	f, err := c.fs.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, RegularFilePerms)
 	if err != nil {
-		return wrapError("create_temp_file", tempPath, err)
+		return fmt.Errorf("create temp file %s: %w", tempPath, err)
 	}
 
 	buf := bufio.NewWriter(f)
@@ -252,7 +253,7 @@ func (c *Content) writeContentToFile(l log.Logger, hash string, data []byte) err
 			l.Warnf("failed to remove temp file %s: %v", tempPath, removeErr)
 		}
 
-		return wrapError("write_to_store", tempPath, err)
+		return fmt.Errorf("write to %s: %w", tempPath, err)
 	}
 
 	if err := buf.Flush(); err != nil {
@@ -264,7 +265,7 @@ func (c *Content) writeContentToFile(l log.Logger, hash string, data []byte) err
 			l.Warnf("failed to remove temp file %s: %v", tempPath, removeErr)
 		}
 
-		return wrapError("flush_buffer", tempPath, err)
+		return fmt.Errorf("flush %s: %w", tempPath, err)
 	}
 
 	if err := f.Close(); err != nil {
@@ -272,7 +273,7 @@ func (c *Content) writeContentToFile(l log.Logger, hash string, data []byte) err
 			l.Warnf("failed to remove temp file %s: %v", tempPath, removeErr)
 		}
 
-		return wrapError("close_file", tempPath, err)
+		return fmt.Errorf("close %s: %w", tempPath, err)
 	}
 
 	// Set read-only permissions on the temporary file
@@ -281,7 +282,7 @@ func (c *Content) writeContentToFile(l log.Logger, hash string, data []byte) err
 			l.Warnf("failed to remove temp file %s: %v", tempPath, removeErr)
 		}
 
-		return wrapError("chmod_temp_file", tempPath, err)
+		return fmt.Errorf("chmod temp %s: %w", tempPath, err)
 	}
 
 	// For Windows, handle readonly attributes specifically
@@ -301,14 +302,14 @@ func (c *Content) writeContentToFile(l log.Logger, hash string, data []byte) err
 			l.Warnf("failed to remove temp file %s: %v", tempPath, removeErr)
 		}
 
-		return wrapError("finalize_store", path, err)
+		return fmt.Errorf("finalize %s: %w", path, err)
 	}
 
 	// For Windows, we need to set the permissions again after rename
 	if runtime.GOOS == WindowsOS {
 		// Ensure the file has read-only permissions after rename
 		if err := c.fs.Chmod(path, StoredFilePerms); err != nil {
-			return wrapError("chmod_final_file", path, err)
+			return fmt.Errorf("chmod %s: %w", path, err)
 		}
 	}
 

--- a/internal/cas/errors.go
+++ b/internal/cas/errors.go
@@ -68,15 +68,11 @@ var (
 	ErrNoMatchingReference = errors.New("no matching reference")
 	ErrReadTree            = errors.New("failed to read tree")
 	ErrNoWorkDir           = errors.New("working directory not set")
+	ErrGitStorePath        = errors.New("failed to prepare git store path")
+	ErrGitStoreLock        = errors.New("failed to acquire git store lock")
+	ErrGitStoreFSNotOS     = errors.New("git store requires an OS-backed filesystem")
+	ErrFallbackCloneDir    = errors.New("failed to create fallback clone directory")
 )
-
-func wrapError(op, path string, err error) error {
-	return &WrappedError{
-		Op:   op,
-		Path: path,
-		Err:  err,
-	}
-}
 
 // UpdateSourceWithCASRequiresCASError is returned when a block sets
 // update_source_with_cas = true but CAS is unavailable, either because the
@@ -90,6 +86,22 @@ type UpdateSourceWithCASRequiresCASError struct {
 	Name string
 	// Path is the file containing the offending block.
 	Path string
+}
+
+// GitStoreObjectMissingError is returned when a fetch into the central git
+// store completes but the requested object is still not reachable. Callers
+// fall back to a temporary clone when they see this.
+type GitStoreObjectMissingError struct {
+	Hash string
+	Ref  string
+	URL  string
+}
+
+func (e *GitStoreObjectMissingError) Error() string {
+	return fmt.Sprintf(
+		"object %s not present in central git store after fetching %s from %s",
+		e.Hash, e.Ref, e.URL,
+	)
 }
 
 func (e *UpdateSourceWithCASRequiresCASError) Error() string {

--- a/internal/cas/gitstore.go
+++ b/internal/cas/gitstore.go
@@ -1,0 +1,185 @@
+package cas
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+const (
+	gitStoreURLHashLen = 16
+	// gitStoreLockTimeout bounds how long EnsureRef waits for the per-URL
+	// lock before giving up and letting the caller fall back to a temporary
+	// clone. Generous enough to outlast a typical fetch, short enough that a
+	// hung holder does not stall every concurrent unit indefinitely.
+	gitStoreLockTimeout = 5 * time.Minute
+)
+
+// GitStore keeps one bare git repository per remote URL on disk so CAS cache
+// misses can issue an incremental git fetch instead of a full shallow clone.
+// Each per-URL repository is gated by an exclusive flock because pack-file
+// writes are not safe to interleave with concurrent reads of the same repo.
+// EnsureRef waits up to gitStoreLockTimeout for the lock; on context
+// cancellation or timeout the caller can fall back to a temporary clone
+// rather than block indefinitely on a hung holder. After acquiring the
+// lock, EnsureRef re-checks for the requested object so a unit that simply
+// waited out a peer's fetch can proceed without re-doing the work.
+// The flock is held from EnsureRef return until the caller releases it.
+type GitStore struct {
+	runner   *git.GitRunner
+	rootPath string
+}
+
+// NewGitStore returns a GitStore rooted at rootPath, creating the directory
+// on fs if needed. The filesystem is not retained; callers pass one explicitly
+// to EnsureRef.
+//
+// The git store shells out to `git`, which only sees the real disk. Callers
+// must pass an OS-backed [vfs.FS] from [vfs.NewOSFS]; an in-memory backing
+// returns [ErrGitStoreFSNotOS].
+func NewGitStore(fs vfs.FS, runner *git.GitRunner, rootPath string) (*GitStore, error) {
+	if !vfs.IsOSFS(fs) {
+		return nil, ErrGitStoreFSNotOS
+	}
+
+	if err := fs.MkdirAll(rootPath, DefaultDirPerms); err != nil {
+		return nil, fmt.Errorf("create git store at %s: %w", rootPath, errors.Join(ErrGitStorePath, err))
+	}
+
+	return &GitStore{
+		runner:   runner,
+		rootPath: rootPath,
+	}, nil
+}
+
+// EnsureRef ensures the bare repository for url contains the object at hash,
+// fetching ref at the requested depth if it does not.
+//
+// On success it returns the bare repository path (suitable for
+// git.GitRunner.WithWorkDir) and an Unlocker the caller must release once
+// done reading objects. Failing to release the lock blocks subsequent
+// fetches against the same URL.
+//
+// On failure the lock is released before returning so callers can take a
+// different code path without managing the lock themselves.
+func (s *GitStore) EnsureRef(
+	ctx context.Context,
+	l log.Logger,
+	fs vfs.FS,
+	url, ref, hash string,
+	depth int,
+) (string, vfs.Unlocker, error) {
+	if !vfs.IsOSFS(fs) {
+		return "", nil, ErrGitStoreFSNotOS
+	}
+
+	dir, repoPath, lockPath := s.repoPaths(url)
+
+	if err := fs.MkdirAll(dir, DefaultDirPerms); err != nil {
+		return "", nil, fmt.Errorf("create git store entry %s: %w", dir, errors.Join(ErrGitStorePath, err))
+	}
+
+	lockCtx, cancel := context.WithTimeout(ctx, gitStoreLockTimeout)
+	defer cancel()
+
+	unlocker, err := vfs.LockContext(lockCtx, fs, lockPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("lock git store for %s: %w", url, errors.Join(ErrGitStoreLock, err))
+	}
+
+	released := false
+
+	defer func() {
+		if released {
+			return
+		}
+
+		if unlockErr := unlocker.Unlock(); unlockErr != nil {
+			l.Warnf("git store: failed to release lock for %s: %v", url, unlockErr)
+		}
+	}()
+
+	if err := fs.MkdirAll(repoPath, DefaultDirPerms); err != nil {
+		return "", nil, fmt.Errorf("create bare repo dir %s: %w", repoPath, errors.Join(ErrGitStorePath, err))
+	}
+
+	runner := s.runner.WithWorkDir(repoPath)
+
+	initialized, err := bareRepoInitialized(fs, repoPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("inspect bare repo %s: %w", repoPath, errors.Join(ErrGitStorePath, err))
+	}
+
+	if !initialized {
+		if err := runner.InitBare(ctx); err != nil {
+			return "", nil, err
+		}
+	}
+
+	has, err := runner.HasObject(ctx, hash)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if !has {
+		fetchRef := ref
+		if fetchRef == "" {
+			fetchRef = "HEAD"
+		}
+
+		if err := runner.Fetch(ctx, url, fetchRef, depth); err != nil {
+			return "", nil, err
+		}
+
+		has, err = runner.HasObject(ctx, hash)
+		if err != nil {
+			return "", nil, err
+		}
+
+		if !has {
+			return "", nil, &GitStoreObjectMissingError{Hash: hash, Ref: fetchRef, URL: url}
+		}
+	}
+
+	released = true
+
+	return repoPath, unlocker, nil
+}
+
+// RootPath returns the directory that contains all per-URL bare repositories.
+func (s *GitStore) RootPath() string {
+	return s.rootPath
+}
+
+// EntryPathForURL returns the directory used for the bare repository
+// belonging to url. Exported so tests can place blocking files at the path.
+func EntryPathForURL(rootPath, url string) string {
+	sum := sha256.Sum256([]byte(url))
+	name := hex.EncodeToString(sum[:])[:gitStoreURLHashLen]
+
+	return filepath.Join(rootPath, name)
+}
+
+func (s *GitStore) repoPaths(url string) (dir, repo, lockPath string) {
+	dir = EntryPathForURL(s.rootPath, url)
+	repo = filepath.Join(dir, "repo")
+	lockPath = filepath.Join(dir, "lock")
+
+	return dir, repo, lockPath
+}
+
+// bareRepoInitialized reports whether repoPath already holds a bare git
+// repository. Checking for HEAD is enough: `git init --bare` writes it as
+// part of repository setup, so its presence lets EnsureRef skip the
+// per-call init spawn once a store entry exists.
+func bareRepoInitialized(fs vfs.FS, repoPath string) (bool, error) {
+	return vfs.FileExists(fs, filepath.Join(repoPath, "HEAD"))
+}

--- a/internal/cas/gitstore_test.go
+++ b/internal/cas/gitstore_test.go
@@ -1,0 +1,236 @@
+package cas_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitStoreEnsureRef_InitsAndFetches(t *testing.T) {
+	t.Parallel()
+
+	url := startTestServer(t)
+	hash := resolveHead(t, url)
+
+	store, fs, root := newTestGitStore(t)
+	l := logger.CreateLogger()
+	ctx := t.Context()
+
+	repoPath, unlock, err := store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(repoPath, root), "repo path %q should be under store root %q", repoPath, root)
+
+	_, err = fs.Stat(filepath.Join(repoPath, "HEAD"))
+	require.NoError(t, err)
+
+	require.NoError(t, unlock.Unlock())
+
+	// Second call hits the cache-warm path: object already present, no fetch.
+	_, unlock2, err := store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
+	require.NoError(t, err)
+	require.NoError(t, unlock2.Unlock())
+}
+
+func TestGitStoreEnsureRef_PartitionsByURL(t *testing.T) {
+	t.Parallel()
+
+	url1 := startTestServer(t)
+	url2 := startTestServer(t)
+
+	store, fs, root := newTestGitStore(t)
+	require.NotEmpty(t, root)
+
+	l := logger.CreateLogger()
+	ctx := t.Context()
+
+	hash1 := resolveHead(t, url1)
+	hash2 := resolveHead(t, url2)
+
+	r1, u1, err := store.EnsureRef(ctx, l, fs, url1, "main", hash1, 0)
+	require.NoError(t, err)
+	require.NoError(t, u1.Unlock())
+
+	r2, u2, err := store.EnsureRef(ctx, l, fs, url2, "main", hash2, 0)
+	require.NoError(t, err)
+	require.NoError(t, u2.Unlock())
+
+	assert.NotEqual(t, r1, r2, "different URLs must map to different bare repos")
+}
+
+func TestGitStoreEnsureRefConcurrentSameURLWithRacing(t *testing.T) {
+	t.Parallel()
+
+	url := startTestServer(t)
+	hash := resolveHead(t, url)
+
+	store, fs, root := newTestGitStore(t)
+	require.NotEmpty(t, root)
+
+	l := logger.CreateLogger()
+
+	const workers = 4
+
+	var wg sync.WaitGroup
+
+	errs := make([]error, workers)
+
+	for i := range workers {
+		wg.Add(1)
+
+		go func(idx int) {
+			defer wg.Done()
+
+			_, unlock, err := store.EnsureRef(t.Context(), l, fs, url, "main", hash, 0)
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+
+			errs[idx] = unlock.Unlock()
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "worker %d", i)
+	}
+}
+
+func TestGitStoreEnsureRef_LockHeldRespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	url := startTestServer(t)
+	hash := resolveHead(t, url)
+
+	store, fs, root := newTestGitStore(t)
+	require.NotEmpty(t, root)
+
+	l := logger.CreateLogger()
+
+	// First caller takes the per-URL lock and holds it.
+	repoPath, unlock, err := store.EnsureRef(t.Context(), l, fs, url, "main", hash, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, repoPath)
+	t.Cleanup(func() { _ = unlock.Unlock() })
+
+	// Second caller arrives with a short deadline. With the lock held it
+	// must return a context error rather than block.
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+
+	_, _, err = store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second, "EnsureRef should not block past the context deadline")
+	assert.True(
+		t,
+		errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled),
+		"expected context error, got %v", err,
+	)
+}
+
+func TestGitStoreEnsureRefLockReleaseAllowsWaiterToProceedWithRacing(t *testing.T) {
+	t.Parallel()
+
+	url := startTestServer(t)
+	hash := resolveHead(t, url)
+
+	store, fs, root := newTestGitStore(t)
+	require.NotEmpty(t, root)
+
+	l := logger.CreateLogger()
+
+	_, unlock, err := store.EnsureRef(t.Context(), l, fs, url, "main", hash, 0)
+	require.NoError(t, err)
+
+	// Release the holder after a short delay so the waiter sees the lock open.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+
+		_ = unlock.Unlock()
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	_, unlock2, err := store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
+	require.NoError(t, err)
+	require.NoError(t, unlock2.Unlock())
+}
+
+func TestGitStoreEnsureRef_FetchFailureSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	store, fs, root := newTestGitStore(t)
+	require.NotEmpty(t, root)
+
+	l := logger.CreateLogger()
+
+	_, _, err := store.EnsureRef(t.Context(), l, fs, "file:///does/not/exist", "main", "deadbeef", 0)
+	require.Error(t, err)
+}
+
+func TestGitStoreRejectsNonOSFilesystem(t *testing.T) {
+	t.Parallel()
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	root := filepath.Join(helpers.TmpDirWOSymlinks(t), "gitstore")
+
+	_, err = cas.NewGitStore(vfs.NewMemMapFS(), runner, root)
+	require.ErrorIs(t, err, cas.ErrGitStoreFSNotOS)
+
+	store, err := cas.NewGitStore(vfs.NewOSFS(), runner, root)
+	require.NoError(t, err)
+
+	_, _, err = store.EnsureRef(
+		t.Context(), logger.CreateLogger(), vfs.NewMemMapFS(),
+		"file:///does/not/exist", "main", "deadbeef", 0,
+	)
+	require.ErrorIs(t, err, cas.ErrGitStoreFSNotOS)
+}
+
+func newTestGitStore(t *testing.T) (*cas.GitStore, vfs.FS, string) {
+	t.Helper()
+
+	root := filepath.Join(helpers.TmpDirWOSymlinks(t), "gitstore")
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	fs := vfs.NewOSFS()
+
+	store, err := cas.NewGitStore(fs, runner, root)
+	require.NoError(t, err)
+
+	return store, fs, root
+}
+
+func resolveHead(t *testing.T, url string) string {
+	t.Helper()
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	results, err := runner.LsRemote(t.Context(), url, "HEAD")
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+
+	return results[0].Hash
+}

--- a/internal/cas/source_detect_test.go
+++ b/internal/cas/source_detect_test.go
@@ -1,0 +1,87 @@
+package cas_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectRemoteSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "github shorthand",
+			src:  "github.com/gruntwork-io/terragrunt-scale-catalog",
+			want: "git::https://github.com/gruntwork-io/terragrunt-scale-catalog.git",
+		},
+		{
+			// Callers strip //subdir via getter.SourceDirSubdir before this,
+			// so the realistic input keeps the query but not the subdir.
+			name: "github shorthand with ref",
+			src:  "github.com/gruntwork-io/terragrunt-scale-catalog?ref=v1.11.0",
+			want: "git::https://github.com/gruntwork-io/terragrunt-scale-catalog.git?ref=v1.11.0",
+		},
+		{
+			name: "gitlab shorthand",
+			src:  "gitlab.com/team/repo",
+			want: "git::https://gitlab.com/team/repo.git",
+		},
+		{
+			name: "scp-style ssh url",
+			src:  "git@github.com:gruntwork-io/terragrunt.git",
+			want: "git::ssh://git@github.com/gruntwork-io/terragrunt.git",
+		},
+		{
+			name: "explicit git:: prefix is preserved",
+			src:  "git::https://github.com/gruntwork-io/terragrunt.git?ref=main",
+			want: "git::https://github.com/gruntwork-io/terragrunt.git?ref=main",
+		},
+		{
+			// No detector matches plain .git URLs without a known host;
+			// callers that want CAS for these must prefix `git::` themselves.
+			name: "plain https .git url is returned unchanged",
+			src:  "https://example.com/team/repo.git",
+			want: "https://example.com/team/repo.git",
+		},
+		{
+			name: "unrecognised plain http url is returned unchanged",
+			src:  "http://127.0.0.1:7654/foo",
+			want: "http://127.0.0.1:7654/foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := cas.DetectRemoteSource(tt.src)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectRemoteSourceRewritesProduceGitPrefixForKnownHosts(t *testing.T) {
+	t.Parallel()
+
+	// Regression guard: any known-host shorthand must come back with `git::`
+	// so the central git store sees a URL git can consume.
+	knownHostShorthands := []string{
+		"github.com/gruntwork-io/terragrunt",
+		"gitlab.com/team/repo",
+	}
+
+	for _, src := range knownHostShorthands {
+		got, err := cas.DetectRemoteSource(src)
+		require.NoError(t, err, "src=%s", src)
+		require.True(t, strings.HasPrefix(got, "git::"), "src=%s rewritten to %q which lacks git:: prefix", src, got)
+	}
+}

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -76,14 +76,14 @@ func (c *CAS) ProcessStackComponent(ctx context.Context, l log.Logger, source, k
 		return c.processLocalStackComponent(ctx, l, repoURL, subdir)
 	}
 
-	repoURL, err := DetectRemoteSource(repoURL)
+	detectedURL, err := DetectRemoteSource(repoURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect source URL %q: %w", repoURL, err)
 	}
 
-	parsedURL, err := url.Parse(repoURL)
+	parsedURL, err := url.Parse(detectedURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse source URL %q: %w", repoURL, err)
+		return nil, fmt.Errorf("failed to parse source URL %q: %w", detectedURL, err)
 	}
 
 	ref := parsedURL.Query().Get("ref")

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -17,6 +17,41 @@ import (
 	"github.com/hashicorp/go-getter/v2"
 )
 
+// RemoteSourceDetectors is the go-getter detector chain CAS applies to
+// shorthand remote sources (e.g. "github.com/org/repo") so they can be
+// rewritten into URLs git understands. Used by ProcessStackComponent to
+// canonicalize sources before resolving refs and dispatching to the
+// central git store.
+var RemoteSourceDetectors = []getter.Detector{
+	new(getter.GitHubDetector),
+	new(getter.GitDetector),
+	new(getter.BitBucketDetector),
+	new(getter.GitLabDetector),
+}
+
+// DetectRemoteSource runs the shorthand-rewriting detectors against src and
+// returns the rewritten URL. Sources already prefixed with "git::" are
+// returned unchanged. If no detector recognizes src, it is returned as-is so
+// the caller can decide whether to treat that as an error.
+func DetectRemoteSource(src string) (string, error) {
+	if strings.HasPrefix(src, "git::") {
+		return src, nil
+	}
+
+	for _, d := range RemoteSourceDetectors {
+		out, ok, err := d.Detect(src, "")
+		if err != nil {
+			return "", err
+		}
+
+		if ok {
+			return out, nil
+		}
+	}
+
+	return src, nil
+}
+
 // StackCASResult holds the results of CAS processing for a stack component.
 type StackCASResult struct {
 	// Cleanup removes the temporary directory when called.
@@ -39,6 +74,11 @@ func (c *CAS) ProcessStackComponent(ctx context.Context, l log.Logger, source, k
 
 	if isLocalPath(repoURL) {
 		return c.processLocalStackComponent(ctx, l, repoURL, subdir)
+	}
+
+	repoURL, err := DetectRemoteSource(repoURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect source URL %q: %w", repoURL, err)
 	}
 
 	parsedURL, err := url.Parse(repoURL)

--- a/internal/cas/stacks_test.go
+++ b/internal/cas/stacks_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
@@ -423,4 +424,47 @@ func TestProcessStackComponent_BlobsStoredInCAS(t *testing.T) {
 	entries, err = os.ReadDir(treeStore.Path())
 	require.NoError(t, err)
 	assert.NotEmpty(t, entries, "tree store should contain entries after processing")
+}
+
+func TestProcessStackComponent_AcceptsExplicitGitPrefix(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	source := "git::" + repoURL + "//stacks/my-stack?ref=main"
+
+	result, err := c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.NoError(t, err)
+
+	defer result.Cleanup()
+
+	assert.FileExists(t, filepath.Join(result.ContentDir, "terragrunt.stack.hcl"))
+}
+
+func TestProcessStackComponent_ShorthandSourceReachesClone(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	// Bogus org so the network call fails fast. The error shape proves the
+	// shorthand was rewritten and reached `git ls-remote`.
+	source := "github.com/gruntwork-io-this-org-does-not-exist/repo?ref=main"
+
+	_, err = c.ProcessStackComponent(t.Context(), l, source, "stack")
+	require.Error(t, err)
+	require.ErrorIs(t, err, git.ErrCommandSpawn, "failure must come from a spawned git command")
+
+	var wrapped *git.WrappedError
+	require.ErrorAs(t, err, &wrapped)
+	assert.Equal(t, "git_ls_remote", wrapped.Op,
+		"failure must originate from ls-remote, proving the URL was handed to git")
 }

--- a/internal/cas/tree.go
+++ b/internal/cas/tree.go
@@ -2,6 +2,7 @@ package cas
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"runtime"
 
@@ -61,7 +62,7 @@ func LinkTree(ctx context.Context, blobStore *Store, treeStore *Store, t *git.Tr
 
 	for dirPath := range dirsToCreate {
 		if err := fs.MkdirAll(dirPath, DefaultDirPerms); err != nil {
-			return wrapError("mkdir_all", dirPath, err)
+			return fmt.Errorf("mkdir %s: %w", dirPath, err)
 		}
 	}
 
@@ -80,22 +81,22 @@ func LinkTree(ctx context.Context, blobStore *Store, treeStore *Store, t *git.Tr
 			case "link":
 				err := blobContent.Link(ctx, work.entry.Hash, work.path)
 				if err != nil {
-					return wrapError("link_blob", work.path, err)
+					return fmt.Errorf("link blob %s: %w", work.path, err)
 				}
 			case "subtree":
 				treeData, err := treeContent.Read(work.entry.Hash)
 				if err != nil {
-					return wrapError("read_tree", work.entry.Hash, err)
+					return fmt.Errorf("read tree %s: %w", work.entry.Hash, err)
 				}
 
 				subTree, err := git.ParseTree(treeData, work.path)
 				if err != nil {
-					return wrapError("parse_tree", work.entry.Hash, err)
+					return fmt.Errorf("parse tree %s: %w", work.entry.Hash, err)
 				}
 
 				err = LinkTree(ctx, blobStore, treeStore, subTree, work.path)
 				if err != nil {
-					return wrapError("link_subtree", work.path, err)
+					return fmt.Errorf("link subtree %s: %w", work.path, err)
 				}
 			}
 

--- a/internal/git/errors.go
+++ b/internal/git/errors.go
@@ -20,6 +20,10 @@ const (
 	ErrParseDiff Error = "failed to parse git diff output"
 	// ErrGitClone is returned when the git clone operation fails
 	ErrGitClone Error = "failed to complete git clone"
+	// ErrGitInitBare is returned when initializing a bare repository fails
+	ErrGitInitBare Error = "failed to initialize bare git repository"
+	// ErrGitFetch is returned when a git fetch operation fails
+	ErrGitFetch Error = "failed to complete git fetch"
 	// ErrCreateTempDir is returned when failing to create a temporary directory
 	ErrCreateTempDir Error = "failed to create temporary directory"
 	// ErrCleanupTempDir is returned when failing to clean up a temporary directory

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -36,6 +36,11 @@ import (
 
 const (
 	minGitPartsLength = 2
+
+	// catFileMissingExitCode is the exit code `git cat-file -e` returns when
+	// the requested object is absent. Any other non-zero exit is an
+	// execution failure (e.g. 128 from a fatal error).
+	catFileMissingExitCode = 1
 )
 
 // GitRunner handles git command execution
@@ -301,6 +306,95 @@ func (g *GitRunner) Clone(ctx context.Context, repo string, bare bool, depth int
 	}
 
 	return nil
+}
+
+// InitBare runs `git init --bare` in the configured working directory.
+// `git init --bare` is itself idempotent (it reinitializes an existing bare
+// repo as a no-op), so callers may invoke this freely.
+func (g *GitRunner) InitBare(ctx context.Context) error {
+	if err := g.RequiresWorkDir(); err != nil {
+		return err
+	}
+
+	cmd := g.prepareCommand(ctx, "init", "--bare", g.WorkDir)
+
+	var stderr bytes.Buffer
+
+	cmd.SetStderr(&stderr)
+
+	if err := cmd.Run(); err != nil {
+		return &WrappedError{
+			Op:      "git_init_bare",
+			Context: stderr.String(),
+			Err:     errors.Join(ErrGitInitBare, err),
+		}
+	}
+
+	return nil
+}
+
+// Fetch runs `git fetch` for a single ref against the given remote URL. A
+// positive depth adds --depth and --no-tags. A zero or negative depth fetches
+// full history.
+func (g *GitRunner) Fetch(ctx context.Context, repo, ref string, depth int) error {
+	if err := g.RequiresWorkDir(); err != nil {
+		return err
+	}
+
+	args := []string{}
+
+	if depth > 0 {
+		args = append(args, "--depth", strconv.Itoa(depth), "--no-tags")
+	}
+
+	args = append(args, repo, ref)
+
+	cmd := g.prepareCommand(ctx, "fetch", args...)
+
+	var stderr bytes.Buffer
+
+	cmd.SetStderr(&stderr)
+
+	if err := cmd.Run(); err != nil {
+		return &WrappedError{
+			Op:      "git_fetch",
+			Context: stderr.String(),
+			Err:     errors.Join(ErrGitFetch, err),
+		}
+	}
+
+	return nil
+}
+
+// HasObject reports whether the given object exists in the configured
+// working-directory repository. Exit code 1 from `git cat-file -e` means
+// the object is absent. Other non-zero exits (e.g. 128 for a corrupted
+// repo or unreadable .git) are returned as errors so callers do not loop
+// into a refetch against a broken store.
+func (g *GitRunner) HasObject(ctx context.Context, hash string) (bool, error) {
+	if err := g.RequiresWorkDir(); err != nil {
+		return false, err
+	}
+
+	cmd := g.prepareCommand(ctx, "cat-file", "-e", hash)
+
+	var stderr bytes.Buffer
+
+	cmd.SetStderr(&stderr)
+
+	if err := cmd.Run(); err != nil {
+		if vexec.ExitCode(err) == catFileMissingExitCode {
+			return false, nil
+		}
+
+		return false, &WrappedError{
+			Op:      "git_cat_file_exists",
+			Context: stderr.String(),
+			Err:     errors.Join(ErrCommandSpawn, err),
+		}
+	}
+
+	return true, nil
 }
 
 // CreateTempDir creates a new temporary directory for git operations

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -257,3 +257,79 @@ func TestGitRunner_RequiresWorkDir(t *testing.T) {
 		assert.ErrorIs(t, wrappedErr.Err, git.ErrNoWorkDir)
 	})
 }
+
+func TestGitRunner_InitBare(t *testing.T) {
+	t.Parallel()
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(dir)
+
+	require.NoError(t, runner.InitBare(t.Context()))
+
+	_, err = os.Stat(filepath.Join(dir, "HEAD"))
+	require.NoError(t, err)
+
+	// Idempotent: second call must not error.
+	require.NoError(t, runner.InitBare(t.Context()))
+}
+
+func TestGitRunner_FetchAndHasObject(t *testing.T) {
+	t.Parallel()
+
+	srv, err := git.NewServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	require.NoError(t, srv.CommitFile("README.md", []byte("# test"), "initial"))
+
+	url, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(dir)
+	require.NoError(t, runner.InitBare(t.Context()))
+
+	// HasObject returns false (without error) for a missing object.
+	missing := "0000000000000000000000000000000000000000"
+	has, err := runner.HasObject(t.Context(), missing)
+	require.NoError(t, err)
+	assert.False(t, has)
+
+	// Fetch HEAD into the bare repo.
+	require.NoError(t, runner.Fetch(t.Context(), url, "HEAD", 0))
+
+	// Resolve the HEAD hash through ls-remote and confirm HasObject is now true.
+	results, err := runner.LsRemote(t.Context(), url, "HEAD")
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+
+	has, err = runner.HasObject(t.Context(), results[0].Hash)
+	require.NoError(t, err)
+	assert.True(t, has)
+}
+
+func TestGitRunner_HasObjectSurfacesNonMissingFailures(t *testing.T) {
+	t.Parallel()
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(dir)
+	require.NoError(t, runner.InitBare(t.Context()))
+
+	// A malformed object name returns exit 128 (fatal). HasObject must
+	// return an error rather than report missing, so a corrupted store
+	// does not trigger a refetch loop.
+	_, err = runner.HasObject(t.Context(), "not-a-hash")
+	require.Error(t, err)
+}

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -5,6 +5,7 @@ package vfs
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -56,6 +57,16 @@ type symlinkEvaluator interface {
 	EvalSymlinksIfPossible(name string) (string, bool, error)
 }
 
+// ContextLocker is an optional interface for filesystems whose locks can be
+// acquired with a context. Implementations should poll/retry until the lock
+// is acquired or ctx is canceled. On ctx cancellation, the returned error
+// wraps ctx.Err(). Implementations also impose a hard upper bound on the
+// total wait (see [maxLockWait]), so a never-canceled ctx will still return
+// after that bound elapses.
+type ContextLocker interface {
+	LockContext(ctx context.Context, name string) (Unlocker, error)
+}
+
 // ErrNoHardLink is returned when a filesystem does not support hard links.
 var ErrNoHardLink = errors.New("hard link not supported")
 
@@ -67,6 +78,15 @@ const maxSymlinkEvaluations = 255
 // NewOSFS returns a filesystem backed by the real operating system filesystem.
 func NewOSFS() FS {
 	return &osFS{afero.NewOsFs()}
+}
+
+// IsOSFS reports whether fs is the OS-backed filesystem from [NewOSFS].
+// Callers that shell out to processes which only see the real disk (e.g.
+// `git`) should reject other filesystems up front rather than failing
+// inside the subprocess.
+func IsOSFS(fs FS) bool {
+	_, ok := fs.(*osFS)
+	return ok
 }
 
 // NewMemMapFS returns an in-memory filesystem for testing purposes.
@@ -227,6 +247,23 @@ func TryLock(fs FS, name string) (Unlocker, bool, error) {
 	return locker.TryLock(name)
 }
 
+// LockContext acquires a lock for the given name, blocking until it is
+// available or ctx is canceled. Filesystems that implement ContextLocker
+// use their native context-aware path; otherwise the call falls back to a
+// blocking Lock without context support.
+//
+// ContextLocker implementations cap the total wait at [maxLockWait], so the
+// call returns after that bound elapses even when ctx is never canceled.
+// Callers that want a shorter deadline should pass a ctx with their own
+// timeout.
+func LockContext(ctx context.Context, fs FS, name string) (Unlocker, error) {
+	if cl, ok := fs.(ContextLocker); ok {
+		return cl.LockContext(ctx, name)
+	}
+
+	return Lock(fs, name)
+}
+
 // WalkDirParallelOption configures a [WalkDirParallel] call.
 type WalkDirParallelOption func(*walkDirParallelConfig)
 
@@ -362,6 +399,43 @@ func (fs *osFS) TryLock(name string) (Unlocker, bool, error) {
 	return l, true, nil
 }
 
+const (
+	// osFlockRetryDelay is how often osFS.LockContext polls for the flock
+	// when the lock is held by another process. gofrs/flock uses a syscall
+	// per attempt, so the tick is coarse enough to limit churn while still
+	// reacting quickly when the holder releases.
+	osFlockRetryDelay = 50 * time.Millisecond
+
+	// memMapLockRetryDelay is how often memMapFS.LockContext retries its
+	// in-process sync.Mutex TryLock. The retry is essentially free, so the
+	// tick is tighter than [osFlockRetryDelay] to keep tests snappy.
+	memMapLockRetryDelay = 10 * time.Millisecond
+
+	// maxLockWait is the hard upper bound on any LockContext call regardless
+	// of the caller's context. It guarantees the retry loop terminates even
+	// if a caller passes a never-canceled context and the lock is permanently
+	// held by another process.
+	maxLockWait = 30 * time.Minute
+)
+
+func (fs *osFS) LockContext(ctx context.Context, name string) (Unlocker, error) {
+	ctx, cancel := context.WithTimeout(ctx, maxLockWait)
+	defer cancel()
+
+	l := flock.New(name)
+
+	acquired, err := l.TryLockContext(ctx, osFlockRetryDelay)
+	if err != nil {
+		return nil, err
+	}
+
+	if !acquired {
+		return nil, ctx.Err()
+	}
+
+	return l, nil
+}
+
 // memMapFS wraps afero.MemMapFs with in-memory symlink support.
 type memMapFS struct {
 	afero.Fs
@@ -468,6 +542,25 @@ func (fs *memMapFS) TryLock(name string) (Unlocker, bool, error) {
 	}
 
 	return l, true, nil
+}
+
+func (fs *memMapFS) LockContext(ctx context.Context, name string) (Unlocker, error) {
+	ctx, cancel := context.WithTimeout(ctx, maxLockWait)
+	defer cancel()
+
+	l := fs.getOrCreateLock(name)
+
+	for {
+		if l.mu.TryLock() {
+			return l, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(memMapLockRetryDelay):
+		}
+	}
 }
 
 func (fs *memMapFS) getOrCreateLock(name string) *memLock {

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -3,11 +3,15 @@ package vfs_test
 import (
 	"archive/zip"
 	"bytes"
+	"context"
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -1160,6 +1164,116 @@ func TestLock(t *testing.T) {
 		require.ErrorIs(t, err, vfs.ErrNoLock)
 
 		_, _, err = vfs.TryLock(readOnlyFs, "test.lock")
+		require.ErrorIs(t, err, vfs.ErrNoLock)
+	})
+}
+
+func TestLockContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("memMapFS acquires when lock is free", func(t *testing.T) {
+		t.Parallel()
+
+		memFs := vfs.NewMemMapFS()
+
+		lock, err := vfs.LockContext(t.Context(), memFs, "test.lock")
+		require.NoError(t, err)
+		require.NotNil(t, lock)
+		require.NoError(t, lock.Unlock())
+	})
+
+	t.Run("memMapFS waits for holder and acquires after release", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			memFs := vfs.NewMemMapFS()
+
+			held, err := vfs.Lock(memFs, "test.lock")
+			require.NoError(t, err)
+
+			// Release the held lock after fake time advances so the
+			// waiter transitions from "blocked" to "acquired".
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+
+				_ = held.Unlock()
+			}()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+
+			lock, err := vfs.LockContext(ctx, memFs, "test.lock")
+			require.NoError(t, err)
+			require.NotNil(t, lock)
+			require.NoError(t, lock.Unlock())
+		})
+	})
+
+	t.Run("memMapFS returns context error when waiter is canceled", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			memFs := vfs.NewMemMapFS()
+
+			held, err := vfs.Lock(memFs, "test.lock")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = held.Unlock() })
+
+			ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+			defer cancel()
+
+			_, err = vfs.LockContext(ctx, memFs, "test.lock")
+			require.Error(t, err)
+			assert.True(
+				t,
+				errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled),
+				"expected context error, got %v", err,
+			)
+		})
+	})
+
+	t.Run("osFS acquires when lock is free", func(t *testing.T) {
+		t.Parallel()
+
+		osFs := vfs.NewOSFS()
+		lockPath := filepath.Join(t.TempDir(), "test.lock")
+
+		lock, err := vfs.LockContext(t.Context(), osFs, lockPath)
+		require.NoError(t, err)
+		require.NotNil(t, lock)
+		require.NoError(t, lock.Unlock())
+	})
+
+	t.Run("osFS returns context error when waiter is canceled", func(t *testing.T) {
+		t.Parallel()
+
+		osFs := vfs.NewOSFS()
+		lockPath := filepath.Join(t.TempDir(), "test.lock")
+
+		held, err := vfs.Lock(osFs, lockPath)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = held.Unlock() })
+
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
+
+		_, err = vfs.LockContext(ctx, osFs, lockPath)
+		require.Error(t, err)
+		assert.True(
+			t,
+			errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled),
+			"expected context error, got %v", err,
+		)
+	})
+
+	t.Run("falls back to blocking Lock when filesystem lacks ContextLocker", func(t *testing.T) {
+		t.Parallel()
+
+		// afero.NewReadOnlyFs implements neither Locker nor ContextLocker, so
+		// LockContext should fall through to vfs.Lock and surface ErrNoLock.
+		readOnlyFs := afero.NewReadOnlyFs(vfs.NewMemMapFS())
+
+		_, err := vfs.LockContext(t.Context(), readOnlyFs, "test.lock")
 		require.ErrorIs(t, err, vfs.ErrNoLock)
 	})
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #3976.

Relates to #5558

Leverages persisted shared bare Git repositories in the central shared directory used by the CAS store to prevent duplicitive work in fetching Git repositories for updates to the CAS.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized per-remote Git cache to reduce redundant clones and share fetches
  * Fallback to temporary clone with a logged warning if the central store is unavailable
  * Remote source URL detection and rewriting for broader URL support
  * Context-aware filesystem locking to better handle concurrent operations

* **Documentation**
  * Updated CAS caching docs and added v1.0.5 changelog entry

* **Tests**
  * Added tests covering git store, fallback behavior, detection, and locking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->