### PR TITLE
chore: Dropping insignificant OpenTelemetry traces

### DIFF
--- a/internal/cli/commands/list/list.go
+++ b/internal/cli/commands/list/list.go
@@ -20,6 +20,9 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/view/dag"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Run runs the list command.
@@ -71,6 +74,11 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		"dependencies": opts.Dependencies || opts.Mode == ModeDAG,
 	}, func(ctx context.Context) error {
 		components, discoverErr = d.Discover(ctx, l, opts.TerragruntOptions)
+
+		if span := trace.SpanFromContext(ctx); span.IsRecording() {
+			span.SetAttributes(attribute.Int("component_count", len(components)))
+		}
+
 		return discoverErr
 	})
 	if err != nil {
@@ -110,6 +118,10 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		"config_count": len(components),
 	}, func(ctx context.Context) error {
 		listedComponents = discoveredToListed(l, components, opts)
+
+		if span := trace.SpanFromContext(ctx); span.IsRecording() {
+			span.SetAttributes(attribute.Int("listed_count", len(listedComponents)))
+		}
 
 		return nil
 	})

--- a/internal/runner/run/creds/providers/amazonsts/provider.go
+++ b/internal/runner/run/creds/providers/amazonsts/provider.go
@@ -6,10 +6,12 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/gruntwork-io/terragrunt/internal/awshelper"
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/iam"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds/providers"
+	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
@@ -47,7 +49,19 @@ func (provider *Provider) GetCredentials(ctx context.Context, l log.Logger) (*pr
 	l.Debugf("Assuming IAM role %s with a session duration of %d seconds.",
 		iamRoleOpts.RoleARN, iamRoleOpts.AssumeRoleDuration)
 
-	resp, err := awshelper.AssumeIamRole(ctx, iamRoleOpts, "", provider.env)
+	var resp *types.Credentials
+
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "creds_assume_role", map[string]any{
+		"role_arn":     iamRoleOpts.RoleARN,
+		"session_name": iamRoleOpts.AssumeRoleSessionName,
+		"duration":     iamRoleOpts.AssumeRoleDuration,
+	}, func(ctx context.Context) error {
+		var assumeErr error
+
+		resp, assumeErr = awshelper.AssumeIamRole(ctx, iamRoleOpts, "", provider.env)
+
+		return assumeErr
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/report"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
+	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -104,7 +105,12 @@ func DownloadTerraformSource(
 			copyOpts = append(copyOpts, util.WithFastCopy())
 		}
 
-		err = util.CopyFolderContents(l, opts.WorkingDir, terraformSource.WorkingDir, ModuleManifestName, copyOpts...)
+		err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "copy_folder_contents", map[string]any{
+			"src":  opts.WorkingDir,
+			"dest": terraformSource.WorkingDir,
+		}, func(_ context.Context) error {
+			return util.CopyFolderContents(l, opts.WorkingDir, terraformSource.WorkingDir, ModuleManifestName, copyOpts...)
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/runner/runnerpool/controller.go
+++ b/internal/runner/runnerpool/controller.go
@@ -15,6 +15,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 
 	"github.com/puzpuzpuz/xsync/v3"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // UnitRunner defines a function type that executes a Unit within a given context and returns an error.
@@ -172,7 +174,20 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 		// Collect errors from results map and check for errors
 		errCollector := &errors.MultiError{}
 
+		var succeeded, failed, earlyExit int
+
 		for _, entry := range dr.q.Entries {
+			switch entry.Status {
+			case queue.StatusSucceeded:
+				succeeded++
+			case queue.StatusFailed:
+				failed++
+			case queue.StatusEarlyExit:
+				earlyExit++
+			case queue.StatusPending, queue.StatusBlocked, queue.StatusUnsorted, queue.StatusReady, queue.StatusRunning:
+				// Non-terminal states are not counted in the summary.
+			}
+
 			if err, ok := results.Load(entry.Component.Path()); ok {
 				if err == nil {
 					continue
@@ -191,6 +206,14 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 			if entry.Status == queue.StatusFailed {
 				errCollector = errCollector.Append(NewUnitFailedError(entry.Component.Path()))
 			}
+		}
+
+		if span := trace.SpanFromContext(childCtx); span.IsRecording() {
+			span.SetAttributes(
+				attribute.Int("tasks_succeeded", succeeded),
+				attribute.Int("tasks_failed", failed),
+				attribute.Int("tasks_early_exit", earlyExit),
+			)
 		}
 
 		return errCollector.ErrorOrNil()

--- a/internal/shell/run_cmd.go
+++ b/internal/shell/run_cmd.go
@@ -18,6 +18,9 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 )
@@ -200,107 +203,143 @@ func RunCommandWithOutput(
 		"args":    fmt.Sprintf("%v", args),
 		"dir":     commandDir,
 	}, func(ctx context.Context) error {
-		l.Debugf("Running command: %s %s", command, strings.Join(args, " "))
+		runErr := runCommand(ctx, l, e, runOpts, commandDir, suppressStdout, needsPTY, command, args, &output)
 
-		var (
-			cmdStderr = io.MultiWriter(runOpts.Writers.ErrWriter, &output.Stderr)
-			cmdStdout = io.MultiWriter(runOpts.Writers.Writer, &output.Stdout)
-		)
+		if span := trace.SpanFromContext(ctx); span.IsRecording() {
+			exitCode := 0
 
-		// Pass the traceparent to the child process if it is available in the context.
-		if traceParent := telemetry.TraceParentFromContext(ctx, runOpts.Telemetry); traceParent != "" {
-			l.Debugf("Setting trace parent=%q for command %s", traceParent, fmt.Sprintf("%s %v", command, args))
-			runOpts.Env[telemetry.TraceParentEnv] = traceParent
-		}
-
-		if suppressStdout {
-			l.Debugf("Command output will be suppressed.")
-
-			cmdStdout = io.MultiWriter(&output.Stdout)
-		}
-
-		if command == runOpts.TFPath {
-			// If the engine is enabled and the command is IaC executable, use the engine to run the command.
-			if runOpts.EngineConfig != nil && runOpts.Experiments.Evaluate(experiment.IacEngine) && !runOpts.NoEngine() {
-				l.Debugf("Using engine to run command: %s %s", command, strings.Join(args, " "))
-
-				cmdOutput, err := engine.Run(ctx, l, e, &engine.ExecutionOptions{
-					Writers: writer.Writers{
-						Writer:                 writer.NewWrappedWriter(cmdStdout, runOpts.Writers.Writer),
-						ErrWriter:              writer.NewWrappedWriter(cmdStderr, runOpts.Writers.ErrWriter),
-						LogShowAbsPaths:        runOpts.Writers.LogShowAbsPaths,
-						LogDisableErrorSummary: runOpts.Writers.LogDisableErrorSummary,
-					},
-					EngineOptions:     runOpts.EngineOptions,
-					EngineConfig:      runOpts.EngineConfig,
-					Env:               runOpts.Env,
-					WorkingDir:        commandDir,
-					RootWorkingDir:    runOpts.RootWorkingDir,
-					Command:           command,
-					Args:              args,
-					Headless:          runOpts.Headless,
-					ForwardTFStdout:   runOpts.ForwardTFStdout,
-					SuppressStdout:    suppressStdout,
-					AllocatePseudoTty: needsPTY,
-				})
-				if err != nil {
-					return errors.New(err)
+			if runErr != nil {
+				if code, codeErr := util.GetExitCode(runErr); codeErr == nil {
+					exitCode = code
+				} else {
+					exitCode = -1
 				}
-
-				output = *cmdOutput
-
-				return err
-			}
-		}
-
-		cmd := exec.Command(ctx, e, command, args...)
-		cmd.SetDir(commandDir)
-		cmd.SetStdout(cmdStdout)
-		cmd.SetStderr(cmdStderr)
-		cmd.Configure(
-			exec.WithUsePTY(needsPTY),
-			exec.WithEnv(runOpts.Env),
-			exec.WithForwardSignalDelay(SignalForwardingDelay),
-		)
-
-		// Save/restore console mode around subprocess — Windows subprocesses can reset it.
-		savedConsole := exec.SaveConsoleState()
-		defer savedConsole.Restore()
-
-		if err := cmd.Start(l); err != nil { //nolint:contextcheck // context already passed to exec.Command
-			err = util.ProcessExecutionError{
-				Err:             err,
-				Args:            args,
-				Command:         command,
-				WorkingDir:      cmd.Dir(),
-				RootWorkingDir:  runOpts.RootWorkingDir,
-				LogShowAbsPaths: runOpts.Writers.LogShowAbsPaths,
-				DisableSummary:  runOpts.Writers.LogDisableErrorSummary,
 			}
 
-			return errors.New(err)
+			span.SetAttributes(
+				attribute.Int("exit_code", exitCode),
+				attribute.Int("stdout_bytes", output.Stdout.Len()),
+				attribute.Int("stderr_bytes", output.Stderr.Len()),
+			)
 		}
 
-		cancelShutdown := cmd.RegisterGracefullyShutdown(ctx, l)
-		defer cancelShutdown()
-
-		if err := cmd.Wait(); err != nil {
-			err = util.ProcessExecutionError{
-				Err:             err,
-				Args:            args,
-				Command:         command,
-				Output:          output,
-				WorkingDir:      cmd.Dir(),
-				RootWorkingDir:  runOpts.RootWorkingDir,
-				LogShowAbsPaths: runOpts.Writers.LogShowAbsPaths,
-				DisableSummary:  runOpts.Writers.LogDisableErrorSummary,
-			}
-
-			return errors.New(err)
-		}
-
-		return nil
+		return runErr
 	})
 
 	return &output, err
+}
+
+// runCommand contains the actual subprocess execution logic, separated to keep
+// RunCommandWithOutput focused on telemetry framing.
+func runCommand(
+	ctx context.Context,
+	l log.Logger,
+	e vexec.Exec,
+	runOpts *ShellOptions,
+	commandDir string,
+	suppressStdout, needsPTY bool,
+	command string,
+	args []string,
+	output *util.CmdOutput,
+) error {
+	l.Debugf("Running command: %s %s", command, strings.Join(args, " "))
+
+	var (
+		cmdStderr = io.MultiWriter(runOpts.Writers.ErrWriter, &output.Stderr)
+		cmdStdout = io.MultiWriter(runOpts.Writers.Writer, &output.Stdout)
+	)
+
+	// Pass the traceparent to the child process if it is available in the context.
+	if traceParent := telemetry.TraceParentFromContext(ctx, runOpts.Telemetry); traceParent != "" {
+		l.Debugf("Setting trace parent=%q for command %s", traceParent, fmt.Sprintf("%s %v", command, args))
+		runOpts.Env[telemetry.TraceParentEnv] = traceParent
+	}
+
+	if suppressStdout {
+		l.Debugf("Command output will be suppressed.")
+
+		cmdStdout = io.MultiWriter(&output.Stdout)
+	}
+
+	if command == runOpts.TFPath {
+		// If the engine is enabled and the command is IaC executable, use the engine to run the command.
+		if runOpts.EngineConfig != nil && runOpts.Experiments.Evaluate(experiment.IacEngine) && !runOpts.NoEngine() {
+			l.Debugf("Using engine to run command: %s %s", command, strings.Join(args, " "))
+
+			cmdOutput, err := engine.Run(ctx, l, e, &engine.ExecutionOptions{
+				Writers: writer.Writers{
+					Writer:                 writer.NewWrappedWriter(cmdStdout, runOpts.Writers.Writer),
+					ErrWriter:              writer.NewWrappedWriter(cmdStderr, runOpts.Writers.ErrWriter),
+					LogShowAbsPaths:        runOpts.Writers.LogShowAbsPaths,
+					LogDisableErrorSummary: runOpts.Writers.LogDisableErrorSummary,
+				},
+				EngineOptions:     runOpts.EngineOptions,
+				EngineConfig:      runOpts.EngineConfig,
+				Env:               runOpts.Env,
+				WorkingDir:        commandDir,
+				RootWorkingDir:    runOpts.RootWorkingDir,
+				Command:           command,
+				Args:              args,
+				Headless:          runOpts.Headless,
+				ForwardTFStdout:   runOpts.ForwardTFStdout,
+				SuppressStdout:    suppressStdout,
+				AllocatePseudoTty: needsPTY,
+			})
+			if err != nil {
+				return errors.New(err)
+			}
+
+			*output = *cmdOutput
+
+			return err
+		}
+	}
+
+	cmd := exec.Command(ctx, e, command, args...)
+	cmd.SetDir(commandDir)
+	cmd.SetStdout(cmdStdout)
+	cmd.SetStderr(cmdStderr)
+	cmd.Configure(
+		exec.WithUsePTY(needsPTY),
+		exec.WithEnv(runOpts.Env),
+		exec.WithForwardSignalDelay(SignalForwardingDelay),
+	)
+
+	// Save/restore console mode around subprocess — Windows subprocesses can reset it.
+	savedConsole := exec.SaveConsoleState()
+	defer savedConsole.Restore()
+
+	if err := cmd.Start(l); err != nil { //nolint:contextcheck // context already passed to exec.Command
+		err = util.ProcessExecutionError{
+			Err:             err,
+			Args:            args,
+			Command:         command,
+			WorkingDir:      cmd.Dir(),
+			RootWorkingDir:  runOpts.RootWorkingDir,
+			LogShowAbsPaths: runOpts.Writers.LogShowAbsPaths,
+			DisableSummary:  runOpts.Writers.LogDisableErrorSummary,
+		}
+
+		return errors.New(err)
+	}
+
+	cancelShutdown := cmd.RegisterGracefullyShutdown(ctx, l)
+	defer cancelShutdown()
+
+	if err := cmd.Wait(); err != nil {
+		err = util.ProcessExecutionError{
+			Err:             err,
+			Args:            args,
+			Command:         command,
+			Output:          *output,
+			WorkingDir:      cmd.Dir(),
+			RootWorkingDir:  runOpts.RootWorkingDir,
+			LogShowAbsPaths: runOpts.Writers.LogShowAbsPaths,
+			DisableSummary:  runOpts.Writers.LogDisableErrorSummary,
+		}
+
+		return errors.New(err)
+	}
+
+	return nil
 }

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/retry"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
@@ -713,7 +714,20 @@ func getAWSField(ctx context.Context, pctx *ParsingContext, l log.Logger, fetchF
 		return "", err
 	}
 
-	return fetchFn(ctx, &awsConfig)
+	var result string
+
+	err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "config_get_aws_field", map[string]any{
+		"config_path": pctx.TerragruntConfigPath,
+		"role_arn":    pctx.IAMRoleOptions.RoleARN,
+	}, func(ctx context.Context) error {
+		var fetchErr error
+
+		result, fetchErr = fetchFn(ctx, &awsConfig)
+
+		return fetchErr
+	})
+
+	return result, err
 }
 
 func getAWSAccountAlias(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
@@ -1023,7 +1037,18 @@ func sopsDecryptFileImpl(ctx context.Context, pctx *ParsingContext, l log.Logger
 
 	l.Debugf("sops decrypt: decrypting %s", path)
 
-	rawData, err := decryptFn(path, format)
+	var rawData []byte
+
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "config_sops_decrypt", map[string]any{
+		"path":   path,
+		"format": format,
+	}, func(ctx context.Context) error {
+		var decryptErr error
+
+		rawData, decryptErr = decryptFn(path, format)
+
+		return decryptErr
+	})
 	if err != nil {
 		return "", errors.New(extractSopsErrors(err))
 	}

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -39,7 +39,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/retry"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
-	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
@@ -273,96 +272,42 @@ func getPlatform(ctx context.Context, pctx *ParsingContext, l log.Logger) (strin
 
 // Return the repository root as an absolute path
 func getRepoRoot(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-
-	var result string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_repo_root", attrs, func(childCtx context.Context) error {
-		var innerErr error
-
-		result, innerErr = shell.GitTopLevelDir(childCtx, l, pctx.Env, pctx.WorkingDir)
-
-		return innerErr
-	})
-
-	return result, err
+	return shell.GitTopLevelDir(ctx, l, pctx.Env, pctx.WorkingDir)
 }
 
 // Return the path from the repository root
 func getPathFromRepoRoot(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
+	repoAbsPath, err := shell.GitTopLevelDir(ctx, l, pctx.Env, pctx.WorkingDir)
+	if err != nil {
+		return "", fmt.Errorf("getting git top level dir: %w", err)
 	}
 
-	var result string
+	repoRelPath, err := filepath.Rel(repoAbsPath, pctx.WorkingDir)
+	if err != nil {
+		return "", fmt.Errorf("computing path relative to repo root: %w", err)
+	}
 
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_path_from_repo_root", attrs, func(childCtx context.Context) error {
-		repoAbsPath, innerErr := shell.GitTopLevelDir(childCtx, l, pctx.Env, pctx.WorkingDir)
-		if innerErr != nil {
-			return errors.New(innerErr)
-		}
-
-		repoRelPath, innerErr := filepath.Rel(repoAbsPath, pctx.WorkingDir)
-		if innerErr != nil {
-			return errors.New(innerErr)
-		}
-
-		result = repoRelPath
-
-		return nil
-	})
-
-	return result, err
+	return repoRelPath, nil
 }
 
 // Return the path to the repository root
 func getPathToRepoRoot(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
+	repoAbsPath, err := shell.GitTopLevelDir(ctx, l, pctx.Env, pctx.WorkingDir)
+	if err != nil {
+		return "", fmt.Errorf("getting git top level dir: %w", err)
 	}
 
-	var result string
+	repoRootPathAbs, err := filepath.Rel(pctx.WorkingDir, repoAbsPath)
+	if err != nil {
+		return "", fmt.Errorf("computing path to repo root: %w", err)
+	}
 
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_path_to_repo_root", attrs, func(childCtx context.Context) error {
-		repoAbsPath, innerErr := shell.GitTopLevelDir(childCtx, l, pctx.Env, pctx.WorkingDir)
-		if innerErr != nil {
-			return errors.New(innerErr)
-		}
-
-		repoRootPathAbs, innerErr := filepath.Rel(pctx.WorkingDir, repoAbsPath)
-		if innerErr != nil {
-			return errors.New(innerErr)
-		}
-
-		result = strings.TrimSpace(repoRootPathAbs)
-
-		return nil
-	})
-
-	return result, err
+	return strings.TrimSpace(repoRootPathAbs), nil
 }
 
 // GetTerragruntDir returns the directory where the Terragrunt configuration file lives.
 func GetTerragruntDir(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-
-	var result string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_terragrunt_dir", attrs, func(childCtx context.Context) error {
-		result = filepath.Dir(pctx.TerragruntConfigPath)
-
-		return nil
-	})
-
-	return result, err
+	return filepath.Dir(pctx.TerragruntConfigPath), nil
 }
 
 // Return the directory where the original Terragrunt configuration file lives. This is primarily useful when one
