### PR TITLE
fix: Adding support for submodules in CAS

### DIFF
--- a/docs/src/content/docs/03-features/07-caching/04-cas/02-git.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/02-git.mdx
@@ -47,6 +47,14 @@ Git is unique among the getters in that a cache miss is not always all-or-nothin
 
 When the commit hash is already keyed in the store, Terragrunt reads the tree and hard links its blobs into the target without fetching again from the remote. For a pinned commit SHA that is already cached, even the ref-resolution step stays offline.
 
+## Submodules
+
+A submodule is recorded in the parent repository as a pointer to a commit in another repository. During a fetch, Terragrunt reads the submodule URL from `.gitmodules`, fetches the pinned commit from that URL into the same central store layout, and materializes the submodule contents in place. Nested submodules are handled the same way, and relative URLs (such as `../sibling.git`) are resolved against the parent repository URL.
+
+Each submodule tree is keyed by its pinned commit hash, so submodule contents are deduplicated like any other content: two repositories pinning the same submodule commit share one stored tree, and a submodule that does not change between parent commits is never fetched again.
+
+A committed submodule path with no `.gitmodules` entry (typically an accidentally committed nested repository) becomes an empty directory, the same result a plain `git clone` produces.
+
 ## Fallback behavior
 
 Concurrent units that target the same remote URL share one Git fetch instead of cloning in parallel. If that shared fetch through the central repository hangs or fails, Terragrunt logs a warning and falls back to a plain clone in a temporary directory. If the host cannot hard link from the store (for example across a filesystem boundary), Terragrunt copies the content instead.

--- a/docs/src/data/changelog/v1.0.8/cas-submodule-support.mdx
+++ b/docs/src/data/changelog/v1.0.8/cas-submodule-support.mdx
@@ -1,0 +1,16 @@
+---
+version: "v1.0.8"
+category: "experiments-updated"
+---
+
+#### `cas` — Repositories with submodules now clone correctly
+
+Cloning a repository that contains git submodules through the Content Addressable Store failed while ingesting the repository:
+
+```text
+git_cat_file: fatal: Not a valid object name <hash>
+```
+
+A submodule appears in the repository tree as a pointer to a commit in another repository, so the object behind it cannot be read from the repository being cloned.
+
+The CAS now fetches each submodule from the URL registered in `.gitmodules` at its pinned commit and materializes its contents in place, including nested submodules. Relative submodule URLs (such as `../sibling.git`) are resolved against the parent repository URL, matching git's behavior. Submodule contents are stored and deduplicated like any other content, so repeated clones reuse the cache.

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -332,7 +332,7 @@ func (c *CAS) populateTreeFromSymbolicRef(
 
 		runner := v.Git.WithWorkDir(repo.Path)
 
-		return c.storeRootTreeFrom(ctx, l, v, runner, ref.Hash, opts)
+		return c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, ref.Hash, opts)
 	}
 
 	l.Warnf("central git store unavailable for %s, falling back to temporary clone: %v", ref.URL, err)
@@ -350,7 +350,7 @@ func (c *CAS) populateTreeFromSymbolicRef(
 		return err
 	}
 
-	return c.storeRootTreeFrom(ctx, l, v, runner, ref.Hash, opts)
+	return c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, ref.Hash, opts)
 }
 
 // populateTreeFromCommitRef resolves ref via [GitStore.EnsureCommit]
