### PR TITLE
docs: added filtering of compatibility table

### DIFF
--- a/docs/src/components/CompatibilityTable.astro
+++ b/docs/src/components/CompatibilityTable.astro
@@ -1,14 +1,31 @@
 ---
 import { getCollection } from 'astro:content';
+import { getLatestRelease } from '@lib/github';
+import { effectiveTerragruntMax, filterByReleasedMin } from '@lib/compatibility';
 
 interface Props {
   tool: 'opentofu' | 'terraform';
 }
 
 const { tool } = Astro.props;
-const entries = (await getCollection('compatibility'))
-  .filter(e => e.data.tool === tool)
-  .sort((a, b) => b.data.order - a.data.order);
+
+const releaseData = await getLatestRelease('gruntwork-io', 'terragrunt');
+// Fail open when we cannot determine the latest release, so the table stays
+// useful even if the GitHub API is unreachable at build time.
+const showUnreleased = import.meta.env.DEV || releaseData === null;
+const latestVersion = (releaseData?.tag_name ?? 'v0.0.0').replace(/^v/, '');
+
+const entries = filterByReleasedMin(
+  (await getCollection('compatibility')).filter(e => e.data.tool === tool),
+  latestVersion,
+  showUnreleased,
+)
+  .sort((a, b) => b.data.order - a.data.order)
+  .map(e => ({
+    version: e.data.version,
+    terragrunt_min: e.data.terragrunt_min,
+    terragrunt_max: effectiveTerragruntMax(e.data.terragrunt_max, latestVersion, showUnreleased),
+  }));
 
 const label = tool === 'opentofu' ? 'OpenTofu' : 'Terraform';
 const baseUrl = 'https://github.com/gruntwork-io/terragrunt/releases/tag/v';
