### PR TITLE
chore: fixed macos and windows version setting in CICD

### DIFF
--- a/.github/workflows/sign-macos.yml
+++ b/.github/workflows/sign-macos.yml
@@ -13,11 +13,6 @@ on:
         required: false
         type: string
         default: 'macos-signed-files'
-      skip-build:
-        description: 'Skip the build job (caller already provides signed-ready binaries)'
-        required: false
-        type: boolean
-        default: false
   workflow_call:
     inputs:
       artifact-pattern:
@@ -31,7 +26,7 @@ on:
         type: string
         default: 'macos-signed-files'
       skip-build:
-        description: 'Skip the build job (caller already provides signed-ready binaries)'
+        description: 'Skip the internal build job and sign artifacts uploaded earlier in this workflow run'
         required: false
         type: boolean
         default: true
@@ -39,7 +34,7 @@ on:
 jobs:
   build:
     name: Build (darwin/${{ matrix.arch }})
-    if: ${{ !inputs.skip-build }}
+    if: ${{ inputs['skip-build'] != true }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/sign-macos.yml
+++ b/.github/workflows/sign-macos.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: 'macos-signed-files'
+      skip-build:
+        description: 'Skip the build job (caller already provides signed-ready binaries)'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       artifact-pattern:
@@ -25,11 +30,16 @@ on:
         required: false
         type: string
         default: 'macos-signed-files'
+      skip-build:
+        description: 'Skip the build job (caller already provides signed-ready binaries)'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   build:
     name: Build (darwin/${{ matrix.arch }})
-    if: github.event_name == 'workflow_dispatch'
+    if: ${{ !inputs.skip-build }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: 'windows-signed-files'
+      skip_build:
+        description: 'Skip the build job (caller already provides signed-ready binaries)'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       artifact_pattern:
@@ -25,11 +30,16 @@ on:
         required: false
         type: string
         default: 'windows-signed-files'
+      skip_build:
+        description: 'Skip the build job (caller already provides signed-ready binaries)'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   build:
     name: Build (windows/${{ matrix.arch }})
-    if: github.event_name == 'workflow_dispatch'
+    if: ${{ !inputs.skip_build }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -13,11 +13,6 @@ on:
         required: false
         type: string
         default: 'windows-signed-files'
-      skip_build:
-        description: 'Skip the build job (caller already provides signed-ready binaries)'
-        required: false
-        type: boolean
-        default: false
   workflow_call:
     inputs:
       artifact_pattern:
@@ -31,7 +26,7 @@ on:
         type: string
         default: 'windows-signed-files'
       skip_build:
-        description: 'Skip the build job (caller already provides signed-ready binaries)'
+        description: 'Skip the internal build job and sign artifacts uploaded earlier in this workflow run'
         required: false
         type: boolean
         default: true
@@ -39,7 +34,7 @@ on:
 jobs:
   build:
     name: Build (windows/${{ matrix.arch }})
-    if: ${{ !inputs.skip_build }}
+    if: ${{ inputs.skip_build != true }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/docs/src/data/changelog/v1.0.5/macos-windows-version-stamp.mdx
+++ b/docs/src/data/changelog/v1.0.5/macos-windows-version-stamp.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.5"
+category: "bug-fixes"
+---
+
+#### macOS and Windows binaries report the correct release version
+
+The v1.0.4 macOS and Windows release binaries reported `terragrunt version main` and parsed as `0.0.0`, breaking any `terragrunt_version_constraint` configured against them.
+
+`sign-macos.yml` and `sign-windows.yml` exposed a build job intended for standalone `workflow_dispatch` runs, but the gating condition (`github.event_name == 'workflow_dispatch'`) also fired during `workflow_call` from `release.yml` because the original event name propagates across reusable workflows. The redundant build ran with `BUILD_VERSION=${{ github.ref_name }}` and replaced the correctly versioned artifact uploaded by `build.yml`.
+
+The signing workflows now skip their internal build job when invoked via `workflow_call` and only build when dispatched directly, so release binaries keep the version stamped by `build.yml`.

--- a/docs/src/data/changelog/v1.0.5/macos-windows-version-stamp.mdx
+++ b/docs/src/data/changelog/v1.0.5/macos-windows-version-stamp.mdx
@@ -7,6 +7,6 @@ category: "bug-fixes"
 
 The v1.0.4 macOS and Windows release binaries reported `terragrunt version main` and parsed as `0.0.0`, breaking any `terragrunt_version_constraint` configured against them.
 
-`sign-macos.yml` and `sign-windows.yml` exposed a build job intended for standalone `workflow_dispatch` runs, but the gating condition (`github.event_name == 'workflow_dispatch'`) also fired during `workflow_call` from `release.yml` because the original event name propagates across reusable workflows. The redundant build ran with `BUILD_VERSION=${{ github.ref_name }}` and replaced the correctly versioned artifact uploaded by `build.yml`.
+`sign-macos.yml` and `sign-windows.yml` included build jobs for standalone `workflow_dispatch` runs. During the release workflow, those jobs still saw the original `workflow_dispatch` event from `release.yml`, so the old condition evaluated to true. The redundant build used `BUILD_VERSION=${{ github.ref_name }}` and replaced the correctly versioned artifact uploaded by `build.yml`.
 
 The signing workflows now skip their internal build job when invoked via `workflow_call` and only build when dispatched directly, so release binaries keep the version stamped by `build.yml`.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* Fixed setting of version for Terragrunt releases

Fixes #6053.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS and Windows release binaries reporting incorrect version information (0.0.0). Signing workflows now preserve correctly version-stamped artifacts from the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->