### PR TITLE
fix: fix ZipSlip path traversal check returning nil in engine extract

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1119,54 +1119,57 @@ func extract(l log.Logger, zipFile, destDir string) error {
 
 	// Extract each file in the archive
 	for _, file := range r.File {
-		fPath := filepath.Join(destDir, file.Name)
-
-		// Check for ZipSlip vulnerability
-		if !strings.HasPrefix(fPath, filepath.Clean(destDir)+string(os.PathSeparator)) {
-			return errors.Errorf("zip archive contains path traversal: %q escapes target dir %q", file.Name, destDir)
-		}
-
-		if file.FileInfo().IsDir() {
-			// Create directories
-			if err := os.MkdirAll(fPath, file.Mode()); err != nil {
-				return errors.New(err)
-			}
-
-			continue
-		}
-
-		if err := os.MkdirAll(filepath.Dir(fPath), dirPerm); err != nil {
-			return errors.New(err)
-		}
-
-		outFile, err := os.OpenFile(fPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
-		if err != nil {
-			return errors.New(err)
-		}
-
-		defer func() {
-			if closeErr := outFile.Close(); closeErr != nil {
-				l.Warnf("warning: failed to close zip reader: %v", closeErr)
-			}
-		}()
-
-		rc, err := file.Open()
-		if err != nil {
-			return errors.New(err)
-		}
-
-		defer func() {
-			if closeErr := rc.Close(); closeErr != nil {
-				l.Warnf("warning: failed to close file reader: %v", closeErr)
-			}
-		}()
-
-		// Write file content
-		if _, err := io.Copy(outFile, rc); err != nil {
-			return errors.New(err)
+		if err := extractFile(l, destDir, dirPerm, file); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+// extractFile extracts a single file from a ZIP archive entry.
+func extractFile(l log.Logger, destDir string, dirPerm os.FileMode, file *zip.File) error {
+	fPath := filepath.Join(destDir, file.Name)
+
+	// Check for ZipSlip vulnerability
+	if !strings.HasPrefix(fPath, filepath.Clean(destDir)+string(os.PathSeparator)) {
+		return errors.Errorf("zip archive contains path traversal: %q escapes target dir %q", file.Name, destDir)
+	}
+
+	if file.FileInfo().IsDir() {
+		if err := os.MkdirAll(fPath, file.Mode()); err != nil {
+			return errors.New(err)
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(fPath), dirPerm); err != nil {
+		return errors.New(err)
+	}
+
+	outFile, err := os.OpenFile(fPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+	if err != nil {
+		return errors.New(err)
+	}
+	defer func() {
+		if closeErr := outFile.Close(); closeErr != nil {
+			l.Warnf("warning: failed to close extracted output file: %v", closeErr)
+		}
+	}()
+
+	rc, err := file.Open()
+	if err != nil {
+		return errors.New(err)
+	}
+	defer func() {
+		if closeErr := rc.Close(); closeErr != nil {
+			l.Warnf("warning: failed to close file reader: %v", closeErr)
+		}
+	}()
+
+	if _, err := io.Copy(outFile, rc); err != nil {
+		return errors.New(err)
+	}
 	return nil
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1123,7 +1123,7 @@ func extract(l log.Logger, zipFile, destDir string) error {
 
 		// Check for ZipSlip vulnerability
 		if !strings.HasPrefix(fPath, filepath.Clean(destDir)+string(os.PathSeparator)) {
-			return errors.New(err)
+			return errors.Errorf("zip archive contains path traversal: %q escapes target dir %q", file.Name, destDir)
 		}
 
 		if file.FileInfo().IsDir() {

--- a/internal/engine/extract_test.go
+++ b/internal/engine/extract_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestExtract_ZipSlipPathTraversal verifies that extract rejects ZIP archives
+// containing entries that traverse outside the target directory (ZipSlip attack).
 func TestExtract_ZipSlipPathTraversal(t *testing.T) {
 	t.Parallel()
 
@@ -36,6 +38,8 @@ func TestExtract_ZipSlipPathTraversal(t *testing.T) {
 		"error should mention path traversal, got: %v", err)
 }
 
+// TestExtract_ValidZip verifies that extract correctly extracts a well-formed
+// ZIP archive and produces the expected files on disk.
 func TestExtract_ValidZip(t *testing.T) {
 	t.Parallel()
 

--- a/internal/engine/extract_test.go
+++ b/internal/engine/extract_test.go
@@ -1,0 +1,63 @@
+package engine
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtract_ZipSlipPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+	zipPath := filepath.Join(t.TempDir(), "malicious.zip")
+
+	// Create a ZIP archive with a path traversal entry
+	f, err := os.Create(zipPath)
+	require.NoError(t, err)
+
+	w := zip.NewWriter(f)
+	// Entry that escapes the target directory
+	_, err = w.Create("../../etc/malicious")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+
+	l := log.New()
+	err = extract(l, zipPath, destDir)
+	require.Error(t, err, "extract should reject ZIP with path traversal entries")
+	assert.True(t, strings.Contains(err.Error(), "path traversal"),
+		"error should mention path traversal, got: %v", err)
+}
+
+func TestExtract_ValidZip(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+	zipPath := filepath.Join(t.TempDir(), "valid.zip")
+
+	f, err := os.Create(zipPath)
+	require.NoError(t, err)
+
+	w := zip.NewWriter(f)
+	writer, err := w.Create("subdir/hello.txt")
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("hello world"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+
+	l := log.New()
+	err = extract(l, zipPath, destDir)
+	require.NoError(t, err, "extract should succeed for valid ZIP")
+
+	data, err := os.ReadFile(filepath.Join(destDir, "subdir", "hello.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", string(data))
+}


### PR DESCRIPTION
## Summary

Fix multiple issues in `internal/engine/engine.go` `extract()` function.

### 1. ZipSlip check returns nil instead of actual error 

When the ZipSlip path traversal check detects a malicious entry, it calls `errors.New(err)` where `err` is `nil` (no OS error occurred — this is a validation failure). Due to the custom `errors` package (`internal/errors/errors.go`), `New(nil)` silently returns `nil`, causing the caller to believe extraction succeeded.

**Fix**: Replace `errors.New(err)` with `errors.Errorf(...)` that constructs an explicit error message.

### 2. Defer-in-loop causes file descriptor exhaustion 

The `defer outFile.Close()` and `defer rc.Close()` calls inside the `for` loop accumulate until `extract()` returns. For large ZIP archives with many entries, this can exhaust file descriptors.

**Fix**: Extract the loop body into a standalone `extractFile()` helper function so each `defer` executes when the helper returns, releasing resources promptly.

### 3. Incorrect log message 

The log message on `outFile.Close()` says `"failed to close zip reader"` but the actual resource being closed is the extracted output file.

**Fix**: Change to `"failed to close extracted output file"`.

## Test Plan

- [x] `TestExtract_ZipSlipPathTraversal` — verifies path traversal entries are rejected with a descriptive error
- [x] `TestExtract_ValidZip` — verifies well-formed ZIP archives extract correctly
- [x] `go build ./internal/engine/` — compiles without errors