### PR TITLE
fix: support tfr:// module sources in terragrunt scaffold

### DIFF
--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -197,7 +197,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, mod
 	if err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "scaffold_get_module", map[string]any{
 		"module_url": moduleURL,
 	}, func(ctx context.Context) error {
-		if _, getErr := getter.GetAny(ctx, tempDir, moduleURL); getErr != nil {
+		if _, getErr := getter.GetAny(ctx, tempDir, moduleURL, getter.WithTFRegistry(getter.NewRegistryGetter(l))); getErr != nil {
 			return fmt.Errorf("downloading scaffold module from %s: %w", moduleURL, getErr)
 		}
 
@@ -292,6 +292,25 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, mod
 func BuildSourceURL(originalURL, resolvedURL string, vars map[string]any) string {
 	if value, found := vars[sourceURLTypeVar]; found && fmt.Sprintf("%s", value) == sourceURLTypeGit {
 		return resolvedURL
+	}
+
+	// For tfr:// URLs, version is carried in the ?version= query param rather than ?ref=
+	if strings.HasPrefix(originalURL, "tfr://") {
+		versionVal := ExtractQueryParam(resolvedURL, getter.VersionQueryKey)
+		if versionVal == "" {
+			return originalURL
+		}
+
+		base, rawQuery := splitURLQuery(originalURL)
+
+		params, err := url.ParseQuery(rawQuery)
+		if err != nil || params.Has(getter.VersionQueryKey) {
+			return originalURL
+		}
+
+		params.Set(getter.VersionQueryKey, versionVal)
+
+		return base + "?" + params.Encode()
 	}
 
 	refVal := ExtractQueryParam(resolvedURL, refParam)
@@ -436,7 +455,7 @@ func downloadTemplate(
 	if err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "scaffold_get_template", map[string]any{
 		"template_url": baseURL.String(),
 	}, func(ctx context.Context) error {
-		if _, getErr := getter.GetAny(ctx, templateDir, baseURL.String()); getErr != nil {
+		if _, getErr := getter.GetAny(ctx, templateDir, baseURL.String(), getter.WithTFRegistry(getter.NewRegistryGetter(l))); getErr != nil {
 			return fmt.Errorf("downloading scaffold template from %s: %w", baseURL.String(), getErr)
 		}
 
@@ -562,10 +581,12 @@ func parseModuleURL(
 
 	moduleURL = parsedModuleURL.String()
 
-	// rewrite module url, if required
-	parsedModuleURL, err = rewriteModuleURL(l, opts, vars, moduleURL)
-	if err != nil {
-		return "", errors.New(err)
+	// rewrite module url, if required (tfr:// URLs are passed through unchanged)
+	if parsedModuleURL.Scheme != "tfr" {
+		parsedModuleURL, err = rewriteModuleURL(l, opts, vars, moduleURL)
+		if err != nil {
+			return "", errors.New(err)
+		}
 	}
 
 	// add ref to module url, if required
@@ -685,21 +706,37 @@ func addRefToModuleURL(
 	}
 
 	ref := params.Get(refParam)
+	// For tfr:// URLs, version is passed as ?version= not ?ref=
+	if ref == "" && moduleURL.Scheme == "tfr" {
+		ref = params.Get(getter.VersionQueryKey)
+	}
+
 	if ref == "" {
-		// if ref is not passed, find last release tag
-		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
-		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8
 		rootSourceURL, _, err := tf.SplitSourceURL(l, moduleURL)
 		if err != nil {
 			return nil, errors.New(err)
 		}
 
-		tag, err := shell.GitLastReleaseTag(ctx, l, opts.Env, opts.WorkingDir, rootSourceURL)
-		if err != nil || tag == "" {
-			l.Warnf("Failed to find last release tag for %s", rootSourceURL)
+		// For tfr:// URLs, query the registry API for the latest version instead of git tags
+		if rootSourceURL.Scheme == "tfr" {
+			version, err := getter.LatestRegistryVersion(ctx, l, nil, rootSourceURL)
+			if err != nil || version == "" {
+				l.Warnf("Failed to find last release tag for %s: %v", rootSourceURL, err)
+			} else {
+				params.Set(getter.VersionQueryKey, version)
+				moduleURL.RawQuery = params.Encode()
+			}
 		} else {
-			params.Add(refParam, tag)
-			moduleURL.RawQuery = params.Encode()
+			// if ref is not passed, find last release tag
+			// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
+			// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8
+			tag, err := shell.GitLastReleaseTag(ctx, l, opts.Env, opts.WorkingDir, rootSourceURL)
+			if err != nil || tag == "" {
+				l.Warnf("Failed to find last release tag for %s", rootSourceURL)
+			} else {
+				params.Add(refParam, tag)
+				moduleURL.RawQuery = params.Encode()
+			}
 		}
 	}
 

--- a/internal/cli/commands/scaffold/source_url_test.go
+++ b/internal/cli/commands/scaffold/source_url_test.go
@@ -80,6 +80,45 @@ func TestBuildSourceURL(t *testing.T) {
 	}
 }
 
+func TestBuildSourceURLTFR(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		originalURL string
+		resolvedURL string
+		expected    string
+	}{
+		{
+			name:        "tfr:// gets version from resolved URL",
+			originalURL: "tfr://registry.example.com/namespace/module/aws",
+			resolvedURL: "tfr://registry.example.com/namespace/module/aws?version=1.2.3",
+			expected:    "tfr://registry.example.com/namespace/module/aws?version=1.2.3",
+		},
+		{
+			name:        "tfr:// with existing version is not overwritten",
+			originalURL: "tfr://registry.example.com/namespace/module/aws?version=1.0.0",
+			resolvedURL: "tfr://registry.example.com/namespace/module/aws?version=1.2.3",
+			expected:    "tfr://registry.example.com/namespace/module/aws?version=1.0.0",
+		},
+		{
+			name:        "tfr:// with no version in resolved URL returns original",
+			originalURL: "tfr://registry.example.com/namespace/module/aws",
+			resolvedURL: "tfr://registry.example.com/namespace/module/aws",
+			expected:    "tfr://registry.example.com/namespace/module/aws",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := scaffold.BuildSourceURL(tc.originalURL, tc.resolvedURL, map[string]any{})
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestExtractQueryParam(t *testing.T) {
 	t.Parallel()
 

--- a/internal/getter/tfr.go
+++ b/internal/getter/tfr.go
@@ -21,6 +21,9 @@ import (
 
 const versionQueryKey = "version"
 
+// VersionQueryKey is exported so callers outside this package can reference the version query parameter name.
+const VersionQueryKey = versionQueryKey
+
 // RegistryGetter is the go-getter v2 implementation of the tfr:// protocol.
 //
 // Source URLs take the form:

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 
+	goversion "github.com/hashicorp/go-version"
+
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -159,6 +161,75 @@ func BuildRequestURL(registryDomain, moduleRegistryBasePath, modulePath, version
 	}
 
 	return &url.URL{Scheme: "https", Host: registryDomain, Path: moduleFullPath}, nil
+}
+
+// registryVersionsResponse is the response from the registry versions endpoint.
+type registryVersionsResponse struct {
+	Modules []struct {
+		Versions []struct {
+			Version string `json:"version"`
+		} `json:"versions"`
+	} `json:"modules"`
+}
+
+// LatestRegistryVersion queries the registry API for the latest version of the module at srcURL.
+// If httpClient is nil, a default client is used.
+func LatestRegistryVersion(ctx context.Context, l log.Logger, httpClient *http.Client, srcURL *url.URL) (string, error) {
+	if httpClient == nil {
+		httpClient = cleanhttp.DefaultClient()
+	}
+
+	registryDomain := srcURL.Host
+
+	moduleRegistryBasePath, err := GetModuleRegistryURLBasePath(ctx, l, httpClient, registryDomain)
+	if err != nil {
+		return "", err
+	}
+
+	modulePath := strings.TrimPrefix(srcURL.Path, "/")
+	versionsRaw := fmt.Sprintf("%s/%s/versions", strings.TrimSuffix(moduleRegistryBasePath, "/"), modulePath)
+
+	// moduleRegistryBasePath may be an absolute URL (e.g. Artifactory returns a full https:// base path).
+	// In that case, parse it directly rather than constructing a new URL with the host prepended.
+	var versionsURL *url.URL
+
+	if parsed, parseErr := url.Parse(versionsRaw); parseErr == nil && parsed.Scheme != "" {
+		versionsURL = parsed
+	} else {
+		versionsURL = &url.URL{Scheme: "https", Host: registryDomain, Path: versionsRaw}
+	}
+
+	bodyData, _, err := httpGETAndGetResponse(ctx, l, httpClient, versionsURL)
+	if err != nil {
+		return "", err
+	}
+
+	var resp registryVersionsResponse
+	if err := json.Unmarshal(bodyData, &resp); err != nil {
+		return "", errors.New(fmt.Sprintf("error parsing versions response: %s", err))
+	}
+
+	if len(resp.Modules) == 0 || len(resp.Modules[0].Versions) == 0 {
+		return "", errors.New(fmt.Sprintf("no versions found for module %s", srcURL))
+	}
+
+	var latest *goversion.Version
+	for _, v := range resp.Modules[0].Versions {
+		parsed, err := goversion.NewVersion(v.Version)
+		if err != nil {
+			continue
+		}
+
+		if latest == nil || parsed.GreaterThan(latest) {
+			latest = parsed
+		}
+	}
+
+	if latest == nil {
+		return "", errors.New(fmt.Sprintf("no valid semver versions found for module %s", srcURL))
+	}
+
+	return latest.Original(), nil
 }
 
 // applyHostToken adds an Authorization header to req based on the user's

--- a/internal/getter/tfrhelpers_test.go
+++ b/internal/getter/tfrhelpers_test.go
@@ -139,6 +139,83 @@ func TestBuildRequestURLRelativePath(t *testing.T) {
 	)
 }
 
+func TestLatestRegistryVersion(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		versionsPayload string
+		expectedVersion string
+		expectError     bool
+	}{
+		{
+			name: "picks highest semver not first returned",
+			versionsPayload: `{"modules":[{"versions":[
+				{"version":"0.1.0"},
+				{"version":"0.2.7"},
+				{"version":"0.2.5"},
+				{"version":"0.2.0"}
+			]}]}`,
+			expectedVersion: "0.2.7",
+		},
+		{
+			name: "single version",
+			versionsPayload: `{"modules":[{"versions":[
+				{"version":"1.0.0"}
+			]}]}`,
+			expectedVersion: "1.0.0",
+		},
+		{
+			name:        "empty versions list returns error",
+			versionsPayload: `{"modules":[{"versions":[]}]}`,
+			expectError: true,
+		},
+		{
+			name:        "empty modules list returns error",
+			versionsPayload: `{"modules":[]}`,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload := tc.versionsPayload
+			mux := http.NewServeMux()
+
+			mux.HandleFunc("/.well-known/terraform.json", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, err := w.Write([]byte(`{"modules.v1":"/v1/modules/"}`))
+				assert.NoError(t, err)
+			})
+
+			mux.HandleFunc("/v1/modules/namespace/module/aws/versions", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, err := w.Write([]byte(payload))
+				assert.NoError(t, err)
+			})
+
+			server := httptest.NewTLSServer(mux)
+			t.Cleanup(server.Close)
+
+			srcURL := &url.URL{
+				Scheme: "tfr",
+				Host:   server.Listener.Addr().String(),
+				Path:   "/namespace/module/aws",
+			}
+
+			version, err := getter.LatestRegistryVersion(t.Context(), logger.CreateLogger(), server.Client(), srcURL)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedVersion, version)
+			}
+		})
+	}
+}
+
 // newRegistryTestServer stands up an httptest TLS server that speaks enough of
 // the OpenTofu/Terraform module-registry protocol to satisfy the
 // RegistryGetter: the service-discovery document, a module download endpoint


### PR DESCRIPTION
## Description

Fixes #6117

`terragrunt scaffold` fails when given a `tfr://` module source URL. This PR fixes three separate bugs that together cause the failure.

## Changes

**1. Wire `RegistryGetter` into scaffold's go-getter client (`scaffold.go`)**

`getter.GetAny` was called without `WithTFRegistry(...)`, so no getter could handle `tfr://` URLs. Fixed by passing `getter.WithTFRegistry(getter.NewRegistryGetter(l))` to both `GetAny` calls in scaffold.

**2. Skip `rewriteModuleURL` for `tfr://` URLs (`scaffold.go`)**

`parseURL` uses the regex `(?:git|hg|s3|gcs)::([^:]+)://([^/]+)(/.*)`  which only matches `forced-getter::scheme://` style URLs. `tfr://` has no forced-getter prefix so it never matched, producing two misleading warnings and incorrect fallback behaviour. Fixed by skipping `rewriteModuleURL` entirely for `tfr://` URLs as there is nothing to rewrite.

**3. Query registry API for latest version instead of git (`scaffold.go`, `tfrhelpers.go`)**

When no `?version=` is specified, `addRefToModuleURL` called `GitLastReleaseTag` which attempts `git remote-tfr` — not a valid git command. Fixed by adding `LatestRegistryVersion` to `tfrhelpers.go` which queries the registry `/versions` endpoint and returns the highest semver version. Also handles registries (e.g. Artifactory) that return an absolute URL in their service discovery response rather than a relative path.

**4. Propagate `?version=` in `BuildSourceURL` for `tfr://` URLs (`scaffold.go`)**

`BuildSourceURL` only looked for `?ref=` — updated to handle `?version=` for `tfr://` URLs.

**5. Export `VersionQueryKey` (`tfr.go`)**

Exported so it can be referenced from the scaffold package.

## Tests

- `TestLatestRegistryVersion` — verifies highest semver is selected (not first returned), handles single version, and errors on empty version lists
- `TestBuildSourceURLTFR` — verifies `?version=` is appended, existing versions are not overwritten, and missing versions return the original URL

## Test output

```
ok  	github.com/gruntwork-io/terragrunt/internal/cli/commands/scaffold	1.282s
ok  	github.com/gruntwork-io/terragrunt/internal/getter	2.013s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Terraform registry (tfr://) URL support for module scaffolding operations
  * Telemetry-backed module downloads now leverage Terraform registry for version lookups
  * Automatic latest version resolution queries the Terraform registry when no version is specified

* **Tests**
  * Added tests to validate registry URL parameter handling and version resolution behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6118)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->