### PR TITLE
fix: Support `autoinclude` in `hcl validate` and fix `read_terragrunt_config()` for configurations using `autoinclude`

### DIFF
--- a/docs/src/data/changelog/v1.0.8/stack-dependencies-autoinclude-hcl-tooling.mdx
+++ b/docs/src/data/changelog/v1.0.8/stack-dependencies-autoinclude-hcl-tooling.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.0.8"
+category: "experiments-updated"
+---
+
+#### `stack-dependencies`: HCL tooling now handles `autoinclude`
+
+Two tooling gaps around the experimental `autoinclude` block are closed:
+
+- **`hcl validate` now validates `autoinclude` blocks.** With the `stack-dependencies` experiment enabled, validating a `terragrunt.stack.hcl` that declares `autoinclude` runs the same strict checks as `terragrunt stack generate`. A malformed block (for example, a `locals` block inside `autoinclude`) is now reported at validation time instead of passing `hcl validate` and only failing later during generation. Without the experiment, validation behavior is unchanged.
+
+- **`read_terragrunt_config()` can read stack-level autoinclude files.** Reading a generated `terragrunt.autoinclude.stack.hcl` previously failed because the file was decoded as a unit configuration, which rejects its `unit` and `stack` blocks. With the experiment enabled, the file is now decoded as the stack-file fragment it is, returning its `unit` and `stack` blocks the same way reading a `terragrunt.stack.hcl` does. Unit-level `terragrunt.autoinclude.hcl` files already read correctly and continue to do so.

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -157,7 +157,16 @@ func RunValidate(ctx context.Context, l log.Logger, v run.Venv, opts *options.Te
 				continue
 			}
 
