### PR TITLE
fix: Fixing combination of `--filter-allow-destroy` with graph + Git expression combo

### DIFF
--- a/docs/src/data/changelog/v1.1.1/filter-allow-destroy-dependents.mdx
+++ b/docs/src/data/changelog/v1.1.1/filter-allow-destroy-dependents.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.1"
+category: "bug-fixes"
+---
+
+#### `--filter-allow-destroy` with `...[]` dependent-traversal filters no longer fails
+
+`--filter-allow-destroy --filter '...[HEAD~1...HEAD]'` failed with "Too many command line arguments" or hung when the deleted unit had dependents. Terragrunt now correctly plans and destroys deleted units regardless of whether dependents are included in the run.

--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -79,8 +79,11 @@ type DiscoveryContext struct {
 }
 
 // Copy returns a copy of the DiscoveryContext.
+// Args is deep-copied so mutations on the copy (e.g. slices.DeleteFunc) do not
+// corrupt the original's backing array.
 func (dc *DiscoveryContext) Copy() *DiscoveryContext {
 	c := *dc
+	c.Args = slices.Clone(dc.Args)
 
 	return &c
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -338,7 +338,9 @@ func (q *Queue) GetReadyWithDependencies(l log.Logger) []*Entry {
 }
 
 // areDependenciesReadyUnsafe checks if all dependencies of an entry are ready for "up" commands.
-// For up commands, all dependencies must be in a succeeded state (or terminal if ignoring errors).
+// For up commands, only other up-command dependencies must be in a succeeded state (or terminal if
+// ignoring errors). Down-command (destroy) dependencies are skipped, mirroring [Entry.UpdateBlocked]:
+// a unit being destroyed does not gate a unit being applied or planned.
 // If a dependency is not in the queue, it is assumed to have existing state.
 // Should only be called when the caller already holds a read lock.
 func (q *Queue) areDependenciesReadyUnsafe(l log.Logger, e *Entry) bool {
@@ -347,6 +349,12 @@ func (q *Queue) areDependenciesReadyUnsafe(l log.Logger, e *Entry) bool {
 		if depEntry == nil {
 			l.Debugf("Dependency %s is not in queue, considering it ready", dep.Path())
 
+			continue
+		}
+
+		// Skip down-command (destroy) dependencies: they run in reverse order and must
+		// not block an up-command entry from proceeding. Mirrors UpdateBlocked.
+		if !depEntry.IsUp() {
 			continue
 		}
 
@@ -369,11 +377,19 @@ func (q *Queue) areDependenciesReadyUnsafe(l log.Logger, e *Entry) bool {
 }
 
 // areDependentsReadyUnsafe checks if all dependents of an entry are ready for "down" commands.
-// For down commands, all dependents must be in a succeeded state (or terminal if ignoring errors).
+// For down commands, only other down-command dependents must be in a succeeded state (or terminal
+// if ignoring errors). Up-command (plan/apply) dependents are skipped, mirroring
+// [Entry.UpdateBlocked]: a unit being planned or applied does not gate a unit being destroyed.
 // Should only be called when the caller already holds a read lock.
 func (q *Queue) areDependentsReadyUnsafe(e *Entry) bool {
 	for _, other := range q.Entries {
 		if other == e || len(other.Component.Dependencies()) == 0 {
+			continue
+		}
+
+		// Skip up-command (plan/apply) dependents: they run in forward order and must
+		// not block a down-command entry from proceeding. Mirrors UpdateBlocked.
+		if other.IsUp() {
 			continue
 		}
 

--- a/test/integration_filter_test.go
+++ b/test/integration_filter_test.go
@@ -2173,25 +2173,9 @@ func TestDestroyWithOutDirGitFilterDependentsWithRacing(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 	outDir := helpers.TmpDirWOSymlinks(t)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
-	require.NoError(t, err)
+	runner := helpers.InitTestGitRunner(t, tmpDir)
 
-	runner = runner.WithWorkDir(tmpDir)
-
-	err = runner.Init(t.Context())
-	require.NoError(t, err)
-
-	err = runner.GoOpenRepo()
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		err = runner.GoCloseStorage()
-		if err != nil {
-			t.Logf("Error closing storage: %s", err)
-		}
-	})
-
-	err = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(".terragrunt-cache/\n.terraform/\n.terraform.lock.hcl\n"), 0644)
+	err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(".terragrunt-cache/\n.terraform/\n.terraform.lock.hcl\n"), 0644)
 	require.NoError(t, err)
 
 	// create unit to destroy
@@ -2230,17 +2214,8 @@ resource "null_resource" "unit_a" {}
 	require.NoError(t, err)
 
 	// Initial commit
-	err = runner.GoAdd(".")
-	require.NoError(t, err)
-
-	err = runner.GoCommit("Initial commit", &gogit.CommitOptions{
-		Author: &object.Signature{
-			Name:  "Test User",
-			Email: "test@example.com",
-			When:  time.Now(),
-		},
-	})
-	require.NoError(t, err)
+	require.NoError(t, runner.Add(t.Context(), "."))
+	require.NoError(t, runner.Commit(t.Context(), "Initial commit"))
 
 	// do initial apply
 	cmd := "terragrunt run --all --no-color --non-interactive --working-dir " + tmpDir +
@@ -2251,17 +2226,8 @@ resource "null_resource" "unit_a" {}
 	err = os.RemoveAll(unitDir)
 	require.NoError(t, err)
 
-	err = runner.GoAdd(".")
-	require.NoError(t, err)
-
-	err = runner.GoCommit("Unit removal", &gogit.CommitOptions{
-		Author: &object.Signature{
-			Name:  "Test User",
-			Email: "test@example.com",
-			When:  time.Now(),
-		},
-	})
-	require.NoError(t, err)
+	require.NoError(t, runner.Add(t.Context(), "."))
+	require.NoError(t, runner.Commit(t.Context(), "Unit removal"))
 
 	// Use ...[HEAD~1...HEAD] (dependents syntax) instead of plain [HEAD~1...HEAD].
 	// The graph expression wrapper must not strip the -destroy flag from the

--- a/test/integration_filter_test.go
+++ b/test/integration_filter_test.go
@@ -2163,6 +2163,137 @@ resource "null_resource" "test" {}
 	require.NotContains(t, output, "Expected at most one positional argument")
 }
 
+// TestDestroyWithOutDirGitFilterDependentsWithRacing is a regression test for
+// https://github.com/gruntwork-io/terragrunt/issues/6319.
+// It verifies that --filter-allow-destroy works correctly when the filter uses
+// the ...[from...to] dependents syntax (not just the plain [from...to] syntax).
+func TestDestroyWithOutDirGitFilterDependentsWithRacing(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	outDir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(tmpDir)
+
+	err = runner.Init(t.Context())
+	require.NoError(t, err)
+
+	err = runner.GoOpenRepo()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = runner.GoCloseStorage()
+		if err != nil {
+			t.Logf("Error closing storage: %s", err)
+		}
+	})
+
+	err = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(".terragrunt-cache/\n.terraform/\n.terraform.lock.hcl\n"), 0644)
+	require.NoError(t, err)
+
+	// create unit to destroy
+	unitDir := filepath.Join(tmpDir, "unit-to-destroy")
+	err = os.MkdirAll(unitDir, 0755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(unitDir, "terragrunt.hcl"), []byte(`# Unit to destroy`), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(unitDir, "main.tf"), []byte(`
+resource "null_resource" "test" {}
+`), 0644)
+	require.NoError(t, err)
+
+	// create unit-a which depends on unit-to-destroy.
+	// This is necessary so that discoverDependentsUpstream finds unit-a as a
+	// dependent and calls processUpstreamCandidate, which exercises the
+	// shallow-copy path in DiscoveryContext.Copy().
+	unitADir := filepath.Join(tmpDir, "unit-a")
+	err = os.MkdirAll(unitADir, 0755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(unitADir, "terragrunt.hcl"), []byte(`
+dependency "b" {
+  config_path = "../unit-to-destroy"
+  mock_outputs = {}
+  mock_outputs_allowed_terraform_commands = ["plan", "apply"]
+}
+`), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(unitADir, "main.tf"), []byte(`
+resource "null_resource" "unit_a" {}
+`), 0644)
+	require.NoError(t, err)
+
+	// Initial commit
+	err = runner.GoAdd(".")
+	require.NoError(t, err)
+
+	err = runner.GoCommit("Initial commit", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	// do initial apply
+	cmd := "terragrunt run --all --no-color --non-interactive --working-dir " + tmpDir +
+		" -- apply"
+	helpers.RunTerragrunt(t, cmd)
+
+	// remove unit to trigger destruction
+	err = os.RemoveAll(unitDir)
+	require.NoError(t, err)
+
+	err = runner.GoAdd(".")
+	require.NoError(t, err)
+
+	err = runner.GoCommit("Unit removal", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	// Use ...[HEAD~1...HEAD] (dependents syntax) instead of plain [HEAD~1...HEAD].
+	// The graph expression wrapper must not strip the -destroy flag from the
+	// deleted unit's DiscoveryContext.
+	cmd = "terragrunt run --all --no-color --experiment-mode --non-interactive --working-dir " + tmpDir +
+		" --out-dir " + outDir + " --filter-allow-destroy --filter '...[HEAD~1...HEAD]' -- plan"
+
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err)
+
+	output := stdout + stderr
+	require.NotContains(t, output, "Too many command line arguments")
+	require.NotContains(t, output, "Expected at most one positional argument")
+
+	// check creation of plan files
+	var planFiles []string
+
+	err = filepath.Walk(outDir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if strings.HasSuffix(path, ".tfplan") {
+			planFiles = append(planFiles, path)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, planFiles)
+}
+
 func TestFilterExcludeByDefault(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6319.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved destroy and plan behavior when using `--filter-allow-destroy` with dependent-style filters.
  * Fixed handling so deleted units can be planned or destroyed without argument errors or hangs, even when dependents are involved.
  * Corrected dependency processing so applicable plan/apply and destroy operations no longer block each other incorrectly.

* **Tests**
  * Added regression coverage for destroy workflows with dependent filters and output directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->