### PR TITLE
fix: Fixing scaffold path traversal check

### DIFF
--- a/docs/src/data/changelog/v1.0.8/catalog-redesign-scaffold-path-traversal.mdx
+++ b/docs/src/data/changelog/v1.0.8/catalog-redesign-scaffold-path-traversal.mdx
@@ -1,0 +1,16 @@
+---
+version: "v1.0.8"
+category: "experiments-updated"
+---
+
+#### `catalog-redesign` — Scaffolding a component no longer fails with a path-traversal error
+
+Scaffolding a component from the catalog (pressing `s`) could fail on macOS while downloading the source:
+
+```text
+subdirectory component contain path traversal out of the repository
+```
+
+The catalog caches each repository under the system temporary directory, which macOS reports through a symlink (`/var/folders/...` pointing at `/private/var/folders/...`). The source location Terragrunt handed to the downloader was built against the unresolved path, so it pointed outside the cached repository and was rejected.
+
+Terragrunt now resolves the temporary directory before discovering components, so the source stays inside the repository and scaffolding proceeds.

--- a/internal/cli/commands/catalog/tui/redesign/load.go
+++ b/internal/cli/commands/catalog/tui/redesign/load.go
@@ -18,6 +18,17 @@ import (
 // repeated runs reuse the same clone on disk.
 const tempDirFormat = "catalog-%s"
 
+// CatalogTempPath returns the local cache directory for repoURL's clone. It
+// resolves os.TempDir() through any symlinks so the subdirectories
+// [ComponentDiscovery] derives via filepath.Rel stay inside the clone. macOS
+// reports os.TempDir() as a /var/folders symlink to /private/var/folders;
+// leaving it unresolved makes Rel emit a "../" traversal that the getter package
+// rejects when scaffolding.
+func CatalogTempPath(repoURL string) string {
+	encodedRepoURL := util.EncodeBase64Sha1(repoURL)
+	return filepath.Join(util.ResolvePath(os.TempDir()), fmt.Sprintf(tempDirFormat, encodedRepoURL))
+}
+
 // LoadURL clones repoURL via module.NewRepo, walks it with DiscoverComponents,
 // resolves the latest release tag once, and emits a *ComponentEntry for each
 // discovered component on componentCh.
@@ -42,8 +53,7 @@ func LoadURL(
 	allowCAS := opts.Experiments.Evaluate(experiment.CAS)
 	slowReporting := opts.Experiments.Evaluate(experiment.SlowTaskReporting)
 
-	encodedRepoURL := util.EncodeBase64Sha1(repoURL)
-	tempPath := filepath.Join(os.TempDir(), fmt.Sprintf(tempDirFormat, encodedRepoURL))
+	tempPath := CatalogTempPath(repoURL)
 
 	l.Debugf("Processing repository %s in temporary path %s", repoURL, tempPath)
 

--- a/internal/cli/commands/catalog/tui/redesign/load_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/load_test.go
@@ -1,0 +1,37 @@
+package redesign_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui/redesign"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCatalogTempPathResolvesSymlinkedTmpDir verifies the clone cache dir is
+// anchored at a symlink-resolved temp dir. macOS reports os.TempDir() as a
+// /var/folders symlink to /private/var/folders; an unresolved root makes
+// discovery's filepath.Rel emit a "../" traversal that go-getter rejects.
+func TestCatalogTempPathResolvesSymlinkedTmpDir(t *testing.T) {
+	// t.Setenv forbids t.Parallel.
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	realTmp := filepath.Join(base, "real")
+	require.NoError(t, os.Mkdir(realTmp, 0o755))
+
+	// linkTmp -> realTmp stands in for /var/folders -> /private/var/folders.
+	linkTmp := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(realTmp, linkTmp))
+
+	t.Setenv("TMPDIR", linkTmp)
+
+	got := redesign.CatalogTempPath("github.com/gruntwork-io/terragrunt-scale-catalog")
+
+	// The clone dir must sit directly under the resolved temp dir, with no
+	// symlink component left for filepath.Rel to trip over later.
+	assert.Equal(t, realTmp, filepath.Dir(got),
+		"CatalogTempPath should anchor the clone at the symlink-resolved temp dir")
+}

--- a/internal/services/catalog/catalog.go
+++ b/internal/services/catalog/catalog.go
@@ -162,10 +162,7 @@ func (s *catalogServiceImpl) Load(ctx context.Context, l log.Logger) error {
 			continue
 		}
 
-		// Create a unique path in the system's temporary directory for this repository.
-		// The path is based on a SHA1 hash of the repository URL to ensure uniqueness and idempotency.
-		encodedRepoURL := util.EncodeBase64Sha1(currentRepoURL)
-		tempPath := filepath.Join(os.TempDir(), fmt.Sprintf(tempDirFormat, encodedRepoURL))
+		tempPath := catalogTempPath(currentRepoURL)
 
 		l.Debugf("Processing repository %s in temporary path %s", currentRepoURL, tempPath)
 
@@ -232,8 +229,7 @@ func (s *catalogServiceImpl) LoadStreamingURL(ctx context.Context, l log.Logger,
 	allowCAS := s.opts.Experiments.Evaluate(experiment.CAS)
 	slowReporting := s.opts.Experiments.Evaluate(experiment.SlowTaskReporting)
 
-	encodedRepoURL := util.EncodeBase64Sha1(repoURL)
-	tempPath := filepath.Join(os.TempDir(), fmt.Sprintf(tempDirFormat, encodedRepoURL))
+	tempPath := catalogTempPath(repoURL)
 
 	l.Debugf("Processing repository %s in temporary path %s", repoURL, tempPath)
 
@@ -280,4 +276,15 @@ func (s *catalogServiceImpl) Scaffold(ctx context.Context, l log.Logger, opts *o
 	l.Debugf("Scaffolding module: %q", module.TerraformSourcePath())
 
 	return scaffold.Run(ctx, l, opts, module.TerraformSourcePath(), "")
+}
+
+// catalogTempPath returns the local cache directory for repoURL's clone. It
+// resolves os.TempDir() through any symlinks so the subdirectories module
+// discovery derives via filepath.Rel stay inside the clone. macOS reports
+// os.TempDir() as a /var/folders symlink to /private/var/folders; leaving it
+// unresolved makes Rel emit a "../" traversal that go-getter rejects when
+// scaffolding.
+func catalogTempPath(repoURL string) string {
+	encodedRepoURL := util.EncodeBase64Sha1(repoURL)
+	return filepath.Join(util.ResolvePath(os.TempDir()), fmt.Sprintf(tempDirFormat, encodedRepoURL))
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes scaffold error when running catalog in a temporary directory in macOS.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS scaffolding failures that occurred when resolving cached repository paths through symlinks. Downloaded sources now properly remain within the cached repository, preventing path-traversal issues and scaffolding failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->