### PR TITLE
chore: Adding no `//` path test for source with CAS

### DIFF
--- a/internal/tf/source_test.go
+++ b/internal/tf/source_test.go
@@ -231,3 +231,33 @@ func TestRegressionCASRefSubdirWorkingDir(t *testing.T) {
 	assert.Equal(t, "cas::sha1:"+hash, src.CanonicalSourceURL.String())
 	assert.Equal(t, filepath.Join(src.DownloadDir, "modules", "vpc"), src.WorkingDir)
 }
+
+// TestRegressionCASRefNoSubdir checks that a cas:: reference without a "//"
+// subdir yields an empty module path: SplitSourceURL preserves the whole ref as
+// the root repo, and NewSource leaves the working directory at the download
+// directory.
+func TestRegressionCASRefNoSubdir(t *testing.T) {
+	t.Parallel()
+
+	const hash = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+
+	sourceURL, err := tf.ToSourceURL("cas::sha1:"+hash, ".")
+	require.NoError(t, err)
+	require.Equal(t, "cas::sha1", sourceURL.Scheme)
+
+	l := logger.CreateLogger()
+
+	actualRootRepo, actualModulePath, err := tf.SplitSourceURL(l, sourceURL)
+	require.NoError(t, err)
+
+	require.Equal(t, "cas::sha1:"+hash, actualRootRepo.String())
+	require.Empty(t, actualModulePath)
+
+	downloadDir := t.TempDir()
+
+	src, err := tf.NewSource(l, "cas::sha1:"+hash, downloadDir, t.TempDir(), false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "cas::sha1:"+hash, src.CanonicalSourceURL.String())
+	assert.Equal(t, src.DownloadDir, src.WorkingDir)
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses feedback in #6234 to introduce a test specifically covering the edge case when modules are referenced without `//` in their path.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify proper handling of `cas::` source URLs without subdirectory components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->