### PR TITLE
fix: Fixing stack autoinclude

### DIFF
--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -784,9 +784,16 @@ func ParseStackConfig(ctx context.Context, l log.Logger, parser *ParsingContext,
 		return nil, decodeErr
 	}
 
-	// Process include blocks when the stack-dependencies experiment is enabled.
+	// Process include blocks and merge any generated stack-level autoinclude file
+	// when the stack-dependencies experiment is enabled.
 	if parser.Experiments.Evaluate(experiment.StackDependencies) {
-		if err := processStackConfigIncludes(config, filepath.Dir(file.ConfigPath), evalParsingContext, parser.ParserOptions); err != nil {
+		stackDir := filepath.Dir(file.ConfigPath)
+
+		if err := processStackConfigIncludes(config, stackDir, evalParsingContext, parser.ParserOptions); err != nil {
+			return nil, err
+		}
+
+		if err := mergeStackAutoIncludeFile(config, stackDir, filepath.Base(file.ConfigPath), evalParsingContext, parser.ParserOptions); err != nil {
 			return nil, err
 		}
 	}
@@ -869,6 +876,45 @@ func processStackConfigIncludes(config *StackConfigFile, stackDir string, evalCt
 
 		seen[s.Name] = struct{}{}
 	}
+
+	return nil
+}
+
+// mergeStackAutoIncludeFile merges a generated terragrunt.autoinclude.stack.hcl, if present
+// beside the stack file, into the stack config. Units and stacks injected by a parent stack's
+// autoinclude block materialize in the nested stack the same way a unit's
+// terragrunt.autoinclude.hcl merges into its terragrunt.hcl via [mergeAutoIncludeIfPresent].
+func mergeStackAutoIncludeFile(config *StackConfigFile, stackDir, stackFileName string, evalCtx *hcl.EvalContext, parserOpts []hclparse.Option) error {
+	// Never merge the autoinclude file into itself.
+	if stackFileName == inthclparse.AutoIncludeStackFile {
+		return nil
+	}
+
+	autoIncludePath := filepath.Join(stackDir, inthclparse.AutoIncludeStackFile)
+	if !util.FileExists(autoIncludePath) {
+		return nil
+	}
+
+	incFile, err := hclparse.NewParser(parserOpts...).ParseFromFile(autoIncludePath)
+	if err != nil {
+		return fmt.Errorf("failed to read stack autoinclude %q: %w", autoIncludePath, err)
+	}
+
+	included := &StackConfigFile{}
+	if decodeErr := incFile.Decode(included, evalCtx); decodeErr != nil {
+		return fmt.Errorf("failed to decode stack autoinclude %q: %w", autoIncludePath, decodeErr)
+	}
+
+	if included.Locals != nil {
+		return fmt.Errorf("stack autoinclude %q must not define locals", autoIncludePath)
+	}
+
+	if len(included.Includes) > 0 {
+		return fmt.Errorf("stack autoinclude %q must not define include blocks", autoIncludePath)
+	}
+
+	config.Units = append(config.Units, included.Units...)
+	config.Stacks = append(config.Stacks, included.Stacks...)
 
 	return nil
 }

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/live/terragrunt.stack.hcl
@@ -1,0 +1,14 @@
+# Stack-level autoinclude that injects a nested stack (not just a unit). The injected
+# stack must itself be re-discovered and expanded by the level-by-level generator, so its
+# units materialize one level deeper than the autoinclude target.
+stack "networking" {
+  source = "../stacks/networking"
+  path   = "networking"
+
+  autoinclude {
+    stack "more" {
+      source = "${get_repo_root()}/stacks/more"
+      path   = "more"
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/stacks/more/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/stacks/more/terragrunt.stack.hcl
@@ -1,0 +1,4 @@
+unit "deep" {
+  source = "${get_repo_root()}/units/deep"
+  path   = "deep"
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/stacks/networking/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/stacks/networking/terragrunt.stack.hcl
@@ -1,0 +1,4 @@
+unit "vpc" {
+  source = "${get_repo_root()}/units/vpc"
+  path   = "vpc"
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/deep/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/deep/main.tf
@@ -1,0 +1,8 @@
+resource "local_file" "marker" {
+  content  = "deep"
+  filename = "${path.module}/marker.txt"
+}
+
+output "deep_id" {
+  value = "deep-from-nested-autoinclude"
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/deep/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/deep/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/vpc/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/vpc/main.tf
@@ -1,0 +1,8 @@
+resource "local_file" "marker" {
+  content  = "vpc"
+  filename = "${path.module}/marker.txt"
+}
+
+output "vpc_id" {
+  value = "vpc-nested-autoinclude"
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/vpc/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/vpc/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -41,6 +41,7 @@ const (
 	testFixtureStackDepsMergePrecedence          = "fixtures/stacks/stack-deps-merge-precedence"
 	testFixtureStackDepsArbitraryOverride        = "fixtures/stacks/stack-deps-arbitrary-override"
 	testFixtureStackDepsStackAutoInclude         = "fixtures/stacks/stack-deps-stack-autoinclude"
+	testFixtureStackDepsStackAutoIncludeNested   = "fixtures/stacks/stack-deps-stack-autoinclude-nested"
 	testFixtureStackDepsCrossLevelValues         = "fixtures/stacks/stack-deps-cross-level-values"
 )
 
@@ -1329,8 +1330,6 @@ func TestStackDepsStackLevelAutoInclude(t *testing.T) {
 func TestStackDepsStackLevelAutoIncludeMergedIntoNestedStack(t *testing.T) {
 	t.Parallel()
 
-	t.Skip("stack-level autoinclude is generated but not yet merged into the nested stack")
-
 	helpers.CleanupTerraformFolder(t, testFixtureStackDepsStackAutoInclude)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackAutoInclude)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackAutoInclude)
@@ -1349,6 +1348,56 @@ func TestStackDepsStackLevelAutoIncludeMergedIntoNestedStack(t *testing.T) {
 	nestedStackDir := filepath.Join(rootPath, inthclparse.StackDir, "networking", inthclparse.StackDir)
 	assert.DirExists(t, filepath.Join(nestedStackDir, "extra"),
 		"the unit injected via the stack-level autoinclude must materialize in the nested stack")
+
+	// The merged unit must also be discoverable, proving the merge feeds downstream
+	// tooling (find/run), not just the on-disk directory copy.
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt find --json --experiment stack-dependencies --working-dir "+rootPath)
+	require.NoError(t, err)
+
+	var components []findComponent
+	require.NoError(t, json.Unmarshal([]byte(stdout), &components))
+
+	foundExtra := false
+
+	for _, c := range components {
+		if c.Type == "unit" && filepath.Base(c.Path) == "extra" {
+			foundExtra = true
+			break
+		}
+	}
+
+	assert.True(t, foundExtra, "the autoinclude-injected extra unit must be discoverable")
+}
+
+// TestStackDepsStackLevelAutoIncludeInjectsNestedStack verifies that a stack-level
+// autoinclude can inject a nested stack (not just a unit). The injected stack must
+// itself be re-discovered and expanded by the level-by-level generator, so its units
+// materialize one level deeper than the autoinclude target.
+func TestStackDepsStackLevelAutoIncludeInjectsNestedStack(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsStackAutoIncludeNested)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackAutoIncludeNested)
+	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackAutoIncludeNested)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
+
+	rootPath := filepath.Join(gitPath, "live")
+	rootPath, err = filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	// The autoinclude-injected "more" stack must merge into the networking stack and then
+	// expand its own units a level deeper.
+	moreStackDir := filepath.Join(rootPath, inthclparse.StackDir, "networking", inthclparse.StackDir, "more")
+	assert.DirExists(t, moreStackDir,
+		"the stack injected via the stack-level autoinclude must materialize in the nested stack")
+	assert.DirExists(t, filepath.Join(moreStackDir, inthclparse.StackDir, "deep"),
+		"the autoinclude-injected nested stack must expand its own units")
 }
 
 // TestStackDepsCrossLevelViaValues verifies a dependency between units at


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes stack autoinclude merge.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
