### PR TITLE
fix: Fixing catalog exit codes

### DIFF
--- a/docs/src/data/changelog/v1.0.8/catalog-redesign-failure-exit-codes.mdx
+++ b/docs/src/data/changelog/v1.0.8/catalog-redesign-failure-exit-codes.mdx
@@ -1,0 +1,18 @@
+---
+version: "v1.0.8"
+category: "experiments-updated"
+---
+
+#### `catalog-redesign` — Failures now exit nonzero and name the sources that failed
+
+The redesigned catalog exited with code 0 even when it failed: a session that ended on an unreachable repository, a failed scaffold, or a failed copy reported success in its exit code. Repositories that failed to load during discovery were dropped too: the warning logged for each one was drawn over by the full-screen interface, so a run where every source failed showed the same "No catalog sources were discovered" screen as a run that genuinely found nothing.
+
+The catalog now exits nonzero when the session ends on a failure: a discovery failure that leaves nothing to browse, a failed scaffold, or a failed copy. Quitting a working session still exits 0. When some sources fail to load while others succeed, the catalog stays usable and a clean quit still exits 0; the component list shows how many sources failed, and the failed repositories are printed with their causes after the catalog closes. When every source fails, the error screen lists each failed repository instead of claiming nothing was found, and dismissing it exits nonzero.
+
+Running `terragrunt catalog` without an interactive terminal, such as in CI, used to fail with a raw error from the underlying TUI library:
+
+```text
+bubbletea: error opening TTY: bubbletea: could not open TTY: open /dev/tty: no such device or address
+```
+
+It now fails immediately with an error stating that the catalog command requires an interactive terminal.

