### PR TITLE
chore: Plumbing in `vfs` to `getter`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.7.0
-	github.com/hashicorp/go-safetemp v1.0.0
+	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 

--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -123,44 +123,45 @@ func TFRunOptsFromOpts(opts *options.TerragruntOptions) *tf.TFOptions {
 // NewRunOptions creates a run.Options from TerragruntOptions.
 // This replaces the former run.NewOptions(opts) function.
 func NewRunOptions(opts *options.TerragruntOptions) *run.Options {
-	return &run.Options{
-		Writers:                      opts.Writers,
-		TerragruntConfigPath:         opts.TerragruntConfigPath,
-		OriginalTerragruntConfigPath: opts.OriginalTerragruntConfigPath,
-		WorkingDir:                   opts.WorkingDir,
-		RootWorkingDir:               opts.RootWorkingDir,
-		DownloadDir:                  opts.DownloadDir,
-		TerraformCommand:             opts.TerraformCommand,
-		OriginalTerraformCommand:     opts.OriginalTerraformCommand,
-		TerraformCliArgs:             opts.TerraformCliArgs,
-		Source:                       opts.Source,
-		SourceMap:                    opts.SourceMap,
-		Env:                          opts.Env,
-		IAMRoleOptions:               opts.IAMRoleOptions,
-		OriginalIAMRoleOptions:       opts.OriginalIAMRoleOptions,
-		EngineConfig:                 opts.EngineConfig,
-		EngineOptions:                opts.EngineOptions,
-		Errors:                       opts.Errors,
-		Experiments:                  opts.Experiments,
-		StrictControls:               opts.StrictControls,
-		FeatureFlags:                 opts.FeatureFlags,
-		TFPath:                       opts.TFPath,
-		TofuImplementation:           opts.TofuImplementation,
-		ForwardTFStdout:              opts.ForwardTFStdout,
-		JSONLogFormat:                opts.JSONLogFormat,
-		Headless:                     opts.Headless,
-		NonInteractive:               opts.NonInteractive,
-		Debug:                        opts.Debug,
-		AutoInit:                     opts.AutoInit,
-		AutoRetry:                    opts.AutoRetry,
-		BackendBootstrap:             opts.BackendBootstrap,
-		Telemetry:                    opts.Telemetry,
-		AuthProviderCmd:              opts.AuthProviderCmd,
-		MaxFoldersToCheck:            opts.MaxFoldersToCheck,
-		FailIfBucketCreationRequired: opts.FailIfBucketCreationRequired,
-		DisableBucketUpdate:          opts.DisableBucketUpdate,
-		SourceUpdate:                 opts.SourceUpdate,
-		CASCloneDepth:                opts.CASCloneDepth,
-		NoCAS:                        opts.NoCAS,
-	}
+	runOpts := run.NewOptions()
+	runOpts.Writers = opts.Writers
+	runOpts.TerragruntConfigPath = opts.TerragruntConfigPath
+	runOpts.OriginalTerragruntConfigPath = opts.OriginalTerragruntConfigPath
+	runOpts.WorkingDir = opts.WorkingDir
+	runOpts.RootWorkingDir = opts.RootWorkingDir
+	runOpts.DownloadDir = opts.DownloadDir
+	runOpts.TerraformCommand = opts.TerraformCommand
+	runOpts.OriginalTerraformCommand = opts.OriginalTerraformCommand
+	runOpts.TerraformCliArgs = opts.TerraformCliArgs
+	runOpts.Source = opts.Source
+	runOpts.SourceMap = opts.SourceMap
+	runOpts.Env = opts.Env
+	runOpts.IAMRoleOptions = opts.IAMRoleOptions
+	runOpts.OriginalIAMRoleOptions = opts.OriginalIAMRoleOptions
+	runOpts.EngineConfig = opts.EngineConfig
+	runOpts.EngineOptions = opts.EngineOptions
+	runOpts.Errors = opts.Errors
+	runOpts.Experiments = opts.Experiments
+	runOpts.StrictControls = opts.StrictControls
+	runOpts.FeatureFlags = opts.FeatureFlags
+	runOpts.TFPath = opts.TFPath
+	runOpts.TofuImplementation = opts.TofuImplementation
+	runOpts.ForwardTFStdout = opts.ForwardTFStdout
+	runOpts.JSONLogFormat = opts.JSONLogFormat
+	runOpts.Headless = opts.Headless
+	runOpts.NonInteractive = opts.NonInteractive
+	runOpts.Debug = opts.Debug
+	runOpts.AutoInit = opts.AutoInit
+	runOpts.AutoRetry = opts.AutoRetry
+	runOpts.BackendBootstrap = opts.BackendBootstrap
+	runOpts.Telemetry = opts.Telemetry
+	runOpts.AuthProviderCmd = opts.AuthProviderCmd
+	runOpts.MaxFoldersToCheck = opts.MaxFoldersToCheck
+	runOpts.FailIfBucketCreationRequired = opts.FailIfBucketCreationRequired
+	runOpts.DisableBucketUpdate = opts.DisableBucketUpdate
+	runOpts.SourceUpdate = opts.SourceUpdate
+	runOpts.CASCloneDepth = opts.CASCloneDepth
+	runOpts.NoCAS = opts.NoCAS
+
+	return runOpts
 }

--- a/internal/getter/filecopy.go
+++ b/internal/getter/filecopy.go
@@ -102,6 +102,20 @@ func (g *FileCopyGetter) WithLogger(l log.Logger) *FileCopyGetter {
 	return g
 }
 
+// WithFS sets the filesystem used to stat source paths before copying.
+// Panics if fs is not OS-backed: Get delegates to util.CopyFolderContents
+// and GetFile to go-getter's FileGetter, both of which bypass the
+// abstraction.
+func (g *FileCopyGetter) WithFS(fs vfs.FS) *FileCopyGetter {
+	if !vfs.IsOSFS(fs) {
+		panic("getter.FileCopyGetter.WithFS: requires an OS-backed filesystem")
+	}
+
+	g.FS = fs
+
+	return g
+}
+
 // WithIncludeInCopy sets the glob patterns that should be included in the
 // copy even when [util.CopyFolderContents] would skip them by default
 // (e.g. hidden folders).

--- a/internal/getter/options_test.go
+++ b/internal/getter/options_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	gogetter "github.com/hashicorp/go-getter/v2"
@@ -283,4 +284,26 @@ func allHTTPGetters(getters []getter.Getter) []*gogetter.HttpGetter {
 
 func writeFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0644)
+}
+
+// TestFileCopyGetterWithFSPanicsOnNonOSFS pins that WithFS rejects a non
+// OS-backed FS at construction time.
+func TestFileCopyGetterWithFSPanicsOnNonOSFS(t *testing.T) {
+	t.Parallel()
+
+	assert.PanicsWithValue(t,
+		"getter.FileCopyGetter.WithFS: requires an OS-backed filesystem",
+		func() { getter.NewFileCopyGetter().WithFS(vfs.NewMemMapFS()) },
+	)
+}
+
+// TestRegistryGetterWithFSPanicsOnNonOSFS pins the same invariant for
+// RegistryGetter.
+func TestRegistryGetterWithFSPanicsOnNonOSFS(t *testing.T) {
+	t.Parallel()
+
+	assert.PanicsWithValue(t,
+		"getter.RegistryGetter.WithFS: requires an OS-backed filesystem",
+		func() { getter.NewRegistryGetter(logger.CreateLogger()).WithFS(vfs.NewMemMapFS()) },
+	)
 }

