### PR TITLE
Fix #5054: support hcl_fmt in generate blocks

### DIFF
--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -1387,6 +1387,8 @@ The `generate` block supports the following arguments:
 - `disable_signature` (attribute): When `true`, disables including a signature in the generated file. This means that
   there will be no difference between `overwrite_terragrunt` and `overwrite` for the `if_exists` setting. Defaults to
   `false`. Optional.
+- `hcl_fmt` (attribute): When `false`, disables HCL formatting for generated `.tf`, `.hcl`, and `.tofu` files. Defaults
+  to `true`. Optional.
 - `contents` (attribute): The contents of the generated file.
 - `disable` (attribute): Disables this generate block.
 

--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -1388,7 +1388,7 @@ The `generate` block supports the following arguments:
 - `disable_signature` (attribute): When `true`, disables including a signature in the generated file. This means that
   there will be no difference between `overwrite_terragrunt` and `overwrite` for the `if_exists` setting. Defaults to
   `false`. Optional.
-<Since version="v1.0.9">
+<Since version="v1.0.8">
 
 - `hcl_fmt` (attribute): When `false`, disables HCL formatting for generated `.tf`, `.hcl`, and `.tofu` files. Defaults to `true`. Optional.
 

--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside } from '@astrojs/starlight/components';
-import { Since } from '@components/Since.astro';
+import Since from '@components/Since.astro';
 
 Terragrunt HCL configuration uses [configuration blocks](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#blocks) when there's a structural configuration that needs to be defined for Terragrunt.
 
@@ -1388,7 +1388,7 @@ The `generate` block supports the following arguments:
 - `disable_signature` (attribute): When `true`, disables including a signature in the generated file. This means that
   there will be no difference between `overwrite_terragrunt` and `overwrite` for the `if_exists` setting. Defaults to
   `false`. Optional.
-<Since version="v1.0.8">
+<Since version="1.0.8">
 
 - `hcl_fmt` (attribute): When `false`, disables HCL formatting for generated `.tf`, `.hcl`, and `.tofu` files. Defaults to `true`. Optional.
 

--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -8,6 +8,7 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside } from '@astrojs/starlight/components';
+import { Since } from '@components/Since.astro';
 
 Terragrunt HCL configuration uses [configuration blocks](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#blocks) when there's a structural configuration that needs to be defined for Terragrunt.
 
@@ -1387,8 +1388,12 @@ The `generate` block supports the following arguments:
 - `disable_signature` (attribute): When `true`, disables including a signature in the generated file. This means that
   there will be no difference between `overwrite_terragrunt` and `overwrite` for the `if_exists` setting. Defaults to
   `false`. Optional.
-- `hcl_fmt` (attribute): When `false`, disables HCL formatting for generated `.tf`, `.hcl`, and `.tofu` files. Defaults
-  to `true`. Optional.
+<Since version="v1.0.9">
+
+- `hcl_fmt` (attribute): When `false`, disables HCL formatting for generated `.tf`, `.hcl`, and `.tofu` files. Defaults to `true`. Optional.
+
+</Since>
+
 - `contents` (attribute): The contents of the generated file.
 - `disable` (attribute): Disables this generate block.
 

--- a/docs/src/data/changelog/v1.0.8/generate-hcl-fmt.mdx
+++ b/docs/src/data/changelog/v1.0.8/generate-hcl-fmt.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.0.9"
+version: "v1.0.8"
 category: "bug-fixes"
 ---
 

--- a/docs/src/data/changelog/v1.0.9/generate-hcl-fmt.mdx
+++ b/docs/src/data/changelog/v1.0.9/generate-hcl-fmt.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.0.9"
+category: "bug-fixes"
+---
+
+#### `generate` blocks now honor `hcl_fmt`
+
+Terragrunt now accepts `hcl_fmt` on `generate` blocks and preserves the setting when configurations are parsed, written, and parsed again. This lets generated `.tf`, `.hcl`, and `.tofu` files opt out of automatic HCL formatting by setting `hcl_fmt = false`, matching the existing `generate = { ... }` attribute-map behavior.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -723,6 +723,7 @@ type terragruntGenerateBlock struct {
 	CommentPrefix    *string `hcl:"comment_prefix,attr" mapstructure:"comment_prefix"`
 	DisableSignature *bool   `hcl:"disable_signature,attr" mapstructure:"disable_signature"`
 	Disable          *bool   `hcl:"disable,attr" mapstructure:"disable"`
+	HclFmt           *bool   `hcl:"hcl_fmt,attr" mapstructure:"hcl_fmt"`
 	Name             string  `hcl:",label" mapstructure:",omitempty"`
 	Path             string  `hcl:"path,attr" mapstructure:"path"`
 	IfExists         string  `hcl:"if_exists,attr" mapstructure:"if_exists"`
@@ -1854,6 +1855,7 @@ func convertToTerragruntConfig(ctx context.Context, pctx *ParsingContext, config
 		}
 
 		genConfig := codegen.GenerateConfig{
+			HclFmt:        block.HclFmt,
 			Path:          block.Path,
 			IfExists:      ifExists,
 			IfExistsStr:   block.IfExists,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -446,6 +446,10 @@ func (cfg *TerragruntConfig) WriteTo(w io.Writer) (int64, error) {
 			genBody.SetAttributeValue("disable", goboolToCty(gen.Disable))
 		}
 
+		if gen.HclFmt != nil {
+			genBody.SetAttributeValue("hcl_fmt", goboolToCty(*gen.HclFmt))
+		}
+
 		rootBody.AppendBlock(genBlock)
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1648,6 +1648,31 @@ func TestParseConfigGenerateBlockWithHclFmt(t *testing.T) {
 	assert.False(t, *generateConfig.HclFmt)
 }
 
+func TestParseConfigGenerateAttrWithHclFmt(t *testing.T) {
+	t.Parallel()
+
+	cfg := `generate = {
+  test = {
+    path = "test.tf"
+    if_exists = "overwrite"
+    contents = "test = 1"
+    hcl_fmt = false
+  }
+}`
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, terragruntConfig)
+
+	generateConfig, ok := terragruntConfig.GenerateConfigs["test"]
+	require.True(t, ok)
+	require.NotNil(t, generateConfig.HclFmt)
+	assert.False(t, *generateConfig.HclFmt)
+}
+
 func TestParseConfigWithMissingIfExists(t *testing.T) {
 	t.Parallel()
 
@@ -1867,6 +1892,7 @@ EOF
 	comment_prefix = "//"
 	disable_signature = true
 	disable = false
+	hcl_fmt = false
 }
 
 feature "test_feature" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1625,6 +1625,7 @@ func TestBestEffortParseConfigString(t *testing.T) {
 	}
 }
 
+// TestParseConfigGenerateBlockWithHclFmt verifies that hcl_fmt is parsed from generate blocks.
 func TestParseConfigGenerateBlockWithHclFmt(t *testing.T) {
 	t.Parallel()
 
@@ -1648,6 +1649,7 @@ func TestParseConfigGenerateBlockWithHclFmt(t *testing.T) {
 	assert.False(t, *generateConfig.HclFmt)
 }
 
+// TestParseConfigGenerateAttrWithHclFmt verifies that hcl_fmt is parsed from generate attribute maps.
 func TestParseConfigGenerateAttrWithHclFmt(t *testing.T) {
 	t.Parallel()
 
@@ -1757,6 +1759,7 @@ dependency "dep" {
 	}, terragruntConfig)
 }
 
+// TestWriteTo verifies that a parsed Terragrunt config can be written and parsed again without losing supported fields.
 func TestWriteTo(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1625,6 +1625,29 @@ func TestBestEffortParseConfigString(t *testing.T) {
 	}
 }
 
+func TestParseConfigGenerateBlockWithHclFmt(t *testing.T) {
+	t.Parallel()
+
+	cfg := `generate "test" {
+  path = "test.tf"
+  if_exists = "overwrite"
+  contents = "test = 1"
+  hcl_fmt = false
+}`
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, terragruntConfig)
+
+	generateConfig, ok := terragruntConfig.GenerateConfigs["test"]
+	require.True(t, ok)
+	require.NotNil(t, generateConfig.HclFmt)
+	assert.False(t, *generateConfig.HclFmt)
+}
+
 func TestParseConfigWithMissingIfExists(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1548,6 +1548,7 @@ func BenchmarkReadTerragruntConfig(b *testing.B) {
 	}
 }
 
