### PR TITLE
feat: Allow opt-out from auth in discovery

### DIFF
--- a/docs/src/components/Command.astro
+++ b/docs/src/components/Command.astro
@@ -3,6 +3,7 @@ import { Aside, Code } from '@astrojs/starlight/components';
 import { getEntry, render } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import Flag from './Flag.astro';
+import { isFlagVisible } from '@lib/flags';
 
 const { path } = Astro.props;
 
@@ -12,6 +13,18 @@ const data = command?.data;
 
 const usage = data?.usage;
 const { Content } = await render(command);
+
+const visibleFlagSlugs = data?.flags
+	? (
+			await Promise.all(
+				data.flags.map(async (slug) => {
+					const flag = await getEntry('flags', slug);
+					if (!flag) return null;
+					return (await isFlagVisible(flag.data.since)) ? slug : null;
+				}),
+			)
+		).filter((slug): slug is string => slug !== null)
+	: [];
 ---
 
 {
@@ -47,11 +60,11 @@ const { Content } = await render(command);
 <Content />
 
 {
-  data?.flags ? (
+  visibleFlagSlugs.length > 0 ? (
   <h2 id="flags">Flags</h2>
   <div>
-    {data?.flags.map((flagSlug) => (
-      flagSlug && <Flag slug={flagSlug} />
+    {visibleFlagSlugs.map((flagSlug) => (
+      <Flag slug={flagSlug} />
     ))}
   </div>
   ) : null

--- a/docs/src/components/Flag.astro
+++ b/docs/src/components/Flag.astro
@@ -3,6 +3,7 @@ import { Badge } from '@astrojs/starlight/components';
 import Card from '@components/vendored/starlight/Card.astro';
 import type { CollectionEntry } from 'astro:content';
 import { render, getEntry } from 'astro:content';
+import { isFlagVisible } from '@lib/flags';
 
 interface Props {
   slug: string;
@@ -11,41 +12,44 @@ interface Props {
 const { slug } = Astro.props;
 
 const flagEntry = await getEntry('flags', slug) as CollectionEntry<'flags'>;
+const visible = await isFlagVisible(flagEntry.data.since);
 const { Content } = await render(flagEntry);
 const { aliases, description, type, env, name, defaultVal } = flagEntry.data;
 ---
 
-<section id={name}>
-  <Card title={"--" + name} icon="custom:terragrunt">
-    <p id={name}>{description}</p>
-    <Content />
-    <div>
-      <span>Type: </span><Badge text={type} variant="note" style={{ fontWeight: 'bold' }}/>
-    </div>
-    {defaultVal && (
+{visible && (
+  <section id={name}>
+    <Card title={"--" + name} icon="custom:terragrunt">
+      <p id={name}>{description}</p>
+      <Content />
       <div>
-        <span>Default: </span><Badge text={defaultVal} variant="tip" style={{ fontWeight: 'bold' }}/>
+        <span>Type: </span><Badge text={type} variant="note" style={{ fontWeight: 'bold' }}/>
       </div>
-    )}
-    {aliases && aliases.length > 0 && (
-      <>
-        <p>Aliases:</p>
-        <ul>
-          {aliases.map((alias: string) => (
-            <li><code dir="auto">{alias}</code></li>
-          ))}
-        </ul>
-      </>
-    )}
-    {env && (
-      <>
-        <p>Environment Variables:</p>
-        <ul>
-          {env.map((envVar: string) => (
-            <li><code dir="auto">{envVar}</code></li>
-          ))}
-        </ul>
-      </>
-    )}
-  </Card>
-</section>
+      {defaultVal && (
+        <div>
+          <span>Default: </span><Badge text={defaultVal} variant="tip" style={{ fontWeight: 'bold' }}/>
+        </div>
+      )}
+      {aliases && aliases.length > 0 && (
+        <>
+          <p>Aliases:</p>
+          <ul>
+            {aliases.map((alias: string) => (
+              <li><code dir="auto">{alias}</code></li>
+            ))}
+          </ul>
+        </>
+      )}
+      {env && (
+        <>
+          <p>Environment Variables:</p>
+          <ul>
+            {env.map((envVar: string) => (
+              <li><code dir="auto">{envVar}</code></li>
+            ))}
+          </ul>
+        </>
+      )}
+    </Card>
+  </section>
+)}

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -56,6 +56,7 @@ const flags = defineCollection({
 		type: z.string(),
 		env: z.array(z.string()).optional(),
 		aliases: z.array(z.string()).optional(),
+		since: z.string().optional(),
 	}),
 });
 

--- a/docs/src/data/changelog/v1.0.6/opt-out-auth.mdx
+++ b/docs/src/data/changelog/v1.0.6/opt-out-auth.mdx
@@ -1,0 +1,26 @@
+---
+version: "v1.0.6"
+category: "experiments-added"
+---
+
+#### `opt-out-auth` — Opt out of `--auth-provider-cmd` during discovery
+
+Enable the new `opt-out-auth` experiment to use `--no-discovery-auth-provider-cmd` (env: `TG_NO_DISCOVERY_AUTH_PROVIDER_CMD`), which disables the auth provider command during the discovery phase.
+
+Without the flag, Terragrunt assumes that `--auth-provider-cmd` must be run per parsed component during the discovery phase so that it can reliably resolve HCL functions such as `get_aws_account_id` and `run_cmd`. On large repositories with `run --all --filter='reading='`, this dominates wall-clock time because the auth command runs for every discovered unit rather than only the subset that will run.
+
+The `--no-discovery-auth-provider-cmd` flag turns off auth invocations during discovery. The auth provider command still runs normally when running units.
+
+Units whose discovery-relevant blocks depend on credentials produced by `--auth-provider-cmd` will fail to parse with the flag set. Use it when you know that parsing will resolve successfully without any authentication done beforehand by Terragrunt.
+
+While this flag is experimental, you must also opt-in to the `opt-out-auth` experiment by setting the `TG_EXPERIMENT` environment variable to `opt-out-auth` or by passing the `--experiment=opt-out-auth` flag to `terragrunt run`. This flag might experience breaking changes based on community feedback for the duration of the experiment.
+
+e.g.
+
+```bash
+terragrunt run --all \
+  --experiment=opt-out-auth \
+  --no-discovery-auth-provider-cmd \
+  --queue-include-units-reading=./changed-file.txt \
+  plan
+```

--- a/docs/src/data/flags/no-discovery-auth-provider-cmd.mdx
+++ b/docs/src/data/flags/no-discovery-auth-provider-cmd.mdx
@@ -1,0 +1,22 @@
+---
+name: no-discovery-auth-provider-cmd
+description: Skip running --auth-provider-cmd during the discovery phase. Requires the opt-out-auth experiment.
+lookup: true
+type: boolean
+env:
+  - TG_NO_DISCOVERY_AUTH_PROVIDER_CMD
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental">
+This flag is gated behind the [`opt-out-auth`](/reference/experiments) experiment. Enable it with `--experiment=opt-out-auth` (or `TG_EXPERIMENT=opt-out-auth`); otherwise setting `--no-discovery-auth-provider-cmd` returns an error. The flag's behavior may change while the experiment is in progress.
+</Aside>
+
+Skip running `--auth-provider-cmd` during the discovery phase.
+
+By default, Terragrunt runs `--auth-provider-cmd` once per parse of a component during the discovery phase so configuration parsing can resolve HCL functions such as `get_aws_account_id` without error. With this flag, those discovery-time invocations are skipped. The auth provider command still executes normally for the units that actually run.
+
+<Aside type="caution">
+Units whose discovery-relevant blocks depend on credentials produced by `--auth-provider-cmd` may fail to parse with this flag set.
+</Aside>

--- a/docs/src/data/flags/no-discovery-auth-provider-cmd.mdx
+++ b/docs/src/data/flags/no-discovery-auth-provider-cmd.mdx
@@ -5,6 +5,7 @@ lookup: true
 type: boolean
 env:
   - TG_NO_DISCOVERY_AUTH_PROVIDER_CMD
+since: "v1.0.6"
 ---
 
 import { Aside } from '@astrojs/starlight/components';

--- a/docs/src/lib/commands/headings/index.ts
+++ b/docs/src/lib/commands/headings/index.ts
@@ -1,4 +1,5 @@
 import { getEntry, type CollectionEntry } from 'astro:content';
+import { isFlagVisible } from '@lib/flags';
 
 export async function getHeadings(
 	command: CollectionEntry<'commands'>,
@@ -33,18 +34,29 @@ export async function getHeadings(
 	}
 
 	if (command.data.flags) {
-		headings.push({ depth: 2, slug: 'flags', text: 'Flags' });
+		const flagEntries = await Promise.all(
+			command.data.flags.map((flagName: string) => getEntry('flags', flagName)),
+		);
+		const visibleFlags = (
+			await Promise.all(
+				flagEntries.map(async (flag) => {
+					if (!flag) return null;
+					return (await isFlagVisible(flag.data.since)) ? flag : null;
+				}),
+			)
+		).filter((flag): flag is NonNullable<typeof flag> => flag !== null);
 
-		const flags = await Promise.all(command.data.flags.map(async (flagName: string) => {
-			const flag = (await getEntry('flags', flagName))!;
-			return {
-				depth: 3,
-				slug: flag.data.name,
-				text: `--${flag.data.name}`,
-			};
-		}));
+		if (visibleFlags.length > 0) {
+			headings.push({ depth: 2, slug: 'flags', text: 'Flags' });
 
-		headings.push(...flags);
+			for (const flag of visibleFlags) {
+				headings.push({
+					depth: 3,
+					slug: flag.data.name,
+					text: `--${flag.data.name}`,
+				});
+			}
+		}
 	}
 
 	return headings;

--- a/docs/src/lib/flags.ts
+++ b/docs/src/lib/flags.ts
@@ -1,0 +1,10 @@
+import { getLatestRelease } from "@lib/github";
+import { isReleased } from "@lib/changelog";
+
+export async function isFlagVisible(since: string | undefined): Promise<boolean> {
+  if (import.meta.env.DEV) return true;
+  if (!since) return true;
+  const release = await getLatestRelease("gruntwork-io", "terragrunt");
+  const latestVersion = (release?.tag_name ?? "v0.0.0").replace(/^v/, "");
+  return isReleased(since, latestVersion);
+}

--- a/internal/cli/commands/find/cli.go
+++ b/internal/cli/commands/find/cli.go
@@ -151,6 +151,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *clihelper.Comman
 	flags := NewFlags(l, cmdOpts, nil)
 	flags = append(flags, shared.NewBackendFlags(opts, nil)...)
 	flags = append(flags, shared.NewFeatureFlags(opts, nil)...)
+	flags = append(flags, shared.NewNoDiscoveryAuthProviderCmdFlag(opts, nil))
 
 	return &clihelper.Command{
 		Name:    CommandName,
@@ -176,7 +177,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *clihelper.Comman
 				return clihelper.NewExitError(err, clihelper.ExitCodeGeneralError)
 			}
 
-			return nil
+			return shared.ValidateNoDiscoveryAuthProviderCmd(opts)
 		},
 		Action: func(ctx context.Context, _ *clihelper.Context) error {
 			return Run(ctx, l, cmdOpts)

--- a/internal/cli/commands/find/cli.go
+++ b/internal/cli/commands/find/cli.go
@@ -177,7 +177,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *clihelper.Comman
 				return clihelper.NewExitError(err, clihelper.ExitCodeGeneralError)
 			}
 
-			return shared.ValidateNoDiscoveryAuthProviderCmd(opts)
+			return nil
 		},
 		Action: func(ctx context.Context, _ *clihelper.Context) error {
 			return Run(ctx, l, cmdOpts)

--- a/internal/cli/commands/list/cli.go
+++ b/internal/cli/commands/list/cli.go
@@ -141,6 +141,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *clihelper.Comman
 	flags := NewFlags(l, cmdOpts, prefix)
 	flags = append(flags, shared.NewBackendFlags(opts, prefix)...)
 	flags = append(flags, shared.NewFeatureFlags(opts, prefix)...)
+	flags = append(flags, shared.NewNoDiscoveryAuthProviderCmdFlag(opts, prefix))
 
 	return &clihelper.Command{
 		Name:    CommandName,
@@ -170,7 +171,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *clihelper.Comman
 				return clihelper.NewExitError(err, clihelper.ExitCodeGeneralError)
 			}
 
-			return nil
+			return shared.ValidateNoDiscoveryAuthProviderCmd(opts)
 		},
 		Action: func(ctx context.Context, _ *clihelper.Context) error {
 			return Run(ctx, l, cmdOpts)

--- a/internal/cli/commands/list/cli.go
+++ b/internal/cli/commands/list/cli.go
@@ -171,7 +171,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *clihelper.Comman
 				return clihelper.NewExitError(err, clihelper.ExitCodeGeneralError)
 			}
 
-			return shared.ValidateNoDiscoveryAuthProviderCmd(opts)
+			return nil
 		},
 		Action: func(ctx context.Context, _ *clihelper.Context) error {
 			return Run(ctx, l, cmdOpts)

--- a/internal/cli/commands/run/cli.go
+++ b/internal/cli/commands/run/cli.go
@@ -32,6 +32,9 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *clihelper.Comman
 		},
 		Flags:       cmdFlags,
 		Subcommands: NewSubcommands(l, opts),
+		Before: func(_ context.Context, _ *clihelper.Context) error {
+			return shared.ValidateNoDiscoveryAuthProviderCmd(opts)
+		},
 		Action: func(ctx context.Context, cliCtx *clihelper.Context) error {
 			tgOpts := opts.OptionsFromContext(ctx)
 

--- a/internal/cli/commands/run/cli.go
+++ b/internal/cli/commands/run/cli.go
@@ -32,9 +32,6 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *clihelper.Comman
 		},
 		Flags:       cmdFlags,
 		Subcommands: NewSubcommands(l, opts),
-		Before: func(_ context.Context, _ *clihelper.Context) error {
-			return shared.ValidateNoDiscoveryAuthProviderCmd(opts)
-		},
 		Action: func(ctx context.Context, cliCtx *clihelper.Context) error {
 			tgOpts := opts.OptionsFromContext(ctx)
 

--- a/internal/cli/commands/run/flags.go
+++ b/internal/cli/commands/run/flags.go
@@ -368,6 +368,8 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 
 		shared.NewAuthProviderCmdFlag(opts, prefix, CommandName),
 
+		shared.NewNoDiscoveryAuthProviderCmdFlag(opts, prefix),
+
 		// Terragrunt engine flags.
 
 		flags.NewFlag(&clihelper.BoolFlag{

--- a/internal/cli/flags/shared/auth.go
+++ b/internal/cli/flags/shared/auth.go
@@ -3,11 +3,14 @@ package shared
 import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
 const (
-	AuthProviderCmdFlagName = "auth-provider-cmd"
+	AuthProviderCmdFlagName            = "auth-provider-cmd"
+	NoDiscoveryAuthProviderCmdFlagName = "no-discovery-auth-provider-cmd"
 )
 
 // NewAuthProviderCmdFlag creates a flag for specifying the auth provider command.
@@ -31,4 +34,37 @@ func NewAuthProviderCmdFlag(opts *options.TerragruntOptions, prefix flags.Prefix
 		},
 		flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("auth-provider-cmd"), terragruntPrefixControl),
 	)
+}
+
+// NewNoDiscoveryAuthProviderCmdFlag opts out of running the auth provider
+// command during the discovery parse phase. Requires the opt-out-auth
+// experiment; callers must validate that with [ValidateNoDiscoveryAuthProviderCmd]
+// from the command's Before hook so the check is order-independent.
+func NewNoDiscoveryAuthProviderCmdFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.Flag {
+	tgPrefix := prefix.Prepend(flags.TgPrefix)
+
+	return flags.NewFlag(&clihelper.BoolFlag{
+		Name:        NoDiscoveryAuthProviderCmdFlagName,
+		EnvVars:     tgPrefix.EnvVars(NoDiscoveryAuthProviderCmdFlagName),
+		Destination: &opts.DiscoveryAuthProviderCmd,
+		Usage:       "Skip running --auth-provider-cmd during the discovery phase. Requires the 'opt-out-auth' experiment. Speeds up commands like 'run --all --queue-include-units-reading' at the cost of parse errors in units whose discovery-relevant blocks (exclude/include/dependency) require credentials.",
+		Negative:    true,
+	})
+}
+
+// ValidateNoDiscoveryAuthProviderCmd returns an error when the user set
+// --no-discovery-auth-provider-cmd without enabling the opt-out-auth
+// experiment. Call from a command's Before hook, by which point both flags
+// (and the experiment registration) have been applied regardless of
+// command-line ordering.
+func ValidateNoDiscoveryAuthProviderCmd(opts *options.TerragruntOptions) error {
+	if opts.DiscoveryAuthProviderCmd {
+		return nil
+	}
+
+	if opts.Experiments.Evaluate(experiment.OptOutAuth) {
+		return nil
+	}
+
+	return errors.New(NoDiscoveryAuthProviderCmdRequiresExperimentError{})
 }

--- a/internal/cli/flags/shared/auth.go
+++ b/internal/cli/flags/shared/auth.go
@@ -1,9 +1,10 @@
 package shared
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
-	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
@@ -36,10 +37,9 @@ func NewAuthProviderCmdFlag(opts *options.TerragruntOptions, prefix flags.Prefix
 	)
 }
 
-// NewNoDiscoveryAuthProviderCmdFlag opts out of running the auth provider
-// command during the discovery parse phase. Requires the opt-out-auth
-// experiment; callers must validate that with [ValidateNoDiscoveryAuthProviderCmd]
-// from the command's Before hook so the check is order-independent.
+// NewNoDiscoveryAuthProviderCmdFlag opts out of running --auth-provider-cmd
+// during the discovery parse phase. Setting it without the opt-out-auth
+// experiment returns ErrNoDiscoveryAuthProviderCmdRequiresExperiment.
 func NewNoDiscoveryAuthProviderCmdFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.Flag {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
@@ -47,24 +47,18 @@ func NewNoDiscoveryAuthProviderCmdFlag(opts *options.TerragruntOptions, prefix f
 		Name:        NoDiscoveryAuthProviderCmdFlagName,
 		EnvVars:     tgPrefix.EnvVars(NoDiscoveryAuthProviderCmdFlagName),
 		Destination: &opts.DiscoveryAuthProviderCmd,
-		Usage:       "Skip running --auth-provider-cmd during the discovery phase. Requires the 'opt-out-auth' experiment. Speeds up commands like 'run --all --queue-include-units-reading' at the cost of parse errors in units whose discovery-relevant blocks (exclude/include/dependency) require credentials.",
+		Usage:       "Skip running --auth-provider-cmd during the discovery phase. Requires the 'opt-out-auth' experiment.",
 		Negative:    true,
+		Action: func(_ context.Context, _ *clihelper.Context, runDiscoveryAuth bool) error {
+			if runDiscoveryAuth {
+				return nil
+			}
+
+			if opts.Experiments.Evaluate(experiment.OptOutAuth) {
+				return nil
+			}
+
+			return ErrNoDiscoveryAuthProviderCmdRequiresExperiment
+		},
 	})
-}
-
-// ValidateNoDiscoveryAuthProviderCmd returns an error when the user set
-// --no-discovery-auth-provider-cmd without enabling the opt-out-auth
-// experiment. Call from a command's Before hook, by which point both flags
-// (and the experiment registration) have been applied regardless of
-// command-line ordering.
-func ValidateNoDiscoveryAuthProviderCmd(opts *options.TerragruntOptions) error {
-	if opts.DiscoveryAuthProviderCmd {
-		return nil
-	}
-
-	if opts.Experiments.Evaluate(experiment.OptOutAuth) {
-		return nil
-	}
-
-	return errors.New(NoDiscoveryAuthProviderCmdRequiresExperimentError{})
 }

--- a/internal/cli/flags/shared/errors.go
+++ b/internal/cli/flags/shared/errors.go
@@ -6,3 +6,12 @@ type AllGraphFlagsError byte
 func (err *AllGraphFlagsError) Error() string {
 	return "Using the `--all` and `--graph` flags simultaneously is not supported."
 }
+
+// NoDiscoveryAuthProviderCmdRequiresExperimentError is returned when
+// --no-discovery-auth-provider-cmd is set without the opt-out-auth experiment
+// enabled.
+type NoDiscoveryAuthProviderCmdRequiresExperimentError struct{}
+
+func (NoDiscoveryAuthProviderCmdRequiresExperimentError) Error() string {
+	return "--no-discovery-auth-provider-cmd requires the 'opt-out-auth' experiment to be enabled (e.g., --experiment=opt-out-auth)"
+}

--- a/internal/cli/flags/shared/errors.go
+++ b/internal/cli/flags/shared/errors.go
@@ -1,5 +1,7 @@
 package shared
 
+import "github.com/gruntwork-io/terragrunt/internal/errors"
+
 // AllGraphFlagsError is returned when both --all and --graph flags are used simultaneously.
 type AllGraphFlagsError byte
 
@@ -7,11 +9,6 @@ func (err *AllGraphFlagsError) Error() string {
 	return "Using the `--all` and `--graph` flags simultaneously is not supported."
 }
 
-// NoDiscoveryAuthProviderCmdRequiresExperimentError is returned when
-// --no-discovery-auth-provider-cmd is set without the opt-out-auth experiment
-// enabled.
-type NoDiscoveryAuthProviderCmdRequiresExperimentError struct{}
-
-func (NoDiscoveryAuthProviderCmdRequiresExperimentError) Error() string {
-	return "--no-discovery-auth-provider-cmd requires the 'opt-out-auth' experiment to be enabled (e.g., --experiment=opt-out-auth)"
-}
+var ErrNoDiscoveryAuthProviderCmdRequiresExperiment = errors.New(
+	"--no-discovery-auth-provider-cmd requires the 'opt-out-auth' experiment to be enabled (e.g., --experiment=opt-out-auth)",
+)

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -348,8 +348,11 @@ func parseComponent(
 		parseOpts.OriginalTerragruntConfigPath = parseOpts.TerragruntConfigPath
 
 		shellOpts := configbridge.ShellRunOptsFromOpts(parseOpts)
-		if _, err := creds.ObtainCredsForParsing(ctx, l, parseOpts.AuthProviderCmd, parseOpts.Env, shellOpts); err != nil {
-			return errors.Errorf("obtaining auth provider credentials for %s: %w", parseOpts.TerragruntConfigPath, err)
+
+		if parseOpts.DiscoveryAuthProviderCmd {
+			if _, err := creds.ObtainCredsForParsing(ctx, l, parseOpts.AuthProviderCmd, parseOpts.Env, shellOpts); err != nil {
+				return errors.Errorf("obtaining auth provider credentials for %s: %w", parseOpts.TerragruntConfigPath, err)
+			}
 		}
 
 		ctx, parsingCtx := configbridge.NewParsingContext(ctx, l, parseOpts)

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -63,6 +63,9 @@ const (
 	AzureBackend = "azure-backend"
 	// DeepMerge enables the deep_merge HCL function.
 	DeepMerge = "deep-merge"
+	// OptOutAuth gates flags that opt out of running --auth-provider-cmd in
+	// specific phases (currently --no-discovery-auth-provider-cmd).
+	OptOutAuth = "opt-out-auth"
 )
 
 const (
@@ -135,6 +138,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: DeepMerge,
+		},
+		{
+			Name: OptOutAuth,
 		},
 	}
 }

--- a/internal/experiment/experiment_test.go
+++ b/internal/experiment/experiment_test.go
@@ -27,6 +27,16 @@ func newTestLogger() (log.Logger, *bytes.Buffer) {
 	return logger, output
 }
 
+func TestOptOutAuthIsOngoing(t *testing.T) {
+	t.Parallel()
+
+	exps := experiment.NewExperiments()
+	got := exps.Find(experiment.OptOutAuth)
+	require.NotNil(t, got, "opt-out-auth experiment must be registered in NewExperiments()")
+	assert.Equal(t, experiment.StatusOngoing, got.Status, "opt-out-auth must be ongoing")
+	assert.False(t, got.Evaluate(), "opt-out-auth must be disabled by default")
+}
+
 func TestValidateExperiments(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -220,6 +220,10 @@ type TerragruntOptions struct {
 	AutoRetry bool
 	// Whether we should automatically run terraform init if necessary when executing other commands
 	AutoInit bool
+	// When false (set via --no-discovery-auth-provider-cmd), skip running the
+	// auth provider command during the discovery parse phase. Requires the
+	// opt-out-auth experiment. Default true preserves existing behavior.
+	DiscoveryAuthProviderCmd bool
 	// Allows to skip the output of all dependencies.
 	SkipOutput bool
 	// Whether we should prompt the user for confirmation or always assume "yes"
@@ -317,30 +321,31 @@ func NewTerragruntOptions() *TerragruntOptions {
 
 func NewTerragruntOptionsWithWriters(stdout, stderr io.Writer) *TerragruntOptions {
 	return &TerragruntOptions{
-		Writers:                writer.Writers{Writer: stdout, ErrWriter: stderr},
-		TFPath:                 DefaultWrappedPath,
-		ExcludesFile:           defaultExcludesFile,
-		FiltersFile:            defaultFiltersFile,
-		AutoInit:               true,
-		RunAllAutoApprove:      true,
-		Env:                    map[string]string{},
-		SourceMap:              map[string]string{},
-		TerraformCliArgs:       iacargs.New(),
-		MaxFoldersToCheck:      DefaultMaxFoldersToCheck,
-		AutoRetry:              true,
-		Parallelism:            DefaultParallelism,
-		JSONOut:                DefaultJSONOutName,
-		TofuImplementation:     tfimpl.Unknown,
-		ProviderCacheOptions:   pcoptions.ProviderCacheOptions{RegistryNames: pcoptions.DefaultRegistryNames},
-		FeatureFlags:           xsync.NewMap[string, string](),
-		Errors:                 defaultErrorsConfig(),
-		StrictControls:         controls.New(),
-		Experiments:            experiment.NewExperiments(),
-		Tips:                   tips.NewTips(),
-		Telemetry:              new(telemetry.Options),
-		EngineOptions:          new(engine.EngineOptions),
-		VersionManagerFileName: defaultVersionManagerFileName,
-		CASCloneDepth:          1,
+		Writers:                  writer.Writers{Writer: stdout, ErrWriter: stderr},
+		TFPath:                   DefaultWrappedPath,
+		ExcludesFile:             defaultExcludesFile,
+		FiltersFile:              defaultFiltersFile,
+		AutoInit:                 true,
+		RunAllAutoApprove:        true,
+		DiscoveryAuthProviderCmd: true,
+		Env:                      map[string]string{},
+		SourceMap:                map[string]string{},
+		TerraformCliArgs:         iacargs.New(),
+		MaxFoldersToCheck:        DefaultMaxFoldersToCheck,
+		AutoRetry:                true,
+		Parallelism:              DefaultParallelism,
+		JSONOut:                  DefaultJSONOutName,
+		TofuImplementation:       tfimpl.Unknown,
+		ProviderCacheOptions:     pcoptions.ProviderCacheOptions{RegistryNames: pcoptions.DefaultRegistryNames},
+		FeatureFlags:             xsync.NewMap[string, string](),
+		Errors:                   defaultErrorsConfig(),
+		StrictControls:           controls.New(),
+		Experiments:              experiment.NewExperiments(),
+		Tips:                     tips.NewTips(),
+		Telemetry:                new(telemetry.Options),
+		EngineOptions:            new(engine.EngineOptions),
+		VersionManagerFileName:   defaultVersionManagerFileName,
+		CASCloneDepth:            1,
 	}
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3456,6 +3456,65 @@ func TestReadTerragruntAuthProviderCmdRunAllCallCountWithRacing(t *testing.T) {
 	}
 }
 
+func TestNoDiscoveryAuthProviderCmdRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsExperimentMode(t) {
+		t.Skip("Skipping: TG_EXPERIMENT_MODE forces all experiments on, defeating the experiment-gate check this test pins")
+	}
+
+	helpers.CleanupTerraformFolder(t, testFixtureAuthProviderCmd)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAuthProviderCmd)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "run-all-call-count")
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt find --no-discovery-auth-provider-cmd --working-dir "+rootPath,
+	)
+	require.Error(t, err)
+
+	var requiresExperimentErr shared.NoDiscoveryAuthProviderCmdRequiresExperimentError
+	assert.True(t, errors.As(err, &requiresExperimentErr), "expected NoDiscoveryAuthProviderCmdRequiresExperimentError, got %T: %v", err, err)
+}
+
+func TestNoDiscoveryAuthProviderCmdSkipsDiscoveryAuthWithRacing(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureAuthProviderCmd)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAuthProviderCmd)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "run-all-call-count")
+	authProviderCmd := filepath.Join(rootPath, "auth-provider.sh")
+	logPath := filepath.Join(rootPath, "calls.jsonl")
+
+	helpers.ValidateAuthProviderScript(t, rootPath, authProviderCmd)
+	require.NoError(t, os.Remove(logPath), "auth-provider.sh should have created %s", logPath)
+
+	helpers.RunTerragrunt(
+		t,
+		fmt.Sprintf(
+			"terragrunt run --all apply --non-interactive "+
+				"--no-discovery-auth-provider-cmd --experiment opt-out-auth "+
+				"--working-dir %s --auth-provider-cmd %s",
+			rootPath,
+			authProviderCmd,
+		),
+	)
+
+	logBytes, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(string(logBytes), "\n"), "\n")
+
+	t.Logf("auth-provider-cmd invocations:\n%s", string(logBytes))
+
+	// Without --no-discovery-auth-provider-cmd this fixture produces five
+	// invocations (see TestReadTerragruntAuthProviderCmdRunAllCallCountWithRacing).
+	// The flag skips the two discovery-relationship-phase invocations, leaving
+	// the three runtime invocations from the runner pool and the dependency
+	// outputs fetch.
+	assert.Len(t, lines, 3)
+}
+
 func TestIamRolesLoadingFromDifferentModules(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3467,14 +3467,24 @@ func TestNoDiscoveryAuthProviderCmdRequiresExperiment(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAuthProviderCmd)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "run-all-call-count")
 
