### PR TITLE
docs: Support `completedSince`

### DIFF
--- a/docs/src/components/ExperimentEntries.astro
+++ b/docs/src/components/ExperimentEntries.astro
@@ -1,6 +1,8 @@
 ---
 import { getCollection, render } from "astro:content";
+import { Aside } from "@astrojs/starlight/components";
 import { getLatestRelease } from "@lib/github";
+import { isCompleted, isVersionReleased } from "@lib/experiments";
 
 interface Props {
   status: "active" | "completed";
@@ -12,28 +14,31 @@ const { status, showUnreleased = false } = Astro.props;
 const releaseData = await getLatestRelease("gruntwork-io", "terragrunt");
 const latestVersion = (releaseData?.tag_name ?? "v0.0.0").replace(/^v/, "");
 
-function isSinceReleased(since?: string): boolean {
-  if (!since) return true;
-  const target = since.replace(/^v/, "");
-  return latestVersion.localeCompare(target, undefined, { numeric: true }) >= 0;
-}
-
 const allEntries = await getCollection("experiments");
 
 const entries = allEntries
-  .filter((entry) => entry.data.status === status)
-  .filter((entry) => showUnreleased || isSinceReleased(entry.data.since))
+  .filter((entry) =>
+    status === "completed"
+      ? isCompleted(entry, latestVersion)
+      : !isCompleted(entry, latestVersion) &&
+        (showUnreleased || isVersionReleased(entry.data.since, latestVersion))
+  )
   .sort((a, b) => a.data.name.localeCompare(b.data.name));
 
 const rendered = await Promise.all(
   entries.map(async (entry) => {
     const { Content } = await render(entry);
-    return { entry, Content };
+    return {
+      entry,
+      Content,
+      completed: isCompleted(entry, latestVersion),
+      completedVersion: entry.data.completedSince?.replace(/^v/, ""),
+    };
   })
 );
 ---
 
-{rendered.map(({ entry, Content }, i) => (
+{rendered.map(({ entry, Content, completed, completedVersion }, i) => (
   <div>
     {i > 0 && <hr />}
     <h2 id={entry.data.name}>
@@ -42,6 +47,12 @@ const rendered = await Promise.all(
         <span aria-hidden="true" class="anchor-icon" />
       </a>
     </h2>
+    {completedVersion && !completed && (
+      <Aside type="tip" title="Completing Soon">
+        This experiment is scheduled to be completed in v{completedVersion}.
+        Once that release ships, the experiment flag is no longer needed.
+      </Aside>
+    )}
     <Content />
   </div>
 ))}

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -85,8 +85,14 @@ const experiments = defineCollection({
 	loader: glob({ pattern: "**/*.mdx", base: "src/data/experiments" }),
 	schema: z.object({
 		name: z.string(),
-		status: z.enum(["active", "completed"]),
+		// `since` is the release an experiment became available for opt-in.
+		// `completedSince` is the release in which the experiment concluded,
+		// whether it graduated to a default feature or was retired; once that
+		// release ships, the experiment is treated as completed. An
+		// experiment's active/completed status is derived from these versions
+		// rather than a separate `status` field.
 		since: z.string().optional(),
+		completedSince: z.string().optional(),
 	}),
 });
 

--- a/docs/src/data/experiments/auto-provider-cache-dir.mdx
+++ b/docs/src/data/experiments/auto-provider-cache-dir.mdx
@@ -1,6 +1,6 @@
 ---
 name: auto-provider-cache-dir
-status: completed
+completedSince: "v1.0.0"
 ---
 
 Enable native OpenTofu provider caching by setting `TF_PLUGIN_CACHE_DIR` instead of using Terragrunt's internal provider cache server.

--- a/docs/src/data/experiments/azure-backend.mdx
+++ b/docs/src/data/experiments/azure-backend.mdx
@@ -1,6 +1,5 @@
 ---
 name: azure-backend
-status: active
 since: "1.0.5"
 ---
 

--- a/docs/src/data/experiments/cas.mdx
+++ b/docs/src/data/experiments/cas.mdx
@@ -1,6 +1,6 @@
 ---
 name: cas
-status: active
+completedSince: "1.1"
 ---
 
 Support for Terragrunt Content Addressable Storage (CAS).

--- a/docs/src/data/experiments/catalog-redesign.mdx
+++ b/docs/src/data/experiments/catalog-redesign.mdx
@@ -1,7 +1,7 @@
 ---
 name: catalog-redesign
-status: active
 since: "1.0.2"
+completedSince: "1.1"
 ---
 
 Redesigned `terragrunt catalog` TUI with whole-repository discovery, tabbed browsing, and an interactive scaffolding form.

--- a/docs/src/data/experiments/cli-redesign.mdx
+++ b/docs/src/data/experiments/cli-redesign.mdx
@@ -1,6 +1,6 @@
 ---
 name: cli-redesign
-status: completed
+completedSince: "v1.0.0"
 ---
 
 Support for the new Terragrunt CLI design.

--- a/docs/src/data/experiments/dag-queue-display.mdx
+++ b/docs/src/data/experiments/dag-queue-display.mdx
@@ -1,6 +1,5 @@
 ---
 name: dag-queue-display
-status: active
 since: "1.0.1"
 ---
 

--- a/docs/src/data/experiments/deep-merge.mdx
+++ b/docs/src/data/experiments/deep-merge.mdx
@@ -1,6 +1,5 @@
 ---
 name: deep-merge
-status: active
 since: "1.0.6"
 ---
 

--- a/docs/src/data/experiments/dependency-fetch-output-from-state.mdx
+++ b/docs/src/data/experiments/dependency-fetch-output-from-state.mdx
@@ -1,6 +1,5 @@
 ---
 name: dependency-fetch-output-from-state
-status: active
 ---
 
 Support for fetching dependency outputs directly from state files.

--- a/docs/src/data/experiments/filter-flag.mdx
+++ b/docs/src/data/experiments/filter-flag.mdx
@@ -1,6 +1,6 @@
 ---
 name: filter-flag
-status: completed
+completedSince: "v1.0.0"
 ---
 
 Support for sophisticated unit and stack filtering using the `--filter` flag.

--- a/docs/src/data/experiments/iac-engine.mdx
+++ b/docs/src/data/experiments/iac-engine.mdx
@@ -1,6 +1,5 @@
 ---
 name: iac-engine
-status: active
 ---
 
 Support for Terragrunt IaC engines.

--- a/docs/src/data/experiments/mark-many-as-read.mdx
+++ b/docs/src/data/experiments/mark-many-as-read.mdx
@@ -1,7 +1,7 @@
 ---
 name: mark-many-as-read
-status: active
 since: "1.0.3"
+completedSince: "1.1"
 ---
 
 Mark many files as read in one step, so reading-based filter expressions cascade changes from shared files to the units that consume them.

--- a/docs/src/data/experiments/opt-out-auth.mdx
+++ b/docs/src/data/experiments/opt-out-auth.mdx
@@ -1,6 +1,5 @@
 ---
 name: opt-out-auth
-status: active
 since: "1.0.6"
 ---
 

--- a/docs/src/data/experiments/report.mdx
+++ b/docs/src/data/experiments/report.mdx
@@ -1,6 +1,6 @@
 ---
 name: report
-status: completed
+completedSince: "v1.0.0"
 ---
 
 Support for Terragrunt Run Reports and Summaries.

--- a/docs/src/data/experiments/runner-pool.mdx
+++ b/docs/src/data/experiments/runner-pool.mdx
@@ -1,6 +1,6 @@
 ---
 name: runner-pool
-status: completed
+completedSince: "v1.0.0"
 ---
 
 Proposes replacing Terragrunt's group-based execution with a dynamic runner pool that schedules Units as soon as dependencies are resolved.

--- a/docs/src/data/experiments/slow-task-reporting.mdx
+++ b/docs/src/data/experiments/slow-task-reporting.mdx
@@ -1,6 +1,5 @@
 ---
 name: slow-task-reporting
-status: active
 since: "1.0.1"
 ---
 

--- a/docs/src/data/experiments/stack-dependencies.mdx
+++ b/docs/src/data/experiments/stack-dependencies.mdx
@@ -1,7 +1,7 @@
 ---
 name: stack-dependencies
-status: active
 since: "1.0.1"
+completedSince: "1.1"
 ---
 
 import Since from '@components/Since.astro';

--- a/docs/src/data/experiments/stacks.mdx
+++ b/docs/src/data/experiments/stacks.mdx
@@ -1,6 +1,6 @@
 ---
 name: stacks
-status: completed
+completedSince: "v1.0.0"
 ---
 
 Support for Terragrunt stacks.

--- a/docs/src/data/experiments/symlinks.mdx
+++ b/docs/src/data/experiments/symlinks.mdx
@@ -1,6 +1,5 @@
 ---
 name: symlinks
-status: active
 ---
 
 Support symlink resolution for Terragrunt units.

--- a/docs/src/lib/experiments.test.ts
+++ b/docs/src/lib/experiments.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isCompleted,
+  isVersionReleased,
+  type ExperimentEntry,
+} from "./experiments";
+
+function makeEntry(
+  data: Partial<ExperimentEntry["data"]> & { name: string },
+): ExperimentEntry {
+  return {
+    id: data.name,
+    collection: "experiments",
+    data,
+  } as ExperimentEntry;
+}
+
+describe("isVersionReleased", () => {
+  test("treats an undefined version as released", () => {
+    expect(isVersionReleased(undefined, "1.0.7")).toBe(true);
+  });
+
+  test("returns false when the version is newer than the latest release", () => {
+    expect(isVersionReleased("1.1", "1.0.7")).toBe(false);
+  });
+
+  test("returns true once the latest release reaches the version", () => {
+    expect(isVersionReleased("1.1", "1.1.0")).toBe(true);
+  });
+
+  test("tolerates a leading v prefix on either side", () => {
+    expect(isVersionReleased("v1.0.0", "1.0.7")).toBe(true);
+  });
+
+  test("compares numerically not lexically (1.0.10 > 1.0.7)", () => {
+    expect(isVersionReleased("1.0.10", "1.0.7")).toBe(false);
+    expect(isVersionReleased("1.0.7", "1.0.10")).toBe(true);
+  });
+});
+
+describe("isCompleted", () => {
+  test("is false when the field is absent", () => {
+    expect(isCompleted(makeEntry({ name: "symlinks", since: "1.0.1" }), "1.0.7")).toBe(false);
+  });
+
+  test("is false while the completion release is unreleased", () => {
+    const entry = makeEntry({ name: "cas", completedSince: "1.1" });
+    expect(isCompleted(entry, "1.0.7")).toBe(false);
+  });
+
+  test("is true once the completion release has shipped", () => {
+    const entry = makeEntry({ name: "cas", completedSince: "1.1" });
+    expect(isCompleted(entry, "1.1.0")).toBe(true);
+  });
+
+  test("treats a v-prefixed completion release the same as an unprefixed one", () => {
+    const entry = makeEntry({ name: "report", completedSince: "v1.0.0" });
+    expect(isCompleted(entry, "1.0.7")).toBe(true);
+  });
+});

--- a/docs/src/lib/experiments.ts
+++ b/docs/src/lib/experiments.ts
@@ -1,0 +1,27 @@
+import type { CollectionEntry } from "astro:content";
+
+export type ExperimentEntry = CollectionEntry<"experiments">;
+
+/**
+ * Returns true when the latest release is equal to or newer than the given
+ * version. An undefined version is treated as released, matching the no-value
+ * case of the `since` field.
+ */
+export function isVersionReleased(version: string | undefined, latestVersion: string): boolean {
+  if (!version) return true;
+  const target = version.replace(/^v/, "");
+  return latestVersion.localeCompare(target, undefined, { numeric: true }) >= 0;
+}
+
+/**
+ * Returns true once the release in which the experiment concluded has shipped.
+ * An experiment completes whether it graduated to a default feature or was
+ * retired, so completion is the umbrella concept and there is no separate
+ * status field. Compares against the real latest release rather than honoring
+ * the dev-only `showUnreleased` override, so the pre-completion notice stays
+ * visible while authoring locally.
+ */
+export function isCompleted(entry: ExperimentEntry, latestVersion: string): boolean {
+  return Boolean(entry.data.completedSince)
+    && isVersionReleased(entry.data.completedSince, latestVersion);
+}

--- a/docs/src/pages/reference/experiments/active.astro
+++ b/docs/src/pages/reference/experiments/active.astro
@@ -4,6 +4,7 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 import ExperimentEntries from '@components/ExperimentEntries.astro';
 import { getCollection } from 'astro:content';
 import { getLatestRelease } from '@lib/github';
+import { isCompleted, isVersionReleased } from '@lib/experiments';
 import { sidebar } from '../../../data/sidebar';
 
 const showUnreleased = import.meta.env.DEV;
@@ -11,17 +12,11 @@ const showUnreleased = import.meta.env.DEV;
 const releaseData = await getLatestRelease('gruntwork-io', 'terragrunt');
 const latestVersion = (releaseData?.tag_name ?? 'v0.0.0').replace(/^v/, '');
 
-function isSinceReleased(since?: string): boolean {
-	if (!since) return true;
-	const target = since.replace(/^v/, '');
-	return latestVersion.localeCompare(target, undefined, { numeric: true }) >= 0;
-}
-
 const allEntries = await getCollection('experiments');
 
 const entries = allEntries
-	.filter((e) => e.data.status === 'active')
-	.filter((e) => showUnreleased || isSinceReleased(e.data.since))
+	.filter((e) => !isCompleted(e, latestVersion))
+	.filter((e) => showUnreleased || isVersionReleased(e.data.since, latestVersion))
 	.sort((a, b) => a.data.name.localeCompare(b.data.name));
 
 const headings: { depth: number; slug: string; text: string }[] = [];

--- a/docs/src/pages/reference/experiments/completed.astro
+++ b/docs/src/pages/reference/experiments/completed.astro
@@ -2,12 +2,17 @@
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 import ExperimentEntries from '@components/ExperimentEntries.astro';
 import { getCollection } from 'astro:content';
+import { getLatestRelease } from '@lib/github';
+import { isCompleted } from '@lib/experiments';
 import { sidebar } from '../../../data/sidebar';
+
+const releaseData = await getLatestRelease('gruntwork-io', 'terragrunt');
+const latestVersion = (releaseData?.tag_name ?? 'v0.0.0').replace(/^v/, '');
 
 const entries = await getCollection('experiments');
 
 const completed = entries
-	.filter((e) => e.data.status === 'completed')
+	.filter((e) => isCompleted(e, latestVersion))
 	.sort((a, b) => a.data.name.localeCompare(b.data.name));
 
 // Build TOC headings


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds the `completedSince` front-matter key for experiment data.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experiment listings now show per-experiment completion state with “Completing Soon” tips for scheduled completions and “Completed in v…​” notes for finished experiments; listings are sorted by name and only show relevant items.

* **Documentation**
  * Experiment docs updated to use explicit since/completedSince metadata for clearer lifecycle and release tracking.

* **Tests**
  * Added tests validating version-release and completion logic used to determine experiment state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->