### PR TITLE
feat(remotestate/gcs): support storage_custom_endpoint parameter

### DIFF
--- a/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
+++ b/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
@@ -333,6 +333,7 @@ remote_state {
     skip_bucket_versioning    = true
     enable_bucket_policy_only = false
     encryption_key            = "GOOGLE_ENCRYPTION_KEY"
+    storage_custom_endpoint   = "https://storage.example.com"
   }
 }
 ```
@@ -340,6 +341,7 @@ remote_state {
 - `skip_bucket_versioning` — Skip versioning on the state bucket. Use only if the object store does not support versioning.
 - `enable_bucket_policy_only` — Enable uniform bucket-level access. See [uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access) for details.
 - `encryption_key` — A Cloud KMS key name to use for encrypting state objects.
+- `storage_custom_endpoint` — A custom endpoint to route Cloud Storage API calls to, instead of the default `https://storage.googleapis.com`. Requires Terraform v1.6.0+ which added native support for this backend setting.
 
 If you experience an error for any of these configurations, confirm you are using Terraform v0.12.0 or greater.
 

--- a/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
+++ b/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
@@ -8,6 +8,7 @@ sidebar:
 
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside } from '@astrojs/starlight/components';
+import Since from '@components/Since.astro';
 
 OpenTofu/Terraform supports [remote state storage](https://opentofu.org/docs/language/state/remote/) via various [backends](https://opentofu.org/docs/language/settings/backends/configuration/) that you normally configure in your `.tf` files as follows:
 
@@ -333,7 +334,6 @@ remote_state {
     skip_bucket_versioning    = true
     enable_bucket_policy_only = false
     encryption_key            = "GOOGLE_ENCRYPTION_KEY"
-    storage_custom_endpoint   = "https://storage.example.com"
   }
 }
 ```
@@ -341,7 +341,21 @@ remote_state {
 - `skip_bucket_versioning` — Skip versioning on the state bucket. Use only if the object store does not support versioning.
 - `enable_bucket_policy_only` — Enable uniform bucket-level access. See [uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access) for details.
 - `encryption_key` — A Cloud KMS key name to use for encrypting state objects.
-- `storage_custom_endpoint` — A custom endpoint to route Cloud Storage API calls to, instead of the default `https://storage.googleapis.com`. Requires Terraform v1.6.0+ which added native support for this backend setting.
+
+<Since version="1.0.9">
+
+- `storage_custom_endpoint` — A custom endpoint to route Cloud Storage API calls to, instead of the default `https://storage.googleapis.com`. Useful when accessing the bucket through [Private Service Connect (PSC)](https://cloud.google.com/vpc/docs/private-service-connect) or a Google Cloud dedicated universe such as S3NS. Terragrunt uses this endpoint for its own GCP storage operations (such as bucket creation and validation) and forwards it to OpenTofu/Terraform unchanged. Requires Terraform v1.6.0+ / OpenTofu, which added native support for this backend setting. The value below is an illustrative placeholder using the reserved `example.com` documentation domain.
+
+  ```hcl
+  # root.hcl
+  remote_state {
+    config = {
+      storage_custom_endpoint = "https://storage.example.com"
+    }
+  }
+  ```
+
+</Since>
 
 If you experience an error for any of these configurations, confirm you are using Terraform v0.12.0 or greater.
 

--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -494,6 +494,7 @@ For the `gcs` backend, the following additional properties are supported in the 
 - `gcs_bucket_labels`: A map of key value pairs to associate as labels on the created GCS bucket.
 - `credentials`: Local path to Google Cloud Platform account credentials in JSON format.
 - `access_token`: A temporary [OAuth 2.0 access token] obtained from the Google Authorization server.
+- `storage_custom_endpoint`: A custom endpoint to route Cloud Storage API calls to, instead of the default `https://storage.googleapis.com`. Terragrunt uses it for its own GCP storage operations and forwards it to Terraform unchanged (requires Terraform v1.6.0+).
 
 Example with S3:
 

--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -494,7 +494,12 @@ For the `gcs` backend, the following additional properties are supported in the 
 - `gcs_bucket_labels`: A map of key value pairs to associate as labels on the created GCS bucket.
 - `credentials`: Local path to Google Cloud Platform account credentials in JSON format.
 - `access_token`: A temporary [OAuth 2.0 access token] obtained from the Google Authorization server.
-- `storage_custom_endpoint`: A custom endpoint to route Cloud Storage API calls to, instead of the default `https://storage.googleapis.com`. Terragrunt uses it for its own GCP storage operations and forwards it to Terraform unchanged (requires Terraform v1.6.0+).
+
+<Since version="1.0.9">
+
+- `storage_custom_endpoint`: A custom endpoint to route Cloud Storage API calls to, instead of the default `https://storage.googleapis.com`. Terragrunt uses it for its own GCP storage operations and forwards it to OpenTofu/Terraform unchanged (requires Terraform v1.6.0+ / OpenTofu).
+
+</Since>
 
 Example with S3:
 

--- a/docs/src/data/changelog/v1.0.9/gcs-storage-custom-endpoint.mdx
+++ b/docs/src/data/changelog/v1.0.9/gcs-storage-custom-endpoint.mdx
@@ -1,0 +1,23 @@
+---
+version: "v1.0.9"
+category: "new-features"
+---
+
+#### `gcs` backend: support `storage_custom_endpoint`
+
+The `gcs` remote state backend now accepts a `storage_custom_endpoint` setting to route Cloud Storage API calls to a custom endpoint instead of the default `https://storage.googleapis.com`.
+
+```hcl
+# root.hcl
+remote_state {
+  backend = "gcs"
+
+  config = {
+    bucket                  = "my-tofu-state"
+    prefix                  = "terraform.tfstate"
+    storage_custom_endpoint = "https://storage.example.com"
+  }
+}
+```
+
+This is useful when reaching the bucket through [Private Service Connect (PSC)](https://cloud.google.com/vpc/docs/private-service-connect) or a Google Cloud dedicated universe such as S3NS. Terragrunt applies the endpoint to its own GCP storage operations (such as bucket creation and validation) and forwards it to OpenTofu/Terraform unchanged. Requires Terraform v1.6.0+ / OpenTofu, which added native support for this backend setting.

--- a/internal/gcphelper/config.go
+++ b/internal/gcphelper/config.go
@@ -31,6 +31,7 @@ type GCPSessionConfig struct {
 	AccessToken                        string
 	ImpersonateServiceAccount          string
 	ImpersonateServiceAccountDelegates []string
+	StorageCustomEndpoint              string
 }
 
 // GCPConfigBuilder constructs GCP client options using the builder pattern.
@@ -132,6 +133,10 @@ func (b *GCPConfigBuilder) Build(ctx context.Context) ([]option.ClientOption, er
 		}
 
 		clientOpts = []option.ClientOption{option.WithTokenSource(ts)}
+	}
+
+	if gcpCfg != nil && gcpCfg.StorageCustomEndpoint != "" {
+		clientOpts = append(clientOpts, option.WithEndpoint(gcpCfg.StorageCustomEndpoint))
 	}
 
 	return clientOpts, nil

--- a/internal/gcphelper/config_test.go
+++ b/internal/gcphelper/config_test.go
@@ -209,3 +209,20 @@ func TestCreateGcpConfigWithGoogleCredentialsFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 }
+
+func TestCreateGcpConfigWithCustomEndpoint(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	env := map[string]string{}
+
+	gcpCfg := &gcphelper.GCPSessionConfig{
+		StorageCustomEndpoint: "https://custom-gcs.example.com",
+	}
+
+	clientOpts, err := gcphelper.NewGCPConfigBuilder().WithSessionConfig(gcpCfg).WithEnv(env).Build(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, clientOpts)
+}
+

