### PR TITLE
fix: report the offending field in Terragrunt config errors

### DIFF
--- a/docs/src/data/changelog/v1.0.8/exposed-include-error-context.mdx
+++ b/docs/src/data/changelog/v1.0.8/exposed-include-error-context.mdx
@@ -3,18 +3,24 @@ version: "v1.0.8"
 category: "bug-fixes"
 ---
 
-#### Exposed-include resolution errors now name the include block and parent file
+#### Exposed-include resolution errors now name the include block, file, and failing field
 
-When resolving an `include` block with `expose = true`, Terragrunt surfaced low-level parsing or conversion errors with no indication of which include block or file was at fault. This was especially hard to debug for errors that carry no source location, such as:
+When resolving an `include` block with `expose = true`, Terragrunt surfaced low-level parsing or conversion errors with no indication of which include block, file, or field was at fault. This was especially hard to debug for errors that carry no source location, such as:
 
 ```text
 unsuitable value: a bool is required
 ```
 
-The error is now annotated with the include block name and the included (parent) file path:
+The error is now annotated with the include block name, the included (parent) file path, and a single dotted locator for the failing field — the top-level config field (`dependency`, `inputs`, `locals`, or `feature`) plus the attribute path within it when go-cty can determine one:
 
 ```text
-exposed include "root" (/path/to/root.hcl): unsuitable value: a bool is required
+exposed include "root" (/path/to/root.hcl): dependency.outputs["enabled"]: unsuitable value: a bool is required
 ```
 
-This narrows the search from the entire configuration tree to the specific included file, making the source of the failure clear.
+When go-cty cannot resolve a precise attribute path, the locator degrades to just the field name:
+
+```text
+exposed include "root" (/path/to/root.hcl): dependency: unsuitable value: a bool is required
+```
+
+Errors that originate in HCL parsing already carry a source range (`file:line:column`) and are preserved unchanged. This narrows the search from the entire configuration tree to a specific file and field.

