### PR TITLE
chore: Completing `mark-many-as-read` experiment

### DIFF
--- a/docs/src/content/docs/03-features/08-filter/04-attributes.mdx
+++ b/docs/src/content/docs/03-features/08-filter/04-attributes.mdx
@@ -8,6 +8,8 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 import FileTree from '@components/vendored/starlight/FileTree.astro';
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Match units and stacks by their configuration attributes.
 
@@ -106,7 +108,13 @@ Reading a file directly in the `inputs` attribute will not mark the file as read
 
 To mark many files at once, use [`mark_glob_as_read`](/reference/hcl/functions/#mark_glob_as_read), which accepts a glob (with `**` support) and marks every matching file.
 
+<Before version="1.1.0">
 If a unit's `terraform` block points at a local module source, enable the [`mark-many-as-read`](/reference/experiments/active#mark-many-as-read) experiment to have Terragrunt automatically mark that module's `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` files as read. Reading-based filters will then cascade local module changes to every unit that consumes the module. The same experiment also enables the [`mark_glob_as_read`](/reference/hcl/functions/#mark_glob_as_read) HCL function.
+</Before>
+
+<Since version="1.1.0">
+If a unit's `terraform` block points at a local module source, Terragrunt automatically marks that module's `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` files as read. Reading-based filters cascade local module changes to every unit that consumes the module.
+</Since>
 
 ## Source-Based Expressions
 

--- a/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -8,6 +8,7 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 import FileTree from '@components/vendored/starlight/FileTree.astro';
+import Before from '@components/Before.astro';
 
 Terragrunt allows you to use built-in functions anywhere in `terragrunt.hcl`, just like OpenTofu/Terraform\!
 
@@ -1078,9 +1079,11 @@ block is not evaluated until *after* the queue has been populated with units to 
 
 ## mark_glob_as_read
 
+<Before version="1.1.0">
 <Aside type="caution">
 `mark_glob_as_read` requires the [`mark-many-as-read`](/reference/experiments/active#mark-many-as-read) experiment. Calling it without the experiment enabled returns an error.
 </Aside>
+</Before>
 
 <Aside type="caution">
 `mark_glob_as_read` writes to the same read tracker as [`mark_as_read`](#mark_as_read), so the same evaluation-order caveat applies: during a `run --all`, the queue is populated before `inputs` is evaluated, so a call placed in `inputs` (or any other later-evaluated block) will not influence queue construction. Call `mark_glob_as_read` from `locals` to ensure matched files are considered when the queue is built.

--- a/docs/src/data/changelog/v1.1.0/mark-many-as-read-enabled-by-default.mdx
+++ b/docs/src/data/changelog/v1.1.0/mark-many-as-read-enabled-by-default.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.0"
+category: "new-features"
+---
+
+#### Reading detection for local module sources
+
+Reading-based filters now detect changes to local module sources by default. When a unit's `terraform` block points at a local module, Terragrunt records the module's `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` files as read by that unit, so `--filter 'reading=<path>'` and `--queue-include-units-reading` pick the unit up when a module file changes. The `mark_glob_as_read()` HCL function, which expands a glob and marks every matching file as read in one call, also works without any experiment flag.
+
+Existing pipelines built on `--queue-include-units-reading` or `reading=` filters may select more units than before, because changes to local module files now count as reads. Previously gated behind the `mark-many-as-read` experiment, these behaviors no longer require `--experiment mark-many-as-read`. Passing the flag is now a no-op that logs a warning about the completed experiment, so it can simply be removed from invocations.

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -51,10 +51,11 @@ const (
 	StackDependencies = "stack-dependencies"
 	// CatalogRedesign is the experiment that enables the redesigned catalog experience.
 	CatalogRedesign = "catalog-redesign"
-	// MarkManyAsRead enables behaviors that mark many files as read in one
-	// step: automatic marking of files inside a local terraform module source
-	// (so reading-based filter expressions detect changes to the module) and
-	// the mark_glob_as_read HCL function.
+	// MarkManyAsRead names the now-stable behaviors that mark many files as
+	// read in one step: automatic marking of files inside a local terraform
+	// module source (so reading-based filter expressions detect changes to
+	// the module) and the mark_glob_as_read HCL function. Both are enabled
+	// by default.
 	MarkManyAsRead = "mark-many-as-read"
 	// AzureBackend reserves the experiment flag for native Azure Storage (azurerm)
 	// remote state support. The backend is stubbed out for now; full Azure helper
@@ -136,7 +137,8 @@ func NewExperiments() Experiments {
 			Name: CatalogRedesign,
 		},
 		{
-			Name: MarkManyAsRead,
+			Name:   MarkManyAsRead,
+			Status: StatusCompleted,
 		},
 		{
 			Name: AzureBackend,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1723,7 +1723,12 @@ func convertToTerragruntConfig(ctx context.Context, pctx *ParsingContext, config
 	if terragruntConfig.Terraform != nil { // since Terraform is nil each time avoid saving metadata when it is nil
 		terragruntConfig.SetFieldMetadata(MetadataTerraform, defaultMetadata)
 
-		if pctx.Experiments.Evaluate(experiment.MarkManyAsRead) && terragruntConfig.Terraform.Source != nil {
+		// This full-parse hook is not redundant with the partial-parse hook in
+		// PartialParseConfig. read_terragrunt_config() runs a full ParseConfigFile
+		// even during discovery's partial parse, and ParsingContext.Clone() shares
+		// FilesRead, so this hook is how files read via read_terragrunt_config of
+		// a config with a local module source reach reading= filters.
+		if terragruntConfig.Terraform.Source != nil {
 			markLocalModuleSourceAsRead(pctx, configPath, *terragruntConfig.Terraform.Source)
 		}
 	}
@@ -1930,6 +1935,14 @@ var moduleSourceReadExtensions = map[string]struct{}{
 // swallowed, since a genuinely broken source will surface during download.
 func markLocalModuleSourceAsRead(pctx *ParsingContext, configPath, rawSource string) {
 	sourceWithoutSubdir, subdir := getter.SourceDirSubdir(rawSource)
+
+	// Anchor a relative config path to the working directory before deriving
+	// the detector pwd. The file detector roots relative output at "/", so a
+	// relative pwd would resolve a relative source to the filesystem root and
+	// walk all of it.
+	if !filepath.IsAbs(configPath) {
+		configPath = filepath.Join(pctx.WorkingDir, configPath)
+	}
 
 	sourceURL, err := tf.ToSourceURL(sourceWithoutSubdir, filepath.Dir(configPath))
 	if err != nil || !tf.IsLocalSource(sourceURL) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1958,6 +1958,10 @@ func markLocalModuleSourceAsRead(pctx *ParsingContext, configPath, rawSource str
 		moduleDir = filepath.Clean(filepath.Join(pctx.WorkingDir, moduleDir))
 	}
 
+	if !pctx.FilesRead.MarkDirIfNew(moduleDir) {
+		return
+	}
+
 	walkFunc := filepath.WalkDir
 	if pctx.Experiments.Evaluate(experiment.Symlinks) {
 		walkFunc = util.WalkDirWithSymlinks

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -1312,18 +1312,6 @@ func markAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []
 // so "a/**/*.tf" will not match "a/b.tf"; use "a/{*.tf,**/*.tf}" to cover
 // both depths. Returns the list of absolute file paths that were marked.
 func markGlobAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) ([]string, error) {
-	if !pctx.Experiments.Evaluate(experiment.MarkManyAsRead) {
-		pattern := ""
-		if len(args) > 0 {
-			pattern = args[0]
-		}
-
-		return nil, MarkGlobAsReadRequiresExperimentError{
-			ConfigPath: pctx.TerragruntConfigPath,
-			Pattern:    pattern,
-		}
-	}
-
 	if len(args) != 1 {
 		return nil, WrongNumberOfParamsError{Func: FuncNameMarkGlobAsRead, Expected: "1", Actual: len(args)}
 	}

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -639,7 +639,7 @@ func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger,
 		}
 	}
 
-	if pctx.Experiments.Evaluate(experiment.MarkManyAsRead) && output.Terraform != nil && output.Terraform.Source != nil {
+	if output.Terraform != nil && output.Terraform.Source != nil {
 		markLocalModuleSourceAsRead(pctx, file.ConfigPath, *output.Terraform.Source)
 	}
 

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -621,6 +621,10 @@ func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger,
 		}
 	}
 
+	if output.Terraform != nil && output.Terraform.Source != nil {
+		markLocalModuleSourceAsRead(pctx, file.ConfigPath, *output.Terraform.Source)
+	}
+
 	// If this file includes another, parse and merge the partial blocks. Otherwise, just return this config.
 	// If there have been errors during this parse, don't attempt to parse the included config.
 	// TrackInclude is nil when DecodeBaseBlocks returned (nil, err), e.g. an invalid feature
@@ -637,10 +641,6 @@ func PartialParseConfig(ctx context.Context, pctx *ParsingContext, l log.Logger,
 			config.ProcessedIncludes = pctx.TrackInclude.CurrentMap
 			output = config
 		}
-	}
-
-	if output.Terraform != nil && output.Terraform.Source != nil {
-		markLocalModuleSourceAsRead(pctx, file.ConfigPath, *output.Terraform.Source)
 	}
 
 	if joined := errors.Join(errs...); joined != nil {

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -314,17 +314,6 @@ func (err MaxParseDepthError) Error() string {
 	return fmt.Sprintf("maximum parse depth of %d exceeded (current depth: %d). This usually indicates circular includes or extremely deep config nesting.", err.Max, err.Depth)
 }
 
-// MarkGlobAsReadRequiresExperimentError is returned when the mark_glob_as_read
-// HCL function is called without the mark-many-as-read experiment enabled.
-type MarkGlobAsReadRequiresExperimentError struct {
-	ConfigPath string
-	Pattern    string
-}
-
-func (err MarkGlobAsReadRequiresExperimentError) Error() string {
-	return fmt.Sprintf("mark_glob_as_read(%q) in %s requires the 'mark-many-as-read' experiment to be enabled", err.Pattern, err.ConfigPath)
-}
-
 // AutoIncludeParserStageError reports which stage of autoinclude parsing failed.
 type AutoIncludeParserStageError struct {
 	Err   error

--- a/pkg/config/files_read.go
+++ b/pkg/config/files_read.go
@@ -11,8 +11,9 @@ import (
 // and returns zero values from accessors, so call sites that don't need to
 // track reads can pass nil.
 type FilesRead struct {
-	seen map[string]struct{}
-	mu   sync.RWMutex
+	seen     map[string]struct{}
+	seenDirs map[string]struct{}
+	mu       sync.Mutex
 }
 
 // NewFilesRead returns an empty FilesRead ready for concurrent use.
@@ -42,8 +43,8 @@ func (f *FilesRead) Paths() []string {
 		return nil
 	}
 
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.mu.Lock()
+	defer f.mu.Unlock()
 
 	return slices.Sorted(maps.Keys(f.seen))
 }
@@ -54,8 +55,33 @@ func (f *FilesRead) Len() int {
 		return 0
 	}
 
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.mu.Lock()
+	defer f.mu.Unlock()
 
 	return len(f.seen)
+}
+
+// MarkDirIfNew records dir as a walked module directory and returns true if dir
+// had not been visited before, false if it was already recorded. The check and
+// mark are a single atomic operation, so concurrent callers for the same dir
+// produce exactly one true result.
+func (f *FilesRead) MarkDirIfNew(dir string) bool {
+	if f == nil {
+		return true
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.seenDirs == nil {
+		f.seenDirs = make(map[string]struct{})
+	}
+
+	if _, ok := f.seenDirs[dir]; ok {
+		return false
+	}
+
+	f.seenDirs[dir] = struct{}{}
+
+	return true
 }

--- a/pkg/config/mark_as_read_test.go
+++ b/pkg/config/mark_as_read_test.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +27,6 @@ func TestMarkGlobAsRead(t *testing.T) {
 	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
 	ctx, pctx := newTestParsingContext(t, configPath)
 	pctx.WorkingDir = dir
-	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MarkManyAsRead))
 
 	// Drive the HCL function via a locals block so we exercise the registered cty wrapper.
 	// Brace alternation covers files at the current depth AND deeper, since gobwas's
@@ -66,7 +64,6 @@ func TestMarkGlobAsReadEscapesMetacharacter(t *testing.T) {
 	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
 	ctx, pctx := newTestParsingContext(t, configPath)
 	pctx.WorkingDir = dir
-	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MarkManyAsRead))
 
 	// The HCL string literal '"a\\*b.tf"' decodes to 'a\*b.tf', which the glob
 	// engine reads as a literal 'a*b.tf'.
@@ -82,29 +79,10 @@ func TestMarkGlobAsReadEscapesMetacharacter(t *testing.T) {
 	assert.NotContains(t, read, filepath.Join(dir, "acb.tf"))
 }
 
-func TestMarkGlobAsReadRequiresExperiment(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "a.tf"), "")
-
-	l := logger.CreateLogger()
-	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
-	ctx, pctx := newTestParsingContext(t, configPath)
-	pctx.WorkingDir = dir
-
-	hcl := `locals { matched = mark_glob_as_read("**/*.tf") }`
-
-	_, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "mark-many-as-read")
-
-	if pctx.FilesRead != nil {
-		assert.NotContains(t, pctx.FilesRead.Paths(), filepath.Join(dir, "a.tf"))
-	}
-}
-
-func TestMarkManyAsReadExperiment(t *testing.T) {
+// TestMarkManyAsReadMarksModuleSourceFilesByDefault pins the default behavior:
+// a full parse of a config with a local terraform source marks the module's
+// configuration files as read, with no experiment flag required.
+func TestMarkManyAsReadMarksModuleSourceFilesByDefault(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -123,45 +101,52 @@ func TestMarkManyAsReadExperiment(t *testing.T) {
 
 	hcl := `terraform { source = "../../modules/foo" }`
 
-	t.Run("off by default", func(t *testing.T) {
-		t.Parallel()
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, configPath)
+	pctx.WorkingDir = unitDir
 
-		l := logger.CreateLogger()
-		ctx, pctx := newTestParsingContext(t, configPath)
-		pctx.WorkingDir = unitDir
+	out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, pctx.FilesRead)
 
-		out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
-		require.NoError(t, err)
-		require.NotNil(t, out)
+	read := pctx.FilesRead.Paths()
+	assert.Contains(t, read, filepath.Join(moduleDir, "main.tf"))
+	assert.Contains(t, read, filepath.Join(moduleDir, "variables.tf.json"))
+	assert.Contains(t, read, filepath.Join(moduleDir, "helpers.hcl"))
+	assert.Contains(t, read, filepath.Join(moduleDir, "sub", "nested.tf"))
+	assert.Contains(t, read, filepath.Join(moduleDir, ".terraform.lock.hcl"))
+	assert.NotContains(t, read, filepath.Join(moduleDir, "README.md"))
+}
 
-		if pctx.FilesRead != nil {
-			for _, f := range pctx.FilesRead.Paths() {
-				assert.NotContains(t, f, moduleDir, "module files should not be marked when experiment is off")
-			}
-		}
-	})
+// TestMarkManyAsReadRelativeConfigPathAnchorsToWorkingDir pins that a relative
+// config path resolves against the parsing context's working directory before
+// the module walk. The file detector roots relative paths at "/", so without
+// anchoring, a relative config path would send the walk to the filesystem root.
+func TestMarkManyAsReadRelativeConfigPathAnchorsToWorkingDir(t *testing.T) {
+	t.Parallel()
 
-	t.Run("on marks source files", func(t *testing.T) {
-		t.Parallel()
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "modules", "foo")
+	unitDir := filepath.Join(root, "units", "bar")
 
-		l := logger.CreateLogger()
-		ctx, pctx := newTestParsingContext(t, configPath)
-		pctx.WorkingDir = unitDir
-		require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MarkManyAsRead))
+	writeFile(t, filepath.Join(moduleDir, "main.tf"), "")
 
-		out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
-		require.NoError(t, err)
-		require.NotNil(t, out)
-		require.NotNil(t, pctx.FilesRead)
+	configPath := filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
+	writeFile(t, configPath, "")
 
-		read := pctx.FilesRead.Paths()
-		assert.Contains(t, read, filepath.Join(moduleDir, "main.tf"))
-		assert.Contains(t, read, filepath.Join(moduleDir, "variables.tf.json"))
-		assert.Contains(t, read, filepath.Join(moduleDir, "helpers.hcl"))
-		assert.Contains(t, read, filepath.Join(moduleDir, "sub", "nested.tf"))
-		assert.Contains(t, read, filepath.Join(moduleDir, ".terraform.lock.hcl"))
-		assert.NotContains(t, read, filepath.Join(moduleDir, "README.md"))
-	})
+	hcl := `terraform { source = "../../modules/foo" }`
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, configPath)
+	pctx.WorkingDir = unitDir
+
+	out, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, hcl, nil)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, pctx.FilesRead)
+
+	assert.Contains(t, pctx.FilesRead.Paths(), filepath.Join(moduleDir, "main.tf"))
 }
 
 func TestMarkManyAsReadPartialParseSource(t *testing.T) {
@@ -187,7 +172,6 @@ func TestMarkManyAsReadPartialParseSource(t *testing.T) {
 			ctx, pctx := newTestParsingContext(t, configPath)
 			pctx.WorkingDir = unitDir
 			pctx = pctx.WithDecodeList(decode)
-			require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MarkManyAsRead))
 
 			out, err := config.PartialParseConfigString(ctx, pctx, l, configPath, hcl, nil)
 			require.NoError(t, err)