@@ -374,7 +374,7 @@ func (c *CAS) populateTreeFromCommitRef(
 
 		runner := v.Git.WithWorkDir(repo.Path)
 
-		if err := c.storeRootTreeFrom(ctx, l, v, runner, repo.Hash, opts); err != nil {
+		if err := c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, repo.Hash, opts); err != nil {
 			return "", err
 		}
 
@@ -417,7 +417,7 @@ func (c *CAS) populateTreeFromCommitRef(
 		return canonicalHash, nil
 	}
 
-	if err := c.storeRootTreeFrom(ctx, l, v, runner, canonicalHash, opts); err != nil {
+	if err := c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, canonicalHash, opts); err != nil {
 		return "", err
 	}
 
@@ -549,13 +549,15 @@ func looksLikeFullSHA(s string) bool {
 // storeRootTreeFrom reads the recursive tree at hash from the supplied
 // runner's working repository and stores its tree and reachable blobs in
 // the CAS. The runner must already have its WorkDir pointed at a bare repo
-// (or worktree) that contains the requested object.
+// (or worktree) that contains the requested object. url is the remote the
+// repository came from; submodule ingestion resolves relative .gitmodules
+// URLs against it.
 func (c *CAS) storeRootTreeFrom(
 	ctx context.Context,
 	l log.Logger,
 	v Venv,
 	runner *git.GitRunner,
-	hash string,
+	url, hash string,
 	opts *CloneOptions,
 ) error {
 	tree, err := runner.LsTreeRecursive(ctx, hash)
@@ -563,7 +565,7 @@ func (c *CAS) storeRootTreeFrom(
 		return err
 	}
 
-	if err = c.storeTreeRecursive(ctx, l, v, runner, hash, tree); err != nil {
+	if err = c.storeTreeRecursive(ctx, l, v, runner, url, hash, tree); err != nil {
 		return err
 	}
 
@@ -609,13 +611,15 @@ func (c *CAS) storeRootTreeFrom(
 	return treeContent.Store(l, v, hash, data)
 }
 
-// storeTreeRecursive stores a tree fetched from git ls-tree -r.
+// storeTreeRecursive stores a tree fetched from git ls-tree -r. The tree
+// object is written last so a tree-store hit implies every blob and
+// submodule tree it references is already present.
 func (c *CAS) storeTreeRecursive(
 	ctx context.Context,
 	l log.Logger,
 	v Venv,
 	runner *git.GitRunner,
-	hash string,
+	url, hash string,
 	tree *git.Tree,
 ) error {
 	if !c.treeStore.NeedsWrite(v, hash) {
@@ -623,6 +627,10 @@ func (c *CAS) storeTreeRecursive(
 	}
 
 	if err := c.storeBlobs(ctx, v, runner, tree.Entries()); err != nil {
+		return err
+	}
+
+	if err := c.storeSubmodules(ctx, l, v, runner, url, tree); err != nil {
 		return err
 	}
 
@@ -634,9 +642,16 @@ func (c *CAS) storeTreeRecursive(
 	return nil
 }
 
-// storeBlobs stores blobs in the CAS.
+// storeBlobs stores blobs in the CAS. Gitlink entries (type "commit")
+// name objects that live in another repository entirely, so only blob
+// entries are written; submodule contents arrive via
+// [CAS.storeSubmodules].
 func (c *CAS) storeBlobs(ctx context.Context, v Venv, runner *git.GitRunner, entries []git.TreeEntry) error {
 	for _, entry := range entries {
+		if entry.Type != git.EntryTypeBlob {
+			continue
+		}
+
 		if !c.blobStore.NeedsWrite(v, entry.Hash) {
 			continue
 		}
@@ -647,6 +662,72 @@ func (c *CAS) storeBlobs(ctx context.Context, v Venv, runner *git.GitRunner, ent
 	}
 
 	return nil
+}
+
+// storeSubmodules ingests the repositories behind gitlink entries so the
+// materializer can later link each submodule's tree by its pinned commit
+// hash, which is exactly the key the recursive ingest stores it under.
+// Submodule URLs come from the tree's .gitmodules blob, with relative
+// URLs resolved against url. Recursion bottoms out naturally: nested
+// gitlinks pin commits by hash, and a hash cycle cannot be constructed.
+//
+// Gitlinks without a .gitmodules entry (the shape left behind by
+// accidentally committing a nested repository) are skipped, and
+// materialization leaves an empty directory for them, matching
+// `git clone`.
+func (c *CAS) storeSubmodules(
+	ctx context.Context,
+	l log.Logger,
+	v Venv,
+	runner *git.GitRunner,
+	url string,
+	tree *git.Tree,
+) error {
+	var gitlinks []git.TreeEntry
+
+	for _, entry := range tree.Entries() {
+		if entry.Type == git.EntryTypeCommit {
+			gitlinks = append(gitlinks, entry)
+		}
+	}
+
+	if len(gitlinks) == 0 {
+		return nil
+	}
+
+	urls, err := submoduleURLs(ctx, runner, tree)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range gitlinks {
+		subURL, ok := urls[entry.Path]
+		if !ok {
+			l.Debugf("cas: gitlink %s has no .gitmodules entry, leaving an empty directory", entry.Path)
+			continue
+		}
+
+		resolvedURL := git.ResolveSubmoduleURL(url, subURL)
+
+		ref := &commitRef{URL: resolvedURL, RawRef: entry.Hash, Hash: entry.Hash}
+		if _, err := c.populateTreeFromRef(ctx, l, v, &CloneOptions{}, ref); err != nil {
+			return fmt.Errorf("fetch submodule %s from %s: %w", entry.Path, resolvedURL, err)
+		}
+	}
+
+	return nil
+}
+
+// submoduleURLs reads the submodule path → URL table from the tree's
+// .gitmodules blob. A tree without one yields an empty table.
+func submoduleURLs(ctx context.Context, runner *git.GitRunner, tree *git.Tree) (map[string]string, error) {
+	for _, entry := range tree.Entries() {
+		if entry.Path == git.GitmodulesPath && entry.Type == git.EntryTypeBlob {
+			return runner.SubmoduleURLs(ctx, entry.Hash)
+		}
+	}
+
+	return nil, nil
 }
 
 // ensureBlob ensures that a blob exists in the CAS.

--- a/internal/cas/submodule_test.go
+++ b/internal/cas/submodule_test.go
@@ -1,0 +1,222 @@
+package cas_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startSubmoduleServer commits the given files to a fresh test server,
+// starts it, and returns its URL together with the HEAD commit hash.
+func startSubmoduleServer(t *testing.T, files map[string]string) (string, string) {
+	t.Helper()
+
+	srv := newEmptyTestServer(t)
+
+	for path, content := range files {
+		require.NoError(t, srv.CommitFile(path, []byte(content), "add "+path))
+	}
+
+	head, err := srv.Head()
+	require.NoError(t, err)
+
+	url, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	return url, head
+}
+
+func TestCAS_CloneRepoWithSubmodule(t *testing.T) {
+	t.Parallel()
+
+	subURL, subHead := startSubmoduleServer(t, map[string]string{
+		"module.tf":     `# child module`,
+		"sub/nested.tf": `# nested file in child`,
+	})
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile("main.tf", []byte(`# parent`), "add main.tf"))
+	require.NoError(t, srv.CommitSubmodule("modules/child", subURL, subHead, "add submodule"))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+
+	v, err := cas.OSVenv()
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	assertClone := func(t *testing.T, targetPath string) {
+		t.Helper()
+
+		data, err := os.ReadFile(filepath.Join(targetPath, "main.tf"))
+		require.NoError(t, err)
+		assert.Equal(t, "# parent", string(data))
+
+		_, err = os.Stat(filepath.Join(targetPath, ".gitmodules"))
+		require.NoError(t, err)
+
+		data, err = os.ReadFile(filepath.Join(targetPath, "modules", "child", "module.tf"))
+		require.NoError(t, err)
+		assert.Equal(t, "# child module", string(data))
+
+		data, err = os.ReadFile(filepath.Join(targetPath, "modules", "child", "sub", "nested.tf"))
+		require.NoError(t, err)
+		assert.Equal(t, "# nested file in child", string(data))
+	}
+
+	firstTarget := filepath.Join(tempDir, "repo")
+	err = c.Clone(t.Context(), l, v, repoURL, cas.WithDir(firstTarget), cas.WithDepth(-1))
+	require.NoError(t, err)
+	assertClone(t, firstTarget)
+
+	// A second clone hits the tree store and materializes the submodule
+	// without refetching anything.
+	secondTarget := filepath.Join(tempDir, "repo-cached")
+	err = c.Clone(t.Context(), l, v, repoURL, cas.WithDir(secondTarget), cas.WithDepth(-1))
+	require.NoError(t, err)
+	assertClone(t, secondTarget)
+}
+
+func TestCAS_CloneRepoWithNestedSubmodules(t *testing.T) {
+	t.Parallel()
+
+	grandchildURL, grandchildHead := startSubmoduleServer(t, map[string]string{
+		"leaf.tf": `# grandchild`,
+	})
+
+	childSrv := newEmptyTestServer(t)
+	require.NoError(t, childSrv.CommitFile("module.tf", []byte(`# child`), "add module.tf"))
+	require.NoError(t, childSrv.CommitSubmodule("vendor/leaf", grandchildURL, grandchildHead, "add grandchild"))
+
+	childHead, err := childSrv.Head()
+	require.NoError(t, err)
+
+	childURL, err := childSrv.Start(t.Context())
+	require.NoError(t, err)
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile("main.tf", []byte(`# parent`), "add main.tf"))
+	require.NoError(t, srv.CommitSubmodule("modules/child", childURL, childHead, "add child"))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	v, err := cas.OSVenv()
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	targetPath := filepath.Join(tempDir, "repo")
+
+	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	require.NoError(t, err)
+
+	err = c.Clone(t.Context(), logger.CreateLogger(), v, repoURL, cas.WithDir(targetPath), cas.WithDepth(-1))
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(targetPath, "modules", "child", "module.tf"))
+	require.NoError(t, err)
+	assert.Equal(t, "# child", string(data))
+
+	data, err = os.ReadFile(filepath.Join(targetPath, "modules", "child", "vendor", "leaf", "leaf.tf"))
+	require.NoError(t, err)
+	assert.Equal(t, "# grandchild", string(data))
+}
+
+// TestCAS_CloneRepoWithUnregisteredGitlink pins the behavior for a
+// gitlink with no .gitmodules entry, the shape left behind by
+// accidentally committing a nested repository: `git clone` produces an
+// empty directory there, and so must CAS.
+func TestCAS_CloneRepoWithUnregisteredGitlink(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile("main.tf", []byte(`# parent`), "add main.tf"))
+
+	// The pinned hash is never fetched, so any well-formed SHA works.
+	const danglingHash = "0123456789abcdef0123456789abcdef01234567"
+
+	require.NoError(t, srv.CommitSubmodule("vendor/orphan", "", danglingHash, "add orphan gitlink"))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	v, err := cas.OSVenv()
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	targetPath := filepath.Join(tempDir, "repo")
+
+	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	require.NoError(t, err)
+
+	err = c.Clone(t.Context(), logger.CreateLogger(), v, repoURL, cas.WithDir(targetPath), cas.WithDepth(-1))
+	require.NoError(t, err)
+
+	_, err = os.ReadFile(filepath.Join(targetPath, "main.tf"))
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(targetPath, "vendor", "orphan"))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	entries, err := os.ReadDir(filepath.Join(targetPath, "vendor", "orphan"))
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+// TestCAS_CloneSubmoduleWithRelativeURL pins relative .gitmodules URL
+// resolution end to end: the submodule URL is declared relative to the
+// parent repository URL and must be resolved before fetching. The
+// child repository is mounted on the parent's server so the resolved
+// URL lands on the same host, just like sibling repos on a forge.
+func TestCAS_CloneSubmoduleWithRelativeURL(t *testing.T) {
+	t.Parallel()
+
+	childSrv := newEmptyTestServer(t)
+	require.NoError(t, childSrv.CommitFile("module.tf", []byte(`# child module`), "add module.tf"))
+
+	childHead, err := childSrv.Head()
+	require.NoError(t, err)
+
+	srv := newEmptyTestServer(t)
+	srv.Mount("/child.git", childSrv)
+
+	require.NoError(t, srv.CommitFile("main.tf", []byte(`# parent`), "add main.tf"))
+	require.NoError(t, srv.CommitSubmodule("modules/child", "../child.git", childHead, "add submodule"))
+
+	baseURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	// The "../child.git" in .gitmodules resolves against this URL to
+	// "<baseURL>/child.git", where the child repository is mounted.
+	repoURL := baseURL + "/parent.git"
+
+	v, err := cas.OSVenv()
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	targetPath := filepath.Join(tempDir, "repo")
+
+	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	require.NoError(t, err)
+
+	err = c.Clone(t.Context(), logger.CreateLogger(), v, repoURL, cas.WithDir(targetPath), cas.WithDepth(-1))
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(targetPath, "modules", "child", "module.tf"))
+	require.NoError(t, err)
+	assert.Equal(t, "# child module", string(data))
+}

--- a/internal/cas/tree.go
+++ b/internal/cas/tree.go
@@ -107,7 +107,7 @@ func linkTree(
 		// entry mode (120000) is the only signal that distinguishes it from a
 		// regular file, so dispatch on the mode rather than the type.
 		switch entry.Type {
-		case "blob":
+		case git.EntryTypeBlob:
 			itemType := "link"
 			if gitEntryIsSymlink(entry.Mode) {
 				itemType = "symlink"
@@ -119,9 +119,16 @@ func linkTree(
 				path:     entryPath,
 				dirPath:  dirPath,
 			})
-		case "tree":
+		case git.EntryTypeTree:
 			workItems = append(workItems, workItem{
 				itemType: "subtree",
+				entry:    entry,
+				path:     entryPath,
+				dirPath:  dirPath,
+			})
+		case git.EntryTypeCommit:
+			workItems = append(workItems, workItem{
+				itemType: "submodule",
 				entry:    entry,
 				path:     entryPath,
 				dirPath:  dirPath,
@@ -177,6 +184,34 @@ func linkTree(
 				err = linkTree(ctx, v, blobStore, treeStore, subTree, rootDir, work.path, o)
 				if err != nil {
 					return fmt.Errorf("link subtree %s: %w", work.path, err)
+				}
+			case "submodule":
+				// A gitlink stands in for the submodule's whole working
+				// tree, which ingestion stored keyed by the pinned commit
+				// hash. The directory is created up front: a gitlink with
+				// no stored tree had no .gitmodules entry to fetch it by,
+				// and `git clone` leaves an empty directory there too.
+				if err := v.FS.MkdirAll(work.path, DefaultDirPerms); err != nil {
+					return fmt.Errorf("mkdir submodule %s: %w", work.path, err)
+				}
+
+				if treeStore.NeedsWrite(v, work.entry.Hash) {
+					return nil
+				}
+
+				treeData, err := treeContent.Read(v, work.entry.Hash)
+				if err != nil {
+					return fmt.Errorf("read submodule tree %s: %w", work.entry.Hash, err)
+				}
+
+				subTree, err := git.ParseTree(treeData, work.path)
+				if err != nil {
+					return fmt.Errorf("parse submodule tree %s: %w", work.entry.Hash, err)
+				}
+
+				err = linkTree(ctx, v, blobStore, treeStore, subTree, rootDir, work.path, o)
+				if err != nil {
+					return fmt.Errorf("link submodule %s: %w", work.path, err)
 				}
 			}
 

--- a/internal/cas/tree_test.go
+++ b/internal/cas/tree_test.go
@@ -63,6 +63,16 @@ func TestParseTreeEntry(t *testing.T) {
 			},
 		},
 		{
+			name:  "submodule gitlink",
+			input: "160000 commit q7r8s9t0 modules/child",
+			want: git.TreeEntry{
+				Mode: "160000",
+				Type: "commit",
+				Hash: "q7r8s9t0",
+				Path: "modules/child",
+			},
+		},
+		{
 			name:    "invalid format",
 			input:   "invalid format",
 			wantErr: true,

--- a/internal/git/server.go
+++ b/internal/git/server.go
@@ -2,15 +2,21 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/util"
 	gogit "github.com/go-git/go-git/v6"
 	backendhttp "github.com/go-git/go-git/v6/backend/http"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
@@ -20,10 +26,11 @@ import (
 // Server is a pure-Go HTTP Git server backed by in-memory storage.
 // It is intended for use in tests.
 type Server struct {
-	store storage.Storer
-	repo  *gogit.Repository
-	ln    net.Listener
-	srv   *http.Server
+	store  storage.Storer
+	repo   *gogit.Repository
+	ln     net.Listener
+	srv    *http.Server
+	mounts map[string]storage.Storer
 }
 
 // NewServer creates a Server with an empty in-memory repository.
@@ -41,9 +48,21 @@ func NewServer() (*Server, error) {
 	}
 
 	return &Server{
-		store: store,
-		repo:  repo,
+		store:  store,
+		repo:   repo,
+		mounts: map[string]storage.Storer{},
 	}, nil
+}
+
+// Mount serves other's repository at the given URL path (e.g.
+// "/child.git") on this server's listener, so tests can exercise
+// same-host relative submodule URLs. Paths without a mount still
+// resolve to this server's own repository. Call before [Server.Start];
+// the mounted server itself does not need to be started.
+func (s *Server) Mount(path string, other *Server) {
+	// The HTTP backend strips the leading slash before it builds the
+	// endpoint handed to the loader, so mount keys are stored bare.
+	s.mounts[strings.TrimPrefix(path, "/")] = other.store
 }
 
 // Repo returns the underlying go-git repository so callers can create
@@ -128,6 +147,56 @@ func (s *Server) CommitSymlink(link, target, msg string) error {
 	return nil
 }
 
+// CommitSubmodule records a gitlink at path pinned to commitHash and,
+// when url is non-empty, registers the submodule in .gitmodules before
+// committing both. An empty url leaves the gitlink unregistered,
+// mirroring the orphaned entry left behind by accidentally committing
+// a nested repository. The gitlink lands as a tree entry with mode
+// 160000 and type commit, matching `git submodule add`.
+func (s *Server) CommitSubmodule(path, url, commitHash, msg string) error {
+	w, err := s.repo.Worktree()
+	if err != nil {
+		return fmt.Errorf("worktree: %w", err)
+	}
+
+	if url != "" {
+		if err := appendGitmodules(w, path, url); err != nil {
+			return err
+		}
+	}
+
+	idx, err := s.repo.Storer.Index()
+	if err != nil {
+		return fmt.Errorf("read index: %w", err)
+	}
+
+	idx.Entries = append(idx.Entries, &index.Entry{
+		Name: path,
+		Hash: plumbing.NewHash(commitHash),
+		Mode: filemode.Submodule,
+	})
+
+	if err := s.repo.Storer.SetIndex(idx); err != nil {
+		return fmt.Errorf("write index: %w", err)
+	}
+
+	sig := &object.Signature{
+		Name:  "Test",
+		Email: "test@test.com",
+		When:  time.Now(),
+	}
+
+	_, err = w.Commit(msg, &gogit.CommitOptions{
+		Author:    sig,
+		Committer: sig,
+	})
+	if err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	return nil
+}
+
 // Head returns the canonical hash of the current HEAD commit. Useful
 // in tests that need to capture a non-tip commit hash before adding
 // further commits.
@@ -189,7 +258,7 @@ func (s *Server) SetBranch(name, hash string) error {
 // Start begins serving Git HTTP on a random local port.
 // Returns the base URL (e.g. "http://127.0.0.1:12345").
 func (s *Server) Start(ctx context.Context) (string, error) {
-	loader := &singleRepoLoader{store: s.store}
+	loader := &repoLoader{store: s.store, mounts: s.mounts}
 	backend := backendhttp.NewBackend(loader)
 
 	var lc net.ListenConfig
@@ -218,12 +287,43 @@ func (s *Server) Close() error {
 	return nil
 }
 
-// singleRepoLoader implements transport.Loader by always returning the same
-// storer, regardless of the endpoint path.
-type singleRepoLoader struct {
-	store storage.Storer
+// gitmodulesPerms is the file mode used for the .gitmodules file
+// written into the test worktree.
+const gitmodulesPerms = 0o644
+
+// appendGitmodules appends a submodule section for path and url to the
+// worktree's .gitmodules file and stages it.
+func appendGitmodules(w *gogit.Worktree, path, url string) error {
+	existing, err := util.ReadFile(w.Filesystem, ".gitmodules")
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read .gitmodules: %w", err)
+	}
+
+	section := fmt.Sprintf("[submodule %q]\n\tpath = %s\n\turl = %s\n", path, path, url)
+
+	if err := util.WriteFile(w.Filesystem, ".gitmodules", append(existing, section...), gitmodulesPerms); err != nil {
+		return fmt.Errorf("write .gitmodules: %w", err)
+	}
+
+	if _, err := w.Add(".gitmodules"); err != nil {
+		return fmt.Errorf("add .gitmodules: %w", err)
+	}
+
+	return nil
 }
 
-func (l *singleRepoLoader) Load(_ *transport.Endpoint) (storage.Storer, error) {
+// repoLoader implements transport.Loader by returning the default
+// storer for any endpoint path, with per-path mounts taking precedence
+// so one listener can serve several test repositories.
+type repoLoader struct {
+	store  storage.Storer
+	mounts map[string]storage.Storer
+}
+
+func (l *repoLoader) Load(ep *transport.Endpoint) (storage.Storer, error) {
+	if store, ok := l.mounts[ep.Path]; ok {
+		return store, nil
+	}
+
 	return l.store, nil
 }

--- a/internal/git/submodule.go
+++ b/internal/git/submodule.go
@@ -1,0 +1,133 @@
+package git
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+)
+
+// SubmoduleURLs returns the submodule path → URL table declared by the
+// .gitmodules blob at gitmodulesHash, read with `git config --blob` so
+// the parsing matches git's own config syntax. Entries missing either
+// a path or a url are dropped. The blob must exist in the repository
+// at [GitRunner.WorkDir].
+func (g *GitRunner) SubmoduleURLs(ctx context.Context, gitmodulesHash string) (map[string]string, error) {
+	if err := g.RequiresWorkDir(); err != nil {
+		return nil, err
+	}
+
+	cmd := g.prepareCommand(ctx, "config", "--blob", gitmodulesHash, "--list", "-z")
+
+	var stdout, stderr bytes.Buffer
+
+	cmd.SetStdout(&stdout)
+	cmd.SetStderr(&stderr)
+
+	if err := cmd.Run(); err != nil {
+		return nil, &WrappedError{
+			Op:      "git_config_blob",
+			Context: stderr.String(),
+			Err:     errors.Join(ErrCommandSpawn, err),
+		}
+	}
+
+	return ParseSubmoduleConfig(stdout.String()), nil
+}
+
+// ParseSubmoduleConfig parses `git config --list -z` output into a
+// submodule path → URL table. The -z form terminates each record with
+// NUL and separates the key from the value with a newline, so values
+// containing newlines survive. Records other than submodule.<name>.path
+// and submodule.<name>.url are ignored, and submodule names keep any
+// embedded dots because only the fixed prefix and suffix are stripped.
+func ParseSubmoduleConfig(output string) map[string]string {
+	paths := map[string]string{}
+	urls := map[string]string{}
+
+	for record := range strings.SplitSeq(output, "\x00") {
+		key, value, ok := strings.Cut(record, "\n")
+		if !ok {
+			continue
+		}
+
+		name, ok := strings.CutPrefix(key, "submodule.")
+		if !ok {
+			continue
+		}
+
+		if sub, ok := strings.CutSuffix(name, ".path"); ok {
+			paths[sub] = value
+			continue
+		}
+
+		if sub, ok := strings.CutSuffix(name, ".url"); ok {
+			urls[sub] = value
+		}
+	}
+
+	resolved := make(map[string]string, len(paths))
+
+	for name, path := range paths {
+		if url, ok := urls[name]; ok {
+			resolved[path] = url
+		}
+	}
+
+	return resolved
+}
+
+// ResolveSubmoduleURL resolves a .gitmodules url value against the
+// remote URL of the repository declaring the submodule, following
+// git's relative-url rules: each leading "../" removes one trailing
+// path component from parentURL, "./" segments are dropped, and
+// anything that does not start with one of those prefixes is returned
+// unchanged. When an SCP-form parent (git@host:path) runs out of path
+// components, the last one is chopped at the colon and the colon is
+// restored on the final join, so "git@host:a/b.git" resolved against
+// "../../c.git" yields "git@host:c.git".
+func ResolveSubmoduleURL(parentURL, url string) string {
+	if !strings.HasPrefix(url, "./") && !strings.HasPrefix(url, "../") {
+		return url
+	}
+
+	base := strings.TrimSuffix(parentURL, "/")
+	colonsep := false
+
+	for {
+		if rest, ok := strings.CutPrefix(url, "./"); ok {
+			url = rest
+			continue
+		}
+
+		rest, ok := strings.CutPrefix(url, "../")
+		if !ok {
+			break
+		}
+
+		url = rest
+
+		if i := strings.LastIndexByte(base, '/'); i >= 0 {
+			base = base[:i]
+			continue
+		}
+
+		if i := strings.LastIndexByte(base, ':'); i >= 0 {
+			base = base[:i]
+			colonsep = true
+
+			continue
+		}
+
+		// Out of components. Git dies here for local parents and
+		// degrades for remote ones; "." keeps the join well-formed
+		// without inventing a path.
+		base = "."
+	}
+
+	if colonsep {
+		return base + ":" + url
+	}
+
+	return base + "/" + url
+}

--- a/internal/git/submodule_test.go
+++ b/internal/git/submodule_test.go
@@ -1,0 +1,193 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSubmoduleURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		parentURL string
+		url       string
+		want      string
+	}{
+		{
+			name:      "absolute https url unchanged",
+			parentURL: "https://example.com/org/repo.git",
+			url:       "https://example.com/other/dep.git",
+			want:      "https://example.com/other/dep.git",
+		},
+		{
+			name:      "absolute scp url unchanged",
+			parentURL: "https://example.com/org/repo.git",
+			url:       "git@github.com:org/dep.git",
+			want:      "git@github.com:org/dep.git",
+		},
+		{
+			name:      "sibling repository",
+			parentURL: "https://example.com/org/repo.git",
+			url:       "../sibling.git",
+			want:      "https://example.com/org/sibling.git",
+		},
+		{
+			name:      "two levels up",
+			parentURL: "https://example.com/org/repo.git",
+			url:       "../../other/dep.git",
+			want:      "https://example.com/other/dep.git",
+		},
+		{
+			name:      "dot slash appends",
+			parentURL: "https://example.com/org/repo.git",
+			url:       "./sub.git",
+			want:      "https://example.com/org/repo.git/sub.git",
+		},
+		{
+			name:      "parent with trailing slash",
+			parentURL: "https://example.com/org/repo.git/",
+			url:       "../sibling.git",
+			want:      "https://example.com/org/sibling.git",
+		},
+		{
+			name:      "scp parent sibling",
+			parentURL: "git@github.com:org/repo.git",
+			url:       "../sibling.git",
+			want:      "git@github.com:org/sibling.git",
+		},
+		{
+			name:      "scp parent exhausts path components",
+			parentURL: "git@github.com:org/repo.git",
+			url:       "../../sibling.git",
+			want:      "git@github.com:sibling.git",
+		},
+		{
+			name:      "mixed dot and dotdot segments",
+			parentURL: "https://example.com/org/repo.git",
+			url:       "./../sibling.git",
+			want:      "https://example.com/org/sibling.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, git.ResolveSubmoduleURL(tt.parentURL, tt.url))
+		})
+	}
+}
+
+func TestParseSubmoduleConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		want   map[string]string
+		name   string
+		output string
+	}{
+		{
+			name:   "empty output",
+			output: "",
+			want:   map[string]string{},
+		},
+		{
+			name: "two submodules",
+			output: "submodule.child.path\nmodules/child\x00" +
+				"submodule.child.url\nhttps://example.com/child.git\x00" +
+				"submodule.dep.path\nvendor/dep\x00" +
+				"submodule.dep.url\n../dep.git\x00",
+			want: map[string]string{
+				"modules/child": "https://example.com/child.git",
+				"vendor/dep":    "../dep.git",
+			},
+		},
+		{
+			name: "name containing dots",
+			output: "submodule.a.b.path\nmodules/a.b\x00" +
+				"submodule.a.b.url\nhttps://example.com/a.b.git\x00",
+			want: map[string]string{
+				"modules/a.b": "https://example.com/a.b.git",
+			},
+		},
+		{
+			name:   "missing url dropped",
+			output: "submodule.child.path\nmodules/child\x00",
+			want:   map[string]string{},
+		},
+		{
+			name:   "missing path dropped",
+			output: "submodule.child.url\nhttps://example.com/child.git\x00",
+			want:   map[string]string{},
+		},
+		{
+			name: "unrelated keys ignored",
+			output: "core.bare\nfalse\x00" +
+				"submodule.child.branch\nmain\x00" +
+				"submodule.child.path\nmodules/child\x00" +
+				"submodule.child.url\nhttps://example.com/child.git\x00",
+			want: map[string]string{
+				"modules/child": "https://example.com/child.git",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, git.ParseSubmoduleConfig(tt.output))
+		})
+	}
+}
+
+// TestGitRunner_SubmoduleURLs exercises the `git config --blob` path
+// against a real repository: the .gitmodules blob committed by the test
+// server is located through ls-tree and parsed by git itself.
+func TestGitRunner_SubmoduleURLs(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	srv, err := git.NewServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	require.NoError(t, srv.CommitFile("README.md", []byte("# repo"), "add readme"))
+
+	const pinnedHash = "0123456789abcdef0123456789abcdef01234567"
+
+	require.NoError(t, srv.CommitSubmodule("modules/child", "https://example.com/child.git", pinnedHash, "add submodule"))
+
+	url, err := srv.Start(ctx)
+	require.NoError(t, err)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(helpers.TmpDirWOSymlinks(t))
+	require.NoError(t, runner.Clone(ctx, url, true, 0, ""))
+
+	tree, err := runner.LsTreeRecursive(ctx, "HEAD")
+	require.NoError(t, err)
+
+	var gitmodulesHash string
+
+	for _, entry := range tree.Entries() {
+		if entry.Path == git.GitmodulesPath {
+			gitmodulesHash = entry.Hash
+		}
+	}
+
+	require.NotEmpty(t, gitmodulesHash, ".gitmodules entry not found in tree")
+
+	urls, err := runner.SubmoduleURLs(ctx, gitmodulesHash)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"modules/child": "https://example.com/child.git"}, urls)
+}