-	_, _, err := helpers.RunTerragruntCommandWithOutput(
-		t,
-		"terragrunt find --no-discovery-auth-provider-cmd --working-dir "+rootPath,
-	)
-	require.Error(t, err)
+	testCases := []struct {
+		name string
+		args string
+	}{
+		{name: "find", args: "find --no-discovery-auth-provider-cmd --working-dir " + rootPath},
+		{name: "list", args: "list --no-discovery-auth-provider-cmd --working-dir " + rootPath},
+		{name: "run", args: "run --no-discovery-auth-provider-cmd --working-dir " + rootPath + " -- plan"},
+		{name: "shortcut", args: "apply --no-discovery-auth-provider-cmd --working-dir " + rootPath},
+	}
 
-	var requiresExperimentErr shared.NoDiscoveryAuthProviderCmdRequiresExperimentError
-	assert.True(t, errors.As(err, &requiresExperimentErr), "expected NoDiscoveryAuthProviderCmdRequiresExperimentError, got %T: %v", err, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt "+tc.args)
+			require.ErrorIs(t, err, shared.ErrNoDiscoveryAuthProviderCmdRequiresExperiment)
+		})
+	}
 }
 
 func TestNoDiscoveryAuthProviderCmdSkipsDiscoveryAuthWithRacing(t *testing.T) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Closes #6115

Adds `--no-discovery-auth-provider-cmd` flag that allows users to opt out of authentication using the `--auth-provider-cmd` flag during discovery parsing. This is something that users have to leverage carefully to avoid assuming they don't need authentication during discovery parsing when they really do.

This is a forwards incompatible change that might need breaking changes before it's stabilized. If so, usage is going to require enabling the `opt-out-auth` experiment.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-discovery-auth-provider-cmd` CLI flag to skip authentication provider command execution during the discovery phase (requires `opt-out-auth` experiment).
  * Introduced `opt-out-auth` experiment to control discovery-phase authentication behavior.

* **Documentation**
  * Added documentation for the new `--no-discovery-auth-provider-cmd` flag and `opt-out-auth` experiment.
  * Flag documentation now displays version availability information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->