### PR TITLE
docs: Adding thanks for #6059

### DIFF
--- a/docs/src/data/changelog/v1.0.5/auto-init-marker-cached-modules.mdx
+++ b/docs/src/data/changelog/v1.0.5/auto-init-marker-cached-modules.mdx
@@ -8,3 +8,5 @@ category: "bug-fixes"
 `terragrunt plan`/`apply` could fail with `Error: Required plugins are not installed` after a source-version change in any unit with a `module ""` block. The `.terragrunt-init-required` marker written on source change was being ignored because `modulesNeedInit` short-circuited as soon as `.terraform/modules/` existed.
 
 The marker check now lives at the top of `needsInitRunCfg` and is honored regardless of cached `.terraform/modules/` contents.
+
+Thanks to [@arnaud-dezandee](https://github.com/arnaud-dezandee) for contributing this fix!


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds thanks for #6059

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v1.0.5 changelog to acknowledge a contributor for the auto-init behavior fix with cached modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6107)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->