--- a/internal/cli/commands/catalog/catalog_redesign.go
+++ b/internal/cli/commands/catalog/catalog_redesign.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"slices"
+	"strings"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 
@@ -26,6 +29,12 @@ const urlChannelBufferSize = 10
 // discovery and component loading in the background. When loading completes,
 // the TUI transitions to the component list or shows a welcome screen.
 func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, repoURL string) error {
+	// Fail fast with a clear error when there is no terminal to attach the
+	// TUI to, instead of surfacing bubbletea's raw TTY failure.
+	if err := redesign.EnsureOSTTY(l); err != nil {
+		return err
+	}
+
 	// If an explicit URL was passed via CLI, use the default path
 	if repoURL != "" {
 		return runDefault(ctx, l, opts, repoURL)
@@ -63,6 +72,15 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 			loaders, loadCtx := errgroup.WithContext(ctx)
 			loaders.SetLimit(maxWorkers)
 
+			// Per-source failures are collected rather than logged: log
+			// writes during the alt-screen shred the TUI's rendering, and
+			// swallowing them would leave the user staring at a misleading
+			// "no sources" screen when every repository failed to load.
+			var (
+				failuresMu sync.Mutex
+				failures   []redesign.SourceFailure
+			)
+
 			seen := make(map[string]struct{})
 
 			for repoURL := range urlCh {
@@ -73,12 +91,20 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 				seen[repoURL] = struct{}{}
 
 				loaders.Go(func() error {
-					if err := redesign.LoadURL(loadCtx, l, opts, repoURL, componentCh); err != nil {
-						// Suppress errors from context cancellation (user quit the TUI).
-						if loadCtx.Err() == nil {
-							l.Warnf("Error loading %s: %v", repoURL, err)
-						}
+					err := redesign.LoadURL(loadCtx, l, opts, repoURL, componentCh)
+					if err == nil {
+						return nil
 					}
+
+					// Suppress errors from context cancellation (user quit the TUI).
+					if loadCtx.Err() != nil {
+						return nil
+					}
+
+					failuresMu.Lock()
+					defer failuresMu.Unlock()
+
+					failures = append(failures, redesign.SourceFailure{URL: repoURL, Err: err})
 
 					return nil
 				})
@@ -90,6 +116,14 @@ func runRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 
 			if err := g.Wait(); err != nil {
 				return fmt.Errorf("discovering sources: %w", err)
+			}
+
+			if len(failures) > 0 {
+				slices.SortFunc(failures, func(a, b redesign.SourceFailure) int {
+					return strings.Compare(a.URL, b.URL)
+				})
+
+				return &redesign.SourceLoadError{Failures: failures, Attempted: len(seen)}
 			}
 
 			return nil

--- a/internal/cli/commands/catalog/tui/redesign/errors.go
+++ b/internal/cli/commands/catalog/tui/redesign/errors.go
@@ -1,0 +1,50 @@
+package redesign
+
+import (
+	"fmt"
+)
+
+// SourceFailure records a single catalog source that failed to load during
+// multi-repo discovery, together with the cause.
+type SourceFailure struct {
+	// Err is the load failure for this source.
+	Err error
+	// URL is the repository URL of the failed source.
+	URL string
+}
+
+// SourceLoadError aggregates per-source load failures from a discovery run.
+// Attempted counts the distinct sources discovery tried to load, so callers
+// can distinguish "every source failed" from a partial failure where the
+// catalog still has usable components.
+type SourceLoadError struct {
+	Failures  []SourceFailure
+	Attempted int
+}
+
+// AllFailed reports whether every attempted source failed to load.
+func (e *SourceLoadError) AllFailed() bool {
+	return e.Attempted > 0 && len(e.Failures) == e.Attempted
+}
+
+// Error returns a one-line summary. Per-source details live in Failures and
+// are rendered by the TUI rather than packed into the error string.
+func (e *SourceLoadError) Error() string {
+	if e.AllFailed() {
+		return fmt.Sprintf("failed to load all %d catalog %s",
+			e.Attempted, pluralize("source", "sources", e.Attempted))
+	}
+
+	return fmt.Sprintf("failed to load %d of %d catalog sources", len(e.Failures), e.Attempted)
+}
+
+// Unwrap exposes the underlying per-source errors to [errors.Is] and
+// [errors.As].
+func (e *SourceLoadError) Unwrap() []error {
+	errs := make([]error, len(e.Failures))
+	for i, f := range e.Failures {
+		errs[i] = f.Err
+	}
+
+	return errs
+}

--- a/internal/cli/commands/catalog/tui/redesign/errors_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/errors_test.go
@@ -1,0 +1,134 @@
+package redesign_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui/redesign"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSourceLoadErrorAllFailed pins the boundary between "every source
+// failed" (terminal for the session) and a partial failure (the catalog
+// stays usable).
+func TestSourceLoadErrorAllFailed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		err  *redesign.SourceLoadError
+		name string
+		want bool
+	}{
+		{
+			name: "all sources failed",
+			err: &redesign.SourceLoadError{
+				Failures: []redesign.SourceFailure{
+					{URL: "github.com/acme/a", Err: errors.New("boom")},
+					{URL: "github.com/acme/b", Err: errors.New("boom")},
+				},
+				Attempted: 2,
+			},
+			want: true,
+		},
+		{
+			name: "partial failure",
+			err: &redesign.SourceLoadError{
+				Failures: []redesign.SourceFailure{
+					{URL: "github.com/acme/a", Err: errors.New("boom")},
+				},
+				Attempted: 3,
+			},
+			want: false,
+		},
+		{
+			name: "no sources attempted",
+			err: &redesign.SourceLoadError{
+				Failures:  nil,
+				Attempted: 0,
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, tc.err.AllFailed())
+		})
+	}
+}
+
+// TestSourceLoadErrorUnwrapExposesCauses verifies that errors.Is can find
+// any per-source cause through the aggregate.
+func TestSourceLoadErrorUnwrapExposesCauses(t *testing.T) {
+	t.Parallel()
+
+	first := errors.New("clone failed")
+	second := errors.New("authentication required")
+
+	err := &redesign.SourceLoadError{
+		Failures: []redesign.SourceFailure{
+			{URL: "github.com/acme/a", Err: first},
+			{URL: "github.com/acme/b", Err: second},
+		},
+		Attempted: 2,
+	}
+
+	require.ErrorIs(t, err, first)
+	require.ErrorIs(t, err, second)
+	require.NotErrorIs(t, err, errors.New("unrelated"))
+}
+
+// TestSourceLoadErrorSummary pins the one-line summary the TUI renders in
+// the list-view notice and the welcome error screen.
+func TestSourceLoadErrorSummary(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		err  *redesign.SourceLoadError
+		name string
+		want string
+	}{
+		{
+			name: "all failed plural",
+			err: &redesign.SourceLoadError{
+				Failures: []redesign.SourceFailure{
+					{URL: "a", Err: errors.New("boom")},
+					{URL: "b", Err: errors.New("boom")},
+				},
+				Attempted: 2,
+			},
+			want: "failed to load all 2 catalog sources",
+		},
+		{
+			name: "all failed singular",
+			err: &redesign.SourceLoadError{
+				Failures: []redesign.SourceFailure{
+					{URL: "a", Err: errors.New("boom")},
+				},
+				Attempted: 1,
+			},
+			want: "failed to load all 1 catalog source",
+		},
+		{
+			name: "partial failure",
+			err: &redesign.SourceLoadError{
+				Failures: []redesign.SourceFailure{
+					{URL: "a", Err: errors.New("boom")},
+				},
+				Attempted: 3,
+			},
+			want: "failed to load 1 of 3 catalog sources",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, tc.err.Error())
+		})
+	}
+}

--- a/internal/cli/commands/catalog/tui/redesign/model.go
+++ b/internal/cli/commands/catalog/tui/redesign/model.go
@@ -23,17 +23,20 @@ import (
 )
 
 // EmitExitMessage prints any post-exit message that the final model stashed
