### PR TITLE
fix: Fixing values without autoinclude

### DIFF
--- a/docs/src/data/changelog/v1.0.8/stack-dependencies-values-sibling-autoinclude.mdx
+++ b/docs/src/data/changelog/v1.0.8/stack-dependencies-values-sibling-autoinclude.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.0.8"
+category: "experiments-updated"
+---
+
+#### `stack-dependencies`: component path references in `values` no longer break next to `autoinclude` blocks
+
+A `unit` or `stack` block's `values` can reference `unit.<name>.path` and `stack.<name>.path` even when another block in the same `terragrunt.stack.hcl` declares an `autoinclude`. Previously, the presence of any `autoinclude` block made `stack generate` reject those references with `Unknown variable; There is no variable named "unit"`, while the same file without an `autoinclude` generated fine.

--- a/internal/hclparse/parse.go
+++ b/internal/hclparse/parse.go
@@ -96,6 +96,11 @@ func ParseStackFile(fs vfs.FS, input *ParseStackFileInput) (*ParseResult, error)
 		return result, err
 	}
 
+	// Publish unit.<name>.path / stack.<name>.path from a path-only pre-decode so the
+	// phase-4 decode can evaluate values expressions that reference sibling component
+	// paths, matching the production parse (injectStackComponentRefs in pkg/config).
+	publishComponentRefs(mergedRemain, evalCtx, input.StackDir)
+
 	// Phase 4 decodes unit/stack blocks and resolves autoincludes.
 	decoded := &unitsAndStacksHCL{}
 	if diags := gohcl.DecodeBody(mergedRemain, evalCtx, decoded); diags.HasErrors() {
@@ -112,9 +117,6 @@ func ParseStackFile(fs vfs.FS, input *ParseStackFileInput) (*ParseResult, error)
 	if err := validateUniqueNames(decoded); err != nil {
 		return result, err
 	}
-
-	evalCtx.Variables[VarUnit] = BuildComponentRefMap(buildUnitRefs(decoded.Units, input.StackDir))
-	evalCtx.Variables[VarStack] = BuildComponentRefMap(buildStackRefs(decoded.Stacks, input.StackDir))
 
 	autoIncludes, err := resolveAutoIncludes(decoded.Units, decoded.Stacks, evalCtx, srcByFilename)
 	if err != nil {
@@ -212,26 +214,22 @@ func validateUniqueNames(decoded *unitsAndStacksHCL) error {
 	return errors.Join(errs...)
 }
 
-// buildUnitRefs builds component refs for unit blocks; no_dot_terragrunt_stack hoists the unit out of .terragrunt-stack.
-func buildUnitRefs(units []*UnitBlockHCL, stackDir string) []ComponentRef {
-	refs := make([]ComponentRef, 0, len(units))
-
-	for _, u := range units {
-		refs = append(refs, ComponentRef{Name: u.Name, Path: u.GeneratedPath(stackDir)})
+// publishComponentRefs publishes unit.<name>.path and stack.<name>.path into evalCtx
+// from a path-only decode of body (the discovery shapes), leaving source, values, and
+// autoinclude content unevaluated. Running it before the phase-4 decode lets values
+// expressions reference sibling component paths, matching the production parse
+// (injectStackComponentRefs in pkg/config). A failed path-only decode publishes
+// nothing and reports no error: the phase-4 decode evaluates a superset of the same
+// attributes against the same context, so it surfaces the identical diagnostics
+// along with partial results.
+func publishComponentRefs(body hcl.Body, evalCtx *hcl.EvalContext, stackDir string) {
+	headers := &discoveryDecode{}
+	if diags := gohcl.DecodeBody(body, evalCtx, headers); diags.HasErrors() {
+		return
 	}
 
-	return refs
-}
-
-// buildStackRefs builds top-level component refs for stack blocks.
-func buildStackRefs(stacks []*StackBlockHCL, stackDir string) []ComponentRef {
-	refs := make([]ComponentRef, 0, len(stacks))
-
-	for _, s := range stacks {
-		refs = append(refs, ComponentRef{Name: s.Name, Path: s.GeneratedPath(stackDir)})
-	}
-
-	return refs
+	evalCtx.Variables[VarUnit] = BuildComponentRefMap(buildDiscoveryUnitRefs(headers.Units, stackDir))
+	evalCtx.Variables[VarStack] = BuildComponentRefMap(buildDiscoveryStackRefs(headers.Stacks, stackDir))
 }
 
 // maxLocalsIterations bounds the fixed-point loop in evaluateLocals as a safeguard against pathological inputs.

--- a/internal/hclparse/parse_test.go
+++ b/internal/hclparse/parse_test.go
@@ -153,6 +153,99 @@ unit "app" {
 	assert.Equal(t, filepath.Join(testStackDir, ".terragrunt-stack", "networking"), resolved.Dependencies[0].ConfigPath)
 }
 
+// TestParseStackFile_ComponentRefInValuesWithSiblingAutoInclude reproduces the
+// regression where a stack block's values referencing unit.<name>.path failed with
+// "There is no variable named \"unit\"" whenever the same file contained an
+// autoinclude block: the phase-4 decode evaluated values before the component refs
+// were published.
+func TestParseStackFile_ComponentRefInValuesWithSiblingAutoInclude(t *testing.T) {
+	t.Parallel()
+
+	src := `
+unit "a" {
+  source = "../catalog/units/a"
+  path   = "a"
+}
+
+stack "b" {
+  source = "../catalog/stacks/b"
+  path   = "b"
+
+  values = {
+    a_path = unit.a.path
+  }
+}
+
+unit "c" {
+  source = "../catalog/units/c"
+  path   = "c"
+
+  autoinclude {
+    dependency "a" {
+      config_path = unit.a.path
+    }
+
+    inputs = {
+      v = dependency.a.outputs.v
+    }
+  }
+}
+`
+
+	result, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{Src: []byte(src), Filename: "terragrunt.stack.hcl", StackDir: testStackDir})
+	require.NoError(t, err)
+	require.Len(t, result.Units, 2)
+	require.Len(t, result.Stacks, 1)
+
+	require.NotNil(t, result.Stacks[0].Values)
+	aPath := result.Stacks[0].Values.GetAttr("a_path")
+	assert.Equal(t, cty.StringVal(filepath.Join(testStackDir, ".terragrunt-stack", "a")), aPath,
+		"stack values must resolve unit.a.path even when a sibling autoinclude block is present")
+
+	resolved, ok := result.AutoIncludes[hclparse.AutoIncludeKey("unit", "c")]
+	require.True(t, ok)
+	require.Len(t, resolved.Dependencies, 1)
+	assert.Equal(t, filepath.Join(testStackDir, ".terragrunt-stack", "a"), resolved.Dependencies[0].ConfigPath)
+}
+
+// TestParseStackFile_UnitValuesStackRefWithSiblingAutoInclude covers the mirrored
+// shape: a unit block's values referencing stack.<name>.path alongside an
+// autoinclude elsewhere in the file.
+func TestParseStackFile_UnitValuesStackRefWithSiblingAutoInclude(t *testing.T) {
+	t.Parallel()
+
+	src := `
+stack "networking" {
+  source = "../stacks/networking"
+  path   = "networking"
+}
+
+unit "app" {
+  source = "../catalog/units/app"
+  path   = "app"
+
+  values = {
+    net_path = stack.networking.path
+  }
+
+  autoinclude {
+    dependency "networking" {
+      config_path = stack.networking.path
+    }
+  }
+}
+`
+
+	result, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{Src: []byte(src), Filename: "terragrunt.stack.hcl", StackDir: testStackDir})
+	require.NoError(t, err)
+	require.Len(t, result.Units, 1)
+
+	require.NotNil(t, result.Units[0].Values)
+	netPath := result.Units[0].Values.GetAttr("net_path")
+	assert.Equal(t, cty.StringVal(filepath.Join(testStackDir, ".terragrunt-stack", "networking")), netPath,
+		"unit values must resolve stack.networking.path even when an autoinclude block is present")
+}
+
 func TestParseStackFile_NoAutoInclude(t *testing.T) {
 	t.Parallel()
 

--- a/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/stacks/child/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/stacks/child/terragrunt.stack.hcl
@@ -1,0 +1,19 @@
+unit "consumer" {
+  source = "${get_repo_root()}/catalog/units/consumer"
+  path   = "consumer"
+
+  autoinclude {
+    dependency "producer" {
+      config_path = values.producer_path
+
+      mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+      mock_outputs = {
+        val = "mock-val"
+      }
+    }
+
+    inputs = {
+      val = dependency.producer.outputs.val
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/consumer/main.tf
+++ b/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/consumer/main.tf
@@ -1,0 +1,12 @@
+variable "val" {
+  type = string
+}
+
+resource "local_file" "marker" {
+  content  = "consumer received: ${var.val}"
+  filename = "${path.module}/input.txt"
+}
+
+output "received" {
+  value = var.val
+}

--- a/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/consumer/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/consumer/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/producer/main.tf
+++ b/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/producer/main.tf
@@ -1,0 +1,8 @@
+resource "local_file" "marker" {
+  content  = "producer"
+  filename = "${path.module}/marker.txt"
+}
+
+output "val" {
+  value = "produced-across-levels"
+}

--- a/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/producer/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/producer/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/live/terragrunt.stack.hcl
@@ -1,0 +1,36 @@
+# Same cross-level shape as stack-deps-cross-level-values, plus a sibling unit
+# carrying its own autoinclude in the parent file. The sibling autoinclude used
+# to break unit.producer.path resolution inside the stack block's values.
+unit "producer" {
+  source = "../catalog/units/producer"
+  path   = "producer"
+}
+
+stack "child" {
+  source = "../catalog/stacks/child"
+  path   = "child"
+
+  values = {
+    producer_path = unit.producer.path
+  }
+}
+
+unit "sibling" {
+  source = "../catalog/units/consumer"
+  path   = "sibling"
+
+  autoinclude {
+    dependency "producer" {
+      config_path = unit.producer.path
+
+      mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+      mock_outputs = {
+        val = "mock-val"
+      }
+    }
+
+    inputs = {
+      val = dependency.producer.outputs.val
+    }
+  }
+}

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -65,6 +65,7 @@ const (
 	testFixtureStackDepsMockLocal                = "fixtures/stacks/stack-deps-mock-local"
 	testFixtureStackDepsAutoIncValuesResolved    = "fixtures/stacks/stack-deps-autoinclude-values-resolved"
 	testFixtureStackDepsAutoIncFuncs             = "fixtures/stacks/stack-deps-autoinclude-funcs"
+	testFixtureStackDepsValuesSiblingAutoInc     = "fixtures/stacks/stack-deps-values-sibling-autoinclude"
 )
 
 // TestStackDepsAutoIncludeGenerationAndDAG tests parsing, autoinclude generation,
@@ -2072,6 +2073,51 @@ func TestStackDepsCrossLevelViaValues(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "consumer received: produced-across-levels", string(inputContent),
 		"consumer must receive the producer's output across stack levels")
+
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- destroy -auto-approve")
+}
+
+// TestStackDepsValuesRefWithSiblingAutoInclude reproduces the regression where a stack
+// block's values referencing unit.<name>.path failed generation with "There is no
+// variable named \"unit\"" whenever the same terragrunt.stack.hcl carried a sibling
+// unit with an autoinclude block. Both the child stack's consumer (wired via values)
+// and the sibling (wired via its own autoinclude) must receive the producer's output.
+func TestStackDepsValuesRefWithSiblingAutoInclude(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsValuesSiblingAutoInc)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsValuesSiblingAutoInc)
+	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsValuesSiblingAutoInc)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
+
+	rootPath := filepath.Join(gitPath, "live")
+	rootPath, err = filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	consumerDir := filepath.Join(rootPath, inthclparse.StackDir, "child", inthclparse.StackDir, "consumer")
+	require.FileExists(t, filepath.Join(consumerDir, inthclparse.AutoIncludeFile),
+		"consumer in the child stack must get an autoinclude wired to the parent's producer")
+
+	siblingDir := filepath.Join(rootPath, inthclparse.StackDir, "sibling")
+	require.FileExists(t, filepath.Join(siblingDir, inthclparse.AutoIncludeFile),
+		"the sibling unit's own autoinclude must still generate")
+
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- apply -auto-approve")
+
+	consumerInput, err := os.ReadFile(helpers.FindCachedFile(t, consumerDir, "input.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "consumer received: produced-across-levels", string(consumerInput),
+		"consumer must receive the producer's output across stack levels despite the sibling autoinclude")
+
+	siblingInput, err := os.ReadFile(helpers.FindCachedFile(t, siblingDir, "input.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "consumer received: produced-across-levels", string(siblingInput),
+		"the sibling unit must receive the producer's output via its own autoinclude")
 
 	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- destroy -auto-approve")
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6288

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where component path references in `values` attributes (e.g., `unit.<name>.path`, `stack.<name>.path`) would fail with an `Unknown variable` error when sibling blocks contained `autoinclude` declarations.

* **Tests**
  * Added integration tests and fixtures validating component path references resolve correctly with sibling autoinclude configurations.

* **Documentation**
  * Updated changelog documenting the fix for stack-dependencies values path references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->