--- a/internal/git/tree.go
+++ b/internal/git/tree.go
@@ -13,6 +13,22 @@ const (
 	minTreePartsLength = 4
 )
 
+// Tree entry types as printed by `git ls-tree` and carried in
+// [TreeEntry.Type].
+const (
+	// EntryTypeBlob marks a file (or symlink) entry.
+	EntryTypeBlob = "blob"
+	// EntryTypeTree marks a directory entry.
+	EntryTypeTree = "tree"
+	// EntryTypeCommit marks a gitlink entry: a submodule pinned to the
+	// named commit, whose objects live in another repository.
+	EntryTypeCommit = "commit"
+)
+
+// GitmodulesPath is the repository-root path of the file registering
+// submodule paths and URLs.
+const GitmodulesPath = ".gitmodules"
+
 // Tree represents a git tree object with its entries
 type Tree struct {
 	entries []TreeEntry


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds support for submodules in CAS.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repositories containing Git submodules now clone correctly through the Content Addressable Store. Previously failed during ingestion with invalid object hash errors.
  * Submodule contents are now properly fetched, materialized, and cached for reuse across repeated clones.
  * Nested submodules and relative submodule URLs are now correctly resolved.

* **Documentation**
  * Added comprehensive documentation on Git submodule handling in the Content Addressable Store, including behavior for nested submodules, relative URLs, and unregistered submodule entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->