@@ -370,50 +315,19 @@ func GetTerragruntDir(ctx context.Context, pctx *ParsingContext, l log.Logger) (
 // calls read_terragrunt_config("/foo/bar.hcl"), and within bar.hcl, you call get_original_terragrunt_dir(), you'll
 // get back /terraform-code.
 func getOriginalTerragruntDir(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-
-	var result string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_original_terragrunt_dir", attrs, func(childCtx context.Context) error {
-		result = filepath.Dir(pctx.OriginalTerragruntConfigPath)
-
-		return nil
-	})
-
-	return result, err
+	return filepath.Dir(pctx.OriginalTerragruntConfigPath), nil
 }
 
 // GetParentTerragruntDir returns the parent directory where the Terragrunt configuration file lives.
 func GetParentTerragruntDir(ctx context.Context, pctx *ParsingContext, l log.Logger, params []string) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-	if len(params) > 0 {
-		attrs["include_label"] = params[0]
+	parentPath, err := PathRelativeFromInclude(ctx, pctx, l, params)
+	if err != nil {
+		return "", fmt.Errorf("getting path relative from include: %w", err)
 	}
 
-	var result string
+	currentPath := filepath.Dir(pctx.TerragruntConfigPath)
 
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_parent_terragrunt_dir", attrs, func(childCtx context.Context) error {
-		parentPath, innerErr := PathRelativeFromInclude(childCtx, pctx, l, params)
-		if innerErr != nil {
-			return errors.New(innerErr)
-		}
-
-		currentPath := filepath.Dir(pctx.TerragruntConfigPath)
-
-		parentPath = filepath.Clean(filepath.Join(currentPath, parentPath))
-
-		result = parentPath
-
-		return nil
-	})
-
-	return result, err
+	return filepath.Clean(filepath.Join(currentPath, parentPath)), nil
 }
 
 func parseGetEnvParameters(parameters []string) (EnvVar, error) {
@@ -441,55 +355,7 @@ func parseGetEnvParameters(parameters []string) (EnvVar, error) {
 // for each `run_cmd` in locals section, function is called twice
 // result
 func RunCommand(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) (string, error) {
-	// Capture original args for telemetry before any modifications
-	originalArgs := make([]string, len(args))
-	copy(originalArgs, args)
-
-	// Parse flags for telemetry attributes
-	suppressOutput := false
-	disableCache := false
-	useGlobalCache := false
-
-	for _, arg := range args {
-		switch arg {
-		case "--terragrunt-quiet":
-			suppressOutput = true
-		case "--terragrunt-global-cache":
-			useGlobalCache = true
-		case "--terragrunt-no-cache":
-			disableCache = true
-		}
-	}
-
-	// Extract command name (first non-flag argument)
-	var command string
-
-	for _, arg := range args {
-		if !strings.HasPrefix(arg, "--terragrunt-") {
-			command = arg
-			break
-		}
-	}
-
-	var result string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_run_cmd", map[string]any{
-		"config_path":     pctx.TerragruntConfigPath,
-		"working_dir":     pctx.WorkingDir,
-		"command":         command,
-		"args":            fmt.Sprintf("%v", originalArgs),
-		"suppress_output": suppressOutput,
-		"global_cache":    useGlobalCache,
-		"no_cache":        disableCache,
-	}, func(childCtx context.Context) error {
-		var innerErr error
-
-		result, innerErr = runCommandImpl(childCtx, pctx, l, args)
-
-		return innerErr
-	})
-
-	return result, err
+	return runCommandImpl(ctx, pctx, l, args)
 }
 
 // runCommandImpl contains the actual implementation of RunCommand
