### PR TITLE
feat: add hook-context-env experiment

### DIFF
--- a/docs/src/content/docs/03-features/01-units/06-hooks.mdx
+++ b/docs/src/content/docs/03-features/01-units/06-hooks.mdx
@@ -57,6 +57,12 @@ All hooks add extra environment variables when executing the hook's run command:
 - `TG_CTX_COMMAND`
 - `TG_CTX_HOOK_NAME`
 
+When the [`hook-context-env`](/reference/experiments/active#hook-context-env) experiment is enabled, three additional variables are also set:
+
+- `TG_CTX_HOOK_TYPE` — `before_hook`, `after_hook`, or `error_hook`
+- `TG_CTX_SOURCE` — the resolved terraform source URL (CLI `--source` override, else evaluated `terraform.source` with source-map applied, else `.`)
+- `TG_CTX_TERRAGRUNT_DIR` — the directory of the current Terragrunt config
+
 For example:
 
 ```hcl

--- a/docs/src/data/changelog/v1.0.7/hook-context-env.mdx
+++ b/docs/src/data/changelog/v1.0.7/hook-context-env.mdx
@@ -1,0 +1,18 @@
+---
+version: "v1.0.7"
+category: "experiments-added"
+---
+
+#### `hook-context-env` experiment exposes additional `TG_CTX_*` env vars to hooks
+
+Enable the new [`hook-context-env`](/reference/experiments/active#hook-context-env) experiment to surface three additional environment variables to every `before_hook`, `after_hook`, and `error_hook`:
+
+- `TG_CTX_HOOK_TYPE` — `before_hook`, `after_hook`, or `error_hook`, identifying which lifecycle phase invoked the hook.
+- `TG_CTX_SOURCE` — the resolved terraform source URL (CLI `--source` override, else evaluated `terraform.source` with source-map applied, else `.`).
+- `TG_CTX_TERRAGRUNT_DIR` — the directory of the current Terragrunt config.
+
+```bash
+terragrunt run --all --experiment hook-context-env -- apply
+```
+
+These variables make it easier to share a single hook script across lifecycle phases and to access the unit's source and config directory without threading them through hook arguments.

--- a/docs/src/data/changelog/v1.0.8/hook-context-env.mdx
+++ b/docs/src/data/changelog/v1.0.8/hook-context-env.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.0.7"
+version: "v1.0.8"
 category: "experiments-added"
 ---
 

--- a/docs/src/data/experiments/hook-context-env.mdx
+++ b/docs/src/data/experiments/hook-context-env.mdx
@@ -1,0 +1,49 @@
+---
+name: hook-context-env
+status: active
+since: "1.0.7"
+---
+
+Expose additional `TG_CTX_*` environment variables to hook scripts.
+
+### `hook-context-env` - What it does
+
+When enabled, Terragrunt sets three additional environment variables on the process running every `before_hook`, `after_hook`, and `error_hook`:
+
+- `TG_CTX_HOOK_TYPE` — `before_hook`, `after_hook`, or `error_hook`, depending on which lifecycle phase is executing the hook.
+- `TG_CTX_SOURCE` — the resolved terraform source URL for the current unit, matching the precedence Terragrunt uses for the actual download: the `--source` CLI override if set, otherwise the evaluated `terraform.source` (with `--source-map` applied), otherwise `.`.
+- `TG_CTX_TERRAGRUNT_DIR` — the directory containing the current Terragrunt config (equivalent to `get_terragrunt_dir()`).
+
+These variables make it easier for hook scripts to branch on lifecycle phase, to know whether the unit pulls remote source, and to locate the config directory without having to thread that information through hook arguments.
+
+```bash
+terragrunt run --all --experiment hook-context-env -- apply
+```
+
+Example hook script:
+
+```bash
+#!/usr/bin/env bash
+
+case "$TG_CTX_HOOK_TYPE" in
+  before_hook) echo "preparing $TG_CTX_TERRAGRUNT_DIR" ;;
+  after_hook)  echo "cleaning up $TG_CTX_TERRAGRUNT_DIR" ;;
+  error_hook)  echo "failure in $TG_CTX_TERRAGRUNT_DIR" ;;
+esac
+
+if [ "$TG_CTX_SOURCE" != "." ]; then
+  echo "unit uses source: $TG_CTX_SOURCE"
+fi
+```
+
+### `hook-context-env` - How to provide feedback
+
+Provide your feedback in the [`hook-context-env` GitHub Discussion](https://github.com/gruntwork-io/terragrunt/discussions/6185).
+
+### `hook-context-env` - Criteria for stabilization
+
+To transition the `hook-context-env` feature to a stable release, the following must be addressed:
+
+- [ ] Confirm the three new variables cover the most common hook scripting needs.
+- [ ] Confirm the chosen variable names and values (`before_hook`/`after_hook`/`error_hook`) match user expectations.
+- [ ] Positive feedback from users relying on the variables in production hook scripts.

--- a/docs/src/data/experiments/hook-context-env.mdx
+++ b/docs/src/data/experiments/hook-context-env.mdx
@@ -1,7 +1,7 @@
 ---
 name: hook-context-env
 status: active
-since: "1.0.7"
+since: "1.0.8"
 ---
 
 Expose additional `TG_CTX_*` environment variables to hook scripts.

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -66,6 +66,9 @@ const (
 	// OptOutAuth gates flags that opt out of running --auth-provider-cmd in
 	// specific phases (currently --no-discovery-auth-provider-cmd).
 	OptOutAuth = "opt-out-auth"
+	// HookContextEnv exposes additional TG_CTX_* environment variables to hook
+	// scripts: TG_CTX_HOOK_TYPE, TG_CTX_SOURCE, and TG_CTX_TERRAGRUNT_DIR.
+	HookContextEnv = "hook-context-env"
 )
 
 const (
@@ -141,6 +144,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: OptOutAuth,
+		},
+		{
+			Name: HookContextEnv,
 		},
 	}
 }

--- a/internal/prepare/prepare.go
+++ b/internal/prepare/prepare.go
@@ -98,9 +98,10 @@ func PrepareSource(
 
 	if err = optsClone.RunWithErrorHandling(ctx, l, r, func() error {
 		return run.ProcessHooks(ctx, l, run.OSVenv(), run.ProcessHooksParams{
-			Hooks: runCfg.Terraform.AfterHooks,
-			Opts:  configbridge.NewRunOptions(optsClone),
-			Cfg:   runCfg,
+			Hooks:    runCfg.Terraform.AfterHooks,
+			Opts:     configbridge.NewRunOptions(optsClone),
+			Cfg:      runCfg,
+			HookType: run.HookTypeAfter,
 		})
 	}); err != nil {
 		return nil, err

--- a/internal/runner/run/hook.go
+++ b/internal/runner/run/hook.go
@@ -33,7 +33,8 @@ const (
 )
 
 const (
-	HookTypeBefore HookType = iota
+	HookTypeUnknown HookType = iota
+	HookTypeBefore
 	HookTypeAfter
 	HookTypeError
 )
@@ -46,12 +47,12 @@ var hookTypeNames = map[HookType]string{
 
 type HookType byte
 
-func (h HookType) String() string {
-	if name, ok := hookTypeNames[h]; ok {
-		return name
+func hookTypeName(hookType HookType) (string, bool) {
+	if name, ok := hookTypeNames[hookType]; ok {
+		return name, true
 	}
 
-	return "unknown_hook"
+	return "", false
 }
 
 // ProcessHooksParams groups the configuration and data inputs for ProcessHooks.
@@ -143,7 +144,11 @@ func ProcessErrorHooks(
 
 				actionToExecute := curHook.Execute[0]
 				actionParams := curHook.Execute[1:]
-				hookOpts := optsWithHookEnvs(opts, cfg, curHook.Name, HookTypeError)
+
+				hookOpts, hookOptsErr := optsWithHookEnvs(opts, cfg, curHook.Name, HookTypeError)
+				if hookOptsErr != nil {
+					return hookOptsErr
+				}
 
 				_, possibleError := shell.RunCommandWithOutput(
 					ctx,
@@ -230,7 +235,11 @@ func runHook(
 
 	actionToExecute := curHook.Execute[0]
 	actionParams := curHook.Execute[1:]
-	hookOpts := optsWithHookEnvs(opts, cfg, curHook.Name, hookType)
+
+	hookOpts, err := optsWithHookEnvs(opts, cfg, curHook.Name, hookType)
+	if err != nil {
+		return err
+	}
 
 	if actionToExecute == "tflint" {
 		return executeTFLint(ctx, l, v, opts, cfg, curHook, workingDir)
@@ -278,7 +287,7 @@ func executeTFLint(
 	return nil
 }
 
-func optsWithHookEnvs(opts *Options, cfg *runcfg.RunConfig, hookName string, hookType HookType) *Options {
+func optsWithHookEnvs(opts *Options, cfg *runcfg.RunConfig, hookName string, hookType HookType) (*Options, error) {
 	newOpts := *opts
 	newOpts.Env = cloner.Clone(opts.Env)
 	newOpts.Env[HookCtxTFPathEnvName] = opts.TFPath
@@ -286,15 +295,20 @@ func optsWithHookEnvs(opts *Options, cfg *runcfg.RunConfig, hookName string, hoo
 	newOpts.Env[HookCtxHookNameEnvName] = hookName
 
 	if opts.Experiments.Evaluate(experiment.HookContextEnv) {
-		source, err := runcfg.GetTerraformSourceURL(opts.Source, opts.SourceMap, opts.OriginalTerragruntConfigPath, cfg)
-		if err != nil {
-			source = cfg.Terraform.Source
+		hookTypeValue, ok := hookTypeName(hookType)
+		if !ok {
+			return nil, fmt.Errorf("unknown hook type: %d", hookType)
 		}
 
-		newOpts.Env[HookCtxHookTypeEnvName] = hookType.String()
+		source, err := runcfg.GetTerraformSourceURL(opts.Source, opts.SourceMap, opts.OriginalTerragruntConfigPath, cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		newOpts.Env[HookCtxHookTypeEnvName] = hookTypeValue
 		newOpts.Env[HookCtxSourceEnvName] = source
 		newOpts.Env[HookCtxTerragruntDirEnvName] = filepath.Dir(opts.TerragruntConfigPath)
 	}
 
-	return &newOpts
+	return &newOpts, nil
 }

--- a/internal/runner/run/hook.go
+++ b/internal/runner/run/hook.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
 
 	"github.com/gruntwork-io/terragrunt/internal/cloner"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/multierror"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
@@ -23,7 +25,34 @@ const (
 	HookCtxTFPathEnvName   = "TG_CTX_TF_PATH"
 	HookCtxCommandEnvName  = "TG_CTX_COMMAND"
 	HookCtxHookNameEnvName = "TG_CTX_HOOK_NAME"
+
+	// The following are gated behind the hook-context-env experiment.
+	HookCtxHookTypeEnvName      = "TG_CTX_HOOK_TYPE"
+	HookCtxSourceEnvName        = "TG_CTX_SOURCE"
+	HookCtxTerragruntDirEnvName = "TG_CTX_TERRAGRUNT_DIR"
 )
+
+const (
+	HookTypeBefore HookType = iota
+	HookTypeAfter
+	HookTypeError
+)
+
+var hookTypeNames = map[HookType]string{
+	HookTypeBefore: "before_hook",
+	HookTypeAfter:  "after_hook",
+	HookTypeError:  "error_hook",
+}
+
+type HookType byte
+
+func (h HookType) String() string {
+	if name, ok := hookTypeNames[h]; ok {
+		return name
+	}
+
+	return "unknown_hook"
+}
 
 // ProcessHooksParams groups the configuration and data inputs for ProcessHooks.
 type ProcessHooksParams struct {
@@ -31,6 +60,7 @@ type ProcessHooksParams struct {
 	Cfg                *runcfg.RunConfig
 	PreviousExecErrors []error
 	Hooks              []runcfg.Hook
+	HookType           HookType
 }
 
 // ProcessHooks processes a list of hooks, executing each one that matches the current command.
@@ -59,7 +89,7 @@ func ProcessHooks(ctx context.Context, l log.Logger, v Venv, p ProcessHooksParam
 				"hook": curHook.Name,
 				"dir":  curHook.WorkingDir,
 			}, func(ctx context.Context) error {
-				return runHook(ctx, l, v, p.Opts, p.Cfg, curHook)
+				return runHook(ctx, l, v, p.Opts, p.Cfg, curHook, p.HookType)
 			})
 			if err != nil {
 				allPreviousErrors = append(allPreviousErrors, err)
@@ -77,6 +107,7 @@ func ProcessErrorHooks(
 	l log.Logger,
 	exec vexec.Exec,
 	hooks []runcfg.ErrorHook,
+	cfg *runcfg.RunConfig,
 	opts *Options,
 	previousExecErrors []error,
 ) error {
@@ -112,7 +143,7 @@ func ProcessErrorHooks(
 
 				actionToExecute := curHook.Execute[0]
 				actionParams := curHook.Execute[1:]
-				hookOpts := optsWithHookEnvs(opts, curHook.Name)
+				hookOpts := optsWithHookEnvs(opts, cfg, curHook.Name, HookTypeError)
 
 				_, possibleError := shell.RunCommandWithOutput(
 					ctx,
@@ -190,6 +221,7 @@ func runHook(
 	opts *Options,
 	cfg *runcfg.RunConfig,
 	curHook *runcfg.Hook,
+	hookType HookType,
 ) error {
 	l.Infof("Executing hook: %s", curHook.Name)
 
@@ -198,7 +230,7 @@ func runHook(
 
 	actionToExecute := curHook.Execute[0]
 	actionParams := curHook.Execute[1:]
-	hookOpts := optsWithHookEnvs(opts, curHook.Name)
+	hookOpts := optsWithHookEnvs(opts, cfg, curHook.Name, hookType)
 
 	if actionToExecute == "tflint" {
 		return executeTFLint(ctx, l, v, opts, cfg, curHook, workingDir)
@@ -246,12 +278,23 @@ func executeTFLint(
 	return nil
 }
 
-func optsWithHookEnvs(opts *Options, hookName string) *Options {
+func optsWithHookEnvs(opts *Options, cfg *runcfg.RunConfig, hookName string, hookType HookType) *Options {
 	newOpts := *opts
 	newOpts.Env = cloner.Clone(opts.Env)
 	newOpts.Env[HookCtxTFPathEnvName] = opts.TFPath
 	newOpts.Env[HookCtxCommandEnvName] = opts.TerraformCommand
 	newOpts.Env[HookCtxHookNameEnvName] = hookName
+
+	if opts.Experiments.Evaluate(experiment.HookContextEnv) {
+		source, err := runcfg.GetTerraformSourceURL(opts.Source, opts.SourceMap, opts.OriginalTerragruntConfigPath, cfg)
+		if err != nil {
+			source = cfg.Terraform.Source
+		}
+
+		newOpts.Env[HookCtxHookTypeEnvName] = hookType.String()
+		newOpts.Env[HookCtxSourceEnvName] = source
+		newOpts.Env[HookCtxTerragruntDirEnvName] = filepath.Dir(opts.TerragruntConfigPath)
+	}
 
 	return &newOpts
 }

--- a/internal/runner/run/hook_test.go
+++ b/internal/runner/run/hook_test.go
@@ -250,7 +250,7 @@ func TestProcessErrorHooks_NoopWhenNoPriorErrors(t *testing.T) {
 		{Name: "on-anything", Commands: []string{"plan"}, OnErrors: []string{".*"}, Execute: []string{"echo", "x"}},
 	}
 
-	require.NoError(t, run.ProcessErrorHooks(t.Context(), l, exec, hooks, newHookOpts(), nil))
+	require.NoError(t, run.ProcessErrorHooks(t.Context(), l, exec, hooks, &runcfg.RunConfig{}, newHookOpts(), nil))
 	assert.Empty(t, rec.snapshot())
 }
 
@@ -284,7 +284,7 @@ func TestProcessErrorHooks_MatchesOnErrorsRegex(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, run.ProcessErrorHooks(t.Context(), l, exec, hooks, newHookOpts(), priorErrs))
+	require.NoError(t, run.ProcessErrorHooks(t.Context(), l, exec, hooks, &runcfg.RunConfig{}, newHookOpts(), priorErrs))
 
 	calls := rec.snapshot()
 	require.Len(t, calls, 1)

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -114,9 +114,10 @@ func Run(
 
 	if err = terragruntOptionsClone.RunWithErrorHandling(ctx, l, r, func() error {
 		return ProcessHooks(ctx, l, OSVenv(), ProcessHooksParams{
-			Hooks: cfg.Terraform.AfterHooks,
-			Opts:  terragruntOptionsClone,
-			Cfg:   cfg,
+			Hooks:    cfg.Terraform.AfterHooks,
+			Opts:     terragruntOptionsClone,
+			Cfg:      cfg,
+			HookType: HookTypeAfter,
 		})
 	}); err != nil {
 		return err
@@ -359,6 +360,7 @@ func RunActionWithHooks(
 		Hooks:              cfg.Terraform.BeforeHooks,
 		Opts:               opts,
 		Cfg:                cfg,
+		HookType:           HookTypeBefore,
 		PreviousExecErrors: allErrors,
 	})
 	if beforeHookErrors != nil {
@@ -377,12 +379,13 @@ func RunActionWithHooks(
 		Hooks:              cfg.Terraform.AfterHooks,
 		Opts:               opts,
 		Cfg:                cfg,
+		HookType:           HookTypeAfter,
 		PreviousExecErrors: allErrors,
 	}); postHookErrors != nil {
 		allErrors = append(allErrors, postHookErrors)
 	}
 
-	if errorHookErrors := ProcessErrorHooks(ctx, l, v.Exec, cfg.Terraform.ErrorHooks, opts, allErrors); errorHookErrors != nil {
+	if errorHookErrors := ProcessErrorHooks(ctx, l, v.Exec, cfg.Terraform.ErrorHooks, cfg, opts, allErrors); errorHookErrors != nil {
 		allErrors = append(allErrors, errorHookErrors)
 	}
 

--- a/test/fixtures/hooks/hook-context-env/hook.sh
+++ b/test/fixtures/hooks/hook-context-env/hook.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -u
+
+out_file="$1"
+
+{
+	echo "TG_CTX_TF_PATH=${TG_CTX_TF_PATH-<unset>}"
+	echo "TG_CTX_COMMAND=${TG_CTX_COMMAND-<unset>}"
+	echo "TG_CTX_HOOK_NAME=${TG_CTX_HOOK_NAME-<unset>}"
+	echo "TG_CTX_HOOK_TYPE=${TG_CTX_HOOK_TYPE-<unset>}"
+	echo "TG_CTX_SOURCE=${TG_CTX_SOURCE-<unset>}"
+	echo "TG_CTX_TERRAGRUNT_DIR=${TG_CTX_TERRAGRUNT_DIR-<unset>}"
+} >"${out_file}"

--- a/test/fixtures/hooks/hook-context-env/modules/foo/.terraform.lock.hcl
+++ b/test/fixtures/hooks/hook-context-env/modules/foo/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = "~> 3.2.4"
+  hashes = [
+    "h1:i+WKhUHL2REY5EGmiHjfUljJB8UKZ9QdhdM5uTeUhC4=",
+    "h1:jsKjBiLb+v3OIC3xuDiY4sR0r1OHUMSWPYKult9MhT0=",
+    "h1:wg0cxqzzWFNnEzw0LSlPL9Ovqy1VFW44A7ayHEU/A1I=",
+    "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
+    "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",
+    "zh:339bf8c2f9733fce068eb6d5612701144c752425cebeafab36563a16be460fb2",
+    "zh:36731f23343aee12a7e078067a98644c0126714c4fe9ac930eecb0f2361788c4",
+    "zh:3d106c7e32a929e2843f732625a582e562ff09120021e510a51a6f5d01175b8d",
+    "zh:74bcb3567708171ad83b234b92c9d63ab441ef882b770b0210c2b14fdbe3b1b6",
+    "zh:90b55bdbffa35df9204282251059e62c178b0ac7035958b93a647839643c0072",
+    "zh:ae24c0e5adc692b8f94cb23a000f91a316070fdc19418578dcf2134ff57cf447",
+    "zh:b5c10d4ad860c4c21273203d1de6d2f0286845edf1c64319fa2362df526b5f58",
+    "zh:e05bbd88e82e1d6234988c85db62fd66f11502645838fff594a2ec25352ecd80",
+  ]
+}

--- a/test/fixtures/hooks/hook-context-env/modules/foo/main.tf
+++ b/test/fixtures/hooks/hook-context-env/modules/foo/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    null = {
+      source  = "registry.opentofu.org/hashicorp/null"
+      version = "~> 3.2.4"
+    }
+  }
+}
+
+resource "null_resource" "fail" {
+  provisioner "local-exec" {
+    command = "exit 1"
+  }
+}

--- a/test/fixtures/hooks/hook-context-env/terragrunt.hcl
+++ b/test/fixtures/hooks/hook-context-env/terragrunt.hcl
@@ -1,0 +1,20 @@
+terraform {
+  source = "${get_terragrunt_dir()}/modules/foo"
+
+  before_hook "shared_name_hook" {
+    commands = ["apply"]
+    execute  = ["${get_terragrunt_dir()}/hook.sh", "${get_terragrunt_dir()}/before.out"]
+  }
+
+  after_hook "shared_name_hook" {
+    commands     = ["apply"]
+    execute      = ["${get_terragrunt_dir()}/hook.sh", "${get_terragrunt_dir()}/after.out"]
+    run_on_error = true
+  }
+
+  error_hook "error_hook_1" {
+    commands  = ["apply"]
+    on_errors = [".*"]
+    execute   = ["${get_terragrunt_dir()}/hook.sh", "${get_terragrunt_dir()}/error.out"]
+  }
+}

--- a/test/integration_hooks_test.go
+++ b/test/integration_hooks_test.go
@@ -36,6 +36,7 @@ const (
 	testFixtureTerragruntHookIfParameter                          = "fixtures/hooks/if-parameter"
 	testFixtureHooksPathPreservation                              = "fixtures/hooks/path-preservation"
 	testFixtureHooksExitCodeError                                 = "fixtures/hooks/exit-code-error"
+	testFixtureHooksContextEnv                                    = "fixtures/hooks/hook-context-env"
 )
 
 func TestTerragruntHookIfParameter(t *testing.T) {
@@ -460,6 +461,87 @@ func TestTerragruntHookPreservesAbsolutePaths(t *testing.T) {
 	// NOT converted to a relative path like "../../../.terraform.d/plugin-cache"
 	assert.Contains(t, stderr, "/home/testuser/.terraform.d/plugin-cache")
 	assert.NotContains(t, stderr, "../")
+}
+
+func TestTerragruntHookContextEnvExperimentEnabled(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureHooksContextEnv)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureHooksContextEnv)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureHooksContextEnv)
+
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+	)
+
+	err := helpers.RunTerragruntCommand(
+		t,
+		"terragrunt apply -auto-approve --non-interactive --experiment hook-context-env --working-dir "+rootPath,
+		&stdout,
+		&stderr,
+	)
+	require.Error(t, err)
+
+	beforeOut, readErr := os.ReadFile(filepath.Join(rootPath, "before.out"))
+	require.NoError(t, readErr)
+	afterOut, readErr := os.ReadFile(filepath.Join(rootPath, "after.out"))
+	require.NoError(t, readErr)
+	errorOut, readErr := os.ReadFile(filepath.Join(rootPath, "error.out"))
+	require.NoError(t, readErr)
+
+	assert.Contains(t, string(beforeOut), "TG_CTX_HOOK_TYPE=before_hook")
+	assert.Contains(t, string(beforeOut), "TG_CTX_HOOK_NAME=shared_name_hook")
+	assert.Contains(t, string(beforeOut), "TG_CTX_TERRAGRUNT_DIR="+rootPath)
+	assert.Contains(t, string(beforeOut), "TG_CTX_SOURCE="+rootPath+"/modules/foo")
+
+	assert.Contains(t, string(afterOut), "TG_CTX_HOOK_TYPE=after_hook")
+	assert.Contains(t, string(afterOut), "TG_CTX_HOOK_NAME=shared_name_hook")
+	assert.Contains(t, string(afterOut), "TG_CTX_TERRAGRUNT_DIR="+rootPath)
+	assert.Contains(t, string(afterOut), "TG_CTX_SOURCE="+rootPath+"/modules/foo")
+
+	assert.Contains(t, string(errorOut), "TG_CTX_HOOK_TYPE=error_hook")
+	assert.Contains(t, string(errorOut), "TG_CTX_HOOK_NAME=error_hook_1")
+	assert.Contains(t, string(errorOut), "TG_CTX_TERRAGRUNT_DIR="+rootPath)
+	assert.Contains(t, string(errorOut), "TG_CTX_SOURCE="+rootPath+"/modules/foo")
+}
+
+func TestTerragruntHookContextEnvExperimentDisabled(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureHooksContextEnv)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureHooksContextEnv)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureHooksContextEnv)
+
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+	)
+
+	err := helpers.RunTerragruntCommand(
+		t,
+		"terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath,
+		&stdout,
+		&stderr,
+	)
+	require.Error(t, err)
+
+	beforeOut, readErr := os.ReadFile(filepath.Join(rootPath, "before.out"))
+	require.NoError(t, readErr)
+	afterOut, readErr := os.ReadFile(filepath.Join(rootPath, "after.out"))
+	require.NoError(t, readErr)
+	errorOut, readErr := os.ReadFile(filepath.Join(rootPath, "error.out"))
+	require.NoError(t, readErr)
+
+	// The existing context env vars are still set unconditionally.
+	assert.Contains(t, string(beforeOut), "TG_CTX_HOOK_NAME=shared_name_hook")
+
+	// The new env vars must NOT be set when the experiment is disabled.
+	for _, out := range [][]byte{beforeOut, afterOut, errorOut} {
+		assert.Contains(t, string(out), "TG_CTX_HOOK_TYPE=<unset>")
+		assert.Contains(t, string(out), "TG_CTX_SOURCE=<unset>")
+		assert.Contains(t, string(out), "TG_CTX_TERRAGRUNT_DIR=<unset>")
+	}
 }
 
 func TestTerragruntHookExitCodeError(t *testing.T) {

--- a/test/integration_hooks_test.go
+++ b/test/integration_hooks_test.go
@@ -490,24 +490,30 @@ func TestTerragruntHookContextEnvExperimentEnabled(t *testing.T) {
 	errorOut, readErr := os.ReadFile(filepath.Join(rootPath, "error.out"))
 	require.NoError(t, readErr)
 
+	wantSource := filepath.Join(rootPath, "modules", "foo")
+
 	assert.Contains(t, string(beforeOut), "TG_CTX_HOOK_TYPE=before_hook")
 	assert.Contains(t, string(beforeOut), "TG_CTX_HOOK_NAME=shared_name_hook")
 	assert.Contains(t, string(beforeOut), "TG_CTX_TERRAGRUNT_DIR="+rootPath)
-	assert.Contains(t, string(beforeOut), "TG_CTX_SOURCE="+rootPath+"/modules/foo")
+	assert.Contains(t, string(beforeOut), "TG_CTX_SOURCE="+wantSource)
 
 	assert.Contains(t, string(afterOut), "TG_CTX_HOOK_TYPE=after_hook")
 	assert.Contains(t, string(afterOut), "TG_CTX_HOOK_NAME=shared_name_hook")
 	assert.Contains(t, string(afterOut), "TG_CTX_TERRAGRUNT_DIR="+rootPath)
-	assert.Contains(t, string(afterOut), "TG_CTX_SOURCE="+rootPath+"/modules/foo")
+	assert.Contains(t, string(afterOut), "TG_CTX_SOURCE="+wantSource)
 
 	assert.Contains(t, string(errorOut), "TG_CTX_HOOK_TYPE=error_hook")
 	assert.Contains(t, string(errorOut), "TG_CTX_HOOK_NAME=error_hook_1")
 	assert.Contains(t, string(errorOut), "TG_CTX_TERRAGRUNT_DIR="+rootPath)
-	assert.Contains(t, string(errorOut), "TG_CTX_SOURCE="+rootPath+"/modules/foo")
+	assert.Contains(t, string(errorOut), "TG_CTX_SOURCE="+wantSource)
 }
 
 func TestTerragruntHookContextEnvExperimentDisabled(t *testing.T) {
 	t.Parallel()
+
+	if helpers.IsExperimentMode(t) {
+		t.Skip()
+	}
 
 	helpers.CleanupTerraformFolder(t, testFixtureHooksContextEnv)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureHooksContextEnv)


### PR DESCRIPTION
Fixes #6172.

Introduces a new `hook-context-env` experiment that exposes three additional environment variables to `before_hook`, `after_hook`, and `error_hook` scripts:

- `TG_CTX_HOOK_TYPE` — `before_hook`, `after_hook`, or `error_hook`, identifying which lifecycle phase invoked the hook.
- `TG_CTX_SOURCE` — the resolved terraform source URL.
- `TG_CTX_TERRAGRUNT_DIR` — the directory of the current Terragrunt config.

The new variables are gated behind the experiment so existing users see no behavior change. See discussion [#6185](https://github.com/gruntwork-io/terragrunt/discussions/6185) for motivation and feedback.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `hook-context-env` experiment which exposes three additional hook environment variables: TG_CTX_HOOK_TYPE, TG_CTX_SOURCE, TG_CTX_TERRAGRUNT_DIR.

* **Documentation**
  * Added docs, examples, and a changelog entry explaining the experiment, variables, usage, and stabilization criteria.

* **Tests**
  * Added integration tests, unit updates and fixtures to verify hook environment behavior with the experiment enabled and disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->