### PR TITLE
chore: Clean-up of comments from #6174

### DIFF
--- a/docs/src/data/changelog/v1.0.6/mark-many-as-read-partial-parse.mdx
+++ b/docs/src/data/changelog/v1.0.6/mark-many-as-read-partial-parse.mdx
@@ -5,6 +5,6 @@ category: "bug-fixes"
 
 #### `mark-many-as-read` experiment now triggers during discovery
 
-With the `mark-many-as-read` experiment enabled, a unit whose `terraform { source = ... }` pointed at a local module did not show up under `--filter'reading='` filters that referenced files inside that module. Discovery would parse the unit, but the module files were never recorded as read, so the [reading filter attribute](https://docs.terragrunt.com/features/filter/attributes/#reading-based-expressions) could not match and the queue came back empty.
+With the `mark-many-as-read` experiment enabled, a unit whose `terraform { source = ... }` pointed at a local module did not show up under `--filter 'reading='` filters that referenced files inside that module. Discovery would parse the unit, but the module files were never recorded as read, so the [reading filter attribute](https://docs.terragrunt.com/features/filter/attributes/#reading-based-expressions) could not match and the queue came back empty.
 
 The module walk now runs on the discovery code path as well, so changes to files in a local module source flow through to the units that depend on them.

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -601,10 +601,6 @@ func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger,
 		}
 	}
 
-	if pctx.Experiments.Evaluate(experiment.MarkManyAsRead) && output.Terraform != nil && output.Terraform.Source != nil {
-		markLocalModuleSourceAsRead(pctx, file.ConfigPath, *output.Terraform.Source)
-	}
-
 	errsContainsIncludeErr := false
 
 	for _, err := range errs.WrappedErrors() {
@@ -629,6 +625,10 @@ func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger,
 			config.ProcessedIncludes = pctx.TrackInclude.CurrentMap
 			output = config
 		}
+	}
+
+	if pctx.Experiments.Evaluate(experiment.MarkManyAsRead) && output.Terraform != nil && output.Terraform.Source != nil {
+		markLocalModuleSourceAsRead(pctx, file.ConfigPath, *output.Terraform.Source)
 	}
 
 	if errs.ErrorOrNil() != nil {

--- a/pkg/config/mark_as_read_test.go
+++ b/pkg/config/mark_as_read_test.go
@@ -202,6 +202,52 @@ func TestMarkManyAsReadPartialParseSource(t *testing.T) {
 	}
 }
 
+// TestMarkManyAsReadPartialParseIncludedSource pins that the experiment hook still
+// fires when the terraform source comes from an included parent rather than the
+// leaf unit itself. The check runs after handleInclude, so output.Terraform is
+// populated from the merged parent at the time the experiment is evaluated.
+func TestMarkManyAsReadPartialParseIncludedSource(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "modules", "foo")
+	unitDir := filepath.Join(root, "units", "bar")
+
+	writeFile(t, filepath.Join(moduleDir, "main.tf"), "")
+	writeFile(t, filepath.Join(moduleDir, "variables.tf.json"), "{}")
+	writeFile(t, filepath.Join(moduleDir, "README.md"), "")
+
+	// Absolute source in the parent sidesteps relative-path resolution, which
+	// markLocalModuleSourceAsRead anchors to the leaf unit's directory.
+	parentPath := filepath.Join(root, "root.hcl")
+	writeFile(t, parentPath, fmt.Sprintf(`terraform { source = %q }`, moduleDir))
+
+	childPath := filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
+	writeFile(t, childPath, fmt.Sprintf(`include "root" { path = %q }`, parentPath))
+
+	for _, decode := range []config.PartialDecodeSectionType{config.TerraformSource, config.TerraformBlock} {
+		t.Run(fmt.Sprintf("decode_%d", decode), func(t *testing.T) {
+			t.Parallel()
+
+			l := logger.CreateLogger()
+			ctx, pctx := newTestParsingContext(t, childPath)
+			pctx.WorkingDir = unitDir
+			pctx = pctx.WithDecodeList(decode)
+			require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MarkManyAsRead))
+
+			out, err := config.PartialParseConfigFile(ctx, pctx, l, childPath, nil)
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			require.NotNil(t, pctx.FilesRead)
+
+			read := pctx.FilesRead.Paths()
+			assert.Contains(t, read, filepath.Join(moduleDir, "main.tf"))
+			assert.Contains(t, read, filepath.Join(moduleDir, "variables.tf.json"))
+			assert.NotContains(t, read, filepath.Join(moduleDir, "README.md"))
+		})
+	}
+}
+
 func writeFile(t *testing.T, path, contents string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses comments from #6174.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed discovery to properly record local module sources as read, enabling `--filter 'reading='` expressions to correctly match modules referenced in included parent configurations.

* **Tests**
  * Added test coverage for `mark-many-as-read` experiment behavior with included source configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->