--- a/internal/getter/tfr.go
+++ b/internal/getter/tfr.go
@@ -3,7 +3,6 @@ package getter
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -16,7 +15,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-cleanhttp"
 	getter "github.com/hashicorp/go-getter/v2"
-	safetemp "github.com/hashicorp/go-safetemp"
 )
 
 const versionQueryKey = "version"
@@ -76,6 +74,19 @@ func (r *RegistryGetter) WithHTTPClient(c *http.Client) *RegistryGetter {
 // the source URL does not specify a host. See [RegistryGetter.TofuImplementation].
 func (r *RegistryGetter) WithTofuImplementation(impl tfimpl.Type) *RegistryGetter {
 	r.TofuImplementation = impl
+	return r
+}
+
+// WithFS sets the filesystem used for archive extraction cleanup.
+// Panics if fs is not OS-backed: getSubdir re-enters go-getter and runs
+// util.CopyFolderContentsWithFilter, both of which bypass this abstraction.
+func (r *RegistryGetter) WithFS(fs vfs.FS) *RegistryGetter {
+	if !vfs.IsOSFS(fs) {
+		panic("getter.RegistryGetter.WithFS: requires an OS-backed filesystem")
+	}
+
+	r.FS = fs
+
 	return r
 }
 
@@ -183,16 +194,21 @@ func (r *RegistryGetter) delegateGet(ctx context.Context, dst, src string) error
 // subdirectory into dstPath. This is how the registry getter handles
 // `MODULE/subdir` selectors.
 func (r *RegistryGetter) getSubdir(ctx context.Context, l log.Logger, dstPath, sourceURL, subDir string) error {
-	tempdirPath, tempdirCloser, err := safetemp.Dir("", "getter")
+	// Hand the consumer a non-existent path inside an existing parent so
+	// go-getter can create the destination itself, and clean up the parent
+	// on return.
+	parent, err := vfs.MkdirTemp(r.FS, "", "getter")
 	if err != nil {
 		return err
 	}
 
-	defer func(tempdirCloser io.Closer) {
-		if err := tempdirCloser.Close(); err != nil {
-			l.Warnf("Error closing temporary directory %s: %v", tempdirPath, err)
+	defer func() {
+		if err := r.FS.RemoveAll(parent); err != nil {
+			l.Warnf("Error removing temporary directory %s: %v", parent, err)
 		}
-	}(tempdirCloser)
+	}()
+
+	tempdirPath := filepath.Join(parent, "temp")
 
 	if err := r.delegateGet(ctx, tempdirPath, sourceURL); err != nil {
 		return fmt.Errorf("downloading registry module archive from %s: %w", sourceURL, err)

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -3,7 +3,6 @@ package run
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -20,8 +19,14 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
+
+// ErrNonOSFilesystem is returned by DownloadTerraformSource when Options.FS
+// is not OS-backed. See the doc comment on Options.FS for why this is
+// required.
+var ErrNonOSFilesystem = errors.New("download requires an OS-backed filesystem; see run.Options.FS")
 
 // ModuleManifestName is the manifest for files copied from terragrunt module folder (i.e., the folder that contains the current terragrunt.hcl).
 const (
@@ -51,6 +56,10 @@ func DownloadTerraformSource(
 	cfg *runcfg.RunConfig,
 	r *report.Report,
 ) (*Options, error) {
+	if !vfs.IsOSFS(opts.FS) {
+		return nil, ErrNonOSFilesystem
+	}
+
 	walkWithSymlinks := opts.Experiments.Evaluate(experiment.Symlinks)
 
 	source = tf.RewriteLegacyGCSPublicSource(ctx, l, source, opts.StrictControls)
@@ -136,6 +145,9 @@ func DownloadTerraformSource(
 
 // DownloadTerraformSourceIfNecessary downloads the specified TerraformSource if the latest code hasn't already been
 // downloaded. It returns true if a download was performed, or false if the existing cache was up to date.
+//
+// opts.FS must be the OS-backed filesystem from [vfs.NewOSFS]; see [Options.FS]
+// for why. Returns [ErrNonOSFilesystem] otherwise.
 func DownloadTerraformSourceIfNecessary(
 	ctx context.Context,
 	l log.Logger,
@@ -144,10 +156,14 @@ func DownloadTerraformSourceIfNecessary(
 	cfg *runcfg.RunConfig,
 	r *report.Report,
 ) (bool, error) {
+	if !vfs.IsOSFS(opts.FS) {
+		return false, ErrNonOSFilesystem
+	}
+
 	if opts.SourceUpdate {
 		l.Debugf("The --source-update flag is set, so deleting the temporary folder %s before downloading source.", terraformSource.DownloadDir)
 
-		if err := os.RemoveAll(terraformSource.DownloadDir); err != nil {
+		if err := opts.FS.RemoveAll(terraformSource.DownloadDir); err != nil {
 			return false, errors.New(err)
 		}
 	} else {
@@ -239,12 +255,14 @@ func DownloadTerraformSourceIfNecessary(
 
 		initFile := filepath.Join(terraformSource.WorkingDir, ModuleInitRequiredFile)
 
-		f, createErr := os.Create(initFile)
+		f, createErr := opts.FS.Create(initFile)
 		if createErr != nil {
 			return false, createErr
 		}
 
-		defer f.Close()
+		if err := f.Close(); err != nil {
+			return false, err
+		}
 	}
 
 	return true, nil
@@ -344,9 +362,12 @@ func downloadSource(
 	}
 
 	return opts.RunWithErrorHandling(ctx, l, r, func() error {
-		client := BuildDownloadClient(l, opts, cfg)
+		client, err := BuildDownloadClient(l, opts, cfg)
+		if err != nil {
+			return err
+		}
 
-		_, err := client.Get(ctx, &getter.Request{
+		_, err = client.Get(ctx, &getter.Request{
 			Src:     src.CanonicalSourceURL.String(),
 			Dst:     src.DownloadDir,
 			GetMode: getter.ModeAny,
@@ -373,7 +394,7 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 		return false, err
 	}
 
-	c, err := cas.New(cas.WithCloneDepth(opts.CASCloneDepth))
+	c, err := cas.New(cas.WithCloneDepth(opts.CASCloneDepth), cas.WithFS(opts.FS))
 	if err != nil {
 		l.Warnf("Failed to initialize CAS: %v. Falling back to standard getter.", err)
 		return false, nil
@@ -409,7 +430,7 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 		// Clear any partial CAS output before the fallback runs; mixing
 		// leftover CAS files with the standard getter's output leaves the
 		// module dir in an inconsistent state.
-		if removeErr := os.RemoveAll(src.DownloadDir); removeErr != nil {
+		if removeErr := opts.FS.RemoveAll(src.DownloadDir); removeErr != nil {
 			l.Warnf("Failed to clean partial CAS output at %s: %v", src.DownloadDir, removeErr)
 		}
 
@@ -426,18 +447,28 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 // protocol set are: FileCopyGetter (copies local sources instead of
 // symlinking) and RegistryGetter (resolves tfr:// sources).
 //
+// opts.FS must be the OS-backed filesystem from [vfs.NewOSFS]; the returned
+// client shells out to go-getter and other libraries that bypass the vfs
+// abstraction. Returns [ErrNonOSFilesystem] otherwise.
+//
 // Exported so tests can assert the protocol set directly.
-func BuildDownloadClient(l log.Logger, opts *Options, cfg *runcfg.RunConfig) *getter.Client {
+func BuildDownloadClient(l log.Logger, opts *Options, cfg *runcfg.RunConfig) (*getter.Client, error) {
+	if !vfs.IsOSFS(opts.FS) {
+		return nil, ErrNonOSFilesystem
+	}
+
 	return getter.NewClient(
 		getter.WithLogger(l),
 		getter.WithFileCopy(getter.NewFileCopyGetter().
 			WithLogger(l).
+			WithFS(opts.FS).
 			WithIncludeInCopy(cfg.Terraform.IncludeInCopy...).
 			WithExcludeFromCopy(cfg.Terraform.ExcludeFromCopy...).
 			WithFastCopy(controls.IsFastCopyEnabled(opts.StrictControls))),
 		getter.WithTFRegistry(getter.NewRegistryGetter(l).
+			WithFS(opts.FS).
 			WithTofuImplementation(opts.TofuImplementation)),
-	)
+	), nil
 }
 
 // ValidateWorkingDir checks if working terraformSource.WorkingDir exists and is a directory

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -194,9 +194,12 @@ func DownloadTerraformSourceIfNecessary(
 	var previousVersion = ""
 	// read previous source version
 	// https://github.com/gruntwork-io/terragrunt/issues/1921
-	if util.FileExists(terraformSource.VersionFile) {
-		var err error
+	versionFileExists, err := vfs.FileExists(opts.FS, terraformSource.VersionFile)
+	if err != nil {
+		return false, errors.New(err)
+	}
 
+	if versionFileExists {
 		previousVersion, err = readVersionFile(terraformSource)
 		if err != nil {
 			return false, err
@@ -272,10 +275,15 @@ func DownloadTerraformSourceIfNecessary(
 // DownloadFolder. This helps avoid downloading the same code multiple times. Note that if the TerraformSource points
 // to a local file path, a hash will be generated from the contents of the source dir. See the ProcessTerraformSource method for more info.
 func AlreadyHaveLatestCode(l log.Logger, terraformSource *tf.Source, opts *Options) (bool, error) {
-	if !util.FileExists(terraformSource.DownloadDir) ||
-		!util.FileExists(terraformSource.WorkingDir) ||
-		!util.FileExists(terraformSource.VersionFile) {
-		return false, nil
+	for _, path := range []string{terraformSource.DownloadDir, terraformSource.WorkingDir, terraformSource.VersionFile} {
+		exists, err := vfs.FileExists(opts.FS, path)
+		if err != nil {
+			return false, errors.New(err)
+		}
+
+		if !exists {
+			return false, nil
+		}
 	}
 
 	hasFiles, err := util.DirContainsTFFiles(terraformSource.WorkingDir)

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
@@ -631,7 +632,8 @@ func TestUpdateGettersExcludeFromCopy(t *testing.T) {
 			terragruntOptions, err := options.NewTerragruntOptionsForTest("./test")
 			require.NoError(t, err)
 
-			client := run.BuildDownloadClient(logger.CreateLogger(), configbridge.NewRunOptions(terragruntOptions), tc.cfg)
+			client, err := run.BuildDownloadClient(logger.CreateLogger(), configbridge.NewRunOptions(terragruntOptions), tc.cfg)
+			require.NoError(t, err)
 
 			fileGetter, ok := findGetter[*getter.FileCopyGetter](client.Getters)
 			require.True(t, ok, "client should register a FileCopyGetter")
@@ -654,11 +656,12 @@ func TestBuildDownloadClientHTTPNetrc(t *testing.T) {
 	terragruntOptions, err := options.NewTerragruntOptionsForTest("./test")
 	require.NoError(t, err)
 
-	client := run.BuildDownloadClient(
+	client, err := run.BuildDownloadClient(
 		logger.CreateLogger(),
 		configbridge.NewRunOptions(terragruntOptions),
 		&runcfg.RunConfig{Terraform: runcfg.TerraformConfig{}},
 	)
+	require.NoError(t, err)
 
 	wrapped, ok := findGetter[*getter.HTTPSchemeGetter](client.Getters)
 	require.True(t, ok, "client should register an HttpGetter")
@@ -676,11 +679,12 @@ func TestBuildDownloadClientCoversDefaultSchemes(t *testing.T) {
 	terragruntOptions, err := options.NewTerragruntOptionsForTest("./test")
 	require.NoError(t, err)
 
-	client := run.BuildDownloadClient(
+	client, err := run.BuildDownloadClient(
 		logger.CreateLogger(),
 		configbridge.NewRunOptions(terragruntOptions),
 		&runcfg.RunConfig{Terraform: runcfg.TerraformConfig{}},
 	)
+	require.NoError(t, err)
 
 	_, ok := findGetter[*getter.FileCopyGetter](client.Getters)
 	assert.True(t, ok, "FileCopyGetter (file scheme)")
@@ -1093,7 +1097,8 @@ func TestHTTPGetterNetrcAuthentication(t *testing.T) {
 
 	dst := filepath.Join(t.TempDir(), "module.tf")
 
-	client := run.BuildDownloadClient(logger.CreateLogger(), configbridge.NewRunOptions(opts), cfg)
+	client, err := run.BuildDownloadClient(logger.CreateLogger(), configbridge.NewRunOptions(opts), cfg)
+	require.NoError(t, err)
 
 	_, err = client.Get(t.Context(), &getter.Request{
 		Src:     server.URL + "/module.tf",
@@ -1105,4 +1110,76 @@ func TestHTTPGetterNetrcAuthentication(t *testing.T) {
 	downloaded, err := os.ReadFile(dst)
 	require.NoError(t, err)
 	assert.Equal(t, fileContent, string(downloaded))
+}
+
+// TestDownloadTerraformSourceRejectsNonOSFilesystem pins that the entry
+// guard returns ErrNonOSFilesystem before any download work runs when
+// Options.FS is not OS-backed.
+func TestDownloadTerraformSourceRejectsNonOSFilesystem(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("./test")
+	require.NoError(t, err)
+
+	runOpts := configbridge.NewRunOptions(opts)
+	runOpts.FS = vfs.NewMemMapFS()
+
+	l := logger.CreateLogger()
+	l.SetOptions(log.WithOutput(io.Discard))
+
+	_, err = run.DownloadTerraformSource(
+		t.Context(),
+		l,
+		".",
+		runOpts,
+		&runcfg.RunConfig{Terraform: runcfg.TerraformConfig{}},
+		report.NewReport(),
+	)
+	require.ErrorIs(t, err, run.ErrNonOSFilesystem)
+}
+
+// TestDownloadTerraformSourceIfNecessaryRejectsNonOSFilesystem pins the guard
+// on the exported helper so external callers cannot bypass the OS-FS invariant.
+func TestDownloadTerraformSourceIfNecessaryRejectsNonOSFilesystem(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("./test")
+	require.NoError(t, err)
+
+	runOpts := configbridge.NewRunOptions(opts)
+	runOpts.FS = vfs.NewMemMapFS()
+
+	src, err := tf.NewSource(logger.CreateLogger(), ".", t.TempDir(), opts.WorkingDir, false)
+	require.NoError(t, err)
+
+	_, err = run.DownloadTerraformSourceIfNecessary(
+		t.Context(),
+		logger.CreateLogger(),
+		src,
+		runOpts,
+		&runcfg.RunConfig{Terraform: runcfg.TerraformConfig{}},
+		report.NewReport(),
+	)
+	require.ErrorIs(t, err, run.ErrNonOSFilesystem)
+}
+
+// TestBuildDownloadClientRejectsNonOSFilesystem pins the guard on the
+// exported client constructor so callers cannot construct a client that would
+// later hand a non-OS FS to FileCopyGetter or RegistryGetter.
+func TestBuildDownloadClientRejectsNonOSFilesystem(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("./test")
+	require.NoError(t, err)
+
+	runOpts := configbridge.NewRunOptions(opts)
+	runOpts.FS = vfs.NewMemMapFS()
+
+	client, err := run.BuildDownloadClient(
+		logger.CreateLogger(),
+		runOpts,
+		&runcfg.RunConfig{Terraform: runcfg.TerraformConfig{}},
+	)
+	require.ErrorIs(t, err, run.ErrNonOSFilesystem)
+	assert.Nil(t, client)
 }

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -365,7 +364,7 @@ func (o *Options) handleIgnoreSignals(l log.Logger, signals map[string]any) erro
 
 	l.Warnf("Writing error signals to %s", signalsFile)
 
-	if err := os.WriteFile(signalsFile, signalsJSON, ownerPerms); err != nil {
+	if err := vfs.WriteFile(o.FS, signalsFile, signalsJSON, ownerPerms); err != nil {
 		return fmt.Errorf("failed to write signals file %s: %w", signalsFile, err)
 	}
 

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/tflint"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
@@ -36,6 +37,14 @@ const (
 	defaultSignalsFile = "error-signals.json"
 )
 
+// NewOptions returns an Options with FS defaulted to the OS-backed
+// filesystem. Callers must construct Options through this function (or copy
+// from another Options) so paths like DownloadTerraformSource, which require
+// an OS-backed FS, work without each caller having to remember to set it.
+func NewOptions() *Options {
+	return &Options{FS: vfs.NewOSFS()}
+}
+
 // Options contains the configuration needed by run.Run and its helpers.
 // This is a focused subset of options.TerragruntOptions.
 type Options struct {
@@ -45,6 +54,7 @@ type Options struct {
 	Errors                       *errorconfig.Config
 	FeatureFlags                 *xsync.Map[string, string]
 	Telemetry                    *telemetry.Options
+	FS                           vfs.FS
 	SourceMap                    map[string]string
 	Env                          map[string]string
 	Writers                      writer.Writers

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1475,38 +1475,35 @@ func runTerragruntOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Lo
 	runWriters := pctx.Writers
 	runWriters.Writer = stdoutBufferWriter
 
-	runOpts := &run.Options{
-		Writers:                      runWriters,
-		TerragruntConfigPath:         pctx.TerragruntConfigPath,
-		OriginalTerragruntConfigPath: pctx.OriginalTerragruntConfigPath,
-		WorkingDir:                   pctx.WorkingDir,
-		RootWorkingDir:               pctx.RootWorkingDir,
-		DownloadDir:                  pctx.DownloadDir,
-		Source:                       pctx.Source,
-		SourceMap:                    pctx.SourceMap,
-		TerraformCommand:             pctx.TerraformCommand,
-		OriginalTerraformCommand:     pctx.OriginalTerraformCommand,
-		TerraformCliArgs:             pctx.TerraformCliArgs,
-		Env:                          pctx.Env,
-		IAMRoleOptions:               pctx.IAMRoleOptions,
-		OriginalIAMRoleOptions:       pctx.OriginalIAMRoleOptions,
-		Experiments:                  pctx.Experiments,
-		StrictControls:               pctx.StrictControls,
-		FeatureFlags:                 pctx.FeatureFlags,
-		EngineConfig:                 pctx.EngineConfig,
-		EngineOptions:                pctx.EngineOptions,
-		TFPath:                       pctx.TFPath,
-		TofuImplementation:           pctx.TofuImplementation,
-		ForwardTFStdout:              false,
-		JSONLogFormat:                false,
-		Headless:                     pctx.Headless,
-		Debug:                        pctx.Debug,
-		AutoInit:                     pctx.AutoInit,
-		BackendBootstrap:             pctx.BackendBootstrap,
-		Telemetry:                    pctx.Telemetry,
-		AuthProviderCmd:              pctx.AuthProviderCmd,
-		CASCloneDepth:                pctx.CASCloneDepth,
-	}
+	runOpts := run.NewOptions()
+	runOpts.Writers = runWriters
+	runOpts.TerragruntConfigPath = pctx.TerragruntConfigPath
+	runOpts.OriginalTerragruntConfigPath = pctx.OriginalTerragruntConfigPath
+	runOpts.WorkingDir = pctx.WorkingDir
+	runOpts.RootWorkingDir = pctx.RootWorkingDir
+	runOpts.DownloadDir = pctx.DownloadDir
+	runOpts.Source = pctx.Source
+	runOpts.SourceMap = pctx.SourceMap
+	runOpts.TerraformCommand = pctx.TerraformCommand
+	runOpts.OriginalTerraformCommand = pctx.OriginalTerraformCommand
+	runOpts.TerraformCliArgs = pctx.TerraformCliArgs
+	runOpts.Env = pctx.Env
+	runOpts.IAMRoleOptions = pctx.IAMRoleOptions
+	runOpts.OriginalIAMRoleOptions = pctx.OriginalIAMRoleOptions
+	runOpts.Experiments = pctx.Experiments
+	runOpts.StrictControls = pctx.StrictControls
+	runOpts.FeatureFlags = pctx.FeatureFlags
+	runOpts.EngineConfig = pctx.EngineConfig
+	runOpts.EngineOptions = pctx.EngineOptions
+	runOpts.TFPath = pctx.TFPath
+	runOpts.TofuImplementation = pctx.TofuImplementation
+	runOpts.Headless = pctx.Headless
+	runOpts.Debug = pctx.Debug
+	runOpts.AutoInit = pctx.AutoInit
+	runOpts.BackendBootstrap = pctx.BackendBootstrap
+	runOpts.Telemetry = pctx.Telemetry
+	runOpts.AuthProviderCmd = pctx.AuthProviderCmd
+	runOpts.CASCloneDepth = pctx.CASCloneDepth
 
 	err = run.Run(ctx, l, runOpts, report.NewReport(), runCfg, credsGetter)
 	if err != nil {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses review feedback in #6030.

Plumbs through the fs where it's used in the `getter` package.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to supply a custom filesystem to download/extraction components.
  * New exported error when a non-OS-backed filesystem is provided.

* **Bug Fixes**
  * Source download and cleanup now reliably use the configured filesystem abstraction.

* **Tests**
  * Added tests covering non-OS filesystem rejection for download and getter flows.

* **Refactor**
  * Improved temporary directory handling during archive extraction and options construction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6070?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->