### PR TITLE
fix: Fixing `download_dir` copy infinite recursion

### DIFF
--- a/docs/src/data/changelog/v1.0.6/copy-folder-recursion.mdx
+++ b/docs/src/data/changelog/v1.0.6/copy-folder-recursion.mdx
@@ -1,0 +1,23 @@
+---
+version: "v1.0.6"
+category: "bug-fixes"
+---
+
+#### `terragrunt` no longer hangs when `download_dir` is a non-hidden subdirectory of the unit
+
+Setting `download_dir` (via the attribute, `--download-dir`, or `TG_DOWNLOAD_DIR`) to a subdirectory of the unit's working directory whose name did not start with a dot caused commands that prepare the OpenTofu or Terraform source (`apply`, `plan`, `run`, and similar) to hang.
+
+For example:
+
+```hcl
+# /infra/web/terragrunt.hcl
+download_dir = "cache"
+
+terraform {
+  source = "./mod"
+}
+```
+
+Here `terragrunt apply` would copy `./mod` into `cache/`, see the new `cache/` directory on the next read of the unit, and recurse into it. The default `.terragrunt-cache` was unaffected because Terragrunt's source-copy step skips any directory whose name starts with a dot.
+
+These configurations now produce an immediate error identifying the source and destination paths.

--- a/internal/cli/commands/hcl/format/format_test.go
+++ b/internal/cli/commands/hcl/format/format_test.go
@@ -19,7 +19,7 @@ import (
 func TestHCLFmt(t *testing.T) {
 	t.Parallel()
 
-	tmpPath, err := util.CopyFolderToTemp("./testdata/fixtures", t.Name(), func(path string) bool { return true })
+	tmpPath, err := util.CopyFolderToTemp(helpers.MustAbs(t, "./testdata/fixtures"), t.Name(), func(path string) bool { return true })
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpPath)
@@ -96,7 +96,7 @@ func TestHCLFmt(t *testing.T) {
 func TestHCLFmtErrors(t *testing.T) {
 	t.Parallel()
 
-	tmpPath, err := util.CopyFolderToTemp("../../../../../test/fixtures/hclfmt-errors", t.Name(), func(path string) bool { return true })
+	tmpPath, err := util.CopyFolderToTemp(helpers.MustAbs(t, "../../../../../test/fixtures/hclfmt-errors"), t.Name(), func(path string) bool { return true })
 	t.Cleanup(func() {
 		os.RemoveAll(tmpPath)
 	})
@@ -130,7 +130,7 @@ func TestHCLFmtErrors(t *testing.T) {
 func TestHCLFmtCheck(t *testing.T) {
 	t.Parallel()
 
-	tmpPath, err := util.CopyFolderToTemp("../../../../../test/fixtures/hclfmt-check", t.Name(), func(path string) bool { return true })
+	tmpPath, err := util.CopyFolderToTemp(helpers.MustAbs(t, "../../../../../test/fixtures/hclfmt-check"), t.Name(), func(path string) bool { return true })
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpPath)
@@ -174,7 +174,7 @@ func TestHCLFmtCheck(t *testing.T) {
 func TestHCLFmtCheckErrors(t *testing.T) {
 	t.Parallel()
 
-	tmpPath, err := util.CopyFolderToTemp("../../../../../test/fixtures/hclfmt-check-errors", t.Name(), func(path string) bool { return true })
+	tmpPath, err := util.CopyFolderToTemp(helpers.MustAbs(t, "../../../../../test/fixtures/hclfmt-check-errors"), t.Name(), func(path string) bool { return true })
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpPath)
@@ -217,7 +217,7 @@ func TestHCLFmtCheckErrors(t *testing.T) {
 func TestHCLFmtFile(t *testing.T) {
 	t.Parallel()
 
-	tmpPath, err := util.CopyFolderToTemp("./testdata/fixtures", t.Name(), func(path string) bool { return true })
+	tmpPath, err := util.CopyFolderToTemp(helpers.MustAbs(t, "./testdata/fixtures"), t.Name(), func(path string) bool { return true })
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpPath)
@@ -314,7 +314,7 @@ func TestHCLFmtStdin(t *testing.T) {
 func TestHCLFmtHeredoc(t *testing.T) {
 	t.Parallel()
 
-	tmpPath, err := util.CopyFolderToTemp("../../../../../test/fixtures/hclfmt-heredoc", t.Name(), func(path string) bool { return true })
+	tmpPath, err := util.CopyFolderToTemp(helpers.MustAbs(t, "../../../../../test/fixtures/hclfmt-heredoc"), t.Name(), func(path string) bool { return true })
 	defer os.RemoveAll(tmpPath)
 
 	require.NoError(t, err)
@@ -340,7 +340,7 @@ func TestRunForFiles(t *testing.T) {
 	t.Parallel()
 
 	tmpPath := t.TempDir()
-	err := util.CopyFolderContentsWithFilter(logger.CreateLogger(), filepath.Join(".", "testdata", "fixtures"), tmpPath, ".copymanifest", func(path string) bool { return true })
+	err := util.CopyFolderContentsWithFilter(logger.CreateLogger(), helpers.MustAbs(t, filepath.Join(".", "testdata", "fixtures")), tmpPath, ".copymanifest", func(path string) bool { return true })
 	require.NoError(t, err)
 
 	expected, err := util.ReadFileAsString(filepath.Join(".", "testdata", "fixtures", "expected.hcl"))
@@ -396,7 +396,7 @@ func TestRunForFilesEmptyList(t *testing.T) {
 func TestHCLFmtFilter(t *testing.T) {
 	t.Parallel()
 
-	tmpPath, err := util.CopyFolderToTemp("./testdata/fixtures", t.Name(), func(path string) bool { return true })
+	tmpPath, err := util.CopyFolderToTemp(helpers.MustAbs(t, "./testdata/fixtures"), t.Name(), func(path string) bool { return true })
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpPath)
@@ -465,7 +465,7 @@ func TestHCLFmtFilter(t *testing.T) {
 func TestHCLFmtFilterMultiple(t *testing.T) {
 	t.Parallel()
 
-	tmpPath, err := util.CopyFolderToTemp("./testdata/fixtures", t.Name(), func(path string) bool { return true })
+	tmpPath, err := util.CopyFolderToTemp(helpers.MustAbs(t, "./testdata/fixtures"), t.Name(), func(path string) bool { return true })
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpPath)
@@ -537,7 +537,7 @@ func TestHCLFmtFilterMultiple(t *testing.T) {
 func TestHCLFmtFilterNegation(t *testing.T) {
 	t.Parallel()
 
-	tmpPath, err := util.CopyFolderToTemp("./testdata/fixtures", t.Name(), func(path string) bool { return true })
+	tmpPath, err := util.CopyFolderToTemp(helpers.MustAbs(t, "./testdata/fixtures"), t.Name(), func(path string) bool { return true })
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpPath)

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -133,7 +133,7 @@ func TestAlreadyHaveLatestCodeLocalFilePath(t *testing.T) {
 	t.Parallel()
 
 	canonicalURL := "file://" + absPath(t, "../../../test/fixtures/download-source/hello-world")
-	downloadDir := "does-not-exist"
+	downloadDir := absPath(t, "does-not-exist")
 
 	testAlreadyHaveLatestCode(t, canonicalURL, downloadDir, false)
 }
@@ -142,7 +142,7 @@ func TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirDoesNotExist(t *testing.T
 	t.Parallel()
 
 	canonicalURL := "http://www.some-url.com"
-	downloadDir := "does-not-exist"
+	downloadDir := absPath(t, "does-not-exist")
 
 	testAlreadyHaveLatestCode(t, canonicalURL, downloadDir, false)
 }
@@ -151,7 +151,7 @@ func TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsNoVersionNoVersionF
 	t.Parallel()
 
 	canonicalURL := "http://www.some-url.com"
-	downloadDir := "../../../test/fixtures/download-source/download-dir-empty"
+	downloadDir := absPath(t, "../../../test/fixtures/download-source/download-dir-empty")
 
 	testAlreadyHaveLatestCode(t, canonicalURL, downloadDir, false)
 }
@@ -160,7 +160,7 @@ func TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsNoVersionWithVersio
 	t.Parallel()
 
 	canonicalURL := "http://www.some-url.com"
-	downloadDir := "../../../test/fixtures/download-source/download-dir-version-file-no-query"
+	downloadDir := absPath(t, "../../../test/fixtures/download-source/download-dir-version-file-no-query")
 
 	testAlreadyHaveLatestCode(t, canonicalURL, downloadDir, true)
 }
@@ -169,7 +169,7 @@ func TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionNoVersio
 	t.Parallel()
 
 	canonicalURL := "http://www.some-url.com?ref=v0.0.1"
-	downloadDir := "../../../test/fixtures/download-source/download-dir-empty"
+	downloadDir := absPath(t, "../../../test/fixtures/download-source/download-dir-empty")
 
 	testAlreadyHaveLatestCode(t, canonicalURL, downloadDir, false)
 }
@@ -178,7 +178,7 @@ func TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersi
 	t.Parallel()
 
 	canonicalURL := "http://www.some-url.com?ref=v0.0.1"
-	downloadDir := "../../../test/fixtures/download-source/download-dir-version-file"
+	downloadDir := absPath(t, "../../../test/fixtures/download-source/download-dir-version-file")
 
 	testAlreadyHaveLatestCode(t, canonicalURL, downloadDir, false)
 }
@@ -187,7 +187,7 @@ func TestAlreadyHaveLatestCodeRemoteFilePathDownloadDirExistsWithVersionAndVersi
 	t.Parallel()
 
 	canonicalURL := "http://www.some-url.com?ref=v0.0.1"
-	downloadDir := "../../../test/fixtures/download-source/download-dir-version-file-tf-code"
+	downloadDir := absPath(t, "../../../test/fixtures/download-source/download-dir-version-file-tf-code")
 
 	testAlreadyHaveLatestCode(t, canonicalURL, downloadDir, true)
 }
@@ -589,8 +589,8 @@ func copyFolder(t *testing.T, src string, dest string) {
 
 	err := util.CopyFolderContents(
 		l,
-		filepath.FromSlash(src),
-		filepath.FromSlash(dest),
+		absPath(t, filepath.FromSlash(src)),
+		absPath(t, filepath.FromSlash(dest)),
 		".terragrunt-test",
 	)
 	require.NoError(t, err)

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -834,8 +834,10 @@ func CopyFolderToTemp(source string, tempPrefix string, filter func(path string)
 // case, e.g. `.terragrunt-cache` is filtered out by [TerragruntExcludes]).
 //
 // Both arguments must be absolute. Relatives are rejected rather than
-// resolved against the process working directory, since callers can
-// shift it independently.
+// resolved against the process working directory, since Terragrunt's
+// `--working-dir` flag detaches the conceptual working directory from
+// the Go process CWD, and resolving here would silently produce wrong
+// answers.
 func assertCopyPathsSafe(source, destination string, filter func(absolutePath string) bool) error {
 	if !filepath.IsAbs(source) {
 		return errors.Errorf("copy source must be an absolute path, got %q", source)

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -824,51 +824,101 @@ func CopyFolderToTemp(source string, tempPrefix string, filter func(path string)
 	return dest, nil
 }
 
+// CopySourceNotAbsoluteError is returned when [CopyFolderContents] or
+// [CopyFolderContentsWithFilter] is called with a non-absolute source.
+type CopySourceNotAbsoluteError struct {
+	Path string
+}
+
+func (err CopySourceNotAbsoluteError) Error() string {
+	return fmt.Sprintf("copy source must be an absolute path, got %q", err.Path)
+}
+
+// CopyDestinationNotAbsoluteError is returned when [CopyFolderContents]
+// or [CopyFolderContentsWithFilter] is called with a non-absolute
+// destination.
+type CopyDestinationNotAbsoluteError struct {
+	Path string
+}
+
+func (err CopyDestinationNotAbsoluteError) Error() string {
+	return fmt.Sprintf("copy destination must be an absolute path, got %q", err.Path)
+}
+
+// CopySourceEqualsDestinationError is returned when [CopyFolderContents]
+// or [CopyFolderContentsWithFilter] is called with source and destination
+// resolving to the same path.
+type CopySourceEqualsDestinationError struct {
+	Path string
+}
+
+func (err CopySourceEqualsDestinationError) Error() string {
+	return fmt.Sprintf("copy source and destination are the same path: %q", err.Path)
+}
+
+// CopyDestinationInsideSourceError is returned when [CopyFolderContents]
+// or [CopyFolderContentsWithFilter] is called with a destination inside
+// the source where the filter would not stop the source walk before
+// reaching the destination subtree.
+type CopyDestinationInsideSourceError struct {
+	Source      string
+	Destination string
+	RelDest     string
+}
+
+func (err CopyDestinationInsideSourceError) Error() string {
+	return fmt.Sprintf("copy destination %q is inside source %q and the filter does not exclude any segment of %q; the copy would recurse into itself", err.Destination, err.Source, err.RelDest)
+}
+
 // assertCopyPathsSafe checks that the copy from source to destination
-// won't recurse forever. The unsafe shape is dest-inside-source where
-// the filter would also walk into dest's first segment: MkdirAll seeds
-// destination as a subtree under source before the loop reads source's
-// children, so the next read surfaces dest's first segment as a fresh
-// entry and the loop descends into it without bound. Dest-inside-source
-// is only safe when the filter excludes that first segment (the typical
-// case, e.g. `.terragrunt-cache` is filtered out by [TerragruntExcludes]).
+// won't recurse forever.
 //
-// Both arguments must be absolute. Relatives are rejected rather than
-// resolved against the process working directory, since Terragrunt's
-// `--working-dir` flag detaches the conceptual working directory from
-// the Go process CWD, and resolving here would silently produce wrong
-// answers.
+// The copy is safe whenever the filter excludes any segment
+// along that path (the typical case, e.g. `.terragrunt-cache` is
+// filtered out by [TerragruntExcludes]); the walker stops there and
+// never reaches the destination subtree.
+//
+// Both arguments must be absolute.
 func assertCopyPathsSafe(source, destination string, filter func(absolutePath string) bool) error {
 	if !filepath.IsAbs(source) {
-		return errors.Errorf("copy source must be an absolute path, got %q", source)
+		return CopySourceNotAbsoluteError{Path: source}
 	}
 
 	if !filepath.IsAbs(destination) {
-		return errors.Errorf("copy destination must be an absolute path, got %q", destination)
+		return CopyDestinationNotAbsoluteError{Path: destination}
 	}
 
 	cleanSource := filepath.Clean(source)
 	cleanDest := filepath.Clean(destination)
 
 	if cleanSource == cleanDest {
-		return errors.Errorf("copy source and destination are the same path: %q", source)
+		return CopySourceEqualsDestinationError{Path: source}
 	}
 
-	sep := string(filepath.Separator)
-	if !strings.HasPrefix(cleanDest+sep, cleanSource+sep) {
+	relDest, err := filepath.Rel(cleanSource, cleanDest)
+	if err != nil {
+		// Different volumes on Windows, etc. The paths can't nest.
 		return nil
 	}
 
-	relDest := strings.TrimPrefix(cleanDest+sep, cleanSource+sep)
-
-	firstSegment, _, _ := strings.Cut(relDest, sep)
-	firstSegmentAbs := filepath.Join(cleanSource, firstSegment)
-
-	if filter == nil || filter(firstSegmentAbs) {
-		return errors.Errorf("copy destination %q is inside source %q and the filter does not exclude %q; the copy would recurse into itself", destination, source, firstSegment)
+	sep := string(filepath.Separator)
+	if relDest == ".." || strings.HasPrefix(relDest, ".."+sep) {
+		return nil
 	}
 
-	return nil
+	accumulated := cleanSource
+	for segment := range strings.SplitSeq(relDest, sep) {
+		accumulated = filepath.Join(accumulated, segment)
+		if filter != nil && !filter(accumulated) {
+			return nil
+		}
+	}
+
+	return errors.New(CopyDestinationInsideSourceError{
+		Source:      source,
+		Destination: destination,
+		RelDest:     relDest,
+	})
 }
 
 // IsSymLink returns true if the given file is a symbolic link
@@ -879,7 +929,6 @@ func IsSymLink(path string) bool {
 }
 
 func TerragruntExcludes(path string) bool {
-	// Do not exclude the terraform lock file (new feature added in terraform 0.14)
 	if filepath.Base(path) == TerraformLockFile {
 		return false
 	}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -377,12 +377,9 @@ func CopyFolderContents(l log.Logger, source, destination, manifestFile string, 
 	source = filepath.ToSlash(source)
 	destination = filepath.ToSlash(destination)
 
-	if cfg.fastCopy {
-		return copyFolderContentsFast(l, source, destination, manifestFile, cfg.includeInCopy, cfg.excludeFromCopy)
-	}
-
 	// Expand all the includeInCopy glob paths, converting the globbed results to relative paths so that they work in
-	// the copy filter.
+	// the copy filter. The expanded globs feed both the dest-inside-source
+	// assertion below and the filter passed to the slow-path implementation.
 	includeExpandedGlobs := []string{}
 
 	for _, includeGlob := range cfg.includeInCopy {
@@ -409,7 +406,7 @@ func CopyFolderContents(l log.Logger, source, destination, manifestFile string, 
 		excludeExpandedGlobs = append(excludeExpandedGlobs, expandGlob...)
 	}
 
-	return CopyFolderContentsWithFilter(l, source, destination, manifestFile, func(absolutePath string) bool {
+	filter := func(absolutePath string) bool {
 		relativePath, err := filepath.Rel(source, absolutePath)
 		if err != nil {
 			l.Warnf("Failed to compute relative path from %s to %s: %v", source, absolutePath, err)
@@ -429,7 +426,17 @@ func CopyFolderContents(l log.Logger, source, destination, manifestFile string, 
 		}
 
 		return !TerragruntExcludes(filepath.FromSlash(relativePath))
-	})
+	}
+
+	if err := assertCopyPathsSafe(source, destination, filter); err != nil {
+		return err
+	}
+
+	if cfg.fastCopy {
+		return copyFolderContentsFast(l, source, destination, manifestFile, cfg.includeInCopy, cfg.excludeFromCopy)
+	}
+
+	return CopyFolderContentsWithFilter(l, source, destination, manifestFile, filter)
 }
 
 // copyFolderContentsFast is the [CopyFolderContents] path used when the
@@ -718,6 +725,10 @@ func compileExcludePattern(patterns []string) (glob.Matcher, error) {
 
 // CopyFolderContentsWithFilter copies the files and folders within the source folder into the destination folder.
 func CopyFolderContentsWithFilter(l log.Logger, source, destination, manifestFile string, filter func(absolutePath string) bool) error {
+	if err := assertCopyPathsSafe(source, destination, filter); err != nil {
+		return err
+	}
+
 	const ownerReadWriteExecutePerms = 0o700
 	if err := os.MkdirAll(destination, ownerReadWriteExecutePerms); err != nil {
 		return errors.New(err)
@@ -811,6 +822,51 @@ func CopyFolderToTemp(source string, tempPrefix string, filter func(path string)
 	}
 
 	return dest, nil
+}
+
+// assertCopyPathsSafe checks that the copy from source to destination
+// won't recurse forever. The unsafe shape is dest-inside-source where
+// the filter would also walk into dest's first segment: MkdirAll seeds
+// destination as a subtree under source before the loop reads source's
+// children, so the next read surfaces dest's first segment as a fresh
+// entry and the loop descends into it without bound. Dest-inside-source
+// is only safe when the filter excludes that first segment (the typical
+// case, e.g. `.terragrunt-cache` is filtered out by [TerragruntExcludes]).
+//
+// Both arguments must be absolute. Relatives are rejected rather than
+// resolved against the process working directory, since callers can
+// shift it independently.
+func assertCopyPathsSafe(source, destination string, filter func(absolutePath string) bool) error {
+	if !filepath.IsAbs(source) {
+		return errors.Errorf("copy source must be an absolute path, got %q", source)
+	}
+
+	if !filepath.IsAbs(destination) {
+		return errors.Errorf("copy destination must be an absolute path, got %q", destination)
+	}
+
+	cleanSource := filepath.Clean(source)
+	cleanDest := filepath.Clean(destination)
+
+	if cleanSource == cleanDest {
+		return errors.Errorf("copy source and destination are the same path: %q", source)
+	}
+
+	sep := string(filepath.Separator)
+	if !strings.HasPrefix(cleanDest+sep, cleanSource+sep) {
+		return nil
+	}
+
+	relDest := strings.TrimPrefix(cleanDest+sep, cleanSource+sep)
+
+	firstSegment, _, _ := strings.Cut(relDest, sep)
+	firstSegmentAbs := filepath.Join(cleanSource, firstSegment)
+
+	if filter == nil || filter(firstSegmentAbs) {
+		return errors.Errorf("copy destination %q is inside source %q and the filter does not exclude %q; the copy would recurse into itself", destination, source, firstSegment)
+	}
+
+	return nil
 }
 
 // IsSymLink returns true if the given file is a symbolic link

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -1309,16 +1309,18 @@ func TestCopyFolderContentsRejectsDestinationInsideSource(t *testing.T) {
 		t.Parallel()
 
 		err := util.CopyFolderContents(l, source, filepath.Join(source, "nested"), ".terragrunt-test")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "inside source")
+
+		var insideErr util.CopyDestinationInsideSourceError
+		require.ErrorAs(t, err, &insideErr)
 	})
 
 	t.Run("destination equals source", func(t *testing.T) {
 		t.Parallel()
 
 		err := util.CopyFolderContents(l, source, source, ".terragrunt-test")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "same path")
+
+		var sameErr util.CopySourceEqualsDestinationError
+		require.ErrorAs(t, err, &sameErr)
 	})
 
 	t.Run("sibling destination is allowed", func(t *testing.T) {
@@ -1341,6 +1343,30 @@ func TestCopyFolderContentsRejectsDestinationInsideSource(t *testing.T) {
 		require.NoError(t, util.CopyFolderContents(l, source, dest, ".terragrunt-test"))
 	})
 
+	// filepath.Rel can produce pure-`..` relative paths when destination
+	// is a strict ancestor of source (e.g. `..`, `../..`). The walker
+	// globs source's children once at entry, so writes into the ancestor
+	// don't re-enter source's tree and the copy is safe.
+	t.Run("destination is parent of source is allowed", func(t *testing.T) {
+		t.Parallel()
+
+		nestedSource := filepath.Join(t.TempDir(), "child")
+		require.NoError(t, os.MkdirAll(nestedSource, 0o700))
+
+		dest := filepath.Dir(nestedSource)
+		require.NoError(t, util.CopyFolderContents(l, nestedSource, dest, ".terragrunt-test"))
+	})
+
+	t.Run("destination is grandparent of source is allowed", func(t *testing.T) {
+		t.Parallel()
+
+		nestedSource := filepath.Join(t.TempDir(), "child", "grandchild")
+		require.NoError(t, os.MkdirAll(nestedSource, 0o700))
+
+		dest := filepath.Dir(filepath.Dir(nestedSource))
+		require.NoError(t, util.CopyFolderContents(l, nestedSource, dest, ".terragrunt-test"))
+	})
+
 	// Dest inside source is the typical Terragrunt source-copy shape:
 	// destination is the .terragrunt-cache subtree, which TerragruntExcludes
 	// filters out on each read. The guard must accept this case; the
@@ -1352,6 +1378,25 @@ func TestCopyFolderContentsRejectsDestinationInsideSource(t *testing.T) {
 		require.NoError(t, util.CopyFolderContents(l, source, nested, ".terragrunt-test"))
 	})
 
+	// dest = source/<unit>/.terragrunt-cache/<h>/<h> is the integration
+	// shape when a unit's `source` URL points to a parent of the unit
+	// itself (`../..//modules/x`). The hidden segment that stops the
+	// walker is not the first component of the relative path, so the
+	// guard has to look at every segment, not just the first.
+	t.Run("destination inside source is allowed when a deeper segment is excluded", func(t *testing.T) {
+		t.Parallel()
+
+		nested := filepath.Join(source, "live", "child", util.TerragruntCacheDir, "h1", "h2")
+		require.NoError(t, util.CopyFolderContents(l, source, nested, ".terragrunt-test"))
+	})
+
+	t.Run("destination inside source is allowed when a deeper segment is excluded on fast-copy path", func(t *testing.T) {
+		t.Parallel()
+
+		nested := filepath.Join(source, "live", "child", util.TerragruntCacheDir, "fast", "h2")
+		require.NoError(t, util.CopyFolderContents(l, source, nested, ".terragrunt-test", util.WithFastCopy()))
+	})
+
 	// Fast copy routes through copyFolderContentsFast (vfs.WalkDirParallel)
 	// instead of CopyFolderContentsWithFilter. The guard at the public
 	// CopyFolderContents dispatch must cover both implementations, or this
@@ -1360,8 +1405,9 @@ func TestCopyFolderContentsRejectsDestinationInsideSource(t *testing.T) {
 		t.Parallel()
 
 		err := util.CopyFolderContents(l, source, filepath.Join(source, "fastnested"), ".terragrunt-test", util.WithFastCopy())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "inside source")
+
+		var insideErr util.CopyDestinationInsideSourceError
+		require.ErrorAs(t, err, &insideErr)
 	})
 
 	t.Run("destination inside source is allowed on fast-copy path when filter excludes it", func(t *testing.T) {
@@ -1375,16 +1421,18 @@ func TestCopyFolderContentsRejectsDestinationInsideSource(t *testing.T) {
 		t.Parallel()
 
 		err := util.CopyFolderContents(l, "relative/source", t.TempDir(), ".terragrunt-test")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "absolute")
+
+		var notAbsErr util.CopySourceNotAbsoluteError
+		require.ErrorAs(t, err, &notAbsErr)
 	})
 
 	t.Run("relative destination is rejected", func(t *testing.T) {
 		t.Parallel()
 
 		err := util.CopyFolderContents(l, t.TempDir(), "relative/destination", ".terragrunt-test")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "absolute")
+
+		var notAbsErr util.CopyDestinationNotAbsoluteError
+		require.ErrorAs(t, err, &notAbsErr)
 	})
 }
 

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -1293,6 +1293,101 @@ func TestRelPathForLog(t *testing.T) {
 
 // buildCopyBenchTree lays out a synthetic module source: topDirs
 // top-level directories, each a chain chainDepth levels deep with
+// TestCopyFolderContentsRejectsDestinationInsideSource pins the guard
+// that prevents CopyFolderContentsWithFilter from recursing forever when
+// destination resolves to a path inside source. Without the guard,
+// MkdirAll seeds the destination subtree under source, the next read of
+// source's children surfaces the destination's first segment, and the
+// loop descends into it indefinitely.
+func TestCopyFolderContentsRejectsDestinationInsideSource(t *testing.T) {
+	t.Parallel()
+
+	source := t.TempDir()
+	l := logger.CreateLogger()
+
+	t.Run("destination inside source", func(t *testing.T) {
+		t.Parallel()
+
+		err := util.CopyFolderContents(l, source, filepath.Join(source, "nested"), ".terragrunt-test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "inside source")
+	})
+
+	t.Run("destination equals source", func(t *testing.T) {
+		t.Parallel()
+
+		err := util.CopyFolderContents(l, source, source, ".terragrunt-test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "same path")
+	})
+
+	t.Run("sibling destination is allowed", func(t *testing.T) {
+		t.Parallel()
+
+		dest := filepath.Join(filepath.Dir(source), filepath.Base(source)+"-copy")
+
+		t.Cleanup(func() { _ = os.RemoveAll(dest) })
+
+		require.NoError(t, util.CopyFolderContents(l, source, dest, ".terragrunt-test"))
+	})
+
+	t.Run("destination sharing a prefix with source is allowed", func(t *testing.T) {
+		t.Parallel()
+
+		dest := source + "-suffix"
+
+		t.Cleanup(func() { _ = os.RemoveAll(dest) })
+
+		require.NoError(t, util.CopyFolderContents(l, source, dest, ".terragrunt-test"))
+	})
+
+	// Dest inside source is the typical Terragrunt source-copy shape:
+	// destination is the .terragrunt-cache subtree, which TerragruntExcludes
+	// filters out on each read. The guard must accept this case; the
+	// previously-failing regression test in pkg/config relies on it.
+	t.Run("destination inside source is allowed when filter excludes it", func(t *testing.T) {
+		t.Parallel()
+
+		nested := filepath.Join(source, util.TerragruntCacheDir, "h1", "h2")
+		require.NoError(t, util.CopyFolderContents(l, source, nested, ".terragrunt-test"))
+	})
+
+	// Fast copy routes through copyFolderContentsFast (vfs.WalkDirParallel)
+	// instead of CopyFolderContentsWithFilter. The guard at the public
+	// CopyFolderContents dispatch must cover both implementations, or this
+	// case hangs the way the slow path used to.
+	t.Run("destination inside source is rejected on fast-copy path", func(t *testing.T) {
+		t.Parallel()
+
+		err := util.CopyFolderContents(l, source, filepath.Join(source, "fastnested"), ".terragrunt-test", util.WithFastCopy())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "inside source")
+	})
+
+	t.Run("destination inside source is allowed on fast-copy path when filter excludes it", func(t *testing.T) {
+		t.Parallel()
+
+		nested := filepath.Join(source, util.TerragruntCacheDir, "fast", "h2")
+		require.NoError(t, util.CopyFolderContents(l, source, nested, ".terragrunt-test", util.WithFastCopy()))
+	})
+
+	t.Run("relative source is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		err := util.CopyFolderContents(l, "relative/source", t.TempDir(), ".terragrunt-test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute")
+	})
+
+	t.Run("relative destination is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		err := util.CopyFolderContents(l, t.TempDir(), "relative/destination", ".terragrunt-test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute")
+	})
+}
+
 // filesPerLevel files at every level. A bare-directory include pattern
 // like the top-level name triggers the legacy expandGlobPath recursion
 // once per nested directory.

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -108,7 +108,7 @@ func CopyEnvironment(t *testing.T, environmentPath string, includeInCopy ...stri
 		t,
 		util.CopyFolderContents(
 			logger.CreateLogger(),
-			environmentPath,
+			MustAbs(t, environmentPath),
 			filepath.Join(tmpDir, environmentPath),
 			".terragrunt-test",
 			util.WithIncludeInCopy(includeInCopy...),

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -25,6 +25,21 @@ func IsWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
+// MustAbs resolves rel against the Go test process working directory.
+// [util.CopyFolderContents] and related helpers require absolute paths
+// so their dest-inside-source guard isn't fooled by Terragrunt's
+// `--working-dir`, which detaches the runtime working directory from
+// the Go process CWD. In tests there's no such flag, so resolving
+// against the test process working directory is safe.
+func MustAbs(t *testing.T, rel string) string {
+	t.Helper()
+
+	abs, err := filepath.Abs(rel)
+	require.NoError(t, err)
+
+	return abs
+}
+
 func ValidateHookTraceParent(t *testing.T, hook, str string) {
 	t.Helper()
 

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -1789,7 +1789,7 @@ func TestAwsParallelStateInit(t *testing.T) {
 
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 	for i := range 20 {
-		err := util.CopyFolderContents(logger.CreateLogger(), testFixtureParallelStateInit, tmpEnvPath, ".terragrunt-test")
+		err := util.CopyFolderContents(logger.CreateLogger(), helpers.MustAbs(t, testFixtureParallelStateInit), tmpEnvPath, ".terragrunt-test")
 		require.NoError(t, err)
 		err = os.Rename(
 			path.Join(tmpEnvPath, "template"),

--- a/test/integration_gcp_test.go
+++ b/test/integration_gcp_test.go
@@ -395,7 +395,7 @@ func TestGcpParallelStateInit(t *testing.T) {
 	}
 
 	for i := range 20 {
-		err := util.CopyFolderContents(createLogger(), testFixtureGcsParallelStateInit, tmpEnvPath, ".terragrunt-test")
+		err := util.CopyFolderContents(createLogger(), helpers.MustAbs(t, testFixtureGcsParallelStateInit), tmpEnvPath, ".terragrunt-test")
 		require.NoError(t, err)
 
 		err = os.Rename(

--- a/test/integration_serial_aws_test.go
+++ b/test/integration_serial_aws_test.go
@@ -185,7 +185,7 @@ func testRemoteFixtureParallelism(t *testing.T, parallelism int, numberOfModules
 	// copy the template `numberOfModules` times into the app
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 	for i := range numberOfModules {
-		err := util.CopyFolderContents(createLogger(), testFixtureParallelism, tmpEnvPath, ".terragrunt-test")
+		err := util.CopyFolderContents(createLogger(), helpers.MustAbs(t, testFixtureParallelism), tmpEnvPath, ".terragrunt-test")
 		if err != nil {
 			return "", 0, err
 		}

--- a/test/integration_tflint_test.go
+++ b/test/integration_tflint_test.go
@@ -221,7 +221,7 @@ func CopyEnvironmentWithTflint(t *testing.T, environmentPath string) string {
 
 	t.Logf("Copying %s to %s", environmentPath, tmpDir)
 
-	require.NoError(t, util.CopyFolderContents(createLogger(), environmentPath, filepath.Join(tmpDir, environmentPath), ".terragrunt-test", util.WithIncludeInCopy(".tflint.hcl")))
+	require.NoError(t, util.CopyFolderContents(createLogger(), helpers.MustAbs(t, environmentPath), filepath.Join(tmpDir, environmentPath), ".terragrunt-test", util.WithIncludeInCopy(".tflint.hcl")))
 
 	return tmpDir
 }

--- a/test/integration_windows_test.go
+++ b/test/integration_windows_test.go
@@ -257,7 +257,7 @@ func CopyEnvironmentToPath(t *testing.T, environmentPath, targetPath string) {
 		t.Fatalf("Failed to create temp dir %s due to error %v", targetPath, err)
 	}
 
-	copyErr := util.CopyFolderContents(createLogger(), environmentPath, filepath.Join(targetPath, environmentPath), ".terragrunt-test")
+	copyErr := util.CopyFolderContents(createLogger(), helpers.MustAbs(t, environmentPath), filepath.Join(targetPath, environmentPath), ".terragrunt-test")
 	require.NoError(t, copyErr)
 }
 
@@ -277,7 +277,7 @@ func CopyEnvironmentWithTflint(t *testing.T, environmentPath string) string {
 		t,
 		util.CopyFolderContents(
 			createLogger(),
-			environmentPath,
+			helpers.MustAbs(t, environmentPath),
 			filepath.Join(tmpDir, environmentPath),
 			".terragrunt-test",
 			util.WithIncludeInCopy(".tflint.hcl"),


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Prevents infinite copy recursion when users use `download_dir` targeting a non-hidden directory in the same directory as the unit. This causes issues because the contents are continuously copied back into the cache directory.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where Terragrunt would hang when `download_dir` points to a non-hidden subdirectory of the working directory. Now raises an immediate error identifying the source and destination paths.

* **Reliability**
  * Improved folder copy operations with enhanced safety validation to prevent invalid recursive copies and provide clearer error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->