### PR TITLE
chore: Getting rid of `fatih/structs` dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/creack/pty v1.1.24
-	github.com/fatih/structs v1.1.0
 	github.com/gitsight/go-vcsurl v1.0.1
 	github.com/go-errors/errors v1.5.1
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,6 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
-github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
-github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/pkg/config/config_as_cty_test.go
+++ b/pkg/config/config_as_cty_test.go
@@ -1,10 +1,10 @@
 package config_test
 
 import (
+	"reflect"
 	"sort"
 	"testing"
 
-	"github.com/fatih/structs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -148,8 +148,7 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test the root properties
-	testConfigStructInfo := structs.New(testConfig)
-	testConfigFields := testConfigStructInfo.Names()
+	testConfigFields := structFieldNames(testConfig)
 	checked := map[string]bool{} // used to track which fields of the ctyMap were seen
 
 	for _, field := range testConfigFields {
@@ -243,8 +242,7 @@ func TestRemoteStateAsCtyDrift(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test the root properties
-	testConfigStructInfo := structs.New(testConfig)
-	testConfigFields := testConfigStructInfo.Names()
+	testConfigFields := structFieldNames(testConfig)
 	checked := map[string]bool{} // used to track which fields of the ctyMap were seen
 
 	for _, field := range testConfigFields {
@@ -273,11 +271,9 @@ func TestTerraformConfigAsCtyDrift(t *testing.T) {
 		"Mutable":             true,
 	}
 
-	terraformConfigStructInfo := structs.New(config.TerraformConfig{})
-
 	var terraformConfigFields []string
 
-	for _, name := range terraformConfigStructInfo.Names() {
+	for _, name := range structFieldNames(config.TerraformConfig{}) {
 		if omitWhenNilFields[name] {
 			continue
 		}
@@ -287,8 +283,7 @@ func TestTerraformConfigAsCtyDrift(t *testing.T) {
 
 	sort.Strings(terraformConfigFields)
 
-	ctyTerraformConfigStructInfo := structs.New(config.CtyTerraformConfig{})
-	ctyTerraformConfigFields := ctyTerraformConfigStructInfo.Names()
+	ctyTerraformConfigFields := structFieldNames(config.CtyTerraformConfig{})
 	sort.Strings(ctyTerraformConfigFields)
 	assert.Equal(t, terraformConfigFields, ctyTerraformConfigFields)
 }
@@ -406,4 +401,25 @@ func remoteStateStructFieldToMapKey(t *testing.T, fieldName string) (string, boo
 		// This should not execute
 		return "", false
 	}
+}
+
+// structFieldNames returns the exported field names declared on v's struct
+// type. v may be a struct value or a pointer to one. Embedded fields appear
+// under the embedded type's name, matching fatih/structs' behavior.
+func structFieldNames(v any) []string {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	names := make([]string, 0, t.NumField())
+
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if f.IsExported() {
+			names = append(names, f.Name)
+		}
+	}
+
+	return names
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Getting rid of `fatih/structs`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an unused third-party dependency to streamline the application and reduce external dependencies.
* **Tests**
  * Updated internal tests to replace the external helper with a local implementation, improving reliability and maintainability of drift-related tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->