### PR TITLE
Collapse reference section

### DIFF
--- a/docs/src/data/sidebar.ts
+++ b/docs/src/data/sidebar.ts
@@ -65,6 +65,7 @@ export const sidebar = [
     items: [
       {
         label: "HCL",
+        collapsed: true,
         autogenerate: { directory: "04-reference/01-hcl", collapsed: true },
       },
       {
@@ -74,6 +75,7 @@ export const sidebar = [
           { label: "Overview", slug: "reference/cli" },
           {
             label: "Commands",
+            collapsed: true,
             autogenerate: {
               directory: "04-reference/02-cli/02-commands",
               collapsed: true,
@@ -84,6 +86,7 @@ export const sidebar = [
       },
       {
         label: "Strict Controls",
+        collapsed: true,
         items: [
           { label: "Overview", slug: "reference/strict-controls" },
           { label: "Active Controls", link: "/reference/strict-controls/active" },
@@ -92,6 +95,7 @@ export const sidebar = [
       },
       {
         label: "Experiments",
+        collapsed: true,
         items: [
           { label: "Overview", slug: "reference/experiments" },
           { label: "Active Experiments", link: "/reference/experiments/active" },
@@ -105,6 +109,7 @@ export const sidebar = [
       { label: "Lock Files", slug: "reference/lock-files" },
       {
         label: "Logging",
+        collapsed: true,
         autogenerate: { directory: "04-reference/07-logging", collapsed: true },
       },
       { label: "Terragrunt Cache", slug: "reference/terragrunt-cache" },
@@ -112,32 +117,32 @@ export const sidebar = [
   },
   {
     label: "Community",
-    autogenerate: { directory: "05-community", collapsed: true },
     collapsed: true,
+    autogenerate: { directory: "05-community", collapsed: true },
   },
   {
     label: "Troubleshooting",
-    autogenerate: { directory: "06-troubleshooting", collapsed: true },
     collapsed: true,
+    autogenerate: { directory: "06-troubleshooting", collapsed: true },
   },
   {
     label: "Process",
+    collapsed: true,
     items: [
       { label: "Terragrunt 1.0 Guarantees", slug: "process/1-0-guarantees" },
       { label: "CLI Rules", slug: "process/cli-rules" },
       { label: "Releases", slug: "process/releases" },
       { label: "Changelog", link: "/process/changelog" },
     ],
-    collapsed: true,
   },
   {
     label: "Migrate",
-    autogenerate: { directory: "08-migrate", collapsed: true },
     collapsed: true,
+    autogenerate: { directory: "08-migrate", collapsed: true },
   },
   {
     label: "Terragrunt Scale",
-    autogenerate: { directory: "09-terragrunt-scale", collapsed: true },
     collapsed: true,
+    autogenerate: { directory: "09-terragrunt-scale", collapsed: true },
   },
 ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Multiple documentation sections now collapse by default in the sidebar: HCL, CLI Commands, Strict Controls, Experiments, Logging, Community, Troubleshooting, Process, Migrate, and Terragrunt Scale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->