### PR TITLE
docs: Cleaning up changelog for `v1.0.4`

### DIFF
--- a/docs/src/data/changelog/v1.0.4/auth-provider-cmd-duplicate-call.mdx
+++ b/docs/src/data/changelog/v1.0.4/auth-provider-cmd-duplicate-call.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.4"
+category: "bug-fixes"
+---
+
+#### `--auth-provider-cmd` no longer runs once per dependency cache directory
+
+Resolving `dependency` outputs ran the configured `--auth-provider-cmd` again from inside each `.terragrunt-cache` working directory, on top of the call already made for the unit.
+
+Terragrunt now reuses the credentials already obtained for the dependency when reading outputs from a cached working directory, so `--auth-provider-cmd` is invoked once per dependency instead of twice.

--- a/docs/src/data/changelog/v1.0.4/autoinclude-error-reporting.mdx
+++ b/docs/src/data/changelog/v1.0.4/autoinclude-error-reporting.mdx
@@ -1,0 +1,15 @@
+---
+version: "v1.0.4"
+category: "experiments-updated"
+---
+
+#### `stack-dependencies` — Stricter validation and clearer parse errors for `autoinclude`
+
+Malformed configuration inside an `autoinclude` block previously produced misleading messages or, in some cases, was silently ignored during stack discovery.
+
+Two changes tighten this up:
+
+- A `dependency` block inside `autoinclude` must declare exactly one label. Zero labels (`dependency {}`) and multiple labels (`dependency "a" "b" {}`) are now rejected at parse time with a diagnostic that points at the offending block.
+- Parse failures encountered while expanding `autoinclude` files during `stack generate`, `find`, and `list` are surfaced with the underlying HCL diagnostic instead of being swallowed or remapped to a generic discovery error.
+
+Reported in [#5980](https://github.com/gruntwork-io/terragrunt/issues/5980).

--- a/docs/src/data/changelog/v1.0.4/cas-local-paths.mdx
+++ b/docs/src/data/changelog/v1.0.4/cas-local-paths.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.0.3"
+version: "v1.0.4"
 category: "experiments-updated"
 ---
 

--- a/docs/src/data/changelog/v1.0.4/catalog-redesign.mdx
+++ b/docs/src/data/changelog/v1.0.4/catalog-redesign.mdx
@@ -1,0 +1,24 @@
+---
+version: "v1.0.4"
+category: "experiments-updated"
+---
+
+#### `catalog-redesign` — Units and stacks, scaffolded values, and key-binding cleanup
+
+The redesigned `terragrunt catalog` TUI gains two new component kinds, a guided scaffolding flow for placing them, and a small key-binding cleanup.
+
+**Units and stacks join modules and templates**
+
+Catalog discovery now classifies units (directories containing a `terragrunt.hcl`) and stacks (directories containing a `terragrunt.stack.hcl`) as first-class component kinds, alongside OpenTofu/Terraform modules and boilerplate templates. The list view picks them up automatically and they appear under their own tabs; press `tab` and `shift+tab` to cycle.
+
+When more than one classification could apply to the same directory (for example, a stack directory that also contains a unit), Terragrunt resolves it to a single kind under a fixed precedence: template, stack, unit, module.
+
+**Copy and scaffolded values**
+
+Selecting a unit or stack from the catalog now offers a copy action that materializes the component into your working directory. Terragrunt walks the copied component for `values.<name>` references and, if it finds any, writes a sibling `terragrunt.values.hcl` stub. Names referenced outside a `try(...)` are listed as required with a `"TODO"` placeholder; names referenced through a `try(...)` are listed as optional, pre-populated with the literal default from the fallback. An existing `terragrunt.values.hcl` is left alone.
+
+After the TUI exits, Terragrunt prints a short callout pointing at the directory it wrote to and any follow-up command you need to run, instead of leaving you to find the new directory yourself.
+
+**Catalog key bindings**
+
+The `ctrl+j` binding on the catalog list has been removed in favor of `enter` alone for choosing a focused entry, and dropped from the navigation set used while filtering. The mini help footer is updated to match.

--- a/docs/src/data/changelog/v1.0.4/context-cache-construction.mdx
+++ b/docs/src/data/changelog/v1.0.4/context-cache-construction.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.4"
+category: "performance-improvements"
+---
+
+#### `run_cmd` and Git repo-root results memoized without the Provider Cache Server
+
+Within a single command, repeated `run_cmd(...)` calls and repeated Git repo-root lookups across units used to share their cached results only when the Provider Cache Server was running. Commands invoked without `--provider-cache` (the common case for `find`, `list`, and `run --all` against estates that do not need provider caching) re-evaluated each `run_cmd` and re-shelled to `git rev-parse --show-toplevel` for every unit.
+
+Both caches are now active for every command, so identical `run_cmd` arguments and repeated repo-root lookups are reused across units regardless of whether the Provider Cache Server is enabled.

--- a/docs/src/data/changelog/v1.0.4/git-rev-parse-windows-path.mdx
+++ b/docs/src/data/changelog/v1.0.4/git-rev-parse-windows-path.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.4"
+category: "bug-fixes"
+---
+
+#### `get_repo_root()` returns OS-native separators on Windows
+
+`git rev-parse --show-toplevel` always emits forward-slash paths, even on Windows. Terragrunt returned that string unchanged from `get_repo_root()`, so configurations that compared the result against `path/filepath`-style paths or fed it back into helpers expecting OS-native separators saw spurious mismatches and broken joins on Windows.
+
+The output is now normalized to OS-native separators before being returned, so `get_repo_root()` produces `C:\repo\path` on Windows and `/repo/path` on Linux and macOS.
+
+Reported in [#5976](https://github.com/gruntwork-io/terragrunt/issues/5976).

--- a/docs/src/data/changelog/v1.0.4/repo-root-caching.mdx
+++ b/docs/src/data/changelog/v1.0.4/repo-root-caching.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.4"
+category: "performance-improvements"
+---
+
+#### Fewer `git rev-parse` invocations on large estates
+
+The `get_repo_root()` HCL function, the runner, and the `find` and `list` discovery commands all ask Git for the enclosing repository root. Previously, two units in the same repository each triggered their own `git rev-parse --show-toplevel`, even when the answer was identical. On large estates this added up to one fork per unit (and sometimes more) for a value that never changed.
+
+A repository discovered for one working directory is now reused for any other working directory inside it, for the duration of the command. Nested repositories (a checkout vendored inside another) still resolve to their own root.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Cleans up the changelog for `v1.0.4`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v1.0.4

* **Bug Fixes**
  * Optimized `--auth-provider-cmd` execution to reduce duplicate credential requests
  * Fixed Windows path separator handling for repository root detection

* **Performance Improvements**
  * Reduced git lookups on large repositories through caching
  * Added result memoization for repeated operations within a single command

* **Experiments Updated**
  * Enhanced `autoinclude` validation with targeted error reporting
  * CAS stack generation now supports local filesystem paths
  * Redesigned catalog UI with improved component classification and scaffolding features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->