### PR TITLE
docs: Support `.md` changelog files

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -61,7 +61,7 @@ const flags = defineCollection({
 });
 
 const changelog = defineCollection({
-	loader: glob({ pattern: "**/*.mdx", base: "src/data/changelog" }),
+	loader: glob({ pattern: "**/*.{md,mdx}", base: "src/data/changelog" }),
 	schema: z.object({
 		version: z.string(),
 		category: z.enum(CHANGELOG_CATEGORY_SLUGS),


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

An `.md` file was being used for a changelog update [here](https://github.com/gruntwork-io/terragrunt/pull/6258), which would have broken the changelog build.

That's pretty non-obvious to contributors, so this fixes it.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog file format support to include both markdown and MDX files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->