### PR TITLE
serve clean Markdown at <url>.md for every page

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "docs",
       "dependencies": {
+        "@astrojs/mdx": "^5.0.5",
         "@astrojs/node": "^10.1.0",
         "@astrojs/partytown": "^2.1.7",
         "@astrojs/sitemap": "3.7.2",
@@ -14,12 +15,20 @@
         "astro": "6.3.2",
         "astro-d2": "^0.10.0",
         "gray-matter": "^4.0.3",
+        "hast-util-select": "^6.0.4",
+        "rehype-parse": "^9.0.1",
+        "rehype-remark": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-stringify": "^11.0.0",
         "starlight-links-validator": "^0.24.0",
         "starlight-llms-txt": "^0.9.0",
         "typescript": "^6.0.3",
+        "unified": "^11.0.5",
+        "unist-util-remove": "^4.0.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
+        "@types/hast": "^3.0.4",
       },
     },
   },
@@ -659,29 +668,29 @@
 
     "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
 
-    "lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
-    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.31.1", "", { "os": "android", "cpu": "arm64" }, "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg=="],
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 
-    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.31.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg=="],
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
 
-    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.31.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA=="],
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
 
-    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.31.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A=="],
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
 
-    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.31.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g=="],
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
 
-    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg=="],
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
 
-    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg=="],
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
 
-    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA=="],
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
 
-    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA=="],
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
 
-    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
-    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
@@ -1139,8 +1148,6 @@
 
     "@rollup/pluginutils/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
-    "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
-
     "@tailwindcss/node/tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
@@ -1197,8 +1204,6 @@
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
-    "lightningcss/detect-libc": ["detect-libc@2.1.1", "", {}, "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw=="],
-
     "mdast-util-definitions/unist-util-visit": ["unist-util-visit@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg=="],
 
     "mdast-util-directive/unist-util-visit-parents": ["unist-util-visit-parents@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw=="],
@@ -1248,28 +1253,6 @@
     "@expressive-code/plugin-shiki/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
     "@mdx-js/mdx/unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw=="],
-
-    "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
-
-    "@tailwindcss/node/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
-
-    "@tailwindcss/node/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
-
-    "@tailwindcss/node/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
-
-    "@tailwindcss/node/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
-
-    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
-
-    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
-
-    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
-
-    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
-
-    "@tailwindcss/node/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
-
-    "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@astrojs/mdx": "^5.0.5",
     "@astrojs/node": "^10.1.0",
     "@astrojs/partytown": "^2.1.7",
     "@astrojs/sitemap": "3.7.2",
@@ -21,12 +22,20 @@
     "astro": "6.3.2",
     "astro-d2": "^0.10.0",
     "gray-matter": "^4.0.3",
+    "hast-util-select": "^6.0.4",
+    "rehype-parse": "^9.0.1",
+    "rehype-remark": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-stringify": "^11.0.0",
     "starlight-links-validator": "^0.24.0",
     "starlight-llms-txt": "^0.9.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "unified": "^11.0.5",
