### PR TITLE
docs: Cleaning up experiment docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -110,7 +110,9 @@ export default defineConfig({
             "/reference/cli/commands/find/#*",
 
             // Custom .astro pages — can't be validated statically
+            "/reference/experiments/active",
             "/reference/experiments/active#*",
+            "/reference/experiments/completed",
             "/reference/experiments/completed#*",
             "/reference/strict-controls/active#*",
             "/reference/strict-controls/completed#*",

--- a/docs/src/content/docs/03-features/08-filter/04-attributes.mdx
+++ b/docs/src/content/docs/03-features/08-filter/04-attributes.mdx
@@ -109,7 +109,7 @@ Reading a file directly in the `inputs` attribute will not mark the file as read
 
 To mark many files at once, use [`mark_glob_as_read`](/reference/hcl/functions/#mark_glob_as_read), which accepts a glob (with `**` support) and marks every matching file.
 
-If a unit's `terraform` block points at a local module source, enable the [`mark-many-as-read`](/reference/experiments) experiment to have Terragrunt automatically mark that module's `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` files as read. Reading-based filters will then cascade local module changes to every unit that consumes the module. The same experiment also enables the [`mark_glob_as_read`](/reference/hcl/functions/#mark_glob_as_read) HCL function.
+If a unit's `terraform` block points at a local module source, enable the [`mark-many-as-read`](/reference/experiments/active#mark-many-as-read) experiment to have Terragrunt automatically mark that module's `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` files as read. Reading-based filters will then cascade local module changes to every unit that consumes the module. The same experiment also enables the [`mark_glob_as_read`](/reference/hcl/functions/#mark_glob_as_read) HCL function.
 
 </Since>
 

--- a/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -1103,7 +1103,7 @@ Coming soon!
 <Since version="1.0.3">
 
 <Aside type="caution">
-`mark_glob_as_read` requires the [`mark-many-as-read`](/reference/experiments) experiment. Calling it without the experiment enabled returns an error.
+`mark_glob_as_read` requires the [`mark-many-as-read`](/reference/experiments/active#mark-many-as-read) experiment. Calling it without the experiment enabled returns an error.
 </Aside>
 
 <Aside type="caution">

--- a/docs/src/content/docs/04-reference/04-experiments.md
+++ b/docs/src/content/docs/04-reference/04-experiments.md
@@ -23,7 +23,7 @@ Sometimes, the criteria for an experiment to be considered stable is unknown, as
 
 ## Controlling Experiment Mode
 
-The simplest way to enable experiment mode is to set the [experiment-mode](/reference/experiments) flag.
+The simplest way to enable experiment mode is to set the [experiment-mode](/reference/cli/global-flags#experiment-mode) flag.
 
 This will enable experiment mode for all Terragrunt commands, for all experiments (note that this isn't generally recommended, unless you are following Terragrunt development closely and are prepared for the possibility of breaking changes).
 
@@ -37,7 +37,7 @@ You can also use the environment variable, which can be more useful in CI/CD pip
 TG_EXPERIMENT_MODE='true' terragrunt plan
 ```
 
-Instead of enabling experiment mode, you can also enable specific experiments by setting the [experiment](/reference/experiments)
+Instead of enabling experiment mode, you can also enable specific experiments by setting the [experiment](/reference/cli/global-flags#experiment)
 flag to a value that's specific to an experiment.
 This can allow you to experiment with a specific unstable feature that you think might be useful to you.
 
@@ -62,3 +62,8 @@ Including the environment variable:
 ```bash
 TG_EXPERIMENT='symlinks,stacks' terragrunt plan
 ```
+
+## Available Experiments
+
+- [Active Experiments](/reference/experiments/active): experiments available for opt-in, including what each one does, how to provide feedback, and the criteria for stabilization.
+- [Completed Experiments](/reference/experiments/completed): experiments that have graduated to stable features. Their flags are no longer needed and setting them has no effect.

--- a/docs/src/content/docs/06-troubleshooting/03-performance.mdx
+++ b/docs/src/content/docs/06-troubleshooting/03-performance.mdx
@@ -50,7 +50,7 @@ Under the hood, Terragrunt dependency blocks leverage the OpenTofu/Terraform `ou
 
 The OpenTofu/Terraform `output -json` command does a bit more work than simply fetching output values from state, and a significant portion of that slowdown is loading providers, which it doesn't really need in most cases.
 
-You can significantly improve the performance of dependency blocks by using the [`dependency-fetch-output-from-state`](https://docs.terragrunt.com/reference/experiments/#dependency-fetch-output-from-state) experiment. When the experiment is active, Terragrunt will resolve outputs by directly fetching the backend state file from S3 and parse it directly, avoiding any overhead incurred by calling the `output -json` command of OpenTofu/Terraform.
+You can significantly improve the performance of dependency blocks by using the [`dependency-fetch-output-from-state`](/reference/experiments/active#dependency-fetch-output-from-state) experiment. When the experiment is active, Terragrunt will resolve outputs by directly fetching the backend state file from S3 and parse it directly, avoiding any overhead incurred by calling the `output -json` command of OpenTofu/Terraform.
 
 For example:
 

--- a/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
+++ b/docs/src/data/changelog/v1.0.3/mark-many-as-read.mdx
@@ -5,7 +5,7 @@ category: "experiments-added"
 
 #### `mark-many-as-read` — Mark many files as read in one step
 
-Enable the new [`mark-many-as-read`](/reference/experiments) experiment to turn on two behaviors that each mark many files as read in a single call: automatic marking of files inside a local `terraform { source = "..." }` block, and the new `mark_glob_as_read` HCL function.
+Enable the new [`mark-many-as-read`](/reference/experiments/active#mark-many-as-read) experiment to turn on two behaviors that each mark many files as read in a single call: automatic marking of files inside a local `terraform { source = "..." }` block, and the new `mark_glob_as_read` HCL function.
 
 With the experiment on, a unit like this:
 

--- a/docs/src/data/experiments/catalog-redesign.mdx
+++ b/docs/src/data/experiments/catalog-redesign.mdx
@@ -4,11 +4,11 @@ status: active
 since: "1.0.2"
 ---
 
-Redesigned `terragrunt catalog` TUI with improved discovery, interactive component placement, and infrastructure estate visualization.
+Redesigned `terragrunt catalog` TUI with whole-repository discovery, tabbed browsing, and an interactive scaffolding form.
 
 ### `catalog-redesign` - What it does
 
-Replaces the existing `terragrunt catalog` experience with a redesigned TUI that removes the need for manual configuration. The new catalog provides multiple views for browsing and discovering modules, an interactive infrastructure estate view for deciding where to place components, and the ability to wire new components together with the rest of your infrastructure.
+Replaces the existing `terragrunt catalog` experience with a redesigned TUI that removes the need for manual configuration. The new catalog discovers modules and templates across the whole repository, lets you browse them in tabbed views, and scaffolds a selected component through an interactive form.
 
 Discovery walks the entire repository instead of only a `modules/` directory, so modules and templates can live anywhere. Boilerplate templates are discovered as a distinct component kind alongside OpenTofu/Terraform modules and labeled as templates in the UI. Catalog authors can commit a `.terragrunt-catalog-ignore` file at the repo root to exclude directories such as `examples/` or `test/` from discovery. See [Excluding paths from discovery](/features/catalog/tui#excluding-paths-from-discovery) for the supported pattern syntax.
 
@@ -20,17 +20,18 @@ Pressing `s` on a selected component opens an in-TUI form that prompts for every
 
 ### `catalog-redesign` - How to provide feedback
 
-TODO: Add a link to the relevant GitHub discussion or issue.
+Provide your feedback on the [`catalog-redesign` GitHub Discussion](https://github.com/gruntwork-io/terragrunt/discussions/6223).
 
 ### `catalog-redesign` - Criteria for stabilization
 
 To transition the `catalog-redesign` feature to a stable release, the following must be addressed:
 
-- [ ] Multiple catalog browse views are implemented and functional.
-- [ ] Interactive infrastructure estate view supports component placement.
-- [ ] Wiring newly placed components to existing infrastructure works end-to-end.
-- [ ] Catalog launches without requiring manual configuration (no pre-existing `catalog` block needed).
-- [ ] Component source is visible in the UI for each catalog entry.
-- [ ] Component type (module, unit, stack, template) is clearly indicated in the UI.
+- [x] Multiple catalog browse views (`All`, `Modules`, `Templates` tabs) are implemented and functional.
+- [x] Catalog launches without requiring manual configuration (no pre-existing `catalog` block needed).
+- [x] Discovery walks the entire repository, surfacing modules and boilerplate templates wherever they live.
+- [x] Authors can exclude paths from discovery with a `.terragrunt-catalog-ignore` file.
+- [x] Component source is visible in the UI for each catalog entry.
+- [x] Component type (module, unit, stack, template) is clearly indicated in the UI.
+- [x] An interactive scaffold form prompts for each variable a component exposes and generates `terragrunt.hcl`/`terragrunt.values.hcl`.
+- [x] Integration tests cover the core catalog workflows.
 - [ ] Positive feedback from users using the redesigned catalog in production environments.
-- [ ] Integration tests covering the core catalog workflows.

--- a/docs/src/data/experiments/dag-queue-display.mdx
+++ b/docs/src/data/experiments/dag-queue-display.mdx
@@ -38,4 +38,4 @@ To transition the `dag-queue-display` feature to a stable release, the following
 
 - [ ] Community feedback on the tree visualization format
 - [ ] Confirm readability with large dependency graphs
-- [ ] Confirm compatibility with CI/CD log viewers (color and Unicode handling)
+- [x] Confirm compatibility with CI/CD log viewers (color and Unicode handling)

--- a/docs/src/data/experiments/dependency-fetch-output-from-state.mdx
+++ b/docs/src/data/experiments/dependency-fetch-output-from-state.mdx
@@ -41,6 +41,6 @@ To transition the `dependency-fetch-output-from-state` feature to a stable relea
 - [ ] Comprehensive integration testing across different backend types
 - [ ] Performance benchmarking to validate speed improvements
 - [ ] Error handling and edge case testing
-- [ ] Documentation of supported backends and limitations
+- [x] Documentation of supported backends and limitations
 - [ ] Handle OpenTofu state encryption gracefully (fallback or explicit error message)
 - [ ] Community feedback on real-world usage

--- a/docs/src/data/experiments/filter-flag.mdx
+++ b/docs/src/data/experiments/filter-flag.mdx
@@ -1,6 +1,6 @@
 ---
 name: filter-flag
-status: active
+status: completed
 ---
 
 Support for sophisticated unit and stack filtering using the `--filter` flag.
@@ -8,9 +8,7 @@ Support for sophisticated unit and stack filtering using the `--filter` flag.
 ### `filter-flag` - What it does
 The `--filter` flag provides a sophisticated querying syntax for targeting units and stacks in Terragrunt commands. This unified approach replaces the need for multiple queue control flags and offers powerful filtering capabilities.
 
-**Current Support Status:**
-
-- Available in `find`, `list`, and `run` commands
+This experiment flag is no longer needed, as the `--filter` flag is now available by default in the `find`, `list`, and `run` commands.
 
 **Supported Filtering Types:**
 
@@ -23,17 +21,16 @@ The `--filter` flag provides a sophisticated querying syntax for targeting units
 4. **Negation filters**: Exclude units using the `!` prefix
 5. **Filter intersection**: Combine filters using the `|` operator for results pruning
 6. **Multiple filters**: Specify multiple `--filter` flags to union results
+7. **Git-based filtering**: Target units/stacks changed between Git references using the `[ref...ref]` syntax
+8. **Dependency/dependent traversal**: Expand results to dependencies and dependents using the `...` syntax
 
-**Not Yet Implemented:**
-
-- Git-based filtering (`[ref...ref]` syntax)
-- Dependency/dependent traversal (`...` syntax)
+The legacy queue control flags (`--queue-exclude-dir`, `--queue-excludes-file`, `--queue-exclude-external`, `--queue-include-dir`, `--queue-include-external`, `--queue-include-units-including`, `--queue-strict-include`) remain supported alongside `--filter`.
 
 ### `filter-flag` - How to provide feedback
-Provide your feedback on the [Filter Flag RFC](https://github.com/gruntwork-io/terragrunt/issues/4060) GitHub issue.
+Now that the `filter-flag` experiment is complete, please provide feedback in the form of standard [GitHub issues](https://github.com/gruntwork-io/terragrunt/issues).
 
 ### `filter-flag` - Criteria for stabilization
-To transition the `filter-flag` feature to a stable release, the following must be addressed, at a minimum:
+To transition the `filter-flag` feature to a stable release, the following were completed:
 
 - [x] Add support for name-based filtering
 - [x] Add support for path-based filtering (relative, absolute, glob)
@@ -50,18 +47,3 @@ To transition the `filter-flag` feature to a stable release, the following must 
 - [x] Add support for `--filter-allow-destroy` flag
 - [x] Add support for `--filter-affected` shorthand
 - [x] Comprehensive integration testing across all commands
-- [ ] Backport legacy queue control flags (queue-exclude-dir, queue-include-dir, etc.) into equivalent filter patterns as aliases.
-
-**Future Deprecations:**
-
-When this experiment stabilizes, the following queue control flags will be deprecated in favor of the unified `--filter` flag:
-
-- `--queue-exclude-dir`
-- `--queue-excludes-file`
-- `--queue-exclude-external`
-- `--queue-include-dir`
-- `--queue-include-external`
-- `--queue-include-units-including`
-- `--queue-strict-include`
-
-The current plan is to continue to support the flags as aliases for particular `--filter` patterns.

--- a/docs/src/data/experiments/iac-engine.mdx
+++ b/docs/src/data/experiments/iac-engine.mdx
@@ -19,7 +19,7 @@ Provide your feedback on the [Terragrunt IaC Engines](https://github.com/gruntwo
 To transition the `iac-engine` feature to a stable release, the following must be addressed, at a minimum:
 
 - [ ] API stability and backward compatibility guarantees
-- [ ] Comprehensive integration testing across all supported operations
+- [x] Comprehensive integration testing across all supported operations
 - [ ] Documentation of engine development and integration process
 - [ ] Performance benchmarks and optimization
 - [ ] Security review of engine execution and isolation mechanisms

--- a/docs/src/data/experiments/mark-many-as-read.mdx
+++ b/docs/src/data/experiments/mark-many-as-read.mdx
@@ -21,13 +21,13 @@ terragrunt run --all --experiment mark-many-as-read -- plan
 
 ### `mark-many-as-read` - How to provide feedback
 
-Provide your feedback on the [GitHub Discussions](https://github.com/gruntwork-io/terragrunt/discussions) page.
+Provide your feedback on the [`mark-many-as-read` GitHub Discussion](https://github.com/gruntwork-io/terragrunt/discussions/6225).
 
 ### `mark-many-as-read` - Criteria for stabilization
 
 To transition the `mark-many-as-read` feature to a stable release, the following must be addressed:
 
-- [ ] Confirm local module walking handles nested modules sensibly across macOS, Linux, and Windows.
-- [ ] Confirm glob semantics match user expectations for common patterns, especially `**` with a wildcard trailing segment.
+- [x] Confirm local module walking handles nested modules sensibly across macOS, Linux, and Windows.
+- [x] Confirm glob semantics match user expectations for common patterns, especially `**` with a wildcard trailing segment.
 - [ ] Positive feedback from users relying on reading-based filters in production pipelines.
-- [ ] Integration tests covering the interaction between module walking, `mark_glob_as_read`, and `--filter 'reading=...'`.
+- [x] Integration tests covering the interaction between module walking, `mark_glob_as_read`, and `--filter 'reading=...'`.

--- a/docs/src/data/experiments/opt-out-auth.mdx
+++ b/docs/src/data/experiments/opt-out-auth.mdx
@@ -1,0 +1,33 @@
+---
+name: opt-out-auth
+status: active
+since: "1.0.6"
+---
+
+Opt out of running `--auth-provider-cmd` during the discovery phase.
+
+### `opt-out-auth` - What it does
+By default, Terragrunt runs `--auth-provider-cmd` once per parsed component during the discovery phase, so configuration parsing can reliably resolve HCL functions such as `get_aws_account_id` and `run_cmd`. On large repositories, this dominates wall-clock time because the auth command runs for every discovered unit rather than only the subset that will actually run.
+
+Enabling this experiment unlocks the `--no-discovery-auth-provider-cmd` flag (env: `TG_NO_DISCOVERY_AUTH_PROVIDER_CMD`), which skips those discovery-time auth invocations. The auth provider command still runs normally for the units that actually execute.
+
+Units whose discovery-relevant blocks depend on credentials produced by `--auth-provider-cmd` will fail to parse with the flag set. Use it when you know parsing will resolve successfully without any prior authentication.
+
+```bash
+terragrunt run --all \
+  --experiment opt-out-auth \
+  --no-discovery-auth-provider-cmd \
+  --queue-include-units-reading=./changed-file.txt \
+  plan
+```
+
+### `opt-out-auth` - How to provide feedback
+Provide your feedback on the [`opt-out-auth` GitHub Discussion](https://github.com/gruntwork-io/terragrunt/discussions/6224).
+
+### `opt-out-auth` - Criteria for stabilization
+To transition the `opt-out-auth` feature to a stable release, the following must be addressed, at a minimum:
+
+- [ ] Confirm the discovery-phase opt-out covers the auth scenarios users rely on without surprising parse failures.
+- [ ] Measure the wall-clock improvement on large `run --all` invocations with reading-based filters.
+- [ ] Decide whether additional phases warrant their own opt-out flags.
+- [ ] Community feedback on real-world usage.

--- a/docs/src/data/experiments/slow-task-reporting.mdx
+++ b/docs/src/data/experiments/slow-task-reporting.mdx
@@ -22,7 +22,7 @@ terragrunt run --all --experiment slow-task-reporting -- plan
 ```
 
 ### `slow-task-reporting` - How to provide feedback
-Provide your feedback on the [GitHub Discussions](https://github.com/gruntwork-io/terragrunt/discussions) page.
+Provide your feedback on the [`slow-task-reporting` GitHub Discussion](https://github.com/gruntwork-io/terragrunt/discussions/6226).
 
 ### `slow-task-reporting` - Criteria for stabilization
 To transition the `slow-task-reporting` feature to a stable release, the following must be addressed:

--- a/docs/src/data/flags/no-discovery-auth-provider-cmd.mdx
+++ b/docs/src/data/flags/no-discovery-auth-provider-cmd.mdx
@@ -11,7 +11,7 @@ since: "v1.0.6"
 import { Aside } from '@astrojs/starlight/components';
 
 <Aside type="tip" title="Experimental">
-This flag is gated behind the [`opt-out-auth`](/reference/experiments) experiment. Enable it with `--experiment=opt-out-auth` (or `TG_EXPERIMENT=opt-out-auth`); otherwise setting `--no-discovery-auth-provider-cmd` returns an error. The flag's behavior may change while the experiment is in progress.
+This flag is gated behind the [`opt-out-auth`](/reference/experiments/active#opt-out-auth) experiment. Enable it with `--experiment=opt-out-auth` (or `TG_EXPERIMENT=opt-out-auth`); otherwise setting `--no-discovery-auth-provider-cmd` returns an error. The flag's behavior may change while the experiment is in progress.
 </Aside>
 
 Skip running `--auth-provider-cmd` during the discovery phase.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Cleans up docs for experiments.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved cross-references and links throughout documentation for better navigation
  * Added documentation for new `opt-out-auth` experiment to skip discovery-time authentication
  * Updated multiple experiment documentation with stabilization progress
  * `--filter` flag is now available by default in `find`, `list`, and `run` commands with expanded capabilities including git-based filtering and dependency traversal

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->