### PR TITLE
fix(telemetry): honor `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` environment variables

### DIFF
--- a/docs/src/content/docs/05-community/01-contributing.mdx
+++ b/docs/src/content/docs/05-community/01-contributing.mdx
@@ -109,19 +109,7 @@ We use the linter as a guide to learn about how we can improve the Terragrunt co
 
 If you feel like the linter is missing a check that would be useful for improving the code quality of Terragrunt, please open an issue to discuss it, then open a pull request to add the check.
 
-There are two lint configurations currently in use:
-
-- **Default linter**
-
-  This is the default configuration that is used when running `golangci-lint run`. The configuration for this lint is defined in the `.golangci.yml` file.
-
-  These lints **must** pass before any code is merged into the `main` branch.
-
-- **Strict linter**
-
-  This is the more strict configuration that is used to check for additional issues in pull requests. This configuration is defined in the `.strict.golanci.yml` file.
-
-  These lints **do not have to pass** before code is merged into the `main` branch, but the results are useful to look at to improve code quality.
+The default in the `.golangci.yml` configuration file is used when running `golangci-lint run`. These lints **must** pass before any code is merged into the `main` branch.
 
 #### Default linter
 

--- a/docs/src/content/docs/06-troubleshooting/02-open-telemetry.md
+++ b/docs/src/content/docs/06-troubleshooting/02-open-telemetry.md
@@ -40,6 +40,11 @@ Metrics configuration:
   - `grpcHttp` - export metrics to an OpenTelemetry collector over gRPC [otlpmetricgrpc](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc)
 - `TG_TELEMETRY_METRIC_EXPORTER_INSECURE_ENDPOINT` - if set to true, the exporter will not validate the server's certificate, helpful for local metrics collection.
 
+Resource attributes:
+
+- `OTEL_SERVICE_NAME` - overrides the `service.name` resource attribute attached to every span and metric. Defaults to `terragrunt`. Useful for distinguishing multiple Terragrunt invocations in the same backend (e.g. per-environment or per-user).
+- `OTEL_RESOURCE_ATTRIBUTES` - additional resource attributes to attach to every span and metric, formatted as a comma-separated list of `key=value` pairs (e.g. `deployment.environment=local,service.namespace=tensho`). Values set here override Terragrunt's defaults; if both `OTEL_SERVICE_NAME` and `service.name` in `OTEL_RESOURCE_ATTRIBUTES` are set, `OTEL_SERVICE_NAME` takes precedence per the [OpenTelemetry specification](https://opentelemetry.io/docs/specs/otel/resource/sdk/).
+
 ## Example configurations for trace collection
 
 Collection of examples how to configure Terragrunt to emit traces and metrics in OpenTelemetry format.

--- a/docs/src/data/changelog/v1.0.8/honor-otel-service-name.mdx
+++ b/docs/src/data/changelog/v1.0.8/honor-otel-service-name.mdx
@@ -1,6 +1,6 @@
 ---
 version: "v1.0.8"
-category: "enhancements"
+category: "bug-fixes"
 ---
 
 #### Telemetry resource now honors `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`

--- a/docs/src/data/changelog/v1.0.8/honor-otel-service-name.mdx
+++ b/docs/src/data/changelog/v1.0.8/honor-otel-service-name.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.8"
+category: "enhancements"
+---
+
+#### Telemetry resource now honors `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`
+
+Terragrunt previously hardcoded the `service.name` resource attribute to `terragrunt` for every emitted trace and metric, ignoring the standard OpenTelemetry environment variables. Multiple Terragrunt invocations could not be distinguished in an OpenTelemetry backend without an intermediate collector to rewrite the attribute.
+
+The resource is now composed via `resource.New` with `WithFromEnv()` placed after Terragrunt's defaults, so `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` are honored on every span and metric. Per the OpenTelemetry specification, `OTEL_SERVICE_NAME` takes precedence over a `service.name` entry in `OTEL_RESOURCE_ATTRIBUTES`. The default `service.name` remains `terragrunt` when neither variable is set.

