### PR TITLE
chore: Add thanks for #5975

### DIFF
--- a/docs/src/data/changelog/v1.0.8/assume-role-list-parsing.mdx
+++ b/docs/src/data/changelog/v1.0.8/assume-role-list-parsing.mdx
@@ -20,4 +20,6 @@ This resulted in errors similar to:
 Missing item separator; Expected a comma to mark the beginning of the next item.
 ```
 
-Terragrunt now preserves commas inside nested list and object expressions when parsing `assume_role` blocks, allowing configurations containing array attributes to be processed correctly. 
+Terragrunt now preserves commas inside nested list and object expressions when parsing `assume_role` blocks, allowing configurations containing array attributes to be processed correctly.
+
+Thanks to [@Rahul-Kumar-prog](https://github.com/Rahul-Kumar-prog) for contributing this fix!

--- a/internal/codegen/generate.go
+++ b/internal/codegen/generate.go
@@ -569,15 +569,14 @@ func convertValue(v any) (ctyjson.SimpleJSONValue, error) {
 	return ctyVal, nil
 }
 
-// ReplaceAllCommasOutsideQuotesWithNewLines replaces all commas outside quotes with new lines.
-// This is useful for instances where a single line of HCL content might contain a comma, and we don't
-// want to split the line into multiple lines.
+// ReplaceAllCommasOutsideQuotesWithNewLines replaces top-level argument-separating commas with new
+// lines. Commas inside quoted strings or nested delimiters (lists, objects, and function-call parens)
+// are left intact, so only commas that separate arguments at depth zero are converted.
 func ReplaceAllCommasOutsideQuotesWithNewLines(s string) string {
 	var result strings.Builder
 
 	inQuotes := false
-	bracketDepth := 0
-	brackDepth := 0
+	depth := 0
 
 	for i := 0; i < len(s); i++ {
 		ch := s[i]
@@ -594,23 +593,15 @@ func ReplaceAllCommasOutsideQuotesWithNewLines(s string) string {
 			inQuotes = !inQuotes
 
 			result.WriteByte(ch)
-		case ch == '[' && !inQuotes:
-			bracketDepth++
+		case (ch == '[' || ch == '{' || ch == '(') && !inQuotes:
+			depth++
 
 			result.WriteByte(ch)
-		case ch == ']' && !inQuotes:
-			bracketDepth--
+		case (ch == ']' || ch == '}' || ch == ')') && !inQuotes:
+			depth--
 
 			result.WriteByte(ch)
-		case ch == '{' && !inQuotes:
-			brackDepth++
-
-			result.WriteByte(ch)
-		case ch == '}' && !inQuotes:
-			brackDepth--
-
-			result.WriteByte(ch)
-		case ch == ',' && !inQuotes && bracketDepth == 0 && brackDepth == 0:
+		case ch == ',' && !inQuotes && depth == 0:
 			result.WriteByte('\n')
 
 		default:

--- a/internal/codegen/generate_test.go
+++ b/internal/codegen/generate_test.go
@@ -460,6 +460,12 @@ enabled=true`,
 			expected: `assume_role={policy_arns=["arn:1","arn:2"],session_name="test"}
 region="us-east-1"`,
 		},
+		{
+			name:  "comma-inside-function-call",
+			input: `tags=merge({a="1"},{b="2"}),enabled=true`,
+			expected: `tags=merge({a="1"},{b="2"})
+enabled=true`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds thanks for #5975.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced `assume_role` block parsing to properly preserve commas within nested lists, objects, and function calls.

* **Documentation**
  * Updated v1.0.8 changelog entry to reflect improvements in `assume_role` parsing behavior and added contributor attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->