### PR TITLE
fix: Fixing tag refs in CAS

### DIFF
--- a/docs/src/content/docs/03-features/07-caching/04-cas.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas.mdx
@@ -221,9 +221,9 @@ When Terragrunt needs to clone a repository using the CAS it does the following,
 
 For cold clones, where the content is not already in the CAS:
 
-1. Terragrunt resolves the Git reference to a commit hash. Branch and tag refs resolve via `git ls-remote`. `ls-remote` lists named refs and does not resolve commit SHAs, so for SHA refs Terragrunt fetches the full history of every branch into the central Git store and resolves the SHA locally.
+1. Terragrunt detects the ref type. Branch and tag refs resolve to a commit hash via `git ls-remote`. `ls-remote` lists named refs only and cannot fetch or resolve commit SHAs, so SHA refs are passed through to Step 3 for resolution against the central Git store.
 2. The tree related to the commit hash is not found in the CAS
-3. Terragrunt opens the bare repository for the remote URL under `cas/store/git/` (initializing it on first use), takes a per-URL lock, and fetches the requested ref (shallow for branch/tag refs, full history for commit SHAs). Subsequent misses against the same URL reuse the existing pack files and only transfer new objects.
+3. Terragrunt opens the bare repository for the remote URL under `cas/store/git/` (initializing it on first use), takes a per-URL lock, and fetches the requested ref. Branch and tag refs use a shallow fetch. SHA refs use a full-history fetch covering every branch and tag so the SHA can be resolved against the local store. Subsequent misses against the same URL reuse the existing pack files and only transfer new objects.
 4. All blobs and trees required to reproduce the repository are extracted from the bare repository
 5. Content is stored in the CAS, partitioned by hash prefix
 6. The tree structure is read from the CAS and hard links are created to the target directory

--- a/internal/cas/commitref_test.go
+++ b/internal/cas/commitref_test.go
@@ -328,6 +328,59 @@ func TestCASClone_TagRef(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestGitStoreEnsureCommit_TagOnlyCommit pins the regression where the
+// fallback fetch only pulled refs/heads/*, so a commit reachable only
+// via an annotated tag stayed missing and surfaced as
+// ErrNoMatchingReference. The fix broadens the refspec so tag-only
+// commits arrive on the first fetch.
+func TestGitStoreEnsureCommit_TagOnlyCommit(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+
+	require.NoError(t, srv.CommitFile("first.txt", []byte("first"), "first commit"))
+
+	firstHash, err := srv.Head()
+	require.NoError(t, err)
+
+	require.NoError(t, srv.CommitFile("tagged.txt", []byte("tagged"), "tagged commit"))
+
+	taggedHash, err := srv.Head()
+	require.NoError(t, err)
+	require.NotEqual(t, firstHash, taggedHash, "tagged commit must differ from first commit")
+
+	require.NoError(t, srv.Tag("v1"))
+
+	// Rewind main past the tagged commit so it is reachable only via the tag.
+	require.NoError(t, srv.SetBranch("main", firstHash))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	store, fs, _ := newTestGitStore(t)
+	l := logger.CreateLogger()
+	ctx := t.Context()
+
+	t.Run("rev-parse fallback", func(t *testing.T) {
+		t.Parallel()
+
+		repo, err := store.EnsureCommit(ctx, l, fs, repoURL, taggedHash, "")
+		require.NoError(t, err)
+		assert.Equal(t, taggedHash, repo.Hash)
+		require.NoError(t, repo.Unlock())
+	})
+
+	t.Run("known-hash fallback", func(t *testing.T) {
+		t.Parallel()
+
+		store2, fs2, _ := newTestGitStore(t)
+		repo, err := store2.EnsureCommit(ctx, l, fs2, repoURL, taggedHash, taggedHash)
+		require.NoError(t, err)
+		assert.Equal(t, taggedHash, repo.Hash)
+		require.NoError(t, repo.Unlock())
+	})
+}
+
 // TestGitStoreEnsureCommit_OfflineWhenCached proves that once a
 // commit is cached in the central git store, EnsureCommit resolves it
 // without touching the network. We tear the server down between the

--- a/internal/cas/gitstore.go
+++ b/internal/cas/gitstore.go
@@ -170,9 +170,10 @@ func (s *GitStore) EnsureRef(
 //  1. If the commit is already cached in the bare repo, no network
 //     call is made.
 //  2. Otherwise the bare repo is updated with a full-history fetch of
-//     every branch (no `--depth`). Fetching by raw SHA is avoided
-//     because it requires `uploadpack.allowAnySHA1InWant`, which is
-//     not universally enabled on git servers.
+//     every ref (no `--depth`). Tags are included so commits reachable
+//     only via tags resolve without a second fetch. Fetching by raw SHA
+//     is avoided because it requires `uploadpack.allowAnySHA1InWant`,
+//     which is not universally enabled on git servers.
 //  3. If rev-parse still cannot resolve rawRef after the fetch, a
 //     [git.WrappedError] wrapping [git.ErrNoMatchingReference] is
 //     returned so callers can use [errors.Is] for the same condition
@@ -207,7 +208,7 @@ func (s *GitStore) EnsureCommit(
 		return nil, err
 	}
 
-	if err := session.runner.Fetch(ctx, url, "+refs/heads/*:refs/heads/*", 0); err != nil {
+	if err := session.runner.Fetch(ctx, url, "+refs/*:refs/*", 0); err != nil {
 		return nil, err
 	}
 
@@ -250,7 +251,7 @@ func (s *GitStore) ensureKnownCommit(
 		return session.keep(), nil
 	}
 
-	if err := session.runner.Fetch(ctx, url, "+refs/heads/*:refs/heads/*", 0); err != nil {
+	if err := session.runner.Fetch(ctx, url, "+refs/*:refs/*", 0); err != nil {
 		return nil, err
 	}
 

--- a/internal/git/server.go
+++ b/internal/git/server.go
@@ -140,6 +140,18 @@ func (s *Server) Branch(name string) error {
 	return nil
 }
 
+// SetBranch points the named branch at the given commit hash, creating
+// it if missing. Tests use this to rewind a branch past a tagged
+// commit so the commit is reachable only via the tag.
+func (s *Server) SetBranch(name, hash string) error {
+	ref := plumbing.NewHashReference(plumbing.NewBranchReferenceName(name), plumbing.NewHash(hash))
+	if err := s.repo.Storer.SetReference(ref); err != nil {
+		return fmt.Errorf("set branch %s to %s: %w", name, hash, err)
+	}
+
+	return nil
+}
+
 // Start begins serving Git HTTP on a random local port.
 // Returns the base URL (e.g. "http://127.0.0.1:12345").
 func (s *Server) Start(ctx context.Context) (string, error) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes tag refs for CAS with the central Git store.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Terragrunt handles branch, tag, and commit SHA references in the caching system.

* **Bug Fixes**
  * Improved resolution of commits reachable via Git tags to eliminate unnecessary additional fetches.

* **Tests**
  * Added regression test ensuring proper commit resolution via annotated tags.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6083)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->