### PR TITLE
fix: Refactoring some HCL fn parameter logic

### DIFF
--- a/internal/shell/run_cmd.go
+++ b/internal/shell/run_cmd.go
@@ -203,7 +203,14 @@ func RunCommandWithOutput(
 		"args":    fmt.Sprintf("%v", args),
 		"dir":     commandDir,
 	}, func(ctx context.Context) error {
-		runErr := runCommand(ctx, l, e, runOpts, commandDir, suppressStdout, needsPTY, command, args, &output)
+		runErr := runCommand(ctx, l, e, runOpts, RunCommandOptions{
+			CommandDir:     commandDir,
+			SuppressStdout: suppressStdout,
+			NeedsPTY:       needsPTY,
+			Command:        command,
+			Args:           args,
+			Output:         &output,
+		})
 
 		if span := trace.SpanFromContext(ctx); span.IsRecording() {
 			exitCode := 0
@@ -229,6 +236,17 @@ func RunCommandWithOutput(
 	return &output, err
 }
 
+// RunCommandOptions groups the per-invocation parameters for runCommand,
+// keeping the function signature short and call sites readable.
+type RunCommandOptions struct {
+	Output         *util.CmdOutput
+	CommandDir     string
+	Command        string
+	Args           []string
+	SuppressStdout bool
+	NeedsPTY       bool
+}
+
 // runCommand contains the actual subprocess execution logic, separated to keep
 // RunCommandWithOutput focused on telemetry framing.
 func runCommand(
@@ -236,35 +254,31 @@ func runCommand(
 	l log.Logger,
 	e vexec.Exec,
 	runOpts *ShellOptions,
-	commandDir string,
-	suppressStdout, needsPTY bool,
-	command string,
-	args []string,
-	output *util.CmdOutput,
+	cmdOpts RunCommandOptions,
 ) error {
-	l.Debugf("Running command: %s %s", command, strings.Join(args, " "))
+	l.Debugf("Running command: %s %s", cmdOpts.Command, strings.Join(cmdOpts.Args, " "))
 
 	var (
-		cmdStderr = io.MultiWriter(runOpts.Writers.ErrWriter, &output.Stderr)
-		cmdStdout = io.MultiWriter(runOpts.Writers.Writer, &output.Stdout)
+		cmdStderr = io.MultiWriter(runOpts.Writers.ErrWriter, &cmdOpts.Output.Stderr)
+		cmdStdout = io.MultiWriter(runOpts.Writers.Writer, &cmdOpts.Output.Stdout)
 	)
 
 	// Pass the traceparent to the child process if it is available in the context.
 	if traceParent := telemetry.TraceParentFromContext(ctx, runOpts.Telemetry); traceParent != "" {
-		l.Debugf("Setting trace parent=%q for command %s", traceParent, fmt.Sprintf("%s %v", command, args))
+		l.Debugf("Setting trace parent=%q for command %s", traceParent, fmt.Sprintf("%s %v", cmdOpts.Command, cmdOpts.Args))
 		runOpts.Env[telemetry.TraceParentEnv] = traceParent
 	}
 
-	if suppressStdout {
+	if cmdOpts.SuppressStdout {
 		l.Debugf("Command output will be suppressed.")
 
-		cmdStdout = io.MultiWriter(&output.Stdout)
+		cmdStdout = io.MultiWriter(&cmdOpts.Output.Stdout)
 	}
 
-	if command == runOpts.TFPath {
+	if cmdOpts.Command == runOpts.TFPath {
 		// If the engine is enabled and the command is IaC executable, use the engine to run the command.
 		if runOpts.EngineConfig != nil && runOpts.Experiments.Evaluate(experiment.IacEngine) && !runOpts.NoEngine() {
-			l.Debugf("Using engine to run command: %s %s", command, strings.Join(args, " "))
+			l.Debugf("Using engine to run command: %s %s", cmdOpts.Command, strings.Join(cmdOpts.Args, " "))
 
 			cmdOutput, err := engine.Run(ctx, l, e, &engine.ExecutionOptions{
 				Writers: writer.Writers{
@@ -276,31 +290,31 @@ func runCommand(
 				EngineOptions:     runOpts.EngineOptions,
 				EngineConfig:      runOpts.EngineConfig,
 				Env:               runOpts.Env,
-				WorkingDir:        commandDir,
+				WorkingDir:        cmdOpts.CommandDir,
 				RootWorkingDir:    runOpts.RootWorkingDir,
-				Command:           command,
-				Args:              args,
+				Command:           cmdOpts.Command,
+				Args:              cmdOpts.Args,
 				Headless:          runOpts.Headless,
 				ForwardTFStdout:   runOpts.ForwardTFStdout,
-				SuppressStdout:    suppressStdout,
-				AllocatePseudoTty: needsPTY,
+				SuppressStdout:    cmdOpts.SuppressStdout,
+				AllocatePseudoTty: cmdOpts.NeedsPTY,
 			})
 			if err != nil {
 				return errors.New(err)
 			}
 
-			*output = *cmdOutput
+			*cmdOpts.Output = *cmdOutput
 
 			return err
 		}
 	}
 
-	cmd := exec.Command(ctx, e, command, args...)
-	cmd.SetDir(commandDir)
+	cmd := exec.Command(ctx, e, cmdOpts.Command, cmdOpts.Args...)
+	cmd.SetDir(cmdOpts.CommandDir)
 	cmd.SetStdout(cmdStdout)
 	cmd.SetStderr(cmdStderr)
 	cmd.Configure(
-		exec.WithUsePTY(needsPTY),
+		exec.WithUsePTY(cmdOpts.NeedsPTY),
 		exec.WithEnv(runOpts.Env),
 		exec.WithForwardSignalDelay(SignalForwardingDelay),
 	)
@@ -312,8 +326,8 @@ func runCommand(
 	if err := cmd.Start(l); err != nil { //nolint:contextcheck // context already passed to exec.Command
 		err = util.ProcessExecutionError{
 			Err:             err,
-			Args:            args,
-			Command:         command,
+			Args:            cmdOpts.Args,
+			Command:         cmdOpts.Command,
 			WorkingDir:      cmd.Dir(),
 			RootWorkingDir:  runOpts.RootWorkingDir,
 			LogShowAbsPaths: runOpts.Writers.LogShowAbsPaths,
@@ -329,9 +343,9 @@ func runCommand(
 	if err := cmd.Wait(); err != nil {
 		err = util.ProcessExecutionError{
 			Err:             err,
-			Args:            args,
-			Command:         command,
-			Output:          *output,
+			Args:            cmdOpts.Args,
+			Command:         cmdOpts.Command,
+			Output:          *cmdOpts.Output,
 			WorkingDir:      cmd.Dir(),
 			RootWorkingDir:  runOpts.RootWorkingDir,
 			LogShowAbsPaths: runOpts.Writers.LogShowAbsPaths,

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -51,6 +52,10 @@ import (
 const (
 	noMatchedPats = 1
 	matchedPats   = 2
+
+	// stringCompParams is the exact number of arguments expected by the
+	// startswith, endswith, and strcontains helpers (haystack + needle).
+	stringCompParams = 2
 )
 
 // RunCmdCacheEntry stores run_cmd results including output for replay.
@@ -1131,8 +1136,8 @@ func getSelectedIncludeBlock(trackInclude TrackInclude, params []string) (*Inclu
 //
 //nolint:dupl
 func StartsWith(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
-	if len(args) == 0 {
-		return false, errors.New(EmptyStringNotAllowedError("parameter to the startswith function"))
+	if len(args) != stringCompParams {
+		return false, errors.New(WrongNumberOfParamsError{Func: "startswith", Expected: strconv.Itoa(stringCompParams), Actual: len(args)})
 	}
 
 	return strings.HasPrefix(args[0], args[1]), nil
@@ -1142,8 +1147,8 @@ func StartsWith(ctx context.Context, pctx *ParsingContext, args []string) (bool,
 //
 //nolint:dupl
 func EndsWith(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
-	if len(args) == 0 {
-		return false, errors.New(EmptyStringNotAllowedError("parameter to the endswith function"))
+	if len(args) != stringCompParams {
+		return false, errors.New(WrongNumberOfParamsError{Func: "endswith", Expected: strconv.Itoa(stringCompParams), Actual: len(args)})
 	}
 
 	return strings.HasSuffix(args[0], args[1]), nil
@@ -1180,8 +1185,8 @@ func TimeCmp(ctx context.Context, pctx *ParsingContext, l log.Logger, args []str
 //
 //nolint:dupl
 func StrContains(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
-	if len(args) == 0 {
-		return false, errors.New(EmptyStringNotAllowedError("parameter to the strcontains function"))
+	if len(args) != stringCompParams {
+		return false, errors.New(WrongNumberOfParamsError{Func: "strcontains", Expected: strconv.Itoa(stringCompParams), Actual: len(args)})
 	}
 
 	return strings.Contains(args[0], args[1]), nil


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Refactoring some HCL function parameter logic.

More correctly requires exactly two parameters for string comparison HCL functions, and refactors `runCommand` to take a `RunCommandOptions` to reduce parameter bloat.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for string comparison functions to enforce correct argument counts with clearer error messages.

* **Chores**
  * Improved internal command execution parameter handling and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->