### PR TITLE
Add curated llms.txt index

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -61,6 +61,34 @@ reviews:
         clarification of existing behavior) do NOT need gating; do not flag
         those.
 
+    - path: 'docs/public/llms.txt'
+      instructions: >-
+        HAND-CURATED llms.txt INDEX. This file (https://llmstxt.org/) is served
+        verbatim at /llms.txt and is NOT auto-generated: the starlight-llms-txt
+        plugin's own /llms.txt route is suppressed by the
+        `starlightLlmsTxtWithoutIndex()` wrapper in docs/astro.config.mjs, while
+        the plugin still generates /llms-full.txt and /llms-small.txt. When this
+        file changes, verify: (1) every link is an absolute
+        https://docs.terragrunt.com/<slug>/ URL that resolves to a real page —
+        cross-check each slug against a content file under
+        docs/src/content/docs/ (the numeric `NN-` directory/file prefixes are
+        stripped from slugs) and against the redirects in docs/astro.config.mjs
+        and docs/vercel.json; flag any link whose target does not exist.
+        (2) The file still parses as valid llms.txt: a single `# Title` H1, an
+        optional `> summary` blockquote, then `##` sections of
+        `- [label](url): description` list items. (3) Each description still
+        accurately reflects the page it links to. Flag broken or stale links at
+        HIGH.
+
+    - path: 'docs/src/content/docs/**'
+      instructions: >-
+        LLMS.TXT DRIFT CHECK. docs/public/llms.txt curates a SUBSET of these
+        pages by slug. Flag at HIGH only if this PR renames, moves, or deletes a
+        page whose slug is referenced in docs/public/llms.txt (read that file
+        for the slug list), or adds a NEW top-level section peering with the
+        index's ## groups. Do NOT flag ordinary body edits or unreferenced
+        pages.
+
     - path: '**/*.go'
       instructions: >-
         Review the Go code for quality and correctness.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -80,7 +80,7 @@ reviews:
         accurately reflects the page it links to. Flag broken or stale links at
         HIGH.
 
-    - path: 'docs/src/content/docs/**'
+    - path: 'docs/src/content/docs/**/*.{md,mdx}'
       instructions: >-
         LLMS.TXT DRIFT CHECK. docs/public/llms.txt curates a SUBSET of these
         pages by slug. Flag at HIGH only if this PR renames, moves, or deletes a

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -18,6 +18,47 @@ import { rehypeChangelogAnchors } from "./src/lib/rehype-changelog-anchors.ts";
 // Check if we're in Vercel environment
 const isVercel = globalThis.process?.env?.VERCEL;
 
+/**
+ * Wraps the `starlight-llms-txt` plugin so it still generates `/llms-full.txt`
+ * and `/llms-small.txt`, but does NOT inject its own `/llms.txt` route. That
+ * frees `/llms.txt` for our hand-curated index at `public/llms.txt`, which the
+ * plugin's generated entrypoint can't reproduce (its body is a fixed template).
+ *
+ * The plugin (node_modules/starlight-llms-txt/index.ts) injects its routes from
+ * inside an Astro integration's `astro:config:setup` hook. We intercept the
+ * `addIntegration` call, then wrap that integration's `injectRoute` to drop the
+ * single `/llms.txt` pattern and pass every other route through untouched.
+ */
+function starlightLlmsTxtWithoutIndex(opts) {
+  const plugin = starlightLlmsTxt(opts);
+  const originalSetup = plugin.hooks.setup;
+  return {
+    ...plugin,
+    hooks: {
+      ...plugin.hooks,
+      setup(setupContext) {
+        return originalSetup({
+          ...setupContext,
+          addIntegration(integration) {
+            const configSetup = integration.hooks?.["astro:config:setup"];
+            if (configSetup) {
+              integration.hooks["astro:config:setup"] = (configContext) =>
+                configSetup({
+                  ...configContext,
+                  injectRoute(route) {
+                    if (route.pattern === "/llms.txt") return;
+                    return configContext.injectRoute(route);
+                  },
+                });
+            }
+            return setupContext.addIntegration(integration);
+          },
+        });
+      },
+    },
+  };
+}
+
 // https://astro.build/config
 export default defineConfig({
   site: "https://docs.terragrunt.com",
@@ -124,7 +165,7 @@ export default defineConfig({
             "/tgs-discord",
           ],
         }),
-        starlightLlmsTxt()
+        starlightLlmsTxtWithoutIndex()
       ],
     }),
     d2({

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -12,7 +12,7 @@
 ## Features
 
 - [Units](https://docs.terragrunt.com/features/units/): The basic building block of Terragrunt configuration
-- [Stacks](https://docs.terragrunt.com/features/stacks/): Group and orchestrate multiple units, including the run queue
+- [Stacks](https://docs.terragrunt.com/features/stacks/): Group and orchestrate multiple units, including documentation on the run queue
 - [Catalog](https://docs.terragrunt.com/features/catalog/): Browse and scaffold modules from a catalog
 - [Caching](https://docs.terragrunt.com/features/caching/): Provider cache server and content-addressable storage (CAS)
 - [Filter](https://docs.terragrunt.com/features/filter/): Select which units a command runs against

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,6 +1,6 @@
 # Terragrunt Docs
 
-> Documentation for Terragrunt, the open-source orchestrator for Terraform and OpenTofu. Covers installation and core concepts, features (units, stacks, catalog, caching, filters), guides, full HCL and CLI reference, migration paths, the release process, troubleshooting, and Terragrunt Scale.
+> Documentation for Terragrunt, the open-source orchestrator for OpenTofu and Terraform. Covers installation and core concepts, features (units, stacks, catalog, caching, filters), guides, full HCL and CLI reference, migration paths, the release process, troubleshooting, and Terragrunt Scale.
 
 ## Getting Started
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,55 @@
+# Terragrunt Docs
+
+> Documentation for Terragrunt, the open-source orchestrator for Terraform and OpenTofu. Covers installation and core concepts, features (units, stacks, catalog, caching, filters), guides, full HCL and CLI reference, migration paths, the release process, troubleshooting, and Terragrunt Scale.
+
+## Getting Started
+
+- [Overview](https://docs.terragrunt.com/getting-started/overview/): What Terragrunt is and why to use it
+- [Install](https://docs.terragrunt.com/getting-started/install/): Installation instructions
+- [Quick Start](https://docs.terragrunt.com/getting-started/quick-start/): Run Terragrunt for the first time
+- [Terminology](https://docs.terragrunt.com/getting-started/terminology/): Key terms and concepts
+
+## Features
+
+- [Units](https://docs.terragrunt.com/features/units/): The basic building block of Terragrunt configuration
+- [Stacks](https://docs.terragrunt.com/features/stacks/): Group and orchestrate multiple units, including the run queue
+- [Catalog](https://docs.terragrunt.com/features/catalog/): Browse and scaffold modules from a catalog
+- [Caching](https://docs.terragrunt.com/features/caching/): Provider cache server and content-addressable storage (CAS)
+- [Filter](https://docs.terragrunt.com/features/filter/): Select which units a command runs against
+
+## Guides
+
+- [Terralith to Terragrunt](https://docs.terragrunt.com/guides/terralith-to-terragrunt/): Step-by-step migration from a monolith to Terragrunt
+- [CI with Terragrunt](https://docs.terragrunt.com/guides/ci-with-terragrunt/): Set up continuous integration
+
+## Reference
+
+- [HCL configuration](https://docs.terragrunt.com/reference/hcl/): Blocks, attributes, and functions
+- [CLI](https://docs.terragrunt.com/reference/cli/): Commands and global flags
+- [Experiments](https://docs.terragrunt.com/reference/experiments/): Opt-in experimental features
+- [Strict controls](https://docs.terragrunt.com/reference/strict-controls/): Enforce stricter behavior
+- [Logging](https://docs.terragrunt.com/reference/logging/): Log formatting and configuration
+- [Supported versions](https://docs.terragrunt.com/reference/supported-versions/)
+
+## Terragrunt Scale
+
+- [Overview](https://docs.terragrunt.com/terragrunt-scale/overview/): CI/CD platform for infrastructure automation
+- [Installation](https://docs.terragrunt.com/terragrunt-scale/installation/)
+- [Pipelines](https://docs.terragrunt.com/terragrunt-scale/pipelines/)
+- [Drift detection](https://docs.terragrunt.com/terragrunt-scale/drift-detection/)
+- [Patcher](https://docs.terragrunt.com/terragrunt-scale/patcher/)
+
+## Troubleshooting
+
+- [Debugging](https://docs.terragrunt.com/troubleshooting/debugging/)
+- [OpenTelemetry](https://docs.terragrunt.com/troubleshooting/open-telemetry/)
+- [Performance](https://docs.terragrunt.com/troubleshooting/performance/)
+
+## Optional
+
+- [Migration guides](https://docs.terragrunt.com/migrate/cli-redesign/): Upgrade paths and migrating from deprecated features
+- [1.0 guarantees](https://docs.terragrunt.com/process/1-0-guarantees/): Backward-compatibility commitments
+- [Releases](https://docs.terragrunt.com/process/releases/) and [changelog](https://docs.terragrunt.com/process/changelog/)
+- [Contributing](https://docs.terragrunt.com/community/contributing/)
+- [Support](https://docs.terragrunt.com/community/support/)
+- [License](https://docs.terragrunt.com/community/license/)

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -29,7 +29,7 @@
 - [Experiments](https://docs.terragrunt.com/reference/experiments/): Opt-in experimental features
 - [Strict controls](https://docs.terragrunt.com/reference/strict-controls/): Enforce stricter behavior
 - [Logging](https://docs.terragrunt.com/reference/logging/): Log formatting and configuration
-- [Supported versions](https://docs.terragrunt.com/reference/supported-versions/)
+- [Supported versions](https://docs.terragrunt.com/reference/supported-versions/): Supported versions of OpenTofu and Terraform
 
 ## Terragrunt Scale
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -15,7 +15,7 @@
 - [Stacks](https://docs.terragrunt.com/features/stacks/): Group and orchestrate multiple units, including documentation on the run queue
 - [Catalog](https://docs.terragrunt.com/features/catalog/): Browse and scaffold modules from a catalog
 - [Caching](https://docs.terragrunt.com/features/caching/): Provider cache server and content-addressable storage (CAS)
-- [Filter](https://docs.terragrunt.com/features/filter/): Select which units a command runs against
+- [Filter](https://docs.terragrunt.com/features/filter/): Filter discovery of components (units & stacks)
 
 ## Guides
 


### PR DESCRIPTION
Adds a hand-written [llms.txt](https://llmstxt.org/) index at /llms.txt for the docs site, while keeping the auto-generated /llms-full.txt and /llms-small.txt.

Why
The starlight-llms-txt plugin generates /llms.txt from a fixed template (Documentation Sets / Notes / Optional), which can't express a curated, sectioned index (Getting Started, Features, Guides, Reference, etc.). We want a deliberate, navigable entrypoint for LLMs while still benefiting from the plugin's full/small documentation dumps.

Changes
public/llms.txt — curated index: title, summary, and grouped links with descriptions.
astro.config.mjs — added a starlightLlmsTxtWithoutIndex() wrapper around the plugin that suppresses only its /llms.txt route injection (leaving /llms-full.txt, /llms-small.txt, and /_llms-txt/[slug].txt untouched), freeing /llms.txt for the static file.
Verification
Full astro build passes; /llms.txt builds byte-identical to public/llms.txt (diff clean).
/llms-full.txt (1.1 MB) and /llms-small.txt (1.0 MB) still generated by the plugin.
No route collision and no build warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a hand-curated documentation index organized by major sections (Getting Started, Features, Guides, Reference, Troubleshooting, Optional, Community) to improve navigation and discoverability.
  * Site build now preserves the curated index while still producing auxiliary machine-generated indexes for completeness.
* **Chores**
  * Strengthened CI/review rules to validate links and detect drift between curated and generated indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->