### PR TITLE
fix: Fixing symlinks in repos for CAS clones

### DIFF
--- a/docs/src/data/changelog/v1.0.5/cas-symlinks.mdx
+++ b/docs/src/data/changelog/v1.0.5/cas-symlinks.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.5"
+category: "experiments-updated"
+---
+
+#### `cas` — symlinks in the source repository
+
+Source repositories fetched through CAS used to materialize committed symlinks as regular files whose contents were the link target path. The destination tree no longer matched the upstream layout, and any tooling that followed the link saw plain text instead.
+
+CAS now writes a real symbolic link at the destination. Symlink targets that resolve outside the destination tree are rejected so a hostile or stale source cannot escape the working directory.

--- a/internal/cas/tree.go
+++ b/internal/cas/tree.go
@@ -9,11 +9,21 @@ import (
 	"strconv"
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"golang.org/x/sync/errgroup"
 )
 
 // unixPermMask isolates the user/group/other rwx bits from a git tree mode.
 const unixPermMask = os.FileMode(0o777)
+
+// Git tree entry mode constants. Git stores the entry type in the high bits of
+// a six-digit octal mode; gitTypeMask isolates them so a symlink blob (120000)
+// can be distinguished from a regular blob (100644 / 100755) at materialization
+// time.
+const (
+	gitTypeMask    = uint64(0o170000)
+	gitTypeSymlink = uint64(0o120000)
+)
 
 // LinkTreeOption configures a LinkTree call.
 type LinkTreeOption func(*linkTreeOpts)
@@ -44,6 +54,23 @@ func LinkTree(
 		opt(&o)
 	}
 
