### PR TITLE
fix: Fixing panic in `--auth-provider-cmd` against `null`

### DIFF
--- a/docs/src/data/changelog/v1.0.5/auth-provider-cmd-null-response.mdx
+++ b/docs/src/data/changelog/v1.0.5/auth-provider-cmd-null-response.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.5"
+category: "bug-fixes"
+---
+
+#### Auth provider command returning `null` no longer crashes Terragrunt
+
+If the command configured via `--auth-provider-cmd` wrote the JSON value `null` to stdout, Terragrunt crashed with a nil pointer dereference before it could obtain credentials.
+
+A `null` response is now treated as an empty response: no environment variables and no credentials are applied, and the run continues.

--- a/internal/runner/run/creds/providers/externalcmd/provider.go
+++ b/internal/runner/run/creds/providers/externalcmd/provider.go
@@ -99,7 +99,7 @@ func (provider *Provider) fetchCredentials(ctx context.Context, l log.Logger) (*
 
 	resp := &Response{Envs: make(map[string]string)}
 
-	if err := json.Unmarshal(output.Stdout.Bytes(), &resp); err != nil {
+	if err := json.Unmarshal(output.Stdout.Bytes(), resp); err != nil {
 		return nil, errors.Errorf("command %s returned a response with invalid JSON format", command)
 	}
 

--- a/internal/runner/run/creds/providers/externalcmd/provider_test.go
+++ b/internal/runner/run/creds/providers/externalcmd/provider_test.go
@@ -1,0 +1,32 @@
+package externalcmd_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds/providers/externalcmd"
+	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetCredentialsHandlesJSONNullResponse pins safe handling of stdout containing the JSON literal `null`.
+func TestGetCredentialsHandlesJSONNullResponse(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("printf"); err != nil {
+		t.Skipf("printf not found on PATH: %v", err)
+	}
+
+	l := logger.CreateLogger()
+	opts := shell.NewShellOptions()
+
+	provider := externalcmd.NewProvider(l, "printf null", opts)
+
+	creds, err := provider.GetCredentials(t.Context(), l)
+
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	require.NotNil(t, creds.Envs)
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes panic when `--auth-provider-cmd` invocation results in the text `null` being returned.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when authentication provider commands configured via `--auth-provider-cmd` return a `null` response; execution now continues safely with no credentials applied.

* **Documentation**
  * Added changelog entry documenting how `null` responses from authentication provider commands are handled as empty responses.

* **Tests**
  * Added test coverage to verify proper handling of `null` responses from authentication provider commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->