### PR TITLE
chore: Completing `cas` experiment

### DIFF
--- a/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
@@ -8,6 +8,8 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside } from '@astrojs/starlight/components';
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 For an alternate approach (that is more flexible, but not necessarily always the better solution), you can define explicit stacks using `terragrunt.stack.hcl` files. These are **blueprints** that programmatically generate units at runtime.
 
@@ -413,9 +415,11 @@ After running the stack, your directory structure will look like this:
 
 ## CAS Integration
 
+<Before version="1.1.0">
 <Aside type="tip">
 This functionality is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`. See the [CAS feature documentation](/features/caching/cas) for more details.
 </Aside>
+</Before>
 
 When authoring stacks in a catalog, you can use the `update_source_with_cas` attribute on nested blocks to replace remote Git URLs with relative paths.
 
@@ -468,7 +472,13 @@ When `update_source_with_cas = true` is set:
 4. Generated `.terragrunt-stack` files contain deterministic CAS references instead of remote URLs.
 5. Subsequent generation waves resolve `cas::` references directly from the CAS store, with no network access required.
 
+<Before version="1.1.0">
 Consumers do not set `update_source_with_cas` themselves. When the `cas` experiment is enabled and the source is remote, Terragrunt uses the CAS path automatically. The attribute only has effect inside catalog files, where it flags nested `source` attributes for rewriting.
+</Before>
+
+<Since version="1.1.0">
+Consumers do not set `update_source_with_cas` themselves. When the source is remote, Terragrunt uses the CAS path automatically. The attribute only has effect inside catalog files, where it flags nested `source` attributes for rewriting.
+</Since>
 
 `unit` and `stack` blocks also accept a `mutable` attribute. When `mutable = true`, the unit's or stack's content under `.terragrunt-stack` is copied from the CAS store and the working tree is editable. The default is `false`: files are materialized read-only so an accidental edit cannot reach back into the shared CAS store.
 
@@ -483,7 +493,13 @@ stack "service" {
 }
 ```
 
+<Before version="1.1.0">
 Running `terragrunt --experiment cas stack generate` produces:
+</Before>
+
+<Since version="1.1.0">
+Running `terragrunt stack generate` produces:
+</Since>
 
 <FileTree>
 