@@ -202,10 +186,10 @@ func TestMarkManyAsReadPartialParseSource(t *testing.T) {
 	}
 }
 
-// TestMarkManyAsReadPartialParseIncludedSource pins that the experiment hook still
-// fires when the terraform source comes from an included parent rather than the
-// leaf unit itself. The check runs after handleInclude, so output.Terraform is
-// populated from the merged parent at the time the experiment is evaluated.
+// TestMarkManyAsReadPartialParseIncludedSource pins that the partial-parse hook
+// still fires when the terraform source comes from an included parent rather
+// than the leaf unit itself. The check runs after handleInclude, so
+// output.Terraform is populated from the merged parent by the time the hook runs.
 func TestMarkManyAsReadPartialParseIncludedSource(t *testing.T) {
 	t.Parallel()
 
@@ -233,7 +217,6 @@ func TestMarkManyAsReadPartialParseIncludedSource(t *testing.T) {
 			ctx, pctx := newTestParsingContext(t, childPath)
 			pctx.WorkingDir = unitDir
 			pctx = pctx.WithDecodeList(decode)
-			require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MarkManyAsRead))
 
 			out, err := config.PartialParseConfigFile(ctx, pctx, l, childPath, nil)
 			require.NoError(t, err)

--- a/test/fixtures/mark-glob-as-read/unit-no-glob/data.yaml
+++ b/test/fixtures/mark-glob-as-read/unit-no-glob/data.yaml
@@ -1,0 +1,1 @@
+environment: test

