### PR TITLE
docs: Calling out update for existing cache locations in `v1.0.4`

### DIFF
--- a/docs/src/data/changelog/v1.0.4/xdg-cache-paths.mdx
+++ b/docs/src/data/changelog/v1.0.4/xdg-cache-paths.mdx
@@ -1,0 +1,18 @@
+---
+version: "v1.0.4"
+category: "experiments-updated"
+---
+
+#### Cache and plugin directories follow platform conventions
+
+Terragrunt's global cache directory now resolves to the platform's user cache location instead of a hard-coded `~/.cache/terragrunt`. On Linux this honors `XDG_CACHE_HOME` (still `~/.cache/terragrunt` by default), on macOS it resolves to `~/Library/Caches/terragrunt`, and on Windows it resolves under `%LocalAppData%`. The CAS content store, the auto provider cache, and the IaC engine plugin directory all move with it.
+
+Existing caches at the previous locations are not migrated. They become orphaned and continue to consume disk space until removed.
+
+Consider deleting the old paths to reclaim that space if you are on macOS or Windows, or have configured a custom `XDG_CACHE_HOME`:
+
+```bash
+# CAS store and engine plugins under the legacy ~/.cache layout
+rm -rf ~/.cache/terragrunt
+```
+


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds call out that the cache location has moved for caches used in experimental features.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog for v1.0.4 documenting cache directory path changes. Cache paths now follow platform conventions (XDG on Linux, ~/Library/Caches on macOS, %LocalAppData% on Windows). Existing caches won't be automatically migrated; users should manually clean up legacy paths to reclaim disk space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->