### PR TITLE
fix: Fix Windows nushell bug

### DIFF
--- a/docs/src/data/changelog/v1.0.8/windows-restore-console-mode-on-exit.mdx
+++ b/docs/src/data/changelog/v1.0.8/windows-restore-console-mode-on-exit.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.8"
+category: "bug-fixes"
+---
+
+#### Windows console mode is restored when Terragrunt exits
+
+On Windows, running a Terragrunt command from Nushell could leave the shell unable to read input afterward, with keystrokes such as the arrow keys appearing as raw escape sequences instead of being interpreted.
+
+While it runs, Terragrunt reconfigures the console it shares with the parent shell so that terminal escape sequences are processed, but it did not put the original mode back when it exited. PowerShell reapplies its own console settings on every prompt and recovers on its own, so the problem surfaces only in shells that keep the inherited mode, such as Nushell. Terragrunt now records the console mode at startup and restores it on exit, returning the shell to the state it was in beforehand.
+
+Reported in [#6245](https://github.com/gruntwork-io/terragrunt/issues/6245).

--- a/internal/os/exec/console_windows_test.go
+++ b/internal/os/exec/console_windows_test.go
@@ -191,6 +191,43 @@ func TestWindowsConsoleStdinFlagsOnCONIN(t *testing.T) {
 		"required flags should be restored")
 }
 
+// TestWindowsConsoleRestoreClearsVirtualTerminalInput is the regression test for
+// issue #6245: PrepareConsole enables ENABLE_VIRTUAL_TERMINAL_INPUT on the console
+// shared with the parent shell, which leaves shells such as Nushell rendering arrow
+// keys as raw escape sequences after Terragrunt exits. A ConsoleState captured
+// before PrepareConsole runs must, on Restore, return stdin to its original mode
+// with virtual terminal input cleared.
+//
+// This exercises the real production handles (os.Stdin) and is therefore skipped
+// when stdin is piped (e.g. CI), where SaveConsoleState/PrepareConsole are no-ops.
+// It is intentionally not parallel: it mutates the global os.Stdin console mode,
+// which would race with the parallel tests that read it.
+func TestWindowsConsoleRestoreClearsVirtualTerminalInput(t *testing.T) { //nolint:paralleltest // mutates global stdin
+	var originalStdin uint32
+	if windows.GetConsoleMode(windows.Handle(os.Stdin.Fd()), &originalStdin) != nil {
+		t.Skip("skipping: os.Stdin is not a real console handle (piped stdin)")
+	}
+
+	// Start from a known state without VT input, matching a typical parent shell.
+	cleared := originalStdin &^ windows.ENABLE_VIRTUAL_TERMINAL_INPUT
+	setMode(t, os.Stdin, cleared)
+	t.Cleanup(func() { setMode(t, os.Stdin, originalStdin) })
+
+	saved := exec.SaveConsoleState()
+
+	exec.PrepareConsole(logger.CreateLogger())
+
+	require.NotEqual(t, uint32(0), getMode(t, os.Stdin)&windows.ENABLE_VIRTUAL_TERMINAL_INPUT,
+		"PrepareConsole should enable virtual terminal input on stdin")
+
+	saved.Restore()
+
+	assert.Equal(t, uint32(0), getMode(t, os.Stdin)&windows.ENABLE_VIRTUAL_TERMINAL_INPUT,
+		"Restore must clear the virtual terminal input that PrepareConsole enabled")
+	assert.Equal(t, cleared, getMode(t, os.Stdin),
+		"Restore must return stdin to exactly the saved mode")
+}
+
 // TestWindowsConsoleSubprocessSaveRestore is an integration test that runs a
 // real subprocess and verifies the save→subprocess→restore pattern preserves
 // console modes. Uses CONOUT$ for a real console handle.

