### PR TITLE
chore: Completing `opt-out-auth` experiment

### DIFF
--- a/docs/src/data/changelog/v1.1.0/opt-out-auth-enabled-by-default.mdx
+++ b/docs/src/data/changelog/v1.1.0/opt-out-auth-enabled-by-default.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.0"
+category: "new-features"
+---
+
+#### `--no-discovery-auth-provider-cmd` added
+
+`--no-discovery-auth-provider-cmd` (env: `TG_NO_DISCOVERY_AUTH_PROVIDER_CMD`) is now stable and no longer requires the `opt-out-auth` experiment flag. The flag skips `--auth-provider-cmd` invocations during the discovery phase, leaving auth to run only for the units that actually execute.
+
+This reduces wall-clock time on large `run --all` invocations with reading-based filters, where the auth command previously ran once per discovered unit rather than only the subset that would run.
+
+Previously gated behind the `opt-out-auth` experiment, the flag now works without `--experiment=opt-out-auth`. Passing the experiment flag is now a no-op that logs a warning about the completed experiment, so it can be removed from invocations.

--- a/docs/src/data/experiments/opt-out-auth.mdx
+++ b/docs/src/data/experiments/opt-out-auth.mdx
@@ -1,6 +1,7 @@
 ---
 name: opt-out-auth
 since: "1.0.6"
+completedSince: "1.1"
 ---
 
 Opt out of running `--auth-provider-cmd` during the discovery phase.

--- a/docs/src/data/flags/no-discovery-auth-provider-cmd.mdx
+++ b/docs/src/data/flags/no-discovery-auth-provider-cmd.mdx
@@ -1,6 +1,6 @@
 ---
 name: no-discovery-auth-provider-cmd
-description: Skip running --auth-provider-cmd during the discovery phase. Requires the opt-out-auth experiment.
+description: Skip running --auth-provider-cmd during the discovery phase.
 lookup: true
 type: boolean
 env:
