### PR TITLE
fix: Fixing values references in locals of `terragrunt.stack.hcl` files

### DIFF
--- a/docs/src/data/changelog/v1.0.8/stack-dependencies-values-in-locals.mdx
+++ b/docs/src/data/changelog/v1.0.8/stack-dependencies-values-in-locals.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.8"
+category: "experiments-updated"
+---
+
+#### `stack-dependencies`: stack dependencies resolve `values.*` in the target stack's locals
+
+Expanding a dependency that points at a generated stack directory no longer fails when that stack's `terragrunt.stack.hcl` reads `values.*` in its `locals` block. Previously, `terragrunt stack generate` succeeded but `terragrunt run --all` then failed with `There is no variable named "values"` while expanding the dependency into its units.
+
+Dependency expansion now reads the generated `terragrunt.values.hcl` next to each `terragrunt.stack.hcl` it visits, including nested stacks, so each nesting level resolves `values.*` from its own values file, the same way a full stack parse does.

--- a/internal/hclparse/stack.go
+++ b/internal/hclparse/stack.go
@@ -19,6 +19,12 @@ import (
 // stackFileName is the canonical filename of a Terragrunt stack file.
 const stackFileName = "terragrunt.stack.hcl"
 
+// valuesFileName is the canonical filename of the generated values file that stack
+// generation writes next to a generated terragrunt.stack.hcl. It mirrors the
+// constant pkg/config uses when writing the file; the two packages cannot share it
+// because internal/hclparse must not depend on pkg/config.
+const valuesFileName = "terragrunt.values.hcl"
+
 // StackFileHCL is the parsed skeleton: locals, includes, and Remain.
 type StackFileHCL struct {
 	Remain   hcl.Body           `hcl:",remain"`
@@ -312,6 +318,19 @@ func decodeDiscovery(fs vfs.FS, stackDir, stackFile string, funcs map[string]fun
 		Variables: map[string]cty.Value{},
 	}
 
+	// Load the sibling terragrunt.values.hcl written by stack generation and publish it
+	// as the `values` variable, so locals (and unit/stack attributes) referencing
+	// values.* resolve during discovery exactly as they do in the full stack parse.
+	// An absent file leaves the variable unset, matching a stack that received no values.
+	values, err := readDiscoveryValues(fs, stackDir, funcs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if values != nil {
+		evalCtx.Variables[varValues] = *values
+	}
+
 	if parsedFile.Locals != nil {
 		if err := evaluateLocals(parsedFile.Locals.Remain, evalCtx); err != nil {
 			return nil, nil, err
@@ -357,6 +376,49 @@ func decodeDiscovery(fs vfs.FS, stackDir, stackFile string, funcs map[string]fun
 	}
 
 	return decoded.Units, decoded.Stacks, nil
+}
+
+// readDiscoveryValues reads the generated terragrunt.values.hcl next to a stack file
+// and decodes its top-level attributes into a single HCL object, mirroring how
+// pkg/config's ReadValues interprets the file during a full stack parse. An absent
+// file returns (nil, nil) so the caller leaves the `values` variable unset; an
+// existing but empty file returns an empty object, matching the full parse.
+//
+// funcs is the same dir-scoped function map used for the rest of discovery, so any
+// function call in a (normally literal-only, generated) values file resolves
+// against the stack directory being expanded.
+func readDiscoveryValues(fs vfs.FS, stackDir string, funcs map[string]function.Function) (*cty.Value, error) {
+	valuesPath := filepath.Join(stackDir, valuesFileName)
+
+	data, err := vfs.ReadFile(fs, valuesPath)
+	if err != nil {
+		if errors.Is(err, iofs.ErrNotExist) {
+			return nil, nil
+		}
+
+		return nil, FileReadError{FilePath: valuesPath, Err: err}
+	}
+
+	file, parseDiags := hclsyntax.ParseConfig(data, valuesPath, hcl.Pos{Line: 1, Column: 1})
+	if parseDiags.HasErrors() {
+		return nil, FileParseError{FilePath: valuesPath, Err: parseDiags}
+	}
+
+	evalCtx := &hcl.EvalContext{
+		Functions: funcs,
+		Variables: map[string]cty.Value{},
+	}
+
+	// Decoding into a map evaluates every top-level attribute and rejects blocks,
+	// the same shape pkg/config's ReadValues decodes.
+	values := map[string]cty.Value{}
+	if diags := gohcl.DecodeBody(file.Body, evalCtx, &values); diags.HasErrors() {
+		return nil, FileDecodeError{Name: valuesPath, Err: diags}
+	}
+
+	result := cty.ObjectVal(values)
+
+	return &result, nil
 }
 
 // mergeDiscoveryStackAutoInclude merges the units and stacks declared by a sibling

--- a/internal/hclparse/stack_test.go
+++ b/internal/hclparse/stack_test.go
@@ -80,6 +80,140 @@ func TestUnitPathsFromStackDir_RecursesNestedStacks(t *testing.T) {
 	assert.Equal(t, []string{filepath.Join("/test", ".terragrunt-stack", "more", ".terragrunt-stack", "deep")}, paths)
 }
 
+// TestUnitPathsFromStackDir_ValuesFileResolvesLocals pins that discovery loads the
+// generated terragrunt.values.hcl next to the stack file and publishes it as the
+// `values` variable, so a stack whose locals reference values.* expands instead of
+// failing with an unknown "values" variable (the gruntwork-io/terragrunt#5663 repro).
+func TestUnitPathsFromStackDir_ValuesFileResolvesLocals(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, fs.MkdirAll("/test", 0755))
+	require.NoError(t, vfs.WriteFile(fs, "/test/terragrunt.stack.hcl", []byte(`locals {
+  env = values.env
+}
+
+unit "vpc" {
+  source = "../units/vpc"
+  path   = "${local.env}-vpc"
+}
+`), 0644))
+	require.NoError(t, vfs.WriteFile(fs, "/test/terragrunt.values.hcl", []byte(`env = "dev"
+`), 0644))
+
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	require.NoError(t, err, "locals referencing values.* must resolve when a sibling terragrunt.values.hcl exists")
+	assert.Equal(t, []string{filepath.Join("/test", ".terragrunt-stack", "dev-vpc")}, paths,
+		"the values file content must feed the local and therefore the generated unit path")
+}
+
+// TestUnitPathsFromStackDir_NoValuesFileLocalsStillResolve pins that a stack without a
+// sibling values file still expands when its locals do not reference values.*.
+func TestUnitPathsFromStackDir_NoValuesFileLocalsStillResolve(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, fs.MkdirAll("/test", 0755))
+	require.NoError(t, vfs.WriteFile(fs, "/test/terragrunt.stack.hcl", []byte(`locals {
+  env = "prod"
+}
+
+unit "vpc" {
+  source = "../units/vpc"
+  path   = "${local.env}-vpc"
+}
+`), 0644))
+
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{filepath.Join("/test", ".terragrunt-stack", "prod-vpc")}, paths)
+}
+
+// TestUnitPathsFromStackDir_ValuesReferenceWithoutFileFails pins that referencing
+// values.* without a sibling values file still fails with a typed local-eval error,
+// the same as a full stack parse that received no values.
+func TestUnitPathsFromStackDir_ValuesReferenceWithoutFileFails(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, fs.MkdirAll("/test", 0755))
+	require.NoError(t, vfs.WriteFile(fs, "/test/terragrunt.stack.hcl", []byte(`locals {
+  env = values.env
+}
+
+unit "vpc" {
+  source = "../units/vpc"
+  path   = "${local.env}-vpc"
+}
+`), 0644))
+
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	require.Error(t, err, "values.* without a sibling values file must fail, matching a full parse with no values")
+
+	var typed hclparse.LocalEvalError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "env", typed.Name)
+}
+
+// TestUnitPathsFromStackDir_NestedStackOwnValuesFile pins that values files are loaded
+// per stack directory during nested expansion: the parent and the nested stack each
+// resolve values.* from their own sibling terragrunt.values.hcl.
+func TestUnitPathsFromStackDir_NestedStackOwnValuesFile(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, fs.MkdirAll("/test", 0755))
+	require.NoError(t, vfs.WriteFile(fs, "/test/terragrunt.stack.hcl", []byte(`locals {
+  env = values.env
+}
+
+stack "more" {
+  source = "."
+  path   = "${local.env}-more"
+}
+`), 0644))
+	require.NoError(t, vfs.WriteFile(fs, "/test/terragrunt.values.hcl", []byte(`env = "dev"
+`), 0644))
+	// The nested generated dir carries its own values file with a different value.
+	require.NoError(t, vfs.WriteFile(fs, "/test/.terragrunt-stack/dev-more/terragrunt.stack.hcl", []byte(`locals {
+  env = values.env
+}
+
+unit "deep" {
+  source = "."
+  path   = "${local.env}-deep"
+}
+`), 0644))
+	require.NoError(t, vfs.WriteFile(fs, "/test/.terragrunt-stack/dev-more/terragrunt.values.hcl", []byte(`env = "stage"
+`), 0644))
+
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{filepath.Join("/test", ".terragrunt-stack", "dev-more", ".terragrunt-stack", "stage-deep")}, paths,
+		"each nesting level must resolve values.* from its own sibling values file")
+}
+
+// TestUnitPathsFromStackDir_MalformedValuesFileReturnsError pins that a corrupt sibling
+// values file surfaces a typed parse error instead of being silently skipped.
+func TestUnitPathsFromStackDir_MalformedValuesFileReturnsError(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, fs.MkdirAll("/test", 0755))
+	require.NoError(t, vfs.WriteFile(fs, "/test/terragrunt.stack.hcl", []byte(`unit "vpc" {
+  source = "../units/vpc"
+  path   = "vpc"
+}
+`), 0644))
+	require.NoError(t, vfs.WriteFile(fs, "/test/terragrunt.values.hcl", []byte(`env = `), 0644))
+
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	require.Error(t, err)
+
+	var typed hclparse.FileParseError
+	require.ErrorAs(t, err, &typed)
+}
+
 // TestUnitPathsFromStackDir_MergesStackAutoInclude pins that discovery folds a sibling
 // terragrunt.autoinclude.stack.hcl into expansion, so a unit injected by a stack-level autoinclude
 // produces a DAG edge the same way a full stack parse materializes it.

