### PR TITLE
fix: Reducing spurious unknown variable dependency errors

### DIFF
--- a/docs/src/data/changelog/v1.0.5/spurious-unknown-variable-dependency-errors.mdx
+++ b/docs/src/data/changelog/v1.0.5/spurious-unknown-variable-dependency-errors.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.5"
+category: "bug-fixes"
+---
+
+#### Suppress spurious `Unknown variable: dependency` errors during dependency resolution
+
+`terragrunt plan` and `apply` no longer print `ERROR Error: Unknown variable "dependency"` lines when a unit pulls in a shared include (e.g. via `find_in_parent_folders`) that references `dependency.*` outputs. The plans completed correctly, but the error lines cluttered CI logs.
+
+Resolves [#6036](https://github.com/gruntwork-io/terragrunt/issues/6036).

--- a/docs/src/data/changelog/v1.0.6/spurious-unknown-variable-dependency-errors.mdx
+++ b/docs/src/data/changelog/v1.0.6/spurious-unknown-variable-dependency-errors.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.0.5"
+version: "v1.0.6"
 category: "bug-fixes"
 ---
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1227,7 +1227,7 @@ func ParseConfigFile(
 			var file *hclparse.File
 
 			if cacheConfig, found := hclCache.Get(childCtx, cacheKey); found {
-				file = cacheConfig
+				file = cacheConfig.Rebind(hclparse.NewParser(pctx.ParserOptions...))
 			} else {
 				// Parse the HCL file into an AST body that can be decoded multiple times later without having to re-parse
 				var parseErr error

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -296,7 +296,7 @@ func PartialParseConfigFile(ctx context.Context, pctx *ParsingContext, l log.Log
 			var file *hclparse.File
 
 			if cacheConfig, found := hclCache.Get(ctx, cacheKey); found {
-				file = cacheConfig
+				file = cacheConfig.Rebind(hclparse.NewParser(pctx.ParserOptions...))
 			} else {
 				var parseErr error
 

--- a/pkg/config/hclparse/file.go
+++ b/pkg/config/hclparse/file.go
@@ -129,3 +129,21 @@ func (file *File) JustAttributes() (Attributes, error) {
 func (file *File) HandleDiagnostics(diags hcl.Diagnostics) error {
 	return file.handleDiagnostics(file, diags)
 }
+
+// Rebind returns a new File wrapper bound to `parser`, sharing the underlying AST.
+//
+// The `parser` argument is mutated: the file's AST is registered in its file map.
+// This is required because `hcl.NewDiagnosticTextWriter` captures the parser's
+// file map by reference at construction time, so a fresh parser cannot render
+// code snippets for a file it has not seen parsed.
+//
+// The original file wrapper is not modified.
+func (file *File) Rebind(parser *Parser) *File {
+	parser.AddFile(file.ConfigPath, file.File)
+
+	return &File{
+		Parser:     parser,
+		File:       file.File,
+		ConfigPath: file.ConfigPath,
+	}
+}

--- a/pkg/config/hclparse/file.go
+++ b/pkg/config/hclparse/file.go
@@ -132,6 +132,9 @@ func (file *File) HandleDiagnostics(diags hcl.Diagnostics) error {
 
 // Rebind returns a new File wrapper bound to `parser`, sharing the underlying AST.
 //
+// `parser` must be non-nil; Rebind panics otherwise. In practice all callers
+// obtain it from [NewParser], which never returns nil.
+//
 // The `parser` argument is mutated: the file's AST is registered in its file map.
 // This is required because `hcl.NewDiagnosticTextWriter` captures the parser's
 // file map by reference at construction time, so a fresh parser cannot render
@@ -139,6 +142,10 @@ func (file *File) HandleDiagnostics(diags hcl.Diagnostics) error {
 //
 // The original file wrapper is not modified.
 func (file *File) Rebind(parser *Parser) *File {
+	if parser == nil {
+		panic("hclparse: Rebind called with nil parser")
+	}
+
 	parser.AddFile(file.ConfigPath, file.File)
 
 	return &File{

--- a/pkg/config/hclparse/file_test.go
+++ b/pkg/config/hclparse/file_test.go
@@ -1,0 +1,171 @@
+// Package hclparse_test exercises the rebinding contract that pkg/config relies on
+// when reusing a cached File across parsing contexts with different ParserOptions.
+package hclparse_test
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// hclWithUndefinedVar parses cleanly but evaluates with an "Unknown variable"
+// diagnostic when the EvalContext has no `dependency` variable.
+const hclWithUndefinedVar = `
+foo = dependency.bar.outputs.baz
+`
+
+const fixturePath = "/virtual/test.hcl"
+
+type fooOnly struct {
+	Foo string `hcl:"foo"`
+}
+
+// TestRebindRoutesDiagnosticsThroughNewWriter checks that Decode-time diagnostics
+// flow through the rebound parser's writer rather than the parser the file was
+// originally parsed with.
+func TestRebindRoutesDiagnosticsThroughNewWriter(t *testing.T) {
+	t.Parallel()
+
+	var (
+		originalBuf bytes.Buffer
+		reboundBuf  bytes.Buffer
+	)
+
+	original := hclparse.NewParser(hclparse.WithDiagnosticsWriter(&originalBuf, true))
+
+	file, err := original.ParseFromString(hclWithUndefinedVar, fixturePath)
+	require.NoError(t, err)
+
+	rebound := file.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(&reboundBuf, true)))
+
+	var out fooOnly
+
+	decodeErr := rebound.Decode(&out, evalContextMissingDependency())
+	require.Error(t, decodeErr, "decode must surface the undefined-variable diagnostic as an error")
+
+	assert.Empty(t, originalBuf.String(),
+		"original parser's writer must not receive diagnostics from the rebound file")
+	assert.Contains(t, reboundBuf.String(), `no variable named "dependency"`,
+		"rebound parser's writer must receive the diagnostic")
+}
+
+// TestRebindLeavesOriginalFileUnaffected checks that decoding the original file
+// after a Rebind still routes diagnostics through the original parser's writer.
+func TestRebindLeavesOriginalFileUnaffected(t *testing.T) {
+	t.Parallel()
+
+	var (
+		originalBuf bytes.Buffer
+		reboundBuf  bytes.Buffer
+	)
+
+	original := hclparse.NewParser(hclparse.WithDiagnosticsWriter(&originalBuf, true))
+
+	file, err := original.ParseFromString(hclWithUndefinedVar, fixturePath)
+	require.NoError(t, err)
+
+	rebound := file.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(&reboundBuf, true)))
+	require.NotNil(t, rebound, "Rebind must return a usable file wrapper")
+
+	var out fooOnly
+
+	decodeErr := file.Decode(&out, evalContextMissingDependency())
+	require.Error(t, decodeErr)
+
+	assert.Contains(t, originalBuf.String(), `no variable named "dependency"`,
+		"original parser's writer must still receive diagnostics from the original file")
+	assert.Empty(t, reboundBuf.String(),
+		"rebound parser must not receive diagnostics from the original file wrapper")
+}
+
+// TestRebindRendersSourceSnippet checks that the rebound parser's diagnostic
+// includes the source snippet. This pins the AddFile side effect: without it,
+// the diagnostic writer's file map (captured by reference at construction time)
+// has no AST for the snippet renderer.
+func TestRebindRendersSourceSnippet(t *testing.T) {
+	t.Parallel()
+
+	var reboundBuf bytes.Buffer
+
+	original := hclparse.NewParser(hclparse.WithDiagnosticsWriter(io.Discard, true))
+
+	file, err := original.ParseFromString(hclWithUndefinedVar, fixturePath)
+	require.NoError(t, err)
+
+	rebound := file.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(&reboundBuf, true)))
+
+	var out fooOnly
+
+	decodeErr := rebound.Decode(&out, evalContextMissingDependency())
+	require.Error(t, decodeErr)
+
+	rendered := reboundBuf.String()
+
+	assert.Contains(t, rendered, fixturePath, "diagnostic must reference the file path")
+	assert.Contains(t, rendered, "dependency.bar.outputs.baz",
+		"diagnostic must render the source snippet, proving the AST was registered with the new parser")
+}
+
+// TestRebindWithRacing exercises concurrent Rebind+Decode on a shared cached
+// File. The CI "Race" job runs tests matching .*WithRacing with -race. This
+// mirrors the production flow where the parse cache is read by many goroutines
+// (e.g. during `run --all`), each binding the file to a fresh parser before
+// decoding.
+func TestRebindWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 32
+
+	cached, err := hclparse.NewParser(hclparse.WithDiagnosticsWriter(io.Discard, true)).
+		ParseFromString(hclWithUndefinedVar, fixturePath)
+	require.NoError(t, err)
+
+	var (
+		start sync.WaitGroup
+		done  sync.WaitGroup
+	)
+
+	start.Add(1)
+
+	for range goroutines {
+		done.Add(1)
+
+		go func() {
+			defer done.Done()
+
+			start.Wait()
+
+			var buf bytes.Buffer
+
+			rebound := cached.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(&buf, true)))
+
+			var out fooOnly
+
+			decodeErr := rebound.Decode(&out, evalContextMissingDependency())
+			assert.Error(t, decodeErr)
+			assert.Contains(t, buf.String(), `no variable named "dependency"`)
+		}()
+	}
+
+	start.Done()
+	done.Wait()
+}
+
+// evalContextMissingDependency returns an EvalContext with a non-empty Variables
+// map that omits `dependency`. A non-empty Variables map is required to produce
+// the "no variable named X" wording; an empty context yields "Variables not
+// allowed" instead.
+func evalContextMissingDependency() *hcl.EvalContext {
+	return &hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"sentinel": cty.StringVal("present"),
+		},
+	}
+}

