### PR TITLE
chore: Adding better symlinks experiment tests

### DIFF
--- a/test/integration_unix_test.go
+++ b/test/integration_unix_test.go
@@ -4,10 +4,14 @@
 package test_test
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,4 +35,120 @@ func TestLocalWithRelativeExtraArgsUnix(t *testing.T) {
 
 	// Run a second time to make sure the temporary folder can be reused without errors
 	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+testPath)
+}
+
+// buildSymlinksExperimentFixture lays out a tree with one real unit at `a` and
+// two symlinks (`b`, `c`) pointing to it, all referencing a shared module. It
+// returns the root directory.
+func buildSymlinksExperimentFixture(t *testing.T) string {
+	t.Helper()
+
+	rootDir := helpers.TmpDirWOSymlinks(t)
+
+	moduleDir := filepath.Join(rootDir, "module")
+	require.NoError(t, os.Mkdir(moduleDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("resource \"null_resource\" \"a\" {}\n"), 0644))
+
+	unitA := filepath.Join(rootDir, "a")
+	require.NoError(t, os.Mkdir(unitA, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(unitA, "terragrunt.hcl"), []byte("terraform {\n  source = \"../module\"\n}\n"), 0644))
+
+	require.NoError(t, os.Symlink(unitA, filepath.Join(rootDir, "b")))
+	require.NoError(t, os.Symlink(unitA, filepath.Join(rootDir, "c")))
+
+	return rootDir
+}
+
+// TestSymlinksExperimentUnitDiscoveryWithRacing pins the symlinks experiment's effect on
+// unit discovery: with the experiment enabled, symlinked unit directories are walked as if
+// they were real directories and surface as distinct units; without it, they're skipped.
+//
+// The CI "Race" job runs tests matching .*WithRacing with -race, which catches concurrent
+// access regressions in the discovery walk.
+func TestSymlinksExperimentUnitDiscoveryWithRacing(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsExperimentMode(t) {
+		t.Skip("Skipping: TG_EXPERIMENT_MODE forces all experiments on, defeating the disabled-vs-enabled comparison this test pins")
+	}
+
+	rootDir := buildSymlinksExperimentFixture(t)
+
+	type entry struct {
+		Type string `json:"type"`
+		Path string `json:"path"`
+	}
+
+	parse := func(t *testing.T, stdout string) []entry {
+		t.Helper()
+
+		var out []entry
+
+		require.NoError(t, json.Unmarshal([]byte(stdout), &out))
+
+		return out
+	}
+
+	t.Run("experiment disabled", func(t *testing.T) {
+		t.Parallel()
+
+		stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+			"terragrunt find --no-color --json --working-dir "+rootDir)
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t, []entry{{Type: "unit", Path: "a"}}, parse(t, stdout))
+	})
+
+	t.Run("experiment enabled", func(t *testing.T) {
+		t.Parallel()
+
+		stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+			"terragrunt find --no-color --json --experiment symlinks --working-dir "+rootDir)
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t, []entry{
+			{Type: "unit", Path: "a"},
+			{Type: "unit", Path: "b"},
+			{Type: "unit", Path: "c"},
+		}, parse(t, stdout))
+	})
+}
+
+// TestSymlinksExperimentRunAllWithRacing pins the symlinks experiment's effect on
+// `run --all`: with the experiment enabled, each symlinked unit is executed as a
+// distinct unit; without it, only the real unit runs. The check counts terraform's
+// "Apply complete!" lines on stdout — one per executed unit.
+//
+// `--parallelism 1` serializes execution since the symlink targets share a single
+// on-disk working directory, so concurrent applies would race over state.
+func TestSymlinksExperimentRunAllWithRacing(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsExperimentMode(t) {
+		t.Skip("Skipping: TG_EXPERIMENT_MODE forces all experiments on, defeating the disabled-vs-enabled comparison this test pins")
+	}
+
+	t.Run("experiment disabled", func(t *testing.T) {
+		t.Parallel()
+
+		rootDir := buildSymlinksExperimentFixture(t)
+
+		stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+			"terragrunt run --all --no-color --non-interactive --parallelism 1 --working-dir "+rootDir+" -- apply -auto-approve")
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, strings.Count(stdout, "Apply complete!"))
+	})
+
+	t.Run("experiment enabled", func(t *testing.T) {
+		t.Parallel()
+
+		rootDir := buildSymlinksExperimentFixture(t)
+
+		stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+			"terragrunt run --all --no-color --non-interactive --parallelism 1 --experiment symlinks --working-dir "+rootDir+" -- apply -auto-approve")
+		require.NoError(t, err)
+
+		assert.Equal(t, 3, strings.Count(stdout, "Apply complete!"))
+	})
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Introduces symlinks tests that pass more reliably.

It also highlights something interesting about `run --all` mechanics when units are symlinks to a unit definition: How should units synchronize their runs when pointing to the same resolved destination? Should they run serially because they're going to need to overwrite the shared cache configurations? It might be logic that we have to build into the runner pool. We might need to decide that despite the fact that two units are technically different units, their resolved paths point to the same destination, and thus should be run serially. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for symlink experiment functionality, including unit discovery and execution behavior with and without the feature enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->