--- a/main.go
+++ b/main.go
@@ -20,10 +20,18 @@ import (
 
 // The main entrypoint for Terragrunt
 func main() {
-	var exitCode int
+	os.Exit(run())
+}
 
-	defer func() { os.Exit(exitCode) }()
-
+// run executes Terragrunt and returns the process exit code. It is kept separate
+// from main so that its deferred cleanup runs before the process exits: main calls
+// os.Exit, which terminates immediately and skips pending defers, so any defer that
+// must run (restoring the parent console mode, recovering from panics) belongs here.
+func run() (exitCode int) {
+	// Restore the parent shell's console mode on the way out. On Windows, PrepareConsole
+	// enables virtual terminal input/processing on the console Terragrunt shares with the
+	// parent shell; without restoring it, shells such as Nushell are left rendering arrow
+	// keys as raw escape sequences. No-op on non-Windows platforms.
 	originalConsole := exec.SaveConsoleState()
 	defer originalConsole.Restore()
 
@@ -41,9 +49,7 @@ func main() {
 	if err := global.NewLogLevelFlag(l, opts, nil).Parse(os.Args); err != nil {
 		l.Error(err.Error())
 
-		exitCode = 1
-
-		return
+		return 1
 	}
 
 	defer func() {
@@ -71,12 +77,10 @@ func main() {
 	err := app.RunContext(ctx, os.Args)
 
 	if opts.TerraformCliArgs.Contains(tf.FlagNameDetailedExitCode) {
-		exitCode = resolveExitCode(l, detailedExitCode.GetFinalDetailedExitCode(), err)
-
-		return
+		return resolveExitCode(l, detailedExitCode.GetFinalDetailedExitCode(), err)
 	}
 
-	exitCode = resolveExitCode(l, detailedExitCode.GetFinalExitCode(), err)
+	return resolveExitCode(l, detailedExitCode.GetFinalExitCode(), err)
 }
 
 // resolveExitCode logs the error, if any, and returns the process exit code to use.

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/global"
+	"github.com/gruntwork-io/terragrunt/internal/os/exec"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runall"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
@@ -19,7 +20,14 @@ import (
 
 // The main entrypoint for Terragrunt
 func main() {
-	exitCode := tf.NewDetailedExitCodeMap()
+	var exitCode int
+
+	defer func() { os.Exit(exitCode) }()
+
+	originalConsole := exec.SaveConsoleState()
+	defer originalConsole.Restore()
+
+	detailedExitCode := tf.NewDetailedExitCodeMap()
 
 	opts := options.NewTerragruntOptions()
 
@@ -32,7 +40,10 @@ func main() {
 	// Immediately parse the `TG_LOG_LEVEL` environment variable, e.g. to set the TRACE level.
 	if err := global.NewLogLevelFlag(l, opts, nil).Parse(os.Args); err != nil {
 		l.Error(err.Error())
-		os.Exit(1)
+
+		exitCode = 1
+
+		return
 	}
 
 	defer func() {
@@ -47,55 +58,54 @@ func main() {
 		}
 
 		if opts.TerraformCliArgs.Contains(tf.FlagNameDetailedExitCode) {
-			checkForErrorsAndExit(l, exitCode.GetFinalDetailedExitCode())(err)
+			exitCode = resolveExitCode(l, detailedExitCode.GetFinalDetailedExitCode(), err)
 			return
 		}
 
-		checkForErrorsAndExit(l, exitCode.GetFinalExitCode())(err)
+		exitCode = resolveExitCode(l, detailedExitCode.GetFinalExitCode(), err)
 	}()
 
 	app := cli.NewApp(l, opts)
 
-	ctx := setupContext(l, exitCode)
+	ctx := setupContext(l, detailedExitCode)
 	err := app.RunContext(ctx, os.Args)
 
 	if opts.TerraformCliArgs.Contains(tf.FlagNameDetailedExitCode) {
-		checkForErrorsAndExit(l, exitCode.GetFinalDetailedExitCode())(err)
+		exitCode = resolveExitCode(l, detailedExitCode.GetFinalDetailedExitCode(), err)
 
 		return
 	}
 
-	checkForErrorsAndExit(l, exitCode.GetFinalExitCode())(err)
+	exitCode = resolveExitCode(l, detailedExitCode.GetFinalExitCode(), err)
 }
 
-// If there is an error, display it in the console and exit with a non-zero exit code. Otherwise, exit 0.
-func checkForErrorsAndExit(l log.Logger, exitCode int) func(error) {
-	return func(err error) {
-		if err == nil {
-			os.Exit(exitCode)
-		}
-
-		// User declined a destructive run-all prompt. Exit 0 without
-		// printing an error message, since they already declined at
-		// the prompt.
-		if errors.Is(err, runall.ErrUserCancelled) {
-			os.Exit(0)
-		}
-
-		l.Error(err.Error())
-
-		// exit with the underlying error code
-		exitCoder, exitCodeErr := util.GetExitCode(err)
-		if exitCodeErr != nil {
-			exitCoder = 1
-		}
-
-		if explain := shell.ExplainError(err); len(explain) > 0 {
-			l.Errorf("Suggested fixes: \n%s", explain)
-		}
-
-		os.Exit(exitCoder)
+// resolveExitCode logs the error, if any, and returns the process exit code to use.
+// A nil error yields the provided exitCode; a user-cancelled run-all yields 0.
+func resolveExitCode(l log.Logger, exitCode int, err error) int {
+	if err == nil {
+		return exitCode
 	}
+
+	// User declined a destructive run-all prompt. Exit 0 without
+	// printing an error message, since they already declined at
+	// the prompt.
+	if errors.Is(err, runall.ErrUserCancelled) {
+		return 0
+	}
+
+	l.Error(err.Error())
+
+	// exit with the underlying error code
+	exitCoder, exitCodeErr := util.GetExitCode(err)
+	if exitCodeErr != nil {
+		exitCoder = 1
+	}
+
+	if explain := shell.ExplainError(err); len(explain) > 0 {
+		l.Errorf("Suggested fixes: \n%s", explain)
+	}
+
+	return exitCoder
 }
 
 func setupContext(l log.Logger, exitCode *tf.DetailedExitCodeMap) context.Context {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6245.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Windows-specific issue where Terragrunt did not restore console mode on exit after running from Nushell, preventing the shell from correctly interpreting input and escape sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->