--- a/pkg/config/hclparse/file_test.go
+++ b/pkg/config/hclparse/file_test.go
@@ -158,6 +158,21 @@ func TestRebindWithRacing(t *testing.T) {
 	done.Wait()
 }
 
+// TestRebindPanicsOnNilParser pins the documented contract that Rebind must be
+// called with a non-nil parser. Production callers obtain the parser from
+// hclparse.NewParser, which never returns nil; the panic exists so a future
+// misuse fails loudly at the call site instead of deep inside AddFile.
+func TestRebindPanicsOnNilParser(t *testing.T) {
+	t.Parallel()
+
+	file, err := hclparse.NewParser().ParseFromString(hclWithUndefinedVar, fixturePath)
+	require.NoError(t, err)
+
+	assert.PanicsWithValue(t, "hclparse: Rebind called with nil parser", func() {
+		file.Rebind(nil)
+	})
+}
+
 // evalContextMissingDependency returns an EvalContext with a non-empty Variables
 // map that omits `dependency`. A non-empty Variables map is required to produce
 // the "no variable named X" wording; an empty context yields "Variables not

--- a/test/fixtures/dependency-include-remote-state/_shared/remote_state.hcl
+++ b/test/fixtures/dependency-include-remote-state/_shared/remote_state.hcl
@@ -1,0 +1,10 @@
+remote_state {
+  backend = "local"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    path = "${dependency.sub.outputs.id}-${dependency.rgs.outputs.name}.tfstate"
+  }
+}