+    "unist-util-remove": "^4.0.0"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.14"
+    "@types/bun": "^1.3.14",
+    "@types/hast": "^3.0.4"
   },
   "overrides": {
     "estree-walker": "2.0.2"

--- a/docs/src/lib/page-to-markdown.ts
+++ b/docs/src/lib/page-to-markdown.ts
@@ -1,0 +1,339 @@
+// Renders an Astro content-collection entry to clean Markdown by rendering it
+// to HTML (resolving MDX components) and converting the HTML back to Markdown.
+//
+// This is a vendored adaptation of `starlight-llms-txt`'s `entryToSimpleMarkdown`
+// (MIT licensed, v0.9.0, https://github.com/HiDeoo/starlight-llms-txt). The plugin
+// only exposes this conversion through its `/llms*.txt` routes, so to serve the
+// same clean Markdown per-page at `<url>.md` we reuse its pipeline here. The only
+// substantive change is dropping the `virtual:starlight-llms-txt/context` module
+// (which is internal to the plugin) and inlining its configuration, so this module
+// is self-contained and usable from our own routes.
+//
+// Keep this roughly in sync with the plugin when it is upgraded.
+
+import mdxServer from '@astrojs/mdx/server.js';
+import type { APIContext } from 'astro';
+import { experimental_AstroContainer } from 'astro/container';
+import { render, type CollectionEntry } from 'astro:content';
+import type { RootContent } from 'hast';
+import { matches, select, selectAll } from 'hast-util-select';
+import rehypeParse from 'rehype-parse';
+import rehypeRemark from 'rehype-remark';
+import remarkGfm from 'remark-gfm';
+import remarkStringify from 'remark-stringify';
+import { unified } from 'unified';
+import { remove } from 'unist-util-remove';
+
+// Mirror the plugin's vfile augmentation so the `minify` flag we thread through
+// the pipeline below is typed.
+declare module 'vfile' {
+	interface DataMap {
+		starlightLlmsTxt: {
+			minify: boolean;
+		};
+	}
+}
+
+/**
+ * Minification options. These only take effect when `entryToSimpleMarkdown` is
+ * called with `shouldMinify: true`; for full per-page Markdown we render with
+ * minification off so asides, details, etc. are preserved. Mirrors the plugin
+ * defaults so behaviour matches the existing `/llms-small.txt` output.
+ */
+const minify = {
+	note: true,
+	tip: true,
+	caution: false,
+	danger: false,
+	details: true,
+	whitespace: true,
+	collapseCodeBlocks: false,
+	customSelectors: [] as string[],
+};
+
+/** Selectors for elements to remove during minification. */
+const selectors = [...minify.customSelectors];
+if (minify.details) selectors.unshift('details');
+
+const astroContainer = await experimental_AstroContainer.create({
+	renderers: [{ name: 'astro:jsx', ssr: mdxServer }],
+});
+
+const htmlToMarkdownPipeline = unified()
+	.use(rehypeParse, { fragment: true })
+	.use(function minifyLlmsTxt() {
+		return (tree, file) => {
+			if (!file.data.starlightLlmsTxt.minify) {
+				return;
+			}
+			remove(tree, (_node) => {
+				const node = _node as RootContent;
+
+				// Remove elements matching any selectors to be minified:
+				for (const selector of selectors) {
+					if (matches(selector, node)) {
+						return true;
+					}
+				}
+
+				// Remove aside components:
+				if (matches('.starlight-aside', node)) {
+					for (const variant of ['note', 'tip', 'caution', 'danger'] as const) {
+						if (minify[variant] && matches(`.starlight-aside--${variant}`, node)) {
+							return true;
+						}
+					}
+				}
+
+				return false;
+			});
+			return tree;
+		};
+	})
+	.use(function improveExpressiveCodeHandling() {
+		return (tree) => {
+			const ecInstances = selectAll('.expressive-code', tree as Parameters<typeof selectAll>[1]);
+			for (const instance of ecInstances) {
+				// Remove the “Terminal Window” label from Expressive Code terminal frames.
+				const figcaption = select('figcaption', instance);
+				if (figcaption) {
+					const terminalWindowTextIndex = figcaption.children.findIndex((child) =>
+						matches('span.sr-only', child),
+					);
+					if (terminalWindowTextIndex > -1) {
+						figcaption.children.splice(terminalWindowTextIndex, 1);
+					}
+				}
+				const pre = select('pre', instance);
+				const code = select('code', instance);
+				// Use Expressive Code’s `data-language=*` attribute to set a `language-*` class name.
+				// This is what `hast-util-to-mdast` checks for code language metadata.
+				if (pre?.properties.dataLanguage && code) {
+					if (!Array.isArray(code.properties.className)) code.properties.className = [];
+
+					const diffLines =
+						pre.properties.dataLanguage === 'diff'
+							? []
+							: code.children.filter((child) => matches('div.ec-line.ins, div.ec-line.del', child));
+					if (diffLines.length === 0) {
+						code.properties.className.push(`language-${pre.properties.dataLanguage}`);
+					} else {
+						code.properties.className.push('language-diff');
+						for (const line of diffLines) {
+							if (line.type !== 'element') continue;
+							const classes = line.properties?.className;
+							if (typeof classes !== 'string' && !Array.isArray(classes)) continue;
+							const marker = classes.includes('ins') ? '+' : '-';
+							const span = select('span:not(.indent)', line);
+							const firstChild = span?.children[0];
+							if (firstChild?.type === 'text') {
+								firstChild.value = `${marker}${firstChild.value}`;
+							}
+						}
+					}
+				}
+			}
+		};
+	})
+	.use(function improveTabsHandling() {
+		return (tree) => {
+			const tabInstances = selectAll('starlight-tabs', tree as Parameters<typeof selectAll>[1]);
+			for (const instance of tabInstances) {
+				const tabs = selectAll('[role="tab"]', instance);
+				const panels = selectAll('[role="tabpanel"]', instance);
+				// Convert parent `<starlight-tabs>` element to empty unordered list.
+				instance.tagName = 'ul';
+				instance.properties = {};
+				instance.children = [];
+				// Iterate over tabs and panels to build a list with tab label as initial list text.
+				for (let i = 0; i < Math.min(tabs.length, panels.length); i++) {
+					const tab = tabs[i];
+					const panel = panels[i];
+					if (!tab || !panel) continue;
+					// Filter out extra whitespace and icons from tab contents.
+					const tabLabel = tab.children
+						.filter((child) => child.type === 'text' && child.value.trim())
+						.map((child) => child.type === 'text' && child.value.trim())
+						.join('');
+					// Add list entry for this tab and panel.
+					instance.children.push({
+						type: 'element',
+						tagName: 'li',
+						properties: {},
+						children: [
+							{
+								type: 'element',
+								tagName: 'p',
+								children: [{ type: 'text', value: tabLabel }],
+								properties: {},
+							},
+							panel,
+						],
+					});
+				}
+			}
+		};
+	})
+	.use(function improveFileTreeHandling() {
+		return (tree) => {
+			const trees = selectAll('starlight-file-tree', tree as Parameters<typeof selectAll>[1]);
+			for (const tree of trees) {
+				// Remove “Directory” screen reader labels from <FileTree> entries.
+				remove(tree, (_node) => {
+					const node = _node as RootContent;
+					return matches('.sr-only', node);
+				});
+			}
+		};
+	})
+	.use(function removeHtmlComments() {
+		return (tree) => {
+			remove(tree, ({ type }) => type === 'comment');
+		};
+	})
+	// Addition (not in the upstream plugin): Starlight (and some of this repo's
+	// own components) render an empty permalink anchor next to headings —
+	// `a.sl-anchor-link` with a screen-reader "Section titled …" label, and
+	// `a.anchor-link` in the experiments/strict-controls components. Left in,
+	// each heading produces a noisy `[Section titled "X"](#x)` line (or an empty
+	// `[](#x)` link) in the output. Strip them so the Markdown is clean.
+	.use(function removeHeadingAnchorLinks() {
+		return (tree) => {
+			remove(tree, (node) =>
+				matches('a.sl-anchor-link, a.anchor-link', node as RootContent),
+			);
+		};
+	})
+	.use(rehypeRemark)
+	.use(remarkGfm)
+	.use(remarkStringify);
+
+/** A content-collection entry that can be rendered to HTML via `render()`. */
+type RenderableEntry = CollectionEntry<
+	'docs' | 'commands' | 'experiments' | 'strictControls' | 'changelog'
+>;
+
+/**
+ * Frame converted Markdown as a standalone document: an H1 title, an optional
+ * blockquote description, then the body. Matches the framing `starlight-llms-txt`
+ * uses for each page in `llms-full.txt`, so the per-page `.md` is consistent.
+ */
+export function markdownDocument(
+	title: string,
+	description: string | undefined,
+	body: string,
+): string {
+	const segments = [`# ${title}`];
+	if (description) segments.push(`> ${description}`);
+	if (body.trim()) segments.push(body);
+	return segments.join('\n\n') + '\n';
+}
+
+/** Run rendered HTML through the rehype→remark pipeline and tidy whitespace. */
+async function htmlToMarkdown(html: string, shouldMinify: boolean) {
+	const file = await htmlToMarkdownPipeline.process({
+		value: html,
+		data: { starlightLlmsTxt: { minify: shouldMinify } },
+	});
+	let markdown = String(file).trim();
+	if (shouldMinify && minify.whitespace) {
+		if (minify.collapseCodeBlocks) {
+			markdown = markdown.replace(/\s+/g, ' ');
+		} else {
+			// Collapse whitespace in prose, but keep the contents of fenced code
+			// blocks (``` and ~~~, of any length ≥ 3) intact so multi-line code
+			// samples stay multi-line.
+			const fenceMatcher =
+				/(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n(?:[\s\S]*?\n)?\1\2[ \t]*(?=\n|$)/g;
+			const parts: string[] = [];
+			let lastIndex = 0;
+			for (const match of markdown.matchAll(fenceMatcher)) {
+				const index = match.index ?? 0;
+				parts.push(markdown.slice(lastIndex, index).replace(/\s+/g, ' '));
+				parts.push('\n', match[0], '\n');
+				lastIndex = index + match[0].length;
+			}
+			parts.push(markdown.slice(lastIndex).replace(/\s+/g, ' '));
+			markdown = parts.join('').trim();
+		}
+	}
+	return markdown;
+}
+
+/**
+ * Render a content collection entry to HTML and back to Markdown to support
+ * rendering and simplifying MDX components.
+ */
+export async function entryToSimpleMarkdown(
+	entry: RenderableEntry,
+	context: APIContext,
+	shouldMinify: boolean = false,
+) {
+	const { Content } = await render(entry);
+	const html = await astroContainer.renderToString(Content, context);
+	return htmlToMarkdown(html, shouldMinify);
+}
+
+/**
+ * Best-effort raw-source fallback for entries whose MDX uses components that
+ * can't be rendered in the container (notably Expressive Code's `<Code>`
+ * component, which needs the EC engine). Drops imports/exports, converts inline
+ * `<Code … code={`…`} />` to fenced blocks, and unwraps simple wrapper
+ * components, keeping their inner prose. Only the body Markdown is affected.
+ */
+function rawMdxToMarkdown(body: string): string {
+	return body
+		.replace(/^[ \t]*import\s[\s\S]*?$/gm, '') // import lines
+		.replace(/^[ \t]*export\s[\s\S]*?$/gm, '') // export lines
+		// Inline `<Code … lang="x" … code={`…`} … />` → fenced code block.
+		.replace(
+			/<Code\b[^>]*?\blang=["']([^"']+)["'][^>]*?\bcode=\{`([\s\S]*?)`\}[^>]*?\/>/g,
+			(_m, lang, code) => '```' + lang + '\n' + code + '\n```',
+		)
+		// Remaining `<Code … />` (e.g. code from an imported variable) can't be
+		// resolved from source — drop the tag.
+		.replace(/<Code\b[^>]*?\/>/g, '')
+		// Unwrap simple wrapper components, keeping inner content.
+		.replace(/<\/?(?:Aside|Before|Since|Tabs|TabItem|Card|Badge)\b[^>]*>/g, '')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim();
+}
+
+/**
+ * Like {@link entryToSimpleMarkdown}, but falls back to a raw-source conversion
+ * if the container render throws (e.g. the entry uses the `<Code>` component).
+ * Keeps the build resilient while still producing clean output for the common
+ * case.
+ */
+export async function safeEntryToMarkdown(
+	entry: RenderableEntry,
+	context: APIContext,
+	shouldMinify: boolean = false,
+) {
+	try {
+		return await entryToSimpleMarkdown(entry, context, shouldMinify);
+	} catch {
+		return rawMdxToMarkdown(entry.body ?? '');
+	}
+}
+
+/**
+ * Render an arbitrary Astro component (with props) to clean Markdown using the
+ * same pipeline. Used for the dynamically-generated reference pages (CLI
+ * commands, changelog releases, experiments, strict-controls), whose visible
+ * content is produced by a component rather than a markdown body. `Component` is
+ * an Astro component module's default export.
+ */
+export async function componentToSimpleMarkdown(
+	Component: Parameters<typeof astroContainer.renderToString>[0],
+	props: Record<string, unknown>,
+	context: APIContext,
+	shouldMinify: boolean = false,
+) {
+	const html = await astroContainer.renderToString(Component, {
+		props,
+		request: context.request,
+		params: context.params,
+	});
+	return htmlToMarkdown(html, shouldMinify);
+}

--- a/docs/src/pages/[...slug].md.ts
+++ b/docs/src/pages/[...slug].md.ts
@@ -1,0 +1,67 @@
+// Serves a clean Markdown version of every prose docs page at `<url>.md`.
+//
+// For a page rendered at `/getting-started/install/`, this emits a static
+// `/getting-started/install.md` containing the same content converted to plain
+// Markdown (MDX components resolved). This is the AEO ".md suffix" pattern
+// popularised by Stripe's docs, letting LLMs and agents fetch a token-cheap,
+// chrome-free version of any page.
+//
+// Prose docs live in the `docs` content collection and are handled here. The
+// dynamically-generated reference pages (CLI commands, changelog, experiments,
+// strict-controls) are `.astro` routes and get their own `.md` endpoints.
+
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getCollection } from 'astro:content';
+import { entryToSimpleMarkdown } from '@lib/page-to-markdown';
+
+export const prerender = true;
+
+/**
+ * Some docs entries are intentionally-empty placeholders whose visible content
+ * is rendered by a dedicated `.astro` route (e.g. the `reference/cli/commands/*`
+ * pages, generated from the `commands` collection, and the `process/changelog`
+ * overview). Their markdown body is just an HTML comment, so rendering them here
+ * would emit a near-empty `.md`. Skip them — their real `.md` is produced by the
+ * matching generated-page endpoints instead.
+ */
+function hasRenderableBody(body: string | undefined): boolean {
+	if (!body) return false;
+	const stripped = body
+		.replace(/<!--[\s\S]*?-->/g, '') // HTML comments (used by CLI command stubs)
+		.replace(/\{\/\*[\s\S]*?\*\/\}/g, '') // MDX/JSX comments (used by the changelog stub)
+		.trim();
+	return stripped.length > 0;
+}
+
+export const getStaticPaths = (async () => {
+	const docs = await getCollection('docs', (doc) => !doc.data.draft);
+	return docs
+		.filter((entry) => hasRenderableBody(entry.body))
+		.map((entry) => ({
+			// `entry.id` is the page's routing slug (frontmatter `slug`, numeric
+			// path prefixes stripped), so `<slug>.md` mirrors the HTML URL exactly.
+			params: { slug: entry.id },
+			props: { entry },
+		}));
+}) satisfies GetStaticPaths;
+
+export const GET: APIRoute = async (context) => {
+	const { entry } = context.props as {
+		entry: Awaited<ReturnType<typeof getCollection<'docs'>>>[number];
+	};
+
+	const title = entry.data.hero?.title || entry.data.title;
+	const description = entry.data.hero?.tagline || entry.data.description;
+
+	const body = await entryToSimpleMarkdown(entry, context, false);
+
+	const segments = [`# ${title}`];
+	if (description) segments.push(`> ${description}`);
+	segments.push(body);
+
+	return new Response(segments.join('\n\n') + '\n', {
+		headers: {
+			'Content-Type': 'text/markdown; charset=utf-8',
+		},
+	});
+};

--- a/docs/src/pages/process/changelog.md.ts
+++ b/docs/src/pages/process/changelog.md.ts
@@ -1,0 +1,62 @@
+// Clean Markdown for the changelog overview (`/process/changelog`). The HTML
+// page is a navigation index (a card per release linking to per-version pages);
+// the `.md` mirrors it as a list of releases with their category breakdown and
+// links to each release's own `.md`.
+
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import {
+	compareVersionsDesc,
+	entriesForVersion,
+	groupByCategory,
+	isReleased,
+	uniqueVersions,
+} from '@lib/changelog';
+import { getLatestRelease } from '@lib/github';
+import { markdownDocument } from '@lib/page-to-markdown';
+
+export const prerender = true;
+
+const RELEASES_URL = 'https://github.com/gruntwork-io/terragrunt/releases';
+
+export const GET: APIRoute = async () => {
+	const showUnreleased = import.meta.env.DEV;
+	const releaseData = await getLatestRelease('gruntwork-io', 'terragrunt');
+	const latestVersion = (releaseData?.tag_name ?? 'v0.0.0').replace(/^v/, '');
+
+	const allEntries = await getCollection('changelog');
+	const versions = uniqueVersions(allEntries)
+		.filter((version) => showUnreleased || isReleased(version, latestVersion))
+		.sort(compareVersionsDesc);
+
+	const sections: string[] = [
+		`This page tracks notable changes to Terragrunt. For the full list of ` +
+			`releases and their assets, see the [GitHub Releases Page](${RELEASES_URL}).`,
+	];
+
+	for (const version of versions) {
+		const groups = groupByCategory(entriesForVersion(allEntries, version));
+		sections.push(`## [${version}](/process/changelog/${version})`);
+		if (groups.length) {
+			sections.push(
+				groups
+					.map((group) => `- ${group.category.label}: ${group.entries.length}`)
+					.join('\n'),
+			);
+		}
+	}
+
+	sections.push(
+		'## Prior Releases',
+		`For all prior releases, see the [GitHub Releases Page](${RELEASES_URL}).`,
+	);
+
+	return new Response(
+		markdownDocument(
+			'Changelog',
+			'A log of notable changes to Terragrunt.',
+			sections.join('\n\n'),
+		),
+		{ headers: { 'Content-Type': 'text/markdown; charset=utf-8' } },
+	);
+};

--- a/docs/src/pages/process/changelog/[version].md.ts
+++ b/docs/src/pages/process/changelog/[version].md.ts
@@ -1,0 +1,46 @@
+// Clean Markdown for the generated per-release changelog pages
+// (`/process/changelog/<version>`), rendered by the sibling `[version].astro`
+// route from the `changelog` collection. Renders the curated `ReleaseEntries`
+// (the human-written release notes) to Markdown.
+//
+// The HTML page also appends a GitHub-derived "Pull Requests" section; we omit
+// it here to keep the `.md` free of build-time GitHub API dependencies — the
+// curated entries are the meaningful content for this format.
+
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getCollection } from 'astro:content';
+import ReleaseEntries from '@components/ReleaseEntries.astro';
+import { entriesForVersion, isReleased, uniqueVersions } from '@lib/changelog';
+import { getLatestRelease } from '@lib/github';
+import { componentToSimpleMarkdown, markdownDocument } from '@lib/page-to-markdown';
+
+export const prerender = true;
+
+export const getStaticPaths = (async () => {
+	// Mirror `[version].astro`: include only released versions in a production
+	// build (DEV additionally shows unreleased ones).
+	const showUnreleased = import.meta.env.DEV;
+	const releaseData = await getLatestRelease('gruntwork-io', 'terragrunt');
+	const latestVersion = (releaseData?.tag_name ?? 'v0.0.0').replace(/^v/, '');
+
+	const entries = await getCollection('changelog');
+	const versions = uniqueVersions(entries).filter(
+		(version) => showUnreleased || isReleased(version, latestVersion),
+	);
+
+	return versions.map((version) => ({ params: { version }, props: { version } }));
+}) satisfies GetStaticPaths;
+
+export const GET: APIRoute = async (context) => {
+	const { version } = context.props as { version: string };
+
+	const allEntries = await getCollection('changelog');
+	const entries = entriesForVersion(allEntries, version);
+
+	const body = await componentToSimpleMarkdown(ReleaseEntries, { entries }, context);
+
+	return new Response(
+		markdownDocument(version, `Notable changes in Terragrunt ${version}.`, body),
+		{ headers: { 'Content-Type': 'text/markdown; charset=utf-8' } },
+	);
+};