-// during its session (e.g. the values-stub callout on a successful copy).
-// It runs after the tea program restores the main terminal buffer, because
-// messages queued via tea.Printf while the alt screen is active get discarded
-// when the alt screen is torn down.
+// during its session (e.g. the values-stub callout on a successful copy, or
+// the discovery-failure details from the welcome screen). It runs after the
+// tea program restores the main terminal buffer, because messages queued via
+// tea.Printf while the alt screen is active get discarded when the alt
+// screen is torn down.
 func EmitExitMessage(finalModel tea.Model, errWriter io.Writer, l log.Logger) {
-	listModel, ok := finalModel.(Model)
-	if !ok || listModel.ExitMessage() == "" {
+	type exitMessenger interface{ ExitMessage() string }
+
+	m, ok := finalModel.(exitMessenger)
+	if !ok || m.ExitMessage() == "" {
 		return
 	}
 
-	if _, err := fmt.Fprintln(errWriter, listModel.ExitMessage()); err != nil {
+	if _, err := fmt.Fprintln(errWriter, m.ExitMessage()); err != nil {
 		l.Warnf("Failed to write exit message: %v", err)
 	}
 }
@@ -66,19 +69,27 @@ type Model struct {
 	// work (e.g. scaffold.Prepare downloading sources) propagates the
 	// user's Ctrl+C through this context, so the call returns instead of
 	// blocking on an abandoned download.
-	ctx                 context.Context
-	lists               [numTabs]list.Model
-	logger              log.Logger
-	terragruntOptions   *options.TerragruntOptions
-	selectedComponent   *Component
-	delegateKeys        *tui.DelegateKeyMap
-	buttonBar           *buttonbar.ButtonBar
-	componentCh         chan *ComponentEntry
-	errCh               chan error
-	mdRenderer          *glamour.TermRenderer
-	form                *FormModel
-	scaffoldPlan        *scaffold.Plan
-	valuesRefs          *ValuesReferences
+	ctx               context.Context
+	lists             [numTabs]list.Model
+	logger            log.Logger
+	terragruntOptions *options.TerragruntOptions
+	selectedComponent *Component
+	delegateKeys      *tui.DelegateKeyMap
+	buttonBar         *buttonbar.ButtonBar
+	componentCh       chan *ComponentEntry
+	errCh             chan error
+	mdRenderer        *glamour.TermRenderer
+	form              *FormModel
+	scaffoldPlan      *scaffold.Plan
+	valuesRefs        *ValuesReferences
+	// terminalErr is the failure that ended the session (a scaffold, copy,
+	// or form-discovery error). RunRedesign returns it so the catalog
+	// command exits nonzero; a deliberate quit leaves it nil.
+	terminalErr error
+	// loadErr is a non-fatal discovery failure (some catalog sources failed
+	// to load while others produced components). It renders as a notice in
+	// the list view rather than ending the session.
+	loadErr             error
 	pagerKeys           tui.PagerKeyMap
 	listKeys            list.KeyMap
 	currentPagerButtons []button
@@ -129,6 +140,13 @@ func NewModelWithExitMessageForTest(msg string) Model {
 // ActiveTab returns which of the All/Modules/Templates tabs is focused.
 func (m Model) ActiveTab() TabKind {
 	return m.activeTab
+}
+
+// Err returns the failure that ended the session, or nil when the session
+// ended without one (a deliberate quit). RunRedesign propagates it so the
+// catalog command exits nonzero after an in-TUI failure.
+func (m Model) Err() error {
+	return m.terminalErr
 }
 
 // Loading reports whether discovery is still running. When true, the tab

--- a/internal/cli/commands/catalog/tui/redesign/model_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/model_test.go
@@ -514,6 +514,95 @@ func TestModelCopyFinishedDisplayPathEscapesBaseDir(t *testing.T) {
 		"displayPath should produce a dot-relative path when baseDir contains abs")
 }
 
+// TestModelScaffoldFailureQuitsWithError verifies that a failed scaffold
+// quits the TUI carrying the failure, while still stashing the styled
+// in-TUI message, so the command exits nonzero and the user sees why.
+func TestModelScaffoldFailureQuitsWithError(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	opts.WorkingDir = t.TempDir()
+
+	l := logger.CreateLogger()
+	components := makeComponents(t)
+
+	componentCh := make(chan *redesign.ComponentEntry)
+	close(componentCh)
+
+	m := redesign.NewModelStreaming(t.Context(), l, opts, components[0], componentCh, nil)
+
+	scaffoldErr := errors.New("generate failed")
+
+	updated, cmd := m.Update(redesign.ScaffoldFinishedMsg{Err: scaffoldErr})
+	finalModel := updated.(redesign.Model)
+
+	require.Error(t, finalModel.Err(), "a failed scaffold should leave the session in an error state")
+	require.ErrorIs(t, finalModel.Err(), scaffoldErr)
+
+	require.NotNil(t, cmd, "a failed scaffold should quit the program")
+	assert.IsType(t, tea.QuitMsg{}, cmd(), "a failed scaffold should quit the program")
+
+	assert.Contains(t, stripANSI(finalModel.ExitMessage()), "error scaffolding component",
+		"the styled failure message should still display after exit")
+}
+
+// TestModelCopyFailureQuitsWithError verifies that a failed copy quits the
+// TUI carrying the failure.
+func TestModelCopyFailureQuitsWithError(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	opts.WorkingDir = t.TempDir()
+
+	l := logger.CreateLogger()
+	components := makeComponents(t)
+
+	componentCh := make(chan *redesign.ComponentEntry)
+	close(componentCh)
+
+	m := redesign.NewModelStreaming(t.Context(), l, opts, components[0], componentCh, nil)
+
+	copyErr := errors.New("destination exists")
+
+	updated, cmd := m.Update(redesign.CopyFinishedMsg{Err: copyErr})
+	finalModel := updated.(redesign.Model)
+
+	require.Error(t, finalModel.Err(), "a failed copy should leave the session in an error state")
+	require.ErrorIs(t, finalModel.Err(), copyErr)
+
+	require.NotNil(t, cmd, "a failed copy should quit the program")
+	assert.IsType(t, tea.QuitMsg{}, cmd(), "a failed copy should quit the program")
+}
+
+// TestModelCleanQuitHasNoErrorWithRacing verifies that quitting the list
+// deliberately, even after a successful session, carries no error.
+func TestModelCleanQuitHasNoErrorWithRacing(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		opts, err := options.NewTerragruntOptionsForTest("")
+		require.NoError(t, err)
+
+		l := logger.CreateLogger()
+		components := makeComponents(t)
+
+		componentCh := make(chan *redesign.ComponentEntry)
+		close(componentCh)
+
+		m := redesign.NewModelStreaming(t.Context(), l, opts, components[0], componentCh, nil)
+
+		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'q', Text: "q"}}
+
+		finalModel := driveModel(t, m, 120, 40, msgs).(redesign.Model)
+
+		require.NoError(t, finalModel.Err(), "a deliberate quit must not carry an error")
+	})
+}
+
 // TestModelRendererErrMsgSetsViewportAndPagerState drives a rendererErrMsg
 // through Update and verifies that the viewport content carries the error
 // and the session advances to PagerState.

