### PR TITLE
fix: Validating CAS sources

### DIFF
--- a/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
@@ -71,7 +71,7 @@ terraform {
 This functionality is part of the [`cas` experiment](/reference/experiments/active#cas). Enable it with `--experiment cas`.
 </Aside>
 
-When authoring stacks in a catalog, you can use the `update_source_with_cas` attribute to allow for relative paths to other components in the catalog in `source` attributes. This removes the need to plumb remote Git URLs through `values` expressions.
+When authoring stacks in a catalog, you can use the `update_source_with_cas` attribute to allow for relative paths to other components in the catalog in `source` attributes. This removes the need to plumb remote Git URLs through `values` expressions. The `source` must be a literal string: interpolation, function calls, and references such as `local.foo` cause stack generation to fail.
 
 ```hcl
 # stacks/my-stack/terragrunt.stack.hcl (in your catalog repository)

--- a/docs/src/data/changelog/v1.0.8/cas-literal-source-validation.mdx
+++ b/docs/src/data/changelog/v1.0.8/cas-literal-source-validation.mdx
@@ -5,6 +5,6 @@ category: "experiments-updated"
 
 #### `cas` — `update_source_with_cas` requires a literal source string
 
-When a catalog `unit`, `stack`, or `terraform` block set `update_source_with_cas = true` with a `source` containing interpolation, such as `"../units/${local.name}"`, the interpolated portion was silently dropped during rewriting. If the remaining prefix happened to name an existing directory, stack generation packaged that wrong directory without any error.
+When a catalog `unit`, `stack`, or `terraform` block set `update_source_with_cas = true` with a `source` that was not a literal string, rewriting silently produced a wrong source. Interpolation such as `"../units/${local.name}"` had the interpolated portion dropped, leaving a bare prefix; a reference such as `local.foo` resolved to the directory containing the block itself. In both cases stack generation packaged the wrong directory without any error.
 
-Stack generation now fails with an error explaining that `update_source_with_cas` requires a literal source string and that interpolation is not supported.
+Stack generation now fails with an error explaining that `update_source_with_cas` requires a literal source string. Non-literal expressions, including interpolation, function calls, and references like `local.foo`, are rejected.

--- a/docs/src/data/changelog/v1.0.8/cas-literal-source-validation.mdx
+++ b/docs/src/data/changelog/v1.0.8/cas-literal-source-validation.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.8"
+category: "experiments-updated"
+---
+
+#### `cas` — `update_source_with_cas` requires a literal source string
+
+When a catalog `unit`, `stack`, or `terraform` block set `update_source_with_cas = true` with a `source` containing interpolation, such as `"../units/${local.name}"`, the interpolated portion was silently dropped during rewriting. If the remaining prefix happened to name an existing directory, stack generation packaged that wrong directory without any error.
+
+Stack generation now fails with an error explaining that `update_source_with_cas` requires a literal source string and that interpolation is not supported.

--- a/docs/src/data/changelog/v1.0.8/cas-ref-hash-validation.mdx
+++ b/docs/src/data/changelog/v1.0.8/cas-ref-hash-validation.mdx
@@ -5,6 +5,6 @@ category: "experiments-updated"
 
 #### `cas` — Malformed `cas::` references fail with a clear error
 
-A `cas::` source with a malformed hash, such as `cas::sha1:a`, used to crash Terragrunt with an internal error while looking the hash up in the store.
+A `cas::` source with a malformed hash, such as `cas::sha1:a`, used to fail with an opaque internal error while looking the hash up in the store.
 
 CAS references are now validated up front: the hash must be lowercase hexadecimal with exactly 40 characters for `sha1` or 64 for `sha256`. References that don't match are rejected with an error identifying the bad reference.

--- a/docs/src/data/changelog/v1.0.8/cas-ref-hash-validation.mdx
+++ b/docs/src/data/changelog/v1.0.8/cas-ref-hash-validation.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.8"
+category: "experiments-updated"
+---
+
+#### `cas` — Malformed `cas::` references fail with a clear error
+
+A `cas::` source with a malformed hash, such as `cas::sha1:a`, used to crash Terragrunt with an internal error while looking the hash up in the store.
+
+CAS references are now validated up front: the hash must be lowercase hexadecimal with exactly 40 characters for `sha1` or 64 for `sha256`. References that don't match are rejected with an error identifying the bad reference.

--- a/internal/cas/errors.go
+++ b/internal/cas/errors.go
@@ -41,8 +41,9 @@ const (
 	ErrAbsoluteSource Error = "update_source_with_cas does not support absolute sources"
 	// ErrSourceEscapesRepo is returned when an update_source_with_cas source resolves outside the cloned repository
 	ErrSourceEscapesRepo Error = "update_source_with_cas source escapes repository root"
-	// ErrSourceNotLiteral is returned when an update_source_with_cas source uses template interpolation
-	ErrSourceNotLiteral Error = "update_source_with_cas requires a literal source string; interpolation is not supported"
+	// ErrSourceNotLiteral is returned when an update_source_with_cas source is not a
+	// literal string, such as one using interpolation, a function call, or a reference
+	ErrSourceNotLiteral Error = "update_source_with_cas requires a literal source string"
 	// ErrNotADirectory is returned when a path expected to be a directory is not.
 	ErrNotADirectory Error = "not a directory"
 )

--- a/internal/cas/errors.go
+++ b/internal/cas/errors.go
@@ -32,12 +32,17 @@ const (
 	ErrCASRefMissingPrefix Error = "CAS reference missing expected hash algorithm prefix"
 	// ErrCASRefEmptyHash is returned when a CAS reference has an empty hash
 	ErrCASRefEmptyHash Error = "CAS reference has empty hash"
+	// ErrCASRefInvalidHash is returned when a CAS reference hash is not lowercase
+	// hex of the digest length for its algorithm (40 characters for sha1, 64 for sha256)
+	ErrCASRefInvalidHash Error = "CAS reference hash must be lowercase hex (40 characters for sha1, 64 for sha256)"
 	// ErrTreeNotFound is returned when a tree hash is not found in any CAS store
 	ErrTreeNotFound Error = "tree not found in CAS store"
 	// ErrAbsoluteSource is returned when an update_source_with_cas source is an absolute path
 	ErrAbsoluteSource Error = "update_source_with_cas does not support absolute sources"
 	// ErrSourceEscapesRepo is returned when an update_source_with_cas source resolves outside the cloned repository
 	ErrSourceEscapesRepo Error = "update_source_with_cas source escapes repository root"
+	// ErrSourceNotLiteral is returned when an update_source_with_cas source uses template interpolation
+	ErrSourceNotLiteral Error = "update_source_with_cas requires a literal source string; interpolation is not supported"
 	// ErrNotADirectory is returned when a path expected to be a directory is not.
 	ErrNotADirectory Error = "not a directory"
 )

--- a/internal/cas/hcl_rewrite.go
+++ b/internal/cas/hcl_rewrite.go
@@ -71,8 +71,8 @@ type stackBlockInfo struct {
 
 // ReadStackBlocks reads all unit and stack blocks from a stack HCL file,
 // extracting the source and update_source_with_cas attributes. Blocks that set
-// update_source_with_cas = true must use a literal source string; an
-// interpolated source returns [ErrSourceNotLiteral] wrapped with the block
+// update_source_with_cas = true must use a literal source string; a
+// non-literal source returns [ErrSourceNotLiteral] wrapped with the block
 // type and name.
 func ReadStackBlocks(content []byte) ([]stackBlockInfo, error) {
 	f, diags := hclwrite.ParseConfig(content, "terragrunt.stack.hcl", hcl.InitialPos)
@@ -127,7 +127,7 @@ func ReadStackBlocks(content []byte) ([]stackBlockInfo, error) {
 
 // ReadTerraformSourceInfo reads the source and update_source_with_cas from a
 // terraform block. When update_source_with_cas = true, the source must be a
-// literal string; an interpolated source returns [ErrSourceNotLiteral].
+// literal string; a non-literal source returns [ErrSourceNotLiteral].
 func ReadTerraformSourceInfo(content []byte) (source string, updateWithCAS bool, err error) {
 	f, diags := hclwrite.ParseConfig(content, "terragrunt.hcl", hcl.InitialPos)
 	if diags.HasErrors() {
@@ -165,27 +165,64 @@ func ReadTerraformSourceInfo(content []byte) (source string, updateWithCAS bool,
 }
 
 // extractStringLiteral extracts a string value from an hclwrite attribute.
-// Returns [ErrSourceNotLiteral] when the expression contains template
-// interpolation ("${...}") or control ("%{...}") sequences, which cannot be
-// evaluated by this raw-token reader. Escaped sequences ("$${", "%%{") are
-// plain literal text and do not trigger the error. Returns empty string for
-// other non-literal expressions.
+// The expression must be a pure quoted string literal: an opening quote,
+// quoted-literal parts, and a closing quote. Escaped template sequences
+// ("$${", "%%{") tokenize as quoted-literal parts and are accepted. Any other
+// token shape, such as template interpolation, function calls, references
+// like local.foo, heredocs, or operators, returns [ErrSourceNotLiteral]
+// wrapped with the kind of expression found. This raw-token reader cannot
+// evaluate expressions, so anything it cannot read verbatim is rejected
+// rather than concatenated into a wrong source.
 func extractStringLiteral(attr *hclwrite.Attribute) (string, error) {
 	tokens := attr.Expr().BuildTokens(nil)
 
+	if len(tokens) < 2 ||
+		tokens[0].Type != hclsyntax.TokenOQuote ||
+		tokens[len(tokens)-1].Type != hclsyntax.TokenCQuote {
+		return "", fmt.Errorf("%w; the source is a %s", ErrSourceNotLiteral, nonLiteralKind(tokens))
+	}
+
 	var b strings.Builder
 
-	for _, tok := range tokens {
-		if tok.Type == hclsyntax.TokenTemplateInterp || tok.Type == hclsyntax.TokenTemplateControl {
-			return "", ErrSourceNotLiteral
+	for _, tok := range tokens[1 : len(tokens)-1] {
+		if tok.Type != hclsyntax.TokenQuotedLit {
+			return "", fmt.Errorf("%w; the source is a %s", ErrSourceNotLiteral, nonLiteralKind(tokens))
 		}
 
-		if tok.Type == hclsyntax.TokenQuotedLit {
-			b.Write(tok.Bytes)
-		}
+		b.Write(tok.Bytes)
 	}
 
 	return b.String(), nil
+}
+
+// nonLiteralKind names the shape of a non-literal expression for error
+// messages. The classification is best-effort: every shape maps to
+// [ErrSourceNotLiteral] either way, so an imprecise name only affects the
+// message text.
+func nonLiteralKind(tokens hclwrite.Tokens) string {
+	for _, tok := range tokens {
+		if tok.Type == hclsyntax.TokenTemplateInterp || tok.Type == hclsyntax.TokenTemplateControl {
+			return "template expression"
+		}
+	}
+
+	if len(tokens) == 0 {
+		return "non-literal expression"
+	}
+
+	if tokens[0].Type == hclsyntax.TokenOHeredoc {
+		return "heredoc"
+	}
+
+	if tokens[0].Type == hclsyntax.TokenIdent {
+		if len(tokens) > 1 && tokens[1].Type == hclsyntax.TokenOParen {
+			return "function call"
+		}
+
+		return "reference"
+	}
+
+	return "non-literal expression"
 }
 
 // extractBoolLiteral extracts a boolean value from an hclwrite attribute.

--- a/internal/cas/hcl_rewrite.go
+++ b/internal/cas/hcl_rewrite.go
@@ -70,7 +70,10 @@ type stackBlockInfo struct {
 }
 
 // ReadStackBlocks reads all unit and stack blocks from a stack HCL file,
-// extracting the source and update_source_with_cas attributes.
+// extracting the source and update_source_with_cas attributes. Blocks that set
+// update_source_with_cas = true must use a literal source string; an
+// interpolated source returns [ErrSourceNotLiteral] wrapped with the block
+// type and name.
 func ReadStackBlocks(content []byte) ([]stackBlockInfo, error) {
 	f, diags := hclwrite.ParseConfig(content, "terragrunt.stack.hcl", hcl.InitialPos)
 	if diags.HasErrors() {
@@ -95,12 +98,25 @@ func ReadStackBlocks(content []byte) ([]stackBlockInfo, error) {
 			BlockType: bt,
 		}
 
+		var sourceErr error
+
 		if attr := block.Body().GetAttribute("source"); attr != nil {
-			info.Source = extractStringLiteral(attr)
+			info.Source, sourceErr = extractStringLiteral(attr)
 		}
 
 		if attr := block.Body().GetAttribute("update_source_with_cas"); attr != nil {
 			info.UpdateSourceWithCAS = extractBoolLiteral(attr)
+		}
+
+		// A non-literal source only matters for blocks CAS will rewrite;
+		// other blocks are skipped by the caller, so their sources stay
+		// untouched and are evaluated later by the full HCL parser.
+		if info.UpdateSourceWithCAS && sourceErr != nil {
+			return nil, &WrappedError{
+				Op:      bt,
+				Context: info.Name,
+				Err:     sourceErr,
+			}
 		}
 
 		blocks = append(blocks, info)
@@ -109,7 +125,9 @@ func ReadStackBlocks(content []byte) ([]stackBlockInfo, error) {
 	return blocks, nil
 }
 
-// ReadTerraformSourceInfo reads the source and update_source_with_cas from a terraform block.
+// ReadTerraformSourceInfo reads the source and update_source_with_cas from a
+// terraform block. When update_source_with_cas = true, the source must be a
+// literal string; an interpolated source returns [ErrSourceNotLiteral].
 func ReadTerraformSourceInfo(content []byte) (source string, updateWithCAS bool, err error) {
 	f, diags := hclwrite.ParseConfig(content, "terragrunt.hcl", hcl.InitialPos)
 	if diags.HasErrors() {
@@ -121,12 +139,23 @@ func ReadTerraformSourceInfo(content []byte) (source string, updateWithCAS bool,
 			continue
 		}
 
+		var sourceErr error
+
 		if attr := block.Body().GetAttribute("source"); attr != nil {
-			source = extractStringLiteral(attr)
+			source, sourceErr = extractStringLiteral(attr)
 		}
 
 		if attr := block.Body().GetAttribute("update_source_with_cas"); attr != nil {
 			updateWithCAS = extractBoolLiteral(attr)
+		}
+
+		// Without the rewrite opt-in the raw source is never consumed, so a
+		// non-literal source is left for the full HCL parser to evaluate.
+		if updateWithCAS && sourceErr != nil {
+			return "", false, &WrappedError{
+				Op:  "terraform",
+				Err: sourceErr,
+			}
 		}
 
 		return source, updateWithCAS, nil
@@ -136,19 +165,27 @@ func ReadTerraformSourceInfo(content []byte) (source string, updateWithCAS bool,
 }
 
 // extractStringLiteral extracts a string value from an hclwrite attribute.
-// Returns empty string if the attribute is not a simple string literal.
-func extractStringLiteral(attr *hclwrite.Attribute) string {
+// Returns [ErrSourceNotLiteral] when the expression contains template
+// interpolation ("${...}") or control ("%{...}") sequences, which cannot be
+// evaluated by this raw-token reader. Escaped sequences ("$${", "%%{") are
+// plain literal text and do not trigger the error. Returns empty string for
+// other non-literal expressions.
+func extractStringLiteral(attr *hclwrite.Attribute) (string, error) {
 	tokens := attr.Expr().BuildTokens(nil)
 
 	var b strings.Builder
 
 	for _, tok := range tokens {
+		if tok.Type == hclsyntax.TokenTemplateInterp || tok.Type == hclsyntax.TokenTemplateControl {
+			return "", ErrSourceNotLiteral
+		}
+
 		if tok.Type == hclsyntax.TokenQuotedLit {
 			b.Write(tok.Bytes)
 		}
 	}
 
-	return b.String()
+	return b.String(), nil
 }
 
 // extractBoolLiteral extracts a boolean value from an hclwrite attribute.

--- a/internal/cas/hcl_rewrite_test.go
+++ b/internal/cas/hcl_rewrite_test.go
@@ -230,3 +230,103 @@ func TestReadTerraformSourceInfo_EscapedTemplateSourceWithCAS(t *testing.T) {
 	assert.Equal(t, "../..//modules/a$${b}", source)
 	assert.True(t, updateWithCAS)
 }
+
+// nonLiteralSourceCases enumerates source expressions that are not pure
+// quoted string literals. Each must be rejected when the block opts in to
+// update_source_with_cas and tolerated when it does not.
+var nonLiteralSourceCases = []struct {
+	name   string
+	source string
+}{
+	{name: "interpolation", source: `"../units/${local.name}"`},
+	{name: "reference", source: `local.foo`},
+	{name: "function call", source: `join("/", ["..", "units", "service"])`},
+	{name: "heredoc", source: "<<-EOT\n  ../units/service\nEOT"},
+	{name: "string concatenation", source: `"../units/" + local.name`},
+	{name: "number", source: `42`},
+}
+
+func TestReadStackBlocks_NonLiteralSourceWithCAS(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range nonLiteralSourceCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := []byte(`unit "service" {
+  source = ` + tc.source + `
+  update_source_with_cas = true
+  path = "service"
+}
+`)
+
+			_, err := cas.ReadStackBlocks(input)
+			require.ErrorIs(t, err, cas.ErrSourceNotLiteral)
+
+			var wrapped *cas.WrappedError
+
+			require.ErrorAs(t, err, &wrapped)
+			assert.Equal(t, "unit", wrapped.Op)
+			assert.Equal(t, "service", wrapped.Context)
+		})
+	}
+}
+
+func TestReadStackBlocks_NonLiteralSourceWithoutCAS(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range nonLiteralSourceCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := []byte(`unit "service" {
+  source = ` + tc.source + `
+  path   = "service"
+}
+`)
+
+			blocks, err := cas.ReadStackBlocks(input)
+			require.NoError(t, err)
+			require.Len(t, blocks, 1)
+			assert.False(t, blocks[0].UpdateSourceWithCAS)
+		})
+	}
+}
+
+func TestReadTerraformSourceInfo_NonLiteralSourceWithCAS(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range nonLiteralSourceCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := []byte(`terraform {
+  source = ` + tc.source + `
+  update_source_with_cas = true
+}
+`)
+
+			_, _, err := cas.ReadTerraformSourceInfo(input)
+			require.ErrorIs(t, err, cas.ErrSourceNotLiteral)
+		})
+	}
+}
+
+func TestReadTerraformSourceInfo_NonLiteralSourceWithoutCAS(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range nonLiteralSourceCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := []byte(`terraform {
+  source = ` + tc.source + `
+}
+`)
+
+			_, updateWithCAS, err := cas.ReadTerraformSourceInfo(input)
+			require.NoError(t, err)
+			assert.False(t, updateWithCAS)
+		})
+	}
+}

--- a/internal/cas/hcl_rewrite_test.go
+++ b/internal/cas/hcl_rewrite_test.go
@@ -141,3 +141,92 @@ func TestReadTerraformSourceInfo_NoUpdateFlag(t *testing.T) {
 	assert.Equal(t, "github.com/foo/bar//modules/vpc?ref=v1.0.0", source)
 	assert.False(t, updateWithCAS)
 }
+
+func TestReadStackBlocks_InterpolatedSourceWithCAS(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`unit "service" {
+  source = "../units/${local.name}"
+  update_source_with_cas = true
+  path = "service"
+}
+`)
+
+	_, err := cas.ReadStackBlocks(input)
+	require.ErrorIs(t, err, cas.ErrSourceNotLiteral)
+}
+
+func TestReadStackBlocks_InterpolatedSourceWithoutCAS(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`unit "service" {
+  source = "../units/${local.name}"
+  path   = "service"
+}
+`)
+
+	blocks, err := cas.ReadStackBlocks(input)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	assert.False(t, blocks[0].UpdateSourceWithCAS)
+}
+
+func TestReadStackBlocks_EscapedTemplateSourceWithCAS(t *testing.T) {
+	t.Parallel()
+
+	// "$${" and "%%{" are escapes for literal "${" and "%{", not
+	// interpolation, so the source still parses as a literal.
+	input := []byte(`unit "service" {
+  source = "../units/a$${b}%%{c}"
+  update_source_with_cas = true
+  path = "service"
+}
+`)
+
+	blocks, err := cas.ReadStackBlocks(input)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	assert.True(t, blocks[0].UpdateSourceWithCAS)
+	assert.Equal(t, "../units/a$${b}%%{c}", blocks[0].Source)
+}
+
+func TestReadTerraformSourceInfo_InterpolatedSourceWithCAS(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`terraform {
+  source = "../..//modules/${var.env}"
+  update_source_with_cas = true
+}
+`)
+
+	_, _, err := cas.ReadTerraformSourceInfo(input)
+	require.ErrorIs(t, err, cas.ErrSourceNotLiteral)
+}
+
+func TestReadTerraformSourceInfo_InterpolatedSourceWithoutCAS(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`terraform {
+  source = "../..//modules/${var.env}"
+}
+`)
+
+	_, updateWithCAS, err := cas.ReadTerraformSourceInfo(input)
+	require.NoError(t, err)
+	assert.False(t, updateWithCAS)
+}
+
+func TestReadTerraformSourceInfo_EscapedTemplateSourceWithCAS(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`terraform {
+  source = "../..//modules/a$${b}"
+  update_source_with_cas = true
+}
+`)
+
+	source, updateWithCAS, err := cas.ReadTerraformSourceInfo(input)
+	require.NoError(t, err)
+	assert.Equal(t, "../..//modules/a$${b}", source)
+	assert.True(t, updateWithCAS)
+}

--- a/internal/cas/materialize_test.go
+++ b/internal/cas/materialize_test.go
@@ -210,13 +210,13 @@ func TestCASProtocolGetterGet(t *testing.T) {
 	l := logger.CreateLogger()
 
 	fileContent := []byte("resource {}\n")
-	fileHash := "file123"
+	fileHash := cas.HashSHA1.Sum(fileContent)
 
 	blobContent := cas.NewContent(blobStore)
 	require.NoError(t, blobContent.Store(l, v, fileHash, fileContent))
 
-	treeHash := "tree456"
-	treeData := []byte("100644 blob file123\tmain.tf\n")
+	treeData := []byte("100644 blob " + fileHash + "\tmain.tf\n")
+	treeHash := cas.HashSHA1.Sum(treeData)
 
 	synthContent := cas.NewContent(synthStore)
 	require.NoError(t, synthContent.Store(l, v, treeHash, treeData))
@@ -266,13 +266,13 @@ func TestCASProtocolGetterGet_Mutable(t *testing.T) {
 	l := logger.CreateLogger()
 
 	fileContent := []byte("resource {}\n")
-	fileHash := "filemut1"
+	fileHash := cas.HashSHA1.Sum(fileContent)
 
 	blobContent := cas.NewContent(blobStore)
 	require.NoError(t, blobContent.Store(l, v, fileHash, fileContent))
 
-	treeHash := "treemut1"
-	treeData := []byte("100644 blob filemut1\tmain.tf\n")
+	treeData := []byte("100644 blob " + fileHash + "\tmain.tf\n")
+	treeHash := cas.HashSHA1.Sum(treeData)
 
 	synthContent := cas.NewContent(synthStore)
 	require.NoError(t, synthContent.Store(l, v, treeHash, treeData))

--- a/internal/cas/protocol.go
+++ b/internal/cas/protocol.go
@@ -29,10 +29,15 @@ const (
 // validAlgorithms are the hash algorithm prefixes accepted in CAS references.
 var validAlgorithms = []HashAlgorithm{HashSHA1, HashSHA256}
 
+const (
+	// sha1HexLen is the length of a hex-encoded SHA-1 digest.
+	sha1HexLen = 40
+	// sha256HexLen is the length of a hex-encoded SHA-256 digest.
+	sha256HexLen = 64
+)
+
 // DetectHashAlgorithm detects the hash algorithm from a hex-encoded hash string.
 func DetectHashAlgorithm(hexHash string) HashAlgorithm {
-	const sha256HexLen = 64
-
 	if len(hexHash) >= sha256HexLen {
 		return HashSHA256
 	}
@@ -59,7 +64,9 @@ func (a HashAlgorithm) Sum(data []byte) string {
 
 // ParseCASRef extracts the hash and algorithm from a CAS reference string.
 // Expected format: "<algorithm>:<hash>" (after cas:: prefix has been stripped by Detect).
-// Accepted algorithms: "sha1", "sha256".
+// Accepted algorithms: "sha1", "sha256". The hash must be lowercase hex of the
+// digest length for the algorithm (40 characters for [HashSHA1], 64 for
+// [HashSHA256]); anything else returns [ErrCASRefInvalidHash].
 func ParseCASRef(ref string) (string, error) {
 	for _, alg := range validAlgorithms {
 		prefix := string(alg) + ":"
@@ -74,6 +81,14 @@ func ParseCASRef(ref string) (string, error) {
 				Op:      "parse_cas_ref",
 				Context: ref,
 				Err:     ErrCASRefEmptyHash,
+			}
+		}
+
+		if !isValidHexDigest(after, alg) {
+			return "", &WrappedError{
+				Op:      "parse_cas_ref",
+				Context: ref,
+				Err:     ErrCASRefInvalidHash,
 			}
 		}
 
@@ -150,4 +165,26 @@ func (c *CAS) MaterializeTree(
 	}
 
 	return LinkTree(ctx, v, c.blobStore, treeStoreUsed, tree, dest, opts...)
+}
+
+// isValidHexDigest reports whether s is a lowercase hex digest of the length
+// expected for alg: 40 characters for [HashSHA1], 64 for [HashSHA256].
+func isValidHexDigest(s string, alg HashAlgorithm) bool {
+	wantLen := sha1HexLen
+	if alg == HashSHA256 {
+		wantLen = sha256HexLen
+	}
+
+	if len(s) != wantLen {
+		return false
+	}
+
+	for i := range len(s) {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/cas/protocol_getter_test.go
+++ b/internal/cas/protocol_getter_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,36 +13,71 @@ import (
 func TestParseCASRef(t *testing.T) {
 	t.Parallel()
 
+	const (
+		sha1Hash   = "f39ea0ebf891c9954c89d07b73b487ff938ef08b"
+		sha256Hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	)
+
 	tests := []struct {
+		wantErr error
 		name    string
 		ref     string
 		want    string
-		wantErr bool
 	}{
 		{
 			name: "valid sha1 ref",
-			ref:  "sha1:abc123def456",
-			want: "abc123def456",
+			ref:  "sha1:" + sha1Hash,
+			want: sha1Hash,
 		},
 		{
 			name:    "missing sha1 prefix",
-			ref:     "abc123def456",
-			wantErr: true,
+			ref:     sha1Hash,
+			wantErr: cas.ErrCASRefMissingPrefix,
 		},
 		{
 			name:    "empty hash",
 			ref:     "sha1:",
-			wantErr: true,
+			wantErr: cas.ErrCASRefEmptyHash,
 		},
 		{
 			name: "valid sha256 ref",
-			ref:  "sha256:abc123def456",
-			want: "abc123def456",
+			ref:  "sha256:" + sha256Hash,
+			want: sha256Hash,
 		},
 		{
 			name:    "unknown algorithm",
 			ref:     "md5:abc123",
-			wantErr: true,
+			wantErr: cas.ErrCASRefMissingPrefix,
+		},
+		{
+			name:    "single character sha1 hash",
+			ref:     "sha1:a",
+			wantErr: cas.ErrCASRefInvalidHash,
+		},
+		{
+			name:    "sha1 hash too short",
+			ref:     "sha1:abc123def456",
+			wantErr: cas.ErrCASRefInvalidHash,
+		},
+		{
+			name:    "sha1 hash with non-hex characters",
+			ref:     "sha1:zz9ea0ebf891c9954c89d07b73b487ff938ef08b",
+			wantErr: cas.ErrCASRefInvalidHash,
+		},
+		{
+			name:    "sha1 hash with uppercase hex",
+			ref:     "sha1:F39EA0EBF891C9954C89D07B73B487FF938EF08B",
+			wantErr: cas.ErrCASRefInvalidHash,
+		},
+		{
+			name:    "sha256 hash too short",
+			ref:     "sha256:" + sha1Hash,
+			wantErr: cas.ErrCASRefInvalidHash,
+		},
+		{
+			name:    "sha1 hash with subdir tail",
+			ref:     "sha1:" + sha1Hash + "//modules/vpc",
+			wantErr: cas.ErrCASRefInvalidHash,
 		},
 	}
 
@@ -50,14 +86,64 @@ func TestParseCASRef(t *testing.T) {
 			t.Parallel()
 
 			got, err := cas.ParseCASRef(tt.ref)
-			if tt.wantErr {
-				require.Error(t, err)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+
+				var wrapped *cas.WrappedError
+
+				require.ErrorAs(t, err, &wrapped)
+				assert.Equal(t, tt.ref, wrapped.Context)
 
 				return
 			}
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestCASProtocolGetterGet_MalformedHash is a regression test: a malformed
+// hash in a cas:: source used to reach the store's partitioning logic and
+// panic with a slice-bounds error. It must instead fail cleanly with
+// [cas.ErrCASRefInvalidHash].
+func TestCASProtocolGetterGet_MalformedHash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "single character hash",
+			src:  "cas::sha1:a",
+		},
+		{
+			name: "non-hex hash",
+			src:  "cas::sha1:zz9ea0ebf891c9954c89d07b73b487ff938ef08b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := cas.New(cas.WithStorePath(t.TempDir()))
+			require.NoError(t, err)
+
+			v, err := cas.OSVenv()
+			require.NoError(t, err)
+
+			l := logger.CreateLogger()
+			g := getter.NewCASProtocolGetter(l, c, v)
+
+			req := &getter.Request{
+				Src: tt.src,
+				Dst: t.TempDir(),
+			}
+
+			err = g.Get(t.Context(), req)
+			require.ErrorIs(t, err, cas.ErrCASRefInvalidHash)
 		})
 	}
 }

--- a/internal/cas/stacks_local_test.go
+++ b/internal/cas/stacks_local_test.go
@@ -297,6 +297,37 @@ func TestProcessStackComponent_EmptySourceFails(t *testing.T) {
 	require.Error(t, err, "empty source must be rejected")
 }
 
+// TestProcessStackComponent_LocalSource_NonLiteralSourceFails pins the
+// end-to-end behavior for a unit block whose source is a bare reference. The
+// raw-token reader used to extract an empty string from such an expression,
+// which resolved to the block's own directory and silently packaged it.
+// Processing must fail with ErrSourceNotLiteral instead.
+func TestProcessStackComponent_LocalSource_NonLiteralSourceFails(t *testing.T) {
+	t.Parallel()
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	root := helpers.TmpDirWOSymlinks(t)
+	stackDir := filepath.Join(root, "stacks", "my-stack")
+	require.NoError(t, os.MkdirAll(stackDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(stackDir, "terragrunt.stack.hcl"),
+		[]byte(`unit "service" {
+  source = local.foo
+
+  update_source_with_cas = true
+
+  path = "service"
+}
+`),
+		0o644,
+	))
+
+	_, err := c.ProcessStackComponent(t.Context(), l, v, root+"//stacks/my-stack", "stack")
+	require.ErrorIs(t, err, cas.ErrSourceNotLiteral)
+}
+
 // TestProcessStackComponent_GitForcerRoutesRemote confirms that a source with
 // a "git::" forcer is treated as remote even though the rest of the string
 // could parse as a path. The in-process test server stands in for a real

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -588,7 +588,7 @@ func fetchComponentSource(
 			return nil
 		}
 
-		// An interpolated source on an update_source_with_cas block can never
+		// A non-literal source on an update_source_with_cas block can never
 		// be rewritten by CAS, so falling back would silently skip the rewrite
 		// the configuration asked for. Surface the error instead.
 		if errors.Is(casErr, cas.ErrSourceNotLiteral) {

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -534,9 +534,11 @@ func generateComponent(ctx context.Context, l log.Logger, opts *generateOpts, cm
 //     branch so nested components already rewritten to cas:: are not re-fetched.
 //  2. Source with CAS enabled: attempt a CAS-backed fetch (remote clone or local copy into a
 //     temp overlay) and copy from its content dir. This fires automatically whenever the cas
-//     experiment is on, so catalog authors don't need consumers to opt in per-block. On any CAS
-//     failure (for example, CAS can't handle a go-getter query param like depth=1), we fall
-//     through to the standard getter.
+//     experiment is on, so catalog authors don't need consumers to opt in per-block. On most CAS
+//     failures (for example, CAS can't handle a go-getter query param like depth=1), we fall
+//     through to the standard getter. Configuration errors that can never succeed via CAS, such
+//     as an interpolated source on a block with update_source_with_cas = true, fail generation
+//     instead of falling through.
 //  3. Standard: local copy or remote getter.
 //
 // The update_source_with_cas attribute on a consumer block is a no-op under path 2. It only
@@ -584,6 +586,13 @@ func fetchComponentSource(
 		casErr := fetchViaCAS(ctx, l, opts, cmp.sourceDir, kindStr, source, dest)
 		if casErr == nil {
 			return nil
+		}
+
+		// An interpolated source on an update_source_with_cas block can never
+		// be rewritten by CAS, so falling back would silently skip the rewrite
+		// the configuration asked for. Surface the error instead.
+		if errors.Is(casErr, cas.ErrSourceNotLiteral) {
+			return fmt.Errorf("failed to fetch %s %q via CAS: %w", kindStr, cmp.name, casErr)
 		}
 
 		l.Warnf("CAS processing failed for %s %q: %v. Falling back to standard getter.", kindStr, cmp.name, casErr)


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds validation of CAS sources to avoid a hidden panic condition, and help users construct their sources correctly for `update_source_with_cas`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed CAS references now produce a clear validation error (invalid hash formats are rejected).
  * Enabling update_source_with_cas now rejects non-literal source values (interpolation, references, function calls, heredocs) with an explicit error instead of silently altering or falling back.

* **Documentation**
  * Added v1.0.8 docs clarifying CAS reference hash requirements and that sources must be literal when CAS updates are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->