### PR TITLE
chore: Completing `dag-queue-display` experiment

### DIFF
--- a/docs/src/data/changelog/v1.1.0/dag-queue-display-completed.mdx
+++ b/docs/src/data/changelog/v1.1.0/dag-queue-display-completed.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.0"
+category: "experiments-updated"
+---
+
+#### `dag-queue-display`: experiment completed
+
+The `dag-queue-display` experiment is complete. The run queue is now displayed as a dependency tree by default, showing units nested under their dependencies so you can see the full execution hierarchy at a glance.
+
+The `--experiment dag-queue-display` flag is no longer needed. Passing it still works but emits a completed-experiment warning, so you can drop it at your convenience.

--- a/docs/src/data/changelog/v1.1.0/stack-dependencies-completed.mdx
+++ b/docs/src/data/changelog/v1.1.0/stack-dependencies-completed.mdx
@@ -7,4 +7,4 @@ category: "experiments-updated"
 
 The `stack-dependencies` experiment is complete. Support for the `autoinclude` block in `terragrunt.stack.hcl` files, including `unit.<name>.path` / `stack.<name>.path` references, dependencies that target stack directories, automatic merge of `terragrunt.autoinclude.hcl`, and stack dependency expansion in the run queue, is now enabled by default.
 
-The `--experiment stack-dependencies` flag is no longer needed. Passing it (or listing it in an `experiments` block) still works but emits a completed-experiment warning, so you can drop it at your convenience.
+The `--experiment stack-dependencies` flag is no longer needed. Passing it still works but emits a completed-experiment warning, so you can drop it at your convenience.

--- a/docs/src/data/experiments/dag-queue-display.mdx
+++ b/docs/src/data/experiments/dag-queue-display.mdx
@@ -1,6 +1,7 @@
 ---
 name: dag-queue-display
 since: "1.0.1"
+completedSince: "1.1"
 ---
 
 Display the run queue as a DAG tree showing dependency hierarchy.

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -128,7 +128,8 @@ func NewExperiments() Experiments {
 			Name: SlowTaskReporting,
 		},
 		{
-			Name: DAGQueueDisplay,
+			Name:   DAGQueueDisplay,
+			Status: StatusCompleted,
 		},
 		{
 			Name:   StackDependencies,

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -625,15 +625,10 @@ func (rnr *Runner) Run(ctx context.Context, l log.Logger, v run.Venv, stackOpts 
 	return err
 }
 
-// LogUnitDeployOrder logs the order of units to be processed.
-// When the dag-queue-display experiment is enabled, the output is rendered as a DAG tree
-// showing dependency relationships between units. Otherwise, a flat list is shown.
+// LogUnitDeployOrder logs the order of units to be processed as a DAG tree
+// showing dependency relationships between units.
 func (rnr *Runner) LogUnitDeployOrder(l log.Logger, isDestroy bool, showAbsPaths bool, experiments experiment.Experiments) error {
-	if experiments.Evaluate(experiment.DAGQueueDisplay) {
-		return rnr.logUnitDeployOrderDAG(l, isDestroy, showAbsPaths)
-	}
-
-	return rnr.logUnitDeployOrderFlat(l, showAbsPaths)
+	return rnr.logUnitDeployOrderDAG(l, isDestroy, showAbsPaths)
 }
 
 // logUnitDeployOrderDAG renders the queue as a DAG tree showing dependency relationships.
@@ -650,24 +645,6 @@ func (rnr *Runner) logUnitDeployOrderDAG(l log.Logger, isDestroy bool, showAbsPa
 	header := deployOrderHeader(isDestroy)
 
 	l.Info(header + t.String())
-
-	return nil
-}
-
-// logUnitDeployOrderFlat renders the queue as a flat list of units.
-func (rnr *Runner) logUnitDeployOrderFlat(l log.Logger, showAbsPaths bool) error {
-	var sb strings.Builder
-
-	for _, unit := range rnr.queue.Entries {
-		unitPath := unit.Component.DisplayPath()
-		if showAbsPaths {
-			unitPath = unit.Component.Path()
-		}
-
-		fmt.Fprintf(&sb, "- Unit %s\n", unitPath)
-	}
-
-	l.Info(sb.String())
 
 	return nil
 }

--- a/internal/runner/runnerpool/runner_functions_test.go
+++ b/internal/runner/runnerpool/runner_functions_test.go
@@ -139,7 +139,6 @@ func TestLogUnitDeployOrder_DAGExperiment(t *testing.T) {
 	l := thlogger.CreateLogger()
 
 	exps := experiment.NewExperiments()
-	require.NoError(t, exps.EnableExperiment(experiment.DAGQueueDisplay))
 
 	err := runner.LogUnitDeployOrder(l, false, false, exps)
 	require.NoError(t, err)

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/log"

--- a/test/integration_regressions_test.go
+++ b/test/integration_regressions_test.go
@@ -896,15 +896,11 @@ func TestExposedIncludeErrorIdentifiesIncludeBlock(t *testing.T) {
 	assert.Contains(t, stderr, "root.hcl", "error should name the included (parent) file")
 }
 
-// TestQueueDisplayOrder verifies that the flat queue display lists units in
+// TestQueueDisplayOrder verifies that the DAG queue display lists units in
 // dependency order: dependencies before dependents.
 // Regression test for https://github.com/gruntwork-io/terragrunt/issues/5035
 func TestQueueDisplayOrder(t *testing.T) {
 	t.Parallel()
-
-	if helpers.IsExperimentMode(t) {
-		t.Skip("Skipping: experiment mode enables dag-queue-display which changes queue output format")
-	}
 
 	// The fixture has the chain: vpc -> database -> backend-app -> frontend-app
 	// plus monitoring (independent).
@@ -995,7 +991,7 @@ func TestDAGQueueDisplay(t *testing.T) {
 		rootPath := filepath.Join(tmpEnvPath, testFixtureDAGQueueDisplay)
 
 		_, stderr, err := helpers.RunTerragruntCommandWithOutput(
-			t, "terragrunt run --all --non-interactive --no-color --experiment dag-queue-display --working-dir "+rootPath+" -- plan",
+			t, "terragrunt run --all --non-interactive --no-color --working-dir "+rootPath+" -- plan",
 		)
 		require.NoError(t, err)
 
@@ -1011,7 +1007,7 @@ func TestDAGQueueDisplay(t *testing.T) {
 		rootPath := filepath.Join(tmpEnvPath, testFixtureDAGQueueDisplay)
 
 		_, stderr, err := helpers.RunTerragruntCommandWithOutput(
-			t, "terragrunt run --all --non-interactive --no-color --experiment dag-queue-display --working-dir "+rootPath+" -- plan -destroy",
+			t, "terragrunt run --all --non-interactive --no-color --working-dir "+rootPath+" -- plan -destroy",
 		)
 		require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Completes the `dag-queue-display` experiment.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Unit execution order is now displayed as a dependency tree (DAG format) by default, nesting units under their parent dependencies
  * The `--experiment dag-queue-display` and `--experiment stack-dependencies` flags are no longer required as their features are now enabled by default; using these flags will produce a deprecation warning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->