### PR TITLE
fix: Fixing race condition in `dependencyBlockToCtyValue`

### DIFF
--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -556,7 +556,10 @@ func dependencyBlocksToCtyValue(traceCtx context.Context, pctx *ParsingContext, 
 			// the higher order dependency map.
 			dependencyEncodingMapEncoded, err := gocty.ToCtyValue(dependencyEncodingMap, generateTypeFromValuesMap(dependencyEncodingMap))
 			if err != nil {
-				err = TerragruntOutputListEncodingError{Paths: paths, Err: err}
+				lock.Lock()
+				err = TerragruntOutputListEncodingError{Paths: slices.Clone(paths), Err: err}
+				lock.Unlock()
+
 				return err
 			}
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes race in `dependencyBlockToCtyValue`.

Given that paths are being read while go-routines are still in-flight, we need synchronization here to ensure safe access to `paths`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concurrency-related issue in dependency processing that could lead to errors during parallel operations, enhancing stability and reliability of dependency resolution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6067)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->