### PR TITLE
fix: Fixing tf binary version over-caching

### DIFF
--- a/docs/src/data/changelog/v1.0.6/terraform-binary-ignored-with-tofu-on-path.mdx
+++ b/docs/src/data/changelog/v1.0.6/terraform-binary-ignored-with-tofu-on-path.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.6"
+category: "bug-fixes"
+---
+
+#### `terraform_binary` properly respected when both `tofu` and `terraform` are on `PATH`
+
+A regression in command execution caching resulted in over-caching the STDOUT result of `tofu --version` when both `tofu` and `terraform` were available on `PATH` and `terraform_binary` was set. Early on in the execution flow, Terragrunt checks if OpenTofu is installed what its version is to determine if it supports setting of the automatic provider cache directory. This resulted in the value of `terraform_binary` being ignored for later version checks to assess compliance with `terraform_version_constraint`.
+
+The version-detection cache used per run is now scoped to the binary that produced each entry, so the version recorded against an early default-binary resolution no longer leaks into the later resolution that honors `terraform_binary`.

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -334,7 +335,7 @@ func setupAutoProviderCacheDir(ctx context.Context, l log.Logger, opts *options.
 
 	if opts.TerraformVersion == nil {
 		_, ver, impl, err := run.PopulateTFVersion(
-			ctx, l, opts.WorkingDir,
+			ctx, l, vexec.NewOSExec(), opts.WorkingDir,
 			opts.VersionManagerFileName,
 			configbridge.TFRunOptsFromOpts(opts),
 		)

--- a/internal/cli/commands/run/run.go
+++ b/internal/cli/commands/run/run.go
@@ -198,7 +198,12 @@ func checkVersionConstraints(ctx context.Context, l log.Logger, opts *options.Te
 		opts.TFPath = partialTerragruntConfig.TerraformBinary
 	}
 
-	l, ver, impl, err := run.PopulateTFVersion(ctx, l, opts.WorkingDir, opts.VersionManagerFileName, configbridge.TFRunOptsFromOpts(opts))
+	l, ver, impl, err := run.PopulateTFVersion(
+		ctx, l, vexec.NewOSExec(),
+		opts.WorkingDir,
+		opts.VersionManagerFileName,
+		configbridge.TFRunOptsFromOpts(opts),
+	)
 	if err != nil {
 		return l, err
 	}
@@ -216,7 +221,10 @@ func checkVersionConstraints(ctx context.Context, l log.Logger, opts *options.Te
 	}
 
 	if partialTerragruntConfig.TerragruntVersionConstraint != "" {
-		if err := run.CheckTerragruntVersionMeetsConstraint(opts.TerragruntVersion, partialTerragruntConfig.TerragruntVersionConstraint); err != nil {
+		if err := run.CheckTerragruntVersionMeetsConstraint(
+			opts.TerragruntVersion,
+			partialTerragruntConfig.TerragruntVersionConstraint,
+		); err != nil {
 			return l, err
 		}
 	}
@@ -240,7 +248,11 @@ func checkVersionConstraints(ctx context.Context, l log.Logger, opts *options.Te
 	return l, nil
 }
 
-func getTerragruntConfig(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) (*config.TerragruntConfig, error) {
+func getTerragruntConfig(
+	ctx context.Context,
+	l log.Logger,
+	opts *options.TerragruntOptions,
+) (*config.TerragruntConfig, error) {
 	ctx, configCtx := configbridge.NewParsingContext(ctx, l, opts)
 	configCtx = configCtx.WithDecodeList(
 		config.TerragruntVersionConstraints,

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
@@ -255,7 +256,8 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirDiffer
 func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVersion(t *testing.T) {
 	t.Parallel()
 
-	canonicalURL := "github.com/gruntwork-io/terragrunt//test/fixtures/download-source/hello-world-version-remote?ref=v0.83.2"
+	canonicalURL := "github.com/gruntwork-io/terragrunt//test/fixtures/" +
+		"download-source/hello-world-version-remote?ref=v0.83.2"
 
 	downloadDir := helpers.TmpDirWOSymlinks(t)
 	defer os.Remove(downloadDir)
@@ -311,7 +313,8 @@ func TestDownloadTerraformSourceIfNecessaryInvalidTerraformSource(t *testing.T) 
 func TestInvalidModulePath(t *testing.T) {
 	t.Parallel()
 
-	canonicalURL := "github.com/gruntwork-io/terragrunt//test/fixtures/download-source/hello-world-version-remote/non-existent-path?ref=v0.83.2"
+	canonicalURL := "github.com/gruntwork-io/terragrunt//test/fixtures/" +
+		"download-source/hello-world-version-remote/non-existent-path?ref=v0.83.2"
 
 	downloadDir := helpers.TmpDirWOSymlinks(t)
 	defer os.Remove(downloadDir)
@@ -483,8 +486,8 @@ func createConfig(
 ) (*tf.Source, *options.TerragruntOptions, *runcfg.RunConfig, error) {
 	t.Helper()
 
-	logger := logger.CreateLogger()
-	logger.SetOptions(log.WithOutput(io.Discard))
+	l := logger.CreateLogger()
+	l.SetOptions(log.WithOutput(io.Discard))
 
 	terraformSource := &tf.Source{
 		CanonicalSourceURL: parseURL(t, canonicalURL),
@@ -505,7 +508,12 @@ func createConfig(
 		},
 	}
 
-	_, ver, impl, err := run.PopulateTFVersion(t.Context(), logger, opts.WorkingDir, opts.VersionManagerFileName, configbridge.TFRunOptsFromOpts(opts))
+	_, ver, impl, err := run.PopulateTFVersion(
+		t.Context(), l, vexec.NewOSExec(),
+		opts.WorkingDir,
+		opts.VersionManagerFileName,
+		configbridge.TFRunOptsFromOpts(opts),
+	)
 	require.NoError(t, err)
 
 	opts.TerraformVersion = ver
@@ -963,7 +971,11 @@ func TestDownloadSourceUpdateSourceWithCASRequiresCAS(t *testing.T) {
 			l := logger.CreateLogger()
 			l.SetOptions(log.WithOutput(io.Discard))
 
-			_, err = run.DownloadTerraformSourceIfNecessary(t.Context(), l, src, configbridge.NewRunOptions(opts), cfg, report.NewReport())
+			_, err = run.DownloadTerraformSourceIfNecessary(
+				t.Context(), l, src,
+				configbridge.NewRunOptions(opts),
+				cfg, report.NewReport(),
+			)
 			require.Error(t, err)
 
 			var target *cas.UpdateSourceWithCASRequiresCASError

--- a/internal/runner/run/version_check.go
+++ b/internal/runner/run/version_check.go
@@ -33,12 +33,21 @@ var TerraformVersionRegex = regexp.MustCompile(`^(\S+)\s(v?\d+\.\d+\.\d+)`)
 const versionParts = 3
 
 // PopulateTFVersion discovers the currently installed version of OpenTofu/Terraform.
-// It uses a cache keyed by workingDir and versionFiles to avoid repeated invocations.
-// Returns the discovered version and implementation type; the caller is responsible
-// for storing them on *options.TerragruntOptions.
-func PopulateTFVersion(ctx context.Context, l log.Logger, workingDir string, versionFiles []string, tfOpts *tf.TFOptions) (log.Logger, *version.Version, tfimpl.Type, error) {
+// It uses a cache keyed by workingDir, versionFiles, and the resolved binary path
+// to avoid repeated invocations while still distinguishing between binaries (e.g.
+// when terraform_binary overrides the default after a prior call has already
+// resolved a different binary). Returns the discovered version and implementation
+// type; the caller is responsible for storing them on *options.TerragruntOptions.
+func PopulateTFVersion(
+	ctx context.Context,
+	l log.Logger,
+	e vexec.Exec,
+	workingDir string,
+	versionFiles []string,
+	tfOpts *tf.TFOptions,
+) (log.Logger, *version.Version, tfimpl.Type, error) {
 	versionCache := GetRunVersionCache(ctx)
-	cacheKey := computeVersionFilesCacheKey(workingDir, versionFiles)
+	cacheKey := computeVersionFilesCacheKey(workingDir, versionFiles, tfOpts.ShellOptions.TFPath)
 	l.Debugf("using cache key for version files: %s", cacheKey)
 
 	if cachedOutput, found := versionCache.Get(ctx, cacheKey); found {
@@ -50,7 +59,7 @@ func PopulateTFVersion(ctx context.Context, l log.Logger, workingDir string, ver
 		return l, terraformVersion, tfImplementation, nil
 	}
 
-	l, terraformVersion, tfImplementation, err := GetTFVersion(ctx, l, tfOpts)
+	l, terraformVersion, tfImplementation, err := GetTFVersion(ctx, l, e, tfOpts)
 	if err != nil {
 		return l, nil, tfimpl.Unknown, err
 	}
@@ -111,7 +120,12 @@ func parseVersionFromCache(cachedData string) (tfimpl.Type, *version.Version, er
 // GetTFVersion checks the OpenTofu/Terraform version directly without using cache.
 // It takes pre-built *tf.TFOptions and runs "terraform version", discarding output
 // and stripping TF_CLI_ARGS env vars to avoid interference.
-func GetTFVersion(ctx context.Context, l log.Logger, tfOpts *tf.TFOptions) (log.Logger, *version.Version, tfimpl.Type, error) {
+func GetTFVersion(
+	ctx context.Context,
+	l log.Logger,
+	e vexec.Exec,
+	tfOpts *tf.TFOptions,
+) (log.Logger, *version.Version, tfimpl.Type, error) {
 	// Clone to avoid mutating the caller's options.
 	optsCopy := *tfOpts
 	shellCopy := *optsCopy.ShellOptions
@@ -131,7 +145,7 @@ func GetTFVersion(ctx context.Context, l log.Logger, tfOpts *tf.TFOptions) (log.
 
 	optsCopy.ShellOptions.Env = envCopy
 
-	output, err := tf.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), &optsCopy, tf.FlagNameVersion)
+	output, err := tf.RunCommandWithOutput(ctx, l, e, &optsCopy, tf.FlagNameVersion)
 	if err != nil {
 		return l, nil, tfimpl.Unknown, err
 	}
@@ -157,7 +171,8 @@ func GetTFVersion(ctx context.Context, l log.Logger, tfOpts *tf.TFOptions) (log.
 	return l, terraformVersion, tfImplementation, nil
 }
 
-// CheckTerragruntVersionMeetsConstraint checks that the current version of Terragrunt meets the specified constraint and return an error if it doesn't
+// CheckTerragruntVersionMeetsConstraint checks that the current version of
+// Terragrunt meets the specified constraint and returns an error if it doesn't.
 func CheckTerragruntVersionMeetsConstraint(currentVersion *version.Version, constraint string) error {
 	versionConstraint, err := version.NewConstraint(constraint)
 	if err != nil {
@@ -182,7 +197,8 @@ func CheckTerragruntVersionMeetsConstraint(currentVersion *version.Version, cons
 	return nil
 }
 
-// CheckTerraformVersionMeetsConstraint checks that the current version of Terraform meets the specified constraint and return an error if it doesn't
+// CheckTerraformVersionMeetsConstraint checks that the current version of
+// Terraform meets the specified constraint and returns an error if it doesn't.
 func CheckTerraformVersionMeetsConstraint(currentVersion *version.Version, constraint string) error {
 	versionConstraint, err := version.NewConstraint(constraint)
 	if err != nil {
@@ -226,8 +242,12 @@ func parseTerraformImplementationType(versionCommandOutput string) (tfimpl.Type,
 	}
 }
 
-// Helper to compute a cache key from the checksums of provided files
-func computeVersionFilesCacheKey(workingDir string, versionFiles []string) string {
+// computeVersionFilesCacheKey builds a cache key from the resolved binary path
+// plus the checksums of any version-pinning files. The binary path is part of
+// the key because the same working directory can legitimately resolve to
+// different binaries within a single run (e.g. when terraform_binary overrides
+// the default), and conflating those produces the wrong version string.
+func computeVersionFilesCacheKey(workingDir string, versionFiles []string, tfPath string) string {
 	var hashes []string
 
 	for _, file := range versionFiles {
@@ -254,6 +274,8 @@ func computeVersionFilesCacheKey(workingDir string, versionFiles []string) strin
 		cacheKey = strings.Join(hashes, "|")
 	}
 
+	cacheKey = tfPath + "|" + cacheKey
+
 	return util.EncodeBase64Sha1(cacheKey)
 }
 
@@ -276,9 +298,17 @@ type InvalidTerragruntVersion struct {
 }
 
 func (err InvalidTerraformVersion) Error() string {
-	return fmt.Sprintf("The currently installed version of Terraform (%s) is not compatible with the version Terragrunt requires (%s).", err.CurrentVersion.String(), err.VersionConstraints.String())
+	return fmt.Sprintf(
+		"The currently installed version of Terraform (%s) is not compatible with the version Terragrunt requires (%s).",
+		err.CurrentVersion.String(),
+		err.VersionConstraints.String(),
+	)
 }
 
 func (err InvalidTerragruntVersion) Error() string {
-	return fmt.Sprintf("The currently installed version of Terragrunt (%s) is not compatible with the version constraint requiring (%s).", err.CurrentVersion.String(), err.VersionConstraints.String())
+	return fmt.Sprintf(
+		"The currently installed version of Terragrunt (%s) is not compatible with the version constraint requiring (%s).",
+		err.CurrentVersion.String(),
+		err.VersionConstraints.String(),
+	)
 }

--- a/internal/runner/run/version_check_internal_test.go
+++ b/internal/runner/run/version_check_internal_test.go
@@ -12,33 +12,48 @@ func Test_computeVersionFilesCacheKey(t *testing.T) {
 	tests := []struct {
 		name         string
 		workingDir   string
+		tfPath       string
 		want         string
 		versionFiles []string
 	}{
 		{
-			name:         "version files slice is empty",
+			name:         "no version files, tofu binary",
 			workingDir:   "",
+			tfPath:       "tofu",
 			versionFiles: nil,
-			want:         "r01AJjVD7VSXCQk1ORuh_no_NRY", // "no-version-files"
+			want:         "H2PcpB8dh-BE5Dz-LiSD1hykSfk", // "tofu|no-version-files"
+		},
+		{
+			// Same inputs as the previous case except for the binary. The key
+			// must differ. That is the property issue #6147 turned on.
+			name:         "no version files, terraform binary",
+			workingDir:   "",
+			tfPath:       "terraform",
+			versionFiles: nil,
+			want:         "rdE9RkSvu7WDQly2KzL2HxpcB3Q", // "terraform|no-version-files"
 		},
 		{
 			name:       "workdir contains version files",
 			workingDir: "../../../test/fixtures/version-files-cache-key",
+			tfPath:     "tofu",
 			versionFiles: []string{
 				".terraform-version",
 				".tool-versions",
 			},
-			want: "XBE-VO9pOnQjPQDmLQCvSCdckSQ",
+			want: "trAjGOdUv3IcX1lU50dck_mqlUs",
 		},
 		{
+			// SanitizePath strips the path-traversal entry before hashing, so
+			// this case must collapse to the same key as the previous one.
 			name:       "workdir contains version files and we try to escape the working dir",
 			workingDir: "../../../test/fixtures/version-files-cache-key",
+			tfPath:     "tofu",
 			versionFiles: []string{
 				".terraform-version",
 				".tool-versions",
 				"../../../dev/random",
 			},
-			want: "XBE-VO9pOnQjPQDmLQCvSCdckSQ",
+			want: "trAjGOdUv3IcX1lU50dck_mqlUs",
 		},
 	}
 	for _, tt := range tests {
@@ -48,10 +63,11 @@ func Test_computeVersionFilesCacheKey(t *testing.T) {
 			assert.Equalf(
 				t,
 				tt.want,
-				computeVersionFilesCacheKey(tt.workingDir, tt.versionFiles),
-				"computeVersionFilesCacheKey(%v, %v)",
+				computeVersionFilesCacheKey(tt.workingDir, tt.versionFiles, tt.tfPath),
+				"computeVersionFilesCacheKey(%v, %v, %v)",
 				tt.workingDir,
 				tt.versionFiles,
+				tt.tfPath,
 			)
 		})
 	}

--- a/internal/runner/run/version_check_test.go
+++ b/internal/runner/run/version_check_test.go
@@ -2,10 +2,17 @@
 package run_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/errors"
+	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
+	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -87,7 +94,12 @@ func TestParseTerraformVersionInvalidSyntax(t *testing.T) {
 	testParseTerraformVersion(t, "invalid-syntax", "", run.InvalidTerraformVersionSyntax("invalid-syntax"))
 }
 
-func testCheckTerraformVersionMeetsConstraint(t *testing.T, currentVersion string, versionConstraint string, versionMeetsConstraint bool) {
+func testCheckTerraformVersionMeetsConstraint(
+	t *testing.T,
+	currentVersion string,
+	versionConstraint string,
+	versionMeetsConstraint bool,
+) {
 	t.Helper()
 
 	current, err := version.NewVersion(currentVersion)
@@ -97,9 +109,13 @@ func testCheckTerraformVersionMeetsConstraint(t *testing.T, currentVersion strin
 
 	err = run.CheckTerraformVersionMeetsConstraint(current, versionConstraint)
 	if versionMeetsConstraint && err != nil {
-		assert.NoError(t, err, "Expected Terraform version %s to meet constraint %s, but got error: %v", currentVersion, versionConstraint, err)
+		assert.NoError(t, err,
+			"Expected Terraform version %s to meet constraint %s, but got error: %v",
+			currentVersion, versionConstraint, err)
 	} else if !versionMeetsConstraint && err == nil {
-		assert.Error(t, err, "Expected Terraform version %s to NOT meet constraint %s, but got back a nil error", currentVersion, versionConstraint)
+		assert.Error(t, err,
+			"Expected Terraform version %s to NOT meet constraint %s, but got back a nil error",
+			currentVersion, versionConstraint)
 	}
 }
 
@@ -154,7 +170,79 @@ func TestCheckTerragruntVersionMeetsConstraintPrerelease(t *testing.T) {
 	testCheckTerragruntVersionMeetsConstraint(t, "v0.23.18-alpha202409013", ">= v0.23.18", true)
 }
 
-func testCheckTerragruntVersionMeetsConstraint(t *testing.T, currentVersion string, versionConstraint string, versionMeetsConstraint bool) {
+// TestPopulateTFVersionRespectsTFPath is a regression test for issue #6147:
+// when both tofu and terraform are installed and `terraform_binary = "terraform"`
+// is set in HCL, the default `tofu` binary was selected anyway. The root cause
+// was that the run-scoped version cache keyed only by workingDir and the
+// contents of any version-pinning files, so an early call (e.g. from
+// setupAutoProviderCacheDir) that resolved against `tofu` would poison the
+// cache for the later call made after `terraform_binary` had taken effect.
+//
+// The fix folds the resolved binary path into the cache key. This test feeds
+// distinct --version stdout per binary through a vexec.MemExec handler and
+// asserts the second call resolves Terraform, not the cached OpenTofu entry.
+func TestPopulateTFVersionRespectsTFPath(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tofuVersionOutput      = "OpenTofu v1.9.0\non darwin_arm64\n"
+		terraformVersionOutput = "Terraform v1.15.3\non darwin_arm64\n"
+	)
+
+	handler := func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		switch inv.Name {
+		case "tofu":
+			return vexec.Result{Stdout: []byte(tofuVersionOutput)}
+		case "terraform":
+			return vexec.Result{Stdout: []byte(terraformVersionOutput)}
+		default:
+			return vexec.Result{ExitCode: 1, Stderr: []byte("unexpected binary: " + inv.Name)}
+		}
+	}
+	e := vexec.NewMemExec(handler)
+
+	ctx := run.WithRunVersionCache(t.Context())
+	l := logger.CreateLogger()
+
+	tfOpts := func(binary string) *tf.TFOptions {
+		return &tf.TFOptions{
+			TerraformCliArgs: iacargs.New(),
+			ShellOptions: shell.NewShellOptions().
+				WithTFPath(binary).
+				WithWorkingDir(t.TempDir()),
+		}
+	}
+
+	// First call mirrors what setupAutoProviderCacheDir does before
+	// terraform_binary is read from HCL: TFPath is still the auto-detected
+	// "tofu", and the OpenTofu version gets resolved and cached.
+	_, tofuVer, tofuImpl, err := run.PopulateTFVersion(ctx, l, e, "", nil, tfOpts("tofu"))
+	require.NoError(t, err)
+	assert.Equal(t, tfimpl.OpenTofu, tofuImpl)
+	assert.Equal(t, "1.9.0", tofuVer.String())
+
+	// Second call mirrors checkVersionConstraints after `terraform_binary =
+	// "terraform"` has been applied. Before the fix, this hit the poisoned
+	// cache entry and returned OpenTofu v1.9.0, which then failed any
+	// terraform-version-constraint check pinned to a real Terraform release.
+	_, terraformVer, terraformImpl, err := run.PopulateTFVersion(ctx, l, e, "", nil, tfOpts("terraform"))
+	require.NoError(t, err)
+	assert.Equal(t, tfimpl.Terraform, terraformImpl,
+		"expected Terraform after switching TFPath to 'terraform'; got %s"+
+			" (version cache likely ignored TFPath)",
+		terraformImpl)
+	assert.Equal(t, "1.15.3", terraformVer.String(),
+		"expected Terraform v1.15.3 after switching TFPath; got %s"+
+			" (version cache likely ignored TFPath)",
+		terraformVer)
+}
+
+func testCheckTerragruntVersionMeetsConstraint(
+	t *testing.T,
+	currentVersion string,
+	versionConstraint string,
+	versionMeetsConstraint bool,
+) {
 	t.Helper()
 
 	current, err := version.NewVersion(currentVersion)
@@ -164,8 +252,10 @@ func testCheckTerragruntVersionMeetsConstraint(t *testing.T, currentVersion stri
 
 	err = run.CheckTerragruntVersionMeetsConstraint(current, versionConstraint)
 	if versionMeetsConstraint && err != nil {
-		t.Fatalf("Expected Terragrunt version %s to meet constraint %s, but got error: %v", currentVersion, versionConstraint, err)
+		t.Fatalf("Expected Terragrunt version %s to meet constraint %s, but got error: %v",
+			currentVersion, versionConstraint, err)
 	} else if !versionMeetsConstraint && err == nil {
-		t.Fatalf("Expected Terragrunt version %s to NOT meet constraint %s, but got back a nil error", currentVersion, versionConstraint)
+		t.Fatalf("Expected Terragrunt version %s to NOT meet constraint %s, but got back a nil error",
+			currentVersion, versionConstraint)
 	}
 }

--- a/internal/runner/runnerpool/builder_helpers.go
+++ b/internal/runner/runnerpool/builder_helpers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/runner/common"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -249,7 +250,12 @@ func checkUnitVersionConstraints(
 		l = unitLogger
 	}
 
-	_, ver, impl, err := run.PopulateTFVersion(ctx, l, unitOpts.WorkingDir, unitOpts.VersionManagerFileName, configbridge.TFRunOptsFromOpts(unitOpts))
+	_, ver, impl, err := run.PopulateTFVersion(
+		ctx, l, vexec.NewOSExec(),
+		unitOpts.WorkingDir,
+		unitOpts.VersionManagerFileName,
+		configbridge.TFRunOptsFromOpts(unitOpts),
+	)
 	if err != nil {
 		return errors.Errorf("failed to populate Terraform version for unit %s: %w", unit.DisplayPath(), err)
 	}
@@ -281,7 +287,10 @@ func checkUnitVersionConstraints(
 
 			defaultValue, err := flag.DefaultAsString()
 			if err != nil {
-				return errors.Errorf("failed to get default value for feature flag %s in unit %s: %w", flagName, unit.DisplayPath(), err)
+				return errors.Errorf(
+					"failed to get default value for feature flag %s in unit %s: %w",
+					flagName, unit.DisplayPath(), err,
+				)
 			}
 
 			if _, exists := unitOpts.FeatureFlags.Load(flagName); !exists {

--- a/test/integration_run_test.go
+++ b/test/integration_run_test.go
@@ -137,12 +137,12 @@ func TestRunVersionFilesCacheKey(t *testing.T) {
 	}{
 		{
 			name:         "use default",
-			expect:       "r01AJjVD7VSXCQk1ORuh_no_NRY",
+			expect:       "H2PcpB8dh-BE5Dz-LiSD1hykSfk",
 			versionFiles: nil,
 		},
 		{
 			name:   "custom files provided",
-			expect: "XBE-VO9pOnQjPQDmLQCvSCdckSQ",
+			expect: "trAjGOdUv3IcX1lU50dck_mqlUs",
 			versionFiles: []string{
 				".terraform-version",
 				".tool-versions",

--- a/test/integration_run_test.go
+++ b/test/integration_run_test.go
@@ -130,19 +130,27 @@ func TestRunNoStacksGenerate(t *testing.T) {
 func TestRunVersionFilesCacheKey(t *testing.T) {
 	t.Parallel()
 
+	// The cache key incorporates the resolved binary path, so the expected
+	// hash differs depending on whether tofu or terraform is wrapped.
 	testdata := []struct {
+		expect       map[string]string
 		name         string
-		expect       string
 		versionFiles []string
 	}{
 		{
-			name:         "use default",
-			expect:       "H2PcpB8dh-BE5Dz-LiSD1hykSfk",
+			name: "use default",
+			expect: map[string]string{
+				helpers.TofuBinary:      "H2PcpB8dh-BE5Dz-LiSD1hykSfk",
+				helpers.TerraformBinary: "rdE9RkSvu7WDQly2KzL2HxpcB3Q",
+			},
 			versionFiles: nil,
 		},
 		{
-			name:   "custom files provided",
-			expect: "trAjGOdUv3IcX1lU50dck_mqlUs",
+			name: "custom files provided",
+			expect: map[string]string{
+				helpers.TofuBinary:      "trAjGOdUv3IcX1lU50dck_mqlUs",
+				helpers.TerraformBinary: "kLXlcfwganOp8AOV4_ErIlU3g6o",
+			},
 			versionFiles: []string{
 				".terraform-version",
 				".tool-versions",
@@ -155,6 +163,10 @@ func TestRunVersionFilesCacheKey(t *testing.T) {
 	for _, tt := range testdata {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			wrapped := helpers.WrappedBinary(t.Context())
+			expect, ok := tt.expect[wrapped]
+			require.Truef(t, ok, "no expected cache key recorded for wrapped binary %q", wrapped)
 
 			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureVersionFilesCacheKey, tt.versionFiles...)
 			path := filepath.Join(tmpEnvPath, testFixtureVersionFilesCacheKey)
@@ -180,7 +192,7 @@ func TestRunVersionFilesCacheKey(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotEmpty(t, stdout)
 			assert.NotEmpty(t, stderr)
-			assert.Contains(t, stderr, "using cache key for version files: "+tt.expect)
+			assert.Contains(t, stderr, "using cache key for version files: "+expect)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6147.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression where the `terraform_binary` configuration setting was ignored when both OpenTofu and Terraform were available on PATH. Version information is now properly scoped to the selected binary, ensuring the correct implementation is consistently used.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->