--- a/internal/cli/commands/catalog/tui/redesign/tty.go
+++ b/internal/cli/commands/catalog/tui/redesign/tty.go
@@ -1,0 +1,68 @@
+package redesign
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	tea "charm.land/bubbletea/v2"
+	"golang.org/x/term"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+// ErrNoTerminal reports that the catalog TUI cannot start because the
+// process has no interactive terminal to attach to (for example, in a CI
+// job or another environment without a controlling terminal).
+var ErrNoTerminal = errors.New("the catalog command requires an interactive terminal")
+
+// EnsureTTY verifies that the process can attach an interactive terminal,
+// mirroring bubbletea's input setup: a terminal stdin is used directly;
+// otherwise the controlling terminal is opened. It returns an error
+// wrapping [ErrNoTerminal] when neither is available, so the catalog
+// command can fail fast with a clear message instead of surfacing the
+// library's raw TTY error.
+//
+// isTerminal and openTTY are injected so tests can simulate environments
+// without a controlling terminal; production callers use [EnsureOSTTY].
+func EnsureTTY(l log.Logger, isTerminal func() bool, openTTY func() (io.Closer, io.Closer, error)) error {
+	if isTerminal() {
+		return nil
+	}
+
+	in, out, err := openTTY()
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrNoTerminal, err)
+	}
+
+	// The probe only checks availability; bubbletea opens its own handles
+	// later, so release these right away. On POSIX systems both handles
+	// are the same /dev/tty file, so close it once.
+	if cerr := in.Close(); cerr != nil {
+		l.Debugf("Failed to close TTY probe input: %v", cerr)
+	}
+
+	if out != in {
+		if cerr := out.Close(); cerr != nil {
+			l.Debugf("Failed to close TTY probe output: %v", cerr)
+		}
+	}
+
+	return nil
+}
+
+// EnsureOSTTY runs [EnsureTTY] against the real process environment.
+func EnsureOSTTY(l log.Logger) error {
+	return EnsureTTY(l, stdinIsTerminal, openOSTTY)
+}
+
+// openOSTTY adapts [tea.OpenTTY] to EnsureTTY's probe signature.
+func openOSTTY() (io.Closer, io.Closer, error) {
+	return tea.OpenTTY()
+}
+
+// stdinIsTerminal reports whether the process's stdin is a terminal.
+func stdinIsTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}

--- a/internal/cli/commands/catalog/tui/redesign/tty_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/tty_test.go
@@ -1,0 +1,102 @@
+package redesign_test
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui/redesign"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingCloser counts Close calls so tests can assert the TTY probe
+// releases its handles.
+type recordingCloser struct {
+	closes int
+}
+
+func (c *recordingCloser) Close() error {
+	c.closes++
+
+	return nil
+}
+
+// TestEnsureTTY_TerminalStdinSkipsProbe verifies that a terminal stdin is
+// accepted without opening the controlling terminal.
+func TestEnsureTTY_TerminalStdinSkipsProbe(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	probed := false
+	openTTY := func() (io.Closer, io.Closer, error) {
+		probed = true
+
+		return nil, nil, errors.New("must not be called")
+	}
+
+	err := redesign.EnsureTTY(l, func() bool { return true }, openTTY)
+
+	require.NoError(t, err)
+	assert.False(t, probed, "openTTY must not be probed when stdin is already a terminal")
+}
+
+// TestEnsureTTY_ProbeSuccessReleasesHandles verifies that a successful
+// controlling-terminal probe closes both handles.
+func TestEnsureTTY_ProbeSuccessReleasesHandles(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	in := &recordingCloser{}
+	out := &recordingCloser{}
+	openTTY := func() (io.Closer, io.Closer, error) {
+		return in, out, nil
+	}
+
+	err := redesign.EnsureTTY(l, func() bool { return false }, openTTY)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, in.closes, "probe input handle should be closed exactly once")
+	assert.Equal(t, 1, out.closes, "probe output handle should be closed exactly once")
+}
+
+// TestEnsureTTY_SharedHandleClosedOnce verifies the POSIX case where the
+// probe returns the same /dev/tty handle for input and output: it must be
+// closed only once.
+func TestEnsureTTY_SharedHandleClosedOnce(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	shared := &recordingCloser{}
+	openTTY := func() (io.Closer, io.Closer, error) {
+		return shared, shared, nil
+	}
+
+	err := redesign.EnsureTTY(l, func() bool { return false }, openTTY)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, shared.closes, "shared probe handle should be closed exactly once")
+}
+
+// TestEnsureTTY_NoTerminal verifies that a failed probe surfaces the typed
+// ErrNoTerminal while preserving the underlying cause.
+func TestEnsureTTY_NoTerminal(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	cause := errors.New("no controlling terminal")
+	openTTY := func() (io.Closer, io.Closer, error) {
+		return nil, nil, cause
+	}
+
+	err := redesign.EnsureTTY(l, func() bool { return false }, openTTY)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, redesign.ErrNoTerminal)
+	require.ErrorIs(t, err, cause, "the probe failure should stay in the error chain")
+}

