### PR TITLE
docs: Cleaning up changelogs for v1.0.7

### DIFF
--- a/docs/src/data/changelog/v1.0.7/cas-generic-getters.mdx
+++ b/docs/src/data/changelog/v1.0.7/cas-generic-getters.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.7"
+category: "experiments-updated"
+---
+
+#### `cas` — content-addressing for non-git sources
+
+CAS now covers module sources beyond git: `http(s)`, Amazon S3, Google Cloud Storage, and Mercurial. Repeat runs against an unchanged remote reuse the cached tree instead of downloading the bytes again.
+
+Before fetching, CAS issues a cheap remote probe (an HTTP `HEAD`, an S3 object-attributes lookup, a GCS metadata read, or `hg identify`) to derive a cache key without pulling the source. On a hit, the cached tree is linked directly; on a miss, or when the remote exposes no usable signal, CAS downloads the source, ingests it, and keys the resulting tree by its content hash. A remote that publishes a new version under the same address pins to a new entry, so a stale cache cannot serve outdated bytes.

--- a/docs/src/data/changelog/v1.0.7/hcl-function-panics.mdx
+++ b/docs/src/data/changelog/v1.0.7/hcl-function-panics.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.7"
+category: "bug-fixes"
+---
+
+#### `startswith`, `endswith`, `strcontains`, and `run_cmd` no longer panic on malformed calls
+
+Calling `startswith`, `endswith`, or `strcontains` with the wrong number of arguments (for example a single argument instead of two) crashed Terragrunt instead of reporting a configuration error. Calling `run_cmd` with only option flags and no command (for example `run_cmd("--terragrunt-quiet")`) crashed the same way.
+
+These calls now return a clear error: a wrong-number-of-parameters error for the string functions, and an empty-command error for `run_cmd`.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CAS now supports module sources beyond Git, including HTTP(S), S3, GCS, and Mercurial, with intelligent caching and lightweight remote probing to reuse cached content on unchanged remotes.

* **Bug Fixes**
  * String functions (`startswith`, `endswith`, `strcontains`) and `run_cmd` no longer panic on malformed arguments; improved error handling instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->