@@ -583,7 +449,7 @@ func runCommandImpl(ctx context.Context, pctx *ParsingContext, l log.Logger, arg
 		args[1:]...,
 	)
 	if err != nil {
-		return "", errors.New(err)
+		return "", fmt.Errorf("running command: %w", err)
 	}
 
 	value := strings.TrimSuffix(cmdOutput.Stdout.String(), "\n")
@@ -619,43 +485,21 @@ func runCommandImpl(ctx context.Context, pctx *ParsingContext, l log.Logger, arg
 }
 
 func getEnvironmentVariable(ctx context.Context, pctx *ParsingContext, l log.Logger, parameters []string) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
+	parameterMap, err := parseGetEnvParameters(parameters)
+	if err != nil {
+		return "", fmt.Errorf("parsing get_env parameters: %w", err)
 	}
 
-	if len(parameters) > 0 {
-		attrs["env_name"] = parameters[0]
-	}
-
-	if len(parameters) > 1 {
-		attrs["default_value"] = parameters[1]
-	}
-
-	var result string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_env", attrs, func(childCtx context.Context) error {
-		parameterMap, innerErr := parseGetEnvParameters(parameters)
-		if innerErr != nil {
-			return errors.New(innerErr)
+	envValue, exists := pctx.Env[parameterMap.Name]
+	if !exists {
+		if parameterMap.IsRequired {
+			return "", errors.New(EnvVarNotFoundError{EnvVar: parameterMap.Name})
 		}
 
-		envValue, exists := pctx.Env[parameterMap.Name]
+		envValue = parameterMap.DefaultValue
+	}
 
-		if !exists {
-			if parameterMap.IsRequired {
-				return errors.New(EnvVarNotFoundError{EnvVar: parameterMap.Name})
-			}
-
-			envValue = parameterMap.DefaultValue
-		}
-
-		result = envValue
-
-		return nil
-	})
-
-	return result, err
+	return envValue, nil
 }
 
 // FindInParentFolders fings a parent Terragrunt configuration file in the parent
