### PR TITLE
fix: tolerate non-JSON warnings in tofu/terraform output -json (#6001)

### DIFF
--- a/docs/src/data/changelog/v1.0.4/fix-dependency-output-warning-pollution.mdx
+++ b/docs/src/data/changelog/v1.0.4/fix-dependency-output-warning-pollution.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.4"
+category: "bug-fixes"
+---
+
+#### Tolerate non-JSON warnings in `tofu/terraform output -json`
+
+Resolving `dependency` outputs no longer fails when the underlying `tofu/terraform output -json` invocation prints a deprecation warning to stdout alongside the JSON payload. Terraform 1.15.0 introduced a backend deprecation warning for the S3 `dynamodb_table` parameter that is emitted on stdout *after* the JSON object, which broke parsing with errors like `invalid character 'W' after top-level value` and the misleading downstream message `There is no variable named "dependency"`.
+
+Terragrunt now isolates the first JSON object in the captured stdout, so leading log lines (for example, the long-standing AWS Client Side Monitoring `Enabling CSM` line) and trailing warning blocks are both ignored when reading dependency outputs.
+
+Resolves [#6001](https://github.com/gruntwork-io/terragrunt/issues/6001).

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -877,16 +877,49 @@ func getOutputJSONWithCaching(ctx context.Context, pctx *ParsingContext, l log.L
 		return nil, err
 	}
 
-	// When AWS Client Side Monitoring (CSM) is enabled the aws-sdk-go displays log as a plaintext "Enabling CSM" to stdout, even if the `output -json` flag is specified. The final output looks like this: "2023/05/04 20:22:43 Enabling CSM{...omitted json string...}", and and prevents proper json parsing. Since there is no way to disable this log, the only way out is to filter.
-	// Related AWS code: https://github.com/aws/aws-sdk-go/blob/81d1cbbc6a2028023aff7bcab0fe1be320cd39f7/aws/session/session.go#L444
-	// Related issues: https://github.com/gruntwork-io/terragrunt/issues/2233 https://github.com/hashicorp/terraform-provider-aws/issues/23620
-	if index := bytes.IndexByte(newJSONBytes, byte('{')); index > 0 {
-		newJSONBytes = newJSONBytes[index:]
+	// `tofu/terraform output -json` stdout can be polluted with non-JSON text on either side of the JSON object:
+	//   - Leading: AWS Client Side Monitoring (CSM) logs (e.g., "2023/05/04 20:22:43 Enabling CSM"),
+	//     ANSI color escape sequences from warning blocks.
+	//     Refs: https://github.com/aws/aws-sdk-go/blob/81d1cbbc6a2028023aff7bcab0fe1be320cd39f7/aws/session/session.go#L444
+	//           https://github.com/gruntwork-io/terragrunt/issues/2233
+	//   - Trailing: Terraform 1.15+ emits backend deprecation warnings (e.g., for the S3
+	//     `dynamodb_table` parameter) on stdout after the JSON has already been printed.
+	//     Refs: https://github.com/gruntwork-io/terragrunt/issues/6001
+	//
+	// To make parsing robust to either, isolate the first JSON object in the buffer.
+	trimmedJSONBytes, trimErr := extractFirstJSONObject(newJSONBytes)
+	if trimErr != nil {
+		return nil, errors.New(TerragruntOutputParsingError{Path: targetConfig, Err: trimErr})
 	}
+
+	newJSONBytes = trimmedJSONBytes
 
 	jsonCache.Put(ctx, targetConfig, newJSONBytes)
 
 	return newJSONBytes, nil
+}
+
+// extractFirstJSONObject returns the first complete JSON object found in data, ignoring any
+// non-JSON content that precedes or follows it. This is needed because `tofu/terraform output -json`
+// can intermix log lines, ANSI escape codes, or deprecation warnings with the JSON output, depending
+// on the version and backend in use.
+//
+// If data contains no `{`, the original bytes are returned so downstream JSON parsing surfaces the
+// usual "unexpected end of JSON input" error rather than a cryptic message from this helper.
+func extractFirstJSONObject(data []byte) ([]byte, error) {
+	start := bytes.IndexByte(data, '{')
+	if start < 0 {
+		return data, nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data[start:]))
+
+	var raw json.RawMessage
+	if err := dec.Decode(&raw); err != nil {
+		return nil, err
+	}
+
+	return raw, nil
 }
 
 // Retrieve the outputs from the terraform state in the target configuration. This attempts to optimize the output

--- a/pkg/config/dependency_internal_test.go
+++ b/pkg/config/dependency_internal_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtractFirstJSONObject verifies that we can isolate the first JSON object emitted by
+// `tofu/terraform output -json` even when stdout is polluted with non-JSON content on either
+// side of the JSON. See https://github.com/gruntwork-io/terragrunt/issues/6001 for the trailing-
+// warning regression introduced by Terraform 1.15, and #2233 for the leading AWS CSM log line.
+func TestExtractFirstJSONObject(t *testing.T) {
+	t.Parallel()
+
+	const validJSON = `{"foo":{"sensitive":false,"type":"string","value":"bar"}}`
+
+	tcs := []struct {
+		name      string
+		input     string
+		want      string
+		wantExact bool // when true, compare bytes exactly instead of as JSON
+		wantErr   bool
+	}{
+		{
+			name:  "pure JSON is returned unchanged",
+			input: validJSON,
+			want:  validJSON,
+		},
+		{
+			name:  "leading AWS CSM log line is stripped",
+			input: "2023/05/04 20:22:43 Enabling CSM" + validJSON,
+			want:  validJSON,
+		},
+		{
+			name:  "leading ANSI-colored warning is stripped",
+			input: "\x1b[33m\x1b[1mWarning:\x1b[0m Deprecated Parameter\n\n" + validJSON,
+			want:  validJSON,
+		},
+		{
+			name: "trailing Terraform 1.15 deprecation warning is ignored",
+			input: validJSON + "\n\n" +
+				"Warning: Deprecated Parameter\n\n" +
+				`The parameter "dynamodb_table" is deprecated. Use parameter "use_lockfile" instead.` + "\n",
+			want: validJSON,
+		},
+		{
+			name: "leading and trailing pollution together",
+			input: "2023/05/04 20:22:43 Enabling CSM" + validJSON +
+				"\nWarning: Deprecated Parameter\n",
+			want: validJSON,
+		},
+		{
+			name:  "empty outputs object is preserved",
+			input: "Warning: something\n{}\nWarning: trailing\n",
+			want:  "{}",
+		},
+		{
+			name:      "no JSON returns input unchanged so downstream surfaces the underlying error",
+			input:     "no json here at all",
+			want:      "no json here at all",
+			wantExact: true,
+		},
+		{
+			name:    "truncated JSON object surfaces a parse error",
+			input:   `{"foo":`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := extractFirstJSONObject([]byte(tc.input))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.wantExact {
+				assert.Equal(t, tc.want, string(got))
+				return
+			}
+
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes #6001.

Terraform 1.15.0 emits a backend deprecation warning on stdout alongside the JSON payload of `output -json` (for example, for the deprecated S3 `dynamodb_table` parameter). Because the warning is printed *after* the JSON object, the long-standing leading-garbage workaround for AWS CSM logging (#2233) does not help, and resolving `dependency` outputs fails with:

```
invalid character 'W' after top-level value
```

…surfaced to the user as the misleading `There is no variable named "dependency"`.

This PR replaces the `bytes.IndexByte('{')` snippet in `getOutputJSONWithCaching` with a small helper, `extractFirstJSONObject`, that:

1. Skips to the first `{` in the captured stdout, and
2. Uses `json.Decoder` to read exactly one JSON value — ignoring anything that follows.

The result is that both leading non-JSON content (CSM logs, ANSI-colored warnings) and trailing non-JSON content (TF 1.15 deprecation warnings) are now tolerated when reading dependency outputs.

## Tests

A new internal test `TestExtractFirstJSONObject` in `pkg/config/dependency_internal_test.go` covers:

- pure JSON
- leading AWS CSM log line (regression coverage for #2233)
- leading ANSI-colored warning
- **trailing TF 1.15 deprecation warning** (the regression in this PR)
- leading + trailing combined
- empty `{}`
- no JSON at all
- truncated JSON object

Local validation:

- `go test ./pkg/config/` — pass
- `go vet ./pkg/config/...` — clean
- `golangci-lint run --new-from-merge-base=main ./pkg/config/...` (v2.11.4, the version pinned in `mise.toml`) — `0 issues`
- `gofmt` / `goimports` — clean

I did not add a live integration test against Terraform 1.15 + a real S3 backend, since that requires AWS credentials and a state bucket. The behaviour is exercised at the seam where the bug actually lives — the JSON-from-stdout extraction — using fixture stdout that exactly reproduces the reporter's `'W' after top-level value` symptom. Happy to add one if maintainers prefer.

## Disclosure

Implementation was drafted with the help of Claude Code (Anthropic) and reviewed/validated by me. The code is not adapted from any third-party project.

## TODOs

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag. (N/A — bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dependency output parsing when Terraform/OpenTofu emit deprecation warnings. Dependency resolution no longer fails when warnings appear in the output (e.g., Terraform 1.15.0's S3 dynamodb_table deprecation).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->