### PR TITLE
fix: Fixing stack path variables in values

### DIFF
--- a/docs/src/data/changelog/v1.0.7/stack-dependencies-path-vars-in-values.mdx
+++ b/docs/src/data/changelog/v1.0.7/stack-dependencies-path-vars-in-values.mdx
@@ -1,0 +1,26 @@
+---
+version: "v1.0.7"
+category: "experiments-updated"
+---
+
+#### `stack-dependencies`: `unit.<name>.path` and `stack.<name>.path` resolve in `values`
+
+The `stack-dependencies` experiment now exposes `unit.<name>.path` and `stack.<name>.path` when evaluating the `values` attribute of a `unit` or `stack` block, not only inside `autoinclude` blocks. A parent stack can pass the generated path of a sibling component down into a child stack, so a unit nested in that child stack can depend on a unit that lives at a different level of the hierarchy.
+
+```hcl
+unit "vpc" {
+  source = "../catalog/units/vpc"
+  path   = "vpc"
+}
+
+stack "app" {
+  source = "../catalog/stacks/app"
+  path   = "app"
+
+  values = {
+    vpc_path = unit.vpc.path
+  }
+}
+```
+
+A unit inside the `app` stack reads `values.vpc_path` and uses it as the `config_path` of an `autoinclude` dependency, wiring the cross-level relationship at generation time. Paths follow the same layout the generator produces, including `no_dot_terragrunt_stack` on the referenced block.

--- a/docs/src/data/experiments/stack-dependencies.mdx
+++ b/docs/src/data/experiments/stack-dependencies.mdx
@@ -20,7 +20,7 @@ The generated filename depends on the component kind:
 
 This experiment enables:
 
-- **`unit.<name>.path`** and **`stack.<name>.path`** variables in `terragrunt.stack.hcl` for referencing sibling component paths
+- **`unit.<name>.path`** and **`stack.<name>.path`** variables for referencing sibling component paths, both inside `autoinclude` blocks and in a unit or stack block's `values` (so a parent stack can pass a component path down to a child stack)
 - **`dependency` blocks targeting stack directories**: aggregated outputs from all units in the stack (`dependency.stack_name.outputs.unit_name.output_key`)
 - **Automatic deep merge** of `terragrunt.autoinclude.hcl` into unit configurations (autoinclude wins)
 - **Stack dependency expansion** in the run queue: depending on a stack waits until all its units complete

--- a/internal/hclparse/parse.go
+++ b/internal/hclparse/parse.go
@@ -27,9 +27,18 @@ const (
 	// HCL variable root names used in eval context.
 	varLocal      = "local"
 	varValues     = "values"
-	varUnit       = "unit"
-	varStack      = "stack"
 	varDependency = blockDependency
+)
+
+const (
+	// VarUnit is the eval-context variable root name under which top-level unit path
+	// references are exposed (unit.<name>.path). Exported so pkg/config can inject the
+	// same variable when decoding terragrunt.stack.hcl values.
+	VarUnit = "unit"
+	// VarStack is the eval-context variable root name under which top-level stack path
+	// references are exposed (stack.<name>.path). Exported so pkg/config can inject the
+	// same variable when decoding terragrunt.stack.hcl values.
+	VarStack = "stack"
 )
 
 // ParseStackFileInput holds the input for ParseStackFile.
@@ -102,9 +111,8 @@ func ParseStackFile(fs vfs.FS, input *ParseStackFileInput) (*ParseResult, error)
 		return result, err
 	}
 
