### PR TITLE
docs: Updating changelog for `v1.0.5`

### DIFF
--- a/docs/src/data/changelog/v1.0.5/catalog-tags.mdx
+++ b/docs/src/data/changelog/v1.0.5/catalog-tags.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.0.4"
+version: "v1.0.5"
 category: "experiments-updated"
 ---
 

--- a/docs/src/data/changelog/v1.0.5/engine-zip-path-traversal.mdx
+++ b/docs/src/data/changelog/v1.0.5/engine-zip-path-traversal.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.5"
+category: "bug-fixes"
+---
+
+#### Engine archive extraction rejects path-traversal entries
+
+When Terragrunt extracted an engine archive while the `engine` experiment was active, entries whose target path resolved outside the extraction directory were not rejected correctly. Such an entry could overwrite files anywhere the Terragrunt process could write.
+
+These entries are now rejected early with a descriptive error before any bytes are written. Engine archives produced by Gruntwork were never affected; the gap only mattered for a tampered or untrusted archive.
+
+Thanks to [@jackiesre721](https://github.com/jackiesre721) for reporting this!

--- a/docs/src/data/changelog/v1.0.5/filter-negation-classification.mdx
+++ b/docs/src/data/changelog/v1.0.5/filter-negation-classification.mdx
@@ -1,0 +1,23 @@
+---
+version: "v1.0.5"
+category: "bug-fixes"
+---
+
+#### `--filter` combined with a negation no longer parses excluded units
+
+When a positive path filter was combined with a negated one, Terragrunt classified any unit that matched neither expression as requiring defensive parsing before exclusion instead of being excluded early. 
+
+e.g.
+
+```bash
+$ terragrunt run --all --filter './foo' --filter '!./baz'
+# If `./bar` existed on disk, it would be parsed before being excluded. This is no longer the case.
+```
+
+Any positive filepath filter now consistently results in units that cannot be discovered during Terragrunt discovery being excluded from parsing for evaluating candidacy of inclusion. When a sufficiently complex filter is present, like the following:
+
+```bash
+$ terragrunt run --all --filter './foo' --filter '!./baz' --filter 'reading=root.hcl'
+# If `./bar` existed on disk, it will still be parsed before being excluded to determine if it reads `root.hcl`.
+```
+


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Keeping `v1.0.5` changelog closer to ready for release.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog for v1.0.5 documenting a security fix for archive extraction path validation and a bug fix for filter negation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6103)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->