### PR TITLE
fix: Fixing `mark-many-as-read` for discovery

### DIFF
--- a/docs/src/data/changelog/v1.0.6/mark-many-as-read-partial-parse.mdx
+++ b/docs/src/data/changelog/v1.0.6/mark-many-as-read-partial-parse.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.6"
+category: "bug-fixes"
+---
+
+#### `mark-many-as-read` experiment now triggers during discovery
+
+With the `mark-many-as-read` experiment enabled, a unit whose `terraform { source = ... }` pointed at a local module did not show up under `--filter'reading='` filters that referenced files inside that module. Discovery would parse the unit, but the module files were never recorded as read, so the [reading filter attribute](https://docs.terragrunt.com/features/filter/attributes/#reading-based-expressions) could not match and the queue came back empty.
+
+The module walk now runs on the discovery code path as well, so changes to files in a local module source flow through to the units that depend on them.

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/huandu/go-clone"
@@ -598,6 +599,10 @@ func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger,
 		default:
 			return nil, InvalidPartialBlockName{decode}
 		}
+	}
+
+	if pctx.Experiments.Evaluate(experiment.MarkManyAsRead) && output.Terraform != nil && output.Terraform.Source != nil {
+		markLocalModuleSourceAsRead(pctx, file.ConfigPath, *output.Terraform.Source)
 	}
 
 	errsContainsIncludeErr := false

--- a/pkg/config/mark_as_read_test.go
+++ b/pkg/config/mark_as_read_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -161,6 +162,44 @@ func TestMarkManyAsReadExperiment(t *testing.T) {
 		assert.Contains(t, read, filepath.Join(moduleDir, ".terraform.lock.hcl"))
 		assert.NotContains(t, read, filepath.Join(moduleDir, "README.md"))
 	})
+}
+
+func TestMarkManyAsReadPartialParseSource(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "modules", "foo")
+	unitDir := filepath.Join(root, "units", "bar")
+
+	writeFile(t, filepath.Join(moduleDir, "main.tf"), "")
+	writeFile(t, filepath.Join(moduleDir, "variables.tf.json"), "{}")
+	writeFile(t, filepath.Join(moduleDir, "README.md"), "")
+
+	configPath := filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
+	hcl := `terraform { source = "../../modules/foo" }`
+	writeFile(t, configPath, hcl)
+
+	for _, decode := range []config.PartialDecodeSectionType{config.TerraformSource, config.TerraformBlock} {
+		t.Run(fmt.Sprintf("decode_%d", decode), func(t *testing.T) {
+			t.Parallel()
+
+			l := logger.CreateLogger()
+			ctx, pctx := newTestParsingContext(t, configPath)
+			pctx.WorkingDir = unitDir
+			pctx = pctx.WithDecodeList(decode)
+			require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MarkManyAsRead))
+
+			out, err := config.PartialParseConfigString(ctx, pctx, l, configPath, hcl, nil)
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			require.NotNil(t, pctx.FilesRead)
+
+			read := pctx.FilesRead.Paths()
+			assert.Contains(t, read, filepath.Join(moduleDir, "main.tf"))
+			assert.Contains(t, read, filepath.Join(moduleDir, "variables.tf.json"))
+			assert.NotContains(t, read, filepath.Join(moduleDir, "README.md"))
+		})
+	}
 }
 
 func writeFile(t *testing.T, path, contents string) {

--- a/test/fixtures/mark-many-as-read-relpath/live/unit/terragrunt.hcl
+++ b/test/fixtures/mark-many-as-read-relpath/live/unit/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "../../modules/foo"
+}

--- a/test/fixtures/mark-many-as-read-relpath/modules/foo/main.tf
+++ b/test/fixtures/mark-many-as-read-relpath/modules/foo/main.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = "foo"
+}

--- a/test/integration_mark_many_as_read_test.go
+++ b/test/integration_mark_many_as_read_test.go
@@ -1,0 +1,72 @@
+package test_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testFixtureMarkManyAsReadRelpath = "fixtures/mark-many-as-read-relpath"
+
+func TestMarkManyAsReadRelpathSourceTriggersDiscovery(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureMarkManyAsReadRelpath)
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureMarkManyAsReadRelpath)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureMarkManyAsReadRelpath)
+	rootPath, err := filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	cmd := fmt.Sprintf(
+		"terragrunt run --all --non-interactive --experiment mark-many-as-read "+
+			"--queue-include-units-reading=modules/foo/main.tf --report-file %s "+
+			"--working-dir %s -- plan",
+		helpers.ReportFile, rootPath,
+	)
+
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
+
+	assert.NotContains(t, stdout+stderr, "No units discovered",
+		"unit should be discovered via mark-many-as-read source walk")
+
+	runs, err := report.ParseJSONRunsFromFile(filepath.Join(rootPath, helpers.ReportFile))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"live/unit"}, runs.Names())
+}
+
+func TestMarkManyAsReadDisabledDoesNotDiscoverModuleChanges(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsExperimentMode(t) {
+		t.Skip("Skipping: TG_EXPERIMENT_MODE forces all experiments on, defeating the disabled-vs-enabled comparison this test pins")
+	}
+
+	helpers.CleanupTerraformFolder(t, testFixtureMarkManyAsReadRelpath)
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureMarkManyAsReadRelpath)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureMarkManyAsReadRelpath)
+	rootPath, err := filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	cmd := fmt.Sprintf(
+		"terragrunt run --all --non-interactive "+
+			"--queue-include-units-reading=modules/foo/main.tf --report-file %s "+
+			"--working-dir %s -- plan",
+		helpers.ReportFile, rootPath,
+	)
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err)
+
+	runs, err := report.ParseJSONRunsFromFile(filepath.Join(rootPath, helpers.ReportFile))
+	require.NoError(t, err)
+	assert.Empty(t, runs.Names(),
+		"without mark-many-as-read, module source changes should not cascade to the unit")
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6173.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "mark-many-as-read" experiment to properly detect and mark module sources as read during discovery, enabling units with Terraform module source configurations to be correctly matched by `--filter 'reading='`.

* **Documentation**
  * Updated changelog for version 1.0.6.

* **Tests**
  * Added integration and unit tests verifying experiment behavior with module source discovery scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->