### PR TITLE
feat: Adding `mutable` attribute for clones to force copy instead of hard links

### DIFF
--- a/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
@@ -412,6 +412,20 @@ When `update_source_with_cas = true` is set:
 
 Consumers do not set `update_source_with_cas` themselves. When the `cas` experiment is enabled and the source is remote, Terragrunt uses the CAS path automatically. The attribute only has effect inside catalog files, where it flags nested `source` attributes for rewriting.
 
+<Before version="1.0.5">
+
+<Aside type="tip">
+A `mutable` attribute that opts a `unit` or `stack` block out of CAS hardlinking is coming in v1.0.5.
+</Aside>
+
+</Before>
+
+<Since version="1.0.5">
+
+`unit` and `stack` blocks also accept a `mutable` attribute. When `mutable = true`, the unit's or stack's content under `.terragrunt-stack` is copied from the CAS store and the working tree is editable. The default is `false`: files are materialized read-only so an accidental edit cannot reach back into the shared CAS store.
+
+</Since>
+
 Given the catalog files above, and an ordinary consumer stack like:
 
 ```hcl

--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -8,6 +8,8 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside } from '@astrojs/starlight/components';
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Terragrunt HCL configuration uses [configuration blocks](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#blocks) when there's a structural configuration that needs to be defined for Terragrunt.
 
@@ -110,6 +112,25 @@ The `terraform` block supports the following arguments:
 - `error_hook` (block): Nested blocks used to specify command hooks that run when an error is thrown. The
   error must match one of the expressions listed in the `on_errors` attribute. Error hooks are executed after the before/after hooks.
   To handle errors during source download (when using the `source` attribute), use `init-from-module` in the `commands` list.
+
+<Before version="1.0.5">
+
+<Aside type="tip">
+A `mutable` attribute that opts a `terraform` block out of CAS hardlinking is coming in v1.0.5.
+</Aside>
+
+</Before>
+
+<Since version="1.0.5">
+
+- `mutable` (attribute): When `true`, content fetched into `.terragrunt-cache` through the
+  [content-addressable storage (CAS)](/features/caching/cas) is copied from the CAS store and the
+  working tree under `.terragrunt-cache` is editable. The default is `false`: files are
+  materialized read-only so an accidental edit cannot reach back into the shared CAS store. The
+  flag has no effect when CAS is not used to fetch the source; the standard download path already
+  produces an independent, writable copy.
+
+</Since>
 
 In addition to supporting before and after hooks for all OpenTofu/Terraform commands, the following specialized hooks are also
 supported:

--- a/docs/src/data/changelog/v1.0.5/cas-mutable-sources.mdx
+++ b/docs/src/data/changelog/v1.0.5/cas-mutable-sources.mdx
@@ -1,0 +1,19 @@
+---
+version: "v1.0.5"
+category: "experiments-updated"
+---
+
+#### `cas` — `mutable` attribute on `terraform`, `unit`, and `stack` blocks
+
+A new `mutable` attribute opts a block out of CAS hardlinking when its source is fetched through CAS. With `mutable = true`, files materialized into `.terragrunt-cache` (for `terraform`) or `.terragrunt-stack` (for `unit` and `stack`) are copied from the CAS store and the working tree is editable.
+
+The default is `false`. Files are materialized read-only so an accidental edit cannot reach back into the shared CAS store.
+
+```hcl
+terraform {
+  source  = "git::https://github.com/acme/infrastructure-modules.git//vpc?ref=v1.0.0"
+  mutable = true
+}
+```
+
+The flag is orthogonal to `update_source_with_cas` and has no effect when content is fetched through the standard download path, which already produces an independent copy.

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -47,6 +48,11 @@ type CloneOptions struct {
 	// If zero, CAS falls back to its configured clone depth (default shallow depth 1).
 	// Set to -1 for full history (Terragrunt omits --depth; git rejects --depth 0).
 	Depth int
+
+	// Mutable, when true, copies blobs into the target directory instead of
+	// hardlinking them from the CAS store. The destination tree becomes safe
+	// to mutate without corrupting the shared store.
+	Mutable bool
 }
 
 // CAS clones a git repository using content-addressable storage.
@@ -198,7 +204,12 @@ func (c *CAS) Clone(ctx context.Context, l log.Logger, opts *CloneOptions, url s
 			return err
 		}
 
-		return LinkTree(childCtx, c.blobStore, c.treeStore, tree, targetDir)
+		var linkOpts []LinkTreeOption
+		if opts.Mutable {
+			linkOpts = append(linkOpts, WithForceCopy())
+		}
+
+		return LinkTree(childCtx, c.blobStore, c.treeStore, tree, targetDir, linkOpts...)
 	})
 }
 
@@ -610,7 +621,7 @@ func (c *CAS) storeBlobs(ctx context.Context, runner *git.GitRunner, entries []g
 			continue
 		}
 
-		if err := c.ensureBlob(ctx, runner, entry.Hash); err != nil {
+		if err := c.ensureBlob(ctx, runner, entry.Hash, gitFilePerm(entry.Mode)); err != nil {
 			return err
 		}
 	}
@@ -621,8 +632,11 @@ func (c *CAS) storeBlobs(ctx context.Context, runner *git.GitRunner, entries []g
 // ensureBlob ensures that a blob exists in the CAS.
 // It doesn't use the standard content.Store method because
 // we want to take advantage of the ability to write to the
-// entry using `git cat-file`.
-func (c *CAS) ensureBlob(ctx context.Context, runner *git.GitRunner, hash string) error {
+// entry using `git cat-file`. gitPerm is the git tree mode for
+// this blob; the stored blob is chmodded to gitPerm with the
+// write bits cleared so the default-link path can hardlink the
+// blob directly without altering its executable-ness.
+func (c *CAS) ensureBlob(ctx context.Context, runner *git.GitRunner, hash string, gitPerm os.FileMode) error {
 	needsWrite, lock, err := c.blobStore.EnsureWithWait(hash)
 	if err != nil {
 		return err
@@ -677,7 +691,7 @@ func (c *CAS) ensureBlob(ctx context.Context, runner *git.GitRunner, hash string
 		return err
 	}
 
-	if err = c.fs.Chmod(content.getPath(hash), StoredFilePerms); err != nil {
+	if err = c.fs.Chmod(content.getPath(hash), gitPerm.Perm()&^WriteBitMask); err != nil {
 		return err
 	}
 

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -22,6 +22,8 @@ const (
 	StoredFilePerms = os.FileMode(0444)
 	// RegularFilePerms represents standard file permissions (rw-r--r--)
 	RegularFilePerms = os.FileMode(0644)
+	// WriteBitMask covers all owner/group/other write bits.
+	WriteBitMask = os.FileMode(0o222)
 	// WindowsOS is the name of the Windows operating system
 	WindowsOS = "windows"
 )
@@ -40,49 +42,99 @@ func NewContent(store *Store) *Content {
 	}
 }
 
-// Link creates a hard link from the store to the target path
-func (c *Content) Link(ctx context.Context, hash, targetPath string) error {
+// LinkOption configures a single Content.Link call.
+type LinkOption func(*linkOpts)
+
+type linkOpts struct {
+	forceCopy bool
+}
+
+// WithLinkForceCopy makes Link copy the file from the store into the target
+// path instead of creating a hard link, so the destination is safe to mutate
+// without affecting the shared store.
+func WithLinkForceCopy() LinkOption {
+	return func(o *linkOpts) { o.forceCopy = true }
+}
+
+// Link materializes a stored blob at targetPath. gitPerm is the original git
+// mode bits for the entry (e.g. 0o644 or 0o755).
+//
+// Default path: the destination has the original git perms with the write bit
+// stripped, so the target is read-only and cannot poison the shared store.
+// Stored blobs already carry these read-only-of-original perms, so the
+// hardlink path covers both regular files (0o444) and executables (0o555).
+// If the stored blob's perms do not match (rare collision: same content
+// referenced under different modes), Link falls back to a copy at the
+// requested perm.
+//
+// WithLinkForceCopy: the destination has the exact original git perms,
+// always via copy, so callers can edit the working tree freely.
+func (c *Content) Link(ctx context.Context, hash, targetPath string, gitPerm os.FileMode, opts ...LinkOption) error {
+	var o linkOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	desired := gitPerm.Perm()
+	if !o.forceCopy {
+		desired &^= WriteBitMask
+	}
+
 	return telemetry.TelemeterFromContext(ctx).Collect(ctx, "cas_link", map[string]any{
-		"hash": hash,
-		"path": targetPath,
+		"hash":       hash,
+		"path":       targetPath,
+		"force_copy": o.forceCopy,
+		"perm":       uint32(desired),
 	}, func(childCtx context.Context) error {
 		sourcePath := c.getPath(hash)
 
-		// Try to create hard link directly (most efficient path)
-		if err := vfs.Link(c.fs, sourcePath, targetPath); err != nil {
-			// Check if it's because target already exists
-			if os.IsExist(err) {
-				// File already exists, which is fine
-				return nil
-			}
-
-			// If hard link fails for other reasons, try to copy the file
-			data, readErr := vfs.ReadFile(c.fs, sourcePath)
-			if readErr != nil {
-				return &WrappedError{
-					Op:   "read_source",
-					Path: sourcePath,
-					Err:  ErrReadFile,
+		// Hardlink when the stored blob's perms already match what the caller
+		// wants. Otherwise we must produce a fresh inode so a chmod cannot
+		// leak back into the shared store and so the destination carries the
+		// requested mode.
+		if !o.forceCopy {
+			if info, statErr := c.fs.Stat(sourcePath); statErr == nil && info.Mode().Perm() == desired {
+				if err := vfs.Link(c.fs, sourcePath, targetPath); err == nil || os.IsExist(err) {
+					return nil
 				}
+				// Fall through to copy on link failure.
 			}
+		}
 
-			// Write to temporary file first
-			tempPath := targetPath + ".tmp"
-			if err := vfs.WriteFile(c.fs, tempPath, data, RegularFilePerms); err != nil {
-				return &WrappedError{
-					Op:   "write_target",
-					Path: tempPath,
-					Err:  err,
-				}
+		data, readErr := vfs.ReadFile(c.fs, sourcePath)
+		if readErr != nil {
+			return &WrappedError{
+				Op:   "read_source",
+				Path: sourcePath,
+				Err:  ErrReadFile,
 			}
+		}
 
-			// Atomic rename to final path
-			if err := c.fs.Rename(tempPath, targetPath); err != nil {
-				return &WrappedError{
-					Op:   "rename_target",
-					Path: tempPath,
-					Err:  err,
-				}
+		// Write to temporary file first
+		tempPath := targetPath + ".tmp"
+		if err := vfs.WriteFile(c.fs, tempPath, data, desired); err != nil {
+			return &WrappedError{
+				Op:   "write_target",
+				Path: tempPath,
+				Err:  err,
+			}
+		}
+
+		// Reapply perms after write to override any umask masking.
+		if err := c.fs.Chmod(tempPath, desired); err != nil {
+			return &WrappedError{
+				Op:   "chmod_target",
+				Path: tempPath,
+				Err:  err,
+			}
+		}
+
+		// Atomic rename to final path
+		if err := c.fs.Rename(tempPath, targetPath); err != nil {
+			return &WrappedError{
+				Op:   "rename_target",
+				Path: tempPath,
+				Err:  err,
 			}
 		}
 
@@ -160,11 +212,19 @@ func (c *Content) EnsureWithWait(l log.Logger, hash string, data []byte) error {
 	return c.writeContentToFile(l, hash, data)
 }
 
-// EnsureCopy ensures that a content item exists in the store by copying from a file
+// EnsureCopy ensures that a content item exists in the store by copying from a file.
+// The stored blob is chmodded to the source file's perms with the write bits cleared,
+// so the default-link path can hardlink the blob directly without losing its
+// executable-ness or risking writes back into the shared store.
 func (c *Content) EnsureCopy(l log.Logger, hash, src string) (err error) {
 	path := c.getPath(hash)
 	if c.store.hasContent(path) {
 		return nil
+	}
+
+	srcInfo, err := c.fs.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source %s: %w", src, err)
 	}
 
 	lock, err := c.store.AcquireLock(hash)
@@ -175,6 +235,14 @@ func (c *Content) EnsureCopy(l log.Logger, hash, src string) (err error) {
 	defer func() {
 		err = errors.Join(err, lock.Unlock())
 	}()
+
+	// Re-check under the lock: another worker may have raced ahead and stored
+	// a read-only blob between the lock-free hasContent check and AcquireLock.
+	// Without this guard, Create below would fail with EACCES on the existing
+	// 0o444 file.
+	if c.store.hasContent(path) {
+		return nil
+	}
 
 	// Ensure partition directory exists
 	partitionDir := c.getPartition(hash)
@@ -202,6 +270,10 @@ func (c *Content) EnsureCopy(l log.Logger, hash, src string) (err error) {
 
 	if _, err := io.Copy(f, r); err != nil {
 		return fmt.Errorf("copy from %s: %w", src, err)
+	}
+
+	if err := c.fs.Chmod(path, srcInfo.Mode().Perm()&^WriteBitMask); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
 	}
 
 	return nil

--- a/internal/cas/content_test.go
+++ b/internal/cas/content_test.go
@@ -118,7 +118,7 @@ func TestContent_Link(t *testing.T) {
 		// Then create a link to it
 		targetPath := filepath.Join("/target", "test.txt")
 
-		err = content.Link(t.Context(), testHash, targetPath)
+		err = content.Link(t.Context(), testHash, targetPath, 0o644)
 		require.NoError(t, err)
 
 		// Verify link was created and contains correct content
@@ -143,7 +143,7 @@ func TestContent_Link(t *testing.T) {
 		require.NoError(t, err)
 
 		targetPath := filepath.Join(targetDir, "test.txt")
-		err = content.Link(t.Context(), testHash, targetPath)
+		err = content.Link(t.Context(), testHash, targetPath, 0o644)
 		require.NoError(t, err)
 
 		// Verify hard link by comparing inodes
@@ -153,6 +153,159 @@ func TestContent_Link(t *testing.T) {
 		targetInfo, err := os.Stat(targetPath)
 		require.NoError(t, err)
 		assert.True(t, os.SameFile(sourceInfo, targetInfo), "expected hard link (same inode)")
+	})
+
+	t.Run("force copy creates independent inode on real filesystem", func(t *testing.T) {
+		t.Parallel()
+
+		osFs := vfs.NewOSFS()
+		storeDir := t.TempDir()
+		targetDir := t.TempDir()
+		store := cas.NewStore(storeDir).WithFS(osFs)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+		testData := []byte("test content")
+
+		err := content.Store(l, testHash, testData)
+		require.NoError(t, err)
+
+		targetPath := filepath.Join(targetDir, "test.txt")
+		err = content.Link(t.Context(), testHash, targetPath, 0o644, cas.WithLinkForceCopy())
+		require.NoError(t, err)
+
+		sourcePath := filepath.Join(storeDir, testHash[:2], testHash)
+		sourceInfo, err := os.Stat(sourcePath)
+		require.NoError(t, err)
+		targetInfo, err := os.Stat(targetPath)
+		require.NoError(t, err)
+		assert.False(t, os.SameFile(sourceInfo, targetInfo), "expected independent inode (copy, not hard link)")
+		assert.Equal(t, os.FileMode(0o644), targetInfo.Mode().Perm(),
+			"force copy must preserve original git perms exactly")
+
+		copied, err := os.ReadFile(targetPath)
+		require.NoError(t, err)
+		assert.Equal(t, testData, copied)
+
+		// The destination must be writable so callers can mutate it without
+		// touching the shared store.
+		require.NoError(t, os.WriteFile(targetPath, []byte("mutated"), 0644))
+
+		stored, err := os.ReadFile(sourcePath)
+		require.NoError(t, err)
+		assert.Equal(t, testData, stored, "store blob must not change when target is mutated")
+	})
+
+	t.Run("default path strips write bit from non-executable", func(t *testing.T) {
+		t.Parallel()
+
+		osFs := vfs.NewOSFS()
+		storeDir := t.TempDir()
+		targetDir := t.TempDir()
+		store := cas.NewStore(storeDir).WithFS(osFs)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+		testData := []byte("test content")
+
+		require.NoError(t, content.Store(l, testHash, testData))
+
+		targetPath := filepath.Join(targetDir, "test.txt")
+		require.NoError(t, content.Link(t.Context(), testHash, targetPath, 0o644))
+
+		info, err := os.Stat(targetPath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o444), info.Mode().Perm(),
+			"default path must clear write bits (0o644 -> 0o444)")
+	})
+
+	t.Run("default path hardlinks executable when store carries matching perms", func(t *testing.T) {
+		t.Parallel()
+
+		osFs := vfs.NewOSFS()
+		storeDir := t.TempDir()
+		targetDir := t.TempDir()
+		store := cas.NewStore(storeDir).WithFS(osFs)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+		testData := []byte("#!/bin/sh\necho hi\n")
+
+		require.NoError(t, content.Store(l, testHash, testData))
+
+		// Mirror the store-side chmod that the git-clone path applies: stored
+		// blobs carry their original git mode with write bits cleared, so
+		// executables sit at 0o555 in the store.
+		sourcePath := filepath.Join(storeDir, testHash[:2], testHash)
+		require.NoError(t, os.Chmod(sourcePath, 0o555))
+
+		targetPath := filepath.Join(targetDir, "run.sh")
+		require.NoError(t, content.Link(t.Context(), testHash, targetPath, 0o755))
+
+		info, err := os.Stat(targetPath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o555), info.Mode().Perm(),
+			"executable entry must keep exec bits and lose only write (0o755 -> 0o555)")
+
+		sourceInfo, err := os.Stat(sourcePath)
+		require.NoError(t, err)
+		assert.True(t, os.SameFile(sourceInfo, info),
+			"executable entry should hardlink when the stored blob already carries 0o555")
+	})
+
+	t.Run("default path falls back to copy on perm collision", func(t *testing.T) {
+		t.Parallel()
+
+		osFs := vfs.NewOSFS()
+		storeDir := t.TempDir()
+		targetDir := t.TempDir()
+		store := cas.NewStore(storeDir).WithFS(osFs)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+		testData := []byte("test content")
+
+		require.NoError(t, content.Store(l, testHash, testData))
+
+		// The blob landed in the store at 0o444 (treated as non-exec). A second
+		// tree referencing the same content under mode 100755 wants 0o555.
+		// Link must produce a fresh inode at 0o555 rather than hardlinking
+		// the 0o444 blob.
+		targetPath := filepath.Join(targetDir, "run.sh")
+		require.NoError(t, content.Link(t.Context(), testHash, targetPath, 0o755))
+
+		info, err := os.Stat(targetPath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o555), info.Mode().Perm())
+
+		sourcePath := filepath.Join(storeDir, testHash[:2], testHash)
+		sourceInfo, err := os.Stat(sourcePath)
+		require.NoError(t, err)
+		assert.False(t, os.SameFile(sourceInfo, info),
+			"perm mismatch must materialize as an independent inode")
+	})
+
+	t.Run("force copy preserves executable bits", func(t *testing.T) {
+		t.Parallel()
+
+		osFs := vfs.NewOSFS()
+		storeDir := t.TempDir()
+		targetDir := t.TempDir()
+		store := cas.NewStore(storeDir).WithFS(osFs)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+		testData := []byte("#!/bin/sh\necho hi\n")
+
+		require.NoError(t, content.Store(l, testHash, testData))
+
+		targetPath := filepath.Join(targetDir, "run.sh")
+		require.NoError(t, content.Link(t.Context(), testHash, targetPath, 0o755, cas.WithLinkForceCopy()))
+
+		info, err := os.Stat(targetPath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(),
+			"force copy must reproduce git mode exactly (0o755)")
 	})
 
 	t.Run("link to existing file", func(t *testing.T) {
@@ -177,7 +330,7 @@ func TestContent_Link(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to create link
-		err = content.Link(t.Context(), testHash, targetPath)
+		err = content.Link(t.Context(), testHash, targetPath, 0o644)
 		require.NoError(t, err)
 
 		// Verify original content remains

--- a/internal/cas/getter_test.go
+++ b/internal/cas/getter_test.go
@@ -191,13 +191,15 @@ func TestCASGetterLocalDir(t *testing.T) {
 	err = g.Get(t.Context(), req)
 	require.NoError(t, err)
 
+	// Default-path materialization clears the write bit so the destination
+	// cannot poison the shared CAS store via shared inodes.
 	stat, err := os.Stat(filepath.Join(fakeDest, "main.tf"))
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0644), stat.Mode())
+	assert.Equal(t, os.FileMode(0o444), stat.Mode())
 
 	stat, err = os.Stat(filepath.Join(fakeDest, "subdir", "subfile.tf"))
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0644), stat.Mode())
+	assert.Equal(t, os.FileMode(0o444), stat.Mode())
 }
 
 // newTestCASGetter constructs a CASGetter wired to a fresh on-disk CAS

--- a/internal/cas/local.go
+++ b/internal/cas/local.go
@@ -21,7 +21,12 @@ const DefaultLocalHashAlgorithm = HashSHA256
 
 // StoreLocalDirectory persists all content from a local source directory into the CAS
 // and then links the persisted files to the target directory.
-func (c *CAS) StoreLocalDirectory(ctx context.Context, l log.Logger, sourceDir, targetDir string) error {
+func (c *CAS) StoreLocalDirectory(
+	ctx context.Context,
+	l log.Logger,
+	sourceDir, targetDir string,
+	opts ...LinkTreeOption,
+) error {
 	hash, treeData, err := c.buildLocalTree(sourceDir, DefaultLocalHashAlgorithm)
 	if err != nil {
 		return fmt.Errorf("failed to hash local directory %s: %w", sourceDir, err)
@@ -36,7 +41,7 @@ func (c *CAS) StoreLocalDirectory(ctx context.Context, l log.Logger, sourceDir, 
 		return fmt.Errorf("failed to parse local tree: %w", err)
 	}
 
-	return LinkTree(ctx, c.blobStore, c.treeStore, tree, targetDir)
+	return LinkTree(ctx, c.blobStore, c.treeStore, tree, targetDir, opts...)
 }
 
 // ComputeLocalRootHash walks dir in deterministic (lexical) order and produces a

--- a/internal/cas/materialize_test.go
+++ b/internal/cas/materialize_test.go
@@ -222,6 +222,66 @@ func TestCASProtocolGetterGet(t *testing.T) {
 	assert.Equal(t, fileContent, result)
 }
 
+// TestCASProtocolGetterGet_Mutable verifies that setting Mutable=true on the
+// protocol getter forces blob copies (independent inodes) instead of hardlinks
+// from the CAS store.
+func TestCASProtocolGetterGet_Mutable(t *testing.T) {
+	t.Parallel()
+
+	storeDir := helpers.TmpDirWOSymlinks(t)
+
+	blobStore := cas.NewStore(filepath.Join(storeDir, "blobs"))
+	synthStore := cas.NewStore(filepath.Join(storeDir, "synth", "trees"))
+
+	for _, s := range []*cas.Store{
+		blobStore,
+		cas.NewStore(filepath.Join(storeDir, "trees")),
+		synthStore,
+	} {
+		require.NoError(t, os.MkdirAll(s.Path(), 0755))
+	}
+
+	fileContent := []byte("resource {}\n")
+	fileHash := "filemut1"
+
+	blobContent := cas.NewContent(blobStore)
+	require.NoError(t, blobContent.Store(nil, fileHash, fileContent))
+
+	treeHash := "treemut1"
+	treeData := []byte("100644 blob filemut1\tmain.tf\n")
+
+	synthContent := cas.NewContent(synthStore)
+	require.NoError(t, synthContent.Store(nil, treeHash, treeData))
+
+	c, err := cas.New(cas.WithStorePath(storeDir))
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+	g := getter.NewCASProtocolGetter(l, c)
+	g.Mutable = true
+
+	destDir := helpers.TmpDirWOSymlinks(t)
+
+	req := &getter.Request{
+		Src: "sha1:" + treeHash,
+		Dst: destDir,
+	}
+
+	require.NoError(t, g.Get(t.Context(), req))
+
+	sourcePath := filepath.Join(blobStore.Path(), fileHash[:2], fileHash)
+	targetPath := filepath.Join(destDir, "main.tf")
+
+	sourceInfo, err := os.Stat(sourcePath)
+	require.NoError(t, err)
+
+	targetInfo, err := os.Stat(targetPath)
+	require.NoError(t, err)
+
+	assert.False(t, os.SameFile(sourceInfo, targetInfo),
+		"Mutable=true must produce an independent inode (copy, not hard link)")
+}
+
 func TestCASProtocolGetterGet_InvalidRef(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cas/protocol.go
+++ b/internal/cas/protocol.go
@@ -103,7 +103,13 @@ func FormatCASRefWithSubdir(hash, subdir string) string {
 
 // MaterializeTree reads a tree from the CAS store and links its contents to the destination directory.
 // It tries the synth store first, then falls back to the git tree store.
-func (c *CAS) MaterializeTree(ctx context.Context, l log.Logger, hash string, dest string) error {
+func (c *CAS) MaterializeTree(
+	ctx context.Context,
+	l log.Logger,
+	hash string,
+	dest string,
+	opts ...LinkTreeOption,
+) error {
 	var treeData []byte
 
 	var treeStoreUsed *Store
@@ -139,5 +145,5 @@ func (c *CAS) MaterializeTree(ctx context.Context, l log.Logger, hash string, de
 		return fmt.Errorf("failed to parse CAS tree %s: %w", hash, err)
 	}
 
-	return LinkTree(ctx, c.blobStore, treeStoreUsed, tree, dest)
+	return LinkTree(ctx, c.blobStore, treeStoreUsed, tree, dest, opts...)
 }

--- a/internal/cas/tree.go
+++ b/internal/cas/tree.go
@@ -3,18 +3,54 @@ package cas
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"golang.org/x/sync/errgroup"
 )
 
+// unixPermMask isolates the user/group/other rwx bits from a git tree mode.
+const unixPermMask = os.FileMode(0o777)
+
+// LinkTreeOption configures a LinkTree call.
+type LinkTreeOption func(*linkTreeOpts)
+
+type linkTreeOpts struct {
+	forceCopy bool
+}
+
+// WithForceCopy makes LinkTree copy blobs from the CAS store into the target
+// directory instead of hardlinking them. The destination tree becomes safe to
+// mutate without affecting the shared store, at the cost of extra I/O.
+func WithForceCopy() LinkTreeOption {
+	return func(o *linkTreeOpts) { o.forceCopy = true }
+}
+
 // LinkTree writes the tree to a target directory.
 // blobStore is used to resolve blob entries, treeStore is used to resolve subtree entries.
-func LinkTree(ctx context.Context, blobStore *Store, treeStore *Store, t *git.Tree, targetDir string) error {
+func LinkTree(
+	ctx context.Context,
+	blobStore *Store,
+	treeStore *Store,
+	t *git.Tree,
+	targetDir string,
+	opts ...LinkTreeOption,
+) error {
+	var o linkTreeOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	blobContent := NewContent(blobStore)
 	treeContent := NewContent(treeStore)
+
+	var linkOpts []LinkOption
+	if o.forceCopy {
+		linkOpts = append(linkOpts, WithLinkForceCopy())
+	}
 
 	dirsToCreate := make(map[string]struct{}, len(t.Entries()))
 
@@ -79,7 +115,7 @@ func LinkTree(ctx context.Context, blobStore *Store, treeStore *Store, t *git.Tr
 		g.Go(func() error {
 			switch work.itemType {
 			case "link":
-				err := blobContent.Link(ctx, work.entry.Hash, work.path)
+				err := blobContent.Link(ctx, work.entry.Hash, work.path, gitFilePerm(work.entry.Mode), linkOpts...)
 				if err != nil {
 					return fmt.Errorf("link blob %s: %w", work.path, err)
 				}
@@ -94,7 +130,7 @@ func LinkTree(ctx context.Context, blobStore *Store, treeStore *Store, t *git.Tr
 					return fmt.Errorf("parse tree %s: %w", work.entry.Hash, err)
 				}
 
-				err = LinkTree(ctx, blobStore, treeStore, subTree, work.path)
+				err = LinkTree(ctx, blobStore, treeStore, subTree, work.path, opts...)
 				if err != nil {
 					return fmt.Errorf("link subtree %s: %w", work.path, err)
 				}
@@ -106,4 +142,21 @@ func LinkTree(ctx context.Context, blobStore *Store, treeStore *Store, t *git.Tr
 
 	// Wait for all goroutines to complete and return first error if any
 	return g.Wait()
+}
+
+// gitFilePerm extracts the unix permission bits from a git tree entry mode
+// string. Git tree modes are six-digit octal: "100644" or "100755" for blobs.
+// Returns RegularFilePerms when the mode is missing or unparsable so callers
+// always have a sane default.
+func gitFilePerm(mode string) os.FileMode {
+	if mode == "" {
+		return RegularFilePerms
+	}
+
+	n, err := strconv.ParseUint(mode, 8, 32)
+	if err != nil {
+		return RegularFilePerms
+	}
+
+	return os.FileMode(n) & unixPermMask
 }

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -25,7 +25,12 @@ type CASGetter struct {
 }
 
 // NewCASGetter constructs a CASGetter wired with the standard detector chain.
+// A nil opts is treated as a zero-value CloneOptions so Get can rely on g.Opts.
 func NewCASGetter(l log.Logger, c *cas.CAS, opts *cas.CloneOptions) *CASGetter {
+	if opts == nil {
+		opts = &cas.CloneOptions{}
+	}
+
 	return &CASGetter{
 		Detectors: []Detector{
 			new(GitHubDetector),
@@ -45,7 +50,12 @@ func NewCASGetter(l log.Logger, c *cas.CAS, opts *cas.CloneOptions) *CASGetter {
 func (g *CASGetter) Get(ctx context.Context, req *getter.Request) error {
 	if req.Copy {
 		// Local directory: persist to CAS and link.
-		return g.CAS.StoreLocalDirectory(ctx, g.Logger, req.Src, req.Dst)
+		var linkOpts []cas.LinkTreeOption
+		if g.Opts.Mutable {
+			linkOpts = append(linkOpts, cas.WithForceCopy())
+		}
+
+		return g.CAS.StoreLocalDirectory(ctx, g.Logger, req.Src, req.Dst, linkOpts...)
 	}
 
 	ref := ""

--- a/internal/getter/casprotocol.go
+++ b/internal/getter/casprotocol.go
@@ -14,8 +14,9 @@ import (
 // CASProtocolGetter resolves cas::<algorithm>:<hash> references by
 // materializing the referenced tree from the CAS store.
 type CASProtocolGetter struct {
-	CAS    *cas.CAS
-	Logger log.Logger
+	CAS     *cas.CAS
+	Logger  log.Logger
+	Mutable bool
 }
 
 // NewCASProtocolGetter creates a new CASProtocolGetter.
@@ -35,7 +36,12 @@ func (g *CASProtocolGetter) Get(ctx context.Context, req *getter.Request) error 
 		return fmt.Errorf("failed to parse CAS reference %q: %w", req.Src, err)
 	}
 
-	return g.CAS.MaterializeTree(ctx, g.Logger, hash, req.Dst)
+	var linkOpts []cas.LinkTreeOption
+	if g.Mutable {
+		linkOpts = append(linkOpts, cas.WithForceCopy())
+	}
+
+	return g.CAS.MaterializeTree(ctx, g.Logger, hash, req.Dst, linkOpts...)
 }
 
 // GetFile is not supported for the CAS protocol getter.

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -333,7 +333,7 @@ func downloadSource(
 	isLocalSource := tf.IsLocalSource(src.CanonicalSourceURL)
 
 	if allowCAS && !isLocalSource {
-		done, err := tryCASDownload(ctx, l, src, opts)
+		done, err := tryCASDownload(ctx, l, src, opts, cfg.Terraform.Mutable)
 		if err != nil {
 			return err
 		}
@@ -364,7 +364,7 @@ func downloadSource(
 // should fall through to the standard getter.
 // Returns (false, err) for fatal misconfiguration the user must fix
 // (e.g. an invalid CASCloneDepth). Caller must propagate the error.
-func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Options) (bool, error) {
+func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Options, mutable bool) (bool, error) {
 	canonicalSourceURL := src.CanonicalSourceURL.String()
 
 	l.Debugf("CAS experiment enabled: attempting to use Content Addressable Storage for source: %s", canonicalSourceURL)
@@ -382,7 +382,11 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 	cloneOpts := cas.CloneOptions{
 		Dir:              src.DownloadDir,
 		IncludedGitFiles: []string{"HEAD", "config"},
+		Mutable:          mutable,
 	}
+
+	casProtocol := getter.NewCASProtocolGetter(l, c)
+	casProtocol.Mutable = mutable
 
 	// CAS-only client: CASProtocolGetter handles cas::sha1:<hash> sources
 	// (from CAS-rewritten stacks); CASGetter handles git:: and other remote
@@ -390,7 +394,7 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 	// caller should retry through the standard client.
 	client := &getter.Client{
 		Getters: []getter.Getter{
-			getter.NewCASProtocolGetter(l, c),
+			casProtocol,
 			getter.NewCASGetter(l, c, &cloneOpts),
 		},
 	}

--- a/internal/runner/runcfg/types.go
+++ b/internal/runner/runcfg/types.go
@@ -81,6 +81,13 @@ type TerraformConfig struct {
 	// rejects this when CAS is unavailable, since the relative path has no
 	// meaning without a resolved repo root.
 	UpdateSourceWithCAS bool
+
+	// Mutable, when true, makes CAS copy fetched content into the working
+	// directory under .terragrunt-cache instead of hardlinking it from the
+	// shared store, so the working tree is safe to edit. Has no effect when
+	// content is fetched via the standard go-getter path, which already
+	// produces a copy.
+	Mutable bool
 }
 
 // Hook represents a lifecycle hook (before/after).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -256,6 +256,10 @@ func (cfg *TerragruntConfig) WriteTo(w io.Writer) (int64, error) {
 			terraformBody.SetAttributeValue("update_source_with_cas", terraformAsCty.GetAttr("update_source_with_cas"))
 		}
 
+		if cfg.Terraform.Mutable != nil {
+			terraformBody.SetAttributeValue("mutable", terraformAsCty.GetAttr("mutable"))
+		}
+
 		// Handle extra_arguments blocks
 		if len(cfg.Terraform.ExtraArgs) > 0 {
 			extraArgsAsCty := terraformAsCty.GetAttr("extra_arguments").AsValueMap()
@@ -860,6 +864,7 @@ func (conf *ErrorHook) String() string {
 type TerraformConfig struct {
 	Source              *string `hcl:"source,attr"`
 	UpdateSourceWithCAS *bool   `hcl:"update_source_with_cas,attr"`
+	Mutable             *bool   `hcl:"mutable,attr"`
 
 	// Ideally we can avoid the pointer to list slice, but if it is not a pointer, Terraform requires the attribute to
 	// be defined and we want to make this optional.

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -548,6 +548,10 @@ func terraformConfigAsCty(config *TerraformConfig) (cty.Value, error) {
 		val = ctyObjectAddField(val, "update_source_with_cas", goboolToCty(*config.UpdateSourceWithCAS))
 	}
 
+	if config.Mutable != nil {
+		val = ctyObjectAddField(val, "mutable", goboolToCty(*config.Mutable))
+	}
+
 	return val, nil
 }
 

--- a/pkg/config/config_as_cty_test.go
+++ b/pkg/config/config_as_cty_test.go
@@ -221,6 +221,7 @@ func TestTerraformConfigAsCtyDrift(t *testing.T) {
 	// they use omit-when-nil semantics via ctyObjectAddField.
 	omitWhenNilFields := map[string]bool{
 		"UpdateSourceWithCAS": true,
+		"Mutable":             true,
 	}
 
 	terraformConfigStructInfo := structs.New(config.TerraformConfig{})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1731,6 +1731,7 @@ locals {
 terraform {
 	source = "git::git@github.com:org/repo.git//modules/test?ref=v0.1.0"
 	update_source_with_cas = true
+	mutable = true
 
 	extra_arguments "secrets" {
 		commands = ["plan", "apply"]
@@ -1897,6 +1898,7 @@ inputs = {
 	assert.Equal(t, terragruntConfig.Locals, rereadConfig.Locals)
 	assert.Equal(t, terragruntConfig.Terraform.Source, rereadConfig.Terraform.Source)
 	assert.Equal(t, terragruntConfig.Terraform.UpdateSourceWithCAS, rereadConfig.Terraform.UpdateSourceWithCAS)
+	assert.Equal(t, terragruntConfig.Terraform.Mutable, rereadConfig.Terraform.Mutable)
 	assert.Equal(t, terragruntConfig.Terraform.ExtraArgs, rereadConfig.Terraform.ExtraArgs)
 	assert.Equal(t, terragruntConfig.Terraform.BeforeHooks, rereadConfig.Terraform.BeforeHooks)
 	assert.Equal(t, terragruntConfig.Terraform.AfterHooks, rereadConfig.Terraform.AfterHooks)

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -66,6 +66,7 @@ type StackConfig struct {
 type Unit struct {
 	Remain              hcl.Body   `hcl:",remain"`
 	UpdateSourceWithCAS *bool      `hcl:"update_source_with_cas,attr"`
+	Mutable             *bool      `hcl:"mutable,attr"`
 	NoStack             *bool      `hcl:"no_dot_terragrunt_stack,attr"`
 	NoValidation        *bool      `hcl:"no_validation,attr"`
 	Values              *cty.Value `hcl:"values,attr"`
@@ -78,6 +79,7 @@ type Unit struct {
 type Stack struct {
 	Remain              hcl.Body   `hcl:",remain"`
 	UpdateSourceWithCAS *bool      `hcl:"update_source_with_cas,attr"`
+	Mutable             *bool      `hcl:"mutable,attr"`
 	NoStack             *bool      `hcl:"no_dot_terragrunt_stack,attr"`
 	NoValidation        *bool      `hcl:"no_validation,attr"`
 	Values              *cty.Value `hcl:"values,attr"`
@@ -248,6 +250,7 @@ func generateUnits(ctx context.Context, l log.Logger, opts *generateOpts, pool *
 				values:       unit.Values,
 				noStack:      unit.NoStack != nil && *unit.NoStack,
 				noValidation: unit.NoValidation != nil && *unit.NoValidation,
+				mutable:      unit.Mutable != nil && *unit.Mutable,
 				kind:         unitKind,
 			}
 
@@ -280,6 +283,7 @@ func generateStacks(ctx context.Context, l log.Logger, opts *generateOpts, pool 
 				source:       stack.Source,
 				noStack:      stack.NoStack != nil && *stack.NoStack,
 				noValidation: stack.NoValidation != nil && *stack.NoValidation,
+				mutable:      stack.Mutable != nil && *stack.Mutable,
 				values:       stack.Values,
 				kind:         stackKind,
 			}
@@ -319,6 +323,7 @@ type componentToGenerate struct {
 	source       string
 	noStack      bool
 	noValidation bool
+	mutable      bool
 	kind         componentKind
 }
 
@@ -484,7 +489,12 @@ func fetchComponentSource(
 			return errors.Errorf("Failed to parse CAS reference for %s %s: %w", kindStr, cmp.name, err)
 		}
 
-		if err := opts.casInstance.MaterializeTree(ctx, l, hash, dest); err != nil {
+		var matOpts []cas.LinkTreeOption
+		if cmp.mutable {
+			matOpts = append(matOpts, cas.WithForceCopy())
+		}
+
+		if err := opts.casInstance.MaterializeTree(ctx, l, hash, dest, matOpts...); err != nil {
 			return errors.Errorf("Failed to materialize CAS tree for %s %s: %w", kindStr, cmp.name, err)
 		}
 

--- a/pkg/config/translate.go
+++ b/pkg/config/translate.go
@@ -67,12 +67,18 @@ func translateTerraformConfig(tf *TerraformConfig, l log.Logger) runcfg.Terrafor
 		updateSourceWithCAS = *tf.UpdateSourceWithCAS
 	}
 
+	mutable := false
+	if tf.Mutable != nil {
+		mutable = *tf.Mutable
+	}
+
 	return runcfg.TerraformConfig{
 		Source:                  source,
 		IncludeInCopy:           includeInCopy,
 		ExcludeFromCopy:         excludeFromCopy,
 		NoCopyTerraformLockFile: noCopyTerraformLockFile,
 		UpdateSourceWithCAS:     updateSourceWithCAS,
+		Mutable:                 mutable,
 		ExtraArgs:               translateExtraArgs(tf.ExtraArgs, l),
 		BeforeHooks:             translateHooks(tf.BeforeHooks),
 		AfterHooks:              translateHooks(tf.AfterHooks),

--- a/test/fixtures/download/remote-mutable/terragrunt.hcl
+++ b/test/fixtures/download/remote-mutable/terragrunt.hcl
@@ -1,0 +1,8 @@
+inputs = {
+  name = "World"
+}
+
+terraform {
+  source  = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
+  mutable = true
+}

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -979,3 +979,54 @@ func TestDownloadWithCASCommitRef(t *testing.T) {
 
 	assert.Equal(t, "Hello, World", stdout.String())
 }
+
+// TestDownloadWithCASMutable exercises the end-to-end path for `mutable = true`
+// on a `terraform` block: CAS materializes the source as a writable copy
+// rather than a read-only hardlink, so every `.tf` file must land with the
+// user-write bit set. The non-mutable path would strip write bits, producing
+// 0o444 / 0o555 instead.
+func TestDownloadWithCASMutable(t *testing.T) {
+	t.Parallel()
+
+	fixturePath := "fixtures/download/remote-mutable"
+
+	tmpEnvPath := helpers.CopyEnvironment(t, fixturePath)
+	testPath := filepath.Join(tmpEnvPath, fixturePath)
+	helpers.CleanupTerraformFolder(t, testPath)
+
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+	)
+
+	cmd := "terragrunt apply --auto-approve --non-interactive --experiment cas --log-level debug --working-dir " + testPath
+	require.NoError(t, helpers.RunTerragruntCommand(t, cmd, &stdout, &stderr))
+
+	cacheDir := filepath.Join(testPath, ".terragrunt-cache")
+
+	var checked int
+
+	require.NoError(t, filepath.WalkDir(cacheDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() || filepath.Ext(path) != ".tf" {
+			return nil
+		}
+
+		info, statErr := d.Info()
+		if statErr != nil {
+			return statErr
+		}
+
+		assert.NotZero(t, info.Mode().Perm()&0o200,
+			"mutable=true must materialize %s as writable (got perms %#o)", path, info.Mode().Perm())
+
+		checked++
+
+		return nil
+	}))
+
+	require.Positive(t, checked, "expected at least one .tf file under %s", cacheDir)
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds the `mutable` attribute for source clones that can be used by CAS.

Relates to #5558.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `mutable` attribute to `terraform`, `unit`, and `stack` blocks. When enabled, downloaded source content becomes editable in your working directory. By default (`mutable = false`), downloaded content remains read-only.

* **Documentation**
  * Added documentation and changelog entry explaining the new `mutable` attribute and its effect on source file editability.

* **Tests**
  * Added integration and unit tests validating the `mutable` attribute behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6011)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->