+	return linkTree(ctx, blobStore, treeStore, t, targetDir, targetDir, &o)
+}
+
+// linkTree is the recursive implementation behind LinkTree. rootDir is the
+// top-level target the caller asked to materialize and stays constant across
+// subtree recursion; targetDir is the directory the current tree is being
+// written into. Splitting them lets symlink validation reject targets that
+// resolve outside the original tree even when the link sits in a subdirectory.
+func linkTree(
+	ctx context.Context,
+	blobStore *Store,
+	treeStore *Store,
+	t *git.Tree,
+	rootDir string,
+	targetDir string,
+	o *linkTreeOpts,
+) error {
 	blobContent := NewContent(blobStore)
 	treeContent := NewContent(treeStore)
 
@@ -75,11 +102,19 @@ func LinkTree(
 		parentDirPath := filepath.Dir(dirPath)
 		delete(dirsToCreate, parentDirPath)
 
-		// Create work items based on entry type
+		// Create work items based on entry type. Git stores symlinks as blobs
+		// whose content is the link target; the entry mode (120000) is the
+		// only signal that distinguishes them from regular files, so dispatch
+		// on the mode here instead of treating every blob as a file to copy.
 		switch entry.Type {
 		case "blob":
+			itemType := "link"
+			if gitEntryIsSymlink(entry.Mode) {
+				itemType = "symlink"
+			}
+
 			workItems = append(workItems, workItem{
-				itemType: "link",
+				itemType: itemType,
 				entry:    entry,
 				path:     entryPath,
 				dirPath:  dirPath,
@@ -119,6 +154,19 @@ func LinkTree(
 				if err != nil {
 					return fmt.Errorf("link blob %s: %w", work.path, err)
 				}
+			case "symlink":
+				target, err := blobContent.Read(work.entry.Hash)
+				if err != nil {
+					return fmt.Errorf("read symlink blob %s: %w", work.entry.Hash, err)
+				}
+
+				if err := vfs.ValidateSymlinkTarget(rootDir, work.path, string(target)); err != nil {
+					return err
+				}
+
+				if err := vfs.Symlink(fs, string(target), work.path); err != nil {
+					return fmt.Errorf("symlink %s -> %s: %w", work.path, string(target), err)
+				}
 			case "subtree":
 				treeData, err := treeContent.Read(work.entry.Hash)
 				if err != nil {
@@ -130,7 +178,7 @@ func LinkTree(
 					return fmt.Errorf("parse tree %s: %w", work.entry.Hash, err)
 				}
 
-				err = LinkTree(ctx, blobStore, treeStore, subTree, work.path, opts...)
+				err = linkTree(ctx, blobStore, treeStore, subTree, rootDir, work.path, o)
 				if err != nil {
 					return fmt.Errorf("link subtree %s: %w", work.path, err)
 				}
@@ -159,4 +207,21 @@ func gitFilePerm(mode string) os.FileMode {
 	}
 
 	return os.FileMode(n) & unixPermMask
+}
+
+// gitEntryIsSymlink reports whether the given git tree entry mode is the
+// symlink type (120000). Git tree modes encode the entry type in their high
+// bits, so the permission-only view used by gitFilePerm cannot distinguish a
+// symlink blob from a regular blob.
+func gitEntryIsSymlink(mode string) bool {
+	if mode == "" {
+		return false
+	}
+
+	n, err := strconv.ParseUint(mode, 8, 32)
+	if err != nil {
+		return false
+	}
+
+	return n&gitTypeMask == gitTypeSymlink
 }

--- a/internal/cas/tree_test.go
+++ b/internal/cas/tree_test.go
@@ -1,12 +1,14 @@
 package cas_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -132,6 +134,106 @@ invalid format`),
 			require.NoError(t, err)
 			assert.Len(t, got.Entries(), tt.wantLen)
 			assert.Equal(t, tt.wantPath, got.Path())
+		})
+	}
+}
+
+func TestLinkTreeSymlinks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		wantLinks    map[string]string // path -> expected target
+		wantBlobs    map[string][]byte // path -> expected file content for non-symlink entries
+		storeTargets map[string]string // hash -> target string for entries the test should not realize as symlinks
+		name         string
+		treeData     []byte
+		wantErr      bool
+	}{
+		{
+			name: "symlink blob materializes as a real symlink",
+			treeData: []byte(`120000 blob 1111111111 link.txt
+100644 blob 2222222222 real.txt`),
+			wantLinks: map[string]string{"link.txt": "real.txt"},
+			wantBlobs: map[string][]byte{"real.txt": []byte("hello")},
+		},
+		{
+			name:      "symlink to sibling within tree via dot-dot",
+			treeData:  []byte(`120000 blob 3333333333 nested/up.txt`),
+			wantLinks: map[string]string{"nested/up.txt": "../sibling.txt"},
+		},
+		{
+			name:         "absolute symlink target is rejected",
+			treeData:     []byte(`120000 blob 4444444444 escape.txt`),
+			storeTargets: map[string]string{"4444444444": "/etc/passwd"},
+			wantErr:      true,
+		},
+		{
+			name:         "relative symlink that escapes root is rejected",
+			treeData:     []byte(`120000 blob 5555555555 escape.txt`),
+			storeTargets: map[string]string{"5555555555": "../../../etc/passwd"},
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := logger.CreateLogger()
+
+			memFs := vfs.NewMemMapFS()
+			require.NoError(t, memFs.MkdirAll("/store", 0755))
+			store := cas.NewStore("/store").WithFS(memFs)
+			content := cas.NewContent(store)
+
+			tree, err := git.ParseTree(tt.treeData, "test-repo")
+			require.NoError(t, err)
+
+			for _, entry := range tree.Entries() {
+				switch entry.Mode {
+				case "120000":
+					target, ok := tt.storeTargets[entry.Hash]
+					if !ok {
+						target = tt.wantLinks[entry.Path]
+					}
+
+					require.NoError(t, content.Store(l, entry.Hash, []byte(target)))
+				default:
+					if data, ok := tt.wantBlobs[entry.Path]; ok {
+						require.NoError(t, content.Store(l, entry.Hash, data))
+					}
+				}
+			}
+
+			targetDir := "/target"
+			require.NoError(t, memFs.MkdirAll(targetDir, 0755))
+
+			err = cas.LinkTree(t.Context(), store, store, tree, targetDir)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			for path, wantTarget := range tt.wantLinks {
+				full := filepath.Join(targetDir, path)
+
+				info, err := vfs.Lstat(memFs, full)
+				require.NoError(t, err)
+				assert.NotZero(t, info.Mode()&os.ModeSymlink, "%s is not a symlink (mode=%s)", full, info.Mode())
+
+				got, err := vfs.Readlink(memFs, full)
+				require.NoError(t, err)
+				assert.Equal(t, wantTarget, got)
+			}
+
+			for path, wantContent := range tt.wantBlobs {
+				full := filepath.Join(targetDir, path)
+				got, err := vfs.ReadFile(memFs, full)
+				require.NoError(t, err)
+				assert.Equal(t, wantContent, got)
+			}
 		})
 	}
 }

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -1121,8 +1121,12 @@ func sanitizeZipPath(dst, name string) (string, error) {
 	return destPath, nil
 }
 
-// validateSymlinkTarget validates that a symlink target doesn't escape the destination directory.
-func validateSymlinkTarget(dst, linkPath, target string) error {
+// ValidateSymlinkTarget reports whether a symbolic link whose path is linkPath
+// and whose stored target is target would resolve inside dst. Both absolute and
+// dot-dot targets that climb above dst are rejected so callers can safely
+// materialize symlinks from untrusted sources (zip archives, git trees) without
+// letting them escape the destination directory.
+func ValidateSymlinkTarget(dst, linkPath, target string) error {
 	// Resolve the target relative to the link's directory
 	absTarget := target
 	if !filepath.IsAbs(target) {
@@ -1161,7 +1165,7 @@ func extractSymlink(l log.Logger, fs FS, dst, destPath string, zipFile *zip.File
 	target := string(targetBytes)
 
 	// Validate symlink target doesn't escape destination
-	if err := validateSymlinkTarget(dst, destPath, target); err != nil {
+	if err := ValidateSymlinkTarget(dst, destPath, target); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds support for symlinks in CAS clones.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Committed symlinks in repositories are now materialized as real filesystem symlinks instead of regular files containing link target text.

* **Bug Fixes**
  * Symlink targets that resolve outside the destination tree are now rejected to prevent escaping the working directory.

* **Tests**
  * Added comprehensive test coverage for symlink materialization and target validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6082)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->