### PR TITLE
fix: Fixing graph traversal bug with intersected filter

### DIFF
--- a/docs/src/data/changelog/v1.0.8/filter-flag-graph-traversal-intersection.mdx
+++ b/docs/src/data/changelog/v1.0.8/filter-flag-graph-traversal-intersection.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.8"
+category: "bug-fixes"
+---
+
+#### Intersecting a graph traversal with another filter no longer drops the traversed components
+
+A graph traversal combined with an intersected filter dropped the components reached in discovery.
+
+e.g., `...a-dependent | type=unit` (the dependents of `a-dependent`, intersected with type of `units`) returned only `a-dependent` itself instead of its dependents, and git-change traversals such as `...[HEAD~1...HEAD] | type=unit` lost the dependents of the changed units.
+
+A component that matched both a graph expression target and a positive filesystem or git filter was classified as discovered before the graph traversal ran, so the traversal never expanded from it. Terragrunt now checks graph expression targets first, so intersecting a traversal with another filter keeps the dependencies and dependents it reaches.

--- a/internal/filter/classifier.go
+++ b/internal/filter/classifier.go
@@ -151,9 +151,9 @@ func NewClassifier(filters Filters) *Classifier {
 // Classification algorithm:
 //  1. Check if component ONLY matches negated filters -> EXCLUDED
 //  2. Check if parse expressions exist and parse data unavailable -> CANDIDATE (RequiresParse)
-//  3. Check if component matches any positive filesystem filter -> DISCOVERED
-//  4. Check if component matches any git expression -> DISCOVERED
-//  5. Check if component matches any graph expression target -> CANDIDATE (GraphTarget, returns index)
+//  3. Check if component matches any graph expression target -> CANDIDATE (GraphTarget, returns index)
+//  4. Check if component matches any positive filesystem filter -> DISCOVERED
+//  5. Check if component matches any git expression -> DISCOVERED
 //  6. Check if dependent filters exist and parse data unavailable -> CANDIDATE (PotentialDependent)
 //  7. If positive filters exist but no match -> EXCLUDED (exclude-by-default)
 //  8. If no positive filters exist -> DISCOVERED (include-by-default)
@@ -176,16 +176,16 @@ func (c *Classifier) Classify(comp component.Component, classCtx ClassificationC
 		return StatusCandidate, CandidacyReasonRequiresParse, -1
 	}
 
+	if graphIdx := c.matchesGraphExpressionTarget(comp); graphIdx >= 0 {
+		return StatusCandidate, CandidacyReasonGraphTarget, graphIdx
+	}
+
 	if c.matchesPathExpression(comp) || c.matchesAttributeExpression(comp) {
 		return StatusReadyForFilter, CandidacyReasonNone, -1
 	}
 
 	if c.matchesGitExpression(comp) {
 		return StatusReadyForFilter, CandidacyReasonNone, -1
-	}
-
-	if graphIdx := c.matchesGraphExpressionTarget(comp); graphIdx >= 0 {
-		return StatusCandidate, CandidacyReasonGraphTarget, graphIdx
 	}
 
 	if c.HasDependentFilters() && !classCtx.ParseDataAvailable {

--- a/internal/filter/classifier_test.go
+++ b/internal/filter/classifier_test.go
@@ -455,6 +455,31 @@ func TestClassifier_Classify(t *testing.T) {
 			expectedReason: filter.CandidacyReasonNone,
 			expectedIdx:    -1,
 		},
+		{
+			name:             "git_graph_target_with_intersected_attribute_returns_graph_target_candidate",
+			filterStrs:       []string{"...[main...feature] | type=unit"},
+			componentPath:    "./libs/db",
+			componentRef:     "main",
+			expectedStatus:   filter.StatusCandidate,
+			expectedReason:   filter.CandidacyReasonGraphTarget,
+			expectIdxGteZero: true,
+		},
+		{
+			name:             "path_graph_target_with_intersected_attribute_returns_graph_target_candidate",
+			filterStrs:       []string{"db... | type=unit"},
+			componentPath:    "./libs/db",
+			expectedStatus:   filter.StatusCandidate,
+			expectedReason:   filter.CandidacyReasonGraphTarget,
+			expectIdxGteZero: true,
+		},
+		{
+			name:           "attribute_filter_without_graph_expression_stays_ready_for_filter",
+			filterStrs:     []string{"type=unit"},
+			componentPath:  "./libs/db",
+			expectedStatus: filter.StatusReadyForFilter,
+			expectedReason: filter.CandidacyReasonNone,
+			expectedIdx:    -1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/integration_filter_graph_test.go
+++ b/test/integration_filter_graph_test.go
@@ -69,6 +69,24 @@ func TestFilterFlagWithFindGraphExpressions(t *testing.T) {
 			expectedOutput: "b-dependency\n",
 			expectError:    false,
 		},
+		{
+			name:           "dependencies intersected with type - a-dependent... | type=unit",
+			filterQuery:    "a-dependent... | type=unit",
+			expectedOutput: "a-dependent\nb-dependency\n",
+			expectError:    false,
+		},
+		{
+			name:           "dependents intersected with type - ...b-dependency | type=unit",
+			filterQuery:    "...b-dependency | type=unit",
+			expectedOutput: "a-dependent\nb-dependency\nc-mixed-deps\nd-dependencies-only\n",
+			expectError:    false,
+		},
+		{
+			name:           "both directions intersected with type - ...a-dependent... | type=unit",
+			filterQuery:    "...a-dependent... | type=unit",
+			expectedOutput: "a-dependent\nb-dependency\nc-mixed-deps\nd-dependencies-only\n",
+			expectError:    false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -542,6 +560,27 @@ dependency "vpc" {
 			filterQuery:   "...^[HEAD~1...HEAD]...",
 			expectedUnits: []string{"vpc", "app"},
 			description:   "Should find vpc (dependency) and app (dependent), excluding db itself",
+			expectError:   false,
+		},
+		{
+			name:          "dependents of git changes intersected with type - ...[HEAD~1...HEAD] | type=unit",
+			filterQuery:   "...[HEAD~1...HEAD] | type=unit",
+			expectedUnits: []string{"db", "app"},
+			description:   "Issue #6269: an intersected attribute filter must not drop the git-changed unit's dependents",
+			expectError:   false,
+		},
+		{
+			name:          "dependencies of git changes intersected with type - [HEAD~1...HEAD]... | type=unit",
+			filterQuery:   "[HEAD~1...HEAD]... | type=unit",
+			expectedUnits: []string{"db", "vpc"},
+			description:   "Issue #6269: an intersected attribute filter must not drop the git-changed unit's dependencies",
+			expectError:   false,
+		},
+		{
+			name:          "both directions intersected with type - ...[HEAD~1...HEAD]... | type=unit",
+			filterQuery:   "...[HEAD~1...HEAD]... | type=unit",
+			expectedUnits: []string{"vpc", "db", "app"},
+			description:   "Issue #6269: an intersected attribute filter must not drop dependencies or dependents",
 			expectError:   false,
 		},
 	}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6269.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed graph traversal behavior when combined with attribute filters. Previously, components reached during dependency or dependent discovery could be incorrectly dropped when filters were applied. Traversals now properly preserve all matched results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->