### PR TITLE
feat: Adding CAS fallback telemetry

### DIFF
--- a/docs/src/data/changelog/v1.0.8/cas-fallback-telemetry.mdx
+++ b/docs/src/data/changelog/v1.0.8/cas-fallback-telemetry.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.8"
+category: "experiments-updated"
+---
+
+#### `cas`: fallbacks now emit telemetry
+
+When the `cas` experiment is enabled and a CAS operation cannot complete, Terragrunt falls back to a slower path (the standard download client, or a temporary clone when the shared git store is unavailable) and keeps going. Until now the only record of a fallback was a warning in the logs, which made it impractical to measure how often CAS degrades across a fleet.
+
+Each fallback now also emits a `cas_fallback` telemetry event whose `reason` attribute identifies the cause: `init_error`, `getter_error`, `git_store_unavailable`, `probe_failure`, or `stack_generation_error`. Operators collecting OpenTelemetry traces or metrics from Terragrunt can count and alert on these events to judge CAS health before relying on it by default.

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -336,6 +336,7 @@ func (c *CAS) populateTreeFromSymbolicRef(
 	}
 
 	l.Warnf("central git store unavailable for %s, falling back to temporary clone: %v", ref.URL, err)
+	RecordFallback(ctx, l, FallbackReasonGitStoreUnavailable, map[string]any{"url": ref.URL})
 
 	tempDir, cleanup, err := c.makeFallbackCloneDir(l, v)
 	if err != nil {
@@ -386,6 +387,7 @@ func (c *CAS) populateTreeFromCommitRef(
 	}
 
 	l.Warnf("central git store unavailable for %s, falling back to temporary clone: %v", ref.URL, err)
+	RecordFallback(ctx, l, FallbackReasonGitStoreUnavailable, map[string]any{"url": ref.URL})
 
 	tempDir, cleanup, err := c.makeFallbackCloneDir(l, v)
 	if err != nil {

--- a/internal/cas/source.go
+++ b/internal/cas/source.go
@@ -211,8 +211,15 @@ func (c *CAS) probeSource(ctx context.Context, l log.Logger, src SourceRequest) 
 
 	key, err := src.Resolver.Probe(ctx, src.URL)
 	if err != nil {
+		// ErrNoVersionMetadata is the resolver's documented "no cheap
+		// signal" answer, not a degradation, so only real probe errors
+		// count as fallbacks.
 		if !errors.Is(err, ErrNoVersionMetadata) {
 			l.Debugf("cas: source probe for %s failed (falling back to content hash): %v", src.URL, err)
+			RecordFallback(ctx, l, FallbackReasonProbeFailure, map[string]any{
+				"url":    src.URL,
+				"scheme": src.Scheme,
+			})
 		}
 
 		return ""

--- a/internal/cas/telemetry.go
+++ b/internal/cas/telemetry.go
@@ -1,0 +1,62 @@
+package cas
+
+import (
+	"context"
+	"maps"
+
+	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+// FallbackReason classifies why a CAS code path degraded to a slower
+// alternative. It travels as the reason attribute on the cas_fallback
+// telemetry event emitted by [RecordFallback].
+type FallbackReason string
+
+const (
+	// FallbackReasonInitError reports that the CAS store or its execution
+	// environment could not be initialized, so the source was downloaded
+	// through the standard getter without CAS.
+	FallbackReasonInitError FallbackReason = "init_error"
+
+	// FallbackReasonGetterError reports that the CAS-backed download
+	// failed and the source was re-downloaded through the standard
+	// getter.
+	FallbackReasonGetterError FallbackReason = "getter_error"
+
+	// FallbackReasonGitStoreUnavailable reports that the central
+	// [GitStore] could not serve a ref or commit (e.g. locked or
+	// corrupted), so the fetch fell back to a temporary clone.
+	FallbackReasonGitStoreUnavailable FallbackReason = "git_store_unavailable"
+
+	// FallbackReasonProbeFailure reports that a [SourceResolver.Probe]
+	// failed, so [CAS.FetchSource] could not short-circuit on a cached
+	// tree and re-downloaded the source.
+	FallbackReasonProbeFailure FallbackReason = "probe_failure"
+
+	// FallbackReasonStackGenerationError reports that CAS-backed stack
+	// generation failed for a component, falling back to the standard
+	// copy or getter path.
+	FallbackReasonStackGenerationError FallbackReason = "stack_generation_error"
+)
+
+// RecordFallback emits a cas_fallback telemetry event so operators can
+// measure how often CAS degrades and why. reason distinguishes the
+// fallback causes; attrs carry site-specific context (e.g. the source
+// URL) and may be nil.
+//
+// The telemeter travels on ctx, matching [CAS.FetchSource]. A failure
+// to record the event is logged at debug level and never affects the
+// fallback itself.
+func RecordFallback(ctx context.Context, l log.Logger, reason FallbackReason, attrs map[string]any) {
+	all := map[string]any{"reason": string(reason)}
+
+	maps.Copy(all, attrs)
+
+	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "cas_fallback", all, func(context.Context) error {
+		return nil
+	})
+	if err != nil {
+		l.Debugf("cas: failed to record fallback telemetry: %v", err)
+	}
+}

--- a/internal/cas/telemetry_test.go
+++ b/internal/cas/telemetry_test.go
@@ -1,0 +1,108 @@
+package cas_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFetchSource_ProbeFailureRecordsFallback pins the cas_fallback
+// telemetry contract on the probe-failure site: a failing probe must
+// emit a span named cas_fallback carrying reason=probe_failure while
+// the fetch itself still succeeds through the download path.
+func TestFetchSource_ProbeFailureRecordsFallback(t *testing.T) {
+	t.Parallel()
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	var buf bytes.Buffer
+
+	tlm, err := telemetry.NewTelemeter(t.Context(), l, "terragrunt", "v0.0.0-test", &buf, &telemetry.Options{
+		TraceExporter: "console",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tlm)
+
+	ctx := telemetry.ContextWithTelemeter(t.Context(), tlm)
+
+	resolver := &fakeResolver{
+		scheme: "http",
+		err:    errors.New("probe exploded"),
+	}
+
+	var fetchCalls atomic.Int32
+
+	dst := filepath.Join(t.TempDir(), "dst")
+	require.NoError(t, c.FetchSource(ctx, l, v, &cas.CloneOptions{Dir: dst}, cas.SourceRequest{
+		Scheme:   "http",
+		URL:      "https://example.com/mod.tgz",
+		Resolver: resolver,
+		Fetch:    fakeFetcher(c, map[string]string{"main.tf": "ok"}, &fetchCalls),
+	}))
+	require.NoError(t, tlm.Shutdown(ctx))
+
+	assert.Equal(t, int32(1), fetchCalls.Load(), "probe failure must still download the source")
+	assert.FileExists(t, filepath.Join(dst, "main.tf"))
+
+	assert.Equal(t, map[string]string{
+		"reason": string(cas.FallbackReasonProbeFailure),
+		"scheme": "http",
+		"url":    "https://example.com/mod.tgz",
+	}, collectFallbackAttrs(t, &buf), "expected one cas_fallback span attributed to the failed probe")
+}
+
+// collectFallbackAttrs decodes the console trace exporter output in buf
+// and returns the string attributes of the cas_fallback spans it finds.
+// Encountering more than one cas_fallback span fails the test, so the
+// returned map is unambiguous.
+func collectFallbackAttrs(t *testing.T, buf *bytes.Buffer) map[string]string {
+	t.Helper()
+
+	// Value is any rather than string because the buffer interleaves
+	// spans from the whole fetch, and cas_link spans carry bool and
+	// int attributes.
+	type span struct {
+		Name       string `json:"Name"`
+		Attributes []struct {
+			Value struct {
+				Value any `json:"Value"`
+			} `json:"Value"`
+			Key string `json:"Key"`
+		} `json:"Attributes"`
+	}
+
+	var attrs map[string]string
+
+	dec := json.NewDecoder(buf)
+	for dec.More() {
+		var s span
+		require.NoError(t, dec.Decode(&s))
+
+		if s.Name != "cas_fallback" {
+			continue
+		}
+
+		require.Nil(t, attrs, "expected exactly one cas_fallback span")
+
+		attrs = map[string]string{}
+
+		for _, attr := range s.Attributes {
+			val, ok := attr.Value.Value.(string)
+			require.True(t, ok, "cas_fallback attribute %q must be a string", attr.Key)
+
+			attrs[attr.Key] = val
+		}
+	}
+
+	return attrs
+}

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -409,12 +409,16 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 	c, err := cas.New(cas.WithCloneDepth(opts.CASCloneDepth))
 	if err != nil {
 		l.Warnf("Failed to initialize CAS: %v. Falling back to standard getter.", err)
+		cas.RecordFallback(ctx, l, cas.FallbackReasonInitError, map[string]any{"url": canonicalSourceURL})
+
 		return false, nil
 	}
 
 	venv, err := cas.OSVenv()
 	if err != nil {
 		l.Warnf("Failed to initialize CAS environment: %v. Falling back to standard getter.", err)
+		cas.RecordFallback(ctx, l, cas.FallbackReasonInitError, map[string]any{"url": canonicalSourceURL})
+
 		return false, nil
 	}
 
@@ -446,6 +450,7 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 		Pwd: opts.WorkingDir,
 	}); err != nil {
 		l.Warnf("CAS download failed: %v. Falling back to standard getter.", err)
+		cas.RecordFallback(ctx, l, cas.FallbackReasonGetterError, map[string]any{"url": canonicalSourceURL})
 
 		// Clear any partial CAS output before the fallback runs; mixing
 		// leftover CAS files with the standard getter's output leaves the

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -587,6 +587,11 @@ func fetchComponentSource(
 		}
 
 		l.Warnf("CAS processing failed for %s %q: %v. Falling back to standard getter.", kindStr, cmp.name, casErr)
+		cas.RecordFallback(ctx, l, cas.FallbackReasonStackGenerationError, map[string]any{
+			"kind":   kindStr,
+			"name":   cmp.name,
+			"source": source,
+		})
 	}
 
 	if err := copyFiles(ctx, l, cmp.name, cmp.sourceDir, source, dest); err != nil {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CAS fallback operations now generate telemetry events with failure reason details, enabling operators to track and measure degradation.

* **Documentation**
  * Added v1.0.8 changelog entry documenting CAS fallback telemetry events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->