### PR TITLE
docs: Since/Before cleanup

### DIFF
--- a/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
@@ -8,8 +8,6 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside } from '@astrojs/starlight/components';
-import Since from '@components/Since.astro';
-import Before from '@components/Before.astro';
 
 For an alternate approach (that is more flexible, but not necessarily always the better solution), you can define explicit stacks using `terragrunt.stack.hcl` files. These are **blueprints** that programmatically generate units at runtime.
 
@@ -345,16 +343,6 @@ After running the stack, your directory structure will look like this:
 
 ## CAS Integration
 
-<Before version="1.0.3">
-
-<Aside type="tip">
-Experimental integration between CAS and Stacks is coming soon. Follow the progress in [#5558](https://github.com/gruntwork-io/terragrunt/issues/5558).
-</Aside>
-
-</Before>
-
-<Since version="1.0.3">
-
 <Aside type="tip">
 This functionality is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`. See the [CAS feature documentation](/features/caching/cas) for more details.
 </Aside>
@@ -412,19 +400,7 @@ When `update_source_with_cas = true` is set:
 
 Consumers do not set `update_source_with_cas` themselves. When the `cas` experiment is enabled and the source is remote, Terragrunt uses the CAS path automatically. The attribute only has effect inside catalog files, where it flags nested `source` attributes for rewriting.
 
-<Before version="1.0.5">
-
-<Aside type="tip">
-A `mutable` attribute that opts a `unit` or `stack` block out of CAS hardlinking is coming in v1.0.5.
-</Aside>
-
-</Before>
-
-<Since version="1.0.5">
-
 `unit` and `stack` blocks also accept a `mutable` attribute. When `mutable = true`, the unit's or stack's content under `.terragrunt-stack` is copied from the CAS store and the working tree is editable. The default is `false`: files are materialized read-only so an accidental edit cannot reach back into the shared CAS store.
-
-</Since>
 
 Given the catalog files above, and an ordinary consumer stack like:
 
@@ -505,8 +481,6 @@ Terragrunt copies the referenced directory into a temporary directory, computes 
 
 This is useful when iterating on a catalog before tagging a release: the same `update_source_with_cas = true` attributes in the catalog's `terragrunt.stack.hcl` and `terragrunt.hcl` files apply unchanged, whether consumers pull the catalog over Git or point at a local checkout.
 
-</Since>
-
 ## Known Limitations of Explicit Stacks
 
 There are currently some known limitations with explicit stacks that you should be aware of as you start to adopt them.
@@ -521,13 +495,7 @@ As such, if you currently have multiple stacks that need to depend on each other
 
 Every generation of a stack from a `terragrunt.stack.hcl` file can potentially result in network traffic to fetch the source for the stack and filesystem traffic to copy the generated units to the `.terragrunt-stack` directory. This can result in slow stack generation if you have very deeply nested stacks.
 
-<Before version="1.0.3">
-The planned solution for this in the future is to allow for some deduplication in stack generation, but this is not currently implemented.
-</Before>
-
-<Since version="1.0.3">
 To mitigate this, enable the [`cas` experiment](/reference/experiments/active#cas) and use `update_source_with_cas = true` in your catalog's stack and unit files. This deduplicates repository clones and resolves content from the local CAS store instead of fetching from the network on every generation. See [CAS Integration](#cas-integration) for details.
-</Since>
 
 ### Includes are not supported in `terragrunt.stack.hcl` files
 

--- a/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
@@ -7,8 +7,6 @@ sidebar:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
-import Since from '@components/Since.astro';
-import Before from '@components/Before.astro';
 
 Launch the user interface for searching and managing your module catalog.
 
@@ -158,14 +156,6 @@ A third key, `tags`, controls the colored pills shown next to each component; se
 This section describes behavior that is only available when the [`catalog-redesign`](/reference/experiments/active#catalog-redesign) experiment is enabled.
 </Aside>
 
-<Before version="1.0.4">
-
-In a future release, the catalog UI will read tag information from the front-matter of component `README.md` files.
-
-</Before>
-
-<Since version="1.0.4">
-
 Catalog authors can attach tags to a component by adding a `tags` key to the component's `README.md` front-matter. Tags appear as colored pills next to the component in the list view, and as a row above the rendered README in the detail view.
 
 Either inline-array or dash-list YAML form is accepted:
@@ -189,8 +179,6 @@ tags:
 ```
 
 Tag values that name a component type also promote the component into that type's tab. For example, a component classified as a `template` whose tags include `module` appears under both the `Templates` tab (by its native kind) and the `Modules` tab (by tag), without changing how it's scaffolded.
-
-</Since>
 
 ## Keybindings
 

--- a/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
@@ -9,8 +9,6 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside, Steps } from '@astrojs/starlight/components';
-import Since from '@components/Since.astro';
-import Before from '@components/Before.astro';
 
 <Aside type="tip" title="Experimental">
 CAS source fetching is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
