### PR TITLE
fix: Fixing panic in `render` `WriteTo`

### DIFF
--- a/docs/src/data/changelog/v1.0.6/render-block-attribute-panics.mdx
+++ b/docs/src/data/changelog/v1.0.6/render-block-attribute-panics.mdx
@@ -1,0 +1,13 @@
+---
+version: "v1.0.6"
+category: "bug-fixes"
+---
+
+#### `terragrunt render` no longer crashes on `exclude` or `catalog` blocks with certain attributes
+
+Rendering a config crashed with a `value has no attribute of that name` panic before any output could be produced when:
+
+- the `exclude` block set `no_run`, or
+- the `catalog` block set `default_template`, `no_shell`, or `no_hooks`.
+
+These attributes are now carried through the render pipeline alongside the other fields on their respective blocks, so both blocks round-trip cleanly.

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -407,7 +407,10 @@ type ValueWithMetadata struct {
 // ctyCatalogConfig is an alternate representation of CatalogConfig that converts internal blocks into a map that
 // maps the name to the underlying struct, as opposed to a list representation.
 type ctyCatalogConfig struct {
-	URLs []string `cty:"urls"`
+	DefaultTemplate string   `cty:"default_template"`
+	URLs            []string `cty:"urls"`
+	NoShell         bool     `cty:"no_shell"`
+	NoHooks         bool     `cty:"no_hooks"`
 }
 
 // ctyEngineConfig is an alternate representation of EngineConfig that converts internal blocks into a map that
@@ -423,6 +426,7 @@ type ctyEngineConfig struct {
 type ctyExclude struct {
 	Actions             []string `cty:"actions"`
 	If                  bool     `cty:"if"`
+	NoRun               bool     `cty:"no_run"`
 	ExcludeDependencies bool     `cty:"exclude_dependencies"`
 }
 
@@ -432,8 +436,21 @@ func catalogConfigAsCty(config *CatalogConfig) (cty.Value, error) {
 		return cty.NilVal, nil
 	}
 
+	noShell := false
+	if config.NoShell != nil {
+		noShell = *config.NoShell
+	}
+
+	noHooks := false
+	if config.NoHooks != nil {
+		noHooks = *config.NoHooks
+	}
+
 	configCty := ctyCatalogConfig{
-		URLs: config.URLs,
+		URLs:            config.URLs,
+		DefaultTemplate: config.DefaultTemplate,
+		NoShell:         noShell,
+		NoHooks:         noHooks,
 	}
 
 	return GoTypeToCty(configCty)
@@ -478,9 +495,15 @@ func excludeConfigAsCty(config *ExcludeConfig) (cty.Value, error) {
 		excludeDependencies = *config.ExcludeDependencies
 	}
 
+	noRun := false
+	if config.NoRun != nil {
+		noRun = *config.NoRun
+	}
+
 	configCty := ctyExclude{
 		If:                  config.If,
 		Actions:             config.Actions,
+		NoRun:               noRun,
 		ExcludeDependencies: excludeDependencies,
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,13 +23,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func createLogger() log.Logger {
-	formatter := format.NewFormatter(format.NewKeyValueFormatPlaceholders())
-	formatter.SetDisabledColors(true)
-
-	return log.New(log.WithLevel(log.DebugLevel), log.WithFormatter(formatter))
-}
-
 func TestParseTerragruntConfigRemoteStateMinimalConfig(t *testing.T) {
 	t.Parallel()
 
@@ -1961,4 +1954,61 @@ inputs = {
 	assert.Equal(t, terragruntConfig.IamAssumeRoleDuration, rereadConfig.IamAssumeRoleDuration)
 	assert.Equal(t, terragruntConfig.IamAssumeRoleSessionName, rereadConfig.IamAssumeRoleSessionName)
 	assert.Equal(t, terragruntConfig.Inputs, rereadConfig.Inputs)
+}
+
+func TestWriteToExcludeNoRun(t *testing.T) {
+	t.Parallel()
+
+	src := `
+exclude {
+  if      = true
+  actions = ["apply"]
+  no_run  = true
+}
+`
+
+	ctx, pctx := newTestParsingContext(t, "test-exclude-no-run")
+	cfg, err := config.ParseConfigString(ctx, pctx, createLogger(), config.DefaultTerragruntConfigPath, src, nil)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Exclude)
+	require.NotNil(t, cfg.Exclude.NoRun)
+
+	var buf bytes.Buffer
+
+	_, writeErr := cfg.WriteTo(&buf)
+	require.NoError(t, writeErr)
+	assert.Contains(t, buf.String(), "no_run")
+}
+
+func TestWriteToCatalogFields(t *testing.T) {
+	t.Parallel()
+
+	noShell := true
+	noHooks := true
+
+	cfg := &config.TerragruntConfig{
+		Catalog: &config.CatalogConfig{
+			URLs:            []string{"github.com/example/modules"},
+			DefaultTemplate: "github.com/example/template",
+			NoShell:         &noShell,
+			NoHooks:         &noHooks,
+		},
+	}
+
+	var buf bytes.Buffer
+
+	_, writeErr := cfg.WriteTo(&buf)
+	require.NoError(t, writeErr)
+
+	rendered := buf.String()
+	assert.Contains(t, rendered, "default_template")
+	assert.Contains(t, rendered, "no_shell")
+	assert.Contains(t, rendered, "no_hooks")
+}
+
+func createLogger() log.Logger {
+	formatter := format.NewFormatter(format.NewKeyValueFormatPlaceholders())
+	formatter.SetDisabledColors(true)
+
+	return log.New(log.WithLevel(log.DebugLevel), log.WithFormatter(formatter))
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes panics in usage of `WriteTo` in `render`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - `terragrunt render` no longer crashes when processing exclude blocks with `no_run` or catalog blocks with `default_template`, `no_shell`, or `no_hooks` attributes. These attributes are now properly preserved during rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->