### PR TITLE
feat: adding support for commit refs in CAS

### DIFF
--- a/docs/src/content/docs/03-features/07-caching/04-cas.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas.mdx
@@ -48,6 +48,20 @@ terraform {
 }
 ```
 
+<Since version="1.0.4">
+
+`ref=` also accepts commit SHAs (full or abbreviated), not only branch and tag names.
+
+```hcl
+terraform {
+  source = "git@github.com:acme/infrastructure-modules.git//vpc?ref=a1b2c3d4e5f67890abcdef1234567890deadbeef"
+}
+```
+
+The first cold clone of a repository pinned to a commit SHA fetches the full history of every branch. Shallow fetches require a ref name, and fetching a commit SHA at limited depth depends on a server option (`uploadpack.allowAnySHA1InWant`) that is not universally enabled, so CAS fetches all branches at full depth and resolves the SHA locally. Subsequent clones reuse the cached repository and never touch the network for the same commit.
+
+</Since>
+
 ### Stack Usage
 
 <Before version="1.0.3">
@@ -207,9 +221,9 @@ When Terragrunt needs to clone a repository using the CAS it does the following,
 
 For cold clones, where the content is not already in the CAS:
 
-1. Terragrunt resolves the Git reference (branch/tag) to a commit hash
+1. Terragrunt resolves the Git reference to a commit hash. Branch and tag refs resolve via `git ls-remote`. `ls-remote` lists named refs and does not resolve commit SHAs, so for SHA refs Terragrunt fetches the full history of every branch into the central Git store and resolves the SHA locally.
 2. The tree related to the commit hash is not found in the CAS
-3. Terragrunt opens the bare repository for the remote URL under `cas/store/git/` (initializing it on first use), takes a per-URL lock, and fetches the requested ref. Subsequent misses against the same URL reuse the existing pack files and only transfer new objects.
+3. Terragrunt opens the bare repository for the remote URL under `cas/store/git/` (initializing it on first use), takes a per-URL lock, and fetches the requested ref (shallow for branch/tag refs, full history for commit SHAs). Subsequent misses against the same URL reuse the existing pack files and only transfer new objects.
 4. All blobs and trees required to reproduce the repository are extracted from the bare repository
 5. Content is stored in the CAS, partitioned by hash prefix
 6. The tree structure is read from the CAS and hard links are created to the target directory
@@ -220,7 +234,7 @@ Concurrent units that target the same remote URL share one fetch instead of clon
 
 For warm clones, where the content is already in the CAS:
 
-1. Terragrunt resolves the Git reference to a commit hash
+1. Terragrunt resolves the Git reference to a commit hash. For commit-SHA refs the local central Git store answers without contacting the remote when the SHA is already cached.
 2. CAS checks if the content exists
 3. The tree structure is read directly from the CAS
 4. Hard links are created from CAS to the target directory

--- a/docs/src/content/docs/03-features/07-caching/04-cas.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas.mdx
@@ -48,7 +48,7 @@ terraform {
 }
 ```
 
-<Since version="1.0.4">
+<Since version="1.0.5">
 
 `ref=` also accepts commit SHAs (full or abbreviated), not only branch and tag names.
 