-			if _, err := config.ParseStackConfig(ctx, l, parser, file, values); err != nil {
+			stackCfg, err := config.ParseStackConfig(ctx, l, parser, file, values)
+			if err != nil {
+				parseErrs = append(parseErrs, err)
+				continue
+			}
+
+			// The lenient stack decode above leaves autoinclude blocks unvalidated, so run the
+			// strict autoinclude parse `stack generate` uses. It no-ops unless the
+			// stack-dependencies experiment is enabled and the config declares autoinclude.
+			if err := config.ValidateStackAutoIncludes(ctx, l, parser, stackFilePath, stackCfg, values); err != nil {
 				parseErrs = append(parseErrs, err)
 			}
 

--- a/pkg/config/autoinclude_test.go
+++ b/pkg/config/autoinclude_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
+	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
@@ -1117,4 +1119,211 @@ dependency "bar" {
 	require.NotNil(t, parsed.Dependencies)
 	assert.Contains(t, parsed.Dependencies.Paths, "./foo",
 		"a dependencies block path overlapping a disabled dependency block must survive the autoinclude merge")
+}
+
+// TestParseTerragruntConfig_ReadsStackAutoIncludeFile pins that read_terragrunt_config can read a
+// generated terragrunt.autoinclude.stack.hcl. The file is a stack-file fragment holding unit and
+// stack blocks, so it must decode through the same stack parsing path as terragrunt.stack.hcl and
+// return its components, not fail the strict unit-config decode.
+func TestParseTerragruntConfig_ReadsStackAutoIncludeFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// The generated stack-level autoinclude lives beside a nested stack's terragrunt.stack.hcl.
+	stackDir := filepath.Join(tmpDir, "stack")
+	require.NoError(t, os.MkdirAll(stackDir, 0755))
+
+	autoIncludePath := filepath.Join(stackDir, config.DefaultAutoIncludeStackFile)
+	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+unit "db" {
+  source = "../catalog/units/db"
+  path   = "db"
+}
+
+stack "networking" {
+  source = "../catalog/stacks/networking"
+  path   = "networking"
+}
+`), 0644))
+
+	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, cfgPath)
+	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
+
+	l := logger.CreateLogger()
+
+	cfgCty, err := config.ParseTerragruntConfig(ctx, pctx, l, autoIncludePath, nil)
+	require.NoError(t, err, "a stack-level autoinclude file must decode through the stack parsing path")
+
+	cfgMap, err := ctyhelper.ParseCtyValueToMap(cfgCty)
+	require.NoError(t, err)
+
+	unitsMap, ok := cfgMap[config.MetadataUnit].(map[string]any)
+	require.True(t, ok, "the decoded autoinclude must expose its unit blocks")
+
+	dbUnit, ok := unitsMap["db"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "../catalog/units/db", dbUnit["source"])
+	assert.Equal(t, "db", dbUnit["path"])
+
+	stacksMap, ok := cfgMap[config.MetadataStack].(map[string]any)
+	require.True(t, ok, "the decoded autoinclude must expose its stack blocks")
+
+	netStack, ok := stacksMap["networking"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "../catalog/stacks/networking", netStack["source"])
+	assert.Equal(t, "networking", netStack["path"])
+}
+
+// TestParseTerragruntConfig_StackAutoIncludeFileRequiresExperiment pins that without the
+// stack-dependencies experiment a terragrunt.autoinclude.stack.hcl still falls through to the strict
+// unit-config decode, which rejects its unit and stack blocks. The stack-file routing is part of the
+// experiment, so behavior without it is unchanged.
+func TestParseTerragruntConfig_StackAutoIncludeFileRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeStackFile)
+	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+unit "db" {
+  source = "../catalog/units/db"
+  path   = "db"
+}
+`), 0644))
+
+	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, cfgPath)
+
+	l := logger.CreateLogger()
+
+	_, err := config.ParseTerragruntConfig(ctx, pctx, l, autoIncludePath, nil)
+	require.Error(t, err, "without the experiment the strict unit-config decode must keep rejecting unit blocks")
+}
+
+// TestParseTerragruntConfig_ReadsUnitAutoIncludeFile pins that read_terragrunt_config reads a
+// generated unit-level terragrunt.autoinclude.hcl through the regular unit-config path, returning
+// its dependency blocks and inputs.
+func TestParseTerragruntConfig_ReadsUnitAutoIncludeFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// The dependency target the autoinclude's dependency block points at.
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "vpc"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "vpc", config.DefaultTerragruntConfigPath), []byte(``), 0644))
+
+	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
+	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+dependency "vpc" {
+  config_path  = "./vpc"
+  skip_outputs = true
+  mock_outputs = {
+    vpc_id = "mock-vpc-id"
+  }
+  mock_outputs_allowed_terraform_commands = ["init"]
+}
+
+inputs = {
+  env = "test"
+}
+`), 0644))
+
+	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, cfgPath)
+	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
+	pctx.OriginalTerraformCommand = tfInitCommand
+
+	l := logger.CreateLogger()
+
+	cfgCty, err := config.ParseTerragruntConfig(ctx, pctx, l, autoIncludePath, nil)
+	require.NoError(t, err, "a unit-level autoinclude file must read through the unit-config path")
+
+	cfgMap, err := ctyhelper.ParseCtyValueToMap(cfgCty)
+	require.NoError(t, err)
+
+	inputs, ok := cfgMap[config.MetadataInputs].(map[string]any)
+	require.True(t, ok, "the decoded autoinclude must expose its inputs")
+	assert.Equal(t, "test", inputs["env"])
+
+	deps, ok := cfgMap[config.MetadataDependency].(map[string]any)
+	require.True(t, ok, "the decoded autoinclude must expose its dependency blocks")
+
+	vpcDep, ok := deps["vpc"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "./vpc", vpcDep["config_path"])
+}
+
+// TestValidateStackAutoIncludes_ReportsMalformedAutoInclude pins that the strict autoinclude parse
+// behind `hcl validate` reports a malformed autoinclude block (here a locals block, which is
+// explicitly rejected) that the lenient ParseStackConfig decode lets through into Remain.
+func TestValidateStackAutoIncludes_ReportsMalformedAutoInclude(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	stackPath := filepath.Join(tmpDir, config.DefaultStackFile)
+	require.NoError(t, os.WriteFile(stackPath, []byte(`
+unit "app" {
+  source = "./units/app"
+  path   = "app"
+
+  autoinclude {
+    locals {
+      env = "dev"
+    }
+  }
+}
+`), 0644))
+
+	ctx, pctx := newTestParsingContext(t, stackPath)
+	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
+
+	l := logger.CreateLogger()
+
+	stackCfg, err := config.ReadStackConfigFile(ctx, l, pctx, stackPath, nil)
+	require.NoError(t, err, "the lenient stack decode must keep accepting the malformed autoinclude block")
+
+	err = config.ValidateStackAutoIncludes(ctx, l, pctx, stackPath, stackCfg, nil)
+	require.Error(t, err, "the strict autoinclude parse must report the locals block")
+
+	var stageErr config.AutoIncludeParserStageError
+	require.ErrorAs(t, err, &stageErr)
+
+	var localsErr inthclparse.AutoIncludeLocalsBlockError
+	require.ErrorAs(t, err, &localsErr)
+	assert.Equal(t, "app", localsErr.Component)
+}
+
+// TestValidateStackAutoIncludes_NoOpWithoutExperiment pins that without the stack-dependencies
+// experiment the strict autoinclude validation does not run, leaving `hcl validate` behavior unchanged.
+func TestValidateStackAutoIncludes_NoOpWithoutExperiment(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	stackPath := filepath.Join(tmpDir, config.DefaultStackFile)
+	require.NoError(t, os.WriteFile(stackPath, []byte(`
+unit "app" {
+  source = "./units/app"
+  path   = "app"
+
+  autoinclude {
+    locals {
+      env = "dev"
+    }
+  }
+}
+`), 0644))
+
+	ctx, pctx := newTestParsingContext(t, stackPath)
+
+	l := logger.CreateLogger()
+
+	stackCfg, err := config.ReadStackConfigFile(ctx, l, pctx, stackPath, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, config.ValidateStackAutoIncludes(ctx, l, pctx, stackPath, stackCfg, nil),
+		"without the experiment the strict autoinclude validation must not run")
 }

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -824,7 +824,15 @@ func ParseTerragruntConfig(ctx context.Context, pctx *ParsingContext, l log.Logg
 	pctx.SkipOutputsResolution = false
 
 	// check if file is stack file, decode as stack file
-	if filepath.Base(targetConfig) == DefaultStackFile {
+	//
+	// A stack-level autoinclude file (terragrunt.autoinclude.stack.hcl) is a stack-file
+	// fragment holding unit and stack blocks, so it decodes through the same stack parsing
+	// path; the strict unit decode below would reject those blocks. Routing is gated on the
+	// experiment that introduces the file so behavior without it is unchanged.
+	targetBase := filepath.Base(targetConfig)
+	isStackAutoIncludeFile := targetBase == DefaultAutoIncludeStackFile && pctx.Experiments.Evaluate(experiment.StackDependencies)
+
+	if targetBase == DefaultStackFile || isStackAutoIncludeFile {
 		stackSourceDir := filepath.Dir(targetConfig)
 
 		values, readErr := ReadValues(ctx, pctx, l, stackSourceDir)

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -120,65 +120,9 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 
 	// When the stack-dependencies experiment is enabled, perform a two-pass
 	// parse to resolve autoinclude blocks and generate terragrunt.autoinclude.hcl files.
-	var autoIncludes map[string]*inthclparse.AutoIncludeResolved
-
-	var stackSrcBytes []byte
-
-	if pctx.Experiments.Evaluate(experiment.StackDependencies) && stackConfigHasAutoInclude(stackFile) {
-		// The autoinclude phase uses the internal HCL parser, which currently expects
-		// hclsyntax input (not JSON bodies). Preserve explicit failure behavior for JSON
-		// stack files that still declare autoinclude.
-		if !stackConfigHasAutoIncludeHCL(stackFile) {
-			return AutoIncludeParserStageError{
-				Stage: "autoinclude-parser",
-				File:  stackFilePath,
-				Err:   fmt.Errorf("stack autoinclude is only supported for HCL stack files, not JSON: %s", stackFilePath),
-			}
-		}
-
-		// stackSrcBytes is read separately for the autoinclude parser, which slices expression byte ranges from the original file when generating terragrunt.autoinclude.hcl.
-		stackSrcBytes, err = os.ReadFile(stackFilePath)
-		if err != nil {
-			return fmt.Errorf("failed to read stack file bytes %s: %w", stackFilePath, err)
-		}
-
-		// Rescope the parsing context to the stack file so terragrunt functions resolve paths relative to it instead of the root caller.
-		scopedLogger, scopedPctx, scopedErr := pctx.WithConfigPath(l, stackFilePath)
-		if scopedErr != nil {
-			return AutoIncludeParserStageError{Stage: "rescope", File: stackFilePath, Err: scopedErr}
-		}
-
-		// Production eval context (functions + caller variables) for the phased parser. The parser populates `local.*`, `unit.*`, `stack.*` itself.
-		prodEvalCtx, evalCtxErr := createTerragruntEvalContext(ctx, scopedPctx, scopedLogger, stackFilePath)
-		if evalCtxErr != nil {
-			return AutoIncludeParserStageError{Stage: "eval-context", File: stackFilePath, Err: evalCtxErr}
-		}
-
-		// Evaluate the autoinclude with the stack-file function set (derived from the eval context already built
-		// above) so directory-context functions like get_working_dir resolve against the stack file instead of
-		// re-parsing it as a regular config.
-		earlyFuncs := StackParseFunctionsFrom(prodEvalCtx.Functions, stackSourceDir)
-
-		parseResult, parseErr := inthclparse.ParseStackFile(vfs.NewOSFS(), &inthclparse.ParseStackFileInput{
-			Src:       stackSrcBytes,
-			Filename:  filepath.Base(stackFilePath),
-			StackDir:  stackSourceDir,
-			Values:    values,
-			Variables: prodEvalCtx.Variables,
-			Functions: earlyFuncs,
-		})
-		if parseErr != nil {
-			return AutoIncludeParserStageError{Stage: "parse", File: stackFilePath, Err: parseErr}
-		}
-
-		autoIncludes = parseResult.AutoIncludes
-
-		// The phased parser resolves autoincludes from the base stack file only. A sibling
-		// terragrunt.autoinclude.stack.hcl overrides same-name components wholesale, so an overridden
-		// component must not inherit the base block's resolved unit-level autoinclude.
-		if pruneErr := pruneOverriddenStackAutoIncludes(autoIncludes, stackSourceDir, prodEvalCtx, scopedPctx.ParserOptions); pruneErr != nil {
-			return AutoIncludeParserStageError{Stage: "autoinclude-override-prune", File: stackFilePath, Err: pruneErr}
-		}
+	autoIncludes, stackSrcBytes, err := resolveStackAutoIncludes(ctx, l, pctx, stackFilePath, stackFile, values)
+	if err != nil {
+		return err
 	}
 
 	casEnabled := pctx.Experiments.Evaluate(experiment.CAS) && !pctx.NoCAS
@@ -218,6 +162,87 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 	}
 
 	return nil
+}
+
+// ValidateStackAutoIncludes runs the strict autoinclude parse over the stack file at
+// stackFilePath without generating anything, so tooling such as `hcl validate` reports
+// the same autoinclude errors [GenerateStackFile] would raise. stackFile is the config
+// already parsed from stackFilePath via [ParseStackConfig]. It is a no-op when the
+// stack-dependencies experiment is disabled or no unit or stack declares autoinclude.
+func ValidateStackAutoIncludes(ctx context.Context, l log.Logger, pctx *ParsingContext, stackFilePath string, stackFile *StackConfig, values *cty.Value) error {
+	_, _, err := resolveStackAutoIncludes(ctx, l, pctx, stackFilePath, stackFile, values)
+
+	return err
+}
+
+// resolveStackAutoIncludes runs the strict phased autoinclude parse over the stack file at
+// stackFilePath and returns the resolved autoincludes keyed by [inthclparse.AutoIncludeKey],
+// plus the raw stack file bytes the generator slices expression ranges from. It returns nil
+// results when the stack-dependencies experiment is disabled or stackFile declares no
+// autoinclude blocks, mirroring the gate [GenerateStackFile] has always applied.
+func resolveStackAutoIncludes(ctx context.Context, l log.Logger, pctx *ParsingContext, stackFilePath string, stackFile *StackConfig, values *cty.Value) (map[string]*inthclparse.AutoIncludeResolved, []byte, error) {
+	if !pctx.Experiments.Evaluate(experiment.StackDependencies) || !stackConfigHasAutoInclude(stackFile) {
+		return nil, nil, nil
+	}
+
+	stackSourceDir := filepath.Dir(stackFilePath)
+
+	// The autoinclude phase uses the internal HCL parser, which currently expects
+	// hclsyntax input (not JSON bodies). Preserve explicit failure behavior for JSON
+	// stack files that still declare autoinclude.
+	if !stackConfigHasAutoIncludeHCL(stackFile) {
+		return nil, nil, AutoIncludeParserStageError{
+			Stage: "autoinclude-parser",
+			File:  stackFilePath,
+			Err:   fmt.Errorf("stack autoinclude is only supported for HCL stack files, not JSON: %s", stackFilePath),
+		}
+	}
+
+	// stackSrcBytes is read separately for the autoinclude parser, which slices expression byte ranges from the original file when generating terragrunt.autoinclude.hcl.
+	stackSrcBytes, err := os.ReadFile(stackFilePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read stack file bytes %s: %w", stackFilePath, err)
+	}
+
+	// Rescope the parsing context to the stack file so terragrunt functions resolve paths relative to it instead of the root caller.
+	scopedLogger, scopedPctx, scopedErr := pctx.WithConfigPath(l, stackFilePath)
+	if scopedErr != nil {
+		return nil, nil, AutoIncludeParserStageError{Stage: "rescope", File: stackFilePath, Err: scopedErr}
+	}
+
+	// Production eval context (functions + caller variables) for the phased parser. The parser populates `local.*`, `unit.*`, `stack.*` itself.
+	prodEvalCtx, evalCtxErr := createTerragruntEvalContext(ctx, scopedPctx, scopedLogger, stackFilePath)
+	if evalCtxErr != nil {
+		return nil, nil, AutoIncludeParserStageError{Stage: "eval-context", File: stackFilePath, Err: evalCtxErr}
+	}
+
+	// Evaluate the autoinclude with the stack-file function set (derived from the eval context already built
+	// above) so directory-context functions like get_working_dir resolve against the stack file instead of
+	// re-parsing it as a regular config.
+	earlyFuncs := StackParseFunctionsFrom(prodEvalCtx.Functions, stackSourceDir)
+
+	parseResult, parseErr := inthclparse.ParseStackFile(vfs.NewOSFS(), &inthclparse.ParseStackFileInput{
+		Src:       stackSrcBytes,
+		Filename:  filepath.Base(stackFilePath),
+		StackDir:  stackSourceDir,
+		Values:    values,
+		Variables: prodEvalCtx.Variables,
+		Functions: earlyFuncs,
+	})
+	if parseErr != nil {
+		return nil, nil, AutoIncludeParserStageError{Stage: "parse", File: stackFilePath, Err: parseErr}
+	}
+
+	autoIncludes := parseResult.AutoIncludes
+
+	// The phased parser resolves autoincludes from the base stack file only. A sibling
+	// terragrunt.autoinclude.stack.hcl overrides same-name components wholesale, so an overridden
+	// component must not inherit the base block's resolved unit-level autoinclude.
+	if pruneErr := pruneOverriddenStackAutoIncludes(autoIncludes, stackSourceDir, prodEvalCtx, scopedPctx.ParserOptions); pruneErr != nil {
+		return nil, nil, AutoIncludeParserStageError{Stage: "autoinclude-override-prune", File: stackFilePath, Err: pruneErr}
+	}
+
+	return autoIncludes, stackSrcBytes, nil
 }
 
 // validateUpdateSourceWithCAS rejects stack files that declare update_source_with_cas = true

--- a/test/fixtures/stacks/stack-deps-hclvalidate-autoinclude/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-hclvalidate-autoinclude/live/terragrunt.stack.hcl
@@ -1,0 +1,12 @@
+unit "app" {
+  source = "../units/app"
+  path   = "app"
+
+  # Malformed on purpose: a locals block inside autoinclude is rejected by the
+  # strict autoinclude parser, but the lenient stack decode leaves it in Remain.
+  autoinclude {
+    locals {
+      env = "dev"
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-hclvalidate-autoinclude/units/app/main.tf
+++ b/test/fixtures/stacks/stack-deps-hclvalidate-autoinclude/units/app/main.tf
@@ -1,0 +1,1 @@
+# Intentionally empty.

--- a/test/fixtures/stacks/stack-deps-hclvalidate-autoinclude/units/app/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-hclvalidate-autoinclude/units/app/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -67,6 +67,7 @@ const (
 	testFixtureStackDepsAutoIncFuncs             = "fixtures/stacks/stack-deps-autoinclude-funcs"
 	testFixtureStackDepsValuesSiblingAutoInc     = "fixtures/stacks/stack-deps-values-sibling-autoinclude"
 	testFixtureStackDepsStackValuesLocals        = "fixtures/stacks/stack-deps-stack-values-locals"
+	testFixtureStackDepsHCLValidateAutoInc       = "fixtures/stacks/stack-deps-hclvalidate-autoinclude"
 )
 
 // TestStackDepsAutoIncludeGenerationAndDAG tests parsing, autoinclude generation,
@@ -2299,4 +2300,45 @@ func stackDepsFuncsFor(ctx context.Context, l log.Logger, pctx *config.ParsingCo
 	return func(dir string) (map[string]function.Function, error) {
 		return config.EarlyStackParseFunctions(ctx, l, dir, pctx)
 	}
+}
+
+// TestStackDepsHCLValidateReportsMalformedAutoInclude pins that `hcl validate` runs the strict
+// autoinclude parse over stack configs: a malformed autoinclude block (a locals block inside
+// autoinclude) fails validation with the experiment enabled instead of only failing later at
+// `stack generate`. Without the experiment the block stays unvalidated, so behavior is unchanged.
+func TestStackDepsHCLValidateReportsMalformedAutoInclude(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsExperimentMode(t) {
+		t.Skip("Skipping: TG_EXPERIMENT_MODE forces all experiments on, defeating the disabled-vs-enabled comparison this test pins")
+	}
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsHCLValidateAutoInc)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsHCLValidateAutoInc)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStackDepsHCLValidateAutoInc, "live")
+	rootPath, err := filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	// Without the experiment the autoinclude block falls into the lenient decode's Remain, as before.
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt hcl validate --working-dir "+rootPath)
+	require.NoError(t, err, "without the experiment hcl validate must keep passing the stack config")
+
+	// With the experiment the same strict parse `stack generate` uses must reject the block.
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt hcl validate --experiment stack-dependencies --working-dir "+rootPath)
+	require.Error(t, err, "with the experiment hcl validate must report the malformed autoinclude block")
+}
+
+// TestStackDepsHCLValidateAcceptsValidAutoInclude pins that the strict autoinclude pass added to
+// `hcl validate` does not reject a well-formed autoinclude block.
+func TestStackDepsHCLValidateAcceptsValidAutoInclude(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStackDepsAutoInclude)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsAutoInclude)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStackDepsAutoInclude, "live")
+	rootPath, err := filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt hcl validate --experiment stack-dependencies --working-dir "+rootPath)
+	require.NoError(t, err, "a well-formed autoinclude block must pass hcl validate")
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `hcl validate` now strictly validates stack autoinclude blocks like `stack generate` (gated by the StackDependencies experiment).
  * Reading/decoding of generated stack-level autoinclude files is supported; unit-level autoincludes remain unchanged.

* **Tests**
  * Added unit and integration tests covering stack-level autoinclude parsing and strict validation behavior (both success and failure cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->