@@ -24,12 +41,12 @@ const baseUrl = 'https://github.com/gruntwork-io/terragrunt/releases/tag/v';
   <tbody>
     {entries.map(e => (
       <tr>
-        <td>{e.data.version}</td>
+        <td>{e.version}</td>
         <td>
-          {e.data.terragrunt_max ? (
-            <><a href={`${baseUrl}${e.data.terragrunt_min}`}>{e.data.terragrunt_min}</a> - <a href={`${baseUrl}${e.data.terragrunt_max}`}>{e.data.terragrunt_max}</a></>
+          {e.terragrunt_max ? (
+            <><a href={`${baseUrl}${e.terragrunt_min}`}>{e.terragrunt_min}</a> - <a href={`${baseUrl}${e.terragrunt_max}`}>{e.terragrunt_max}</a></>
           ) : (
-            <>&gt;= <a href={`${baseUrl}${e.data.terragrunt_min}`}>{e.data.terragrunt_min}</a></>
+            <>&gt;= <a href={`${baseUrl}${e.terragrunt_min}`}>{e.terragrunt_min}</a></>
           )}
         </td>
       </tr>

--- a/docs/src/lib/compatibility.test.ts
+++ b/docs/src/lib/compatibility.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import {
+  effectiveTerragruntMax,
+  filterByReleasedMin,
+  type CompatibilityEntry,
+} from "./compatibility";
+
+function makeEntry(id: string, terragrunt_min: string): CompatibilityEntry {
+  return {
+    id,
+    collection: "compatibility",
+    data: {
+      id,
+      tool: "opentofu",
+      version: "1.0.x",
+      terragrunt_min,
+      terragrunt_max: null,
+      order: 1,
+    },
+  } as CompatibilityEntry;
+}
+
+describe("filterByReleasedMin", () => {
+  test("keeps entries whose terragrunt_min is at or below the latest release", () => {
+    const entries = [makeEntry("a", "1.0.0"), makeEntry("b", "1.0.5")];
+    const result = filterByReleasedMin(entries, "1.0.5");
+    expect(result.map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  test("drops entries whose terragrunt_min is newer than the latest release", () => {
+    const entries = [makeEntry("released", "1.0.5"), makeEntry("future", "1.1.0")];
+    const result = filterByReleasedMin(entries, "1.0.5");
+    expect(result.map((e) => e.id)).toEqual(["released"]);
+  });
+
+  test("compares numerically not lexically (1.0.10 > 1.0.5)", () => {
+    const entries = [makeEntry("a", "1.0.10")];
+    expect(filterByReleasedMin(entries, "1.0.5")).toEqual([]);
+    expect(filterByReleasedMin(entries, "1.0.10").map((e) => e.id)).toEqual(["a"]);
+  });
+
+  test("returns all entries when showUnreleased is true", () => {
+    const entries = [makeEntry("a", "1.0.0"), makeEntry("future", "99.0.0")];
+    const result = filterByReleasedMin(entries, "1.0.0", true);
+    expect(result.map((e) => e.id)).toEqual(["a", "future"]);
+  });
+
+  test("returns empty array when latest is 0.0.0 (treats nothing as released)", () => {
+    const entries = [makeEntry("a", "1.0.0")];
+    expect(filterByReleasedMin(entries, "0.0.0")).toEqual([]);
+  });
+});
+
+describe("effectiveTerragruntMax", () => {
+  test("returns null when input is already null", () => {
+    expect(effectiveTerragruntMax(null, "1.0.5")).toBe(null);
+  });
+
+  test("returns the value when it is at or below the latest release", () => {
+    expect(effectiveTerragruntMax("1.0.5", "1.0.5")).toBe("1.0.5");
+    expect(effectiveTerragruntMax("0.24.4", "1.0.5")).toBe("0.24.4");
+  });
+
+  test("returns null when the value is newer than the latest release", () => {
+    expect(effectiveTerragruntMax("1.1.0", "1.0.5")).toBe(null);
+  });
+
+  test("compares numerically not lexically", () => {
+    expect(effectiveTerragruntMax("1.0.10", "1.0.5")).toBe(null);
+    expect(effectiveTerragruntMax("1.0.10", "1.0.10")).toBe("1.0.10");
+  });
+
+  test("returns the original value unchanged when showUnreleased is true", () => {
+    expect(effectiveTerragruntMax("99.0.0", "1.0.5", true)).toBe("99.0.0");
+  });
+});

--- a/docs/src/lib/compatibility.ts
+++ b/docs/src/lib/compatibility.ts
@@ -1,0 +1,26 @@
+import type { CollectionEntry } from "astro:content";
+import { isReleased } from "./changelog";
+
+export type CompatibilityEntry = CollectionEntry<"compatibility">;
+
+// Hide entries whose terragrunt_min has not been released yet.
+export function filterByReleasedMin<T extends CompatibilityEntry>(
+  entries: T[],
+  latestVersion: string,
+  showUnreleased = false,
+): T[] {
+  if (showUnreleased) return entries;
+  return entries.filter((e) => isReleased(`v${e.data.terragrunt_min}`, latestVersion));
+}
+
+// Clear terragrunt_max when it points to a version that has not been released yet.
+export function effectiveTerragruntMax(
+  terragruntMax: string | null,
+  latestVersion: string,
+  showUnreleased = false,
+): string | null {
+  if (terragruntMax === null) return null;
+  if (showUnreleased) return terragruntMax;
+  if (!isReleased(`v${terragruntMax}`, latestVersion)) return null;
+  return terragruntMax;
+}

--- a/docs/src/pages/api/v1/compatibility/[tool].ts
+++ b/docs/src/pages/api/v1/compatibility/[tool].ts
@@ -1,5 +1,7 @@
 import type { APIRoute, GetStaticPaths } from 'astro';
 import { getCollection } from 'astro:content';
+import { getLatestRelease } from '@lib/github';
+import { effectiveTerragruntMax, filterByReleasedMin } from '@lib/compatibility';
 
 export const prerender = true;
 
@@ -11,8 +13,20 @@ export const getStaticPaths: GetStaticPaths = () => [
 
 export const GET: APIRoute = async ({ params }) => {
 	const tool = params.tool === 'index' ? undefined : params.tool;
-	const entries = (await getCollection('compatibility'))
-		.filter(e => !tool || e.data.tool === tool)
+
+	const releaseData = await getLatestRelease('gruntwork-io', 'terragrunt');
+	// Fail open when we cannot determine the latest release, so the API still
+	// returns historical compatibility data if the GitHub API is unreachable.
+	const showUnreleased = import.meta.env.DEV || releaseData === null;
+	const latestVersion = (releaseData?.tag_name ?? 'v0.0.0').replace(/^v/, '');
+
+	const filtered = filterByReleasedMin(
+		(await getCollection('compatibility')).filter(e => !tool || e.data.tool === tool),
+		latestVersion,
+		showUnreleased,
+	);
+
+	const entries = filtered
 		.sort((a, b) => {
 			if (a.data.tool !== b.data.tool) {
 				return a.data.tool === 'opentofu' ? -1 : 1;
@@ -23,7 +37,7 @@ export const GET: APIRoute = async ({ params }) => {
 			tool: e.data.tool,
 			version: e.data.version,
 			terragrunt_min: e.data.terragrunt_min,
-			terragrunt_max: e.data.terragrunt_max,
+			terragrunt_max: effectiveTerragruntMax(e.data.terragrunt_max, latestVersion, showUnreleased),
 		}));
 
 	return new Response(JSON.stringify(entries), {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* added filtering of the compatibility table based on the Terragrunt release
* added filtering of terragrunt_min and terragrunt_max fields

Fixes #6146.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compatibility table now automatically fetches the latest release information at build time for more accurate version data.
  * Improved resilience with automatic fallback behavior when external services are unavailable.

* **Tests**
  * Added comprehensive test coverage for compatibility filtering and version normalization logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->