--- a/test/fixtures/dependency-include-remote-state/parent/child/main.tf
+++ b/test/fixtures/dependency-include-remote-state/parent/child/main.tf
@@ -1,0 +1,7 @@
+variable "parent_value" {
+  type = string
+}
+
+output "result" {
+  value = var.parent_value
+}

--- a/test/fixtures/dependency-include-remote-state/parent/child/terragrunt.hcl
+++ b/test/fixtures/dependency-include-remote-state/parent/child/terragrunt.hcl
@@ -1,0 +1,23 @@
+terraform {
+  source = "."
+}
+
+include "remote_state" {
+  path = find_in_parent_folders("_shared/remote_state.hcl")
+}
+
+dependency "parent" {
+  config_path = "../"
+}
+
+dependency "sub" {
+  config_path = "../../sub"
+}
+
+dependency "rgs" {
+  config_path = "../../rgs"
+}
+
+inputs = {
+  parent_value = dependency.parent.outputs.value
+}

--- a/test/fixtures/dependency-include-remote-state/parent/main.tf
+++ b/test/fixtures/dependency-include-remote-state/parent/main.tf
@@ -1,0 +1,11 @@
+variable "sub_id" {
+  type = string
+}
+
+variable "rgs_name" {
+  type = string
+}
+
+output "value" {
+  value = "${var.sub_id}/${var.rgs_name}"
+}

--- a/test/fixtures/dependency-include-remote-state/parent/terragrunt.hcl
+++ b/test/fixtures/dependency-include-remote-state/parent/terragrunt.hcl
@@ -1,0 +1,20 @@
+terraform {
+  source = "."
+}
+
+include "remote_state" {
+  path = find_in_parent_folders("_shared/remote_state.hcl")
+}
+
+dependency "sub" {
+  config_path = "../sub"
+}
+
+dependency "rgs" {
+  config_path = "../rgs"
+}
+
+inputs = {
+  sub_id   = dependency.sub.outputs.id
+  rgs_name = dependency.rgs.outputs.name
+}

--- a/test/fixtures/dependency-include-remote-state/rgs/main.tf
+++ b/test/fixtures/dependency-include-remote-state/rgs/main.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = "fake-rgs-name"
+}

--- a/test/fixtures/dependency-include-remote-state/rgs/terragrunt.hcl
+++ b/test/fixtures/dependency-include-remote-state/rgs/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/dependency-include-remote-state/sub/main.tf
+++ b/test/fixtures/dependency-include-remote-state/sub/main.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = "fake-sub-id"
+}

