### PR TITLE
chore: Ensuring full support for tfr in CAS

### DIFF
--- a/docs/src/data/changelog/v1.0.7/cas-tfr-sources.mdx
+++ b/docs/src/data/changelog/v1.0.7/cas-tfr-sources.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.7"
+category: "experiments-updated"
+---
+
+#### `cas` — OpenTofu/Terraform registry sources
+
+Module sources of the form `tfr://...` are now content-addressed in CAS. Repeat runs against the same pinned registry version reuse the cached module instead of re-downloading the archive from the registry.
+
+CAS resolves a `tfr://` source by asking the registry where the underlying archive lives and uses that resolved URL as the cache key. Two runs that pin the same version share one entry; a republish under the same version pins to a new entry, so a stale cache cannot serve outdated bytes.

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -23,13 +23,14 @@ const SchemeGit = "git"
 // CASGetter is the go-getter implementation that routes git, local, and
 // configured non-git sources through Terragrunt's content-addressable store.
 type CASGetter struct {
-	CAS       *cas.CAS
-	Logger    log.Logger
-	Opts      *cas.CloneOptions
-	Venv      cas.Venv
-	fetchers  map[string]getter.Getter
-	resolvers map[string]cas.SourceResolver
-	Detectors []Detector
+	CAS         *cas.CAS
+	Logger      log.Logger
+	Opts        *cas.CloneOptions
+	Venv        cas.Venv
+	fetchers    map[string]getter.Getter
+	resolvers   map[string]cas.SourceResolver
+	innerClient InnerClientBuilder
+	Detectors   []Detector
 
 	// userDisabledArchive records that the source for the current
 	// request carried an explicit archive=false. Detect sets it; Get
@@ -44,6 +45,14 @@ type CASGetter struct {
 	// concurrent requests. Do not share one CASGetter across goroutines.
 	userDisabledArchive bool
 }
+
+// InnerClientBuilder builds the per-fetch [getter.Client] used to invoke
+// the bare scheme-specific getter from a [SourceFetcher]. Schemes that
+// download in a single step want a one-getter client; multi-stage
+// protocols (notably tfr://, where [RegistryGetter] resolves an archive
+// URL and delegates the actual download through
+// [getter.ClientFromContext]) need a richer client.
+type InnerClientBuilder func(bare getter.Getter, scheme string) *getter.Client
 
 // CASGetterOption mutates a CASGetter at construction time.
 type CASGetterOption func(*CASGetter)
@@ -62,14 +71,22 @@ func WithGenericResolvers(m map[string]cas.SourceResolver) CASGetterOption {
 	return func(g *CASGetter) { g.resolvers = m }
 }
 
+// WithInnerClientBuilder overrides the per-fetch inner [getter.Client]
+// builder. The default builder is sufficient for production wiring;
+// tests use this hook to inject a TLS-trusting [getter.HttpGetter] for
+// the delegated tfr:// archive download.
+func WithInnerClientBuilder(b InnerClientBuilder) CASGetterOption {
+	return func(g *CASGetter) { g.innerClient = b }
+}
+
 // WithDefaultGenericDispatch is the shorthand for the canonical pairing of
 // [WithGenericFetchers]([DefaultGenericFetchers]) and [WithGenericResolvers]
-// ([DefaultSourceResolvers]). fetcherOpts are forwarded so HTTP auth headers
-// still reach the fetcher.
-func WithDefaultGenericDispatch(fetcherOpts ...GenericFetcherOption) CASGetterOption {
+// ([DefaultSourceResolvers]). opts are forwarded to both helpers so HTTP
+// auth headers reach the fetcher and tfr config reaches both.
+func WithDefaultGenericDispatch(opts ...GenericFetcherOption) CASGetterOption {
 	return func(g *CASGetter) {
-		g.fetchers = DefaultGenericFetchers(fetcherOpts...)
-		g.resolvers = DefaultSourceResolvers()
+		g.fetchers = DefaultGenericFetchers(opts...)
+		g.resolvers = DefaultSourceResolvers(opts...)
 	}
 }
 
@@ -99,10 +116,11 @@ func NewCASGetter(l log.Logger, c *cas.CAS, v cas.Venv, opts *cas.CloneOptions, 
 			new(GitLabDetector),
 			new(FileDetector),
 		},
-		CAS:    c,
-		Logger: l,
-		Opts:   opts,
-		Venv:   v,
+		CAS:         c,
+		Logger:      l,
+		Opts:        opts,
+		Venv:        v,
+		innerClient: defaultInnerClientBuilder,
 	}
 
 	for _, opt := range options {
@@ -241,11 +259,12 @@ func GitCloneURL(urlStr string) string {
 // source URL. req.Forced (set by the outer client when it stripped a
 // "<scheme>::" prefix) wins; otherwise the URL scheme is consulted.
 //
-// URL-scheme claiming is restricted to http and https. The bare go-getter
-// v2 protocol getters for s3, gcs, hg, smb reject `<scheme>://...` URLs
-// (they expect canonical HTTPS forms or the forced-prefix syntax), so
-// claiming those schemes here would set up a doomed inner fetch on every
-// cache miss.
+// URL-scheme claiming is restricted to http, https, and tfr. The bare
+// go-getter v2 protocol getters for s3, gcs, hg, smb reject
+// `<scheme>://...` URLs (they expect canonical HTTPS forms or the
+// forced-prefix syntax), so claiming those schemes here would set up a
+// doomed inner fetch on every cache miss. The tfr fetcher
+// ([RegistryGetter]) accepts tfr:// URLs natively.
 //
 // HTTPS URLs against AWS S3 hosts are an exception: virtual-host forms
 // (`<bucket>.s3.amazonaws.com/<key>`) would route through the HTTPS
@@ -280,7 +299,7 @@ func (g *CASGetter) matchGenericScheme(req *getter.Request) (string, string, boo
 
 	scheme := strings.ToLower(u.Scheme)
 	switch scheme {
-	case SchemeHTTP, SchemeHTTPS:
+	case SchemeHTTP, SchemeHTTPS, SchemeTFR:
 		if canonical, ok := canonicalAWSS3HTTPSURL(u); ok {
 			if _, fok := g.fetchers[SchemeS3]; fok {
 				return SchemeS3, canonical, true
@@ -424,10 +443,10 @@ func (g *CASGetter) getGeneric(ctx context.Context, req *getter.Request) error {
 }
 
 // buildInnerFetch returns a SourceFetcher that downloads urlStr into a
-// fresh temp directory through a single-getter inner [getter.Client] and
-// ingests the result via [cas.CAS.IngestDirectory]. The inner client uses
-// the default decompressor map so `.tar.gz`/`.zip` URLs extract before
-// ingest.
+// fresh temp directory through an inner [getter.Client] built by
+// [InnerClientBuilder] and ingests the result via
+// [cas.CAS.IngestDirectory]. The inner client uses the default
+// decompressor map so `.tar.gz`/`.zip` URLs extract before ingest.
 //
 // scheme is set on the inner request's Forced field so the bare
 // scheme-specific getter still claims the request. The bare go-getter v2
@@ -443,9 +462,7 @@ func (g *CASGetter) buildInnerFetch(bare getter.Getter, scheme, urlStr string) c
 
 		defer cleanup()
 
-		inner := &getter.Client{
-			Getters: []getter.Getter{bare},
-		}
+		inner := g.innerClient(bare, scheme)
 
 		if _, err := inner.Get(ctx, &getter.Request{
 			Src:     urlStr,
@@ -458,4 +475,17 @@ func (g *CASGetter) buildInnerFetch(bare getter.Getter, scheme, urlStr string) c
 
 		return g.CAS.IngestDirectory(l, v, tempDir, suggestedKey)
 	}
+}
+
+// defaultInnerClientBuilder is the inner-client builder used when none
+// is configured via [WithInnerClientBuilder]. For tfr it returns a
+// Terragrunt client with the bare [RegistryGetter] prepended so the
+// default protocol set is available for [RegistryGetter]'s delegated
+// archive download. Every other scheme uses a single-getter client.
+func defaultInnerClientBuilder(bare getter.Getter, scheme string) *getter.Client {
+	if scheme == SchemeTFR {
+		return NewClient(WithCustomGettersPrepended(bare))
+	}
+
+	return &getter.Client{Getters: []getter.Getter{bare}}
 }

--- a/internal/getter/casgetter_tfr_test.go
+++ b/internal/getter/casgetter_tfr_test.go
@@ -1,0 +1,204 @@
+package getter_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	tgcas "github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	gogetter "github.com/hashicorp/go-getter/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCASGetter_TFRRoutesThroughCAS_FirstRunDownloads pins that a
+// tfr:// source claimed by CASGetter resolves to an archive download
+// and lands a tree in the CAS store.
+//
+// The wiring mirrors the production tryCASDownload path but routes the
+// underlying HTTPS calls through the httptest TLS server.
+func TestCASGetter_TFRRoutesThroughCAS(t *testing.T) {
+	t.Parallel()
+
+	var archiveGets atomic.Int32
+
+	server := newCountingRegistryTestServer(t, &archiveGets)
+
+	l := logger.CreateLogger()
+	httpClient := server.Client()
+
+	tfr := getter.NewRegistryGetter(l).
+		WithHTTPClient(httpClient).
+		WithTofuImplementation(tfimpl.Terraform)
+
+	resolver := getter.NewTFRResolver().
+		WithHTTPClient(httpClient).
+		WithLogger(l).
+		WithTofuImplementation(tfimpl.Terraform)
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+
+	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	v, err := tgcas.OSVenv()
+	require.NoError(t, err)
+
+	// Inner client builder injects a TLS-trusting HttpGetter so the
+	// RegistryGetter's delegated archive download trusts the
+	// httptest TLS server's self-signed cert. Production wiring does
+	// not need this hook — the default builder uses the standard
+	// HttpGetter, which is fine for a real registry.
+	innerBuilder := func(bare gogetter.Getter, _ string) *gogetter.Client {
+		return getter.NewClient(getter.WithCustomGettersPrepended(
+			bare,
+			&gogetter.HttpGetter{Client: httpClient, Netrc: true},
+		))
+	}
+
+	g := getter.NewCASGetter(l, c, v, &tgcas.CloneOptions{},
+		getter.WithGenericFetchers(map[string]gogetter.Getter{
+			getter.SchemeTFR: tfr,
+		}),
+		getter.WithGenericResolvers(map[string]getter.SourceResolver{
+			getter.SchemeTFR: resolver,
+		}),
+		getter.WithInnerClientBuilder(innerBuilder),
+	)
+
+	client := &gogetter.Client{Getters: []gogetter.Getter{g}}
+
+	src := "tfr://" + server.Listener.Addr().String() + "/terraform-aws-modules/vpc/aws?version=3.3.0"
+
+	first := filepath.Join(helpers.TmpDirWOSymlinks(t), "first")
+	_, err = client.Get(t.Context(), &gogetter.Request{
+		Src:     src,
+		Dst:     first,
+		GetMode: gogetter.ModeAny,
+	})
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(first, "main.tf"))
+
+	firstGets := archiveGets.Load()
+	assert.Equal(t, int32(1), firstGets, "first run must download the archive once")
+
+	// Second run against the same source — probe resolves to the
+	// same key, CAS materializes from the store, and the archive
+	// endpoint must not be hit again.
+	second := filepath.Join(helpers.TmpDirWOSymlinks(t), "second")
+	_, err = client.Get(t.Context(), &gogetter.Request{
+		Src:     src,
+		Dst:     second,
+		GetMode: gogetter.ModeAny,
+	})
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(second, "main.tf"))
+
+	assert.Equal(t, firstGets, archiveGets.Load(),
+		"second run must hit the CAS cache and skip the archive download")
+}
+
+// TestCASGetter_TFRBareScheme pins that a tfr:// URL with no forced
+// prefix is claimed by CASGetter's detector and routed through the
+// generic dispatch.
+func TestCASGetter_TFRBareSchemeIsClaimed(t *testing.T) {
+	t.Parallel()
+
+	server := newRegistryTestServer(t)
+
+	l := logger.CreateLogger()
+
+	// A no-op fetcher we register as the TFR entry. The test only
+	// verifies detection; we count how many times the fetcher is
+	// invoked to confirm CASGetter routed the URL here.
+	calls := atomic.Int32{}
+	stub := &countingGetter{calls: &calls}
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+
+	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	v, err := tgcas.OSVenv()
+	require.NoError(t, err)
+
+	g := getter.NewCASGetter(l, c, v, &tgcas.CloneOptions{},
+		getter.WithGenericFetchers(map[string]gogetter.Getter{
+			getter.SchemeTFR: stub,
+		}),
+	)
+
+	req := &gogetter.Request{
+		Src: "tfr://" + server.Listener.Addr().String() + "/terraform-aws-modules/vpc/aws?version=3.3.0",
+	}
+
+	ok, err := g.Detect(req)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "tfr", req.Forced, "matchGenericScheme must set Forced=tfr")
+}
+
+// countingGetter is a no-op gogetter.Getter used to confirm CASGetter
+// dispatched a request without actually performing a fetch.
+type countingGetter struct {
+	calls *atomic.Int32
+}
+
+func (c *countingGetter) Detect(_ *gogetter.Request) (bool, error) { return true, nil }
+func (c *countingGetter) Get(_ context.Context, _ *gogetter.Request) error {
+	c.calls.Add(1)
+	return nil
+}
+func (c *countingGetter) GetFile(_ context.Context, _ *gogetter.Request) error { return nil }
+func (c *countingGetter) Mode(_ context.Context, _ *url.URL) (gogetter.Mode, error) {
+	return gogetter.ModeDir, nil
+}
+
+// newCountingRegistryTestServer is a variant of newRegistryTestServer
+// that records every successful archive GET in archiveGets. Use it to
+// pin that the CAS cache hit on a second probe skips the underlying
+// archive download.
+func newCountingRegistryTestServer(t *testing.T, archiveGets *atomic.Int32) *httptest.Server {
+	t.Helper()
+
+	zipBody := buildModuleZip(t)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/terraform.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"modules.v1":"/v1/modules/"}`))
+		assert.NoError(t, err)
+	})
+
+	mux.HandleFunc("/v1/modules/terraform-aws-modules/vpc/aws/3.3.0/download", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Terraform-Get", "https://"+r.Host+"/download/terraform-aws-vpc.zip")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("/download/terraform-aws-vpc.zip", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+
+		if r.Method != http.MethodGet {
+			return
+		}
+
+		archiveGets.Add(1)
+
+		_, err := w.Write(zipBody)
+		assert.NoError(t, err)
+	})
+
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	return server
+}

--- a/internal/getter/defaults.go
+++ b/internal/getter/defaults.go
@@ -3,6 +3,8 @@ package getter
 import (
 	"net/http"
 
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 	gcs "github.com/hashicorp/go-getter/gcs/v2"
 	s3 "github.com/hashicorp/go-getter/s3/v2"
 	getter "github.com/hashicorp/go-getter/v2"
@@ -19,14 +21,18 @@ const (
 	SchemeHTTPS = "https"
 	SchemeHg    = "hg"
 	SchemeSMB   = "smb"
+	SchemeTFR   = "tfr"
 )
 
-// GenericFetcherOption configures DefaultGenericFetchers.
+// GenericFetcherOption configures the generic-dispatch defaults consumed
+// by DefaultGenericFetchers and DefaultSourceResolvers.
 type GenericFetcherOption func(*genericFetcherConfig)
 
 type genericFetcherConfig struct {
 	httpExtra  http.Header
 	httpsExtra http.Header
+	tfrLogger  log.Logger
+	tfrImpl    tfimpl.Type
 }
 
 // WithHTTPExtraHeaders attaches header to the bare http getter so
@@ -42,6 +48,18 @@ func WithHTTPSExtraHeaders(header http.Header) GenericFetcherOption {
 	return func(c *genericFetcherConfig) { c.httpsExtra = header }
 }
 
+// WithTFRConfig registers the dependencies the tfr:// fetcher and
+// resolver need. When unset, tfr is omitted from the generic-dispatch
+// maps so [CASGetter] cannot route tfr:// through CAS. The standard
+// (non-CAS) client registers its own [RegistryGetter] via
+// [WithTFRegistry] and is unaffected.
+func WithTFRConfig(l log.Logger, impl tfimpl.Type) GenericFetcherOption {
+	return func(c *genericFetcherConfig) {
+		c.tfrLogger = l
+		c.tfrImpl = impl
+	}
+}
+
 // DefaultGenericFetchers returns the per-scheme bare getters CASGetter
 // uses on a cache miss. Exported so callers that build dedicated
 // CAS-only clients (the CAS-experiment path in
@@ -52,7 +70,7 @@ func DefaultGenericFetchers(opts ...GenericFetcherOption) map[string]getter.Gett
 		opt(&cfg)
 	}
 
-	return map[string]getter.Getter{
+	m := map[string]getter.Getter{
 		SchemeS3:    new(s3.Getter),
 		SchemeGCS:   new(gcs.Getter),
 		SchemeHTTP:  &HTTPSchemeGetter{Inner: newHTTPGetter(cfg.httpExtra), Scheme: SchemeHTTP},
@@ -60,6 +78,12 @@ func DefaultGenericFetchers(opts ...GenericFetcherOption) map[string]getter.Gett
 		SchemeHg:    new(getter.HgGetter),
 		SchemeSMB:   new(getter.SmbClientGetter),
 	}
+
+	if cfg.tfrLogger != nil {
+		m[SchemeTFR] = NewRegistryGetter(cfg.tfrLogger).WithTofuImplementation(cfg.tfrImpl)
+	}
+
+	return m
 }
 
 // buildGetters realizes the option set into the ordered Getter slice
@@ -116,11 +140,18 @@ func buildGetters(b *builder) []Getter {
 			SchemeSMB:   smbClientGetter,
 		}
 
+		resolverOpts := []GenericFetcherOption(nil)
+
+		if b.tfRegistry != nil {
+			fetchers[SchemeTFR] = b.tfRegistry
+			resolverOpts = append(resolverOpts, WithTFRConfig(b.logger, b.tfRegistry.TofuImplementation))
+		}
+
 		out = append(out,
 			NewCASProtocolGetter(b.logger, b.casStore, b.casVenv),
 			NewCASGetter(b.logger, b.casStore, b.casVenv, b.casCloneOpts,
 				WithGenericFetchers(fetchers),
-				WithGenericResolvers(DefaultSourceResolvers()),
+				WithGenericResolvers(DefaultSourceResolvers(resolverOpts...)),
 			),
 		)
 	}

--- a/internal/getter/resolver.go
+++ b/internal/getter/resolver.go
@@ -12,12 +12,34 @@ type SourceResolver = cas.SourceResolver
 // through. SMB has no cheap probe so smb:// sources fall through to the
 // no-resolver path in [cas.CAS.FetchSource] (download then content-hash); git
 // is handled separately by [cas.CAS.Clone].
-func DefaultSourceResolvers() map[string]SourceResolver {
+//
+// The tfr resolver is always registered. CASGetter only claims tfr:// URLs
+// when the matching fetcher is registered (gated on [WithTFRConfig], since
+// [RegistryGetter] requires a logger at construction), so an unused tfr
+// resolver entry is harmless. Pass [WithTFRConfig] to align its logger and
+// tofu implementation with the fetcher so the probe and the fetch resolve
+// against the same registry host.
+func DefaultSourceResolvers(opts ...GenericFetcherOption) map[string]SourceResolver {
+	var cfg genericFetcherConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	tfr := NewTFRResolver()
+	if cfg.tfrLogger != nil {
+		tfr.WithLogger(cfg.tfrLogger)
+	}
+
+	if cfg.tfrImpl != "" {
+		tfr.WithTofuImplementation(cfg.tfrImpl)
+	}
+
 	return map[string]SourceResolver{
-		"http":  NewHTTPResolver(),
-		"https": NewHTTPSResolver(),
-		"s3":    NewS3Resolver(),
-		"gcs":   NewGCSResolver(),
-		"hg":    NewHgResolver(),
+		SchemeHTTP:  NewHTTPResolver(),
+		SchemeHTTPS: NewHTTPSResolver(),
+		SchemeS3:    NewS3Resolver(),
+		SchemeGCS:   NewGCSResolver(),
+		SchemeHg:    NewHgResolver(),
+		SchemeTFR:   tfr,
 	}
 }

--- a/internal/getter/resolver_tfr.go
+++ b/internal/getter/resolver_tfr.go
@@ -1,0 +1,129 @@
+package getter
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+// tfrResolverTimeout caps the registry probe so a slow registry can't
+// stall CAS dispatch. On timeout the resolver returns
+// [cas.ErrNoVersionMetadata] and CAS falls back to content hashing
+// after the fetch.
+const tfrResolverTimeout = 10 * time.Second
+
+// TFRResolver is a [cas.SourceResolver] for tfr:// URLs.
+//
+// Probe resolves the source via the Terraform/OpenTofu registry's module
+// download endpoint and returns the resolved X-Terraform-Get URL as a
+// content-addressed cache key. That URL encodes the immutable underlying
+// archive (a versioned tarball, a git commit SHA, etc.), so two identical
+// tfr:// requests share one CAS entry while a republish under the same
+// version pins to a new key.
+type TFRResolver struct {
+	HTTPClient         *http.Client
+	Logger             log.Logger
+	TofuImplementation tfimpl.Type
+}
+
+// NewTFRResolver returns a [TFRResolver] with sensible defaults: a
+// [github.com/hashicorp/go-cleanhttp.DefaultClient] capped at
+// [tfrResolverTimeout], [log.Default] for diagnostic output, and
+// [tfimpl.OpenTofu] as the default implementation.
+func NewTFRResolver() *TFRResolver {
+	client := cleanhttp.DefaultClient()
+	client.Timeout = tfrResolverTimeout
+
+	return &TFRResolver{
+		HTTPClient:         client,
+		Logger:             log.Default(),
+		TofuImplementation: tfimpl.OpenTofu,
+	}
+}
+
+// WithHTTPClient overrides the HTTP client used for registry-protocol
+// requests. Intended for tests routing through a
+// [net/http/httptest.Server].
+func (r *TFRResolver) WithHTTPClient(c *http.Client) *TFRResolver {
+	r.HTTPClient = c
+	return r
+}
+
+// WithLogger overrides the logger used for diagnostic output.
+func (r *TFRResolver) WithLogger(l log.Logger) *TFRResolver {
+	r.Logger = l
+	return r
+}
+
+// WithTofuImplementation selects which default registry domain is used
+// when a tfr:// URL omits its host. See [tfimpl.DefaultRegistryDomain].
+func (r *TFRResolver) WithTofuImplementation(impl tfimpl.Type) *TFRResolver {
+	r.TofuImplementation = impl
+	return r
+}
+
+// Scheme returns "tfr".
+func (r *TFRResolver) Scheme() string { return SchemeTFR }
+
+// Probe runs the registry's service-discovery + module-download protocol
+// against rawURL and returns the resolved X-Terraform-Get URL as a
+// content-addressed cache key.
+//
+// Any failure — malformed URL, missing version query, registry error —
+// returns [cas.ErrNoVersionMetadata] so the fetch falls through to the
+// download-then-content-hash path. The underlying error surfaces on the
+// real fetch attempt.
+func (r *TFRResolver) Probe(ctx context.Context, rawURL string) (string, error) {
+	srcURL, err := url.Parse(rawURL)
+	if err != nil || srcURL.Scheme != SchemeTFR {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	registryDomain := srcURL.Host
+	if registryDomain == "" {
+		registryDomain = tfimpl.DefaultRegistryDomain(r.TofuImplementation)
+	}
+
+	versionList, hasVersion := srcURL.Query()[versionQueryKey]
+	if !hasVersion || len(versionList) != 1 || versionList[0] == "" {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	version := versionList[0]
+
+	// Strip the //subdir selector so two URLs that only differ in subdir
+	// produce the same probe key. The fetcher still sees the original
+	// URL and handles subdir extraction itself.
+	modulePath, _ := SourceDirSubdir(srcURL.Path)
+
+	ctx, cancel := context.WithTimeout(ctx, tfrResolverTimeout)
+	defer cancel()
+
+	moduleRegistryBasePath, err := GetModuleRegistryURLBasePath(ctx, r.Logger, r.HTTPClient, registryDomain)
+	if err != nil {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	moduleURL, err := BuildRequestURL(registryDomain, moduleRegistryBasePath, modulePath, version)
+	if err != nil {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	terraformGet, err := GetTerraformGetHeader(ctx, r.Logger, r.HTTPClient, moduleURL)
+	if err != nil {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	downloadURL, err := GetDownloadURLFromHeader(moduleURL, terraformGet)
+	if err != nil {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	return cas.ContentKey("tfr-xtg", downloadURL), nil
+}

--- a/internal/getter/resolver_tfr_test.go
+++ b/internal/getter/resolver_tfr_test.go
@@ -1,0 +1,123 @@
+package getter_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTFRResolver_ProbeReturnsContentKey(t *testing.T) {
+	t.Parallel()
+
+	server := newRegistryTestServer(t)
+
+	r := getter.NewTFRResolver().
+		WithHTTPClient(server.Client()).
+		WithLogger(logger.CreateLogger())
+
+	src := "tfr://" + server.Listener.Addr().String() +
+		"/terraform-aws-modules/vpc/aws?version=3.3.0"
+
+	key, err := r.Probe(t.Context(), src)
+	require.NoError(t, err)
+
+	expected := cas.ContentKey("tfr-xtg", "https://"+server.Listener.Addr().String()+"/download/terraform-aws-vpc.zip")
+	assert.Equal(t, expected, key)
+}
+
+// TestTFRResolver_ProbeIsStable pins that two probes of the same URL
+// produce the same key, so the CAS hit path on a repeated run is
+// deterministic.
+func TestTFRResolver_ProbeIsStable(t *testing.T) {
+	t.Parallel()
+
+	server := newRegistryTestServer(t)
+
+	r := getter.NewTFRResolver().
+		WithHTTPClient(server.Client()).
+		WithLogger(logger.CreateLogger())
+
+	src := "tfr://" + server.Listener.Addr().String() +
+		"/terraform-aws-modules/vpc/aws?version=3.3.0"
+
+	first, err := r.Probe(t.Context(), src)
+	require.NoError(t, err)
+
+	second, err := r.Probe(t.Context(), src)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+}
+
+// TestTFRResolver_SubdirCollapsesToSameKey pins that two tfr:// URLs
+// that only differ in their //subdir selector share one CAS entry: the
+// fetcher copies out the subdir, but the upstream archive is identical.
+func TestTFRResolver_SubdirCollapsesToSameKey(t *testing.T) {
+	t.Parallel()
+
+	server := newRegistryTestServer(t)
+
+	r := getter.NewTFRResolver().
+		WithHTTPClient(server.Client()).
+		WithLogger(logger.CreateLogger())
+
+	base := "tfr://" + server.Listener.Addr().String() +
+		"/terraform-aws-modules/vpc/aws"
+
+	bare, err := r.Probe(t.Context(), base+"?version=3.3.0")
+	require.NoError(t, err)
+
+	withSubdir, err := r.Probe(t.Context(), base+"//modules/public?version=3.3.0")
+	require.NoError(t, err)
+
+	assert.Equal(t, bare, withSubdir)
+}
+
+func TestTFRResolver_MissingVersionReturnsErrNoVersionMetadata(t *testing.T) {
+	t.Parallel()
+
+	r := getter.NewTFRResolver().WithLogger(logger.CreateLogger())
+
+	_, err := r.Probe(t.Context(), "tfr://registry.terraform.io/terraform-aws-modules/vpc/aws")
+	require.ErrorIs(t, err, cas.ErrNoVersionMetadata)
+}
+
+func TestTFRResolver_EmptyVersionReturnsErrNoVersionMetadata(t *testing.T) {
+	t.Parallel()
+
+	r := getter.NewTFRResolver().WithLogger(logger.CreateLogger())
+
+	_, err := r.Probe(t.Context(), "tfr://registry.terraform.io/terraform-aws-modules/vpc/aws?version=")
+	require.ErrorIs(t, err, cas.ErrNoVersionMetadata)
+}
+
+func TestTFRResolver_DiscoveryFailureReturnsErrNoVersionMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	r := getter.NewTFRResolver().
+		WithHTTPClient(server.Client()).
+		WithLogger(logger.CreateLogger())
+
+	src := "tfr://" + server.Listener.Addr().String() +
+		"/terraform-aws-modules/vpc/aws?version=3.3.0"
+
+	_, err := r.Probe(t.Context(), src)
+	require.ErrorIs(t, err, cas.ErrNoVersionMetadata)
+}
+
+func TestTFRResolver_SchemeReportsTFR(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "tfr", getter.NewTFRResolver().Scheme())
+}

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -430,7 +430,9 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 	client := &getter.Client{
 		Getters: []getter.Getter{
 			casProtocol,
-			getter.NewCASGetter(l, c, venv, &cloneOpts, getter.WithDefaultGenericDispatch()),
+			getter.NewCASGetter(l, c, venv, &cloneOpts, getter.WithDefaultGenericDispatch(
+				getter.WithTFRConfig(l, opts.TofuImplementation),
+			)),
 		},
 	}
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Ensures full support for `tfr://` URLs in CAS.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added content-addressing support for Terraform Registry module sources (`tfr://`). Repeat runs pinned to the same registry version now reuse cached modules instead of re-downloading. The resolved registry archive URL serves as the cache key to prevent stale cache from serving outdated bytes after republishing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->