### PR TITLE
fix: Fixing nested generation for paths with `//`

### DIFF
--- a/internal/tf/source.go
+++ b/internal/tf/source.go
@@ -325,7 +325,23 @@ func IsLocalSource(sourceURL *url.URL) bool {
 // (//), which typically represents the root of a modules repo (e.g. github.com/foo/infrastructure-modules) and the
 // path is everything after the double slash. If there is no double-slash in the URL, the root repo is the entire
 // sourceUrl and the path is an empty string.
+//
+// A cas:: reference parses as an opaque URL (scheme "cas::sha1", opaque
+// "<hash>//modules/foo"), so the "//" is split out of the opaque component
+// rather than the path.
 func SplitSourceURL(l log.Logger, sourceURL *url.URL) (*url.URL, string, error) {
+	if sourceURL.Opaque != "" {
+		opaqueSplitOnDoubleSlash := strings.SplitN(sourceURL.Opaque, "//", 2) //nolint:mnd
+		if len(opaqueSplitOnDoubleSlash) > 1 {
+			rootSourceURL := *sourceURL
+			rootSourceURL.Opaque = opaqueSplitOnDoubleSlash[0]
+
+			return &rootSourceURL, opaqueSplitOnDoubleSlash[1], nil
+		}
+
+		return sourceURL, "", nil
+	}
+
 	pathSplitOnDoubleSlash := strings.SplitN(sourceURL.Path, "//", 2) //nolint:mnd
 
 	if len(pathSplitOnDoubleSlash) > 1 {

--- a/internal/tf/source_test.go
+++ b/internal/tf/source_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -190,4 +191,43 @@ func TestRegressionSupportForGitRemoteCodecommit(t *testing.T) {
 
 	require.Equal(t, "git::codecommit::ap-northeast-1://my_app_modules", actualRootRepo.String())
 	require.Equal(t, "my-app/modules/main-module", actualModulePath)
+}
+
+// TestRegressionCASRefPreservesSubdir checks that SplitSourceURL splits the
+// "//" subdir out of a cas:: reference, whose subdir lives in the URL's opaque
+// component rather than its path.
+func TestRegressionCASRefPreservesSubdir(t *testing.T) {
+	t.Parallel()
+
+	const hash = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+
+	sourceURL, err := tf.ToSourceURL("cas::sha1:"+hash+"//modules/vpc", ".")
+	require.NoError(t, err)
+	require.Equal(t, "cas::sha1", sourceURL.Scheme)
+
+	l := logger.CreateLogger()
+
+	actualRootRepo, actualModulePath, err := tf.SplitSourceURL(l, sourceURL)
+	require.NoError(t, err)
+
+	require.Equal(t, "cas::sha1:"+hash, actualRootRepo.String())
+	require.Equal(t, "modules/vpc", actualModulePath)
+}
+
+// TestRegressionCASRefSubdirWorkingDir checks that NewSource points the working
+// directory at the subdir of a cas:: reference while keeping the canonical
+// source free of it, so the getter downloads the whole tree.
+func TestRegressionCASRefSubdirWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	const hash = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+
+	l := logger.CreateLogger()
+	downloadDir := t.TempDir()
+
+	src, err := tf.NewSource(l, "cas::sha1:"+hash+"//modules/vpc", downloadDir, t.TempDir(), false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "cas::sha1:"+hash, src.CanonicalSourceURL.String())
+	assert.Equal(t, filepath.Join(src.DownloadDir, "modules", "vpc"), src.WorkingDir)
 }

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -2491,6 +2491,84 @@ func TestCASInStacks(t *testing.T) {
 	assert.Equal(t, wantUnit, unitStr)
 }
 
+// TestCASInStacksUnitSourceSubdirSiblingsResolve is a regression test for a
+// unit whose terraform.source uses the "//" subdir convention with
+// update_source_with_cas. Generation rewrites the source to
+// cas::sha1:<hash>//modules/vpc. At runtime the full tree must materialize with
+// the working directory at the subdir, or a module that references a sibling
+// via a relative path (modules/vpc -> ../sibling) cannot resolve.
+func TestCASInStacksUnitSourceSubdirSiblingsResolve(t *testing.T) {
+	t.Parallel()
+
+	if !helpers.IsExperimentMode(t) {
+		t.Skip("Experiment mode is not enabled")
+	}
+
+	srv, err := git.NewServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	// modules/vpc references a sibling module via a relative path. This only
+	// resolves if the materialized working directory keeps the surrounding tree
+	// (modules/sibling) reachable from modules/vpc.
+	require.NoError(t, srv.CommitFile("modules/vpc/main.tf", []byte(`module "sibling" {
+  source = "../sibling"
+}
+`), "commit vpc module"))
+
+	require.NoError(t, srv.CommitFile("modules/sibling/main.tf", []byte(`output "name" {
+  value = "sibling"
+}
+`), "commit sibling module"))
+
+	require.NoError(t, srv.CommitFile("units/bar/terragrunt.hcl", []byte(`terraform {
+  source = "../..//modules/vpc"
+
+  update_source_with_cas = true
+}
+`), "commit unit"))
+
+	url, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	remoteStack := `unit "bar" {
+  source = "../..//units/bar"
+  path   = "bar"
+
+  update_source_with_cas = true
+}
+`
+	require.NoError(t, srv.CommitFile("stacks/foo/terragrunt.stack.hcl", []byte(remoteStack), "commit stack"))
+
+	tmp := helpers.TmpDirWOSymlinks(t)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tmp, "live"), 0755))
+
+	liveStack := fmt.Sprintf(`stack "foo" {
+  source = "git::%s//stacks/foo"
+  path   = "foo"
+
+  update_source_with_cas = true
+}
+`, url)
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "live", "terragrunt.stack.hcl"), []byte(liveStack), 0644))
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack generate --cas-clone-depth=-1 --working-dir "+tmp,
+	)
+	require.NoError(t, err)
+
+	// Running the unit forces the runtime materialization path. The unit's
+	// source resolves to cas::sha1:<hash>//modules/vpc; if the subdir handling
+	// drops the surrounding tree, "../sibling" is unreachable and the run fails.
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack run plan --non-interactive --cas-clone-depth=-1 --working-dir "+tmp,
+	)
+	require.NoError(t, err, "stack run plan failed; the sibling module referenced via ../sibling was likely unreachable:\n%s", stdout+stderr)
+}
+
 // TestCASInStacksRejectsUpdateSourceWithCASWithNoCAS verifies that stack generation
 // errors when a unit or stack block declares update_source_with_cas = true while
 // --no-cas is set. The "experiment off" branch is covered by the unit tests in


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6217.

Addresses a gap in the fix initially performed in #6218.

I fixed the logic for the initial generation of the unit to preserve the `//`, but I didn't also fix the logic for how that unit would then generate the contents of the `.terragrunt-cache` directory to ensure that the OpenTofu/Terraform root module would have sufficient context to have nested modules reference sibling modules.

This fixes that and adds a test that exercises the flow end to end. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of Content-Addressable Storage (CAS) source URLs when using subdirectories, ensuring proper path resolution for module references and directory structures.

* **Tests**
  * Added tests for CAS source handling with subdirectories in stack unit operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->