### PR TITLE
chore: stacks autoinclude  reference components inside a nested stack

### DIFF
--- a/docs/src/data/changelog/v1.0.8/stack-dependencies-nested-unit-dependency.mdx
+++ b/docs/src/data/changelog/v1.0.8/stack-dependencies-nested-unit-dependency.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.8"
+category: "experiments-updated"
+---
+
+#### `stack-dependencies`: depend on a unit inside a nested stack
+
+A dependency that drills into a specific unit of a nested stack, for example `config_path = "${stack.core.path}/vpc"`, now resolves to that unit. Previously the path landed one level too high, because `stack.<name>.path` points at the nested stack's own directory while its units and sub-stacks live under that stack's inner `.terragrunt-stack` directory, so the run would fail with "You attempted to run terragrunt in a folder that does not contain a terragrunt.hcl file" pointing at `<stack>/<unit>`.
+
+Terragrunt now redirects such a dependency path through the nested `.terragrunt-stack` directory when the target resolves there, applied consistently to run-queue expansion and to `dependency.<name>.outputs.*` resolution, and at any nesting depth. Depending on a whole nested stack (`config_path = stack.<name>.path` and consuming `dependency.<name>.outputs.<unit>.<key>`) is unchanged, and a `no_dot_terragrunt_stack` component, a normal unit dependency, and a genuinely missing path keep their existing behavior.

--- a/docs/src/data/changelog/v1.0.8/stack-dependencies-nested-unit-dependency.mdx
+++ b/docs/src/data/changelog/v1.0.8/stack-dependencies-nested-unit-dependency.mdx
@@ -3,8 +3,16 @@ version: "v1.0.8"
 category: "experiments-updated"
 ---
 
-#### `stack-dependencies`: depend on a unit inside a nested stack
+#### `stack-dependencies`: reference a component inside a nested stack
 
-A dependency that drills into a specific unit of a nested stack, for example `config_path = "${stack.core.path}/vpc"`, now resolves to that unit. Previously the path landed one level too high, because `stack.<name>.path` points at the nested stack's own directory while its units and sub-stacks live under that stack's inner `.terragrunt-stack` directory, so the run would fail with "You attempted to run terragrunt in a folder that does not contain a terragrunt.hcl file" pointing at `<stack>/<unit>`.
+A `stack` block now exposes its nested components, so a dependency can address a specific unit or sub-stack inside a nested stack the same way `unit.<name>.path` and `stack.<name>.path` already work:
 
