### PR TITLE
fix: Fixing files read race

### DIFF
--- a/docs/src/data/changelog/v1.0.6/stack-output-files-read-race.mdx
+++ b/docs/src/data/changelog/v1.0.6/stack-output-files-read-race.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.6"
+category: "bug-fixes"
+---
+
+#### `terragrunt stack` commands no longer crash on stacks with multiple units
+
+Running `terragrunt stack output` (or any command that resolves concurrently parsing multiple configuration files) against a stack with several units could intermittently crash while the units were being parsed in parallel due to a race on internal bookkeeping of files read (used in the [reading filter attribute](https://docs.terragrunt.com/features/filter/attributes/#reading-based-expressions)).
+
+Parallel unit parsing now coordinates safely when recording which source files were read, preventing crashes.

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -403,7 +403,7 @@ func parseComponent(
 		}
 
 		if parsingCtx.FilesRead != nil {
-			readFiles := sanitizeReadFiles(*parsingCtx.FilesRead)
+			readFiles := sanitizeReadFiles(parsingCtx.FilesRead.Paths())
 			c.SetReading(readFiles...)
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2005,7 +2005,7 @@ func markLocalModuleSourceAsRead(pctx *ParsingContext, configPath, rawSource str
 			return nil
 		}
 
-		trackFileRead(pctx.FilesRead, path)
+		pctx.FilesRead.Add(path)
 
 		return nil
 	})

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -782,7 +782,7 @@ func ParseTerragruntConfig(ctx context.Context, pctx *ParsingContext, l log.Logg
 	}
 
 	// Track that this file was read during parsing
-	trackFileRead(pctx.FilesRead, path)
+	pctx.FilesRead.Add(path)
 
 	// We update the ctx of terragruntOptions to the config being read in.
 	l, pctx, err := pctx.WithConfigPath(l, targetConfig)
@@ -986,7 +986,7 @@ func sopsDecryptFile(ctx context.Context, pctx *ParsingContext, l log.Logger, pa
 		path = filepath.Clean(path)
 	}
 
-	trackFileRead(pctx.FilesRead, path)
+	pctx.FilesRead.Add(path)
 
 	return sopsDecryptFileImpl(ctx, pctx, l, path, format, decrypt.File)
 }
@@ -1219,7 +1219,7 @@ func readTFVarsFileImpl(pctx *ParsingContext, l log.Logger, args []string) (stri
 	}
 
 	// Track that this file was read during parsing
-	trackFileRead(pctx.FilesRead, varFile)
+	pctx.FilesRead.Add(varFile)
 
 	fileContents, err := os.ReadFile(varFile)
 	if err != nil {
@@ -1267,7 +1267,7 @@ func markAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []
 		path = filepath.Clean(path)
 	}
 
-	trackFileRead(pctx.FilesRead, path)
+	pctx.FilesRead.Add(path)
 
 	return file, nil
 }
@@ -1317,7 +1317,7 @@ func markGlobAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, arg
 	result := make([]string, 0, len(matches))
 
 	for _, match := range matches {
-		trackFileRead(pctx.FilesRead, match)
+		pctx.FilesRead.Add(match)
 		result = append(result, match)
 	}
 
@@ -1432,18 +1432,4 @@ func ConstraintCheck(ctx context.Context, pctx *ParsingContext, args []string) (
 	}
 
 	return c.Check(v), nil
-}
-
-// trackFileRead adds a file path to the FilesRead slice if it's not already present.
-// This prevents duplicate entries when the same file is read multiple times during parsing.
-func trackFileRead(filesRead *[]string, path string) {
-	if filesRead == nil {
-		return
-	}
-
-	if slices.Contains(*filesRead, path) {
-		return
-	}
-
-	*filesRead = append(*filesRead, path)
 }

