### PR TITLE
fix: Fixing legacy virtual hosted style S3 URLs

### DIFF
--- a/docs/src/data/changelog/v1.0.8/s3-virtual-hosted-style-urls.mdx
+++ b/docs/src/data/changelog/v1.0.8/s3-virtual-hosted-style-urls.mdx
@@ -1,0 +1,23 @@
+---
+version: "v1.0.8"
+category: "bug-fixes"
+---
+
+#### `s3::` sources: support virtual-hosted-style URLs
+
+`s3::` source URLs using the virtual-hosted-style S3 endpoint format were rejected:
+
+```hcl
+terraform {
+  source = "s3::https://my-bucket.s3.us-west-2.amazonaws.com/terraform/modules/myapp.zip"
+}
+```
+
+This resulted in errors like:
+
+```text
+ERROR downloading source url s3::https://my-bucket.s3.us-west-2.amazonaws.com/...
+* URL is not a valid S3 URL
+```
+
+Terragrunt now accepts every AWS S3 endpoint form, including virtual-hosted-style URLs (`<bucket>.s3.<region>.amazonaws.com`) and modern path-style URLs (`s3.<region>.amazonaws.com`).

--- a/internal/getter/casgetter_detect_test.go
+++ b/internal/getter/casgetter_detect_test.go
@@ -169,6 +169,21 @@ func TestCASGetterDetect_AWSS3HTTPSRoutesToS3Fetcher(t *testing.T) {
 			wantSrc: "https://s3-us-west-2.amazonaws.com/my-bucket/path.zip",
 		},
 		{
+			name:    "modern virtual-host rewritten to regional path-style",
+			src:     "https://my-bucket.s3.us-west-2.amazonaws.com/path.zip",
+			wantSrc: "https://s3-us-west-2.amazonaws.com/my-bucket/path.zip",
+		},
+		{
+			name:    "modern us-east-1 virtual-host rewritten to global path-style",
+			src:     "https://my-bucket.s3.us-east-1.amazonaws.com/path.zip",
+			wantSrc: "https://s3.amazonaws.com/my-bucket/path.zip",
+		},
+		{
+			name:    "modern path-style rewritten to legacy regional path-style",
+			src:     "https://s3.us-west-2.amazonaws.com/my-bucket/path.zip",
+			wantSrc: "https://s3-us-west-2.amazonaws.com/my-bucket/path.zip",
+		},
+		{
 			name:    "global path-style claimed unchanged",
 			src:     "https://s3.amazonaws.com/my-bucket/path.zip",
 			wantSrc: "https://s3.amazonaws.com/my-bucket/path.zip",

--- a/internal/getter/defaults.go
+++ b/internal/getter/defaults.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	gcs "github.com/hashicorp/go-getter/gcs/v2"
-	s3 "github.com/hashicorp/go-getter/s3/v2"
 	getter "github.com/hashicorp/go-getter/v2"
 )
 
