### PR TITLE
chore: Increasing virtualization further

### DIFF
--- a/internal/prepare/prepare.go
+++ b/internal/prepare/prepare.go
@@ -97,7 +97,10 @@ func PrepareSource(
 	optsClone.TerraformCommand = run.CommandNameTerragruntReadConfig
 
 	if err = optsClone.RunWithErrorHandling(ctx, l, r, func() error {
-		return run.ProcessHooks(ctx, l, runCfg.Terraform.AfterHooks, configbridge.NewRunOptions(optsClone), runCfg, nil, r)
+		return run.ProcessHooks(
+			ctx, l, run.OSVenv(), runCfg.Terraform.AfterHooks,
+			configbridge.NewRunOptions(optsClone), runCfg, nil, r,
+		)
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/prepare/prepare.go
+++ b/internal/prepare/prepare.go
@@ -97,10 +97,11 @@ func PrepareSource(
 	optsClone.TerraformCommand = run.CommandNameTerragruntReadConfig
 
 	if err = optsClone.RunWithErrorHandling(ctx, l, r, func() error {
-		return run.ProcessHooks(
-			ctx, l, run.OSVenv(), runCfg.Terraform.AfterHooks,
-			configbridge.NewRunOptions(optsClone), runCfg, nil, r,
-		)
+		return run.ProcessHooks(ctx, l, run.OSVenv(), run.ProcessHooksParams{
+			Hooks: runCfg.Terraform.AfterHooks,
+			Opts:  configbridge.NewRunOptions(optsClone),
+			Cfg:   runCfg,
+		})
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/runner/run/hook.go
+++ b/internal/runner/run/hook.go
@@ -26,36 +26,55 @@ const (
 	HookCtxHookNameEnvName = "TG_CTX_HOOK_NAME"
 )
 
-// hookErrorMessage extracts command, args and output from the error
-// so users see WHY a hook failed, not just the exit code.
-func hookErrorMessage(hookName string, err error) string {
-	var processErr util.ProcessExecutionError
-	if !errors.As(err, &processErr) {
-		return fmt.Sprintf("Hook %q failed to execute: %v", hookName, err)
-	}
-
-	exitCode, exitCodeErr := processErr.ExitStatus()
-	if exitCodeErr != nil {
-		return fmt.Sprintf("Hook %q failed to execute: %v", hookName, err)
-	}
-
-	cmd := strings.Join(append([]string{processErr.Command}, processErr.Args...), " ")
-
-	output := strings.TrimSpace(processErr.Output.Stderr.String())
-	if output == "" {
-		output = strings.TrimSpace(processErr.Output.Stdout.String())
-	}
-
-	if output != "" {
-		return fmt.Sprintf("Hook %q (command: %s) exited with non-zero exit code %d:\n%s", hookName, cmd, exitCode, output)
-	}
-
-	return fmt.Sprintf("Hook %q (command: %s) exited with non-zero exit code %d", hookName, cmd, exitCode)
-}
-
-func processErrorHooks(
+// ProcessHooks processes a list of hooks, executing each one that matches the current command.
+func ProcessHooks(
 	ctx context.Context,
 	l log.Logger,
+	v Venv,
+	hooks []runcfg.Hook,
+	opts *Options,
+	cfg *runcfg.RunConfig,
+	previousExecErrors *errors.MultiError,
+	_ *report.Report,
+) error {
+	if len(hooks) == 0 {
+		return nil
+	}
+
+	var errorsOccured *multierror.Error
+
+	l.Debugf("Detected %d Hooks", len(hooks))
+
+	for i := range hooks {
+		curHook := &hooks[i]
+		if !curHook.If {
+			l.Debugf("Skipping hook: %s", curHook.Name)
+			continue
+		}
+
+		allPreviousErrors := previousExecErrors.Append(errorsOccured)
+		if shouldRunHook(curHook, opts, allPreviousErrors) {
+			err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hook_"+curHook.Name, map[string]any{
+				"hook": curHook.Name,
+				"dir":  curHook.WorkingDir,
+			}, func(ctx context.Context) error {
+				return runHook(ctx, l, v, opts, cfg, curHook)
+			})
+			if err != nil {
+				errorsOccured = multierror.Append(errorsOccured, err)
+			}
+		}
+	}
+
+	return errorsOccured.ErrorOrNil()
+}
+
+// ProcessErrorHooks runs error_hook blocks whose OnErrors regex matches one
+// of previousExecErrors. It is the error-path complement to [ProcessHooks].
+func ProcessErrorHooks(
+	ctx context.Context,
+	l log.Logger,
+	exec vexec.Exec,
 	hooks []runcfg.ErrorHook,
 	opts *Options,
 	previousExecErrors *errors.MultiError,
@@ -108,7 +127,7 @@ func processErrorHooks(
 				_, possibleError := shell.RunCommandWithOutput(
 					ctx,
 					l,
-					vexec.NewOSExec(),
+					exec,
 					hookOpts.shellRunOptions(),
 					curHook.WorkingDir,
 					curHook.SuppressStdout,
@@ -131,46 +150,31 @@ func processErrorHooks(
 	return errorsOccured.ErrorOrNil()
 }
 
-// ProcessHooks processes a list of hooks, executing each one that matches the current command.
-func ProcessHooks(
-	ctx context.Context,
-	l log.Logger,
-	hooks []runcfg.Hook,
-	opts *Options,
-	cfg *runcfg.RunConfig,
-	previousExecErrors *errors.MultiError,
-	_ *report.Report,
-) error {
-	if len(hooks) == 0 {
-		return nil
+// hookErrorMessage extracts command, args and output from the error
+// so users see WHY a hook failed, not just the exit code.
+func hookErrorMessage(hookName string, err error) string {
+	var processErr util.ProcessExecutionError
+	if !errors.As(err, &processErr) {
+		return fmt.Sprintf("Hook %q failed to execute: %v", hookName, err)
 	}
 
-	var errorsOccured *multierror.Error
-
-	l.Debugf("Detected %d Hooks", len(hooks))
-
-	for i := range hooks {
-		curHook := &hooks[i]
-		if !curHook.If {
-			l.Debugf("Skipping hook: %s", curHook.Name)
-			continue
-		}
-
-		allPreviousErrors := previousExecErrors.Append(errorsOccured)
-		if shouldRunHook(curHook, opts, allPreviousErrors) {
-			err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hook_"+curHook.Name, map[string]any{
-				"hook": curHook.Name,
-				"dir":  curHook.WorkingDir,
-			}, func(ctx context.Context) error {
-				return runHook(ctx, l, opts, cfg, curHook)
-			})
-			if err != nil {
-				errorsOccured = multierror.Append(errorsOccured, err)
-			}
-		}
+	exitCode, exitCodeErr := processErr.ExitStatus()
+	if exitCodeErr != nil {
+		return fmt.Sprintf("Hook %q failed to execute: %v", hookName, err)
 	}
 
-	return errorsOccured.ErrorOrNil()
+	cmd := strings.Join(append([]string{processErr.Command}, processErr.Args...), " ")
+
+	output := strings.TrimSpace(processErr.Output.Stderr.String())
+	if output == "" {
+		output = strings.TrimSpace(processErr.Output.Stdout.String())
+	}
+
+	if output != "" {
+		return fmt.Sprintf("Hook %q (command: %s) exited with non-zero exit code %d:\n%s", hookName, cmd, exitCode, output)
+	}
+
+	return fmt.Sprintf("Hook %q (command: %s) exited with non-zero exit code %d", hookName, cmd, exitCode)
 }
 
 func shouldRunHook(
@@ -193,6 +197,7 @@ func shouldRunHook(
 func runHook(
 	ctx context.Context,
 	l log.Logger,
+	v Venv,
 	opts *Options,
 	cfg *runcfg.RunConfig,
 	curHook *runcfg.Hook,
@@ -207,13 +212,13 @@ func runHook(
 	hookOpts := optsWithHookEnvs(opts, curHook.Name)
 
 	if actionToExecute == "tflint" {
-		return executeTFLint(ctx, l, opts, cfg, curHook, workingDir)
+		return executeTFLint(ctx, l, v, opts, cfg, curHook, workingDir)
 	}
 
 	_, possibleError := shell.RunCommandWithOutput(
 		ctx,
 		l,
-		vexec.NewOSExec(),
+		v.Exec,
 		hookOpts.shellRunOptions(),
 		workingDir,
 		suppressStdout,
@@ -230,6 +235,7 @@ func runHook(
 func executeTFLint(
 	ctx context.Context,
 	l log.Logger,
+	v Venv,
 	opts *Options,
 	cfg *runcfg.RunConfig,
 	curHook *runcfg.Hook,
@@ -242,7 +248,7 @@ func executeTFLint(
 	actualLock.Lock()
 	defer actualLock.Unlock()
 
-	err := tflint.RunTflintWithOpts(ctx, l, opts.tflintRunOptions(), cfg, curHook)
+	err := tflint.RunTflintWithOpts(ctx, l, v.tflintVenv(), opts.tflintRunOptions(), cfg, curHook)
 	if err != nil {
 		l.Errorf("%s", hookErrorMessage(curHook.Name, err))
 		return err

--- a/internal/runner/run/hook.go
+++ b/internal/runner/run/hook.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cloner"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
-	"github.com/gruntwork-io/terragrunt/internal/report"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
@@ -26,39 +25,38 @@ const (
 	HookCtxHookNameEnvName = "TG_CTX_HOOK_NAME"
 )
 
+// ProcessHooksParams groups the configuration and data inputs for ProcessHooks.
+type ProcessHooksParams struct {
+	Opts               *Options
+	Cfg                *runcfg.RunConfig
+	PreviousExecErrors *errors.MultiError
+	Hooks              []runcfg.Hook
+}
+
 // ProcessHooks processes a list of hooks, executing each one that matches the current command.
-func ProcessHooks(
-	ctx context.Context,
-	l log.Logger,
-	v Venv,
-	hooks []runcfg.Hook,
-	opts *Options,
-	cfg *runcfg.RunConfig,
-	previousExecErrors *errors.MultiError,
-	_ *report.Report,
-) error {
-	if len(hooks) == 0 {
+func ProcessHooks(ctx context.Context, l log.Logger, v Venv, p ProcessHooksParams) error {
+	if len(p.Hooks) == 0 {
 		return nil
 	}
 
 	var errorsOccured *multierror.Error
 
-	l.Debugf("Detected %d Hooks", len(hooks))
+	l.Debugf("Detected %d Hooks", len(p.Hooks))
 
-	for i := range hooks {
-		curHook := &hooks[i]
+	for i := range p.Hooks {
+		curHook := &p.Hooks[i]
 		if !curHook.If {
 			l.Debugf("Skipping hook: %s", curHook.Name)
 			continue
 		}
 
-		allPreviousErrors := previousExecErrors.Append(errorsOccured)
-		if shouldRunHook(curHook, opts, allPreviousErrors) {
+		allPreviousErrors := p.PreviousExecErrors.Append(errorsOccured)
+		if shouldRunHook(curHook, p.Opts, allPreviousErrors) {
 			err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "hook_"+curHook.Name, map[string]any{
 				"hook": curHook.Name,
 				"dir":  curHook.WorkingDir,
 			}, func(ctx context.Context) error {
-				return runHook(ctx, l, v, opts, cfg, curHook)
+				return runHook(ctx, l, v, p.Opts, p.Cfg, curHook)
 			})
 			if err != nil {
 				errorsOccured = multierror.Append(errorsOccured, err)

--- a/internal/runner/run/hook_internal_test.go
+++ b/internal/runner/run/hook_internal_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
@@ -11,20 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func getExitError(t *testing.T, exitCode int) *exec.ExitError {
-	t.Helper()
-
-	cmd := exec.CommandContext(t.Context(), "sh", "-c", fmt.Sprintf("exit %d", exitCode))
-	err := cmd.Run()
-	require.Error(t, err)
-
-	var exitErr *exec.ExitError
-
-	require.True(t, errors.As(err, &exitErr))
-
-	return exitErr
-}
 
 func TestHookErrorMessage_WithStderr(t *testing.T) {
 	t.Parallel()
@@ -119,3 +106,84 @@ func TestHookErrorMessage_NonProcessError(t *testing.T) {
 	msg := hookErrorMessage("my-hook", err)
 	assert.Equal(t, `Hook "my-hook" failed to execute: exec: "tflint": executable file not found in $PATH`, msg)
 }
+
+// FuzzHookErrorMessage pins the formatter against arbitrary inputs. The
+// formatter dereferences ProcessExecutionError fields, so its contract is
+// "must not panic on any field value." We exercise both wrapped and bare
+// errors via a one-bit selector in the corpus.
+func FuzzHookErrorMessage(f *testing.F) {
+	type seed struct {
+		hookName, command, errMsg, stderr, stdout string
+		args                                      []string
+		exitCode                                  int
+		wrap                                      bool
+	}
+
+	seeds := []seed{
+		{hookName: "lint", command: "tflint", args: []string{"--config", ".tflint.hcl"}, exitCode: 2, stderr: "3 issues", wrap: true},
+		{hookName: "", command: "", args: nil, exitCode: 0, wrap: true},
+		{hookName: "x", errMsg: "raw error", wrap: false},
+		{hookName: "long", command: "go", args: []string{strings.Repeat("a", 1024)}, exitCode: 137, stdout: "out\nput", wrap: true},
+		{hookName: "neg", command: "x", exitCode: -1, wrap: true},
+	}
+
+	for _, s := range seeds {
+		args := strings.Join(s.args, "\x00")
+		f.Add(s.hookName, s.command, args, s.errMsg, s.stderr, s.stdout, s.exitCode, s.wrap)
+	}
+
+	f.Fuzz(func(_ *testing.T,
+		hookName, command, argsJoined, errMsg, stderr, stdout string,
+		exitCode int, wrap bool,
+	) {
+		var args []string
+
+		if argsJoined != "" {
+			args = strings.Split(argsJoined, "\x00")
+		}
+
+		var feed error
+
+		if wrap {
+			var output util.CmdOutput
+
+			output.Stderr.WriteString(stderr)
+			output.Stdout.WriteString(stdout)
+
+			feed = util.ProcessExecutionError{
+				Err:        fuzzExitErr{code: exitCode},
+				Command:    command,
+				Args:       args,
+				WorkingDir: "/tmp",
+				Output:     output,
+			}
+		} else {
+			feed = errors.New(errMsg)
+		}
+
+		// Contract: must not panic for any input.
+		_ = hookErrorMessage(hookName, feed)
+	})
+}
+
+func getExitError(t *testing.T, exitCode int) *exec.ExitError {
+	t.Helper()
+
+	cmd := exec.CommandContext(t.Context(), "sh", "-c", fmt.Sprintf("exit %d", exitCode))
+	err := cmd.Run()
+	require.Error(t, err)
+
+	var exitErr *exec.ExitError
+
+	require.True(t, errors.As(err, &exitErr))
+
+	return exitErr
+}
+
+// fuzzExitErr is a stand-in error that exposes an ExitStatus() so
+// [util.GetExitCode] resolves to the encoded code. It lets the fuzz target
+// avoid the per-iteration cost of shelling out for a real *exec.ExitError.
+type fuzzExitErr struct{ code int }
+
+func (e fuzzExitErr) Error() string            { return fmt.Sprintf("exit status %d", e.code) }
+func (e fuzzExitErr) ExitStatus() (int, error) { return e.code, nil }

--- a/internal/runner/run/hook_test.go
+++ b/internal/runner/run/hook_test.go
@@ -1,0 +1,334 @@
+package run_test
+
+import (
+	"context"
+	"io"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/runner/run"
+	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/writer"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessHooks_DispatchesCommandsForMatchingTerraformCommand(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	v := newHookVenv(rec.handler(vexec.Result{}))
+	l := logger.CreateLogger()
+
+	hooks := []runcfg.Hook{
+		{
+			Name:     "echo-hook",
+			Commands: []string{"plan"},
+			Execute:  []string{"echo", "before-plan"},
+			If:       true,
+		},
+		{
+			Name:     "apply-only",
+			Commands: []string{"apply"},
+			Execute:  []string{"echo", "should-not-run"},
+			If:       true,
+		},
+	}
+
+	err := run.ProcessHooks(t.Context(), l, v, hooks, newHookOpts(), &runcfg.RunConfig{}, nil, nil)
+	require.NoError(t, err)
+
+	calls := rec.snapshot()
+	require.Len(t, calls, 1, "only the plan hook should fire on a plan command")
+	assert.Equal(t, "echo", calls[0].Name)
+	assert.Equal(t, []string{"before-plan"}, calls[0].Args)
+}
+
+func TestProcessHooks_SkipsHookWhenIfFalse(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	v := newHookVenv(rec.handler(vexec.Result{}))
+	l := logger.CreateLogger()
+
+	hooks := []runcfg.Hook{
+		{
+			Name:     "gated",
+			Commands: []string{"plan"},
+			Execute:  []string{"echo", "skip-me"},
+			If:       false,
+		},
+	}
+
+	require.NoError(t, run.ProcessHooks(t.Context(), l, v, hooks, newHookOpts(), &runcfg.RunConfig{}, nil, nil))
+	assert.Empty(t, rec.snapshot(), "If=false should suppress dispatch")
+}
+
+func TestProcessHooks_RunOnErrorGate(t *testing.T) {
+	t.Parallel()
+
+	priorErr := new(errors.MultiError).Append(errors.New("prior failure"))
+
+	testCases := []struct {
+		name        string
+		hook        runcfg.Hook
+		wantInvoked bool
+	}{
+		{
+			name: "default behavior: skip after prior error",
+			hook: runcfg.Hook{
+				Name: "after", Commands: []string{"plan"},
+				Execute: []string{"echo", "skipped"}, If: true,
+			},
+			wantInvoked: false,
+		},
+		{
+			name: "RunOnError opts back in",
+			hook: runcfg.Hook{
+				Name: "after", Commands: []string{"plan"},
+				Execute: []string{"echo", "ran"}, If: true, RunOnError: true,
+			},
+			wantInvoked: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := &recorder{}
+			v := newHookVenv(rec.handler(vexec.Result{}))
+			l := logger.CreateLogger()
+
+			require.NoError(t, run.ProcessHooks(
+				t.Context(), l, v, []runcfg.Hook{tc.hook},
+				newHookOpts(), &runcfg.RunConfig{}, priorErr, nil,
+			))
+
+			invoked := len(rec.snapshot()) == 1
+			assert.Equal(t, tc.wantInvoked, invoked)
+		})
+	}
+}
+
+func TestProcessHooks_InjectsHookContextEnv(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	v := newHookVenv(rec.handler(vexec.Result{}))
+	l := logger.CreateLogger()
+
+	opts := newHookOpts()
+	opts.TFPath = "/fake/tofu"
+	opts.TerraformCommand = "plan"
+
+	hooks := []runcfg.Hook{
+		{
+			Name:     "ctx-hook",
+			Commands: []string{"plan"},
+			Execute:  []string{"echo", "hi"},
+			If:       true,
+		},
+	}
+
+	require.NoError(t, run.ProcessHooks(
+		t.Context(), l, v, hooks, opts, &runcfg.RunConfig{}, nil, nil,
+	))
+
+	calls := rec.snapshot()
+	require.Len(t, calls, 1)
+
+	env := envToMap(calls[0].Env)
+	assert.Equal(t, "/fake/tofu", env[run.HookCtxTFPathEnvName])
+	assert.Equal(t, "plan", env[run.HookCtxCommandEnvName])
+	assert.Equal(t, "ctx-hook", env[run.HookCtxHookNameEnvName])
+
+	// The opts.Env we passed in must not have been mutated.
+	_, mutated := opts.Env[run.HookCtxTFPathEnvName]
+	assert.False(t, mutated, "ProcessHooks must not mutate the caller's opts.Env")
+}
+
+func TestProcessHooks_PropagatesFailures(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	v := newHookVenv(rec.handler(vexec.Result{ExitCode: 7, Stderr: []byte("boom")}))
+	l := logger.CreateLogger()
+
+	hooks := []runcfg.Hook{
+		{
+			Name:     "fails",
+			Commands: []string{"plan"},
+			Execute:  []string{"failbin"},
+			If:       true,
+		},
+	}
+
+	err := run.ProcessHooks(t.Context(), l, v, hooks, newHookOpts(), &runcfg.RunConfig{}, nil, nil)
+	require.Error(t, err)
+	assert.NotEmpty(t, rec.snapshot())
+}
+
+func TestProcessHooks_TflintActionRoutesThroughTflint(t *testing.T) {
+	t.Parallel()
+
+	var (
+		tflintInitCalls atomic.Int32
+		tflintRunCalls  atomic.Int32
+	)
+
+	h := func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		if inv.Name != "tflint" {
+			return vexec.Result{ExitCode: 127, Stderr: []byte("unexpected binary")}
+		}
+
+		if slices.Contains(inv.Args, "--init") {
+			tflintInitCalls.Add(1)
+		} else {
+			tflintRunCalls.Add(1)
+		}
+
+		return vexec.Result{}
+	}
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fs, "/work/.tflint.hcl", []byte("config {}"), 0o644))
+
+	v := run.Venv{Exec: vexec.NewMemExec(h), FS: fs}
+	l := logger.CreateLogger()
+
+	hooks := []runcfg.Hook{
+		{
+			Name:     "tflint",
+			Commands: []string{"plan"},
+			Execute:  []string{"tflint"},
+			If:       true,
+		},
+	}
+
+	require.NoError(t, run.ProcessHooks(
+		t.Context(), l, v, hooks, newHookOpts(), &runcfg.RunConfig{}, nil, nil,
+	))
+
+	assert.Equal(t, int32(1), tflintInitCalls.Load())
+	assert.Equal(t, int32(1), tflintRunCalls.Load())
+}
+
+func TestProcessErrorHooks_NoopWhenNoPriorErrors(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	exec := vexec.NewMemExec(rec.handler(vexec.Result{}))
+	l := logger.CreateLogger()
+
+	hooks := []runcfg.ErrorHook{
+		{Name: "on-anything", Commands: []string{"plan"}, OnErrors: []string{".*"}, Execute: []string{"echo", "x"}},
+	}
+
+	require.NoError(t, run.ProcessErrorHooks(t.Context(), l, exec, hooks, newHookOpts(), nil))
+	assert.Empty(t, rec.snapshot())
+}
+
+func TestProcessErrorHooks_MatchesOnErrorsRegex(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	exec := vexec.NewMemExec(rec.handler(vexec.Result{}))
+	l := logger.CreateLogger()
+
+	priorErrs := new(errors.MultiError).Append(errors.New("oh no: permission denied on resource"))
+
+	hooks := []runcfg.ErrorHook{
+		{
+			Name:     "match-perm",
+			Commands: []string{"plan"},
+			OnErrors: []string{".*permission denied.*"},
+			Execute:  []string{"echo", "matched"},
+		},
+		{
+			Name:     "match-throttling",
+			Commands: []string{"plan"},
+			OnErrors: []string{".*throttl.*"},
+			Execute:  []string{"echo", "should-not-fire"},
+		},
+		{
+			Name:     "command-mismatch",
+			Commands: []string{"apply"},
+			OnErrors: []string{".*"},
+			Execute:  []string{"echo", "wrong-command"},
+		},
+	}
+
+	require.NoError(t, run.ProcessErrorHooks(t.Context(), l, exec, hooks, newHookOpts(), priorErrs))
+
+	calls := rec.snapshot()
+	require.Len(t, calls, 1)
+	assert.Equal(t, []string{"matched"}, calls[0].Args)
+}
+
+// recorder is a thread-safe accumulator for in-memory subprocess invocations.
+type recorder struct {
+	calls []vexec.Invocation
+	mu    sync.Mutex
+}
+
+func (r *recorder) handler(result vexec.Result) vexec.Handler {
+	return func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+
+		r.calls = append(r.calls, vexec.Invocation{
+			Name: inv.Name,
+			Dir:  inv.Dir,
+			Args: slices.Clone(inv.Args),
+			Env:  slices.Clone(inv.Env),
+		})
+
+		return result
+	}
+}
+
+func (r *recorder) snapshot() []vexec.Invocation {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.calls)
+}
+
+func newHookOpts() *run.Options {
+	return &run.Options{
+		Env:               map[string]string{},
+		WorkingDir:        "/work",
+		RootWorkingDir:    "/work",
+		TerraformCommand:  "plan",
+		TFPath:            "/fake/tofu",
+		MaxFoldersToCheck: 5,
+		Writers:           writer.Writers{Writer: io.Discard, ErrWriter: io.Discard},
+	}
+}
+
+func newHookVenv(h vexec.Handler) run.Venv {
+	return run.Venv{Exec: vexec.NewMemExec(h), FS: vfs.NewMemMapFS()}
+}
+
+func envToMap(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+
+	for _, kv := range env {
+		for i := range len(kv) {
+			if kv[i] == '=' {
+				out[kv[:i]] = kv[i+1:]
+				break
+			}
+		}
+	}
+
+	return out
+}

--- a/internal/runner/run/hook_test.go
+++ b/internal/runner/run/hook_test.go
@@ -42,7 +42,11 @@ func TestProcessHooks_DispatchesCommandsForMatchingTerraformCommand(t *testing.T
 		},
 	}
 
-	err := run.ProcessHooks(t.Context(), l, v, hooks, newHookOpts(), &runcfg.RunConfig{}, nil, nil)
+	err := run.ProcessHooks(t.Context(), l, v, run.ProcessHooksParams{
+		Hooks: hooks,
+		Opts:  newHookOpts(),
+		Cfg:   &runcfg.RunConfig{},
+	})
 	require.NoError(t, err)
 
 	calls := rec.snapshot()
@@ -67,7 +71,11 @@ func TestProcessHooks_SkipsHookWhenIfFalse(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, run.ProcessHooks(t.Context(), l, v, hooks, newHookOpts(), &runcfg.RunConfig{}, nil, nil))
+	require.NoError(t, run.ProcessHooks(t.Context(), l, v, run.ProcessHooksParams{
+		Hooks: hooks,
+		Opts:  newHookOpts(),
+		Cfg:   &runcfg.RunConfig{},
+	}))
 	assert.Empty(t, rec.snapshot(), "If=false should suppress dispatch")
 }
 
@@ -107,10 +115,12 @@ func TestProcessHooks_RunOnErrorGate(t *testing.T) {
 			v := newHookVenv(rec.handler(vexec.Result{}))
 			l := logger.CreateLogger()
 
-			require.NoError(t, run.ProcessHooks(
-				t.Context(), l, v, []runcfg.Hook{tc.hook},
-				newHookOpts(), &runcfg.RunConfig{}, priorErr, nil,
-			))
+			require.NoError(t, run.ProcessHooks(t.Context(), l, v, run.ProcessHooksParams{
+				Hooks:              []runcfg.Hook{tc.hook},
+				Opts:               newHookOpts(),
+				Cfg:                &runcfg.RunConfig{},
+				PreviousExecErrors: priorErr,
+			}))
 
 			invoked := len(rec.snapshot()) == 1
 			assert.Equal(t, tc.wantInvoked, invoked)
@@ -138,9 +148,11 @@ func TestProcessHooks_InjectsHookContextEnv(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, run.ProcessHooks(
-		t.Context(), l, v, hooks, opts, &runcfg.RunConfig{}, nil, nil,
-	))
+	require.NoError(t, run.ProcessHooks(t.Context(), l, v, run.ProcessHooksParams{
+		Hooks: hooks,
+		Opts:  opts,
+		Cfg:   &runcfg.RunConfig{},
+	}))
 
 	calls := rec.snapshot()
 	require.Len(t, calls, 1)
@@ -171,7 +183,11 @@ func TestProcessHooks_PropagatesFailures(t *testing.T) {
 		},
 	}
 
-	err := run.ProcessHooks(t.Context(), l, v, hooks, newHookOpts(), &runcfg.RunConfig{}, nil, nil)
+	err := run.ProcessHooks(t.Context(), l, v, run.ProcessHooksParams{
+		Hooks: hooks,
+		Opts:  newHookOpts(),
+		Cfg:   &runcfg.RunConfig{},
+	})
 	require.Error(t, err)
 	assert.NotEmpty(t, rec.snapshot())
 }
@@ -213,9 +229,11 @@ func TestProcessHooks_TflintActionRoutesThroughTflint(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, run.ProcessHooks(
-		t.Context(), l, v, hooks, newHookOpts(), &runcfg.RunConfig{}, nil, nil,
-	))
+	require.NoError(t, run.ProcessHooks(t.Context(), l, v, run.ProcessHooksParams{
+		Hooks: hooks,
+		Opts:  newHookOpts(),
+		Cfg:   &runcfg.RunConfig{},
+	}))
 
 	assert.Equal(t, int32(1), tflintInitCalls.Load())
 	assert.Equal(t, int32(1), tflintRunCalls.Load())

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -113,7 +113,7 @@ func Run(
 	terragruntOptionsClone.TerraformCommand = CommandNameTerragruntReadConfig
 
 	if err = terragruntOptionsClone.RunWithErrorHandling(ctx, l, r, func() error {
-		return ProcessHooks(ctx, l, cfg.Terraform.AfterHooks, terragruntOptionsClone, cfg, nil, r)
+		return ProcessHooks(ctx, l, OSVenv(), cfg.Terraform.AfterHooks, terragruntOptionsClone, cfg, nil, r)
 	}); err != nil {
 		return err
 	}
@@ -349,7 +349,9 @@ func RunActionWithHooks(
 ) error {
 	var allErrors *errors.MultiError
 
-	beforeHookErrors := ProcessHooks(ctx, l, cfg.Terraform.BeforeHooks, opts, cfg, allErrors, r)
+	v := OSVenv()
+
+	beforeHookErrors := ProcessHooks(ctx, l, v, cfg.Terraform.BeforeHooks, opts, cfg, allErrors, r)
 	allErrors = allErrors.Append(beforeHookErrors)
 
 	var actionErrors error
@@ -360,8 +362,8 @@ func RunActionWithHooks(
 		l.Errorf("Errors encountered running before_hooks. Not running '%s'.", description)
 	}
 
-	postHookErrors := ProcessHooks(ctx, l, cfg.Terraform.AfterHooks, opts, cfg, allErrors, r)
-	errorHookErrors := processErrorHooks(ctx, l, cfg.Terraform.ErrorHooks, opts, allErrors)
+	postHookErrors := ProcessHooks(ctx, l, v, cfg.Terraform.AfterHooks, opts, cfg, allErrors, r)
+	errorHookErrors := ProcessErrorHooks(ctx, l, v.Exec, cfg.Terraform.ErrorHooks, opts, allErrors)
 	allErrors = allErrors.Append(postHookErrors, errorHookErrors)
 
 	return allErrors.ErrorOrNil()

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -113,7 +113,11 @@ func Run(
 	terragruntOptionsClone.TerraformCommand = CommandNameTerragruntReadConfig
 
 	if err = terragruntOptionsClone.RunWithErrorHandling(ctx, l, r, func() error {
-		return ProcessHooks(ctx, l, OSVenv(), cfg.Terraform.AfterHooks, terragruntOptionsClone, cfg, nil, r)
+		return ProcessHooks(ctx, l, OSVenv(), ProcessHooksParams{
+			Hooks: cfg.Terraform.AfterHooks,
+			Opts:  terragruntOptionsClone,
+			Cfg:   cfg,
+		})
 	}); err != nil {
 		return err
 	}
@@ -351,7 +355,12 @@ func RunActionWithHooks(
 
 	v := OSVenv()
 
-	beforeHookErrors := ProcessHooks(ctx, l, v, cfg.Terraform.BeforeHooks, opts, cfg, allErrors, r)
+	beforeHookErrors := ProcessHooks(ctx, l, v, ProcessHooksParams{
+		Hooks:              cfg.Terraform.BeforeHooks,
+		Opts:               opts,
+		Cfg:                cfg,
+		PreviousExecErrors: allErrors,
+	})
 	allErrors = allErrors.Append(beforeHookErrors)
 
 	var actionErrors error
@@ -362,7 +371,12 @@ func RunActionWithHooks(
 		l.Errorf("Errors encountered running before_hooks. Not running '%s'.", description)
 	}
 
-	postHookErrors := ProcessHooks(ctx, l, v, cfg.Terraform.AfterHooks, opts, cfg, allErrors, r)
+	postHookErrors := ProcessHooks(ctx, l, v, ProcessHooksParams{
+		Hooks:              cfg.Terraform.AfterHooks,
+		Opts:               opts,
+		Cfg:                cfg,
+		PreviousExecErrors: allErrors,
+	})
 	errorHookErrors := ProcessErrorHooks(ctx, l, v.Exec, cfg.Terraform.ErrorHooks, opts, allErrors)
 	allErrors = allErrors.Append(postHookErrors, errorHookErrors)
 

--- a/internal/runner/run/venv.go
+++ b/internal/runner/run/venv.go
@@ -1,0 +1,33 @@
+package run
+
+import (
+	"github.com/gruntwork-io/terragrunt/internal/tflint"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+)
+
+// Venv is the virtualized environment threaded through the hook execution
+// chain. It bundles the process-execution handle and the filesystem so
+// callers supply both per call rather than the run package holding them as
+// package-level state. The name avoids "Env" so it is not confused with
+// shell environment variables.
+type Venv struct {
+	// Exec runs hook commands and the embedded tflint binary.
+	Exec vexec.Exec
+	// FS backs filesystem reads performed inside hooks, including
+	// tflint's .tflint.hcl discovery.
+	FS vfs.FS
+}
+
+// OSVenv builds the production [Venv]: real OS process execution and the
+// real OS filesystem.
+func OSVenv() Venv {
+	return Venv{Exec: vexec.NewOSExec(), FS: vfs.NewOSFS()}
+}
+
+// tflintVenv translates a run.Venv into the tflint package's Venv. The
+// two carry the same handles but are distinct types so each package owns
+// its own contract.
+func (v Venv) tflintVenv() tflint.Venv {
+	return tflint.Venv{Exec: v.Exec, FS: v.FS}
+}

--- a/internal/tflint/fuzz_test.go
+++ b/internal/tflint/fuzz_test.go
@@ -1,0 +1,90 @@
+package tflint_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/tflint"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+// FuzzFindConfigInProject pins the walk-safety contract of [tflint.FindConfigInProject]:
+// no panic, no unbounded recursion, and a deterministic return for any
+// (startDir, MaxFoldersToCheck) on an arbitrarily seeded MemMapFS.
+//
+// The corpus encodes the directory layout as a newline-separated list of
+// paths that get seeded onto a fresh MemMapFS, plus the starting WorkingDir
+// and a max-folders bound. The bound is wrapped to [0, 64] so the fuzzer
+// does not chew CPU on absurd values.
+func FuzzFindConfigInProject(f *testing.F) {
+	seeds := []struct {
+		layout     string
+		workingDir string
+		maxFolders int
+	}{
+		{"/work/.tflint.hcl", "/work", 5},
+		{"/work/.tflint.hcl\n/work/a/b/c", "/work/a/b/c", 5},
+		{"/a/b/c/d/e/f/.tflint.hcl", "/", 2},
+		{"", "/", 1},
+		{"/.tflint.hcl", "/", 1},
+		{".tflint.hcl", "relative", 3},
+		{"/work/.tflint.hcl\n/work/.tflint.hcl/nested", "/work/x/y/z", 10},
+	}
+
+	for _, s := range seeds {
+		f.Add(s.layout, s.workingDir, s.maxFolders)
+	}
+
+	f.Fuzz(func(t *testing.T, layout, workingDir string, maxFolders int) {
+		fs := vfs.NewMemMapFS()
+
+		// Seed each non-empty line as a file. We bound the file size to
+		// keep the in-memory FS cheap.
+		for line := range strings.SplitSeq(layout, "\n") {
+			p := strings.TrimSpace(line)
+			if p == "" {
+				continue
+			}
+
+			// Reject absurdly long paths; the OS layer also rejects them
+			// and there is no signal value in fuzzing them.
+			if len(p) > 4096 {
+				continue
+			}
+
+			// Skip paths that filepath.Clean rejects with separator-only
+			// names; the goal is shapes the real walker would see.
+			if filepath.Clean(p) == "" {
+				continue
+			}
+
+			// Ignore write errors: pathological filenames are part of the
+			// fuzz domain, but we only care about the walk that follows.
+			_ = vfs.WriteFile(fs, p, []byte{}, 0o644)
+		}
+
+		// Bound the loop count so the fuzzer cannot ask for billions of
+		// iterations of the parent walk.
+		const maxBound = 64
+
+		if maxFolders < 0 {
+			maxFolders = -maxFolders
+		}
+
+		maxFolders %= maxBound + 1
+
+		opts := &tflint.TFLintOptions{
+			WorkingDir:        workingDir,
+			RootWorkingDir:    "/",
+			MaxFoldersToCheck: maxFolders,
+		}
+
+		l := logger.CreateLogger()
+
+		// Contract: must not panic. Returned (string, error) may take any
+		// value; we are only validating absence of panics and termination.
+		_, _ = tflint.FindConfigInProject(l, fs, opts)
+	})
+}

--- a/internal/tflint/fuzz_test.go
+++ b/internal/tflint/fuzz_test.go
@@ -1,7 +1,6 @@
 package tflint_test
 
 import (
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -16,21 +15,23 @@ import (
 //
 // The corpus encodes the directory layout as a newline-separated list of
 // paths that get seeded onto a fresh MemMapFS, plus the starting WorkingDir
-// and a max-folders bound. The bound is wrapped to [0, 64] so the fuzzer
-// does not chew CPU on absurd values.
+// and a max-folders bound. The bound is clamped to [0, maxFolderBound] so
+// the fuzzer does not chew CPU on absurd values.
 func FuzzFindConfigInProject(f *testing.F) {
-	seeds := []struct {
+	type seed struct {
 		layout     string
 		workingDir string
 		maxFolders int
-	}{
-		{"/work/.tflint.hcl", "/work", 5},
-		{"/work/.tflint.hcl\n/work/a/b/c", "/work/a/b/c", 5},
-		{"/a/b/c/d/e/f/.tflint.hcl", "/", 2},
-		{"", "/", 1},
-		{"/.tflint.hcl", "/", 1},
-		{".tflint.hcl", "relative", 3},
-		{"/work/.tflint.hcl\n/work/.tflint.hcl/nested", "/work/x/y/z", 10},
+	}
+
+	seeds := []seed{
+		{layout: "/work/.tflint.hcl", workingDir: "/work", maxFolders: 5},
+		{layout: "/work/.tflint.hcl\n/work/a/b/c", workingDir: "/work/a/b/c", maxFolders: 5},
+		{layout: "/a/b/c/d/e/f/.tflint.hcl", workingDir: "/", maxFolders: 2},
+		{layout: "", workingDir: "/", maxFolders: 1},
+		{layout: "/.tflint.hcl", workingDir: "/", maxFolders: 1},
+		{layout: ".tflint.hcl", workingDir: "relative", maxFolders: 3},
+		{layout: "/work/.tflint.hcl\n/work/.tflint.hcl/nested", workingDir: "/work/x/y/z", maxFolders: 10},
 	}
 
 	for _, s := range seeds {
@@ -54,31 +55,21 @@ func FuzzFindConfigInProject(f *testing.F) {
 				continue
 			}
 
-			// Skip paths that filepath.Clean rejects with separator-only
-			// names; the goal is shapes the real walker would see.
-			if filepath.Clean(p) == "" {
-				continue
-			}
-
 			// Ignore write errors: pathological filenames are part of the
 			// fuzz domain, but we only care about the walk that follows.
 			_ = vfs.WriteFile(fs, p, []byte{}, 0o644)
 		}
 
-		// Bound the loop count so the fuzzer cannot ask for billions of
-		// iterations of the parent walk.
-		const maxBound = 64
-
-		if maxFolders < 0 {
-			maxFolders = -maxFolders
-		}
-
-		maxFolders %= maxBound + 1
+		// Clamp the loop count so the fuzzer cannot ask for billions of
+		// iterations of the parent walk. Going through min/max avoids the
+		// two's-complement overflow on math.MinInt that bit a prior
+		// mod/negate version of this clamp.
+		const maxFolderBound = 64
 
 		opts := &tflint.TFLintOptions{
 			WorkingDir:        workingDir,
 			RootWorkingDir:    "/",
-			MaxFoldersToCheck: maxFolders,
+			MaxFoldersToCheck: max(0, min(maxFolders, maxFolderBound)),
 		}
 
 		l := logger.CreateLogger()

--- a/internal/tflint/tflint.go
+++ b/internal/tflint/tflint.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
@@ -41,6 +41,7 @@ const (
 func RunTflintWithOpts(
 	ctx context.Context,
 	l log.Logger,
+	v Venv,
 	opts *TFLintOptions,
 	cfg *runcfg.RunConfig,
 	hook *runcfg.Hook,
@@ -51,7 +52,7 @@ func RunTflintWithOpts(
 	})
 
 	// try to fetch configuration file from hook parameters
-	configFile, err := tflintConfigFilePath(l, opts, hookExecute)
+	configFile, err := ConfigFilePath(l, v.FS, opts, hookExecute)
 	if err != nil {
 		return err
 	}
@@ -64,7 +65,7 @@ func RunTflintWithOpts(
 		return err
 	}
 
-	tfVariables, err := tfArgumentsToTflintVar(l, hook, &cfg.Terraform)
+	tfVariables, err := TFArgumentsToVar(l, v.FS, hook, &cfg.Terraform)
 	if err != nil {
 		return err
 	}
@@ -83,7 +84,7 @@ func RunTflintWithOpts(
 	initArgs := []string{"tflint", "--init", "--config", configFileRel, "--chdir", chdirRel}
 	l.Debugf("Running external tflint init with args %v", initArgs)
 
-	_, err = shell.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), opts.ShellOptions, opts.RootWorkingDir, false, false,
+	_, err = shell.RunCommandWithOutput(ctx, l, v.Exec, opts.ShellOptions, opts.RootWorkingDir, false, false,
 		initArgs[0], initArgs[1:]...)
 	if err != nil {
 		return errors.New(ErrorRunningTflint{Args: initArgs, Err: err})
@@ -102,7 +103,7 @@ func RunTflintWithOpts(
 
 	l.Debugf("Running external tflint with args %v", args)
 
-	_, err = shell.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), opts.ShellOptions, opts.RootWorkingDir, false, false,
+	_, err = shell.RunCommandWithOutput(ctx, l, v.Exec, opts.ShellOptions, opts.RootWorkingDir, false, false,
 		args[0], args[1:]...)
 	if err != nil {
 		return errors.New(ErrorRunningTflint{Args: args, Err: err})
@@ -171,8 +172,8 @@ func (err ConfigNotFound) Error() string {
 	return "Could not find .tflint.hcl config file in the parent folders: " + err.cause
 }
 
-// tfArgumentsToTflintVar converts variables from the terraform config to a list of tflint variables.
-func tfArgumentsToTflintVar(l log.Logger, hook *runcfg.Hook,
+// TFArgumentsToVar converts variables from the terraform config to a list of tflint variables.
+func TFArgumentsToVar(l log.Logger, fs vfs.FS, hook *runcfg.Hook,
 	tfCfg *runcfg.TerraformConfig) ([]string, error) {
 	var variables []string
 
@@ -230,12 +231,19 @@ func tfArgumentsToTflintVar(l log.Logger, hook *runcfg.Hook,
 		if len(arg.OptionalVarFiles) > 0 {
 			// extract optional variables
 			for _, file := range util.RemoveDuplicatesKeepLast(arg.OptionalVarFiles) {
-				if util.FileExists(file) {
+				exists, err := vfs.FileExists(fs, file)
+				if err != nil {
+					return nil, err
+				}
+
+				if exists {
 					newVar := "--var-file=" + file
 					variables = append(variables, newVar)
-				} else {
-					l.Debugf("Skipping tflint var-file %s as it does not exist", file)
+
+					continue
 				}
+
+				l.Debugf("Skipping tflint var-file %s as it does not exist", file)
 			}
 		}
 	}
@@ -243,10 +251,10 @@ func tfArgumentsToTflintVar(l log.Logger, hook *runcfg.Hook,
 	return variables, nil
 }
 
-// findTflintConfigInProject looks for a .tflint.hcl file in the current
+// FindConfigInProject looks for a .tflint.hcl file in the current
 // folder or it's parents. When running from cache, we start searching
 // from the original config directory to find config in the source directory.
-func findTflintConfigInProject(l log.Logger, opts *TFLintOptions) (string, error) {
+func FindConfigInProject(l log.Logger, fs vfs.FS, opts *TFLintOptions) (string, error) {
 	startDir := opts.WorkingDir
 	if opts.TerragruntConfigPath != "" {
 		startDir = filepath.Dir(opts.TerragruntConfigPath)
@@ -267,7 +275,13 @@ func findTflintConfigInProject(l log.Logger, opts *TFLintOptions) (string, error
 		}
 
 		fileToFind := filepath.Join(previousDir, ".tflint.hcl")
-		if util.FileExists(fileToFind) {
+
+		exists, err := vfs.FileExists(fs, fileToFind)
+		if err != nil {
+			return "", err
+		}
+
+		if exists {
 			l.Debugf("Found .tflint.hcl in %s",
 				util.RelPathForLog(opts.RootWorkingDir, fileToFind, opts.Writers.LogShowAbsPaths))
 
@@ -282,15 +296,16 @@ func findTflintConfigInProject(l log.Logger, opts *TFLintOptions) (string, error
 	})
 }
 
-// tflintConfigFilePath returns the configuration file specified in --config argument
-func tflintConfigFilePath(l log.Logger, opts *TFLintOptions, arguments []string) (string, error) {
+// ConfigFilePath returns the configuration file specified in --config argument,
+// or the result of walking parents to find a .tflint.hcl file.
+func ConfigFilePath(l log.Logger, fs vfs.FS, opts *TFLintOptions, arguments []string) (string, error) {
 	for i, arg := range arguments {
 		if arg == "--config" && len(arguments) > i+1 {
 			return arguments[i+1], nil
 		}
 	}
 	// find .tflint.hcl configuration in project files if it is not provided in arguments
-	projectConfigFile, err := findTflintConfigInProject(l, opts)
+	projectConfigFile, err := FindConfigInProject(l, fs, opts)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tflint/tflint.go
+++ b/internal/tflint/tflint.go
@@ -233,7 +233,8 @@ func TFArgumentsToVar(l log.Logger, fs vfs.FS, hook *runcfg.Hook,
 			for _, file := range util.RemoveDuplicatesKeepLast(arg.OptionalVarFiles) {
 				exists, err := vfs.FileExists(fs, file)
 				if err != nil {
-					return nil, err
+					l.Debugf("Skipping tflint var-file %s: %v", file, err)
+					continue
 				}
 
 				if exists {

--- a/internal/tflint/tflint_test.go
+++ b/internal/tflint/tflint_test.go
@@ -1,9 +1,20 @@
 package tflint_test
 
 import (
+	"context"
+	"io"
+	"slices"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
+	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/tflint"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/writer"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,30 +23,30 @@ func TestInputsToTflintVar(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name     string
 		inputs   map[string]any
+		name     string
 		expected []string
 	}{
 		{
-			"strings",
-			map[string]any{"region": "eu-central-1", "instance_count": 3},
-			[]string{"--var=region=eu-central-1", "--var=instance_count=3"},
+			name:     "strings",
+			inputs:   map[string]any{"region": "eu-central-1", "instance_count": 3},
+			expected: []string{"--var=region=eu-central-1", "--var=instance_count=3"},
 		},
 		{
-			"strings and arrays",
-			map[string]any{"cidr_blocks": []string{"10.0.0.0/16"}},
-			[]string{"--var=cidr_blocks=[\"10.0.0.0/16\"]"},
+			name:     "strings and arrays",
+			inputs:   map[string]any{"cidr_blocks": []string{"10.0.0.0/16"}},
+			expected: []string{"--var=cidr_blocks=[\"10.0.0.0/16\"]"},
 		},
 		{
-			"boolean",
-			map[string]any{"create_resource": true},
-			[]string{"--var=create_resource=true"},
+			name:     "boolean",
+			inputs:   map[string]any{"create_resource": true},
+			expected: []string{"--var=create_resource=true"},
 		},
 		{
-			"with white spaces",
+			name: "with white spaces",
 			// With white spaces, the string is still validated by tflint.
-			map[string]any{"region": " eu-central-1 "},
-			[]string{"--var=region= eu-central-1 "},
+			inputs:   map[string]any{"region": " eu-central-1 "},
+			expected: []string{"--var=region= eu-central-1 "},
 		},
 	}
 
@@ -47,5 +58,439 @@ func TestInputsToTflintVar(t *testing.T) {
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tc.expected, actual)
 		})
+	}
+}
+
+func TestTFArgumentsToVar(t *testing.T) {
+	t.Parallel()
+
+	const (
+		optionalPresent = "/work/present.tfvars"
+		optionalAbsent  = "/work/absent.tfvars"
+	)
+
+	testCases := []struct {
+		name     string
+		expected []string
+		hook     runcfg.Hook
+		cfg      runcfg.TerraformConfig
+	}{
+		{
+			name: "command mismatch is skipped",
+			hook: runcfg.Hook{Commands: []string{"plan"}},
+			cfg: runcfg.TerraformConfig{ExtraArgs: []runcfg.TerraformExtraArguments{
+				{
+					Commands:  []string{"apply"},
+					Arguments: []string{"-var=foo=bar"},
+				},
+			}},
+			expected: nil,
+		},
+		{
+			name: "TF_VAR_ env extracts; non-TF env ignored",
+			hook: runcfg.Hook{Commands: []string{"plan"}},
+			cfg: runcfg.TerraformConfig{ExtraArgs: []runcfg.TerraformExtraArguments{
+				{
+					Commands: []string{"plan"},
+					EnvVars: map[string]string{
+						"TF_VAR_region": "us-east-1",
+						"PATH":          "/ignored",
+					},
+				},
+			}},
+			expected: []string{"--var='region=us-east-1'"},
+		},
+		{
+			name: "-var= and -var-file= arguments split correctly",
+			hook: runcfg.Hook{Commands: []string{"plan"}},
+			cfg: runcfg.TerraformConfig{ExtraArgs: []runcfg.TerraformExtraArguments{
+				{
+					Commands: []string{"plan"},
+					Arguments: []string{
+						"-var=foo=bar",
+						"-var-file=common.tfvars",
+						"--unrelated", // no prefix → ignored by tflint translation
+					},
+				},
+			}},
+			expected: []string{"--var='foo=bar'", "--var-file=common.tfvars"},
+		},
+		{
+			name: "required var files pass through verbatim",
+			hook: runcfg.Hook{Commands: []string{"plan"}},
+			cfg: runcfg.TerraformConfig{ExtraArgs: []runcfg.TerraformExtraArguments{
+				{
+					Commands:         []string{"plan"},
+					RequiredVarFiles: []string{"/missing.tfvars"},
+				},
+			}},
+			expected: []string{"--var-file=/missing.tfvars"},
+		},
+		{
+			name: "optional var files filter on existence",
+			hook: runcfg.Hook{Commands: []string{"plan"}},
+			cfg: runcfg.TerraformConfig{ExtraArgs: []runcfg.TerraformExtraArguments{
+				{
+					Commands:         []string{"plan"},
+					OptionalVarFiles: []string{optionalPresent, optionalAbsent},
+				},
+			}},
+			expected: []string{"--var-file=" + optionalPresent},
+		},
+		{
+			name: "optional var files: duplicates collapse to last occurrence",
+			hook: runcfg.Hook{Commands: []string{"plan"}},
+			cfg: runcfg.TerraformConfig{ExtraArgs: []runcfg.TerraformExtraArguments{
+				{
+					Commands:         []string{"plan"},
+					OptionalVarFiles: []string{optionalPresent, optionalPresent},
+				},
+			}},
+			expected: []string{"--var-file=" + optionalPresent},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := vfs.NewMemMapFS()
+			require.NoError(t, vfs.WriteFile(fs, optionalPresent, []byte("x = 1"), 0o644))
+
+			l := logger.CreateLogger()
+			actual, err := tflint.TFArgumentsToVar(l, fs, &tc.hook, &tc.cfg)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestConfigFilePath_ShortCircuitsOnConfigFlag(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	l := logger.CreateLogger()
+
+	got, err := tflint.ConfigFilePath(l, fs, &tflint.TFLintOptions{
+		WorkingDir:        "/work/unit",
+		RootWorkingDir:    "/work",
+		MaxFoldersToCheck: 5,
+	}, []string{"tflint", "--config", "/explicit/.tflint.hcl"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/explicit/.tflint.hcl", got)
+}
+
+func TestConfigFilePath_FallsBackToProjectWalk(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fs, "/work/.tflint.hcl", []byte("config {}"), 0o644))
+
+	l := logger.CreateLogger()
+
+	got, err := tflint.ConfigFilePath(l, fs, &tflint.TFLintOptions{
+		WorkingDir:        "/work/unit",
+		RootWorkingDir:    "/work",
+		MaxFoldersToCheck: 5,
+	}, []string{"tflint"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/work/.tflint.hcl", got)
+}
+
+func TestFindConfigInProject(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		wantErrType error
+		name        string
+		wantPath    string
+		seedFiles   []string
+		opts        tflint.TFLintOptions
+	}{
+		{
+			name:      "config in WorkingDir itself",
+			seedFiles: []string{"/work/unit/.tflint.hcl"},
+			opts: tflint.TFLintOptions{
+				WorkingDir:        "/work/unit",
+				RootWorkingDir:    "/work",
+				MaxFoldersToCheck: 3,
+			},
+			wantPath: "/work/unit/.tflint.hcl",
+		},
+		{
+			name:      "config two parents up",
+			seedFiles: []string{"/work/.tflint.hcl"},
+			opts: tflint.TFLintOptions{
+				WorkingDir:        "/work/a/b",
+				RootWorkingDir:    "/work",
+				MaxFoldersToCheck: 5,
+			},
+			wantPath: "/work/.tflint.hcl",
+		},
+		{
+			name:      "TerragruntConfigPath overrides WorkingDir as start",
+			seedFiles: []string{"/source/.tflint.hcl"},
+			opts: tflint.TFLintOptions{
+				WorkingDir:           "/cache/abc",
+				TerragruntConfigPath: "/source/unit/terragrunt.hcl",
+				RootWorkingDir:       "/source",
+				MaxFoldersToCheck:    5,
+			},
+			wantPath: "/source/.tflint.hcl",
+		},
+		{
+			name:      "walk exceeds MaxFoldersToCheck before reaching config",
+			seedFiles: []string{"/.tflint.hcl"},
+			opts: tflint.TFLintOptions{
+				WorkingDir:        "/a/b/c/d/e/f",
+				RootWorkingDir:    "/",
+				MaxFoldersToCheck: 2,
+			},
+			wantErrType: tflint.ConfigNotFound{},
+		},
+		{
+			name:      "no config anywhere - walks to root",
+			seedFiles: nil,
+			opts: tflint.TFLintOptions{
+				WorkingDir:        "/work/a/b",
+				RootWorkingDir:    "/work",
+				MaxFoldersToCheck: 50,
+			},
+			wantErrType: tflint.ConfigNotFound{},
+		},
+		{
+			name:      "MaxFoldersToCheck of zero returns ConfigNotFound immediately",
+			seedFiles: []string{"/work/unit/.tflint.hcl"},
+			opts: tflint.TFLintOptions{
+				WorkingDir:        "/work/unit",
+				RootWorkingDir:    "/work",
+				MaxFoldersToCheck: 0,
+			},
+			wantErrType: tflint.ConfigNotFound{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := vfs.NewMemMapFS()
+			for _, p := range tc.seedFiles {
+				require.NoError(t, vfs.WriteFile(fs, p, []byte("config {}"), 0o644))
+			}
+
+			l := logger.CreateLogger()
+
+			got, err := tflint.FindConfigInProject(l, fs, &tc.opts)
+			if tc.wantErrType != nil {
+				require.Error(t, err)
+
+				var notFound tflint.ConfigNotFound
+
+				assert.True(t, errors.As(err, &notFound), "expected ConfigNotFound, got %T", err)
+				assert.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPath, got)
+		})
+	}
+}
+
+func TestRunTflintWithOpts_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fs, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
+
+	var calls []vexec.Invocation
+
+	exec := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		calls = append(calls, cloneInvocation(&inv))
+
+		return vexec.Result{}
+	})
+
+	runErr := runWithOpts(t, fs, exec, &runcfg.Hook{
+		Name:     "tflint",
+		Commands: []string{"plan"},
+		Execute:  []string{"tflint"},
+	}, &runcfg.RunConfig{
+		Inputs: map[string]any{"region": "us-east-1"},
+		Terraform: runcfg.TerraformConfig{
+			ExtraArgs: []runcfg.TerraformExtraArguments{
+				{
+					Commands:  []string{"plan"},
+					Arguments: []string{"-var=foo=bar"},
+				},
+			},
+		},
+	})
+	require.NoError(t, runErr)
+
+	require.Len(t, calls, 2, "expected exactly init + lint subprocess calls")
+
+	// Both invocations name the tflint binary and are dispatched from RootWorkingDir.
+	assert.Equal(t, "tflint", calls[0].Name)
+	assert.Equal(t, "tflint", calls[1].Name)
+
+	// init call carries --init plus the resolved relative paths.
+	assert.Equal(t, []string{"--init", "--config", "./.tflint.hcl", "--chdir", "./unit"}, calls[0].Args)
+
+	// lint call: the fixed prefix is deterministic; --var/--var-file order is
+	// map-iteration dependent so check membership separately.
+	require.GreaterOrEqual(t, len(calls[1].Args), 5)
+	assert.Equal(t, []string{"--config", "./.tflint.hcl", "--chdir", "./unit"}, calls[1].Args[:4])
+	assert.Contains(t, calls[1].Args, "--var=region=us-east-1")
+	assert.Contains(t, calls[1].Args, "--var='foo=bar'")
+}
+
+func TestRunTflintWithOpts_StripsExternalTflintFlag(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fs, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
+
+	var calls []vexec.Invocation
+
+	exec := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		calls = append(calls, cloneInvocation(&inv))
+
+		return vexec.Result{}
+	})
+
+	require.NoError(t, runWithOpts(t, fs, exec, &runcfg.Hook{
+		Name:     "tflint",
+		Commands: []string{"plan"},
+		Execute:  []string{"tflint", "--terragrunt-external-tflint", "--minimum-failure-severity=warning"},
+	}, &runcfg.RunConfig{}))
+
+	require.Len(t, calls, 2)
+
+	for _, inv := range calls {
+		assert.NotContains(t, inv.Args, "--terragrunt-external-tflint",
+			"flag should not be forwarded to the tflint binary")
+	}
+
+	assert.Contains(t, calls[1].Args, "--minimum-failure-severity=warning")
+}
+
+func TestRunTflintWithOpts_InitFailureWraps(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fs, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
+
+	exec := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		if slices.Contains(inv.Args, "--init") {
+			return vexec.Result{ExitCode: 1, Stderr: []byte("init failed\n")}
+		}
+
+		return vexec.Result{}
+	})
+
+	err := runWithOpts(t, fs, exec, &runcfg.Hook{
+		Name:     "tflint",
+		Commands: []string{"plan"},
+		Execute:  []string{"tflint"},
+	}, &runcfg.RunConfig{})
+
+	require.Error(t, err)
+
+	var wrapped tflint.ErrorRunningTflint
+
+	require.True(t, errors.As(err, &wrapped), "expected ErrorRunningTflint, got %T", err)
+	assert.Contains(t, wrapped.Args, "--init")
+}
+
+func TestRunTflintWithOpts_LintFailureWraps(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fs, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
+
+	exec := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		if slices.Contains(inv.Args, "--init") {
+			return vexec.Result{}
+		}
+
+		return vexec.Result{ExitCode: 2, Stderr: []byte("3 issue(s) found\n")}
+	})
+
+	err := runWithOpts(t, fs, exec, &runcfg.Hook{
+		Name:     "tflint",
+		Commands: []string{"plan"},
+		Execute:  []string{"tflint"},
+	}, &runcfg.RunConfig{})
+
+	require.Error(t, err)
+
+	var wrapped tflint.ErrorRunningTflint
+
+	require.True(t, errors.As(err, &wrapped), "expected ErrorRunningTflint, got %T", err)
+	assert.NotContains(t, wrapped.Args, "--init")
+}
+
+func TestRunTflintWithOpts_MissingConfigSurfacesNotFound(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	exec := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		t.Fatal("subprocess invoked despite missing config")
+		return vexec.Result{}
+	})
+
+	err := runWithOpts(t, fs, exec, &runcfg.Hook{
+		Name:     "tflint",
+		Commands: []string{"plan"},
+		Execute:  []string{"tflint"},
+	}, &runcfg.RunConfig{})
+
+	require.Error(t, err)
+
+	var notFound tflint.ConfigNotFound
+
+	assert.True(t, errors.As(err, &notFound), "expected ConfigNotFound, got %T", err)
+}
+
+// runWithOpts wires the standard test fixture so each test does not have to
+// rebuild the same TFLintOptions and Venv.
+func runWithOpts(
+	t *testing.T,
+	fs vfs.FS,
+	exec vexec.Exec,
+	hook *runcfg.Hook,
+	cfg *runcfg.RunConfig,
+) error {
+	t.Helper()
+
+	opts := &tflint.TFLintOptions{
+		ShellOptions: shell.NewShellOptions().WithWriters(writer.Writers{
+			Writer:    io.Discard,
+			ErrWriter: io.Discard,
+		}),
+		Writers:           writer.Writers{Writer: io.Discard, ErrWriter: io.Discard},
+		WorkingDir:        "/work/unit",
+		RootWorkingDir:    "/work",
+		MaxFoldersToCheck: 5,
+	}
+
+	venv := tflint.Venv{Exec: exec, FS: fs}
+
+	l := logger.CreateLogger()
+
+	return tflint.RunTflintWithOpts(t.Context(), l, venv, opts, cfg, hook)
+}
+
+func cloneInvocation(inv *vexec.Invocation) vexec.Invocation {
+	return vexec.Invocation{
+		Name: inv.Name,
+		Dir:  inv.Dir,
+		Args: slices.Clone(inv.Args),
+		Env:  slices.Clone(inv.Env),
 	}
 }

--- a/internal/tflint/venv.go
+++ b/internal/tflint/venv.go
@@ -1,0 +1,26 @@
+package tflint
+
+import (
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+)
+
+// Venv is the virtualized environment passed to tflint operations. It
+// bundles the process-execution handle and the filesystem so callers
+// supply both per call rather than the tflint package holding them as
+// package-level state. The name avoids "Env" so it is not confused with
+// shell environment variables.
+type Venv struct {
+	// Exec runs the tflint binary. Tests can substitute a stub via
+	// [vexec.NewMemExec].
+	Exec vexec.Exec
+	// FS is the filesystem tflint reads through when searching for
+	// .tflint.hcl and filtering optional var-files.
+	FS vfs.FS
+}
+
+// OSVenv builds the production [Venv]: real OS process execution and the
+// real OS filesystem.
+func OSVenv() Venv {
+	return Venv{Exec: vexec.NewOSExec(), FS: vfs.NewOSFS()}
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Further propagating usage of `vfs` and `vexec`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests and new fuzz tests to improve hook and tflint behavior coverage.

* **Refactor**
  * Hook execution now runs in a shared, injectable execution/filesystem environment for more reliable and testable subprocess handling.
  * tflint integration and config discovery were refactored to use injected execution/filesystem abstractions, improving configurability and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6084?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->