-Terragrunt now redirects such a dependency path through the nested `.terragrunt-stack` directory when the target resolves there, applied consistently to run-queue expansion and to `dependency.<name>.outputs.*` resolution, and at any nesting depth. Depending on a whole nested stack (`config_path = stack.<name>.path` and consuming `dependency.<name>.outputs.<unit>.<key>`) is unchanged, and a `no_dot_terragrunt_stack` component, a normal unit dependency, and a genuinely missing path keep their existing behavior.
+```hcl
+dependency "vpc" {
+  config_path = stack.core.unit.vpc.path
+}
+```
+
+`stack.<name>.unit.<unit>.path` and `stack.<name>.stack.<substack>.path` resolve to the component's full generated path, through the nested stack's inner `.terragrunt-stack` directory, by construction. The accessors are recursive (`stack.core.stack.net.unit.gw.path`) and correct at any nesting depth. The nested components are enumerated from the nested stack's source, so local stack sources are supported; consuming a whole nested stack via the aggregate form (`config_path = stack.<name>.path` with `dependency.<name>.outputs.<unit>.<key>`) is unchanged.
+
+As a forgiving fallback, a dependency `config_path` that points one `.terragrunt-stack` segment too high (for example a hand-written `"${stack.core.path}/vpc"`) is now redirected to the real component directory when it resolves there, so it no longer fails with "You attempted to run terragrunt in a folder that does not contain a terragrunt.hcl file". This applies to run-queue expansion and `dependency.<name>.outputs.*` resolution alike. A normal unit dependency, a `no_dot_terragrunt_stack` component, and a genuinely missing path keep their existing behavior.

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -319,6 +319,11 @@ func stackDependencyPaths(
 	expanded := make([]string, 0, len(depPaths))
 
 	for _, depPath := range depPaths {
+		// Correct a dependency that drills into a nested stack's component via "${stack.X.path}/<name>",
+		// which lands one .terragrunt-stack segment too high. RedirectIntoStackDir is a no-op for an
+		// aggregate stack dependency, a normal unit dependency, or a no_dot_terragrunt_stack component.
+		depPath = inthclparse.RedirectIntoStackDir(fs, depPath)
+
 		// Stat upfront so a non-directory dep path (e.g. another-name.hcl) is preserved instead of
 		// being passed to the parser, which would reject it as ENOTDIR. The duplication of work is
 		// intentional.

--- a/internal/hclparse/parse.go
+++ b/internal/hclparse/parse.go
@@ -112,7 +112,7 @@ func ParseStackFile(fs vfs.FS, input *ParseStackFileInput) (*ParseResult, error)
 	}
 
 	evalCtx.Variables[VarUnit] = BuildComponentRefMap(buildUnitRefs(decoded.Units, input.StackDir))
-	evalCtx.Variables[VarStack] = BuildComponentRefMap(buildStackRefs(decoded.Stacks, input.StackDir))
+	evalCtx.Variables[VarStack] = BuildComponentRefMap(buildStackRefs(fs, evalCtx.Functions, decoded.Stacks, input.StackDir))
 
 	autoIncludes, err := resolveAutoIncludes(decoded.Units, decoded.Stacks, evalCtx, srcByFilename)
 	if err != nil {
@@ -222,11 +222,24 @@ func buildUnitRefs(units []*UnitBlockHCL, stackDir string) []ComponentRef {
 }
 
 // buildStackRefs builds top-level component refs for stack blocks.
-func buildStackRefs(stacks []*StackBlockHCL, stackDir string) []ComponentRef {
+func buildStackRefs(fs vfs.FS, funcs map[string]function.Function, stacks []*StackBlockHCL, stackDir string) []ComponentRef {
 	refs := make([]ComponentRef, 0, len(stacks))
 
 	for _, s := range stacks {
-		refs = append(refs, ComponentRef{Name: s.Name, Path: s.GeneratedPath(stackDir)})
+		genDir := s.GeneratedPath(stackDir)
+		ref := ComponentRef{Name: s.Name, Path: genDir, IsStack: true}
+
+		// Expose the nested stack's components (stack.<name>.unit.<unit>.path / stack.<name>.stack.<sub>.path)
+		// by enumerating its source, resolved relative to the stack file being parsed.
+		if source := s.Source; source != "" {
+			if !filepath.IsAbs(source) {
+				source = filepath.Join(stackDir, source)
+			}
+
+			ref.Units, ref.Stacks = NestedStackComponentRefs(fs, funcs, filepath.Clean(source), genDir)
+		}
+
+		refs = append(refs, ref)
 	}
 
 	return refs

--- a/internal/hclparse/stack.go
+++ b/internal/hclparse/stack.go
@@ -71,22 +71,32 @@ type StackBlockHCL struct {
 	Name         string          `hcl:",label"`
 }
 
-// ComponentRef is a top-level unit or stack ref injected into the eval context
-// as `unit.<name>` or `stack.<name>`. Each ref carries its label and its
-// generated path; only the path is exposed in HCL.
+// ComponentRef is a unit or stack ref injected into the eval context as
+// `unit.<name>` or `stack.<name>`. Each ref carries its label and its generated
+// path; only the path is exposed in HCL. A stack ref additionally exposes its
+// nested components (Units and Stacks) so a dependency can address a component
+// inside a nested stack via `stack.<name>.unit.<unit>.path` or
+// `stack.<name>.stack.<substack>.path`, recursively and at any depth. IsStack
+// marks a ref as a stack so its (possibly empty) `unit` and `stack` accessors
+// are always present.
 type ComponentRef struct {
-	Name string
-	Path string
+	Name    string
+	Path    string
+	Units   []ComponentRef
+	Stacks  []ComponentRef
+	IsStack bool
 }
 
 // BuildComponentRefMap converts component refs into an HCL object injected as
 // the `unit` or `stack` variable in the eval context. Empty input returns
 // EmptyObjectVal so typos surface as "Unsupported attribute" diagnostics.
 //
-// Output shape:
+// Output shape (a unit exposes only path; a stack also exposes its nested
+// components so they can be addressed recursively):
 //
 //	{
-//	  "<name>": { "path": "<generated path>" }
+//	  "<unit>":  { "path": "<generated path>" },
+//	  "<stack>": { "path": "<generated path>", "unit": { ... }, "stack": { ... } }
 //	}
 func BuildComponentRefMap(refs []ComponentRef) cty.Value {
 	if len(refs) == 0 {
@@ -95,13 +105,27 @@ func BuildComponentRefMap(refs []ComponentRef) cty.Value {
 
 	refMap := make(map[string]cty.Value, len(refs))
 
-	for _, ref := range refs {
-		refMap[ref.Name] = cty.ObjectVal(map[string]cty.Value{
-			"path": cty.StringVal(ref.Path),
-		})
+	for i := range refs {
+		refMap[refs[i].Name] = buildComponentRefValue(&refs[i])
 	}
 
 	return cty.ObjectVal(refMap)
+}
+
+// buildComponentRefValue renders a single component ref. A unit ref exposes only
+// its path; a stack ref also exposes its nested `unit` and `stack` maps so the
+// nested components are addressable, with empty maps when a stack has none.
+func buildComponentRefValue(ref *ComponentRef) cty.Value {
+	obj := map[string]cty.Value{
+		"path": cty.StringVal(ref.Path),
+	}
+
+	if ref.IsStack {
+		obj[VarUnit] = BuildComponentRefMap(ref.Units)
+		obj[VarStack] = BuildComponentRefMap(ref.Stacks)
+	}
+
+	return cty.ObjectVal(obj)
 }
 
 // GeneratedComponentPath returns the on-disk path a unit or stack block in a
@@ -159,6 +183,77 @@ func isStackComponentDir(fs vfs.FS, dir string) bool {
 	}
 
 	return false
+}
+
+// NestedStackComponentRefs enumerates the units and sub-stacks of the stack whose source lives at sourceDir,
+// computing each component's generated path under genDir. It lets a dependency address a component inside a
+// nested stack via stack.<name>.unit.<unit>.path or stack.<name>.stack.<substack>.path. Reading the SOURCE
+// (available before the nested stack is generated) keeps the refs correct by construction. Unreadable or
+// remote sources yield no nested refs (best-effort).
+func NestedStackComponentRefs(fs vfs.FS, funcs map[string]function.Function, sourceDir, genDir string) (units, stacks []ComponentRef) {
+	return nestedStackComponentRefs(fs, funcs, sourceDir, genDir, 1, map[string]struct{}{})
+}
+
+// nestedStackComponentRefs is the bounded, cycle-safe recursive worker behind NestedStackComponentRefs.
+func nestedStackComponentRefs(fs vfs.FS, funcs map[string]function.Function, sourceDir, genDir string, depth int, visited map[string]struct{}) (units, stacks []ComponentRef) {
+	if depth > maxStackRecursionDepth {
+		return nil, nil
+	}
+
+	resolved := util.ResolvePath(sourceDir)
+	if _, seen := visited[resolved]; seen {
+		return nil, nil
+	}
+
+	visited[resolved] = struct{}{}
+
+	stackFile := filepath.Join(sourceDir, stackFileName)
+	if ok, err := vfs.FileExists(fs, stackFile); err != nil || !ok {
+		return nil, nil
+	}
+
+	// Best-effort: a nested enumeration failure must not fail the parent parse. The aggregate dependency
+	// form and the runtime path redirect remain available as fallbacks.
+	decUnits, decStacks, err := decodeDiscovery(fs, sourceDir, stackFile, funcs)
+	if err != nil {
+		return nil, nil
+	}
+
+	for _, u := range decUnits {
+		units = append(units, ComponentRef{Name: u.Name, Path: u.GeneratedPath(genDir)})
+	}
+
+	for _, s := range decStacks {
+		childGenDir := s.GeneratedPath(genDir)
+		ref := ComponentRef{Name: s.Name, Path: childGenDir, IsStack: true}
+
+		if childSource, ok := evalStackSource(s, funcs); ok {
+			if !filepath.IsAbs(childSource) {
+				childSource = filepath.Join(sourceDir, childSource)
+			}
+
+			ref.Units, ref.Stacks = nestedStackComponentRefs(fs, funcs, filepath.Clean(childSource), childGenDir, depth+1, visited)
+		}
+
+		stacks = append(stacks, ref)
+	}
+
+	return units, stacks
+}
+
+// evalStackSource evaluates a discovery stack block's source expression with the given functions. It returns
+// ok=false when the source is absent, non-literal, or fails to evaluate (e.g. a remote getter URL).
+func evalStackSource(s *stackPathOnlyHCL, funcs map[string]function.Function) (string, bool) {
+	if s == nil || s.Source == nil {
+		return "", false
+	}
+
+	v, diags := s.Source.Value(&hcl.EvalContext{Functions: funcs})
+	if diags.HasErrors() || v.IsNull() || v.Type() != cty.String {
+		return "", false
+	}
+
+	return v.AsString(), true
 }
 
 // unitPathOnlyHCL is the discovery shape for unit name and path.

--- a/internal/hclparse/stack.go
+++ b/internal/hclparse/stack.go
@@ -19,6 +19,9 @@ import (
 // stackFileName is the canonical filename of a Terragrunt stack file.
 const stackFileName = "terragrunt.stack.hcl"
 
+// unitFileName is the canonical filename of a Terragrunt unit config.
+const unitFileName = "terragrunt.hcl"
+
 // StackFileHCL is the parsed skeleton: locals, includes, and Remain.
 type StackFileHCL struct {
 	Remain   hcl.Body           `hcl:",remain"`
@@ -127,6 +130,35 @@ func (s *StackBlockHCL) GeneratedPath(stackDir string) string {
 // GeneratedPath returns the on-disk path this unit generates to under stackDir.
 func (u *unitPathOnlyHCL) GeneratedPath(stackDir string) string {
 	return GeneratedComponentPath(stackDir, u.Path, u.NoStack != nil && *u.NoStack)
+}
+
+// RedirectIntoStackDir corrects a dependency directory that points one .terragrunt-stack segment too high.
+// This happens when a config_path drills into a nested stack's component via "${stack.X.path}/<name>":
+// stack.X.path is the nested stack's own directory, but its units and sub-stacks live under that stack's
+// inner .terragrunt-stack directory. If dir is already a stack component (unit or stack), or the
+// .terragrunt-stack sibling is not a component, dir is returned unchanged so existing behavior is preserved.
+func RedirectIntoStackDir(fs vfs.FS, dir string) string {
+	if isStackComponentDir(fs, dir) {
+		return dir
+	}
+
+	hopped := filepath.Join(filepath.Dir(dir), StackDir, filepath.Base(dir))
+	if isStackComponentDir(fs, hopped) {
+		return hopped
+	}
+
+	return dir
+}
+
+// isStackComponentDir reports whether dir is a unit (terragrunt.hcl) or a stack (terragrunt.stack.hcl) directory.
+func isStackComponentDir(fs vfs.FS, dir string) bool {
+	for _, name := range []string{unitFileName, stackFileName} {
+		if ok, err := vfs.FileExists(fs, filepath.Join(dir, name)); err == nil && ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 // unitPathOnlyHCL is the discovery shape for unit name and path.

--- a/internal/hclparse/stack_test.go
+++ b/internal/hclparse/stack_test.go
@@ -825,3 +825,75 @@ func TestRedirectIntoStackDir(t *testing.T) {
 		})
 	}
 }
+
+// TestNestedStackComponentRefs pins that a nested stack's units and sub-stacks are enumerated from its source
+// with generated paths computed under the stack's generated directory, recursively through sub-stacks.
+func TestNestedStackComponentRefs(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, fs.MkdirAll("/src/core", 0755))
+	require.NoError(t, vfs.WriteFile(fs, "/src/core/terragrunt.stack.hcl", []byte(`unit "vpc" {
+  source = "."
+  path   = "vpc"
+}
+
+stack "net" {
+  source = "/src/net"
+  path   = "net"
+}
+`), 0644))
+	require.NoError(t, fs.MkdirAll("/src/net", 0755))
+	require.NoError(t, vfs.WriteFile(fs, "/src/net/terragrunt.stack.hcl", []byte(`unit "gw" {
+  source = "."
+  path   = "gw"
+}
+`), 0644))
+
+	genDir := filepath.Join("/live", ".terragrunt-stack", "core")
+	units, stacks := hclparse.NestedStackComponentRefs(fs, map[string]function.Function{}, "/src/core", genDir)
+
+	require.Len(t, units, 1)
+	assert.Equal(t, "vpc", units[0].Name)
+	assert.Equal(t, filepath.Join(genDir, ".terragrunt-stack", "vpc"), units[0].Path)
+
+	require.Len(t, stacks, 1)
+	assert.Equal(t, "net", stacks[0].Name)
+	assert.True(t, stacks[0].IsStack)
+
+	netGen := filepath.Join(genDir, ".terragrunt-stack", "net")
+	assert.Equal(t, netGen, stacks[0].Path)
+
+	require.Len(t, stacks[0].Units, 1, "the sub-stack's units must be enumerated recursively")
+	assert.Equal(t, "gw", stacks[0].Units[0].Name)
+	assert.Equal(t, filepath.Join(netGen, ".terragrunt-stack", "gw"), stacks[0].Units[0].Path)
+}
+
+// TestBuildComponentRefMapNestsStackComponents pins that a stack ref exposes its nested unit and stack maps
+// (stack.<name>.unit.<unit>.path) while a unit ref exposes only its path.
+func TestBuildComponentRefMapNestsStackComponents(t *testing.T) {
+	t.Parallel()
+
+	refs := []hclparse.ComponentRef{
+		{Name: "vpc", Path: "/u/vpc"},
+		{
+			Name:    "core",
+			Path:    "/s/core",
+			IsStack: true,
+			Units:   []hclparse.ComponentRef{{Name: "db", Path: "/s/core/.terragrunt-stack/db"}},
+		},
+	}
+
+	got := hclparse.BuildComponentRefMap(refs).AsValueMap()
+
+	vpc := got["vpc"].AsValueMap()
+	assert.Equal(t, "/u/vpc", vpc["path"].AsString())
+	_, hasUnit := vpc["unit"]
+	assert.False(t, hasUnit, "a unit ref must not expose nested unit/stack maps")
+
+	core := got["core"].AsValueMap()
+	assert.Equal(t, "/s/core", core["path"].AsString())
+	db := core["unit"].AsValueMap()["db"].AsValueMap()
+	assert.Equal(t, "/s/core/.terragrunt-stack/db", db["path"].AsString(),
+		"a stack ref must expose its nested units as stack.<name>.unit.<unit>.path")
+}

--- a/internal/hclparse/stack_test.go
+++ b/internal/hclparse/stack_test.go
@@ -132,6 +132,58 @@ func TestUnitPathsFromStackDir_StackAutoIncludePathReferencesSiblingRef(t *testi
 	assert.Len(t, paths, 2, "both the base anchor unit and the injected vpc unit must expand")
 }
 
+// TestUnitPathsFromStackDir_RecursesTwoStackLevels pins that discovery recurses through two levels of nested
+// stacks (a stack whose generated stack references another stack), so a unit two levels deep enumerates with
+// BOTH .terragrunt-stack segments. This guards the deep-nested case where a unit was reported one level too
+// high (e.g. core/data instead of core/.terragrunt-stack/data).
+func TestUnitPathsFromStackDir_RecursesTwoStackLevels(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, fs.MkdirAll("/test", 0755))
+
+	// Top stack references the eks stack.
+	require.NoError(t, vfs.WriteFile(fs, "/test/terragrunt.stack.hcl", []byte(`stack "eks" {
+  source = "."
+  path   = "eks"
+}
+`), 0644))
+
+	// The generated eks stack references the core stack and declares a sibling unit.
+	require.NoError(t, vfs.WriteFile(fs, "/test/.terragrunt-stack/eks/terragrunt.stack.hcl", []byte(`stack "core" {
+  source = "."
+  path   = "core"
+}
+
+unit "cluster" {
+  source = "."
+  path   = "cluster"
+}
+`), 0644))
+
+	// The generated core stack declares two units.
+	require.NoError(t, vfs.WriteFile(fs, "/test/.terragrunt-stack/eks/.terragrunt-stack/core/terragrunt.stack.hcl", []byte(`unit "data" {
+  source = "."
+  path   = "data"
+}
+
+unit "vpc" {
+  source = "."
+  path   = "vpc"
+}
+`), 0644))
+
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	require.NoError(t, err)
+
+	clusterPath := filepath.Join("/test", ".terragrunt-stack", "eks", ".terragrunt-stack", "cluster")
+	dataPath := filepath.Join("/test", ".terragrunt-stack", "eks", ".terragrunt-stack", "core", ".terragrunt-stack", "data")
+	vpcPath := filepath.Join("/test", ".terragrunt-stack", "eks", ".terragrunt-stack", "core", ".terragrunt-stack", "vpc")
+
+	assert.ElementsMatch(t, []string{clusterPath, dataPath, vpcPath}, paths,
+		"a unit two stack levels deep must enumerate through both .terragrunt-stack segments, not one level too high")
+}
+
 // TestUnitPathsFromStackDir_RecursesStackAutoIncludeInjectedStack pins that a stack injected by a
 // stack-level autoinclude is recursed into, so its nested units also produce DAG edges.
 func TestUnitPathsFromStackDir_RecursesStackAutoIncludeInjectedStack(t *testing.T) {
@@ -700,4 +752,76 @@ func TestBuildComponentRefMap_WithRefs(t *testing.T) {
 	appVal := result.GetAttr("app")
 	require.True(t, appVal.Type().IsObjectType())
 	assert.Equal(t, "app-service", appVal.GetAttr("path").AsString())
+}
+
+// TestRedirectIntoStackDir pins the dependency-path hop: a path that drills into a nested stack's component
+// (one .terragrunt-stack segment too high) is corrected to the real component directory, while an existing
+// component, a missing target, and a no_dot_terragrunt_stack-style literal are left unchanged.
+func TestRedirectIntoStackDir(t *testing.T) {
+	t.Parallel()
+
+	const (
+		unitFile  = "terragrunt.hcl"
+		stackFile = "terragrunt.stack.hcl"
+	)
+
+	testCases := []struct {
+		name  string
+		input string
+		want  string
+		files []string
+	}{
+		{
+			name:  "existing unit dir is returned unchanged",
+			files: []string{"/s/.terragrunt-stack/vpc/" + unitFile},
+			input: "/s/.terragrunt-stack/vpc",
+			want:  "/s/.terragrunt-stack/vpc",
+		},
+		{
+			name:  "existing stack dir is returned unchanged",
+			files: []string{"/s/.terragrunt-stack/core/" + stackFile},
+			input: "/s/.terragrunt-stack/core",
+			want:  "/s/.terragrunt-stack/core",
+		},
+		{
+			name:  "drill into a nested unit hops through .terragrunt-stack",
+			files: []string{"/s/core/.terragrunt-stack/vpc/" + unitFile},
+			input: "/s/core/vpc",
+			want:  "/s/core/.terragrunt-stack/vpc",
+		},
+		{
+			name:  "drill into a nested sub-stack hops through .terragrunt-stack",
+			files: []string{"/s/core/.terragrunt-stack/net/" + stackFile},
+			input: "/s/core/net",
+			want:  "/s/core/.terragrunt-stack/net",
+		},
+		{
+			name:  "no component at either location returns the input unchanged",
+			files: []string{"/s/core/" + stackFile},
+			input: "/s/core/missing",
+			want:  "/s/core/missing",
+		},
+		{
+			name:  "a literal component wins over a hopped sibling",
+			files: []string{"/s/core/vpc/" + unitFile, "/s/core/.terragrunt-stack/vpc/" + unitFile},
+			input: "/s/core/vpc",
+			want:  "/s/core/vpc",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := vfs.NewMemMapFS()
+
+			for _, f := range tc.files {
+				require.NoError(t, fs.MkdirAll(filepath.Dir(f), 0755))
+				require.NoError(t, vfs.WriteFile(fs, f, []byte("# test"), 0644))
+			}
+
+			got := hclparse.RedirectIntoStackDir(fs, tc.input)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -18,8 +18,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/awshelper"
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
 	s3backend "github.com/gruntwork-io/terragrunt/internal/remotestate/backend/s3"
@@ -707,9 +709,17 @@ func getTerragruntOutput(
 	l log.Logger,
 	dependencyConfig *Dependency,
 ) (*cty.Value, bool, error) {
+	configPathStr := dependencyConfig.ConfigPath.AsString()
+
+	// When the stack-dependencies experiment is enabled, correct a config_path that drills into a nested
+	// stack's component via "${stack.X.path}/<name>", which lands one .terragrunt-stack segment too high.
+	if pctx.Experiments.Evaluate(experiment.StackDependencies) {
+		configPathStr = redirectDependencyConfigPathIntoStack(configPathStr, pctx.TerragruntConfigPath)
+	}
+
 	// target config check: make sure the target config exists
 	targetConfigPath := getCleanedTargetConfigPath(
-		dependencyConfig.ConfigPath.AsString(),
+		configPathStr,
 		pctx.TerragruntConfigPath,
 	)
 
@@ -798,6 +808,18 @@ func collectStackUnitOutputs(ctx context.Context, pctx *ParsingContext, l log.Lo
 	}
 
 	return unitOutputs, nil
+}
+
+// redirectDependencyConfigPathIntoStack rewrites a dependency config_path that drills into a nested stack's
+// component (via "${stack.X.path}/<name>") to that component's real directory under .terragrunt-stack. It
+// returns the input unchanged when no correction applies (aggregate stack dep, normal unit dep, missing path).
+func redirectDependencyConfigPathIntoStack(configPath, workingPath string) string {
+	dir := configPath
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(filepath.Dir(workingPath), dir)
+	}
+
+	return inthclparse.RedirectIntoStackDir(vfs.NewOSFS(), filepath.Clean(dir))
 }
 
 // tryGetStackOutput checks if targetConfigPath points to a stack directory

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -862,6 +862,7 @@ type stackComponentHeader struct {
 	Remain  hcl.Body `hcl:",remain"`
 	NoStack *bool    `hcl:"no_dot_terragrunt_stack,optional"`
 	Path    string   `hcl:"path,attr"`
+	Source  string   `hcl:"source,optional"`
 	Name    string   `hcl:",label"`
 }
 
@@ -885,7 +886,7 @@ func injectStackComponentRefs(file *hclparse.File, evalCtx *hcl.EvalContext, sta
 
 	// Publish the base refs first so a sibling autoinclude block whose path references unit.<name>.path /
 	// stack.<name>.path can resolve against the base components, matching how the full decode resolves them.
-	setStackComponentRefVars(evalCtx, stackDir, headers.Units, headers.Stacks)
+	setStackComponentRefVars(vfs.NewOSFS(), evalCtx, stackDir, headers.Units, headers.Stacks)
 
 	autoUnits, autoStacks, err := stackAutoIncludeComponentHeaders(stackDir, evalCtx, parserOpts)
 	if err != nil {
@@ -895,13 +896,13 @@ func injectStackComponentRefs(file *hclparse.File, evalCtx *hcl.EvalContext, sta
 	// Republish so an overridden component's path reflects the override, not the base path it replaced.
 	units := util.MergeNamed(headers.Units, autoUnits, componentHeaderName)
 	stacks := util.MergeNamed(headers.Stacks, autoStacks, componentHeaderName)
-	setStackComponentRefVars(evalCtx, stackDir, units, stacks)
+	setStackComponentRefVars(vfs.NewOSFS(), evalCtx, stackDir, units, stacks)
 
 	return nil
 }
 
 // setStackComponentRefVars publishes the unit.<name> and stack.<name> path variables into evalCtx.
-func setStackComponentRefVars(evalCtx *hcl.EvalContext, stackDir string, units, stacks []*stackComponentHeader) {
+func setStackComponentRefVars(fs vfs.FS, evalCtx *hcl.EvalContext, stackDir string, units, stacks []*stackComponentHeader) {
 	unitRefs := make([]inthclparse.ComponentRef, 0, len(units))
 
 	for _, u := range units {
@@ -919,7 +920,20 @@ func setStackComponentRefVars(evalCtx *hcl.EvalContext, stackDir string, units, 
 			continue
 		}
 
-		stackRefs = append(stackRefs, inthclparse.ComponentRef{Name: s.Name, Path: s.GeneratedPath(stackDir)})
+		genDir := s.GeneratedPath(stackDir)
+		ref := inthclparse.ComponentRef{Name: s.Name, Path: genDir, IsStack: true}
+
+		// Expose the nested stack's components (stack.<name>.unit.<unit>.path) by enumerating its source,
+		// resolved relative to the stack file being parsed, so direct value references resolve too.
+		if source := s.Source; source != "" {
+			if !filepath.IsAbs(source) {
+				source = filepath.Join(stackDir, source)
+			}
+
+			ref.Units, ref.Stacks = inthclparse.NestedStackComponentRefs(fs, evalCtx.Functions, filepath.Clean(source), genDir)
+		}
+
+		stackRefs = append(stackRefs, ref)
 	}
 
 	evalCtx.Variables[inthclparse.VarUnit] = inthclparse.BuildComponentRefMap(unitRefs)

--- a/test/fixtures/stacks/stack-deps-deep-nested-dep/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-deep-nested-dep/live/terragrunt.stack.hcl
@@ -1,0 +1,7 @@
+# Sandbox references the eks stack, which itself references the core stack: two levels of nested
+# .terragrunt-stack directories. A unit autoinclude in the core stack depends on a sibling unit via
+# unit.X.path; that config_path must account for BOTH nested .terragrunt-stack segments.
+stack "eks" {
+  source = "${get_repo_root()}/stacks/eks"
+  path   = "eks"
+}

--- a/test/fixtures/stacks/stack-deps-deep-nested-dep/stacks/core/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-deep-nested-dep/stacks/core/terragrunt.stack.hcl
@@ -1,0 +1,27 @@
+unit "data" {
+  source = "${get_repo_root()}/units/data"
+  path   = "data"
+}
+
+unit "vpc" {
+  source = "${get_repo_root()}/units/vpc"
+  path   = "vpc"
+
+  autoinclude {
+    dependency "data" {
+      config_path = unit.data.path
+
+      mock_outputs = {
+        availability_zones = ["region-a", "region-b", "region-c"]
+      }
+    }
+
+    inputs = {
+      availability_zones = try(values.availability_zones, dependency.data.outputs.availability_zones)
+    }
+  }
+
+  values = {
+    vpc_cidr = "172.29.0.0/16"
+  }
+}

--- a/test/fixtures/stacks/stack-deps-deep-nested-dep/stacks/eks/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-deep-nested-dep/stacks/eks/terragrunt.stack.hcl
@@ -1,0 +1,28 @@
+stack "core" {
+  source = "${get_repo_root()}/stacks/core"
+  path   = "core"
+}
+
+unit "cluster" {
+  source = "${get_repo_root()}/units/eks"
+  path   = "cluster"
+
+  autoinclude {
+    dependency "vpc" {
+      config_path = stack.core.path
+
+      mock_outputs_allowed_terraform_commands = ["init", "validate", "plan", "apply"]
+      mock_outputs = {
+        vpc = {
+          vpc_id             = "vpc-mock"
+          private_subnet_ids = ["subnet-mock-a", "subnet-mock-b"]
+        }
+      }
+    }
+
+    inputs = {
+      vpc_id     = try(values.vpc_id, dependency.vpc.outputs.vpc.vpc_id)
+      subnet_ids = try(values.subnet_ids, dependency.vpc.outputs.vpc.private_subnet_ids)
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-deep-nested-dep/units/data/main.tf
+++ b/test/fixtures/stacks/stack-deps-deep-nested-dep/units/data/main.tf
@@ -1,0 +1,3 @@
+output "availability_zones" {
+  value = ["region-a", "region-b", "region-c"]
+}

--- a/test/fixtures/stacks/stack-deps-deep-nested-dep/units/data/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-deep-nested-dep/units/data/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-deep-nested-dep/units/eks/main.tf
+++ b/test/fixtures/stacks/stack-deps-deep-nested-dep/units/eks/main.tf
@@ -1,0 +1,13 @@
+variable "vpc_id" {
+  type    = string
+  default = ""
+}
+
+variable "subnet_ids" {
+  type    = list(string)
+  default = []
+}
+
+output "cluster_vpc" {
+  value = var.vpc_id
+}

--- a/test/fixtures/stacks/stack-deps-deep-nested-dep/units/eks/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-deep-nested-dep/units/eks/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-deep-nested-dep/units/vpc/main.tf
+++ b/test/fixtures/stacks/stack-deps-deep-nested-dep/units/vpc/main.tf
@@ -1,0 +1,12 @@
+variable "availability_zones" {
+  type    = list(string)
+  default = []
+}
+
+output "vpc_id" {
+  value = "vpc-real-output"
+}
+
+output "private_subnet_ids" {
+  value = ["subnet-real-a", "subnet-real-b"]
+}

--- a/test/fixtures/stacks/stack-deps-deep-nested-dep/units/vpc/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-deep-nested-dep/units/vpc/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-nested-unit-ref/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-nested-unit-ref/live/terragrunt.stack.hcl
@@ -1,0 +1,27 @@
+# The consumer depends on a specific unit inside the nested core stack using the explicit nested reference
+# stack.core.unit.producer.path, which resolves to the unit's full generated path (through the nested
+# .terragrunt-stack directory) by construction, symmetric with unit.<name>.path and stack.<name>.path.
+stack "core" {
+  source = "${get_repo_root()}/stacks/core"
+  path   = "core"
+}
+
+unit "consumer" {
+  source = "${get_repo_root()}/units/consumer"
+  path   = "consumer"
+
+  autoinclude {
+    dependency "producer" {
+      config_path = stack.core.unit.producer.path
+
+      mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+      mock_outputs = {
+        value = "mock-producer-output"
+      }
+    }
+
+    inputs = {
+      received = try(values.received, dependency.producer.outputs.value)
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-nested-unit-ref/stacks/core/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-nested-unit-ref/stacks/core/terragrunt.stack.hcl
@@ -1,0 +1,4 @@
+unit "producer" {
+  source = "${get_repo_root()}/units/producer"
+  path   = "producer"
+}

--- a/test/fixtures/stacks/stack-deps-nested-unit-ref/units/consumer/main.tf
+++ b/test/fixtures/stacks/stack-deps-nested-unit-ref/units/consumer/main.tf
@@ -1,0 +1,8 @@
+variable "received" {
+  type    = string
+  default = ""
+}
+
+output "received" {
+  value = var.received
+}

--- a/test/fixtures/stacks/stack-deps-nested-unit-ref/units/consumer/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-nested-unit-ref/units/consumer/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-nested-unit-ref/units/producer/main.tf
+++ b/test/fixtures/stacks/stack-deps-nested-unit-ref/units/producer/main.tf
@@ -1,0 +1,3 @@
+output "value" {
+  value = "real-producer-output"
+}

--- a/test/fixtures/stacks/stack-deps-nested-unit-ref/units/producer/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-nested-unit-ref/units/producer/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-stack-unit-drill/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-unit-drill/live/terragrunt.stack.hcl
@@ -1,0 +1,27 @@
+# The consumer unit depends on a SPECIFIC unit inside the nested core stack by drilling into it with
+# ${stack.core.path}/producer. The core stack's units live under its inner .terragrunt-stack directory, so
+# this config_path must resolve through that segment rather than landing at core/producer one level too high.
+stack "core" {
+  source = "${get_repo_root()}/stacks/core"
+  path   = "core"
+}
+
+unit "consumer" {
+  source = "${get_repo_root()}/units/consumer"
+  path   = "consumer"
+
+  autoinclude {
+    dependency "producer" {
+      config_path = "${stack.core.path}/producer"
+
+      mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+      mock_outputs = {
+        value = "mock-producer-output"
+      }
+    }
+
+    inputs = {
+      received = try(values.received, dependency.producer.outputs.value)
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-stack-unit-drill/stacks/core/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-unit-drill/stacks/core/terragrunt.stack.hcl
@@ -1,0 +1,4 @@
+unit "producer" {
+  source = "${get_repo_root()}/units/producer"
+  path   = "producer"
+}

--- a/test/fixtures/stacks/stack-deps-stack-unit-drill/units/consumer/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-unit-drill/units/consumer/main.tf
@@ -1,0 +1,8 @@
+variable "received" {
+  type    = string
+  default = ""
+}
+
+output "received" {
+  value = var.received
+}

--- a/test/fixtures/stacks/stack-deps-stack-unit-drill/units/consumer/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-unit-drill/units/consumer/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-stack-unit-drill/units/producer/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-unit-drill/units/producer/main.tf
@@ -1,0 +1,3 @@
+output "value" {
+  value = "real-producer-output"
+}

--- a/test/fixtures/stacks/stack-deps-stack-unit-drill/units/producer/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-unit-drill/units/producer/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -64,6 +64,7 @@ const (
 	testFixtureStackDepsStackAutoIncLocalPath    = "fixtures/stacks/stack-deps-stack-autoinclude-local-path"
 	testFixtureStackDepsDeepNestedDep            = "fixtures/stacks/stack-deps-deep-nested-dep"
 	testFixtureStackDepsStackUnitDrill           = "fixtures/stacks/stack-deps-stack-unit-drill"
+	testFixtureStackDepsNestedUnitRef            = "fixtures/stacks/stack-deps-nested-unit-ref"
 )
 
 // TestStackDepsAutoIncludeGenerationAndDAG tests parsing, autoinclude generation,
@@ -1972,6 +1973,46 @@ func TestStackDepsStackUnitDrillDependency(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, consumerOut, "real-producer-output",
 		"the consumer must resolve the drilled unit's real output")
+}
+
+// TestStackDepsNestedUnitRefDependency pins the explicit nested reference: config_path =
+// stack.core.unit.producer.path resolves to the nested unit's full generated path (through the nested
+// .terragrunt-stack directory) by construction, symmetric with unit.<name>.path. Generation bakes the
+// correct relative path and the dependency resolves the real output end-to-end.
+func TestStackDepsNestedUnitRefDependency(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsNestedUnitRef)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsNestedUnitRef)
+	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsNestedUnitRef)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
+
+	rootPath := filepath.Join(gitPath, "live")
+	rootPath, err = filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	// The nested reference must bake the unit's full generated path, through the nested .terragrunt-stack.
+	consumerAutoInclude, err := os.ReadFile(filepath.Join(rootPath, inthclparse.StackDir, "consumer", inthclparse.AutoIncludeFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(consumerAutoInclude), `"../core/.terragrunt-stack/producer"`,
+		"stack.core.unit.producer.path must resolve through the nested .terragrunt-stack directory")
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- apply -auto-approve")
+	require.NoError(t, err, "the nested-reference dependency must resolve; stderr=%s", stderr)
+	assert.NotContains(t, stderr, "does not contain a terragrunt.hcl")
+
+	consumerDir := filepath.Join(rootPath, inthclparse.StackDir, "consumer")
+	consumerOut, _, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt output -no-color --experiment stack-dependencies --working-dir "+consumerDir)
+	require.NoError(t, err)
+	assert.Contains(t, consumerOut, "real-producer-output",
+		"the consumer must resolve the nested unit's real output via the explicit reference")
 }
 
 // TestStackDepsStackLevelAutoIncludeInjectsNestedStack verifies that a stack-level

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -62,6 +62,8 @@ const (
 	testFixtureStackDepsApplyNoMocks             = "fixtures/stacks/stack-deps-apply-no-mocks"
 	testFixtureStackDepsStackAutoIncOverride     = "fixtures/stacks/stack-deps-stack-autoinclude-override"
 	testFixtureStackDepsStackAutoIncLocalPath    = "fixtures/stacks/stack-deps-stack-autoinclude-local-path"
+	testFixtureStackDepsDeepNestedDep            = "fixtures/stacks/stack-deps-deep-nested-dep"
+	testFixtureStackDepsStackUnitDrill           = "fixtures/stacks/stack-deps-stack-unit-drill"
 )
 
 // TestStackDepsAutoIncludeGenerationAndDAG tests parsing, autoinclude generation,
@@ -1879,6 +1881,97 @@ func TestStackDepsStackLevelAutoIncludeOverridePathUsesLocal(t *testing.T) {
 		"the injected unit path referencing local.region must resolve during generation")
 	assert.NoDirExists(t, filepath.Join(rootPath, inthclparse.StackDir, "extra-${local.region}"),
 		"the local reference must not be left unresolved in the generated path")
+}
+
+// TestStackDepsDeepNestedStackCrossDependency exercises a stack-of-stacks two levels deep: a sandbox stack
+// references an eks stack, which references a core stack and a cluster unit. The cluster's autoinclude
+// depends on the core stack (stack.core.path) and reads an aggregated unit output, while the core stack's
+// vpc unit autoinclude depends on a sibling unit (unit.data.path). Both dependency config_paths must account
+// for the two nested .terragrunt-stack segments, so a unit two levels deep is not addressed one level too
+// high (e.g. core/data rather than core/.terragrunt-stack/data).
+func TestStackDepsDeepNestedStackCrossDependency(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsDeepNestedDep)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsDeepNestedDep)
+	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsDeepNestedDep)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
+
+	rootPath := filepath.Join(gitPath, "live")
+	rootPath, err = filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	// The units two levels deep must materialize through both nested .terragrunt-stack segments.
+	coreStackDir := filepath.Join(rootPath, inthclparse.StackDir, "eks", inthclparse.StackDir, "core", inthclparse.StackDir)
+	assert.DirExists(t, filepath.Join(coreStackDir, "data"), "the core stack's data unit must materialize two levels deep")
+	assert.DirExists(t, filepath.Join(coreStackDir, "vpc"), "the core stack's vpc unit must materialize two levels deep")
+
+	// The vpc unit's autoinclude dependency on unit.data.path must resolve to the sibling unit through the
+	// nested .terragrunt-stack directory, not one level too high.
+	vpcAutoInclude, err := os.ReadFile(filepath.Join(coreStackDir, "vpc", inthclparse.AutoIncludeFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(vpcAutoInclude), `"../data"`,
+		"the deep-nested unit dependency must resolve to the sibling unit through .terragrunt-stack")
+
+	// The full cross-stack chain must apply: data -> vpc (sibling unit dep), then cluster reading the core
+	// stack's aggregated vpc output (dependency.vpc.outputs.vpc.vpc_id) one stack level up.
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- apply -auto-approve")
+	require.NoError(t, err, "the deep-nested cross-stack dependency chain must apply; stderr=%s", stderr)
+	assert.NotContains(t, stderr, "does not contain a terragrunt.hcl",
+		"no dependency path may drop a nested .terragrunt-stack segment")
+
+	// The cluster must have resolved the REAL aggregated output from core.vpc, proving deep cross-stack
+	// stack-output aggregation works (not the mock).
+	clusterDir := filepath.Join(rootPath, inthclparse.StackDir, "eks", inthclparse.StackDir, "cluster")
+	clusterOut, _, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt output -no-color --experiment stack-dependencies --working-dir "+clusterDir)
+	require.NoError(t, err)
+	assert.Contains(t, clusterOut, "vpc-real-output",
+		"the cluster must resolve the real aggregated vpc output across two stack levels")
+}
+
+// TestStackDepsStackUnitDrillDependency pins that a dependency that drills into a SPECIFIC unit of a nested
+// stack via config_path = "${stack.X.path}/<unit>" resolves through the nested stack's inner
+// .terragrunt-stack directory, rather than landing at <stack>/<unit> one segment too high. Before the fix
+// this failed at run time with "does not contain a terragrunt.hcl file" for <stack>/<unit>.
+func TestStackDepsStackUnitDrillDependency(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsStackUnitDrill)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackUnitDrill)
+	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackUnitDrill)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
+
+	rootPath := filepath.Join(gitPath, "live")
+	rootPath, err = filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	// The whole chain must apply: producer (inside core) then consumer drilling into it.
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- apply -auto-approve")
+	require.NoError(t, err, "a dependency drilling into a nested stack's unit must resolve; stderr=%s", stderr)
+	assert.NotContains(t, stderr, "does not contain a terragrunt.hcl",
+		"the drill config_path must resolve through the nested .terragrunt-stack segment")
+
+	// The consumer must have received the producer's REAL output, proving the drilled dependency resolved
+	// to the actual unit (not the mock, not a missing path).
+	consumerDir := filepath.Join(rootPath, inthclparse.StackDir, "consumer")
+	consumerOut, _, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt output -no-color --experiment stack-dependencies --working-dir "+consumerDir)
+	require.NoError(t, err)
+	assert.Contains(t, consumerOut, "real-producer-output",
+		"the consumer must resolve the drilled unit's real output")
 }
 
 // TestStackDepsStackLevelAutoIncludeInjectsNestedStack verifies that a stack-level


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* Added reference a component inside a nested stack : a stack block now exposes its children, so a dependency can address a nested unit/sub-stack directly: `config_path = stack.core.unit.vpc.path` (and `stack.core.stack.net.path`), symmetric with `unit.<name>.path / stack.<name>.path`

RFC: https://github.com/gruntwork-io/terragrunt/issues/5663

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
