### PR TITLE
fix: Fixing experiment promotion

### DIFF
--- a/docs/src/data/changelog/v1.0.8/completed-experiments-evaluate-enabled.mdx
+++ b/docs/src/data/changelog/v1.0.8/completed-experiments-evaluate-enabled.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.8"
+category: "bug-fixes"
+---
+
+#### Completed experiments now evaluate as permanently enabled
+
+Features gated behind a completed experiment were treated as disabled instead of permanently enabled, so functionality that graduated out of experiment status could silently stop working.
+
+The one affected code path was `hcl validate --inputs` with a git filter expression such as `--filter '[HEAD~1...HEAD]'`: after the `filter-flag` experiment completed, the command stopped preparing git worktrees for the filter. Git filter expressions now work with `hcl validate --inputs` again, matching `find`, `list`, and the other commands that accept filters.

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 
 	"github.com/google/shlex"
@@ -258,23 +257,23 @@ func RunValidateInputs(ctx context.Context, l log.Logger, v run.Venv, opts *opti
 		return err
 	}
 
-	if opts.Experiments.Evaluate(experiment.FilterFlag) {
-		gitFilters := opts.Filters.UniqueGitFilters()
+	// We do worktree generation here instead of in the discovery constructor
+	// so that we can defer cleanup in the same context.
+	gitFilters := opts.Filters.UniqueGitFilters()
 
-		worktrees, worktreeErr := worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{WorkingDir: opts.WorkingDir, GitExpressions: gitFilters, Experiments: opts.Experiments})
-		if worktreeErr != nil {
-			return fmt.Errorf("failed to create worktrees: %w", worktreeErr)
-		}
-
-		defer func() {
-			cleanupErr := worktrees.Cleanup(ctx, l)
-			if cleanupErr != nil {
-				l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
-			}
-		}()
-
-		d = d.WithWorktrees(worktrees)
+	worktrees, worktreeErr := worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{WorkingDir: opts.WorkingDir, GitExpressions: gitFilters, Experiments: opts.Experiments})
+	if worktreeErr != nil {
+		return fmt.Errorf("failed to create worktrees: %w", worktreeErr)
 	}
+
+	defer func() {
+		cleanupErr := worktrees.Cleanup(ctx, l)
+		if cleanupErr != nil {
+			l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
+		}
+	}()
+
+	d = d.WithWorktrees(worktrees)
 
 	components, err := d.Discover(ctx, l, opts)
 	if err != nil {

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -231,9 +231,11 @@ func (exps Experiments) NotifyCompletedExperiments(logger log.Logger) {
 	logger.Warnf("%s", NewCompletedExperimentsWarning(completed.Names()).String())
 }
 
-// Evaluate returns true if the experiment is found and enabled otherwise returns false.
+// Evaluate returns true if the experiment is found and evaluates to true, otherwise returns false.
+//
+// Completed experiments evaluate to true, per [Experiment.Evaluate].
 func (exps Experiments) Evaluate(name string) bool {
-	if experiment := exps.FilterByStatus(StatusOngoing).Find(name); experiment != nil {
+	if experiment := exps.Find(name); experiment != nil {
 		return experiment.Evaluate()
 	}
 

--- a/internal/experiment/experiment_test.go
+++ b/internal/experiment/experiment_test.go
@@ -47,6 +47,74 @@ func TestOptionalHooksIsOngoing(t *testing.T) {
 	assert.False(t, got.Evaluate(), "optional-hooks must be disabled by default")
 }
 
+func TestEvaluate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		experiment  string
+		experiments experiment.Experiments
+		want        bool
+	}{
+		{
+			name: "ongoing disabled",
+			experiments: experiment.Experiments{
+				{
+					Name: testOngoingA,
+				},
+			},
+			experiment: testOngoingA,
+			want:       false,
+		},
+		{
+			name: "ongoing enabled",
+			experiments: experiment.Experiments{
+				{
+					Name:    testOngoingA,
+					Enabled: true,
+				},
+			},
+			experiment: testOngoingA,
+			want:       true,
+		},
+		{
+			name: "completed evaluates as permanently enabled",
+			experiments: experiment.Experiments{
+				{
+					Name:   testCompletedA,
+					Status: experiment.StatusCompleted,
+				},
+			},
+			experiment: testCompletedA,
+			want:       true,
+		},
+		{
+			name: "unknown experiment",
+			experiments: experiment.Experiments{
+				{
+					Name: testOngoingA,
+				},
+			},
+			experiment: "unknown",
+			want:       false,
+		},
+		{
+			name:        "promoted filter-flag experiment",
+			experiments: experiment.NewExperiments(),
+			experiment:  experiment.FilterFlag,
+			want:        true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, tc.experiments.Evaluate(tc.experiment))
+		})
+	}
+}
+
 func TestValidateExperiments(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

We didn't encounter any bugs here because we usually remove experiments when they're completed.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where features gated behind completed experiments were incorrectly remaining disabled. These features are now properly treated as permanently enabled once their experiments complete.
  * Restored git filter expression support in `hcl validate --inputs`, ensuring filter behavior is consistent across filter-capable commands.

* **Tests**
  * Added comprehensive test coverage for experiment evaluation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->