--- a/test/fixtures/dependency-include-remote-state/sub/terragrunt.hcl
+++ b/test/fixtures/dependency-include-remote-state/sub/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -30,6 +30,8 @@ const (
 	includeMultipleFixturePath   = "fixtures/include-multiple/"
 	includeRunAllFixturePath     = "fixtures/include-runall/"
 	rootTerragruntHCLFixturePath = "fixtures/root-terragrunt-hcl-regression/"
+
+	includeRemoteStateDepsFixturePath = "fixtures/dependency-include-remote-state/"
 )
 
 func TestTerragruntWorksWithIncludeLocals(t *testing.T) {
@@ -303,6 +305,82 @@ func TestTerragruntWorksWithRootTerragruntHCL(t *testing.T) {
 	// Root should not be treated as a runnable unit (the "." directory should be excluded)
 	rootRun := runs.FindByName(".")
 	assert.Nil(t, rootRun, "Root directory should not be in the report as it should be excluded")
+}
+
+// TestIncludeRemoteStateNoSpuriousUnknownVariableErrors covers both sides of
+// the rebind contract.
+//
+// The first subtest asserts the `Unknown variable "dependency"` log line no
+// longer appears when a unit's shared include references `dependency.*`
+// outputs.
+//
+// The second subtest patches the child config to reference an undeclared
+// identifier and asserts the resulting error still reaches stderr, so the
+// rebind path is not silently swallowing real diagnostics.
+func TestIncludeRemoteStateNoSpuriousUnknownVariableErrors(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T) string {
+		t.Helper()
+
+		helpers.CleanupTerraformFolder(t, includeRemoteStateDepsFixturePath)
+		tmpEnvPath := helpers.CopyEnvironment(t, includeRemoteStateDepsFixturePath)
+		rootPath := filepath.Join(tmpEnvPath, includeRemoteStateDepsFixturePath)
+
+		for _, dir := range []string{"sub", "rgs", "parent"} {
+			unitPath := filepath.Join(rootPath, dir)
+
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t,
+				"terragrunt apply -auto-approve --non-interactive --working-dir "+unitPath)
+			require.NoError(t, err)
+		}
+
+		return rootPath
+	}
+
+	t.Run("spurious dependency errors are suppressed", func(t *testing.T) {
+		t.Parallel()
+
+		rootPath := setup(t)
+		childPath := filepath.Join(rootPath, "parent", "child")
+
+		_, stderr, err := helpers.RunTerragruntCommandWithOutput(t,
+			"terragrunt plan --non-interactive --working-dir "+childPath)
+		require.NoError(t, err)
+
+		assert.NotContains(t, stderr, `There is no variable named "dependency"`)
+	})
+
+	t.Run("real undefined references still surface", func(t *testing.T) {
+		t.Parallel()
+
+		rootPath := setup(t)
+		childPath := filepath.Join(rootPath, "parent", "child")
+		childHCL := filepath.Join(childPath, "terragrunt.hcl")
+
+		// Patch in a reference to an undeclared identifier. The traversal does not
+		// start with `dependency`, so the dependency.go suppression path must not
+		// silence it; the error has to reach stderr.
+		const sentinel = "undeclared_identifier_that_should_surface"
+
+		contents, err := os.ReadFile(childHCL)
+		require.NoError(t, err)
+
+		patched := strings.Replace(
+			string(contents),
+			"parent_value = dependency.parent.outputs.value",
+			"parent_value = "+sentinel,
+			1,
+		)
+		require.NotEqual(t, string(contents), patched, "fixture must contain the line being patched")
+		require.NoError(t, os.WriteFile(childHCL, []byte(patched), 0o644))
+
+		_, stderr, err := helpers.RunTerragruntCommandWithOutput(t,
+			"terragrunt plan --non-interactive --working-dir "+childPath)
+		require.Error(t, err, "an undeclared identifier must produce a terragrunt error")
+		assert.Contains(t, stderr, sentinel,
+			"diagnostic for the undeclared identifier must reach stderr")
+	})
 }
 
 func validateMultipleIncludeTestOutput(t *testing.T, outputs map[string]helpers.TerraformOutput) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6036.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spurious "Unknown variable 'dependency'" error messages during terragrunt plan/apply when using shared includes that reference dependency outputs.
* **Documentation**
  * Added changelog entry describing the fix and its impact on plan/apply output.
* **Tests**
  * Added integration and unit tests to validate the fix and ensure diagnostics are routed correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->