@@ -530,9 +546,16 @@ The `cas::` reference format includes a hash algorithm prefix (`sha1:` or `sha25
 
 Requirements:
 
+<Before version="1.1.0">
 - The `cas` experiment must be enabled (`--experiment cas`).
 - The `--no-cas` flag must not be set.
 - Sources using `update_source_with_cas` must be relative paths within the same repository.
+</Before>
+
+<Since version="1.1.0">
+- The `--no-cas` flag must not be set.
+- Sources using `update_source_with_cas` must be relative paths within the same repository.
+</Since>
 
 ### Local catalog sources
 
@@ -567,7 +590,12 @@ The [`stack-dependencies` experiment](/reference/experiments/active#stack-depend
 
 Every generation of a stack from a `terragrunt.stack.hcl` file can potentially result in network traffic to fetch the source for the stack and filesystem traffic to copy the generated units to the `.terragrunt-stack` directory. This can result in slow stack generation if you have very deeply nested stacks.
 
+<Before version="1.1.0">
 To mitigate this, enable the [`cas` experiment](/reference/experiments/active#cas) and use `update_source_with_cas = true` in your catalog's stack and unit files. This deduplicates repository clones and resolves content from the local CAS store instead of fetching from the network on every generation. See [CAS Integration](#cas-integration) for details.
+</Before>
+<Since version="1.1.0">
+To mitigate this, use `update_source_with_cas = true` in your catalog's stack and unit files. This deduplicates repository clones and resolves content from the local CAS store instead of fetching from the network on every generation. See [CAS Integration](#cas-integration) for details.
+</Since>
 
 ### Includes are not supported in `terragrunt.stack.hcl` files
 

--- a/docs/src/content/docs/03-features/07-caching/04-cas/02-git.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/02-git.mdx
@@ -7,11 +7,14 @@ sidebar:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
 </Aside>
 
+</Before>
 Git is the most common source Terragrunt fetches and has the richest support in the CAS.
 
 ## Overview

--- a/docs/src/content/docs/03-features/07-caching/04-cas/03-http.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/03-http.mdx
@@ -7,11 +7,14 @@ sidebar:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
 </Aside>
 
+</Before>
 ## Overview
 
 An HTTP source is identified by its URL. Terragrunt cannot key it by a content hash up front, so it asks the server for a validator (an `ETag` or `Last-Modified` value) and keys the cached tree by that validator, scoped to the URL.

--- a/docs/src/content/docs/03-features/07-caching/04-cas/04-s3.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/04-s3.mdx
@@ -7,11 +7,14 @@ sidebar:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
 </Aside>
 
+</Before>
 ## Overview
 
 An S3 source is identified by a bucket, an object key, and an optional version. Terragrunt reads the object's metadata to derive a cache key, preferring a real content checksum over the weaker `ETag`.

--- a/docs/src/content/docs/03-features/07-caching/04-cas/05-gcs.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/05-gcs.mdx
@@ -7,11 +7,14 @@ sidebar:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
 </Aside>
 
+</Before>
 ## Overview
 
 A GCS source is identified by a bucket and an object. Terragrunt reads the object's metadata to derive a content-addressed cache key.

--- a/docs/src/content/docs/03-features/07-caching/04-cas/06-mercurial.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/06-mercurial.mdx
@@ -7,11 +7,14 @@ sidebar:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
 </Aside>
 
+</Before>
 ## Overview
 
 A Mercurial source is identified by a repository URL and an optional revision. Terragrunt resolves that revision to a node hash and keys the cached tree by it.

--- a/docs/src/content/docs/03-features/07-caching/04-cas/07-registry.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/07-registry.mdx
@@ -7,11 +7,14 @@ sidebar:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
 </Aside>
 
+</Before>
 ## Overview
 
 A registry address is an indirection: the registry resolves a module and version to an underlying archive, such as a versioned tarball or a Git commit. The CAS keys that resolved archive, so caching tracks the immutable artifact rather than the registry address.

--- a/docs/src/content/docs/03-features/07-caching/04-cas/08-smb.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/08-smb.mdx
@@ -7,11 +7,14 @@ sidebar:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
 </Aside>
 
+</Before>
 ## Overview
 
 An SMB source is identified by a share path. SMB exposes no low-cost way to resolve a version without reading the content, so Terragrunt always downloads the source and then keys the result by its content hash. The CAS still deduplicates the bytes once they are in the store.

--- a/docs/src/content/docs/03-features/07-caching/04-cas/09-local.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/09-local.mdx
@@ -7,11 +7,14 @@ sidebar:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
 </Aside>
 
+</Before>
 ## Overview
 
 A local source is a directory on the machine running Terragrunt. There is nothing remote to probe, so Terragrunt reads the directory directly and keys it by the content hash of its tree.

--- a/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
@@ -14,9 +14,15 @@ import Before from '@components/Before.astro';
 
 <Before version="1.1.0">
 <Aside type="tip" title="Experimental">
-CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
+CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas` to opt in before it becomes the default in 1.1.
 </Aside>
 </Before>
+
+<Since version="1.1.0">
+<Aside type="note">
+CAS source fetching is enabled by default as of 1.1. Upgrade to 1.1 or later to use it; disable it with `--no-cas`.
+</Aside>
+</Since>
 
 Terragrunt supports a Content Addressable Store (CAS) to deduplicate content across multiple Terragrunt configurations.
 

--- a/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
@@ -9,10 +9,14 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside, Steps } from '@astrojs/starlight/components';
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
 </Aside>
+</Before>
 
 Terragrunt supports a Content Addressable Store (CAS) to deduplicate content across multiple Terragrunt configurations.
 
