### PR TITLE
fix: Fixing `run --all` early exit

### DIFF
--- a/docs/src/data/changelog/v1.0.5/runall-cancel-bypasses-cleanup.mdx
+++ b/docs/src/data/changelog/v1.0.5/runall-cancel-bypasses-cleanup.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.5"
+category: "bug-fixes"
+---
+
+#### Declining a `run --all` or `--graph` confirmation no longer skips cleanup
+
+When `terragrunt run --all destroy` (or `--all state`, `--all apply`, or the equivalent `--graph` variants) prompted for confirmation and the user answered "no", Terragrunt terminated the process directly, skipping cleanup the run had registered.
+
+Cleanup now runs before Terragrunt exits.

--- a/internal/runner/graph/graph.go
+++ b/internal/runner/graph/graph.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
-func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
+func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) (err error) {
 	// Get credentials BEFORE config parsing — sops_decrypt_file() and
 	// get_aws_account_id() in locals need auth-provider credentials
 	// available in opts.Env during HCL evaluation.
@@ -112,8 +112,12 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 
 	if !opts.SummaryDisable {
 		defer func() {
-			if err := r.WriteSummary(opts.Writers.Writer); err != nil {
-				l.Warnf("Failed to write summary: %v", err)
+			if errors.Is(err, runall.ErrUserCancelled) {
+				return
+			}
+
+			if writeErr := r.WriteSummary(opts.Writers.Writer); writeErr != nil {
+				l.Warnf("Failed to write summary: %v", writeErr)
 			}
 		}()
 	}

--- a/internal/runner/runall/errors.go
+++ b/internal/runner/runall/errors.go
@@ -1,6 +1,10 @@
 package runall
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/gruntwork-io/terragrunt/internal/errors"
+)
 
 type RunAllDisabledErr struct {
 	command string
@@ -16,3 +20,8 @@ type MissingCommand struct{}
 func (err MissingCommand) Error() string {
 	return "Missing run --all command argument (Example: terragrunt run --all plan)"
 }
+
+// ErrUserCancelled signals that the user answered "no" to a destructive
+// `run --all` confirmation prompt. The top-level error handler treats
+// it as a clean exit.
+var ErrUserCancelled = errors.New("run --all cancelled by user")

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -3,7 +3,6 @@ package runall
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/runner"
@@ -43,7 +42,7 @@ var runAllDisabledCommands = map[string]string{
 		" and thus should not be run with run --all.",
 }
 
-func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
+func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) (err error) {
 	// --filter sets RunAll, so the CLI layer dispatches here without going
 	// through the single-unit run path. Emit the tip here as well; the
 	// underlying sync.Once dedupes if both paths fire.
@@ -88,21 +87,26 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) err
 	// Skip summary for programmatic interactions:
 	// - When JSON output is requested (--json or report format is JSON)
 	// - When running 'output' command (typically for programmatic consumption)
+	// - When the user cancelled the run-all confirmation prompt, since
+	//   no units ran.
 	if !opts.SummaryDisable && !shouldSkipSummary(opts) {
 		defer func() {
-			if err := r.WriteSummary(opts.Writers.Writer); err != nil {
-				l.Warnf("Failed to write summary: %v", err)
+			if errors.Is(err, ErrUserCancelled) {
+				return
+			}
+
+			if writeErr := r.WriteSummary(opts.Writers.Writer); writeErr != nil {
+				l.Warnf("Failed to write summary: %v", writeErr)
 			}
 		}()
 	}
 
 	gitFilters := opts.Filters.UniqueGitFilters()
 
-	// Only create worktrees when git filter expressions are present
-	var (
-		wts *worktrees.Worktrees
-		err error
-	)
+	// Only create worktrees when git filter expressions are present.
+	// `err` is the named return; the summary defer reads it to detect
+	// ErrUserCancelled.
+	var wts *worktrees.Worktrees
 	if len(gitFilters) > 0 {
 		wts, err = worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{
 			WorkingDir:     opts.WorkingDir,
@@ -204,8 +208,11 @@ func RunAllOnStack(
 		}
 
 		if !shouldRunAll {
-			// We explicitly exit here to avoid running any defers that might be registered, like from the run summary.
-			os.Exit(0)
+			// Return a sentinel so the caller can map the cancellation
+			// to a clean exit. os.Exit here would skip every defer in
+			// the program, including worktree cleanup and telemetry
+			// shutdown.
+			return ErrUserCancelled
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/global"
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/runner/runall"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
@@ -61,6 +62,13 @@ func checkForErrorsAndExit(l log.Logger, exitCode int) func(error) {
 	return func(err error) {
 		if err == nil {
 			os.Exit(exitCode)
+		}
+
+		// User declined a destructive run-all prompt. Exit 0 without
+		// printing an error message, since they already declined at
+		// the prompt.
+		if errors.Is(err, runall.ErrUserCancelled) {
+			os.Exit(0)
 		}
 
 		l.Error(err.Error())


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Prevents failure to cleanup from defers by using a sentinel error instead of an `os.Exit(0)`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Declining the confirmation prompt for destructive "run --all" (destroy/apply/state and related --graph variants) now performs registered cleanup before exiting and returns a normal (zero) exit status instead of terminating immediately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->