### PR TITLE
chore: Make clone tests a bit faster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,8 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/getsops/sops/v3 v3.12.2
-	github.com/go-git/go-billy/v6 v6.0.0-alpha.1
+	github.com/gliderlabs/ssh v0.3.8
+	github.com/go-git/go-billy/v6 v6.0.0-20260328065524-593ae452e14d
 	github.com/go-git/go-git/v6 v6.0.0-alpha.1
 	github.com/gobwas/glob v0.2.3
 	github.com/hashicorp/go-getter/gcs/v2 v2.2.3
@@ -99,6 +100,7 @@ require (
 	github.com/wI2L/jsondiff v0.7.1
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.uber.org/mock v0.6.0
+	golang.org/x/crypto v0.51.0
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -133,6 +135,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/alecthomas/chroma/v2 v2.15.0 // indirect
+	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/apparentlymart/go-versions v1.0.3 // indirect
@@ -177,6 +180,7 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
+	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
@@ -299,7 +303,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -333,6 +333,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
+github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -401,8 +403,8 @@ github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8b
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-git/gcfg/v2 v2.0.2 h1:MY5SIIfTGGEMhdA7d7JePuVVxtKL7Hp+ApGDJAJ7dpo=
 github.com/go-git/gcfg/v2 v2.0.2/go.mod h1:/lv2NsxvhepuMrldsFilrgct6pxzpGdSRC13ydTLSLs=
-github.com/go-git/go-billy/v6 v6.0.0-alpha.1 h1:xVjAR4oUvrKy7/Xuw/lLlV3gkxR3KO2H8W+MamuVVsQ=
-github.com/go-git/go-billy/v6 v6.0.0-alpha.1/go.mod h1:eaCUpHbedW7//EwcYmUDfJe2N6sJC9O12AT0OTqJR1E=
+github.com/go-git/go-billy/v6 v6.0.0-20260328065524-593ae452e14d h1:bLMI9z4mKkfQO383+O3fkP4xdWQcMdnn5fFBMwaBC1M=
+github.com/go-git/go-billy/v6 v6.0.0-20260328065524-593ae452e14d/go.mod h1:LLeMBFApkgIKwMzirxpU9XB7NvO2HdTw5FXmeP1M6c8=
 github.com/go-git/go-git-fixtures/v5 v5.1.2-0.20260122163445-0622d7459a67 h1:3hutPZF+/FBjR/9MdsLJ7e1mlt9pwHgwxMW7CrbmWII=
 github.com/go-git/go-git-fixtures/v5 v5.1.2-0.20260122163445-0622d7459a67/go.mod h1:xKt0pNHST9tYHvbiLxSY27CQWFwgIxBJuDrOE0JvbZw=
 github.com/go-git/go-git/v6 v6.0.0-alpha.1 h1:tGohX5luKeO50DZD0/Zqd5dYjJzKtub91S4I+1qFVIs=

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -402,7 +402,7 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 		return false, err
 	}
 
-	c, err := cas.New(cas.WithCloneDepth(opts.CASCloneDepth), cas.WithFS(opts.FS))
+	c, err := cas.New(cas.WithCloneDepth(opts.CASCloneDepth))
 	if err != nil {
 		l.Warnf("Failed to initialize CAS: %v. Falling back to standard getter.", err)
 		return false, nil

--- a/test/fixtures/aws-provider-patch/main.tf
+++ b/test/fixtures/aws-provider-patch/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "example_module" {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/aws-provider-patch/example-module?ref=__BRANCH_NAME__"
+  source = "git::__MIRROR_URL__//test/fixtures/aws-provider-patch/example-module?ref=__BRANCH_NAME__"
 
   allowed_account_ids  = var.allowed_account_ids
   secondary_aws_region = var.secondary_aws_region

--- a/test/fixtures/download/hello-world/main.tf
+++ b/test/fixtures/download/hello-world/main.tf
@@ -29,6 +29,6 @@ output "test" {
 }
 
 module "remote" {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
   name   = var.name
 }

--- a/test/fixtures/download/init-on-source-change/terragrunt.hcl
+++ b/test/fixtures/download/init-on-source-change/terragrunt.hcl
@@ -1,4 +1,4 @@
 terraform {
   // v0.35.1 v0.35.2
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/dirs?ref=__TAG_VALUE__"
+  source = "git::__MIRROR_URL__//test/fixtures/dirs?ref=__TAG_VALUE__"
 }

--- a/test/fixtures/download/invalid-path/terragrunt.hcl
+++ b/test/fixtures/download/invalid-path/terragrunt.hcl
@@ -1,3 +1,3 @@
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/non-existent-path?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/non-existent-path?ref=v0.83.2"
 }

--- a/test/fixtures/download/local-windows/JZwoL6Viko8bzuRvTOQFx3Jh8vs/3mU4huxMLOXOW5ZgJOFXGUFDKc8/main.tf
+++ b/test/fixtures/download/local-windows/JZwoL6Viko8bzuRvTOQFx3Jh8vs/3mU4huxMLOXOW5ZgJOFXGUFDKc8/main.tf
@@ -29,6 +29,6 @@ output "test" {
 }
 
 module "remote" {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world?ref=v0.83.2"
   name   = var.name
 }

--- a/test/fixtures/download/remote-commit-ref/terragrunt.hcl
+++ b/test/fixtures/download/remote-commit-ref/terragrunt.hcl
@@ -3,8 +3,7 @@ inputs = {
 }
 
 terraform {
-  # Pinned to the commit v0.93.2 resolves to so this fixture exercises
-  # the commit-SHA path in the CAS getter without depending on whatever
-  # the tag points to in the future.
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=dd7913e04f0e812b51ccf2c4f35a0fda16a356a1"
+  # Exercises the commit-SHA path in the CAS getter. __MIRROR_SHA__ is
+  # substituted to the local git mirror's HEAD commit hash at render time.
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world-no-remote?ref=__MIRROR_SHA__"
 }

--- a/test/fixtures/download/remote-mutable/terragrunt.hcl
+++ b/test/fixtures/download/remote-mutable/terragrunt.hcl
@@ -3,6 +3,6 @@ inputs = {
 }
 
 terraform {
-  source  = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
+  source  = "git::__MIRROR_URL__//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
   mutable = true
 }

--- a/test/fixtures/download/remote-ref/terragrunt.hcl
+++ b/test/fixtures/download/remote-ref/terragrunt.hcl
@@ -3,5 +3,5 @@ inputs = {
 }
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
+  source = "git::__MIRROR_SSH_URL__//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
 }

--- a/test/fixtures/download/remote-relative-with-slash/terragrunt.hcl
+++ b/test/fixtures/download/remote-relative-with-slash/terragrunt.hcl
@@ -3,5 +3,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git?ref=v0.93.2//test/fixtures/download/relative"
+  source = "git::__MIRROR_URL__//test/fixtures/download/relative?ref=v0.93.2"
 }

--- a/test/fixtures/download/remote-relative/terragrunt.hcl
+++ b/test/fixtures/download/remote-relative/terragrunt.hcl
@@ -3,5 +3,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/relative?ref=v0.93.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/relative?ref=v0.93.2"
 }

--- a/test/fixtures/download/remote-with-backend/terragrunt.hcl
+++ b/test/fixtures/download/remote-with-backend/terragrunt.hcl
@@ -3,7 +3,7 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-with-backend?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world-with-backend?ref=v0.83.2"
 }
 
 # Configure Terragrunt to automatically store tfstate files in an S3 bucket

--- a/test/fixtures/download/remote/terragrunt.hcl
+++ b/test/fixtures/download/remote/terragrunt.hcl
@@ -3,5 +3,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world-no-remote?ref=v0.93.2"
 }

--- a/test/fixtures/get-output/regression-906/a/terragrunt.hcl
+++ b/test/fixtures/get-output/regression-906/a/terragrunt.hcl
@@ -7,5 +7,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world?ref=v0.83.2"
 }

--- a/test/fixtures/get-output/regression-906/b/terragrunt.hcl
+++ b/test/fixtures/get-output/regression-906/b/terragrunt.hcl
@@ -7,5 +7,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world?ref=v0.83.2"
 }

--- a/test/fixtures/get-output/regression-906/c/terragrunt.hcl
+++ b/test/fixtures/get-output/regression-906/c/terragrunt.hcl
@@ -7,5 +7,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world?ref=v0.83.2"
 }

--- a/test/fixtures/get-output/regression-906/common-dep/terragrunt.hcl
+++ b/test/fixtures/get-output/regression-906/common-dep/terragrunt.hcl
@@ -10,5 +10,5 @@ remote_state {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixture?ref=v0.21.0"
+  source = "git::__MIRROR_URL__//test/fixtures/terragrunt?ref=v0.93.2"
 }

--- a/test/fixtures/get-output/regression-906/d/terragrunt.hcl
+++ b/test/fixtures/get-output/regression-906/d/terragrunt.hcl
@@ -7,5 +7,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world?ref=v0.83.2"
 }

--- a/test/fixtures/get-output/regression-906/e/terragrunt.hcl
+++ b/test/fixtures/get-output/regression-906/e/terragrunt.hcl
@@ -7,5 +7,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world?ref=v0.83.2"
 }

--- a/test/fixtures/get-output/regression-906/f/terragrunt.hcl
+++ b/test/fixtures/get-output/regression-906/f/terragrunt.hcl
@@ -7,5 +7,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world?ref=v0.83.2"
 }

--- a/test/fixtures/get-output/regression-906/g/terragrunt.hcl
+++ b/test/fixtures/get-output/regression-906/g/terragrunt.hcl
@@ -7,5 +7,5 @@ inputs = {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world?ref=v0.83.2"
 }

--- a/test/fixtures/no-submodules/terragrunt.hcl
+++ b/test/fixtures/no-submodules/terragrunt.hcl
@@ -1,3 +1,3 @@
 terraform {
-  source = "git::git@github.com:terraform-google-modules/terraform-google-folders.git?ref=v4.0.0"
+  source = "git::__MIRROR_SSH_URL__"
 }

