### PR TITLE
chore: Increasing test coverage for stack dependencies

### DIFF
--- a/test/fixtures/stacks/stack-deps-arbitrary-override/catalog/units/gen/main.tf
+++ b/test/fixtures/stacks/stack-deps-arbitrary-override/catalog/units/gen/main.tf
@@ -1,0 +1,4 @@
+resource "local_file" "marker" {
+  content  = "gen"
+  filename = "${path.module}/marker.txt"
+}

--- a/test/fixtures/stacks/stack-deps-arbitrary-override/catalog/units/gen/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-arbitrary-override/catalog/units/gen/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-arbitrary-override/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-arbitrary-override/live/terragrunt.stack.hcl
@@ -1,0 +1,19 @@
+# An autoinclude patches a unit with config beyond dependency/inputs. Here a
+# generate block is injected; it must land in the generated unit and emit the file
+# when the unit runs.
+unit "gen" {
+  source = "../catalog/units/gen"
+  path   = "gen"
+
+  autoinclude {
+    generate "injected" {
+      path      = "injected.tf"
+      if_exists = "overwrite"
+      contents  = <<-TF
+        output "injected" {
+          value = "injected-by-autoinclude"
+        }
+      TF
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-cross-level-values/catalog/stacks/child/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-cross-level-values/catalog/stacks/child/terragrunt.stack.hcl
@@ -1,0 +1,19 @@
+unit "consumer" {
+  source = "${get_repo_root()}/catalog/units/consumer"
+  path   = "consumer"
+
+  autoinclude {
+    dependency "producer" {
+      config_path = values.producer_path
+
+      mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+      mock_outputs = {
+        val = "mock-val"
+      }
+    }
+
+    inputs = {
+      val = dependency.producer.outputs.val
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/consumer/main.tf
+++ b/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/consumer/main.tf
@@ -1,0 +1,12 @@
+variable "val" {
+  type = string
+}
+
+resource "local_file" "marker" {
+  content  = "consumer received: ${var.val}"
+  filename = "${path.module}/input.txt"
+}
+
+output "received" {
+  value = var.val
+}

--- a/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/consumer/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/consumer/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/producer/main.tf
+++ b/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/producer/main.tf
@@ -1,0 +1,8 @@
+resource "local_file" "marker" {
+  content  = "producer"
+  filename = "${path.module}/marker.txt"
+}
+
+output "val" {
+  value = "produced-across-levels"
+}

--- a/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/producer/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/producer/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-cross-level-values/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-cross-level-values/live/terragrunt.stack.hcl
@@ -1,0 +1,16 @@
+# A dependency between units at different stack levels: the parent passes
+# unit.producer.path down to the child stack via values, and a unit inside the
+# child stack uses it as its autoinclude dependency config_path.
+unit "producer" {
+  source = "../catalog/units/producer"
+  path   = "producer"
+}
+
+stack "child" {
+  source = "../catalog/stacks/child"
+  path   = "child"
+
+  values = {
+    producer_path = unit.producer.path
+  }
+}

--- a/test/fixtures/stacks/stack-deps-cross-stack/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-cross-stack/live/terragrunt.stack.hcl
@@ -15,14 +15,16 @@ unit "app" {
     dependency "network" {
       config_path = stack.network.path
 
-      mock_outputs_allowed_terraform_commands = ["validate", "plan", "apply", "destroy"]
+      mock_outputs_allowed_terraform_commands = ["validate", "plan"]
       mock_outputs = {
-        vpc_id = "mock-vpc"
+        vpc = {
+          vpc_id = "mock-vpc"
+        }
       }
     }
 
     inputs = {
-      vpc_id = dependency.network.outputs.vpc_id
+      vpc_id = dependency.network.outputs.vpc.vpc_id
     }
   }
 }

--- a/test/fixtures/stacks/stack-deps-merge-precedence/catalog/units/target/main.tf
+++ b/test/fixtures/stacks/stack-deps-merge-precedence/catalog/units/target/main.tf
@@ -1,0 +1,8 @@
+variable "val" {
+  type = string
+}
+
+resource "local_file" "marker" {
+  content  = "received: ${var.val}"
+  filename = "${path.module}/marker.txt"
+}

--- a/test/fixtures/stacks/stack-deps-merge-precedence/catalog/units/target/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-merge-precedence/catalog/units/target/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  val = "from-unit"
+}

--- a/test/fixtures/stacks/stack-deps-merge-precedence/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-merge-precedence/live/terragrunt.stack.hcl
@@ -1,0 +1,12 @@
+# The unit's own terragrunt.hcl sets inputs.val; the autoinclude sets the same
+# key to a different value. The documented deep-merge has the autoinclude win.
+unit "target" {
+  source = "../catalog/units/target"
+  path   = "target"
+
+  autoinclude {
+    inputs = {
+      val = "from-autoinclude"
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-no-deps/catalog/units/alpha/main.tf
+++ b/test/fixtures/stacks/stack-deps-no-deps/catalog/units/alpha/main.tf
@@ -1,0 +1,4 @@
+resource "local_file" "marker" {
+  content  = "alpha"
+  filename = "${path.module}/marker.txt"
+}

--- a/test/fixtures/stacks/stack-deps-no-deps/catalog/units/alpha/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-no-deps/catalog/units/alpha/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-no-deps/catalog/units/beta/main.tf
+++ b/test/fixtures/stacks/stack-deps-no-deps/catalog/units/beta/main.tf
@@ -1,0 +1,4 @@
+resource "local_file" "marker" {
+  content  = "beta"
+  filename = "${path.module}/marker.txt"
+}

--- a/test/fixtures/stacks/stack-deps-no-deps/catalog/units/beta/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-no-deps/catalog/units/beta/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-no-deps/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-no-deps/live/terragrunt.stack.hcl
@@ -1,0 +1,11 @@
+# Experiment enabled, multiple units, zero autoinclude / dependencies.
+# Pins that turning the experiment on is inert when no autoinclude is used.
+unit "alpha" {
+  source = "../catalog/units/alpha"
+  path   = "alpha"
+}
+
+unit "beta" {
+  source = "../catalog/units/beta"
+  path   = "beta"
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude/live/terragrunt.stack.hcl
@@ -1,0 +1,18 @@
+# Stack-level autoinclude: the autoinclude sits on a "stack" block, so it must
+# generate terragrunt.autoinclude.stack.hcl (NOT the unit filename) in the
+# generated nested-stack directory.
+#
+# Stacks do not have dependencies (only units do), so a stack autoinclude injects
+# valid terragrunt.stack.hcl content. Here it patches the nested stack to add an
+# "extra" unit.
+stack "networking" {
+  source = "../stacks/networking"
+  path   = "networking"
+
+  autoinclude {
+    unit "extra" {
+      source = "${get_repo_root()}/units/extra"
+      path   = "extra"
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude/stacks/networking/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude/stacks/networking/terragrunt.stack.hcl
@@ -1,0 +1,4 @@
+unit "vpc" {
+  source = "${get_repo_root()}/units/vpc"
+  path   = "vpc"
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude/units/extra/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude/units/extra/main.tf
@@ -1,0 +1,8 @@
+resource "local_file" "marker" {
+  content  = "extra"
+  filename = "${path.module}/marker.txt"
+}
+
+output "extra_id" {
+  value = "extra-from-stack-autoinclude"
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude/units/extra/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude/units/extra/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude/units/vpc/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude/units/vpc/main.tf
@@ -1,0 +1,8 @@
+resource "local_file" "marker" {
+  content  = "vpc"
+  filename = "${path.module}/marker.txt"
+}
+
+output "vpc_id" {
+  value = "vpc-stack-autoinclude"
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude/units/vpc/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude/units/vpc/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -37,6 +37,11 @@ const (
 	testFixtureStackDepsAutoIncViaIncludeSuccess = "fixtures/stacks/stack-deps-autoinclude-via-include-success"
 	testFixtureStackDepsAutoIncComplexSiblings   = "fixtures/stacks/stack-deps-autoinclude-complex-siblings"
 	testFixtureStackDepsRunAllFuncsInNestedStack = "fixtures/stacks/stack-deps-runall-funcs-in-nested-stack"
+	testFixtureStackDepsNoDeps                   = "fixtures/stacks/stack-deps-no-deps"
+	testFixtureStackDepsMergePrecedence          = "fixtures/stacks/stack-deps-merge-precedence"
+	testFixtureStackDepsArbitraryOverride        = "fixtures/stacks/stack-deps-arbitrary-override"
+	testFixtureStackDepsStackAutoInclude         = "fixtures/stacks/stack-deps-stack-autoinclude"
+	testFixtureStackDepsCrossLevelValues         = "fixtures/stacks/stack-deps-cross-level-values"
 )
 
 // TestStackDepsAutoIncludeGenerationAndDAG tests parsing, autoinclude generation,
@@ -340,6 +345,18 @@ func TestStackDepsE2ECrossStack(t *testing.T) {
 	require.NoError(t, depErr)
 	require.Len(t, depPaths, 1)
 	assert.Equal(t, filepath.Join(rootPath, inthclparse.StackDir, "network"), depPaths[0])
+
+	// Apply the whole tree: the network stack's units run first, then app consumes the
+	// real aggregated output dependency.network.outputs.vpc.vpc_id (not the mock).
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- apply -auto-approve")
+
+	markerPath := helpers.FindCachedFile(t, appDir, "marker.txt")
+	markerContent, err := os.ReadFile(markerPath)
+	require.NoError(t, err)
+	assert.Equal(t, "app received: vpc-cross-stack", string(markerContent),
+		"app must receive the network stack's real vpc output, not the mock")
+
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- destroy -auto-approve")
 }
 
 // Regression: a non-literal expression (here, format()) in an unrelated unit must not block autoinclude resolution. Generation succeeds and the autoinclude file is produced for the unit that declares it.
@@ -1150,4 +1167,263 @@ func writeStackDepsFile(t *testing.T, root, rel, body string) {
 	full := filepath.Join(root, rel)
 	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
 	require.NoError(t, os.WriteFile(full, []byte(body), 0644))
+}
+
+// TestStackDepsNoDependenciesBaseline verifies the baseline case: the experiment
+// is enabled and the stack has multiple units but no autoinclude. Generation must
+// emit no autoinclude files and the stack must apply/destroy.
+func TestStackDepsNoDependenciesBaseline(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsNoDeps)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsNoDeps)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStackDepsNoDeps, "live")
+	rootPath, err := filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	// No autoinclude declared anywhere: generation must not emit autoinclude files.
+	assert.NoFileExists(t, filepath.Join(rootPath, inthclparse.StackDir, "alpha", inthclparse.AutoIncludeFile))
+	assert.NoFileExists(t, filepath.Join(rootPath, inthclparse.StackDir, "beta", inthclparse.AutoIncludeFile))
+
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- apply -auto-approve")
+
+	require.FileExists(t, helpers.FindCachedFile(t, filepath.Join(rootPath, inthclparse.StackDir, "alpha"), "marker.txt"))
+	require.FileExists(t, helpers.FindCachedFile(t, filepath.Join(rootPath, inthclparse.StackDir, "beta"), "marker.txt"))
+
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- destroy -auto-approve")
+}
+
+// TestStackDepsAutoIncludeWinsOnConflict pins the documented merge precedence:
+// when the unit's own terragrunt.hcl and the autoinclude both set the same
+// input, the autoinclude value wins.
+func TestStackDepsAutoIncludeWinsOnConflict(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsMergePrecedence)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsMergePrecedence)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStackDepsMergePrecedence, "live")
+	rootPath, err := filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+	require.FileExists(t, filepath.Join(rootPath, inthclparse.StackDir, "target", inthclparse.AutoIncludeFile))
+
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- apply -auto-approve")
+
+	markerPath := helpers.FindCachedFile(t, filepath.Join(rootPath, inthclparse.StackDir, "target"), "marker.txt")
+	markerContent, err := os.ReadFile(markerPath)
+	require.NoError(t, err)
+	assert.Equal(t, "received: from-autoinclude", string(markerContent),
+		"autoinclude value must win over the unit's own inputs on conflict")
+
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- destroy -auto-approve")
+}
+
+// TestStackDepsAutoIncludeArbitraryOverride verifies that an autoinclude may patch
+// a unit with config beyond dependency/inputs. Here a generate block is injected;
+// it must be preserved in the generated file and emit its file on apply.
+func TestStackDepsAutoIncludeArbitraryOverride(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsArbitraryOverride)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsArbitraryOverride)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStackDepsArbitraryOverride, "live")
+	rootPath, err := filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	autoIncludePath := filepath.Join(rootPath, inthclparse.StackDir, "gen", inthclparse.AutoIncludeFile)
+	require.FileExists(t, autoIncludePath)
+	content, err := os.ReadFile(autoIncludePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `generate "injected"`,
+		"non-dependency blocks in autoinclude must be preserved in the generated file")
+
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- apply -auto-approve")
+
+	injectedPath := helpers.FindCachedFile(t, filepath.Join(rootPath, inthclparse.StackDir, "gen"), "injected.tf")
+	require.FileExists(t, injectedPath, "generate block injected via autoinclude must produce its file")
+
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- destroy -auto-approve")
+}
+
+// TestStackDepsMockOutputsAtPlan exercises mock_outputs functionally: with no
+// prior apply, planning the dependent unit must succeed against the dependency's
+// mock_outputs (allowed for "plan"), rather than failing on unavailable outputs.
+func TestStackDepsMockOutputsAtPlan(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsBasic)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsBasic)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStackDepsBasic, "live")
+	rootPath, err := filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- plan")
+	require.NoError(t, err, "plan must succeed using mock_outputs before any apply; stderr=%s", stderr)
+}
+
+// TestStackDepsStackLevelAutoInclude verifies stack-level autoinclude generation.
+// A stack does not have dependencies (only units do), so a stack-block autoinclude
+// injects valid terragrunt.stack.hcl content (here an extra unit). Generation must
+// produce terragrunt.autoinclude.stack.hcl (not the unit filename) in the generated
+// nested-stack directory, preserving that content, without breaking discovery of
+// the nested units.
+func TestStackDepsStackLevelAutoInclude(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsStackAutoInclude)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackAutoInclude)
+	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackAutoInclude)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
+
+	rootPath := filepath.Join(gitPath, "live")
+	rootPath, err = filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	stackAutoInc := filepath.Join(rootPath, inthclparse.StackDir, "networking", inthclparse.AutoIncludeStackFile)
+	require.FileExists(t, stackAutoInc, "a stack-block autoinclude must generate terragrunt.autoinclude.stack.hcl")
+	assert.NoFileExists(t, filepath.Join(rootPath, inthclparse.StackDir, "networking", inthclparse.AutoIncludeFile),
+		"stack autoinclude must not be written with the unit-level filename")
+
+	content, err := os.ReadFile(stackAutoInc)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `unit "extra"`, "the injected stack content must be preserved in the generated file")
+
+	// Generation must not break discovery: the nested vpc unit must still enumerate.
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt find --json --experiment stack-dependencies --working-dir "+rootPath)
+	require.NoError(t, err)
+
+	var components []findComponent
+	require.NoError(t, json.Unmarshal([]byte(stdout), &components))
+
+	foundVPC := false
+
+	for _, c := range components {
+		if c.Type == "unit" && filepath.Base(c.Path) == "vpc" {
+			foundVPC = true
+			break
+		}
+	}
+
+	assert.True(t, foundVPC, "nested vpc unit must be discoverable")
+}
+
+// TestStackDepsStackLevelAutoIncludeMergedIntoNestedStack verifies that a unit
+// injected via a stack-level autoinclude materializes in the nested stack, once
+// the generated terragrunt.autoinclude.stack.hcl is merged into the nested
+// terragrunt.stack.hcl the same way a unit's terragrunt.autoinclude.hcl is merged
+// into its terragrunt.hcl.
+func TestStackDepsStackLevelAutoIncludeMergedIntoNestedStack(t *testing.T) {
+	t.Parallel()
+
+	t.Skip("stack-level autoinclude is generated but not yet merged into the nested stack")
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsStackAutoInclude)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackAutoInclude)
+	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackAutoInclude)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
+
+	rootPath := filepath.Join(gitPath, "live")
+	rootPath, err = filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	// The injected unit must be merged into the nested stack and generated.
+	nestedStackDir := filepath.Join(rootPath, inthclparse.StackDir, "networking", inthclparse.StackDir)
+	assert.DirExists(t, filepath.Join(nestedStackDir, "extra"),
+		"the unit injected via the stack-level autoinclude must materialize in the nested stack")
+}
+
+// TestStackDepsCrossLevelViaValues verifies a dependency between units at
+// different stack levels. The parent passes unit.producer.path down to the child
+// stack via values, and a unit inside the child stack consumes it as its
+// autoinclude dependency config_path; the consumer must receive the producer's
+// real output after apply.
+func TestStackDepsCrossLevelViaValues(t *testing.T) {
+	t.Parallel()
+
+	t.Skip("unit.*.path is not yet available in a stack block's values")
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsCrossLevelValues)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsCrossLevelValues)
+	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsCrossLevelValues)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
+
+	rootPath := filepath.Join(gitPath, "live")
+	rootPath, err = filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	consumerDir := filepath.Join(rootPath, inthclparse.StackDir, "child", inthclparse.StackDir, "consumer")
+	autoInc := filepath.Join(consumerDir, inthclparse.AutoIncludeFile)
+	require.FileExists(t, autoInc, "consumer in the child stack must get an autoinclude wired to the parent's producer")
+
+	content, err := os.ReadFile(autoInc)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `dependency "producer"`)
+
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- apply -auto-approve")
+
+	inputPath := helpers.FindCachedFile(t, consumerDir, "input.txt")
+	inputContent, err := os.ReadFile(inputPath)
+	require.NoError(t, err)
+	assert.Equal(t, "consumer received: produced-across-levels", string(inputContent),
+		"consumer must receive the producer's output across stack levels")
+
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- destroy -auto-approve")
+}
+
+// TestStackDepsAutoIncludeUnknownTarget is the negative path: an autoinclude
+// dependency whose config_path references an undeclared unit must fail stack
+// generate with a clean error, not a panic.
+func TestStackDepsAutoIncludeUnknownTarget(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	stackDir := filepath.Join(tmpDir, "live")
+	require.NoError(t, os.MkdirAll(stackDir, 0755))
+
+	unitDir := filepath.Join(tmpDir, "catalog", "units", "a")
+	require.NoError(t, os.MkdirAll(unitDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(unitDir, "terragrunt.hcl"), []byte("inputs = {}\n"), 0644))
+
+	stackHCL := `
+unit "a" {
+  source = "../catalog/units/a"
+  path   = "a"
+
+  autoinclude {
+    dependency "missing" {
+      config_path = unit.does_not_exist.path
+    }
+  }
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stackDir, "terragrunt.stack.hcl"), []byte(stackHCL), 0644))
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt stack generate --experiment stack-dependencies --working-dir "+stackDir)
+	require.Error(t, err, "autoinclude referencing an undeclared unit must fail generation")
+	assert.NotContains(t, stderr, "panic", "the failure must be a clean error, not a panic")
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds some e2e coverage for the `stack-dependencies` experiment.

Highlights two gaps that we need to address.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for stack dependency configurations, including scenarios for multiple units, autoinclude behaviors, mock outputs, nested stacks, and error handling.
  * Expanded test fixture coverage to validate dependency wiring, input merging, and cross-level stack interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->