--- a/internal/cli/commands/catalog/tui/redesign/update.go
+++ b/internal/cli/commands/catalog/tui/redesign/update.go
@@ -2,6 +2,7 @@ package redesign
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -189,7 +190,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loading = false
 
 		if msg.Err != nil {
-			m.logger.Warnf("Discovery error: %v", msg.Err)
+			// Components already streamed in, so the failure is partial and
+			// the session stays usable. Logging here would shred the
+			// alt-screen rendering (see discoverModuleFields), so surface
+			// it as a notice line in the list view and stash the per-source
+			// detail for the post-exit message.
+			m.loadErr = msg.Err
+			m.exitMessage = formatSourceFailureNotice(msg.Err, valuesBoxAccentYellow)
 		}
 
 		return m, nil
@@ -250,6 +257,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case formDiscoveryErrMsg:
 		m.exitMessage = formatActionFailure("discovering variables", msg.err)
+		m.terminalErr = fmt.Errorf("discovering variables: %w", msg.err)
 
 		return m, tea.Quit
 
@@ -266,6 +274,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ScaffoldFinishedMsg:
 		if msg.Err != nil {
 			m.exitMessage = formatActionFailure("scaffolding component", msg.Err)
+			m.terminalErr = fmt.Errorf("scaffolding component: %w", msg.Err)
 
 			return m, tea.Quit
 		}
@@ -277,6 +286,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case CopyFinishedMsg:
 		if msg.Err != nil {
 			m.exitMessage = formatActionFailure("copying component", msg.Err)
+			m.terminalErr = fmt.Errorf("copying component: %w", msg.Err)
 
 			return m, tea.Quit
 		}
@@ -402,6 +412,40 @@ var (
 	valuesBoxPathStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(valuesBoxPathColor))
 	valuesBoxMuteStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(valuesBoxMutedColor))
 )
+
+// formatSourceFailureNotice renders the post-exit callout for source-load
+// failures: a summary heading plus one line per failed source. The in-TUI
+// surfaces (the list-view notice line, the welcome error screen) live in
+// the alt screen and vanish on exit, so the detail lands in the user's
+// scrollback here. accent picks the border color: yellow for partial
+// failures that left the session usable, red for failures that ended it.
+func formatSourceFailureNotice(err error, accent string) string {
+	heading := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(accent)).
+		Bold(true).
+		Render(err.Error())
+
+	rows := []string{heading}
+
+	var srcErr *SourceLoadError
+	if errors.As(err, &srcErr) {
+		for _, f := range srcErr.Failures {
+			rows = append(rows,
+				"",
+				valuesBoxPathStyle.Render(f.URL),
+				valuesBoxMuteStyle.Render(f.Err.Error()),
+			)
+		}
+	}
+
+	content := lipgloss.JoinVertical(lipgloss.Left, rows...)
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(accent)).
+		Padding(bodyPaddingVertical, bodyPaddingHorizontal).
+		Render(content)
+}
 
 // formatCopyValuesMessage returns a lipgloss-bordered callout summarizing
 // what happened with the values stub, or "" when there's nothing to say.

--- a/internal/cli/commands/catalog/tui/redesign/view.go
+++ b/internal/cli/commands/catalog/tui/redesign/view.go
@@ -25,6 +25,7 @@ var (
 	infoPositionStyle = lipgloss.NewStyle().Padding(0, 1).BorderStyle(lipgloss.HiddenBorder())
 	infoLineStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#1D252F"))
 	infoHelp          = lipgloss.NewStyle().Padding(infoHelpPaddingTop, 0, 0, bodyPaddingHorizontal)
+	loadNoticeStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color(valuesBoxAccentYellow))
 )
 
 // View implements bubbletea.Model.View, dispatching to a sub-view based on
