### PR TITLE
docs: Fixing unreleased changelog page

### DIFF
--- a/docs/src/lib/changelog.test.ts
+++ b/docs/src/lib/changelog.test.ts
@@ -5,8 +5,16 @@ import {
   isReleased,
   parsePullRequests,
   prepareForGitHub,
+  pullRequestsFromCommits,
   pullRequestsToMarkdown,
 } from "./changelog";
+
+function commit(message: string, login: string | null, name?: string) {
+  return {
+    commit: { message, author: name ? { name } : null },
+    author: login === null ? null : { login },
+  };
+}
 
 const SITE = "https://terragrunt.gruntwork.io";
 
@@ -99,6 +107,57 @@ describe("pullRequestsToMarkdown", () => {
     expect(md).toContain("### ✨ Features");
     expect(md).toContain("[@alice](https://github.com/alice)");
     expect(md).toContain("[#1](https://github.com/o/r/pull/1)");
+  });
+});
+
+describe("pullRequestsFromCommits", () => {
+  test("groups commits by type and strips the PR-number suffix from titles", () => {
+    const groups = pullRequestsFromCommits(
+      [
+        commit("feat: add a thing (#1)", "alice"),
+        commit("fix(parser): tighten regex (#2)", "bob"),
+        commit("feat!: rip out the old API (#3)", "carol"),
+      ],
+      "gruntwork-io",
+      "terragrunt",
+    );
+
+    expect(groups.map((g) => g.type.key)).toEqual(["breaking", "feat", "fix"]);
+    expect(groups[1].items[0].title).toBe("feat: add a thing");
+  });
+
+  test("derives prNumber and prUrl from the suffix", () => {
+    const [group] = pullRequestsFromCommits(
+      [commit("fix: a bug (#6218)", "alice")],
+      "gruntwork-io",
+      "terragrunt",
+    );
+
+    expect(group.items[0].prNumber).toBe(6218);
+    expect(group.items[0].prUrl).toBe(
+      "https://github.com/gruntwork-io/terragrunt/pull/6218",
+    );
+  });
+
+  test("skips commits without a PR-number suffix", () => {
+    const groups = pullRequestsFromCommits(
+      [commit("fix: direct push, no PR", "alice"), commit("feat: real PR (#7)", "bob")],
+      "gruntwork-io",
+      "terragrunt",
+    );
+
+    const titles = groups.flatMap((g) => g.items.map((i) => i.title));
+    expect(titles).toEqual(["feat: real PR"]);
+  });
+
+  test("falls back to the git author name when the GitHub login is missing", () => {
+    const [group] = pullRequestsFromCommits(
+      [commit("fix: a bug (#8)", null, "Detached Committer")],
+      "gruntwork-io",
+      "terragrunt",
+    );
+
+    expect(group.items[0].author).toBe("Detached Committer");
   });
 });
 

--- a/docs/src/lib/changelog.ts
+++ b/docs/src/lib/changelog.ts
@@ -206,6 +206,42 @@ export function parsePullRequests(body: string | null | undefined): PullRequestG
   return groupItemsByType(items);
 }
 
