### PR TITLE
chore: Adding thank you to @jpke for fix in #6029

### DIFF
--- a/docs/src/data/changelog/v1.0.4/fix-dependency-output-warning-pollution.mdx
+++ b/docs/src/data/changelog/v1.0.4/fix-dependency-output-warning-pollution.mdx
@@ -9,4 +9,4 @@ Resolving `dependency` outputs no longer fails when the underlying `tofu/terrafo
 
 Terragrunt now isolates the first JSON object in the captured stdout, so leading log lines (for example, the long-standing AWS Client Side Monitoring `Enabling CSM` line) and trailing warning blocks are both ignored when reading dependency outputs.
 
-Resolves [#6001](https://github.com/gruntwork-io/terragrunt/issues/6001).
+Resolves [#6001](https://github.com/gruntwork-io/terragrunt/issues/6001). Thanks to [@jpke](https://github.com/jpke) for contributing this fix!


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Thanks @jpke for the fix in #6029

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog entry for v1.0.4 fix addressing tolerant parsing of non-JSON warnings in output commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->