@@ -54,7 +55,15 @@ func (m Model) listView() string {
 	bar := RenderTabBar(m.activeTab, m.loading)
 	active := m.lists[m.activeTab]
 
-	return lipgloss.JoinVertical(lipgloss.Left, bar, "", active.View())
+	// The blank spacer between the tab strip and the list doubles as a
+	// status line: partial source-load failures render there, so the
+	// height math in the WindowSizeMsg handler stays unchanged.
+	notice := ""
+	if m.loadErr != nil {
+		notice = loadNoticeStyle.Render("⚠ " + m.loadErr.Error())
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left, bar, notice, active.View())
 }
 
 func (m Model) pagerView() string {

--- a/internal/cli/commands/catalog/tui/redesign/view_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/view_test.go
@@ -125,6 +125,42 @@ func TestWelcomeDiscoveryErrorView_RendersErrorAndHint(t *testing.T) {
 	assert.Contains(t, content, "q/esc: exit", "should render the quit hint")
 }
 
+// TestWelcomeDiscoveryErrorView_AllSourcesFailedDetail verifies that when
+// every catalog source fails to load, the error screen lists each failed
+// source with its cause and does not masquerade as the "nothing found"
+// welcome screen.
+func TestWelcomeDiscoveryErrorView_AllSourcesFailedDetail(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+
+	m := redesign.NewWelcomeModel(t.Context(), l, opts, blockingLoad)
+	m = updateModel(m, windowSize).(redesign.WelcomeModel)
+
+	srcErr := &redesign.SourceLoadError{
+		Failures: []redesign.SourceFailure{
+			{URL: "github.com/acme/modules", Err: errors.New("clone failed")},
+			{URL: "github.com/acme/templates", Err: errors.New("authentication required")},
+		},
+		Attempted: 2,
+	}
+
+	m = updateModel(m, redesign.DiscoveryCompleteMsg{Err: srcErr}).(redesign.WelcomeModel)
+
+	content := stripANSI(m.View().Content)
+
+	assert.Contains(t, content, "failed to load all 2 catalog sources", "should summarize that every source failed")
+	assert.Contains(t, content, "github.com/acme/modules", "should list the first failed source")
+	assert.Contains(t, content, "clone failed", "should show the first source's cause")
+	assert.Contains(t, content, "github.com/acme/templates", "should list the second failed source")
+	assert.Contains(t, content, "authentication required", "should show the second source's cause")
+	assert.NotContains(t, content, "No catalog sources were discovered",
+		"all-sources-failed must be distinguishable from nothing-found")
+}
+
 // --- Component List View ---
 
 func TestComponentListView_LoadingTitle(t *testing.T) {
@@ -155,6 +191,48 @@ func TestComponentListView_LoadingTitle(t *testing.T) {
 	content = stripANSI(m.View().Content)
 	assert.Contains(t, content, "All", "tab bar should still show the All tab")
 	assert.NotContains(t, content, "(loading...)", "loading indicator should be gone after discovery completes")
+}
+
+// TestComponentListView_PartialSourceFailureNotice verifies that when some
+// sources fail while others produced components, the list view renders a
+// notice line, the session does not end, and the per-source detail is
+// stashed for the post-exit message.
+func TestComponentListView_PartialSourceFailureNotice(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+	components := makeComponents(t)
+	require.NotEmpty(t, components)
+
+	componentCh := make(chan *redesign.ComponentEntry, 10)
+	m := redesign.NewModelStreaming(t.Context(), l, opts, components[0], componentCh, nil)
+
+	updated, _ := m.Update(windowSize)
+	m = updated.(redesign.Model)
+
+	srcErr := &redesign.SourceLoadError{
+		Failures: []redesign.SourceFailure{
+			{URL: "github.com/acme/broken", Err: errors.New("clone failed")},
+		},
+		Attempted: 2,
+	}
+
+	updated, _ = m.Update(redesign.DiscoveryCompleteMsg{Err: srcErr})
+	m = updated.(redesign.Model)
+
+	content := stripANSI(m.View().Content)
+	assert.Contains(t, content, "failed to load 1 of 2 catalog sources",
+		"list view should carry a partial-failure notice")
+	assert.NotContains(t, content, "(loading...)", "discovery is complete despite the failure")
+
+	require.NoError(t, m.Err(), "a partial failure must not end the session")
+
+	exit := stripANSI(m.ExitMessage())
+	assert.Contains(t, exit, "github.com/acme/broken", "post-exit notice should name the failed source")
+	assert.Contains(t, exit, "clone failed", "post-exit notice should include the cause")
 }
 
 func TestComponentListView_MetadataRowRendered(t *testing.T) {

--- a/internal/cli/commands/catalog/tui/redesign/welcome.go
+++ b/internal/cli/commands/catalog/tui/redesign/welcome.go
@@ -121,6 +121,10 @@ func NewWelcomeModel(ctx context.Context, l log.Logger, opts *options.Terragrunt
 // screen immediately while discovery runs in the background, then transitions
 // to the component list if components are found. Post-exit messages are
 // written to errWriter after the tea program restores the main terminal.
+//
+// When the session ends after a failure (discovery error, scaffold or copy
+// failure), the failure is returned so the command exits nonzero; a
+// deliberate quit with no failure returns nil.
 func RunRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, errWriter io.Writer, loadFunc LoadFunc) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -142,6 +146,20 @@ func RunRedesign(ctx context.Context, l log.Logger, opts *options.TerragruntOpti
 		}
 
 		return err
+	}
+
+	return sessionErr(finalModel)
+}
+
+// sessionErr extracts the failure the final model recorded during its
+// session, if any. The detailed, styled rendering has already been shown
+// in the TUI (or stashed as the exit message), so the returned error is
+// the concise form the CLI reports.
+func sessionErr(finalModel tea.Model) error {
+	type errCarrier interface{ Err() error }
+
+	if m, ok := finalModel.(errCarrier); ok {
+		return m.Err()
 	}
 
 	return nil
@@ -213,6 +231,26 @@ func (m WelcomeModel) View() tea.View {
 	return v
 }
 
+// Err returns the discovery failure that ended the session, or nil when
+// discovery succeeded or is still running. RunRedesign propagates it as the
+// command error after the user dismisses the error screen, so the catalog
+// command exits nonzero.
+func (m WelcomeModel) Err() error {
+	return m.lastDiscoveryErr
+}
+
+// ExitMessage returns the styled callout describing the discovery failure,
+// or "" when there is none. The error screen lives in the alt screen and
+// vanishes when the program exits, so EmitExitMessage reprints the details
+// into the user's scrollback while the returned error stays concise.
+func (m WelcomeModel) ExitMessage() string {
+	if m.lastDiscoveryErr == nil {
+		return ""
+	}
+
+	return formatSourceFailureNotice(m.lastDiscoveryErr, valuesBoxAccentRed)
+}
+
 // WithOpenURL replaces the function used to open URLs in the browser.
 func (m WelcomeModel) WithOpenURL(fn OpenURLFunc) WelcomeModel {
 	m.openURL = fn
@@ -221,26 +259,62 @@ func (m WelcomeModel) WithOpenURL(fn OpenURLFunc) WelcomeModel {
 }
 
 func (m WelcomeModel) discoveryErrorView() string {
+	// One slot per fixed line surrounding the detail block.
+	const fixedRows = 8
+
 	title := welcomeTitleStyle.Render(" Terragrunt Catalog ")
 
-	errMsg := "unknown error"
-	if m.lastDiscoveryErr != nil {
-		errMsg = m.lastDiscoveryErr.Error()
-	}
+	detail := m.discoveryErrorDetail()
 
-	body := welcomeBodyStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
+	rows := make([]string, 0, len(detail)+fixedRows)
+
+	rows = append(rows,
 		"",
 		"An error occurred while discovering catalog sources:",
 		"",
-		welcomeCodeStyle.Render("  "+errMsg),
+	)
+
+	rows = append(rows, detail...)
+
+	rows = append(rows,
 		"",
 		"Please check your network connection, authentication, and",
 		"catalog configuration, then try again.",
 		"",
 		welcomeHintStyle.Render("q/esc: exit"),
-	))
+	)
+
+	body := welcomeBodyStyle.Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
 
 	return lipgloss.JoinVertical(lipgloss.Center, title, body)
+}
+
+// discoveryErrorDetail returns the body lines describing the discovery
+// failure. Per-source load failures render a summary plus one line per
+// failed source, so "all N sources failed" reads differently from the
+// no-sources welcome screen.
+func (m WelcomeModel) discoveryErrorDetail() []string {
+	errMsg := "unknown error"
+	if m.lastDiscoveryErr != nil {
+		errMsg = m.lastDiscoveryErr.Error()
+	}
+
+	var srcErr *SourceLoadError
+	if !errors.As(m.lastDiscoveryErr, &srcErr) {
+		return []string{welcomeCodeStyle.Render("  " + errMsg)}
+	}
+
+	rows := []string{welcomeCodeStyle.Render("  " + errMsg + ":")}
+
+	for _, f := range srcErr.Failures {
+		rows = append(rows,
+			"",
+			welcomeCodeStyle.Render("    "+f.URL),
+			welcomeHintStyle.Render("      "+f.Err.Error()),
+		)
+	}
+
+	return rows
 }
 
 func (m WelcomeModel) handleComponentMsg(msg componentMsg) (tea.Model, tea.Cmd) {
@@ -260,7 +334,12 @@ func (m WelcomeModel) handleComponentMsg(msg componentMsg) (tea.Model, tea.Cmd) 
 
 func (m WelcomeModel) handleDiscoveryComplete(msg DiscoveryCompleteMsg) (tea.Model, tea.Cmd) {
 	if msg.Err != nil {
-		m.logger.Warnf("Discovery error: %v", msg.Err)
+		// No components arrived before the failure (otherwise the streaming
+		// Model would be handling this message), so the session has nothing
+		// to show. Render the error screen; the stashed error is returned
+		// by RunRedesign when the user quits and its details are reprinted
+		// via ExitMessage. Logging here would shred the alt-screen
+		// rendering, so nothing is logged.
 		m.lastDiscoveryErr = msg.Err
 		m.state = welcomeDiscoveryError
 

--- a/internal/cli/commands/catalog/tui/redesign/welcome_test.go
+++ b/internal/cli/commands/catalog/tui/redesign/welcome_test.go
@@ -3,6 +3,7 @@ package redesign_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"testing/synctest"
@@ -92,6 +93,110 @@ func TestWelcomeLoadingScreen_NoSourcesWithRacing(t *testing.T) {
 
 		_, isWelcome := finalModel.(redesign.WelcomeModel)
 		assert.True(t, isWelcome, "should remain on welcome screen when no sources found")
+	})
+}
+
+// TestWelcomeDiscoveryErrorQuitPropagatesErrorWithRacing verifies that a
+// discovery failure recorded by the welcome model survives the user's quit,
+// so RunRedesign returns it and the catalog command exits nonzero.
+func TestWelcomeDiscoveryErrorQuitPropagatesErrorWithRacing(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		opts, err := options.NewTerragruntOptionsForTest("")
+		require.NoError(t, err)
+
+		l := logger.CreateLogger()
+
+		discoveryErr := errors.New("network unreachable")
+		erroringLoad := func(_ context.Context, _ redesign.StatusFunc, _ chan<- *redesign.ComponentEntry) error {
+			return discoveryErr
+		}
+
+		m := redesign.NewWelcomeModel(t.Context(), l, opts, erroringLoad)
+
+		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'q', Text: "q"}}
+
+		finalModel := driveModel(t, m, 120, 40, msgs)
+
+		welcome, isWelcome := finalModel.(redesign.WelcomeModel)
+		require.True(t, isWelcome, "should remain on welcome screen after a discovery error")
+		require.Error(t, welcome.Err(), "quitting after a discovery error should carry the failure")
+		require.ErrorIs(t, welcome.Err(), discoveryErr)
+	})
+}
+
+// TestWelcomeAllSourcesFailedPropagatesTypedErrorWithRacing verifies that
+// when every catalog source fails to load, the welcome model ends the
+// session with the aggregated SourceLoadError.
+func TestWelcomeAllSourcesFailedPropagatesTypedErrorWithRacing(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		opts, err := options.NewTerragruntOptionsForTest("")
+		require.NoError(t, err)
+
+		l := logger.CreateLogger()
+
+		allFailedLoad := func(_ context.Context, _ redesign.StatusFunc, _ chan<- *redesign.ComponentEntry) error {
+			return &redesign.SourceLoadError{
+				Failures: []redesign.SourceFailure{
+					{URL: "github.com/acme/modules", Err: errors.New("clone failed")},
+					{URL: "github.com/acme/templates", Err: errors.New("authentication required")},
+				},
+				Attempted: 2,
+			}
+		}
+
+		m := redesign.NewWelcomeModel(t.Context(), l, opts, allFailedLoad)
+
+		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'q', Text: "q"}}
+
+		finalModel := driveModel(t, m, 120, 40, msgs)
+
+		welcome, isWelcome := finalModel.(redesign.WelcomeModel)
+		require.True(t, isWelcome, "should remain on welcome screen when every source fails")
+
+		var srcErr *redesign.SourceLoadError
+
+		require.ErrorAs(t, welcome.Err(), &srcErr)
+		assert.True(t, srcErr.AllFailed(), "every attempted source failed")
+
+		// The error screen vanishes with the alt screen, so the details
+		// must also be stashed for the post-exit message.
+		exit := stripANSI(welcome.ExitMessage())
+		assert.Contains(t, exit, "github.com/acme/modules")
+		assert.Contains(t, exit, "clone failed")
+		assert.Contains(t, exit, "github.com/acme/templates")
+		assert.Contains(t, exit, "authentication required")
+	})
+}
+
+// TestWelcomeCleanQuitReturnsNoErrorWithRacing verifies that a deliberate
+// quit with no failure leaves the model error-free, so the command exits
+// zero.
+func TestWelcomeCleanQuitReturnsNoErrorWithRacing(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		opts, err := options.NewTerragruntOptionsForTest("")
+		require.NoError(t, err)
+
+		l := logger.CreateLogger()
+
+		noSourcesLoad := func(_ context.Context, _ redesign.StatusFunc, _ chan<- *redesign.ComponentEntry) error {
+			return nil
+		}
+
+		m := redesign.NewWelcomeModel(t.Context(), l, opts, noSourcesLoad)
+
+		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'q', Text: "q"}}
+
+		finalModel := driveModel(t, m, 120, 40, msgs)
+
+		welcome, isWelcome := finalModel.(redesign.WelcomeModel)
+		require.True(t, isWelcome)
+		require.NoError(t, welcome.Err(), "a clean quit must not carry an error")
 	})
 }
 