@@ -20,9 +18,7 @@ Terragrunt supports a Content Addressable Store (CAS) to deduplicate content acr
 
 The CAS is used to speed up catalog cloning, OpenTofu/Terraform source fetching, and stack generation by avoiding redundant downloads of remote sources. See [Supported sources](#supported-sources) for the full list of supported getters and a dedicated page on how each one interacts with the CAS.
 
-<Since version="1.0.3">
 You can disable the CAS at any time using the `--no-cas` flag. This flag is available on the [`run`](/reference/cli/commands/run), [`stack generate`](/reference/cli/commands/stack/generate), and [`stack run`](/reference/cli/commands/stack/run) commands.
-</Since>
 
 ## Supported sources
 

--- a/docs/src/content/docs/03-features/08-filter/04-attributes.mdx
+++ b/docs/src/content/docs/03-features/08-filter/04-attributes.mdx
@@ -8,7 +8,6 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 import FileTree from '@components/vendored/starlight/FileTree.astro';
-import Since from '@components/Since.astro';
 
 Match units and stacks by their configuration attributes.
 
@@ -105,13 +104,9 @@ Due to how Terragrunt parses configurations during `run --all`, functions will o
 Reading a file directly in the `inputs` attribute will not mark the file as read, as the `inputs` attribute is not parsed until after the queue has already been populated to support rendering of dependency outputs, which are only available after dependencies have been run.
 </Aside>
 
-<Since version="1.0.3">
-
 To mark many files at once, use [`mark_glob_as_read`](/reference/hcl/functions/#mark_glob_as_read), which accepts a glob (with `**` support) and marks every matching file.
 
 If a unit's `terraform` block points at a local module source, enable the [`mark-many-as-read`](/reference/experiments/active#mark-many-as-read) experiment to have Terragrunt automatically mark that module's `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` files as read. Reading-based filters will then cascade local module changes to every unit that consumes the module. The same experiment also enables the [`mark_glob_as_read`](/reference/hcl/functions/#mark_glob_as_read) HCL function.
-
-</Since>
 
 ## Source-Based Expressions
 

--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -8,8 +8,6 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside } from '@astrojs/starlight/components';
-import Since from '@components/Since.astro';
-import Before from '@components/Before.astro';
 
 Terragrunt HCL configuration uses [configuration blocks](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#blocks) when there's a structural configuration that needs to be defined for Terragrunt.
 
@@ -31,10 +29,10 @@ The `terraform` block supports the following arguments:
 
   - The `source` parameter can be configured to pull OpenTofu/Terraform modules from any Terraform module registry using
     the `tfr` protocol. The `tfr` protocol expects URLs to be provided in the format
-    <Before version="1.0.7">`tfr://REGISTRY_HOST/MODULE_SOURCE?version=VERSION`</Before><Since version="1.0.7">`tfr://REGISTRY_HOST/MODULE_SOURCE[?version=VERSION]`</Since>. For example, to pull the `terraform-aws-modules/vpc/aws`
+    `tfr://REGISTRY_HOST/MODULE_SOURCE[?version=VERSION]`. For example, to pull the `terraform-aws-modules/vpc/aws`
     module from the public Terraform registry, you can use the following as the source parameter:
     `tfr://registry.terraform.io/terraform-aws-modules/vpc/aws?version=3.3.0`.
-    <Before version="1.0.7">The `version` query parameter is required.</Before><Since version="1.0.7">The `version` query parameter is optional. When omitted, Terragrunt queries the registry's list-versions endpoint and downloads the latest stable (non-prerelease) version. Pin a version explicitly for reproducible builds in production.</Since>
+    The `version` query parameter is optional. When omitted, Terragrunt queries the registry's list-versions endpoint and downloads the latest stable (non-prerelease) version. Pin a version explicitly for reproducible builds in production.
   - If you wish to access a private module registry (e.g., [Terraform Cloud/Enterprise](https://www.terraform.io/docs/cloud/registry/index.html)),
     you can provide the authentication to Terragrunt as an environment variable with the key `TG_TF_REGISTRY_TOKEN`.
     This token can be any registry API token.
@@ -114,24 +112,12 @@ The `terraform` block supports the following arguments:
   error must match one of the expressions listed in the `on_errors` attribute. Error hooks are executed after the before/after hooks.
   To handle errors during source download (when using the `source` attribute), use `init-from-module` in the `commands` list.
 
-<Before version="1.0.5">
-
-<Aside type="tip">
-A `mutable` attribute that opts a `terraform` block out of CAS hardlinking is coming in v1.0.5.
-</Aside>
-
-</Before>
-
-<Since version="1.0.5">
-
 - `mutable` (attribute): When `true`, content fetched into `.terragrunt-cache` through the
   [content-addressable storage (CAS)](/features/caching/cas) is copied from the CAS store and the
   working tree under `.terragrunt-cache` is editable. The default is `false`: files are
   materialized read-only so an accidental edit cannot reach back into the shared CAS store. The
   flag has no effect when CAS is not used to fetch the source; the standard download path already
   produces an independent, writable copy.
-
-</Since>
 
 In addition to supporting before and after hooks for all OpenTofu/Terraform commands, the following specialized hooks are also
 supported:

--- a/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -8,8 +8,6 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 import FileTree from '@components/vendored/starlight/FileTree.astro';
-import Since from '@components/Since.astro';
-import Before from '@components/Before.astro';
 
 Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, just like OpenTofu/Terraform\!
 
@@ -833,16 +831,6 @@ This caching behavior can be modified using the special parameters described in 
 
 ## deep_merge
 
-<Before version="1.0.6">
-
-<Aside type="tip">
-The `deep_merge` function will be available starting in Terragrunt v1.0.6.
-</Aside>
-
-</Before>
-
-<Since version="1.0.6">
-
 `deep_merge(map1, map2, ...)` deeply merges maps/objects. For overlapping keys, values from later arguments override earlier ones. Nested maps are merged recursively, and lists are appended. This function takes positional arguments.
 
 `deep_merge` requires the [`deep-merge`](/reference/experiments/active#deep-merge) experiment. Calling it without the experiment enabled returns an error.
@@ -873,8 +861,6 @@ locals {
 
 inputs = local.config
 ```
-
-</Since>
 
 ## read_terragrunt_config
 
@@ -1092,16 +1078,6 @@ block is not evaluated until *after* the queue has been populated with units to 
 
 ## mark_glob_as_read
 
-<Before version="1.0.3">
-
-<Aside type="tip">
-Coming soon!
-</Aside>
-
-</Before>
-
-<Since version="1.0.3">
-
 <Aside type="caution">
 `mark_glob_as_read` requires the [`mark-many-as-read`](/reference/experiments/active#mark-many-as-read) experiment. Calling it without the experiment enabled returns an error.
 </Aside>
@@ -1143,8 +1119,6 @@ inputs = {
 A typical use case is a unit that consumes a directory of configuration files indirectly (for example, through `run_cmd`, `templatefile`, or a shared helper module) and wants changes to any of them to trigger the unit through [reading-based filter expressions](/features/filter/attributes#reading-based-expressions) such as `--filter 'reading=./config/**'`.
 
 If the pattern matches nothing, the function returns an empty list without error.
-
-</Since>
 
 ## constraint_check
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Manually ran the workflow being introduced in https://github.com/gruntwork-io/terragrunt/pull/6276 to clean up the Since/Before gates we don't need anymore.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined documentation presentation across multiple feature and reference pages by removing version-gated content markers, making instructions and guidance more directly accessible throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->