### PR TITLE
chore: Fixing release bug fix notification

### DIFF
--- a/.github/scripts/release-notify-issues.js
+++ b/.github/scripts/release-notify-issues.js
@@ -111,12 +111,16 @@ module.exports = async ({
 };
 
 async function listCommitsInRange({ github, owner, repo, base, head }) {
-  return await github.paginate(github.rest.repos.compareCommitsWithBasehead, {
-    owner,
-    repo,
-    basehead: `${base}...${head}`,
-    per_page: 100,
-  });
+  return await github.paginate(
+    github.rest.repos.compareCommitsWithBasehead,
+    {
+      owner,
+      repo,
+      basehead: `${base}...${head}`,
+      per_page: 100,
+    },
+    (response) => response.data.commits,
+  );
 }
 
 async function collectMergedPRs({ github, owner, repo, commits }) {

--- a/.github/scripts/release-notify-issues.test.js
+++ b/.github/scripts/release-notify-issues.test.js
@@ -257,14 +257,15 @@ describe("collectMergedPRs", () => {
 });
 
 describe("listCommitsInRange", () => {
-  test("uses paginate with the basehead form and 100 per_page", async () => {
-    let capturedMethod, capturedOpts;
+  test("uses paginate with the basehead form, 100 per_page, and extracts commits via mapFn", async () => {
+    let capturedMethod, capturedOpts, capturedMapFn;
     const compareFn = () => {};
     const github = {
-      paginate: async (method, opts) => {
+      paginate: async (method, opts, mapFn) => {
         capturedMethod = method;
         capturedOpts = opts;
-        return [{ sha: "a" }, { sha: "b" }];
+        capturedMapFn = mapFn;
+        return mapFn({ data: { commits: [{ sha: "a" }, { sha: "b" }] } });
       },
       rest: { repos: { compareCommitsWithBasehead: compareFn } },
     };
@@ -285,5 +286,9 @@ describe("listCommitsInRange", () => {
       basehead: "v0.95.0...v0.96.0",
       per_page: 100,
     });
+    expect(typeof capturedMapFn).toBe("function");
+    expect(
+      capturedMapFn({ data: { commits: [{ sha: "x" }] } }),
+    ).toEqual([{ sha: "x" }]);
   });
 });


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Bug fix notifications didn't fire on bug reports after the `v1.0.5` release was cut. This should fix that. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release notification infrastructure to improve pagination handling in GitHub integration scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->