### PR TITLE
chore: Speeding up files read

### DIFF
--- a/docs/src/data/changelog/v1.0.8/mark-many-as-read-tracking-scaling.mdx
+++ b/docs/src/data/changelog/v1.0.8/mark-many-as-read-tracking-scaling.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.0.8"
+category: "performance-improvements"
+---
+
+#### Faster read-file tracking with the `mark-many-as-read` experiment
+
+With the `mark-many-as-read` experiment enabled, Terragrunt records every module file it marks as read during parsing. The bookkeeping for that record scaled quadratically: each new path was checked against every path recorded so far, which got expensive for units with large local module sources, and monorepos paid that cost again for every unit and every command.
+
+Recording a path now takes constant time no matter how many paths came before it, and re-marking already-recorded files is cheaper still. The `reading` lists reported by `find` and `list` are unchanged.

--- a/pkg/config/files_read.go
+++ b/pkg/config/files_read.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"maps"
 	"slices"
 	"sync"
 )
@@ -10,8 +11,8 @@ import (
 // and returns zero values from accessors, so call sites that don't need to
 // track reads can pass nil.
 type FilesRead struct {
-	paths []string
-	mu    sync.RWMutex
+	seen map[string]struct{}
+	mu   sync.RWMutex
 }
 
 // NewFilesRead returns an empty FilesRead ready for concurrent use.
@@ -28,14 +29,14 @@ func (f *FilesRead) Add(path string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	if slices.Contains(f.paths, path) {
-		return
+	if f.seen == nil {
+		f.seen = make(map[string]struct{})
 	}
 
-	f.paths = append(f.paths, path)
+	f.seen[path] = struct{}{}
 }
 
-// Paths returns a snapshot copy of the recorded paths in insertion order.
+// Paths returns the recorded paths in lexical order.
 func (f *FilesRead) Paths() []string {
 	if f == nil {
 		return nil
@@ -44,7 +45,7 @@ func (f *FilesRead) Paths() []string {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	return slices.Clone(f.paths)
+	return slices.Sorted(maps.Keys(f.seen))
 }
 
 // Len returns the number of recorded paths.
@@ -56,5 +57,5 @@ func (f *FilesRead) Len() int {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	return len(f.paths)
+	return len(f.seen)
 }

--- a/pkg/config/files_read_bench_test.go
+++ b/pkg/config/files_read_bench_test.go
@@ -1,0 +1,51 @@
+package config_test
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+)
+
+// BenchmarkFilesReadAdd measures accumulation cost at sizes representative of
+// walking local module directories in a monorepo. "unique" adds n distinct
+// paths into a fresh set; "duplicate" re-adds n already-recorded paths, the
+// all-dedup-hit pattern seen when the same module dir is marked repeatedly.
+func BenchmarkFilesReadAdd(b *testing.B) {
+	for _, size := range []int{1000, 5000, 20000} {
+		paths := benchPaths(size)
+
+		b.Run("unique/"+strconv.Itoa(size), func(b *testing.B) {
+			for b.Loop() {
+				f := config.NewFilesRead()
+				for _, path := range paths {
+					f.Add(path)
+				}
+			}
+		})
+
+		b.Run("duplicate/"+strconv.Itoa(size), func(b *testing.B) {
+			f := config.NewFilesRead()
+			for _, path := range paths {
+				f.Add(path)
+			}
+
+			for b.Loop() {
+				for _, path := range paths {
+					f.Add(path)
+				}
+			}
+		})
+	}
+}
+
+// benchPaths fabricates n distinct module-file paths.
+func benchPaths(n int) []string {
+	paths := make([]string, n)
+	for i := range n {
+		paths[i] = filepath.Join("modules", strconv.Itoa(i%100), "file-"+strconv.Itoa(i)+".tf")
+	}
+
+	return paths
+}

--- a/pkg/config/files_read_test.go
+++ b/pkg/config/files_read_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFilesReadDeduplicates(t *testing.T) {
+func TestFilesReadDeduplicatesAndSorts(t *testing.T) {
 	t.Parallel()
 
 	f := config.NewFilesRead()
-	f.Add("a")
 	f.Add("b")
 	f.Add("a")
+	f.Add("b")
 
 	assert.Equal(t, []string{"a", "b"}, f.Paths())
 	assert.Equal(t, 2, f.Len())
@@ -33,10 +33,10 @@ func TestFilesReadNilReceiver(t *testing.T) {
 }
 
 // TestFilesReadConcurrentAddWithRacing pins the concurrency-safety of FilesRead.
-// Without the mutex, concurrent Add calls produce a slice header / backing
-// array mismatch that crashes inside slices.Contains (the original panic seen
-// in TestStackOutputsRaw). The -race suffix flags this test for CI execution
-// under `go test -race`.
+// Without the mutex, concurrent Add calls fault on concurrent map writes; the
+// pre-FilesRead version of this race crashed inside slices.Contains (the panic
+// originally seen in TestStackOutputsRaw). The -race suffix flags this test for
+// CI execution under `go test -race`.
 func TestFilesReadConcurrentAddWithRacing(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

I initially advocated against doing this, but the changes in `mark-many-as-read` made my justifications wrong. Units are much more likely now to get to the > 10-50 read files that result in tipping over to tracking them in a map being better than tracking them as a slice. I admit my defeat.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Improved performance when marking many items as read through enhanced file tracking efficiency.

* **Tests**
  * Added comprehensive benchmarks measuring file tracking performance across unique and duplicate path scenarios.

* **Documentation**
  * Updated changelog documenting performance optimizations for read-file tracking operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->