+// Squash-merged commits carry the PR number as a trailing "(#NNNN)" suffix.
+const COMMIT_PR_SUFFIX = /\s*\(#(\d+)\)\s*$/;
+
+interface CommitLike {
+  commit: { message: string; author?: { name?: string } | null };
+  author: { login: string } | null;
+}
+
+// Builds the grouped pull-request list for a version that has no GitHub release
+// yet, reconstructing each item from a squash-merge commit. Commits without a
+// "(#NNNN)" suffix aren't pull requests, so they're skipped.
+export function pullRequestsFromCommits(
+  commits: CommitLike[],
+  owner: string,
+  repo: string,
+): PullRequestGroup[] {
+  const items: PullRequestItem[] = [];
+  for (const commit of commits) {
+    const subject = commit.commit.message.split(/\r?\n/, 1)[0];
+    const match = COMMIT_PR_SUFFIX.exec(subject);
+    if (match === null) continue;
+    const prNumber = Number(match[1]);
+    const title = subject.replace(COMMIT_PR_SUFFIX, "");
+    const author = commit.author?.login ?? commit.commit.author?.name ?? "unknown";
+    items.push({
+      title,
+      author,
+      prUrl: `https://github.com/${owner}/${repo}/pull/${prNumber}`,
+      prNumber,
+      type: classifyTitle(title),
+    });
+  }
+  if (items.length === 0) return [];
+  return groupItemsByType(items);
+}
+
 export function pullRequestsToMarkdown(groups: PullRequestGroup[]): string {
   if (groups.length === 0) return "";
   const sections = groups.map((group) => {

--- a/docs/src/lib/github.ts
+++ b/docs/src/lib/github.ts
@@ -45,6 +45,19 @@ interface GitHubReleaseResponse {
   [key: string]: unknown;
 }
 
+export interface GitHubCommit {
+  sha: string;
+  html_url: string;
+  commit: { message: string; author?: { name?: string } | null };
+  // null when the committer isn't a linked GitHub user.
+  author: { login: string } | null;
+}
+
+interface GitHubCompareResponse {
+  commits: GitHubCommit[];
+  [key: string]: unknown;
+}
+
 /**
  * Fetches GitHub repository data with memoization.
  * Results are cached for 1 hour to avoid rate limiting.
@@ -182,6 +195,64 @@ export async function getReleaseByTag(
     });
   } catch (error) {
     console.error(`Error fetching release ${tag} for ${owner}/${repo}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Compares two refs and returns the commits in `head` that are not in `base`,
+ * memoized for 1 hour to avoid rate limiting. Used to list the pull requests
+ * merged since the latest release for versions that aren't published yet.
+ *
+ * The compare endpoint returns at most 250 commits; that's sufficient here
+ * because releases are cut frequently.
+ */
+export async function compareCommits(
+  owner: string,
+  repo: string,
+  base: string,
+  head: string
+): Promise<GitHubCommit[] | null> {
+  const cacheKey = `compare:${owner}/${repo}/${base}...${head}`;
+
+  try {
+    return await memoizedFetch(cacheKey, async () => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+      try {
+        const response = await fetch(
+          `https://api.github.com/repos/${owner}/${repo}/compare/${base}...${head}`,
+          {
+            headers: {
+              'User-Agent': 'Terragrunt-Docs',
+            },
+            signal: controller.signal,
+          }
+        );
+
+        if (!response.ok) {
+          if (response.status !== 404) {
+            console.error(
+              `Failed to compare ${base}...${head} for ${owner}/${repo}:`,
+              response.status,
+              await response.text()
+            );
+          }
+          return null;
+        }
+
+        const data = (await response.json()) as GitHubCompareResponse;
+        return data.commits;
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    });
+  } catch (error) {
+    console.error(
+      `Error comparing ${base}...${head} for ${owner}/${repo}:`,
+      error
+    );
     return null;
   }
 }

--- a/docs/src/pages/process/changelog/[version].astro
+++ b/docs/src/pages/process/changelog/[version].astro
@@ -5,7 +5,7 @@ import ReleaseEntries from '@components/ReleaseEntries.astro';
 import PullRequests from '@components/PullRequests.astro';
 import CopyReleaseNotes from '@components/CopyReleaseNotes.astro';
 import { getCollection } from 'astro:content';
-import { getLatestRelease, getReleaseByTag } from '@lib/github';
+import { compareCommits, getLatestRelease, getReleaseByTag } from '@lib/github';
 import {
   compareVersionsDesc,
   entriesForVersion,
@@ -13,8 +13,10 @@ import {
   isReleased,
   parsePullRequests,
   prepareForGitHub,
+  pullRequestsFromCommits,
   pullRequestsToMarkdown,
   uniqueVersions,
+  type PullRequestGroup,
 } from '@lib/changelog';
 import { sidebar } from '../../../data/sidebar';
 
@@ -60,8 +62,17 @@ const older =
     : null;
 
 const tagName = version.startsWith('v') ? version : `v${version}`;
-const versionRelease = await getReleaseByTag('gruntwork-io', 'terragrunt', tagName);
-const pullRequestGroups = parsePullRequests(versionRelease?.body);
+// Published releases carry an auto-generated "What's Changed" body. An
+// unreleased version has no release yet, so list the pull requests merged into
+// main since the latest release instead.
+let pullRequestGroups: PullRequestGroup[] = [];
+if (isReleased(version, latestVersion)) {
+  const versionRelease = await getReleaseByTag('gruntwork-io', 'terragrunt', tagName);
+  pullRequestGroups = parsePullRequests(versionRelease?.body);
+} else if (releaseData?.tag_name) {
+  const commits = await compareCommits('gruntwork-io', 'terragrunt', releaseData.tag_name, 'main');
+  pullRequestGroups = pullRequestsFromCommits(commits ?? [], 'gruntwork-io', 'terragrunt');
+}
 
 const siteUrl = Astro.site?.origin ?? 'https://docs.terragrunt.com';
 const isSemver = version.startsWith('v');


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Ensures that the Pull Requests section at the bottom of unreleased changelog pages show pull requests when running locally so that they can help with release prep.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
