### PR TITLE
fix: Fixing CAS symlink bug

### DIFF
--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -691,7 +691,15 @@ func (c *CAS) ensureBlob(ctx context.Context, runner *git.GitRunner, hash string
 		return err
 	}
 
-	if err = c.fs.Chmod(content.getPath(hash), gitPerm.Perm()&^WriteBitMask); err != nil {
+	// Symlink entries (git mode 120000) have no permission bits, but the blob
+	// stores the link target string and must stay readable so linkTree can
+	// resolve the symlink at materialization time.
+	storedPerm := gitPerm.Perm() &^ WriteBitMask
+	if storedPerm == 0 {
+		storedPerm = StoredFilePerms
+	}
+
+	if err = c.fs.Chmod(content.getPath(hash), storedPerm); err != nil {
 		return err
 	}
 

--- a/internal/cas/cas_test.go
+++ b/internal/cas/cas_test.go
@@ -126,6 +126,53 @@ func TestCAS_FallbackWhenGitStoreFails(t *testing.T) {
 	assert.False(t, info.IsDir(), "fallback should not have replaced the blocking file")
 }
 
+// TestCAS_CloneRepoWithSymlink pins the fix for the stored-blob permission
+// bug: a git symlink entry (mode 120000) has no unix permission bits, so the
+// permission-only view masks to 0. Without a fallback, the blob holding the
+// symlink target was chmodded unreadable, and materializing the symlink later
+// failed because linkTree could not read the target string.
+func TestCAS_CloneRepoWithSymlink(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile("real.txt", []byte("hello"), "add real.txt"))
+	require.NoError(t, srv.CommitSymlink("link.txt", "real.txt", "add symlink"))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+	targetPath := filepath.Join(tempDir, "repo")
+
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	err = c.Clone(t.Context(), logger.CreateLogger(), &cas.CloneOptions{
+		Dir:   targetPath,
+		Depth: -1,
+	}, repoURL)
+	require.NoError(t, err)
+
+	linkPath := filepath.Join(targetPath, "link.txt")
+
+	info, err := os.Lstat(linkPath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink, "link.txt is not a symlink (mode=%s)", info.Mode())
+
+	target, err := os.Readlink(linkPath)
+	require.NoError(t, err)
+	assert.Equal(t, "real.txt", target)
+
+	// Reading through the symlink exercises the stored-blob readability that
+	// the fix preserves: the target file is hard-linked from the CAS, and the
+	// symlink resolution had to read the symlink-blob's contents (the target
+	// string) from a stored blob whose permission bits derived from gitPerm=0.
+	data, err := os.ReadFile(linkPath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), data)
+}
+
 // TestCASRejectsNonOSFilesystem pins the early OS-filesystem gate
 // in [cas.New]: a non-OS backing must fail at construction.
 func TestCASRejectsNonOSFilesystem(t *testing.T) {

--- a/internal/git/server.go
+++ b/internal/git/server.go
@@ -94,6 +94,40 @@ func (s *Server) CommitFile(path string, data []byte, msg string) error {
 	return nil
 }
 
+// CommitSymlink creates a symlink in the worktree pointing at target and
+// commits it. The recorded tree entry is mode 120000 (git's symlink type),
+// matching the on-disk representation produced by `git add` on a symlink.
+func (s *Server) CommitSymlink(link, target, msg string) error {
+	w, err := s.repo.Worktree()
+	if err != nil {
+		return fmt.Errorf("worktree: %w", err)
+	}
+
+	if err := w.Filesystem.Symlink(target, link); err != nil {
+		return fmt.Errorf("symlink %s -> %s: %w", link, target, err)
+	}
+
+	if _, err := w.Add(link); err != nil {
+		return fmt.Errorf("add %s: %w", link, err)
+	}
+
+	sig := &object.Signature{
+		Name:  "Test",
+		Email: "test@test.com",
+		When:  time.Now(),
+	}
+
+	_, err = w.Commit(msg, &gogit.CommitOptions{
+		Author:    sig,
+		Committer: sig,
+	})
+	if err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	return nil
+}
+
 // Head returns the canonical hash of the current HEAD commit. Useful
 // in tests that need to capture a non-tip commit hash before adding
 // further commits.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6100.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed symlink handling in repository cloning by correcting file permission assignment for symlink entries, ensuring symlinks remain properly readable after materialization.

* **Tests**
  * Added test coverage validating symlink cloning functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6102)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->