### PR TITLE
chore: Improving local evaluation in stacks

### DIFF
--- a/internal/hclparse/errors.go
+++ b/internal/hclparse/errors.go
@@ -115,23 +115,17 @@ func (e LocalEvalError) Error() string {
 	return fmt.Sprintf("failed to evaluate local %q: %s", e.Name, e.Detail)
 }
 
-// LocalsCycleError indicates that locals have circular dependencies.
+// LocalsCycleError indicates that locals have circular dependencies. Names lists
+// every attribute that could not be evaluated, sorted. Edges maps each name to
+// its unresolved local-to-local dependencies so callers can reconstruct the
+// cycle without re-reading the source.
 type LocalsCycleError struct {
+	Edges map[string][]string
 	Names []string
 }
 
 func (e LocalsCycleError) Error() string {
 	return fmt.Sprintf("could not evaluate locals (possible cycle): %v", e.Names)
-}
-
-// LocalsMaxIterError indicates that locals evaluation exceeded the maximum iterations.
-type LocalsMaxIterError struct {
-	MaxIterations int
-	Remaining     int
-}
-
-func (e LocalsMaxIterError) Error() string {
-	return fmt.Sprintf("locals evaluation exceeded %d iterations with %d unresolved locals", e.MaxIterations, e.Remaining)
 }
 
 // MalformedDependencyError indicates a dependency block in an autoinclude file is malformed. Err optionally carries the original HCL diagnostics so callers can extract position info via errors.As/Is.

--- a/internal/hclparse/errors_test.go
+++ b/internal/hclparse/errors_test.go
@@ -29,7 +29,6 @@ func TestTypedErrors_Messages(t *testing.T) {
 		{name: "DirCreateError", err: hclparse.DirCreateError{DirPath: "/tmp/dir", Err: baseErr}, contains: "/tmp/dir"},
 		{name: "LocalEvalError", err: hclparse.LocalEvalError{Name: "env", Detail: "unknown var"}, contains: "env"},
 		{name: "LocalsCycleError", err: hclparse.LocalsCycleError{Names: []string{"a", "b"}}, contains: "[a b]"},
-		{name: "LocalsMaxIterError", err: hclparse.LocalsMaxIterError{MaxIterations: 100, Remaining: 5}, contains: "100"},
 	}
 
 	for _, tt := range tests {

--- a/internal/hclparse/parse.go
+++ b/internal/hclparse/parse.go
@@ -136,107 +136,226 @@ func ParseStackFile(fs vfs.FS, input *ParseStackFileInput) (*ParseResult, error)
 	}, nil
 }
 
