### PR TITLE
Prevent duplicate getCredentialsFromEnv (fixes #5105)

### DIFF
--- a/internal/awshelper/config.go
+++ b/internal/awshelper/config.go
@@ -131,10 +131,6 @@ func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config,
 		return aws.Config{}, errors.Errorf("Error loading AWS config: %w", err)
 	}
 
-	if createCredentialsFromEnv(b.env) != nil {
-		return cfg, nil
-	}
-
 	mergedIAMRoleOptions := getMergedIAMRoleOptions(b.sessionConfig, b.iamRoleOpts)
 	if mergedIAMRoleOptions.RoleARN == "" {
 		return cfg, nil


### PR DESCRIPTION
## Description

Fixes #5105.

Prior to this change, getCredentialsFromEnv() was called twice instead of using the AWS config package. In my tests, this prevented the AssumeRoleARN to be respected correctly. In my tests and the unit tests, this didn't break any other tests.

## TODOs

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS credential handling to allow IAM role assumption even when environment credentials are already detected, enabling proper credential resolution in scenarios requiring role assumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->