### PR TITLE
docs: Documenting `--parallelism` tweaking considerations better

### DIFF
--- a/docs/src/content/docs/06-troubleshooting/03-performance.mdx
+++ b/docs/src/content/docs/06-troubleshooting/03-performance.mdx
@@ -70,6 +70,48 @@ Additionally, this experiment is **not compatible with OpenTofu state encryption
 
 See [#1549](https://github.com/opentofu/opentofu/issues/1549) for more details.
 
+## Tuning Parallelism
+
+When you use commands with the `--all` or `--graph` flags, Terragrunt queues up a run for every unit involved. The [`--parallelism`](/reference/cli/commands/run#parallelism) flag (or the `TG_PARALLELISM` environment variable) caps how many of those runs are allowed to execute at the same time.
+
+### How Runs Are Scheduled
+
+Before running anything, Terragrunt builds a graph of the dependencies between units. A unit becomes eligible to run once every unit it depends on has finished successfully. Eligible units start immediately as long as the number of runs already in flight is below the parallelism limit. Otherwise, they wait for a running unit to finish and free up a slot.
+
+Each run is a separate OpenTofu/Terraform process, scheduled by the operating system like any other, and the parallelism limit caps how many of them run at once.
+
+By default, there is no limit. Every eligible unit starts right away, no matter how many cores the machine has. This is usually fine, because OpenTofu/Terraform runs spend most of their time waiting on network requests to provider APIs rather than using the CPU, so a machine can typically make progress on many more runs than it has cores. It also means you can see far more OpenTofu/Terraform processes than you might expect, and that an update to a file shared by every unit in a large tree (a root configuration, say) can start every one of those units at once.
+
+### Picking a Value
+
+There is no universally correct setting for `--parallelism`. The right value depends on how much memory, CPU, and network I/O your units consume, so treat tuning as an exercise in [measurement](#measuring-performance).
+
+Two trends are worth knowing before you start measuring:
+
+- Peak memory usage grows roughly in proportion to parallelism. Every concurrent run is its own OpenTofu/Terraform process, loading its own provider plugins and its own copy of state.
+- Speed improvements reach a diminishing return with increasing parallelism. Once there are enough runs in flight to keep the machine and network busy, additional concurrent runs just queue up, bottlenecked by the same resources.
+
+Once speed gains level off, higher parallelism costs you memory (and pressure on provider API rate limits) without making anything faster.
+
+A reasonable procedure is to start with parallelism set to the number of CPU cores on your machine, then double or halve it while measuring wall clock time and peak memory usage until you stop seeing improvements.
+
+If your runs happen on shared infrastructure, like CI runners used by other jobs, consider setting a value below the optimum you measure in isolation. Even when day-to-day runs never come close to the limit, a cap bounds the worst-case resource usage of a run that touches every unit at once. An out-of-memory kill from an unbounded full-tree run is a worse outcome than a slower, bounded one.
+
+### Parallelism Within a Single Run
+
+OpenTofu/Terraform has its own `-parallelism` flag, which limits how many resource operations a single run performs concurrently (10 by default). Terragrunt's `--parallelism` flag doesn't touch this setting. The two multiply: total concurrent operations against your cloud provider scale with both the number of units in flight and the parallelism within each of them.
+
+If you need to adjust within-run parallelism across units, use an [`extra_arguments`](/features/units/extra-arguments) block with the [`get_terraform_commands_that_need_parallelism`](/reference/hcl/functions/#get_terraform_commands_that_need_parallelism) function:
+
+```hcl
+terraform {
+  extra_arguments "parallelism" {
+    commands  = get_terraform_commands_that_need_parallelism()
+    arguments = ["-parallelism=5"]
+  }
+}
+```
+
 ## Measuring Performance
 
 Before diving into any particular performance optimization, it's important to first measure performance, and to make sure that you measure performance after any changes so that you understand the impact of your changes.

--- a/docs/src/data/flags/parallelism.mdx
+++ b/docs/src/data/flags/parallelism.mdx
@@ -8,7 +8,11 @@ env:
 
 import { Aside } from '@astrojs/starlight/components';
 
-Sets the maximum number of concurrent operations when running commands with `--all`. This helps control resource usage and API rate limits when working with multiple units.
+Sets the maximum number of concurrent unit runs when running commands with `--all` or `--graph`. This helps control resource usage and API rate limits when working with multiple units.
+
+By default, there is no limit, and every unit whose dependencies have finished starts immediately.
+
+For details on how runs are scheduled and guidance on choosing a value, see [Tuning Parallelism](/troubleshooting/performance#tuning-parallelism).
 
 <Aside type="caution">
 When using `--parallelism` with provider caching, `terraform init` is always executed sequentially if OpenTofu/Terraform provider plugin cache is configured.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Documenting considerations for `--parallelism` tweaking better.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Tuning Parallelism" troubleshooting section with guidance on scheduling, default behavior, and choosing appropriate parallelism values based on resource tradeoffs
  * Expanded `--parallelism` flag documentation to clarify behavior for `--all` and `--graph` commands and interaction with OpenTofu/Terraform settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->