### PR TITLE
chore: added handling of draft releases

### DIFF
--- a/.github/scripts/release/resolve-version-ref.sh
+++ b/.github/scripts/release/resolve-version-ref.sh
@@ -3,7 +3,9 @@
 set -euo pipefail
 
 # Script to resolve the release version and target ref from a
-# workflow_dispatch input by looking up the existing draft release.
+# workflow_dispatch input by looking up the existing release.
+# Works for both draft and published releases so an existing release
+# can be rebuilt and clobbered with new assets.
 #
 # Usage: resolve-version-ref.sh
 # Environment variables:
@@ -20,15 +22,8 @@ function main {
 
 	# Look up the release to get target_commitish
 	local release_json
-	if ! release_json=$(gh release view "$version" --json 'isDraft,targetCommitish' 2>/dev/null); then
+	if ! release_json=$(gh release view "$version" --json 'targetCommitish' 2>/dev/null); then
 		echo "ERROR: No release found for version $version" >&2
-		exit 1
-	fi
-
-	local is_draft
-	is_draft=$(jq -r '.isDraft' <<<"$release_json")
-	if [[ "$is_draft" != "true" ]]; then
-		echo "ERROR: Release $version is already published. Cannot rebuild a published release." >&2
 		exit 1
 	fi
 

--- a/.github/scripts/release/tests/resolve-version-ref.bats
+++ b/.github/scripts/release/tests/resolve-version-ref.bats
@@ -27,7 +27,7 @@ teardown() {
 
   run "$SCRIPT"
   [ "$status" -eq 0 ]
-  grep -q "^version=v1.2.3$" "$GITHUB_OUTPUT"
+  grep -q "^version=${INPUT_VERSION}$" "$GITHUB_OUTPUT"
   grep -q "^ref=${sha}$" "$GITHUB_OUTPUT"
 }
 
@@ -40,12 +40,14 @@ teardown() {
   [[ "$output" == *"No release found"* ]]
 }
 
-@test "errors if release is already published" {
-  export GH_STUB_RESPONSE='{"isDraft":false,"targetCommitish":"a1b2c3d4e5f6789012345678901234567890abcd"}'
+@test "resolves published release to version + ref" {
+  local sha="a1b2c3d4e5f6789012345678901234567890abcd"
+  export GH_STUB_RESPONSE="{\"targetCommitish\":\"${sha}\"}"
 
   run "$SCRIPT"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"already published"* ]]
+  [ "$status" -eq 0 ]
+  grep -q "^version=${INPUT_VERSION}$" "$GITHUB_OUTPUT"
+  grep -q "^ref=${sha}$" "$GITHUB_OUTPUT"
 }
 
 @test "fails when INPUT_VERSION missing" {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Drops the is_draft guard in resolve-version-ref.sh so release.yml can rebuild and clobber an already-published release

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal release workflow scripts and test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->