@@ -666,29 +510,7 @@ func FindInParentFolders(
 	l log.Logger,
 	params []string,
 ) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-	if len(params) > 0 {
-		attrs["file_to_find"] = params[0]
-	}
-
-	if len(params) > 1 {
-		attrs["fallback"] = params[1]
-	}
-
-	var result string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_find_in_parent_folders", attrs, func(childCtx context.Context) error {
-		var innerErr error
-
-		result, innerErr = findInParentFoldersImpl(childCtx, pctx, l, params)
-
-		return innerErr
-	})
-
-	return result, err
+	return findInParentFoldersImpl(ctx, pctx, l, params)
 }
 
 // findInParentFoldersImpl contains the actual implementation of FindInParentFolders
@@ -772,94 +594,62 @@ func findInParentFoldersImpl(ctx context.Context, pctx *ParsingContext, l log.Lo
 // and the current Terragrunt configuration file. Name param is required and used to lookup the
 // relevant import block when called in a child config with multiple import blocks.
 func PathRelativeToInclude(ctx context.Context, pctx *ParsingContext, l log.Logger, params []string) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-	if len(params) > 0 {
-		attrs["include_label"] = params[0]
+	if pctx.TrackInclude == nil {
+		return ".", nil
 	}
 
-	var result string
+	var included IncludeConfig
 
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_path_relative_to_include", attrs, func(childCtx context.Context) error {
-		if pctx.TrackInclude == nil {
-			result = "."
-			return nil
+	switch {
+	case pctx.TrackInclude.Original != nil:
+		included = *pctx.TrackInclude.Original
+	case len(pctx.TrackInclude.CurrentList) > 0:
+		// Called in child ctx, so we need to select the right include file.
+		selected, err := getSelectedIncludeBlock(*pctx.TrackInclude, params)
+		if err != nil {
+			return "", err
 		}
 
-		var included IncludeConfig
+		included = *selected
+	default:
+		return ".", nil
+	}
 
-		switch {
-		case pctx.TrackInclude.Original != nil:
-			included = *pctx.TrackInclude.Original
-		case len(pctx.TrackInclude.CurrentList) > 0:
-			// Called in child ctx, so we need to select the right include file.
-			selected, innerErr := getSelectedIncludeBlock(*pctx.TrackInclude, params)
-			if innerErr != nil {
-				return innerErr
-			}
+	currentPath := filepath.Dir(pctx.TerragruntConfigPath)
+	includePath := filepath.Dir(included.Path)
 
-			included = *selected
-		default:
-			result = "."
-			return nil
-		}
+	result, err := filepath.Rel(includePath, currentPath)
+	if err != nil {
+		return "", fmt.Errorf("relativize current path %q against include path %q: %w", currentPath, includePath, err)
+	}
 
-		currentPath := filepath.Dir(pctx.TerragruntConfigPath)
-		includePath := filepath.Dir(included.Path)
-
-		var innerErr error
-
-		result, innerErr = filepath.Rel(includePath, currentPath)
-		if innerErr != nil {
-			return fmt.Errorf("relativize current path %q against include path %q: %w", currentPath, includePath, innerErr)
-		}
-
-		return nil
-	})
-
-	return result, err
+	return result, nil
 }
 
 // PathRelativeFromInclude returns the relative path from the current Terragrunt configuration to the included Terragrunt configuration file
 func PathRelativeFromInclude(ctx context.Context, pctx *ParsingContext, l log.Logger, params []string) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-	if len(params) > 0 {
-		attrs["include_label"] = params[0]
+	if pctx.TrackInclude == nil {
+		return ".", nil
 	}
 
-	var result string
+	included, err := getSelectedIncludeBlock(*pctx.TrackInclude, params)
+	if err != nil {
+		return "", err
+	}
 
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_path_relative_from_include", attrs, func(childCtx context.Context) error {
-		if pctx.TrackInclude == nil {
-			result = "."
-			return nil
-		}
+	if included == nil {
+		return ".", nil
+	}
 
-		included, innerErr := getSelectedIncludeBlock(*pctx.TrackInclude, params)
-		if innerErr != nil {
-			return innerErr
-		} else if included == nil {
-			result = "."
-			return nil
-		}
+	includePath := filepath.Dir(included.Path)
+	currentPath := filepath.Dir(pctx.TerragruntConfigPath)
 
-		includePath := filepath.Dir(included.Path)
-		currentPath := filepath.Dir(pctx.TerragruntConfigPath)
+	result, err := filepath.Rel(currentPath, includePath)
+	if err != nil {
+		return "", fmt.Errorf("relativize include path %q against current path %q: %w", includePath, currentPath, err)
+	}
 
-		result, innerErr = filepath.Rel(currentPath, includePath)
-		if innerErr != nil {
-			return fmt.Errorf("relativize include path %q against current path %q: %w", includePath, currentPath, innerErr)
-		}
-
-		return nil
-	})
-
-	return result, err
+	return result, nil
 }
 
 // getTerraformCommand returns the current terraform command in execution
