### PR TITLE
docs: Cleaning up changelog for stack dependencies permissive parser

### DIFF
--- a/docs/src/data/changelog/v1.0.6/stack-dependencies-permissive-parser.mdx
+++ b/docs/src/data/changelog/v1.0.6/stack-dependencies-permissive-parser.mdx
@@ -3,18 +3,47 @@ version: "v1.0.6"
 category: "experiments-updated"
 ---
 
-#### `stack-dependencies`: richer `terragrunt.stack.hcl` parsing
+#### `stack-dependencies`: parser tolerates HCL expressions throughout `terragrunt.stack.hcl`
 
-The `stack-dependencies` experiment now lets you write `terragrunt.stack.hcl` files closer to how regular `terragrunt.hcl` files work. With `--experiment stack-dependencies`:
+The `stack-dependencies` experiment now defers evaluation of `source`, `path`, `values`, and `include.path` until each unit or stack block is parsed on its own. As a result, `autoinclude` resolution during stack generation and `run --all` discovery no longer fall over when other parts of a stack file use Terragrunt functions, `local.*`, or `values.*`. A few adjacent behaviors are tightened up at the same time.
 
-- **Use `local.*`, `values.*`, and Terragrunt functions in `source` and `path`.** Expressions like `source = "${get_terragrunt_dir()}/../catalog/units/${values.cloud}-provider"` and `path = "${local.env}-${values.cloud}"` are evaluated during stack generation. Locals can also reference other locals.
-- **Pull shared content into `terragrunt.stack.hcl` via `include` blocks.** Compose a stack file from sibling fragments the same way you do with `terragrunt.hcl`.
-- **Reference units and stacks by name inside `autoinclude` blocks** using `unit.<name>.path`, `stack.<name>.path`, and `stack.<name>.<unit_name>.path`. Stacks named with the same label as a nested unit (`stack "foo" { unit "foo" { ... } }`) resolve cleanly through `stack.foo.foo.path`.
-- **Depend on entire stacks.** A `dependency` block whose `config_path` points at a generated stack directory exposes outputs as `dependency.<stack>.outputs.<unit>.<output_key>`. Terragrunt waits for every unit in the stack to finish before running the dependent unit.
-- **Bare relative `source` paths in catalog stack files now work.** When a `stack` block copies a catalog into `.terragrunt-stack/<name>/`, units inside that catalog file can keep writing `source = "../../units/foo"` and Terragrunt resolves the path against the original catalog directory. No need to rewrite catalog files with `find_in_parent_folders()` just to satisfy generation.
-- **`terragrunt run --all` sees autoinclude dependencies automatically.** Dependencies declared inside `autoinclude { dependency "..." { ... } }` participate in the DAG without any extra wiring.
-- **`run --all` can now handle nested catalog stacks that use Terragrunt functions in unit `source`.** Function calls inside generated nested stack files are tolerated by discovery.
-- **Clearer error messages with source position.** Invalid `autoinclude` content (null/unknown `config_path`, missing labels, `values` used inside `autoinclude`), include-path failures, and locals cycles now produce diagnostics that point at the exact line and column. Cycle errors list the participating locals in a stable order across runs.
-- **Safer generation on unusual inputs.** Generation no longer crashes on deeply-nested expressions or on unknown/null values flowing through `autoinclude` partial evaluation. Terragrunt preserves the original source text and returns a typed error instead.
+**Autoinclude resolves even when sibling units use expressions.**
 
-Behavior outside the experiment is unchanged. Enable with `--experiment stack-dependencies`.
+Before 1.0.6, if any unit in a stack file used a function call or a `local.*` / `values.*` reference in `source`, `path`, or `values`, generating an `autoinclude` on a different unit in the same file could fail. The parser now leaves those expressions alone until they're needed, so an unrelated unit can carry an `autoinclude` block without being blocked by its neighbors:
+
+```hcl
+locals {
+  shared_region = "us-east-1"
+}
+
+unit "account" {
+  source = "${get_terragrunt_dir()}/../catalog/units/account"
+  path   = "account"
+  values = {
+    account = values.account
+    region  = local.shared_region
+  }
+}
+
+unit "roles" {
+  source = "${get_terragrunt_dir()}/../catalog/units/roles"
+  path   = "roles"
+
+  autoinclude {
+    dependency "account" {
+      config_path = unit.account.path
+    }
+  }
+}
+```
+
+**`include` blocks in `terragrunt.stack.hcl` accept computed paths.**
+
+The `path` attribute on an `include` block can be an HCL expression, not just a string literal. An `autoinclude` block in the included file is resolved normally after the include merges in:
+
+```hcl
+include "shared" {
+  path = find_in_parent_folders("shared.stack.hcl")
+}
+```
+


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Cleans up changelog entry for stack dependencies permissive parser update.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated changelog for v1.0.6 documenting parser improvements to the `stack-dependencies` experiment. The parser now defers evaluation of certain properties until parsing each unit/stack block, improving reliability when stack files contain expressions and functions. Enhanced `autoinclude` resolution and added support for computed paths in `include` blocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->