--- a/pkg/config/files_read.go
+++ b/pkg/config/files_read.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"slices"
+	"sync"
+)
+
+// FilesRead is a concurrency-safe set of file paths that have been read while
+// parsing a configuration. A nil receiver is treated as a no-op for mutations
+// and returns zero values from accessors, so call sites that don't need to
+// track reads can pass nil.
+type FilesRead struct {
+	paths []string
+	mu    sync.RWMutex
+}
+
+// NewFilesRead returns an empty FilesRead ready for concurrent use.
+func NewFilesRead() *FilesRead {
+	return &FilesRead{}
+}
+
+// Add records path as read. Duplicate paths are ignored.
+func (f *FilesRead) Add(path string) {
+	if f == nil {
+		return
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if slices.Contains(f.paths, path) {
+		return
+	}
+
+	f.paths = append(f.paths, path)
+}
+
+// Paths returns a snapshot copy of the recorded paths in insertion order.
+func (f *FilesRead) Paths() []string {
+	if f == nil {
+		return nil
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	return slices.Clone(f.paths)
+}
+
+// Len returns the number of recorded paths.
+func (f *FilesRead) Len() int {
+	if f == nil {
+		return 0
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	return len(f.paths)
+}

--- a/pkg/config/files_read_test.go
+++ b/pkg/config/files_read_test.go
@@ -1,0 +1,67 @@
+package config_test
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilesReadDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	f := config.NewFilesRead()
+	f.Add("a")
+	f.Add("b")
+	f.Add("a")
+
+	assert.Equal(t, []string{"a", "b"}, f.Paths())
+	assert.Equal(t, 2, f.Len())
+}
+
+func TestFilesReadNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var f *config.FilesRead
+
+	assert.NotPanics(t, func() { f.Add("a") })
+	assert.Nil(t, f.Paths())
+	assert.Equal(t, 0, f.Len())
+}
+
+// TestFilesReadConcurrentAddWithRacing pins the concurrency-safety of FilesRead.
+// Without the mutex, concurrent Add calls produce a slice header / backing
+// array mismatch that crashes inside slices.Contains (the original panic seen
+// in TestStackOutputsRaw). The -race suffix flags this test for CI execution
+// under `go test -race`.
+func TestFilesReadConcurrentAddWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workers       = 32
+		addsPerWorker = 200
+	)
+
+	f := config.NewFilesRead()
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for w := range workers {
+		go func() {
+			defer wg.Done()
+
+			for i := range addsPerWorker {
+				f.Add(strconv.Itoa(w*addsPerWorker + i))
+				_ = f.Paths()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	require.Equal(t, workers*addsPerWorker, f.Len())
+}

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -139,7 +139,7 @@ func handleInclude(ctx context.Context, pctx *ParsingContext, l log.Logger, conf
 			logPrefix           string
 		)
 
-		trackFileRead(pctx.FilesRead, includeConfig.Path)
+		pctx.FilesRead.Add(includeConfig.Path)
 
 		if isPartial {
 			parsedIncludeConfig, err = partialParseIncludedConfig(ctx, pctx, l, &includeConfig)

--- a/pkg/config/mark_as_read_test.go
+++ b/pkg/config/mark_as_read_test.go
@@ -39,7 +39,7 @@ func TestMarkGlobAsRead(t *testing.T) {
 	require.NotNil(t, out)
 
 	require.NotNil(t, pctx.FilesRead)
-	read := *pctx.FilesRead
+	read := pctx.FilesRead.Paths()
 	assert.Contains(t, read, filepath.Join(dir, "a.tf"))
 	assert.Contains(t, read, filepath.Join(dir, "b.tf"))
 	assert.Contains(t, read, filepath.Join(dir, "nested", "c.tf"))
@@ -76,7 +76,7 @@ func TestMarkGlobAsReadEscapesMetacharacter(t *testing.T) {
 	require.NotNil(t, out)
 
 	require.NotNil(t, pctx.FilesRead)
-	read := *pctx.FilesRead
+	read := pctx.FilesRead.Paths()
 	assert.Contains(t, read, filepath.Join(dir, "a*b.tf"))
 	assert.NotContains(t, read, filepath.Join(dir, "acb.tf"))
 }
@@ -99,7 +99,7 @@ func TestMarkGlobAsReadRequiresExperiment(t *testing.T) {
 	assert.Contains(t, err.Error(), "mark-many-as-read")
 
 	if pctx.FilesRead != nil {
-		assert.NotContains(t, *pctx.FilesRead, filepath.Join(dir, "a.tf"))
+		assert.NotContains(t, pctx.FilesRead.Paths(), filepath.Join(dir, "a.tf"))
 	}
 }
 
@@ -134,7 +134,7 @@ func TestMarkManyAsReadExperiment(t *testing.T) {
 		require.NotNil(t, out)
 
 		if pctx.FilesRead != nil {
-			for _, f := range *pctx.FilesRead {
+			for _, f := range pctx.FilesRead.Paths() {
 				assert.NotContains(t, f, moduleDir, "module files should not be marked when experiment is off")
 			}
 		}
@@ -153,7 +153,7 @@ func TestMarkManyAsReadExperiment(t *testing.T) {
 		require.NotNil(t, out)
 		require.NotNil(t, pctx.FilesRead)
 
-		read := *pctx.FilesRead
+		read := pctx.FilesRead.Paths()
 		assert.Contains(t, read, filepath.Join(moduleDir, "main.tf"))
 		assert.Contains(t, read, filepath.Join(moduleDir, "variables.tf.json"))
 		assert.Contains(t, read, filepath.Join(moduleDir, "helpers.hcl"))

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -45,7 +45,7 @@ type ParsingContext struct {
 	EngineConfig     *engine.EngineConfig
 	EngineOptions    *engine.EngineOptions
 	FeatureFlags     *xsync.Map[string, string]
-	FilesRead        *[]string
+	FilesRead        *FilesRead
 	Telemetry        *telemetry.Options
 
 	DecodedDependencies *cty.Value
@@ -105,11 +105,9 @@ type ParsingContext struct {
 }
 
 func NewParsingContext(ctx context.Context, l log.Logger, opts ...Option) (context.Context, *ParsingContext) {
-	filesRead := make([]string, 0)
-
 	pctx := &ParsingContext{
 		TerraformCliArgs: iacargs.New(),
-		FilesRead:        &filesRead,
+		FilesRead:        NewFilesRead(),
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes race in files read from concurrently parsing configurations for `stack output`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent crashes when running `terragrunt stack` commands against stacks containing multiple units. Configuration files are now safely parsed in parallel without race conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->