### PR TITLE
fix: Dropping references to `ctrl-\+j` in the catalog key bindings

### DIFF
--- a/internal/cli/commands/catalog/tui/keys.go
+++ b/internal/cli/commands/catalog/tui/keys.go
@@ -50,7 +50,7 @@ func NewListKeyMap() list.KeyMap {
 			key.WithHelp("esc", "cancel"),
 		),
 		AcceptWhileFiltering: key.NewBinding(
-			key.WithKeys("enter", "tab", "shift+tab", "ctrl+k", "up", "ctrl+j", "down"),
+			key.WithKeys("enter", "tab", "shift+tab", "ctrl+k", "up", "down"),
 			key.WithHelp("enter", "apply filter"),
 		),
 
@@ -102,8 +102,8 @@ func (d DelegateKeyMap) FullHelp() [][]key.Binding {
 func NewDelegateKeyMap() *DelegateKeyMap {
 	return &DelegateKeyMap{
 		Choose: key.NewBinding(
-			key.WithKeys("enter", "ctrl-j"),
-			key.WithHelp("enter/ctrl-j", "choose"),
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "choose"),
 		),
 		Scaffold: key.NewBinding(
 			key.WithKeys("S", "s"),
@@ -205,8 +205,8 @@ func NewPagerKeyMap() PagerKeyMap {
 			key.WithHelp("shift+tab", "navigation"),
 		),
 		Choose: key.NewBinding(
-			key.WithKeys("enter", "ctrl-j"),
-			key.WithHelp("enter/ctrl-j", "choose"),
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "choose"),
 		),
 		Scaffold: key.NewBinding(
 			key.WithKeys("S", "s"),


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Drops references to `ctrl-/+j` bindings in the catalog UI. It's not likely anyone is using this over enter.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated keyboard shortcuts for selection operations to use the enter key exclusively.
  * Adjusted available keyboard combinations for list filtering actions.
  * Updated help text to reflect the new keyboard bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->