### PR TITLE
fix: Fixing git filters on Windows

### DIFF
--- a/docs/src/data/changelog/v1.0.7/filter-windows-path-separators.mdx
+++ b/docs/src/data/changelog/v1.0.7/filter-windows-path-separators.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.7"
+category: "bug-fixes"
+---
+
+#### `--filter` now detects affected units on Windows
+
+On Windows, `terragrunt find --filter '[origin/main...HEAD]'` (and its variants) returned no affected units even when `git diff` reported changed files. The `source=` and `reading=` filters were affected by the same problem.
+
+Filter glob patterns are always written with forward slashes, but the affected-unit comparison was being made with Windows backslash separators, so nothing matched. Terragrunt now compares paths consistently with forward slashes on every platform, and the filter detects changed units on Windows as it already did on Linux and macOS.
+
+Reported in [#6214](https://github.com/gruntwork-io/terragrunt/issues/6214).

--- a/internal/filter/ast.go
+++ b/internal/filter/ast.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"path"
 	"path/filepath"
 	"strconv"
 
@@ -37,7 +38,8 @@ type PathExpression struct {
 
 // NewPathFilter creates a new PathFilter with eager glob compilation.
 func NewPathFilter(value string) (*PathExpression, error) {
-	pattern := filepath.Clean(filepath.ToSlash(value))
+	// Glob patterns are matched against '/'-separated paths on every platform.
+	pattern := path.Clean(filepath.ToSlash(value))
 
 	compiled, err := glob.Compile(pattern)
 	if err != nil {
@@ -75,7 +77,8 @@ func NewAttributeExpression(key string, value string) (*AttributeExpression, err
 		pattern := value
 
 		if key == AttributeReading {
-			pattern = filepath.Clean(filepath.ToSlash(pattern))
+			// Clean in forward-slash space, as in NewPathFilter.
+			pattern = path.Clean(filepath.ToSlash(pattern))
 		}
 
 		compiled, err := glob.Compile(pattern)

--- a/internal/filter/evaluator.go
+++ b/internal/filter/evaluator.go
@@ -157,7 +157,10 @@ func evaluateAttributeFilter(l log.Logger, filter *AttributeExpression, componen
 		g := filter.Glob()
 
 		for _, c := range components {
-			if slices.ContainsFunc(c.Reading(), g.Match) {
+			// Read paths are OS-native; the glob is '/'-separated, so normalize first.
+			if slices.ContainsFunc(c.Reading(), func(reading string) bool {
+				return g.Match(filepath.ToSlash(reading))
+			}) {
 				result = append(result, c)
 
 				continue
@@ -192,7 +195,11 @@ func evaluateAttributeFilter(l log.Logger, filter *AttributeExpression, componen
 		g := filter.Glob()
 
 		for _, c := range components {
-			if slices.ContainsFunc(c.Sources(), g.Match) {
+			// terraform.source can carry native or mixed separators on Windows, so
+			// normalize before matching the '/'-separated glob.
+			if slices.ContainsFunc(c.Sources(), func(source string) bool {
+				return g.Match(filepath.ToSlash(source))
+			}) {
 				result = append(result, c)
 
 				continue

--- a/internal/filter/evaluator_windows_test.go
+++ b/internal/filter/evaluator_windows_test.go
@@ -1,0 +1,67 @@
+//go:build windows
+
+package filter_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWindowsFilterNativeSeparators covers issue #6214: on Windows, path, reading, and
+// source filters matched glob patterns built with backslash separators against components
+// in forward-slash space, so `--filter` found no affected units. Gated to Windows because
+// filepath.ToSlash and filepath.Clean are no-ops on Unix separators.
+func TestWindowsFilterNativeSeparators(t *testing.T) {
+	t.Parallel()
+
+	t.Run("path filter built from native separators matches forward-slash component", func(t *testing.T) {
+		t.Parallel()
+
+		// filepath.Dir on a git diff path yields backslashes on Windows; the resulting
+		// path filter must still match the forward-slash component path.
+		expr := mustPath(t, `apps\app1`)
+		c := component.NewUnit("apps/app1")
+
+		l := logger.CreateLogger()
+		result, err := filter.Evaluate(l, expr, []component.Component{c})
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+	})
+
+	t.Run("reading filter matches native read paths", func(t *testing.T) {
+		t.Parallel()
+
+		c := component.NewUnit("apps/app1").WithReading(`shared\config.hcl`)
+		expr := mustAttr(t, "reading", "shared/config.hcl")
+
+		l := logger.CreateLogger()
+		result, err := filter.Evaluate(l, expr, []component.Component{c})
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+	})
+
+	t.Run("source filter matches mixed separators from get_repo_root", func(t *testing.T) {
+		t.Parallel()
+
+		c := component.NewUnit("apps/app1").WithConfig(
+			&config.TerragruntConfig{
+				Terraform: &config.TerraformConfig{
+					Source: helpers.PointerTo(`D:\a\1\s/IaC/modules/sns`),
+				},
+			},
+		)
+		expr := mustAttr(t, "source", "**/IaC/modules/sns")
+
+		l := logger.CreateLogger()
+		result, err := filter.Evaluate(l, expr, []component.Component{c})
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+	})
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6214

Fixes Git filter expressions on Windows.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Windows-specific bug where the `find --filter` command with `source=` and `reading=` filters failed to detect affected units. Path separators are now normalized consistently across all platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt/pull/6242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->