### PR TITLE
fix: add mutex protection for Config/StoreConfig in Unit

### DIFF
--- a/internal/component/component_test.go
+++ b/internal/component/component_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -204,6 +205,72 @@ func TestThreadSafeComponentsFindByPath(t *testing.T) {
 	// Find non-existent path
 	notFound := tsc.FindByPath("/nonexistent")
 	assert.Nil(t, notFound, "should not find non-existent path")
+}
+
+func TestUnitConfigConcurrentReadWrite(t *testing.T) {
+	t.Parallel()
+
+	unit := component.NewUnit("/test/unit")
+
+	source := "git::https://example.com/repo.git?ref=main"
+
+	cfg := &config.TerragruntConfig{
+		Terraform: &config.TerraformConfig{
+			Source: &source,
+		},
+	}
+
+	var wg sync.WaitGroup
+
+	const writers = 5
+	const readers = 10
+	const iterations = 200
+
+	// Writers: concurrently store config via StoreConfig and WithConfig
+	for i := range writers {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			for range iterations {
+				if i%2 == 0 {
+					unit.StoreConfig(cfg)
+				} else {
+					unit.WithConfig(cfg)
+				}
+			}
+		}(i)
+	}
+
+	// Readers: concurrently read config via Config and Sources
+	for i := range readers {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			for range iterations {
+				if i%2 == 0 {
+					_ = unit.Config()
+				} else {
+					_ = unit.Sources()
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify final state is consistent
+	finalCfg := unit.Config()
+	require.NotNil(t, finalCfg)
+	require.NotNil(t, finalCfg.Terraform)
+	assert.Equal(t, source, *finalCfg.Terraform.Source)
+
+	sources := unit.Sources()
+	assert.Len(t, sources, 1)
+	assert.Equal(t, source, sources[0])
 }
 
 func TestThreadSafeComponentsConcurrentAccess(t *testing.T) {

--- a/internal/component/unit.go
+++ b/internal/component/unit.go
@@ -51,6 +51,9 @@ func (u *Unit) WithReading(files ...string) *Unit {
 
 // WithConfig adds configuration to a Unit component.
 func (u *Unit) WithConfig(cfg *config.TerragruntConfig) *Unit {
+	u.lock()
+	defer u.unlock()
+
 	u.cfg = cfg
 
 	return u
@@ -65,11 +68,17 @@ func (u *Unit) WithDiscoveryContext(ctx *DiscoveryContext) *Unit {
 
 // Config returns the parsed Terragrunt configuration for this unit.
 func (u *Unit) Config() *config.TerragruntConfig {
+	u.rLock()
+	defer u.rUnlock()
+
 	return u.cfg
 }
 
 // StoreConfig stores the parsed Terragrunt configuration for this unit.
 func (u *Unit) StoreConfig(cfg *config.TerragruntConfig) {
+	u.lock()
+	defer u.unlock()
+
 	u.cfg = cfg
 }
 
@@ -130,6 +139,9 @@ func (u *Unit) SetReading(files ...string) {
 
 // Sources returns the list of sources for this component.
 func (u *Unit) Sources() []string {
+	u.rLock()
+	defer u.rUnlock()
+
 	if u.cfg == nil || u.cfg.Terraform == nil || u.cfg.Terraform.Source == nil {
 		return []string{}
 	}


### PR DESCRIPTION
## Description

`Config()`, `StoreConfig()`, `WithConfig()`, and `Sources()` in `internal/component/unit.go` access `u.cfg` without holding the unit's `sync.RWMutex`. During parallel execution (e.g. `run --all`), one goroutine can write `cfg` via `StoreConfig()` while another reads it via `Config()` / `Sources()`, causing a **data race** detectable by the Go race detector.

All other mutable fields in `Unit` (`dependencies`, `dependents`) already use `lock`/`rLock` for concurrent access. This change brings `cfg` in line with the same pattern.

## Changes

| Method | Access | Lock Added |
|--------|--------|------------|
| `Config()` | reads `u.cfg` | `rLock` / `rUnlock` |
| `StoreConfig()` | writes `u.cfg` | `lock` / `unlock` |
| `WithConfig()` | writes `u.cfg` | `lock` / `unlock` |
| `Sources()` | reads `u.cfg` | `rLock` / `rUnlock` |

## Testing

- `go vet ./internal/component/...` — pass
- `golangci-lint run ./internal/component/...` — pass (no new warnings)

## Context

This follows the existing locking pattern already established for `Dependencies()`, `Dependents()`, `ensureDependency()`, and `ensureDependent()` in the same file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved thread-safety to enhance reliability and stability during concurrent operations.
* **Tests**
  * Added a new concurrency test to validate consistent configuration and source behavior under concurrent reads/writes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->