@@ -869,26 +659,6 @@ func getTerraformCommand(ctx context.Context, pctx *ParsingContext, l log.Logger
 
 // getWorkingDir returns the current working dir
 func getWorkingDir(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-
-	var result string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_working_dir", attrs, func(childCtx context.Context) error {
-		var innerErr error
-
-		result, innerErr = getWorkingDirImpl(childCtx, pctx, l)
-
-		return innerErr
-	})
-
-	return result, err
-}
-
-// getWorkingDirImpl contains the actual implementation of getWorkingDir
-func getWorkingDirImpl(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
 	l.Debugf("Start processing get_working_dir built-in function")
 	defer l.Debugf("Complete processing get_working_dir built-in function")
 
@@ -920,87 +690,46 @@ func getWorkingDirImpl(ctx context.Context, pctx *ParsingContext, l log.Logger) 
 
 // getTerraformCliArgs returns cli args for terraform
 func getTerraformCliArgs(ctx context.Context, pctx *ParsingContext, l log.Logger) ([]string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
+	if pctx.TerraformCliArgs == nil {
+		return nil, nil
 	}
 
-	var result []string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_terraform_cli_args", attrs, func(childCtx context.Context) error {
-		if pctx.TerraformCliArgs != nil {
-			result = pctx.TerraformCliArgs.Slice()
-		}
-
-		return nil
-	})
-
-	return result, err
+	return pctx.TerraformCliArgs.Slice(), nil
 }
 
 // getDefaultRetryableErrors returns default retryable errors for use in errors.retry blocks
 func getDefaultRetryableErrors(ctx context.Context, pctx *ParsingContext, l log.Logger) ([]string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-
-	var result []string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_default_retryable_errors", attrs, func(childCtx context.Context) error {
-		result = retry.DefaultRetryableErrors
-		return nil
-	})
-
-	return result, err
+	return retry.DefaultRetryableErrors, nil
 }
 
