### PR TITLE
docs: Changelog for #6085

### DIFF
--- a/docs/src/data/changelog/v1.0.5/run-report-writer-contention.mdx
+++ b/docs/src/data/changelog/v1.0.5/run-report-writer-contention.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.5"
+category: "bug-fixes"
+---
+
+#### Run report file generation no longer stalls or deadlocks with many runs
+
+Generating a run report via `--report-file` could stall or deadlock when a queue contained many runs and some were still recording their final status as the report was written.
+
+Reports now serialize each run independently, so writing a report no longer blocks status updates from runs that are still finishing.
+
+Thanks to [@jackiesre721](https://github.com/jackiesre721) for contributing this fix!


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Documents fix from #6085 in the changelog.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed run report generation stalling when using `--report-file` with many runs. Reports now serialize each run independently to prevent blocking final status updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6091)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->