--- a/docs/src/data/changelog/v1.0.8/exposed-include-error-context.mdx
+++ b/docs/src/data/changelog/v1.0.8/exposed-include-error-context.mdx
@@ -1,0 +1,20 @@
+---
+version: "v1.0.8"
+category: "bug-fixes"
+---
+
+#### Exposed-include resolution errors now name the include block and parent file
+
+When resolving an `include` block with `expose = true`, Terragrunt surfaced low-level parsing or conversion errors with no indication of which include block or file was at fault. This was especially hard to debug for errors that carry no source location, such as:
+
+```text
+unsuitable value: a bool is required
+```
+
+The error is now annotated with the include block name and the included (parent) file path:
+
+```text
+exposed include "root" (/path/to/root.hcl): unsuitable value: a bool is required
+```
+
+This narrows the search from the entire configuration tree to the specific included file, making the source of the failure clear.

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -97,7 +96,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 
 	dependencyCty, err := dependencyBlocksAsCty(config.TerragruntDependencies)
 	if err != nil {
-		return cty.NilVal, fmt.Errorf("%s%s: %w", MetadataDependency, ctyPathString(err), err)
+		return cty.NilVal, fieldError(MetadataDependency, err)
 	}
 
 	if dependencyCty != cty.NilVal {
@@ -124,7 +123,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 
 	inputsCty, err := convertToCtyWithJSON(config.Inputs)
 	if err != nil {
-		return cty.NilVal, fmt.Errorf("%s%s: %w", MetadataInputs, ctyPathString(err), err)
+		return cty.NilVal, fieldError(MetadataInputs, err)
 	}
 
 	if inputsCty != cty.NilVal {
@@ -133,7 +132,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 
 	localsCty, err := convertToCtyWithJSON(config.Locals)
 	if err != nil {
-		return cty.NilVal, fmt.Errorf("%s%s: %w", MetadataLocals, ctyPathString(err), err)
+		return cty.NilVal, fieldError(MetadataLocals, err)
 	}
 
 	if localsCty != cty.NilVal {
@@ -142,7 +141,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 
 	featureFlagsCty, err := featureFlagsBlocksAsCty(config.FeatureFlags)
 	if err != nil {
-		return cty.NilVal, fmt.Errorf("%s%s: %w", MetadataFeatureFlag, ctyPathString(err), err)
+		return cty.NilVal, fieldError(MetadataFeatureFlag, err)
 	}
 
 	if featureFlagsCty != cty.NilVal {

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -96,7 +97,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 
 	dependencyCty, err := dependencyBlocksAsCty(config.TerragruntDependencies)
 	if err != nil {
-		return cty.NilVal, err
+		return cty.NilVal, fmt.Errorf("%s%s: %w", MetadataDependency, ctyPathString(err), err)
 	}
 
 	if dependencyCty != cty.NilVal {
@@ -123,7 +124,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 
 	inputsCty, err := convertToCtyWithJSON(config.Inputs)
 	if err != nil {
-		return cty.NilVal, err
+		return cty.NilVal, fmt.Errorf("%s%s: %w", MetadataInputs, ctyPathString(err), err)
 	}
 
 	if inputsCty != cty.NilVal {
@@ -132,7 +133,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 
 	localsCty, err := convertToCtyWithJSON(config.Locals)
 	if err != nil {
-		return cty.NilVal, err
+		return cty.NilVal, fmt.Errorf("%s%s: %w", MetadataLocals, ctyPathString(err), err)
 	}
 
 	if localsCty != cty.NilVal {
@@ -141,7 +142,7 @@ func TerragruntConfigAsCty(config *TerragruntConfig) (cty.Value, error) {
 
 	featureFlagsCty, err := featureFlagsBlocksAsCty(config.FeatureFlags)
 	if err != nil {
-		return cty.NilVal, err
+		return cty.NilVal, fmt.Errorf("%s%s: %w", MetadataFeatureFlag, ctyPathString(err), err)
 	}
 
 	if featureFlagsCty != cty.NilVal {

--- a/pkg/config/cty_helpers.go
+++ b/pkg/config/cty_helpers.go
@@ -4,7 +4,9 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
 	"dario.cat/mergo"
 	"github.com/zclconf/go-cty/cty"
@@ -383,13 +385,41 @@ func includeBlockLabel(includeConfig IncludeConfig) string {
 	return fmt.Sprintf("%q", includeConfig.Name)
 }
 
+// ctyPathString renders the cty.Path carried by a cty.PathError as a dotted/indexed attribute string
+// (e.g. `.outputs["enabled"]` or `.list[1]`). It returns "" when err carries no cty.PathError or an empty path,
+// so callers can omit the segment. The path is populated only when go-cty descended into a Go map/struct to
+// reach the offending value; a top-level conversion such as gocty.ToCtyValue(v, cty.Bool) yields none.
+func ctyPathString(err error) string {
+	var pathErr cty.PathError
+	if !errors.As(err, &pathErr) {
+		return ""
+	}
+
+	var b strings.Builder
+
+	for _, step := range pathErr.Path {
+		switch s := step.(type) {
+		case cty.GetAttrStep:
+			b.WriteString("." + s.Name)
+		case cty.IndexStep:
+			// Let go-cty's JSON encoder render the key so we don't special-case string vs number keys.
+			key, _ := ctyjson.Marshal(s.Key, s.Key.Type())
+			b.WriteString("[" + string(key) + "]")
+		}
+	}
+
+	return b.String()
+}
+
 // includeConfigAsCtyVal returns the parsed include block as a cty.Value object if expose is true. Otherwise, return
 // the nil representation of cty.Value.
 func includeConfigAsCtyVal(ctx context.Context, pctx *ParsingContext, l log.Logger, includeConfig IncludeConfig) (cty.Value, error) {
 	pctx = pctx.WithTrackInclude(nil)
 
 	if includeConfig.GetExpose() {
-		// Annotate resolution errors with the include name and parent file, since low-level errors carry no source location.
+		// Annotate resolution errors with the include name and parent file. The conversion layer further annotates
+		// these with the failing field/attribute path (see TerragruntConfigAsCty), since low-level conversion errors
+		// carry no source location of their own.
 		parsedIncluded, err := parseIncludedConfig(ctx, pctx, l, &includeConfig)
 		if err != nil {
 			return cty.NilVal, fmt.Errorf("exposed include %s (%s): %w", includeBlockLabel(includeConfig), includeConfig.Path, err)

--- a/pkg/config/cty_helpers.go
+++ b/pkg/config/cty_helpers.go
@@ -389,10 +389,7 @@ func includeConfigAsCtyVal(ctx context.Context, pctx *ParsingContext, l log.Logg
 	pctx = pctx.WithTrackInclude(nil)
 
 	if includeConfig.GetExpose() {
-		// Annotate any resolution error with the include block name and the included (parent) file path. Low-level
-		// errors from parsing/converting the included config (e.g. the gocty "unsuitable value: a bool is required")
-		// carry no source location, so without this wrapping the user has no way to tell which include block or file
-		// is at fault. See https://github.com/gruntwork-io/terragrunt/issues/6282.
+		// Annotate resolution errors with the include name and parent file, since low-level errors carry no source location.
 		parsedIncluded, err := parseIncludedConfig(ctx, pctx, l, &includeConfig)
 		if err != nil {
 			return cty.NilVal, fmt.Errorf("exposed include %s (%s): %w", includeBlockLabel(includeConfig), includeConfig.Path, err)

--- a/pkg/config/cty_helpers.go
+++ b/pkg/config/cty_helpers.go
@@ -403,12 +403,22 @@ func ctyPathString(err error) string {
 			b.WriteString("." + s.Name)
 		case cty.IndexStep:
 			// Let go-cty's JSON encoder render the key so we don't special-case string vs number keys.
-			key, _ := ctyjson.Marshal(s.Key, s.Key.Type())
+			key, err := ctyjson.Marshal(s.Key, s.Key.Type())
+			if err != nil {
+				key = []byte(fmt.Sprintf("%v", s.Key))
+			}
+
 			b.WriteString("[" + string(key) + "]")
 		}
 	}
 
 	return b.String()
+}
+
+// fieldError annotates a config-field conversion error with the field name and, when go-cty can determine one,
+// the failing attribute path within it, as a single dotted locator (e.g. `dependency.outputs["enabled"]`).
+func fieldError(field string, err error) error {
+	return fmt.Errorf("%s%s: %w", field, ctyPathString(err), err)
 }
 
 // includeConfigAsCtyVal returns the parsed include block as a cty.Value object if expose is true. Otherwise, return

--- a/pkg/config/cty_helpers.go
+++ b/pkg/config/cty_helpers.go
@@ -4,6 +4,7 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"dario.cat/mergo"
 	"github.com/zclconf/go-cty/cty"
@@ -371,20 +372,35 @@ func includeMapAsCtyVal(ctx context.Context, pctx *ParsingContext, l log.Logger)
 	return ConvertValuesMapToCtyVal(exposedIncludeMap)
 }
 
+// includeBlockLabel returns a human-readable identifier for an include block to use in error messages:
+// the quoted name for a named include, or "(bare include)" for the legacy unnamed include
+// (whose Name is bareIncludeKey == "").
+func includeBlockLabel(includeConfig IncludeConfig) string {
+	if includeConfig.Name == bareIncludeKey {
+		return "(bare include)"
+	}
+
+	return fmt.Sprintf("%q", includeConfig.Name)
+}
+
 // includeConfigAsCtyVal returns the parsed include block as a cty.Value object if expose is true. Otherwise, return
 // the nil representation of cty.Value.
 func includeConfigAsCtyVal(ctx context.Context, pctx *ParsingContext, l log.Logger, includeConfig IncludeConfig) (cty.Value, error) {
 	pctx = pctx.WithTrackInclude(nil)
 
 	if includeConfig.GetExpose() {
+		// Annotate any resolution error with the include block name and the included (parent) file path. Low-level
+		// errors from parsing/converting the included config (e.g. the gocty "unsuitable value: a bool is required")
+		// carry no source location, so without this wrapping the user has no way to tell which include block or file
+		// is at fault. See https://github.com/gruntwork-io/terragrunt/issues/6282.
 		parsedIncluded, err := parseIncludedConfig(ctx, pctx, l, &includeConfig)
 		if err != nil {
-			return cty.NilVal, err
+			return cty.NilVal, fmt.Errorf("exposed include %s (%s): %w", includeBlockLabel(includeConfig), includeConfig.Path, err)
 		}
 
 		parsedIncludedCty, err := TerragruntConfigAsCty(parsedIncluded)
 		if err != nil {
-			return cty.NilVal, err
+			return cty.NilVal, fmt.Errorf("exposed include %s (%s): %w", includeBlockLabel(includeConfig), includeConfig.Path, err)
 		}
 
 		return parsedIncludedCty, nil

--- a/pkg/config/cty_helpers_internal_test.go
+++ b/pkg/config/cty_helpers_internal_test.go
@@ -1,7 +1,6 @@
 package config //nolint:testpackage // needs access to unexported includeConfigAsCtyVal / includeBlockLabel
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -66,8 +65,8 @@ func TestCtyPathString(t *testing.T) {
 	require.Error(t, descend)
 	assert.Equal(t, `.outputs["enabled"]`, ctyPathString(descend))
 
-	// Mirror the conversion-layer wrap: field name + path collapse into one locator.
-	folded := fmt.Errorf("%s%s: %w", MetadataDependency, ctyPathString(descend), descend)
+	// fieldError folds the field name + path into one locator.
+	folded := fieldError(MetadataDependency, descend)
 	assert.Equal(t, `dependency.outputs["enabled"]: unsuitable value: a bool is required`, folded.Error())
 
 	var pathErr cty.PathError
@@ -77,7 +76,5 @@ func TestCtyPathString(t *testing.T) {
 	_, bare := gocty.ToCtyValue(cty.StringVal("x"), cty.Bool)
 	require.Error(t, bare)
 	assert.Empty(t, ctyPathString(bare))
-
-	foldedBare := fmt.Errorf("%s%s: %w", MetadataDependency, ctyPathString(bare), bare)
-	assert.Equal(t, `dependency: unsuitable value: a bool is required`, foldedBare.Error())
+	assert.Equal(t, `dependency: unsuitable value: a bool is required`, fieldError(MetadataDependency, bare).Error())
 }

--- a/pkg/config/cty_helpers_internal_test.go
+++ b/pkg/config/cty_helpers_internal_test.go
@@ -1,0 +1,50 @@
+package config //nolint:testpackage // needs access to unexported includeConfigAsCtyVal / includeBlockLabel
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIncludeConfigAsCtyValWrapsErrorWithIncludeNameAndPath is a regression test for
+// https://github.com/gruntwork-io/terragrunt/issues/6282. When resolving an exposed include fails, the error must
+// identify WHICH include block and WHICH included (parent) file caused it — otherwise low-level, location-less
+// errors (e.g. the gocty "unsuitable value: a bool is required") are impossible to debug.
+func TestIncludeConfigAsCtyValWrapsErrorWithIncludeNameAndPath(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Parent (included) config with an invalid expression so its full parse fails deterministically.
+	parentPath := filepath.Join(tmpDir, "root.hcl")
+	require.NoError(t, os.WriteFile(parentPath, []byte("locals {\n  x = \n}\n"), 0644))
+
+	childPath := filepath.Join(tmpDir, "terragrunt.hcl")
+	require.NoError(t, os.WriteFile(childPath, []byte("terraform {\n  source = \".\"\n}\n"), 0644))
+
+	l := logger.CreateLogger()
+	ctx, pctx := NewParsingContext(t.Context(), l, WithStrictControls(controls.New()))
+	pctx.TerragruntConfigPath = childPath
+	pctx.WorkingDir = tmpDir
+
+	expose := true
+	inc := IncludeConfig{Name: "root", Path: parentPath, Expose: &expose}
+
+	_, err := includeConfigAsCtyVal(ctx, pctx, l, inc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `exposed include "root"`,
+		"error should name the include block so the user knows WHERE resolution failed")
+	require.Contains(t, err.Error(), parentPath, "error should name the included (parent) file")
+}
+
+// TestIncludeBlockLabel verifies the human-readable identifier used in exposed-include error messages.
+func TestIncludeBlockLabel(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, `"root"`, includeBlockLabel(IncludeConfig{Name: "root"}))
+	require.Equal(t, "(bare include)", includeBlockLabel(IncludeConfig{Name: bareIncludeKey}))
+}

--- a/pkg/config/cty_helpers_internal_test.go
+++ b/pkg/config/cty_helpers_internal_test.go
@@ -1,13 +1,17 @@
 package config //nolint:testpackage // needs access to unexported includeConfigAsCtyVal / includeBlockLabel
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
 )
 
 // TestIncludeConfigAsCtyValWrapsErrorWithIncludeNameAndPath is a regression test for
@@ -47,4 +51,33 @@ func TestIncludeBlockLabel(t *testing.T) {
 
 	require.Equal(t, `"root"`, includeBlockLabel(IncludeConfig{Name: "root"}))
 	require.Equal(t, "(bare include)", includeBlockLabel(IncludeConfig{Name: bareIncludeKey}))
+}
+
+// TestCtyPathString covers field-level annotation of exposed-include resolution errors (issue #6282). The
+// conversion layer folds the field name and the failing attribute path into a single dotted locator (e.g.
+// `dependency.outputs["enabled"]`) so the message is unambiguous, and degrades to just the field name when
+// go-cty has no path. The underlying cty.PathError is preserved through the %w chain.
+func TestCtyPathString(t *testing.T) {
+	t.Parallel()
+
+	// Conversion that descends through a Go map to reach the bad value -> populated cty.Path.
+	target := cty.Object(map[string]cty.Type{"outputs": cty.Map(cty.Bool)})
+	_, descend := gocty.ToCtyValue(map[string]any{"outputs": map[string]cty.Value{"enabled": cty.StringVal("x")}}, target)
+	require.Error(t, descend)
+	assert.Equal(t, `.outputs["enabled"]`, ctyPathString(descend))
+
+	// Mirror the conversion-layer wrap: field name + path collapse into one locator.
+	folded := fmt.Errorf("%s%s: %w", MetadataDependency, ctyPathString(descend), descend)
+	assert.Equal(t, `dependency.outputs["enabled"]: unsuitable value: a bool is required`, folded.Error())
+
+	var pathErr cty.PathError
+	require.ErrorAs(t, folded, &pathErr, "cty.PathError should survive the %w chain")
+
+	// Top-level conversion of an already-typed value -> empty path: folds to just the field name.
+	_, bare := gocty.ToCtyValue(cty.StringVal("x"), cty.Bool)
+	require.Error(t, bare)
+	assert.Empty(t, ctyPathString(bare))
+
+	foldedBare := fmt.Errorf("%s%s: %w", MetadataDependency, ctyPathString(bare), bare)
+	assert.Equal(t, `dependency: unsuitable value: a bool is required`, foldedBare.Error())
 }

--- a/test/integration_regressions_test.go
+++ b/test/integration_regressions_test.go
@@ -873,6 +873,29 @@ func TestExposedIncludeFullParseReturnsError(t *testing.T) {
 	require.Error(t, err, "Full parsing should fail when exposed include has unresolved dependency")
 }
 
+// TestExposedIncludeErrorIdentifiesIncludeBlock is a regression test for
+// https://github.com/gruntwork-io/terragrunt/issues/6282. When resolving an exposed include fails, the error must
+// identify WHICH include block and WHICH included (parent) file caused it, not just the child config path —
+// otherwise location-less errors (e.g. "unsuitable value: a bool is required") are impossible to debug.
+func TestExposedIncludeErrorIdentifiesIncludeBlock(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureExposedIncludePartialParseError)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureExposedIncludePartialParseError)
+
+	helpers.CleanupTerraformFolder(t, rootPath)
+
+	childPath := filepath.Join(rootPath, "child")
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt run --non-interactive --working-dir "+childPath+" -- plan",
+	)
+	require.Error(t, err)
+	assert.Contains(t, stderr, `exposed include "root"`,
+		"error should name the include block so the user knows WHERE resolution failed")
+	assert.Contains(t, stderr, "root.hcl", "error should name the included (parent) file")
+}
+
 // TestQueueDisplayOrder verifies that the flat queue display lists units in
 // dependency order: dependencies before dependents.
 // Regression test for https://github.com/gruntwork-io/terragrunt/issues/5035


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* Updated error messages to include error fields
* Added tests to track the issue

Fixes #6282.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for exposed include resolution and cty conversion failures: messages now include the include block label, parent file path, and a dotted attribute locator when available.

* **Tests**
  * Added unit and integration tests to validate the improved error reporting and path formatting.

* **Documentation**
  * Updated changelog to describe the enhanced error context and preserved source ranges for parsing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->