-// getAWSField is a common helper for fetching a single AWS field with telemetry.
+// getAWSField is a common helper for fetching a single AWS field.
 // It builds an AWS config from the parsing context, then calls fetchFn to get the value.
-func getAWSField(ctx context.Context, pctx *ParsingContext, l log.Logger, telemetryName string, fetchFn func(context.Context, *aws.Config) (string, error)) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
+func getAWSField(ctx context.Context, pctx *ParsingContext, l log.Logger, fetchFn func(context.Context, *aws.Config) (string, error)) (string, error) {
+	awsConfig, err := awshelper.NewAWSConfigBuilder().
+		WithEnv(pctx.Env).
+		WithIAMRoleOptions(pctx.IAMRoleOptions).
+		Build(ctx, l)
+	if err != nil {
+		return "", err
 	}
 
-	var result string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, telemetryName, attrs, func(childCtx context.Context) error {
-		awsConfig, err := awshelper.NewAWSConfigBuilder().
-			WithEnv(pctx.Env).
-			WithIAMRoleOptions(pctx.IAMRoleOptions).
-			Build(childCtx, l)
-		if err != nil {
-			return err
-		}
-
-		val, err := fetchFn(childCtx, &awsConfig)
-		if err != nil {
-			return err
-		}
-
-		result = val
-
-		return nil
-	})
-
-	return result, err
+	return fetchFn(ctx, &awsConfig)
 }
 
 func getAWSAccountAlias(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	return getAWSField(ctx, pctx, l, "hcl_fn_get_aws_account_alias", awshelper.GetAWSAccountAlias)
+	return getAWSField(ctx, pctx, l, awshelper.GetAWSAccountAlias)
 }
 
 func getAWSAccountID(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	return getAWSField(ctx, pctx, l, "hcl_fn_get_aws_account_id", awshelper.GetAWSAccountID)
+	return getAWSField(ctx, pctx, l, awshelper.GetAWSAccountID)
 }
 
 func getAWSCallerIdentityARN(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	return getAWSField(ctx, pctx, l, "hcl_fn_get_aws_caller_identity_arn", awshelper.GetAWSIdentityArn)
+	return getAWSField(ctx, pctx, l, awshelper.GetAWSIdentityArn)
 }
 
 func getAWSCallerIdentityUserID(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	return getAWSField(ctx, pctx, l, "hcl_fn_get_aws_caller_identity_user_id", awshelper.GetAWSUserID)
+	return getAWSField(ctx, pctx, l, awshelper.GetAWSUserID)
 }
 
 // ParseTerragruntConfig parses the terragrunt config and return a
@@ -1122,24 +851,7 @@ func readTerragruntConfigAsFuncImpl(ctx context.Context, pctx *ParsingContext, l
 
 			targetConfigPath := strArgs[0]
 
-			attrs := map[string]any{
-				"config_path":        pctx.TerragruntConfigPath,
-				"working_dir":        pctx.WorkingDir,
-				"target_config_path": targetConfigPath,
-				"has_default":        defaultVal != nil,
-			}
-
-			var result cty.Value
-
-			err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_read_terragrunt_config", attrs, func(childCtx context.Context) error {
-				var innerErr error
-
-				result, innerErr = ParseTerragruntConfig(childCtx, pctx, l, targetConfigPath, defaultVal)
-
-				return innerErr
-			})
-
-			return result, err
+			return ParseTerragruntConfig(ctx, pctx, l, targetConfigPath, defaultVal)
 		},
 	})
 }
@@ -1233,46 +945,27 @@ func getModulePathFromSourceURL(sourceURL string) (string, error) {
 
 // decrypts and returns sops encrypted utf-8 yaml or json data as a string
 func sopsDecryptFile(ctx context.Context, pctx *ParsingContext, l log.Logger, params []string) (string, error) {
-	var sourceFile string
-	if len(params) > 0 {
-		sourceFile = params[0]
+	if len(params) != 1 {
+		return "", errors.New(WrongNumberOfParamsError{Func: "sops_decrypt_file", Expected: "1", Actual: len(params)})
 	}
 
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-		"file_path":   sourceFile,
+	sourceFile := params[0]
+
+	format, err := getSopsFileFormat(sourceFile)
+	if err != nil {
+		return "", fmt.Errorf("determining sops file format: %w", err)
 	}
 
-	var result string
+	path := sourceFile
 
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_sops_decrypt_file", attrs, func(childCtx context.Context) error {
-		if len(params) != 1 {
-			return errors.New(WrongNumberOfParamsError{Func: "sops_decrypt_file", Expected: "1", Actual: len(params)})
-		}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(pctx.WorkingDir, path)
+		path = filepath.Clean(path)
+	}
 
-		format, err := getSopsFileFormat(sourceFile)
-		if err != nil {
-			return errors.New(err)
-		}
+	trackFileRead(pctx.FilesRead, path)
 
-		path := sourceFile
-
-		if !filepath.IsAbs(path) {
-			path = filepath.Join(pctx.WorkingDir, path)
-			path = filepath.Clean(path)
-		}
-
-		trackFileRead(pctx.FilesRead, path)
-
-		var innerErr error
-
-		result, innerErr = sopsDecryptFileImpl(childCtx, pctx, l, path, format, decrypt.File)
-
-		return innerErr
-	})
-
-	return result, err
+	return sopsDecryptFileImpl(ctx, pctx, l, path, format, decrypt.File)
 }
 
 // sopsDecryptFileImpl contains the actual implementation of sopsDecryptFile
@@ -1368,19 +1061,7 @@ func getSopsFileFormat(sourceFile string) (string, error) {
 
 // Return the location of the Terraform files provided via --source
 func getTerragruntSourceCliFlag(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-
-	var result string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_get_terragrunt_source_cli_flag", attrs, func(childCtx context.Context) error {
-		result = pctx.Source
-		return nil
-	})
-
-	return result, err
+	return pctx.Source, nil
 }
 
 // Return the selected include block based on a label passed in as a function param. Note that the assumption is that:
