### PR TITLE
fix(auto-init): Re-init on source change when modules are cached

### DIFF
--- a/docs/src/data/changelog/v1.0.5/auto-init-marker-cached-modules.mdx
+++ b/docs/src/data/changelog/v1.0.5/auto-init-marker-cached-modules.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.5"
+category: "bug-fixes"
+---
+
+#### Auto-init now re-runs after a source change when modules are already cached
+
+`terragrunt plan`/`apply` could fail with `Error: Required plugins are not installed` after a source-version change in any unit with a `module ""` block. The `.terragrunt-init-required` marker written on source change was being ignored because `modulesNeedInit` short-circuited as soon as `.terraform/modules/` existed.
+
+The marker check now lives at the top of `needsInitRunCfg` and is honored regardless of cached `.terraform/modules/` contents.

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -483,11 +483,6 @@ func modulesNeedInit(opts *Options) (bool, error) {
 		return false, nil
 	}
 
-	moduleNeedInit := filepath.Join(opts.WorkingDir, ModuleInitRequiredFile)
-	if util.FileExists(moduleNeedInit) {
-		return true, nil
-	}
-
 	// Check for module definitions in .tf and .tofu files using WalkDir
 	hasModuleDefinition, err := util.RegexFoundInTFFiles(opts.WorkingDir, ModuleRegex)
 	if err != nil {
@@ -659,6 +654,12 @@ func PrepareNonInitCommand(
 func needsInitRunCfg(ctx context.Context, l log.Logger, opts *Options, cfg *runcfg.RunConfig) (bool, error) {
 	if slices.Contains(TerraformCommandsThatDoNotNeedInit, opts.TerraformCliArgs.First()) {
 		return false, nil
+	}
+
+	// Marker check lives here, not in modulesNeedInit, so a populated .terraform/modules/
+	// can't short-circuit past it. Refs: #1921, #6058.
+	if util.FileExists(filepath.Join(opts.WorkingDir, ModuleInitRequiredFile)) {
+		return true, nil
 	}
 
 	if providersNeedInit(opts) {

--- a/test/fixtures/init-once/terragrunt.hcl
+++ b/test/fixtures/init-once/terragrunt.hcl
@@ -1,3 +1,3 @@
 terraform {
-  source = ".//module"
+  source = "./module"
 }

--- a/test/fixtures/regressions/auto-init-marker-with-cached-modules/src/leaf/main.tf
+++ b/test/fixtures/regressions/auto-init-marker-with-cached-modules/src/leaf/main.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "noop" {}

--- a/test/fixtures/regressions/auto-init-marker-with-cached-modules/src/main.tf
+++ b/test/fixtures/regressions/auto-init-marker-with-cached-modules/src/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "registry.opentofu.org/hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
+}
+
+provider "null" {}
+
+module "leaf" {
+  source = "./leaf"
+}

--- a/test/fixtures/regressions/auto-init-marker-with-cached-modules/terragrunt.hcl
+++ b/test/fixtures/regressions/auto-init-marker-with-cached-modules/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = ".//src"
+}

--- a/test/integration_regressions_test.go
+++ b/test/integration_regressions_test.go
@@ -39,6 +39,7 @@ const (
 	testFixtureChainedDepsExposedInclude         = "fixtures/regressions/chained-deps-exposed-include"
 	testFixtureExposedIncludePartialParseError   = "fixtures/regressions/exposed-include-partial-parse-error"
 	testFixtureDAGQueueDisplay                   = "fixtures/regressions/dag-queue-display"
+	testFixtureAutoInitMarkerCachedModules       = "fixtures/regressions/auto-init-marker-with-cached-modules"
 )
 
 func TestNoAutoInit(t *testing.T) {
@@ -55,6 +56,32 @@ func TestNoAutoInit(t *testing.T) {
 	helpers.LogBufferContentsLineByLine(t, stderr, "no force apply stderr")
 	require.Error(t, err)
 	assert.Contains(t, stderr.String(), "Required plugins are not installed")
+}
+
+// Regression test for https://github.com/gruntwork-io/terragrunt/issues/6058
+func TestAutoInitHonorsMarkerWhenModulesCached(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAutoInitMarkerCachedModules)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureAutoInitMarkerCachedModules)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := helpers.RunTerragruntCommand(t, "terragrunt plan --non-interactive --tf-forward-stdout --working-dir "+rootPath, &stdout, &stderr)
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"), "first plan should run init")
+
+	// Bump mtime so EncodeSourceVersion sees a different hash and writes the marker.
+	sourceFile := filepath.Join(rootPath, "src", "main.tf")
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(sourceFile, future, future))
+
+	stdout = bytes.Buffer{}
+	stderr = bytes.Buffer{}
+	err = helpers.RunTerragruntCommand(t, "terragrunt plan --non-interactive --tf-forward-stdout --working-dir "+rootPath, &stdout, &stderr)
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"), "second plan should re-run init because the source-change marker was written")
+	assert.NotContains(t, stderr.String(), "Required plugins are not installed")
 }
 
 // Test case for yamldecode bug: https://github.com/gruntwork-io/terragrunt/issues/834


### PR DESCRIPTION
## Description

Fixes #6058.

`needsInitRunCfg()` was deciding whether auto-init must run by calling `modulesNeedInit()`, which short-circuits on `.terraform/modules/` existence before consulting the `.terragrunt-init-required` marker. Once the cache is populated (i.e. after the first init in any unit with a `module ""` block), the marker written by `download_source.go` on a source-version change was silently ignored, and the next `terragrunt plan`/`apply` would fail with `Error: Required plugins are not installed` whenever the source change invalidated cached providers.

This PR hoists the marker check out of `modulesNeedInit()` and into `needsInitRunCfg()` so it is consulted regardless of cached `.terraform/modules/` contents. Adds a regression test using a local-source fixture (mtime bump on `src/main.tf` triggers `EncodeSourceVersion` to write the marker on the next download). Verified the test fails on `main` with the predicted symptom and passes with the fix.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-init marker is now honored even when Terraform modules appear cached: initialization will rerun when the marker exists, preventing missing-plugin failures during plan.

* **Tests**
  * Added a regression test and fixtures to verify init runs when the marker is present and that repeated plans re-run init as expected.

* **Documentation**
  * Changelog entry describing the auto-init behavior fix.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6059)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->