### PR TITLE
chore: Addressing UI/UX feedback for interactive scaffold in catalog

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = go.mod,go.sum,*.svg,Gemfile.lock,bun.lock,package-lock.json,node_modules,dist
-ignore-words-list = dRan,implementors,pressEnter
+ignore-words-list = dRan,implementors,pressEnter,pressS

--- a/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
@@ -45,16 +45,15 @@ This will recursively search for OpenTofu/Terraform modules in the root of the r
 1. Search and filter the table: `/` and start typing.
 1. Select a module in the table: use the arrow keys to go up and down and next/previous page using the left and right arrow keys.
 1. Read the docs for a selected module: `ENTER`.
-1. Use [`terragrunt scaffold`](/features/catalog/scaffold) to render a `terragrunt.hcl` for using the module with an interactive form: `s`.
-1. Use [`terragrunt scaffold`](/features/catalog/scaffold) to render a `terragrunt.hcl` that leaves every input as a `# TODO` placeholder for you to fill in by hand: `S`.
+1. Use [`terragrunt scaffold`](/features/catalog/scaffold) to render a `terragrunt.hcl` for using the module with an interactive form: `s`. Inside the form, `ctrl+d` writes the file even when required fields are still unset, leaving them as `# TODO` placeholders for you to fill in by hand.
 
 <Aside type="tip" title="Catalog Redesign Experiment">
-The interactive form is only available when the [`catalog-redesign`](/reference/experiments/active#catalog-redesign) experiment is enabled. Without the experiment, both `s` and `S` produce the same placeholder-style output as `S`.
+The interactive form is only available when the [`catalog-redesign`](/reference/experiments/active#catalog-redesign) experiment is enabled. Without the experiment, `s` produces a placeholder-style file with every input marked `# TODO`.
 </Aside>
 
 ## Scaffolding Flags
 
-The following `catalog` flags control behavior of the underlying `scaffold` command, regardless of whether you launch it with `s` (interactive form) or `S` (placeholder file):
+The following `catalog` flags control behavior of the underlying `scaffold` command launched via `s`:
 
 - `--no-include-root` - Do not include the root configuration file in any generated `terragrunt.hcl` during scaffolding.
 - `--root-file-name` - The name of the root configuration file to include in any generated `terragrunt.hcl` during scaffolding. This value also controls the name of the root configuration file to search for when trying to determine Catalog urls.
@@ -211,7 +210,6 @@ The default view, shown after discovery completes.
 | `end`, `ctrl+e` | Jump to last row |
 | `enter` | View the selected component's README |
 | `s` | Scaffold the selected component (interactive form) |
-| `S` | Scaffold the selected component (TODO placeholders) |
 | `tab` | Next tab (redesign experiment) |
 | `shift+tab` | Previous tab (redesign experiment) |
 | `/` | Search and filter the visible list |
@@ -233,7 +231,7 @@ Active after pressing `enter` on a component.
 | `shift+tab` | Focus the previous button in the footer |
 | `enter` | Activate the focused button |
 | `s` | Scaffold (interactive form) |
-| `S` | Scaffold (TODO placeholders) |
+| `w` | Toggle soft-wrapping of long README lines |
 | `?` | Toggle the expanded help view |
 | `q`, `esc` | Back to the list |
 | `ctrl+c` | Force quit |
@@ -257,11 +255,11 @@ The form opens in *navigate* mode. Pressing `enter` on a text field switches to 
 | `home`, `ctrl+a` | Jump to the first field |
 | `end`, `ctrl+e` | Jump to the last field |
 | `enter`, `i` | Enter edit mode on a text field, or toggle a checkbox |
-| `x` | Mark the focused field as "use default" |
-| `X` | Mark every optional field as "use default" |
+| `x` | Reset the focused optional field to its source default |
+| `X` | Reset every optional field to its source default |
 | `/` | Filter fields by name |
-| `s` | Scaffold (refuses if any required field is unset) |
-| `S`, `ctrl+d` | Scaffold (leaves unset required fields as `# TODO`) |
+| `s` | Scaffold; if any required field is unset, the form prompts you to press `ctrl+d` to write anyway |
+| `ctrl+d` | Scaffold immediately, leaving unset required fields as `# TODO` |
 | `esc` | Cancel and return to the previous view |
 
 #### Edit mode
@@ -271,7 +269,9 @@ Active while typing into a text field. Keys not listed here are forwarded to the
 | Key | Action |
 |-----|--------|
 | `esc` | Finish editing and return to navigate mode |
-| `enter` | Toggle (bool/checkbox fields only) |
+| `enter` | On a text/HCL field, finish editing and return to navigate mode (same as `esc`). On a bool field, toggle between `[x] true` and `[ ] false` |
+| `tab` | Commit the current field and jump to the next visible one, staying in edit mode |
+| `shift+tab` | Commit the current field and jump to the previous visible one, staying in edit mode |
 | `ctrl+d` | Scaffold immediately, skipping the required-field check |
 
 ### Welcome screen

--- a/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
@@ -255,10 +255,10 @@ The form opens in *navigate* mode. Pressing `enter` on a text field switches to 
 | `home`, `ctrl+a` | Jump to the first field |
 | `end`, `ctrl+e` | Jump to the last field |
 | `enter`, `i` | Enter edit mode on a text field, or toggle a checkbox |
-| `x` | Reset the focused optional field to its source default |
-| `X` | Reset every optional field to its source default |
+| `x` | Unset the focused field, clearing its value and any error (optional fields fall back to their source default; required fields read as missing again) |
+| `r` | Reset the whole form: unset every field and clear all errors |
 | `/` | Filter fields by name |
-| `s` | Scaffold; if any required field is unset, the form prompts you to press `ctrl+d` to write anyway |
+| `s` | Scaffold; if any required field is unset, the cursor jumps to the first one and a status line reports how many are missing, prompting you to press `ctrl+d` to write anyway |
 | `ctrl+d` | Scaffold immediately, leaving unset required fields as `# TODO` |
 | `esc` | Cancel and return to the previous view |
 

--- a/docs/src/data/changelog/v1.0.6/catalog-redesign-interactive-scaffold.mdx
+++ b/docs/src/data/changelog/v1.0.6/catalog-redesign-interactive-scaffold.mdx
@@ -5,16 +5,20 @@ category: "experiments-updated"
 
 #### `catalog-redesign` — Interactive scaffold form on `s`
 
-Pressing `s` from the catalog list or detail view now opens an in-TUI form that prompts for every variable/value the selected component exposes. The form is modal: in navigate mode `j` and `k` (or the arrow keys) move between fields and `enter` interacts with the focused one. Required entries are flagged, and optional entries show their default in a muted style until the user opts in.
+Pressing `s` from the catalog list or detail view opens an in-TUI form that prompts for every variable/value the selected component exposes. The form is modal: in navigate mode `j` and `k` (or the arrow keys) move between fields and `enter` interacts with the focused one. Required entries are flagged, and optional entries show their default in a muted style until the user opts in.
 
 `enter` on a text or HCL field switches the form into edit mode. Typing edits the value in place; `esc` returns to navigate. Only fields the user actually changes get written to the generated file, and optional defaults stay implicit, so the result is leaner than the placeholder flow.
 
 `enter` on a boolean field toggles between `[x] true` and `[ ] false` directly, without a separate edit mode.
 
-`x` on an optional field marks it "use default" again, removing any in-progress value and leaving the source's default to apply.
+`x` on an optional field resets it to the source default, dropping any in-progress value. `X` resets every optional field in one pass.
 
-Complex types (lists, maps, objects) accept raw HCL and are validated before the file is written, so a typo surfaces inline rather than producing a broken `terragrunt.hcl` or `terragrunt.values.hcl` file.
+`tab` and `shift+tab` cycle the All / Required / Optional category tabs at the top of the form, mirroring the list view's tab strip. Inside edit mode, `tab` and `shift+tab` commit the current field and jump to the next/previous one without leaving edit mode, so a long form fills out like a web form.
 
-`ctrl+d` finishes the form. Required fields the user never set still write as `# TODO: fill in value` so the rest of the file is usable.
+`?` opens a scrollable detail overlay anchored on the focused field, showing the full description, type, and current value. Unfocused field descriptions truncate after a few lines with an `…` marker so a long comment doesn't dominate the page.
 
-`S` (capital) keeps the previous placeholder-only flow, generating the same TODO-laden file as before for users who prefer to populate values by editing the generated file.
+Complex types (lists, maps, objects) accept raw HCL and are validated when focus leaves the field, so a typo surfaces on the way out instead of flickering under the cursor while you're still typing.
+
+`s` finishes the form. Required fields the user never filled keep the form open with a "press `ctrl+d` to scaffold anyway" prompt; `ctrl+d` writes the file with unset required fields rendered as `# TODO: fill in value`. The previous capital-`S` shortcut for the same skip-required flow is removed; everything is reachable from inside the form on `s`.
+
+In the README pager (`enter` on a component), `w` toggles soft-wrapping of long lines so an ASCII diagram or wide table reads as authored.

--- a/internal/cli/commands/catalog/tui/delegate.go
+++ b/internal/cli/commands/catalog/tui/delegate.go
@@ -25,7 +25,7 @@ func NewItemDelegate(keys *DelegateKeyMap) list.DefaultDelegate {
 		Foreground(lipgloss.Color(selectedDescForegroundColorDark)).
 		BorderForeground(lipgloss.Color(selectedDescBorderForegroundColorDark))
 
-	help := []key.Binding{keys.Choose, keys.ScaffoldInteractive, keys.ScaffoldPlaceholder}
+	help := []key.Binding{keys.Choose, keys.ScaffoldInteractive}
 
 	d.ShortHelpFunc = func() []key.Binding {
 		return help

--- a/internal/cli/commands/catalog/tui/keys.go
+++ b/internal/cli/commands/catalog/tui/keys.go
@@ -73,13 +73,12 @@ func NewListKeyMap() list.KeyMap {
 	}
 }
 
-// DelegateKeyMap defines the list-row keybindings. Scaffold is split into
-// two bindings so users can pick between the interactive form (`s`) and the
-// placeholder-only flow (`S`).
+// DelegateKeyMap defines the list-row keybindings. `s` opens the
+// interactive scaffold form; the placeholder-only flow is reachable from
+// inside that form via ctrl+d when required values are still unfilled.
 type DelegateKeyMap struct {
 	Choose              key.Binding
 	ScaffoldInteractive key.Binding
-	ScaffoldPlaceholder key.Binding
 }
 
 // ShortHelp returns additional short help entries. This satisfies the help.KeyMap interface and
@@ -88,7 +87,6 @@ func (d DelegateKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		d.Choose,
 		d.ScaffoldInteractive,
-		d.ScaffoldPlaceholder,
 	}
 }
 
@@ -99,7 +97,6 @@ func (d DelegateKeyMap) FullHelp() [][]key.Binding {
 		{
 			d.Choose,
 			d.ScaffoldInteractive,
-			d.ScaffoldPlaceholder,
 		},
 	}
 }
@@ -114,10 +111,6 @@ func NewDelegateKeyMap() *DelegateKeyMap {
 		ScaffoldInteractive: key.NewBinding(
 			key.WithKeys("s"),
 			key.WithHelp("s", "scaffold"),
-		),
-		ScaffoldPlaceholder: key.NewBinding(
-			key.WithKeys("S"),
-			key.WithHelp("S", "scaffold (TODO placeholders)"),
 		),
 	}
 }
@@ -141,8 +134,8 @@ type PagerKeyMap struct {
 	// Run the interactive scaffold flow (s).
 	ScaffoldInteractive key.Binding
 
-	// Run the placeholder scaffold flow (S).
-	ScaffoldPlaceholder key.Binding
+	// Toggle soft-wrapping of long README lines (w).
+	ToggleWrap key.Binding
 
 	// Help toggle keybindings.
 	Help key.Binding
@@ -166,7 +159,7 @@ func (keys PagerKeyMap) ShortHelp() []key.Binding {
 		keys.NavigationBack,
 		keys.Choose,
 		keys.ScaffoldInteractive,
-		keys.ScaffoldPlaceholder,
+		keys.ToggleWrap,
 		keys.Help,
 		keys.Quit,
 	}
@@ -178,7 +171,7 @@ func (keys PagerKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{keys.Up, keys.Down, keys.PageDown, keys.PageUp},                              // first column
 		{keys.Navigation, keys.NavigationBack, keys.Choose, keys.ScaffoldInteractive}, // second column
-		{keys.ScaffoldPlaceholder, keys.Help, keys.Quit, keys.ForceQuit},              // third column
+		{keys.ToggleWrap, keys.Help, keys.Quit, keys.ForceQuit},                       // third column
 	}
 }
 
@@ -226,9 +219,9 @@ func NewPagerKeyMap() PagerKeyMap {
 			key.WithKeys("s"),
 			key.WithHelp("s", "scaffold"),
 		),
