### PR TITLE
fix: Fixing synthetic trees for `terraform.source` URLs with `//`

### DIFF
--- a/docs/src/data/changelog/v1.0.7/cas-unit-source-preserves-subdir.mdx
+++ b/docs/src/data/changelog/v1.0.7/cas-unit-source-preserves-subdir.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.7"
+category: "bug-fixes"
+---
+
+#### `update_source_with_cas`: preserve `//subdir` on a unit's `terraform.source`
+
+When a unit's `terraform.source` used the `//` subdir convention (for example, `source = "../..//modules/foo"`) and opted into `update_source_with_cas`, the rewritten source dropped the `//subdir` tail and the synthetic tree contained only the leaf module's files. A module that referenced a sibling via a relative path (`source = "../bar"`) could not resolve that reference after materialization.
+
+Rewrites now preserve the original `//subdir` (for example, `cas::sha1:<hash>//modules/foo`), and the synthetic tree is rooted at the path before `//`, so sibling files reachable via relative paths land in the materialized working directory.
+
+Sources without `//` are unchanged: the tree stays scoped to the leaf module, and the rewritten reference has no `//subdir` tail.

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -326,6 +326,14 @@ func (c *CAS) processStackFile(
 
 // processUnitFile processes a terragrunt.hcl file, rewriting the
 // terraform.source if update_source_with_cas is set.
+//
+// When the source uses the "//" subdir convention (e.g. "../..//modules/foo"),
+// the synthetic tree is built from the resolved base path (everything before
+// "//") and the rewritten CAS reference preserves the "//subdir" tail. This
+// keeps sibling files reachable from the materialized working directory, so
+// OpenTofu/Terraform modules that reference each other via relative paths
+// (e.g. source = "../bar") resolve correctly. Sources without "//" produce a
+// shallow tree of just the leaf module and a CAS reference with no subdir.
 func (c *CAS) processUnitFile(
 	l log.Logger,
 	v Venv,
@@ -352,17 +360,35 @@ func (c *CAS) processUnitFile(
 
 	l.Debugf("Processing CAS source rewrite for terraform source %q in %s", source, unitFile)
 
-	moduleDir, err := ResolveInRepoSource(repoRoot, dirPath, source)
+	basePath, subdir := SplitSourceDoubleSlash(source)
+
+	treeDir, err := ResolveInRepoSource(repoRoot, dirPath, basePath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve terraform source %q: %w", source, err)
 	}
 
-	synthHash, err := c.buildSyntheticTree(l, v, moduleDir, refHash, repoRoot, hashAlg)
+	if subdir != "" {
+		moduleDir := filepath.Clean(filepath.Join(treeDir, subdir))
+
+		rel, relErr := filepath.Rel(treeDir, moduleDir)
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("%w: %q", ErrSourceEscapesRepo, source)
+		}
+
+		if _, err := v.FS.Stat(moduleDir); err != nil {
+			return fmt.Errorf("subdir %q not found under %s: %w", subdir, treeDir, err)
+		}
+	}
+
+	synthHash, err := c.buildSyntheticTree(l, v, treeDir, refHash, repoRoot, hashAlg)
 	if err != nil {
 		return fmt.Errorf("failed to build synthetic tree for terraform source %q: %w", source, err)
 	}
 
 	newSource := FormatCASRef(synthHash)
+	if subdir != "" {
+		newSource = FormatCASRefWithSubdir(synthHash, subdir)
+	}
 
 	content, err = RewriteTerraformSource(content, newSource)
 	if err != nil {

--- a/internal/cas/stacks_local_test.go
+++ b/internal/cas/stacks_local_test.go
@@ -83,7 +83,10 @@ func TestProcessStackComponent_LocalSource_RewritesUnitSources(t *testing.T) {
 	contentStr := string(content)
 
 	assert.Contains(t, contentStr, "cas::sha256:", "unit terraform source should be rewritten to a SHA-256 CAS ref")
-	assert.NotContains(t, contentStr, "modules/vpc", "module path should not appear in the rewritten source")
+	// The terraform.source uses "//", so the rewritten CAS ref must preserve
+	// the "//subdir" tail. The synthetic tree is rooted at the resolved base
+	// directory so sibling files stay reachable from the materialized unit.
+	assert.Contains(t, contentStr, "//modules/vpc", "rewritten CAS ref should preserve the //subdir tail")
 }
 
 func TestProcessStackComponent_LocalSource_DoesNotMutateInput(t *testing.T) {

--- a/internal/cas/stacks_test.go
+++ b/internal/cas/stacks_test.go
@@ -220,12 +220,120 @@ func TestProcessStackComponent_RewritesUnitSources(t *testing.T) {
 
 	assert.Contains(t, contentStr, "cas::", "unit terraform source should be rewritten to CAS ref")
 	assert.Contains(t, contentStr, "sha1:", "CAS ref should name the hash algorithm")
-	assert.NotContains(
+	// When the original terraform.source uses "//", the rewritten CAS ref must
+	// carry the same "//subdir" tail so the synthetic tree's surrounding files
+	// (e.g. sibling modules referenced via "../sibling") stay reachable after
+	// materialization.
+	assert.Contains(
 		t,
 		contentStr,
-		"modules/vpc",
-		"module path should not appear in the cas:: URL when using a synthetic tree",
+		"//modules/vpc",
+		"rewritten CAS ref should preserve the original //subdir tail",
 	)
+}
+
+// TestProcessStackComponent_UnitSourceSyntheticTreeContainsSiblings verifies
+// that a unit's terraform.source written with "//" produces a synthetic tree
+// rooted at the resolved base directory, so sibling modules referenced via
+// relative paths (e.g. `module "x" { source = "../sibling" }`) are present
+// alongside the target module.
+func TestProcessStackComponent_UnitSourceSyntheticTreeContainsSiblings(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	v, err := cas.OSVenv()
+	require.NoError(t, err)
+
+	source := repoURL + "//stacks/my-stack?ref=main"
+
+	result, err := c.ProcessStackComponent(ctx, l, v, source, "stack")
+	require.NoError(t, err)
+
+	defer result.Cleanup()
+
+	repoRoot := filepath.Dir(filepath.Dir(result.ContentDir))
+	unitFile := filepath.Join(repoRoot, "units", "my-service", "terragrunt.hcl")
+
+	content, err := os.ReadFile(unitFile)
+	require.NoError(t, err)
+
+	rewrittenSource, _, err := cas.ReadTerraformSourceInfo(content)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(rewrittenSource, "cas::"), "rewritten source should be a CAS ref")
+
+	withoutPrefix := strings.TrimPrefix(rewrittenSource, "cas::")
+	baseRef, subdir, found := strings.Cut(withoutPrefix, "//")
+	require.True(t, found, "rewritten source should carry a //subdir tail")
+	assert.Equal(t, "modules/vpc", subdir)
+
+	hash, err := cas.ParseCASRef(baseRef)
+	require.NoError(t, err)
+
+	synthStore := cas.NewStore(filepath.Join(storePath, "synth", "trees"))
+	synthContent := cas.NewContent(synthStore)
+	treeData, err := synthContent.Read(v, hash)
+	require.NoError(t, err)
+
+	tree := string(treeData)
+	assert.Contains(t, tree, "modules/vpc/main.tf", "synthetic tree must include the target module")
+	assert.Contains(t, tree, "modules/sibling/main.tf", "synthetic tree must include siblings reachable via relative refs")
+}
+
+// TestProcessStackComponent_UnitSourceWithoutDoubleSlash pins the shallow-tree
+// behavior for terraform.source values that omit "//". The synthetic tree
+// should contain only the leaf module's files and the rewritten CAS ref must
+// have no //subdir tail.
+func TestProcessStackComponent_UnitSourceWithoutDoubleSlash(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	repoURL := startStackTestServer(t)
+	l := logger.CreateLogger()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	require.NoError(t, err)
+
+	v, err := cas.OSVenv()
+	require.NoError(t, err)
+
+	source := repoURL + "//stacks/my-stack?ref=main"
+
+	result, err := c.ProcessStackComponent(ctx, l, v, source, "stack")
+	require.NoError(t, err)
+
+	defer result.Cleanup()
+
+	repoRoot := filepath.Dir(filepath.Dir(result.ContentDir))
+	leafUnitFile := filepath.Join(repoRoot, "units", "leaf-service", "terragrunt.hcl")
+
+	content, err := os.ReadFile(leafUnitFile)
+	require.NoError(t, err)
+
+	rewrittenSource, _, err := cas.ReadTerraformSourceInfo(content)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(rewrittenSource, "cas::"), "leaf unit source should be rewritten to CAS ref")
+	assert.NotContains(t, rewrittenSource, "//modules", "leaf rewrite must not synthesize a //subdir tail")
+
+	hash, err := cas.ParseCASRef(strings.TrimPrefix(rewrittenSource, "cas::"))
+	require.NoError(t, err)
+
+	synthStore := cas.NewStore(filepath.Join(storePath, "synth", "trees"))
+	synthContent := cas.NewContent(synthStore)
+	treeData, err := synthContent.Read(v, hash)
+	require.NoError(t, err)
+
+	tree := string(treeData)
+	assert.Contains(t, tree, "main.tf", "leaf tree should include the module's own files")
+	assert.NotContains(t, tree, "modules/vpc", "leaf tree should not include the surrounding repo structure")
+	assert.NotContains(t, tree, "modules/sibling", "leaf tree should not pull in siblings")
 }
 
 func TestProcessStackComponent_CreatesSyntheticTrees(t *testing.T) {

--- a/internal/cas/testserver_test.go
+++ b/internal/cas/testserver_test.go
@@ -47,8 +47,10 @@ func startTestServer(t *testing.T) string {
 // The repo layout is:
 //
 //	stacks/my-stack/terragrunt.stack.hcl   stack file with update_source_with_cas
-//	units/my-service/terragrunt.hcl        unit file with update_source_with_cas
+//	units/my-service/terragrunt.hcl        unit with `//` terraform.source
+//	units/leaf-service/terragrunt.hcl      unit with no-`//` terraform.source
 //	modules/vpc/main.tf                    plain Terraform module
+//	modules/sibling/main.tf                sibling module reachable from vpc via "../sibling"
 func startStackTestServer(t *testing.T) string {
 	t.Helper()
 
@@ -56,13 +58,21 @@ func startStackTestServer(t *testing.T) string {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = srv.Close() })
 
-	// Stack file that references a sibling unit via relative path with //.
+	// Stack file that references sibling units via relative paths with //.
 	stackHCL := []byte(`unit "service" {
   source = "../..//units/my-service"
 
   update_source_with_cas = true
 
   path = "service"
+}
+
+unit "leaf" {
+  source = "../..//units/leaf-service"
+
+  update_source_with_cas = true
+
+  path = "leaf"
 }
 
 unit "plain" {
@@ -72,7 +82,8 @@ unit "plain" {
 `)
 	require.NoError(t, srv.CommitFile("stacks/my-stack/terragrunt.stack.hcl", stackHCL, "add stack file"))
 
-	// Unit file whose terraform.source references a module via relative path.
+	// Unit file whose terraform.source references a module via "//" so the
+	// synthetic tree retains the surrounding repo structure.
 	unitHCL := []byte(`terraform {
   source = "../..//modules/vpc"
 
@@ -81,6 +92,17 @@ unit "plain" {
 `)
 	require.NoError(t, srv.CommitFile("units/my-service/terragrunt.hcl", unitHCL, "add unit file"))
 
+	// Unit file whose terraform.source omits "//". The synthetic tree must
+	// stay scoped to the leaf module and the rewritten ref must carry no
+	// "//subdir" tail.
+	leafUnitHCL := []byte(`terraform {
+  source = "../../modules/vpc"
+
+  update_source_with_cas = true
+}
+`)
+	require.NoError(t, srv.CommitFile("units/leaf-service/terragrunt.hcl", leafUnitHCL, "add leaf unit"))
+
 	// Plain unit (no CAS flag) should remain unchanged after processing.
 	plainUnitHCL := []byte(`terraform {
   source = "../../modules/vpc"
@@ -88,8 +110,14 @@ unit "plain" {
 `)
 	require.NoError(t, srv.CommitFile("units/plain-service/terragrunt.hcl", plainUnitHCL, "add plain unit"))
 
-	// Terraform module referenced by the unit.
-	require.NoError(t, srv.CommitFile("modules/vpc/main.tf", []byte(`resource "aws_vpc" "main" {
+	// OpenTofu/Terraform module referenced by the unit. It cross-references a
+	// sibling module via a relative path, which only resolves if the synthetic
+	// tree retains the surrounding repo structure.
+	require.NoError(t, srv.CommitFile("modules/vpc/main.tf", []byte(`module "sibling" {
+  source = "../sibling"
+}
+
+resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 }
 `), "add vpc module"))
@@ -98,6 +126,12 @@ unit "plain" {
   type = string
 }
 `), "add vpc variables"))
+
+	// Sibling module that the vpc module references via "../sibling".
+	require.NoError(t, srv.CommitFile("modules/sibling/main.tf", []byte(`output "name" {
+  value = "sibling"
+}
+`), "add sibling module"))
 
 	url, err := srv.Start(t.Context())
 	require.NoError(t, err)

--- a/pkg/config/config_helpers_test.go
+++ b/pkg/config/config_helpers_test.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"errors"
-
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/engine"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -2457,11 +2457,14 @@ func TestCASInStacks(t *testing.T) {
 	unitStr := string(unitConfigContent)
 
 	// CAS digests depend on the resolved git ref and repo paths; assert exact file shape using the emitted hashes.
+	// Stack blocks always materialize the leaf directory directly, so the rewritten ref has no "//subdir" tail.
+	// Only the terraform.source inside the unit preserves the "//" tail so sibling files in the synthetic tree remain reachable.
 	casSHA1Quoted := regexp.MustCompile(`"cas::sha1:([a-f0-9]{40})"`)
 	stackMatch := casSHA1Quoted.FindStringSubmatch(stackStr)
 	require.Len(t, stackMatch, 2, "generated stack should contain exactly one cas::sha1 reference in a quoted source attribute")
 
-	unitMatch := casSHA1Quoted.FindStringSubmatch(unitStr)
+	casSHA1QuotedUnit := regexp.MustCompile(`"cas::sha1:([a-f0-9]{40})//modules/baz"`)
+	unitMatch := casSHA1QuotedUnit.FindStringSubmatch(unitStr)
 	require.Len(t, unitMatch, 2, "generated unit terragrunt should contain exactly one cas::sha1 reference in a quoted source attribute")
 
 	wantStack := fmt.Sprintf(`unit "bar" {
@@ -2473,7 +2476,7 @@ func TestCASInStacks(t *testing.T) {
 `, stackMatch[1])
 
 	wantUnit := fmt.Sprintf(`terraform {
-  source = "cas::sha1:%s"
+  source = "cas::sha1:%s//modules/baz"
 
   update_source_with_cas = true
 }
@@ -2636,12 +2639,14 @@ func TestCASInStacksLocalSource(t *testing.T) {
 	unitStr := string(unitConfigContent)
 
 	// Local sources are content-addressed with SHA-256.
-	casSHA256Quoted := regexp.MustCompile(`"cas::sha256:([a-f0-9]{64})"`)
-
-	stackMatch := casSHA256Quoted.FindStringSubmatch(stackStr)
+	// Stack blocks always materialize the leaf directory directly, so the rewritten ref has no "//subdir" tail.
+	// Only the terraform.source inside the unit preserves the "//" tail so sibling files in the synthetic tree remain reachable.
+	casSHA256QuotedStack := regexp.MustCompile(`"cas::sha256:([a-f0-9]{64})"`)
+	stackMatch := casSHA256QuotedStack.FindStringSubmatch(stackStr)
 	require.Len(t, stackMatch, 2, "generated stack should contain exactly one cas::sha256 reference")
 
-	unitMatch := casSHA256Quoted.FindStringSubmatch(unitStr)
+	casSHA256QuotedUnit := regexp.MustCompile(`"cas::sha256:([a-f0-9]{64})//modules/baz"`)
+	unitMatch := casSHA256QuotedUnit.FindStringSubmatch(unitStr)
 	require.Len(t, unitMatch, 2, "generated unit terragrunt should contain exactly one cas::sha256 reference")
 
 	wantStack := fmt.Sprintf(`unit "bar" {
@@ -2653,7 +2658,7 @@ func TestCASInStacksLocalSource(t *testing.T) {
 `, stackMatch[1])
 
 	wantUnit := fmt.Sprintf(`terraform {
-  source = "cas::sha256:%s"
+  source = "cas::sha256:%s//modules/baz"
 
   update_source_with_cas = true
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6217.

Relates to #5558

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CAS reference handling to preserve subdirectory conventions in Terraform sources, enabling correct resolution of relative module references to sibling modules after materialization.

* **Documentation**
  * Added changelog entry documenting subdirectory preservation in CAS unit source rewrites.

* **Tests**
  * Updated and added tests to verify correct behavior for subdirectory-aware CAS references and synthetic tree scoping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->