-// evaluateLocals iteratively evaluates attributes from a locals block body.
-// Uses Variables() to pre-check whether each local's dependencies are satisfied
-// before attempting evaluation. Shrinks the work set each pass. Returns an error
-// if any locals cannot be evaluated (cycle or invalid reference).
+// evaluateLocals evaluates the attributes of a locals block in dependency order.
+//
+// The algorithm builds a DAG of local-to-local references from each attribute's
+// AST traversals, sorts it with Kahn's algorithm, and evaluates each attribute
+// once its dependencies have been resolved. evalCtx.Variables[varLocal] is
+// refreshed after every successful evaluation so later attributes resolve
+// against the cumulative result.
+//
+// References to other namespaces (unit, stack, values, feature, dependency, …)
+// are not edges in the graph: they are external to the locals block and must
+// already be populated in evalCtx by the caller. If they are missing or fail
+// to resolve, HCL's own diagnostics surface as LocalEvalError at evaluation time.
+//
+// Cycles among locals are reported as LocalsCycleError listing the participating
+// names and their remaining edges.
 func evaluateLocals(body hcl.Body, evalCtx *hcl.EvalContext) error {
 	syntaxBody, ok := body.(*hclsyntax.Body)
 	if !ok {
-		// Non-syntax bodies (e.g. from JSON configs) cannot be iteratively evaluated.
+		// Non-syntax bodies (e.g. from JSON configs) don't expose the AST we need
+		// to build the dependency graph; fall through silently rather than error.
 		return nil
 	}
 
-	remaining := make(map[string]*hclsyntax.Attribute, len(syntaxBody.Attributes))
-	for name, attr := range syntaxBody.Attributes {
-		remaining[name] = attr
+	attrs := syntaxBody.Attributes
+	if len(attrs) == 0 {
+		return nil
 	}
 
-	evaluated := make(map[string]cty.Value, len(remaining))
+	deps := buildLocalsGraph(attrs)
 
-	const maxLocalsIterations = 10000
-
-	for i := 0; len(remaining) > 0 && i < maxLocalsIterations; i++ {
-		progress, err := evaluateLocalsPass(remaining, evaluated, evalCtx)
-		if err != nil {
-			return err
-		}
-
-		if !progress {
-			return localsEvalCycleError(remaining)
-		}
-
-		evalCtx.Variables[varLocal] = cty.ObjectVal(evaluated)
-	}
-
-	if len(remaining) > 0 {
-		return LocalsMaxIterError{MaxIterations: maxLocalsIterations, Remaining: len(remaining)}
-	}
-
-	return nil
+	return evaluateLocalsInOrder(attrs, deps, evalCtx)
 }
 
-// evaluateLocalsPass attempts to evaluate all ready locals in a single pass.
-// Returns true if at least one local was evaluated.
-func evaluateLocalsPass(remaining map[string]*hclsyntax.Attribute, evaluated map[string]cty.Value, evalCtx *hcl.EvalContext) (bool, error) {
-	progress := false
+// buildLocalsGraph returns each attribute's set of sibling-local dependencies,
+// derived from `local.<name>` traversals in its expression AST. References to
+// non-sibling names (e.g. `local.<undefined>`) are deliberately ignored so HCL
+// can surface a precise diagnostic at eval time; only sibling-to-sibling edges
+// drive evaluation order.
+//
+// A traversal rooted at `local` with no static attribute step — for example
+// the bare reference `local` or a dynamic subscript like `local[expr]` — is
+// promoted to "depends on every sibling," guaranteeing the attribute is
+// evaluated last and observes the fully-populated local map (or surfaces a
+// cycle if every attribute does this).
+//
+// Dependencies are deduped and sorted so the evaluation order is deterministic.
+func buildLocalsGraph(attrs map[string]*hclsyntax.Attribute) map[string][]string {
+	deps := make(map[string][]string, len(attrs))
+	broadDeps := map[string]struct{}{}
 
-	for name, attr := range remaining {
-		if !canEvalLocal(attr, evaluated) {
-			continue
+	for name, attr := range attrs {
+		seen := map[string]struct{}{}
+
+		for _, traversal := range attr.Expr.Variables() {
+			if traversal.RootName() != varLocal {
+				continue
+			}
+
+			depName := firstAttrStep(traversal)
+			if depName == "" {
+				broadDeps[name] = struct{}{}
+
+				continue
+			}
+
+			if _, sibling := attrs[depName]; !sibling {
+				continue
+			}
+
+			if _, dup := seen[depName]; dup {
+				continue
+			}
+
+			seen[depName] = struct{}{}
+			deps[name] = append(deps[name], depName)
+		}
+	}
+
+	for name := range broadDeps {
+		existing := map[string]struct{}{}
+		for _, d := range deps[name] {
+			existing[d] = struct{}{}
 		}
 
-		val, diags := attr.Expr.Value(evalCtx)
+		for sib := range attrs {
+			if sib == name {
+				continue
+			}
+
+			if _, dup := existing[sib]; dup {
+				continue
+			}
+
+			deps[name] = append(deps[name], sib)
+		}
+	}
+
+	for name := range deps {
+		slices.Sort(deps[name])
+	}
+
+	return deps
+}
+
+// evaluateLocalsInOrder runs Kahn's algorithm over deps, evaluating each
+// attribute once its dependencies are resolved. evalCtx.Variables[varLocal]
+// is refreshed after every successful evaluation. Returns LocalsCycleError if
+// any attribute remains unresolved after the queue drains.
+func evaluateLocalsInOrder(
+	attrs map[string]*hclsyntax.Attribute,
+	deps map[string][]string,
+	evalCtx *hcl.EvalContext,
+) error {
+	inDegree := make(map[string]int, len(attrs))
+	dependents := make(map[string][]string, len(attrs))
+
+	for name := range attrs {
+		inDegree[name] = len(deps[name])
+
+		for _, d := range deps[name] {
+			dependents[d] = append(dependents[d], name)
+		}
+	}
+
+	ready := make([]string, 0, len(attrs))
+
+	for name, d := range inDegree {
+		if d == 0 {
+			ready = append(ready, name)
+		}
+	}
+
+	slices.Sort(ready)
+
+	evaluated := make(map[string]cty.Value, len(attrs))
+
+	for len(ready) > 0 {
+		name := ready[0]
+		ready = ready[1:]
+
+		val, diags := attrs[name].Expr.Value(evalCtx)
 		if diags.HasErrors() {
-			return false, LocalEvalError{Name: name, Detail: diags.Error()}
+			return LocalEvalError{Name: name, Detail: diags.Error()}
 		}
 
 		evaluated[name] = val
-		delete(remaining, name)
+		evalCtx.Variables[varLocal] = cty.ObjectVal(evaluated)
 
-		progress = true
+		var nextReady []string
+
+		for _, dep := range dependents[name] {
+			inDegree[dep]--
+			if inDegree[dep] == 0 {
+				nextReady = append(nextReady, dep)
+			}
+		}
+
+		if len(nextReady) > 0 {
+			slices.Sort(nextReady)
+			ready = append(ready, nextReady...)
+		}
 	}
 
-	return progress, nil
+	if len(evaluated) == len(attrs) {
+		return nil
+	}
+
+	return cycleErrorFor(attrs, deps, evaluated)
 }
 
-// localsEvalCycleError builds an error listing the locals that could not be evaluated.
-func localsEvalCycleError(remaining map[string]*hclsyntax.Attribute) error {
-	names := make([]string, 0, len(remaining))
-	for name := range remaining {
-		names = append(names, name)
+// cycleErrorFor builds a LocalsCycleError naming every attribute that did not
+// evaluate and surfacing the local→local edges that survived among them. The
+// edges help users locate the cycle without having to re-read the source.
+func cycleErrorFor(
+	attrs map[string]*hclsyntax.Attribute,
+	deps map[string][]string,
+	evaluated map[string]cty.Value,
+) error {
+	remaining := make([]string, 0, len(attrs)-len(evaluated))
+
+	for name := range attrs {
+		if _, ok := evaluated[name]; !ok {
+			remaining = append(remaining, name)
+		}
 	}
 
-	slices.Sort(names)
+	slices.Sort(remaining)
 
-	return LocalsCycleError{Names: names}
+	cycleDeps := make(map[string][]string, len(remaining))
+
+	for _, name := range remaining {
+		for _, d := range deps[name] {
+			if _, ok := evaluated[d]; ok {
+				continue
+			}
+
+			cycleDeps[name] = append(cycleDeps[name], d)
+		}
+
+		slices.Sort(cycleDeps[name])
+	}
+
+	return LocalsCycleError{Names: remaining, Edges: cycleDeps}
 }
 
-// canEvalLocal checks whether all local.* dependencies of an attribute
-// are already evaluated. Non-local references (unit, stack, values, etc.)
-// are assumed available in the eval context.
-func canEvalLocal(attr *hclsyntax.Attribute, evaluated map[string]cty.Value) bool {
-	for _, traversal := range attr.Expr.Variables() {
-		if traversal.RootName() != varLocal {
-			continue
-		}
-
-		split := traversal.SimpleSplit()
-		if len(split.Rel) == 0 {
-			continue
-		}
-
-		step, ok := split.Rel[0].(hcl.TraverseAttr)
-		if !ok {
-			continue
-		}
-
-		if _, exists := evaluated[step.Name]; !exists {
-			return false
-		}
+// firstAttrStep returns the name of the first TraverseAttr after the traversal
+// root, or the empty string if the traversal has no relative steps or the
+// first step is not an attribute access (e.g. dynamic subscript, splat).
+func firstAttrStep(traversal hcl.Traversal) string {
+	split := traversal.SimpleSplit()
+	if len(split.Rel) == 0 {
+		return ""
 	}
 
-	return true
+	step, ok := split.Rel[0].(hcl.TraverseAttr)
+	if !ok {
+		return ""
+	}
+
+	return step.Name
 }
 
 // AutoIncludeKey returns the map key for an autoinclude entry, namespaced by component kind to prevent collisions between same-name units and stacks.

--- a/internal/hclparse/parse_test.go
+++ b/internal/hclparse/parse_test.go
@@ -1,14 +1,17 @@
 package hclparse_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/hclparse"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 )
 
 const (
@@ -680,7 +683,532 @@ unit "vpc" {
 
 	var cycleErr hclparse.LocalsCycleError
 	require.ErrorAs(t, err, &cycleErr)
-	assert.Len(t, cycleErr.Names, 2)
+	assert.Equal(t, []string{"a", "b"}, cycleErr.Names)
+	assert.Equal(t, map[string][]string{
+		"a": {"b"},
+		"b": {"a"},
+	}, cycleErr.Edges)
+}
+
+// TestParseStackFile_LocalsThreeNodeCycle verifies that cycles longer than two
+// participants are surfaced with every member and edge intact.
+func TestParseStackFile_LocalsThreeNodeCycle(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+  a = local.b
+  b = local.c
+  c = local.a
+}
+
+unit "vpc" {
+  source = "../catalog/units/vpc"
+  path   = "vpc"
+}
+`
+
+	_, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{
+		Src:      []byte(src),
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.Error(t, err)
+
+	var cycleErr hclparse.LocalsCycleError
+	require.ErrorAs(t, err, &cycleErr)
+	assert.Equal(t, []string{"a", "b", "c"}, cycleErr.Names)
+	assert.Equal(t, map[string][]string{
+		"a": {"b"},
+		"b": {"c"},
+		"c": {"a"},
+	}, cycleErr.Edges)
+}
+
+// TestParseStackFile_LocalsSelfReference pins the self-reference behavior: an
+// attribute that depends on itself is a cycle of length 1.
+func TestParseStackFile_LocalsSelfReference(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+  a = local.a
+}
+
+unit "vpc" {
+  source = "../catalog/units/vpc"
+  path   = "vpc"
+}
+`
+
+	_, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{
+		Src:      []byte(src),
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.Error(t, err)
+
+	var cycleErr hclparse.LocalsCycleError
+	require.ErrorAs(t, err, &cycleErr)
+	assert.Equal(t, []string{"a"}, cycleErr.Names)
+	assert.Equal(t, map[string][]string{"a": {"a"}}, cycleErr.Edges)
+}
+
+// TestParseStackFile_LocalsCycleWithUnrelatedSiblings verifies that locals
+// outside the cycle still resolve and only the cycle members are reported.
+func TestParseStackFile_LocalsCycleWithUnrelatedSiblings(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+  ok_one  = "value-1"
+  ok_two  = local.ok_one
+  bad_one = local.bad_two
+  bad_two = local.bad_one
+}
+
+unit "vpc" {
+  source = "../catalog/units/vpc"
+  path   = "vpc"
+}
+`
+
+	_, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{
+		Src:      []byte(src),
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.Error(t, err)
+
+	var cycleErr hclparse.LocalsCycleError
+	require.ErrorAs(t, err, &cycleErr)
+	assert.Equal(t, []string{"bad_one", "bad_two"}, cycleErr.Names)
+	assert.Equal(t, map[string][]string{
+		"bad_one": {"bad_two"},
+		"bad_two": {"bad_one"},
+	}, cycleErr.Edges)
+}
+
+// TestParseStackFile_LocalsUnknownReference checks that referencing an
+// undefined sibling surfaces as a precise HCL evaluation error (via
+// LocalEvalError), not as a cycle.
+func TestParseStackFile_LocalsUnknownReference(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+  a = local.does_not_exist
+}
+
+unit "vpc" {
+  source = "../catalog/units/vpc"
+  path   = "vpc"
+}
+`
+
+	_, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{
+		Src:      []byte(src),
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.Error(t, err)
+
+	var evalErr hclparse.LocalEvalError
+	require.ErrorAs(t, err, &evalErr)
+	assert.Equal(t, "a", evalErr.Name)
+
+	var cycleErr hclparse.LocalsCycleError
+	assert.NotErrorAs(t, err, &cycleErr, "expected eval error, not cycle error")
+}
+
+// TestParseStackFile_LocalsLinearChain exercises deep dependency chains to
+// confirm the topological evaluator handles long paths without the iteration
+// cap the previous implementation relied on. A chain of 200 locals would have
+// stayed well under the cap, but encoding it as a single test makes the
+// expected ordering visible.
+func TestParseStackFile_LocalsLinearChain(t *testing.T) {
+	t.Parallel()
+
+	const depth = 200
+
+	var b strings.Builder
+
+	b.WriteString("locals {\n")
+	b.WriteString("  l0 = 1\n")
+
+	for i := 1; i < depth; i++ {
+		fmt.Fprintf(&b, "  l%d = local.l%d + 1\n", i, i-1)
+	}
+
+	b.WriteString("}\n\n")
+	b.WriteString("unit \"sink\" {\n")
+	b.WriteString("  source = \"../catalog/units/sink\"\n")
+	b.WriteString("  path   = \"sink\"\n\n")
+	b.WriteString("  autoinclude {\n")
+	b.WriteString("    dependency \"foo\" {\n")
+	b.WriteString("      config_path = \"../foo\"\n")
+	b.WriteString("    }\n\n")
+	fmt.Fprintf(&b, "    last_value = local.l%d\n", depth-1)
+	b.WriteString("  }\n}\n")
+
+	srcBytes := []byte(b.String())
+	fs := vfs.NewMemMapFS()
+
+	result, err := hclparse.ParseStackFile(fs, &hclparse.ParseStackFileInput{
+		Src:      srcBytes,
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.NoError(t, err)
+
+	resolved := result.AutoIncludes[hclparse.AutoIncludeKey("unit", "sink")]
+	require.NotNil(t, resolved)
+
+	sinkDir := filepath.Join(testStackDir, ".terragrunt-stack", "sink")
+	err = hclparse.GenerateAutoIncludeFile(fs, resolved, sinkDir, srcBytes, resolved.EvalCtx)
+	require.NoError(t, err)
+
+	generated, err := vfs.ReadFile(fs, filepath.Join(sinkDir, hclparse.AutoIncludeFile))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(generated), fmt.Sprintf("last_value = %d", depth))
+}
+
+// TestParseStackFile_LocalsDiamond verifies that diamond-shaped graphs (A -> B,
+// A -> C, B -> D, C -> D) evaluate cleanly without revisiting nodes.
+func TestParseStackFile_LocalsDiamond(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+  base   = "base"
+  left   = "${local.base}-left"
+  right  = "${local.base}-right"
+  merged = "${local.left}+${local.right}"
+}
+
+unit "app" {
+  source = "../catalog/units/app"
+  path   = "app"
+
+  autoinclude {
+    dependency "vpc" {
+      config_path = "../vpc"
+    }
+
+    merged_tag = local.merged
+  }
+}
+`
+	srcBytes := []byte(src)
+	fs := vfs.NewMemMapFS()
+
+	result, err := hclparse.ParseStackFile(fs, &hclparse.ParseStackFileInput{
+		Src:      srcBytes,
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.NoError(t, err)
+
+	resolved := result.AutoIncludes[hclparse.AutoIncludeKey("unit", "app")]
+	require.NotNil(t, resolved)
+
+	err = hclparse.GenerateAutoIncludeFile(fs, resolved, testGenDir, srcBytes, resolved.EvalCtx)
+	require.NoError(t, err)
+
+	generated, err := vfs.ReadFile(fs, filepath.Join(testGenDir, hclparse.AutoIncludeFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(generated), `"base-left+base-right"`)
+}
+
+// TestParseStackFile_LocalsDuplicateReference verifies that referencing the
+// same sibling more than once in a single expression doesn't inflate the
+// dependency count or affect evaluation.
+func TestParseStackFile_LocalsDuplicateReference(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+  base    = "base"
+  doubled = "${local.base}-${local.base}-${local.base}"
+}
+
+unit "app" {
+  source = "../catalog/units/app"
+  path   = "app"
+
+  autoinclude {
+    dependency "vpc" {
+      config_path = "../vpc"
+    }
+
+    tag = local.doubled
+  }
+}
+`
+	srcBytes := []byte(src)
+	fs := vfs.NewMemMapFS()
+
+	result, err := hclparse.ParseStackFile(fs, &hclparse.ParseStackFileInput{
+		Src:      srcBytes,
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.NoError(t, err)
+
+	resolved := result.AutoIncludes[hclparse.AutoIncludeKey("unit", "app")]
+	require.NotNil(t, resolved)
+
+	err = hclparse.GenerateAutoIncludeFile(fs, resolved, testGenDir, srcBytes, resolved.EvalCtx)
+	require.NoError(t, err)
+
+	generated, err := vfs.ReadFile(fs, filepath.Join(testGenDir, hclparse.AutoIncludeFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(generated), `"base-base-base"`)
+}
+
+// TestParseStackFile_LocalsReferenceValues exercises the caller-injected
+// `values` namespace inside a locals block. It is the closest analogue stack
+// files have today to how `feature.<name>.value` references resolve in the
+// broader Terragrunt locals pipeline: the namespace is supplied externally,
+// the DAG builder ignores it (no graph edge), and HCL reads it from the
+// evaluation context at eval time. The same shape will keep working when
+// feature blocks are extended into terragrunt.stack.hcl — the only change
+// needed is the caller populating evalCtx.Variables["feature"].
+func TestParseStackFile_LocalsReferenceValues(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+  env    = values.env
+  region = values.region
+  tag    = "${local.env}-${local.region}"
+}
+
+unit "app" {
+  source = "../catalog/units/app"
+  path   = "app"
+
+  autoinclude {
+    dependency "vpc" {
+      config_path = "../vpc"
+    }
+
+    name_tag = local.tag
+  }
+}
+`
+	srcBytes := []byte(src)
+	fs := vfs.NewMemMapFS()
+
+	values := cty.ObjectVal(map[string]cty.Value{
+		"env":    cty.StringVal("prod"),
+		"region": cty.StringVal("us-west-2"),
+	})
+
+	result, err := hclparse.ParseStackFile(fs, &hclparse.ParseStackFileInput{
+		Src:      srcBytes,
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+		Values:   &values,
+	})
+	require.NoError(t, err)
+
+	resolved := result.AutoIncludes[hclparse.AutoIncludeKey("unit", "app")]
+	require.NotNil(t, resolved)
+
+	err = hclparse.GenerateAutoIncludeFile(fs, resolved, testGenDir, srcBytes, resolved.EvalCtx)
+	require.NoError(t, err)
+
+	generated, err := vfs.ReadFile(fs, filepath.Join(testGenDir, hclparse.AutoIncludeFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(generated), `"prod-us-west-2"`)
+}
+
+// TestParseStackFile_LocalsMissingExternalNamespace verifies that referencing
+// a namespace the caller never populated (the same failure mode users would
+// see for an unwired feature block) surfaces as a LocalEvalError naming the
+// offending local, not as a cycle.
+func TestParseStackFile_LocalsMissingExternalNamespace(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+  oops = values.absent
+}
+
+unit "vpc" {
+  source = "../catalog/units/vpc"
+  path   = "vpc"
+}
+`
+
+	_, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{
+		Src:      []byte(src),
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.Error(t, err)
+
+	var evalErr hclparse.LocalEvalError
+	require.ErrorAs(t, err, &evalErr)
+	assert.Equal(t, "oops", evalErr.Name)
+
+	var cycleErr hclparse.LocalsCycleError
+	assert.NotErrorAs(t, err, &cycleErr, "missing external ref must not be reported as a cycle")
+}
+
+// TestParseStackFile_LocalsReferenceExternalNamespace confirms that locals
+// referencing a different namespace (here, unit.<name>.path) evaluate against
+// the eval context that the caller pre-populated, without being treated as
+// edges in the locals DAG. This is the same path that feature.* references
+// will take once feature blocks are wired into stack files.
+func TestParseStackFile_LocalsReferenceExternalNamespace(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+  vpc_path = unit.vpc.path
+}
+
+unit "vpc" {
+  source = "../catalog/units/vpc"
+  path   = "vpc"
+}
+
+unit "app" {
+  source = "../catalog/units/app"
+  path   = "app"
+
+  autoinclude {
+    dependency "vpc" {
+      config_path = local.vpc_path
+    }
+  }
+}
+`
+	srcBytes := []byte(src)
+	fs := vfs.NewMemMapFS()
+
+	result, err := hclparse.ParseStackFile(fs, &hclparse.ParseStackFileInput{
+		Src:      srcBytes,
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.NoError(t, err)
+
+	resolved := result.AutoIncludes[hclparse.AutoIncludeKey("unit", "app")]
+	require.NotNil(t, resolved)
+	require.Len(t, resolved.Dependencies, 1)
+	assert.Equal(t, filepath.Join(testStackDir, ".terragrunt-stack", "vpc"), resolved.Dependencies[0].ConfigPath)
+}
+
+// TestParseStackFile_LocalsBareLocalRoot pins the broad-dependency rule for
+// bare `local` references: because the graph builder can't tell statically
+// which sibling is being read, it forces the attribute to evaluate after every
+// other sibling so the value observed is the fully-populated local map. This
+// keeps the result independent of Go's randomized map iteration order.
+//
+// The test reads each sibling through the bare-`local` snapshot inside a
+// string interpolation, which the autoinclude generator fully evaluates and
+// emits as a literal. Seeing both values in the output proves both siblings
+// were resolved before the snapshot was taken.
+func TestParseStackFile_LocalsBareLocalRoot(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+  a     = "alpha"
+  z     = "zulu"
+  whole = local
+}
+
+unit "app" {
+  source = "../catalog/units/app"
+  path   = "app"
+
+  autoinclude {
+    dependency "vpc" {
+      config_path = "../vpc"
+    }
+
+    snapshot = "a=${local.whole.a};z=${local.whole.z}"
+  }
+}
+`
+	srcBytes := []byte(src)
+	fs := vfs.NewMemMapFS()
+
+	result, err := hclparse.ParseStackFile(fs, &hclparse.ParseStackFileInput{
+		Src:      srcBytes,
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.NoError(t, err)
+
+	resolved := result.AutoIncludes[hclparse.AutoIncludeKey("unit", "app")]
+	require.NotNil(t, resolved)
+
+	err = hclparse.GenerateAutoIncludeFile(fs, resolved, testGenDir, srcBytes, resolved.EvalCtx)
+	require.NoError(t, err)
+
+	generated, err := vfs.ReadFile(fs, filepath.Join(testGenDir, hclparse.AutoIncludeFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(generated), `"a=alpha;z=zulu"`)
+}
+
+// TestParseStackFile_LocalsBareLocalCycle confirms the broad-dependency rule
+// surfaces as a cycle when two or more attributes both reference bare `local`
+// (each demands the other be evaluated first).
+func TestParseStackFile_LocalsBareLocalCycle(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+  a = local
+  b = local
+}
+
+unit "vpc" {
+  source = "../catalog/units/vpc"
+  path   = "vpc"
+}
+`
+
+	_, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{
+		Src:      []byte(src),
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.Error(t, err)
+
+	var cycleErr hclparse.LocalsCycleError
+	require.ErrorAs(t, err, &cycleErr)
+	assert.Equal(t, []string{"a", "b"}, cycleErr.Names)
+}
+
+// TestParseStackFile_EmptyLocalsBlock makes sure an empty locals block — which
+// has no attributes to evaluate — is a no-op and not an error.
+func TestParseStackFile_EmptyLocalsBlock(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {
+}
+
+unit "vpc" {
+  source = "../catalog/units/vpc"
+  path   = "vpc"
+}
+`
+
+	result, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{
+		Src:      []byte(src),
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Units, 1)
 }
 
 func TestParseStackFile_MultipleLocals(t *testing.T) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adjusts locals evaluation so that we progressively work through locals based on the DAG of self referencing locals variables instead of naively iterating over the loop and seeing if we learned anything. Should make expensive locals blocks evaluate faster, avoids the heuristic of considering evaluation of a dependency chain that's too long as being a cycle and ensures that each local is evaluated once.  

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and reporting of circular dependencies among local variables with more detailed relationship information in error messages.
  * Enhanced robustness of local variable evaluation in complex dependency scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6108)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->