### PR TITLE
Make guides collapsed to start

### DIFF
--- a/docs/src/data/sidebar.ts
+++ b/docs/src/data/sidebar.ts
@@ -8,10 +8,12 @@ export const sidebar = [
     items: [
       {
         label: "Terralith to Terragrunt",
+        collapsed: true,
         autogenerate: { directory: "02-guides/01-terralith-to-terragrunt", collapsed: true },
       },
       {
         label: "Continuous Integration with Terragrunt",
+        collapsed: true,
         autogenerate: { directory: "02-guides/02-continuous-integration-with-terragrunt", collapsed: true },
       },
     ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation sidebar navigation to collapse specific guide sections by default, enhancing readability and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->