--- a/test/fixtures/stacks/stack-deps-stack-values-locals/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-values-locals/live/terragrunt.stack.hcl
@@ -1,0 +1,35 @@
+# Cross-stack dependency where the child stack's terragrunt.stack.hcl reads
+# values.* in its locals. The parent passes values to the stack block, so stack
+# generation writes a terragrunt.values.hcl next to the generated child stack
+# file; run-queue expansion of the stack-dir dependency must load it.
+
+stack "network" {
+  source = "../stacks/network"
+  path   = "network"
+
+  values = {
+    env = "dev"
+  }
+}
+
+unit "app" {
+  source = "../units/app"
+  path   = "app"
+
+  autoinclude {
+    dependency "network" {
+      config_path = stack.network.path
+
+      mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+      mock_outputs = {
+        vpc = {
+          vpc_id = "mock-vpc"
+        }
+      }
+    }
+
+    inputs = {
+      vpc_id = dependency.network.outputs.vpc.vpc_id
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-stack-values-locals/stacks/network/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-values-locals/stacks/network/terragrunt.stack.hcl
@@ -1,0 +1,8 @@
+locals {
+  env = values.env
+}
+
+unit "vpc" {
+  source = "${get_repo_root()}/units/vpc"
+  path   = "${local.env}-vpc"
+}

--- a/test/fixtures/stacks/stack-deps-stack-values-locals/units/app/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-values-locals/units/app/main.tf
@@ -1,0 +1,7 @@
+variable "vpc_id" {
+  type = string
+}
+
+output "status" {
+  value = "running-on-${var.vpc_id}"
+}

--- a/test/fixtures/stacks/stack-deps-stack-values-locals/units/app/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-values-locals/units/app/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-stack-values-locals/units/vpc/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-values-locals/units/vpc/main.tf
@@ -1,0 +1,3 @@
+output "vpc_id" {
+  value = "vpc-values-locals"
+}

--- a/test/fixtures/stacks/stack-deps-stack-values-locals/units/vpc/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-values-locals/units/vpc/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -66,6 +66,7 @@ const (
 	testFixtureStackDepsAutoIncValuesResolved    = "fixtures/stacks/stack-deps-autoinclude-values-resolved"
 	testFixtureStackDepsAutoIncFuncs             = "fixtures/stacks/stack-deps-autoinclude-funcs"
 	testFixtureStackDepsValuesSiblingAutoInc     = "fixtures/stacks/stack-deps-values-sibling-autoinclude"
+	testFixtureStackDepsStackValuesLocals        = "fixtures/stacks/stack-deps-stack-values-locals"
 )
 
 // TestStackDepsAutoIncludeGenerationAndDAG tests parsing, autoinclude generation,
@@ -745,6 +746,41 @@ func TestStackDepsE2ECrossStack(t *testing.T) {
 		"app must receive the network stack's real vpc output, not the mock")
 
 	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- destroy -auto-approve")
+}
+
+// TestStackDepsStackValuesInLocals pins that run-queue expansion of a stack-dir
+// dependency resolves values.* referenced in the target stack's locals from the
+// generated terragrunt.values.hcl sitting next to the generated terragrunt.stack.hcl,
+// instead of failing with an unknown "values" variable (gruntwork-io/terragrunt#5663).
+func TestStackDepsStackValuesInLocals(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsStackValuesLocals)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackValuesLocals)
+	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackValuesLocals)
+
+	// The child stack uses get_repo_root() for unit sources, so the fixture copy must be a git repo.
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	err = runner.WithWorkDir(gitPath).Init(t.Context())
+	require.NoError(t, err)
+
+	rootPath := filepath.Join(gitPath, "live")
+	rootPath, err = filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --experiment stack-dependencies --working-dir "+rootPath)
+
+	// Generation wrote the child stack's values file and its locals consumed it: the
+	// generated unit dir carries the env prefix from values.env.
+	networkDir := filepath.Join(rootPath, inthclparse.StackDir, "network")
+	require.FileExists(t, filepath.Join(networkDir, "terragrunt.values.hcl"))
+	require.DirExists(t, filepath.Join(networkDir, inthclparse.StackDir, "dev-vpc"))
+
+	// Run-queue expansion of app's stack-dir dependency re-evaluates the child stack's
+	// locals; it must load the sibling values file rather than fail on values.env.
+	helpers.RunTerragrunt(t, "terragrunt run --all --non-interactive --experiment stack-dependencies --working-dir "+rootPath+" -- plan")
 }
 
 // Regression: a non-literal expression (here, format()) in an unrelated unit must not block autoinclude resolution. Generation succeeds and the autoinclude file is produced for the unit that declares it.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6289.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stack dependency expansion now resolves values.* references in stack locals by loading sibling generated values files at each nesting level.

* **Tests**
  * Added unit and integration tests covering values file resolution: nested stacks, missing files, malformed files, and end-to-end stack generation/run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->