### PR TITLE
Fix for light/dark mode

### DIFF
--- a/docs/src/data/sidebar.ts
+++ b/docs/src/data/sidebar.ts
@@ -1,4 +1,6 @@
-export const sidebar = [
+import type { StarlightUserConfig } from "@astrojs/starlight/types";
+
+export const sidebar: StarlightUserConfig["sidebar"] = [
   {
     label: "Getting Started",
     autogenerate: { directory: "01-getting-started" },

--- a/docs/src/pages/process/changelog.astro
+++ b/docs/src/pages/process/changelog.astro
@@ -74,34 +74,33 @@ const headings = [
     margin-bottom: 2rem;
   }
   .category-list {
-    list-style: none;
-    padding: 0;
-    margin: 0.5rem 0;
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+    list-style: none;
+    margin: 0.5rem 0;
+    padding: 0;
   }
   .category-list li {
     font-size: 0.8125rem;
   }
   .category-list a {
-    display: inline-flex;
     align-items: center;
-    gap: 0.375rem;
-    padding: 0.25rem 0.625rem;
     border: 1px solid var(--sl-color-docs-stroke);
     border-radius: 999px;
-    background: var(--sl-color-bg-nav);
     color: inherit;
+    display: inline-flex;
+    gap: 0.375rem;
+    padding: 0.25rem 0.625rem;
     text-decoration: none;
   }
   .category-list a:hover,
   .category-list a:focus-visible {
-    border-color: var(--sl-color-accent);
     background: var(--sl-color-bg);
+    border-color: var(--sl-color-accent);
   }
   .category-count {
-    font-weight: 600;
     color: var(--sl-color-white);
+    font-weight: 600;
   }
 </style>


### PR DESCRIPTION
Fixes a visual bug in the changelog for light mode

Before:
<img width="817" height="751" alt="Screenshot 2026-06-03 at 4 35 46 PM" src="https://github.com/user-attachments/assets/44d4d44a-f9ca-4e83-bac6-2e06c4c44e92" />

After
<img width="817" height="749" alt="Screenshot 2026-06-03 at 4 35 28 PM" src="https://github.com/user-attachments/assets/7c6c10cf-c720-496d-a135-9f9db8f85c2f" />
:
