### PR TITLE
docs: Adding changelog entry for #6024

### DIFF
--- a/docs/src/data/changelog/v1.0.5/download-dir-dependency-blocks.mdx
+++ b/docs/src/data/changelog/v1.0.5/download-dir-dependency-blocks.mdx
@@ -1,0 +1,18 @@
+---
+version: "v1.0.5"
+category: "bug-fixes"
+---
+
+#### `--download-dir` is now respected through `dependency` blocks and `read_terragrunt_config`
+
+A custom download directory set via `--download-dir` (or `TG_DOWNLOAD_DIR`) was honored for the unit being run, but lost as soon as parsing crossed into another config. `dependency` blocks and `read_terragrunt_config()` would fall back to the dependency's local `.terragrunt-cache` next to its `terragrunt.hcl`, ignoring the user-set path.
+
+```sh
+TG_DOWNLOAD_DIR=/tmp/tg-cache terragrunt run --all plan
+# Root unit: outputs landed in /tmp/tg-cache ✓
+# Dependency outputs: written next to each dependency's terragrunt.hcl ✗
+```
+
+When the parsing context switches to a new config path, the download directory is now updated only if it still points at the previous module's default location. A user-supplied path never matches any module's default and is carried through every dependency hop unchanged.
+
+Thanks to [@maonat](https://github.com/maonat) for contributing this fix!


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds changelog entry for #6024

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `--download-dir` (and `TG_DOWNLOAD_DIR` environment variable) to be properly honored across dependency blocks and configuration path switches, ensuring consistent download directory usage instead of reverting to local cache directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6110)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->