@@ -69,9 +73,11 @@ terraform {
 
 ### Stack Usage
 
+<Before version="1.1.0">
 <Aside type="tip">
 This functionality is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
 </Aside>
+</Before>
 
 When authoring stacks in a catalog, you can use the `update_source_with_cas` attribute to allow for relative paths to other components in the catalog in `source` attributes. This removes the need to plumb remote Git URLs through `values` expressions. The `source` must be a literal string: interpolation, function calls, and references such as `local.foo` cause stack generation to fail.
 
@@ -105,9 +111,17 @@ The catalog source can be either a remote Git URL or a local filesystem path (ab
 
 For more details on using this with stacks, see [Explicit Stacks: CAS Integration](/features/stacks/explicit#cas-integration).
 
+<Before version="1.1.0">
 <Aside type="caution">
 Setting `update_source_with_cas = true` requires that the `cas` experiment is enabled and that `--no-cas` is not set. Terragrunt errors out otherwise, since the relative source must be updated to a synthetic tree stored in the CAS.
 </Aside>
+</Before>
+
+<Since version="1.1.0">
+<Aside type="caution">
+Setting `update_source_with_cas = true` requires that `--no-cas` is not set. Terragrunt errors out otherwise, since the relative source must be updated to a synthetic tree stored in the CAS.
+</Aside>
+</Since>
 
 When Terragrunt fetches a Git source while using the CAS, if the content is not found in the CAS, Terragrunt fetches into the central bare repository for that remote URL and stores the resulting blobs and trees in the CAS for future use. If the central store is unavailable, Terragrunt falls back to cloning the repository from the original URL into a temporary directory. Other getters follow the equivalent pattern for their source type, described on the [per-getter pages](#supported-sources).
 

--- a/docs/src/data/changelog/v1.1.0/cas-enabled-by-default.mdx
+++ b/docs/src/data/changelog/v1.1.0/cas-enabled-by-default.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.0"
+category: "new-features"
+---
+
+#### Content Addressable Storage (CAS)
+
+Terragrunt now uses a Content Addressable Store to deduplicate Git content across configurations, speeding up catalog cloning, OpenTofu/Terraform source cloning, and stack generation by avoiding redundant downloads. When used with stacks, it also lets catalog authors use relative paths in `source` attributes via the `update_source_with_cas` attribute.
+
+CAS is enabled by default. Use the `--no-cas` flag (or `TG_NO_CAS=true`) to opt out. Previously gated behind the `cas` experiment, it no longer requires `--experiment cas`.

--- a/docs/src/data/experiments/stack-dependencies.mdx
+++ b/docs/src/data/experiments/stack-dependencies.mdx
@@ -107,7 +107,7 @@ Provide your feedback on the [Stack Dependencies RFC](https://github.com/gruntwo
 
 <Since version="1.0.7">
 
-- [x] The `.terragrunt-stack-origin` marker file is no longer written when nested stack files are copied into `.terragrunt-stack/<name>/`. Use `update_source_with_cas = true` (with the `cas` experiment enabled) on `unit` and `stack` blocks to keep relative `source` paths working in catalog stack files; relative attributes are rewritten to `cas::` references at generation time so the generated tree is self-contained.
+- [x] The `.terragrunt-stack-origin` marker file is no longer written when nested stack files are copied into `.terragrunt-stack/<name>/`. Use `update_source_with_cas = true` <Before version="1.1.0">(with the `cas` experiment enabled) </Before>on `unit` and `stack` blocks to keep relative `source` paths working in catalog stack files; relative attributes are rewritten to `cas::` references at generation time so the generated tree is self-contained.
 - [ ] Community feedback on `autoinclude` syntax and merge behavior
 - [ ] Validate performance at scale
 

--- a/docs/src/data/flags/no-cas.mdx
+++ b/docs/src/data/flags/no-cas.mdx
@@ -1,11 +1,11 @@
 ---
 name: no-cas
-description: Disable the CAS (Content Addressable Storage) feature even when the experiment is enabled.
+description: Disable the CAS (Content Addressable Storage) feature.
 type: bool
 env:
   - TG_NO_CAS
 ---
 
-When enabled, Terragrunt skips all CAS operations even if the `cas` experiment is active. Use this to temporarily bypass CAS without removing the experiment flag.
+When this flag is set, Terragrunt skips all CAS operations and clones sources directly.
 
 Generation or runs error when `update_source_with_cas = true` is set on any `unit`, `stack`, or `terraform` block reachable from the current invocation, since relative sources rewritten by CAS cannot be resolved without it.

--- a/internal/cas/errors.go
+++ b/internal/cas/errors.go
@@ -119,7 +119,7 @@ func (e *UpdateSourceWithCASRequiresCASError) Error() string {
 
 	return fmt.Sprintf(
 		"%s in %s sets update_source_with_cas = true, which requires "+
-			"the 'cas' experiment to be enabled and the --no-cas flag to be unset",
+			"the --no-cas flag to be unset",
 		subject, e.Path,
 	)
 }

--- a/internal/cas/local_test.go
+++ b/internal/cas/local_test.go
@@ -14,6 +14,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const osWindows = "windows"
+
 func TestComputeLocalRootHash_Deterministic(t *testing.T) {
 	t.Parallel()
 
@@ -56,7 +58,7 @@ func TestComputeLocalRootHash_DiffersOnContentChange(t *testing.T) {
 func TestComputeLocalRootHash_DiffersOnModeChange(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("file mode changes are not meaningfully observable on Windows")
 	}
 
@@ -149,7 +151,7 @@ func TestStoreLocalDirectoryConcurrentWithRacing(t *testing.T) {
 func TestStoreLocalDirectorySymlink(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("os.Symlink on Windows requires special permissions; covered by Unix CI")
 	}
 
@@ -173,6 +175,42 @@ func TestStoreLocalDirectorySymlink(t *testing.T) {
 	assert.Equal(t, "main.tf", got)
 }
 
+// TestStoreLocalDirectorySymlinkRematerialize pins that materializing a
+// symlink-bearing tree into a directory that already holds a prior
+// materialization succeeds. Terragrunt reuses one download dir across versions
+// of the same source, so a version bump re-materializes in place; without
+// clearing the existing entry, os.Symlink would fail with "file exists".
+func TestStoreLocalDirectorySymlinkRematerialize(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == osWindows {
+		t.Skip("os.Symlink on Windows requires special permissions; covered by Unix CI")
+	}
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	src := writeLocalFixture(t, map[string]string{
+		"main.tf": "ok",
+	})
+	require.NoError(t, os.Symlink("main.tf", filepath.Join(src, "alias.tf")))
+
+	dst := filepath.Join(t.TempDir(), "dst")
+	require.NoError(t, c.StoreLocalDirectory(t.Context(), l, v, src, dst))
+
+	// Second materialization into the same dst, which now holds the read-only
+	// blob and the symlink from the first pass.
+	require.NoError(t, c.StoreLocalDirectory(t.Context(), l, v, src, dst))
+
+	info, err := os.Lstat(filepath.Join(dst, "alias.tf"))
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink, "alias.tf must remain a symlink")
+
+	got, err := os.Readlink(filepath.Join(dst, "alias.tf"))
+	require.NoError(t, err)
+	assert.Equal(t, "main.tf", got)
+}
+
 // TestStoreLocalDirectoryRejectsEscapingSymlink pins the safety check: a
 // symlink whose target climbs above the source root is rejected at ingest
 // time rather than poisoning the CAS with content a later materialize would
@@ -180,7 +218,7 @@ func TestStoreLocalDirectorySymlink(t *testing.T) {
 func TestStoreLocalDirectoryRejectsEscapingSymlink(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("os.Symlink on Windows requires special permissions; covered by Unix CI")
 	}
 
@@ -205,7 +243,7 @@ func TestStoreLocalDirectoryRejectsEscapingSymlink(t *testing.T) {
 func TestComputeLocalRootHashIncludesSymlinks(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("os.Symlink on Windows requires special permissions; covered by Unix CI")
 	}
 

--- a/internal/cas/tree.go
+++ b/internal/cas/tree.go
@@ -167,6 +167,10 @@ func linkTree(
 					return err
 				}
 
+				if err := v.FS.RemoveAll(work.path); err != nil {
+					return fmt.Errorf("clear existing entry before symlink %s: %w", work.path, err)
+				}
+
 				if err := vfs.Symlink(v.FS, string(target), work.path); err != nil {
 					return fmt.Errorf("symlink %s -> %s: %w", work.path, string(target), err)
 				}

--- a/internal/cli/commands/catalog/tui/redesign/load.go
+++ b/internal/cli/commands/catalog/tui/redesign/load.go
@@ -50,7 +50,7 @@ func LoadURL(
 	}
 
 	walkWithSymlinks := opts.Experiments.Evaluate(experiment.Symlinks)
-	allowCAS := opts.Experiments.Evaluate(experiment.CAS) && !opts.NoCAS
+	allowCAS := !opts.NoCAS
 	slowReporting := opts.Experiments.Evaluate(experiment.SlowTaskReporting)
 
 	tempPath := CatalogTempPath(repoURL)

--- a/internal/cli/flags/shared/cas.go
+++ b/internal/cli/flags/shared/cas.go
@@ -24,7 +24,7 @@ func NewCASFlags(opts *options.TerragruntOptions, prefix flags.Prefix) clihelper
 			Name:        NoCASFlagName,
 			EnvVars:     tgPrefix.EnvVars(NoCASFlagName),
 			Destination: &opts.NoCAS,
-			Usage:       "Disable the CAS (Content Addressable Storage) feature even when the experiment is enabled.",
+			Usage:       "Disable the CAS (Content Addressable Storage) feature.",
 		}),
 		flags.NewFlag(&clihelper.GenericFlag[int]{
 			Name:        CASCloneDepthFlagName,

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -20,8 +20,10 @@ const (
 	CLIRedesign = "cli-redesign"
 	// Stacks is the experiment that allows stacks to be used in Terragrunt.
 	Stacks = "stacks"
-	// CAS is the experiment that enables using the CAS package for git operations
-	// in the catalog command, which provides better performance through content-addressable storage.
+	// CAS names the now-stable content-addressable storage behavior. CAS speeds up
+	// catalog cloning, OpenTofu/Terraform source cloning, and stack generation by
+	// avoiding redundant downloads of Git repositories. It is enabled by default and
+	// can be disabled with the --no-cas flag.
 	CAS = "cas"
 	// Report is the experiment that enables the new run report.
 	Report = "report"
@@ -99,7 +101,8 @@ func NewExperiments() Experiments {
 			Status: StatusCompleted,
 		},
 		{
-			Name: CAS,
+			Name:   CAS,
+			Status: StatusCompleted,
 		},
 		{
 			Name:   Report,

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -136,7 +136,8 @@ func NewExperiments() Experiments {
 			Name: StackDependencies,
 		},
 		{
-			Name: CatalogRedesign,
+			Name:   CatalogRedesign,
+			Status: StatusCompleted,
 		},
 		{
 			Name: MarkManyAsRead,

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -400,7 +400,7 @@ func downloadSource(
 func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Options, mutable bool) (bool, error) {
 	canonicalSourceURL := src.CanonicalSourceURL.String()
 
-	l.Debugf("CAS experiment enabled: attempting to use Content Addressable Storage for source: %s", canonicalSourceURL)
+	l.Debugf("CAS enabled: attempting to use Content Addressable Storage for source: %s", canonicalSourceURL)
 
 	if err := cas.ValidateCASCloneDepth(opts.CASCloneDepth); err != nil {
 		return false, err

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -351,7 +351,7 @@ func downloadSource(
 		util.RelPathForLog(opts.RootWorkingDir, canonicalSourceURL, opts.Writers.LogShowAbsPaths),
 		util.RelPathForLog(opts.RootWorkingDir, src.DownloadDir, opts.Writers.LogShowAbsPaths))
 
-	allowCAS := opts.Experiments.Evaluate(experiment.CAS) && !opts.NoCAS
+	allowCAS := !opts.NoCAS
 
 	if cfg.Terraform.UpdateSourceWithCAS && !allowCAS {
 		return &cas.UpdateSourceWithCASRequiresCASError{

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -264,7 +264,31 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVe
 
 	copyFolder(t, "../../../test/fixtures/download-source/hello-world-version-remote", downloadDir)
 
-	testDownloadTerraformSourceIfNecessary(t, canonicalURL, downloadDir, false, "# Hello, World version remote", false)
+	terraformSource, opts, cfg, err := createConfig(t, canonicalURL, downloadDir, false)
+	require.NoError(t, err)
+
+	// The hello-world-version-remote fixture ships a file literally named
+	// "version-file.txt". CAS materializes downloaded sources read-only, so a
+	// bookkeeping write to that path would collide with the module's own file.
+	// Use the name Terragrunt actually writes in production
+	// (.terragrunt-source-version), which never appears in module content.
+	terraformSource.VersionFile = filepath.Join(downloadDir, ".terragrunt-source-version")
+
+	_, err = run.DownloadTerraformSourceIfNecessary(
+		t.Context(),
+		logger.CreateLogger(),
+		terraformSource,
+		configbridge.NewRunOptions(opts),
+		cfg,
+		report.NewReport(),
+	)
+	require.NoError(t, err, "For terraform source %v: %v", terraformSource, err)
+
+	expectedFilePath := filepath.Join(downloadDir, "main.tf")
+	if assert.True(t, util.FileExists(expectedFilePath), "For terraform source %v", terraformSource) {
+		actualFileContents := readFile(t, expectedFilePath)
+		assert.Equal(t, "# Hello, World version remote", actualFileContents, "For terraform source %v", terraformSource)
+	}
 }
 
 func TestDownloadTerraformSourceIfNecessaryRemoteUrlOverrideSource(t *testing.T) {

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -277,6 +277,7 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVe
 	_, err = run.DownloadTerraformSourceIfNecessary(
 		t.Context(),
 		logger.CreateLogger(),
+		run.OSVenv(),
 		terraformSource,
 		configbridge.NewRunOptions(opts),
 		cfg,

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -822,10 +822,7 @@ func TestDownloadSourceWithCASExperimentEnabled(t *testing.T) {
 	opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")
 	require.NoError(t, err)
 
-	// Enable CAS experiment
 	opts.Experiments = experiment.NewExperiments()
-	err = opts.Experiments.EnableExperiment(experiment.CAS)
-	require.NoError(t, err)
 
 	cfg := &runcfg.RunConfig{
 		Terraform: runcfg.TerraformConfig{
@@ -864,10 +861,7 @@ func TestDownloadSourceWithCASGitSource(t *testing.T) {
 	opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")
 	require.NoError(t, err)
 
-	// Enable CAS experiment
 	opts.Experiments = experiment.NewExperiments()
-	err = opts.Experiments.EnableExperiment(experiment.CAS)
-	require.NoError(t, err)
 
 	cfg := &runcfg.RunConfig{
 		Terraform: runcfg.TerraformConfig{
@@ -905,10 +899,7 @@ func TestDownloadSourceCASInitializationFailure(t *testing.T) {
 	opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")
 	require.NoError(t, err)
 
-	// Enable CAS experiment
 	opts.Experiments = experiment.NewExperiments()
-	err = opts.Experiments.EnableExperiment(experiment.CAS)
-	require.NoError(t, err)
 
 	cfg := &runcfg.RunConfig{
 		Terraform: runcfg.TerraformConfig{
@@ -929,67 +920,47 @@ func TestDownloadSourceCASInitializationFailure(t *testing.T) {
 }
 
 // TestDownloadSourceUpdateSourceWithCASRequiresCAS verifies that setting
-// update_source_with_cas = true on a terraform block errors when CAS is unavailable,
-// either because the experiment is off or because --no-cas is set.
+// update_source_with_cas = true on a terraform block errors when CAS is
+// disabled via --no-cas.
 func TestDownloadSourceUpdateSourceWithCASRequiresCAS(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		name      string
-		enableCAS bool
-		noCAS     bool
-	}{
-		{name: "experiment off", enableCAS: false, noCAS: false},
-		{name: "experiment on with --no-cas", enableCAS: true, noCAS: true},
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	localSourcePath := absPath(t, "../../../test/fixtures/download-source/hello-world")
+	src := &tf.Source{
+		CanonicalSourceURL: parseURL(t, "file://"+localSourcePath),
+		DownloadDir:        tmpDir,
+		WorkingDir:         tmpDir,
+		VersionFile:        filepath.Join(tmpDir, "version-file.txt"),
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")
+	require.NoError(t, err)
 
-			tmpDir := helpers.TmpDirWOSymlinks(t)
+	opts.NoCAS = true
+	opts.TerragruntConfigPath = "/tmp/terragrunt.hcl"
 
-			localSourcePath := absPath(t, "../../../test/fixtures/download-source/hello-world")
-			src := &tf.Source{
-				CanonicalSourceURL: parseURL(t, "file://"+localSourcePath),
-				DownloadDir:        tmpDir,
-				WorkingDir:         tmpDir,
-				VersionFile:        filepath.Join(tmpDir, "version-file.txt"),
-			}
-
-			opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")
-			require.NoError(t, err)
-
-			opts.Experiments = experiment.NewExperiments()
-			if tc.enableCAS {
-				require.NoError(t, opts.Experiments.EnableExperiment(experiment.CAS))
-			}
-
-			opts.NoCAS = tc.noCAS
-			opts.TerragruntConfigPath = "/tmp/terragrunt.hcl"
-
-			cfg := &runcfg.RunConfig{
-				Terraform: runcfg.TerraformConfig{
-					UpdateSourceWithCAS: true,
-				},
-			}
-
-			l := logger.CreateLogger()
-			l.SetOptions(log.WithOutput(io.Discard))
-
-			_, err = run.DownloadTerraformSourceIfNecessary(
-				t.Context(), l, run.OSVenv(), src,
-				configbridge.NewRunOptions(opts),
-				cfg, report.NewReport(),
-			)
-			require.Error(t, err)
-
-			var target *cas.UpdateSourceWithCASRequiresCASError
-			require.ErrorAs(t, err, &target)
-			assert.Equal(t, "terraform", target.BlockType)
-			assert.Equal(t, opts.TerragruntConfigPath, target.Path)
-		})
+	cfg := &runcfg.RunConfig{
+		Terraform: runcfg.TerraformConfig{
+			UpdateSourceWithCAS: true,
+		},
 	}
+
+	l := logger.CreateLogger()
+	l.SetOptions(log.WithOutput(io.Discard))
+
+	_, err = run.DownloadTerraformSourceIfNecessary(
+		t.Context(), l, run.OSVenv(), src,
+		configbridge.NewRunOptions(opts),
+		cfg, report.NewReport(),
+	)
+	require.Error(t, err)
+
+	var target *cas.UpdateSourceWithCASRequiresCASError
+	require.ErrorAs(t, err, &target)
+	assert.Equal(t, "terraform", target.BlockType)
+	assert.Equal(t, opts.TerragruntConfigPath, target.Path)
 }
 
 // TestDownloadSourceWithCASMultipleSources tests that CAS works with multiple different sources
@@ -1001,10 +972,7 @@ func TestDownloadSourceWithCASMultipleSources(t *testing.T) {
 
 	opts.Env = util.EnvironMap()
 
-	// Enable CAS experiment
 	opts.Experiments = experiment.NewExperiments()
-	err = opts.Experiments.EnableExperiment(experiment.CAS)
-	require.NoError(t, err)
 
 	cfg := &runcfg.RunConfig{
 		Terraform: runcfg.TerraformConfig{

--- a/internal/services/catalog/catalog.go
+++ b/internal/services/catalog/catalog.go
@@ -150,9 +150,8 @@ func (s *catalogServiceImpl) Load(ctx context.Context, l log.Logger) error {
 
 	var allModules module.Modules
 
-	// Evaluate experimental features for symlinks and content-addressable storage.
 	walkWithSymlinks := s.opts.Experiments.Evaluate(experiment.Symlinks)
-	allowCAS := s.opts.Experiments.Evaluate(experiment.CAS) && !s.opts.NoCAS
+	allowCAS := !s.opts.NoCAS
 	slowReporting := s.opts.Experiments.Evaluate(experiment.SlowTaskReporting)
 
 	var errs []error
@@ -227,7 +226,7 @@ func (s *catalogServiceImpl) LoadStreamingURL(ctx context.Context, l log.Logger,
 	}
 
 	walkWithSymlinks := s.opts.Experiments.Evaluate(experiment.Symlinks)
-	allowCAS := s.opts.Experiments.Evaluate(experiment.CAS) && !s.opts.NoCAS
+	allowCAS := !s.opts.NoCAS
 	slowReporting := s.opts.Experiments.Evaluate(experiment.SlowTaskReporting)
 
 	tempPath := catalogTempPath(repoURL)

--- a/internal/services/catalog/catalog_test.go
+++ b/internal/services/catalog/catalog_test.go
@@ -317,9 +317,8 @@ func TestLoad_PassesCASOptions(t *testing.T) {
 		noCAS        bool
 		wantAllowCAS bool
 	}{
-		{name: "cas experiment enabled", cloneDepth: 1, enableCAS: true, noCAS: false, wantAllowCAS: true},
-		{name: "cas experiment enabled with no-cas", cloneDepth: 1, enableCAS: true, noCAS: true, wantAllowCAS: false},
-		{name: "cas experiment disabled", cloneDepth: 1, enableCAS: false, noCAS: false, wantAllowCAS: false},
+		{name: "cas enabled", cloneDepth: 1, enableCAS: true, noCAS: false, wantAllowCAS: true},
+		{name: "no-cas flag disables cas", cloneDepth: 1, enableCAS: true, noCAS: true, wantAllowCAS: false},
 		{name: "custom clone depth", cloneDepth: 5, enableCAS: true, noCAS: false, wantAllowCAS: true},
 	}
 

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -125,7 +125,7 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 		return err
 	}
 
-	casEnabled := pctx.Experiments.Evaluate(experiment.CAS) && !pctx.NoCAS
+	casEnabled := !pctx.NoCAS
 
 	if err := validateUpdateSourceWithCAS(stackFile, stackFilePath, casEnabled); err != nil {
 		return err

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -580,7 +580,7 @@ func fetchComponentSource(
 
 	if isCASProtocol(source) {
 		if !opts.casEnabled {
-			return fmt.Errorf("cas:: source on %s %q requires the 'cas' experiment to be enabled", kindStr, cmp.name)
+			return fmt.Errorf("cas:: source on %s %q requires the --no-cas flag to be unset", kindStr, cmp.name)
 		}
 
 		if err := os.MkdirAll(dest, os.ModePerm); err != nil {

--- a/test/benchmarks/integration_cas_bench_test.go
+++ b/test/benchmarks/integration_cas_bench_test.go
@@ -29,7 +29,6 @@ func BenchmarkCASInit(b *testing.B) {
 			b,
 			"terragrunt",
 			"init",
-			"--experiment", "cas",
 			"--non-interactive",
 			"--provider-cache",
 			"--working-dir",
@@ -49,6 +48,7 @@ func BenchmarkCASInit(b *testing.B) {
 				b,
 				"terragrunt",
 				"init",
+				"--no-cas",
 				"--non-interactive",
 				"--provider-cache",
 				"--source-update",
@@ -70,7 +70,6 @@ func BenchmarkCASInit(b *testing.B) {
 				b,
 				"terragrunt",
 				"init",
-				"--experiment", "cas",
 				"--non-interactive",
 				"--provider-cache",
 				"--source-update",
@@ -151,8 +150,8 @@ func BenchmarkCASWithManyUnits(b *testing.B) {
 					tmpDir,
 				}
 
-				if cas {
-					args = append(args, "--experiment", "cas")
+				if !cas {
+					args = append(args, "--no-cas")
 				}
 
 				b.ResetTimer()

--- a/test/integration_download_test.go
+++ b/test/integration_download_test.go
@@ -947,13 +947,13 @@ func TestDownloadWithCASEnabled(t *testing.T) {
 	testPath := filepath.Join(tmpEnvPath, fixturePath)
 	helpers.CleanupTerraformFolder(t, testPath)
 
-	// Run with CAS experiment enabled
+	// CAS is enabled by default.
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer
 	)
 
-	cmd := "terragrunt apply --auto-approve --non-interactive --experiment cas --log-level debug --working-dir " + testPath
+	cmd := "terragrunt apply --auto-approve --non-interactive --log-level debug --working-dir " + testPath
 	err := helpers.RunTerragruntCommand(t, cmd, &stdout, &stderr)
 	require.NoError(t, err)
 
@@ -970,7 +970,7 @@ func TestDownloadWithCASCommitRef(t *testing.T) {
 	testPath := filepath.Join(tmpEnvPath, fixturePath)
 	helpers.CleanupTerraformFolder(t, testPath)
 
-	applyCmd := "terragrunt apply --auto-approve --non-interactive --experiment cas --working-dir " + testPath
+	applyCmd := "terragrunt apply --auto-approve --non-interactive --working-dir " + testPath
 	require.NoError(t, helpers.RunTerragruntCommand(t, applyCmd, io.Discard, io.Discard))
 
 	var (
@@ -978,7 +978,7 @@ func TestDownloadWithCASCommitRef(t *testing.T) {
 		stderr bytes.Buffer
 	)
 
-	outputCmd := "terragrunt output -raw test --non-interactive --experiment cas --working-dir " + testPath
+	outputCmd := "terragrunt output -raw test --non-interactive --working-dir " + testPath
 	require.NoError(t, helpers.RunTerragruntCommand(t, outputCmd, &stdout, &stderr))
 
 	assert.Equal(t, "Hello, World", stdout.String())
@@ -1004,7 +1004,7 @@ func TestDownloadWithCASMutable(t *testing.T) {
 		stderr bytes.Buffer
 	)
 
-	cmd := "terragrunt apply --auto-approve --non-interactive --experiment cas --log-level debug --working-dir " + testPath
+	cmd := "terragrunt apply --auto-approve --non-interactive --log-level debug --working-dir " + testPath
 	require.NoError(t, helpers.RunTerragruntCommand(t, cmd, &stdout, &stderr))
 
 	cacheDir := filepath.Join(testPath, ".terragrunt-cache")

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -2371,10 +2371,6 @@ func TestStackOutputWithExclude(t *testing.T) {
 func TestCASInStacks(t *testing.T) {
 	t.Parallel()
 
-	if !helpers.IsExperimentMode(t) {
-		t.Skip("Experiment mode is not enabled")
-	}
-
 	srv, err := git.NewServer()
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = srv.Close() })
@@ -2500,10 +2496,6 @@ func TestCASInStacks(t *testing.T) {
 func TestCASInStacksUnitSourceSubdirSiblingsResolve(t *testing.T) {
 	t.Parallel()
 
-	if !helpers.IsExperimentMode(t) {
-		t.Skip("Experiment mode is not enabled")
-	}
-
 	srv, err := git.NewServer()
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = srv.Close() })
@@ -2571,16 +2563,10 @@ func TestCASInStacksUnitSourceSubdirSiblingsResolve(t *testing.T) {
 
 // TestCASInStacksRejectsUpdateSourceWithCASWithNoCAS verifies that stack generation
 // errors when a unit or stack block declares update_source_with_cas = true while
-// --no-cas is set. The "experiment off" branch is covered by the unit tests in
-// internal/runner/run/download_source_test.go; integration-mode here always has the
-// cas experiment enabled via TG_EXPERIMENT_MODE, so --no-cas is the only way to
-// disable CAS for this scenario.
+// --no-cas is set. CAS is enabled by default, so --no-cas is the way to disable it
+// for this scenario.
 func TestCASInStacksRejectsUpdateSourceWithCASWithNoCAS(t *testing.T) {
 	t.Parallel()
-
-	if !helpers.IsExperimentMode(t) {
-		t.Skip("Experiment mode is not enabled")
-	}
 
 	testCases := []struct {
 		name        string
@@ -2640,10 +2626,6 @@ func TestCASInStacksRejectsUpdateSourceWithCASWithNoCAS(t *testing.T) {
 // rewritten to cas::sha256 references that materialize correctly at run time.
 func TestCASInStacksLocalSource(t *testing.T) {
 	t.Parallel()
-
-	if !helpers.IsExperimentMode(t) {
-		t.Skip("Experiment mode is not enabled")
-	}
 
 	// Keep the catalog on a sibling path outside the live working directory so
 	// terragrunt stack generate doesn't discover the catalog's stack file as a


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Completes the `cas` experiment.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content Addressable Storage (CAS) is now enabled by default for improved cloning and stack generation performance. The `cas` experiment flag is no longer required. Disable with `--no-cas` if needed.

* **Documentation**
  * Version-gated documentation clarifies CAS availability and configuration across different Terragrunt versions.

* **Bug Fixes**
  * Improved symlink handling during local cache storage rematerialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->