@@ -1425,175 +1106,65 @@ func getSelectedIncludeBlock(trackInclude TrackInclude, params []string) (*Inclu
 //
 //nolint:dupl
 func StartsWith(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-	if len(args) > 0 {
-		attrs["str"] = args[0]
+	if len(args) == 0 {
+		return false, errors.New(EmptyStringNotAllowedError("parameter to the startswith function"))
 	}
 
-	if len(args) > 1 {
-		attrs["prefix"] = args[1]
-	}
-
-	var result bool
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_startswith", attrs, func(childCtx context.Context) error {
-		if len(args) == 0 {
-			return errors.New(EmptyStringNotAllowedError("parameter to the startswith function"))
-		}
-
-		str := args[0]
-		prefix := args[1]
-
-		result = strings.HasPrefix(str, prefix)
-
-		return nil
-	})
-
-	return result, err
+	return strings.HasPrefix(args[0], args[1]), nil
 }
 
 // EndsWith Implementation of Terraform's EndsWith function
 //
 //nolint:dupl
 func EndsWith(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-	if len(args) > 0 {
-		attrs["str"] = args[0]
+	if len(args) == 0 {
+		return false, errors.New(EmptyStringNotAllowedError("parameter to the endswith function"))
 	}
 
-	if len(args) > 1 {
-		attrs["suffix"] = args[1]
-	}
-
-	var result bool
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_endswith", attrs, func(childCtx context.Context) error {
-		if len(args) == 0 {
-			return errors.New(EmptyStringNotAllowedError("parameter to the endswith function"))
-		}
-
-		str := args[0]
-		suffix := args[1]
-
-		result = strings.HasSuffix(str, suffix)
-
-		return nil
-	})
-
-	return result, err
+	return strings.HasSuffix(args[0], args[1]), nil
 }
 
 // TimeCmp implements Terraform's `timecmp` function that compares two timestamps.
 func TimeCmp(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) (int64, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-	if len(args) > 0 {
-		attrs["timestamp_a"] = args[0]
+	if len(args) != matchedPats {
+		return 0, errors.New(errors.New("function can take only two parameters: timestamp_a and timestamp_b"))
 	}
 
-	if len(args) > 1 {
-		attrs["timestamp_b"] = args[1]
+	tsA, err := util.ParseTimestamp(args[0])
+	if err != nil {
+		return 0, errors.New(fmt.Errorf("could not parse first parameter %q: %w", args[0], err))
 	}
 
-	var result int64
+	tsB, err := util.ParseTimestamp(args[1])
+	if err != nil {
+		return 0, errors.New(fmt.Errorf("could not parse second parameter %q: %w", args[1], err))
+	}
 
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_timecmp", attrs, func(childCtx context.Context) error {
-		if len(args) != matchedPats {
-			return errors.New(errors.New("function can take only two parameters: timestamp_a and timestamp_b"))
-		}
-
-		tsA, innerErr := util.ParseTimestamp(args[0])
-		if innerErr != nil {
-			return errors.New(fmt.Errorf("could not parse first parameter %q: %w", args[0], innerErr))
-		}
-
-		tsB, innerErr := util.ParseTimestamp(args[1])
-		if innerErr != nil {
-			return errors.New(fmt.Errorf("could not parse second parameter %q: %w", args[1], innerErr))
-		}
-
-		switch {
-		case tsA.Equal(tsB):
-			result = 0
-		case tsA.Before(tsB):
-			result = -1
-		default:
-			// By elimination, tsA must be after tsB.
-			result = 1
-		}
-
-		return nil
-	})
-
-	return result, err
+	switch {
+	case tsA.Equal(tsB):
+		return 0, nil
+	case tsA.Before(tsB):
+		return -1, nil
+	default:
+		// By elimination, tsA must be after tsB.
+		return 1, nil
+	}
 }
 
 // StrContains Implementation of Terraform's StrContains function
 //
 //nolint:dupl
 func StrContains(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-	if len(args) > 0 {
-		attrs["str"] = args[0]
+	if len(args) == 0 {
+		return false, errors.New(EmptyStringNotAllowedError("parameter to the strcontains function"))
 	}
 
-	if len(args) > 1 {
-		attrs["substr"] = args[1]
-	}
-
-	var result bool
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_strcontains", attrs, func(childCtx context.Context) error {
-		if len(args) == 0 {
-			return errors.New(EmptyStringNotAllowedError("parameter to the strcontains function"))
-		}
-
-		str := args[0]
-		substr := args[1]
-
-		result = strings.Contains(str, substr)
-
-		return nil
-	})
-
-	return result, err
+	return strings.Contains(args[0], args[1]), nil
 }
 
 // readTFVarsFile reads a *.tfvars or *.tfvars.json file and returns the contents as a JSON encoded string
 func readTFVarsFile(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) (string, error) {
-	var filePath string
-	if len(args) > 0 {
-		filePath = args[0]
-	}
-
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-		"file_path":   filePath,
-	}
-
-	var result string
-
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_read_tfvars_file", attrs, func(childCtx context.Context) error {
-		var innerErr error
-
-		result, innerErr = readTFVarsFileImpl(pctx, l, args)
-
-		return innerErr
-	})
-
-	return result, err
+	return readTFVarsFileImpl(pctx, l, args)
 }
 
 // readTFVarsFileImpl contains the actual implementation of readTFVarsFile
@@ -1646,42 +1217,25 @@ func readTFVarsFileImpl(pctx *ParsingContext, l log.Logger, args []string) (stri
 
 // markAsRead marks a file as explicitly read. This is useful for detection via TerragruntUnitsReading flag.
 func markAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) (string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-	if len(args) > 0 {
-		attrs["file_path"] = args[0]
+	if len(args) != 1 {
+		return "", errors.New(WrongNumberOfParamsError{Func: "mark_as_read", Expected: "1", Actual: len(args)})
 	}
 
-	var result string
+	file := args[0]
 
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_mark_as_read", attrs, func(childCtx context.Context) error {
-		if len(args) != 1 {
-			return errors.New(WrongNumberOfParamsError{Func: "mark_as_read", Expected: "1", Actual: len(args)})
-		}
+	// Copy the file path to avoid modifying the original.
+	// This is necessary so that the HCL function doesn't
+	// return a different value than the original file path.
+	path := file
 
-		file := args[0]
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(pctx.WorkingDir, path)
+		path = filepath.Clean(path)
+	}
 
-		// Copy the file path to avoid modifying the original.
-		// This is necessary so that the HCL function doesn't
-		// return a different value than the original file path.
-		path := file
+	trackFileRead(pctx.FilesRead, path)
 
-		if !filepath.IsAbs(path) {
-			path = filepath.Join(pctx.WorkingDir, path)
-			path = filepath.Clean(path)
-		}
-
-		// Track that this file was read during parsing
-		trackFileRead(pctx.FilesRead, path)
-
-		result = file
-
-		return nil
-	})
-
-	return result, err
+	return file, nil
 }
 
 // markGlobAsRead expands the given glob pattern and marks each matched file as