@@ -9,10 +9,13 @@ since: "v1.0.6"
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 This flag is gated behind the [`opt-out-auth`](/reference/experiments/active#opt-out-auth) experiment. Enable it with `--experiment=opt-out-auth` (or `TG_EXPERIMENT=opt-out-auth`); otherwise setting `--no-discovery-auth-provider-cmd` returns an error. The flag's behavior may change while the experiment is in progress.
 </Aside>
+</Before>
 
 Skip running `--auth-provider-cmd` during the discovery phase.
 

--- a/internal/cli/flags/shared/auth.go
+++ b/internal/cli/flags/shared/auth.go
@@ -1,11 +1,8 @@
 package shared
 
 import (
-	"context"
-
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
@@ -31,8 +28,7 @@ func NewAuthProviderCmdFlag(opts *options.TerragruntOptions, prefix flags.Prefix
 }
 
 // NewNoDiscoveryAuthProviderCmdFlag opts out of running --auth-provider-cmd
-// during the discovery parse phase. Setting it without the opt-out-auth
-// experiment returns ErrNoDiscoveryAuthProviderCmdRequiresExperiment.
+// during the discovery parse phase.
 func NewNoDiscoveryAuthProviderCmdFlag(opts *options.TerragruntOptions, prefix flags.Prefix) *flags.Flag {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
@@ -40,18 +36,7 @@ func NewNoDiscoveryAuthProviderCmdFlag(opts *options.TerragruntOptions, prefix f
 		Name:        NoDiscoveryAuthProviderCmdFlagName,
 		EnvVars:     tgPrefix.EnvVars(NoDiscoveryAuthProviderCmdFlagName),
 		Destination: &opts.DiscoveryAuthProviderCmd,
-		Usage:       "Skip running --auth-provider-cmd during the discovery phase. Requires the 'opt-out-auth' experiment.",
+		Usage:       "Skip running --auth-provider-cmd during the discovery phase.",
 		Negative:    true,
-		Action: func(_ context.Context, _ *clihelper.Context, runDiscoveryAuth bool) error {
-			if runDiscoveryAuth {
-				return nil
-			}
-
-			if opts.Experiments.Evaluate(experiment.OptOutAuth) {
-				return nil
-			}
-
-			return ErrNoDiscoveryAuthProviderCmdRequiresExperiment
-		},
 	})
 }

--- a/internal/cli/flags/shared/errors.go
+++ b/internal/cli/flags/shared/errors.go
@@ -1,14 +1,8 @@
 package shared
 
-import "errors"
-
 // AllGraphFlagsError is returned when both --all and --graph flags are used simultaneously.
 type AllGraphFlagsError byte
 
 func (err *AllGraphFlagsError) Error() string {
 	return "Using the `--all` and `--graph` flags simultaneously is not supported."
 }
-
-var ErrNoDiscoveryAuthProviderCmdRequiresExperiment = errors.New(
-	"--no-discovery-auth-provider-cmd requires the 'opt-out-auth' experiment to be enabled (e.g., --experiment=opt-out-auth)",
-)

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -64,8 +64,9 @@ const (
 	AzureBackend = "azure-backend"
 	// DeepMerge enables the deep_merge HCL function.
 	DeepMerge = "deep-merge"
-	// OptOutAuth gates flags that opt out of running --auth-provider-cmd in
-	// specific phases (currently --no-discovery-auth-provider-cmd).
+	// OptOutAuth names the now-stable flags that opt out of running
+	// --auth-provider-cmd in specific phases. The
+	// --no-discovery-auth-provider-cmd flag is enabled by default.
 	OptOutAuth = "opt-out-auth"
 	// HookContextEnv exposes additional TG_CTX_* environment variables to hook
 	// scripts: TG_CTX_HOOK_TYPE, TG_CTX_SOURCE, and TG_CTX_TERRAGRUNT_DIR.
@@ -148,7 +149,8 @@ func NewExperiments() Experiments {
 			Name: DeepMerge,
 		},
 		{
-			Name: OptOutAuth,
+			Name:   OptOutAuth,
+			Status: StatusCompleted,
 		},
 		{
 			Name: HookContextEnv,

--- a/internal/experiment/experiment_test.go
+++ b/internal/experiment/experiment_test.go
@@ -27,14 +27,14 @@ func newTestLogger() (log.Logger, *bytes.Buffer) {
 	return logger, output
 }
 
-func TestOptOutAuthIsOngoing(t *testing.T) {
+func TestOptOutAuthIsCompleted(t *testing.T) {
 	t.Parallel()
 
 	exps := experiment.NewExperiments()
 	got := exps.Find(experiment.OptOutAuth)
 	require.NotNil(t, got, "opt-out-auth experiment must be registered in NewExperiments()")
-	assert.Equal(t, experiment.StatusOngoing, got.Status, "opt-out-auth must be ongoing")
-	assert.False(t, got.Evaluate(), "opt-out-auth must be disabled by default")
+	assert.Equal(t, experiment.StatusCompleted, got.Status, "opt-out-auth must be completed")
+	assert.True(t, got.Evaluate(), "opt-out-auth must be enabled by default")
 }
 
 func TestOptionalHooksIsOngoing(t *testing.T) {

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/log"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3478,37 +3478,6 @@ func TestReadTerragruntAuthProviderCmdRunAllCallCountWithRacing(t *testing.T) {
 	}
 }
 
-func TestNoDiscoveryAuthProviderCmdRequiresExperiment(t *testing.T) {
-	t.Parallel()
-
-	if helpers.IsExperimentMode(t) {
-		t.Skip("Skipping: TG_EXPERIMENT_MODE forces all experiments on, defeating the experiment-gate check this test pins")
-	}
-
-	helpers.CleanupTerraformFolder(t, testFixtureAuthProviderCmd)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAuthProviderCmd)
-	rootPath := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "run-all-call-count")
-
-	testCases := []struct {
-		name string
-		args string
-	}{
-		{name: "find", args: "find --no-discovery-auth-provider-cmd --working-dir " + rootPath},
-		{name: "list", args: "list --no-discovery-auth-provider-cmd --working-dir " + rootPath},
-		{name: "run", args: "run --no-discovery-auth-provider-cmd --working-dir " + rootPath + " -- plan"},
-		{name: "shortcut", args: "apply --no-discovery-auth-provider-cmd --working-dir " + rootPath},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt "+tc.args)
-			require.ErrorIs(t, err, shared.ErrNoDiscoveryAuthProviderCmdRequiresExperiment)
-		})
-	}
-}
-
 func TestNoDiscoveryAuthProviderCmdSkipsDiscoveryAuthWithRacing(t *testing.T) {
 	t.Parallel()
 
@@ -3525,7 +3494,7 @@ func TestNoDiscoveryAuthProviderCmdSkipsDiscoveryAuthWithRacing(t *testing.T) {
 		t,
 		fmt.Sprintf(
 			"terragrunt run --all apply --non-interactive "+
-				"--no-discovery-auth-provider-cmd --experiment opt-out-auth "+
+				"--no-discovery-auth-provider-cmd "+
 				"--working-dir %s --auth-provider-cmd %s",
 			rootPath,
 			authProviderCmd,


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Completing the `opt-out-auth` experiment.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--no-discovery-auth-provider-cmd` flag is now stable and no longer requires the experimental `--experiment opt-out-auth` flag. This feature allows skipping authentication provider command executions during the discovery phase, reducing repeated auth invocations.

* **Documentation**
  * Updated documentation to reflect the stabilization of the `--no-discovery-auth-provider-cmd` flag in version 1.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->