### PR TITLE
chore: Integrating `vexec` into `Command`

### DIFF
--- a/internal/cli/commands/exec/exec.go
+++ b/internal/cli/commands/exec/exec.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
@@ -82,7 +83,7 @@ func runTargetCommand(
 
 	return run.RunActionWithHooks(ctx, l, command, runOpts, cfg, r, func(ctx context.Context) error {
 		_, err := shell.RunCommandWithOutput(
-			ctx, l, configbridge.ShellRunOptsFromOpts(opts), dir, false, false, command, cmdArgs...,
+			ctx, l, vexec.NewOSExec(), configbridge.ShellRunOptsFromOpts(opts), dir, false, false, command, cmdArgs...,
 		)
 		if err != nil {
 			return errors.Errorf("failed to run command in directory %s: %w", dir, err)

--- a/internal/cli/commands/run/help.go
+++ b/internal/cli/commands/run/help.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
@@ -59,7 +60,7 @@ func runTFHelp(ctx context.Context, cliCtx *clihelper.Context, l log.Logger, opt
 
 	terraformHelpCmd := []string{tf.FlagNameHelpLong, cliCtx.Command.Name}
 
-	out, err := tf.RunCommandWithOutput(ctx, l, configbridge.TFRunOptsFromOpts(opts), terraformHelpCmd...)
+	out, err := tf.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), configbridge.TFRunOptsFromOpts(opts), terraformHelpCmd...)
 	if err != nil {
 		var processError util.ProcessExecutionError
 		if ok := errors.As(err, &processError); ok {

--- a/internal/cli/commands/run/run.go
+++ b/internal/cli/commands/run/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -158,7 +159,7 @@ func runVersionCommand(ctx context.Context, l log.Logger, opts *options.Terragru
 		}
 	}
 
-	return tf.RunCommand(ctx, l, configbridge.TFRunOptsFromOpts(opts), opts.TerraformCliArgs.Slice()...)
+	return tf.RunCommand(ctx, l, vexec.NewOSExec(), configbridge.TFRunOptsFromOpts(opts), opts.TerraformCliArgs.Slice()...)
 }
 
 func getTFPathFromConfig(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) (string, error) {

--- a/internal/os/exec/cmd.go
+++ b/internal/os/exec/cmd.go
@@ -3,13 +3,14 @@ package exec
 
 import (
 	"context"
+	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sync/atomic"
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/os/signal"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -21,55 +22,86 @@ import (
 // gracefully after sending an interrupt signal before escalating to SIGKILL.
 const DefaultGracefulShutdownDelay = 30 * time.Second
 
-// Cmd is a command type.
+// ErrPTYRequiresOSBackend is returned when a Cmd is started with PTY allocation
+// requested but the underlying vexec.Exec is not OS-backed.
+var ErrPTYRequiresOSBackend = errors.New("PTY allocation requires an OS-backed vexec.Exec")
+
+// Cmd wraps a vexec.Cmd with signal forwarding and optional PTY support.
+// The Cmd may be backed by a real OS process or by an in-memory vexec backend
+// (used in tests and fuzzers to prevent fork of external binaries).
 type Cmd struct {
-	logger          log.Logger
-	interruptSignal os.Signal
-	*exec.Cmd
+	vc                         vexec.Cmd
+	interruptSignal            os.Signal
 	filename                   string
+	dir                        string
 	forwardSignalDelay         time.Duration
 	usePTY                     bool
 	gracefulShutdownRegistered atomic.Bool
 }
 
-// Command returns the `Cmd` struct to execute the named program with
-// the given arguments.
-func Command(ctx context.Context, name string, args ...string) *Cmd {
+// Command returns a `Cmd` configured to execute the named program with
+// the given arguments via the provided vexec.Exec. PTY allocation requires
+// an OS-backed Exec; non-OS backends are accepted but `WithUsePTY(true)`
+// will fail at Start with ErrPTYRequiresOSBackend.
+func Command(ctx context.Context, e vexec.Exec, name string, args ...string) *Cmd {
+	vc := e.Command(ctx, name, args...)
+
 	cmd := &Cmd{
-		Cmd:             exec.CommandContext(ctx, name, args...),
-		logger:          log.Default(),
+		vc:              vc,
 		filename:        filepath.Base(name),
 		interruptSignal: signal.InterruptSignal,
 	}
 
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.SetStdin(os.Stdin)
+	cmd.SetStdout(os.Stdout)
+	cmd.SetStderr(os.Stderr)
 
-	cmd.WaitDelay = DefaultGracefulShutdownDelay
+	vc.SetWaitDelay(DefaultGracefulShutdownDelay)
 
-	cmd.Cancel = func() error {
+	vc.SetCancel(func() error {
 		if cmd.gracefulShutdownRegistered.Load() {
 			return nil
 		}
 
-		if cmd.Process == nil {
-			return nil
+		sig := signal.SignalFromContext(ctx)
+		if sig == nil {
+			sig = cmd.interruptSignal
 		}
 
-		if sig := signal.SignalFromContext(ctx); sig != nil {
-			return cmd.Process.Signal(sig)
+		if sig == nil {
+			sig = os.Kill
 		}
 
-		if cmd.interruptSignal != nil {
-			return cmd.Process.Signal(cmd.interruptSignal)
+		if err := vc.Signal(sig); err != nil && !errors.Is(err, vexec.ErrProcessNotStarted) {
+			return err
 		}
 
-		return cmd.Process.Signal(os.Kill)
-	}
+		return nil
+	})
 
 	return cmd
 }
+
+// SetStdin sets the command's standard input.
+func (cmd *Cmd) SetStdin(r io.Reader) { cmd.vc.SetStdin(r) }
+
+// SetStdout sets the command's standard output.
+func (cmd *Cmd) SetStdout(w io.Writer) { cmd.vc.SetStdout(w) }
+
+// SetStderr sets the command's standard error.
+func (cmd *Cmd) SetStderr(w io.Writer) { cmd.vc.SetStderr(w) }
+
+// SetEnv sets the command's environment in `KEY=value` form.
+func (cmd *Cmd) SetEnv(env []string) { cmd.vc.SetEnv(env) }
+
+// SetDir sets the command's working directory.
+func (cmd *Cmd) SetDir(dir string) {
+	cmd.dir = dir
+	cmd.vc.SetDir(dir)
+}
+
+// Dir returns the working directory previously set via SetDir.
+func (cmd *Cmd) Dir() string { return cmd.dir }
 
 // Configure sets options to the `Cmd`.
 func (cmd *Cmd) Configure(opts ...Option) {
@@ -78,19 +110,35 @@ func (cmd *Cmd) Configure(opts ...Option) {
 	}
 }
 
-// Start starts the specified command but does not wait for it to complete.
-func (cmd *Cmd) Start() error {
-	// If we need to allocate a ptty for the command, route through the ptty routine.
-	// Otherwise, directly call the command.
+// Start starts the command but does not wait for it to complete. When PTY
+// allocation is requested, the underlying backend must be OS-backed.
+func (cmd *Cmd) Start(l log.Logger) error {
 	if cmd.usePTY {
-		if err := runCommandWithPTY(cmd.logger, cmd.Cmd); err != nil {
-			return err
+		osCmder, ok := cmd.vc.(vexec.OSCmder)
+		if !ok {
+			return ErrPTYRequiresOSBackend
 		}
-	} else if err := cmd.Cmd.Start(); err != nil {
+
+		return runCommandWithPTY(l, osCmder.OSCmd())
+	}
+
+	if err := cmd.vc.Start(); err != nil {
 		return errors.New(err)
 	}
 
 	return nil
+}
+
+// Wait waits for the command to exit and returns its error.
+func (cmd *Cmd) Wait() error { return cmd.vc.Wait() }
+
+// Run starts the command and waits for it to complete.
+func (cmd *Cmd) Run(l log.Logger) error {
+	if err := cmd.Start(l); err != nil {
+		return err
+	}
+
+	return cmd.Wait()
 }
 
 // RegisterGracefullyShutdown registers a graceful shutdown for the
@@ -106,7 +154,7 @@ func (cmd *Cmd) Start() error {
 //     was some failure and we need to terminate all executed commands,
 //     in this situation we are sure that commands did not receive any
 //     signal, so we send them an interrupt signal immediately.
-func (cmd *Cmd) RegisterGracefullyShutdown(ctx context.Context) func() {
+func (cmd *Cmd) RegisterGracefullyShutdown(ctx context.Context, l log.Logger) func() {
 	cmd.gracefulShutdownRegistered.Store(true)
 
 	ctxShutdown, cancelShutdown := context.WithCancel(context.Background())
@@ -116,12 +164,12 @@ func (cmd *Cmd) RegisterGracefullyShutdown(ctx context.Context) func() {
 		case <-ctxShutdown.Done():
 		case <-ctx.Done():
 			if cause := new(signal.ContextCanceledError); errors.As(context.Cause(ctx), &cause) && cause.Signal != nil {
-				cmd.ForwardSignal(ctxShutdown, cause.Signal)
+				cmd.ForwardSignal(ctxShutdown, l, cause.Signal)
 
 				return
 			}
 
-			cmd.SendSignal(cmd.interruptSignal)
+			cmd.SendSignal(l, cmd.interruptSignal)
 		}
 	}()
 
@@ -130,7 +178,7 @@ func (cmd *Cmd) RegisterGracefullyShutdown(ctx context.Context) func() {
 
 // ForwardSignal forwards a given `sig` with a delay if cmd.forwardSignalDelay is greater than 0,
 // and if the same signal is received again, it is forwarded immediately.
-func (cmd *Cmd) ForwardSignal(ctx context.Context, sig os.Signal) {
+func (cmd *Cmd) ForwardSignal(ctx context.Context, l log.Logger, sig os.Signal) {
 	ctxDelay, cancelDelay := context.WithCancel(ctx)
 	defer cancelDelay()
 
@@ -139,7 +187,7 @@ func (cmd *Cmd) ForwardSignal(ctx context.Context, sig os.Signal) {
 	}, sig)
 
 	if cmd.forwardSignalDelay > 0 {
-		cmd.logger.Debugf("%s signal will be forwarded to %s with delay %s",
+		l.Debugf("%s signal will be forwarded to %s with delay %s",
 			cases.Title(language.English).String(sig.String()),
 			cmd.filename,
 			cmd.forwardSignalDelay,
@@ -153,14 +201,16 @@ func (cmd *Cmd) ForwardSignal(ctx context.Context, sig os.Signal) {
 	case <-ctxDelay.Done():
 	}
 
-	cmd.SendSignal(sig)
+	cmd.SendSignal(l, sig)
 }
 
-// SendSignal sends the given `sig` to the executed command.
-func (cmd *Cmd) SendSignal(sig os.Signal) {
-	cmd.logger.Debugf("%s signal is forwarded to %s", cases.Title(language.English).String(sig.String()), cmd.filename)
+// SendSignal sends the given `sig` to the executed command. Errors are logged
+// rather than returned; ErrProcessNotStarted is silently ignored because
+// callers may race against process startup.
+func (cmd *Cmd) SendSignal(l log.Logger, sig os.Signal) {
+	l.Debugf("%s signal is forwarded to %s", cases.Title(language.English).String(sig.String()), cmd.filename)
 
-	if err := cmd.Process.Signal(sig); err != nil {
-		cmd.logger.Errorf("Failed to forwarding signal %s to %s: %v", sig, cmd.filename, err)
+	if err := cmd.vc.Signal(sig); err != nil && !errors.Is(err, vexec.ErrProcessNotStarted) {
+		l.Errorf("Failed to forwarding signal %s to %s: %v", sig, cmd.filename, err)
 	}
 }

--- a/internal/os/exec/cmd_test.go
+++ b/internal/os/exec/cmd_test.go
@@ -1,0 +1,77 @@
+package exec_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/os/exec"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommandWithMemBackend verifies that the wrapper drives a mem-backed
+// vexec.Exec end-to-end without forking a real process.
+func TestCommandWithMemBackend(t *testing.T) {
+	t.Parallel()
+
+	var got vexec.Invocation
+
+	e := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		got = inv
+
+		return vexec.Result{Stdout: []byte("Plan: 0 to add\n")}
+	})
+
+	stdout := &bytes.Buffer{}
+
+	cmd := exec.Command(t.Context(), e, "tofu", "plan")
+	cmd.SetStdout(stdout)
+	cmd.SetDir("/work")
+	cmd.SetEnv([]string{"FOO=bar"})
+
+	require.NoError(t, cmd.Run(logger.CreateLogger()))
+
+	assert.Equal(t, "tofu", got.Name)
+	assert.Equal(t, []string{"plan"}, got.Args)
+	assert.Equal(t, "/work", got.Dir)
+	assert.Equal(t, []string{"FOO=bar"}, got.Env)
+	assert.Equal(t, "Plan: 0 to add\n", stdout.String())
+	assert.Equal(t, "/work", cmd.Dir())
+}
+
+// TestCommandWithMemBackendExitCode verifies that handler-reported exit codes
+// are recoverable via vexec.ExitCode.
+func TestCommandWithMemBackendExitCode(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewMemExec(func(context.Context, vexec.Invocation) vexec.Result {
+		return vexec.Result{ExitCode: 7}
+	})
+
+	cmd := exec.Command(t.Context(), e, "tofu", "apply")
+
+	err := cmd.Run(logger.CreateLogger())
+	require.Error(t, err)
+
+	assert.Equal(t, 7, vexec.ExitCode(err))
+}
+
+// TestCommandWithMemBackendPTYRejected verifies that requesting a PTY against
+// a non-OS backend is refused at Start, rather than silently degrading.
+func TestCommandWithMemBackendPTYRejected(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewMemExec(func(context.Context, vexec.Invocation) vexec.Result {
+		return vexec.Result{}
+	})
+
+	cmd := exec.Command(t.Context(), e, "tofu", "apply")
+	cmd.Configure(exec.WithUsePTY(true))
+
+	err := cmd.Run(logger.CreateLogger())
+	assert.ErrorIs(t, err, exec.ErrPTYRequiresOSBackend)
+}

--- a/internal/os/exec/cmd_unix_test.go
+++ b/internal/os/exec/cmd_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package exec_test
 
@@ -13,6 +12,8 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/os/exec"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,9 +26,11 @@ var (
 func TestExitCodeUnix(t *testing.T) {
 	t.Parallel()
 
+	l := logger.CreateLogger()
+
 	for index := 0; index <= 255; index++ {
-		cmd := exec.Command(t.Context(), "testdata/test_exit_code.sh", strconv.Itoa(index))
-		err := cmd.Run()
+		cmd := exec.Command(t.Context(), vexec.NewOSExec(), "testdata/test_exit_code.sh", strconv.Itoa(index))
+		err := cmd.Run(l)
 
 		if index == 0 {
 			require.NoError(t, err)
@@ -52,19 +55,21 @@ func TestNewSignalsForwarderWaitUnix(t *testing.T) {
 
 	expectedWait := 5
 
-	cmd := exec.Command(t.Context(), "testdata/test_sigint_wait.sh", strconv.Itoa(expectedWait))
+	l := logger.CreateLogger()
+
+	cmd := exec.Command(t.Context(), vexec.NewOSExec(), "testdata/test_sigint_wait.sh", strconv.Itoa(expectedWait))
 
 	runChannel := make(chan error)
 
 	go func() {
-		runChannel <- cmd.Run()
+		runChannel <- cmd.Run(l)
 	}()
 
 	time.Sleep(time.Second)
 
 	start := time.Now()
 
-	cmd.Process.Signal(os.Interrupt)
+	cmd.SendSignal(l, os.Interrupt)
 
 	err := <-runChannel
 	require.Error(t, err)
@@ -83,12 +88,17 @@ func TestNewSignalsForwarderMultipleUnix(t *testing.T) {
 
 	expectedInterrupts := 10
 
-	cmd := exec.Command(t.Context(), "testdata/test_sigint_multiple.sh", strconv.Itoa(expectedInterrupts))
+	l := logger.CreateLogger()
+
+	cmd := exec.Command(
+		t.Context(), vexec.NewOSExec(),
+		"testdata/test_sigint_multiple.sh", strconv.Itoa(expectedInterrupts),
+	)
 
 	runChannel := make(chan error)
 
 	go func() {
-		runChannel <- cmd.Run()
+		runChannel <- cmd.Run(l)
 	}()
 
 	time.Sleep(time.Second)
@@ -106,7 +116,7 @@ func TestNewSignalsForwarderMultipleUnix(t *testing.T) {
 			case err = <-runChannel:
 				return interrupts, err
 			default:
-				cmd.Process.Signal(os.Interrupt)
+				cmd.SendSignal(l, os.Interrupt)
 
 				interrupts++
 			}
@@ -132,14 +142,16 @@ func TestGracefulShutdownOnContextCancelUnix(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	cmd := exec.Command(ctx, "testdata/test_graceful_shutdown.sh")
+	l := logger.CreateLogger()
+
+	cmd := exec.Command(ctx, vexec.NewOSExec(), "testdata/test_graceful_shutdown.sh")
 
 	cmd.Configure(exec.WithGracefulShutdownDelay(5 * time.Second))
 
 	runChannel := make(chan error)
 
 	go func() {
-		runChannel <- cmd.Run()
+		runChannel <- cmd.Run(l)
 	}()
 
 	time.Sleep(500 * time.Millisecond)

--- a/internal/os/exec/cmd_windows_test.go
+++ b/internal/os/exec/cmd_windows_test.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 
 	"github.com/gruntwork-io/terragrunt/internal/os/exec"
 	"github.com/stretchr/testify/assert"
@@ -35,9 +37,11 @@ func TestWindowsConsolePrepare(t *testing.T) {
 func TestWindowsExitCode(t *testing.T) {
 	t.Parallel()
 
+	l := logger.CreateLogger()
+
 	for i := 0; i <= 255; i++ {
-		cmd := exec.Command(t.Context(), `testdata\test_exit_code.bat`, strconv.Itoa(i))
-		err := cmd.Run()
+		cmd := exec.Command(t.Context(), vexec.NewOSExec(), `testdata\test_exit_code.bat`, strconv.Itoa(i))
+		err := cmd.Run(l)
 
 		if i == 0 {
 			assert.NoError(t, err)
@@ -62,20 +66,20 @@ func TestWindowsNewSignalsForwarderWait(t *testing.T) {
 
 	expectedWait := 5
 
-	cmd := exec.Command(t.Context(), `testdata\test_sigint_wait.bat`, strconv.Itoa(expectedWait))
+	l := logger.CreateLogger()
+
+	cmd := exec.Command(t.Context(), vexec.NewOSExec(), `testdata\test_sigint_wait.bat`, strconv.Itoa(expectedWait))
 
 	runChannel := make(chan error)
 
 	go func() {
-		runChannel <- cmd.Run()
+		runChannel <- cmd.Run(l)
 	}()
 
 	time.Sleep(time.Second)
 	// start := time.Now()
 	// Note: sending interrupt on Windows is not supported by Windows and not implemented in Go
-	if cmd.Process != nil { // on some Go versions(Go 1.23, Windows), cmd.Process is nil
-		cmd.Process.Signal(os.Kill)
-	}
+	cmd.SendSignal(l, os.Kill)
 
 	err := <-runChannel
 

--- a/internal/os/exec/console_windows_test.go
+++ b/internal/os/exec/console_windows_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/os/exec"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
@@ -205,13 +207,13 @@ func TestWindowsConsoleSubprocessSaveRestore(t *testing.T) {
 
 	before := getMode(t, conout)
 
-	cmd := exec.Command(t.Context(), "cmd.exe", "/C", "echo hello")
-	cmd.Stdout = nil
-	cmd.Stderr = nil
+	cmd := exec.Command(t.Context(), vexec.NewOSExec(), "cmd.exe", "/C", "echo hello")
+	cmd.SetStdout(nil)
+	cmd.SetStderr(nil)
 
 	saved := exec.SaveConsoleState()
 
-	require.NoError(t, cmd.Run())
+	require.NoError(t, cmd.Run(logger.CreateLogger()))
 
 	saved.Restore()
 

--- a/internal/os/exec/opts.go
+++ b/internal/os/exec/opts.go
@@ -4,20 +4,12 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/go-commons/collections"
-	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
 const envVarsListFormat = "%s=%s"
 
 // Option is type for passing options to the Cmd.
 type Option func(*Cmd)
-
-// WithLogger sets Logger to the Cmd.
-func WithLogger(logger log.Logger) Option {
-	return func(cmd *Cmd) {
-		cmd.logger = logger
-	}
-}
 
 // WithUsePTY enables a pty for the Cmd.
 func WithUsePTY(state bool) Option {
@@ -29,7 +21,7 @@ func WithUsePTY(state bool) Option {
 // WithEnv sets envs to the Cmd.
 func WithEnv(env map[string]string) Option {
 	return func(cmd *Cmd) {
-		cmd.Env = collections.KeyValueStringSliceWithFormat(env, envVarsListFormat)
+		cmd.SetEnv(collections.KeyValueStringSliceWithFormat(env, envVarsListFormat))
 	}
 }
 
@@ -45,6 +37,6 @@ func WithForwardSignalDelay(delay time.Duration) Option {
 // This allows processes like Terraform to clean up child processes (e.g., provider plugins).
 func WithGracefulShutdownDelay(delay time.Duration) Option {
 	return func(cmd *Cmd) {
-		cmd.WaitDelay = delay
+		cmd.vc.SetWaitDelay(delay)
 	}
 }

--- a/internal/providercache/providercache.go
+++ b/internal/providercache/providercache.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/getproviders"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -218,7 +219,7 @@ func (pc *ProviderCache) TerraformCommandHook(
 		}
 	default:
 		// skip cache creation for all other commands
-		return tf.RunCommandWithOutput(ctx, l, tfOpts, args...)
+		return tf.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), tfOpts, args...)
 	}
 
 	env := pc.providerCacheEnvironment(tfOpts.ShellOptions.Env, tfOpts.TofuImplementation, cliConfigFilename)
@@ -340,7 +341,7 @@ func (pc *ProviderCache) runTerraformWithCache(
 		ShellOptions:                 &shellOpts,
 	}
 
-	return tf.RunCommandWithOutput(ctx, l, newTFOpts, args...)
+	return tf.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), newTFOpts, args...)
 }
 
 // createLocalCLIConfig creates a local CLI config that merges the default/user configuration with our Provider Cache configuration.
@@ -471,7 +472,7 @@ func (pc *ProviderCache) runTerraformCommand(ctx context.Context, l log.Logger, 
 			errWriter := util.NewTrapWriter(tfOpts.ShellOptions.Writers.ErrWriter)
 			shellOpts.Writers.ErrWriter = errWriter
 
-			output, cmdErr := tf.RunCommandWithOutput(ctx, l, newTFOpts, newCliArgs.Slice()...)
+			output, cmdErr := tf.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), newTFOpts, newCliArgs.Slice()...)
 			finalOutput = output
 
 			// If the OpenTofu/Terraform error matches `httpStatusCacheProviderReg` (423 Locked),

--- a/internal/remotestate/remote_state.go
+++ b/internal/remotestate/remote_state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend/gcs"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend/s3"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
@@ -178,7 +179,7 @@ func (remote *RemoteState) pullState(ctx context.Context, l log.Logger, tfOpts *
 
 	args := []string{tf.CommandNameState, tf.CommandNamePull}
 
-	output, err := tf.RunCommandWithOutput(ctx, l, tfOpts, args...)
+	output, err := tf.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), tfOpts, args...)
 	if err != nil {
 		return "", err
 	}
@@ -206,5 +207,5 @@ func (remote *RemoteState) pushState(ctx context.Context, l log.Logger, tfOpts *
 
 	args := []string{tf.CommandNameState, tf.CommandNamePush, stateFile}
 
-	return tf.RunCommand(ctx, l, tfOpts, args...)
+	return tf.RunCommand(ctx, l, vexec.NewOSExec(), tfOpts, args...)
 }

--- a/internal/runner/run/creds/providers/externalcmd/provider.go
+++ b/internal/runner/run/creds/providers/externalcmd/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds/providers"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds/providers/amazonsts"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/mattn/go-shellwords"
 )
@@ -58,7 +59,10 @@ func (provider *Provider) GetCredentials(ctx context.Context, l log.Logger) (*pr
 		args = parts[1:]
 	}
 
-	output, err := shell.RunCommandWithOutput(ctx, l, provider.runOpts, "", true, false, command, args...)
+	output, err := shell.RunCommandWithOutput(
+		ctx, l, vexec.NewOSExec(), provider.runOpts,
+		"", true, false, command, args...,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runner/run/hook.go
+++ b/internal/runner/run/hook.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tflint"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-multierror"
 )
@@ -107,6 +108,7 @@ func processErrorHooks(
 				_, possibleError := shell.RunCommandWithOutput(
 					ctx,
 					l,
+					vexec.NewOSExec(),
 					hookOpts.shellRunOptions(),
 					curHook.WorkingDir,
 					curHook.SuppressStdout,
@@ -211,6 +213,7 @@ func runHook(
 	_, possibleError := shell.RunCommandWithOutput(
 		ctx,
 		l,
+		vexec.NewOSExec(),
 		hookOpts.shellRunOptions(),
 		workingDir,
 		suppressStdout,

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -276,7 +277,7 @@ func runTerragruntWithConfig(
 
 	return RunActionWithHooks(ctx, l, "terraform", opts, cfg, r, func(childCtx context.Context) error {
 		// Execute the underlying command once; retries and ignores are handled by outer RunWithErrorHandling
-		out, runTerraformError := tf.RunCommandWithOutput(childCtx, l, opts.tfRunOptions(), opts.TerraformCliArgs.Slice()...)
+		out, runTerraformError := tf.RunCommandWithOutput(childCtx, l, vexec.NewOSExec(), opts.tfRunOptions(), opts.TerraformCliArgs.Slice()...)
 
 		var lockFileError error
 		if ShouldCopyLockFile(opts.TerraformCliArgs, &cfg.Terraform) {

--- a/internal/runner/run/version_check.go
+++ b/internal/runner/run/version_check.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-version"
 )
@@ -130,7 +131,7 @@ func GetTFVersion(ctx context.Context, l log.Logger, tfOpts *tf.TFOptions) (log.
 
 	optsCopy.ShellOptions.Env = envCopy
 
-	output, err := tf.RunCommandWithOutput(ctx, l, &optsCopy, tf.FlagNameVersion)
+	output, err := tf.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), &optsCopy, tf.FlagNameVersion)
 	if err != nil {
 		return l, nil, tfimpl.Unknown, err
 	}

--- a/internal/shell/git.go
+++ b/internal/shell/git.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-version"
@@ -72,7 +73,7 @@ func GitTopLevelDir(ctx context.Context, l log.Logger, env map[string]string, pa
 		WithEnv(env).
 		WithWriters(writer.Writers{Writer: &stdout, ErrWriter: &stderr})
 
-	cmd, err := RunCommandWithOutput(ctx, l, gitRunOpts, path, true, false, "git", "rev-parse", "--show-toplevel")
+	cmd, err := RunCommandWithOutput(ctx, l, vexec.NewOSExec(), gitRunOpts, path, true, false, "git", "rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", err
 	}
@@ -184,7 +185,7 @@ func GitRepoTags(ctx context.Context, l log.Logger, env map[string]string, worki
 		WithEnv(env).
 		WithWriters(writer.Writers{Writer: &stdout, ErrWriter: &stderr})
 
-	output, err := RunCommandWithOutput(ctx, l, gitRunOpts, workingDir, true, false, "git", "ls-remote", "--tags", repoPath)
+	output, err := RunCommandWithOutput(ctx, l, vexec.NewOSExec(), gitRunOpts, workingDir, true, false, "git", "ls-remote", "--tags", repoPath)
 	if err != nil {
 		return nil, errors.New(err)
 	}

--- a/internal/shell/run_cmd.go
+++ b/internal/shell/run_cmd.go
@@ -160,14 +160,17 @@ func (o *ShellOptions) NoEngine() bool {
 	return o.EngineOptions != nil && o.EngineOptions.NoEngine
 }
 
-// RunCommand runs the given shell command.
-func RunCommand(ctx context.Context, l log.Logger, runOpts *ShellOptions, command string, args ...string) error {
-	_, err := RunCommandWithOutput(ctx, l, runOpts, "", false, false, command, args...)
+// RunCommand runs the given shell command using the provided vexec.Exec.
+// Pass vexec.NewMemExec from tests and fuzzers to intercept subprocess
+// invocations so external binaries like tofu/terraform are never forked.
+func RunCommand(ctx context.Context, l log.Logger, e vexec.Exec, runOpts *ShellOptions, command string, args ...string) error {
+	_, err := RunCommandWithOutput(ctx, l, e, runOpts, "", false, false, command, args...)
 
 	return err
 }
 
-// RunCommandWithOutput runs the specified shell command with the specified arguments.
+// RunCommandWithOutput runs the specified shell command using the provided
+// vexec.Exec and captures stdout/stderr in addition to streaming.
 //
 // Connect the command's stdin, stdout, and stderr to
 // the currently running app. The command can be executed in a custom working directory by using the parameter
@@ -175,6 +178,7 @@ func RunCommand(ctx context.Context, l log.Logger, runOpts *ShellOptions, comman
 func RunCommandWithOutput(
 	ctx context.Context,
 	l log.Logger,
+	e vexec.Exec,
 	runOpts *ShellOptions,
 	workingDir string,
 	suppressStdout bool,
@@ -220,7 +224,7 @@ func RunCommandWithOutput(
 			if runOpts.EngineConfig != nil && runOpts.Experiments.Evaluate(experiment.IacEngine) && !runOpts.NoEngine() {
 				l.Debugf("Using engine to run command: %s %s", command, strings.Join(args, " "))
 
-				cmdOutput, err := engine.Run(ctx, l, vexec.NewOSExec(), &engine.ExecutionOptions{
+				cmdOutput, err := engine.Run(ctx, l, e, &engine.ExecutionOptions{
 					Writers: writer.Writers{
 						Writer:                 writer.NewWrappedWriter(cmdStdout, runOpts.Writers.Writer),
 						ErrWriter:              writer.NewWrappedWriter(cmdStderr, runOpts.Writers.ErrWriter),
@@ -249,12 +253,11 @@ func RunCommandWithOutput(
 			}
 		}
 
-		cmd := exec.Command(ctx, command, args...)
-		cmd.Dir = commandDir
-		cmd.Stdout = cmdStdout
-		cmd.Stderr = cmdStderr
+		cmd := exec.Command(ctx, e, command, args...)
+		cmd.SetDir(commandDir)
+		cmd.SetStdout(cmdStdout)
+		cmd.SetStderr(cmdStderr)
 		cmd.Configure(
-			exec.WithLogger(l),
 			exec.WithUsePTY(needsPTY),
 			exec.WithEnv(runOpts.Env),
 			exec.WithForwardSignalDelay(SignalForwardingDelay),
@@ -264,12 +267,12 @@ func RunCommandWithOutput(
 		savedConsole := exec.SaveConsoleState()
 		defer savedConsole.Restore()
 
-		if err := cmd.Start(); err != nil { //nolint:contextcheck // context already passed to exec.Command
+		if err := cmd.Start(l); err != nil { //nolint:contextcheck // context already passed to exec.Command
 			err = util.ProcessExecutionError{
 				Err:             err,
 				Args:            args,
 				Command:         command,
-				WorkingDir:      cmd.Dir,
+				WorkingDir:      cmd.Dir(),
 				RootWorkingDir:  runOpts.RootWorkingDir,
 				LogShowAbsPaths: runOpts.Writers.LogShowAbsPaths,
 				DisableSummary:  runOpts.Writers.LogDisableErrorSummary,
@@ -278,7 +281,7 @@ func RunCommandWithOutput(
 			return errors.New(err)
 		}
 
-		cancelShutdown := cmd.RegisterGracefullyShutdown(ctx)
+		cancelShutdown := cmd.RegisterGracefullyShutdown(ctx, l)
 		defer cancelShutdown()
 
 		if err := cmd.Wait(); err != nil {
@@ -287,7 +290,7 @@ func RunCommandWithOutput(
 				Args:            args,
 				Command:         command,
 				Output:          output,
-				WorkingDir:      cmd.Dir,
+				WorkingDir:      cmd.Dir(),
 				RootWorkingDir:  runOpts.RootWorkingDir,
 				LogShowAbsPaths: runOpts.Writers.LogShowAbsPaths,
 				DisableSummary:  runOpts.Writers.LogDisableErrorSummary,

--- a/internal/shell/run_cmd_mem_test.go
+++ b/internal/shell/run_cmd_mem_test.go
@@ -1,0 +1,58 @@
+package shell_test
+
+import (
+	"bytes"
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/writer"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunCommandMemBackendWithRacing verifies that passing a mem-backed
+// vexec.Exec into RunCommand intercepts every subprocess invocation so neither
+// tofu, terraform, nor any other binary is actually forked.
+func TestRunCommandMemBackendWithRacing(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	e := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		calls.Add(1)
+
+		switch {
+		case inv.Name == "tofu" && len(inv.Args) > 0 && inv.Args[0] == "plan":
+			return vexec.Result{Stdout: []byte("Plan: 0 to add\n")}
+		case inv.Name == "terraform" && len(inv.Args) > 0 && inv.Args[0] == "apply":
+			return vexec.Result{ExitCode: 1, Stderr: []byte("boom\n")}
+		}
+
+		return vexec.Result{ExitCode: 127, Stderr: []byte("unknown\n")}
+	})
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	opts := shell.NewShellOptions().
+		WithWriters(writer.Writers{Writer: stdout, ErrWriter: stderr})
+
+	l := logger.CreateLogger()
+
+	require.NoError(t, shell.RunCommand(t.Context(), l, e, opts, "tofu", "plan"))
+	assert.Contains(t, stdout.String(), "Plan: 0 to add")
+
+	stdout.Reset()
+	stderr.Reset()
+
+	err := shell.RunCommand(t.Context(), l, e, opts, "terraform", "apply")
+	require.Error(t, err)
+	assert.Contains(t, stderr.String(), "boom")
+
+	assert.Equal(t, int32(2), calls.Load(), "expected exactly two intercepted invocations")
+}

--- a/internal/shell/run_cmd_output_test.go
+++ b/internal/shell/run_cmd_output_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 
 	"github.com/stretchr/testify/assert"
@@ -68,7 +69,7 @@ func testCommandOutput(t *testing.T, withOptions func(*options.TerragruntOptions
 
 	l := logger.CreateLogger()
 
-	out, err := shell.RunCommandWithOutput(t.Context(), l, configbridge.ShellRunOptsFromOpts(terragruntOptions), "", !allocateStdout, false, "testdata/test_outputs.sh", "same")
+	out, err := shell.RunCommandWithOutput(t.Context(), l, vexec.NewOSExec(), configbridge.ShellRunOptsFromOpts(terragruntOptions), "", !allocateStdout, false, "testdata/test_outputs.sh", "same")
 
 	assert.NotNil(t, out, "Should get output")
 	require.NoError(t, err, "Should have no error")

--- a/internal/shell/run_cmd_test.go
+++ b/internal/shell/run_cmd_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
@@ -26,10 +27,10 @@ func TestRunShellCommand(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	cmd := shell.RunCommand(t.Context(), l, configbridge.ShellRunOptsFromOpts(terragruntOptions), "tofu", "--version")
+	cmd := shell.RunCommand(t.Context(), l, vexec.NewOSExec(), configbridge.ShellRunOptsFromOpts(terragruntOptions), "tofu", "--version")
 	require.NoError(t, cmd)
 
-	cmd = shell.RunCommand(t.Context(), l, configbridge.ShellRunOptsFromOpts(terragruntOptions), "tofu", "not-a-real-command")
+	cmd = shell.RunCommand(t.Context(), l, vexec.NewOSExec(), configbridge.ShellRunOptsFromOpts(terragruntOptions), "tofu", "not-a-real-command")
 	require.Error(t, cmd)
 }
 
@@ -48,7 +49,7 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	cmd := shell.RunCommand(t.Context(), l, configbridge.ShellRunOptsFromOpts(terragruntOptions), "tofu", "--version")
+	cmd := shell.RunCommand(t.Context(), l, vexec.NewOSExec(), configbridge.ShellRunOptsFromOpts(terragruntOptions), "tofu", "--version")
 	require.NoError(t, cmd)
 
 	assert.Contains(t, stdout.String(), "OpenTofu", "Output directed to stdout")
@@ -61,7 +62,7 @@ func TestRunShellOutputToStderrAndStdout(t *testing.T) {
 	terragruntOptions.Writers.Writer = stderr
 	terragruntOptions.Writers.ErrWriter = stderr
 
-	cmd = shell.RunCommand(t.Context(), l, configbridge.ShellRunOptsFromOpts(terragruntOptions), "tofu", "--version")
+	cmd = shell.RunCommand(t.Context(), l, vexec.NewOSExec(), configbridge.ShellRunOptsFromOpts(terragruntOptions), "tofu", "--version")
 	require.NoError(t, cmd)
 
 	assert.Contains(t, stderr.String(), "OpenTofu", "Output directed to stderr")

--- a/internal/shell/run_cmd_unix_test.go
+++ b/internal/shell/run_cmd_unix_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/os/signal"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -36,7 +37,7 @@ func TestRunCommandWithOutputInterrupt(t *testing.T) {
 	cmdPath := "testdata/test_sigint_wait.sh"
 
 	go func() {
-		_, err := shell.RunCommandWithOutput(ctx, l, configbridge.ShellRunOptsFromOpts(terragruntOptions), "", false, false, cmdPath, strconv.Itoa(expectedWait))
+		_, err := shell.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), configbridge.ShellRunOptsFromOpts(terragruntOptions), "", false, false, cmdPath, strconv.Itoa(expectedWait))
 		errCh <- err
 	}()
 

--- a/internal/shell/run_cmd_windows_test.go
+++ b/internal/shell/run_cmd_windows_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/os/signal"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
@@ -37,7 +38,7 @@ func TestWindowsRunCommandWithOutputInterrupt(t *testing.T) {
 	cmdPath := "testdata\\test_sigint_wait.bat"
 
 	go func() {
-		_, err := shell.RunCommandWithOutput(ctx, l, configbridge.ShellRunOptsFromOpts(terragruntOptions), "", false, false, cmdPath, strconv.Itoa(expectedWait))
+		_, err := shell.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), configbridge.ShellRunOptsFromOpts(terragruntOptions), "", false, false, cmdPath, strconv.Itoa(expectedWait))
 		errCh <- err
 	}()
 

--- a/internal/tf/run_cmd.go
+++ b/internal/tf/run_cmd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
@@ -52,16 +53,19 @@ type TFOptions struct {
 	JSONLogFormat                bool
 }
 
-// RunCommand runs the given Terraform command.
-func RunCommand(ctx context.Context, l log.Logger, runOpts *TFOptions, args ...string) error {
-	_, err := RunCommandWithOutput(ctx, l, runOpts, args...)
+// RunCommand runs the given Terraform command using the provided vexec.Exec.
+// Pass vexec.NewMemExec from tests and fuzzers to intercept invocations so
+// tofu/terraform are never forked.
+func RunCommand(ctx context.Context, l log.Logger, e vexec.Exec, runOpts *TFOptions, args ...string) error {
+	_, err := RunCommandWithOutput(ctx, l, e, runOpts, args...)
 
 	return err
 }
 
-// RunCommandWithOutput runs the given Terraform command, writing its stdout/stderr to the terminal AND returning stdout/stderr to this
-// method's caller
-func RunCommandWithOutput(ctx context.Context, l log.Logger, runOpts *TFOptions, args ...string) (*util.CmdOutput, error) {
+// RunCommandWithOutput runs the given Terraform command using the provided
+// vexec.Exec, writing its stdout/stderr to the terminal AND returning
+// stdout/stderr to this method's caller.
+func RunCommandWithOutput(ctx context.Context, l log.Logger, e vexec.Exec, runOpts *TFOptions, args ...string) (*util.CmdOutput, error) {
 	args = clihelper.Args(args).Normalize(clihelper.SingleDashFlag)
 
 	if fn := TerraformCommandHookFromContext(ctx); fn != nil {
@@ -84,7 +88,7 @@ func RunCommandWithOutput(ctx context.Context, l log.Logger, runOpts *TFOptions,
 		shellOpts.Writers.ErrWriter = errWriter
 	}
 
-	output, err := shell.RunCommandWithOutput(ctx, l, shellOpts, "", false, needsPTY, runOpts.ShellOptions.TFPath, args...)
+	output, err := shell.RunCommandWithOutput(ctx, l, e, shellOpts, "", false, needsPTY, runOpts.ShellOptions.TFPath, args...)
 
 	hasDetailedExitCode := slices.Contains(args, FlagNameDetailedExitCode)
 	if hasDetailedExitCode {

--- a/internal/tf/run_cmd_test.go
+++ b/internal/tf/run_cmd_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
@@ -76,7 +77,7 @@ func testCommandOutput(t *testing.T, withOptions func(*options.TerragruntOptions
 	l := logger.CreateLogger()
 	l = withLogger(l)
 
-	out, err := tf.RunCommandWithOutput(t.Context(), l, configbridge.TFRunOptsFromOpts(terragruntOptions), "same")
+	out, err := tf.RunCommandWithOutput(t.Context(), l, vexec.NewOSExec(), configbridge.TFRunOptsFromOpts(terragruntOptions), "same")
 
 	assert.NotNil(t, out, "Should get output")
 	require.NoError(t, err, "Should have no error")

--- a/internal/tflint/tflint.go
+++ b/internal/tflint/tflint.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
@@ -82,7 +83,7 @@ func RunTflintWithOpts(
 	initArgs := []string{"tflint", "--init", "--config", configFileRel, "--chdir", chdirRel}
 	l.Debugf("Running external tflint init with args %v", initArgs)
 
-	_, err = shell.RunCommandWithOutput(ctx, l, opts.ShellOptions, opts.RootWorkingDir, false, false,
+	_, err = shell.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), opts.ShellOptions, opts.RootWorkingDir, false, false,
 		initArgs[0], initArgs[1:]...)
 	if err != nil {
 		return errors.New(ErrorRunningTflint{Args: initArgs, Err: err})
@@ -101,7 +102,7 @@ func RunTflintWithOpts(
 
 	l.Debugf("Running external tflint with args %v", args)
 
-	_, err = shell.RunCommandWithOutput(ctx, l, opts.ShellOptions, opts.RootWorkingDir, false, false,
+	_, err = shell.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), opts.ShellOptions, opts.RootWorkingDir, false, false,
 		args[0], args[1:]...)
 	if err != nil {
 		return errors.New(ErrorRunningTflint{Args: args, Err: err})

--- a/internal/vexec/vexec.go
+++ b/internal/vexec/vexec.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"strconv"
 	"sync"
+	"time"
 )
 
 // Sentinel errors returned by the in-memory backend for misuse of the Cmd
@@ -55,6 +56,9 @@ type Cmd interface {
 	SetStderr(w io.Writer)
 	SetEnv(env []string)
 	SetDir(dir string)
+	// SetWaitDelay bounds the time Wait blocks after the context is canceled,
+	// mirroring exec.Cmd.WaitDelay. The in-memory backend ignores it.
+	SetWaitDelay(d time.Duration)
 
 	Run() error
 	Start() error
@@ -146,6 +150,8 @@ func (c *osCmd) SetStdout(w io.Writer) { c.cmd.Stdout = w }
 func (c *osCmd) SetStderr(w io.Writer) { c.cmd.Stderr = w }
 func (c *osCmd) SetEnv(env []string)   { c.cmd.Env = env }
 func (c *osCmd) SetDir(dir string)     { c.cmd.Dir = dir }
+
+func (c *osCmd) SetWaitDelay(d time.Duration) { c.cmd.WaitDelay = d }
 
 func (c *osCmd) SetCancel(fn func() error) { c.cmd.Cancel = fn }
 
@@ -274,6 +280,8 @@ func (c *memCmd) SetStdout(w io.Writer) { c.stdout = w }
 func (c *memCmd) SetStderr(w io.Writer) { c.stderr = w }
 func (c *memCmd) SetEnv(env []string)   { c.env = env }
 func (c *memCmd) SetDir(dir string)     { c.dir = dir }
+
+func (c *memCmd) SetWaitDelay(time.Duration) {}
 
 func (c *memCmd) ProcessState() *os.ProcessState { return nil }
 

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -573,6 +574,7 @@ func runCommandImpl(ctx context.Context, pctx *ParsingContext, l log.Logger, arg
 	cmdOutput, err := shell.RunCommandWithOutput(
 		ctx,
 		l,
+		vexec.NewOSExec(),
 		shellRunOptsFromPctx(pctx),
 		currentPath,
 		true,

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 )
 
@@ -1121,7 +1122,7 @@ func getTerragruntOutputJSONFromInitFolder(
 
 	bareCtx := tf.ContextWithTerraformCommandHook(ctx, nil)
 
-	out, err := tf.RunCommandWithOutput(bareCtx, l, tfRunOpts, tf.CommandNameOutput, "-json")
+	out, err := tf.RunCommandWithOutput(bareCtx, l, vexec.NewOSExec(), tfRunOpts, tf.CommandNameOutput, "-json")
 	if err != nil {
 		return nil, err
 	}
@@ -1259,7 +1260,7 @@ func getTerragruntOutputJSONFromRemoteState(
 	// Now that the backend is initialized, run terraform output to get the data and return it.
 	bareCtx := tf.ContextWithTerraformCommandHook(ctx, nil)
 
-	out, err := tf.RunCommandWithOutput(bareCtx, l, tfRunOpts, tf.CommandNameOutput, "-json")
+	out, err := tf.RunCommandWithOutput(bareCtx, l, vexec.NewOSExec(), tfRunOpts, tf.CommandNameOutput, "-json")
 	if err != nil {
 		return nil, err
 	}
@@ -1523,7 +1524,7 @@ func runTerraformInitForDependencyOutput(ctx context.Context, pctx *ParsingConte
 
 	bareCtx := tf.ContextWithTerraformCommandHook(ctx, nil)
 
-	if err := tf.RunCommand(bareCtx, l, initRunOpts, tf.CommandNameInit, "-get=false"); err != nil {
+	if err := tf.RunCommand(bareCtx, l, vexec.NewOSExec(), initRunOpts, tf.CommandNameInit, "-get=false"); err != nil {
 		l.Debugf("Ignoring expected error from dependency init call")
 		l.Debugf("Init call stderr:")
 		l.Debugf("%s", stderr.String())

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -57,7 +58,7 @@ func TestDebugGeneratedInputs(t *testing.T) {
 
 	require.NoError(
 		t,
-		tf.RunCommand(t.Context(), l, configbridge.TFRunOptsFromOpts(mockOptions), "apply", "-auto-approve", "-var-file", debugFile),
+		tf.RunCommand(t.Context(), l, vexec.NewOSExec(), configbridge.TFRunOptsFromOpts(mockOptions), "apply", "-auto-approve", "-var-file", debugFile),
 	)
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Integrates vexec into `Command` so that we can control the interaction between business logic and process spawning using the `e` handler.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured internal command execution infrastructure to standardize how commands are handled across the application.

* **Tests**
  * Expanded test coverage for command execution scenarios with improved test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->