### PR TITLE
docs: Enhance documentation for `--out-dir` usage

### DIFF
--- a/docs/src/content/docs/03-features/02-stacks/04-stack-operations.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/04-stack-operations.mdx
@@ -492,7 +492,7 @@ If a plan is missing for any unit, the command will fail.
 If a plan job was scoped with `--filter`, you must pass the **same** `--filter` to the apply so the apply discovery set matches the artifact contents. For example:
 
 ```bash
-# Plan `<svc>` and its dependencies:
+# Plan `<unit>` and its dependencies:
 terragrunt run --all --filter '<unit>...' --out-dir /tmp/tfplan -- plan
 
 # Apply must reuse the same filter:

--- a/docs/src/content/docs/03-features/02-stacks/04-stack-operations.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/04-stack-operations.mdx
@@ -484,6 +484,23 @@ This integration also exists for the `apply` command, where the generated plan w
 $ terragrunt run --all --out-dir /tmp/tfplan -- apply
 ```
 
+<Aside type="note">
+
+Performing a `run --all --out-dir <dir> -- apply` requires that a plan already exists for each unit in the stack.
+If a plan is missing for any unit, the command will fail.
+
+If a plan job was scoped with `--filter`, you must pass the **same** `--filter` to the apply so the apply discovery set matches the artifact contents. For example:
+
+```bash
+# Plan `<svc>` and its dependencies:
+terragrunt run --all --filter '<unit>...' --out-dir /tmp/tfplan -- plan
+
+# Apply must reuse the same filter:
+terragrunt run --all --filter '<unit>...' --out-dir /tmp/tfplan -- apply
+```
+
+</Aside>
+
 For planning a destroy operation, use the following commands:
 
 ```bash

--- a/docs/src/data/flags/out-dir.mdx
+++ b/docs/src/data/flags/out-dir.mdx
@@ -26,6 +26,15 @@ Specifies where Terragrunt writes native OpenTofu/Terraform plan files for each 
 - If the directory does not exist, Terragrunt creates it.
 - Relative paths are resolved against the root working directory, and Terragrunt mirrors the unit path under this directory (e.g. `<out-dir>/<relative-unit-path>/tfplan.tfplan`).
 
+<Aside type="caution">
+
+`--out-dir` controls **where** Terragrunt reads and writes per-unit plan files, but it does **not** restrict which units `run --all apply` discovers. If your plan was scoped with `--filter`, you must reuse the same `--filter` on
+`apply` — otherwise Terragrunt will discover unfiltered units, fail to find their plan files in `--out-dir`, and error out.
+
+See [Saving OpenTofu/Terraform plan output](https://docs.terragrunt.com/features/stacks/stack-operations/#saving-opentofuterraform-plan-output) for the full plan-then-apply pattern.
+
+</Aside>
+
 Examples:
 
 ```bash


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6170

Documents that `--out-dir` does not restrict the unit-discovery scope on `run --all apply`. If the plan was scoped with `--filter`, the same `--filter` must be passed to the apply or the run fails on the first unit without a saved plan.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that using an output directory for saved plans requires pre-existing plan artifacts for every unit—apply will fail if any unit’s plan is missing.
  * Added guidance that apply must reuse the exact same filter used at plan time so discovered units match saved artifacts.
  * Added cross-reference to the plan-then-apply guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->