### PR TITLE
fix: Fixing weak path classifier

### DIFF
--- a/internal/filter/classifier.go
+++ b/internal/filter/classifier.go
@@ -132,6 +132,10 @@ func NewClassifier(filters Filters) *Classifier {
 			continue
 		}
 
+		if !IsNegated(expr) {
+			c.hasPositiveFilters = true
+		}
+
 		c.analyzeExpression(expr, i)
 	}
 
@@ -151,9 +155,8 @@ func NewClassifier(filters Filters) *Classifier {
 //  4. Check if component matches any git expression -> DISCOVERED
 //  5. Check if component matches any graph expression target -> CANDIDATE (GraphTarget, returns index)
 //  6. Check if dependent filters exist and parse data unavailable -> CANDIDATE (PotentialDependent)
-//  7. If negated expressions exist and component doesn't match any -> DISCOVERED (negation acts as inclusion)
-//  8. If positive filters exist but no match -> EXCLUDED (exclude-by-default)
-//  9. If no positive filters exist -> DISCOVERED (include-by-default)
+//  7. If positive filters exist but no match -> EXCLUDED (exclude-by-default)
+//  8. If no positive filters exist -> DISCOVERED (include-by-default)
 func (c *Classifier) Classify(comp component.Component, classCtx ClassificationContext) (ClassificationStatus, CandidacyReason, int) {
 	hasNegativeMatch := c.matchesAnyNegated(comp)
 	hasPositiveMatch := c.matchesAnyPositive(comp)
@@ -189,10 +192,6 @@ func (c *Classifier) Classify(comp component.Component, classCtx ClassificationC
 		return StatusCandidate, CandidacyReasonPotentialDependent, -1
 	}
 
-	if len(c.negatedExprs) > 0 && !hasNegativeMatch {
-		return StatusReadyForFilter, CandidacyReasonNone, -1
-	}
-
 	if c.hasPositiveFilters {
 		return StatusExcluded, CandidacyReasonNone, -1
 	}
@@ -205,7 +204,6 @@ func (c *Classifier) analyzeExpression(expr Expression, filterIndex int) {
 	switch node := expr.(type) {
 	case *PathExpression:
 		c.pathExprs = append(c.pathExprs, node)
-		c.hasPositiveFilters = true
 
 	case *AttributeExpression:
 		if _, requiresParse := node.RequiresParse(); requiresParse {
@@ -213,8 +211,6 @@ func (c *Classifier) analyzeExpression(expr Expression, filterIndex int) {
 		} else {
 			c.attributeExprs = append(c.attributeExprs, node)
 		}
-
-		c.hasPositiveFilters = true
 
 	case *GraphExpression:
 		info := &GraphExpressionInfo{
@@ -228,11 +224,9 @@ func (c *Classifier) analyzeExpression(expr Expression, filterIndex int) {
 			DependentDepth:      node.DependentDepth,
 		}
 		c.graphExprs = append(c.graphExprs, info)
-		c.hasPositiveFilters = true
 
 	case *GitExpression:
 		c.gitExprs = append(c.gitExprs, node)
-		c.hasPositiveFilters = true
 
 	case *PrefixExpression:
 		// Right now, the only prefix operator is "!".

--- a/internal/filter/classifier_test.go
+++ b/internal/filter/classifier_test.go
@@ -439,6 +439,22 @@ func TestClassifier_Classify(t *testing.T) {
 			expectedReason: filter.CandidacyReasonNone,
 			expectedIdx:    -1,
 		},
+		{
+			name:           "positive_filter_with_unrelated_negation_excludes_non_matching",
+			filterStrs:     []string{"./apps/app1", "!./libs/db"},
+			componentPath:  "./apps/app2",
+			expectedStatus: filter.StatusExcluded,
+			expectedReason: filter.CandidacyReasonNone,
+			expectedIdx:    -1,
+		},
+		{
+			name:           "compound_negation_filter_does_not_force_exclude_by_default",
+			filterStrs:     []string{"!./_stacks | type=stack"},
+			componentPath:  "./unit1",
+			expectedStatus: filter.StatusReadyForFilter,
+			expectedReason: filter.CandidacyReasonNone,
+			expectedIdx:    -1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/integration_filter_test.go
+++ b/test/integration_filter_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/report"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
@@ -1953,37 +1953,20 @@ func TestFilterFlagMinimizesParsing(t *testing.T) {
 
 		// Verify the report file exists and parse it
 		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
-		if util.FileExists(reportFilePath) {
-			runs, err := report.ParseJSONRunsFromFile(reportFilePath)
-			require.NoError(t, err, "Should be able to parse report JSON")
+		require.FileExists(t, reportFilePath, "Report file should exist")
+		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		require.NoError(t, err, "Should be able to parse report JSON")
 
-			names := runs.Names()
+		names := runs.Names()
 
-			// Verify expected units are in the report
-			found := false
+		require.True(t, slices.ContainsFunc(names, func(name string) bool {
+			return strings.Contains(name, "target-unit")
+		}), "target-unit should be in report. Found units: %v", names)
 
-			for _, name := range names {
-				if strings.Contains(name, "target-unit") {
-					found = true
-					break
-				}
-			}
-
-			require.True(t, found, "target-unit should be in report. Found units: %v", names)
-
-			// Verify land-mine units are NOT in the report
-			for _, excludedUnit := range []string{"excluded-unit-1", "excluded-unit-2", "excluded-unit-3"} {
-				found := false
-
-				for _, name := range names {
-					if strings.Contains(name, excludedUnit) {
-						found = true
-						break
-					}
-				}
-
-				assert.False(t, found, "Excluded unit '%s' should NOT be in report", excludedUnit)
-			}
+		for _, excludedUnit := range []string{"excluded-unit-1", "excluded-unit-2", "excluded-unit-3"} {
+			assert.False(t, slices.ContainsFunc(names, func(name string) bool {
+				return strings.Contains(name, excludedUnit)
+			}), "Excluded unit '%s' should NOT be in report", excludedUnit)
 		}
 	})
 
@@ -2008,49 +1991,119 @@ func TestFilterFlagMinimizesParsing(t *testing.T) {
 
 		// Verify the report file exists and parse it
 		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
-		if util.FileExists(reportFilePath) {
-			runs, err := report.ParseJSONRunsFromFile(reportFilePath)
-			require.NoError(t, err, "Should be able to parse report JSON")
+		require.FileExists(t, reportFilePath)
 
-			names := runs.Names()
+		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		require.NoError(t, err, "Should be able to parse report JSON")
 
-			// Verify expected units are in the report
-			found := false
+		names := runs.Names()
 
-			for _, name := range names {
-				if strings.Contains(name, "target-unit") {
-					found = true
-					break
-				}
-			}
-
-			require.True(t, found, "target-unit should be in report. Found units: %v", names)
-
-			found = false
-
-			for _, name := range names {
-				if strings.Contains(name, "dependency-unit") {
-					found = true
-					break
-				}
-			}
-
-			require.True(t, found, "dependency-unit should be in report. Found units: %v", names)
-
-			// Verify land-mine units are NOT in the report
-			for _, excludedUnit := range []string{"excluded-unit-1", "excluded-unit-2", "excluded-unit-3"} {
-				found := false
-
-				for _, name := range names {
-					if strings.Contains(name, excludedUnit) {
-						found = true
-						break
-					}
-				}
-
-				assert.False(t, found, "Excluded unit '%s' should NOT be in report", excludedUnit)
-			}
+		for _, expected := range []string{"target-unit", "dependency-unit"} {
+			require.True(t, slices.ContainsFunc(names, func(name string) bool {
+				return strings.Contains(name, expected)
+			}), "%s should be in report. Found units: %v", expected, names)
 		}
+
+		for _, excludedUnit := range []string{"excluded-unit-1", "excluded-unit-2", "excluded-unit-3"} {
+			assert.False(t, slices.ContainsFunc(names, func(name string) bool {
+				return strings.Contains(name, excludedUnit)
+			}), "Excluded unit '%s' should NOT be in report", excludedUnit)
+		}
+	})
+
+	t.Run("positive and negative filter", func(t *testing.T) {
+		t.Parallel()
+
+		helpers.CleanupTerraformFolder(t, testFixtureMinimizeParsing)
+		tmpEnvPath := helpers.CopyEnvironment(t, testFixtureMinimizeParsing)
+		rootPath := filepath.Join(tmpEnvPath, testFixtureMinimizeParsing)
+
+		// excluded-unit-{2,3} match neither expression; classifier must early-exclude them or their land-mine run_cmd fires.
+		cmd := "terragrunt run --all plan --no-color --experiment-mode --working-dir " + rootPath +
+			" --filter './target-unit' --filter '!./excluded-unit-1' --report-file " + helpers.ReportFile
+		_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+
+		require.NoError(t, err)
+
+		assert.NotContains(t, stderr, "excluded-unit-1", "excluded-unit-1 should not be parsed")
+		assert.NotContains(t, stderr, "excluded-unit-2", "excluded-unit-2 should not be parsed")
+		assert.NotContains(t, stderr, "excluded-unit-3", "excluded-unit-3 should not be parsed")
+
+		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
+		require.FileExists(t, reportFilePath)
+
+		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		require.NoError(t, err, "Should be able to parse report JSON")
+
+		names := runs.Names()
+
+		require.True(t, slices.ContainsFunc(names, func(name string) bool {
+			return strings.Contains(name, "target-unit")
+		}), "target-unit should be in report. Found units: %v", names)
+
+		for _, excludedUnit := range []string{"excluded-unit-1", "excluded-unit-2", "excluded-unit-3"} {
+			assert.False(t, slices.ContainsFunc(names, func(name string) bool {
+				return strings.Contains(name, excludedUnit)
+			}), "Excluded unit '%s' should NOT be in report", excludedUnit)
+		}
+	})
+
+	t.Run("graph filter with negation", func(t *testing.T) {
+		t.Parallel()
+
+		helpers.CleanupTerraformFolder(t, testFixtureMinimizeParsing)
+		tmpEnvPath := helpers.CopyEnvironment(t, testFixtureMinimizeParsing)
+		rootPath := filepath.Join(tmpEnvPath, testFixtureMinimizeParsing)
+
+		// Pins step-1 ordering: a simple negation must short-circuit before graph dep traversal forces parsing.
+		cmd := "terragrunt run --all plan --no-color --experiment-mode --working-dir " + rootPath +
+			" --filter './target-unit...' --filter '!./excluded-unit-1' --report-file " + helpers.ReportFile
+		_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+
+		require.NoError(t, err)
+
+		assert.NotContains(t, stderr, "excluded-unit-1", "excluded-unit-1 should not be parsed")
+		assert.NotContains(t, stderr, "excluded-unit-2", "excluded-unit-2 should not be parsed")
+		assert.NotContains(t, stderr, "excluded-unit-3", "excluded-unit-3 should not be parsed")
+
+		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
+		require.FileExists(t, reportFilePath)
+
+		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		require.NoError(t, err, "Should be able to parse report JSON")
+
+		names := runs.Names()
+
+		for _, expected := range []string{"target-unit", "dependency-unit"} {
+			require.True(t, slices.ContainsFunc(names, func(name string) bool {
+				return strings.Contains(name, expected)
+			}), "%s should be in report. Found units: %v", expected, names)
+		}
+
+		for _, excludedUnit := range []string{"excluded-unit-1", "excluded-unit-2", "excluded-unit-3"} {
+			assert.False(t, slices.ContainsFunc(names, func(name string) bool {
+				return strings.Contains(name, excludedUnit)
+			}), "Excluded unit '%s' should NOT be in report", excludedUnit)
+		}
+	})
+
+	t.Run("negated graph target still parses for traversal", func(t *testing.T) {
+		t.Parallel()
+
+		helpers.CleanupTerraformFolder(t, testFixtureMinimizeParsing)
+		tmpEnvPath := helpers.CopyEnvironment(t, testFixtureMinimizeParsing)
+		rootPath := filepath.Join(tmpEnvPath, testFixtureMinimizeParsing)
+
+		// Graph traversal requires parsing the target to discover deps; negation only scopes the final result.
+		// Verifies minimization still applies to the unrelated land-mine units.
+		cmd := "terragrunt run --all plan --no-color --experiment-mode --working-dir " + rootPath +
+			" --filter './excluded-unit-1...' --filter '!./excluded-unit-1' --report-file " + helpers.ReportFile
+		_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+
+		require.Error(t, err)
+		assert.Contains(t, stderr, "excluded-unit-1", "excluded-unit-1 must be parsed because it is the graph target")
+		assert.NotContains(t, stderr, "excluded-unit-2", "excluded-unit-2 should not be parsed")
+		assert.NotContains(t, stderr, "excluded-unit-3", "excluded-unit-3 should not be parsed")
 	})
 
 	t.Run("destroy without graph filter", func(t *testing.T) {
@@ -2075,37 +2128,21 @@ func TestFilterFlagMinimizesParsing(t *testing.T) {
 
 		// Verify the report file exists and parse it
 		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
-		if util.FileExists(reportFilePath) {
-			runs, err := report.ParseJSONRunsFromFile(reportFilePath)
-			require.NoError(t, err, "Should be able to parse report JSON")
+		require.FileExists(t, reportFilePath)
 
-			names := runs.Names()
+		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		require.NoError(t, err, "Should be able to parse report JSON")
 
-			// Verify expected unit is in the report
-			found := false
+		names := runs.Names()
 
-			for _, name := range names {
-				if strings.Contains(name, "unit-a") {
-					found = true
-					break
-				}
-			}
+		require.True(t, slices.ContainsFunc(names, func(name string) bool {
+			return strings.Contains(name, "unit-a")
+		}), "unit-a should be in report. Found units: %v", names)
 
-			require.True(t, found, "unit-a should be in report. Found units: %v", names)
-
-			// Verify land-mine units are NOT in the report
-			for _, excludedUnit := range []string{"landmine-unit-1", "landmine-unit-2"} {
-				found := false
-
-				for _, name := range names {
-					if strings.Contains(name, excludedUnit) {
-						found = true
-						break
-					}
-				}
-
-				assert.False(t, found, "Excluded unit '%s' should NOT be in report", excludedUnit)
-			}
+		for _, excludedUnit := range []string{"landmine-unit-1", "landmine-unit-2"} {
+			assert.False(t, slices.ContainsFunc(names, func(name string) bool {
+				return strings.Contains(name, excludedUnit)
+			}), "Excluded unit '%s' should NOT be in report", excludedUnit)
 		}
 	})
 
@@ -2132,37 +2169,21 @@ func TestFilterFlagMinimizesParsing(t *testing.T) {
 
 		// Verify the report file exists and parse it
 		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
-		if util.FileExists(reportFilePath) {
-			runs, err := report.ParseJSONRunsFromFile(reportFilePath)
-			require.NoError(t, err, "Should be able to parse report JSON")
+		require.FileExists(t, reportFilePath)
 
-			names := runs.Names()
+		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		require.NoError(t, err, "Should be able to parse report JSON")
 
-			// Verify expected unit is in the report
-			found := false
+		names := runs.Names()
 
-			for _, name := range names {
-				if strings.Contains(name, "unit-a") {
-					found = true
-					break
-				}
-			}
+		require.True(t, slices.ContainsFunc(names, func(name string) bool {
+			return strings.Contains(name, "unit-a")
+		}), "unit-a should be in report. Found units: %v", names)
 
-			require.True(t, found, "unit-a should be in report. Found units: %v", names)
-
-			// Verify land-mine units are NOT in the report
-			for _, excludedUnit := range []string{"landmine-unit-1", "landmine-unit-2"} {
-				found := false
-
-				for _, name := range names {
-					if strings.Contains(name, excludedUnit) {
-						found = true
-						break
-					}
-				}
-
-				assert.False(t, found, "Excluded unit '%s' should NOT be in report", excludedUnit)
-			}
+		for _, excludedUnit := range []string{"landmine-unit-1", "landmine-unit-2"} {
+			assert.False(t, slices.ContainsFunc(names, func(name string) bool {
+				return strings.Contains(name, excludedUnit)
+			}), "Excluded unit '%s' should NOT be in report", excludedUnit)
 		}
 	})
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6061.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated filter classification logic to correctly handle negated filter expressions combined with positive filters.
  * Improved evaluation of compound negation expressions in filter combinations.

* **Tests**
  * Added test coverage for positive filters combined with unrelated negations.
  * Extended integration tests to cover filter minimization, negation short-circuits, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->