--- a/docs/src/data/changelog/v1.0.5/cas-commit-refs.mdx
+++ b/docs/src/data/changelog/v1.0.5/cas-commit-refs.mdx
@@ -1,0 +1,18 @@
+---
+version: "v1.0.5"
+category: "experiments-updated"
+---
+
+#### `cas` — Commit SHAs accepted in `ref=`
+
+Source URLs of the form `git::<url>?ref=<commit-sha>` now resolve through CAS. Previously these clones failed because Terragrunt asked the remote to look up the SHA as a symbolic reference, which Git servers don't support.
+
+Both full SHAs (SHA-1 and SHA-256) and abbreviated SHAs are accepted. Abbreviated SHAs must disambiguate inside the repository, the same rule Git itself applies.
+
+```hcl
+terraform {
+  source = "git::https://github.com/acme/infrastructure-modules.git//vpc?ref=a1b2c3d4e5f67890abcdef1234567890deadbeef"
+}
+```
+
+The first cold clone of a repository pinned to a commit SHA fetches the full history of every branch. Shallow fetches require a ref name, and fetching a commit SHA at limited depth depends on a server option (`uploadpack.allowAnySHA1InWant`) that is not universally enabled, so CAS fetches all branches at full depth and resolves the SHA locally. Subsequent clones reuse the cached repository and never touch the network for the same commit. Branch and tag refs continue to use the existing shallow path.

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -237,6 +237,10 @@ func (c *CAS) populateTreeFromRef(
 		return ref.Hash, nil
 
 	case *commitRef:
+		if ref.Hash != "" && !c.treeStore.NeedsWrite(ref.Hash) {
+			return ref.Hash, nil
+		}
+
 		return c.populateTreeFromCommitRef(ctx, l, opts, ref)
 
 	default:
@@ -293,7 +297,7 @@ func (c *CAS) populateTreeFromCommitRef(
 	opts *CloneOptions,
 	ref *commitRef,
 ) (string, error) {
-	repo, err := c.gitStore.EnsureCommit(ctx, l, c.fs, ref.URL, ref.RawRef)
+	repo, err := c.gitStore.EnsureCommit(ctx, l, c.fs, ref.URL, ref.RawRef, ref.Hash)
 	if err == nil {
 		defer repo.Release(l)
 
@@ -401,8 +405,9 @@ func (c *CAS) prepareTargetDirectory(dir, url string) string {
 // [commitRef] when it did not. Sealed by package visibility.
 type resolvedRef interface {
 	// CommitHash returns the canonical commit hash for [symbolicRef]
-	// and the user-supplied SHA for [commitRef]. Abbreviated SHAs
-	// passed in as commit refs remain abbreviated.
+	// and the raw user-supplied ref for [commitRef] (no
+	// canonicalization: an abbreviated SHA is returned as-is, not
+	// expanded to a full hash).
 	CommitHash() string
 }
 
@@ -416,33 +421,61 @@ type symbolicRef struct {
 // CommitHash returns the canonical commit hash ls-remote resolved.
 func (r *symbolicRef) CommitHash() string { return r.Hash }
 
-// commitRef carries a commit-form ref ls-remote did not recognize.
-// Resolution against the central git store happens later via
-// rev-parse, with a full-depth fetch on a cache miss.
+// commitRef carries a ref ls-remote did not canonicalize to a
+// commit on the remote. The typical case is a SHA the server does
+// not publish as a branch tip, but any user-supplied name
+// ls-remote returned no match for funnels here too. Resolution
+// against the central git store happens later via rev-parse, with
+// a full-history fetch on a cache miss.
 type commitRef struct {
-	URL    string
-	RawRef string // user-supplied SHA, full or abbreviated
+	// URL is the remote repository URL.
+	URL string
+
+	// RawRef is the user-supplied ref. SHAs (full SHA-1, full
+	// SHA-256, or abbreviated prefixes) are the common case because
+	// ls-remote does not surface commit hashes, but any name
+	// ls-remote did not match also lands here. The central git
+	// store canonicalizes via rev-parse, so any form git accepts
+	// works.
+	RawRef string
+
+	// Hash is the canonical full SHA pre-resolved by
+	// [GitStore.ProbeCachedCommit] before reaching ls-remote;
+	// empty when the commitRef arose from an ls-remote miss. When
+	// set, downstream code keys the tree-store short-circuit on it
+	// and forwards it to [GitStore.EnsureCommit] to skip a
+	// redundant rev-parse.
+	Hash string
 }
 
-// CommitHash returns the user-supplied SHA before central-store
-// canonicalization.
+// CommitHash returns the user-supplied ref. Hash is intentionally
+// not returned: stacks key the CAS on this value, and the key
+// must not depend on whether the central git store happened to
+// have the commit cached.
 func (r *commitRef) CommitHash() string { return r.RawRef }
 
 // resolveReference resolves branch into a [resolvedRef].
 //
-// SHA-form input is probed against the central git store first; a
-// cached hit returns a [*commitRef] without contacting the remote so
-// previously-cloned commits succeed offline. ls-remote spawn
-// failures would otherwise propagate as clone errors.
+// Full-length SHA input (40 or 64 hex chars) is probed against the
+// central git store first. A cached hit returns a [*commitRef]
+// carrying the canonical hash without contacting the remote, so
+// previously-cloned commits succeed offline even when ls-remote
+// would fail to spawn. The pre-resolved hash also lets
+// [CAS.populateTreeFromCommitRef] skip a redundant rev-parse
+// inside [GitStore.EnsureCommit]. Abbreviated SHAs skip the probe
+// because a hex-named branch could share the abbreviation as a
+// prefix of its tip, which would freeze that branch at the
+// first-fetched tip; see [looksLikeFullSHA].
 //
 // Otherwise ls-remote is authoritative: a result returns a
 // [*symbolicRef] with the canonical hash; an empty result or
-// [git.ErrNoMatchingReference] returns a [*commitRef] so the central
-// store resolves the input via rev-parse and a full-history fetch.
+// [git.ErrNoMatchingReference] returns a [*commitRef] with an
+// empty Hash so the central store resolves the input via rev-parse
+// and a full-history fetch.
 func (c *CAS) resolveReference(ctx context.Context, url, branch string) (resolvedRef, error) {
-	if looksLikeSHA(branch) {
-		if _, ok := c.gitStore.ProbeCachedCommit(ctx, c.fs, url, branch); ok {
-			return &commitRef{URL: url, RawRef: branch}, nil
+	if looksLikeFullSHA(branch) {
+		if hash, ok := c.gitStore.ProbeCachedCommit(ctx, c.fs, url, branch); ok {
+			return &commitRef{URL: url, RawRef: branch, Hash: hash}, nil
 		}
 	}
 
@@ -462,26 +495,24 @@ func (c *CAS) resolveReference(ctx context.Context, url, branch string) (resolve
 	return &symbolicRef{URL: url, Branch: branch, Hash: results[0].Hash}, nil
 }
 
-// looksLikeSHA reports whether s is 4-64 hex characters, the range
-// that covers abbreviated SHA-1 through full SHA-256.
-func looksLikeSHA(s string) bool {
-	const minSHALen, maxSHALen = 4, 64
-
-	if len(s) < minSHALen || len(s) > maxSHALen {
+// looksLikeFullSHA reports whether s is exactly 40 or 64 hex
+// characters, the canonical full lengths for SHA-1 and SHA-256
+// commit hashes.
+//
+// Abbreviations are rejected so the probe in [CAS.resolveReference]
+// cannot mistake a hex-named branch (e.g. branch "a1b2" whose tip
+// happens to start with "a1b2...") for a cached commit prefix and
+// freeze the branch at its first-fetched tip. Abbreviated SHAs
+// still resolve correctly via the [GitStore.EnsureCommit] fallback
+// once ls-remote returns no match.
+func looksLikeFullSHA(s string) bool {
+	if len(s) != 40 && len(s) != 64 {
 		return false
 	}
 
-	for _, c := range s {
-		switch {
-		case c >= '0' && c <= '9',
-			c >= 'a' && c <= 'f',
-			c >= 'A' && c <= 'F':
-		default:
-			return false
-		}
-	}
+	_, err := hex.DecodeString(s)
 
-	return true
+	return err == nil
 }
 
 // storeRootTreeFrom reads the recursive tree at hash from the supplied

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -101,6 +101,13 @@ func New(opts ...Option) (*CAS, error) {
 		c.fs = vfs.NewOSFS()
 	}
 
+	// CAS shells out to git, which only sees the real disk. Validate
+	// here so a non-OS backing fails at the constructor instead of
+	// from a deeper store-init step.
+	if !vfs.IsOSFS(c.fs) {
+		return nil, ErrGitStoreFSNotOS
+	}
+
 	if c.storePath == "" {
 		cacheDir, err := util.EnsureCacheDir()
 		if err != nil {
@@ -159,35 +166,29 @@ func (c *CAS) SynthStore() *Store { return c.synthStore }
 //
 // TODO: Make options optional
 func (c *CAS) Clone(ctx context.Context, l log.Logger, opts *CloneOptions, url string) error {
-	// Ensure the store paths exist
-	if err := c.fs.MkdirAll(c.blobStore.Path(), DefaultDirPerms); err != nil {
-		return fmt.Errorf("failed to create blob store path: %w", err)
-	}
-
-	if err := c.fs.MkdirAll(c.treeStore.Path(), DefaultDirPerms); err != nil {
-		return fmt.Errorf("failed to create tree store path: %w", err)
+	if err := c.ensureCloneStores(); err != nil {
+		return err
 	}
 
 	return telemetry.TelemeterFromContext(ctx).Collect(ctx, "cas_clone", map[string]any{
 		"url":    url,
 		"branch": opts.Branch,
 	}, func(childCtx context.Context) error {
-		hash, err := c.resolveReference(childCtx, url, opts.Branch)
+		ref, err := c.resolveReference(childCtx, url, opts.Branch)
 		if err != nil {
 			return err
 		}
 
 		targetDir := c.prepareTargetDirectory(opts.Dir, url)
 
-		if c.treeStore.NeedsWrite(hash) {
-			if err := c.populateTreeFromGit(childCtx, l, opts, url, hash); err != nil {
-				return err
-			}
+		canonicalHash, err := c.populateTreeFromRef(childCtx, l, opts, ref)
+		if err != nil {
+			return err
 		}
 
 		treeContent := NewContent(c.treeStore)
 
-		treeData, err := treeContent.Read(hash)
+		treeData, err := treeContent.Read(canonicalHash)
 		if err != nil {
 			return err
 		}
@@ -201,46 +202,172 @@ func (c *CAS) Clone(ctx context.Context, l log.Logger, opts *CloneOptions, url s
 	})
 }
 
-// populateTreeFromGit fetches the commit at hash and stores its tree and
-// reachable blobs in the CAS. It tries the central git store first. Any
-// error from the central store is logged as a warning, and the function
-// then falls back to a bare clone in a temporary directory.
-func (c *CAS) populateTreeFromGit(ctx context.Context, l log.Logger, opts *CloneOptions, url, hash string) error {
+// ensureCloneStores creates the blob and tree store directories that
+// [CAS.Clone] writes to. Defensive: [New] already creates them, but a
+// long-lived [CAS] instance could see them removed between calls.
+func (c *CAS) ensureCloneStores() error {
+	for _, s := range []*Store{c.blobStore, c.treeStore} {
+		if err := c.fs.MkdirAll(s.Path(), DefaultDirPerms); err != nil {
+			return fmt.Errorf("create CAS store path %s: %w", s.Path(), err)
+		}
+	}
+
+	return nil
+}
+
+// populateTreeFromRef dispatches by ref kind, short-circuiting on a
+// cached [symbolicRef] and otherwise calling the kind-specific
+// populate. Returns the canonical commit hash.
+func (c *CAS) populateTreeFromRef(
+	ctx context.Context,
+	l log.Logger,
+	opts *CloneOptions,
+	ref resolvedRef,
+) (string, error) {
+	switch ref := ref.(type) {
+	case *symbolicRef:
+		if !c.treeStore.NeedsWrite(ref.Hash) {
+			return ref.Hash, nil
+		}
+
+		if err := c.populateTreeFromSymbolicRef(ctx, l, opts, ref); err != nil {
+			return "", err
+		}
+
+		return ref.Hash, nil
+
+	case *commitRef:
+		return c.populateTreeFromCommitRef(ctx, l, opts, ref)
+
+	default:
+		return "", fmt.Errorf("unsupported resolved ref type %T", ref)
+	}
+}
+
+// populateTreeFromSymbolicRef stores the tree and reachable blobs
+// for ref.Hash in the CAS. Tries the central [GitStore] first; on
+// any error from it, logs a warning and falls back to a bare clone
+// in a temporary directory.
+func (c *CAS) populateTreeFromSymbolicRef(
+	ctx context.Context,
+	l log.Logger,
+	opts *CloneOptions,
+	ref *symbolicRef,
+) error {
 	depth := resolveCloneDepth(opts.Depth, c.cloneDepth)
 
-	repoPath, unlocker, err := c.gitStore.EnsureRef(ctx, l, c.fs, url, opts.Branch, hash, depth)
+	repo, err := c.gitStore.EnsureRef(ctx, l, c.fs, ref.URL, ref.Branch, ref.Hash, depth)
 	if err == nil {
-		defer func() {
-			if unlockErr := unlocker.Unlock(); unlockErr != nil {
-				l.Warnf("git store: failed to release lock for %s: %v", url, unlockErr)
-			}
-		}()
+		defer repo.Release(l)
 
-		runner := c.git.WithWorkDir(repoPath)
+		runner := c.git.WithWorkDir(repo.Path)
 
-		return c.storeRootTreeFrom(ctx, l, runner, hash, opts)
+		return c.storeRootTreeFrom(ctx, l, runner, ref.Hash, opts)
 	}
 
-	l.Warnf("central git store unavailable for %s, falling back to temporary clone: %v", url, err)
+	l.Warnf("central git store unavailable for %s, falling back to temporary clone: %v", ref.URL, err)
 
-	tempDir, err := vfs.MkdirTemp(c.fs, "", "terragrunt-cas-fallback-*")
+	tempDir, cleanup, err := c.makeFallbackCloneDir(l)
 	if err != nil {
-		return fmt.Errorf("create fallback clone dir: %w", errors.Join(ErrFallbackCloneDir, err))
-	}
-
-	defer func() {
-		if rmErr := c.fs.RemoveAll(tempDir); rmErr != nil {
-			l.Warnf("cleanup error: %v", rmErr)
-		}
-	}()
-
-	runner := c.git.WithWorkDir(tempDir)
-
-	if err := runner.Clone(ctx, url, true, depth, opts.Branch); err != nil {
 		return err
 	}
 
-	return c.storeRootTreeFrom(ctx, l, runner, hash, opts)
+	defer cleanup()
+
+	runner := c.git.WithWorkDir(tempDir)
+
+	if err := runner.Clone(ctx, ref.URL, true, depth, ref.Branch); err != nil {
+		return err
+	}
+
+	return c.storeRootTreeFrom(ctx, l, runner, ref.Hash, opts)
+}
+
+// populateTreeFromCommitRef resolves ref via [GitStore.EnsureCommit]
+// (full-depth fetch on a cache miss) and stores its tree in the CAS.
+// Returns the canonical commit hash. Falls back to a temporary bare
+// clone if the central [GitStore] is unavailable.
+func (c *CAS) populateTreeFromCommitRef(
+	ctx context.Context,
+	l log.Logger,
+	opts *CloneOptions,
+	ref *commitRef,
+) (string, error) {
+	repo, err := c.gitStore.EnsureCommit(ctx, l, c.fs, ref.URL, ref.RawRef)
+	if err == nil {
+		defer repo.Release(l)
+
+		if !c.treeStore.NeedsWrite(repo.Hash) {
+			return repo.Hash, nil
+		}
+
+		runner := c.git.WithWorkDir(repo.Path)
+
+		if err := c.storeRootTreeFrom(ctx, l, runner, repo.Hash, opts); err != nil {
+			return "", err
+		}
+
+		return repo.Hash, nil
+	}
+
+	if errors.Is(err, git.ErrNoMatchingReference) {
+		return "", err
+	}
+
+	l.Warnf("central git store unavailable for %s, falling back to temporary clone: %v", ref.URL, err)
+
+	tempDir, cleanup, err := c.makeFallbackCloneDir(l)
+	if err != nil {
+		return "", err
+	}
+
+	defer cleanup()
+
+	runner := c.git.WithWorkDir(tempDir)
+
+	if err := runner.Clone(ctx, ref.URL, true, 0, ""); err != nil {
+		return "", err
+	}
+
+	canonicalHash, err := runner.RevParseCommit(ctx, ref.RawRef)
+	if err != nil {
+		if errors.Is(err, git.ErrUnknownRevision) {
+			return "", &git.WrappedError{
+				Op:      "git_clone_resolve",
+				Context: fmt.Sprintf("%q in %s", ref.RawRef, ref.URL),
+				Err:     git.ErrNoMatchingReference,
+			}
+		}
+
+		return "", err
+	}
+
+	if !c.treeStore.NeedsWrite(canonicalHash) {
+		return canonicalHash, nil
+	}
+
+	if err := c.storeRootTreeFrom(ctx, l, runner, canonicalHash, opts); err != nil {
+		return "", err
+	}
+
+	return canonicalHash, nil
+}
+
+// makeFallbackCloneDir creates a temporary directory for a bare clone
+// fallback and returns a cleanup function that removes it.
+func (c *CAS) makeFallbackCloneDir(l log.Logger) (string, func(), error) {
+	tempDir, err := vfs.MkdirTemp(c.fs, "", "terragrunt-cas-fallback-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create fallback clone dir: %w", errors.Join(ErrFallbackCloneDir, err))
+	}
+
+	cleanup := func() {
+		if rmErr := c.fs.RemoveAll(tempDir); rmErr != nil {
+			l.Warnf("cleanup error: %v", rmErr)
+		}
+	}
+
+	return tempDir, cleanup, nil
 }
 
 func resolveCloneDepth(optDepth, casDepth int) int {
@@ -269,21 +396,92 @@ func (c *CAS) prepareTargetDirectory(dir, url string) string {
 	return filepath.Clean(targetDir)
 }
 
-func (c *CAS) resolveReference(ctx context.Context, url, branch string) (string, error) {
-	results, err := c.git.LsRemote(ctx, url, branch)
-	if err != nil {
-		return "", err
-	}
+// resolvedRef is what [CAS.resolveReference] returns: a [symbolicRef]
+// when ls-remote resolved the input to a branch, tag, or HEAD; a
+// [commitRef] when it did not. Sealed by package visibility.
+type resolvedRef interface {
+	// CommitHash returns the canonical commit hash for [symbolicRef]
+	// and the user-supplied SHA for [commitRef]. Abbreviated SHAs
+	// passed in as commit refs remain abbreviated.
+	CommitHash() string
+}
 
-	if len(results) == 0 {
-		return "", &WrappedError{
-			Op:      "clone",
-			Context: "no matching reference",
-			Err:     ErrNoMatchingReference,
+// symbolicRef carries an ls-remote-resolved branch, tag, or HEAD.
+type symbolicRef struct {
+	URL    string
+	Branch string // ref name, used for the per-ref fetch
+	Hash   string // canonical commit hash
+}
+
+// CommitHash returns the canonical commit hash ls-remote resolved.
+func (r *symbolicRef) CommitHash() string { return r.Hash }
+
+// commitRef carries a commit-form ref ls-remote did not recognize.
+// Resolution against the central git store happens later via
+// rev-parse, with a full-depth fetch on a cache miss.
+type commitRef struct {
+	URL    string
+	RawRef string // user-supplied SHA, full or abbreviated
+}
+
+// CommitHash returns the user-supplied SHA before central-store
+// canonicalization.
+func (r *commitRef) CommitHash() string { return r.RawRef }
+
+// resolveReference resolves branch into a [resolvedRef].
+//
+// SHA-form input is probed against the central git store first; a
+// cached hit returns a [*commitRef] without contacting the remote so
+// previously-cloned commits succeed offline. ls-remote spawn
+// failures would otherwise propagate as clone errors.
+//
+// Otherwise ls-remote is authoritative: a result returns a
+// [*symbolicRef] with the canonical hash; an empty result or
+// [git.ErrNoMatchingReference] returns a [*commitRef] so the central
+// store resolves the input via rev-parse and a full-history fetch.
+func (c *CAS) resolveReference(ctx context.Context, url, branch string) (resolvedRef, error) {
+	if looksLikeSHA(branch) {
+		if _, ok := c.gitStore.ProbeCachedCommit(ctx, c.fs, url, branch); ok {
+			return &commitRef{URL: url, RawRef: branch}, nil
 		}
 	}
 
-	return results[0].Hash, nil
+	results, err := c.git.LsRemote(ctx, url, branch)
+	if err != nil {
+		if errors.Is(err, git.ErrNoMatchingReference) {
+			return &commitRef{URL: url, RawRef: branch}, nil
+		}
+
+		return nil, err
+	}
+
+	if len(results) == 0 {
+		return &commitRef{URL: url, RawRef: branch}, nil
+	}
+
+	return &symbolicRef{URL: url, Branch: branch, Hash: results[0].Hash}, nil
+}
+
+// looksLikeSHA reports whether s is 4-64 hex characters, the range
+// that covers abbreviated SHA-1 through full SHA-256.
+func looksLikeSHA(s string) bool {
+	const minSHALen, maxSHALen = 4, 64
+
+	if len(s) < minSHALen || len(s) > maxSHALen {
+		return false
+	}
+
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9',
+			c >= 'a' && c <= 'f',
+			c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+
+	return true
 }
 
 // storeRootTreeFrom reads the recursive tree at hash from the supplied

--- a/internal/cas/cas_test.go
+++ b/internal/cas/cas_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
@@ -123,4 +124,15 @@ func TestCAS_FallbackWhenGitStoreFails(t *testing.T) {
 	info, err := os.Stat(entry)
 	require.NoError(t, err)
 	assert.False(t, info.IsDir(), "fallback should not have replaced the blocking file")
+}
+
+// TestCASRejectsNonOSFilesystem pins the early OS-filesystem gate
+// in [cas.New]: a non-OS backing must fail at construction.
+func TestCASRejectsNonOSFilesystem(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+
+	_, err := cas.New(cas.WithFS(vfs.NewMemMapFS()), cas.WithStorePath(storePath))
+	require.ErrorIs(t, err, cas.ErrGitStoreFSNotOS)
 }

--- a/internal/cas/commitref_test.go
+++ b/internal/cas/commitref_test.go
@@ -119,14 +119,14 @@ func TestGitStoreEnsureCommit_CachedAfterFirstFetch(t *testing.T) {
 	ctx := t.Context()
 
 	// First call must fetch.
-	repo, err := store.EnsureCommit(ctx, l, fs, url, hash)
+	repo, err := store.EnsureCommit(ctx, l, fs, url, hash, "")
 	require.NoError(t, err)
 	assert.Equal(t, hash, repo.Hash)
 	assert.NotEmpty(t, repo.Path)
 	require.NoError(t, repo.Unlock())
 
 	// Second call hits the local-cache short-circuit.
-	repo2, err := store.EnsureCommit(ctx, l, fs, url, hash)
+	repo2, err := store.EnsureCommit(ctx, l, fs, url, hash, "")
 	require.NoError(t, err)
 	assert.Equal(t, hash, repo2.Hash)
 	require.NoError(t, repo2.Unlock())
@@ -141,7 +141,7 @@ func TestGitStoreEnsureCommit_AbbreviatedSHA(t *testing.T) {
 	store, fs, _ := newTestGitStore(t)
 	l := logger.CreateLogger()
 
-	repo, err := store.EnsureCommit(t.Context(), l, fs, url, hash[:8])
+	repo, err := store.EnsureCommit(t.Context(), l, fs, url, hash[:8], "")
 	require.NoError(t, err)
 	assert.Equal(t, hash, repo.Hash, "abbreviated SHA must canonicalize to the full hash")
 	require.NoError(t, repo.Unlock())
@@ -155,7 +155,7 @@ func TestGitStoreEnsureCommit_UnresolvableSurfacesNoMatchingReference(t *testing
 	store, fs, _ := newTestGitStore(t)
 	l := logger.CreateLogger()
 
-	_, err := store.EnsureCommit(t.Context(), l, fs, url, "0000000000000000000000000000000000000000")
+	_, err := store.EnsureCommit(t.Context(), l, fs, url, "0000000000000000000000000000000000000000", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, git.ErrNoMatchingReference)
 }
@@ -204,6 +204,64 @@ func TestCASClone_NonTipCommit(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(targetPath, "second.txt"))
 	require.Error(t, err, "non-tip clone must not include later commits")
+}
+
+// TestCASClone_AbbreviatedHexBranchAdvancesAcrossClones pins that a
+// branch whose name happens to be a hex prefix of its own tip is not
+// frozen at the first-fetched tip on subsequent clones. The probe in
+// resolveReference shells out to git rev-parse against the per-URL
+// bare repo, which resolves ref names ahead of object hashes; before
+// the looksLikeFullSHA tightening, an abbreviated hex branch name
+// (e.g. the first 8 chars of its own tip) would pass the probe's
+// prefix check and short-circuit ls-remote, so the branch would
+// appear stuck at the cached commit even after the server-side tip
+// moved on.
+func TestCASClone_AbbreviatedHexBranchAdvancesAcrossClones(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile("v1.txt", []byte("v1"), "first"))
+
+	firstHash, err := srv.Head()
+	require.NoError(t, err)
+
+	// Branch name is the 8-char prefix of its own tip: the worst case
+	// for the probe's prefix check.
+	branch := firstHash[:8]
+	require.NoError(t, srv.Branch(branch))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+
+	require.NoError(t, c.Clone(t.Context(), l, &cas.CloneOptions{
+		Dir:    filepath.Join(tempDir, "first"),
+		Branch: branch,
+		Depth:  -1,
+	}, repoURL))
+
+	// Advance the branch to a new commit. ls-remote must see the new
+	// tip on the second clone; the probe would otherwise serve the
+	// stale cached commit.
+	require.NoError(t, srv.CommitFile("v2.txt", []byte("v2"), "second"))
+	require.NoError(t, srv.Branch(branch))
+
+	secondDir := filepath.Join(tempDir, "second")
+	require.NoError(t, c.Clone(t.Context(), l, &cas.CloneOptions{
+		Dir:    secondDir,
+		Branch: branch,
+		Depth:  -1,
+	}, repoURL))
+
+	_, err = os.Stat(filepath.Join(secondDir, "v2.txt"))
+	require.NoError(t, err, "second clone must reflect the moved branch tip, not the cached prefix-matching commit")
 }
 
 // TestCASClone_HexBranchNameResolvesViaLsRemote verifies that a
@@ -291,14 +349,47 @@ func TestGitStoreEnsureCommit_OfflineWhenCached(t *testing.T) {
 	l := logger.CreateLogger()
 	ctx := t.Context()
 
-	primed, err := store.EnsureCommit(ctx, l, fs, repoURL, hash)
+	primed, err := store.EnsureCommit(ctx, l, fs, repoURL, hash, "")
 	require.NoError(t, err)
 	require.NoError(t, primed.Unlock())
 
 	require.NoError(t, srv.Close())
 
-	cached, err := store.EnsureCommit(ctx, l, fs, repoURL, hash)
+	cached, err := store.EnsureCommit(ctx, l, fs, repoURL, hash, "")
 	require.NoError(t, err, "cached commit must resolve without contacting the server")
+	assert.Equal(t, hash, cached.Hash)
+	require.NoError(t, cached.Unlock())
+}
+
+// TestGitStoreEnsureCommit_KnownHashFastPath pins the knownHash
+// branch: when the caller has already canonicalized rawRef via
+// ProbeCachedCommit, EnsureCommit verifies presence with HasObject
+// and skips rev-parse. The server is dropped after priming so any
+// accidental fetch surfaces as a failure.
+func TestGitStoreEnsureCommit_KnownHashFastPath(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile("README.md", []byte("# fast path"), "initial"))
+
+	hash, err := srv.Head()
+	require.NoError(t, err)
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	store, fs, _ := newTestGitStore(t)
+	l := logger.CreateLogger()
+	ctx := t.Context()
+
+	primed, err := store.EnsureCommit(ctx, l, fs, repoURL, hash, "")
+	require.NoError(t, err)
+	require.NoError(t, primed.Unlock())
+
+	require.NoError(t, srv.Close())
+
+	cached, err := store.EnsureCommit(ctx, l, fs, repoURL, hash, hash)
+	require.NoError(t, err, "knownHash path must resolve without contacting the server")
 	assert.Equal(t, hash, cached.Hash)
 	require.NoError(t, cached.Unlock())
 }

--- a/internal/cas/commitref_test.go
+++ b/internal/cas/commitref_test.go
@@ -1,0 +1,458 @@
+package cas_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCASCloneByCommitRef(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	repoURL := startTestServer(t)
+	headHash := resolveHead(t, repoURL)
+
+	t.Run("clone with full commit SHA", func(t *testing.T) {
+		t.Parallel()
+		tempDir := helpers.TmpDirWOSymlinks(t)
+
+		c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+		require.NoError(t, err)
+
+		targetPath := filepath.Join(tempDir, "repo")
+		err = c.Clone(t.Context(), l, &cas.CloneOptions{
+			Dir:    targetPath,
+			Branch: headHash,
+			Depth:  -1,
+		}, repoURL)
+		require.NoError(t, err)
+
+		_, err = os.Stat(filepath.Join(targetPath, "README.md"))
+		require.NoError(t, err)
+	})
+
+	t.Run("clone with abbreviated commit SHA", func(t *testing.T) {
+		t.Parallel()
+		tempDir := helpers.TmpDirWOSymlinks(t)
+
+		c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+		require.NoError(t, err)
+
+		targetPath := filepath.Join(tempDir, "repo")
+		err = c.Clone(t.Context(), l, &cas.CloneOptions{
+			Dir:    targetPath,
+			Branch: headHash[:8],
+			Depth:  -1,
+		}, repoURL)
+		require.NoError(t, err)
+
+		_, err = os.Stat(filepath.Join(targetPath, "README.md"))
+		require.NoError(t, err)
+	})
+
+	t.Run("commit ref reuses central store on second clone", func(t *testing.T) {
+		t.Parallel()
+		tempDir := helpers.TmpDirWOSymlinks(t)
+		storePath := filepath.Join(tempDir, "store")
+
+		c, err := cas.New(cas.WithStorePath(storePath))
+		require.NoError(t, err)
+
+		// Prime the central git store.
+		require.NoError(t, c.Clone(t.Context(), l, &cas.CloneOptions{
+			Dir:    filepath.Join(tempDir, "first"),
+			Branch: headHash,
+			Depth:  -1,
+		}, repoURL))
+
+		// Drop the test server: a cached clone must not need it.
+		repoEntry := cas.EntryPathForURL(filepath.Join(storePath, "git"), repoURL)
+		_, err = os.Stat(filepath.Join(repoEntry, "repo"))
+		require.NoError(t, err)
+
+		secondClone := filepath.Join(tempDir, "second")
+		require.NoError(t, c.Clone(t.Context(), l, &cas.CloneOptions{
+			Dir:    secondClone,
+			Branch: headHash,
+			Depth:  -1,
+		}, repoURL))
+
+		_, err = os.Stat(filepath.Join(secondClone, "README.md"))
+		require.NoError(t, err)
+	})
+
+	t.Run("unresolvable ref reports no matching reference", func(t *testing.T) {
+		t.Parallel()
+		tempDir := helpers.TmpDirWOSymlinks(t)
+
+		c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+		require.NoError(t, err)
+
+		err = c.Clone(t.Context(), l, &cas.CloneOptions{
+			Dir:    filepath.Join(tempDir, "repo"),
+			Branch: "0000000000000000000000000000000000000000",
+			Depth:  -1,
+		}, repoURL)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, git.ErrNoMatchingReference)
+	})
+}
+
+func TestGitStoreEnsureCommit_CachedAfterFirstFetch(t *testing.T) {
+	t.Parallel()
+
+	url := startTestServer(t)
+	hash := resolveHead(t, url)
+
+	store, fs, _ := newTestGitStore(t)
+	l := logger.CreateLogger()
+	ctx := t.Context()
+
+	// First call must fetch.
+	repo, err := store.EnsureCommit(ctx, l, fs, url, hash)
+	require.NoError(t, err)
+	assert.Equal(t, hash, repo.Hash)
+	assert.NotEmpty(t, repo.Path)
+	require.NoError(t, repo.Unlock())
+
+	// Second call hits the local-cache short-circuit.
+	repo2, err := store.EnsureCommit(ctx, l, fs, url, hash)
+	require.NoError(t, err)
+	assert.Equal(t, hash, repo2.Hash)
+	require.NoError(t, repo2.Unlock())
+}
+
+func TestGitStoreEnsureCommit_AbbreviatedSHA(t *testing.T) {
+	t.Parallel()
+
+	url := startTestServer(t)
+	hash := resolveHead(t, url)
+
+	store, fs, _ := newTestGitStore(t)
+	l := logger.CreateLogger()
+
+	repo, err := store.EnsureCommit(t.Context(), l, fs, url, hash[:8])
+	require.NoError(t, err)
+	assert.Equal(t, hash, repo.Hash, "abbreviated SHA must canonicalize to the full hash")
+	require.NoError(t, repo.Unlock())
+}
+
+func TestGitStoreEnsureCommit_UnresolvableSurfacesNoMatchingReference(t *testing.T) {
+	t.Parallel()
+
+	url := startTestServer(t)
+
+	store, fs, _ := newTestGitStore(t)
+	l := logger.CreateLogger()
+
+	_, err := store.EnsureCommit(t.Context(), l, fs, url, "0000000000000000000000000000000000000000")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, git.ErrNoMatchingReference)
+}
+
+// TestCASClone_NonTipCommit pins the actual reason this feature
+// exists: cloning a commit that is not the tip of any branch. With
+// the previous --depth 1 path the fetch would have failed; the new
+// commit-fallback flow does a full-history fetch so older commits
+// remain reachable.
+func TestCASClone_NonTipCommit(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile("first.txt", []byte("first"), "first commit"))
+
+	firstHash, err := srv.Head()
+	require.NoError(t, err)
+
+	require.NoError(t, srv.CommitFile("second.txt", []byte("second"), "second commit"))
+	require.NoError(t, srv.CommitFile("third.txt", []byte("third"), "third commit"))
+
+	headHash, err := srv.Head()
+	require.NoError(t, err)
+	require.NotEqual(t, firstHash, headHash, "non-tip test requires HEAD to differ from target")
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+
+	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	require.NoError(t, err)
+
+	targetPath := filepath.Join(tempDir, "repo")
+	err = c.Clone(t.Context(), logger.CreateLogger(), &cas.CloneOptions{
+		Dir:    targetPath,
+		Branch: firstHash,
+		Depth:  -1,
+	}, repoURL)
+	require.NoError(t, err)
+
+	// Only the first commit's file should be present; later commits
+	// belong to descendants we did not check out.
+	_, err = os.Stat(filepath.Join(targetPath, "first.txt"))
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(targetPath, "second.txt"))
+	require.Error(t, err, "non-tip clone must not include later commits")
+}
+
+// TestCASClone_HexBranchNameResolvesViaLsRemote verifies that a
+// branch whose name happens to be 40 lowercase hex characters still
+// resolves through ls-remote rather than being treated as a commit
+// SHA. The branch is intentionally named with a hash that does not
+// match any commit so commit-fallback resolution would fail, leaving
+// ls-remote as the only path to success.
+func TestCASClone_HexBranchNameResolvesViaLsRemote(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile("README.md", []byte("# test"), "initial"))
+
+	const hexBranch = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	require.NoError(t, srv.Branch(hexBranch))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+
+	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	require.NoError(t, err)
+
+	targetPath := filepath.Join(tempDir, "repo")
+	err = c.Clone(t.Context(), logger.CreateLogger(), &cas.CloneOptions{
+		Dir:    targetPath,
+		Branch: hexBranch,
+		Depth:  -1,
+	}, repoURL)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(targetPath, "README.md"))
+	require.NoError(t, err)
+}
+
+// TestCASClone_TagRef pins that ls-remote-resolved tag refs continue
+// to work after the commit-fallback wiring landed.
+func TestCASClone_TagRef(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile("README.md", []byte("# tagged"), "initial"))
+	require.NoError(t, srv.Tag("v1.0.0"))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+
+	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	require.NoError(t, err)
+
+	targetPath := filepath.Join(tempDir, "repo")
+	err = c.Clone(t.Context(), logger.CreateLogger(), &cas.CloneOptions{
+		Dir:    targetPath,
+		Branch: "v1.0.0",
+		Depth:  -1,
+	}, repoURL)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(targetPath, "README.md"))
+	require.NoError(t, err)
+}
+
+// TestGitStoreEnsureCommit_OfflineWhenCached proves that once a
+// commit is cached in the central git store, EnsureCommit resolves it
+// without touching the network. We tear the server down between the
+// priming call and the cached call to make any accidental fetch
+// explicit.
+func TestGitStoreEnsureCommit_OfflineWhenCached(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile("README.md", []byte("# offline"), "initial"))
+
+	hash, err := srv.Head()
+	require.NoError(t, err)
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	store, fs, _ := newTestGitStore(t)
+	l := logger.CreateLogger()
+	ctx := t.Context()
+
+	primed, err := store.EnsureCommit(ctx, l, fs, repoURL, hash)
+	require.NoError(t, err)
+	require.NoError(t, primed.Unlock())
+
+	require.NoError(t, srv.Close())
+
+	cached, err := store.EnsureCommit(ctx, l, fs, repoURL, hash)
+	require.NoError(t, err, "cached commit must resolve without contacting the server")
+	assert.Equal(t, hash, cached.Hash)
+	require.NoError(t, cached.Unlock())
+}
+
+// TestCASClone_OfflineWhenCommitCached pins offline behavior for
+// previously-cached commit refs: once a SHA has been cloned, a
+// subsequent clone for the same SHA must succeed even when the
+// remote is unreachable. The test server is shut down between the
+// priming and the cached call so any ls-remote call would surface as
+// a clone failure.
+func TestCASClone_OfflineWhenCommitCached(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile("README.md", []byte("# offline cached"), "initial"))
+
+	hash, err := srv.Head()
+	require.NoError(t, err)
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+
+	require.NoError(t, c.Clone(t.Context(), l, &cas.CloneOptions{
+		Dir:    filepath.Join(tempDir, "primed"),
+		Branch: hash,
+		Depth:  -1,
+	}, repoURL))
+
+	require.NoError(t, srv.Close())
+
+	cachedDir := filepath.Join(tempDir, "cached")
+	require.NoError(t, c.Clone(t.Context(), l, &cas.CloneOptions{
+		Dir:    cachedDir,
+		Branch: hash,
+		Depth:  -1,
+	}, repoURL), "cached commit ref must resolve without contacting the server")
+
+	_, err = os.Stat(filepath.Join(cachedDir, "README.md"))
+	require.NoError(t, err)
+}
+
+// TestCASGetterGet_WithCommitRef exercises the full URL-parsing path
+// through CASGetter for a ref=<sha> query string.
+func TestCASGetterGet_WithCommitRef(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startTestServer(t)
+	headHash := resolveHead(t, repoURL)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	g := getter.NewCASGetter(logger.CreateLogger(), c, &cas.CloneOptions{Depth: -1})
+	client := getter.Client{Getters: []getter.Getter{g}}
+
+	dst := filepath.Join(tempDir, "repo")
+
+	res, err := client.Get(t.Context(), &getter.Request{
+		Src: "git::" + repoURL + "?ref=" + headHash,
+		Dst: dst,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, dst, res.Dst)
+
+	_, err = os.Stat(filepath.Join(dst, "README.md"))
+	require.NoError(t, err)
+}
+
+// TestCAS_CommitRefFallbackWhenGitStoreFails mirrors
+// TestCAS_FallbackWhenGitStoreFails for the commit-fallback path: if
+// the central git store cannot create its per-URL directory, the
+// commit-ref clone falls back to a temporary bare clone (no --depth)
+// and resolves the SHA there.
+func TestCAS_CommitRefFallbackWhenGitStoreFails(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startTestServer(t)
+	headHash := resolveHead(t, repoURL)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	gitStoreRoot := filepath.Join(storePath, "git")
+	require.NoError(t, os.MkdirAll(gitStoreRoot, 0o755))
+
+	blocker := cas.EntryPathForURL(gitStoreRoot, repoURL)
+	require.NoError(t, os.WriteFile(blocker, []byte("not a directory"), 0o644))
+
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	targetPath := filepath.Join(tempDir, "repo")
+	err = c.Clone(t.Context(), logger.CreateLogger(), &cas.CloneOptions{
+		Dir:    targetPath,
+		Branch: headHash,
+		Depth:  -1,
+	}, repoURL)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(targetPath, "README.md"))
+	require.NoError(t, err)
+
+	info, err := os.Stat(blocker)
+	require.NoError(t, err)
+	assert.False(t, info.IsDir(), "fallback must not have replaced the blocking file")
+}
+
+func TestCASCloneByCommitRefConcurrentWithRacing(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	repoURL := startTestServer(t)
+	headHash := resolveHead(t, repoURL)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	const workers = 4
+
+	var wg sync.WaitGroup
+
+	errs := make([]error, workers)
+
+	for i := range workers {
+		wg.Add(1)
+
+		go func(idx int) {
+			defer wg.Done()
+
+			errs[idx] = c.Clone(t.Context(), l, &cas.CloneOptions{
+				Dir:    filepath.Join(tempDir, "repo", "worker", string(rune('a'+idx))),
+				Branch: headHash,
+				Depth:  -1,
+			}, repoURL)
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, e := range errs {
+		require.NoErrorf(t, e, "worker %d", i)
+	}
+}

--- a/internal/cas/gitstore.go
+++ b/internal/cas/gitstore.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
@@ -38,9 +39,46 @@ type GitStore struct {
 	rootPath string
 }
 
-// NewGitStore returns a GitStore rooted at rootPath, creating the directory
+// GitStoreRepo is a locked handle to a per-URL bare repository. The
+// caller has exclusive access to the underlying repo until [GitStoreRepo.Unlock]
+// is called; failing to release the lock blocks subsequent fetches
+// against the same URL.
+type GitStoreRepo struct {
+	unlocker vfs.Unlocker
+
+	// url records the URL acquire was called with so Release can
+	// include it in unlock-failure log messages without callers
+	// re-threading it.
+	url string
+
+	// Path is the bare repository path, suitable for
+	// [git.GitRunner.WithWorkDir].
+	Path string
+
+	// Hash is the canonical commit hash resolved by [GitStore.EnsureCommit].
+	// Empty for repos returned by [GitStore.EnsureRef], where the caller
+	// already knows the hash.
+	Hash string
+}
+
+// Unlock releases the per-URL flock held by this repo handle and
+// returns any unlock error to the caller.
+func (r *GitStoreRepo) Unlock() error {
+	return r.unlocker.Unlock()
+}
+
+// Release unlocks the repo handle, logging unlock failures against the
+// originating URL. Intended for `defer repo.Release(l)`; callers that
+// need the unlock error directly should call [GitStoreRepo.Unlock] instead.
+func (r *GitStoreRepo) Release(l log.Logger) {
+	if err := r.unlocker.Unlock(); err != nil {
+		l.Warnf("git store: failed to release lock for %s: %v", r.url, err)
+	}
+}
+
+// NewGitStore returns a [GitStore] rooted at rootPath, creating the directory
 // on fs if needed. The filesystem is not retained; callers pass one explicitly
-// to EnsureRef.
+// to [GitStore.EnsureRef] and [GitStore.EnsureCommit].
 //
 // The git store shells out to `git`, which only sees the real disk. Callers
 // must pass an OS-backed [vfs.FS] from [vfs.NewOSFS]; an in-memory backing
@@ -60,73 +98,33 @@ func NewGitStore(fs vfs.FS, runner *git.GitRunner, rootPath string) (*GitStore, 
 	}, nil
 }
 
-// EnsureRef ensures the bare repository for url contains the object at hash,
-// fetching ref at the requested depth if it does not.
+// EnsureRef ensures the bare repository for url contains the object at
+// hash, fetching ref at the requested depth if it does not.
 //
-// On success it returns the bare repository path (suitable for
-// git.GitRunner.WithWorkDir) and an Unlocker the caller must release once
-// done reading objects. Failing to release the lock blocks subsequent
-// fetches against the same URL.
+// On success the returned repo's Path is suitable for
+// [git.GitRunner.WithWorkDir], and the caller must release the embedded
+// flock with [GitStoreRepo.Unlock] (or [GitStoreRepo.Release]) once done
+// reading objects.
 //
-// On failure the lock is released before returning so callers can take a
-// different code path without managing the lock themselves.
+// On failure the lock is released before returning so callers can take
+// a different code path without managing the lock themselves.
 func (s *GitStore) EnsureRef(
 	ctx context.Context,
 	l log.Logger,
 	fs vfs.FS,
 	url, ref, hash string,
 	depth int,
-) (string, vfs.Unlocker, error) {
-	if !vfs.IsOSFS(fs) {
-		return "", nil, ErrGitStoreFSNotOS
-	}
-
-	dir, repoPath, lockPath := s.repoPaths(url)
-
-	if err := fs.MkdirAll(dir, DefaultDirPerms); err != nil {
-		return "", nil, fmt.Errorf("create git store entry %s: %w", dir, errors.Join(ErrGitStorePath, err))
-	}
-
-	lockCtx, cancel := context.WithTimeout(ctx, gitStoreLockTimeout)
-	defer cancel()
-
-	unlocker, err := vfs.LockContext(lockCtx, fs, lockPath)
+) (*GitStoreRepo, error) {
+	session, err := s.acquire(ctx, fs, l, url)
 	if err != nil {
-		return "", nil, fmt.Errorf("lock git store for %s: %w", url, errors.Join(ErrGitStoreLock, err))
+		return nil, err
 	}
 
-	released := false
+	defer session.cleanup()
 
-	defer func() {
-		if released {
-			return
-		}
-
-		if unlockErr := unlocker.Unlock(); unlockErr != nil {
-			l.Warnf("git store: failed to release lock for %s: %v", url, unlockErr)
-		}
-	}()
-
-	if err := fs.MkdirAll(repoPath, DefaultDirPerms); err != nil {
-		return "", nil, fmt.Errorf("create bare repo dir %s: %w", repoPath, errors.Join(ErrGitStorePath, err))
-	}
-
-	runner := s.runner.WithWorkDir(repoPath)
-
-	initialized, err := bareRepoInitialized(fs, repoPath)
+	has, err := session.runner.HasObject(ctx, hash)
 	if err != nil {
-		return "", nil, fmt.Errorf("inspect bare repo %s: %w", repoPath, errors.Join(ErrGitStorePath, err))
-	}
-
-	if !initialized {
-		if err := runner.InitBare(ctx); err != nil {
-			return "", nil, err
-		}
-	}
-
-	has, err := runner.HasObject(ctx, hash)
-	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
 	if !has {
@@ -135,23 +133,133 @@ func (s *GitStore) EnsureRef(
 			fetchRef = "HEAD"
 		}
 
-		if err := runner.Fetch(ctx, url, fetchRef, depth); err != nil {
-			return "", nil, err
+		if err := session.runner.Fetch(ctx, url, fetchRef, depth); err != nil {
+			return nil, err
 		}
 
-		has, err = runner.HasObject(ctx, hash)
+		has, err = session.runner.HasObject(ctx, hash)
 		if err != nil {
-			return "", nil, err
+			return nil, err
 		}
 
 		if !has {
-			return "", nil, &GitStoreObjectMissingError{Hash: hash, Ref: fetchRef, URL: url}
+			return nil, &GitStoreObjectMissingError{Hash: hash, Ref: fetchRef, URL: url}
 		}
 	}
 
-	released = true
+	return session.keep(), nil
+}
 
-	return repoPath, unlocker, nil
+// EnsureCommit ensures the bare repository for url contains a commit
+// reachable from rawRef and returns its canonical full hash via
+// [GitStoreRepo.Hash].
+//
+// rawRef may be a full SHA-1 (40 hex chars), full SHA-256 (64 hex
+// chars), or an abbreviated SHA that disambiguates inside the repo.
+// Resolution runs `git rev-parse <ref>^{commit}` against the per-URL
+// bare repository, so any form git accepts works.
+//
+// Behavior:
+//
+//  1. If the commit is already cached in the bare repo, no network
+//     call is made.
+//  2. Otherwise the bare repo is updated with a full-history fetch of
+//     every branch (no `--depth`). Fetching by raw SHA is avoided
+//     because it requires `uploadpack.allowAnySHA1InWant`, which is
+//     not universally enabled on git servers.
+//  3. If rev-parse still cannot resolve rawRef after the fetch, a
+//     [git.WrappedError] wrapping [git.ErrNoMatchingReference] is
+//     returned so callers can use [errors.Is] for the same condition
+//     `git ls-remote` surfaces for symbolic refs.
+//
+// On success the caller must release the lock via [GitStoreRepo.Unlock]
+// or [GitStoreRepo.Release], matching the contract of [GitStore.EnsureRef].
+func (s *GitStore) EnsureCommit(
+	ctx context.Context,
+	l log.Logger,
+	fs vfs.FS,
+	url, rawRef string,
+) (*GitStoreRepo, error) {
+	session, err := s.acquire(ctx, fs, l, url)
+	if err != nil {
+		return nil, err
+	}
+
+	defer session.cleanup()
+
+	hash, err := session.runner.RevParseCommit(ctx, rawRef)
+	if err == nil {
+		session.repo.Hash = hash
+		return session.keep(), nil
+	}
+
+	if !errors.Is(err, git.ErrUnknownRevision) {
+		return nil, err
+	}
+
+	if err := session.runner.Fetch(ctx, url, "+refs/heads/*:refs/heads/*", 0); err != nil {
+		return nil, err
+	}
+
+	hash, err = session.runner.RevParseCommit(ctx, rawRef)
+	if err != nil {
+		if errors.Is(err, git.ErrUnknownRevision) {
+			return nil, &git.WrappedError{
+				Op:      "git_store_resolve",
+				Context: fmt.Sprintf("%q in %s", rawRef, url),
+				Err:     git.ErrNoMatchingReference,
+			}
+		}
+
+		return nil, err
+	}
+
+	session.repo.Hash = hash
+
+	return session.keep(), nil
+}
+
+// ProbeCachedCommit returns the canonical commit hash if rawRef
+// resolves to a commit already stored in the per-URL bare repository
+// for url and rawRef is a prefix of that hash. Returns ok=false in
+// any other case (no bare repo yet, unresolvable ref, or a name that
+// resolved through ref lookup such as a hex-named branch whose tip
+// is a different commit).
+//
+// Panics if fs is not OS-backed. git only sees the real disk, so a
+// non-OS backing cannot satisfy the probe.
+//
+// The probe is lock-free on purpose. The per-URL flock serializes
+// fetches so concurrent pack-file writes do not interleave, but
+// rev-parse only reads pack indices and refs, both of which git
+// updates atomically. Acquiring the flock for a read would queue the
+// probe behind any in-flight fetch and erase the offline win.
+func (s *GitStore) ProbeCachedCommit(ctx context.Context, fs vfs.FS, url, rawRef string) (string, bool) {
+	if !vfs.IsOSFS(fs) {
+		panic(ErrGitStoreFSNotOS)
+	}
+
+	_, repoPath, _ := s.repoPaths(url)
+
+	initialized, err := bareRepoInitialized(fs, repoPath)
+	if err != nil || !initialized {
+		return "", false
+	}
+
+	hash, err := s.runner.WithWorkDir(repoPath).RevParseCommit(ctx, rawRef)
+	if err != nil {
+		return "", false
+	}
+
+	// rev-parse falls back to ref lookup when the input is not an
+	// object hash, so a hex-named branch resolves to its tip. Without
+	// this prefix check the probe would mistake those branches for
+	// cached commits and serve stale data when the branch has moved.
+	if !strings.HasPrefix(strings.ToLower(hash), strings.ToLower(rawRef)) {
+		return "", false
+	}
+
+	return hash, true
 }
 
 // RootPath returns the directory that contains all per-URL bare repositories.
@@ -178,8 +286,91 @@ func (s *GitStore) repoPaths(url string) (dir, repo, lockPath string) {
 
 // bareRepoInitialized reports whether repoPath already holds a bare git
 // repository. Checking for HEAD is enough: `git init --bare` writes it as
-// part of repository setup, so its presence lets EnsureRef skip the
+// part of repository setup, so its presence lets acquire skip the
 // per-call init spawn once a store entry exists.
 func bareRepoInitialized(fs vfs.FS, repoPath string) (bool, error) {
 	return vfs.FileExists(fs, filepath.Join(repoPath, "HEAD"))
+}
+
+// repoSession bundles everything a [GitStore.acquire] caller needs
+// to operate on a per-URL bare repository: the [GitStoreRepo] handle
+// (the locked thing), a runner pointed at it, and a deferred-cleanup
+// helper. Callers defer cleanup(); keep() promotes the handle so the
+// lock survives until the caller releases it explicitly.
+type repoSession struct {
+	l      log.Logger
+	repo   *GitStoreRepo
+	runner *git.GitRunner
+	kept   bool
+}
+
+// keep promotes the session's repo handle to the caller. After keep
+// the deferred cleanup is a no-op and the caller owns the lock until
+// it invokes [GitStoreRepo.Unlock] or [GitStoreRepo.Release].
+func (s *repoSession) keep() *GitStoreRepo {
+	s.kept = true
+	return s.repo
+}
+
+// cleanup releases the lock unless keep was called. Intended for
+// `defer session.cleanup()`.
+func (s *repoSession) cleanup() {
+	if s.kept {
+		return
+	}
+
+	s.repo.Release(s.l)
+}
+
+// acquire claims the per-URL flock for url, prepares the bare-repo
+// directory, and returns a [repoSession] carrying the locked handle
+// and a runner pointed at it. The caller defers session.cleanup();
+// session.keep() promotes the handle so the lock survives.
+//
+// `git init --bare` is invoked only on first use of a store entry;
+// subsequent calls detect the existing HEAD and skip the spawn.
+func (s *GitStore) acquire(ctx context.Context, fs vfs.FS, l log.Logger, url string) (*repoSession, error) {
+	if !vfs.IsOSFS(fs) {
+		return nil, ErrGitStoreFSNotOS
+	}
+
+	dir, repoPath, lockPath := s.repoPaths(url)
+
+	if err := fs.MkdirAll(dir, DefaultDirPerms); err != nil {
+		return nil, fmt.Errorf("create git store entry %s: %w", dir, errors.Join(ErrGitStorePath, err))
+	}
+
+	lockCtx, cancel := context.WithTimeout(ctx, gitStoreLockTimeout)
+	defer cancel()
+
+	unlocker, err := vfs.LockContext(lockCtx, fs, lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("lock git store for %s: %w", url, errors.Join(ErrGitStoreLock, err))
+	}
+
+	session := &repoSession{
+		l:      l,
+		repo:   &GitStoreRepo{unlocker: unlocker, url: url, Path: repoPath},
+		runner: s.runner.WithWorkDir(repoPath),
+	}
+
+	if err := fs.MkdirAll(repoPath, DefaultDirPerms); err != nil {
+		session.cleanup()
+		return nil, fmt.Errorf("create bare repo dir %s: %w", repoPath, errors.Join(ErrGitStorePath, err))
+	}
+
+	initialized, err := bareRepoInitialized(fs, repoPath)
+	if err != nil {
+		session.cleanup()
+		return nil, fmt.Errorf("inspect bare repo %s: %w", repoPath, errors.Join(ErrGitStorePath, err))
+	}
+
+	if !initialized {
+		if err := session.runner.InitBare(ctx); err != nil {
+			session.cleanup()
+			return nil, err
+		}
+	}
+
+	return session, nil
 }

--- a/internal/cas/gitstore.go
+++ b/internal/cas/gitstore.go
@@ -159,6 +159,12 @@ func (s *GitStore) EnsureRef(
 // Resolution runs `git rev-parse <ref>^{commit}` against the per-URL
 // bare repository, so any form git accepts works.
 //
+// If knownHash is non-empty, it is taken as the canonical hash of
+// rawRef (typically from a prior [GitStore.ProbeCachedCommit] call).
+// Presence is verified via [git.GitRunner.HasObject] and rev-parse
+// is skipped on the cache-hit path. Pass "" to canonicalize via
+// rev-parse.
+//
 // Behavior:
 //
 //  1. If the commit is already cached in the bare repo, no network
@@ -178,7 +184,7 @@ func (s *GitStore) EnsureCommit(
 	ctx context.Context,
 	l log.Logger,
 	fs vfs.FS,
-	url, rawRef string,
+	url, rawRef, knownHash string,
 ) (*GitStoreRepo, error) {
 	session, err := s.acquire(ctx, fs, l, url)
 	if err != nil {
@@ -186,6 +192,10 @@ func (s *GitStore) EnsureCommit(
 	}
 
 	defer session.cleanup()
+
+	if knownHash != "" {
+		return s.ensureKnownCommit(ctx, session, url, rawRef, knownHash)
+	}
 
 	hash, err := session.runner.RevParseCommit(ctx, rawRef)
 	if err == nil {
@@ -215,6 +225,49 @@ func (s *GitStore) EnsureCommit(
 	}
 
 	session.repo.Hash = hash
+
+	return session.keep(), nil
+}
+
+// ensureKnownCommit handles the [GitStore.EnsureCommit] cache-hit path
+// when the caller has already canonicalized rawRef via
+// [GitStore.ProbeCachedCommit]. Presence of knownHash is verified
+// with [git.GitRunner.HasObject], skipping the rev-parse spawn. On
+// miss (e.g. a peer ran git-gc between the lock-free probe and the
+// locked verify) a full-history fetch runs and presence is rechecked.
+func (s *GitStore) ensureKnownCommit(
+	ctx context.Context,
+	session *repoSession,
+	url, rawRef, knownHash string,
+) (*GitStoreRepo, error) {
+	has, err := session.runner.HasObject(ctx, knownHash)
+	if err != nil {
+		return nil, err
+	}
+
+	if has {
+		session.repo.Hash = knownHash
+		return session.keep(), nil
+	}
+
+	if err := session.runner.Fetch(ctx, url, "+refs/heads/*:refs/heads/*", 0); err != nil {
+		return nil, err
+	}
+
+	has, err = session.runner.HasObject(ctx, knownHash)
+	if err != nil {
+		return nil, err
+	}
+
+	if !has {
+		return nil, &git.WrappedError{
+			Op:      "git_store_resolve",
+			Context: fmt.Sprintf("%q in %s", rawRef, url),
+			Err:     git.ErrNoMatchingReference,
+		}
+	}
+
+	session.repo.Hash = knownHash
 
 	return session.keep(), nil
 }

--- a/internal/cas/gitstore_test.go
+++ b/internal/cas/gitstore_test.go
@@ -29,20 +29,20 @@ func TestGitStoreEnsureRef_InitsAndFetches(t *testing.T) {
 	l := logger.CreateLogger()
 	ctx := t.Context()
 
-	repoPath, unlock, err := store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
+	repo, err := store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
 	require.NoError(t, err)
 
-	assert.True(t, strings.HasPrefix(repoPath, root), "repo path %q should be under store root %q", repoPath, root)
+	assert.True(t, strings.HasPrefix(repo.Path, root), "repo path %q should be under store root %q", repo.Path, root)
 
-	_, err = fs.Stat(filepath.Join(repoPath, "HEAD"))
+	_, err = fs.Stat(filepath.Join(repo.Path, "HEAD"))
 	require.NoError(t, err)
 
-	require.NoError(t, unlock.Unlock())
+	require.NoError(t, repo.Unlock())
 
 	// Second call hits the cache-warm path: object already present, no fetch.
-	_, unlock2, err := store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
+	repo2, err := store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
 	require.NoError(t, err)
-	require.NoError(t, unlock2.Unlock())
+	require.NoError(t, repo2.Unlock())
 }
 
 func TestGitStoreEnsureRef_PartitionsByURL(t *testing.T) {
@@ -60,15 +60,15 @@ func TestGitStoreEnsureRef_PartitionsByURL(t *testing.T) {
 	hash1 := resolveHead(t, url1)
 	hash2 := resolveHead(t, url2)
 
-	r1, u1, err := store.EnsureRef(ctx, l, fs, url1, "main", hash1, 0)
+	e1, err := store.EnsureRef(ctx, l, fs, url1, "main", hash1, 0)
 	require.NoError(t, err)
-	require.NoError(t, u1.Unlock())
+	require.NoError(t, e1.Unlock())
 
-	r2, u2, err := store.EnsureRef(ctx, l, fs, url2, "main", hash2, 0)
+	e2, err := store.EnsureRef(ctx, l, fs, url2, "main", hash2, 0)
 	require.NoError(t, err)
-	require.NoError(t, u2.Unlock())
+	require.NoError(t, e2.Unlock())
 
-	assert.NotEqual(t, r1, r2, "different URLs must map to different bare repos")
+	assert.NotEqual(t, e1.Path, e2.Path, "different URLs must map to different bare repos")
 }
 
 func TestGitStoreEnsureRefConcurrentSameURLWithRacing(t *testing.T) {
@@ -94,13 +94,13 @@ func TestGitStoreEnsureRefConcurrentSameURLWithRacing(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 
-			_, unlock, err := store.EnsureRef(t.Context(), l, fs, url, "main", hash, 0)
+			repo, err := store.EnsureRef(t.Context(), l, fs, url, "main", hash, 0)
 			if err != nil {
 				errs[idx] = err
 				return
 			}
 
-			errs[idx] = unlock.Unlock()
+			errs[idx] = repo.Unlock()
 		}(i)
 	}
 
@@ -123,10 +123,10 @@ func TestGitStoreEnsureRef_LockHeldRespectsContextCancellation(t *testing.T) {
 	l := logger.CreateLogger()
 
 	// First caller takes the per-URL lock and holds it.
-	repoPath, unlock, err := store.EnsureRef(t.Context(), l, fs, url, "main", hash, 0)
+	repo, err := store.EnsureRef(t.Context(), l, fs, url, "main", hash, 0)
 	require.NoError(t, err)
-	require.NotEmpty(t, repoPath)
-	t.Cleanup(func() { _ = unlock.Unlock() })
+	require.NotEmpty(t, repo.Path)
+	t.Cleanup(func() { _ = repo.Unlock() })
 
 	// Second caller arrives with a short deadline. With the lock held it
 	// must return a context error rather than block.
@@ -135,7 +135,7 @@ func TestGitStoreEnsureRef_LockHeldRespectsContextCancellation(t *testing.T) {
 
 	start := time.Now()
 
-	_, _, err = store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
+	_, err = store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
 	require.Error(t, err)
 	assert.Less(t, time.Since(start), 5*time.Second, "EnsureRef should not block past the context deadline")
 	assert.True(
@@ -156,22 +156,22 @@ func TestGitStoreEnsureRefLockReleaseAllowsWaiterToProceedWithRacing(t *testing.
 
 	l := logger.CreateLogger()
 
-	_, unlock, err := store.EnsureRef(t.Context(), l, fs, url, "main", hash, 0)
+	repo, err := store.EnsureRef(t.Context(), l, fs, url, "main", hash, 0)
 	require.NoError(t, err)
 
 	// Release the holder after a short delay so the waiter sees the lock open.
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 
-		_ = unlock.Unlock()
+		_ = repo.Unlock()
 	}()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
-	_, unlock2, err := store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
+	repo2, err := store.EnsureRef(ctx, l, fs, url, "main", hash, 0)
 	require.NoError(t, err)
-	require.NoError(t, unlock2.Unlock())
+	require.NoError(t, repo2.Unlock())
 }
 
 func TestGitStoreEnsureRef_FetchFailureSurfacesError(t *testing.T) {
@@ -182,7 +182,7 @@ func TestGitStoreEnsureRef_FetchFailureSurfacesError(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	_, _, err := store.EnsureRef(t.Context(), l, fs, "file:///does/not/exist", "main", "deadbeef", 0)
+	_, err := store.EnsureRef(t.Context(), l, fs, "file:///does/not/exist", "main", "deadbeef", 0)
 	require.Error(t, err)
 }
 
@@ -200,7 +200,7 @@ func TestGitStoreRejectsNonOSFilesystem(t *testing.T) {
 	store, err := cas.NewGitStore(vfs.NewOSFS(), runner, root)
 	require.NoError(t, err)
 
-	_, _, err = store.EnsureRef(
+	_, err = store.EnsureRef(
 		t.Context(), logger.CreateLogger(), vfs.NewMemMapFS(),
 		"file:///does/not/exist", "main", "deadbeef", 0,
 	)

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -95,11 +95,18 @@ func (c *CAS) ProcessStackComponent(ctx context.Context, l log.Logger, source, k
 
 	cleanURL := strings.TrimPrefix(parsedURL.String(), "git::")
 
-	// Resolve ref to commit hash
-	refHash, err := c.resolveReference(ctx, cleanURL, ref)
+	// Stack processing derives deterministic CAS keys from refHash, so
+	// abbreviated SHAs would produce keys that depend on the input
+	// shape. Full SHAs are the supported form for commit refs in
+	// stacks; CommitHash returns the user input as-is for the
+	// commit-ref path, and the canonical hash for the symbolic-ref
+	// path.
+	resolved, err := c.resolveReference(ctx, cleanURL, ref)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve reference %q: %w", ref, err)
 	}
+
+	refHash := resolved.CommitHash()
 
 	// Create temp dir for the clone
 	tempDir, err := os.MkdirTemp("", "terragrunt-cas-stack-*")

--- a/internal/cas/testserver_test.go
+++ b/internal/cas/testserver_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newEmptyTestServer creates a Server that the caller can populate
+// before starting. The returned cleanup is registered on the test, so
+// the caller only needs to invoke Start. Useful for tests that need
+// access to commit hashes, tags, or want to shut the server down
+// mid-test to verify offline behavior.
+func newEmptyTestServer(t *testing.T) *git.Server {
+	t.Helper()
+
+	srv, err := git.NewServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	return srv
+}
+
 // startTestServer creates a local Git server with a few test files and
 // returns its URL. The server is shut down when the test completes.
 func startTestServer(t *testing.T) string {

--- a/internal/git/errors.go
+++ b/internal/git/errors.go
@@ -57,4 +57,5 @@ var (
 	ErrReadTree            = errors.New("failed to read tree")
 	ErrNoWorkDir           = errors.New("working directory not set")
 	ErrNoGoRepo            = errors.New("go repository not set")
+	ErrUnknownRevision     = errors.New("unknown revision")
 )

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -366,6 +366,46 @@ func (g *GitRunner) Fetch(ctx context.Context, repo, ref string, depth int) erro
 	return nil
 }
 
+// RevParseCommit resolves ref to its canonical commit hash in the
+// configured working-directory repository. ref may be a full SHA
+// (SHA-1 or SHA-256) or an abbreviated SHA that disambiguates inside
+// the repo. The `^{commit}` peeling suffix is what enforces that the
+// object actually exists locally and is a commit; plain rev-parse
+// (even with --verify) only checks revision syntax and would let a
+// caller treat an empty bare repo as already containing the commit.
+// A non-zero exit returns [ErrUnknownRevision] so callers can branch
+// on the typed error without parsing stderr.
+func (g *GitRunner) RevParseCommit(ctx context.Context, ref string) (string, error) {
+	if err := g.RequiresWorkDir(); err != nil {
+		return "", err
+	}
+
+	cmd := g.prepareCommand(ctx, "rev-parse", "--verify", ref+"^{commit}")
+
+	var stdout, stderr bytes.Buffer
+
+	cmd.SetStdout(&stdout)
+	cmd.SetStderr(&stderr)
+
+	if err := cmd.Run(); err != nil {
+		if vexec.ExitCode(err) > 0 {
+			return "", &WrappedError{
+				Op:      "git_rev_parse",
+				Context: strings.TrimSpace(stderr.String()),
+				Err:     ErrUnknownRevision,
+			}
+		}
+
+		return "", &WrappedError{
+			Op:      "git_rev_parse",
+			Context: stderr.String(),
+			Err:     errors.Join(ErrCommandSpawn, err),
+		}
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
 // HasObject reports whether the given object exists in the configured
 // working-directory repository. Exit code 1 from `git cat-file -e` means
 // the object is absent. Other non-zero exits (e.g. 128 for a corrupted

--- a/internal/git/server.go
+++ b/internal/git/server.go
@@ -94,6 +94,52 @@ func (s *Server) CommitFile(path string, data []byte, msg string) error {
 	return nil
 }
 
+// Head returns the canonical hash of the current HEAD commit. Useful
+// in tests that need to capture a non-tip commit hash before adding
+// further commits.
+func (s *Server) Head() (string, error) {
+	ref, err := s.repo.Head()
+	if err != nil {
+		return "", fmt.Errorf("resolve HEAD: %w", err)
+	}
+
+	return ref.Hash().String(), nil
+}
+
+// Tag creates an annotated tag at the current HEAD with the given name.
+func (s *Server) Tag(name string) error {
+	ref, err := s.repo.Head()
+	if err != nil {
+		return fmt.Errorf("resolve HEAD: %w", err)
+	}
+
+	sig := &object.Signature{Name: "Test", Email: "test@test.com", When: time.Now()}
+
+	if _, err := s.repo.CreateTag(name, ref.Hash(), &gogit.CreateTagOptions{
+		Tagger:  sig,
+		Message: name,
+	}); err != nil {
+		return fmt.Errorf("create tag %s: %w", name, err)
+	}
+
+	return nil
+}
+
+// Branch creates a branch at the current HEAD with the given name.
+func (s *Server) Branch(name string) error {
+	ref, err := s.repo.Head()
+	if err != nil {
+		return fmt.Errorf("resolve HEAD: %w", err)
+	}
+
+	branchRef := plumbing.NewHashReference(plumbing.NewBranchReferenceName(name), ref.Hash())
+	if err := s.repo.Storer.SetReference(branchRef); err != nil {
+		return fmt.Errorf("set branch %s: %w", name, err)
+	}
+
+	return nil
+}
+
 // Start begins serving Git HTTP on a random local port.
 // Returns the base URL (e.g. "http://127.0.0.1:12345").
 func (s *Server) Start(ctx context.Context) (string, error) {

--- a/test/fixtures/download/remote-commit-ref/terragrunt.hcl
+++ b/test/fixtures/download/remote-commit-ref/terragrunt.hcl
@@ -1,0 +1,10 @@
+inputs = {
+  name = "World"
+}
+
+terraform {
+  # Pinned to the commit v0.93.2 resolves to so this fixture exercises
+  # the commit-SHA path in the CAS getter without depending on whatever
+  # the tag points to in the future.
+  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=dd7913e04f0e812b51ccf2c4f35a0fda16a356a1"
+}

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -3,6 +3,7 @@ package test_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -954,4 +955,27 @@ func TestDownloadWithCASEnabled(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, stderr.String(), "Downloading Terraform configurations")
+}
+
+func TestDownloadWithCASCommitRef(t *testing.T) {
+	t.Parallel()
+
+	fixturePath := "fixtures/download/remote-commit-ref"
+
+	tmpEnvPath := helpers.CopyEnvironment(t, fixturePath)
+	testPath := filepath.Join(tmpEnvPath, fixturePath)
+	helpers.CleanupTerraformFolder(t, testPath)
+
+	applyCmd := "terragrunt apply --auto-approve --non-interactive --experiment cas --working-dir " + testPath
+	require.NoError(t, helpers.RunTerragruntCommand(t, applyCmd, io.Discard, io.Discard))
+
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+	)
+
+	outputCmd := "terragrunt output -raw test --non-interactive --experiment cas --working-dir " + testPath
+	require.NoError(t, helpers.RunTerragruntCommand(t, outputCmd, &stdout, &stderr))
+
+	assert.Equal(t, "Hello, World", stdout.String())
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Right now, the CAS only supports branch/tag refs. This updates the implementation to also support commit refs.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CAS now accepts commit SHAs (full or abbreviated) in addition to branch/tag names for Git sources.

* **Documentation**
  * Added clarification on how Terragrunt handles commit SHA references in CAS, including cold and warm clone behavior.
  * Updated changelog documentation for commit SHA resolution and caching behavior.

* **Tests**
  * Added comprehensive test coverage for commit reference cloning, caching, and offline behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6010)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->