### PR TITLE
fix: Fixing panic in ignore signal

### DIFF
--- a/docs/src/data/changelog/v1.0.6/render-ignore-signals-panic.mdx
+++ b/docs/src/data/changelog/v1.0.6/render-ignore-signals-panic.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.6"
+category: "bug-fixes"
+---
+
+#### `terragrunt render` no longer crashes on multiple `errors.ignore` blocks with mismatched signals
+
+Rendering a config that defined more than one `errors.ignore` block crashed with an `inconsistent list element types` panic when the `signals` map was populated on one block and absent (or differently typed) on another. The same crash showed up in dependency-output evaluation, since both paths build the same rendered representation of the config.
+
+Each `ignore` block is now rendered with a uniform shape. Indexed access (`errors.ignore[0]`), length, and iteration still work, and the signals map on each block is preserved as written.

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -666,16 +666,58 @@ func errorsConfigAsCty(config *ErrorsConfig) (cty.Value, error) {
 		output[MetadataRetry] = retryCty
 	}
 
-	ignoreCty, err := GoTypeToCty(config.Ignore)
-	if err != nil {
-		return cty.NilVal, err
-	}
-
-	if ignoreCty != cty.NilVal {
+	if ignoreCty := ignoreBlocksAsCty(config.Ignore); ignoreCty != cty.NilVal {
 		output[MetadataIgnore] = ignoreCty
 	}
 
 	return ConvertValuesMapToCtyVal(output)
+}
+
+// ignoreBlocksAsCty returns the blocks as cty.TupleVal. gocty infers each
+// Signals map's element type from its contents (cty.Map(cty.String) when
+// populated, cty.Map(cty.DynamicPseudoType) when empty), so cty.ListVal
+// panics on "inconsistent list element types" when blocks disagree.
+// Tuples allow per-position type variation.
+func ignoreBlocksAsCty(blocks []*IgnoreBlock) cty.Value {
+	if len(blocks) == 0 {
+		return cty.NilVal
+	}
+
+	values := make([]cty.Value, 0, len(blocks))
+	for _, b := range blocks {
+		values = append(values, ignoreBlockAsCty(b))
+	}
+
+	return cty.TupleVal(values)
+}
+
+func ignoreBlockAsCty(b *IgnoreBlock) cty.Value {
+	if b == nil {
+		return cty.NullVal(cty.DynamicPseudoType)
+	}
+
+	ignorableErrors := cty.ListValEmpty(cty.String)
+
+	if len(b.IgnorableErrors) > 0 {
+		items := make([]cty.Value, len(b.IgnorableErrors))
+		for i, s := range b.IgnorableErrors {
+			items[i] = cty.StringVal(s)
+		}
+
+		ignorableErrors = cty.ListVal(items)
+	}
+
+	signals := cty.MapValEmpty(cty.DynamicPseudoType)
+	if len(b.Signals) > 0 {
+		signals = cty.ObjectVal(b.Signals)
+	}
+
+	return cty.ObjectVal(map[string]cty.Value{
+		"name":             cty.StringVal(b.Label),
+		"ignorable_errors": ignorableErrors,
+		"message":          cty.StringVal(b.Message),
+		"signals":          signals,
+	})
 }
 
 // stackConfigAsCty converts a StackConfig into a cty Value so its attributes can be used in other configs.

--- a/pkg/config/config_as_cty_test.go
+++ b/pkg/config/config_as_cty_test.go
@@ -167,6 +167,55 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 	}
 }
 
+// TestTerragruntConfigAsCtyMixedIgnoreSignals pins the fix for a panic
+// reachable from `terragrunt render` when two errors.ignore blocks have
+// differently-shaped signals maps. Before the fix, cty.ListVal panicked
+// on "inconsistent list element types" because gocty inferred
+// cty.Map(cty.String) for the populated block and
+// cty.Map(cty.DynamicPseudoType) for the empty one.
+func TestTerragruntConfigAsCtyMixedIgnoreSignals(t *testing.T) {
+	t.Parallel()
+
+	testConfig := config.TerragruntConfig{
+		Errors: &config.ErrorsConfig{
+			Ignore: []*config.IgnoreBlock{
+				{
+					Label:           "with-signals",
+					IgnorableErrors: []string{".*timeout.*"},
+					Message:         "ignored",
+					Signals: map[string]cty.Value{
+						"foo": cty.StringVal("bar"),
+					},
+				},
+				{
+					Label:           "without-signals",
+					IgnorableErrors: []string{".*5xx.*"},
+					Message:         "also ignored",
+				},
+			},
+		},
+	}
+
+	ctyVal, err := config.TerragruntConfigAsCty(&testConfig)
+	require.NoError(t, err)
+
+	ctyMap, err := ctyhelper.ParseCtyValueToMap(ctyVal)
+	require.NoError(t, err)
+
+	errorsMap := ctyMap["errors"].(map[string]any)
+	ignore := errorsMap["ignore"].([]any)
+	require.Len(t, ignore, 2)
+
+	first := ignore[0].(map[string]any)
+	assert.Equal(t, "with-signals", first["name"])
+	assert.Equal(t, "ignored", first["message"])
+	assert.Equal(t, map[string]any{"foo": "bar"}, first["signals"])
+
+	second := ignore[1].(map[string]any)
+	assert.Equal(t, "without-signals", second["name"])
+	assert.Equal(t, "also ignored", second["message"])
+}
+
 // This test makes sure that all the fields in RemoteState are converted to cty
 func TestRemoteStateAsCtyDrift(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes panic discovered when two ignore signals resolve to different cty types in parsing of the `signals` attribute of the `ignore` block in `errors`. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a crash in `terragrunt render` that occurred when rendering multiple error ignore blocks with mismatched signal configurations. Error ignore blocks now render consistently regardless of signal map variations.

* **Tests**
  * Added test coverage for mixed signal configurations in error ignore blocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->