@@ -74,7 +73,7 @@ func DefaultGenericFetchers(opts ...GenericFetcherOption) map[string]getter.Gett
 	}
 
 	m := map[string]getter.Getter{
-		SchemeS3:    new(s3.Getter),
+		SchemeS3:    new(S3Getter),
 		SchemeGCS:   new(gcs.Getter),
 		SchemeHTTP:  &HTTPSchemeGetter{Inner: newHTTPGetter(cfg.httpExtra), Scheme: SchemeHTTP},
 		SchemeHTTPS: &HTTPSchemeGetter{Inner: newHTTPGetter(cfg.httpsExtra), Scheme: SchemeHTTPS},
@@ -126,7 +125,7 @@ func buildGetters(b *builder) []Getter {
 	hgGetter := new(getter.HgGetter)
 	smbClientGetter := new(getter.SmbClientGetter)
 	smbMountGetter := new(getter.SmbMountGetter)
-	s3Getter := new(s3.Getter)
+	s3Getter := new(S3Getter)
 	gcsGetter := new(gcs.Getter)
 
 	if b.tfRegistry != nil {

--- a/internal/getter/resolver_s3.go
+++ b/internal/getter/resolver_s3.go
@@ -17,13 +17,8 @@ import (
 )
 
 // ErrS3UnrecognizedURL is returned when an amazonaws.com URL does not match
-// a supported S3 path-style or legacy virtual-host shape.
+// a supported S3 path-style or virtual-host shape.
 var ErrS3UnrecognizedURL = errors.New("not a recognized S3 URL")
-
-// ErrS3ModernPathStyleUnsupported is returned for `s3.<region>.amazonaws.com`
-// URLs. The upstream go-getter/s3 v2 Getter rejects them, so the resolver
-// rejects them too to keep probe success aligned with fetch success.
-var ErrS3ModernPathStyleUnsupported = errors.New("modern path-style S3 URL not supported (use s3-<region>.amazonaws.com instead)")
 
 // ErrS3CompatibleUnrecognizedURL is returned when a non-amazonaws.com URL
 // does not have the host/<bucket>/<key> path shape required for S3-compatible
@@ -35,11 +30,14 @@ var ErrS3CompatibleUnrecognizedURL = errors.New("not a recognized S3-compatible 
 const s3ResolverTimeout = 10 * time.Second
 
 // Host-part counts for AWS S3 URL forms.
-// Path style: `<region>.amazonaws.com`.
-// Virtual-host style: `<bucket>.<region>.amazonaws.com`.
+// Legacy path style: `s3[-<region>].amazonaws.com`.
+// Legacy virtual-host style: `<bucket>.s3[-<region>].amazonaws.com`.
+// Modern path style: `s3.<region>.amazonaws.com`.
+// Modern virtual-host style: `<bucket>.s3.<region>.amazonaws.com`.
 const (
-	s3HostPartsPathStyle  = 3
-	s3HostPartsVHostStyle = 4
+	s3HostPartsPathStyle        = 3
+	s3HostPartsVHostStyle       = 4
+	s3HostPartsModernVHostStyle = 5
 	// s3URLPathSegments is the count produced by splitting `/bucket/key`
 	// on "/" with limit 3: ["", "bucket", "key"]. Used as a validation
 	// gate before indexing.
@@ -55,17 +53,19 @@ type S3API interface {
 // S3Resolver is a [cas.SourceResolver] for objects in Amazon S3 and
 // S3-compatible services.
 //
-// Supported URL forms (constrained by the upstream go-getter/s3/v2
-// Getter, whose parseUrl enforces a 3-part `amazonaws.com` hostname):
+// Supported URL forms:
 //
-//	https://s3.amazonaws.com/<bucket>/<key>           (global path-style)
-//	https://s3-<region>.amazonaws.com/<bucket>/<key>  (legacy regional path-style)
-//	https://<host>/<bucket>/<key>?region=<region>     (S3-compatible service)
+//	https://s3.amazonaws.com/<bucket>/<key>                  (global path-style)
+//	https://s3-<region>.amazonaws.com/<bucket>/<key>         (legacy regional path-style)
+//	https://s3.<region>.amazonaws.com/<bucket>/<key>         (modern path-style)
+//	https://<bucket>.s3.amazonaws.com/<key>                  (global virtual-host)
+//	https://<bucket>.s3-<region>.amazonaws.com/<key>         (legacy regional virtual-host)
+//	https://<bucket>.s3.<region>.amazonaws.com/<key>         (modern virtual-host)
+//	https://<host>/<bucket>/<key>?region=<region>            (S3-compatible service)
 //
-// Modern virtual-host URLs (`<bucket>.s3.<region>.amazonaws.com`,
-// 5-part) and modern path-style URLs (`s3.<region>.amazonaws.com`,
-// 4-part) are rejected by both the bare getter and this resolver. Use
-// the legacy regional form above.
+// The upstream go-getter/s3/v2 Getter only parses the path-style forms;
+// [S3Getter] canonicalizes the rest before the fetch, so probe support
+// here stays aligned with fetch support there.
 type S3Resolver struct {
 	// NewClient builds an S3 client per request. Nil means the resolver
 	// uses the AWS SDK default config (env, profile, IMDS) with a
@@ -222,13 +222,18 @@ func parseS3URL(u *url.URL) (s3Target, error) {
 
 			return s3Target{Region: region, Bucket: pathParts[1], Key: pathParts[2], Version: version}, nil
 		case s3HostPartsVHostStyle:
-			// hostParts[0] == "s3" is the modern path-style
-			// (`s3.<region>.amazonaws.com`), which the upstream
-			// go-getter/s3 v2 Getter rejects. Reject at probe time too
-			// so the failure mode matches the fetcher's rather than
-			// silently misparsing bucket="s3".
+			// hostParts[0] == "s3" is the modern path-style form
+			// (`s3.<region>.amazonaws.com/<bucket>/<key>`); the region
+			// is the second label. An exact "s3" match keeps non-S3
+			// services (e.g. sts.us-east-1.amazonaws.com) from parsing
+			// as S3 with a bogus region.
 			if hostParts[0] == "s3" {
-				return s3Target{}, fmt.Errorf("%w: %q", ErrS3ModernPathStyleUnsupported, u.String())
+				pathParts := strings.SplitN(u.Path, "/", s3URLPathSegments)
+				if len(pathParts) != s3URLPathSegments {
+					return s3Target{}, fmt.Errorf("%w: %q", ErrS3UnrecognizedURL, u.String())
+				}
+
+				return s3Target{Region: hostParts[1], Bucket: pathParts[1], Key: pathParts[2], Version: version}, nil
 			}
 
 			// Legacy virtual-host style: <bucket>.s3[-<region>].amazonaws.com/<key>.
@@ -242,6 +247,21 @@ func parseS3URL(u *url.URL) (s3Target, error) {
 
 			return s3Target{
 				Region:  region,
+				Bucket:  hostParts[0],
+				Key:     strings.TrimPrefix(u.Path, "/"),
+				Version: version,
+			}, nil
+		case s3HostPartsModernVHostStyle:
+			// Modern virtual-host style: <bucket>.s3.<region>.amazonaws.com/<key>.
+			// The label after the bucket must be exactly "s3"; any other
+			// label means a non-S3 service or an endpoint variant
+			// (dualstack, fips, accesspoint) this parser does not claim.
+			if hostParts[1] != "s3" {
+				return s3Target{}, fmt.Errorf("%w: %q", ErrS3UnrecognizedURL, u.String())
+			}
+
+			return s3Target{
+				Region:  hostParts[2],
 				Bucket:  hostParts[0],
 				Key:     strings.TrimPrefix(u.Path, "/"),
 				Version: version,
@@ -295,13 +315,12 @@ func strPtr(p *string) string {
 // canonicalAWSS3HTTPSURL returns the path-style HTTPS URL for an AWS S3
 // URL in any supported form, preserving the user's query string. ok is
 // false when u is not http/https against an amazonaws.com host, or when
-// the host matches a form the bare go-getter v2 s3 getter rejects (modern
-// virtual-host and modern path-style).
+// the host is not a recognized S3 shape (e.g. another AWS service).
 //
-// The rewrite exists because the bare s3 getter's parseUrl only accepts
-// path-style hosts (`s3.amazonaws.com`, `s3-<region>.amazonaws.com`), so
-// routing a virtual-host URL to it without canonicalization would set up
-// a doomed inner fetch on every cache miss.
+// The rewrite exists because the bare go-getter/s3/v2 getter's parseUrl
+// only accepts legacy path-style hosts (`s3.amazonaws.com`,
+// `s3-<region>.amazonaws.com`), so routing any other S3 URL form to it
+// without canonicalization would set up a doomed fetch.
 func canonicalAWSS3HTTPSURL(u *url.URL) (string, bool) {
 	if u == nil {
 		return "", false

--- a/internal/getter/resolver_s3_test.go
+++ b/internal/getter/resolver_s3_test.go
@@ -122,31 +122,35 @@ func TestS3Resolver_HeadFailureSurfacesErrNoVersionMetadata(t *testing.T) {
 	require.ErrorIs(t, err, cas.ErrNoVersionMetadata)
 }
 
-// TestS3Resolver_RejectsModernURLForms pins the upstream
-// go-getter/s3/v2 limitation: modern virtual-host URLs
-// (`<bucket>.s3.<region>.amazonaws.com`) and modern path-style URLs
-// (`s3.<region>.amazonaws.com`) are rejected by the bare getter's
-// parseUrl. The resolver tracks the bare getter's behavior so probe
-// success aligns with fetch success. The fake fails the test if
-// HeadObject is reached, since rejection has to happen at parse time
-// rather than silently downgrade through a doomed HeadObject call.
-func TestS3Resolver_RejectsModernURLForms(t *testing.T) {
+// TestS3Resolver_AcceptsModernURLForms pins probe support for the URL
+// forms AWS documents today: virtual-hosted style
+// (`<bucket>.s3.<region>.amazonaws.com`) and modern path style
+// (`s3.<region>.amazonaws.com`). Region, bucket, and key are all
+// encoded in the hostname and path, so the probe's HeadObject must
+// target exactly the object the fetcher downloads.
+func TestS3Resolver_AcceptsModernURLForms(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		wantErr error
-		name    string
-		url     string
+		name       string
+		url        string
+		wantRegion string
+		wantBucket string
+		wantKey    string
 	}{
 		{
-			wantErr: getter.ErrS3UnrecognizedURL,
-			name:    "modern virtual-host style with 5 host parts",
-			url:     "https://bucket.s3.us-west-2.amazonaws.com/modules/example.tar.gz",
+			name:       "modern virtual-host style with 5 host parts",
+			url:        "https://bucket.s3.us-west-2.amazonaws.com/modules/example.tar.gz",
+			wantRegion: "us-west-2",
+			wantBucket: "bucket",
+			wantKey:    "modules/example.tar.gz",
 		},
 		{
-			wantErr: getter.ErrS3ModernPathStyleUnsupported,
-			name:    "modern path-style with 4 host parts",
-			url:     "https://s3.us-west-2.amazonaws.com/bucket/modules/example.tar.gz",
+			name:       "modern path-style with 4 host parts",
+			url:        "https://s3.us-west-2.amazonaws.com/bucket/modules/example.tar.gz",
+			wantRegion: "us-west-2",
+			wantBucket: "bucket",
+			wantKey:    "modules/example.tar.gz",
 		},
 	}
 
@@ -154,13 +158,26 @@ func TestS3Resolver_RejectsModernURLForms(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			r := newS3ResolverWith(&assertingS3Head{t: t})
+			head := &fakeS3Head{out: &s3.HeadObjectOutput{
+				ChecksumSHA256: aws.String("sha256-token"),
+			}}
 
-			_, err := r.Probe(t.Context(), tt.url)
-			require.ErrorIs(t, err, tt.wantErr,
-				"parseS3URL must reject %s; upstream go-getter/s3/v2 also rejects it", tt.url)
-			require.NotErrorIs(t, err, cas.ErrNoVersionMetadata,
-				"rejection must come from parseS3URL, not from an empty HeadObject result")
+			var gotRegion string
+
+			r := getter.NewS3Resolver()
+			r.NewClient = func(_ context.Context, region string) (getter.S3API, error) {
+				gotRegion = region
+				return head, nil
+			}
+
+			got, err := r.Probe(t.Context(), tt.url)
+			require.NoError(t, err, "parseS3URL must accept %s", tt.url)
+			assert.Equal(t, cas.ContentKey("sha256", "sha256-token"), got)
+
+			assert.Equal(t, tt.wantRegion, gotRegion, "region must come from the hostname")
+			require.NotNil(t, head.gotInput)
+			assert.Equal(t, tt.wantBucket, aws.ToString(head.gotInput.Bucket))
+			assert.Equal(t, tt.wantKey, aws.ToString(head.gotInput.Key))
 		})
 	}
 }

--- a/internal/getter/s3.go
+++ b/internal/getter/s3.go
@@ -1,0 +1,39 @@
+package getter
+
+import (
+	"net/url"
+
+	s3 "github.com/hashicorp/go-getter/s3/v2"
+	getter "github.com/hashicorp/go-getter/v2"
+)
+
+// S3Getter is Terragrunt's s3-protocol getter. It wraps the upstream
+// go-getter/s3/v2 Getter, whose URL parser only accepts legacy
+// path-style hostnames (`s3.amazonaws.com`, `s3-<region>.amazonaws.com`),
+// and canonicalizes the other AWS S3 endpoint forms — virtual-host style
+// and modern path style — into that shape so they fetch instead of
+// failing URL validation.
+type S3Getter struct {
+	s3.Getter
+}
+
+// Detect delegates to the upstream getter and, when the request is
+// claimed, rewrites an AWS S3 URL to the path-style form the upstream
+// Get/GetFile/Mode parser accepts. Detect is the only hook where a
+// getter may rewrite the source: Client.Get re-parses req.Src into the
+// request URL after detection, while later mutation would be ignored.
+// Non-AWS (S3-compatible) hosts pass through untouched.
+func (g *S3Getter) Detect(req *getter.Request) (bool, error) {
+	ok, err := g.Getter.Detect(req)
+	if err != nil || !ok {
+		return ok, err
+	}
+
+	if u, perr := url.Parse(req.Src); perr == nil {
+		if canonical, cok := canonicalAWSS3HTTPSURL(u); cok {
+			req.Src = canonical
+		}
+	}
+
+	return true, nil
+}

--- a/internal/getter/s3_test.go
+++ b/internal/getter/s3_test.go
@@ -1,0 +1,94 @@
+package getter_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	gogetter "github.com/hashicorp/go-getter/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultClientCanonicalizesS3SourceURLs pins that `s3::https://`
+// sources work in every AWS S3 endpoint form, including the
+// virtual-hosted style (`<bucket>.s3.<region>.amazonaws.com`) AWS
+// documents as canonical. The upstream go-getter/s3/v2 getter only
+// parses path-style hostnames (`s3.amazonaws.com`,
+// `s3-<region>.amazonaws.com`), so whichever getter claims the request
+// must canonicalize req.Src at Detect time: Client.Get re-parses
+// req.Src after detection into the URL the fetch uses.
+//
+// The test mirrors the outer client's getter-selection loop instead of
+// calling Client.Get so no network I/O happens.
+func TestDefaultClientCanonicalizesS3SourceURLs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		src      string
+		wantHost string
+		wantPath string
+	}{
+		{
+			name:     "modern virtual-host style",
+			src:      "s3::https://my-bucket.s3.us-west-2.amazonaws.com/terraform/modules/myapp.zip",
+			wantHost: "s3-us-west-2.amazonaws.com",
+			wantPath: "/my-bucket/terraform/modules/myapp.zip",
+		},
+		{
+			name:     "legacy regional virtual-host style",
+			src:      "s3::https://my-bucket.s3-us-west-2.amazonaws.com/terraform/modules/myapp.zip",
+			wantHost: "s3-us-west-2.amazonaws.com",
+			wantPath: "/my-bucket/terraform/modules/myapp.zip",
+		},
+		{
+			name:     "global virtual-host style",
+			src:      "s3::https://my-bucket.s3.amazonaws.com/terraform/modules/myapp.zip",
+			wantHost: "s3.amazonaws.com",
+			wantPath: "/my-bucket/terraform/modules/myapp.zip",
+		},
+		{
+			name:     "modern path-style",
+			src:      "s3::https://s3.us-west-2.amazonaws.com/my-bucket/terraform/modules/myapp.zip",
+			wantHost: "s3-us-west-2.amazonaws.com",
+			wantPath: "/my-bucket/terraform/modules/myapp.zip",
+		},
+		{
+			name:     "legacy regional path-style stays unchanged",
+			src:      "s3::https://s3-us-west-2.amazonaws.com/my-bucket/terraform/modules/myapp.zip",
+			wantHost: "s3-us-west-2.amazonaws.com",
+			wantPath: "/my-bucket/terraform/modules/myapp.zip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := getter.NewClient()
+			req := &gogetter.Request{Src: tt.src, GetMode: getter.ModeAny}
+
+			claimed := false
+
+			for _, g := range client.Getters {
+				ok, err := gogetter.Detect(req, g)
+				require.NoError(t, err)
+
+				if ok {
+					claimed = true
+					break
+				}
+			}
+
+			require.True(t, claimed, "a getter must claim %s", tt.src)
+			assert.Equal(t, getter.SchemeS3, req.Forced)
+
+			u, err := url.Parse(req.Src)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHost, u.Host,
+				"Detect must canonicalize to a path-style host the bare go-getter/s3 v2 getter accepts")
+			assert.Equal(t, tt.wantPath, u.Path)
+		})
+	}
+}

--- a/internal/getter/types.go
+++ b/internal/getter/types.go
@@ -40,13 +40,13 @@ type (
 
 // Concrete getter type aliases for callers that need to assert on the
 // underlying getter type (typically tests pinning the protocol set). The
-// git slot is intentionally absent: GitGetter is Terragrunt's own type
-// (defined in git.go), not the upstream go-getter/v2 GitGetter.
+// git and s3 slots are intentionally absent: GitGetter and S3Getter are
+// Terragrunt's own types (defined in git.go and s3.go), not the upstream
+// go-getter/v2 getters.
 type (
 	HgGetter        = getter.HgGetter
 	SmbClientGetter = getter.SmbClientGetter
 	SmbMountGetter  = getter.SmbMountGetter
 	FileGetter      = getter.FileGetter
-	S3Getter        = s3.Getter
 	GCSGetter       = gcs.Getter
 )

--- a/test/integration_cas_s3_test.go
+++ b/test/integration_cas_s3_test.go
@@ -3,14 +3,8 @@
 package test_test
 
 import (
-	"bytes"
 	"path/filepath"
-	"strings"
 	"testing"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	tgcas "github.com/gruntwork-io/terragrunt/internal/cas"
 	tggetter "github.com/gruntwork-io/terragrunt/internal/getter"
@@ -28,33 +22,8 @@ func TestAwsCASS3ChecksumProbe(t *testing.T) {
 	t.Parallel()
 
 	region := helpers.TerraformRemoteStateS3Region
-	bucket := "terragrunt-cas-test-" + strings.ToLower(helpers.UniqueID())
 	key := "modules/example.tar.gz"
-
-	s3Client := helpers.CreateS3ClientForTest(t, region)
-
-	_, err := s3Client.CreateBucket(t.Context(), &s3.CreateBucketInput{
-		Bucket: aws.String(bucket),
-		CreateBucketConfiguration: &types.CreateBucketConfiguration{
-			LocationConstraint: types.BucketLocationConstraint(region),
-		},
-	})
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		if err := helpers.DeleteS3Bucket(t, region, bucket); err != nil {
-			t.Logf("delete bucket %s: %v", bucket, err)
-		}
-	})
-
-	body := makeModuleArchive(t)
-	_, err = s3Client.PutObject(t.Context(), &s3.PutObjectInput{
-		Bucket:            aws.String(bucket),
-		Key:               aws.String(key),
-		Body:              bytes.NewReader(body),
-		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
-	})
-	require.NoError(t, err)
+	bucket := provisionS3ModuleArchive(t, region, key)
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
 	c, err := tgcas.New(tgcas.WithStorePath(storePath))
@@ -66,13 +35,6 @@ func TestAwsCASS3ChecksumProbe(t *testing.T) {
 	g := tggetter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{}, tggetter.WithDefaultGenericDispatch())
 	client := &tggetter.Client{Getters: []tggetter.Getter{g}}
 
-	// Legacy regional path-style URL: the bare go-getter s3.Getter's
-	// parseUrl only handles 3-part hostnames. Modern virtual-host
-	// URLs (`bucket.s3.region.amazonaws.com`, 5 parts) and modern
-	// path-style URLs (`s3.region.amazonaws.com`, 4 parts) both fail
-	// the bare getter's len(hostParts) != 3 check. `s3-region.amazonaws.com`
-	// is the form both the bare getter and our S3Resolver's parseS3URL
-	// recognize, so the test URL stays compatible with both.
 	src := "s3::https://s3-" + region + ".amazonaws.com/" + bucket + "/" + key
 
 	first := filepath.Join(helpers.TmpDirWOSymlinks(t), "first")

--- a/test/integration_s3_source_test.go
+++ b/test/integration_s3_source_test.go
@@ -1,0 +1,98 @@
+//go:build aws
+
+package test_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	tggetter "github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAwsS3SourceURLForms downloads a module archive through the default
+// (non-CAS) client in each AWS S3 endpoint form a `source` URL can use.
+// The forms differ only in how the hostname encodes bucket and region;
+// all of them must fetch the same object.
+func TestAwsS3SourceURLForms(t *testing.T) {
+	t.Parallel()
+
+	region := helpers.TerraformRemoteStateS3Region
+	key := "modules/example.tar.gz"
+	bucket := provisionS3ModuleArchive(t, region, key)
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "virtual-host style",
+			src:  "s3::https://" + bucket + ".s3." + region + ".amazonaws.com/" + key,
+		},
+		{
+			name: "modern path-style",
+			src:  "s3::https://s3." + region + ".amazonaws.com/" + bucket + "/" + key,
+		},
+		{
+			name: "legacy regional path-style",
+			src:  "s3::https://s3-" + region + ".amazonaws.com/" + bucket + "/" + key,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "module")
+
+			_, err := tggetter.GetAny(t.Context(), dst, tt.src)
+			require.NoError(t, err)
+			require.FileExists(t, filepath.Join(dst, "main.tf"))
+		})
+	}
+}
+
+// provisionS3ModuleArchive creates a throwaway bucket in region holding
+// the shared module archive under key, registers cleanup, and returns
+// the bucket name. The PutObject sets a SHA-256 checksum so CAS
+// resolver probes can exercise the content-addressed path against the
+// same object.
+func provisionS3ModuleArchive(t *testing.T, region, key string) string {
+	t.Helper()
+
+	bucket := "terragrunt-getter-test-" + strings.ToLower(helpers.UniqueID())
+
+	s3Client := helpers.CreateS3ClientForTest(t, region)
+
+	_, err := s3Client.CreateBucket(t.Context(), &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+		CreateBucketConfiguration: &types.CreateBucketConfiguration{
+			LocationConstraint: types.BucketLocationConstraint(region),
+		},
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if err := helpers.DeleteS3Bucket(t, region, bucket); err != nil {
+			t.Logf("delete bucket %s: %v", bucket, err)
+		}
+	})
+
+	body := makeModuleArchive(t)
+	_, err = s3Client.PutObject(t.Context(), &s3.PutObjectInput{
+		Bucket:            aws.String(bucket),
+		Key:               aws.String(key),
+		Body:              bytes.NewReader(body),
+		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
+	})
+	require.NoError(t, err)
+
+	return bucket
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6309.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terragrunt now accepts all AWS S3 endpoint URL formats, including virtual-hosted-style and modern path-style URLs. Previously, these URLs were incorrectly rejected with "URL is not a valid S3 URL" errors.

* **Tests**
  * Added comprehensive test coverage for S3 URL format variations and detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->