-		ScaffoldPlaceholder: key.NewBinding(
-			key.WithKeys("S"),
-			key.WithHelp("S", "scaffold (TODO placeholders)"),
+		ToggleWrap: key.NewBinding(
+			key.WithKeys("w"),
+			key.WithHelp("w", "wrap"),
 		),
 		Help: key.NewBinding(
 			key.WithKeys("?"),

--- a/internal/cli/commands/catalog/tui/keys_test.go
+++ b/internal/cli/commands/catalog/tui/keys_test.go
@@ -16,10 +16,9 @@ func TestKeyDelegateKeyMapShortHelp(t *testing.T) {
 	km := tui.NewDelegateKeyMap()
 	got := km.ShortHelp()
 
-	require.Len(t, got, 3)
+	require.Len(t, got, 2)
 	assert.Equal(t, km.Choose, got[0])
 	assert.Equal(t, km.ScaffoldInteractive, got[1])
-	assert.Equal(t, km.ScaffoldPlaceholder, got[2])
 
 	for i, b := range got {
 		assert.NotEmpty(t, b.Keys(), "binding %d has no keys", i)
@@ -33,19 +32,20 @@ func TestKeyDelegateKeyMapFullHelp(t *testing.T) {
 	got := km.FullHelp()
 
 	require.Len(t, got, 1)
-	require.Len(t, got[0], 3)
+	require.Len(t, got[0], 2)
 	assert.Equal(t, km.Choose, got[0][0])
 	assert.Equal(t, km.ScaffoldInteractive, got[0][1])
-	assert.Equal(t, km.ScaffoldPlaceholder, got[0][2])
 }
 
-func TestKeyDelegateKeyMapSeparatesLowerAndUpperS(t *testing.T) {
+func TestKeyDelegateScaffoldBoundToLowerS(t *testing.T) {
 	t.Parallel()
 
+	// The previous design split scaffold across `s` (validated) and `S`
+	// (skip checks). The skip-checks path now lives inside the form on
+	// ctrl+d, so the list/pager only exposes the lowercase entry point.
 	km := tui.NewDelegateKeyMap()
 
 	assert.Equal(t, []string{"s"}, km.ScaffoldInteractive.Keys())
-	assert.Equal(t, []string{"S"}, km.ScaffoldPlaceholder.Keys())
 }
 
 func TestKeyPagerKeyMapShortHelp(t *testing.T) {
@@ -63,7 +63,7 @@ func TestKeyPagerKeyMapShortHelp(t *testing.T) {
 		km.NavigationBack,
 		km.Choose,
 		km.ScaffoldInteractive,
-		km.ScaffoldPlaceholder,
+		km.ToggleWrap,
 		km.Help,
 		km.Quit,
 	}
@@ -96,17 +96,19 @@ func TestKeyPagerKeyMapFullHelp(t *testing.T) {
 	assert.Equal(t, km.ScaffoldInteractive, got[1][3])
 
 	require.Len(t, got[2], 4)
-	assert.Equal(t, km.ScaffoldPlaceholder, got[2][0])
+	assert.Equal(t, km.ToggleWrap, got[2][0])
 	assert.Equal(t, km.Help, got[2][1])
 	assert.Equal(t, km.Quit, got[2][2])
 	assert.Equal(t, km.ForceQuit, got[2][3])
 }
 
-func TestKeyPagerKeyMapSeparatesLowerAndUpperS(t *testing.T) {
+func TestKeyPagerScaffoldBoundToLowerS(t *testing.T) {
 	t.Parallel()
 
+	// Pager mirrors the list: only the lowercase scaffold entry point;
+	// skip-required lives inside the form on ctrl+d.
 	km := tui.NewPagerKeyMap()
 
 	assert.Equal(t, []string{"s"}, km.ScaffoldInteractive.Keys())
-	assert.Equal(t, []string{"S"}, km.ScaffoldPlaceholder.Keys())
+	assert.Equal(t, []string{"w"}, km.ToggleWrap.Keys())
 }

--- a/internal/cli/commands/catalog/tui/model_test.go
+++ b/internal/cli/commands/catalog/tui/model_test.go
@@ -297,8 +297,10 @@ func TestTUIScaffoldWithRealRepository(t *testing.T) {
 	m := tui.NewModel(l, opts, svc)
 
 	finalModel := runModel(t, m, 120, 40, func(p *tea.Program) {
-		// Press 'S' to scaffold the first module
-		p.Send(tea.KeyPressMsg{Code: 'S', Text: "S"})
+		// Press 's' to scaffold the first module. The legacy TUI only ever
+		// exposed one scaffold key, and the redesign drop of the capital
+		// `S` variant brings the legacy keymap in line.
+		p.Send(tea.KeyPressMsg{Code: 's', Text: "s"})
 	})
 
 	// Verify the model transitioned to ScaffoldState

--- a/internal/cli/commands/catalog/tui/redesign/component_discovery.go
+++ b/internal/cli/commands/catalog/tui/redesign/component_discovery.go
@@ -219,7 +219,7 @@ func classifyDir(fsys vfs.FS, dir string) (ComponentKind, bool, error) {
 
 // isSkippableDir reports whether a directory name should not be descended
 // into during component discovery. Skipping all dot-prefixed dirs covers .git,
-// .terraform, .terragrunt-cache, .boilerplate, and similar — their contents
+// .terraform, .terragrunt-cache, .boilerplate, and similar; their contents
 // either can't be components or are reached through their parent.
 func isSkippableDir(name string) bool {
 	return strings.HasPrefix(name, ".")

--- a/internal/cli/commands/catalog/tui/redesign/component_discovery_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/component_discovery_test.go
@@ -23,7 +23,7 @@ const (
 )
 
 // TestDiscoverComponents_WithCustomFS proves discovery runs against an
-// injected vfs.FS — the same in-memory FS that materialized the fixture is
+// injected vfs.FS, the same in-memory FS that materialized the fixture, is
 // passed to module.NewRepo (so .git/config and .git/HEAD are read from
 // memory) and to ComponentDiscovery (so the walk runs against memory).
 func TestDiscoverComponents_WithCustomFS(t *testing.T) {

--- a/internal/cli/commands/catalog/tui/redesign/copy.go
+++ b/internal/cli/commands/catalog/tui/redesign/copy.go
@@ -79,7 +79,7 @@ func (c *CopyCmd) WithFS(fsys vfs.FS) *CopyCmd {
 
 // WithValues threads user-supplied HCL fragments into the generated
 // terragrunt.values.hcl. The map is keyed by the bare variable name (e.g.,
-// `name`, not `values.name`) — the lookup in WriteValuesFile uses the
+// `name`, not `values.name`); the lookup in WriteValuesFile uses the
 // reference's bare name. Entries not in the map fall back to the same
 // `"TODO"` / try-fallback behavior as the placeholder flow.
 func (c *CopyCmd) WithValues(values map[string]string) *CopyCmd {

--- a/internal/cli/commands/catalog/tui/redesign/delegate.go
+++ b/internal/cli/commands/catalog/tui/redesign/delegate.go
@@ -98,7 +98,7 @@ func newCatalogDelegate(keys *tui.DelegateKeyMap) catalogDelegate {
 		Foreground(lipgloss.Color(selectedDescForegroundColorDark)).
 		BorderForeground(lipgloss.Color(selectedDescBorderForegroundColorDark))
 
-	help := []key.Binding{keys.Choose, keys.ScaffoldInteractive, keys.ScaffoldPlaceholder}
+	help := []key.Binding{keys.Choose, keys.ScaffoldInteractive}
 
 	return catalogDelegate{
 		styles: styles,

--- a/internal/cli/commands/catalog/tui/redesign/form.go
+++ b/internal/cli/commands/catalog/tui/redesign/form.go
@@ -156,7 +156,7 @@ type navigateKeyMap struct {
 	GoToEnd       key.Binding
 	Interact      key.Binding
 	Unset         key.Binding
-	UnsetAll      key.Binding
+	Reset         key.Binding
 	Filter        key.Binding
 	NextTab       key.Binding
 	PrevTab       key.Binding
@@ -213,14 +213,21 @@ type FormModel struct {
 	submitted    bool
 	detailOpen   bool
 	detailCursor int
+	// requiredErrShown flips to true once the user attempts a checked
+	// submit (the `s` shortcut) while required fields are still unset. It
+	// gates the bottom status line so the missing-required count only
+	// appears after that first blocked attempt, not from the start. The
+	// line auto-hides again once every required field is set, since the
+	// render also requires a live missingRequiredCount() > 0.
+	requiredErrShown bool
 	// userNavigated flips to true the first time the user moves the
 	// cursor with a navigation key (j/k, arrows, home/end, page nav, or
 	// tab-in-edit field jump). While false, every category change or
 	// filter mutation snaps the cursor onto the first visible field
 	// instead of preserving the prior position, mirroring how the list
 	// view treats freshly-inserted items. Tab (category cycle), `/`
-	// (filter), `?` (detail), and the submit / cancel keys don't count
-	// — they restructure the visible set or open an overlay, neither of
+	// (filter), `?` (detail), and the submit / cancel keys don't count;
+	// they restructure the visible set or open an overlay, neither of
 	// which signals "park me on this specific field".
 	userNavigated bool
 }
@@ -332,11 +339,11 @@ func newNavigateKeyMap() navigateKeyMap {
 		),
 		Unset: key.NewBinding(
 			key.WithKeys("x"),
-			key.WithHelp("x", "reset to default (X reset all)"),
+			key.WithHelp("x", "unset"),
 		),
-		UnsetAll: key.NewBinding(
-			key.WithKeys("X"),
-			key.WithHelp("X", "reset all to default"),
+		Reset: key.NewBinding(
+			key.WithKeys("r"),
+			key.WithHelp("r", "reset form"),
 		),
 		Filter: key.NewBinding(
 			key.WithKeys("/"),
@@ -640,12 +647,14 @@ func (f *FormModel) computeBodyHeight() {
 	// one top blank for breathing room, one between the header and the
 	// tab bar, and one between the tab bar and the body. Pagination,
 	// header, tab bar, and hint are counted via their rendered heights
-	// below; filter is only included when it'll actually appear.
+	// below; filter and status are only included when they'll appear.
 	const reservedRows = 3
 
+	// The filter line, when shown, carries a trailing blank row beneath it
+	// (see viewBase), so it costs its own height plus one.
 	filterHeight := 0
 	if filterLine := f.renderFilterLine(); filterLine != "" {
-		filterHeight = lipgloss.Height(filterLine)
+		filterHeight = lipgloss.Height(filterLine) + 1
 	}
 
 	used := reservedRows +
@@ -653,6 +662,7 @@ func (f *FormModel) computeBodyHeight() {
 		lipgloss.Height(f.renderTabBar()) +
 		filterHeight +
 		1 + // pagination row (always reserved, blank when one page)
+		1 + // status row (always reserved, blank when nothing missing)
 		lipgloss.Height(f.renderHint())
 
 	f.bodyHeight = max(f.height-used, 1)
@@ -1050,7 +1060,9 @@ func (f *FormModel) submitChecked() (*FormModel, tea.Cmd) {
 	}
 
 	if missing := f.firstMissingRequired(); missing >= 0 {
+		f.requiredErrShown = true
 		f.setCursor(missing)
+
 		return f, nil
 	}
 
@@ -1059,9 +1071,9 @@ func (f *FormModel) submitChecked() (*FormModel, tea.Cmd) {
 
 // firstMissingRequired marks each unset required field with a "required
 // value missing" validation error and returns the index of the first such
-// field, or -1 when every required field has been set. The first unset
-// field also gets a ctrl+d hint appended so the user discovers the
-// force-submit escape hatch without it taking up help-area real estate.
+// field, or -1 when every required field has been set. The ctrl+d escape
+// hatch isn't advertised here; the bottom status line (renderStatusLine)
+// carries that hint once for the whole form.
 func (f *FormModel) firstMissingRequired() int {
 	missing := -1
 
@@ -1075,11 +1087,25 @@ func (f *FormModel) firstMissingRequired() int {
 
 		if missing < 0 {
 			missing = i
-			fld.ValidationErr += " (press ctrl+d to scaffold anyway)"
 		}
 	}
 
 	return missing
+}
+
+// missingRequiredCount returns how many required fields are still unset,
+// without mutating any field state. renderStatusLine uses it for the live
+// count so the status line auto-clears as the user fills required values.
+func (f *FormModel) missingRequiredCount() int {
+	count := 0
+
+	for i := range f.fields {
+		if f.fields[i].Required && !f.fields[i].Set {
+			count++
+		}
+	}
+
+	return count
 }
 
 // Update handles a single tea.Msg and returns the (possibly mutated) form
@@ -1219,8 +1245,8 @@ func (f *FormModel) updateNavigate(msg tea.Msg) (*FormModel, tea.Cmd) {
 		f.jumpCursor(true)
 	case key.Matches(keyMsg, f.navKeys.Interact):
 		return f.interact()
-	case key.Matches(keyMsg, f.navKeys.UnsetAll):
-		f.unsetAllFields()
+	case key.Matches(keyMsg, f.navKeys.Reset):
+		f.resetForm()
 	case key.Matches(keyMsg, f.navKeys.Unset):
 		f.unsetField(f.cursor)
 	}
@@ -1357,7 +1383,7 @@ func (f *FormModel) setCategory(c formCategory) {
 // current filter would render. Called after every filter-query and
 // category change so the focused-field highlight stays aligned with
 // what the user sees. While the user has yet to navigate with j/k/
-// arrows, the cursor always snaps to the first visible field — same
+// arrows, the cursor always snaps to the first visible field, the same
 // pattern the list view uses, so a freshly-opened form (or one whose
 // only interaction has been tab/filter) keeps focus pinned to the top
 // of whatever slice is on screen.
@@ -1491,18 +1517,19 @@ func (f *FormModel) interact() (*FormModel, tea.Cmd) {
 	return f, f.enterEdit()
 }
 
-// unsetField marks the focused optional field as "use default" so it is
-// left out of the generated file. The call is a no-op on required fields
-// (the user owes the form a value either way) and on fields that are
-// already unset (no toggling: x only unsets). The field's Input and Bool
-// stay as the user left them, so re-entering edit picks up where they
-// last were instead of jumping back to a blank slate.
+// unsetField clears the focused field's value, marking it unset so an
+// optional field falls back to its source default and a required field
+// reads as missing again. Any validation error on the field is cleared
+// too. The call is a no-op on a field that's already unset (x only
+// unsets, it never toggles). The field's Input and Bool stay as the user
+// left them, so re-entering edit picks up where they last were instead of
+// jumping back to a blank slate.
 //
 // updateNavigate guarantees a valid cursor before calling, so there's no
 // bounds check here.
 func (f *FormModel) unsetField(i int) {
 	fld := &f.fields[i]
-	if fld.Required || !fld.Set {
+	if !fld.Set {
 		return
 	}
 
@@ -1510,20 +1537,18 @@ func (f *FormModel) unsetField(i int) {
 	fld.ValidationErr = ""
 }
 
-// unsetAllFields marks every optional Set field as "use default" in one
-// pass. Required fields and already-unset optionals are skipped. Input
-// and Bool state is preserved so the user can recover prior edits by
-// re-entering edit mode.
-func (f *FormModel) unsetAllFields() {
+// resetForm returns the whole form to its pristine state: every field
+// (required and optional) is unset, every validation error is cleared,
+// and the missing-required status line is suppressed until the next
+// blocked submit. Input and Bool state is preserved so the user can
+// recover prior edits by re-entering edit mode.
+func (f *FormModel) resetForm() {
 	for i := range f.fields {
-		fld := &f.fields[i]
-		if fld.Required || !fld.Set {
-			continue
-		}
-
-		fld.Set = false
-		fld.ValidationErr = ""
+		f.fields[i].Set = false
+		f.fields[i].ValidationErr = ""
 	}
+
+	f.requiredErrShown = false
 }
 
 // toggleBool flips a checkbox field's value between true and false and
@@ -1610,10 +1635,6 @@ var (
 
 	formErrorStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#FF5555"))
-
-	formErrorBoldStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#FF5555")).
-				Bold(true)
 
 	// Set bool values get a clear positive/negative color so the user
 	// can see at a glance which checkboxes they flipped. True is fixed;
@@ -1777,8 +1798,8 @@ const EnvScaffoldFalseStyle = "TG_TMP_CATALOG_SCAFFOLD_FALSE_STYLE"
 // `false` value. The selection is read from [EnvScaffoldFalseStyle] on
 // every call so the user can flip variants between launches without
 // recompiling. Default is "neutral" because it's the only variant that
-// fully eliminates the warning vibe Eben flagged. Once a winner is
-// agreed on, drop this helper and inline the chosen style.
+// fully eliminates the false-as-warning read flagged in review. Once a
+// winner is agreed on, drop this helper and inline the chosen style.
 func falseStyle() lipgloss.Style {
 	switch os.Getenv(EnvScaffoldFalseStyle) {
 	case "muted":
@@ -1811,20 +1832,23 @@ func (f *FormModel) viewBase() string {
 	header := f.renderHeader()
 	tabBar := f.renderTabBar()
 	filterLine := f.renderFilterLine()
+	statusLine := f.renderStatusLine()
 	hint := f.renderHint()
 	pagination := f.renderPagination()
 	body := padToHeight(f.renderBody(), f.bodyHeight)
 
-	// Lay out: blank top, header, blank, tab bar, blank, [filter], body,
-	// pagination, hint. filterLine is optional and only takes a row when
-	// shown; pagination always claims its row (blank when there's only
-	// one page).
+	// Lay out: blank top, header, blank, tab bar, blank, [filter, blank],
+	// body, pagination, status, hint. The filter line is optional and only
+	// takes rows when shown, with a blank row beneath it so the first field
+	// doesn't crowd the input. Pagination and the status line always claim
+	// their row (blank when there's only one page / no missing-required
+	// message) so neither one's appearance shifts the rest of the form.
 	rows := []string{"", header, "", tabBar, ""}
 	if filterLine != "" {
-		rows = append(rows, filterLine)
+		rows = append(rows, filterLine, "")
 	}
 
-	rows = append(rows, body, pagination, hint)
+	rows = append(rows, body, pagination, statusLine, hint)
 
 	return lipgloss.JoinVertical(lipgloss.Left, rows...)
 }
@@ -2000,6 +2024,7 @@ func (f *FormModel) hintBindings() []key.Binding {
 		f.navKeys.Filter,
 		f.navKeys.Interact,
 		f.navKeys.Unset,
+		f.navKeys.Reset,
 		f.navKeys.SubmitChecked,
 		cancel,
 	}
@@ -2245,6 +2270,33 @@ func (f *FormModel) renderFilterLine() string {
 	return ""
 }
 
+// renderStatusLine renders the form-level status row that sits just above
+// the keybinding hint. It surfaces a single missing-required summary once
+// the user has attempted a checked submit (the `s` shortcut) and required
+// fields are still unset, naming the count and the ctrl+d force-submit
+// escape hatch. It returns "" until that first blocked attempt and again
+// once every required field is set; viewBase still reserves the row in both
+// cases, so the message's appearance never shifts the rest of the form.
+func (f *FormModel) renderStatusLine() string {
+	if !f.requiredErrShown {
+		return ""
+	}
+
+	missing := f.missingRequiredCount()
+	if missing == 0 {
+		return ""
+	}
+
+	noun := "field"
+	if missing > 1 {
+		noun = "fields"
+	}
+
+	msg := fmt.Sprintf("%d required %s missing. Press ctrl+d to scaffold anyway.", missing, noun)
+
+	return "  " + formErrorStyle.Render(msg)
+}
+
 // renderField composes one field card: name (with focus highlight + req
 // tag), type meta, optional description, the value widget, and any
 // validation error. The focused field gets a colored vertical bar running
@@ -2293,8 +2345,14 @@ func (f *FormModel) renderField(i int) string {
 
 	lines = append(lines, prefix+formMetaStyle.Render("value: ")+f.renderFieldValue(fld, focused))
 
+	// The error row is always present so a field's height stays constant
+	// whether or not it carries a validation error; otherwise the whole
+	// list reflows the moment errors appear (e.g. after a blocked submit).
+	// When there's no error the row renders empty.
 	if fld.ValidationErr != "" {
 		lines = append(lines, prefix+formErrorStyle.Render(fld.ValidationErr))
+	} else {
+		lines = append(lines, "")
 	}
 
 	return strings.Join(lines, "\n")
@@ -2303,19 +2361,16 @@ func (f *FormModel) renderField(i int) string {
 // cursorPrefix returns the two-character indent for a focused field's
 // line: a colored vertical bar followed by a space. Unfocused fields use
 // two spaces (`"  "`), so the leading column lines up across the form.
-// The bar's color reflects the mode (cyan in navigate, yellow in edit)
-// or flips to red when the focused field carries a validation error.
+// The bar's color reflects the mode (cyan in navigate, yellow in edit);
+// validation errors surface in the inline error row, never on the cursor.
 func (f *FormModel) cursorPrefix() string {
 	return f.cursorPlainStyle().Render("│") + " "
 }
 
 // cursorBoldStyle returns the bold variant of the cursor color so the
-// focused field's name color matches the bar.
+// focused field's name color matches the bar: cyan in navigate mode,
+// yellow in edit mode.
 func (f *FormModel) cursorBoldStyle() lipgloss.Style {
-	if f.focusedHasError() {
-		return formErrorBoldStyle
-	}
-
 	if f.mode == editMode {
 		return formEditCursorBoldStyle
 	}
@@ -2326,36 +2381,11 @@ func (f *FormModel) cursorBoldStyle() lipgloss.Style {
 // cursorPlainStyle is the non-bold counterpart to cursorBoldStyle, used
 // for the vertical bar character.
 func (f *FormModel) cursorPlainStyle() lipgloss.Style {
-	if f.focusedHasError() {
-		return formErrorStyle
-	}
-
 	if f.mode == editMode {
 		return formEditCursorStyle
 	}
 
 	return formNavCursorStyle
-}
-
-// focusedHasError reports whether the currently focused field's stored
-// validation error should drive the cursor color. Unset fields are
-// excluded in navigate mode because their value is irrelevant: the
-// source default will apply at write time regardless of what's typed.
-func (f *FormModel) focusedHasError() bool {
-	if f.cursor < 0 || f.cursor >= len(f.fields) {
-		return false
-	}
-
-	fld := f.fields[f.cursor]
-	if fld.ValidationErr == "" {
-		return false
-	}
-
-	if f.mode == navigateMode && !fld.Set {
-		return false
-	}
-
-	return true
 }
 
 // descLineWidth returns the column count available for a description

--- a/internal/cli/commands/catalog/tui/redesign/form.go
+++ b/internal/cli/commands/catalog/tui/redesign/form.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -12,8 +13,10 @@ import (
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/paginator"
 	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -21,6 +24,13 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 )
+
+// descPreviewLines bounds how many lines of a field's comment render
+// next to the field when it isn't focused. Long comments past this
+// count get an `…` marker so the user knows to press ? for the full
+// text. Focused fields render the description in full so the user can
+// read context while editing.
+const descPreviewLines = 2
 
 // formMode is the form's modal state. The form opens in navigate mode;
 // `enter` on a text field switches to edit mode, and `esc` from edit mode
@@ -44,6 +54,55 @@ const (
 	filterTyping
 	filterApplied
 )
+
+// formCategory partitions the field list into All / Required / Optional,
+// driven by tab / shift+tab in navigate mode. The text filter (`/`) is
+// ANDed with the category so the user can narrow Required-only with a
+// substring search and the cursor walks the intersection.
+type formCategory int
+
+const (
+	categoryAll formCategory = iota
+	categoryRequired
+	categoryOptional
+	numFormCategories
+)
+
+// String returns the visible tab label.
+func (c formCategory) String() string {
+	switch c {
+	case categoryRequired:
+		return "Required"
+	case categoryOptional:
+		return "Optional"
+	case categoryAll, numFormCategories:
+	}
+
+	return "All"
+}
+
+// next cycles to the following category, wrapping past the last entry.
+func (c formCategory) next() formCategory {
+	return (c + 1) % numFormCategories
+}
+
+// prev cycles to the previous category, wrapping past the first entry.
+func (c formCategory) prev() formCategory {
+	return (c + numFormCategories - 1) % numFormCategories
+}
+
+// matches reports whether the given field belongs in this category.
+func (c formCategory) matches(fld *FormField) bool {
+	switch c {
+	case categoryRequired:
+		return fld.Required
+	case categoryOptional:
+		return !fld.Required
+	case categoryAll, numFormCategories:
+	}
+
+	return true
+}
 
 // FormField captures the prompt and current value of one discovered
 // variable. Placeholder is the ghost text shown when the input is empty;
@@ -85,7 +144,9 @@ type FormField struct {
 // navigateKeyMap groups the navigate-mode bindings. These mirror the
 // list-view conventions used elsewhere in the catalog TUI: j/k (and
 // arrows) for line moves, h/l (with pgup/pgdn aliases) for page moves,
-// home/end for jump-to-end, and `/` for filter.
+// home/end for jump-to-end, `/` for filter, and tab/shift+tab for
+// cycling the category tabs (same convention the list view uses for
+// All / Modules / Templates / ...).
 type navigateKeyMap struct {
 	Next          key.Binding
 	Prev          key.Binding
@@ -97,18 +158,27 @@ type navigateKeyMap struct {
 	Unset         key.Binding
 	UnsetAll      key.Binding
 	Filter        key.Binding
+	NextTab       key.Binding
+	PrevTab       key.Binding
+	Detail        key.Binding
 	SubmitChecked key.Binding
 	Submit        key.Binding
 	Cancel        key.Binding
 }
 
 // editKeyMap groups the edit-mode bindings. Most keypresses on a text
-// field fall through to the focused textinput; ExitEdit, Submit, and
-// Toggle (bool-only) are intercepted.
+// field fall through to the focused textinput; ExitEdit, Submit, Toggle
+// (bool-only), and the tab-to-next/prev field bindings are intercepted.
+// Tab in edit mode commits the current value (running validation), then
+// jumps to the next visible field and reopens edit mode, so a typist can
+// fill out the form without dropping back to navigate between each
+// field.
 type editKeyMap struct {
-	ExitEdit key.Binding
-	Submit   key.Binding
-	Toggle   key.Binding
+	ExitEdit  key.Binding
+	Submit    key.Binding
+	Toggle    key.Binding
+	NextField key.Binding
+	PrevField key.Binding
 }
 
 // FormModel is the interactive value-collection view shown when the user
@@ -123,22 +193,36 @@ type editKeyMap struct {
 //
 //nolint:govet // field order chosen for readability over alignment
 type FormModel struct {
-	component   *Component
-	fields      []FormField
-	navKeys     navigateKeyMap
-	editKeys    editKeyMap
-	filterInput textinput.Model
-	help        help.Model
-	paginator   paginator.Model
-	editPreEdit string
-	mode        formMode
-	filter      filterState
-	cursor      int
-	pageStart   int
-	bodyHeight  int
-	width       int
-	height      int
-	submitted   bool
+	component    *Component
+	fields       []FormField
+	navKeys      navigateKeyMap
+	editKeys     editKeyMap
+	filterInput  textinput.Model
+	help         help.Model
+	paginator    paginator.Model
+	detailView   viewport.Model
+	editPreEdit  string
+	mode         formMode
+	filter       filterState
+	category     formCategory
+	cursor       int
+	pageStart    int
+	bodyHeight   int
+	width        int
+	height       int
+	submitted    bool
+	detailOpen   bool
+	detailCursor int
+	// userNavigated flips to true the first time the user moves the
+	// cursor with a navigation key (j/k, arrows, home/end, page nav, or
+	// tab-in-edit field jump). While false, every category change or
+	// filter mutation snaps the cursor onto the first visible field
+	// instead of preserving the prior position, mirroring how the list
+	// view treats freshly-inserted items. Tab (category cycle), `/`
+	// (filter), `?` (detail), and the submit / cancel keys don't count
+	// — they restructure the visible set or open an overlay, neither of
+	// which signals "park me on this specific field".
+	userNavigated bool
 }
 
 // FormSubmitMsg carries the collected values from a completed form back to
@@ -163,6 +247,13 @@ func (f *FormModel) Cursor() int {
 // submission the form ignores further input.
 func (f *FormModel) Submitted() bool {
 	return f.submitted
+}
+
+// DetailOpen reports whether the field-detail overlay is currently
+// visible. Exposed for tests that drive `?` and verify the overlay's
+// lifecycle.
+func (f *FormModel) DetailOpen() bool {
+	return f.detailOpen
 }
 
 // Field returns a copy of the i-th field, for tests and renderers that
@@ -205,6 +296,7 @@ func NewFormModel(c *Component, fields []FormField) *FormModel {
 		filterInput: filter,
 		help:        help.New(),
 		paginator:   p,
+		detailView:  viewport.New(),
 	}
 }
 
@@ -240,23 +332,35 @@ func newNavigateKeyMap() navigateKeyMap {
 		),
 		Unset: key.NewBinding(
 			key.WithKeys("x"),
-			key.WithHelp("x", "use default"),
+			key.WithHelp("x", "reset to default (X reset all)"),
 		),
 		UnsetAll: key.NewBinding(
 			key.WithKeys("X"),
-			key.WithHelp("X", "use default (all)"),
+			key.WithHelp("X", "reset all to default"),
 		),
 		Filter: key.NewBinding(
 			key.WithKeys("/"),
 			key.WithHelp("/", "filter"),
+		),
+		NextTab: key.NewBinding(
+			key.WithKeys("tab"),
+			key.WithHelp("tab", "next tab"),
+		),
+		PrevTab: key.NewBinding(
+			key.WithKeys("shift+tab"),
+			key.WithHelp("shift+tab", "prev tab"),
+		),
+		Detail: key.NewBinding(
+			key.WithKeys("?"),
+			key.WithHelp("?", "detail"),
 		),
 		SubmitChecked: key.NewBinding(
 			key.WithKeys("s"),
 			key.WithHelp("s", "scaffold"),
 		),
 		Submit: key.NewBinding(
-			key.WithKeys("S", "ctrl+d"),
-			key.WithHelp("S", "scaffold (skip checks)"),
+			key.WithKeys("ctrl+d"),
+			key.WithHelp("ctrl+d", "scaffold (skip checks)"),
 		),
 		Cancel: key.NewBinding(
 			key.WithKeys("esc"),
@@ -278,6 +382,14 @@ func newEditKeyMap() editKeyMap {
 		Toggle: key.NewBinding(
 			key.WithKeys("enter"),
 			key.WithHelp("enter", "toggle"),
+		),
+		NextField: key.NewBinding(
+			key.WithKeys("tab"),
+			key.WithHelp("tab", "next field"),
+		),
+		PrevField: key.NewBinding(
+			key.WithKeys("shift+tab"),
+			key.WithHelp("shift+tab", "prev field"),
 		),
 	}
 }
@@ -508,6 +620,10 @@ func (f *FormModel) SetSize(w, h int) {
 	f.help.SetWidth(w)
 
 	f.syncLayout()
+
+	if f.detailOpen {
+		f.refreshDetailContent()
+	}
 }
 
 // computeBodyHeight derives the rows available for field cards from the
@@ -521,10 +637,11 @@ func (f *FormModel) computeBodyHeight() {
 	}
 
 	// reservedRows counts the literal blank rows in View()'s row list:
-	// one top blank for breathing room and one between the header and
-	// the body. Pagination and hint are counted via their rendered
-	// heights below; filter is only included when it'll actually appear.
-	const reservedRows = 2
+	// one top blank for breathing room, one between the header and the
+	// tab bar, and one between the tab bar and the body. Pagination,
+	// header, tab bar, and hint are counted via their rendered heights
+	// below; filter is only included when it'll actually appear.
+	const reservedRows = 3
 
 	filterHeight := 0
 	if filterLine := f.renderFilterLine(); filterLine != "" {
@@ -533,6 +650,7 @@ func (f *FormModel) computeBodyHeight() {
 
 	used := reservedRows +
 		lipgloss.Height(f.renderHeader()) +
+		lipgloss.Height(f.renderTabBar()) +
 		filterHeight +
 		1 + // pagination row (always reserved, blank when one page)
 		lipgloss.Height(f.renderHint())
@@ -557,45 +675,64 @@ func (f *FormModel) setCursor(i int) {
 }
 
 // visibleIndices returns the indices the cursor is allowed to land on.
-// With no filter the cursor walks every field; with the filter active
-// (typing or applied) it walks only matching fields, so j/k skips over
-// non-matches.
+// The active category narrows the set first (All passes everything,
+// Required/Optional drop the other half); when the filter is active and
+// the user has typed a non-empty query, the remaining names also have to
+// contain the substring. j/k walks whatever survives both filters.
 func (f *FormModel) visibleIndices() []int {
-	if f.filter == filterInactive {
-		return f.allIndices()
+	matches := f.categoryIndices()
+
+	query := f.filterQuery()
+	if f.filter == filterInactive || query == "" {
+		return matches
 	}
 
-	query := strings.ToLower(strings.TrimSpace(f.filterInput.Value()))
-	if query == "" {
-		return f.allIndices()
-	}
+	out := matches[:0:0]
 
-	matches := make([]int, 0, len(f.fields))
-
-	for i := range f.fields {
+	for _, i := range matches {
 		if strings.Contains(strings.ToLower(f.fields[i].Name), query) {
-			matches = append(matches, i)
+			out = append(out, i)
 		}
 	}
 
-	return matches
+	return out
 }
 
 // renderIndices returns the indices renderBody should emit. With the
-// filter open but no query typed yet, every field is rendered (dimmed,
-// so the user sees the full inventory before they narrow it). Once any
-// query character is typed, the body collapses to matching fields only,
-// matching the list view's "all dim then narrow" filter UX.
+// filter open but no query typed yet, every category-visible field is
+// rendered (dimmed) so the user sees the full inventory before they
+// narrow it further. Once any query character is typed the body
+// collapses to the intersection of the category and the substring
+// match, matching the list view's "all dim then narrow" filter UX.
 func (f *FormModel) renderIndices() []int {
 	if f.filter == filterInactive {
-		return f.allIndices()
+		return f.categoryIndices()
 	}
 
 	if f.filterQuery() == "" {
-		return f.allIndices()
+		return f.categoryIndices()
 	}
 
 	return f.visibleIndices()
+}
+
+// categoryIndices returns the indices of fields included by the active
+// category tab, in declaration order. All preserves the full list;
+// Required and Optional drop the other half.
+func (f *FormModel) categoryIndices() []int {
+	if f.category == categoryAll {
+		return f.allIndices()
+	}
+
+	out := make([]int, 0, len(f.fields))
+
+	for i := range f.fields {
+		if f.category.matches(&f.fields[i]) {
+			out = append(out, i)
+		}
+	}
+
+	return out
 }
 
 // filterQuery returns the trimmed, lowercased query string when the
@@ -637,7 +774,9 @@ func (f *FormModel) cursorVisiblePos(visible []int) int {
 
 // moveCursor walks the cursor delta positions through visibleIndices,
 // clamping at either end. Used by j/k (delta ±1) and h/l/pgup/pgdn
-// (delta ±pageSize).
+// (delta ±pageSize). Marks the form as user-navigated so subsequent
+// category or filter changes preserve the cursor instead of snapping
+// back to the first visible field.
 func (f *FormModel) moveCursor(delta int) {
 	visible := f.visibleIndices()
 	if len(visible) == 0 {
@@ -650,6 +789,7 @@ func (f *FormModel) moveCursor(delta int) {
 	}
 
 	f.cursor = visible[pos]
+	f.userNavigated = true
 }
 
 // jumpCursor moves the cursor to the first or last visible field. Used by
@@ -660,12 +800,13 @@ func (f *FormModel) jumpCursor(toEnd bool) {
 		return
 	}
 
+	target := visible[0]
 	if toEnd {
-		f.cursor = visible[len(visible)-1]
-		return
+		target = visible[len(visible)-1]
 	}
 
-	f.cursor = visible[0]
+	f.cursor = target
+	f.userNavigated = true
 }
 
 // nextPage advances the cursor (and pageStart) to the first field of the
@@ -683,6 +824,7 @@ func (f *FormModel) nextPage() {
 
 	f.pageStart = end
 	f.cursor = rendered[end]
+	f.userNavigated = true
 }
 
 // prevPage moves the cursor (and pageStart) to the first field of the
@@ -695,6 +837,7 @@ func (f *FormModel) prevPage() {
 
 	f.pageStart = f.prevPageStart(f.pageStart, rendered)
 	f.cursor = rendered[f.pageStart]
+	f.userNavigated = true
 }
 
 // enterEdit transitions navigate to edit on the focused field. For text
@@ -724,10 +867,12 @@ func (f *FormModel) enterEdit() tea.Cmd {
 
 // exitEdit transitions edit to navigate. For text fields, if the input
 // value changed during the edit session the field is marked Set so
-// values() emits it. Bool fields don't track edit-session changes (each
-// toggle commits via toggleBool), so we only reset the mode flag here.
-// Only called after a successful enterEdit, so len(f.fields) > 0 is
-// guaranteed.
+// values() emits it, and validation runs once now (the "on blur" model)
+// so a typo surfaces as the user steps away from the field rather than
+// flickering on every keystroke. Bool fields don't track edit-session
+// changes (each toggle commits via toggleBool), so we only reset the
+// mode flag here. Only called after a successful enterEdit, so
+// len(f.fields) > 0 is guaranteed.
 func (f *FormModel) exitEdit() {
 	fld := &f.fields[f.cursor]
 
@@ -737,6 +882,7 @@ func (f *FormModel) exitEdit() {
 		}
 
 		fld.Input.Blur()
+		f.refreshValidationErr(f.cursor)
 	}
 
 	f.editPreEdit = ""
@@ -913,7 +1059,9 @@ func (f *FormModel) submitChecked() (*FormModel, tea.Cmd) {
 
 // firstMissingRequired marks each unset required field with a "required
 // value missing" validation error and returns the index of the first such
-// field, or -1 when every required field has been set.
+// field, or -1 when every required field has been set. The first unset
+// field also gets a ctrl+d hint appended so the user discovers the
+// force-submit escape hatch without it taking up help-area real estate.
 func (f *FormModel) firstMissingRequired() int {
 	missing := -1
 
@@ -927,6 +1075,7 @@ func (f *FormModel) firstMissingRequired() int {
 
 		if missing < 0 {
 			missing = i
+			fld.ValidationErr += " (press ctrl+d to scaffold anyway)"
 		}
 	}
 
@@ -950,7 +1099,14 @@ func (f *FormModel) Update(msg tea.Msg) (*FormModel, tea.Cmd) {
 }
 
 // dispatch routes an incoming message to the mode-appropriate handler.
+// The detail overlay (opened by `?` from navigate mode) intercepts input
+// first so its esc/`?` close and scroll keys take precedence over the
+// underlying form's bindings.
 func (f *FormModel) dispatch(msg tea.Msg) (*FormModel, tea.Cmd) {
+	if f.detailOpen {
+		return f.updateDetail(msg)
+	}
+
 	if f.mode == editMode {
 		return f.updateEdit(msg)
 	}
@@ -1031,6 +1187,15 @@ func (f *FormModel) updateNavigate(msg tea.Msg) (*FormModel, tea.Cmd) {
 		return f.submit()
 	case key.Matches(keyMsg, f.navKeys.Filter):
 		return f, f.beginFilter()
+	case key.Matches(keyMsg, f.navKeys.NextTab):
+		f.setCategory(f.category.next())
+		return f, nil
+	case key.Matches(keyMsg, f.navKeys.PrevTab):
+		f.setCategory(f.category.prev())
+		return f, nil
+	case key.Matches(keyMsg, f.navKeys.Detail):
+		f.openDetail()
+		return f, nil
 	}
 
 	// The remaining bindings all operate on the focused field; on an
@@ -1119,12 +1284,91 @@ func (f *FormModel) clearFilter() {
 	f.filter = filterInactive
 }
 
+// openDetail opens the field-detail overlay anchored on the currently
+// focused field. The overlay shows the field's name, type, full
+// description, and current value in a scrollable viewport so the user
+// can read long comments that don't fit next to the field. No-op on an
+// empty form.
+func (f *FormModel) openDetail() {
+	if len(f.fields) == 0 {
+		return
+	}
+
+	f.detailOpen = true
+	f.detailCursor = f.cursor
+	f.refreshDetailContent()
+}
+
+// closeDetail dismisses the overlay and returns control to the
+// underlying form mode (navigate or edit, whichever was active when the
+// overlay was opened).
+func (f *FormModel) closeDetail() {
+	f.detailOpen = false
+}
+
+// refreshDetailContent rebuilds the overlay's scrollable body from the
+// currently anchored field. Called on open and whenever the focused
+// field changes underneath an already-open overlay.
+func (f *FormModel) refreshDetailContent() {
+	if !f.detailOpen || f.detailCursor < 0 || f.detailCursor >= len(f.fields) {
+		return
+	}
+
+	w, h := f.detailOverlaySize()
+	f.detailView.SetWidth(w - detailContentPadding*2)
+	f.detailView.SetHeight(max(h-detailChromeRows, 1))
+	f.detailView.SetContent(f.renderDetailBody(f.detailCursor))
+	f.detailView.GotoTop()
+}
+
+// updateDetail handles input while the overlay is open. esc or ? closes
+// the overlay; everything else (arrow keys, pgup/pgdn) feeds the
+// viewport so the user can scroll a long comment.
+func (f *FormModel) updateDetail(msg tea.Msg) (*FormModel, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		switch {
+		case key.Matches(keyMsg, f.editKeys.ExitEdit),
+			key.Matches(keyMsg, f.navKeys.Detail):
+			f.closeDetail()
+			return f, nil
+		}
+	}
+
+	vp, cmd := f.detailView.Update(msg)
+	f.detailView = vp
+
+	return f, cmd
+}
+
+// setCategory switches the active category tab and reconciles the
+// cursor + paging state so the focused field stays visible (or snaps to
+// the first field of the new category when the old focus drops out).
+func (f *FormModel) setCategory(c formCategory) {
+	if c == f.category {
+		return
+	}
+
+	f.category = c
+	f.pageStart = 0
+	f.snapCursorToVisible()
+}
+
 // snapCursorToVisible ensures the cursor points at a field that the
-// current filter would render. Called after every filter-query change so
-// the focused-field highlight stays aligned with what the user sees.
+// current filter would render. Called after every filter-query and
+// category change so the focused-field highlight stays aligned with
+// what the user sees. While the user has yet to navigate with j/k/
+// arrows, the cursor always snaps to the first visible field — same
+// pattern the list view uses, so a freshly-opened form (or one whose
+// only interaction has been tab/filter) keeps focus pinned to the top
+// of whatever slice is on screen.
 func (f *FormModel) snapCursorToVisible() {
 	visible := f.visibleIndices()
 	if len(visible) == 0 {
+		return
+	}
+
+	if !f.userNavigated {
+		f.cursor = visible[0]
 		return
 	}
 
@@ -1137,10 +1381,12 @@ func (f *FormModel) snapCursorToVisible() {
 
 // updateEdit handles keypresses while the form is in edit mode. esc
 // returns to navigate mode (committing any change as Set=true on text
-// fields); ctrl+d submits the form after a forced edit-to-navigate
-// transition. On bool fields, enter toggles the value in place so the
-// user can flip it as many times as they like before pressing esc.
-// Everything else on a text field is forwarded to the focused textinput.
+// fields and running validation on the just-edited value); ctrl+d
+// submits the form after a forced edit-to-navigate transition. On bool
+// fields, enter toggles the value in place so the user can flip it as
+// many times as they like before pressing esc. Everything else on a
+// text field is forwarded to the focused textinput; validation does not
+// fire until the user moves focus away.
 //
 // A short-circuit guard at the top covers the (currently unreachable)
 // case of an out-of-range cursor: interact() refuses to enter edit mode
@@ -1160,10 +1406,23 @@ func (f *FormModel) updateEdit(msg tea.Msg) (*FormModel, tea.Cmd) {
 			return f, nil
 		case key.Matches(keyMsg, f.editKeys.Submit):
 			return f.submit()
+		case key.Matches(keyMsg, f.editKeys.NextField):
+			return f, f.tabToField(1)
+		case key.Matches(keyMsg, f.editKeys.PrevField):
+			return f, f.tabToField(-1)
 		}
 
-		if fld.Checkbox && key.Matches(keyMsg, f.editKeys.Toggle) {
-			f.toggleBool(f.cursor)
+		if key.Matches(keyMsg, f.editKeys.Toggle) {
+			if fld.Checkbox {
+				f.toggleBool(f.cursor)
+				return f, nil
+			}
+
+			// On a text/HCL field, enter is the symmetric counterpart
+			// to the enter that brought the user into edit mode: commit
+			// and return to navigate, same as esc.
+			f.exitEdit()
+
 			return f, nil
 		}
 	}
@@ -1177,15 +1436,40 @@ func (f *FormModel) updateEdit(msg tea.Msg) (*FormModel, tea.Cmd) {
 	ti, cmd := fld.Input.Update(msg)
 	fld.Input = ti
 
-	f.refreshValidationErr(f.cursor)
-
 	return f, cmd
 }
 
+// tabToField commits the current edit (running on-blur validation via
+// exitEdit), advances the cursor delta positions through the visible
+// field list, and immediately re-enters edit mode on the new field. The
+// user stays in edit mode the whole way, so a long form fills out like a
+// web form rather than requiring esc / move / enter between each field.
+// When the cursor is already at the boundary the move is a no-op and
+// the user stays where they are with the original field re-focused.
+func (f *FormModel) tabToField(delta int) tea.Cmd {
+	visible := f.visibleIndices()
+	if len(visible) == 0 {
+		return nil
+	}
+
+	pos := f.cursorVisiblePos(visible)
+	target := pos + delta
+
+	if target < 0 || target >= len(visible) {
+		return nil
+	}
+
+	f.exitEdit()
+	f.cursor = visible[target]
+	f.userNavigated = true
+
+	return f.enterEdit()
+}
+
 // refreshValidationErr re-runs validateField on the i-th field and stores
-// the result. Called after every keystroke in edit mode (so the cursor
-// bar turns red the moment the value goes off-type) and on enterEdit (so
-// a previously-broken value surfaces immediately).
+// the result. Called on focus changes (enterEdit, exitEdit, tab-move)
+// rather than on every keystroke so partial syntax mid-typing doesn't
+// flash a long error message under the field.
 func (f *FormModel) refreshValidationErr(i int) {
 	if err := f.validateField(i); err != nil {
 		f.fields[i].ValidationErr = err.Error()
@@ -1289,6 +1573,12 @@ var (
 				Foreground(lipgloss.Color("#A8ACB1")).
 				Render(" optional")
 
+	// Inactive tab style mirrors RenderTabBar's tabBarInactiveStyle so
+	// the form's tab strip blends with the list view's.
+	formInactiveTabStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#6C7086")).
+				Padding(0, 1)
+
 	formMetaStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#A8ACB1"))
 
@@ -1326,13 +1616,31 @@ var (
 				Bold(true)
 
 	// Set bool values get a clear positive/negative color so the user
-	// can see at a glance which checkboxes they flipped.
+	// can see at a glance which checkboxes they flipped. True is fixed;
+	// false ships three variants (selectable via [EnvScaffoldFalseStyle])
+	// while we workshop which reads best alongside the required-red tag
+	// and validation-error red. Once a winner is picked the env knob and
+	// the unused variants get deleted; see TODO in [falseStyle].
 	formBoolTrueStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#50FA7B")).
 				Bold(true)
 
-	formBoolFalseStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#FF5555")).
+	// neutral: same muted gray as `(default)` / `(unset)`. Removes any
+	// warning vibe; false reads as a plain value alongside true.
+	formBoolFalseNeutralStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("#A8ACB1")).
+					Bold(true)
+
+	// muted: keeps the red family but desaturates it deeply so it no
+	// longer competes with the required/error red.
+	formBoolFalseMutedStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#7A2A2A")).
+				Bold(true)
+
+	// cool: pairs green true with a cool cyan false, reserving red for
+	// required/error semantics only.
+	formBoolFalseCoolStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#63C5DA")).
 				Bold(true)
 
 	formDefaultHintStyle = lipgloss.NewStyle().
@@ -1361,7 +1669,63 @@ var (
 const (
 	formPaginationBullet  = "•"
 	formPaginationLeftPad = 2
+
+	// detailContentPadding is the inner padding (left + right) inside the
+	// overlay box; subtracted from the box width to size the viewport.
+	detailContentPadding = 2
+
+	// detailChromeRows accounts for the overlay's title row, the blank
+	// row beneath it, the bottom hint row, and the box border on each
+	// side. Subtracted from the overlay height to size the viewport.
+	detailChromeRows = 5
 )
+
+// Overlay styles. The overlay is drawn over the form body, so it needs
+// a solid background and a clear border to read against any column of
+// field cards behind it.
+var (
+	formDetailBoxStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("#63C5DA")).
+				Background(lipgloss.Color("#11161C")).
+				Padding(0, detailContentPadding)
+
+	formDetailTitleStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("#63C5DA"))
+
+	formDetailHintStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#6C7086")).
+				Italic(true)
+)
+
+// formActiveTabStyle returns the bold pill style for the focused
+// category tab. All gets the neutral title palette; Required and
+// Optional reuse the same red/gray accents the field-level tags use, so
+// the tab and tag colors agree.
+func formActiveTabStyle(c formCategory) lipgloss.Style {
+	switch c {
+	case categoryRequired:
+		return lipgloss.NewStyle().
+			Background(lipgloss.Color("#3A1F22")).
+			Foreground(lipgloss.Color("#FF8888")).
+			Bold(true).
+			Padding(0, 1)
+	case categoryOptional:
+		return lipgloss.NewStyle().
+			Background(lipgloss.Color("#2A2E36")).
+			Foreground(lipgloss.Color("#A8ACB1")).
+			Bold(true).
+			Padding(0, 1)
+	case categoryAll, numFormCategories:
+	}
+
+	return lipgloss.NewStyle().
+		Background(lipgloss.Color(titleBackgroundColor)).
+		Foreground(lipgloss.Color(titleForegroundColor)).
+		Bold(true).
+		Padding(0, 1)
+}
 
 // typeStyle picks the color used to render an HCL type label. Primitives
 // get distinct shades; collections (list, set, tuple) and structures
@@ -1389,32 +1753,73 @@ func typeStyle(typeStr string) lipgloss.Style {
 	return formTypeStyle
 }
 
-// renderCheckbox produces the visual for a Set bool-mode field. True
-// renders green and false red so the user can scan the form and see the
-// set choices without re-reading each field's value.
+// renderCheckbox produces the visual for a Set bool-mode field. True is
+// rendered in fixed green; false picks one of three workshop variants
+// (see [falseStyle]) so reviewers can compare them side by side without
+// a rebuild.
 func renderCheckbox(checked bool) string {
 	if checked {
 		return formBoolTrueStyle.Render("[x] true")
 	}
 
-	return formBoolFalseStyle.Render("[ ] false")
+	return falseStyle().Render("[ ] false")
+}
+
+// EnvScaffoldFalseStyle is a temporary, undocumented environment variable
+// used during development to A/B the three checkbox `false` color variants.
+// Do NOT rely on it: it can be removed or have its name changed at any time
+// without notice and is not part of Terragrunt's user-facing configuration
+// surface. Once a winner is picked, drop this constant, the helper that
+// reads it, and the two unused style variants.
+const EnvScaffoldFalseStyle = "TG_TMP_CATALOG_SCAFFOLD_FALSE_STYLE"
+
+// falseStyle resolves which of the three workshop variants renders the
+// `false` value. The selection is read from [EnvScaffoldFalseStyle] on
+// every call so the user can flip variants between launches without
+// recompiling. Default is "neutral" because it's the only variant that
+// fully eliminates the warning vibe Eben flagged. Once a winner is
+// agreed on, drop this helper and inline the chosen style.
+func falseStyle() lipgloss.Style {
+	switch os.Getenv(EnvScaffoldFalseStyle) {
+	case "muted":
+		return formBoolFalseMutedStyle
+	case "cool":
+		return formBoolFalseCoolStyle
+	}
+
+	return formBoolFalseNeutralStyle
 }
 
 // View renders the form. When the rendered body exceeds the available
 // height the viewport scrolls it; the cursor is kept on-screen by
 // adjusting the y-offset to track the focused field. A blank top row
-// mirrors the list view's breathing room above the tab bar.
+// mirrors the list view's breathing room above the tab bar. When the
+// detail overlay is open it replaces the form view with a centered
+// detail box; closing the overlay restores the previous layout in one
+// frame.
 func (f *FormModel) View() string {
+	if f.detailOpen {
+		return centerInCanvas(f.renderDetailOverlay(), f.width, f.height)
+	}
+
+	return f.viewBase()
+}
+
+// viewBase produces the underlying form layout, without the detail
+// overlay. Extracted so View() can composite the overlay on top.
+func (f *FormModel) viewBase() string {
 	header := f.renderHeader()
+	tabBar := f.renderTabBar()
 	filterLine := f.renderFilterLine()
 	hint := f.renderHint()
 	pagination := f.renderPagination()
 	body := padToHeight(f.renderBody(), f.bodyHeight)
 
-	// Lay out: blank top, header, blank, [filter], body, pagination, hint.
-	// filterLine is optional and only takes a row when shown; pagination
-	// always claims its row (blank when there's only one page).
-	rows := []string{"", header, ""}
+	// Lay out: blank top, header, blank, tab bar, blank, [filter], body,
+	// pagination, hint. filterLine is optional and only takes a row when
+	// shown; pagination always claims its row (blank when there's only
+	// one page).
+	rows := []string{"", header, "", tabBar, ""}
 	if filterLine != "" {
 		rows = append(rows, filterLine)
 	}
@@ -1422,6 +1827,122 @@ func (f *FormModel) View() string {
 	rows = append(rows, body, pagination, hint)
 
 	return lipgloss.JoinVertical(lipgloss.Left, rows...)
+}
+
+// detailOverlaySize returns the overlay box's outer dimensions (width
+// and height including border). The box is sized to roughly two thirds
+// of the form's footprint, with a minimum that keeps it readable on
+// small terminals and a maximum that leaves a margin of whitespace
+// around the box so the underlying form's edges are still visible.
+func (f *FormModel) detailOverlaySize() (int, int) {
+	const (
+		minW           = 40
+		minH           = 10
+		outsideMargin  = 4
+		denominator    = 3
+		fractionOfHost = 2
+	)
+
+	w := min(max(f.width*fractionOfHost/denominator, minW), f.width-outsideMargin)
+	h := min(max(f.height*fractionOfHost/denominator, minH), f.height-outsideMargin)
+
+	return w, h
+}
+
+// renderDetailOverlay renders the boxed overlay shown when the user
+// presses `?`. The title strip carries the field name and tag, the
+// scrollable body carries the full description, and the hint row at
+// the bottom describes how to close.
+func (f *FormModel) renderDetailOverlay() string {
+	if f.detailCursor < 0 || f.detailCursor >= len(f.fields) {
+		return ""
+	}
+
+	fld := &f.fields[f.detailCursor]
+
+	tag := formFieldOptionalTag
+	if fld.Required {
+		tag = formFieldRequiredTag
+	}
+
+	title := formDetailTitleStyle.Render(fld.Name) + tag
+	typeLine := formMetaStyle.Render("type: ") + typeStyle(fld.TypeStr).Render(fld.TypeStr)
+	hint := formDetailHintStyle.Render("? close • ↑↓ scroll")
+
+	body := f.detailView.View()
+
+	rows := []string{title, typeLine, "", body, hint}
+
+	w, h := f.detailOverlaySize()
+
+	// The rounded border claims one column on each side; subtract it so
+	// the box's outer footprint matches detailOverlaySize().
+	const borderEdges = 2
+
+	return formDetailBoxStyle.
+		Width(w - borderEdges).
+		Height(h - borderEdges).
+		Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+}
+
+// renderDetailBody composes the scrollable body shown inside the
+// overlay: the full field description (when present) followed by the
+// current value rendered the same way the field card does. Empty
+// descriptions still render the value line so the overlay never looks
+// blank.
+func (f *FormModel) renderDetailBody(i int) string {
+	fld := &f.fields[i]
+
+	parts := []string{}
+	if fld.Description != "" {
+		parts = append(parts, formDescStyle.Render(fld.Description), "")
+	}
+
+	parts = append(parts, formMetaStyle.Render("value: ")+f.renderFieldValue(fld, false))
+
+	if fld.ValidationErr != "" {
+		parts = append(parts, formErrorStyle.Render(fld.ValidationErr))
+	}
+
+	return strings.Join(parts, "\n")
+}
+
+// centerInCanvas paints content centered within a w by h canvas of
+// whitespace. Used when the detail overlay takes over the screen so the
+// box sits cleanly in the middle of the form area.
+func centerInCanvas(content string, w, h int) string {
+	if content == "" {
+		return ""
+	}
+
+	return lipgloss.Place(
+		w, h,
+		lipgloss.Center, lipgloss.Center,
+		content,
+		lipgloss.WithWhitespaceChars(" "),
+	)
+}
+
+// renderTabBar produces the All / Required / Optional category strip
+// styled like the list view's RenderTabBar. The active tab gets a bold
+// pill in a category-appropriate color so the user can tell at a glance
+// which slice of fields is on screen.
+func (f *FormModel) renderTabBar() string {
+	parts := make([]string, 0, int(numFormCategories))
+
+	for i := range int(numFormCategories) {
+		c := formCategory(i)
+		label := c.String()
+
+		if c == f.category {
+			parts = append(parts, formActiveTabStyle(c).Render(label))
+			continue
+		}
+
+		parts = append(parts, formInactiveTabStyle.Render(label))
+	}
+
+	return strings.Join(parts, " ")
 }
 
 // renderHeader is the title strip identifying the component being
@@ -1444,11 +1965,11 @@ func (f *FormModel) renderHint() string {
 
 // hintBindings returns the bindings visible in the hint bar for the
 // current form state. Edit mode shows the few keys that get the user
-// back out; the filter-typing state shows just enter/esc; navigate mode
-// shows the full nav + action set.
+// back out plus tab for next-field; the filter-typing state shows just
+// enter/esc; navigate mode shows the full nav + action set.
 func (f *FormModel) hintBindings() []key.Binding {
 	if f.mode == editMode {
-		bindings := []key.Binding{f.editKeys.ExitEdit}
+		bindings := []key.Binding{f.editKeys.ExitEdit, f.editKeys.NextField}
 
 		if f.cursor >= 0 && f.cursor < len(f.fields) && f.fields[f.cursor].Checkbox {
 			bindings = append(bindings, f.editKeys.Toggle)
@@ -1475,12 +1996,11 @@ func (f *FormModel) hintBindings() []key.Binding {
 	return []key.Binding{
 		f.navKeys.Next,
 		f.navKeys.Prev,
+		f.navKeys.NextTab,
 		f.navKeys.Filter,
 		f.navKeys.Interact,
 		f.navKeys.Unset,
-		f.navKeys.UnsetAll,
 		f.navKeys.SubmitChecked,
-		f.navKeys.Submit,
 		cancel,
 	}
 }
@@ -1763,7 +2283,12 @@ func (f *FormModel) renderField(i int) string {
 	}
 
 	if fld.Description != "" {
-		lines = append(lines, prefixEveryLine(formDescStyle.Render(fld.Description), prefix))
+		desc := fld.Description
+		if !focused {
+			desc = truncateDescription(desc, descPreviewLines, f.descLineWidth())
+		}
+
+		lines = append(lines, prefixEveryLine(formDescStyle.Render(desc), prefix))
 	}
 
 	lines = append(lines, prefix+formMetaStyle.Render("value: ")+f.renderFieldValue(fld, focused))
@@ -1831,6 +2356,63 @@ func (f *FormModel) focusedHasError() bool {
 	}
 
 	return true
+}
+
+// descLineWidth returns the column count available for a description
+// line, after subtracting the cursor prefix that every field row carries.
+// Falls back to a sensible minimum when the form's width isn't set yet
+// (e.g. during construction before SetSize fires).
+func (f *FormModel) descLineWidth() int {
+	const (
+		prefixCols = 2
+		minWidth   = 20
+	)
+
+	w := f.width - prefixCols
+	if w < minWidth {
+		return minWidth
+	}
+
+	return w
+}
+
+// truncateDescription wraps the description on whitespace boundaries
+// (so a multi-line author-formatted comment renders as-authored) and
+// returns at most `lines` lines. The final line gets an `…` suffix when
+// content was dropped, signaling that pressing `?` will reveal the
+// rest. Lines longer than `width` get truncated with `…` too.
+func truncateDescription(desc string, lines, width int) string {
+	if lines <= 0 || desc == "" {
+		return desc
+	}
+
+	parts := strings.Split(desc, "\n")
+	truncated := false
+
+	if len(parts) > lines {
+		parts = parts[:lines]
+		truncated = true
+	}
+
+	for i, line := range parts {
+		if ansi.StringWidth(line) > width {
+			parts[i] = ansi.Truncate(line, width, "…")
+			truncated = true
+		}
+	}
+
+	if truncated {
+		last := parts[len(parts)-1]
+		if !strings.HasSuffix(last, "…") {
+			if ansi.StringWidth(last)+1 > width {
+				parts[len(parts)-1] = ansi.Truncate(last, width-1, "") + "…"
+			} else {
+				parts[len(parts)-1] = last + "…"
+			}
+		}
+	}
+
+	return strings.Join(parts, "\n")
 }
 
 // prefixEveryLine prepends prefix to every line of s. Used to extend the

--- a/internal/cli/commands/catalog/tui/redesign/form_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/form_test.go
@@ -2,6 +2,7 @@ package redesign_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -38,6 +39,19 @@ func drainFormCmds(cmd tea.Cmd) tea.Msg {
 	}
 
 	return nil
+}
+
+// lineIndexOf returns the index of the first line in view that contains
+// substr, or -1 when none does. Used to assert a field's vertical
+// position in the rendered form is stable across state changes.
+func lineIndexOf(view, substr string) int {
+	for i, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, substr) {
+			return i
+		}
+	}
+
+	return -1
 }
 
 // pressJ etc. are tiny ergonomic helpers so the modal test sequences stay
@@ -660,6 +674,86 @@ func TestFormStatusLineClearsOnceRequiredFieldsSet(t *testing.T) {
 
 	assert.NotContains(t, f.View(), "required field",
 		"the status line should disappear once every required field is set")
+}
+
+func TestFormErrorRowDoesNotShiftLayout(t *testing.T) {
+	t.Parallel()
+
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "vpc_id", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "tier", Required: false, Literal: true, TypeStr: "string"},
+	})
+	f.SetSize(120, 40)
+
+	// Record where a downstream field sits before any error is shown. The
+	// total view height is always the terminal height (the body is padded
+	// to a fixed bodyHeight), so the meaningful "shift" is fields reflowing
+	// within the body, not the overall height.
+	before := lineIndexOf(f.View(), "tier")
+	require.GreaterOrEqual(t, before, 0, "the tier field should be visible before the submit")
+
+	// A blocked submit flags every required field inline. Because each
+	// field reserves its error row whether or not an error is present, the
+	// required fields above tier gain no extra height, so tier must not
+	// move down.
+	f, _ = f.Update(pressS())
+	require.NotEmpty(t, f.Field(0).ValidationErr, "the submit should have flagged the required fields")
+
+	assert.Equal(t, before, lineIndexOf(f.View(), "tier"),
+		"reserving each field's error row should keep downstream fields from shifting when errors appear")
+}
+
+func TestFormForceSubmitWritesDespiteMissingRequired(t *testing.T) {
+	t.Parallel()
+
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "tier", Literal: true, TypeStr: "string", Initial: "basic"},
+	})
+	f.SetSize(120, 40)
+
+	// ctrl+d force-submits without filling anything, bypassing the
+	// required-field check that `s` enforces.
+	updated, cmd := f.Update(pressCtrlD())
+	require.True(t, updated.Submitted(), "ctrl+d should submit even with required fields unset")
+
+	msg := drainFormCmds(cmd)
+	sub, ok := msg.(redesign.FormSubmitMsg)
+	require.True(t, ok, "expected FormSubmitMsg, got %T", msg)
+
+	assert.Empty(t, sub.Values,
+		"unset fields are omitted from the submit map; the missing required field becomes a TODO at write time")
+}
+
+func TestFormUnsetReshowsMissingRequiredCount(t *testing.T) {
+	t.Parallel()
+
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string"},
+	})
+	f.SetSize(120, 40)
+
+	// Blocked submit shows the line, then fill the field to clear it.
+	f, _ = f.Update(pressS())
+	require.Contains(t, f.View(), "required field", "the line should appear after the blocked submit")
+
+	f, _ = f.Update(pressEnter())
+
+	for _, r := range "us-east-1" {
+		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+
+	f, _ = f.Update(pressEsc())
+	require.NotContains(t, f.View(), "required field", "filling the field should clear the line")
+
+	// Unsetting the now-set required field makes it missing again, and the
+	// status line's live count should bring the message back.
+	f, _ = f.Update(pressX())
+
+	require.False(t, f.Field(0).Set, "x should unset the required field")
+	assert.Contains(t, f.View(), "1 required field missing",
+		"unsetting a required field should re-show the missing-required status line")
 }
 
 func TestFormFilterEntryReturnsFocusCmd(t *testing.T) {

--- a/internal/cli/commands/catalog/tui/redesign/form_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/form_test.go
@@ -45,6 +45,8 @@ func drainFormCmds(cmd tea.Cmd) tea.Msg {
 func pressJ() tea.KeyPressMsg        { return tea.KeyPressMsg{Code: 'j', Text: "j"} }
 func pressK() tea.KeyPressMsg        { return tea.KeyPressMsg{Code: 'k', Text: "k"} }
 func pressX() tea.KeyPressMsg        { return tea.KeyPressMsg{Code: 'x', Text: "x"} }
+func pressS() tea.KeyPressMsg        { return tea.KeyPressMsg{Code: 's', Text: "s"} }
+func pressR() tea.KeyPressMsg        { return tea.KeyPressMsg{Code: 'r', Text: "r"} }
 func pressEnter() tea.KeyPressMsg    { return tea.KeyPressMsg{Code: tea.KeyEnter} }
 func pressEsc() tea.KeyPressMsg      { return tea.KeyPressMsg{Code: tea.KeyEscape} }
 func pressCtrlD() tea.KeyPressMsg    { return tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl} }
@@ -233,7 +235,7 @@ func TestFormXIsNoOpWhenAlreadyUnset(t *testing.T) {
 		"x on an already-unset field should remain a no-op (one-way unset)")
 }
 
-func TestFormCapitalXUnsetsAllOptionalsAndLeavesRequired(t *testing.T) {
+func TestFormResetUnsetsAllFieldsAndClearsErrors(t *testing.T) {
 	t.Parallel()
 
 	f := redesign.NewFormModel(nil, []redesign.FormField{
@@ -243,10 +245,9 @@ func TestFormCapitalXUnsetsAllOptionalsAndLeavesRequired(t *testing.T) {
 	})
 	f.SetSize(120, 40)
 
-	// Set all three fields.
-	f, _ = f.Update(pressEnter()) // edit region
-	f, _ = f.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
-	f, _ = f.Update(pressEsc())
+	// Set the optional fields but leave the required one blank, then run a
+	// checked submit so the required field gets flagged and the status
+	// line appears.
 	f, _ = f.Update(pressJ())
 	f, _ = f.Update(pressEnter()) // edit tier
 	f, _ = f.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
@@ -256,21 +257,27 @@ func TestFormCapitalXUnsetsAllOptionalsAndLeavesRequired(t *testing.T) {
 	f, _ = f.Update(pressEnter()) // toggle
 	f, _ = f.Update(pressEsc())
 
-	require.True(t, f.Field(0).Set)
+	f, _ = f.Update(pressS())
+
 	require.True(t, f.Field(1).Set)
 	require.True(t, f.Field(2).Set)
+	require.NotEmpty(t, f.Field(0).ValidationErr, "the unset required field should be flagged after a checked submit")
+	require.Contains(t, f.View(), "required field", "the status line should be visible before reset")
 
-	f, _ = f.Update(tea.KeyPressMsg{Code: 'X', Text: "X"})
+	f, _ = f.Update(pressR())
 
-	assert.True(t, f.Field(0).Set, "required fields should keep their Set state")
-	assert.False(t, f.Field(1).Set, "optional text field should be unset by X")
-	assert.False(t, f.Field(2).Set, "optional checkbox should be unset by X")
+	assert.False(t, f.Field(0).Set, "reset should unset required fields too")
+	assert.False(t, f.Field(1).Set, "reset should unset optional fields")
+	assert.False(t, f.Field(2).Set, "reset should unset optional checkboxes")
+	assert.Empty(t, f.Field(0).ValidationErr, "reset should clear every field's validation error")
+	assert.NotContains(t, f.View(), "required field",
+		"reset should suppress the missing-required status line")
 
-	// Input/Bool are preserved for the unset optionals.
+	// Input/Bool are preserved so prior edits are recoverable.
 	assert.Equal(t, "basicp", f.Field(1).Input.Value())
 }
 
-func TestFormXIsNoOpOnRequired(t *testing.T) {
+func TestFormXUnsetsRequiredAndClearsError(t *testing.T) {
 	t.Parallel()
 
 	f := redesign.NewFormModel(nil, []redesign.FormField{
@@ -285,11 +292,13 @@ func TestFormXIsNoOpOnRequired(t *testing.T) {
 
 	require.True(t, f.Field(0).Set)
 
-	// x must not flip Required fields.
+	// x now unsets required fields as well, clearing any error and
+	// preserving the input for recovery.
 	f, _ = f.Update(pressX())
-	assert.True(t, f.Field(0).Set, "required fields can't be marked unset")
+	assert.False(t, f.Field(0).Set, "x should unset a required field")
+	assert.Empty(t, f.Field(0).ValidationErr, "x should clear the field's validation error")
 	assert.Equal(t, "a", f.Field(0).Input.Value(),
-		"the input value should be preserved when x is ignored")
+		"the input value should be preserved when the field is unset")
 }
 
 func TestFormSubmitOmitsUnsetFields(t *testing.T) {
@@ -499,8 +508,8 @@ func TestFormValidationOnExitAcceptsReferences(t *testing.T) {
 func TestFormValidationDoesNotFireMidTyping(t *testing.T) {
 	t.Parallel()
 
-	// Eben specifically called out distracting partial-syntax errors
-	// flashing while typing. Confirm no validation error appears until
+	// Review called out distracting partial-syntax errors flashing
+	// while typing. Confirm no validation error appears until
 	// the user signals they're done (esc, or a future tab to the next
 	// field).
 	f := redesign.NewFormModel(nil, []redesign.FormField{
@@ -592,6 +601,65 @@ func TestFormFilterNarrowsAndNavigates(t *testing.T) {
 	assert.Contains(t, f.Field(f.Cursor()).Name, "vpc",
 		"j should walk to the next matching field, skipping non-matches")
 	assert.NotEqual(t, startCursor, f.Cursor())
+}
+
+func TestFormCheckedSubmitReportsMissingRequiredCount(t *testing.T) {
+	t.Parallel()
+
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "vpc_id", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "tier", Required: false, Literal: true, TypeStr: "string"},
+	})
+	f.SetSize(120, 40)
+
+	updated, cmd := f.Update(pressS())
+
+	assert.False(t, updated.Submitted(), "checked submit must not submit while required fields are unset")
+	assert.Nil(t, drainFormCmds(cmd), "no submit message should fire when required fields are missing")
+	assert.Equal(t, 0, updated.Cursor(), "the cursor should jump to the first missing required field")
+	assert.Contains(t, updated.View(), "2 required fields missing",
+		"the bottom status line should report the count of missing required fields")
+	assert.NotEmpty(t, updated.Field(0).ValidationErr, "each unset required field stays flagged inline")
+	assert.NotEmpty(t, updated.Field(1).ValidationErr)
+}
+
+func TestFormStatusLineClearsOnceRequiredFieldsSet(t *testing.T) {
+	t.Parallel()
+
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "vpc_id", Required: true, Literal: true, TypeStr: "string"},
+	})
+	f.SetSize(120, 40)
+
+	f, _ = f.Update(pressS())
+	require.Contains(t, f.View(), "required field", "the status line should appear after a blocked submit")
+
+	// Fill the first required field (region): enter edit, type, blur.
+	f, _ = f.Update(pressEnter())
+
+	for _, r := range "us-east-1" {
+		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+
+	f, _ = f.Update(pressEsc())
+
+	assert.Contains(t, f.View(), "1 required field missing",
+		"with one required field still unset the count should read singular")
+
+	// Fill the second required field (vpc_id).
+	f, _ = f.Update(pressJ())
+	f, _ = f.Update(pressEnter())
+
+	for _, r := range "vpc-123" {
+		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+
+	f, _ = f.Update(pressEsc())
+
+	assert.NotContains(t, f.View(), "required field",
+		"the status line should disappear once every required field is set")
 }
 
 func TestFormFilterEntryReturnsFocusCmd(t *testing.T) {

--- a/internal/cli/commands/catalog/tui/redesign/form_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/form_test.go
@@ -42,12 +42,14 @@ func drainFormCmds(cmd tea.Cmd) tea.Msg {
 
 // pressJ etc. are tiny ergonomic helpers so the modal test sequences stay
 // readable.
-func pressJ() tea.KeyPressMsg     { return tea.KeyPressMsg{Code: 'j', Text: "j"} }
-func pressK() tea.KeyPressMsg     { return tea.KeyPressMsg{Code: 'k', Text: "k"} }
-func pressX() tea.KeyPressMsg     { return tea.KeyPressMsg{Code: 'x', Text: "x"} }
-func pressEnter() tea.KeyPressMsg { return tea.KeyPressMsg{Code: tea.KeyEnter} }
-func pressEsc() tea.KeyPressMsg   { return tea.KeyPressMsg{Code: tea.KeyEscape} }
-func pressCtrlD() tea.KeyPressMsg { return tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl} }
+func pressJ() tea.KeyPressMsg        { return tea.KeyPressMsg{Code: 'j', Text: "j"} }
+func pressK() tea.KeyPressMsg        { return tea.KeyPressMsg{Code: 'k', Text: "k"} }
+func pressX() tea.KeyPressMsg        { return tea.KeyPressMsg{Code: 'x', Text: "x"} }
+func pressEnter() tea.KeyPressMsg    { return tea.KeyPressMsg{Code: tea.KeyEnter} }
+func pressEsc() tea.KeyPressMsg      { return tea.KeyPressMsg{Code: tea.KeyEscape} }
+func pressCtrlD() tea.KeyPressMsg    { return tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl} }
+func pressTab() tea.KeyPressMsg      { return tea.KeyPressMsg{Code: tea.KeyTab} }
+func pressShiftTab() tea.KeyPressMsg { return tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift} }
 
 func TestFormFieldsFromParsedVariables_OrderingAndMetadata(t *testing.T) {
 	t.Parallel()
@@ -386,11 +388,12 @@ func TestFormHCLValidationBlocksSubmit(t *testing.T) {
 		"validation failure should attach an error to the field")
 }
 
-func TestFormLiveValidationFlagsBadHCL(t *testing.T) {
+func TestFormValidationOnExitFlagsBadHCL(t *testing.T) {
 	t.Parallel()
 
-	// Type a partial map literal one keystroke at a time and confirm the
-	// field's ValidationErr toggles in response to the syntactic state.
+	// Type a partial map literal and confirm no error surfaces while
+	// the user is still typing; on esc back to navigate the validator
+	// runs once and flags the broken value.
 	f := redesign.NewFormModel(nil, []redesign.FormField{
 		{Name: "tags", TypeStr: "map"},
 	})
@@ -402,19 +405,29 @@ func TestFormLiveValidationFlagsBadHCL(t *testing.T) {
 		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
 	}
 
-	assert.NotEmpty(t, f.Field(0).ValidationErr,
-		"partial map literal should be flagged while still being typed")
+	assert.Empty(t, f.Field(0).ValidationErr,
+		"validation shouldn't fire mid-typing; the user is still working")
 
-	// Finish the literal; the error should clear.
+	f, _ = f.Update(pressEsc())
+
+	assert.NotEmpty(t, f.Field(0).ValidationErr,
+		"on blur (esc back to navigate) the broken literal should be flagged")
+
+	// Re-enter edit and finish the literal; on the next blur the error
+	// should clear.
+	f, _ = f.Update(pressEnter())
+
 	for _, r := range `r"}` {
 		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
 	}
 
+	f, _ = f.Update(pressEsc())
+
 	assert.Empty(t, f.Field(0).ValidationErr,
-		"completing the map literal should clear the error")
+		"completing the literal then blurring should clear the error")
 }
 
-func TestFormLiveValidationFlagsTypeMismatch(t *testing.T) {
+func TestFormValidationOnExitFlagsTypeMismatch(t *testing.T) {
 	t.Parallel()
 
 	// Declared type is "number" but the user types a string.
@@ -429,11 +442,13 @@ func TestFormLiveValidationFlagsTypeMismatch(t *testing.T) {
 		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
 	}
 
+	f, _ = f.Update(pressEsc())
+
 	assert.NotEmpty(t, f.Field(0).ValidationErr,
-		"a string literal in a number field should be flagged")
+		"a string literal in a number field should be flagged on blur")
 }
 
-func TestFormLiveValidationFlagsBareIdentifier(t *testing.T) {
+func TestFormValidationOnExitFlagsBareIdentifier(t *testing.T) {
 	t.Parallel()
 
 	// A bare word in a map field parses as a single-step traversal,
@@ -452,11 +467,13 @@ func TestFormLiveValidationFlagsBareIdentifier(t *testing.T) {
 		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
 	}
 
+	f, _ = f.Update(pressEsc())
+
 	assert.NotEmpty(t, f.Field(0).ValidationErr,
-		"a bare identifier should be flagged as not matching the declared type")
+		"a bare identifier should be flagged on blur as not matching the declared type")
 }
 
-func TestFormLiveValidationAcceptsReferences(t *testing.T) {
+func TestFormValidationOnExitAcceptsReferences(t *testing.T) {
 	t.Parallel()
 
 	// References can't be evaluated without context; the validator
@@ -473,8 +490,32 @@ func TestFormLiveValidationAcceptsReferences(t *testing.T) {
 		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
 	}
 
+	f, _ = f.Update(pressEsc())
+
 	assert.Empty(t, f.Field(0).ValidationErr,
-		"references should be accepted; eval errors aren't validation errors")
+		"references should be accepted on blur; eval errors aren't validation errors")
+}
+
+func TestFormValidationDoesNotFireMidTyping(t *testing.T) {
+	t.Parallel()
+
+	// Eben specifically called out distracting partial-syntax errors
+	// flashing while typing. Confirm no validation error appears until
+	// the user signals they're done (esc, or a future tab to the next
+	// field).
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "port", TypeStr: "number"},
+	})
+	f.SetSize(120, 40)
+
+	f, _ = f.Update(pressEnter())
+
+	for _, r := range `"abc` {
+		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+
+		assert.Empty(t, f.Field(0).ValidationErr,
+			"validation must not fire on any keystroke; only on blur")
+	}
 }
 
 func TestFormPageNavigationJumpsMultipleFields(t *testing.T) {
@@ -649,6 +690,406 @@ func TestFormValuesReferencesPromotesBoolDefaults(t *testing.T) {
 
 	assert.True(t, fields[2].Checkbox)
 	assert.False(t, fields[2].Bool)
+}
+
+func TestFormTabCyclesCategoryAndNarrowsCursor(t *testing.T) {
+	t.Parallel()
+
+	// Mix required and optional fields; the cursor starts at the first
+	// required field. tab moves to the Required-only tab (no-op for the
+	// cursor since it's already on a required), then to Optional which
+	// snaps the cursor onto the first optional field.
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "vpc_id", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "tier", Literal: true, TypeStr: "string", Initial: "basic"},
+		{Name: "debug", Checkbox: true, TypeStr: "bool"},
+	})
+	f.SetSize(120, 40)
+
+	require.Equal(t, 0, f.Cursor())
+
+	// All -> Required.
+	f, _ = f.Update(pressTab())
+	assert.Equal(t, 0, f.Cursor(),
+		"first required is already focused; cursor doesn't move")
+
+	// j should stay inside Required-only.
+	f, _ = f.Update(pressJ())
+	assert.Equal(t, 1, f.Cursor(), "j walks to the next required field")
+
+	f, _ = f.Update(pressJ())
+	assert.Equal(t, 1, f.Cursor(),
+		"j past the last required clamps; Optional fields aren't reachable here")
+
+	// Required -> Optional snaps to the first optional.
+	f, _ = f.Update(pressTab())
+	assert.Equal(t, 2, f.Cursor(),
+		"switching to Optional should land on the first optional field")
+
+	// shift+tab back to Required.
+	f, _ = f.Update(pressShiftTab())
+	assert.Less(t, f.Cursor(), 2,
+		"shift+tab from Optional cycles back to Required; cursor returns to a required field")
+}
+
+func TestFormCategoryANDsWithTextFilter(t *testing.T) {
+	t.Parallel()
+
+	// Optional category + "vpc" text filter should leave only optional
+	// fields whose names contain "vpc".
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "vpc_required", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "vpc_cidr", Literal: true, TypeStr: "string", Initial: "10.0.0.0/16"},
+		{Name: "vpc_name", Literal: true, TypeStr: "string", Initial: "main"},
+		{Name: "tier", Literal: true, TypeStr: "string", Initial: "basic"},
+	})
+	f.SetSize(120, 40)
+
+	// Switch to Optional (tab x2: All -> Required -> Optional).
+	f, _ = f.Update(pressTab())
+	f, _ = f.Update(pressTab())
+
+	// Open the filter and type "vpc".
+	f, _ = f.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
+
+	for _, r := range "vpc" {
+		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+
+	f, _ = f.Update(pressEnter())
+
+	// Walk every visible field and confirm the visible set is the
+	// intersection of Optional + contains("vpc").
+	const walkSteps = 4
+
+	visited := make([]string, 0, walkSteps+1)
+	visited = append(visited, f.Field(f.Cursor()).Name)
+
+	for range walkSteps {
+		f, _ = f.Update(pressJ())
+		visited = append(visited, f.Field(f.Cursor()).Name)
+	}
+
+	for _, name := range visited {
+		assert.Contains(t, name, "vpc", "filter should restrict to vpc-named fields")
+		assert.NotEqual(t, "vpc_required", name,
+			"required vpc_required must be excluded by the Optional category")
+	}
+}
+
+func TestFormTabInEditCommitsValidatesAndAdvancesStayingInEdit(t *testing.T) {
+	t.Parallel()
+
+	// Enter edit on the first field, type a value, tab to the next field.
+	// The first field should be marked Set with no validation error (the
+	// value is a valid HCL number), the cursor should move to field 1,
+	// and edit mode should persist so the next character lands in the
+	// new textinput.
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "port", Required: true, TypeStr: "number"},
+		{Name: "host", Required: true, TypeStr: "string", Literal: true},
+	})
+	f.SetSize(120, 40)
+
+	f, _ = f.Update(pressEnter())
+
+	for _, r := range "8080" {
+		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+
+	f, _ = f.Update(pressTab())
+
+	assert.Equal(t, 1, f.Cursor(), "tab should advance the cursor")
+	assert.True(t, f.Field(0).Set,
+		"the original field should be committed (Set=true) on tab")
+	assert.Empty(t, f.Field(0).ValidationErr,
+		"valid input should produce no on-blur validation error")
+
+	// Type into the new field; if edit mode persisted, the textinput
+	// should pick up the character.
+	f, _ = f.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+
+	assert.Equal(t, "a", f.Field(1).Input.Value(),
+		"after tab the next field should be in edit mode and accept input")
+}
+
+func TestFormTabInEditFlagsBadValueOnBlur(t *testing.T) {
+	t.Parallel()
+
+	// Tab away from a broken value: validation should fire as part of
+	// the tab-commit step, same as it would on esc.
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "port", Required: true, TypeStr: "number"},
+		{Name: "host", Required: true, TypeStr: "string", Literal: true},
+	})
+	f.SetSize(120, 40)
+
+	f, _ = f.Update(pressEnter())
+
+	for _, r := range `"oops"` {
+		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+
+	f, _ = f.Update(pressTab())
+
+	assert.Equal(t, 1, f.Cursor())
+	assert.NotEmpty(t, f.Field(0).ValidationErr,
+		"a type mismatch should be flagged when tab commits the field")
+}
+
+func TestFormShiftTabInEditMovesPrev(t *testing.T) {
+	t.Parallel()
+
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "port", Required: true, TypeStr: "number"},
+		{Name: "host", Required: true, TypeStr: "string", Literal: true},
+	})
+	f.SetSize(120, 40)
+
+	// Move cursor to field 1, enter edit, then shift+tab back to field 0.
+	f, _ = f.Update(pressJ())
+	f, _ = f.Update(pressEnter())
+	f, _ = f.Update(pressShiftTab())
+
+	assert.Equal(t, 0, f.Cursor(),
+		"shift+tab in edit mode should move to the previous visible field")
+}
+
+func TestFormTabInEditAtBoundaryIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	// On the last field, tab should not wrap; the user stays put with
+	// edit mode preserved.
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "a", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "b", Required: true, Literal: true, TypeStr: "string"},
+	})
+	f.SetSize(120, 40)
+
+	f, _ = f.Update(pressJ())
+	f, _ = f.Update(pressEnter())
+
+	for _, r := range "x" {
+		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+
+	f, _ = f.Update(pressTab())
+
+	assert.Equal(t, 1, f.Cursor(),
+		"tab at the last field is a no-op")
+
+	// Subsequent character still lands in field 1.
+	f, _ = f.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	assert.Equal(t, "xy", f.Field(1).Input.Value())
+}
+
+func TestFormDetailOverlayOpenAndClose(t *testing.T) {
+	t.Parallel()
+
+	// `?` from navigate opens the overlay; `?` again closes it.
+	// Default-state form is in navigate mode.
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string",
+			Description: "AWS region for the resource."},
+	})
+	f.SetSize(120, 40)
+
+	assert.False(t, f.DetailOpen())
+
+	f, _ = f.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
+	assert.True(t, f.DetailOpen(), "? in navigate mode should open the overlay")
+
+	view := f.View()
+	assert.Contains(t, view, "AWS region for the resource.",
+		"the overlay should render the full description")
+	assert.Contains(t, view, "? close",
+		"the overlay should advertise how to close")
+
+	f, _ = f.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
+	assert.False(t, f.DetailOpen(), "? again should close the overlay")
+}
+
+func TestFormDetailOverlayEscClosesWithoutCancelingForm(t *testing.T) {
+	t.Parallel()
+
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string",
+			Description: "AWS region."},
+	})
+	f.SetSize(120, 40)
+
+	f, _ = f.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
+	require.True(t, f.DetailOpen())
+
+	f, cmd := f.Update(pressEsc())
+
+	assert.False(t, f.DetailOpen(), "esc should close the overlay")
+	assert.Nil(t, drainFormCmds(cmd),
+		"esc in the overlay must not also cancel the form")
+}
+
+func TestFormUnfocusedDescriptionIsTruncatedAndFocusedIsFull(t *testing.T) {
+	t.Parallel()
+
+	longDesc := "L1\nL2\nL3\nL4"
+
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "a", Required: true, Literal: true, TypeStr: "string",
+			Description: longDesc},
+		{Name: "b", Required: true, Literal: true, TypeStr: "string",
+			Description: longDesc},
+	})
+	f.SetSize(120, 40)
+
+	view := f.View()
+
+	// Field 0 is focused: full description visible.
+	for _, line := range []string{"L1", "L2", "L3", "L4"} {
+		assert.Contains(t, view, line,
+			"focused field's description should render in full")
+	}
+
+	// Move focus to field 1; field 0 is now unfocused. With descPreviewLines=2
+	// and an extra paragraph past it, the unfocused field's render should
+	// end with an ellipsis marker. We can't tell which field's L3/L4 lines
+	// are which without parsing, so confirm an ellipsis appears in the view
+	// (which only happens via the truncation helper).
+	f, _ = f.Update(pressJ())
+
+	view = f.View()
+	assert.Contains(t, view, "…",
+		"unfocused field with a long description should be truncated with …")
+}
+
+func TestFormUntouchedCursorTracksFirstVisibleAcrossTabs(t *testing.T) {
+	t.Parallel()
+
+	// A user who only tabs / searches (no j/k) should keep focus on the
+	// first visible field as the category changes. Mirrors the list view's
+	// "freshly inserted item snaps selection to 0 until you navigate"
+	// pattern.
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "vpc_id", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "tier", Literal: true, TypeStr: "string", Initial: "basic"},
+		{Name: "size", Literal: true, TypeStr: "string", Initial: "small"},
+	})
+	f.SetSize(120, 40)
+
+	// All -> Required: still first.
+	f, _ = f.Update(pressTab())
+	assert.Equal(t, 0, f.Cursor(), "first required is still index 0")
+
+	// Required -> Optional: first optional is index 2.
+	f, _ = f.Update(pressTab())
+	assert.Equal(t, 2, f.Cursor(),
+		"un-navigated user should land on the first visible field after a tab")
+
+	// Optional -> All: first overall is index 0.
+	f, _ = f.Update(pressTab())
+	assert.Equal(t, 0, f.Cursor(),
+		"un-navigated user should snap back to the first field on All")
+}
+
+func TestFormNavigationStickyAfterJK(t *testing.T) {
+	t.Parallel()
+
+	// Once the user presses j/k, subsequent tabs preserve the cursor
+	// (when the field stays visible) instead of snapping to the top.
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "a", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "b", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "c", Required: true, Literal: true, TypeStr: "string"},
+	})
+	f.SetSize(120, 40)
+
+	f, _ = f.Update(pressJ())
+	require.Equal(t, 1, f.Cursor())
+
+	// Tab cycles to Required (already required-only fields here); the
+	// cursor's field is still visible, so it should stay put.
+	f, _ = f.Update(pressTab())
+	assert.Equal(t, 1, f.Cursor(),
+		"after j, the cursor sticks across category cycles when still visible")
+}
+
+func TestFormUntouchedCursorTracksFirstMatchWhileFiltering(t *testing.T) {
+	t.Parallel()
+
+	// A user who hasn't navigated should also have the cursor snap to
+	// the first match as they type into the filter, even when their
+	// pre-filter cursor would have stayed visible.
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string"},
+		{Name: "vpc_id", Required: true, Literal: true, TypeStr: "string"},
+	})
+	f.SetSize(120, 40)
+
+	// Open filter, type 'v' so "vpc_id" matches but "region" doesn't.
+	f, _ = f.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
+	f, _ = f.Update(tea.KeyPressMsg{Code: 'v', Text: "v"})
+
+	assert.Equal(t, 1, f.Cursor(),
+		"un-navigated cursor should snap to the first matching field")
+}
+
+func TestFormEnterInEditExitsBackToNavigateOnTextField(t *testing.T) {
+	t.Parallel()
+
+	// Enter on a text/HCL field acts as the symmetric counterpart to
+	// the enter that brought the user into edit mode: commit + validate
+	// + return to navigate, same as esc.
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "region", Required: true, Literal: true, TypeStr: "string"},
+	})
+	f.SetSize(120, 40)
+
+	f, _ = f.Update(pressEnter())
+
+	for _, r := range "us-east-1" {
+		f, _ = f.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+
+	// Sanity: the keystrokes went into the input (edit mode is live).
+	require.Equal(t, "us-east-1", f.Field(0).Input.Value())
+
+	f, _ = f.Update(pressEnter())
+
+	// After enter we should be back in navigate; a typed character
+	// should no longer reach the input.
+	f, _ = f.Update(tea.KeyPressMsg{Code: 'z', Text: "z"})
+
+	assert.Equal(t, "us-east-1", f.Field(0).Input.Value(),
+		"enter in edit mode should exit; subsequent keystrokes shouldn't reach the input")
+	assert.True(t, f.Field(0).Set,
+		"the edited field should be committed (Set=true) on enter")
+}
+
+func TestFormEnterInEditStillTogglesBool(t *testing.T) {
+	t.Parallel()
+
+	// Enter on a bool field in edit mode keeps its toggle semantics; the
+	// new exit-on-enter behavior is text-field-only.
+	f := redesign.NewFormModel(nil, []redesign.FormField{
+		{Name: "debug", Checkbox: true, TypeStr: "bool"},
+	})
+	f.SetSize(120, 40)
+
+	require.False(t, f.Field(0).Bool)
+	require.False(t, f.Field(0).Set)
+
+	// First enter: navigate -> edit on a checkbox flips into edit mode
+	// without committing yet (Set stays false until a toggle).
+	f, _ = f.Update(pressEnter())
+
+	// Second enter: toggle to true.
+	f, _ = f.Update(pressEnter())
+
+	assert.True(t, f.Field(0).Bool, "enter in checkbox edit mode should toggle")
+	assert.True(t, f.Field(0).Set,
+		"toggle commits the field so values() emits it")
 }
 
 func TestCtyValueAsHCLRoundTrips(t *testing.T) {

--- a/internal/cli/commands/catalog/tui/redesign/model.go
+++ b/internal/cli/commands/catalog/tui/redesign/model.go
@@ -96,6 +96,11 @@ type Model struct {
 	userNavigated       bool
 	hasDarkBG           bool
 	mdRendererDark      bool
+	// softWrap toggles glamour's word-wrap in the pager view. Default true
+	// matches the prior behavior; the `w` key flips it so users reading a
+	// README with intentionally long lines (ascii diagrams, wide tables)
+	// can see them as-authored.
+	softWrap bool
 }
 
 // NewModelStreaming creates a Model with a single initial entry and a channel
@@ -130,6 +135,13 @@ func (m Model) ActiveTab() TabKind {
 // strip renders a "(loading...)" suffix.
 func (m Model) Loading() bool {
 	return m.loading
+}
+
+// SoftWrap reports whether the pager's glamour renderer wraps long
+// lines at terminal width. Exposed for tests that drive the `w` key
+// and verify the toggle.
+func (m Model) SoftWrap() bool {
+	return m.softWrap
 }
 
 // ExitMessage returns the styled post-exit message the model set while
@@ -354,5 +366,8 @@ func newModelWithItems(l log.Logger, opts *options.TerragruntOptions, items []li
 		// Matches lipgloss.HasDarkBackground's fallback. Corrected on the
 		// first tea.BackgroundColorMsg.
 		hasDarkBG: true,
+		// Soft-wrap on by default keeps glamour wrapping at terminal width
+		// like before; `w` flips it.
+		softWrap: true,
 	}
 }

--- a/internal/cli/commands/catalog/tui/redesign/model_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/model_test.go
@@ -179,53 +179,6 @@ func TestModelTabShiftTabCyclesWithRacing(t *testing.T) {
 	})
 }
 
-// TestModelCopyActionPlaceholderTransitionsToScaffoldStateWithRacing asserts that
-// pressing the placeholder scaffold key (`S`) on a copyable component
-// transitions the Model directly to ScaffoldState, which is what
-// dispatches the copy action with TODO placeholders.
-//
-// The copy itself is exercised end-to-end in copy_test.go; here we only
-// verify the wire-up, because tea.Exec (used by the copy dispatch) only runs
-// the underlying ExecCommand inside a real bubbletea runtime.
-func TestModelCopyActionPlaceholderTransitionsToScaffoldStateWithRacing(t *testing.T) {
-	t.Parallel()
-
-	synctest.Test(t, func(t *testing.T) {
-		fsys := vfs.NewMemMapFS()
-		repoDir := testRepoDir
-
-		unitBody := `locals { region = values.region }` + "\n"
-		writeFileFS(t, fsys, filepath.Join(repoDir, "vpc", "terragrunt.hcl"), unitBody)
-
-		repo := newFakeRepo(t, fsys, repoDir)
-
-		components, err := redesign.NewComponentDiscovery().WithFS(fsys).Discover(repo)
-		require.NoError(t, err)
-		require.Len(t, components, 1)
-		require.Equal(t, redesign.ComponentKindUnit, components[0].Kind)
-
-		opts, err := options.NewTerragruntOptionsForTest("")
-		require.NoError(t, err)
-
-		opts.WorkingDir = t.TempDir()
-
-		entry := redesign.NewComponentEntry(components[0]).WithSource("github.com/gruntwork-io/fake-repo")
-
-		componentCh := make(chan *redesign.ComponentEntry)
-		close(componentCh)
-
-		m := redesign.NewModelStreaming(t.Context(), logger.CreateLogger(), opts, entry, componentCh, nil)
-
-		// Capital S = placeholder scaffold flow.
-		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'S', Text: "S"}}
-
-		finalModel := driveModel(t, m, 120, 40, msgs).(redesign.Model)
-
-		assert.Equal(t, redesign.ScaffoldState, finalModel.State,
-			"pressing 'S' on a unit should transition to ScaffoldState")
-	})
-}
-
 // TestModelInteractiveScaffoldTransitionsToFormStateWithRacing asserts that pressing
 // the interactive scaffold key (`s`) on a copyable component transitions
 // the Model to FormState. The discovery goroutine runs synchronously via
@@ -636,5 +589,54 @@ func TestModelPagerViewRendersAfterEnterWithRacing(t *testing.T) {
 		content := stripANSI(finalModel.View().Content)
 		assert.Contains(t, content, "100%",
 			"pager footer should render scroll percent")
+	})
+}
+
+// TestModelPagerWToggleFlipsSoftWrapWithRacing exercises the `w` key in
+// PagerState: starting from default soft-wrap on, one press flips it
+// off, a second flips it back. The toggle also rebuilds the cached
+// glamour renderer, which is hard to inspect from outside, so we rely on
+// the visible softWrap accessor to verify the lifecycle.
+func TestModelPagerWToggleFlipsSoftWrapWithRacing(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		opts, err := options.NewTerragruntOptionsForTest("")
+		require.NoError(t, err)
+
+		opts.WorkingDir = t.TempDir()
+
+		l := logger.CreateLogger()
+
+		entry := redesign.NewComponentEntry(redesign.NewComponentForTest(
+			redesign.ComponentKindModule,
+			"github.com/gruntwork-io/fake-repo",
+			"modules/vpc",
+			"# VPC Module\nA module.",
+		)).WithSource("github.com/gruntwork-io/fake-repo")
+
+		componentCh := make(chan *redesign.ComponentEntry)
+		close(componentCh)
+
+		m := redesign.NewModelStreaming(t.Context(), l, opts, entry, componentCh, nil)
+
+		// Enter pager, then toggle `w` twice. driveModel runs the
+		// messages through Update in order and returns the final model.
+		msgs := []tea.Msg{
+			tea.KeyPressMsg{Code: tea.KeyEnter},
+			tea.KeyPressMsg{Code: 'w', Text: "w"},
+		}
+
+		afterFirstToggle := driveModel(t, m, 120, 40, msgs).(redesign.Model)
+
+		assert.Equal(t, redesign.PagerState, afterFirstToggle.State)
+		assert.False(t, afterFirstToggle.SoftWrap(),
+			"first `w` press should flip soft-wrap off")
+
+		updated, _ := afterFirstToggle.Update(tea.KeyPressMsg{Code: 'w', Text: "w"})
+		afterSecondToggle := updated.(redesign.Model)
+
+		assert.True(t, afterSecondToggle.SoftWrap(),
+			"second `w` press should flip soft-wrap back on")
 	})
 }

--- a/internal/cli/commands/catalog/tui/redesign/renderer.go
+++ b/internal/cli/commands/catalog/tui/redesign/renderer.go
@@ -8,6 +8,12 @@ import (
 // prepended content aligns with the rendered body.
 const glamourDocumentMargin = 2
 
+// noWrapColumnWidth is the wrap column glamour gets when soft-wrap is off.
+// Glamour's word-wrap can't be disabled outright (`0` collapses the
+// document), so a very wide value preserves the author's line breaks and
+// lets the viewport letterbox anything that overruns the terminal.
+const noWrapColumnWidth = 1 << 14
+
 // markdownRenderer returns a renderer matching the current width and
 // dark/light setting, reusing a cached one when both still match.
 //
@@ -24,9 +30,14 @@ func (m Model) markdownRenderer() (Model, *glamour.TermRenderer, error) {
 		style = "light"
 	}
 
+	wrap := m.width
+	if !m.softWrap {
+		wrap = noWrapColumnWidth
+	}
+
 	r, err := glamour.NewTermRenderer(
 		glamour.WithStandardStyle(style),
-		glamour.WithWordWrap(m.width),
+		glamour.WithWordWrap(wrap),
 	)
 	if err != nil {
 		return m, nil, err

--- a/internal/cli/commands/catalog/tui/redesign/update.go
+++ b/internal/cli/commands/catalog/tui/redesign/update.go
@@ -378,7 +378,7 @@ const (
 // formatActionFailure renders a bordered callout describing a failed
 // scaffold or copy action. action is a verb phrase ("scaffolding component",
 // "copying component"). The message is stashed on the model so RunRedesign
-// can print it after the alt screen is restored — tea.Printf lines emitted
+// can print it after the alt screen is restored; tea.Printf lines emitted
 // during alt-screen are discarded on exit.
 func formatActionFailure(action string, err error) string {
 	heading := lipgloss.NewStyle().

--- a/internal/cli/commands/catalog/tui/redesign/update.go
+++ b/internal/cli/commands/catalog/tui/redesign/update.go
@@ -54,7 +54,7 @@ func updateList(msg tea.Msg, m Model) (tea.Model, tea.Cmd) {
 			m.activeTab = m.activeTab.prev()
 
 			return m, nil
-		case key.Matches(msg, m.delegateKeys.Choose, m.delegateKeys.ScaffoldInteractive, m.delegateKeys.ScaffoldPlaceholder):
+		case key.Matches(msg, m.delegateKeys.Choose, m.delegateKeys.ScaffoldInteractive):
 			selectedEntry, ok := m.lists[m.activeTab].SelectedItem().(*ComponentEntry)
 			if !ok {
 				break
@@ -96,10 +96,6 @@ func updateList(msg tea.Msg, m Model) (tea.Model, tea.Cmd) {
 				return m, nil
 			case key.Matches(msg, m.delegateKeys.ScaffoldInteractive):
 				return enterFormState(m, selectedComponent, ListState)
-			case key.Matches(msg, m.delegateKeys.ScaffoldPlaceholder):
-				m.State = ScaffoldState
-
-				return m, primaryActionCmd(m.logger, m, selectedComponent)
 			}
 
 		case key.Matches(msg, m.listKeys.Quit):
@@ -146,10 +142,21 @@ func updatePager(msg tea.Msg, m Model) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, m.pagerKeys.ScaffoldInteractive):
 			return enterFormState(m, m.selectedComponent, PagerState)
-		case key.Matches(msg, m.pagerKeys.ScaffoldPlaceholder):
-			m.State = ScaffoldState
+		case key.Matches(msg, m.pagerKeys.ToggleWrap):
+			m.softWrap = !m.softWrap
+			m.mdRenderer = nil
 
-			return m, primaryActionCmd(m.logger, m, m.selectedComponent)
+			if m.selectedComponent != nil {
+				updated, content, err := m.renderComponentContent(m.selectedComponent, ResolveTagsDetailStyle(), m.selectedComponent.Tags())
+				if err != nil {
+					return m, rendererErrCmd(err)
+				}
+
+				m = updated
+				m.viewport.SetContent(content)
+			}
+
+			return m, nil
 
 		case key.Matches(msg, m.pagerKeys.Quit):
 			m.State = ListState
@@ -360,20 +367,6 @@ type CopyFinishedMsg struct {
 	Interactive bool
 }
 
-func scaffoldComponentCmd(l log.Logger, m Model, c *Component) tea.Cmd {
-	return tea.Exec(newScaffoldCmd(l, m.terragruntOptions, c), func(err error) tea.Msg {
-		return ScaffoldFinishedMsg{Err: err}
-	})
-}
-
-func copyComponentCmd(l log.Logger, m Model, c *Component) tea.Cmd {
-	cmd := NewCopyCmd(l, m.terragruntOptions, c)
-
-	return tea.Exec(cmd, func(err error) tea.Msg {
-		return CopyFinishedMsg{Err: err, Result: cmd.Result()}
-	})
-}
-
 const (
 	valuesBoxAccentGreen  = "#50FA7B"
 	valuesBoxAccentYellow = "#F1FA8C"
@@ -558,16 +551,6 @@ func displayPath(baseDir, abs string) string {
 	// the string reads obviously as a relative path. filepath.Join/Clean both
 	// strip this prefix, so we compose it explicitly.
 	return "." + string(filepath.Separator) + rel
-}
-
-// primaryActionCmd dispatches to scaffold or copy based on the component's
-// kind. Units and stacks copy; modules and templates scaffold.
-func primaryActionCmd(l log.Logger, m Model, c *Component) tea.Cmd {
-	if c.Kind.IsCopyable() {
-		return copyComponentCmd(l, m, c)
-	}
-
-	return scaffoldComponentCmd(l, m, c)
 }
 
 // formReadyMsg is delivered once discovery has built a populated FormModel

--- a/internal/cli/commands/catalog/tui/redesign/view_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/view_test.go
@@ -321,7 +321,7 @@ func TestWelcomeStreamingFlowWithRacing(t *testing.T) {
 // runUntilQuiet dispatches initialCmd into the synctest bubble and applies
 // every message it produces (and the transitive cmds those messages return)
 // until budget elapses without new activity. Used by tests that need
-// post-Init state transitions to actually update the model — unlike
+// post-Init state transitions to actually update the model, unlike
 // driveModel's settle loop, which discards trailing messages so background
 // tickers can finish cleanly.
 func runUntilQuiet(t *testing.T, m tea.Model, initialCmd tea.Cmd, budget time.Duration) tea.Model {

--- a/internal/cli/commands/catalog/tui/update.go
+++ b/internal/cli/commands/catalog/tui/update.go
@@ -33,7 +33,7 @@ func updateList(msg tea.Msg, m Model) (tea.Model, tea.Cmd) {
 		}
 
 		switch {
-		case key.Matches(msg, m.delegateKeys.Choose, m.delegateKeys.ScaffoldInteractive, m.delegateKeys.ScaffoldPlaceholder):
+		case key.Matches(msg, m.delegateKeys.Choose, m.delegateKeys.ScaffoldInteractive):
 			if selectedModule, ok := m.List.SelectedItem().(*module.Module); ok {
 				switch {
 				case key.Matches(msg, m.delegateKeys.Choose):
@@ -88,7 +88,7 @@ func updateList(msg tea.Msg, m Model) (tea.Model, tea.Cmd) {
 					// advance state
 					m.selectedModule = selectedModule
 					m.State = PagerState
-				case key.Matches(msg, m.delegateKeys.ScaffoldInteractive, m.delegateKeys.ScaffoldPlaceholder):
+				case key.Matches(msg, m.delegateKeys.ScaffoldInteractive):
 					if m.SVC == nil {
 						return m, nil
 					}
@@ -160,7 +160,7 @@ func updatePager(msg tea.Msg, m Model) (tea.Model, tea.Cmd) {
 				m.logger.Warnf("Unknown button pressed: %s", currentAction)
 			}
 
-		case key.Matches(msg, m.pagerKeys.ScaffoldInteractive, m.pagerKeys.ScaffoldPlaceholder):
+		case key.Matches(msg, m.pagerKeys.ScaffoldInteractive):
 			if m.SVC == nil {
 				return m, nil
 			}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses UI/UX feedback on TUI scaffold design.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive scaffolding form with field-by-field navigation, category tabs (All/Required/Optional), focused-field help (?) and README pager soft-wrap toggle (w)
  * New in-form keys: x to unset a field, r to reset the form; tab/Shift+Tab commit-and-move while staying in edit; Enter handles text/HCL vs boolean fields

* **Bug Fixes**
  * Validation runs on field blur/exit (not every keystroke)
  * Checked-submit focuses first missing required field and shows “Press ctrl+d to scaffold anyway”; placeholder-only scaffold (uppercase S) removed

* **Documentation**
  * Updated Catalog TUI docs and v1.0.6 changelog to reflect these changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->