--- a/docs/src/pages/reference/cli/commands/[...slug].md.ts
+++ b/docs/src/pages/reference/cli/commands/[...slug].md.ts
@@ -1,0 +1,112 @@
+// Clean Markdown for the dynamically-generated CLI command reference pages.
+//
+// The HTML pages at `/reference/cli/commands/<path>/` are rendered by the
+// sibling `[...slug].astro` route from the `commands` collection; the matching
+// `docs` collection entries are intentionally-empty placeholders. We mirror the
+// structure of `Command.astro` here (experiment note → Usage → Examples → body
+// → Flags), building the structured parts from collection data and rendering the
+// command/flag MDX bodies through the Markdown pipeline.
+//
+// Note: `Command.astro` renders examples and one flag body with Expressive
+// Code's `<Code>` component, which can't run in the container used by the
+// pipeline. We therefore emit examples as fenced code blocks from data, and use
+// `safeEntryToMarkdown` for bodies so the rare `<Code>`-using flag degrades
+// gracefully instead of failing the build.
+
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getCollection, getEntry } from 'astro:content';
+import { isFlagVisible } from '@lib/flags';
+import {
+	markdownDocument,
+	safeEntryToMarkdown,
+} from '@lib/page-to-markdown';
+
+export const prerender = true;
+
+export const getStaticPaths = (async () => {
+	const commands = await getCollection('commands');
+	return commands.map((command) => ({
+		// `data.path` is the slug the HTML route uses, so `<path>.md` mirrors it.
+		params: { slug: command.data.path },
+		props: { command },
+	}));
+}) satisfies GetStaticPaths;
+
+type CommandEntry = Awaited<ReturnType<typeof getCollection<'commands'>>>[number];
+
+async function flagToMarkdown(
+	slug: string,
+	context: Parameters<APIRoute>[0],
+): Promise<string | null> {
+	const flag = await getEntry('flags', slug);
+	if (!flag) return null;
+	if (!(await isFlagVisible(flag.data.since))) return null;
+
+	const { name, description, type, defaultVal, aliases, env } = flag.data;
+	const parts = [`### \`--${name}\``];
+	if (description) parts.push(description);
+
+	const body = await safeEntryToMarkdown(flag, context);
+	if (body.trim()) parts.push(body);
+
+	const meta: string[] = [`- **Type:** \`${type}\``];
+	if (defaultVal) meta.push(`- **Default:** \`${defaultVal}\``);
+	if (aliases?.length) meta.push(`- **Aliases:** ${aliases.map((a) => `\`${a}\``).join(', ')}`);
+	if (env?.length) {
+		meta.push(`- **Environment variables:** ${env.map((e) => `\`${e}\``).join(', ')}`);
+	}
+	parts.push(meta.join('\n'));
+
+	return parts.join('\n\n');
+}
+
+async function commandToMarkdown(
+	command: CommandEntry,
+	context: Parameters<APIRoute>[0],
+): Promise<string> {
+	const data = command.data;
+	const sections: string[] = [];
+
+	if (data.experiment) {
+		sections.push(
+			`> **Experimental:** the \`${data.name}\` command requires the ` +
+				`\`--experiment ${data.experiment.control}\` flag ` +
+				`([${data.experiment.name}](/reference/experiments/active#${data.experiment.control})).`,
+		);
+	}
+
+	if (data.usage) {
+		sections.push('## Usage', data.usage.trim());
+	}
+
+	if (data.examples?.length) {
+		sections.push('## Examples');
+		for (const example of data.examples) {
+			if (example.description) sections.push(example.description.trim());
+			sections.push('```bash\n' + example.code.trim() + '\n```');
+		}
+	}
+
+	const body = await safeEntryToMarkdown(command, context);
+	if (body.trim()) sections.push(body);
+
+	if (data.flags?.length) {
+		const flagSections = (
+			await Promise.all(data.flags.map((slug) => flagToMarkdown(slug, context)))
+		).filter((s): s is string => s !== null);
+		if (flagSections.length) {
+			sections.push('## Flags', ...flagSections);
+		}
+	}
+
+	return sections.join('\n\n');
+}
+
+export const GET: APIRoute = async (context) => {
+	const { command } = context.props as { command: CommandEntry };
+	const body = await commandToMarkdown(command, context);
+	return new Response(
+		markdownDocument(command.data.name, command.data.description, body),
+		{ headers: { 'Content-Type': 'text/markdown; charset=utf-8' } },
+	);
+};