-	stackTargetDir := filepath.Join(input.StackDir, StackDir)
-	evalCtx.Variables[varUnit] = BuildComponentRefMap(buildUnitRefs(decoded.Units, stackTargetDir))
-	evalCtx.Variables[varStack] = BuildComponentRefMap(buildStackRefs(decoded.Stacks, stackTargetDir))
+	evalCtx.Variables[VarUnit] = BuildComponentRefMap(buildUnitRefs(decoded.Units, input.StackDir))
+	evalCtx.Variables[VarStack] = BuildComponentRefMap(buildStackRefs(decoded.Stacks, input.StackDir))
 
 	autoIncludes, err := resolveAutoIncludes(decoded.Units, decoded.Stacks, evalCtx, srcByFilename)
 	if err != nil {
@@ -163,7 +171,7 @@ func buildBaseEvalContext(input *ParseStackFileInput) *hcl.EvalContext {
 
 	// Strip namespaces the phased parser populates itself so unevaluated refs fail loudly instead of leaking caller values.
 	maps.DeleteFunc(evalCtx.Variables, func(name string, _ cty.Value) bool {
-		return name == varLocal || name == varUnit || name == varStack || name == varValues
+		return name == varLocal || name == VarUnit || name == VarStack || name == varValues
 	})
 
 	if input.Values != nil {
@@ -203,32 +211,22 @@ func validateUniqueNames(decoded *unitsAndStacksHCL) error {
 }
 
 // buildUnitRefs builds component refs for unit blocks; no_dot_terragrunt_stack hoists the unit out of .terragrunt-stack.
-func buildUnitRefs(units []*UnitBlockHCL, stackTargetDir string) []ComponentRef {
+func buildUnitRefs(units []*UnitBlockHCL, stackDir string) []ComponentRef {
 	refs := make([]ComponentRef, 0, len(units))
 
 	for _, u := range units {
-		unitPath := filepath.Join(stackTargetDir, u.Path)
-		if u.NoStack != nil && *u.NoStack {
-			unitPath = filepath.Join(filepath.Dir(stackTargetDir), u.Path)
-		}
-
-		refs = append(refs, ComponentRef{Name: u.Name, Path: unitPath})
+		refs = append(refs, ComponentRef{Name: u.Name, Path: u.GeneratedPath(stackDir)})
 	}
 
 	return refs
 }
 
 // buildStackRefs builds top-level component refs for stack blocks.
-func buildStackRefs(stacks []*StackBlockHCL, stackTargetDir string) []ComponentRef {
+func buildStackRefs(stacks []*StackBlockHCL, stackDir string) []ComponentRef {
 	refs := make([]ComponentRef, 0, len(stacks))
 
 	for _, s := range stacks {
-		stackGenPath := filepath.Join(stackTargetDir, s.Path)
-		if s.NoStack != nil && *s.NoStack {
-			stackGenPath = filepath.Join(filepath.Dir(stackTargetDir), s.Path)
-		}
-
-		refs = append(refs, ComponentRef{Name: s.Name, Path: stackGenPath})
+		refs = append(refs, ComponentRef{Name: s.Name, Path: s.GeneratedPath(stackDir)})
 	}
 
 	return refs

--- a/internal/hclparse/stack.go
+++ b/internal/hclparse/stack.go
@@ -100,6 +100,34 @@ func BuildComponentRefMap(refs []ComponentRef) cty.Value {
 	return cty.ObjectVal(refMap)
 }
 
+// GeneratedComponentPath returns the on-disk path a unit or stack block in a
+// terragrunt.stack.hcl generates to. stackDir is the directory containing the
+// stack file, path is the block's path attribute, and noStack reports whether the
+// block sets no_dot_terragrunt_stack, which hoists the component out of the
+// .terragrunt-stack subdirectory.
+func GeneratedComponentPath(stackDir, path string, noStack bool) string {
+	if noStack {
+		return filepath.Join(stackDir, path)
+	}
+
+	return filepath.Join(stackDir, StackDir, path)
+}
+
+// GeneratedPath returns the on-disk path this unit block generates to under stackDir.
+func (u *UnitBlockHCL) GeneratedPath(stackDir string) string {
+	return GeneratedComponentPath(stackDir, u.Path, u.NoStack != nil && *u.NoStack)
+}
+
+// GeneratedPath returns the on-disk path this stack block generates to under stackDir.
+func (s *StackBlockHCL) GeneratedPath(stackDir string) string {
+	return GeneratedComponentPath(stackDir, s.Path, s.NoStack != nil && *s.NoStack)
+}
+
+// GeneratedPath returns the on-disk path this unit generates to under stackDir.
+func (u *unitPathOnlyHCL) GeneratedPath(stackDir string) string {
+	return GeneratedComponentPath(stackDir, u.Path, u.NoStack != nil && *u.NoStack)
+}
+
 // unitPathOnlyHCL is the discovery shape for unit name and path.
 type unitPathOnlyHCL struct {
 	Remain  hcl.Body `hcl:",remain"`
@@ -186,12 +214,7 @@ func UnitPathsFromStackDir(fs vfs.FS, stackDir string, funcs map[string]function
 	paths := make([]string, 0, len(units))
 
 	for _, unit := range units {
-		unitPath := filepath.Join(stackDir, StackDir, unit.Path)
-		if unit.NoStack != nil && *unit.NoStack {
-			unitPath = filepath.Join(stackDir, unit.Path)
-		}
-
-		paths = append(paths, unitPath)
+		paths = append(paths, unit.GeneratedPath(stackDir))
 	}
 
 	return paths, nil

--- a/internal/stacks/output/output.go
+++ b/internal/stacks/output/output.go
@@ -153,7 +153,7 @@ func StackOutput(
 		}
 
 		for _, unit := range stackFile.Units {
-			unitDir := config.GetUnitDir(dir, unit)
+			unitDir := unit.GeneratedPath(dir)
 
 			// Excluded units are fully omitted from the final output, matching stack run behavior.
 			if _, excluded := excludedPaths[filepath.Clean(unitDir)]; excluded {

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -762,7 +762,7 @@ func collectStackUnitOutputs(ctx context.Context, pctx *ParsingContext, l log.Lo
 	unitOutputs := make(map[string]cty.Value)
 
 	for _, unit := range units {
-		unitDir := GetUnitDir(stackDir, unit)
+		unitDir := unit.GeneratedPath(stackDir)
 		unitConfigPath := filepath.Join(unitDir, DefaultTerragruntConfigPath)
 
 		if !util.FileExists(unitConfigPath) {

--- a/pkg/config/external_test.go
+++ b/pkg/config/external_test.go
@@ -229,7 +229,7 @@ func TestExternalTerraformOutputJSONToCtyValueMap(t *testing.T) {
 	assert.Equal(t, "vpc-abc123", vpcID.AsString())
 }
 
-func TestExternalGetUnitDir(t *testing.T) {
+func TestExternalUnitGeneratedPath(t *testing.T) {
 	t.Parallel()
 
 	t.Run("with stack dir", func(t *testing.T) {
@@ -240,7 +240,7 @@ func TestExternalGetUnitDir(t *testing.T) {
 			Source: "./modules/app",
 			Path:   "app",
 		}
-		dir := config.GetUnitDir("/project", unit)
+		dir := unit.GeneratedPath("/project")
 		assert.Equal(t, filepath.Join("/project", config.StackDir, "app"), dir)
 	})
 
@@ -254,7 +254,7 @@ func TestExternalGetUnitDir(t *testing.T) {
 			Path:    "app",
 			NoStack: &noStack,
 		}
-		dir := config.GetUnitDir("/project", unit)
+		dir := unit.GeneratedPath("/project")
 		assert.Equal(t, filepath.Join("/project", "app"), dir)
 	})
 }

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -78,6 +78,11 @@ type Unit struct {
 	Path                string     `hcl:"path,attr"`
 }
 
+// GeneratedPath returns the on-disk path this unit generates to under stackDir.
+func (u *Unit) GeneratedPath(stackDir string) string {
+	return inthclparse.GeneratedComponentPath(stackDir, u.Path, u.NoStack != nil && *u.NoStack)
+}
+
 // Stack represents the stack block in the configuration.
 type Stack struct {
 	Remain              hcl.Body   `hcl:",remain"`
@@ -89,6 +94,11 @@ type Stack struct {
 	Name                string     `hcl:",label"`
 	Source              string     `hcl:"source,attr"`
 	Path                string     `hcl:"path,attr"`
+}
+
+// GeneratedPath returns the on-disk path this stack generates to under stackDir.
+func (s *Stack) GeneratedPath(stackDir string) string {
+	return inthclparse.GeneratedComponentPath(stackDir, s.Path, s.NoStack != nil && *s.NoStack)
 }
 
 // GenerateStackFile generates the Terragrunt stack configuration from the given stackFilePath,
@@ -779,6 +789,15 @@ func ParseStackConfig(ctx context.Context, l log.Logger, parser *ParsingContext,
 		return nil, err
 	}
 
+	// Expose unit.<name>.path / stack.<name>.path so a unit or stack block's values
+	// can reference where sibling components generate to (e.g. to pass a unit path
+	// down to a child stack). Gated on the experiment that introduces the feature.
+	if parser.Experiments.Evaluate(experiment.StackDependencies) {
+		if err := injectStackComponentRefs(file, evalParsingContext, filepath.Dir(file.ConfigPath)); err != nil {
+			return nil, err
+		}
+	}
+
 	config := &StackConfigFile{}
 	if decodeErr := file.Decode(config, evalParsingContext); decodeErr != nil {
 		return nil, decodeErr
@@ -813,6 +832,55 @@ func ParseStackConfig(ctx context.Context, l log.Logger, parser *ParsingContext,
 	}
 
 	return stackConfig, nil
+}
+
+// stackComponentHeaders captures only the label and path of each unit/stack block
+// so component paths can be resolved before the full decode evaluates values.
+// source, values, and every other attribute are left in the block body, unevaluated.
+type stackComponentHeaders struct {
+	Remain hcl.Body                `hcl:",remain"`
+	Stacks []*stackComponentHeader `hcl:"stack,block"`
+	Units  []*stackComponentHeader `hcl:"unit,block"`
+}
+
+// stackComponentHeader is the path-only shape of a unit or stack block.
+type stackComponentHeader struct {
+	Remain  hcl.Body `hcl:",remain"`
+	NoStack *bool    `hcl:"no_dot_terragrunt_stack,optional"`
+	Path    string   `hcl:"path,attr"`
+	Name    string   `hcl:",label"`
+}
+
+// GeneratedPath returns the on-disk path this component generates to under stackDir.
+func (h *stackComponentHeader) GeneratedPath(stackDir string) string {
+	return inthclparse.GeneratedComponentPath(stackDir, h.Path, h.NoStack != nil && *h.NoStack)
+}
+
+// injectStackComponentRefs adds the unit.<name> and stack.<name> path variables to
+// evalCtx so a unit/stack block's values can reference where sibling components
+// generate to. It decodes only block labels and paths first, leaving source and
+// values unevaluated, so it can run before the value that depends on these refs is
+// evaluated. stackDir is the directory containing the stack file.
+func injectStackComponentRefs(file *hclparse.File, evalCtx *hcl.EvalContext, stackDir string) error {
+	headers := &stackComponentHeaders{}
+	if err := file.Decode(headers, evalCtx); err != nil {
+		return err
+	}
+
+	unitRefs := make([]inthclparse.ComponentRef, 0, len(headers.Units))
+	for _, u := range headers.Units {
+		unitRefs = append(unitRefs, inthclparse.ComponentRef{Name: u.Name, Path: u.GeneratedPath(stackDir)})
+	}
+
+	stackRefs := make([]inthclparse.ComponentRef, 0, len(headers.Stacks))
+	for _, s := range headers.Stacks {
+		stackRefs = append(stackRefs, inthclparse.ComponentRef{Name: s.Name, Path: s.GeneratedPath(stackDir)})
+	}
+
+	evalCtx.Variables[inthclparse.VarUnit] = inthclparse.BuildComponentRefMap(unitRefs)
+	evalCtx.Variables[inthclparse.VarStack] = inthclparse.BuildComponentRefMap(stackRefs)
+
+	return nil
 }
 
 // processStackConfigIncludes resolves include blocks during stack file parsing.
@@ -1044,15 +1112,6 @@ func validateTargetDir(kind, name, destDir, expectedFile string) error {
 	}
 
 	return nil
-}
-
-// GetUnitDir returns the directory path for a unit based on its no_dot_terragrunt_stack setting.
-func GetUnitDir(dir string, unit *Unit) string {
-	if unit.NoStack != nil && *unit.NoStack {
-		return filepath.Join(dir, unit.Path)
-	}
-
-	return filepath.Join(dir, StackDir, unit.Path)
 }
 
 // stackConfigHasAutoInclude reports whether any unit or stack in the include-merged stack config declares an autoinclude block.

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -1359,8 +1359,6 @@ func TestStackDepsStackLevelAutoIncludeMergedIntoNestedStack(t *testing.T) {
 func TestStackDepsCrossLevelViaValues(t *testing.T) {
 	t.Parallel()
 
-	t.Skip("unit.*.path is not yet available in a stack block's values")
-
 	helpers.CleanupTerraformFolder(t, testFixtureStackDepsCrossLevelValues)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsCrossLevelValues)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsCrossLevelValues)


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Allows usage of `unit.<unit_name>.path` and `stack.<stack_name>.path` variables in the `values` attribute of unit/stack blocks.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
