### PR TITLE
feat: Add run_weight for budget-based parallelism

### DIFF
--- a/docs/src/content/docs/03-features/02-stacks/06-run-queue.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/06-run-queue.mdx
@@ -8,6 +8,8 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Terragrunt's "Run Queue" is the mechanism it uses to manage the run order and concurrency when running OpenTofu/Terraform commands across multiple Terragrunt [units](/features/units). This is particularly relevant when using the [`run --all`](/reference/cli/commands/run#all) or [`run --graph`](/reference/cli/commands/run#graph) commands.
 
@@ -187,8 +189,14 @@ This will tell Terragrunt to run all units in the directory `subtree` except tho
 
 ## Weighted Parallelism
 
-<Aside type="caution">
-This feature requires the `run-weight` [experiment](/reference/experiments) to be enabled.
+<Before version="1.0.7">
+Coming soon in v1.0.7.
+</Before>
+
+<Since version="1.0.7">
+
+<Aside type="tip">
+This feature requires the [`run-weight`](/reference/experiments/active#run-weight) experiment. Enable it with `--experiment run-weight`.
 </Aside>
 
 By default, `--parallelism=N` treats every unit as occupying one slot, so N units run concurrently. The `run_weight` attribute lets you assign a relative cost to each unit, turning the parallelism value into a weight budget.
@@ -219,6 +227,8 @@ If a unit's weight exceeds the parallelism budget (e.g. `run_weight = 20` with `
 ### Choosing weights
 
 Weights are unitless and relative. Assign them based on whatever is your binding constraint — memory, API rate limits, CPU, or any other resource. The same model is used by Make's `-l`, Bazel's resource tags, and Nix's `max-jobs`.
+
+</Since>
 
 ## Important Considerations
 

--- a/docs/src/content/docs/03-features/02-stacks/06-run-queue.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/06-run-queue.mdx
@@ -185,6 +185,41 @@ This will tell Terragrunt to run all units in the directory `subtree` except tho
   This flag is useful when you want to fail the run as soon as any unit fails, and stop running any more units.
   </Aside>
 
+## Weighted Parallelism
+
+<Aside type="caution">
+This feature requires the `run-weight` [experiment](/reference/experiments) to be enabled.
+</Aside>
+
+By default, `--parallelism=N` treats every unit as occupying one slot, so N units run concurrently. The `run_weight` attribute lets you assign a relative cost to each unit, turning the parallelism value into a weight budget.
+
+```hcl
+# terragrunt.hcl for an EKS cluster
+run_weight = 5
+```
+
+```bash
+terragrunt run --all plan --parallelism 10 --experiment run-weight
+```
+
+With this configuration:
+
+- A unit with `run_weight = 5` consumes 5 of the 10-unit budget.
+- Two EKS units run concurrently (5+5=10), or one EKS unit alongside five lightweight units (5+1+1+1+1+1=10).
+- Units without `run_weight` default to `1`, so existing repos behave identically.
+
+### Skip-ahead scheduling
+
+When a heavy unit doesn't fit in the remaining budget, lighter units that do fit skip ahead and run immediately. The heavy unit is retried once capacity frees up. This prevents a single heavy unit from stalling the entire queue.
+
+### Oversized units
+
+If a unit's weight exceeds the parallelism budget (e.g. `run_weight = 20` with `--parallelism=10`), Terragrunt runs it solo when the pool is empty rather than deadlocking. This ensures that increasing a unit's weight never causes CI failures.
+
+### Choosing weights
+
+Weights are unitless and relative. Assign them based on whatever is your binding constraint — memory, API rate limits, CPU, or any other resource. The same model is used by Make's `-l`, Bazel's resource tags, and Nix's `max-jobs`.
+
 ## Important Considerations
 
 <Aside type="caution">

--- a/docs/src/content/docs/04-reference/01-hcl/03-attributes.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/03-attributes.mdx
@@ -8,6 +8,8 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside } from '@astrojs/starlight/components';
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Terragrunt HCL configuration uses [attributes](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#attribute-definitions) when there are values that need to be defined for Terragrunt as a whole.
 
@@ -139,8 +141,14 @@ prevent_destroy = true
 
 ## run_weight
 
-<Aside type="caution">
-This attribute requires the `run-weight` [experiment](/reference/experiments) to be enabled.
+<Before version="1.0.7">
+Coming soon in v1.0.7.
+</Before>
+
+<Since version="1.0.7">
+
+<Aside type="tip">
+This attribute requires the [`run-weight`](/reference/experiments/active#run-weight) experiment. Enable it with `--experiment run-weight`.
 </Aside>
 
 The `run_weight` attribute sets the scheduling weight for a unit when using [`--parallelism`](/reference/cli/commands/run#parallelism) with [`run --all`](/reference/cli/commands/run#all). Terragrunt reinterprets the parallelism value as a weight budget: a unit is admitted only when the sum of in-flight weights plus the candidate's weight is within the budget.
@@ -160,6 +168,8 @@ With `--parallelism=10`, the pool admits at most 2 units of weight 5 concurrentl
 If a unit's weight exceeds the parallelism budget, it runs solo when the pool is empty to avoid deadlocking the run queue. Values less than 1 are clamped to 1.
 
 See the [Run Queue](/features/stacks/run-queue#weighted-parallelism) documentation for more details.
+
+</Since>
 
 ## iam_role
 

--- a/docs/src/content/docs/04-reference/01-hcl/03-attributes.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/03-attributes.mdx
@@ -7,6 +7,7 @@ sidebar:
 ---
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
+import { Aside } from '@astrojs/starlight/components';
 
 Terragrunt HCL configuration uses [attributes](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#attribute-definitions) when there are values that need to be defined for Terragrunt as a whole.
 
@@ -135,6 +136,30 @@ terraform {
 
 prevent_destroy = true
 ```
+
+## run_weight
+
+<Aside type="caution">
+This attribute requires the `run-weight` [experiment](/reference/experiments) to be enabled.
+</Aside>
+
+The `run_weight` attribute sets the scheduling weight for a unit when using [`--parallelism`](/reference/cli/commands/run#parallelism) with [`run --all`](/reference/cli/commands/run#all). Terragrunt reinterprets the parallelism value as a weight budget: a unit is admitted only when the sum of in-flight weights plus the candidate's weight is within the budget.
+
+Units without `run_weight` default to `1`, preserving existing behavior. This is useful when a fleet contains a mix of heavyweight units (e.g. EKS clusters that consume significant memory and API quota) and lightweight units (e.g. IAM roles, parameter store entries) that can safely run with higher concurrency.
+
+Example:
+
+```hcl
+# terragrunt.hcl
+
+run_weight = 5
+```
+
+With `--parallelism=10`, the pool admits at most 2 units of weight 5 concurrently (5+5=10), or 1 heavy unit alongside 5 lightweight units (5+1+1+1+1+1=10).
+
+If a unit's weight exceeds the parallelism budget, it runs solo when the pool is empty to avoid deadlocking the run queue. Values less than 1 are clamped to 1.
+
+See the [Run Queue](/features/stacks/run-queue#weighted-parallelism) documentation for more details.
 
 ## iam_role
 

--- a/docs/src/data/changelog/v1.0.7/run-weight.mdx
+++ b/docs/src/data/changelog/v1.0.7/run-weight.mdx
@@ -1,0 +1,27 @@
+---
+version: "v1.0.7"
+category: "experiments-added"
+---
+
+#### `run-weight`: budget-based parallelism for heterogeneous units
+
+The new `run-weight` experiment adds an optional `run_weight` integer attribute to `terragrunt.hcl` that reinterprets `--parallelism=N` as a weight budget instead of a flat slot count.
+
+Enable the experiment:
+
+```bash
+terragrunt run --all plan --parallelism 10 --experiment run-weight
+```
+
+Declare weights in your unit configs:
+
+```hcl
+# terragrunt.hcl for an EKS cluster unit
+run_weight = 5
+```
+
+The Runner Pool admits a unit only when the sum of in-flight weights plus the candidate's weight is within the budget. Units without `run_weight` default to `1`, so existing repos behave identically.
+
+With `--parallelism=10`: the pool admits 2 EKS units (5+5=10), or 1 EKS + 5 lightweight units (5+1+1+1+1+1=10), or 10 default-weight units. Light units skip ahead of heavy units that don't fit, preventing starvation. Oversized units (weight exceeding the budget) run solo when the pool is empty.
+
+See [#6165](https://github.com/gruntwork-io/terragrunt/issues/6165) for motivation and design details.

--- a/internal/component/component_test.go
+++ b/internal/component/component_test.go
@@ -241,46 +241,46 @@ func TestThreadSafeComponentsConcurrentAccess(t *testing.T) {
 	assert.Equal(t, 1, tsc.Len(), "should have exactly one component after concurrent adds")
 }
 
-func TestUnitExecutionWeight_Default(t *testing.T) {
+func TestUnitRunWeight_Default(t *testing.T) {
 	t.Parallel()
 
 	unit := component.NewUnit("/test/path")
-	assert.Equal(t, 1, unit.ExecutionWeight(), "unit without config should default to weight 1")
+	assert.Equal(t, 1, unit.RunWeight(), "unit without config should default to weight 1")
 }
 
-func TestUnitExecutionWeight_NilWeight(t *testing.T) {
+func TestUnitRunWeight_NilWeight(t *testing.T) {
 	t.Parallel()
 
 	unit := component.NewUnit("/test/path").WithConfig(&config.TerragruntConfig{})
-	assert.Equal(t, 1, unit.ExecutionWeight(), "unit with config but nil weight should default to 1")
+	assert.Equal(t, 1, unit.RunWeight(), "unit with config but nil weight should default to 1")
 }
 
-func TestUnitExecutionWeight_Explicit(t *testing.T) {
+func TestUnitRunWeight_Explicit(t *testing.T) {
 	t.Parallel()
 
 	weight := 5
 	unit := component.NewUnit("/test/path").WithConfig(&config.TerragruntConfig{
-		ExecutionWeight: &weight,
+		RunWeight: &weight,
 	})
-	assert.Equal(t, 5, unit.ExecutionWeight(), "unit should return configured weight")
+	assert.Equal(t, 5, unit.RunWeight(), "unit should return configured weight")
 }
 
-func TestUnitExecutionWeight_ZeroClampsToOne(t *testing.T) {
+func TestUnitRunWeight_ZeroClampsToOne(t *testing.T) {
 	t.Parallel()
 
 	weight := 0
 	unit := component.NewUnit("/test/path").WithConfig(&config.TerragruntConfig{
-		ExecutionWeight: &weight,
+		RunWeight: &weight,
 	})
-	assert.Equal(t, 1, unit.ExecutionWeight(), "weight 0 should clamp to 1")
+	assert.Equal(t, 1, unit.RunWeight(), "weight 0 should clamp to 1")
 }
 
-func TestUnitExecutionWeight_NegativeClampsToOne(t *testing.T) {
+func TestUnitRunWeight_NegativeClampsToOne(t *testing.T) {
 	t.Parallel()
 
 	weight := -3
 	unit := component.NewUnit("/test/path").WithConfig(&config.TerragruntConfig{
-		ExecutionWeight: &weight,
+		RunWeight: &weight,
 	})
-	assert.Equal(t, 1, unit.ExecutionWeight(), "negative weight should clamp to 1")
+	assert.Equal(t, 1, unit.RunWeight(), "negative weight should clamp to 1")
 }

--- a/internal/component/component_test.go
+++ b/internal/component/component_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -238,4 +239,48 @@ func TestThreadSafeComponentsConcurrentAccess(t *testing.T) {
 
 	// Should have exactly one component despite concurrent adds
 	assert.Equal(t, 1, tsc.Len(), "should have exactly one component after concurrent adds")
+}
+
+func TestUnitExecutionWeight_Default(t *testing.T) {
+	t.Parallel()
+
+	unit := component.NewUnit("/test/path")
+	assert.Equal(t, 1, unit.ExecutionWeight(), "unit without config should default to weight 1")
+}
+
+func TestUnitExecutionWeight_NilWeight(t *testing.T) {
+	t.Parallel()
+
+	unit := component.NewUnit("/test/path").WithConfig(&config.TerragruntConfig{})
+	assert.Equal(t, 1, unit.ExecutionWeight(), "unit with config but nil weight should default to 1")
+}
+
+func TestUnitExecutionWeight_Explicit(t *testing.T) {
+	t.Parallel()
+
+	weight := 5
+	unit := component.NewUnit("/test/path").WithConfig(&config.TerragruntConfig{
+		ExecutionWeight: &weight,
+	})
+	assert.Equal(t, 5, unit.ExecutionWeight(), "unit should return configured weight")
+}
+
+func TestUnitExecutionWeight_ZeroClampsToOne(t *testing.T) {
+	t.Parallel()
+
+	weight := 0
+	unit := component.NewUnit("/test/path").WithConfig(&config.TerragruntConfig{
+		ExecutionWeight: &weight,
+	})
+	assert.Equal(t, 1, unit.ExecutionWeight(), "weight 0 should clamp to 1")
+}
+
+func TestUnitExecutionWeight_NegativeClampsToOne(t *testing.T) {
+	t.Parallel()
+
+	weight := -3
+	unit := component.NewUnit("/test/path").WithConfig(&config.TerragruntConfig{
+		ExecutionWeight: &weight,
+	})
+	assert.Equal(t, 1, unit.ExecutionWeight(), "negative weight should clamp to 1")
 }

--- a/internal/component/unit.go
+++ b/internal/component/unit.go
@@ -68,6 +68,16 @@ func (u *Unit) Config() *config.TerragruntConfig {
 	return u.cfg
 }
 
+// ExecutionWeight returns the execution weight for this unit.
+// Defaults to 1 when unset, zero, or negative.
+func (u *Unit) ExecutionWeight() int {
+	if u.cfg != nil && u.cfg.ExecutionWeight != nil && *u.cfg.ExecutionWeight >= 1 {
+		return *u.cfg.ExecutionWeight
+	}
+
+	return 1
+}
+
 // StoreConfig stores the parsed Terragrunt configuration for this unit.
 func (u *Unit) StoreConfig(cfg *config.TerragruntConfig) {
 	u.cfg = cfg

--- a/internal/component/unit.go
+++ b/internal/component/unit.go
@@ -68,11 +68,11 @@ func (u *Unit) Config() *config.TerragruntConfig {
 	return u.cfg
 }
 
-// ExecutionWeight returns the execution weight for this unit.
+// RunWeight returns the execution weight for this unit.
 // Defaults to 1 when unset, zero, or negative.
-func (u *Unit) ExecutionWeight() int {
-	if u.cfg != nil && u.cfg.ExecutionWeight != nil && *u.cfg.ExecutionWeight >= 1 {
-		return *u.cfg.ExecutionWeight
+func (u *Unit) RunWeight() int {
+	if u.cfg != nil && u.cfg.RunWeight != nil && *u.cfg.RunWeight >= 1 {
+		return *u.cfg.RunWeight
 	}
 
 	return 1

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -66,6 +66,9 @@ const (
 	// OptOutAuth gates flags that opt out of running --auth-provider-cmd in
 	// specific phases (currently --no-discovery-auth-provider-cmd).
 	OptOutAuth = "opt-out-auth"
+	// RunWeight enables the run_weight attribute in terragrunt.hcl, which
+	// reinterprets --parallelism as a weight budget instead of a slot count.
+	RunWeight = "run-weight"
 )
 
 const (
@@ -141,6 +144,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: OptOutAuth,
+		},
+		{
+			Name: RunWeight,
 		},
 	}
 }

--- a/internal/runner/runnerpool/controller.go
+++ b/internal/runner/runnerpool/controller.go
@@ -173,7 +173,7 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 				// Look up unit weight for budget-based admission
 				weight := 1
 				if unit, ok := dr.unitsMap[e.Component.Path()]; ok {
-					weight = unit.ExecutionWeight()
+					weight = unit.RunWeight()
 				}
 
 				sem.acquire(weight)

--- a/internal/runner/runnerpool/controller.go
+++ b/internal/runner/runnerpool/controller.go
@@ -87,12 +87,10 @@ func NewController(q *queue.Queue, units []*component.Unit, opts ...ControllerOp
 // weightedSemaphore tracks in-flight weight against a budget (--parallelism).
 // When all units have weight 1, it behaves identically to a channel-based semaphore.
 type weightedSemaphore struct {
-	mu       sync.Mutex
-	budget   int
-	inflight int
-	// releaseCh is signaled whenever a unit finishes and budget is freed.
-	// The controller selects on this alongside readyCh and ctx.Done().
 	releaseCh chan struct{}
+	budget    int
+	inflight  int
+	mu        sync.Mutex
 }
 
 func newWeightedSemaphore(budget int) *weightedSemaphore {

--- a/internal/runner/runnerpool/controller.go
+++ b/internal/runner/runnerpool/controller.go
@@ -84,6 +84,55 @@ func NewController(q *queue.Queue, units []*component.Unit, opts ...ControllerOp
 	return dr
 }
 
+// weightedSemaphore tracks in-flight weight against a budget (--parallelism).
+// When all units have weight 1, it behaves identically to a channel-based semaphore.
+type weightedSemaphore struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	budget   int
+	inflight int
+}
+
+func newWeightedSemaphore(budget int) *weightedSemaphore {
+	ws := &weightedSemaphore{budget: budget}
+	ws.cond = sync.NewCond(&ws.mu)
+
+	return ws
+}
+
+// acquire blocks until inflight + weight <= budget, or until the unit can run solo
+// (weight > budget and inflight == 0). This prevents oversized units from deadlocking.
+func (ws *weightedSemaphore) acquire(weight int) {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+
+	for {
+		// Normal case: unit fits within remaining budget
+		if ws.inflight+weight <= ws.budget {
+			ws.inflight += weight
+
+			return
+		}
+
+		// Oversized unit: weight exceeds budget, run solo when pool is empty
+		if weight > ws.budget && ws.inflight == 0 {
+			ws.inflight += weight
+
+			return
+		}
+
+		ws.cond.Wait()
+	}
+}
+
+// release returns weight to the budget and wakes waiters.
+func (ws *weightedSemaphore) release(weight int) {
+	ws.mu.Lock()
+	ws.inflight -= weight
+	ws.mu.Unlock()
+	ws.cond.Broadcast()
+}
+
 // Run executes the Queue return error summarizing all entries that failed to run.
 func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 	return telemetry.TelemeterFromContext(ctx).Collect(ctx, "runner_pool_controller", map[string]any{
@@ -94,7 +143,7 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 	}, func(childCtx context.Context) error {
 		var (
 			wg      sync.WaitGroup
-			sem     = make(chan struct{}, dr.concurrency)
+			sem     = newWeightedSemaphore(dr.concurrency)
 			results = xsync.NewMap[string, error]()
 		)
 
@@ -121,15 +170,21 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 					continue
 				}
 
-				l.Debugf("Runner Pool Controller: running %s", e.Component.Path())
+				// Look up unit weight for budget-based admission
+				weight := 1
+				if unit, ok := dr.unitsMap[e.Component.Path()]; ok {
+					weight = unit.ExecutionWeight()
+				}
 
-				sem <- struct{}{}
+				sem.acquire(weight)
+
+				l.Debugf("Runner Pool Controller: running %s (weight %d)", e.Component.Path(), weight)
 
 				wg.Add(1)
 
-				go func(ent *queue.Entry) {
+				go func(ent *queue.Entry, w int) {
 					defer func() {
-						<-sem
+						sem.release(w)
 						wg.Done()
 
 						select {
@@ -160,7 +215,7 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 
 					l.Debugf("Runner Pool Controller: %s succeeded", ent.Component.Path())
 					dr.q.SetEntryStatus(ent, queue.StatusSucceeded)
-				}(e)
+				}(e, weight)
 			}
 
 			if dr.q.Finished() {

--- a/internal/runner/runnerpool/controller.go
+++ b/internal/runner/runnerpool/controller.go
@@ -88,49 +88,55 @@ func NewController(q *queue.Queue, units []*component.Unit, opts ...ControllerOp
 // When all units have weight 1, it behaves identically to a channel-based semaphore.
 type weightedSemaphore struct {
 	mu       sync.Mutex
-	cond     *sync.Cond
 	budget   int
 	inflight int
+	// releaseCh is signaled whenever a unit finishes and budget is freed.
+	// The controller selects on this alongside readyCh and ctx.Done().
+	releaseCh chan struct{}
 }
 
 func newWeightedSemaphore(budget int) *weightedSemaphore {
-	ws := &weightedSemaphore{budget: budget}
-	ws.cond = sync.NewCond(&ws.mu)
-
-	return ws
-}
-
-// acquire blocks until inflight + weight <= budget, or until the unit can run solo
-// (weight > budget and inflight == 0). This prevents oversized units from deadlocking.
-func (ws *weightedSemaphore) acquire(weight int) {
-	ws.mu.Lock()
-	defer ws.mu.Unlock()
-
-	for {
-		// Normal case: unit fits within remaining budget
-		if ws.inflight+weight <= ws.budget {
-			ws.inflight += weight
-
-			return
-		}
-
-		// Oversized unit: weight exceeds budget, run solo when pool is empty
-		if weight > ws.budget && ws.inflight == 0 {
-			ws.inflight += weight
-
-			return
-		}
-
-		ws.cond.Wait()
+	return &weightedSemaphore{
+		budget:    budget,
+		releaseCh: make(chan struct{}, 1),
 	}
 }
 
-// release returns weight to the budget and wakes waiters.
+// tryAcquire attempts to reserve weight without blocking. Returns true if
+// the unit was admitted. Handles two cases:
+//   - Normal: inflight + weight <= budget
+//   - Oversized: weight > budget but inflight == 0 (run solo to avoid deadlock)
+func (ws *weightedSemaphore) tryAcquire(weight int) bool {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+
+	if ws.inflight+weight <= ws.budget {
+		ws.inflight += weight
+
+		return true
+	}
+
+	// Oversized unit: weight exceeds budget, run solo when pool is empty
+	if weight > ws.budget && ws.inflight == 0 {
+		ws.inflight += weight
+
+		return true
+	}
+
+	return false
+}
+
+// release returns weight to the budget and signals that capacity is available.
 func (ws *weightedSemaphore) release(weight int) {
 	ws.mu.Lock()
 	ws.inflight -= weight
 	ws.mu.Unlock()
-	ws.cond.Broadcast()
+
+	// Non-blocking signal so the scheduling loop re-evaluates deferred entries.
+	select {
+	case ws.releaseCh <- struct{}{}:
+	default:
+	}
 }
 
 // Run executes the Queue return error summarizing all entries that failed to run.
@@ -164,6 +170,8 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 			readyEntries := dr.q.GetReadyWithDependencies(l)
 			l.Debugf("Runner Pool Controller: found %d readyEntries tasks", len(readyEntries))
 
+			admitted := 0
+
 			for _, e := range readyEntries {
 				if !dr.q.ClaimForRunning(e) {
 					l.Debugf("Runner Pool Controller: skipping %s; fail-fast cancelled before dispatch", e.Component.Path())
@@ -176,7 +184,16 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 					weight = unit.RunWeight()
 				}
 
-				sem.acquire(weight)
+				if !sem.tryAcquire(weight) {
+					// Doesn't fit in remaining budget. Unclaim so it returns to
+					// Ready status and can be retried once capacity frees up.
+					dr.q.SetEntryStatus(e, queue.StatusReady)
+					l.Debugf("Runner Pool Controller: deferring %s (weight %d); insufficient budget", e.Component.Path(), weight)
+
+					continue
+				}
+
+				admitted++
 
 				l.Debugf("Runner Pool Controller: running %s (weight %d)", e.Component.Path(), weight)
 
@@ -222,8 +239,11 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 				break
 			}
 
+			// Wait for either: new entries becoming ready (dependency resolved),
+			// budget being freed (a running unit finished), or context cancellation.
 			select {
 			case <-dr.readyCh:
+			case <-sem.releaseCh:
 			case <-childCtx.Done():
 				wg.Wait()
 				return nil

--- a/internal/runner/runnerpool/controller.go
+++ b/internal/runner/runnerpool/controller.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/multierror"
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -31,6 +32,7 @@ type Controller struct {
 	runner      UnitRunner
 	readyCh     chan struct{}
 	unitsMap    map[string]*component.Unit
+	experiments experiment.Experiments
 	concurrency int
 }
 
@@ -41,6 +43,13 @@ type ControllerOption func(*Controller)
 func WithRunner(runner UnitRunner) ControllerOption {
 	return func(dr *Controller) {
 		dr.runner = runner
+	}
+}
+
+// WithExperiments sets the experiments for the Controller.
+func WithExperiments(experiments experiment.Experiments) ControllerOption {
+	return func(dr *Controller) {
+		dr.experiments = experiments
 	}
 }
 
@@ -176,10 +185,15 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 					continue
 				}
 
-				// Look up unit weight for budget-based admission
+				// Look up unit weight for budget-based admission.
+				// Only used when the run-weight experiment is enabled;
+				// otherwise all units have weight 1 (preserving existing behavior).
 				weight := 1
-				if unit, ok := dr.unitsMap[e.Component.Path()]; ok {
-					weight = unit.RunWeight()
+
+				if dr.experiments.Evaluate(experiment.RunWeight) {
+					if unit, ok := dr.unitsMap[e.Component.Path()]; ok {
+						weight = unit.RunWeight()
+					}
 				}
 
 				if !sem.tryAcquire(weight) {

--- a/internal/runner/runnerpool/controller.go
+++ b/internal/runner/runnerpool/controller.go
@@ -133,6 +133,14 @@ func (ws *weightedSemaphore) tryAcquire(weight int) bool {
 	return false
 }
 
+// remaining returns the budget not currently consumed by in-flight units.
+func (ws *weightedSemaphore) remaining() int {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+
+	return ws.budget - ws.inflight
+}
+
 // release returns weight to the budget and signals that capacity is available.
 func (ws *weightedSemaphore) release(weight int) {
 	ws.mu.Lock()
@@ -177,8 +185,6 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 			readyEntries := dr.q.GetReadyWithDependencies(l)
 			l.Debugf("Runner Pool Controller: found %d readyEntries tasks", len(readyEntries))
 
-			admitted := 0
-
 			for _, e := range readyEntries {
 				if !dr.q.ClaimForRunning(e) {
 					l.Debugf("Runner Pool Controller: skipping %s; fail-fast cancelled before dispatch", e.Component.Path())
@@ -200,14 +206,14 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 					// Doesn't fit in remaining budget. Unclaim so it returns to
 					// Ready status and can be retried once capacity frees up.
 					dr.q.SetEntryStatus(e, queue.StatusReady)
-					l.Debugf("Runner Pool Controller: deferring %s (weight %d); insufficient budget", e.Component.Path(), weight)
+					l.Debugf("Runner Pool Controller: deferring %s (weight %d, remaining %d); insufficient budget",
+						e.Component.Path(), weight, sem.remaining())
 
 					continue
 				}
 
-				admitted++
-
-				l.Debugf("Runner Pool Controller: running %s (weight %d)", e.Component.Path(), weight)
+				l.Debugf("Runner Pool Controller: running %s (weight %d, remaining %d)",
+					e.Component.Path(), weight, sem.remaining())
 
 				wg.Add(1)
 

--- a/internal/runner/runnerpool/controller_test.go
+++ b/internal/runner/runnerpool/controller_test.go
@@ -358,6 +358,7 @@ func TestRunnerPool_DefaultWeightBackwardsCompatWithRacing(t *testing.T) {
 
 		err := runWeightedController(t, units, 3, func(ctx context.Context, u *component.Unit) error {
 			mu.Lock()
+
 			current++
 			if current > maxConcurrent {
 				maxConcurrent = current
@@ -397,6 +398,7 @@ func TestRunnerPool_WeightedBudgetAdmissionWithRacing(t *testing.T) {
 			w := u.RunWeight()
 
 			mu.Lock()
+
 			currentWeight += w
 			if currentWeight > maxWeight {
 				maxWeight = currentWeight
@@ -443,6 +445,7 @@ func TestRunnerPool_OversizedWeightRunsSoloWithRacing(t *testing.T) {
 
 		_, hugeRan := executedPaths.Load("huge")
 		_, smallRan := executedPaths.Load("small")
+
 		assert.True(t, hugeRan, "Oversized unit should still execute")
 		assert.True(t, smallRan, "Small unit should also execute")
 	})
@@ -472,6 +475,7 @@ func TestRunnerPool_HeavyUnitDoesNotBlockLightUnitsWithRacing(t *testing.T) {
 			w := u.RunWeight()
 
 			mu.Lock()
+
 			currentWeight += w
 			if currentWeight > maxWeight {
 				maxWeight = currentWeight
@@ -496,4 +500,3 @@ func TestRunnerPool_HeavyUnitDoesNotBlockLightUnitsWithRacing(t *testing.T) {
 		assert.True(t, lightRanWhileFirstRunning, "Light units should run concurrently with first, not blocked behind heavy")
 	})
 }
-

--- a/internal/runner/runnerpool/controller_test.go
+++ b/internal/runner/runnerpool/controller_test.go
@@ -439,3 +439,50 @@ func TestRunnerPool_OversizedWeightRunsSolo(t *testing.T) {
 	assert.True(t, smallRan, "Small unit should also execute")
 }
 
+func TestRunnerPool_HeavyUnitDoesNotBlockLightUnits(t *testing.T) {
+	t.Parallel()
+
+	// Budget=10. All units independent (no deps).
+	// first(3) runs and holds 3 of 10. heavy(9) can't fit (3+9=12 > 10) but
+	// light units (1 each) should skip ahead since they do fit (3+1=4 <= 10).
+	// Without skip-ahead logic, heavy would block the loop and light units would starve.
+	units := buildWeightedUnits(
+		[]string{"first", "heavy", "light1", "light2"},
+		map[string]int{"first": 3, "heavy": 9, "light1": 1, "light2": 1},
+		map[string][]string{},
+	)
+
+	var mu sync.Mutex
+
+	var maxWeight, currentWeight int
+
+	lightRanWhileFirstRunning := false
+
+	err := runWeightedController(t, units, 10, func(ctx context.Context, u *component.Unit) error {
+		w := u.RunWeight()
+
+		mu.Lock()
+		currentWeight += w
+		if currentWeight > maxWeight {
+			maxWeight = currentWeight
+		}
+
+		// If a light unit is running while first is still in-flight, skip-ahead worked
+		if w == 1 && currentWeight > 1 {
+			lightRanWhileFirstRunning = true
+		}
+
+		mu.Unlock()
+
+		time.Sleep(50 * time.Millisecond)
+
+		mu.Lock()
+		currentWeight -= w
+		mu.Unlock()
+
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, lightRanWhileFirstRunning, "Light units should run concurrently with first, not blocked behind heavy")
+}
+

--- a/internal/runner/runnerpool/controller_test.go
+++ b/internal/runner/runnerpool/controller_test.go
@@ -3,7 +3,6 @@ package runnerpool_test
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -351,26 +350,29 @@ func TestRunnerPool_DefaultWeightBackwardsCompat(t *testing.T) {
 	// Units without run_weight should default to 1, preserving existing behavior.
 	units := buildComponentUnits([]string{"A", "B", "C"}, map[string][]string{})
 
-	var maxConcurrent atomic.Int32
+	var mu sync.Mutex
 
-	var current atomic.Int32
+	var current, maxConcurrent int
 
 	err := runWeightedController(t, units, 3, func(ctx context.Context, u *component.Unit) error {
-		val := current.Add(1)
-		for {
-			old := maxConcurrent.Load()
-			if val <= old || maxConcurrent.CompareAndSwap(old, val) {
-				break
-			}
+		mu.Lock()
+		current++
+		if current > maxConcurrent {
+			maxConcurrent = current
 		}
 
+		mu.Unlock()
+
 		time.Sleep(50 * time.Millisecond)
-		current.Add(-1)
+
+		mu.Lock()
+		current--
+		mu.Unlock()
 
 		return nil
 	})
 	require.NoError(t, err)
-	assert.Equal(t, int32(3), maxConcurrent.Load(), "All 3 default-weight units should run concurrently with budget 3")
+	assert.Equal(t, 3, maxConcurrent, "All 3 default-weight units should run concurrently with budget 3")
 }
 
 func TestRunnerPool_WeightedBudgetAdmission(t *testing.T) {

--- a/internal/runner/runnerpool/controller_test.go
+++ b/internal/runner/runnerpool/controller_test.go
@@ -344,7 +344,7 @@ func runWeightedController(t *testing.T, units []*component.Unit, concurrency in
 	return ctrl.Run(t.Context(), logger.CreateLogger())
 }
 
-func TestRunnerPool_DefaultWeightBackwardsCompat(t *testing.T) {
+func TestRunnerPool_DefaultWeightBackwardsCompatWithRacing(t *testing.T) {
 	t.Parallel()
 
 	// Units without run_weight should default to 1, preserving existing behavior.
@@ -375,7 +375,7 @@ func TestRunnerPool_DefaultWeightBackwardsCompat(t *testing.T) {
 	assert.Equal(t, 3, maxConcurrent, "All 3 default-weight units should run concurrently with budget 3")
 }
 
-func TestRunnerPool_WeightedBudgetAdmission(t *testing.T) {
+func TestRunnerPool_WeightedBudgetAdmissionWithRacing(t *testing.T) {
 	t.Parallel()
 
 	// Budget=10, heavy units weight=5, light units weight=1.
@@ -416,7 +416,7 @@ func TestRunnerPool_WeightedBudgetAdmission(t *testing.T) {
 	assert.Greater(t, maxWeight, 1, "Should have achieved some concurrency")
 }
 
-func TestRunnerPool_OversizedWeightRunsSolo(t *testing.T) {
+func TestRunnerPool_OversizedWeightRunsSoloWithRacing(t *testing.T) {
 	t.Parallel()
 
 	// A unit with weight > budget should still run (solo, when pool is empty).
@@ -441,7 +441,7 @@ func TestRunnerPool_OversizedWeightRunsSolo(t *testing.T) {
 	assert.True(t, smallRan, "Small unit should also execute")
 }
 
-func TestRunnerPool_HeavyUnitDoesNotBlockLightUnits(t *testing.T) {
+func TestRunnerPool_HeavyUnitDoesNotBlockLightUnitsWithRacing(t *testing.T) {
 	t.Parallel()
 
 	// Budget=10. All units independent (no deps).

--- a/internal/runner/runnerpool/controller_test.go
+++ b/internal/runner/runnerpool/controller_test.go
@@ -292,14 +292,14 @@ func TestRunnerPool_ComplexDependency_BFails_FailFast(t *testing.T) {
 	}
 }
 
-// buildWeightedUnits creates units with execution_weight set via config.
+// buildWeightedUnits creates units with run_weight set via config.
 func buildWeightedUnits(paths []string, weights map[string]int, depMap map[string][]string) []*component.Unit {
 	unitMap := make(map[string]*component.Unit)
 
 	for _, path := range paths {
 		u := component.NewUnit(path)
 		if w, ok := weights[path]; ok {
-			cfg := &config.TerragruntConfig{ExecutionWeight: &w}
+			cfg := &config.TerragruntConfig{RunWeight: &w}
 			u.WithConfig(cfg)
 		}
 
@@ -323,21 +323,39 @@ func buildWeightedUnits(paths []string, weights map[string]int, depMap map[strin
 	return units
 }
 
+// runWeightedController is a helper that wires up units into a queue and controller, then runs it.
+func runWeightedController(t *testing.T, units []*component.Unit, concurrency int, runner runnerpool.UnitRunner) error {
+	t.Helper()
+
+	components := make(component.Components, len(units))
+	for i, u := range units {
+		components[i] = u
+	}
+
+	q, err := queue.NewQueue(components)
+	require.NoError(t, err)
+
+	ctrl := runnerpool.NewController(
+		q,
+		units,
+		runnerpool.WithRunner(runner),
+		runnerpool.WithMaxConcurrency(concurrency),
+	)
+
+	return ctrl.Run(t.Context(), logger.CreateLogger())
+}
+
 func TestRunnerPool_DefaultWeightBackwardsCompat(t *testing.T) {
 	t.Parallel()
 
-	// Units without execution_weight should default to 1, preserving existing behavior.
-	// With parallelism=3, all 3 units should be able to run concurrently.
-	units := buildComponentUnits(
-		[]string{"A", "B", "C"},
-		map[string][]string{},
-	)
+	// Units without run_weight should default to 1, preserving existing behavior.
+	units := buildComponentUnits([]string{"A", "B", "C"}, map[string][]string{})
 
 	var maxConcurrent atomic.Int32
 
 	var current atomic.Int32
 
-	runner := func(ctx context.Context, u *component.Unit) error {
+	err := runWeightedController(t, units, 3, func(ctx context.Context, u *component.Unit) error {
 		val := current.Add(1)
 		for {
 			old := maxConcurrent.Load()
@@ -350,23 +368,7 @@ func TestRunnerPool_DefaultWeightBackwardsCompat(t *testing.T) {
 		current.Add(-1)
 
 		return nil
-	}
-
-	components := make(component.Components, len(units))
-	for i, u := range units {
-		components[i] = u
-	}
-
-	q, err := queue.NewQueue(components)
-	require.NoError(t, err)
-
-	dagRunner := runnerpool.NewController(
-		q,
-		units,
-		runnerpool.WithRunner(runner),
-		runnerpool.WithMaxConcurrency(3),
-	)
-	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	})
 	require.NoError(t, err)
 	assert.Equal(t, int32(3), maxConcurrent.Load(), "All 3 default-weight units should run concurrently with budget 3")
 }
@@ -375,19 +377,9 @@ func TestRunnerPool_WeightedBudgetAdmission(t *testing.T) {
 	t.Parallel()
 
 	// Budget=10, heavy units weight=5, light units weight=1.
-	// All units are independent (no deps).
-	// Heavy units: at most 2 concurrent (5+5=10).
-	// We verify the pool never exceeds the budget.
 	units := buildWeightedUnits(
 		[]string{"heavy1", "heavy2", "heavy3", "light1", "light2", "light3"},
-		map[string]int{
-			"heavy1": 5,
-			"heavy2": 5,
-			"heavy3": 5,
-			"light1": 1,
-			"light2": 1,
-			"light3": 1,
-		},
+		map[string]int{"heavy1": 5, "heavy2": 5, "heavy3": 5, "light1": 1, "light2": 1, "light3": 1},
 		map[string][]string{},
 	)
 
@@ -395,8 +387,8 @@ func TestRunnerPool_WeightedBudgetAdmission(t *testing.T) {
 
 	var maxWeight, currentWeight int
 
-	runner := func(ctx context.Context, u *component.Unit) error {
-		w := u.ExecutionWeight()
+	err := runWeightedController(t, units, 10, func(ctx context.Context, u *component.Unit) error {
+		w := u.RunWeight()
 
 		mu.Lock()
 		currentWeight += w
@@ -416,23 +408,7 @@ func TestRunnerPool_WeightedBudgetAdmission(t *testing.T) {
 		mu.Unlock()
 
 		return nil
-	}
-
-	components := make(component.Components, len(units))
-	for i, u := range units {
-		components[i] = u
-	}
-
-	q, err := queue.NewQueue(components)
-	require.NoError(t, err)
-
-	dagRunner := runnerpool.NewController(
-		q,
-		units,
-		runnerpool.WithRunner(runner),
-		runnerpool.WithMaxConcurrency(10),
-	)
-	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	})
 	require.NoError(t, err)
 	assert.LessOrEqual(t, maxWeight, 10, "Peak in-flight weight must not exceed budget")
 	assert.Greater(t, maxWeight, 1, "Should have achieved some concurrency")
@@ -444,36 +420,17 @@ func TestRunnerPool_OversizedWeightRunsSolo(t *testing.T) {
 	// A unit with weight > budget should still run (solo, when pool is empty).
 	units := buildWeightedUnits(
 		[]string{"huge", "small"},
-		map[string]int{
-			"huge":  20,
-			"small": 1,
-		},
+		map[string]int{"huge": 20, "small": 1},
 		map[string][]string{},
 	)
 
 	var executedPaths sync.Map
 
-	runner := func(ctx context.Context, u *component.Unit) error {
+	err := runWeightedController(t, units, 5, func(ctx context.Context, u *component.Unit) error {
 		executedPaths.Store(u.Path(), true)
 
 		return nil
-	}
-
-	components := make(component.Components, len(units))
-	for i, u := range units {
-		components[i] = u
-	}
-
-	q, err := queue.NewQueue(components)
-	require.NoError(t, err)
-
-	dagRunner := runnerpool.NewController(
-		q,
-		units,
-		runnerpool.WithRunner(runner),
-		runnerpool.WithMaxConcurrency(5),
-	)
-	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	})
 	require.NoError(t, err)
 
 	_, hugeRan := executedPaths.Load("huge")

--- a/internal/runner/runnerpool/controller_test.go
+++ b/internal/runner/runnerpool/controller_test.go
@@ -2,7 +2,10 @@ package runnerpool_test
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -10,6 +13,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runnerpool"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 
 	"github.com/gruntwork-io/terragrunt/internal/queue"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -287,3 +291,194 @@ func TestRunnerPool_ComplexDependency_BFails_FailFast(t *testing.T) {
 		assert.Contains(t, err.Error(), want, "Expected error message '%s' in errors", want)
 	}
 }
+
+// buildWeightedUnits creates units with execution_weight set via config.
+func buildWeightedUnits(paths []string, weights map[string]int, depMap map[string][]string) []*component.Unit {
+	unitMap := make(map[string]*component.Unit)
+
+	for _, path := range paths {
+		u := component.NewUnit(path)
+		if w, ok := weights[path]; ok {
+			cfg := &config.TerragruntConfig{ExecutionWeight: &w}
+			u.WithConfig(cfg)
+		}
+
+		unitMap[path] = u
+	}
+
+	for path, deps := range depMap {
+		unit := unitMap[path]
+		for _, depPath := range deps {
+			if depUnit, ok := unitMap[depPath]; ok {
+				unit.AddDependency(depUnit)
+			}
+		}
+	}
+
+	units := make([]*component.Unit, 0, len(paths))
+	for _, path := range paths {
+		units = append(units, unitMap[path])
+	}
+
+	return units
+}
+
+func TestRunnerPool_DefaultWeightBackwardsCompat(t *testing.T) {
+	t.Parallel()
+
+	// Units without execution_weight should default to 1, preserving existing behavior.
+	// With parallelism=3, all 3 units should be able to run concurrently.
+	units := buildComponentUnits(
+		[]string{"A", "B", "C"},
+		map[string][]string{},
+	)
+
+	var maxConcurrent atomic.Int32
+
+	var current atomic.Int32
+
+	runner := func(ctx context.Context, u *component.Unit) error {
+		val := current.Add(1)
+		for {
+			old := maxConcurrent.Load()
+			if val <= old || maxConcurrent.CompareAndSwap(old, val) {
+				break
+			}
+		}
+
+		time.Sleep(50 * time.Millisecond)
+		current.Add(-1)
+
+		return nil
+	}
+
+	components := make(component.Components, len(units))
+	for i, u := range units {
+		components[i] = u
+	}
+
+	q, err := queue.NewQueue(components)
+	require.NoError(t, err)
+
+	dagRunner := runnerpool.NewController(
+		q,
+		units,
+		runnerpool.WithRunner(runner),
+		runnerpool.WithMaxConcurrency(3),
+	)
+	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), maxConcurrent.Load(), "All 3 default-weight units should run concurrently with budget 3")
+}
+
+func TestRunnerPool_WeightedBudgetAdmission(t *testing.T) {
+	t.Parallel()
+
+	// Budget=10, heavy units weight=5, light units weight=1.
+	// All units are independent (no deps).
+	// Heavy units: at most 2 concurrent (5+5=10).
+	// We verify the pool never exceeds the budget.
+	units := buildWeightedUnits(
+		[]string{"heavy1", "heavy2", "heavy3", "light1", "light2", "light3"},
+		map[string]int{
+			"heavy1": 5,
+			"heavy2": 5,
+			"heavy3": 5,
+			"light1": 1,
+			"light2": 1,
+			"light3": 1,
+		},
+		map[string][]string{},
+	)
+
+	var mu sync.Mutex
+
+	var maxWeight, currentWeight int
+
+	runner := func(ctx context.Context, u *component.Unit) error {
+		w := u.ExecutionWeight()
+
+		mu.Lock()
+		currentWeight += w
+		if currentWeight > maxWeight {
+			maxWeight = currentWeight
+		}
+
+		cw := currentWeight
+		mu.Unlock()
+
+		assert.LessOrEqual(t, cw, 10, "In-flight weight should never exceed budget of 10")
+
+		time.Sleep(50 * time.Millisecond)
+
+		mu.Lock()
+		currentWeight -= w
+		mu.Unlock()
+
+		return nil
+	}
+
+	components := make(component.Components, len(units))
+	for i, u := range units {
+		components[i] = u
+	}
+
+	q, err := queue.NewQueue(components)
+	require.NoError(t, err)
+
+	dagRunner := runnerpool.NewController(
+		q,
+		units,
+		runnerpool.WithRunner(runner),
+		runnerpool.WithMaxConcurrency(10),
+	)
+	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	require.NoError(t, err)
+	assert.LessOrEqual(t, maxWeight, 10, "Peak in-flight weight must not exceed budget")
+	assert.Greater(t, maxWeight, 1, "Should have achieved some concurrency")
+}
+
+func TestRunnerPool_OversizedWeightRunsSolo(t *testing.T) {
+	t.Parallel()
+
+	// A unit with weight > budget should still run (solo, when pool is empty).
+	units := buildWeightedUnits(
+		[]string{"huge", "small"},
+		map[string]int{
+			"huge":  20,
+			"small": 1,
+		},
+		map[string][]string{},
+	)
+
+	var executedPaths sync.Map
+
+	runner := func(ctx context.Context, u *component.Unit) error {
+		executedPaths.Store(u.Path(), true)
+
+		return nil
+	}
+
+	components := make(component.Components, len(units))
+	for i, u := range units {
+		components[i] = u
+	}
+
+	q, err := queue.NewQueue(components)
+	require.NoError(t, err)
+
+	dagRunner := runnerpool.NewController(
+		q,
+		units,
+		runnerpool.WithRunner(runner),
+		runnerpool.WithMaxConcurrency(5),
+	)
+	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	require.NoError(t, err)
+
+	_, hugeRan := executedPaths.Load("huge")
+	_, smallRan := executedPaths.Load("small")
+	assert.True(t, hugeRan, "Oversized unit should still execute")
+	assert.True(t, smallRan, "Small unit should also execute")
+}
+

--- a/internal/runner/runnerpool/controller_test.go
+++ b/internal/runner/runnerpool/controller_test.go
@@ -438,29 +438,27 @@ func TestRunnerPool_WeightedBudgetAdmissionWithRacing(t *testing.T) {
 func TestRunnerPool_OversizedWeightRunsSoloWithRacing(t *testing.T) {
 	t.Parallel()
 
-	synctest.Test(t, func(t *testing.T) {
-		// A unit with weight > budget should still run (solo, when pool is empty).
-		units := buildWeightedUnits(
-			[]string{"huge", "small"},
-			map[string]int{"huge": 20, "small": 1},
-			map[string][]string{},
-		)
+	// A unit with weight > budget should still run (solo, when pool is empty).
+	units := buildWeightedUnits(
+		[]string{"huge", "small"},
+		map[string]int{"huge": 20, "small": 1},
+		map[string][]string{},
+	)
 
-		var executedPaths sync.Map
+	var executedPaths sync.Map
 
-		err := runWeightedController(t, units, 5, func(ctx context.Context, u *component.Unit) error {
-			executedPaths.Store(u.Path(), true)
+	err := runWeightedController(t, units, 5, func(ctx context.Context, u *component.Unit) error {
+		executedPaths.Store(u.Path(), true)
 
-			return nil
-		}, runWeightExperimentOpts())
-		require.NoError(t, err)
+		return nil
+	}, runWeightExperimentOpts())
+	require.NoError(t, err)
 
-		_, hugeRan := executedPaths.Load("huge")
-		_, smallRan := executedPaths.Load("small")
+	_, hugeRan := executedPaths.Load("huge")
+	_, smallRan := executedPaths.Load("small")
 
-		assert.True(t, hugeRan, "Oversized unit should still execute")
-		assert.True(t, smallRan, "Small unit should also execute")
-	})
+	assert.True(t, hugeRan, "Oversized unit should still execute")
+	assert.True(t, smallRan, "Small unit should also execute")
 }
 
 func TestRunnerPool_HeavyUnitDoesNotBlockLightUnitsWithRacing(t *testing.T) {

--- a/internal/runner/runnerpool/controller_test.go
+++ b/internal/runner/runnerpool/controller_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runnerpool"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 
@@ -324,7 +325,7 @@ func buildWeightedUnits(paths []string, weights map[string]int, depMap map[strin
 }
 
 // runWeightedController is a helper that wires up units into a queue and controller, then runs it.
-func runWeightedController(t *testing.T, units []*component.Unit, concurrency int, runner runnerpool.UnitRunner) error {
+func runWeightedController(t *testing.T, units []*component.Unit, concurrency int, runner runnerpool.UnitRunner, opts ...runnerpool.ControllerOption) error {
 	t.Helper()
 
 	components := make(component.Components, len(units))
@@ -335,14 +336,25 @@ func runWeightedController(t *testing.T, units []*component.Unit, concurrency in
 	q, err := queue.NewQueue(components)
 	require.NoError(t, err)
 
+	allOpts := make([]runnerpool.ControllerOption, 0, 2+len(opts))
+	allOpts = append(allOpts, runnerpool.WithRunner(runner), runnerpool.WithMaxConcurrency(concurrency))
+	allOpts = append(allOpts, opts...)
+
 	ctrl := runnerpool.NewController(
 		q,
 		units,
-		runnerpool.WithRunner(runner),
-		runnerpool.WithMaxConcurrency(concurrency),
+		allOpts...,
 	)
 
 	return ctrl.Run(t.Context(), logger.CreateLogger())
+}
+
+// runWeightExperimentOpts returns a ControllerOption that enables the run-weight experiment.
+func runWeightExperimentOpts() runnerpool.ControllerOption {
+	exps := experiment.NewExperiments()
+	_ = exps.EnableExperiment(experiment.RunWeight)
+
+	return runnerpool.WithExperiments(exps)
 }
 
 func TestRunnerPool_DefaultWeightBackwardsCompatWithRacing(t *testing.T) {
@@ -416,7 +428,7 @@ func TestRunnerPool_WeightedBudgetAdmissionWithRacing(t *testing.T) {
 			mu.Unlock()
 
 			return nil
-		})
+		}, runWeightExperimentOpts())
 		require.NoError(t, err)
 		assert.LessOrEqual(t, maxWeight, 10, "Peak in-flight weight must not exceed budget")
 		assert.Greater(t, maxWeight, 1, "Should have achieved some concurrency")
@@ -440,7 +452,7 @@ func TestRunnerPool_OversizedWeightRunsSoloWithRacing(t *testing.T) {
 			executedPaths.Store(u.Path(), true)
 
 			return nil
-		})
+		}, runWeightExperimentOpts())
 		require.NoError(t, err)
 
 		_, hugeRan := executedPaths.Load("huge")
@@ -495,7 +507,7 @@ func TestRunnerPool_HeavyUnitDoesNotBlockLightUnitsWithRacing(t *testing.T) {
 			mu.Unlock()
 
 			return nil
-		})
+		}, runWeightExperimentOpts())
 		require.NoError(t, err)
 		assert.True(t, lightRanWhileFirstRunning, "Light units should run concurrently with first, not blocked behind heavy")
 	})

--- a/internal/runner/runnerpool/controller_test.go
+++ b/internal/runner/runnerpool/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -347,144 +348,152 @@ func runWeightedController(t *testing.T, units []*component.Unit, concurrency in
 func TestRunnerPool_DefaultWeightBackwardsCompatWithRacing(t *testing.T) {
 	t.Parallel()
 
-	// Units without run_weight should default to 1, preserving existing behavior.
-	units := buildComponentUnits([]string{"A", "B", "C"}, map[string][]string{})
+	synctest.Test(t, func(t *testing.T) {
+		// Units without run_weight should default to 1, preserving existing behavior.
+		units := buildComponentUnits([]string{"A", "B", "C"}, map[string][]string{})
 
-	var mu sync.Mutex
+		var mu sync.Mutex
 
-	var current, maxConcurrent int
+		var current, maxConcurrent int
 
-	err := runWeightedController(t, units, 3, func(ctx context.Context, u *component.Unit) error {
-		mu.Lock()
-		current++
-		if current > maxConcurrent {
-			maxConcurrent = current
-		}
+		err := runWeightedController(t, units, 3, func(ctx context.Context, u *component.Unit) error {
+			mu.Lock()
+			current++
+			if current > maxConcurrent {
+				maxConcurrent = current
+			}
 
-		mu.Unlock()
+			mu.Unlock()
 
-		time.Sleep(50 * time.Millisecond)
+			time.Sleep(50 * time.Millisecond)
 
-		mu.Lock()
-		current--
-		mu.Unlock()
+			mu.Lock()
+			current--
+			mu.Unlock()
 
-		return nil
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, maxConcurrent, "All 3 default-weight units should run concurrently with budget 3")
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 3, maxConcurrent, "All 3 default-weight units should run concurrently with budget 3")
 }
 
 func TestRunnerPool_WeightedBudgetAdmissionWithRacing(t *testing.T) {
 	t.Parallel()
 
-	// Budget=10, heavy units weight=5, light units weight=1.
-	units := buildWeightedUnits(
-		[]string{"heavy1", "heavy2", "heavy3", "light1", "light2", "light3"},
-		map[string]int{"heavy1": 5, "heavy2": 5, "heavy3": 5, "light1": 1, "light2": 1, "light3": 1},
-		map[string][]string{},
-	)
+	synctest.Test(t, func(t *testing.T) {
+		// Budget=10, heavy units weight=5, light units weight=1.
+		units := buildWeightedUnits(
+			[]string{"heavy1", "heavy2", "heavy3", "light1", "light2", "light3"},
+			map[string]int{"heavy1": 5, "heavy2": 5, "heavy3": 5, "light1": 1, "light2": 1, "light3": 1},
+			map[string][]string{},
+		)
 
-	var mu sync.Mutex
+		var mu sync.Mutex
 
-	var maxWeight, currentWeight int
+		var maxWeight, currentWeight int
 
-	err := runWeightedController(t, units, 10, func(ctx context.Context, u *component.Unit) error {
-		w := u.RunWeight()
+		err := runWeightedController(t, units, 10, func(ctx context.Context, u *component.Unit) error {
+			w := u.RunWeight()
 
-		mu.Lock()
-		currentWeight += w
-		if currentWeight > maxWeight {
-			maxWeight = currentWeight
-		}
+			mu.Lock()
+			currentWeight += w
+			if currentWeight > maxWeight {
+				maxWeight = currentWeight
+			}
 
-		cw := currentWeight
-		mu.Unlock()
+			cw := currentWeight
+			mu.Unlock()
 
-		assert.LessOrEqual(t, cw, 10, "In-flight weight should never exceed budget of 10")
+			assert.LessOrEqual(t, cw, 10, "In-flight weight should never exceed budget of 10")
 
-		time.Sleep(50 * time.Millisecond)
+			time.Sleep(50 * time.Millisecond)
 
-		mu.Lock()
-		currentWeight -= w
-		mu.Unlock()
+			mu.Lock()
+			currentWeight -= w
+			mu.Unlock()
 
-		return nil
+			return nil
+		})
+		require.NoError(t, err)
+		assert.LessOrEqual(t, maxWeight, 10, "Peak in-flight weight must not exceed budget")
+		assert.Greater(t, maxWeight, 1, "Should have achieved some concurrency")
 	})
-	require.NoError(t, err)
-	assert.LessOrEqual(t, maxWeight, 10, "Peak in-flight weight must not exceed budget")
-	assert.Greater(t, maxWeight, 1, "Should have achieved some concurrency")
 }
 
 func TestRunnerPool_OversizedWeightRunsSoloWithRacing(t *testing.T) {
 	t.Parallel()
 
-	// A unit with weight > budget should still run (solo, when pool is empty).
-	units := buildWeightedUnits(
-		[]string{"huge", "small"},
-		map[string]int{"huge": 20, "small": 1},
-		map[string][]string{},
-	)
+	synctest.Test(t, func(t *testing.T) {
+		// A unit with weight > budget should still run (solo, when pool is empty).
+		units := buildWeightedUnits(
+			[]string{"huge", "small"},
+			map[string]int{"huge": 20, "small": 1},
+			map[string][]string{},
+		)
 
-	var executedPaths sync.Map
+		var executedPaths sync.Map
 
-	err := runWeightedController(t, units, 5, func(ctx context.Context, u *component.Unit) error {
-		executedPaths.Store(u.Path(), true)
+		err := runWeightedController(t, units, 5, func(ctx context.Context, u *component.Unit) error {
+			executedPaths.Store(u.Path(), true)
 
-		return nil
+			return nil
+		})
+		require.NoError(t, err)
+
+		_, hugeRan := executedPaths.Load("huge")
+		_, smallRan := executedPaths.Load("small")
+		assert.True(t, hugeRan, "Oversized unit should still execute")
+		assert.True(t, smallRan, "Small unit should also execute")
 	})
-	require.NoError(t, err)
-
-	_, hugeRan := executedPaths.Load("huge")
-	_, smallRan := executedPaths.Load("small")
-	assert.True(t, hugeRan, "Oversized unit should still execute")
-	assert.True(t, smallRan, "Small unit should also execute")
 }
 
 func TestRunnerPool_HeavyUnitDoesNotBlockLightUnitsWithRacing(t *testing.T) {
 	t.Parallel()
 
-	// Budget=10. All units independent (no deps).
-	// first(3) runs and holds 3 of 10. heavy(9) can't fit (3+9=12 > 10) but
-	// light units (1 each) should skip ahead since they do fit (3+1=4 <= 10).
-	// Without skip-ahead logic, heavy would block the loop and light units would starve.
-	units := buildWeightedUnits(
-		[]string{"first", "heavy", "light1", "light2"},
-		map[string]int{"first": 3, "heavy": 9, "light1": 1, "light2": 1},
-		map[string][]string{},
-	)
+	synctest.Test(t, func(t *testing.T) {
+		// Budget=10. All units independent (no deps).
+		// first(3) runs and holds 3 of 10. heavy(9) can't fit (3+9=12 > 10) but
+		// light units (1 each) should skip ahead since they do fit (3+1=4 <= 10).
+		// Without skip-ahead logic, heavy would block the loop and light units would starve.
+		units := buildWeightedUnits(
+			[]string{"first", "heavy", "light1", "light2"},
+			map[string]int{"first": 3, "heavy": 9, "light1": 1, "light2": 1},
+			map[string][]string{},
+		)
 
-	var mu sync.Mutex
+		var mu sync.Mutex
 
-	var maxWeight, currentWeight int
+		var maxWeight, currentWeight int
 
-	lightRanWhileFirstRunning := false
+		lightRanWhileFirstRunning := false
 
-	err := runWeightedController(t, units, 10, func(ctx context.Context, u *component.Unit) error {
-		w := u.RunWeight()
+		err := runWeightedController(t, units, 10, func(ctx context.Context, u *component.Unit) error {
+			w := u.RunWeight()
 
-		mu.Lock()
-		currentWeight += w
-		if currentWeight > maxWeight {
-			maxWeight = currentWeight
-		}
+			mu.Lock()
+			currentWeight += w
+			if currentWeight > maxWeight {
+				maxWeight = currentWeight
+			}
 
-		// If a light unit is running while first is still in-flight, skip-ahead worked
-		if w == 1 && currentWeight > 1 {
-			lightRanWhileFirstRunning = true
-		}
+			// If a light unit is running while first is still in-flight, skip-ahead worked
+			if w == 1 && currentWeight > 1 {
+				lightRanWhileFirstRunning = true
+			}
 
-		mu.Unlock()
+			mu.Unlock()
 
-		time.Sleep(50 * time.Millisecond)
+			time.Sleep(50 * time.Millisecond)
 
-		mu.Lock()
-		currentWeight -= w
-		mu.Unlock()
+			mu.Lock()
+			currentWeight -= w
+			mu.Unlock()
 
-		return nil
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, lightRanWhileFirstRunning, "Light units should run concurrently with first, not blocked behind heavy")
 	})
-	require.NoError(t, err)
-	assert.True(t, lightRanWhileFirstRunning, "Light units should run concurrently with first, not blocked behind heavy")
 }
 

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -523,6 +523,7 @@ func (rnr *Runner) Run(ctx context.Context, l log.Logger, stackOpts *options.Ter
 		rnr.Stack.Units,
 		WithRunner(task),
 		WithMaxConcurrency(stackOpts.Parallelism),
+		WithExperiments(stackOpts.Experiments),
 	)
 
 	err := controller.Run(ctx, l)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,6 +71,7 @@ const (
 	MetadataDependency                  = "dependency"
 	MetadataDownloadDir                 = "download_dir"
 	MetadataPreventDestroy              = "prevent_destroy"
+	MetadataExecutionWeight             = "execution_weight"
 	MetadataIamRole                     = "iam_role"
 	MetadataIamAssumeRoleDuration       = "iam_assume_role_duration"
 	MetadataIamAssumeRoleSessionName    = "iam_assume_role_session_name"
@@ -152,6 +153,7 @@ type TerragruntConfig struct {
 	Dependencies                *ModuleDependencies
 	Exclude                     *ExcludeConfig
 	PreventDestroy              *bool
+	ExecutionWeight             *int
 	GenerateConfigs             map[string]codegen.GenerateConfig
 	IamAssumeRoleDuration       *int64
 	Inputs                      map[string]any
@@ -620,6 +622,10 @@ func (cfg *TerragruntConfig) WriteTo(w io.Writer) (int64, error) {
 		rootBody.SetAttributeValue("prevent_destroy", cfgAsCty.GetAttr("prevent_destroy"))
 	}
 
+	if cfg.ExecutionWeight != nil {
+		rootBody.SetAttributeValue("execution_weight", cfgAsCty.GetAttr("execution_weight"))
+	}
+
 	if cfg.IamRole != "" {
 		rootBody.SetAttributeValue("iam_role", cfgAsCty.GetAttr("iam_role"))
 	}
@@ -669,6 +675,7 @@ type terragruntConfigFile struct {
 	Dependencies             *ModuleDependencies `hcl:"dependencies,block"`
 	DownloadDir              *string             `hcl:"download_dir,attr"`
 	PreventDestroy           *bool               `hcl:"prevent_destroy,attr"`
+	ExecutionWeight          *int                `hcl:"execution_weight,attr"`
 	IamRole                  *string             `hcl:"iam_role,attr"`
 	IamAssumeRoleDuration    *int64              `hcl:"iam_assume_role_duration,attr"`
 	IamAssumeRoleSessionName *string             `hcl:"iam_assume_role_session_name,attr"`
@@ -1805,6 +1812,11 @@ func convertToTerragruntConfig(ctx context.Context, pctx *ParsingContext, config
 	if terragruntConfigFromFile.PreventDestroy != nil {
 		terragruntConfig.PreventDestroy = terragruntConfigFromFile.PreventDestroy
 		terragruntConfig.SetFieldMetadata(MetadataPreventDestroy, defaultMetadata)
+	}
+
+	if terragruntConfigFromFile.ExecutionWeight != nil {
+		terragruntConfig.ExecutionWeight = terragruntConfigFromFile.ExecutionWeight
+		terragruntConfig.SetFieldMetadata(MetadataExecutionWeight, defaultMetadata)
 	}
 
 	if terragruntConfigFromFile.IamRole != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,7 +71,7 @@ const (
 	MetadataDependency                  = "dependency"
 	MetadataDownloadDir                 = "download_dir"
 	MetadataPreventDestroy              = "prevent_destroy"
-	MetadataExecutionWeight             = "execution_weight"
+	MetadataRunWeight             = "run_weight"
 	MetadataIamRole                     = "iam_role"
 	MetadataIamAssumeRoleDuration       = "iam_assume_role_duration"
 	MetadataIamAssumeRoleSessionName    = "iam_assume_role_session_name"
@@ -153,7 +153,7 @@ type TerragruntConfig struct {
 	Dependencies                *ModuleDependencies
 	Exclude                     *ExcludeConfig
 	PreventDestroy              *bool
-	ExecutionWeight             *int
+	RunWeight             *int
 	GenerateConfigs             map[string]codegen.GenerateConfig
 	IamAssumeRoleDuration       *int64
 	Inputs                      map[string]any
@@ -622,8 +622,8 @@ func (cfg *TerragruntConfig) WriteTo(w io.Writer) (int64, error) {
 		rootBody.SetAttributeValue("prevent_destroy", cfgAsCty.GetAttr("prevent_destroy"))
 	}
 
-	if cfg.ExecutionWeight != nil {
-		rootBody.SetAttributeValue("execution_weight", cfgAsCty.GetAttr("execution_weight"))
+	if cfg.RunWeight != nil {
+		rootBody.SetAttributeValue("run_weight", cfgAsCty.GetAttr("run_weight"))
 	}
 
 	if cfg.IamRole != "" {
@@ -675,7 +675,7 @@ type terragruntConfigFile struct {
 	Dependencies             *ModuleDependencies `hcl:"dependencies,block"`
 	DownloadDir              *string             `hcl:"download_dir,attr"`
 	PreventDestroy           *bool               `hcl:"prevent_destroy,attr"`
-	ExecutionWeight          *int                `hcl:"execution_weight,attr"`
+	RunWeight          *int                `hcl:"run_weight,attr"`
 	IamRole                  *string             `hcl:"iam_role,attr"`
 	IamAssumeRoleDuration    *int64              `hcl:"iam_assume_role_duration,attr"`
 	IamAssumeRoleSessionName *string             `hcl:"iam_assume_role_session_name,attr"`
@@ -1814,9 +1814,9 @@ func convertToTerragruntConfig(ctx context.Context, pctx *ParsingContext, config
 		terragruntConfig.SetFieldMetadata(MetadataPreventDestroy, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.ExecutionWeight != nil {
-		terragruntConfig.ExecutionWeight = terragruntConfigFromFile.ExecutionWeight
-		terragruntConfig.SetFieldMetadata(MetadataExecutionWeight, defaultMetadata)
+	if terragruntConfigFromFile.RunWeight != nil {
+		terragruntConfig.RunWeight = terragruntConfigFromFile.RunWeight
+		terragruntConfig.SetFieldMetadata(MetadataRunWeight, defaultMetadata)
 	}
 
 	if terragruntConfigFromFile.IamRole != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,7 +71,7 @@ const (
 	MetadataDependency                  = "dependency"
 	MetadataDownloadDir                 = "download_dir"
 	MetadataPreventDestroy              = "prevent_destroy"
-	MetadataRunWeight             = "run_weight"
+	MetadataRunWeight                   = "run_weight"
 	MetadataIamRole                     = "iam_role"
 	MetadataIamAssumeRoleDuration       = "iam_assume_role_duration"
 	MetadataIamAssumeRoleSessionName    = "iam_assume_role_session_name"
@@ -153,7 +153,7 @@ type TerragruntConfig struct {
 	Dependencies                *ModuleDependencies
 	Exclude                     *ExcludeConfig
 	PreventDestroy              *bool
-	RunWeight             *int
+	RunWeight                   *int
 	GenerateConfigs             map[string]codegen.GenerateConfig
 	IamAssumeRoleDuration       *int64
 	Inputs                      map[string]any
@@ -675,7 +675,7 @@ type terragruntConfigFile struct {
 	Dependencies             *ModuleDependencies `hcl:"dependencies,block"`
 	DownloadDir              *string             `hcl:"download_dir,attr"`
 	PreventDestroy           *bool               `hcl:"prevent_destroy,attr"`
-	RunWeight          *int                `hcl:"run_weight,attr"`
+	RunWeight                *int                `hcl:"run_weight,attr"`
 	IamRole                  *string             `hcl:"iam_role,attr"`
 	IamAssumeRoleDuration    *int64              `hcl:"iam_assume_role_duration,attr"`
 	IamAssumeRoleSessionName *string             `hcl:"iam_assume_role_session_name,attr"`

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -94,13 +94,13 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 		output[MetadataPreventDestroy] = goboolToCty(*config.PreventDestroy)
 	}
 
-	if config.ExecutionWeight != nil {
-		executionWeightCty, err := GoTypeToCty(*config.ExecutionWeight)
+	if config.RunWeight != nil {
+		executionWeightCty, err := GoTypeToCty(*config.RunWeight)
 		if err != nil {
 			return cty.NilVal, err
 		}
 
-		output[MetadataExecutionWeight] = executionWeightCty
+		output[MetadataRunWeight] = executionWeightCty
 	}
 
 	dependencyCty, err := dependencyBlocksAsCty(config.TerragruntDependencies)
@@ -194,8 +194,8 @@ func TerragruntConfigAsCtyWithMetadata(config *TerragruntConfig) (cty.Value, err
 		}
 	}
 
-	if config.ExecutionWeight != nil {
-		if err := wrapWithMetadata(config, *config.ExecutionWeight, MetadataExecutionWeight, &output); err != nil {
+	if config.RunWeight != nil {
+		if err := wrapWithMetadata(config, *config.RunWeight, MetadataRunWeight, &output); err != nil {
 			return cty.NilVal, err
 		}
 	}

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -94,6 +94,15 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 		output[MetadataPreventDestroy] = goboolToCty(*config.PreventDestroy)
 	}
 
+	if config.ExecutionWeight != nil {
+		executionWeightCty, err := GoTypeToCty(*config.ExecutionWeight)
+		if err != nil {
+			return cty.NilVal, err
+		}
+
+		output[MetadataExecutionWeight] = executionWeightCty
+	}
+
 	dependencyCty, err := dependencyBlocksAsCty(config.TerragruntDependencies)
 	if err != nil {
 		return cty.NilVal, err
@@ -181,6 +190,12 @@ func TerragruntConfigAsCtyWithMetadata(config *TerragruntConfig) (cty.Value, err
 
 	if config.PreventDestroy != nil {
 		if err := wrapWithMetadata(config, *config.PreventDestroy, MetadataPreventDestroy, &output); err != nil {
+			return cty.NilVal, err
+		}
+	}
+
+	if config.ExecutionWeight != nil {
+		if err := wrapWithMetadata(config, *config.ExecutionWeight, MetadataExecutionWeight, &output); err != nil {
 			return cty.NilVal, err
 		}
 	}

--- a/pkg/config/config_as_cty_test.go
+++ b/pkg/config/config_as_cty_test.go
@@ -87,7 +87,7 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 		},
 		DownloadDir:     ".terragrunt-cache",
 		PreventDestroy:  &testTrue,
-		ExecutionWeight: &testWeight,
+		RunWeight: &testWeight,
 		IamRole:        "terragruntRole",
 		Inputs: map[string]any{
 			"aws_region": "us-east-1",
@@ -345,8 +345,8 @@ func terragruntConfigStructFieldToMapKey(t *testing.T, fieldName string) (string
 		return "download_dir", true
 	case "PreventDestroy":
 		return "prevent_destroy", true
-	case "ExecutionWeight":
-		return "execution_weight", true
+	case "RunWeight":
+		return "run_weight", true
 	case "IamRole":
 		return "iam_role", true
 	case "IamAssumeRoleDuration":

--- a/pkg/config/config_as_cty_test.go
+++ b/pkg/config/config_as_cty_test.go
@@ -24,6 +24,7 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 	testSource := "./foo"
 	testTrue := true
 	testFalse := false
+	testWeight := 10
 	mockOutputs := cty.Zero
 	mockOutputsAllowedTerraformCommands := []string{"init"}
 	metaVal := cty.MapVal(map[string]cty.Value{
@@ -84,8 +85,9 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 		Dependencies: &config.ModuleDependencies{
 			Paths: []string{"foo"},
 		},
-		DownloadDir:    ".terragrunt-cache",
-		PreventDestroy: &testTrue,
+		DownloadDir:     ".terragrunt-cache",
+		PreventDestroy:  &testTrue,
+		ExecutionWeight: &testWeight,
 		IamRole:        "terragruntRole",
 		Inputs: map[string]any{
 			"aws_region": "us-east-1",
@@ -343,6 +345,8 @@ func terragruntConfigStructFieldToMapKey(t *testing.T, fieldName string) (string
 		return "download_dir", true
 	case "PreventDestroy":
 		return "prevent_destroy", true
+	case "ExecutionWeight":
+		return "execution_weight", true
 	case "IamRole":
 		return "iam_role", true
 	case "IamAssumeRoleDuration":

--- a/pkg/config/config_as_cty_test.go
+++ b/pkg/config/config_as_cty_test.go
@@ -85,9 +85,9 @@ func TestTerragruntConfigAsCtyDrift(t *testing.T) {
 		Dependencies: &config.ModuleDependencies{
 			Paths: []string{"foo"},
 		},
-		DownloadDir:     ".terragrunt-cache",
-		PreventDestroy:  &testTrue,
-		RunWeight: &testWeight,
+		DownloadDir:    ".terragrunt-cache",
+		PreventDestroy: &testTrue,
+		RunWeight:      &testWeight,
 		IamRole:        "terragruntRole",
 		Inputs: map[string]any{
 			"aws_region": "us-east-1",

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -90,7 +90,7 @@ type terragruntFlags struct {
 	IamRole             *string  `hcl:"iam_role,attr"`
 	IamWebIdentityToken *string  `hcl:"iam_web_identity_token,attr"`
 	PreventDestroy      *bool    `hcl:"prevent_destroy,attr"`
-	RunWeight     *int     `hcl:"run_weight,attr"`
+	RunWeight           *int     `hcl:"run_weight,attr"`
 	Remain              hcl.Body `hcl:",remain"`
 }
 

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -83,11 +83,14 @@ type terraformConfigSourceOnly struct {
 	Remain hcl.Body `hcl:",remain"`
 }
 
-// terragruntFlags is a struct that can be used to only decode the flag attributes (prevent_destroy)
+// terragruntFlags is a struct that can be used to only decode the flag attributes (prevent_destroy, execution_weight).
+// execution_weight is included here because discovery partial-parses configs via TerragruntFlags
+// and stores the result on each unit before the Runner Pool reads ExecutionWeight() for admission.
 type terragruntFlags struct {
 	IamRole             *string  `hcl:"iam_role,attr"`
 	IamWebIdentityToken *string  `hcl:"iam_web_identity_token,attr"`
 	PreventDestroy      *bool    `hcl:"prevent_destroy,attr"`
+	ExecutionWeight     *int     `hcl:"execution_weight,attr"`
 	Remain              hcl.Body `hcl:",remain"`
 }
 
@@ -514,6 +517,10 @@ func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger,
 
 			if decoded.PreventDestroy != nil {
 				output.PreventDestroy = decoded.PreventDestroy
+			}
+
+			if decoded.ExecutionWeight != nil {
+				output.ExecutionWeight = decoded.ExecutionWeight
 			}
 
 			if decoded.IamRole != nil {

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -83,14 +83,14 @@ type terraformConfigSourceOnly struct {
 	Remain hcl.Body `hcl:",remain"`
 }
 
-// terragruntFlags is a struct that can be used to only decode the flag attributes (prevent_destroy, execution_weight).
-// execution_weight is included here because discovery partial-parses configs via TerragruntFlags
-// and stores the result on each unit before the Runner Pool reads ExecutionWeight() for admission.
+// terragruntFlags is a struct that can be used to only decode the flag attributes (prevent_destroy, run_weight).
+// run_weight is included here because discovery partial-parses configs via TerragruntFlags
+// and stores the result on each unit before the Runner Pool reads RunWeight() for admission.
 type terragruntFlags struct {
 	IamRole             *string  `hcl:"iam_role,attr"`
 	IamWebIdentityToken *string  `hcl:"iam_web_identity_token,attr"`
 	PreventDestroy      *bool    `hcl:"prevent_destroy,attr"`
-	ExecutionWeight     *int     `hcl:"execution_weight,attr"`
+	RunWeight     *int     `hcl:"run_weight,attr"`
 	Remain              hcl.Body `hcl:",remain"`
 }
 
@@ -519,8 +519,8 @@ func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger,
 				output.PreventDestroy = decoded.PreventDestroy
 			}
 
-			if decoded.ExecutionWeight != nil {
-				output.ExecutionWeight = decoded.ExecutionWeight
+			if decoded.RunWeight != nil {
+				output.RunWeight = decoded.RunWeight
 			}
 
 			if decoded.IamRole != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2005,6 +2005,58 @@ func TestWriteToCatalogFields(t *testing.T) {
 	assert.Contains(t, rendered, "no_hooks")
 }
 
+func TestWriteToExecutionWeight(t *testing.T) {
+	t.Parallel()
+
+	weight := 10
+	cfg := &config.TerragruntConfig{
+		ExecutionWeight: &weight,
+	}
+
+	var buf bytes.Buffer
+
+	_, writeErr := cfg.WriteTo(&buf)
+	require.NoError(t, writeErr)
+
+	rendered := buf.String()
+	assert.Contains(t, rendered, "execution_weight")
+	assert.Contains(t, rendered, "10")
+}
+
+func TestParseTerragruntConfigExecutionWeight(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+execution_weight = 10
+`
+
+	l := createLogger()
+
+	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, terragruntConfig.ExecutionWeight)
+	assert.Equal(t, 10, *terragruntConfig.ExecutionWeight)
+}
+
+func TestParseTerragruntConfigExecutionWeightNotSet(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+terraform {
+}
+`
+
+	l := createLogger()
+
+	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	require.NoError(t, err)
+
+	assert.Nil(t, terragruntConfig.ExecutionWeight, "execution_weight should be nil when not set")
+}
+
 func createLogger() log.Logger {
 	formatter := format.NewFormatter(format.NewKeyValueFormatPlaceholders())
 	formatter.SetDisabledColors(true)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2005,12 +2005,12 @@ func TestWriteToCatalogFields(t *testing.T) {
 	assert.Contains(t, rendered, "no_hooks")
 }
 
-func TestWriteToExecutionWeight(t *testing.T) {
+func TestWriteToRunWeight(t *testing.T) {
 	t.Parallel()
 
 	weight := 10
 	cfg := &config.TerragruntConfig{
-		ExecutionWeight: &weight,
+		RunWeight: &weight,
 	}
 
 	var buf bytes.Buffer
@@ -2019,15 +2019,15 @@ func TestWriteToExecutionWeight(t *testing.T) {
 	require.NoError(t, writeErr)
 
 	rendered := buf.String()
-	assert.Contains(t, rendered, "execution_weight")
+	assert.Contains(t, rendered, "run_weight")
 	assert.Contains(t, rendered, "10")
 }
 
-func TestParseTerragruntConfigExecutionWeight(t *testing.T) {
+func TestParseTerragruntConfigRunWeight(t *testing.T) {
 	t.Parallel()
 
 	cfg := `
-execution_weight = 10
+run_weight = 10
 `
 
 	l := createLogger()
@@ -2036,11 +2036,11 @@ execution_weight = 10
 	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 
-	require.NotNil(t, terragruntConfig.ExecutionWeight)
-	assert.Equal(t, 10, *terragruntConfig.ExecutionWeight)
+	require.NotNil(t, terragruntConfig.RunWeight)
+	assert.Equal(t, 10, *terragruntConfig.RunWeight)
 }
 
-func TestParseTerragruntConfigExecutionWeightNotSet(t *testing.T) {
+func TestParseTerragruntConfigRunWeightNotSet(t *testing.T) {
 	t.Parallel()
 
 	cfg := `
@@ -2054,7 +2054,7 @@ terraform {
 	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
 
-	assert.Nil(t, terragruntConfig.ExecutionWeight, "execution_weight should be nil when not set")
+	assert.Nil(t, terragruntConfig.RunWeight, "run_weight should be nil when not set")
 }
 
 func createLogger() log.Logger {

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -303,8 +303,8 @@ func (cfg *TerragruntConfig) Merge(l log.Logger, sourceConfig *TerragruntConfig)
 		cfg.PreventDestroy = sourceConfig.PreventDestroy
 	}
 
-	if sourceConfig.ExecutionWeight != nil {
-		cfg.ExecutionWeight = sourceConfig.ExecutionWeight
+	if sourceConfig.RunWeight != nil {
+		cfg.RunWeight = sourceConfig.RunWeight
 	}
 
 	if sourceConfig.TerragruntVersionConstraint != "" {
@@ -429,8 +429,8 @@ func (cfg *TerragruntConfig) DeepMerge(l log.Logger, sourceConfig *TerragruntCon
 		cfg.PreventDestroy = sourceConfig.PreventDestroy
 	}
 
-	if sourceConfig.ExecutionWeight != nil {
-		cfg.ExecutionWeight = sourceConfig.ExecutionWeight
+	if sourceConfig.RunWeight != nil {
+		cfg.RunWeight = sourceConfig.RunWeight
 	}
 
 	if sourceConfig.TerragruntVersionConstraint != "" {

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -303,6 +303,10 @@ func (cfg *TerragruntConfig) Merge(l log.Logger, sourceConfig *TerragruntConfig)
 		cfg.PreventDestroy = sourceConfig.PreventDestroy
 	}
 
+	if sourceConfig.ExecutionWeight != nil {
+		cfg.ExecutionWeight = sourceConfig.ExecutionWeight
+	}
+
 	if sourceConfig.TerragruntVersionConstraint != "" {
 		cfg.TerragruntVersionConstraint = sourceConfig.TerragruntVersionConstraint
 	}
@@ -423,6 +427,10 @@ func (cfg *TerragruntConfig) DeepMerge(l log.Logger, sourceConfig *TerragruntCon
 
 	if sourceConfig.PreventDestroy != nil {
 		cfg.PreventDestroy = sourceConfig.PreventDestroy
+	}
+
+	if sourceConfig.ExecutionWeight != nil {
+		cfg.ExecutionWeight = sourceConfig.ExecutionWeight
 	}
 
 	if sourceConfig.TerragruntVersionConstraint != "" {


### PR DESCRIPTION
## Description

Fixes #6165.

Adds an optional `run_weight` integer attribute to `terragrunt.hcl`, gated behind the `run-weight` experiment flag. When enabled, `--parallelism=N` becomes a weight budget: the Runner Pool admits a unit only when `in_flight_weight + candidate_weight <= N`. Light units skip ahead of heavy units that don't fit, preventing starvation. Oversized units (weight > budget) run solo when the pool is empty.

Fully backwards-compatible: without the experiment enabled, all units have weight 1 and behavior is identical to today.

### Example

```bash
terragrunt run --all plan --parallelism 10 --experiment run-weight
```

```hcl
# terragrunt.hcl for an EKS cluster unit
run_weight = 5
```

With `--parallelism=10`: the pool admits 2 EKS units (5+5=10), or 1 EKS + 5 lightweight units (5+1+1+1+1+1=10), or 10 default-weight units.

### Changes

**Experiment flag** (`internal/experiment/experiment.go`)
- Added `RunWeight` ("run-weight") experiment constant

**Config parsing** (`pkg/config/config.go`, `config_as_cty.go`, `config_partial.go`, `include.go`)
- `RunWeight *int` on `TerragruntConfig` and `terragruntConfigFile`
- Metadata constant, cty conversion, partial parse (needed by discovery), include merge (shallow + deep), `WriteTo` serialization

**Runner Pool** (`internal/runner/runnerpool/controller.go`)
- Replaced channel-based semaphore with `weightedSemaphore` (mutex + non-blocking `tryAcquire`)
- Admission loop skips heavy units that don't fit and admits lighter ones that do
- `releaseCh` signals the scheduler to re-evaluate deferred entries when capacity frees up
- Weight lookup gated behind `experiment.RunWeight`

**Component** (`internal/component/unit.go`)
- `RunWeight()` accessor, defaults to 1 when unset/zero/negative

**Documentation**
- Changelog entry under v1.0.7 (`experiments-added`)
- HCL attributes reference for `run_weight`
- Weighted Parallelism section in Run Queue docs

### Test output

https://gist.github.com/jameslett/80b1292e31d29caa075a9c77c95a4b68

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added run_weight config and a run-weight experiment to enable weighted parallelism; units default to weight 1, weights <1 clamp to 1, oversized units may run solo, and scheduler enforces a weight budget to avoid starvation.

* **Documentation**
  * Updated docs and changelog with examples, behavior notes, and guidance for choosing run_weight.

* **Tests**
  * Added tests covering parsing/serialization, defaults/clamping, weighted admission, oversized behavior, and skip-ahead scheduling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->