--- a/docs/src/pages/reference/experiments/[status].md.ts
+++ b/docs/src/pages/reference/experiments/[status].md.ts
@@ -1,0 +1,44 @@
+// Clean Markdown for the generated experiments reference pages
+// (`/reference/experiments/active` and `/reference/experiments/completed`),
+// which are rendered by the sibling `.astro` routes from the `experiments`
+// collection. Renders the same `ExperimentEntries` component to Markdown.
+
+import type { APIRoute, GetStaticPaths } from 'astro';
+import ExperimentEntries from '@components/ExperimentEntries.astro';
+import { componentToSimpleMarkdown, markdownDocument } from '@lib/page-to-markdown';
+
+export const prerender = true;
+
+const META = {
+	active: {
+		title: 'Active Experiments',
+		description: 'Experimental features available for opt-in.',
+	},
+	completed: {
+		title: 'Completed Experiments',
+		description: 'Experiments that have graduated to stable features.',
+	},
+} as const;
+
+export const getStaticPaths = (() =>
+	(Object.keys(META) as (keyof typeof META)[]).map((status) => ({
+		params: { status },
+	}))) satisfies GetStaticPaths;
+
+export const GET: APIRoute = async (context) => {
+	const status = context.params.status as keyof typeof META;
+	const meta = META[status];
+	if (!meta) return new Response('Not found', { status: 404 });
+
+	// `showUnreleased` mirrors the `.astro` pages, which use `import.meta.env.DEV`
+	// (i.e. false in a production build).
+	const body = await componentToSimpleMarkdown(
+		ExperimentEntries,
+		{ status, showUnreleased: false },
+		context,
+	);
+
+	return new Response(markdownDocument(meta.title, meta.description, body), {
+		headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+	});
+};

