### PR TITLE
fix: unit config_path resolution when using stack dependencies

### DIFF
--- a/internal/hclparse/parse.go
+++ b/internal/hclparse/parse.go
@@ -42,10 +42,29 @@ type ParseStackFileInput struct {
 	Functions map[string]function.Function
 	// Filename is the basename (not full path) used for parse diagnostics.
 	Filename string
-	// StackDir is used to resolve include paths.
+	// StackDir is the directory the stack file currently lives in. Generated
+	// units land in StackDir/.terragrunt-stack/<unit>, so unit.*.path and
+	// stack.*.path are computed against this directory.
 	StackDir string
+	// SourceResolveDir anchors relative `source` strings and include `path`
+	// values against the catalog source directory. Defaults to StackDir when
+	// empty. Set this to the original catalog path when the stack file was
+	// copied from a catalog (see .terragrunt-stack-origin) so source/include
+	// resolution targets the catalog, while unit/stack path refs still resolve
+	// against the generated StackDir.
+	SourceResolveDir string
 	// Src is the raw stack file bytes.
 	Src []byte
+}
+
+// resolveSourceDir returns the dir to use for resolving relative source and
+// include paths, defaulting to StackDir when SourceResolveDir is empty.
+func (i *ParseStackFileInput) resolveSourceDir() string {
+	if i.SourceResolveDir != "" {
+		return i.SourceResolveDir
+	}
+
+	return i.StackDir
 }
 
 // ParseResult holds the output of ParseStackFile.
@@ -79,8 +98,10 @@ func ParseStackFile(fs vfs.FS, input *ParseStackFileInput) (*ParseResult, error)
 	// srcByFilename tracks source bytes by filename so the generator can slice expression bytes from the correct file even after include merging.
 	srcByFilename := map[string][]byte{input.Filename: input.Src}
 
-	// Phase 3 resolves include blocks and merges included Remain bodies.
-	mergedRemain, err := mergeIncludes(fs, parsedStackFile, input.StackDir, evalCtx, srcByFilename)
+	sourceResolveDir := input.resolveSourceDir()
+
+	// Phase 3 resolves include blocks and merges included Remain bodies; relative include paths resolve against the catalog source dir, not the generated stack dir.
+	mergedRemain, err := mergeIncludes(fs, parsedStackFile, sourceResolveDir, evalCtx, srcByFilename)
 	if err != nil {
 		return result, err
 	}

--- a/internal/hclparse/parse_test.go
+++ b/internal/hclparse/parse_test.go
@@ -80,6 +80,95 @@ unit "db" {
 	assert.NotNil(t, resolved.RawBody)
 }
 
+// TestParseStackFile_AutoIncludeUsesGeneratedStackDir pins the behavior that
+// unit.*.path inside an autoinclude block resolves against the generated
+// StackDir, not the catalog SourceResolveDir. This is the case when a stack
+// file has been copied from a catalog and a .terragrunt-stack-origin sidecar
+// redirects source resolution: unit paths must still point at the generated
+// location where units will actually land on disk.
+func TestParseStackFile_AutoIncludeUsesGeneratedStackDir(t *testing.T) {
+	t.Parallel()
+
+	const (
+		generatedStackDir = "/generated/us-gov-west-1"
+		catalogSourceDir  = "/catalog/us-gov-west-1"
+	)
+
+	src := `
+unit "s3" {
+  source = "../catalog/units/s3"
+  path   = "s3"
+
+  autoinclude {
+    dependency "kms" {
+      config_path = unit.kms.path
+    }
+  }
+}
+
+unit "kms" {
+  source = "../catalog/units/kms"
+  path   = "kms"
+}
+`
+
+	result, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{
+		Src:              []byte(src),
+		Filename:         "terragrunt.stack.hcl",
+		StackDir:         generatedStackDir,
+		SourceResolveDir: catalogSourceDir,
+	})
+	require.NoError(t, err)
+
+	resolved, ok := result.AutoIncludes[hclparse.AutoIncludeKey("unit", "s3")]
+	require.True(t, ok)
+	require.Len(t, resolved.Dependencies, 1)
+
+	expectedPath := filepath.Join(generatedStackDir, ".terragrunt-stack", "kms")
+	assert.Equal(t, expectedPath, resolved.Dependencies[0].ConfigPath,
+		"unit.kms.path must resolve to the generated StackDir, not SourceResolveDir")
+}
+
+// TestParseStackFile_SourceResolveDirDefaultsToStackDir pins the backwards-
+// compatible fallback: when SourceResolveDir is empty, unit paths and source
+// resolution both anchor on StackDir.
+func TestParseStackFile_SourceResolveDirDefaultsToStackDir(t *testing.T) {
+	t.Parallel()
+
+	src := `
+unit "s3" {
+  source = "../catalog/units/s3"
+  path   = "s3"
+
+  autoinclude {
+    dependency "kms" {
+      config_path = unit.kms.path
+    }
+  }
+}
+
+unit "kms" {
+  source = "../catalog/units/kms"
+  path   = "kms"
+}
+`
+
+	result, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{
+		Src:      []byte(src),
+		Filename: "terragrunt.stack.hcl",
+		StackDir: testStackDir,
+	})
+	require.NoError(t, err)
+
+	resolved, ok := result.AutoIncludes[hclparse.AutoIncludeKey("unit", "s3")]
+	require.True(t, ok)
+	require.Len(t, resolved.Dependencies, 1)
+
+	assert.Equal(t,
+		filepath.Join(testStackDir, ".terragrunt-stack", "kms"),
+		resolved.Dependencies[0].ConfigPath)
+}
+
 func TestParseStackFile_MultipleDependencies(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -155,13 +155,18 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 			return AutoIncludeParserStageError{Stage: "eval-context", File: stackFilePath, Err: evalCtxErr}
 		}
 
+		// StackDir must be the GENERATED location so unit.*.path / stack.*.path
+		// resolve to where units actually land. SourceResolveDir carries the
+		// catalog origin so relative `source` strings and include paths still
+		// resolve against the original catalog.
 		parseResult, parseErr := inthclparse.ParseStackFile(vfs.NewOSFS(), &inthclparse.ParseStackFileInput{
-			Src:       stackSrcBytes,
-			Filename:  filepath.Base(stackFilePath),
-			StackDir:  resolveDir,
-			Values:    values,
-			Variables: prodEvalCtx.Variables,
-			Functions: prodEvalCtx.Functions,
+			Src:              stackSrcBytes,
+			Filename:         filepath.Base(stackFilePath),
+			StackDir:         stackSourceDir,
+			SourceResolveDir: resolveDir,
+			Values:           values,
+			Variables:        prodEvalCtx.Variables,
+			Functions:        prodEvalCtx.Functions,
 		})
 		if parseErr != nil {
 			return AutoIncludeParserStageError{Stage: "parse", File: stackFilePath, Err: parseErr}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #5663, [comment](https://github.com/gruntwork-io/terragrunt/issues/5663#issuecomment-4548804756)

<!-- Description of the changes introduced by this PR. -->

When using stack dependencies autoinclude feature, config_path resolves correctly when using unit path 
```
  autoinclude {
    dependency "kms" {
      config_path = unit.kms.path
    }

    inputs = {
      kms_input = dependency.kms.outputs.kms_output
    }
  }
```

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved path resolution for include statements in stack configurations, ensuring relative paths are anchored correctly to their source origin while maintaining compatibility with existing configurations.

* **Tests**
  * Added tests to verify correct behavior for path resolution in include blocks across different configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->