--- a/internal/remotestate/backend/gcs/backend_test.go
+++ b/internal/remotestate/backend/gcs/backend_test.go
@@ -38,6 +38,19 @@ func TestBackend_GetTFInitArgs(t *testing.T) {
 			},
 		},
 		{
+			name: "gcs-custom-endpoint-preservation",
+			config: backend.Config{
+				"bucket":                  "my-bucket",
+				"prefix":                  "terraform/state",
+				"storage_custom_endpoint": "https://custom-gcs.example.com",
+			},
+			expected: map[string]any{
+				"bucket":                  "my-bucket",
+				"prefix":                  "terraform/state",
+				"storage_custom_endpoint": "https://custom-gcs.example.com",
+			},
+		},
+		{
 			name: "terragrunt-keys-filtered",
 			config: backend.Config{
 				"bucket":                    "my-bucket",

--- a/internal/remotestate/backend/gcs/config_test.go
+++ b/internal/remotestate/backend/gcs/config_test.go
@@ -219,3 +219,17 @@ func TestParseExtendedGCSConfig_InvalidStringBool(t *testing.T) {
 	_, err := cfg.ParseExtendedGCSConfig()
 	require.Error(t, err)
 }
+
+func TestParseExtendedGCSConfig_CustomEndpoint(t *testing.T) {
+	t.Parallel()
+
+	cfg := gcs.Config{
+		"bucket":                  "my-bucket",
+		"storage_custom_endpoint": "https://custom-gcs.example.com",
+	}
+
+	extGCSCfg, err := cfg.ParseExtendedGCSConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://custom-gcs.example.com", extGCSCfg.RemoteStateConfigGCS.StorageCustomEndpoint)
+}
+

--- a/internal/remotestate/backend/gcs/remote_state_config.go
+++ b/internal/remotestate/backend/gcs/remote_state_config.go
@@ -57,6 +57,7 @@ type RemoteStateConfigGCS struct {
 
 	ImpersonateServiceAccount          string   `mapstructure:"impersonate_service_account"`
 	ImpersonateServiceAccountDelegates []string `mapstructure:"impersonate_service_account_delegates"`
+	StorageCustomEndpoint              string   `mapstructure:"storage_custom_endpoint"`
 }
 
 // CacheKey returns a unique key for the given GCS config that can be used to cache the initialization.
@@ -71,5 +72,6 @@ func (cfg *ExtendedRemoteStateConfigGCS) GetGCPSessionConfig() *gcphelper.GCPSes
 		AccessToken:                        cfg.RemoteStateConfigGCS.AccessToken,
 		ImpersonateServiceAccount:          cfg.RemoteStateConfigGCS.ImpersonateServiceAccount,
 		ImpersonateServiceAccountDelegates: cfg.RemoteStateConfigGCS.ImpersonateServiceAccountDelegates,
+		StorageCustomEndpoint:              cfg.RemoteStateConfigGCS.StorageCustomEndpoint,
 	}
 }


### PR DESCRIPTION
## Description

Add support for the `storage_custom_endpoint` configuration parameter in the GCS remote state backend block. This propagates the custom endpoint setting to Terragrunt's internal GCP storage client (e.g. for bucket creation and health checks) and ensures it is forwarded to Terraform as-is.

This aligns Terragrunt's GCS backend with Terraform's backend capability (from v1.6.0+) to route API calls to custom endpoints. It is useful over Google Cloud Dedicated universe like S3NS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom GCS storage endpoints via the storage_custom_endpoint option for the GCS remote state backend, enabling routing of Cloud Storage API calls to a custom endpoint (requires Terraform v1.6.0+/OpenTofu).

* **Documentation**
  * Updated docs and changelog with examples and guidance for the new storage_custom_endpoint setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->