--- a/docs/src/pages/reference/strict-controls/[status].md.ts
+++ b/docs/src/pages/reference/strict-controls/[status].md.ts
@@ -1,0 +1,43 @@
+// Clean Markdown for the generated strict-controls reference pages
+// (`/reference/strict-controls/active` and `/completed`), rendered by the
+// sibling `.astro` routes from the `strictControls` collection. Renders the same
+// `StrictControlEntries` component to Markdown.
+
+import type { APIRoute, GetStaticPaths } from 'astro';
+import StrictControlEntries from '@components/StrictControlEntries.astro';
+import { componentToSimpleMarkdown, markdownDocument } from '@lib/page-to-markdown';
+
+export const prerender = true;
+
+const META = {
+	active: {
+		title: 'Active Strict Controls',
+		description:
+			'Strict controls that convert deprecated feature warnings into errors.',
+	},
+	completed: {
+		title: 'Completed Strict Controls',
+		description: 'Strict controls whose behaviour is now the default.',
+	},
+} as const;
+
+export const getStaticPaths = (() =>
+	(Object.keys(META) as (keyof typeof META)[]).map((status) => ({
+		params: { status },
+	}))) satisfies GetStaticPaths;
+
+export const GET: APIRoute = async (context) => {
+	const status = context.params.status as keyof typeof META;
+	const meta = META[status];
+	if (!meta) return new Response('Not found', { status: 404 });
+
+	const body = await componentToSimpleMarkdown(
+		StrictControlEntries,
+		{ status, showUnreleased: false },
+		context,
+	);
+
+	return new Response(markdownDocument(meta.title, meta.description, body), {
+		headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+	});
+};


### PR DESCRIPTION
Serves a clean Markdown version of every docs.terragrunt.com page at the same
URL + `.md` (e.g. `/getting-started/install.md`) — the Stripe-style AEO pattern
for LLMs/agents.

Build-time static files: prerendered Astro endpoints emit one `.md` per page.
MDX→Markdown reuses the `starlight-llms-txt` pipeline (vendored into
`src/lib/page-to-markdown.ts`, with heading-anchor noise stripped). **128 pages**:
prose docs (95), CLI commands (20), experiments, strict-controls, and changelog.

**Notes:** CLI examples are built from collection data (Expressive Code's
`<Code>` can't render in the converter); changelog `.md` omits the GitHub-API PR
section to keep the build API-free.

**Tested:** `bunx astro build` green, links valid, `.md` serves as
`text/markdown`. Caveat: bogus `.md` URLs `500` under `astro preview` but should
`404` as static files on Vercel — confirm on preview deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown format endpoints for documentation pages, version-specific changelogs, CLI command references, experiments, and strict controls are now available for programmatic access.
  * All documentation content is readily accessible in clean markdown format, enabling external tool integration, content distribution workflows, and flexible access methods beyond the web interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->