@@ -1692,60 +1246,48 @@ func markAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []
 // so "a/**/*.tf" will not match "a/b.tf"; use "a/{*.tf,**/*.tf}" to cover
 // both depths. Returns the list of absolute file paths that were marked.
 func markGlobAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) ([]string, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
+	if !pctx.Experiments.Evaluate(experiment.MarkManyAsRead) {
+		pattern := ""
+		if len(args) > 0 {
+			pattern = args[0]
+		}
+
+		return nil, errors.New(MarkGlobAsReadRequiresExperimentError{
+			ConfigPath: pctx.TerragruntConfigPath,
+			Pattern:    pattern,
+		})
 	}
-	if len(args) > 0 {
-		attrs["glob"] = args[0]
+
+	if len(args) != 1 {
+		return nil, errors.New(WrongNumberOfParamsError{Func: FuncNameMarkGlobAsRead, Expected: "1", Actual: len(args)})
 	}
 
-	var result []string
+	raw := args[0]
 
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_mark_glob_as_read", attrs, func(childCtx context.Context) error {
-		if !pctx.Experiments.Evaluate(experiment.MarkManyAsRead) {
-			pattern := ""
-			if len(args) > 0 {
-				pattern = args[0]
-			}
+	// Keep the pattern in forward-slash space end-to-end. filepath.Join and
+	// filepath.Clean would rewrite '/' to '\' on Windows, and a subsequent
+	// filepath.ToSlash would then clobber any user-supplied '\' escapes that
+	// gobwas relies on to match literal metacharacters.
+	var pattern string
+	if filepath.IsAbs(raw) {
+		pattern = path.Clean(raw)
+	} else {
+		pattern = path.Clean(filepath.ToSlash(pctx.WorkingDir) + "/" + raw)
+	}
 
-			return errors.New(MarkGlobAsReadRequiresExperimentError{
-				ConfigPath: pctx.TerragruntConfigPath,
-				Pattern:    pattern,
-			})
-		}
+	matches, err := glob.Expand(vfs.NewOSFS(), pattern, glob.WithFilesOnly())
+	if err != nil {
+		return nil, errors.New(fmt.Errorf("could not expand glob %q: %w", raw, err))
+	}
 
-		if len(args) != 1 {
-			return errors.New(WrongNumberOfParamsError{Func: FuncNameMarkGlobAsRead, Expected: "1", Actual: len(args)})
-		}
+	result := make([]string, 0, len(matches))
 
-		raw := args[0]
+	for _, match := range matches {
+		trackFileRead(pctx.FilesRead, match)
+		result = append(result, match)
+	}
 
-		// Keep the pattern in forward-slash space end-to-end. filepath.Join and
-		// filepath.Clean would rewrite '/' to '\' on Windows, and a subsequent
-		// filepath.ToSlash would then clobber any user-supplied '\' escapes that
-		// gobwas relies on to match literal metacharacters.
-		var pattern string
-		if filepath.IsAbs(raw) {
-			pattern = path.Clean(raw)
-		} else {
-			pattern = path.Clean(filepath.ToSlash(pctx.WorkingDir) + "/" + raw)
-		}
-
-		matches, err := glob.Expand(vfs.NewOSFS(), pattern, glob.WithFilesOnly())
-		if err != nil {
-			return errors.New(fmt.Errorf("could not expand glob %q: %w", raw, err))
-		}
-
-		for _, match := range matches {
-			trackFileRead(pctx.FilesRead, match)
-			result = append(result, match)
-		}
-
-		return nil
-	})
-
-	return result, err
+	return result, nil
 }
 
 // warnWhenFileNotMarkedAsRead warns when a file is not being marked as read, even though a user might expect it to be.
@@ -1841,41 +1383,21 @@ func extractSopsErrors(err error) *errors.MultiError {
 
 // ConstraintCheck Implementation of Terraform's StartsWith function
 func ConstraintCheck(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
-	attrs := map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"working_dir": pctx.WorkingDir,
-	}
-	if len(args) > 0 {
-		attrs["version"] = args[0]
+	if len(args) != matchedPats {
+		return false, errors.New(WrongNumberOfParamsError{Func: FuncNameConstraintCheck, Expected: "2", Actual: len(args)})
 	}
 
-	if len(args) > 1 {
-		attrs["constraint"] = args[1]
+	v, err := version.NewSemver(args[0])
+	if err != nil {
+		return false, errors.Errorf("invalid version %s: %w", args[0], err)
 	}
 
-	var result bool
+	c, err := version.NewConstraint(args[1])
+	if err != nil {
+		return false, errors.Errorf("invalid constraint %s: %w", args[1], err)
+	}
 
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_constraint_check", attrs, func(childCtx context.Context) error {
-		if len(args) != matchedPats {
-			return errors.New(WrongNumberOfParamsError{Func: FuncNameConstraintCheck, Expected: "2", Actual: len(args)})
-		}
-
-		v, innerErr := version.NewSemver(args[0])
-		if innerErr != nil {
-			return errors.Errorf("invalid version %s: %w", args[0], innerErr)
-		}
-
-		c, innerErr := version.NewConstraint(args[1])
-		if innerErr != nil {
-			return errors.Errorf("invalid constraint %s: %w", args[1], innerErr)
-		}
-
-		result = c.Check(v)
-
-		return nil
-	})
-
-	return result, err
+	return c.Check(v), nil
 }
 
 // trackFileRead adds a file path to the FilesRead slice if it's not already present.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Dropping insignificant HCL function otel traces, enriching existing spans for more details and adding more spans for operations that are likely to have significant side-effects.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry tracing instrumentation across multiple operations (list command, AWS credential assumption, module downloads, shell execution, and runner tasks) for enhanced observability.

* **Improvements**
  * Refactored configuration helpers and command execution logic to reduce overhead and improve performance.
  * Enhanced telemetry context capture for AWS operations and task execution tracking.

* **Bug Fixes**
  * Updated error handling and task status reporting in the runner controller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->