--- a/internal/telemetry/meter.go
+++ b/internal/telemetry/meter.go
@@ -145,7 +145,11 @@ func NewMetricsExporter(ctx context.Context, writer io.Writer, opts *Options) (m
 }
 
 // newMetricsProvider creates a new metrics provider.
-func newMetricsProvider(ctx context.Context, exp metric.Exporter, appName, appVersion string) (*metric.MeterProvider, error) {
+func newMetricsProvider(
+	ctx context.Context,
+	exp metric.Exporter,
+	appName, appVersion string,
+) (*metric.MeterProvider, error) {
 	r, err := resource.New(ctx,
 		resource.WithSchemaURL(semconv.SchemaURL),
 		resource.WithAttributes(

--- a/internal/telemetry/meter.go
+++ b/internal/telemetry/meter.go
@@ -53,7 +53,7 @@ func NewMeter(ctx context.Context, appName, appVersion string, writer io.Writer,
 		return nil, nil
 	}
 
-	provider, err := newMetricsProvider(exporter, appName, appVersion)
+	provider, err := newMetricsProvider(ctx, exporter, appName, appVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -145,14 +145,15 @@ func NewMetricsExporter(ctx context.Context, writer io.Writer, opts *Options) (m
 }
 
 // newMetricsProvider creates a new metrics provider.
-func newMetricsProvider(exp metric.Exporter, appName, appVersion string) (*metric.MeterProvider, error) {
-	r, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
+func newMetricsProvider(ctx context.Context, exp metric.Exporter, appName, appVersion string) (*metric.MeterProvider, error) {
+	r, err := resource.New(ctx,
+		resource.WithSchemaURL(semconv.SchemaURL),
+		resource.WithAttributes(
 			semconv.ServiceName(appName),
 			semconv.ServiceVersion(appVersion),
 		),
+		resource.WithTelemetrySDK(),
+		resource.WithFromEnv(),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/telemetry/telemeter_test.go
+++ b/internal/telemetry/telemeter_test.go
@@ -1,0 +1,97 @@
+package telemetry_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTelemeterEnvOverrides(t *testing.T) {
+	cases := []struct {
+		name             string
+		envServiceName   string
+		envResourceAttrs string
+		wantServiceName  string
+	}{
+		{
+			name:            "default",
+			wantServiceName: "terragrunt",
+		},
+		{
+			name:            "OTEL_SERVICE_NAME overrides default",
+			envServiceName:  "Service-Name-From-Env",
+			wantServiceName: "Service-Name-From-Env",
+		},
+		{
+			name:             "OTEL_RESOURCE_ATTRIBUTES service.name overrides default",
+			envResourceAttrs: "service.name=Service-Name-From-Resource-Attributes",
+			wantServiceName:  "Service-Name-From-Resource-Attributes",
+		},
+		{
+			name:             "OTEL_SERVICE_NAME overrides OTEL_RESOURCE_ATTRIBUTES service.name",
+			envServiceName:   "Service-Name-From-Env",
+			envResourceAttrs: "service.name=Service-Name-From-Resource-Attributes",
+			wantServiceName:  "Service-Name-From-Env",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OTEL_SERVICE_NAME", tc.envServiceName)
+			t.Setenv("OTEL_RESOURCE_ATTRIBUTES", tc.envResourceAttrs)
+
+			var buf bytes.Buffer
+
+			opts := options.NewTerragruntOptionsWithWriters(io.Discard, io.Discard)
+			opts.Telemetry.TraceExporter = "console"
+			opts.Telemetry.MetricExporter = "console"
+
+			tlm, err := telemetry.NewTelemeter(t.Context(), nil, "terragrunt", "v0.0.0-test", &buf, opts.Telemetry)
+			require.NoError(t, err)
+			require.NotNil(t, tlm)
+
+			require.NoError(t, tlm.Trace(t.Context(), "test_span", nil, func(context.Context) error { return nil }))
+			tlm.Count(t.Context(), "test_metric", 1)
+			require.NoError(t, tlm.Shutdown(t.Context()))
+
+			type entry struct {
+				Resource []struct {
+					Key   string
+					Value struct{ Value string }
+				}
+				ScopeMetrics []json.RawMessage `json:",omitempty"`
+			}
+
+			var spanFound, metricFound bool
+
+			dec := json.NewDecoder(&buf)
+			for dec.More() {
+				var e entry
+				require.NoError(t, dec.Decode(&e))
+
+				got := map[string]string{}
+				for _, kv := range e.Resource {
+					got[kv.Key] = kv.Value.Value
+				}
+
+				assert.Equal(t, tc.wantServiceName, got["service.name"])
+
+				if len(e.ScopeMetrics) > 0 {
+					metricFound = true
+				} else {
+					spanFound = true
+				}
+			}
+
+			assert.True(t, spanFound, "expected span emission")
+			assert.True(t, metricFound, "expected metric emission")
+		})
+	}
+}

--- a/internal/telemetry/telemeter_test.go
+++ b/internal/telemetry/telemeter_test.go
@@ -63,10 +63,12 @@ func TestNewTelemeterEnvOverrides(t *testing.T) {
 
 			type entry struct {
 				Resource []struct {
-					Key   string
-					Value struct{ Value string }
-				}
-				ScopeMetrics []json.RawMessage `json:",omitempty"`
+					Key   string `json:"Key"`
+					Value struct {
+						Value string `json:"Value"`
+					} `json:"Value"`
+				} `json:"Resource"`
+				ScopeMetrics []json.RawMessage `json:"ScopeMetrics,omitempty"`
 			}
 
 			var spanFound, metricFound bool

--- a/internal/telemetry/tracer.go
+++ b/internal/telemetry/tracer.go
@@ -56,7 +56,7 @@ func NewTracer(
 		return nil, nil
 	}
 
-	provider, err := newTraceProvider(spanExporter, appName, appVersion, opts)
+	provider, err := newTraceProvider(ctx, spanExporter, appName, appVersion, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -118,15 +118,16 @@ func NewTracer(
 
 // newTraceProvider creates a new trace tracer with terragrunt version.
 func newTraceProvider(
-	exp sdktrace.SpanExporter, appName, appVersion string, opts *Options,
+	ctx context.Context, exp sdktrace.SpanExporter, appName, appVersion string, opts *Options,
 ) (*sdktrace.TracerProvider, error) {
-	r, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
+	r, err := resource.New(ctx,
+		resource.WithSchemaURL(semconv.SchemaURL),
+		resource.WithAttributes(
 			semconv.ServiceName(appName),
 			semconv.ServiceVersion(appVersion),
 		),
+		resource.WithTelemetrySDK(),
+		resource.WithFromEnv(),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

Terragrunt OTel telemeter doesn't honor [`OTEL_SERVICE_NAME` environment variable](https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_service_name), hence [hardcoded `"terragrunt"` service name](https://github.com/Tensho/terragrunt/blob/main/internal/cli/app.go#L33) is only available. Multiple Terragrunt invocations across different environments could not be distinguished in an OpenTelemetry backend without an intermediate collector to rewrite the attribute.

This PR reshuffles merging strategy for meter and tracer constructor options and brings it closer to the industry expectations.

Merge rule (Go SDK): `resource.New(ctx, opts...)` applies options in order. Each option produces a `*Resource`; SDK merges left → right. Later options override earlier on key conflicts.

  Source: `go.opentelemetry.io/otel/sdk/resource` – see [`New()`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#New) and [`Merge()`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#Merge).

* ["OTel Resource SDK" → "Detecting resource information from the environment"](https://opentelemetry.io/docs/specs/otel/resource/sdk/#detecting-resource-information-from-the-environment)

## Improvements

* Drop "Strict linter" section from "Contributing" doc ([redundency confirmation](https://discord.com/channels/1090098780344422490/1314225486867468309/1511320943681601567) by @yhakbar)

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributing docs to simplify linting guidance and added troubleshooting guidance for OpenTelemetry resource attribute environment variables.

* **Features**
  * Telemetry now honors OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES; environment variables override defaults and OTEL_SERVICE_NAME takes precedence when both are set.

* **Tests**
  * Added tests verifying telemetry records reflect OpenTelemetry environment variable behavior and precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->