### PR TITLE
validate that `--parallelism` value is positive

### DIFF
--- a/docs/src/data/changelog/v1.0.7/parallelism-flag-validation.mdx
+++ b/docs/src/data/changelog/v1.0.7/parallelism-flag-validation.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.7"
+category: "bug-fixes"
+---
+
+#### the `--parallelism` flag no longer accepts non-positive numbers
+
+Previously, terragrunt commands that accept the --parallelism flag (or equivalently the `$TG_PARALLELISM` environment variable) used to hang indefinitely when invoked with `--parallelism=0`.
+
+Terragrunt now validates that the value is positive and exits with an error otherwise.
+
+Reported in [#6211](https://github.com/gruntwork-io/terragrunt/issues/6211)

--- a/internal/cli/flags/shared/parallelism.go
+++ b/internal/cli/flags/shared/parallelism.go
@@ -1,6 +1,8 @@
 package shared
 
 import (
+	"errors"
+
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -8,6 +10,10 @@ import (
 
 const (
 	ParallelismFlagName = "parallelism"
+)
+
+var (
+	errInvalidParallelism = errors.New("must be positive")
 )
 
 // NewParallelismFlag creates a flag for specifying parallelism level.
@@ -21,6 +27,13 @@ func NewParallelismFlag(opts *options.TerragruntOptions) *flags.Flag {
 			EnvVars:     tgPrefix.EnvVars(ParallelismFlagName),
 			Destination: &opts.Parallelism,
 			Usage:       "Parallelism for --all commands.",
+			Setter: func(value int) error {
+				if value <= 0 {
+					return errInvalidParallelism
+				}
+
+				return nil
+			},
 		},
 		flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars("parallelism"), opts.StrictControls),
 	)

--- a/internal/cli/flags/shared/parallelism_test.go
+++ b/internal/cli/flags/shared/parallelism_test.go
@@ -1,0 +1,54 @@
+package shared_test
+
+import (
+	"flag"
+	"io"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParallelismFlag(t *testing.T) {
+	t.Parallel()
+
+	for _, it := range []struct {
+		name    string
+		args    clihelper.Args
+		wantErr bool
+		wantVal int
+	}{
+		{"empty", clihelper.Args{}, false, 0},
+		{"valid", clihelper.Args{"--parallelism", "1"}, false, 1},
+		{"zero", clihelper.Args{"--parallelism", "0"}, true, 0},
+		{"negative", clihelper.Args{"--parallelism", "-1"}, true, 0},
+		{"invalid", clihelper.Args{"--parallelism", "invalid"}, true, 0},
+	} {
+		t.Run(it.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				opts options.TerragruntOptions
+				f    = shared.NewParallelismFlag(&opts)
+				fs   = new(flag.FlagSet)
+			)
+
+			// necessary in order to initialise GenericFlag internals
+			fs.SetOutput(io.Discard) // avoid panics on invalid values
+			f.Apply(fs)
+
+			err := fs.Parse(it.args)
+
+			if it.wantErr {
+				require.Error(t, err)
+			}
+
+			if !it.wantErr {
+				require.NoError(t, err)
+				require.Equal(t, it.wantVal, opts.Parallelism)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes: #6211

When running any terragrunt command that accepts the --parallelism flag (or equivalently $TG_PARALLELISM environment variable), when the setting is set to 0, terragrunt will obediently run 0 tasks in parallel; i.e. it will appear to hang without making progress.

Validate the flag value and exit with an error if the value is not positive.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The parallelism flag now requires a positive integer and rejects zero, negative, or non-numeric values, improving CLI validation and error feedback.

* **Tests**
  * Added unit tests covering empty, valid positive, zero, negative, and non-numeric parallelism inputs to verify correct acceptance or rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->