--- a/test/integration_catalog_redesign_test.go
+++ b/test/integration_catalog_redesign_test.go
@@ -1,9 +1,13 @@
 package test_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"golang.org/x/term"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog"
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui/redesign"
@@ -140,6 +144,40 @@ func TestCatalogRedesignDiscoveryWithIgnoreFiles(t *testing.T) {
 	}
 
 	assert.Equal(t, want, got)
+}
+
+// TestCatalogRedesignNonTTYFailsFast verifies that running the redesigned
+// catalog without an interactive terminal exits with the friendly typed
+// error instead of bubbletea's raw TTY failure.
+//
+// The guard mirrors the command's own TTY probe: when the test environment
+// has a controlling terminal (a developer's shell), the command would
+// launch the real TUI and block, so the test only runs where a TTY is
+// genuinely unavailable (e.g. CI runners).
+func TestCatalogRedesignNonTTYFailsFast(t *testing.T) {
+	t.Parallel()
+
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		t.Skip("stdin is a terminal; the catalog TUI would launch for real")
+	}
+
+	if in, out, err := tea.OpenTTY(); err == nil {
+		closeErr := in.Close()
+		if out != in {
+			closeErr = errors.Join(closeErr, out.Close())
+		}
+
+		require.NoError(t, closeErr)
+		t.Skip("a controlling terminal is available; the catalog TUI would launch for real")
+	}
+
+	workDir := t.TempDir()
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt catalog --experiment catalog-redesign --working-dir "+workDir)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, redesign.ErrNoTerminal)
 }
 
 func ignoreFileAction(t *testing.T, opts *options.TerragruntOptions) clihelper.FlagActionFunc[string] {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog now exits with non-zero status when sessions fail due to discovery failures or failed operations, instead of always exiting successfully
  * Error screens display specific failed repositories with causes rather than generic messages
  * UI reports count of failed sources during partial failures and remains functional
  * Fails immediately with clear error when run in non-interactive environments instead of surfacing raw system errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->