### PR TITLE
chore: Adding checkbox for changelog updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->
+<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->
 
 ## Description
 
@@ -14,15 +14,7 @@ Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Grunt
 - [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
 - [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
 - [ ] Update the docs.
+- [ ] Update the changelog in the docs.
 - [ ] Run the relevant tests successfully, including pre-commit checks.
-- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
-
-## Release Notes (draft)
-
-<!-- One-line description of the PR that can be included in the final release notes. -->
-Added / Removed / Updated [X].
-
-### Migration Guide
-
-<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
-
+- [ ] This change is backwards compatible.
+- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updates the template that generates this pull request body placeholder.

We now track changes as formal documentation in the Terragrunt docs site, and we use GitHub draft/ready for review status to signal that work is in-progress.

Also updated the checkboxes to include a call out that all changes are supposed to be backwards compatible, and if they aren't forwards compatible, they should be gated behind a feature flag.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR template to ask contributors to keep work-in-progress PRs in draft and mark ready when ready for review.
  * Added a checklist item to ensure the changelog is updated.
  * Replaced prior prompts about draft release notes and migration guides with explicit checkboxes confirming backward compatibility and that any forward-incompatibility is gated behind a feature flag.

* **Chores**
  * Internal process refinements only; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->