### PR TITLE
perf: Moving context cache construction earlier

### DIFF
--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gruntwork-io/go-commons/env"
+	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/providercache"
@@ -274,8 +275,10 @@ func runAction(
 		l.Formatter().SetDisabledColors(true)
 	}
 
-	// actionCtx is the context passed to the action, which may be wrapped with hooks
-	actionCtx := ctx
+	// Install run-scoped caches on actionCtx so memoized helpers like
+	// [github.com/gruntwork-io/terragrunt/internal/shell.GitTopLevelDir] share
+	// state across the whole action.
+	actionCtx := cache.ContextWithCache(ctx)
 
 	// Run provider cache server
 	if opts.ProviderCacheOptions.Enabled {
@@ -290,7 +293,7 @@ func runAction(
 		}
 		defer ln.Close() //nolint:errcheck
 
-		actionCtx = tf.ContextWithTerraformCommandHook(ctx, server.TerraformCommandHook)
+		actionCtx = tf.ContextWithTerraformCommandHook(actionCtx, server.TerraformCommandHook)
 
 		errGroup.Go(func() error {
 			return server.Run(ctx, ln)

--- a/internal/tf/context.go
+++ b/internal/tf/context.go
@@ -3,7 +3,6 @@ package tf
 import (
 	"context"
 
-	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -19,8 +18,10 @@ type ctxKey byte
 // RunShellCommandFunc is a context value for `TerraformCommandContextKey` key, used to intercept shell commands.
 type RunShellCommandFunc func(ctx context.Context, l log.Logger, tfOpts *TFOptions, args clihelper.Args) (*util.CmdOutput, error)
 
+// ContextWithTerraformCommandHook sets fn as the terraform command hook on ctx.
+// It does not touch any caches on ctx; callers that need run-scoped caches must
+// install them with [github.com/gruntwork-io/terragrunt/internal/cache.ContextWithCache].
 func ContextWithTerraformCommandHook(ctx context.Context, fn RunShellCommandFunc) context.Context {
-	ctx = cache.ContextWithCache(ctx)
 	return context.WithValue(ctx, TerraformCommandContextKey, fn)
 }
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Moves context cache construction earlier so that more memoization can happen between different units.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache state handling to ensure Terraform command execution properly shares cached state across the pipeline.

* **Refactor**
  * Streamlined internal cache context management in the CLI command pipeline for improved reliability and simplified initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->