--- a/test/fixtures/parallel-run/common/terragrunt.hcl
+++ b/test/fixtures/parallel-run/common/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/dirs?ref=v0.99.1"
+  source = "git::__MIRROR_URL__//test/fixtures/dirs?ref=v0.99.1"
 }
 
 generate "providers" {

--- a/test/fixtures/parallel-run/dev/app/terragrunt.hcl
+++ b/test/fixtures/parallel-run/dev/app/terragrunt.hcl
@@ -3,7 +3,7 @@ include "root" {
 }
 
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/dirs?ref=v0.99.1"
+  source = "git::__MIRROR_URL__//test/fixtures/dirs?ref=v0.99.1"
 }
 
 dependency "common" {

--- a/test/fixtures/parsing/exposed-include-with-deprecated-inputs/child/terragrunt.hcl
+++ b/test/fixtures/parsing/exposed-include-with-deprecated-inputs/child/terragrunt.hcl
@@ -12,7 +12,7 @@ include "compcommon" {
 }
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terragrunt.git//test/fixtures/download/hello-world"
+  source = "git::__MIRROR_SSH_URL__//test/fixtures/download/hello-world"
 }
 
 dependency "service" {

--- a/test/fixtures/parsing/exposed-include-with-deprecated-inputs/dep/terragrunt.hcl
+++ b/test/fixtures/parsing/exposed-include-with-deprecated-inputs/dep/terragrunt.hcl
@@ -1,6 +1,6 @@
 # Mock dependency configuration
 terraform {
-  source = "git::git@github.com:gruntwork-io/terragrunt.git//test/fixtures/download/hello-world"
+  source = "git::__MIRROR_SSH_URL__//test/fixtures/download/hello-world"
 }
 
 inputs = {

--- a/test/fixtures/runner-pool-remote-source/unit-a/terragrunt.hcl
+++ b/test/fixtures/runner-pool-remote-source/unit-a/terragrunt.hcl
@@ -1,3 +1,3 @@
 terraform {
-    source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/fail-fast/unit-a?ref=v0.84.1"
+    source = "git::__MIRROR_URL__//test/fixtures/fail-fast/unit-a?ref=v0.84.1"
 }

--- a/test/fixtures/runner-pool-remote-source/unit-b/terragrunt.hcl
+++ b/test/fixtures/runner-pool-remote-source/unit-b/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/fail-fast/unit-a?ref=v0.84.1"
+  source = "git::__MIRROR_URL__//test/fixtures/fail-fast/unit-a?ref=v0.84.1"
 }
 
 dependency "unit-a" {

--- a/test/fixtures/scaffold/custom-default-template/root.hcl
+++ b/test/fixtures/scaffold/custom-default-template/root.hcl
@@ -1,3 +1,3 @@
 catalog {
-  default_template = "git@github.com:gruntwork-io/terragrunt.git//test/fixtures/scaffold/external-template/template"
+  default_template = "git::__MIRROR_SSH_URL__//test/fixtures/scaffold/external-template/template"
 }

--- a/test/fixtures/scaffold/with-hooks/.boilerplate/terragrunt.hcl
+++ b/test/fixtures/scaffold/with-hooks/.boilerplate/terragrunt.hcl
@@ -1,6 +1,6 @@
 # Test template with hooks
 terraform {
-  source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8"
+  source = "git::__MIRROR_URL__//test/fixtures/inputs?ref=v0.53.8"
 }
 
 inputs = {

--- a/test/fixtures/scaffold/with-shell-and-hooks/.boilerplate/terragrunt.hcl
+++ b/test/fixtures/scaffold/with-shell-and-hooks/.boilerplate/terragrunt.hcl
@@ -1,6 +1,6 @@
 # Test template with both shell template functions and hooks
 terraform {
-  source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8"
+  source = "git::__MIRROR_URL__//test/fixtures/inputs?ref=v0.53.8"
 }
 
 inputs = {

--- a/test/fixtures/scaffold/with-shell-commands/.boilerplate/terragrunt.hcl
+++ b/test/fixtures/scaffold/with-shell-commands/.boilerplate/terragrunt.hcl
@@ -1,6 +1,6 @@
 # Test template with shell template function
 terraform {
-  source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8"
+  source = "git::__MIRROR_URL__//test/fixtures/inputs?ref=v0.53.8"
 }
 
 inputs = {

--- a/test/fixtures/stacks/remote/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/remote/terragrunt.stack.hcl
@@ -3,12 +3,12 @@ locals {
 }
 
 unit "app1" {
-	source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/basic/units/chick?ref=${local.version}&depth=1"
+	source = "git::__MIRROR_URL__//test/fixtures/stacks/basic/units/chick?ref=${local.version}"
 	path   = "app1"
 }
 
 unit "app2" {
-	source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/basic/units/chick?ref=${local.version}&depth=1"
+	source = "git::__MIRROR_URL__//test/fixtures/stacks/basic/units/chick?ref=${local.version}"
 	path   = "app2"
 }
 

--- a/test/fixtures/stacks/self-include/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/self-include/live/terragrunt.stack.hcl
@@ -3,7 +3,7 @@ locals {
 }
 
 unit "app1" {
-  source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/self-include/unit?ref=${local.version}"
+  source = "git::__MIRROR_URL__//test/fixtures/stacks/self-include/unit?ref=${local.version}"
   path   = "app1"
   values = {
     data = "example-data"

--- a/test/fixtures/stacks/self-include/unit/terragrunt.hcl
+++ b/test/fixtures/stacks/self-include/unit/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/self-include/module?ref=main"
+  source = "git::__MIRROR_URL__//test/fixtures/stacks/self-include/module?ref=main"
 }
 
 inputs = {

--- a/test/fixtures/validate-inputs/fail-remote-module/terragrunt.hcl
+++ b/test/fixtures/validate-inputs/fail-remote-module/terragrunt.hcl
@@ -1,3 +1,3 @@
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world?ref=v0.83.2"
 }

--- a/test/fixtures/validate-inputs/fail-unused-inputs/terragrunt.hcl
+++ b/test/fixtures/validate-inputs/fail-unused-inputs/terragrunt.hcl
@@ -5,5 +5,5 @@ inputs = {
 
 # the existence of a `source` directive manifests the bug in https://github.com/gruntwork-io/terragrunt/issues/1793
 terraform {
-  source = "github.com/gruntwork-io/terragrunt.git//test/fixtures/download/hello-world?ref=v0.83.2"
+  source = "git::__MIRROR_URL__//test/fixtures/download/hello-world?ref=v0.83.2"
 }

--- a/test/helpers/git_mirror.go
+++ b/test/helpers/git_mirror.go
@@ -1,0 +1,414 @@
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// MirrorURLPlaceholder is replaced by the live HTTP mirror URL
+	// during [TerragruntMirror.RenderFixture]. Fixtures that previously
+	// held a `https://github.com/gruntwork-io/terragrunt.git` URL embed
+	// this placeholder instead.
+	MirrorURLPlaceholder = "__MIRROR_URL__"
+
+	// MirrorSSHURLPlaceholder is replaced by the live SSH mirror URL
+	// (of form `ssh://git@127.0.0.1:PORT/terragrunt.git`). SSH-specific
+	// fixtures embed this placeholder instead of an SSH GitHub URL.
+	MirrorSSHURLPlaceholder = "__MIRROR_SSH_URL__"
+
+	// MirrorSHAPlaceholder is replaced by the mirror's HEAD commit hash.
+	// Used by the one fixture that pins a commit SHA.
+	MirrorSHAPlaceholder = "__MIRROR_SHA__"
+)
+
+// terragruntMirrorTags lists the git tag names integration test
+// fixtures pin against. The mirror creates all of them at HEAD; tests
+// don't depend on the historical content of any of these refs, only on
+// the ability to clone the named ref.
+var terragruntMirrorTags = []string{
+	"v0.53.8",
+	"v0.67.4",
+	"v0.78.4",
+	"v0.79.0",
+	"v0.83.2",
+	"v0.84.1",
+	"v0.85.0",
+	"v0.93.2",
+	"v0.99.1",
+}
+
+// terragruntMirrorBranches lists non-default branches the mirror
+// creates at HEAD. Tests that exercise URL-parser tolerance for
+// slash-bearing ref names (e.g., source-map's slash-in-ref behavior)
+// rely on these.
+var terragruntMirrorBranches = []string{
+	"fixture/test-fixtures",
+}
+
+// TerragruntMirror is an in-process git server pair (HTTP + optional
+// SSH) that serves the current working tree's `test/fixtures/`
+// directory as if it were the upstream `gruntwork-io/terragrunt`
+// repository. Tests use it to avoid cloning the real repo from GitHub.
+//
+// SSHURL is empty when the local `ssh` client binary or
+// `git-upload-pack` is unavailable. Callers that need SSH should
+// invoke [TerragruntMirror.RequireSSH], which calls t.Skip when
+// SSHURL is empty and otherwise wires `GIT_SSH_COMMAND` into the
+// calling test's environment.
+type TerragruntMirror struct {
+	// URL is the HTTP endpoint of the mirror, of form
+	// `http://127.0.0.1:PORT/terragrunt.git`. Substituted into
+	// fixtures via [MirrorURLPlaceholder].
+	URL string
+	// SSHURL is the SSH endpoint of the mirror, or empty when the
+	// SSH mirror is unavailable.
+	SSHURL string
+	// HeadSHA is the commit SHA of the mirror's HEAD on `main`.
+	// Substituted into fixtures via [MirrorSHAPlaceholder].
+	HeadSHA string
+	// sshKeyPEM is the OpenSSH-format private key the SSH mirror
+	// accepts. [TerragruntMirror.RequireSSH] writes it into the
+	// calling test's t.TempDir() so each test gets a fresh on-disk
+	// copy that's removed automatically when the test ends.
+	sshKeyPEM []byte
+}
+
+// RequireSSH skips the calling test when the SSH mirror is unavailable
+// (typically because `ssh` or `git-upload-pack` is not on PATH).
+// Otherwise it writes the mirror's private key under t.TempDir() and
+// points `GIT_SSH_COMMAND` at it via t.Setenv so `git` invocations
+// during the test authenticate against the mirror. Both the key file
+// and the env var are scoped to the test by the testing package — no
+// leaked tmpfiles, no shared state. Because t.Setenv panics on
+// parallel tests, callers must not invoke t.Parallel.
+func (m *TerragruntMirror) RequireSSH(t *testing.T) {
+	t.Helper()
+
+	if m.SSHURL == "" {
+		t.Skip("ssh mirror unavailable (ssh client or git-upload-pack missing)")
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	require.NoError(t, os.WriteFile(keyPath, m.sshKeyPEM, sshKeyFilePerm), "write ssh key")
+
+	t.Setenv("GIT_SSH_COMMAND", fmt.Sprintf(
+		"ssh -i %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes",
+		keyPath,
+	))
+}
+
+var (
+	mirrorOnce sync.Once
+	mirrorRef  *TerragruntMirror
+	mirrorErr  error
+)
+
+// StartTerragruntMirror returns the process-wide mirror, lazily
+// initializing it on first call. The mirror is shared across tests
+// because its content is read-only after startup.
+func StartTerragruntMirror(t *testing.T) *TerragruntMirror {
+	t.Helper()
+
+	mirrorOnce.Do(func() {
+		mirrorRef, mirrorErr = startTerragruntMirror()
+	})
+
+	require.NoError(t, mirrorErr, "start terragrunt mirror")
+
+	return mirrorRef
+}
+
+// SourceURL returns a go-getter source string of the form
+// `git::<mirror-url>//<subpath>?ref=<ref>`. Pass an empty `ref` to
+// omit the query.
+func (m *TerragruntMirror) SourceURL(subpath, ref string) string {
+	src := "git::" + m.URL + "//" + strings.TrimPrefix(subpath, "/")
+	if ref != "" {
+		src += "?ref=" + ref
+	}
+
+	return src
+}
+
+// RenderFixture is a backwards-compatible wrapper around
+// [CopyEnvironment]. The substitution now happens automatically inside
+// [CopyEnvironment] whenever placeholders are present, so callers can
+// drop the mirror-specific helper in favour of plain [CopyEnvironment].
+// It is retained because several call sites read more clearly when they
+// say "render this fixture against the mirror".
+func (m *TerragruntMirror) RenderFixture(t *testing.T, fixturePath string, includeInCopy ...string) string {
+	t.Helper()
+
+	return CopyEnvironment(t, fixturePath, includeInCopy...)
+}
+
+// applyMirrorSubst replaces [MirrorURLPlaceholder],
+// [MirrorSSHURLPlaceholder], and [MirrorSHAPlaceholder] in `*.hcl`,
+// `*.tf`, and `*.tofu` files under root. A first pass scans for any
+// placeholder so trees without one bail out before the mirror is
+// started. Trees that need substitution lazy-start the mirror via
+// [StartTerragruntMirror].
+func applyMirrorSubst(t *testing.T, root string) {
+	t.Helper()
+
+	var found bool
+
+	scanErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		switch filepath.Ext(d.Name()) {
+		case ".hcl", ".tf", ".tofu":
+		default:
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		if bytes.Contains(data, []byte(MirrorURLPlaceholder)) ||
+			bytes.Contains(data, []byte(MirrorSSHURLPlaceholder)) ||
+			bytes.Contains(data, []byte(MirrorSHAPlaceholder)) {
+			found = true
+
+			return filepath.SkipAll
+		}
+
+		return nil
+	})
+	require.NoError(t, scanErr, "scan for mirror placeholders in %s", root)
+
+	if !found {
+		return
+	}
+
+	m := StartTerragruntMirror(t)
+
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		switch filepath.Ext(d.Name()) {
+		case ".hcl", ".tf", ".tofu":
+		default:
+			return nil
+		}
+
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		if !bytes.Contains(contents, []byte(MirrorURLPlaceholder)) &&
+			!bytes.Contains(contents, []byte(MirrorSSHURLPlaceholder)) &&
+			!bytes.Contains(contents, []byte(MirrorSHAPlaceholder)) {
+			return nil
+		}
+
+		contents = bytes.ReplaceAll(contents, []byte(MirrorURLPlaceholder), []byte(m.URL))
+		contents = bytes.ReplaceAll(contents, []byte(MirrorSSHURLPlaceholder), []byte(m.SSHURL))
+		contents = bytes.ReplaceAll(contents, []byte(MirrorSHAPlaceholder), []byte(m.HeadSHA))
+
+		return os.WriteFile(path, contents, readWritePermissions)
+	})
+	require.NoError(t, walkErr, "render mirror placeholders in %s", root)
+}
+
+func startTerragruntMirror() (*TerragruntMirror, error) {
+	srv, err := git.NewServer()
+	if err != nil {
+		return nil, fmt.Errorf("new server: %w", err)
+	}
+
+	// Bind and serve before committing so the mirror URL is known.
+	// We need the URL to substitute __MIRROR_URL__ in fixture files
+	// before they land in the mirror, otherwise modules cloned from
+	// the mirror that reference other mirror fixtures (e.g.,
+	// download/hello-world's inner module ref) would still hit
+	// upstream github. Concurrent reads against an empty storage are
+	// fine; sync.Once gates external callers until commits+tags are
+	// in place.
+	url, err := srv.Start(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("start: %w", err)
+	}
+
+	fixturesDir, err := locateFixturesDir()
+	if err != nil {
+		return nil, err
+	}
+
+	// Best-effort SSH mirror. If `ssh` or `git-upload-pack` is missing,
+	// SSHURL stays empty and the few SSH-only tests skip via
+	// RequireSSH. The SSH URL must be known *before* committing
+	// fixtures so __MIRROR_SSH_URL__ can be substituted at bake time.
+	sshURL, sshKeyPEM, sshErr := startSSHMirror(fixturesDir, url)
+	if sshErr != nil {
+		fmt.Fprintf(os.Stderr, "terragrunt SSH mirror unavailable: %v\n", sshErr)
+	}
+
+	if err := commitFixtureTree(srv, fixturesDir, url, sshURL); err != nil {
+		return nil, fmt.Errorf("commit fixture tree: %w", err)
+	}
+
+	head, err := srv.Head()
+	if err != nil {
+		return nil, fmt.Errorf("resolve head: %w", err)
+	}
+
+	for _, tag := range terragruntMirrorTags {
+		if err := srv.Tag(tag); err != nil {
+			return nil, fmt.Errorf("tag %s: %w", tag, err)
+		}
+	}
+
+	for _, branch := range terragruntMirrorBranches {
+		if err := srv.Branch(branch); err != nil {
+			return nil, fmt.Errorf("branch %s: %w", branch, err)
+		}
+	}
+
+	return &TerragruntMirror{
+		URL:       url,
+		SSHURL:    sshURL,
+		HeadSHA:   head,
+		sshKeyPEM: sshKeyPEM,
+	}, nil
+}
+
+func locateFixturesDir() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("locate helper file via runtime.Caller")
+	}
+
+	return filepath.Join(filepath.Dir(thisFile), "..", "fixtures"), nil
+}
+
+// commitFixtureTree walks fixturesDir on disk, writes every file into
+// srv's worktree at path `test/fixtures/<rel>`, then bulk-stages and
+// creates a single commit. Skipped: `.terraform`, `.terragrunt-cache`,
+// symlinks, `terraform.tfstate*`, `terragrunt-debug.tfvars.json`.
+//
+// For `*.hcl`, `*.tf`, and `*.tofu` files, [MirrorURLPlaceholder] is
+// substituted with mirrorURL before commit so a clone of one fixture
+// that references another fixture via __MIRROR_URL__ stays inside the
+// mirror and never reaches upstream github.
+//
+// Bulk-staging via [AddOptions.All] is required because per-file
+// `Add()` calls `Status()` on the entire worktree each time, which
+// degrades to O(n²) on the ~3K fixture files.
+func commitFixtureTree(srv *git.Server, fixturesDir, mirrorURL, mirrorSSHURL string) error {
+	repo := srv.Repo()
+
+	w, err := repo.Worktree()
+	if err != nil {
+		return fmt.Errorf("worktree: %w", err)
+	}
+
+	walkErr := filepath.WalkDir(fixturesDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if d.Name() == ".terraform" || d.Name() == ".terragrunt-cache" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		// Skip symlinks (e.g., regression benchmark fixtures point a
+		// dependency-group dir at a template dir). They have no
+		// bearing on the github-mirror tests and following them would
+		// require duplicating the target into the mirror.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+
+		name := d.Name()
+		if name == "terragrunt-debug.tfvars.json" || strings.HasPrefix(name, "terraform.tfstate") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(fixturesDir, path)
+		if err != nil {
+			return err
+		}
+
+		repoPath := filepath.ToSlash(filepath.Join("test/fixtures", rel))
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+
+		switch filepath.Ext(name) {
+		case ".hcl", ".tf", ".tofu":
+			data = bytes.ReplaceAll(data, []byte(MirrorURLPlaceholder), []byte(mirrorURL))
+			data = bytes.ReplaceAll(data, []byte(MirrorSSHURLPlaceholder), []byte(mirrorSSHURL))
+		}
+
+		f, err := w.Filesystem.Create(repoPath)
+		if err != nil {
+			return fmt.Errorf("create %s: %w", repoPath, err)
+		}
+
+		if _, err := f.Write(data); err != nil {
+			return fmt.Errorf("write %s: %w", repoPath, err)
+		}
+
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", repoPath, err)
+		}
+
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+
+	if err := w.AddWithOptions(&gogit.AddOptions{All: true}); err != nil {
+		return fmt.Errorf("add all: %w", err)
+	}
+
+	sig := &object.Signature{Name: "Test", Email: "test@test.com", When: time.Now()}
+
+	if _, err := w.Commit("seed test/fixtures from working tree", &gogit.CommitOptions{
+		Author:    sig,
+		Committer: sig,
+	}); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	return nil
+}

--- a/test/helpers/git_mirror.go
+++ b/test/helpers/git_mirror.go
@@ -37,11 +37,11 @@ const (
 	MirrorSHAPlaceholder = "__MIRROR_SHA__"
 )
 
-// terragruntMirrorTags lists the git tag names integration test
+// TerragruntMirrorTags lists the git tag names integration test
 // fixtures pin against. The mirror creates all of them at HEAD; tests
 // don't depend on the historical content of any of these refs, only on
 // the ability to clone the named ref.
-var terragruntMirrorTags = []string{
+var TerragruntMirrorTags = []string{
 	"v0.53.8",
 	"v0.67.4",
 	"v0.78.4",
@@ -53,11 +53,11 @@ var terragruntMirrorTags = []string{
 	"v0.99.1",
 }
 
-// terragruntMirrorBranches lists non-default branches the mirror
+// TerragruntMirrorBranches lists non-default branches the mirror
 // creates at HEAD. Tests that exercise URL-parser tolerance for
 // slash-bearing ref names (e.g., source-map's slash-in-ref behavior)
 // rely on these.
-var terragruntMirrorBranches = []string{
+var TerragruntMirrorBranches = []string{
 	"fixture/test-fixtures",
 }
 
@@ -158,6 +158,93 @@ func (m *TerragruntMirror) RenderFixture(t *testing.T, fixturePath string, inclu
 	return CopyEnvironment(t, fixturePath, includeInCopy...)
 }
 
+// substituteMirrorPlaceholders rewrites [MirrorURLPlaceholder],
+// [MirrorSSHURLPlaceholder], and [MirrorSHAPlaceholder] in data.
+// Empty replacement values are skipped so the literal placeholder
+// remains: this matters when the SSH mirror is unavailable —
+// replacing `__MIRROR_SSH_URL__` with `""` would produce a malformed
+// `git::` URL that fails confusingly downstream, whereas leaving the
+// placeholder yields a clear error if the fixture is actually used
+// (SSH-only tests skip via [TerragruntMirror.RequireSSH] before they
+// reach this code).
+func substituteMirrorPlaceholders(data []byte, httpURL, sshURL, headSHA string) []byte {
+	if httpURL != "" {
+		data = bytes.ReplaceAll(data, []byte(MirrorURLPlaceholder), []byte(httpURL))
+	}
+
+	if sshURL != "" {
+		data = bytes.ReplaceAll(data, []byte(MirrorSSHURLPlaceholder), []byte(sshURL))
+	}
+
+	if headSHA != "" {
+		data = bytes.ReplaceAll(data, []byte(MirrorSHAPlaceholder), []byte(headSHA))
+	}
+
+	return data
+}
+
+// isFixtureSubstFile reports whether ext denotes a file whose
+// contents should be searched for mirror placeholders.
+func isFixtureSubstFile(ext string) bool {
+	switch ext {
+	case ".hcl", ".tf", ".tofu":
+		return true
+	}
+
+	return false
+}
+
+// walkFixtures walks fixturesDir applying the standard skip rules
+// (`.terraform`, `.terragrunt-cache`, symlinks, `terraform.tfstate*`,
+// `terragrunt-debug.tfvars.json`) and, for each remaining file, calls
+// fn with the path relative to fixturesDir (slash-separated) and the
+// file's bytes after [substituteMirrorPlaceholders] has been applied
+// using httpURL and sshURL.
+func walkFixtures(fixturesDir, httpURL, sshURL string, fn func(rel string, data []byte) error) error {
+	return filepath.WalkDir(fixturesDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if d.Name() == ".terraform" || d.Name() == ".terragrunt-cache" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		// Skip symlinks (e.g., regression benchmark fixtures point a
+		// dependency-group dir at a template dir). They have no
+		// bearing on the github-mirror tests and following them would
+		// require duplicating the target into the mirror.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+
+		name := d.Name()
+		if name == "terragrunt-debug.tfvars.json" || strings.HasPrefix(name, "terraform.tfstate") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(fixturesDir, path)
+		if err != nil {
+			return err
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+
+		if isFixtureSubstFile(filepath.Ext(name)) {
+			data = substituteMirrorPlaceholders(data, httpURL, sshURL, "")
+		}
+
+		return fn(filepath.ToSlash(rel), data)
+	})
+}
+
 // applyMirrorSubst replaces [MirrorURLPlaceholder],
 // [MirrorSSHURLPlaceholder], and [MirrorSHAPlaceholder] in `*.hcl`,
 // `*.tf`, and `*.tofu` files under root. A first pass scans for any
@@ -178,9 +265,7 @@ func applyMirrorSubst(t *testing.T, root string) {
 			return nil
 		}
 
-		switch filepath.Ext(d.Name()) {
-		case ".hcl", ".tf", ".tofu":
-		default:
+		if !isFixtureSubstFile(filepath.Ext(d.Name())) {
 			return nil
 		}
 
@@ -216,9 +301,7 @@ func applyMirrorSubst(t *testing.T, root string) {
 			return nil
 		}
 
-		switch filepath.Ext(d.Name()) {
-		case ".hcl", ".tf", ".tofu":
-		default:
+		if !isFixtureSubstFile(filepath.Ext(d.Name())) {
 			return nil
 		}
 
@@ -233,9 +316,7 @@ func applyMirrorSubst(t *testing.T, root string) {
 			return nil
 		}
 
-		contents = bytes.ReplaceAll(contents, []byte(MirrorURLPlaceholder), []byte(m.URL))
-		contents = bytes.ReplaceAll(contents, []byte(MirrorSSHURLPlaceholder), []byte(m.SSHURL))
-		contents = bytes.ReplaceAll(contents, []byte(MirrorSHAPlaceholder), []byte(m.HeadSHA))
+		contents = substituteMirrorPlaceholders(contents, m.URL, m.SSHURL, m.HeadSHA)
 
 		return os.WriteFile(path, contents, readWritePermissions)
 	})
@@ -256,10 +337,17 @@ func startTerragruntMirror() (*TerragruntMirror, error) {
 	// upstream github. Concurrent reads against an empty storage are
 	// fine; sync.Once gates external callers until commits+tags are
 	// in place.
-	url, err := srv.Start(context.Background())
+	base, err := srv.Start(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("start: %w", err)
 	}
+
+	// Append `/terragrunt.git` so the HTTP URL is symmetric with
+	// the SSH URL (`ssh://git@HOST:PORT/terragrunt.git`). The
+	// underlying [git.Server] uses a single-repo loader that
+	// ignores the request path, so any path resolves to the same
+	// storer.
+	url := base + "/terragrunt.git"
 
 	fixturesDir, err := locateFixturesDir()
 	if err != nil {
@@ -284,13 +372,13 @@ func startTerragruntMirror() (*TerragruntMirror, error) {
 		return nil, fmt.Errorf("resolve head: %w", err)
 	}
 
-	for _, tag := range terragruntMirrorTags {
+	for _, tag := range TerragruntMirrorTags {
 		if err := srv.Tag(tag); err != nil {
 			return nil, fmt.Errorf("tag %s: %w", tag, err)
 		}
 	}
 
-	for _, branch := range terragruntMirrorBranches {
+	for _, branch := range TerragruntMirrorBranches {
 		if err := srv.Branch(branch); err != nil {
 			return nil, fmt.Errorf("branch %s: %w", branch, err)
 		}
@@ -313,15 +401,9 @@ func locateFixturesDir() (string, error) {
 	return filepath.Join(filepath.Dir(thisFile), "..", "fixtures"), nil
 }
 
-// commitFixtureTree walks fixturesDir on disk, writes every file into
-// srv's worktree at path `test/fixtures/<rel>`, then bulk-stages and
-// creates a single commit. Skipped: `.terraform`, `.terragrunt-cache`,
-// symlinks, `terraform.tfstate*`, `terragrunt-debug.tfvars.json`.
-//
-// For `*.hcl`, `*.tf`, and `*.tofu` files, [MirrorURLPlaceholder] is
-// substituted with mirrorURL before commit so a clone of one fixture
-// that references another fixture via __MIRROR_URL__ stays inside the
-// mirror and never reaches upstream github.
+// commitFixtureTree walks fixturesDir via [walkFixtures], writes every
+// file into srv's worktree at path `test/fixtures/<rel>`, then
+// bulk-stages and creates a single commit.
 //
 // Bulk-staging via [AddOptions.All] is required because per-file
 // `Add()` calls `Status()` on the entire worktree each time, which
@@ -334,49 +416,8 @@ func commitFixtureTree(srv *git.Server, fixturesDir, mirrorURL, mirrorSSHURL str
 		return fmt.Errorf("worktree: %w", err)
 	}
 
-	walkErr := filepath.WalkDir(fixturesDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if d.IsDir() {
-			if d.Name() == ".terraform" || d.Name() == ".terragrunt-cache" {
-				return filepath.SkipDir
-			}
-
-			return nil
-		}
-
-		// Skip symlinks (e.g., regression benchmark fixtures point a
-		// dependency-group dir at a template dir). They have no
-		// bearing on the github-mirror tests and following them would
-		// require duplicating the target into the mirror.
-		if d.Type()&fs.ModeSymlink != 0 {
-			return nil
-		}
-
-		name := d.Name()
-		if name == "terragrunt-debug.tfvars.json" || strings.HasPrefix(name, "terraform.tfstate") {
-			return nil
-		}
-
-		rel, err := filepath.Rel(fixturesDir, path)
-		if err != nil {
-			return err
-		}
-
-		repoPath := filepath.ToSlash(filepath.Join("test/fixtures", rel))
-
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("read %s: %w", path, err)
-		}
-
-		switch filepath.Ext(name) {
-		case ".hcl", ".tf", ".tofu":
-			data = bytes.ReplaceAll(data, []byte(MirrorURLPlaceholder), []byte(mirrorURL))
-			data = bytes.ReplaceAll(data, []byte(MirrorSSHURLPlaceholder), []byte(mirrorSSHURL))
-		}
+	walkErr := walkFixtures(fixturesDir, mirrorURL, mirrorSSHURL, func(rel string, data []byte) error {
+		repoPath := "test/fixtures/" + rel
 
 		f, err := w.Filesystem.Create(repoPath)
 		if err != nil {

--- a/test/helpers/git_mirror_ssh.go
+++ b/test/helpers/git_mirror_ssh.go
@@ -1,0 +1,310 @@
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	gliderssh "github.com/gliderlabs/ssh"
+	cryptossh "golang.org/x/crypto/ssh"
+)
+
+const (
+	sshKeyFilePerm    fs.FileMode = 0o600
+	sshDirPerm        fs.FileMode = 0o755
+	sshOutputFilePerm fs.FileMode = 0o644
+)
+
+// startSSHMirror brings up a localhost SSH git server backed by an
+// on-disk bare repo populated from fixturesDir. The server execs
+// `git-upload-pack` (or `git-receive-pack`) against the bare repo on
+// each session, ignoring the path the client requested because there
+// is only one repo to serve. Returns the SSH URL
+// (`ssh://git@HOST:PORT/terragrunt.git`) and the OpenSSH-format
+// private key PEM bytes that consumer tests materialize on disk via
+// [TerragruntMirror.RequireSSH] for the duration of each test.
+//
+// Returns an error if `ssh` or `git-upload-pack` is not on PATH;
+// callers should treat that as "skip SSH tests" rather than fatal.
+func startSSHMirror(fixturesDir, mirrorHTTPURL string) (string, []byte, error) {
+	if _, err := exec.LookPath("ssh"); err != nil {
+		return "", nil, fmt.Errorf("ssh client not available: %w", err)
+	}
+
+	if _, err := exec.LookPath("git-upload-pack"); err != nil {
+		return "", nil, fmt.Errorf("git-upload-pack not available: %w", err)
+	}
+
+	// Bind first so the port (and therefore the SSH URL) is known
+	// before populating the bare repo. Fixtures that embed
+	// __MIRROR_SSH_URL__ need the substitution to happen at bake time.
+	var lc net.ListenConfig
+
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, fmt.Errorf("listen: %w", err)
+	}
+
+	tcpAddr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		_ = ln.Close()
+
+		return "", nil, fmt.Errorf("listener returned non-TCP addr %T", ln.Addr())
+	}
+
+	sshURL := fmt.Sprintf("ssh://git@127.0.0.1:%d/terragrunt.git", tcpAddr.Port)
+
+	clientPriv, clientPub, err := generateSSHKey()
+	if err != nil {
+		_ = ln.Close()
+
+		return "", nil, fmt.Errorf("generate client key: %w", err)
+	}
+
+	hostSigner, err := generateHostSigner()
+	if err != nil {
+		_ = ln.Close()
+
+		return "", nil, fmt.Errorf("host signer: %w", err)
+	}
+
+	bareDir, err := os.MkdirTemp("", "terragrunt-ssh-bare-*.git")
+	if err != nil {
+		_ = ln.Close()
+
+		return "", nil, fmt.Errorf("mkdir bare: %w", err)
+	}
+
+	if err := populateBareRepo(fixturesDir, bareDir, mirrorHTTPURL, sshURL); err != nil {
+		_ = ln.Close()
+
+		return "", nil, fmt.Errorf("populate bare repo: %w", err)
+	}
+
+	server := &gliderssh.Server{
+		Handler: func(s gliderssh.Session) {
+			handleGitSSHSession(s, bareDir)
+		},
+		PublicKeyHandler: func(_ gliderssh.Context, key gliderssh.PublicKey) bool {
+			return gliderssh.KeysEqual(key, clientPub)
+		},
+	}
+	server.AddHostKey(hostSigner)
+
+	go func() { _ = server.Serve(ln) }()
+
+	return sshURL, clientPriv, nil
+}
+
+// handleGitSSHSession services a single SSH `exec` request by running
+// `git-upload-pack` (or `git-receive-pack`) against the bare repo and
+// piping stdin/stdout/stderr through the SSH channel.
+func handleGitSSHSession(s gliderssh.Session, bareDir string) {
+	cmd := s.Command()
+	if len(cmd) == 0 {
+		_, _ = fmt.Fprintln(s.Stderr(), "no command provided")
+		_ = s.Exit(1)
+
+		return
+	}
+
+	switch cmd[0] {
+	case "git-upload-pack", "git-receive-pack":
+	default:
+		_, _ = fmt.Fprintf(s.Stderr(), "unsupported command %q\n", cmd[0])
+		_ = s.Exit(1)
+
+		return
+	}
+
+	// Ignore the path the client requested. The server has a single
+	// bare repo and tests only need the upload-pack stream to succeed.
+	execCmd := exec.CommandContext(s.Context(), cmd[0], bareDir)
+	execCmd.Stdin = s
+	execCmd.Stdout = s
+	execCmd.Stderr = s.Stderr()
+
+	if err := execCmd.Run(); err != nil {
+		_, _ = fmt.Fprintf(s.Stderr(), "%s failed: %v\n", cmd[0], err)
+		_ = s.Exit(1)
+
+		return
+	}
+
+	_ = s.Exit(0)
+}
+
+// generateSSHKey returns an ed25519 keypair: the private key encoded
+// in OpenSSH format (suitable for writing to a file the `ssh` client
+// can read via `ssh -i`), and the matching `crypto/ssh.PublicKey` for
+// the server's authorization check.
+func generateSSHKey() ([]byte, cryptossh.PublicKey, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pemBlock, err := cryptossh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sshPub, err := cryptossh.NewPublicKey(pub)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pem.EncodeToMemory(pemBlock), sshPub, nil
+}
+
+// generateHostSigner returns a fresh ed25519 signer for the server's
+// host key. The client disables host-key verification, so the host
+// signer just needs to exist.
+func generateHostSigner() (cryptossh.Signer, error) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return cryptossh.NewSignerFromKey(priv)
+}
+
+// populateBareRepo writes the fixture tree into a working repo on
+// disk, commits and tags it (using [terragruntMirrorTags] and
+// [terragruntMirrorBranches]), then runs `git push --mirror` into
+// the empty bare repo at bareDir. The work goes through the real
+// `git` binary, not go-git, because the SSH server execs the real
+// `git-upload-pack`, which only reads on-disk repositories.
+//
+// __MIRROR_URL__ and __MIRROR_SSH_URL__ in `*.hcl`, `*.tf`, and
+// `*.tofu` files are substituted at copy time so a clone of one
+// fixture that references another stays inside the local mirror.
+func populateBareRepo(fixturesDir, bareDir, httpURL, sshURL string) error {
+	workDir, err := os.MkdirTemp("", "terragrunt-ssh-work-*")
+	if err != nil {
+		return fmt.Errorf("mkdir work: %w", err)
+	}
+
+	defer func() { _ = os.RemoveAll(workDir) }()
+
+	initCmds := [][]string{
+		{"init", "-b", "main"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test"},
+		{"config", "commit.gpgSign", "false"},
+		{"config", "tag.gpgSign", "false"},
+	}
+	for _, args := range initCmds {
+		if err := runGit(workDir, args...); err != nil {
+			return err
+		}
+	}
+
+	if err := copyFixturesToDisk(fixturesDir, workDir, httpURL, sshURL); err != nil {
+		return fmt.Errorf("copy fixtures: %w", err)
+	}
+
+	if err := runGit(workDir, "add", "."); err != nil {
+		return err
+	}
+
+	if err := runGit(workDir, "commit", "-m", "seed test/fixtures"); err != nil {
+		return err
+	}
+
+	for _, tag := range terragruntMirrorTags {
+		if err := runGit(workDir, "tag", tag); err != nil {
+			return err
+		}
+	}
+
+	for _, branch := range terragruntMirrorBranches {
+		if err := runGit(workDir, "branch", branch); err != nil {
+			return err
+		}
+	}
+
+	if err := runGit("", "init", "--bare", "-b", "main", bareDir); err != nil {
+		return err
+	}
+
+	if err := runGit(workDir, "push", "--mirror", bareDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func runGit(dir string, args ...string) error {
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git %v: %w: %s", args, err, out)
+	}
+
+	return nil
+}
+
+// copyFixturesToDisk mirrors fixturesDir into `<workDir>/test/fixtures/`,
+// substituting placeholders in `*.hcl`, `*.tf`, and `*.tofu` files.
+// Skips the same paths as [commitFixtureTree] (`.terraform`,
+// `.terragrunt-cache`, symlinks, `terraform.tfstate*`, debug files).
+func copyFixturesToDisk(fixturesDir, workDir, httpURL, sshURL string) error {
+	return filepath.WalkDir(fixturesDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if d.Name() == ".terraform" || d.Name() == ".terragrunt-cache" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+
+		name := d.Name()
+		if name == "terragrunt-debug.tfvars.json" || strings.HasPrefix(name, "terraform.tfstate") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(fixturesDir, path)
+		if err != nil {
+			return err
+		}
+
+		dst := filepath.Join(workDir, "test", "fixtures", rel)
+		if err := os.MkdirAll(filepath.Dir(dst), sshDirPerm); err != nil {
+			return err
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		switch filepath.Ext(name) {
+		case ".hcl", ".tf", ".tofu":
+			data = bytes.ReplaceAll(data, []byte(MirrorURLPlaceholder), []byte(httpURL))
+			data = bytes.ReplaceAll(data, []byte(MirrorSSHURLPlaceholder), []byte(sshURL))
+		}
+
+		return os.WriteFile(dst, data, sshOutputFilePerm)
+	})
+}

--- a/test/helpers/git_mirror_ssh.go
+++ b/test/helpers/git_mirror_ssh.go
@@ -1,7 +1,6 @@
 package helpers
 
 import (
-	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -12,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	gliderssh "github.com/gliderlabs/ssh"
 	cryptossh "golang.org/x/crypto/ssh"
@@ -179,8 +177,8 @@ func generateHostSigner() (cryptossh.Signer, error) {
 }
 
 // populateBareRepo writes the fixture tree into a working repo on
-// disk, commits and tags it (using [terragruntMirrorTags] and
-// [terragruntMirrorBranches]), then runs `git push --mirror` into
+// disk, commits and tags it (using [TerragruntMirrorTags] and
+// [TerragruntMirrorBranches]), then runs `git push --mirror` into
 // the empty bare repo at bareDir. The work goes through the real
 // `git` binary, not go-git, because the SSH server execs the real
 // `git-upload-pack`, which only reads on-disk repositories.
@@ -221,13 +219,16 @@ func populateBareRepo(fixturesDir, bareDir, httpURL, sshURL string) error {
 		return err
 	}
 
-	for _, tag := range terragruntMirrorTags {
-		if err := runGit(workDir, "tag", tag); err != nil {
+	for _, tag := range TerragruntMirrorTags {
+		// `-a -m` matches the annotated tags created on the HTTP
+		// mirror via [git.Server.Tag], so both mirrors expose the
+		// same tag object type.
+		if err := runGit(workDir, "tag", "-a", "-m", tag, tag); err != nil {
 			return err
 		}
 	}
 
-	for _, branch := range terragruntMirrorBranches {
+	for _, branch := range TerragruntMirrorBranches {
 		if err := runGit(workDir, "branch", branch); err != nil {
 			return err
 		}
@@ -258,51 +259,13 @@ func runGit(dir string, args ...string) error {
 }
 
 // copyFixturesToDisk mirrors fixturesDir into `<workDir>/test/fixtures/`,
-// substituting placeholders in `*.hcl`, `*.tf`, and `*.tofu` files.
-// Skips the same paths as [commitFixtureTree] (`.terraform`,
-// `.terragrunt-cache`, symlinks, `terraform.tfstate*`, debug files).
+// reusing [walkFixtures] so the skip rules and placeholder
+// substitution stay in lockstep with the HTTP path.
 func copyFixturesToDisk(fixturesDir, workDir, httpURL, sshURL string) error {
-	return filepath.WalkDir(fixturesDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if d.IsDir() {
-			if d.Name() == ".terraform" || d.Name() == ".terragrunt-cache" {
-				return filepath.SkipDir
-			}
-
-			return nil
-		}
-
-		if d.Type()&fs.ModeSymlink != 0 {
-			return nil
-		}
-
-		name := d.Name()
-		if name == "terragrunt-debug.tfvars.json" || strings.HasPrefix(name, "terraform.tfstate") {
-			return nil
-		}
-
-		rel, err := filepath.Rel(fixturesDir, path)
-		if err != nil {
-			return err
-		}
-
-		dst := filepath.Join(workDir, "test", "fixtures", rel)
+	return walkFixtures(fixturesDir, httpURL, sshURL, func(rel string, data []byte) error {
+		dst := filepath.Join(workDir, "test", "fixtures", filepath.FromSlash(rel))
 		if err := os.MkdirAll(filepath.Dir(dst), sshDirPerm); err != nil {
 			return err
-		}
-
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-
-		switch filepath.Ext(name) {
-		case ".hcl", ".tf", ".tofu":
-			data = bytes.ReplaceAll(data, []byte(MirrorURLPlaceholder), []byte(httpURL))
-			data = bytes.ReplaceAll(data, []byte(MirrorSSHURLPlaceholder), []byte(sshURL))
 		}
 
 		return os.WriteFile(dst, data, sshOutputFilePerm)

--- a/test/helpers/git_mirror_test.go
+++ b/test/helpers/git_mirror_test.go
@@ -1,0 +1,87 @@
+package helpers_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartTerragruntMirror(t *testing.T) {
+	t.Parallel()
+
+	m := helpers.StartTerragruntMirror(t)
+
+	require.NotEmpty(t, m.URL)
+	require.NotEmpty(t, m.HeadSHA)
+	require.True(t, strings.HasPrefix(m.URL, "http://"), "URL must be http: %q", m.URL)
+
+	out, err := exec.CommandContext(t.Context(), "git", "ls-remote", m.URL).CombinedOutput()
+	require.NoError(t, err, "git ls-remote: %s", out)
+
+	refs := string(out)
+	assert.Contains(t, refs, "refs/heads/main")
+
+	for _, tag := range []string{"v0.53.8", "v0.67.4", "v0.83.2", "v0.93.2", "v0.99.1"} {
+		assert.Contains(t, refs, "refs/tags/"+tag, "tag %s missing from refs:\n%s", tag, refs)
+	}
+
+	assert.Contains(t, refs, m.HeadSHA, "HEAD SHA %s missing from ls-remote output:\n%s", m.HeadSHA, refs)
+}
+
+func TestTerragruntMirrorCloneSubpath(t *testing.T) {
+	t.Parallel()
+
+	m := helpers.StartTerragruntMirror(t)
+
+	dst := t.TempDir()
+
+	out, err := exec.CommandContext(t.Context(), "git", "clone", "--single-branch", "--branch=v0.93.2", m.URL, dst).CombinedOutput()
+	require.NoError(t, err, "git clone: %s", out)
+
+	helloWorldMain := filepath.Join(dst, "test", "fixtures", "download", "hello-world", "main.tf")
+	require.FileExists(t, helloWorldMain)
+
+	contents, err := os.ReadFile(helloWorldMain)
+	require.NoError(t, err)
+	assert.Contains(t, string(contents), "git::"+m.URL,
+		"hello-world/main.tf should have __MIRROR_URL__ substituted to the live mirror URL "+
+			"so a clone of one fixture stays inside the mirror instead of resolving back to GitHub")
+	assert.NotContains(t, string(contents), "__MIRROR_URL__")
+	assert.NotContains(t, string(contents), "github.com/gruntwork-io/terragrunt.git")
+}
+
+func TestTerragruntMirrorSourceURL(t *testing.T) {
+	t.Parallel()
+
+	m := helpers.StartTerragruntMirror(t)
+
+	got := m.SourceURL("/test/fixtures/download/hello-world", "v0.93.2")
+	want := "git::" + m.URL + "//test/fixtures/download/hello-world?ref=v0.93.2"
+	assert.Equal(t, want, got)
+
+	got = m.SourceURL("test/fixtures/inputs", "")
+	want = "git::" + m.URL + "//test/fixtures/inputs"
+	assert.Equal(t, want, got)
+}
+
+//nolint:paralleltest // RequireSSH calls t.Setenv, which panics in parallel tests.
+func TestTerragruntMirrorSSHClone(t *testing.T) {
+	m := helpers.StartTerragruntMirror(t)
+	m.RequireSSH(t)
+
+	require.NotEmpty(t, m.SSHURL)
+	require.True(t, strings.HasPrefix(m.SSHURL, "ssh://git@127.0.0.1:"), "SSH URL: %q", m.SSHURL)
+
+	out, err := exec.CommandContext(t.Context(), "git", "ls-remote", m.SSHURL).CombinedOutput()
+	require.NoError(t, err, "git ls-remote over SSH: %s", out)
+
+	refs := string(out)
+	assert.Contains(t, refs, "refs/heads/main")
+	assert.Contains(t, refs, "refs/tags/v0.93.2")
+}

--- a/test/helpers/git_mirror_test.go
+++ b/test/helpers/git_mirror_test.go
@@ -27,8 +27,12 @@ func TestStartTerragruntMirror(t *testing.T) {
 	refs := string(out)
 	assert.Contains(t, refs, "refs/heads/main")
 
-	for _, tag := range []string{"v0.53.8", "v0.67.4", "v0.83.2", "v0.93.2", "v0.99.1"} {
+	for _, tag := range helpers.TerragruntMirrorTags {
 		assert.Contains(t, refs, "refs/tags/"+tag, "tag %s missing from refs:\n%s", tag, refs)
+	}
+
+	for _, branch := range helpers.TerragruntMirrorBranches {
+		assert.Contains(t, refs, "refs/heads/"+branch, "branch %s missing from refs:\n%s", branch, refs)
 	}
 
 	assert.Contains(t, refs, m.HeadSHA, "HEAD SHA %s missing from ls-remote output:\n%s", m.HeadSHA, refs)

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -138,6 +138,12 @@ func CopyEnvironment(t *testing.T, environmentPath string, includeInCopy ...stri
 		),
 	)
 
+	// If the copied tree references the local git mirror via placeholder
+	// (e.g., fixtures under `fixtures/download/` include `hello-world`,
+	// whose main.tf has a `__MIRROR_URL__` source), substitute against
+	// the live mirror so terraform/tofu can resolve the URL.
+	applyMirrorSubst(t, tmpDir)
+
 	return tmpDir
 }
 

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -1093,7 +1093,8 @@ func TestAwsRemoteWithBackend(t *testing.T) {
 	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
 	defer cleanupTableForTest(t, lockTableName, helpers.TerraformRemoteStateS3Region)
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRemoteWithBackend)
+	mirror := helpers.StartTerragruntMirror(t)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureRemoteWithBackend)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureRemoteWithBackend)
 
 	rootTerragruntConfigPath := filepath.Join(rootPath, "terragrunt.hcl")
@@ -1344,7 +1345,8 @@ func TestAwsDependencyOutputOptimizationDisableTest(t *testing.T) {
 func TestAwsProviderPatch(t *testing.T) {
 	t.Parallel()
 
-	rootPath := helpers.CopyEnvironment(t, testFixtureAwsProviderPatch)
+	mirror := helpers.StartTerragruntMirror(t)
+	rootPath := mirror.RenderFixture(t, testFixtureAwsProviderPatch)
 	modulePath := filepath.Join(rootPath, testFixtureAwsProviderPatch)
 	mainTFFile := filepath.Join(modulePath, "main.tf")
 
@@ -1551,9 +1553,11 @@ func TestAwsDependencyOutputSameOutputConcurrencyRegression(t *testing.T) {
 	// Use func to isolate each test run to a single s3 bucket that is deleted. We run the test multiple times
 	// because the underlying error we are trying to test against is nondeterministic, and thus may not always work
 	// the first time.
+	mirror := helpers.StartTerragruntMirror(t)
+
 	tt := func() {
 		helpers.CleanupTerraformFolder(t, testFixtureGetOutput)
-		tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGetOutput)
+		tmpEnvPath := mirror.RenderFixture(t, testFixtureGetOutput)
 		rootPath := filepath.Join(tmpEnvPath, testFixtureGetOutput, "regression-906")
 
 		// Make sure to fill in the s3 bucket to the config. Also ensure the bucket is deleted before the next for

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -97,13 +97,20 @@ func TestTerragruntValidateInputs(t *testing.T) {
 	moduleDirs, err := filepath.Glob(filepath.Join("fixtures/validate-inputs", "*"))
 	require.NoError(t, err)
 
+	mirror := helpers.StartTerragruntMirror(t)
+
 	for _, module := range moduleDirs {
 		name := filepath.Base(module)
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
+			// Render so __MIRROR_URL__ in the fixture resolves to the
+			// local git mirror instead of the literal placeholder.
+			tmpEnvPath := mirror.RenderFixture(t, module)
+			modulePath := filepath.Join(tmpEnvPath, module)
+
 			nameDashSplit := strings.Split(name, "-")
-			helpers.RunTerragruntValidateInputs(t, module, []string{"--strict"}, nameDashSplit[0] == "success")
+			helpers.RunTerragruntValidateInputs(t, modulePath, []string{"--strict"}, nameDashSplit[0] == "success")
 		})
 	}
 }
@@ -154,9 +161,10 @@ func TestTerragruntValidateInputsWithStrictModeEnabledAndUnusedVar(t *testing.T)
 func TestTerragruntValidateInputsWithStrictModeEnabledAndUnusedInputs(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	moduleDir := filepath.Join("fixtures/validate-inputs", "fail-unused-inputs")
 	helpers.CleanupTerraformFolder(t, moduleDir)
-	tmpEnvPath, _ := filepath.EvalSymlinks(helpers.CopyEnvironment(t, moduleDir))
+	tmpEnvPath, _ := filepath.EvalSymlinks(mirror.RenderFixture(t, moduleDir))
 	rootPath := filepath.Join(tmpEnvPath, moduleDir)
 
 	args := []string{"--strict"}
@@ -166,9 +174,10 @@ func TestTerragruntValidateInputsWithStrictModeEnabledAndUnusedInputs(t *testing
 func TestTerragruntValidateInputsWithStrictModeDisabledAndUnusedInputs(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	moduleDir := filepath.Join("fixtures/validate-inputs", "fail-unused-inputs")
 	helpers.CleanupTerraformFolder(t, moduleDir)
-	tmpEnvPath, _ := filepath.EvalSymlinks(helpers.CopyEnvironment(t, moduleDir))
+	tmpEnvPath, _ := filepath.EvalSymlinks(mirror.RenderFixture(t, moduleDir))
 	rootPath := filepath.Join(tmpEnvPath, moduleDir)
 
 	args := []string{}

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -169,7 +169,8 @@ func TestLocalWithMissingBackend(t *testing.T) {
 func TestRemoteDownload(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRemoteDownloadPath)
+	mirror := helpers.StartTerragruntMirror(t)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureRemoteDownloadPath)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureRemoteDownloadPath)
 	helpers.CleanupTerraformFolder(t, rootPath)
 
@@ -218,7 +219,8 @@ func TestInvalidRemoteDownloadWithRetries(t *testing.T) {
 func TestRemoteDownloadWithRelativePath(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRemoteRelativeDownloadPath)
+	mirror := helpers.StartTerragruntMirror(t)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureRemoteRelativeDownloadPath)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureRemoteRelativeDownloadPath)
 	helpers.CleanupTerraformFolder(t, rootPath)
 
@@ -231,7 +233,8 @@ func TestRemoteDownloadWithRelativePath(t *testing.T) {
 func TestRemoteDownloadWithRelativePathAndSlashInBranch(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRemoteRelativeDownloadPathWithSlash)
+	mirror := helpers.StartTerragruntMirror(t)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureRemoteRelativeDownloadPathWithSlash)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureRemoteRelativeDownloadPathWithSlash)
 	helpers.CleanupTerraformFolder(t, rootPath)
 
@@ -244,7 +247,8 @@ func TestRemoteDownloadWithRelativePathAndSlashInBranch(t *testing.T) {
 func TestRemoteDownloadOverride(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures/download")
+	mirror := helpers.StartTerragruntMirror(t)
+	tmpEnvPath := mirror.RenderFixture(t, "fixtures/download")
 	rootPath := filepath.Join(tmpEnvPath, testFixtureOverrideDownloadPath)
 	helpers.CleanupTerraformFolder(t, rootPath)
 
@@ -940,7 +944,8 @@ func TestDownloadWithCASEnabled(t *testing.T) {
 
 	fixturePath := "fixtures/download/remote"
 
-	tmpEnvPath := helpers.CopyEnvironment(t, fixturePath)
+	mirror := helpers.StartTerragruntMirror(t)
+	tmpEnvPath := mirror.RenderFixture(t, fixturePath)
 	testPath := filepath.Join(tmpEnvPath, fixturePath)
 	helpers.CleanupTerraformFolder(t, testPath)
 
@@ -962,7 +967,8 @@ func TestDownloadWithCASCommitRef(t *testing.T) {
 
 	fixturePath := "fixtures/download/remote-commit-ref"
 
-	tmpEnvPath := helpers.CopyEnvironment(t, fixturePath)
+	mirror := helpers.StartTerragruntMirror(t)
+	tmpEnvPath := mirror.RenderFixture(t, fixturePath)
 	testPath := filepath.Join(tmpEnvPath, fixturePath)
 	helpers.CleanupTerraformFolder(t, testPath)
 
@@ -990,7 +996,8 @@ func TestDownloadWithCASMutable(t *testing.T) {
 
 	fixturePath := "fixtures/download/remote-mutable"
 
-	tmpEnvPath := helpers.CopyEnvironment(t, fixturePath)
+	mirror := helpers.StartTerragruntMirror(t)
+	tmpEnvPath := mirror.RenderFixture(t, fixturePath)
 	testPath := filepath.Join(tmpEnvPath, fixturePath)
 	helpers.CleanupTerraformFolder(t, testPath)
 

--- a/test/integration_runner_pool_test.go
+++ b/test/integration_runner_pool_test.go
@@ -249,8 +249,9 @@ func TestRunnerPoolDestroyDependencies(t *testing.T) {
 func TestRunnerPoolRemoteSource(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	helpers.CleanupTerraformFolder(t, testFixtureRunnerPoolRemoteSource)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRunnerPoolRemoteSource)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureRunnerPoolRemoteSource)
 	testPath := filepath.Join(tmpEnvPath, testFixtureRunnerPoolRemoteSource)
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --non-interactive --log-level debug --working-dir "+testPath+"  -- apply")
@@ -262,18 +263,19 @@ func TestRunnerPoolRemoteSource(t *testing.T) {
 func TestRunnerPoolSourceMap(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureSourceMapSlashes)
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	testPath := filepath.Join(tmpEnvPath, testFixtureSourceMapSlashes)
 	_, stderr, err := helpers.RunTerragruntCommandWithOutput(
 		t,
 		"terragrunt run --all --non-interactive "+
-			"--source-map git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=github.com/gruntwork-io/terragrunt.git?ref=v0.85.0 "+
+			"--source-map git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=git::"+mirror.URL+"?ref=v0.85.0 "+
 			"--working-dir "+testPath+" -- apply ",
 	)
 	require.NoError(t, err)
 	// Verify that source map values are used
-	require.Contains(t, stderr, "configurations from git::https://github.com/gruntwork-io/terragrunt.git?ref=v0.85.0")
+	require.Contains(t, stderr, "configurations from git::"+mirror.URL+"?ref=v0.85.0")
 }
 
 // TestAuthProviderParallelExecution verifies that --auth-provider-cmd is executed in parallel

--- a/test/integration_scaffold_ssh_test.go
+++ b/test/integration_scaffold_ssh_test.go
@@ -1,12 +1,4 @@
-//go:build ssh
-
-// We don't want contributors to have to install SSH keys to run these tests, so we skip
-// them by default. Contributors need to opt in to run these tests by setting the
-// build flag `ssh` when running the tests. This is done by adding the `-tags ssh` flag
-// to the `go test` command. For example:
-//
-// go test -tags ssh ./...
-
+//nolint:paralleltest,tparallel // Every test in this file calls RequireSSH, which uses t.Setenv and therefore can't run in parallel.
 package test_test
 
 import (
@@ -23,25 +15,48 @@ import (
 )
 
 const (
-	testScaffoldModuleGit                 = "git@github.com:gruntwork-io/terragrunt.git//test/fixtures/scaffold/scaffold-module"
-	testScaffoldTemplateModule            = "git@github.com:gruntwork-io/terragrunt.git//test/fixtures/scaffold/module-with-template"
-	testScaffoldExternalTemplateModule    = "git@github.com:gruntwork-io/terragrunt.git//test/fixtures/scaffold/external-template/template"
 	testScaffoldWithCustomDefaultTemplate = "fixtures/scaffold/custom-default-template"
 )
 
-func TestSSHScaffoldWithCustomDefaultTemplate(t *testing.T) {
-	t.Parallel()
+// sshScaffoldModuleURL is the SSH-form source for scaffold-module
+// against the local mirror.
+func sshScaffoldModuleURL(m *helpers.TerragruntMirror) string {
+	return "git::" + m.SSHURL + "//test/fixtures/scaffold/scaffold-module"
+}
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testScaffoldWithCustomDefaultTemplate)
+// sshScaffoldTemplateModule is the SSH-form source for the
+// scaffold module-with-template fixture against the local mirror.
+func sshScaffoldTemplateModule(m *helpers.TerragruntMirror) string {
+	return "git::" + m.SSHURL + "//test/fixtures/scaffold/module-with-template"
+}
+
+// sshScaffoldExternalTemplateModule is the SSH-form source for the
+// scaffold external-template/template fixture against the local mirror.
+func sshScaffoldExternalTemplateModule(m *helpers.TerragruntMirror) string {
+	return "git::" + m.SSHURL + "//test/fixtures/scaffold/external-template/template"
+}
+
+// sshScaffoldInputsURL is the SSH-form source for the inputs fixture
+// against the local mirror.
+func sshScaffoldInputsURL(m *helpers.TerragruntMirror) string {
+	return "git::" + m.SSHURL + "//test/fixtures/inputs"
+}
+
+func TestSSHScaffoldWithCustomDefaultTemplate(t *testing.T) {
+	mirror := helpers.StartTerragruntMirror(t)
+	mirror.RequireSSH(t)
+
+	// Render so __MIRROR_SSH_URL__ in the fixture's root.hcl
+	// (default_template) resolves to the live SSH mirror URL.
+	tmpEnvPath := mirror.RenderFixture(t, testScaffoldWithCustomDefaultTemplate)
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	testPath := filepath.Join(tmpEnvPath, testScaffoldWithCustomDefaultTemplate)
 
 	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
 		"terragrunt --non-interactive --working-dir %s scaffold %s",
 		filepath.Join(testPath, "unit"),
-		testScaffoldModuleURL,
+		scaffoldModuleURL(mirror),
 	))
-
 	require.NoError(t, err)
 
 	assert.FileExists(t, filepath.Join(testPath, "unit", "terragrunt.hcl"))
@@ -49,56 +64,87 @@ func TestSSHScaffoldWithCustomDefaultTemplate(t *testing.T) {
 }
 
 func TestSSHScaffoldModuleExternalTemplate(t *testing.T) {
-	t.Parallel()
+	mirror := helpers.StartTerragruntMirror(t)
+	mirror.RequireSSH(t)
 
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s %s", tmpEnvPath, testScaffoldModuleGit, testScaffoldExternalTemplateModule))
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
+		"terragrunt scaffold --non-interactive --working-dir %s %s %s",
+		tmpEnvPath,
+		sshScaffoldModuleURL(mirror),
+		sshScaffoldExternalTemplateModule(mirror),
+	))
 	require.NoError(t, err)
-	// check that exists file from external template
 	assert.FileExists(t, tmpEnvPath+"/external-template.txt")
 	assert.FileExists(t, tmpEnvPath+"/dependency/dependency.txt")
 }
 
+// TestSSHScaffoldModuleDifferentRevisionAndSSH used to assert on the
+// HTTPS→SSH URL transformation in the generated terragrunt.hcl. That
+// transformation is unit-tested in
+// internal/cli/commands/scaffold/source_url_test.go, so this
+// integration test now just verifies that scaffold runs end-to-end
+// against an SSH source URL.
 func TestSSHScaffoldModuleDifferentRevisionAndSSH(t *testing.T) {
-	t.Parallel()
+	mirror := helpers.StartTerragruntMirror(t)
+	mirror.RequireSSH(t)
 
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s --var=Ref=v0.67.4 --var=SourceUrlType=git-ssh", tmpEnvPath, testScaffoldModuleShort))
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
+		"terragrunt scaffold --non-interactive --working-dir %s %s --var=Ref=v0.67.4",
+		tmpEnvPath,
+		sshScaffoldInputsURL(mirror),
+	))
 	require.NoError(t, err)
 
-	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
-	require.NoError(t, err)
-	assert.Contains(t, content, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.67.4")
+	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
 }
 
 func TestSSHScaffoldModuleSSH(t *testing.T) {
-	t.Parallel()
+	mirror := helpers.StartTerragruntMirror(t)
+	mirror.RequireSSH(t)
 
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s", tmpEnvPath, testScaffoldModuleGit))
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
+		"terragrunt scaffold --non-interactive --working-dir %s %s",
+		tmpEnvPath,
+		sshScaffoldModuleURL(mirror),
+	))
 	require.NoError(t, err)
 }
 
 func TestSSHScaffoldModuleTemplate(t *testing.T) {
-	t.Parallel()
+	mirror := helpers.StartTerragruntMirror(t)
+	mirror.RequireSSH(t)
 
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s", tmpEnvPath, testScaffoldTemplateModule))
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
+		"terragrunt scaffold --non-interactive --working-dir %s %s",
+		tmpEnvPath,
+		sshScaffoldTemplateModule(mirror),
+	))
 	require.NoError(t, err)
-	// check that exists file from .boilerplate dir
+
 	assert.FileExists(t, tmpEnvPath+"/template-file.txt")
 }
 
+// TestSSHScaffoldModuleVarFile previously asserted the
+// SourceUrlType=git-ssh transformation produced a github.com SSH URL
+// in the generated config. That URL-format check is unit-covered by
+// scaffold's source_url_test; this test now just verifies the
+// var-file plumbing reaches scaffold and EnableRootInclude=false
+// suppresses find_in_parent_folders.
 func TestSSHScaffoldModuleVarFile(t *testing.T) {
-	t.Parallel()
-	// generate var file with specific version, without root include and use GIT/SSH to clone module.
+	mirror := helpers.StartTerragruntMirror(t)
+	mirror.RequireSSH(t)
+
 	varFileContent := `
 Ref: v0.67.4
 EnableRootInclude: false
-SourceUrlType: "git-ssh"
 `
 	varFile := filepath.Join(helpers.TmpDirWOSymlinks(t), "var-file.yaml")
 	err := os.WriteFile(varFile, []byte(varFileContent), 0644)
@@ -106,11 +152,15 @@ SourceUrlType: "git-ssh"
 
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s --var-file=%s", tmpEnvPath, testScaffoldModuleShort, varFile))
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
+		"terragrunt scaffold --non-interactive --working-dir %s %s --var-file=%s",
+		tmpEnvPath,
+		sshScaffoldInputsURL(mirror),
+		varFile,
+	))
 	require.NoError(t, err)
 
 	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
 	require.NoError(t, err)
-	assert.Contains(t, content, "git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.67.4")
 	assert.NotContains(t, content, "find_in_parent_folders")
 }

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 const (
-	testScaffoldModuleURL           = "https://github.com/gruntwork-io/terragrunt.git//test/fixtures/scaffold/scaffold-module"
-	testScaffoldModuleShort         = "github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs"
 	testScaffoldLocalModulePath     = "fixtures/scaffold/scaffold-module"
 	testScaffoldWithRootHCL         = "fixtures/scaffold/root-hcl"
 	testScaffold3rdPartyModulePath  = "git::https://github.com/Azure/terraform-azurerm-avm-res-compute-virtualmachine.git//.?ref=v0.15.0"
@@ -23,12 +21,24 @@ const (
 	testScaffoldLocalTofuModulePath = "fixtures/scaffold/scaffold-module-tofu"
 )
 
+// scaffoldModuleURL returns the canonical scaffold-module source on the
+// local mirror.
+func scaffoldModuleURL(m *helpers.TerragruntMirror) string {
+	return m.SourceURL("/test/fixtures/scaffold/scaffold-module", "")
+}
+
+// scaffoldInputsURL returns the inputs fixture source on the local mirror.
+func scaffoldInputsURL(m *helpers.TerragruntMirror) string {
+	return m.SourceURL("/test/fixtures/inputs", "")
+}
+
 func TestScaffoldModule(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s", tmpEnvPath, testScaffoldModuleURL))
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s", tmpEnvPath, scaffoldModuleURL(mirror)))
 	require.NoError(t, err)
 	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
 }
@@ -36,9 +46,10 @@ func TestScaffoldModule(t *testing.T) {
 func TestScaffoldModuleShortUrl(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s", tmpEnvPath, testScaffoldModuleShort))
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s", tmpEnvPath, scaffoldInputsURL(mirror)))
 
 	require.NoError(t, err)
 	// check that find_in_parent_folders is generated in terragrunt.hcl
@@ -50,9 +61,10 @@ func TestScaffoldModuleShortUrl(t *testing.T) {
 func TestScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s --var=EnableRootInclude=false", tmpEnvPath, testScaffoldModuleShort))
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s --var=EnableRootInclude=false", tmpEnvPath, scaffoldInputsURL(mirror)))
 	require.NoError(t, err)
 	// check that find_in_parent_folders is NOT generated in  terragrunt.hcl
 	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
@@ -63,15 +75,16 @@ func TestScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
 func TestScaffoldModuleDifferentRevision(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s --var=Ref=v0.67.4", tmpEnvPath, testScaffoldModuleShort))
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt scaffold --non-interactive --working-dir %s %s --var=Ref=v0.67.4", tmpEnvPath, scaffoldInputsURL(mirror)))
 
 	require.NoError(t, err)
 
 	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
 	require.NoError(t, err)
-	assert.Contains(t, content, "github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.67.4")
+	assert.Contains(t, content, mirror.URL+"//test/fixtures/inputs?ref=v0.67.4")
 }
 
 func TestScaffoldErrorNoModuleUrl(t *testing.T) {
@@ -144,10 +157,11 @@ func TestScaffold3rdPartyModule(t *testing.T) {
 func TestScaffoldOutputFolderFlag(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
 	outputFolder := tmpEnvPath + "/foo/bar"
-	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --non-interactive --working-dir %s scaffold %s --output-folder %s", tmpEnvPath, testScaffoldModuleURL, outputFolder))
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf("terragrunt --non-interactive --working-dir %s scaffold %s --output-folder %s", tmpEnvPath, scaffoldModuleURL(mirror), outputFolder))
 	require.NoError(t, err)
 	assert.FileExists(t, outputFolder+"/terragrunt.hcl")
 }
@@ -155,6 +169,7 @@ func TestScaffoldOutputFolderFlag(t *testing.T) {
 func TestScaffoldWithRootHCL(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	tmpEnvPath := helpers.CopyEnvironment(t, testScaffoldWithRootHCL)
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	testPath := filepath.Join(tmpEnvPath, testScaffoldWithRootHCL)
@@ -162,7 +177,7 @@ func TestScaffoldWithRootHCL(t *testing.T) {
 	_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
 		"terragrunt --non-interactive --working-dir %s scaffold %s",
 		filepath.Join(testPath, "unit"),
-		testScaffoldModuleURL,
+		scaffoldModuleURL(mirror),
 	))
 	require.NoError(t, err)
 
@@ -329,6 +344,7 @@ func TestScaffoldWithBothFlagsDisabled(t *testing.T) {
 func TestScaffoldDoesNotFormatPreExistingFiles(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
 	// Write a pre-existing HCL file with intentionally poor formatting.
@@ -347,7 +363,7 @@ baz="qux"
 		fmt.Sprintf(
 			"terragrunt scaffold --non-interactive --working-dir %s %s",
 			tmpEnvPath,
-			testScaffoldModuleURL,
+			scaffoldModuleURL(mirror),
 		),
 	)
 	require.NoError(t, err)

--- a/test/integration_ssh_test.go
+++ b/test/integration_ssh_test.go
@@ -1,12 +1,4 @@
-//go:build ssh
-
-// We don't want contributors to have to install SSH keys to run these tests, so we skip
-// them by default. Contributors need to opt in to run these tests by setting the
-// build flag `ssh` when running the tests. This is done by adding the `-tags ssh` flag
-// to the `go test` command. For example:
-//
-// go test -tags ssh ./...
-
+//nolint:paralleltest,tparallel // Every test in this file calls RequireSSH, which uses t.Setenv and therefore can't run in parallel.
 package test_test
 
 import (
@@ -20,7 +12,8 @@ import (
 )
 
 func TestSSHSourceMapWithSlashInRef(t *testing.T) {
-	t.Parallel()
+	mirror := helpers.StartTerragruntMirror(t)
+	mirror.RequireSSH(t)
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureSourceMapSlashes)
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
@@ -29,35 +22,41 @@ func TestSSHSourceMapWithSlashInRef(t *testing.T) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err := helpers.RunTerragruntCommand(t, "terragrunt plan --non-interactive --source-map git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=git::git@github.com:gruntwork-io/terragrunt.git?ref=fixture/test-fixtures --working-dir "+testPath, &stdout, &stderr)
-	require.NoError(t, err)
+	// Source-map redirects the fake SSH URL in the fixture to the
+	// local mirror. The `?ref=fixture/test-fixtures` is a slash-in-ref
+	// regression check; the mirror exposes that branch so the
+	// URL parser sees a real slash-bearing ref value.
+	cmd := "terragrunt plan --non-interactive " +
+		"--source-map git::ssh://git@github.com/gruntwork-io/i-dont-exist.git=git::" + mirror.SSHURL + "?ref=fixture/test-fixtures " +
+		"--working-dir " + testPath
+	require.NoError(t, helpers.RunTerragruntCommand(t, cmd, &stdout, &stderr))
 }
 
 func TestSSHTerragruntNoWarningRemotePath(t *testing.T) {
-	t.Parallel()
+	mirror := helpers.StartTerragruntMirror(t)
+	mirror.RequireSSH(t)
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNoSubmodules)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureNoSubmodules)
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	testPath := filepath.Join(tmpEnvPath, testFixtureNoSubmodules)
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err := helpers.RunTerragruntCommand(t, "terragrunt init --non-interactive --working-dir "+testPath, &stdout, &stderr)
-	require.NoError(t, err)
+	require.NoError(t, helpers.RunTerragruntCommand(t, "terragrunt init --non-interactive --working-dir "+testPath, &stdout, &stderr))
 	assert.NotContains(t, stderr.String(), "No double-slash (//) found in source URL")
 }
 
 func TestSSHDownloadSourceWithRef(t *testing.T) {
-	t.Parallel()
+	mirror := helpers.StartTerragruntMirror(t)
+	mirror.RequireSSH(t)
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRefSource)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureRefSource)
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	testPath := filepath.Join(tmpEnvPath, testFixtureRefSource)
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	err := helpers.RunTerragruntCommand(t, "terragrunt plan --non-interactive --working-dir "+testPath, &stdout, &stderr)
-	require.NoError(t, err)
+	require.NoError(t, helpers.RunTerragruntCommand(t, "terragrunt plan --non-interactive --working-dir "+testPath, &stdout, &stderr))
 }

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -259,8 +259,9 @@ func TestStacksRunParseErrorNotSilentlySkipped(t *testing.T) {
 func TestStacksGenerateRemote(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	helpers.CleanupTerraformFolder(t, testFixtureStacksRemote)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksRemote)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureStacksRemote)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureStacksRemote)
 
 	helpers.RunTerragrunt(t, "terragrunt stack generate --working-dir "+rootPath)
@@ -371,15 +372,16 @@ func TestStacksApply(t *testing.T) {
 func TestStacksApplyRemote(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	helpers.CleanupTerraformFolder(t, testFixtureStacksRemote)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksRemote)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureStacksRemote)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureStacksRemote)
 
 	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack run apply --log-level debug --non-interactive --working-dir "+rootPath)
 	require.NoError(t, err)
 
-	assert.Contains(t, stderr, "app1 (git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/basic/units/chick?ref=main&depth=1)")
-	assert.Contains(t, stderr, "app2 (git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/basic/units/chick?ref=main&depth=1)")
+	assert.Contains(t, stderr, "app1 (git::"+mirror.URL+"//test/fixtures/stacks/basic/units/chick?ref=main)")
+	assert.Contains(t, stderr, "app2 (git::"+mirror.URL+"//test/fixtures/stacks/basic/units/chick?ref=main)")
 	assert.Contains(t, stdout, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed")
 	assert.Contains(t, stdout, "local_file.file: Creation complete")
 
@@ -1151,6 +1153,8 @@ func TestStackApplyStrictIncludeWithFilter(t *testing.T) {
 func TestStacksSourceMap(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
+
 	// prepare local path to do override of source url
 	helpers.CleanupTerraformFolder(t, testFixtureStacksBasic)
 	localTmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksBasic)
@@ -1168,11 +1172,11 @@ func TestStacksSourceMap(t *testing.T) {
 
 	// prepare local environment with remote to use source map to replace
 	helpers.CleanupTerraformFolder(t, testFixtureStacksRemote)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksRemote)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureStacksRemote)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureStacksRemote)
 
 	// generate path with replacement of local source with local path
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack generate --source-map git::https://github.com/gruntwork-io/terragrunt.git="+localTmpEnvPath+" --working-dir "+rootPath)
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack generate --source-map git::"+mirror.URL+"="+localTmpEnvPath+" --working-dir "+rootPath)
 	require.NoError(t, err)
 
 	assert.Contains(t, stderr, "Generating unit app1")
@@ -1181,12 +1185,12 @@ func TestStacksSourceMap(t *testing.T) {
 	path := filepath.Join(rootPath, ".terragrunt-stack")
 	validateStackDir(t, path)
 
-	_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack run apply --log-level debug --source-map git::https://github.com/gruntwork-io/terragrunt.git="+localTmpEnvPath+" --non-interactive --working-dir "+rootPath)
+	_, stderr, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt stack run apply --log-level debug --source-map git::"+mirror.URL+"="+localTmpEnvPath+" --non-interactive --working-dir "+rootPath)
 	require.NoError(t, err)
 
 	// validate that the source map was used to replace the source
-	assert.NotContains(t, stderr, "app1 (git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/basic/units/chick?ref=main&depth=1)")
-	assert.NotContains(t, stderr, "app2 (git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/stacks/basic/units/chick?ref=main&depth=1)")
+	assert.NotContains(t, stderr, "app1 (git::"+mirror.URL+"//test/fixtures/stacks/basic/units/chick?ref=main)")
+	assert.NotContains(t, stderr, "app2 (git::"+mirror.URL+"//test/fixtures/stacks/basic/units/chick?ref=main)")
 
 	assert.Contains(t, stderr, "Running ./.terragrunt-stack/app1")
 	assert.Contains(t, stderr, "Running ./.terragrunt-stack/app2")
@@ -1630,8 +1634,9 @@ func validateNoStackDirs(t *testing.T, rootPath string) {
 func TestStacksSelfInclude(t *testing.T) {
 	t.Parallel()
 
+	mirror := helpers.StartTerragruntMirror(t)
 	helpers.CleanupTerraformFolder(t, testFixtureStackSelfInclude)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackSelfInclude)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureStackSelfInclude)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureStackSelfInclude, "live")
 
 	helpers.RunTerragrunt(t, "terragrunt stack run apply --non-interactive --working-dir "+rootPath)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1276,7 +1276,8 @@ func TestTerragruntStackCommandsWithPlanFile(t *testing.T) {
 func TestInvalidSource(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNotExistingSource)
+	mirror := helpers.StartTerragruntMirror(t)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureNotExistingSource)
 	generateTestCase := filepath.Join(tmpEnvPath, testFixtureNotExistingSource)
 	helpers.CleanupTerraformFolder(t, generateTestCase)
 	helpers.CleanupTerragruntFolder(t, generateTestCase)
@@ -3706,7 +3707,8 @@ func TestNoMultipleInitsWithoutSourceChange(t *testing.T) {
 func TestAutoInitWhenSourceIsChanged(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDownload)
+	mirror := helpers.StartTerragruntMirror(t)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureDownload)
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	testPath := filepath.Join(tmpEnvPath, testFixtureAutoInit)
 
@@ -4355,7 +4357,8 @@ func TestTerragruntRunAllPlanAndShow(t *testing.T) {
 func TestLogFormatJSONOutput(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNotExistingSource)
+	mirror := helpers.StartTerragruntMirror(t)
+	tmpEnvPath := mirror.RenderFixture(t, testFixtureNotExistingSource)
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	testPath := filepath.Join(tmpEnvPath, testFixtureNotExistingSource)
 
@@ -4385,7 +4388,8 @@ func TestLogFormatJSONOutput(t *testing.T) {
 		msgs = append(msgs, msg)
 	}
 
-	assert.Contains(t, strings.Join(msgs, ""), "Downloading Terraform configurations from git::https://github.com/gruntwork-io/terragrunt.git?ref=v0.83.2")
+	assert.Contains(t, strings.Join(msgs, ""), "Downloading Terraform configurations from git::"+mirror.URL)
+	assert.Contains(t, strings.Join(msgs, ""), "ref=v0.83.2")
 }
 
 func TestTerragruntOutputFromDependencyLogsJson(t *testing.T) {

--- a/test/integration_tflint_test.go
+++ b/test/integration_tflint_test.go
@@ -99,7 +99,8 @@ func TestTflintFindsConfigInCurrentPath(t *testing.T) {
 }
 
 func TestTflintInitSameModule(t *testing.T) {
-	rootPath := CopyEnvironmentWithTflint(t, testFixtureParallelRun)
+	mirror := helpers.StartTerragruntMirror(t)
+	rootPath := mirror.RenderFixture(t, testFixtureParallelRun, ".tflint.hcl")
 	t.Cleanup(func() {
 		helpers.RemoveFolder(t, rootPath)
 	})

--- a/test/integration_windows_test.go
+++ b/test/integration_windows_test.go
@@ -81,7 +81,8 @@ func TestMain(m *testing.M) {
 func TestWindowsLocalWithRelativeExtraArgsWindows(t *testing.T) {
 	t.Parallel()
 
-	rootPath := CopyEnvironmentWithTflint(t, testFixtureDownloadPath)
+	mirror := helpers.StartTerragruntMirror(t)
+	rootPath := mirror.RenderFixture(t, testFixtureDownloadPath)
 	modulePath := filepath.Join(rootPath, testFixtureLocalRelativeArgsWindowsDownloadPath)
 
 	helpers.RunTerragrunt(t, fmt.Sprintf("terragrunt apply -auto-approve --non-interactive --working-dir %s", modulePath))


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Replaces all Git clones of the Terragrunt repo in tests with clones of locally running Git servers for both HTTP and SSH tests. Saves us from having to clone the entire Terragrunt repo, making tests faster while making them more reliable.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go module dependencies, including `gliderlabs/ssh` and `go-billy`.
  * Refactored test infrastructure to use local git mirrors instead of external GitHub URLs for faster, more reliable integration testing across multiple test suites and fixtures.
  * Improved CAS client initialization configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->