### PR TITLE
docs: Re-organizing content related to the run queue out of stack documentation

### DIFF
--- a/docs/src/content/docs/03-features/02-stacks/04-stack-operations.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/04-stack-operations.mdx
@@ -1,6 +1,6 @@
 ---
 title: Stack Operations
-description: Work with dependencies, visualize the DAG, control parallelism, and manage stack runs.
+description: Pass outputs between units, declare dependencies, test units locally, and structure nested stacks.
 slug: features/stacks/stack-operations
 sidebar:
   order: 4
@@ -373,28 +373,6 @@ This is because Terragrunt knows that once resources in a dependency are destroy
 For example, if `destroy` was called on the `Valkey` unit, you'd be asked for confirmation, as the `backend-app` depends on `Valkey`. You can suppress the prompt by using the `--non-interactive` flag.
 </Aside>
 
-## Visualizing the DAG
-
-To visualize the dependency graph you can use the `dag graph` command (similar to the `tofu/terraform graph` command), or its equivalent `list --format=dot --dependencies --external` command.
-
-The graph is output in DOT format. The typical program used to render this file format is GraphViz, but many web services are available that can do this as well.
-
-```bash
-terragrunt dag graph | dot -Tsvg > graph.svg
-# Or equivalently:
-terragrunt list --format=dot --dependencies --external | dot -Tsvg > graph.svg
-```
-
-The example above generates the following graph:
-
-![terragrunt dag graph](../../../../assets/img/collections/documentation/graph.png)
-
-Note that this graph shows the dependency relationship in the direction of the arrow, with the tip pointing to the dependency (e.g. `frontend-app` depends on `backend-app`).
-
-For plans and applies, Terragrunt will run units in the opposite direction, however (e.g. `backend-app` would be applied before `frontend-app`).
-
-The exception to this rule is during the `destroy` (and `plan/apply -destroy`) commands, where Terragrunt will run in the direction of the arrow (e.g. `frontend-app` would be destroyed before `backend-app`).
-
 ## Testing multiple units locally
 
 If you are using Terragrunt to download [remote OpenTofu/Terraform modules](/features/units/#remote-opentofuterraform-modules) and all of your units have the `source` parameter set to a Git URL, but you want to test with a local checkout of the code, you can use the `--source` parameter to override that value:
@@ -428,138 +406,6 @@ terragrunt run --all --source /source/infrastructure-modules -- apply
 ```
 
 Will result in a unit with the configuration for the source above being resolved to `/source/infrastructure-modules//networking/vpc`.
-
-## Limiting run parallelism
-
-By default, Terragrunt will not impose a limit on the number of units it executes when it traverses the dependency graph,
-meaning that if it finds 5 units without dependencies, it'll run OpenTofu/Terraform 5 times in parallel, once in each unit.
-
-Sometimes, this can create a problem if there are a lot of units in the dependency graph, like hitting a rate limit on a
-cloud provider.
-
-To limit the maximum number of unit executions at any given time use the `--parallelism [number]` flag
-
-```sh
-terragrunt run --all --parallelism 4 -- apply
-```
-
-## Limiting stack output parallelism
-
-`terragrunt stack output` reads unit outputs in parallel. Use the same `--parallelism` flag to lower concurrency if a large stack hits resource limits (for example, file descriptors or cloud-provider rate limits):
-
-```sh
-terragrunt stack output --parallelism 4
-```
-
-## Saving OpenTofu/Terraform plan output
-
-A powerful feature of OpenTofu/Terraform is the ability to save the result of a plan as a binary file using the [-out flag](https://opentofu.org/docs/cli/commands/plan/).
-
-Terragrunt provides special tooling in `run --all` execution to ensure that the saved plan for a `run --all` against a stack has
-a corresponding entry for each unit in the stack in a directory structure that mirrors the stack structure.
-
-To save every plan generated when running a stack, use the `--out-dir` flag (or `TG_OUT_DIR` environment variable) as demonstrated below:
-
-```bash
-$ terragrunt run --all --out-dir /tmp/tfplan -- plan
-```
-
-<FileTree>
-
-- app1
-  - tfplan.tfplan
-- app2
-  - tfplan.tfplan
-- app3
-  - tfplan.tfplan
-- project-2
-  - project-2-app1
-    - tfplan.tfplan
-
-</FileTree>
-
-This integration also exists for the `apply` command, where the generated plan will be used when performing the apply.
-
-```bash
-$ terragrunt run --all --out-dir /tmp/tfplan -- apply
-```
-
-<Aside type="note">
-
-Performing a `run --all --out-dir <dir> -- apply` requires that a plan already exists for each unit in the stack.
-If a plan is missing for any unit, the command will fail.
-
-If a plan job was scoped with `--filter`, you must pass the **same** `--filter` to the apply so the apply discovery set matches the artifact contents. For example:
-
-```bash
-# Plan `<unit>` and its dependencies:
-terragrunt run --all --filter '<unit>...' --out-dir /tmp/tfplan -- plan
-
-# Apply must reuse the same filter:
-terragrunt run --all --filter '<unit>...' --out-dir /tmp/tfplan -- apply
-```
-
-</Aside>
-
-For planning a destroy operation, use the following commands:
-
-```bash
-terragrunt run --all --out-dir /tmp/tfplan -- plan -destroy
-terragrunt run --all --out-dir /tmp/tfplan -- apply
-```
-
-<Aside type="caution">
-
-If you are leveraging [mock outputs](#unapplied-dependency-and-mock-outputs) in your stack, you may get unexpected results when applying saved plans, as the plans will have mock outputs in them.
-
-There's a workaround documented [here](https://github.com/gruntwork-io/terragrunt/issues/2178#issuecomment-2615842856), but no first-class feature in Terragrunt to address this issue, currently.
-
-If you would like Terragrunt to have first-class support for a solution to this, please [create an RFC](https://github.com/gruntwork-io/terragrunt/issues/new?template=03-rfc.yml) to propose it.
-
-</Aside>
-
-To save plans in json format use the `--json-out-dir` flag:
-
-```bash
-terragrunt run --all --json-out-dir /tmp/json -- plan
-```
-
-<FileTree>
-
-- app1
-  - tfplan.json
-- app2
-  - tfplan.json
-- app3
-  - tfplan.json
-- project-2
-  - project-2-app1
-    - tfplan.json
-
-</FileTree>
-
-
-```bash
-terragrunt run --all --out-dir /tmp/all --json-out-dir /tmp/all -- plan
-```
-
-<FileTree>
-
-- app1
-  - tfplan.json
-  - tfplan.tfplan
-- app2
-  - tfplan.json
-  - tfplan.tfplan
-- app3
-  - tfplan.json
-  - tfplan.tfplan
-- project-2
-  - project-2-app1
-    - tfplan.json
-    - tfplan.tfplan
-
-</FileTree>
 
 ## Nested Stacks
 

--- a/docs/src/content/docs/03-features/02-stacks/06-run-queue.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/06-run-queue.mdx
@@ -77,6 +77,26 @@ Assuming a current working directory of the `root` directory, Terragrunt would r
 -   **`run --all plan` Order:** Terragrunt would run `independent` and `ancestor-dependency` concurrently. Once `ancestor-dependency` finishes, `dependency` would run. Once `dependency` finishes, `dependent` would run.
 -   **`run --all destroy` Order:** Terragrunt would run `dependent` and `independent` concurrently. Once `dependent` finishes, `dependency` would run. Once `dependency` finishes, `ancestor-dependency` would run.
 
+### Visualizing the DAG
+
+To visualize the dependency graph you can use the `dag graph` command (similar to the `tofu/terraform graph` command), or its equivalent `list --format=dot --dependencies --external` command.
+
+The graph is output in DOT format. The typical program used to render this file format is GraphViz, but many web services are available that can do this as well.
+
+```bash
+terragrunt dag graph | dot -Tsvg > graph.svg
+# Or equivalently:
+terragrunt list --format=dot --dependencies --external | dot -Tsvg > graph.svg
+```
+
+For a stack with `frontend-app`, `backend-app`, `mysql`, `valkey`, and `vpc` units (where `frontend-app` depends on `backend-app` and `vpc`, `backend-app` depends on `mysql`/`valkey`/`vpc`, and `mysql`/`valkey` depend on `vpc`), the rendered graph looks like:
+
+![terragrunt dag graph](../../../../assets/img/collections/documentation/graph.png)
+
+The arrow points from a unit to its dependency (e.g. `frontend-app` depends on `backend-app`).
+
+For `plan` and `apply`, Terragrunt runs units in the opposite direction of the arrow (e.g. `backend-app` is applied before `frontend-app`). For `destroy` (and `plan/apply -destroy`), Terragrunt runs in the direction of the arrow (e.g. `frontend-app` is destroyed before `backend-app`).
+
 ## Controlling the Queue
 
 Several flags allow you to customize how Terragrunt builds and executes the run queue. By default, Terragrunt will include all units that are in the current working directory.
@@ -184,6 +204,135 @@ This will tell Terragrunt to run all units in the directory `subtree` except tho
   <Aside type="tip">
   This flag is useful when you want to fail the run as soon as any unit fails, and stop running any more units.
   </Aside>
+
+### Limiting run parallelism
+
+By default, Terragrunt does not impose a limit on the number of units it executes when it traverses the dependency graph. If it finds 5 units without dependencies, it runs OpenTofu/Terraform 5 times in parallel, once in each unit.
+
+This can create problems when a graph has many units, like hitting a cloud provider's rate limit.
+
+Use the `--parallelism [number]` flag to cap the maximum number of unit executions at any given time:
+
+```sh
+terragrunt run --all --parallelism 4 -- apply
+```
+
+### Limiting stack output parallelism
+
+`terragrunt stack output` reads unit outputs in parallel. Use the same `--parallelism` flag to lower concurrency if a large stack hits resource limits (for example, file descriptors or cloud-provider rate limits):
+
+```sh
+terragrunt stack output --parallelism 4
+```
+
+## Saving OpenTofu/Terraform plan output
+
+A powerful feature of OpenTofu/Terraform is the ability to save the result of a plan as a binary file using the [-out flag](https://opentofu.org/docs/cli/commands/plan/).
+
+Terragrunt provides special tooling in `run --all` execution to ensure that the saved plan for a `run --all` against a stack has a corresponding entry for each unit in the stack in a directory structure that mirrors the stack structure.
+
+To save every plan generated when running a stack, use the `--out-dir` flag (or `TG_OUT_DIR` environment variable) as demonstrated below:
+
+```bash
+$ terragrunt run --all --out-dir /tmp/tfplan -- plan
+```
+
+<FileTree>
+
+- app1
+  - tfplan.tfplan
+- app2
+  - tfplan.tfplan
+- app3
+  - tfplan.tfplan
+- project-2
+  - project-2-app1
+    - tfplan.tfplan
+
+</FileTree>
+
+This integration also exists for the `apply` command, where the generated plan will be used when performing the apply.
+
+```bash
+$ terragrunt run --all --out-dir /tmp/tfplan -- apply
+```
+
+<Aside type="note">
+
+Performing a `run --all --out-dir <dir> -- apply` requires that a plan already exists for each unit in the stack.
+If a plan is missing for any unit, the command will fail.
+
+If a plan job was scoped with `--filter`, you must pass the **same** `--filter` to the apply so the apply discovery set matches the artifact contents. For example:
+
+```bash
+# Plan `<unit>` and its dependencies:
+terragrunt run --all --filter '<unit>...' --out-dir /tmp/tfplan -- plan
+
+# Apply must reuse the same filter:
+terragrunt run --all --filter '<unit>...' --out-dir /tmp/tfplan -- apply
+```
+
+</Aside>
+
+For planning a destroy operation, use the following commands:
+
+```bash
+terragrunt run --all --out-dir /tmp/tfplan -- plan -destroy
+terragrunt run --all --out-dir /tmp/tfplan -- apply
+```
+
+<Aside type="caution">
+
+If you are leveraging [mock outputs](/features/stacks/stack-operations#unapplied-dependency-and-mock-outputs) in your stack, you may get unexpected results when applying saved plans, as the plans will have mock outputs in them.
+
+There's a workaround documented [here](https://github.com/gruntwork-io/terragrunt/issues/2178#issuecomment-2615842856), but no first-class feature in Terragrunt to address this issue, currently.
+
+If you would like Terragrunt to have first-class support for a solution to this, please [create an RFC](https://github.com/gruntwork-io/terragrunt/issues/new?template=03-rfc.yml) to propose it.
+
+</Aside>
+
+To save plans in json format use the `--json-out-dir` flag:
+
+```bash
+terragrunt run --all --json-out-dir /tmp/json -- plan
+```
+
+<FileTree>
+
+- app1
+  - tfplan.json
+- app2
+  - tfplan.json
+- app3
+  - tfplan.json
+- project-2
+  - project-2-app1
+    - tfplan.json
+
+</FileTree>
+
+
+```bash
+terragrunt run --all --out-dir /tmp/all --json-out-dir /tmp/all -- plan
+```
+
+<FileTree>
+
+- app1
+  - tfplan.json
+  - tfplan.tfplan
+- app2
+  - tfplan.json
+  - tfplan.tfplan
+- app3
+  - tfplan.json
+  - tfplan.tfplan
+- project-2
+  - project-2-app1
+    - tfplan.json
+    - tfplan.tfplan
+
+</FileTree>
 
 ## Important Considerations
 

--- a/docs/src/data/changelog/v1.0.8/run-queue-content-reorganized.mdx
+++ b/docs/src/data/changelog/v1.0.8/run-queue-content-reorganized.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.0.7"
+category: "documentation-updates"
+---
+
+#### Run queue content reorganized
+
+Documentation for visualizing the DAG, limiting `--all` parallelism, and saving plan output now lives on the [Run Queue](/features/stacks/run-queue) page. These sections previously sat under [Stack Operations](/features/stacks/stack-operations) but they describe behavior of the run queue itself rather than stack-specific concepts.

--- a/docs/src/data/flags/json-out-dir.mdx
+++ b/docs/src/data/flags/json-out-dir.mdx
@@ -40,6 +40,6 @@ terragrunt run --all --out-dir /tmp/all --json-out-dir /tmp/all plan
 terragrunt run --all --out-dir /tmp/plan --json-out-dir /tmp/json plan
 ```
 
-See the [Stacks](/features/stacks/stack-operations#saving-opentofuterraform-plan-output) docs for more usage examples.
+See the [Run Queue](/features/stacks/run-queue#saving-opentofuterraform-plan-output) docs for more usage examples.
 
 

--- a/docs/src/data/flags/out-dir.mdx
+++ b/docs/src/data/flags/out-dir.mdx
@@ -31,7 +31,7 @@ Specifies where Terragrunt writes native OpenTofu/Terraform plan files for each 
 `--out-dir` controls **where** Terragrunt reads and writes per-unit plan files, but it does **not** restrict which units `run --all apply` discovers. If your plan was scoped with `--filter`, you must reuse the same `--filter` on
 `apply` — otherwise Terragrunt will discover unfiltered units, fail to find their plan files in `--out-dir`, and error out.
 
-See [Saving OpenTofu/Terraform plan output](https://docs.terragrunt.com/features/stacks/stack-operations/#saving-opentofuterraform-plan-output) for the full plan-then-apply pattern.
+See [Saving OpenTofu/Terraform plan output](/features/stacks/run-queue#saving-opentofuterraform-plan-output) for the full plan-then-apply pattern.
 
 </Aside>
 
@@ -45,6 +45,6 @@ terragrunt run --all plan --out-dir /tmp/tfplan
 terragrunt run --all apply --out-dir /tmp/tfplan
 ```
 
-See the [Stacks](/features/stacks/stack-operations#saving-opentofuterraform-plan-output) docs for more usage examples.
+See the [Run Queue](/features/stacks/run-queue#saving-opentofuterraform-plan-output) docs for more usage examples.
 
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #4762.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized stack operations and run queue docs for clearer navigation.
  * Removed outdated “Stack Operations” content and relocated the following guidance to the Run Queue page: DAG visualization, parallelism limiting (`--parallelism`) for concurrent runs and stack output, and saving OpenTofu/Terraform plan artifacts during `run --all` (including `--out-dir`/`TG_OUT_DIR` and `--json-out-dir`).
  * Updated internal links and clarified plan/apply vs. destroy execution ordering and arrow direction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->