### PR TITLE
fix: Ensuring relativization is safer

### DIFF
--- a/docs/src/data/changelog/v1.0.4/find-include-rel-error.mdx
+++ b/docs/src/data/changelog/v1.0.4/find-include-rel-error.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.4"
+category: "bug-fixes"
+---
+
+#### Fixed `terragrunt find --include` failing on relative include paths
+
+Running `terragrunt find --include` against units whose `include` blocks reference parent configs with relative paths (`../root.hcl`, `./common.hcl`, bare filenames, etc.) emitted errors like `Rel: can't make ../root.hcl relative to /abs/working-dir` and dropped those entries from the output.
+
+Relative include paths are now resolved against the unit's directory before being made relative to the working directory, matching how the rest of Terragrunt interprets the `path` attribute on an `include` block.
+
+`find` and `list` no longer hard-fail when a path cannot be made relative to its base. The condition is logged as a warning and the path is emitted as-is, so output stays complete and the command exits zero.

--- a/internal/cli/commands/find/find.go
+++ b/internal/cli/commands/find/find.go
@@ -3,11 +3,11 @@ package find
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
@@ -166,14 +166,14 @@ func discoveredToFound(components component.Components, opts *Options) (FoundCom
 			err     error
 		)
 
+		base := opts.WorkingDir
 		if c.DiscoveryContext() != nil && c.DiscoveryContext().WorkingDir != "" {
-			relPath, err = filepath.Rel(c.DiscoveryContext().WorkingDir, c.Path())
-		} else {
-			relPath, err = filepath.Rel(opts.WorkingDir, c.Path())
+			base = c.DiscoveryContext().WorkingDir
 		}
 
+		relPath, err = filepath.Rel(base, c.Path())
 		if err != nil {
-			errs = append(errs, errors.New(err))
+			errs = append(errs, fmt.Errorf("relativize component path %q against base %q: %w", c.Path(), base, err))
 
 			continue
 		}
