### PR TITLE
fix: support tfr:// module sources in scaffold command

### DIFF
--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -298,6 +298,24 @@ func BuildSourceURL(originalURL, resolvedURL string, vars map[string]any) string
 		return resolvedURL
 	}
 
+	if getter.IsTFRSource(originalURL) {
+		versionVal := ExtractQueryParam(resolvedURL, getter.VersionQueryKey)
+		if versionVal == "" {
+			return originalURL
+		}
+
+		base, rawQuery := splitURLQuery(originalURL)
+
+		params, err := url.ParseQuery(rawQuery)
+		if err != nil || params.Has(getter.VersionQueryKey) {
+			return originalURL
+		}
+
+		params.Set(getter.VersionQueryKey, versionVal)
+
+		return base + "?" + params.Encode()
+	}
+
 	refVal := ExtractQueryParam(resolvedURL, refParam)
 	if refVal == "" {
 		return originalURL

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -714,6 +714,11 @@ func addRefToModuleURL(
 	if ref == "" {
 		// For tfr:// URLs, resolve the latest version via the registry API.
 		if getter.IsTFRSource(moduleURL.String()) {
+			// If version is already specified, skip resolution.
+			if params.Has(getter.VersionQueryKey) {
+				return moduleURL, nil
+			}
+
 			latestVersion, err := resolveTFRVersion(ctx, l, opts, moduleURL)
 			if err != nil {
 				return nil, err
@@ -724,7 +729,7 @@ func addRefToModuleURL(
 				return moduleURL, nil
 			}
 
-			params.Add(getter.VersionQueryKey, latestVersion)
+			params.Set(getter.VersionQueryKey, latestVersion)
 			moduleURL.RawQuery = params.Encode()
 
 			return moduleURL, nil

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
@@ -45,6 +46,9 @@ const (
 
 	moduleURLPattern = `(?:git|hg|s3|gcs)::([^:]+)://([^/]+)(/.*)`
 	moduleURLParts   = 4
+
+	// versionQueryParam is the query parameter used for tfr:// version resolution.
+	versionQueryParam = "version"
 
 	// TODO: Make the root configuration file name configurable
 	DefaultBoilerplateConfig = `
@@ -197,7 +201,10 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, mod
 	if err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "scaffold_get_module", map[string]any{
 		"module_url": moduleURL,
 	}, func(ctx context.Context) error {
-		if _, getErr := getter.GetAny(ctx, tempDir, moduleURL); getErr != nil {
+		if _, getErr := getter.GetAny(ctx, tempDir, moduleURL,
+			getter.WithTFRegistry(getter.NewRegistryGetter(l).
+				WithTofuImplementation(opts.TofuImplementation)),
+		); getErr != nil {
 			return fmt.Errorf("downloading scaffold module from %s: %w", moduleURL, getErr)
 		}
 
@@ -436,7 +443,10 @@ func downloadTemplate(
 	if err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "scaffold_get_template", map[string]any{
 		"template_url": baseURL.String(),
 	}, func(ctx context.Context) error {
-		if _, getErr := getter.GetAny(ctx, templateDir, baseURL.String()); getErr != nil {
+		if _, getErr := getter.GetAny(ctx, templateDir, baseURL.String(),
+			getter.WithTFRegistry(getter.NewRegistryGetter(l).
+				WithTofuImplementation(opts.TofuImplementation)),
+		); getErr != nil {
 			return fmt.Errorf("downloading scaffold template from %s: %w", baseURL.String(), getErr)
 		}
 
@@ -594,14 +604,15 @@ func rewriteModuleURL(
 		sourceURLType = fmt.Sprintf("%s", value)
 	}
 
-	// expand module url
+	// Try to parse the URL as a forced-getter URL (git::https://... etc.)
 	parsedValue, err := parseURL(l, moduleURL)
 	if err != nil {
-		l.Warnf("Failed to parse module url %s", moduleURL)
-
-		parsedModuleURL, err := tf.ToSourceURL(updatedModuleURL, opts.WorkingDir)
-		if err != nil {
-			return nil, errors.New(err)
+		// Not a forced-getter URL. This is normal for many URL formats
+		// (e.g. tfr:// URLs, plain https:// URLs). Just convert to a
+		// standard url.URL without rewriting.
+		parsedModuleURL, parseErr := tf.ToSourceURL(updatedModuleURL, opts.WorkingDir)
+		if parseErr != nil {
+			return nil, errors.New(parseErr)
 		}
 
 		return parsedModuleURL, nil
@@ -686,6 +697,19 @@ func addRefToModuleURL(
 
 	ref := params.Get(refParam)
 	if ref == "" {
+		// For tfr:// URLs, resolve the latest version via the registry API.
+		if getter.IsTFRSource(moduleURL.String()) {
+			latestVersion, err := resolveTFRVersion(ctx, l, opts, moduleURL)
+			if err != nil || latestVersion == "" {
+				l.Warnf("Failed to find latest version for %s: %v", moduleURL, err)
+			} else {
+				params.Add(versionQueryParam, latestVersion)
+				moduleURL.RawQuery = params.Encode()
+			}
+
+			return moduleURL, nil
+		}
+
 		// if ref is not passed, find last release tag
 		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
 		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8
@@ -706,11 +730,33 @@ func addRefToModuleURL(
 	return moduleURL, nil
 }
 
+// resolveTFRVersion resolves the latest version of a tfr:// module
+// by querying the registry's /versions endpoint.
+func resolveTFRVersion(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, moduleURL *url.URL) (string, error) {
+	// Determine the registry domain. If not specified in the URL, use the
+	// default for the current tofu implementation.
+	registryDomain := moduleURL.Host
+	if registryDomain == "" {
+		registryDomain = tfimpl.DefaultRegistryDomain(opts.TofuImplementation)
+	}
+
+	// Extract the module path (e.g. "terraform-aws-modules/vpc/aws")
+	// using SourceDirSubdir which handles the "//subdir" syntax.
+	modulePath, _ := getter.SourceDirSubdir(strings.TrimPrefix(moduleURL.Path, "/"))
+	if modulePath == "" {
+		modulePath = strings.TrimPrefix(moduleURL.Path, "/")
+	}
+
+	return getter.ResolveTFRVersion(ctx, l, nil, registryDomain, modulePath)
+}
+
 // parseURL parses module url to scheme, host and path
+// The regex only matches forced-getter URLs (e.g. git::https://host/path).
+// URLs that don't match (like tfr:// or plain https://) return nil error
+// and the caller handles them as non-rewritable URLs.
 func parseURL(l log.Logger, moduleURL string) (*parsedURL, error) {
 	matches := moduleURLRegex.FindStringSubmatch(moduleURL)
 	if len(matches) != moduleURLParts {
-		l.Warnf("Failed to parse url %s", moduleURL)
 		return nil, failedToParseURLError{}
 	}
 

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -47,9 +47,6 @@ const (
 	moduleURLPattern = `(?:git|hg|s3|gcs)::([^:]+)://([^/]+)(/.*)`
 	moduleURLParts   = 4
 
-	// versionQueryParam is the query parameter used for tfr:// version resolution.
-	versionQueryParam = "version"
-
 	// TODO: Make the root configuration file name configurable
 	DefaultBoilerplateConfig = `
 variables:
@@ -700,12 +697,17 @@ func addRefToModuleURL(
 		// For tfr:// URLs, resolve the latest version via the registry API.
 		if getter.IsTFRSource(moduleURL.String()) {
 			latestVersion, err := resolveTFRVersion(ctx, l, opts, moduleURL)
-			if err != nil || latestVersion == "" {
-				l.Warnf("Failed to find latest version for %s: %v", moduleURL, err)
-			} else {
-				params.Add(versionQueryParam, latestVersion)
-				moduleURL.RawQuery = params.Encode()
+			if err != nil {
+				return nil, err
 			}
+
+			if latestVersion == "" {
+				l.Warnf("Failed to find latest version for %s", moduleURL)
+				return moduleURL, nil
+			}
+
+			params.Add(getter.VersionQueryKey, latestVersion)
+			moduleURL.RawQuery = params.Encode()
 
 			return moduleURL, nil
 		}
@@ -721,10 +723,11 @@ func addRefToModuleURL(
 		tag, err := shell.GitLastReleaseTag(ctx, l, opts.Env, opts.WorkingDir, rootSourceURL)
 		if err != nil || tag == "" {
 			l.Warnf("Failed to find last release tag for %s", rootSourceURL)
-		} else {
-			params.Add(refParam, tag)
-			moduleURL.RawQuery = params.Encode()
+			return moduleURL, nil
 		}
+
+		params.Add(refParam, tag)
+		moduleURL.RawQuery = params.Encode()
 	}
 
 	return moduleURL, nil
@@ -743,9 +746,6 @@ func resolveTFRVersion(ctx context.Context, l log.Logger, opts *options.Terragru
 	// Extract the module path (e.g. "terraform-aws-modules/vpc/aws")
 	// using SourceDirSubdir which handles the "//subdir" syntax.
 	modulePath, _ := getter.SourceDirSubdir(strings.TrimPrefix(moduleURL.Path, "/"))
-	if modulePath == "" {
-		modulePath = strings.TrimPrefix(moduleURL.Path, "/")
-	}
 
 	return getter.ResolveTFRVersion(ctx, l, nil, registryDomain, modulePath)
 }

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -706,7 +706,12 @@ func addRefToModuleURL(
 
 	refReplacement, refVarPassed := vars[refVar]
 	if refVarPassed {
-		params.Set(refParam, fmt.Sprintf("%s", refReplacement))
+		paramKey := refParam
+		if getter.IsTFRSource(moduleURL.String()) {
+			paramKey = getter.VersionQueryKey
+		}
+
+		params.Set(paramKey, fmt.Sprintf("%s", refReplacement))
 		moduleURL.RawQuery = params.Encode()
 	}
 

--- a/internal/getter/tfr.go
+++ b/internal/getter/tfr.go
@@ -19,7 +19,8 @@ import (
 	safetemp "github.com/hashicorp/go-safetemp"
 )
 
-const versionQueryKey = "version"
+// VersionQueryKey is the query parameter used for tfr:// version resolution.
+const VersionQueryKey = "version"
 
 // RegistryGetter is the go-getter v2 implementation of the tfr:// protocol.
 //
@@ -113,7 +114,7 @@ func (r *RegistryGetter) Get(ctx context.Context, req *getter.Request) error {
 	queryValues := srcURL.Query()
 	modulePath, moduleSubDir := SourceDirSubdir(srcURL.Path)
 
-	versionList, hasVersion := queryValues[versionQueryKey]
+	versionList, hasVersion := queryValues[VersionQueryKey]
 	if !hasVersion {
 		return errors.New(MalformedRegistryURLErr{reason: "missing version query"})
 	}

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -8,13 +8,14 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-cleanhttp"
+	version "github.com/hashicorp/go-version"
 	svchost "github.com/hashicorp/terraform-svchost"
 )
 
@@ -287,29 +288,30 @@ func ResolveTFRVersion(ctx context.Context, l log.Logger, httpClient *http.Clien
 		return "", nil
 	}
 
-	versions := make([]string, len(resp.Modules[0].Versions))
-	for i, v := range resp.Modules[0].Versions {
-		versions[i] = v.Version
+	versions := make([]*version.Version, 0, len(resp.Modules[0].Versions))
+	for _, v := range resp.Modules[0].Versions {
+		parsed, err := version.NewVersion(v.Version)
+		if err != nil {
+			continue
+		}
+
+		versions = append(versions, parsed)
+	}
+
+	if len(versions) == 0 {
+		return "", nil
 	}
 
 	// Sort in descending semver order and return the top.
-	sort.Slice(versions, func(i, j int) bool {
-		return versions[i] > versions[j]
+	slices.SortFunc(versions, func(a, b *version.Version) int {
+		return b.Compare(a)
 	})
 
-	return versions[0], nil
+	return versions[0].Original(), nil
 }
 
 // IsTFRSource checks whether the given URL is a tfr:// registry URL.
 func IsTFRSource(rawURL string) bool {
-	if strings.HasPrefix(rawURL, "tfr://") {
-		return true
-	}
-
 	u, err := url.Parse(rawURL)
-	if err == nil && u.Scheme == "tfr" {
-		return true
-	}
-
-	return false
+	return err == nil && u.Scheme == "tfr"
 }

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
@@ -25,6 +26,21 @@ const (
 // RegistryServicePath is the modules service path returned by service discovery.
 type RegistryServicePath struct {
 	ModulesPath string `json:"modules.v1"`
+}
+
+// ModuleVersionsResponse is the JSON response from the registry's /versions endpoint.
+type ModuleVersionsResponse struct {
+	Modules []ModuleVersionEntry `json:"modules"`
+}
+
+// ModuleVersionEntry is an entry in the module versions response.
+type ModuleVersionEntry struct {
+	Versions []VersionEntry `json:"versions"`
+}
+
+// VersionEntry represents a single version returned by the registry.
+type VersionEntry struct {
+	Version string `json:"version"`
 }
 
 // MalformedRegistryURLErr is returned when the tfr:// URL is malformed.
@@ -222,4 +238,78 @@ func httpGETAndGetResponse(ctx context.Context, l log.Logger, httpClient *http.C
 	}
 
 	return bodyData, &resp.Header, nil
+}
+
+// ResolveTFRVersion queries the registry's /versions endpoint for the given
+// module path and returns the latest (highest semver) version. If versions is
+// empty, it returns an empty string.
+//
+// The modulePath should be in the form "namespace/name/system" (e.g.
+// "terraform-aws-modules/vpc/aws") as it appears in a tfr:// URL.
+func ResolveTFRVersion(ctx context.Context, l log.Logger, httpClient *http.Client, registryDomain, modulePath string) (string, error) {
+	if httpClient == nil {
+		httpClient = cleanhttp.DefaultClient()
+	}
+
+	// Perform service discovery to find the modules API base path.
+	moduleRegistryBasePath, err := GetModuleRegistryURLBasePath(ctx, l, httpClient, registryDomain)
+	if err != nil {
+		return "", err
+	}
+
+	// Build the versions endpoint URL:
+	// {basePath}/{namespace}/{name}/{system}/versions
+	modulePath = strings.TrimSuffix(modulePath, "/")
+	modulePath = strings.TrimPrefix(modulePath, "/")
+
+	versionsURL := fmt.Sprintf("%s/%s/versions", strings.TrimSuffix(moduleRegistryBasePath, "/"), modulePath)
+
+	u, err := url.Parse(versionsURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing versions URL: %w", err)
+	}
+
+	if u.Scheme == "" {
+		u = &url.URL{Scheme: "https", Host: registryDomain, Path: versionsURL}
+	}
+
+	body, _, err := httpGETAndGetResponse(ctx, l, httpClient, u)
+	if err != nil {
+		return "", fmt.Errorf("fetching module versions from %s: %w", u.String(), err)
+	}
+
+	var resp ModuleVersionsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("parsing module versions response: %w", err)
+	}
+
+	if len(resp.Modules) == 0 || len(resp.Modules[0].Versions) == 0 {
+		return "", nil
+	}
+
+	versions := make([]string, len(resp.Modules[0].Versions))
+	for i, v := range resp.Modules[0].Versions {
+		versions[i] = v.Version
+	}
+
+	// Sort in descending semver order and return the top.
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i] > versions[j]
+	})
+
+	return versions[0], nil
+}
+
+// IsTFRSource checks whether the given URL is a tfr:// registry URL.
+func IsTFRSource(rawURL string) bool {
+	if strings.HasPrefix(rawURL, "tfr://") {
+		return true
+	}
+
+	u, err := url.Parse(rawURL)
+	if err == nil && u.Scheme == "tfr" {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
## Description

This PR fixes three issues that prevented `terragrunt scaffold` from working with `tfr://` (Terraform Registry) module sources.

### Root Causes

**1. RegistryGetter not wired into the scaffold download client** (Fixes the download error)

`scaffold.go` calls `getter.GetAny(ctx, tempDir, moduleURL)` without passing `getter.WithTFRegistry(...)`. The `RegistryGetter` that handles `tfr://` URLs is only included in the go-getter client when explicitly opted in. Without it, no getter can handle the download.

**2. Spurious warnings for tfr:// URLs** (Fixes the misleading warnings)

`rewriteModuleURL` calls `parseURL` which uses a regex only matching forced-getter URLs (`git::https://...` style). `tfr://` has no forced-getter prefix so the regex never matches, producing two misleading warnings about failing to parse the URL.

**3. Version auto-detection uses git instead of the registry API** (Fixes version resolution)

When no `?version=` is specified, `addRefToModuleURL` calls `shell.GitLastReleaseTag` which is not meaningful for `tfr://` URLs. The fix queries the registry's `/versions` endpoint and picks the highest semver version.

### Changes

| File | Change |
|------|--------|
| `internal/getter/tfrhelpers.go` | Added `ResolveTFRVersion()` function that queries the registry API to find the latest version. Added `IsTFRSource()` helper. |
| `internal/cli/commands/scaffold/scaffold.go` | (1) Pass `getter.WithTFRegistry(...)` to both `getter.GetAny` calls. (2) Remove spurious warnings from `parseURL`/`rewriteModuleURL` for non-forced-getter URL formats. (3) Added `resolveTFRVersion()` and updated `addRefToModuleURL` to use registry API for `tfr://` URLs. |

### Related Issues

Closes #6117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic registry version resolution for tfr:// module sources (appends latest version when no ref supplied).

* **Improvements**
  * Scaffold downloads use registry-aware retrieval for both modules and templates.
  * tfr:// source handling injects resolved version info into URLs and avoids unnecessary git ref lookups.
  * Registry lookup selects the correct registry domain and reliably picks the newest semver.

* **Bug Fixes**
  * Reduced noisy warnings when module URL parsing fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->