### PR TITLE
fix: Fixing string coercion in tags for catalog

### DIFF
--- a/internal/cli/commands/catalog/tui/redesign/component_doc.go
+++ b/internal/cli/commands/catalog/tui/redesign/component_doc.go
@@ -240,9 +240,8 @@ func (doc *ComponentDoc) parseFrontmatter(key docDataKey) string {
 	return doc.frontmatterCache[key]
 }
 
-// ensureFrontmatter parses the README front-matter block as YAML on first
-// use, populating frontmatterCache (name/description) and frontmatterTags.
-//
+// ensureFrontmatter parses the README front-matter as YAML on first use,
+// populating frontmatterCache (name/description) and frontmatterTags.
 // Unknown keys and parse errors are silently ignored.
 func (doc *ComponentDoc) ensureFrontmatter() {
 	if doc.frontmatterDone {
@@ -256,23 +255,39 @@ func (doc *ComponentDoc) ensureFrontmatter() {
 		return
 	}
 
-	var raw map[string]any
-	if err := yaml.Unmarshal([]byte(doc.frontmatterBody), &raw); err != nil || raw == nil {
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(doc.frontmatterBody), &root); err != nil {
 		return
 	}
 
-	for k, v := range raw {
-		switch strings.ToLower(strings.TrimSpace(k)) {
+	if len(root.Content) == 0 {
+		return
+	}
+
+	mapping := root.Content[0]
+	if mapping.Kind != yaml.MappingNode {
+		return
+	}
+
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		keyNode := mapping.Content[i]
+		valNode := mapping.Content[i+1]
+
+		if keyNode.Kind != yaml.ScalarNode {
+			continue
+		}
+
+		switch strings.ToLower(strings.TrimSpace(keyNode.Value)) {
 		case "name":
-			if s, ok := v.(string); ok {
-				doc.frontmatterCache[docTitle] = strings.TrimSpace(s)
+			if s, ok := scalarString(valNode); ok {
+				doc.frontmatterCache[docTitle] = s
 			}
 		case "description":
-			if s, ok := v.(string); ok {
-				doc.frontmatterCache[docDescription] = strings.TrimSpace(s)
+			if s, ok := scalarString(valNode); ok {
+				doc.frontmatterCache[docDescription] = s
 			}
 		case "tags":
-			doc.frontmatterTags = coerceTags(v)
+			doc.frontmatterTags = coerceTags(valNode)
 		}
 	}
 }
@@ -300,22 +315,38 @@ func (doc *ComponentDoc) extractFrontmatter() {
 	}
 }
 
-// coerceTags accepts the YAML-decoded value of the `tags` key and returns a
-// trimmed, non-empty slice of strings. It accepts either a sequence
-// (`["a","b"]` or a `- a` block) or a single string.
-func coerceTags(v any) []string {
-	switch val := v.(type) {
-	case []any:
-		out := make([]string, 0, len(val))
+// scalarString returns the trimmed source text of a scalar YAML node, or
+// false for null, empty, or non-scalar nodes. Reading Value directly rather
+// than decoding into Go types preserves source forms like `no`, `000123`,
+// and `1.0` that would otherwise become `false`, `123`, and `1`.
+func scalarString(node *yaml.Node) (string, bool) {
+	if node == nil || node.Kind != yaml.ScalarNode || node.Tag == "!!null" {
+		return "", false
+	}
 
-		for _, item := range val {
-			s, ok := item.(string)
+	s := strings.TrimSpace(node.Value)
+	if s == "" {
+		return "", false
+	}
+
+	return s, true
+}
+
+// coerceTags returns the tag list from the value node of a `tags` key. The
+// node may be a sequence (`["a","b"]` or a `- a` block) or a single scalar;
+// empty, null, and non-scalar items are skipped.
+func coerceTags(node *yaml.Node) []string {
+	if node == nil {
+		return nil
+	}
+
+	switch node.Kind {
+	case yaml.SequenceNode:
+		out := make([]string, 0, len(node.Content))
+
+		for _, item := range node.Content {
+			s, ok := scalarString(item)
 			if !ok {
-				continue
-			}
-
-			s = strings.TrimSpace(s)
-			if s == "" {
 				continue
 			}
 
@@ -323,13 +354,15 @@ func coerceTags(v any) []string {
 		}
 
 		return out
-	case string:
-		s := strings.TrimSpace(val)
-		if s == "" {
+	case yaml.ScalarNode:
+		s, ok := scalarString(node)
+		if !ok {
 			return nil
 		}
 
 		return []string{s}
+	case yaml.DocumentNode, yaml.MappingNode, yaml.AliasNode:
+		return nil
 	}
 
 	return nil

--- a/internal/cli/commands/catalog/tui/redesign/component_doc_tags_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/component_doc_tags_test.go
@@ -105,6 +105,54 @@ tags: ["", "aws", "  "]
 `,
 			want: []string{"aws"},
 		},
+		{
+			name: "boolean-shaped scalars preserve source text",
+			content: `<!-- Frontmatter
+tags: [no, yes, true, false]
+-->
+# VPC App
+`,
+			want: []string{"no", "yes", "true", "false"},
+		},
+		{
+			name: "numeric scalars preserve source text",
+			content: `<!-- Frontmatter
+tags: [123, 000123, 0x10, 1.0]
+-->
+# VPC App
+`,
+			want: []string{"123", "000123", "0x10", "1.0"},
+		},
+		{
+			name: "null entries are dropped",
+			content: `<!-- Frontmatter
+tags: [foo, ~, null, bar]
+-->
+# VPC App
+`,
+			want: []string{"foo", "bar"},
+		},
+		{
+			name: "single scalar tag",
+			content: `<!-- Frontmatter
+tags: networking
+-->
+# VPC App
+`,
+			want: []string{"networking"},
+		},
+		{
+			name: "non-scalar items are skipped",
+			content: `<!-- Frontmatter
+tags:
+  - foo
+  - {nested: value}
+  - bar
+-->
+# VPC App
+`,
+			want: []string{"foo", "bar"},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses review feedback from #6033.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component documentation front-matter parsing to correctly handle edge cases including numeric values, boolean-like scalars, and null entries in YAML metadata.

* **Tests**
  * Expanded test coverage for front-matter tag parsing with additional edge case scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6066)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->