@@ -196,10 +196,17 @@ func discoveredToFound(components component.Components, opts *Options) (FoundCom
 				if cfg := unit.Config(); cfg != nil && cfg.ProcessedIncludes != nil {
 					foundComponent.Include = make(map[string]string, len(cfg.ProcessedIncludes))
 					for _, v := range cfg.ProcessedIncludes {
-						foundComponent.Include[v.Name], err = util.GetPathRelativeTo(v.Path, opts.RootWorkingDir)
-						if err != nil {
-							errs = append(errs, errors.New(err))
+						relIncludePath, relErr := filepath.Rel(opts.RootWorkingDir, v.Path)
+						if relErr != nil {
+							errs = append(errs, fmt.Errorf(
+								"relativize include %q (path %q) for unit %q against root %q: %w",
+								v.Name, v.Path, unit.Path(), opts.RootWorkingDir, relErr,
+							))
+
+							continue
 						}
+
+						foundComponent.Include[v.Name] = relIncludePath
 					}
 				}
 			}
@@ -208,17 +215,18 @@ func discoveredToFound(components component.Components, opts *Options) (FoundCom
 		if opts.Reading && len(c.Reading()) > 0 {
 			foundComponent.Reading = make([]string, len(c.Reading()))
 
+			readingBase := opts.WorkingDir
+			if c.DiscoveryContext() != nil && c.DiscoveryContext().WorkingDir != "" {
+				readingBase = c.DiscoveryContext().WorkingDir
+			}
+
 			for i, reading := range c.Reading() {
-				var relReadingPath string
-
-				if c.DiscoveryContext() != nil && c.DiscoveryContext().WorkingDir != "" {
-					relReadingPath, err = filepath.Rel(c.DiscoveryContext().WorkingDir, reading)
-				} else {
-					relReadingPath, err = filepath.Rel(opts.WorkingDir, reading)
-				}
-
-				if err != nil {
-					errs = append(errs, errors.New(err))
+				relReadingPath, relErr := filepath.Rel(readingBase, reading)
+				if relErr != nil {
+					errs = append(errs, fmt.Errorf(
+						"relativize reading path %q for unit %q against base %q: %w",
+						reading, c.Path(), readingBase, relErr,
+					))
 
 					continue
 				}
@@ -231,16 +239,17 @@ func discoveredToFound(components component.Components, opts *Options) (FoundCom
 			foundComponent.Dependencies = make([]string, len(c.Dependencies()))
 
 			for i, dep := range c.Dependencies() {
-				var relDepPath string
-
+				depBase := opts.WorkingDir
 				if dep.DiscoveryContext() != nil && dep.DiscoveryContext().WorkingDir != "" {
-					relDepPath, err = filepath.Rel(dep.DiscoveryContext().WorkingDir, dep.Path())
-				} else {
-					relDepPath, err = filepath.Rel(opts.WorkingDir, dep.Path())
+					depBase = dep.DiscoveryContext().WorkingDir
 				}
 
-				if err != nil {
-					errs = append(errs, errors.New(err))
+				relDepPath, relErr := filepath.Rel(depBase, dep.Path())
+				if relErr != nil {
+					errs = append(errs, fmt.Errorf(
+						"relativize dependency path %q (of unit %q) against base %q: %w",
+						dep.Path(), c.Path(), depBase, relErr,
+					))
 
 					continue
 				}

--- a/internal/cli/commands/find/find.go
+++ b/internal/cli/commands/find/find.go
@@ -111,11 +111,9 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		"working_dir":  opts.WorkingDir,
 		"config_count": len(components),
 	}, func(ctx context.Context) error {
-		var convErr error
+		foundComponents = discoveredToFound(l, components, opts)
 
-		foundComponents, convErr = discoveredToFound(components, opts)
-
-		return convErr
+		return nil
 	})
 	if err != nil {
 		return errors.New(err)
@@ -146,9 +144,8 @@ type FoundComponent struct {
 	Reading      []string `json:"reading,omitempty"`
 }
 
-func discoveredToFound(components component.Components, opts *Options) (FoundComponents, error) {
+func discoveredToFound(l log.Logger, components component.Components, opts *Options) FoundComponents {
 	foundComponents := make(FoundComponents, 0, len(components))
-	errs := []error{}
 
 	for _, c := range components {
 		if opts.QueueConstructAs != "" {
@@ -161,26 +158,14 @@ func discoveredToFound(components component.Components, opts *Options) (FoundCom
 			}
 		}
 
-		var (
-			relPath string
-			err     error
-		)
-
 		base := opts.WorkingDir
 		if c.DiscoveryContext() != nil && c.DiscoveryContext().WorkingDir != "" {
 			base = c.DiscoveryContext().WorkingDir
 		}
 
-		relPath, err = filepath.Rel(base, c.Path())
-		if err != nil {
-			errs = append(errs, fmt.Errorf("relativize component path %q against base %q: %w", c.Path(), base, err))
-
-			continue
-		}
-
 		foundComponent := &FoundComponent{
 			Type: c.Kind(),
-			Path: relPath,
+			Path: discovery.RelPathOrAbs(l, base, c.Path(), "component"),
 		}
 
 		if opts.Exclude {
@@ -196,17 +181,8 @@ func discoveredToFound(components component.Components, opts *Options) (FoundCom
 				if cfg := unit.Config(); cfg != nil && cfg.ProcessedIncludes != nil {
 					foundComponent.Include = make(map[string]string, len(cfg.ProcessedIncludes))
 					for _, v := range cfg.ProcessedIncludes {
-						relIncludePath, relErr := filepath.Rel(opts.RootWorkingDir, v.Path)
-						if relErr != nil {
-							errs = append(errs, fmt.Errorf(
-								"relativize include %q (path %q) for unit %q against root %q: %w",
-								v.Name, v.Path, unit.Path(), opts.RootWorkingDir, relErr,
-							))
-
-							continue
-						}
-
-						foundComponent.Include[v.Name] = relIncludePath
+						desc := fmt.Sprintf("include %q of unit %q", v.Name, unit.Path())
+						foundComponent.Include[v.Name] = discovery.RelPathOrAbs(l, opts.RootWorkingDir, v.Path, desc)
 					}
 				}
 			}
@@ -220,48 +196,30 @@ func discoveredToFound(components component.Components, opts *Options) (FoundCom
 				readingBase = c.DiscoveryContext().WorkingDir
 			}
 
+			desc := fmt.Sprintf("read path of unit %q", c.Path())
 			for i, reading := range c.Reading() {
-				relReadingPath, relErr := filepath.Rel(readingBase, reading)
-				if relErr != nil {
-					errs = append(errs, fmt.Errorf(
-						"relativize reading path %q for unit %q against base %q: %w",
-						reading, c.Path(), readingBase, relErr,
-					))
-
-					continue
-				}
-
-				foundComponent.Reading[i] = relReadingPath
+				foundComponent.Reading[i] = discovery.RelPathOrAbs(l, readingBase, reading, desc)
 			}
 		}
 
 		if opts.Dependencies && len(c.Dependencies()) > 0 {
 			foundComponent.Dependencies = make([]string, len(c.Dependencies()))
 
+			desc := fmt.Sprintf("dependency of unit %q", c.Path())
 			for i, dep := range c.Dependencies() {
 				depBase := opts.WorkingDir
 				if dep.DiscoveryContext() != nil && dep.DiscoveryContext().WorkingDir != "" {
 					depBase = dep.DiscoveryContext().WorkingDir
 				}
 
-				relDepPath, relErr := filepath.Rel(depBase, dep.Path())
-				if relErr != nil {
-					errs = append(errs, fmt.Errorf(
-						"relativize dependency path %q (of unit %q) against base %q: %w",
-						dep.Path(), c.Path(), depBase, relErr,
-					))
-
-					continue
-				}
-
-				foundComponent.Dependencies[i] = relDepPath
+				foundComponent.Dependencies[i] = discovery.RelPathOrAbs(l, depBase, dep.Path(), desc)
 			}
 		}
 
 		foundComponents = append(foundComponents, foundComponent)
 	}
 
-	return foundComponents, errors.Join(errs...)
+	return foundComponents
 }
 
 // outputJSON outputs the discovered components in JSON format.

--- a/internal/cli/commands/list/list.go
+++ b/internal/cli/commands/list/list.go
@@ -109,11 +109,9 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		"working_dir":  opts.WorkingDir,
 		"config_count": len(components),
 	}, func(ctx context.Context) error {
-		var convErr error
+		listedComponents = discoveredToListed(l, components, opts)
 
-		listedComponents, convErr = discoveredToListed(components, opts)
-
-		return convErr
+		return nil
 	})
 	if err != nil {
 		return errors.New(err)
@@ -135,9 +133,8 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 	}
 }
 
-func discoveredToListed(components component.Components, opts *Options) (dag.ListedComponents, error) {
+func discoveredToListed(l log.Logger, components component.Components, opts *Options) dag.ListedComponents {
 	listedComponents := make(dag.ListedComponents, 0, len(components))
-	errs := []error{}
 
 	for _, c := range components {
 		excluded := false
@@ -156,26 +153,14 @@ func discoveredToListed(components component.Components, opts *Options) (dag.Lis
 			}
 		}
 
-		var (
-			relPath string
-			err     error
-		)
-
+		base := opts.WorkingDir
 		if c.DiscoveryContext() != nil && c.DiscoveryContext().WorkingDir != "" {
-			relPath, err = filepath.Rel(c.DiscoveryContext().WorkingDir, c.Path())
-		} else {
-			relPath, err = filepath.Rel(opts.WorkingDir, c.Path())
-		}
-
-		if err != nil {
-			errs = append(errs, errors.New(err))
-
-			continue
+			base = c.DiscoveryContext().WorkingDir
 		}
 
 		listedCfg := &dag.ListedComponent{
 			Type:     c.Kind(),
-			Path:     relPath,
+			Path:     discovery.RelPathOrAbs(l, base, c.Path(), "component"),
 			Excluded: excluded,
 		}
 
@@ -187,19 +172,11 @@ func discoveredToListed(components component.Components, opts *Options) (dag.Lis
 
 		listedCfg.Dependencies = make([]*dag.ListedComponent, len(c.Dependencies()))
 
+		desc := fmt.Sprintf("dependency of unit %q", c.Path())
 		for i, dep := range c.Dependencies() {
-			var relDepPath string
-
+			depBase := opts.WorkingDir
 			if dep.DiscoveryContext() != nil && dep.DiscoveryContext().WorkingDir != "" {
-				relDepPath, err = filepath.Rel(dep.DiscoveryContext().WorkingDir, dep.Path())
-			} else {
-				relDepPath, err = filepath.Rel(opts.WorkingDir, dep.Path())
-			}
-
-			if err != nil {
-				errs = append(errs, errors.New(err))
-
-				continue
+				depBase = dep.DiscoveryContext().WorkingDir
 			}
 
 			depExcluded := false
@@ -216,7 +193,7 @@ func discoveredToListed(components component.Components, opts *Options) (dag.Lis
 
 			listedCfg.Dependencies[i] = &dag.ListedComponent{
 				Type:     dep.Kind(),
-				Path:     relDepPath,
+				Path:     discovery.RelPathOrAbs(l, depBase, dep.Path(), desc),
 				Excluded: depExcluded,
 			}
 		}
@@ -228,7 +205,7 @@ func discoveredToListed(components component.Components, opts *Options) (dag.Lis
 		listedComponents = append(listedComponents, listedCfg)
 	}
 
-	return listedComponents, errors.Join(errs...)
+	return listedComponents
 }
 
 // outputText outputs the discovered components in text format.

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
 const (
@@ -70,6 +71,20 @@ func (s *stringSet) Load(key string) bool {
 	_, ok := s.m[key]
 
 	return ok
+}
+
+// RelPathOrAbs returns target made relative to base. On filepath.Rel failure (Windows cross-volume, etc.), it warns
+// and returns target unchanged so the entry still appears in output. The desc is included parenthetically in the
+// warning to identify which path failed.
+func RelPathOrAbs(l log.Logger, base, target, desc string) string {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		l.Warnf("could not make %q relative to %q (%s): %v; emitting as-is", target, base, desc, err)
+
+		return target
+	}
+
+	return rel
 }
 
 // isExternal checks if a component path is outside the given working directory.

--- a/internal/discovery/helpers_test.go
+++ b/internal/discovery/helpers_test.go
@@ -1,0 +1,98 @@
+package discovery_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRelPathOrAbs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		base   string
+		target string
+		want   string
+	}{
+		{
+			name:   "both empty",
+			base:   "",
+			target: "",
+			want:   ".",
+		},
+		{
+			name:   "empty target against absolute base falls back to target",
+			base:   "/a",
+			target: "",
+			want:   "",
+		},
+		{
+			name:   "empty base against absolute target falls back to target",
+			base:   "",
+			target: "/a",
+			want:   "/a",
+		},
+		{
+			name:   "child of base",
+			base:   "/a",
+			target: "/a/b",
+			want:   "b",
+		},
+		{
+			name:   "same path",
+			base:   "/a",
+			target: "/a",
+			want:   ".",
+		},
+		{
+			name:   "up traversal",
+			base:   "/a/b",
+			target: "/a",
+			want:   "..",
+		},
+		{
+			name:   "sibling of base",
+			base:   "/a/b",
+			target: "/a/c",
+			want:   "../c",
+		},
+		{
+			name:   "absolute base with relative target falls back to target",
+			base:   "/a",
+			target: "b",
+			want:   "b",
+		},
+		{
+			name:   "relative base with absolute target falls back to target",
+			base:   "a",
+			target: "/b",
+			want:   "/b",
+		},
+		{
+			name:   "both relative, sibling",
+			base:   "a/b",
+			target: "a/c",
+			want:   "../c",
+		},
+		{
+			name:   "both relative, no shared ancestor",
+			base:   "a",
+			target: "b",
+			want:   "../b",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := logger.CreateLogger()
+
+			got := discovery.RelPathOrAbs(l, tc.base, tc.target, "test")
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -262,24 +262,6 @@ func IsFile(path string) bool {
 	return err == nil && !fileInfo.IsDir()
 }
 
-// GetPathRelativeTo returns the relative path you would have to take to get from basePath to path.
-func GetPathRelativeTo(path string, basePath string) (string, error) {
-	if path == "" {
-		path = "."
-	}
-
-	if basePath == "" {
-		basePath = "."
-	}
-
-	relPath, err := filepath.Rel(basePath, path)
-	if err != nil {
-		return "", errors.New(err)
-	}
-
-	return relPath, nil
-}
-
 // ReadFileAsString returns the contents of the file at the given path as a string.
 func ReadFileAsString(path string) (string, error) {
 	bytes, err := os.ReadFile(path)
@@ -325,9 +307,9 @@ func expandGlobPath(source, absoluteGlobPath string) ([]string, error) {
 			continue
 		}
 
-		relativeExpandGlobPath, err := GetPathRelativeTo(absoluteExpandGlobPath, source)
+		relativeExpandGlobPath, err := filepath.Rel(source, absoluteExpandGlobPath)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("relativize glob match %q against source %q: %w", absoluteExpandGlobPath, source, err)
 		}
 
 		includeExpandedGlobs = append(includeExpandedGlobs, filepath.ToSlash(relativeExpandGlobPath))
@@ -428,7 +410,7 @@ func CopyFolderContents(l log.Logger, source, destination, manifestFile string, 
 	}
 
 	return CopyFolderContentsWithFilter(l, source, destination, manifestFile, func(absolutePath string) bool {
-		relativePath, err := GetPathRelativeTo(absolutePath, source)
+		relativePath, err := filepath.Rel(source, absolutePath)
 		if err != nil {
 			return false
 		}
@@ -765,9 +747,9 @@ func CopyFolderContentsWithFilter(l log.Logger, source, destination, manifestFil
 	}
 
 	for _, file := range files {
-		fileRelativePath, err := GetPathRelativeTo(file, source)
+		fileRelativePath, err := filepath.Rel(source, file)
 		if err != nil {
-			return err
+			return fmt.Errorf("relativize %q against source %q: %w", file, source, err)
 		}
 
 		if !filter(file) {

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -18,35 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetPathRelativeTo(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		path     string
-		basePath string
-		expected string
-	}{
-		{"", "", "."},
-		{helpers.RootFolder, helpers.RootFolder, "."},
-		{helpers.RootFolder, helpers.RootFolder + "child", ".."},
-		{helpers.RootFolder, helpers.RootFolder + "child/sub-child/sub-sub-child", "../../.."},
-		{helpers.RootFolder + "other-child", helpers.RootFolder + "child", "../other-child"},
-		{helpers.RootFolder + "other-child/sub-child", helpers.RootFolder + "child/sub-child", "../../other-child/sub-child"},
-		{helpers.RootFolder + "root", helpers.RootFolder + "other-root", "../root"},
-		{helpers.RootFolder + "root", helpers.RootFolder + "other-root/sub-child/sub-sub-child", "../../../root"},
-	}
-
-	for i, tc := range testCases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			t.Parallel()
-
-			actual, err := util.GetPathRelativeTo(tc.path, tc.basePath)
-			require.NoError(t, err)
-			assert.Equal(t, tc.expected, actual, "For path %s and basePath %s", tc.path, tc.basePath)
-		})
-	}
-}
-
 func TestCanonicalPath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1995,6 +1995,10 @@ func markLocalModuleSourceAsRead(pctx *ParsingContext, configPath, rawSource str
 		moduleDir = filepath.Clean(filepath.Join(moduleDir, subdir))
 	}
 
+	if !filepath.IsAbs(moduleDir) {
+		moduleDir = filepath.Clean(filepath.Join(pctx.WorkingDir, moduleDir))
+	}
+
 	walkFunc := filepath.WalkDir
 	if pctx.Experiments.Evaluate(experiment.Symlinks) {
 		walkFunc = util.WalkDirWithSymlinks

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -809,15 +809,14 @@ func PathRelativeToInclude(ctx context.Context, pctx *ParsingContext, l log.Logg
 		currentPath := filepath.Dir(pctx.TerragruntConfigPath)
 		includePath := filepath.Dir(included.Path)
 
-		if !filepath.IsAbs(includePath) {
-			includePath = filepath.Join(currentPath, includePath)
-		}
-
 		var innerErr error
 
-		result, innerErr = util.GetPathRelativeTo(currentPath, includePath)
+		result, innerErr = filepath.Rel(includePath, currentPath)
+		if innerErr != nil {
+			return fmt.Errorf("relativize current path %q against include path %q: %w", currentPath, includePath, innerErr)
+		}
 
-		return innerErr
+		return nil
 	})
 
 	return result, err
@@ -852,13 +851,12 @@ func PathRelativeFromInclude(ctx context.Context, pctx *ParsingContext, l log.Lo
 		includePath := filepath.Dir(included.Path)
 		currentPath := filepath.Dir(pctx.TerragruntConfigPath)
 
-		if !filepath.IsAbs(includePath) {
-			includePath = filepath.Join(currentPath, includePath)
+		result, innerErr = filepath.Rel(currentPath, includePath)
+		if innerErr != nil {
+			return fmt.Errorf("relativize include path %q against current path %q: %w", includePath, currentPath, innerErr)
 		}
 
-		result, innerErr = util.GetPathRelativeTo(includePath, currentPath)
-
-		return innerErr
+		return nil
 	})
 
 	return result, err

--- a/pkg/config/config_helpers_test.go
+++ b/pkg/config/config_helpers_test.go
@@ -99,7 +99,7 @@ func TestPathRelativeToInclude(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params)
+		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params, tc.configPath)
 		l := logger.CreateLogger()
 		ctx, pctx := newTestParsingContext(t, tc.configPath)
 		pctx = pctx.WithTrackInclude(trackInclude)
@@ -164,7 +164,7 @@ func TestPathRelativeFromInclude(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params)
+		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params, tc.configPath)
 		l := logger.CreateLogger()
 		ctx, pctx := newTestParsingContext(t, tc.configPath)
 		pctx = pctx.WithTrackInclude(trackInclude)
@@ -823,7 +823,7 @@ func TestGetParentTerragruntDir(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params)
+		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params, tc.configPath)
 		l := logger.CreateLogger()
 		ctx, pctx := newTestParsingContext(t, tc.configPath)
 		pctx = pctx.WithTrackInclude(trackInclude)
@@ -1328,22 +1328,29 @@ func getKeys(valueMap map[string]cty.Value) map[string]bool {
 	return keys
 }
 
-func getTrackIncludeFromTestData(includeMap map[string]config.IncludeConfig, params []string) *config.TrackInclude {
+// getTrackIncludeFromTestData mirrors getTrackInclude: include paths are resolved to absolute against the directory of
+// configPath so production callers can rely on IncludeConfig.Path being absolute.
+func getTrackIncludeFromTestData(includeMap map[string]config.IncludeConfig, params []string, configPath string) *config.TrackInclude {
 	if len(includeMap) == 0 {
 		return nil
 	}
 
-	currentList := make([]config.IncludeConfig, len(includeMap))
+	configDir := filepath.Dir(configPath)
+	normalizedMap := make(map[string]config.IncludeConfig, len(includeMap))
+	currentList := make([]config.IncludeConfig, 0, len(includeMap))
 
-	i := 0
-	for _, val := range includeMap {
-		currentList[i] = val
-		i++
+	for name, val := range includeMap {
+		if val.Path != "" && !filepath.IsAbs(val.Path) {
+			val.Path = filepath.Clean(filepath.Join(configDir, val.Path))
+		}
+
+		normalizedMap[name] = val
+		currentList = append(currentList, val)
 	}
 
 	trackInclude := &config.TrackInclude{
 		CurrentList: currentList,
-		CurrentMap:  includeMap,
+		CurrentMap:  normalizedMap,
 	}
 	if len(params) == 0 {
 		trackInclude.Original = &currentList[0]

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -682,10 +682,6 @@ func partialParseIncludedConfig(ctx context.Context, pctx *ParsingContext, l log
 
 	includePath := includedConfig.Path
 
-	if !filepath.IsAbs(includePath) {
-		includePath = filepath.Join(filepath.Dir(pctx.TerragruntConfigPath), includePath)
-	}
-
 	config, err := PartialParseConfigFile(
 		ctx,
 		pctx,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -651,14 +651,15 @@ include {
 }
 `, "root.hcl")
 
-	cfgPath := "../../test/fixtures/parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/" + config.DefaultTerragruntConfigPath
+	cfgPath, err := filepath.Abs(filepath.Join("../..", "test", "fixtures", "parent-folders", "terragrunt-in-root", "child", "sub-child", "sub-sub-child", config.DefaultTerragruntConfigPath))
+	require.NoError(t, err)
 
 	l := createLogger()
 
 	ctx, pctx := newTestParsingContext(t, cfgPath)
 
-	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, cfgPath, cfg, nil)
-	if assert.NoError(t, err, "Unexpected error: %v", errors.New(err)) {
+	terragruntConfig, parseErr := config.ParseConfigString(ctx, pctx, l, cfgPath, cfg, nil)
+	if assert.NoError(t, parseErr, "Unexpected error: %v", errors.New(parseErr)) {
 		assert.Nil(t, terragruntConfig.Terraform)
 
 		if assert.NotNil(t, terragruntConfig.RemoteState) {

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -34,10 +34,6 @@ func parseIncludedConfig(ctx context.Context, pctx *ParsingContext, l log.Logger
 
 	includePath := includedConfig.Path
 
-	if !filepath.IsAbs(includePath) {
-		includePath = filepath.Join(filepath.Dir(pctx.TerragruntConfigPath), includePath)
-	}
-
 	// These condition are here to specifically handle the `run --all` command. During any `run --all` call, terragrunt
 	// needs to first build up the dependency graph to know what order to process the modules in. We want to limit users
 	// from creating a dependency between the dependency path for graph generation, and a module output. This is because
@@ -143,12 +139,7 @@ func handleInclude(ctx context.Context, pctx *ParsingContext, l log.Logger, conf
 			logPrefix           string
 		)
 
-		trackedIncludePath := includeConfig.Path
-		if !filepath.IsAbs(trackedIncludePath) {
-			trackedIncludePath = filepath.Clean(filepath.Join(filepath.Dir(pctx.TerragruntConfigPath), trackedIncludePath))
-		}
-
-		trackFileRead(pctx.FilesRead, trackedIncludePath)
+		trackFileRead(pctx.FilesRead, includeConfig.Path)
 
 		if isPartial {
 			parsedIncludeConfig, err = partialParseIncludedConfig(ctx, pctx, l, &includeConfig)
@@ -797,19 +788,30 @@ func mergeErrorHooks(l log.Logger, childHooks []ErrorHook, parentHooks *[]ErrorH
 // getTrackInclude converts the terragrunt include blocks into TrackInclude structs that differentiate between an
 // included config in the current parsing ctx, and an included config that was passed through from a previous
 // parsing ctx.
+//
+// Each include's Path is normalized to an absolute path here, resolved against the directory of the current config
+// file. Downstream consumers can rely on IncludeConfig.Path being absolute and need not redo this resolution.
 func getTrackInclude(ctx *ParsingContext, terragruntIncludeList IncludeConfigs, includeFromChild *IncludeConfig) (*TrackInclude, error) {
+	configDir := filepath.Dir(ctx.TerragruntConfigPath)
+
+	normalizedList := make(IncludeConfigs, len(terragruntIncludeList))
 	includedPaths := make([]string, 0, len(terragruntIncludeList))
 	terragruntIncludeMap := make(map[string]IncludeConfig, len(terragruntIncludeList))
 
-	for _, tgInc := range terragruntIncludeList {
+	for i, tgInc := range terragruntIncludeList {
+		if tgInc.Path != "" && !filepath.IsAbs(tgInc.Path) {
+			tgInc.Path = filepath.Clean(filepath.Join(configDir, tgInc.Path))
+		}
+
+		normalizedList[i] = tgInc
 		includedPaths = append(includedPaths, tgInc.Path)
 		terragruntIncludeMap[tgInc.Name] = tgInc
 	}
 
-	hasInclude := len(terragruntIncludeList) > 0
+	hasInclude := len(normalizedList) > 0
 
 	trackInc := TrackInclude{
-		CurrentList: terragruntIncludeList,
+		CurrentList: normalizedList,
 		CurrentMap:  terragruntIncludeMap,
 	}
 
@@ -827,7 +829,14 @@ func getTrackInclude(ctx *ParsingContext, terragruntIncludeList IncludeConfigs, 
 	case hasInclude && includeFromChild == nil:
 		// Current parsing ctx where there is no included config already loaded.
 	case !hasInclude:
-		// Parsing ctx where there is an included config already loaded.
+		// Parsing ctx where there is an included config already loaded. Normalize the inherited include's Path so
+		// downstream consumers see the same absolute-path invariant as entries in CurrentList/CurrentMap.
+		if includeFromChild != nil && includeFromChild.Path != "" && !filepath.IsAbs(includeFromChild.Path) {
+			normalized := *includeFromChild
+			normalized.Path = filepath.Clean(filepath.Join(configDir, includeFromChild.Path))
+			includeFromChild = &normalized
+		}
+
 		trackInc.Original = includeFromChild
 	}
 

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -514,7 +514,7 @@ func RunValidateAllWithFilteredPlusDependenciesAndGetIncludedModules(
 func GetPathRelativeTo(t *testing.T, path string, basePath string) string {
 	t.Helper()
 
-	relPath, err := util.GetPathRelativeTo(path, basePath)
+	relPath, err := filepath.Rel(basePath, path)
 	require.NoError(t, err)
 
 	return relPath
@@ -526,7 +526,7 @@ func GetPathsRelativeTo(t *testing.T, basePath string, paths []string) []string 
 	relPaths := make([]string, len(paths))
 
 	for i, path := range paths {
-		relPath, err := util.GetPathRelativeTo(path, basePath)
+		relPath, err := filepath.Rel(basePath, path)
 		require.NoError(t, err)
 
 		relPaths[i] = relPath


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6026.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `terragrunt find --include` to correctly handle relative include paths (e.g., `../root.hcl`, `./common.hcl`, bare filenames)
  * `find` and `list` commands no longer fail when paths cannot be made relative; warnings are logged instead and commands exit successfully

<!-- end of auto-generated comment: release notes by coderabbit.ai -->