### PR TITLE
fix: Addressing catalog tag feedback

### DIFF
--- a/internal/cli/commands/catalog/tui/redesign/delegate.go
+++ b/internal/cli/commands/catalog/tui/redesign/delegate.go
@@ -57,8 +57,9 @@ const (
 	sourceColor  = "#4A4A4A"
 	sourceColorS = "#5A5A5A"
 
-	// Description (muted blue-gray, readable but secondary to title).
-	descForegroundColor = "#8393A7"
+	// Description (blue-gray; bold titles carry the hierarchy so this can read
+	// brighter than a typical "secondary" color without competing).
+	descForegroundColor = "#B0BFD0"
 
 	metaMuted = "#6C7086"
 
@@ -81,6 +82,8 @@ type catalogDelegate struct {
 func newCatalogDelegate(keys *tui.DelegateKeyMap) catalogDelegate {
 	// Use the same default item styles as the production delegate, with our color overrides.
 	styles := list.NewDefaultItemStyles(true)
+
+	styles.NormalTitle = styles.NormalTitle.Bold(true)
 
 	styles.SelectedTitle = styles.SelectedTitle.
 		Bold(true).
@@ -332,6 +335,6 @@ const (
 	selectedTitleForegroundColorDark       = "#63C5DA"
 	selectedTitleBorderForegroundColorDark = "#63C5DA"
 
-	selectedDescForegroundColorDark       = "#59788E"
+	selectedDescForegroundColorDark       = "#8AA3B5"
 	selectedDescBorderForegroundColorDark = "#63C5DA"
 )


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses catalog UI/UX feedback on the catalog redesign.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined catalog interface styling with brighter description colors, bolder titles, and enhanced visual appearance for improved readability and user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6073)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->