--- a/test/fixtures/mark-glob-as-read/unit-no-glob/terragrunt.hcl
+++ b/test/fixtures/mark-glob-as-read/unit-no-glob/terragrunt.hcl
@@ -1,0 +1,1 @@
+# Intentionally marks nothing as read; data.yaml must not match reading= filters.

--- a/test/fixtures/mark-glob-as-read/unit/settings.yaml
+++ b/test/fixtures/mark-glob-as-read/unit/settings.yaml
@@ -1,0 +1,1 @@
+environment: test

--- a/test/fixtures/mark-glob-as-read/unit/terragrunt.hcl
+++ b/test/fixtures/mark-glob-as-read/unit/terragrunt.hcl
@@ -1,0 +1,3 @@
+locals {
+  settings = mark_glob_as_read("{*.yaml,**/*.yaml}")
+}

--- a/test/integration_mark_many_as_read_test.go
+++ b/test/integration_mark_many_as_read_test.go
@@ -3,6 +3,7 @@ package test_test
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
@@ -11,42 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testFixtureMarkManyAsReadRelpath = "fixtures/mark-many-as-read-relpath"
+const (
+	testFixtureMarkManyAsReadRelpath = "fixtures/mark-many-as-read-relpath"
+	testFixtureMarkGlobAsRead        = "fixtures/mark-glob-as-read"
+)
 
 func TestMarkManyAsReadRelpathSourceTriggersDiscovery(t *testing.T) {
 	t.Parallel()
-
-	helpers.CleanupTerraformFolder(t, testFixtureMarkManyAsReadRelpath)
-
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureMarkManyAsReadRelpath)
-	rootPath := filepath.Join(tmpEnvPath, testFixtureMarkManyAsReadRelpath)
-	rootPath, err := filepath.EvalSymlinks(rootPath)
-	require.NoError(t, err)
-
-	cmd := fmt.Sprintf(
-		"terragrunt run --all --non-interactive --experiment mark-many-as-read "+
-			"--queue-include-units-reading=modules/foo/main.tf --report-file %s "+
-			"--working-dir %s -- plan",
-		helpers.ReportFile, rootPath,
-	)
-
-	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
-	require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
-
-	assert.NotContains(t, stdout+stderr, "No units discovered",
-		"unit should be discovered via mark-many-as-read source walk")
-
-	runs, err := report.ParseJSONRunsFromFile(filepath.Join(rootPath, helpers.ReportFile))
-	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"live/unit"}, runs.Names())
-}
-
-func TestMarkManyAsReadDisabledDoesNotDiscoverModuleChanges(t *testing.T) {
-	t.Parallel()
-
-	if helpers.IsExperimentMode(t) {
-		t.Skip("Skipping: TG_EXPERIMENT_MODE forces all experiments on, defeating the disabled-vs-enabled comparison this test pins")
-	}
 
 	helpers.CleanupTerraformFolder(t, testFixtureMarkManyAsReadRelpath)
 
@@ -62,11 +34,90 @@ func TestMarkManyAsReadDisabledDoesNotDiscoverModuleChanges(t *testing.T) {
 		helpers.ReportFile, rootPath,
 	)
 
-	_, _, err = helpers.RunTerragruntCommandWithOutput(t, cmd)
-	require.NoError(t, err)
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
+
+	assert.NotContains(t, stdout+stderr, "No units discovered",
+		"unit should be discovered via the local module source walk")
 
 	runs, err := report.ParseJSONRunsFromFile(filepath.Join(rootPath, helpers.ReportFile))
 	require.NoError(t, err)
-	assert.Empty(t, runs.Names(),
-		"without mark-many-as-read, module source changes should not cascade to the unit")
+	assert.ElementsMatch(t, []string{"live/unit"}, runs.Names())
+}
+
+// TestMarkManyAsReadDefaultDiscoversModuleChanges pins that the local module
+// source walk is on by default: a reading= filter naming a module file selects
+// the unit consuming that module, with no experiment flag.
+func TestMarkManyAsReadDefaultDiscoversModuleChanges(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureMarkManyAsReadRelpath)
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureMarkManyAsReadRelpath)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureMarkManyAsReadRelpath)
+	rootPath, err := filepath.EvalSymlinks(rootPath)
+	require.NoError(t, err)
+
+	cmd := fmt.Sprintf(
+		"terragrunt run --all --non-interactive "+
+			"--filter 'reading=modules/foo/main.tf' --report-file %s "+
+			"--working-dir %s -- plan",
+		helpers.ReportFile, rootPath,
+	)
+
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
+
+	runs, err := report.ParseJSONRunsFromFile(filepath.Join(rootPath, helpers.ReportFile))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"live/unit"}, runs.Names(),
+		"module source changes should cascade to the unit by default")
+}
+
+// TestMarkGlobAsReadReadingFilter exercises mark_glob_as_read() end-to-end:
+// the unit's terragrunt.hcl globs a sibling data file, and a reading= filter
+// matching that file selects the unit. A data file that no unit marks as read
+// matches nothing.
+func TestMarkGlobAsReadReadingFilter(t *testing.T) {
+	t.Parallel()
+
+	workingDir, err := filepath.Abs(testFixtureMarkGlobAsRead)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name          string
+		filterQuery   string
+		expectedUnits []string
+	}{
+		{
+			name:          "exact path to the globbed data file selects the unit",
+			filterQuery:   "reading=unit/settings.yaml",
+			expectedUnits: []string{"unit"},
+		},
+		{
+			name:          "glob filter matching the globbed data file selects the unit",
+			filterQuery:   "reading=*/settings.yaml",
+			expectedUnits: []string{"unit"},
+		},
+		{
+			name:          "data file not marked by any unit selects nothing",
+			filterQuery:   "reading=*/data.yaml",
+			expectedUnits: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			helpers.CleanupTerraformFolder(t, workingDir)
+
+			cmd := "terragrunt find --no-color --working-dir " + workingDir + " --filter '" + tc.filterQuery + "'"
+			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+			require.NoError(t, err, "stderr: %s", stderr)
+
+			assert.ElementsMatch(t, tc.expectedUnits, strings.Fields(stdout),
+				"output mismatch for filter query: %s", tc.filterQuery)
+		})
+	}
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Completes the `mark-many-as-read` experiment.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reading-based discovery now automatically tracks local Terraform module source changes, enabling filters like `--filter 'reading=<path>'` and `--queue-include-units-reading` to work by default.
  * The `mark_glob_as_read()` HCL function is now generally available without requiring an experiment flag.

* **Bug Fixes**
  * Fixed relative config path resolution in module file detection.

* **Documentation**
  * Updated documentation to reflect v1.1.0 behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->