### PR TITLE
chore: Adding TGS `--help` footer

### DIFF
--- a/internal/cli/commands/run/help.go
+++ b/internal/cli/commands/run/help.go
@@ -29,6 +29,10 @@ const TFCommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Comman
 {{ if isTerraformPath }}Terraform{{ else }}OpenTofu{{ end }} ` + "`{{ tfCommand }}`" + ` help:{{ $tfHelp := runTFHelp }}{{ if $tfHelp }}
 
 {{ $tfHelp }}{{ end }}
+
+See also:
+  Terragrunt Scale: CI/CD and Drift Management for Terragrunt, from Gruntwork.
+  https://terragrunt.com/scale
 `
 
 // ShowTFHelp prints TF help for the given `cliCtx.Command` command.

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,5 +1,12 @@
 package cli
 
+// HelpFooter is appended to all Terragrunt help output to promote Terragrunt Scale.
+const HelpFooter = `
+See also:
+  Terragrunt Scale: CI/CD and Drift Management for Terragrunt, from Gruntwork.
+  https://terragrunt.com/scale
+`
+
 // AppHelpTemplate is the main CLI help template.
 const AppHelpTemplate = `Usage: {{ if .App.UsageText }}{{ wrap .App.UsageText 3 }}{{ else }}{{ .App.HelpName }} [global options] <command> [options]{{ end }}{{ $description := .App.Usage }}{{ if .App.Description }}{{ $description = .App.Description }}{{ end }}{{ if $description }}
 
@@ -16,7 +23,7 @@ Global Options:
 Version: {{ .App.Version }}{{ end }}{{ if len .App.Authors }}
 
 Author: {{ range .App.Authors }}{{ . }}{{ end }} {{ end }}
-`
+` + HelpFooter
 
 // CommandHelpTemplate is the command CLI help template.
 const CommandHelpTemplate = `Usage: {{ if .Command.UsageText }}{{ wrap .Command.UsageText 3 }}{{ else }}{{ range $index, $parent := parentCommands . }}{{ $parent.HelpName }} {{ end }}{{ .Command.HelpName }}{{ if .Command.VisibleSubcommands }} <command>{{ end }}{{ if .Command.VisibleFlags }} [options]{{ end }}{{ end }}{{ $description := .Command.Usage }}{{ if .Command.Description }}{{ $description = .Command.Description }}{{ end }}{{ if $description }}
@@ -36,8 +43,7 @@ Options:
 Global Options:
    {{ range $index, $option := .App.VisibleFlags }}{{ if $index }}
    {{ end }}{{ wrap $option.String 6 }}{{ end }}{{ end }}
-
-`
+` + HelpFooter
 
 const AppVersionTemplate = `{{ .App.Name }} version {{ .App.Version }}
 `

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -114,6 +114,9 @@ Global Options:
    --log-disable        Disable logging. [%sTG_LOG_DISABLE%s]
    --working-dir value  The path to the directory of Terragrunt configurations. Default is current directory. [%sTG_WORKING_DIR%s]
 
+See also:
+  Terragrunt Scale: CI/CD and Drift Management for Terragrunt, from Gruntwork.
+  https://terragrunt.com/scale
 `, envVarChar, closeEnvVarChar, envVarChar, closeEnvVarChar, envVarChar, closeEnvVarChar, envVarChar, closeEnvVarChar)
 
 	assert.Equal(t, expectedOutput, out.String())


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds a footer to the `--help` text to call out Gruntwork offers support through commercial services as well.

Looks like this:

```bash
$ terragrunt --help
Usage: terragrunt [global options] <command> [options]

   Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale.
   For documentation, see https://docs.terragrunt.com/.

...

Author: Gruntwork <www.gruntwork.io>

See also:
  Terragrunt Scale: offerings from Gruntwork for Terragrunt at scale.
  https://terragrunt.com/scale

```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help text to include a new "See also" section referencing Terragrunt Scale with additional resources.
  * Enhanced help output footer with improved user guidance content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->