### PR TITLE
chore: Getting rid of `go-homedir` direct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/mattn/go-zglob v0.0.6
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/glob"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -38,9 +37,9 @@ const (
 // FileOrData will read the contents of the data of the given arg if it is a file, and otherwise return the contents by
 // itself. This will return an error if the given path is a directory.
 func FileOrData(maybePath string) (string, error) {
-	// We can blindly pass in maybePath to homedir.Expand, because homedir.Expand only does something if the first
-	// character is ~, and if it is, there is a high chance of it being a path instead of data contents.
-	expandedMaybePath, err := homedir.Expand(maybePath)
+	// Blindly call expandHome: it's a no-op for anything that doesn't start with `~`,
+	// and a leading `~` is far more likely to be a path than literal data.
+	expandedMaybePath, err := expandHome(maybePath)
 	if err != nil {
 		return "", errors.New(err)
 	}
@@ -1867,6 +1866,26 @@ func SkipDirIfIgnorable(dir string) error {
 	}
 
 	return nil
+}
+
+// expandHome resolves a leading `~` (with no user qualifier) to the current
+// user's home directory. Anything else is returned unchanged. `~user/...` is
+// rejected because per-user lookup is platform-specific and not needed here.
+func expandHome(path string) (string, error) {
+	if path == "" || path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != filepath.Separator {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, path[1:]), nil
 }
 
 func (manifest *fileManifest) cleanManifestEntry(l log.Logger, fsys vfs.FS, rootDir string, entry fileManifestEntry) (string, error) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Gets rid of the `go-homedir` direct dependency (we still pull it in as an indirect dependency).

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized internal home-directory path handling to reduce external dependency usage.
* **Bug Fixes / Behavior**
  * Only a leading "~" (current user) is expanded to the home directory; "~user/..." forms are no longer expanded and will return an error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->