### PR TITLE
docs: Documenting hook exit code control

### DIFF
--- a/docs/src/content/docs/03-features/01-units/06-hooks.mdx
+++ b/docs/src/content/docs/03-features/01-units/06-hooks.mdx
@@ -231,6 +231,14 @@ terraform {
 This configuration will cause Terragrunt to output `Will run OpenTofu` and then `Running OpenTofu` before the call
 to OpenTofu/Terraform.
 
+## Hook exit codes
+
+Hooks control the exit code Terragrunt returns. If any `before_hook`, `after_hook`, or `error_hook` exits with a non-zero status, the `terragrunt` command exits with a non-zero status, even when the underlying `tofu`/`terraform` command succeeded.
+
+A failing `before_hook` short-circuits the run: Terragrunt does not invoke `tofu`/`terraform` at all, and does not run any `after_hook` whose `run_on_error` is not set.
+
+For example, suppose you run `terragrunt apply` on a unit with no `before_hook` and one `after_hook`. Terragrunt runs `tofu apply` and it returns `0`. Terragrunt then runs the `after_hook`, which returns `1`. The `terragrunt apply` command exits with `1`, even though `tofu apply` succeeded.
+
 ## Tflint hook
 
 _Before Hooks_ or _After Hooks_ natively support _tflint_, a linter for OpenTofu/Terraform code. It will validate the


### PR DESCRIPTION
## Description

Closes #4680

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for Hook exit codes, detailing how Terragrunt determines command exit status based on hook results and failure scenarios with concrete examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6106)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->