### PR TITLE
Changelog

### DIFF
--- a/docs/src/data/changelog/v1.0.8/ai-ready-docs.mdx
+++ b/docs/src/data/changelog/v1.0.8/ai-ready-docs.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.8"
+category: "documentation-updates"
+---
+
+#### Clean Markdown for every docs page
+
+Every page on the docs is now available as plain Markdown — just append `.md` to the URL. For example, [`/getting-started/install.md`](/getting-started/install.md) returns the install guide as clean Markdown.
+
+This makes the docs easy to hand to LLMs and AI coding assistants. The `.md` version drops the navigation, scripts, and other page chrome, so tools get just the content — a fraction of the tokens of the rendered page, which is cheaper and faster to feed into a model. It works on every page, including the [CLI command reference](/reference/cli/commands/run.md) and the changelog.
+
+Paste a `.md` link into Claude, Cursor, or your own retrieval pipeline to get a page exactly as written. It complements the existing [`llms.txt`](/llms.txt) and [`llms-full.txt`](/llms-full.txt) files with a precise, per-page source.

--- a/docs/src/data/changelog/v1.0.8/ai-ready-docs.mdx
+++ b/docs/src/data/changelog/v1.0.8/ai-ready-docs.mdx
@@ -3,10 +3,14 @@ version: "v1.0.8"
 category: "documentation-updates"
 ---
 
-#### Clean Markdown for every docs page
+#### Clean Markdown is available for every docs page at `<url>.md`
 
-Every page on the docs is now available as plain Markdown — just append `.md` to the URL. For example, [`/getting-started/install.md`](/getting-started/install.md) returns the install guide as clean Markdown.
+Every docs page is now served as clean Markdown at the same URL with `.md` appended. For example, [`/getting-started/install`](/getting-started/install) is also available at [`/getting-started/install.md`](/getting-started/install.md).
 
-This makes the docs easy to hand to LLMs and AI coding assistants. The `.md` version drops the navigation, scripts, and other page chrome, so tools get just the content — a fraction of the tokens of the rendered page, which is cheaper and faster to feed into a model. It works on every page, including the [CLI command reference](/reference/cli/commands/run.md) and the changelog.
+```bash
+curl https://docs.terragrunt.com/getting-started/install.md
+```
 
-Paste a `.md` link into Claude, Cursor, or your own retrieval pipeline to get a page exactly as written. It complements the existing [`llms.txt`](/llms.txt) and [`llms-full.txt`](/llms-full.txt) files with a precise, per-page source.
+The `.md` version contains the page content without the site navigation or other surrounding HTML, which makes it well suited as context for LLMs and AI tooling: it is smaller and carries only the documentation itself. Coverage includes every page, including the [CLI command reference](/reference/cli/commands/run.md) and the changelog.
+
+This complements the existing [`llms.txt`](/llms.txt) and [`llms-full.txt`](/llms-full.txt) files by providing a per-page Markdown source.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation pages are now accessible as clean Markdown by appending `.md` to any page URL, excluding site navigation and HTML markup. This covers all documentation including CLI command references and changelog, enabling easier programmatic access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->