+// TestBestEffortParseConfigString verifies that best-effort parsing returns a partial config when recoverable errors occur.
 func TestBestEffortParseConfigString(t *testing.T) {
 	t.Parallel()
 
@@ -1675,6 +1676,7 @@ func TestParseConfigGenerateAttrWithHclFmt(t *testing.T) {
 	assert.False(t, *generateConfig.HclFmt)
 }
 
+// TestParseConfigWithMissingIfExists verifies that generate blocks require the if_exists attribute.
 func TestParseConfigWithMissingIfExists(t *testing.T) {
 	t.Parallel()
 
@@ -2007,6 +2009,7 @@ inputs = {
 	assert.Equal(t, terragruntConfig.Inputs, rereadConfig.Inputs)
 }
 
+// TestWriteToExcludeNoRun verifies that the exclude no-run setting is preserved when writing config.
 func TestWriteToExcludeNoRun(t *testing.T) {
 	t.Parallel()
 
@@ -2031,6 +2034,7 @@ exclude {
 	assert.Contains(t, buf.String(), "no_run")
 }
 
+// TestWriteToCatalogFields verifies that catalog fields are written to config output.
 func TestWriteToCatalogFields(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #5054.

`hcl_fmt` is already supported by `codegen.GenerateConfig`, but the `generate` block parser did not accept or propagate the `hcl_fmt` attribute. As a result, a config like this failed with `Unsupported argument`:

```hcl
generate "test" {
  path      = "test.tf"
  if_exists = "overwrite"
  contents  = "test = 1"
  hcl_fmt   = false
}
```

This PR adds `hcl_fmt` to `terragruntGenerateBlock` and passes the parsed value through to `codegen.GenerateConfig` so users can disable automatic formatting for generated `.tf`, `.hcl`, and `.tofu` files.

Follow-up changes from review/contribution checklist:

- Serialize `hcl_fmt` in `TerragruntConfig.WriteTo` so parse -> write -> parse preserves the setting.
- Add coverage for the `generate = { ... }` attribute-map decode path.
- Document `hcl_fmt` in the `generate` block reference.
- Add a changelog entry.
- Verified the regression test is RED on `origin/main` and GREEN on this branch.

## Changes

- Parse `hcl_fmt` in `generate` blocks.
- Propagate `hcl_fmt` to `codegen.GenerateConfig`.
- Preserve `hcl_fmt` when writing generate blocks.
- Add regression tests for block syntax and attribute-map syntax.
- Update docs and changelog.

## Test Plan

- [x] RED regression check on `origin/main` worktree:
  - Added only `TestParseConfigGenerateBlockWithHclFmt` to a temporary `origin/main` worktree.
  - Ran `go test ./pkg/config -run TestParseConfigGenerateBlockWithHclFmt -count=1 -v`.
  - Confirmed it fails with `Unsupported argument; An argument named "hcl_fmt" is not expected here`.
- [x] `gofmt -w pkg/config/config.go pkg/config/config_test.go`
- [x] `E:\hermes\oss-contrib\go\bin\goimports.exe -w pkg/config/config.go pkg/config/config_test.go`
- [x] `git diff --check`
- [x] `go mod download -x charm.land/glamour/v2@v2.0.0`
- [x] `go test ./pkg/config -run 'TestParseConfigGenerate(Block|Attr)WithHclFmt|TestWriteTo' -count=1 -v`

Note: `pre-commit` and `make` are not installed in this Windows environment, so I ran the configured Go formatting hook equivalent directly with workspace-local `goimports`, plus `gofmt` and `git diff --check`. The local checksum issue with `charm.land/glamour/v2@v2.0.0` was resolved by running Go with an isolated cache under `E:\hermes\oss-contrib\go` and the public module proxy/sumdb (`GOPROXY=https://proxy.golang.org,direct`, `GOSUMDB=sum.golang.org`, `GONOSUMDB=`), avoiding the previously corrupted/local module cache state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hcl_fmt` attribute support on `generate` blocks. This optional attribute controls whether generated `.tf`, `.hcl`, and `.tofu` files are automatically formatted. Defaults to `true`; set to `false` to disable formatting.

* **Documentation**
  * Updated reference documentation for the `generate` block with the new `hcl_fmt` attribute details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->