### PR TITLE
fix: Reusing parsed configs across multiple dependents filters

### DIFF
--- a/docs/src/data/changelog/v1.1.0/find-multiple-dependents-filters.mdx
+++ b/docs/src/data/changelog/v1.1.0/find-multiple-dependents-filters.mdx
@@ -1,0 +1,16 @@
+---
+version: "v1.1.0"
+category: "performance-improvements"
+---
+
+#### `find`: constant-time evaluation of multiple dependents filters
+
+Running `terragrunt find` with many `...<unit>` dependents filters re-parsed every discovered configuration once per filter, so runtime grew linearly with the number of filters:
+
+```bash
+terragrunt find --filter '...units/a' --filter '...units/b' --filter '...units/c'
+```
+
+On large repositories this added roughly the cost of a full discovery per filter (e.g., ~5–6s per filter on an 814-unit repository, adding up to over half an hour for CI invocations passing hundreds of filters).
+
+Discovery now reuses parsed configurations across all filter targets, so passing many dependents filters in one invocation costs roughly the same as passing one. Results are unchanged.

--- a/internal/component/stack.go
+++ b/internal/component/stack.go
@@ -136,6 +136,11 @@ func (s *Stack) ConfigFile() string {
 }
 
 // DiscoveryContext returns the discovery context for this component.
+//
+// The returned context must be treated as read-only once the component is
+// shared across goroutines: the lock guards the pointer, not the pointed-to
+// struct. Use Copy or CopyWithNewOrigin to derive a modified context and
+// publish it via SetDiscoveryContext.
 func (s *Stack) DiscoveryContext() *DiscoveryContext {
 	s.rLock()
 	defer s.rUnlock()
@@ -144,6 +149,9 @@ func (s *Stack) DiscoveryContext() *DiscoveryContext {
 }
 
 // SetDiscoveryContext sets the discovery context for this component.
+//
+// The context must not be mutated after it is published here; derive a copy
+// first if changes are needed (see DiscoveryContext).
 func (s *Stack) SetDiscoveryContext(ctx *DiscoveryContext) {
 	s.lock()
 	defer s.unlock()

--- a/internal/component/stack.go
+++ b/internal/component/stack.go
@@ -40,18 +40,24 @@ func NewStack(path string) *Stack {
 
 // WithDiscoveryContext sets the discovery context for this stack.
 func (s *Stack) WithDiscoveryContext(ctx *DiscoveryContext) *Stack {
-	s.discoveryContext = ctx
+	s.SetDiscoveryContext(ctx)
 
 	return s
 }
 
 // Config returns the parsed Stack configuration for this stack.
 func (s *Stack) Config() *config.StackConfig {
+	s.rLock()
+	defer s.rUnlock()
+
 	return s.cfg
 }
 
 // StoreConfig stores the parsed Stack configuration for this stack.
 func (s *Stack) StoreConfig(cfg *config.StackConfig) {
+	s.lock()
+	defer s.unlock()
+
 	s.cfg = cfg
 }
 
@@ -73,11 +79,12 @@ func (s *Stack) SetPath(path string) {
 // DisplayPath returns the path relative to DiscoveryContext.WorkingDir for display purposes.
 // Falls back to the original path if relative path calculation fails or WorkingDir is empty.
 func (s *Stack) DisplayPath() string {
-	if s.discoveryContext == nil || s.discoveryContext.WorkingDir == "" {
+	dCtx := s.DiscoveryContext()
+	if dCtx == nil || dCtx.WorkingDir == "" {
 		return s.path
 	}
 
-	if rel, err := filepath.Rel(s.discoveryContext.WorkingDir, s.path); err == nil {
+	if rel, err := filepath.Rel(dCtx.WorkingDir, s.path); err == nil {
 		return rel
 	}
 
@@ -86,21 +93,33 @@ func (s *Stack) DisplayPath() string {
 
 // External returns whether the component is external.
 func (s *Stack) External() bool {
+	s.rLock()
+	defer s.rUnlock()
+
 	return s.external
 }
 
 // SetExternal marks the component as external.
 func (s *Stack) SetExternal() {
+	s.lock()
+	defer s.unlock()
+
 	s.external = true
 }
 
 // Reading returns the list of files being read by this component.
 func (s *Stack) Reading() []string {
+	s.rLock()
+	defer s.rUnlock()
+
 	return s.reading
 }
 
 // SetReading sets the list of files being read by this component.
 func (s *Stack) SetReading(files ...string) {
+	s.lock()
+	defer s.unlock()
+
 	s.reading = files
 }
 
@@ -118,21 +137,28 @@ func (s *Stack) ConfigFile() string {
 
 // DiscoveryContext returns the discovery context for this component.
 func (s *Stack) DiscoveryContext() *DiscoveryContext {
+	s.rLock()
+	defer s.rUnlock()
+
 	return s.discoveryContext
 }
 
 // SetDiscoveryContext sets the discovery context for this component.
 func (s *Stack) SetDiscoveryContext(ctx *DiscoveryContext) {
+	s.lock()
+	defer s.unlock()
+
 	s.discoveryContext = ctx
 }
 
 // Origin returns the origin of the discovery context for this component.
 func (s *Stack) Origin() Origin {
-	if s.discoveryContext == nil {
+	dCtx := s.DiscoveryContext()
+	if dCtx == nil {
 		return OriginUnknown
 	}
 
-	return s.discoveryContext.Origin()
+	return dCtx.Origin()
 }
 
 // lock locks the Stack.
@@ -229,8 +255,8 @@ func (s *Stack) String() string {
 	sort.Strings(units)
 
 	workingDir := s.path
-	if s.discoveryContext != nil && s.discoveryContext.WorkingDir != "" {
-		workingDir = s.discoveryContext.WorkingDir
+	if dCtx := s.DiscoveryContext(); dCtx != nil && dCtx.WorkingDir != "" {
+		workingDir = dCtx.WorkingDir
 	}
 
 	return fmt.Sprintf("Stack at %s:\n%s", workingDir, strings.Join(units, "\n"))

--- a/internal/component/unit.go
+++ b/internal/component/unit.go
@@ -188,6 +188,11 @@ func (u *Unit) Sources() []string {
 }
 
 // DiscoveryContext returns the discovery context for this component.
+//
+// The returned context must be treated as read-only once the component is
+// shared across goroutines: the lock guards the pointer, not the pointed-to
+// struct. Use Copy or CopyWithNewOrigin to derive a modified context and
+// publish it via SetDiscoveryContext.
 func (u *Unit) DiscoveryContext() *DiscoveryContext {
 	u.rLock()
 	defer u.rUnlock()
@@ -196,6 +201,9 @@ func (u *Unit) DiscoveryContext() *DiscoveryContext {
 }
 
 // SetDiscoveryContext sets the discovery context for this component.
+//
+// The context must not be mutated after it is published here; derive a copy
+// first if changes are needed (see DiscoveryContext).
 func (u *Unit) SetDiscoveryContext(ctx *DiscoveryContext) {
 	u.lock()
 	defer u.unlock()

--- a/internal/component/unit.go
+++ b/internal/component/unit.go
@@ -26,8 +26,12 @@ type Unit struct {
 	dependencies     Components
 	dependents       Components
 	mu               sync.RWMutex
-	external         bool
-	excluded         bool
+	// parseMu serializes config parsing (see EnsureConfig). Lock ordering is
+	// parseMu before mu: parseMu is held while parsing, which stores the result
+	// via StoreConfig (mu). Never acquire parseMu while holding mu.
+	parseMu  sync.Mutex
+	external bool
+	excluded bool
 }
 
 // NewUnit creates a new Unit component with the given path.
@@ -51,35 +55,62 @@ func (u *Unit) WithReading(files ...string) *Unit {
 
 // WithConfig adds configuration to a Unit component.
 func (u *Unit) WithConfig(cfg *config.TerragruntConfig) *Unit {
-	u.cfg = cfg
+	u.StoreConfig(cfg)
 
 	return u
 }
 
 // WithDiscoveryContext sets the discovery context for this unit.
 func (u *Unit) WithDiscoveryContext(ctx *DiscoveryContext) *Unit {
-	u.discoveryContext = ctx
+	u.SetDiscoveryContext(ctx)
 
 	return u
 }
 
 // Config returns the parsed Terragrunt configuration for this unit.
 func (u *Unit) Config() *config.TerragruntConfig {
+	u.rLock()
+	defer u.rUnlock()
+
 	return u.cfg
 }
 
 // StoreConfig stores the parsed Terragrunt configuration for this unit.
 func (u *Unit) StoreConfig(cfg *config.TerragruntConfig) {
+	u.lock()
+	defer u.unlock()
+
 	u.cfg = cfg
+}
+
+// EnsureConfig populates the unit's config by running parse, unless a config is
+// already cached. Concurrent callers are serialized, so the config is parsed at
+// most once: callers that lose the race block until the winner finishes and then
+// observe the cached config. parse is expected to store the config on the unit.
+func (u *Unit) EnsureConfig(parse func() error) error {
+	u.parseMu.Lock()
+	defer u.parseMu.Unlock()
+
+	if u.Config() != nil {
+		return nil
+	}
+
+	return parse()
 }
 
 // ConfigFile returns the discovered config filename for this unit.
 func (u *Unit) ConfigFile() string {
+	u.rLock()
+	defer u.rUnlock()
+
 	return u.configFile
 }
 
 // SetConfigFile sets the discovered config filename for this unit.
 func (u *Unit) SetConfigFile(filename string) {
+	u.lock()
+	defer u.unlock()
+
 	u.configFile = filename
 }
 
@@ -100,60 +131,86 @@ func (u *Unit) SetPath(path string) {
 
 // External returns whether the component is external.
 func (u *Unit) External() bool {
+	u.rLock()
+	defer u.rUnlock()
+
 	return u.external
 }
 
 // SetExternal marks the component as external.
 func (u *Unit) SetExternal() {
+	u.lock()
+	defer u.unlock()
+
 	u.external = true
 }
 
 // Excluded returns whether the unit was excluded during discovery/filtering.
 func (u *Unit) Excluded() bool {
+	u.rLock()
+	defer u.rUnlock()
+
 	return u.excluded
 }
 
 // SetExcluded marks the unit as excluded during discovery/filtering.
 func (u *Unit) SetExcluded(excluded bool) {
+	u.lock()
+	defer u.unlock()
+
 	u.excluded = excluded
 }
 
 // Reading returns the list of files being read by this component.
 func (u *Unit) Reading() []string {
+	u.rLock()
+	defer u.rUnlock()
+
 	return u.reading
 }
 
 // SetReading sets the list of files being read by this component.
 func (u *Unit) SetReading(files ...string) {
+	u.lock()
+	defer u.unlock()
+
 	u.reading = files
 }
 
 // Sources returns the list of sources for this component.
 func (u *Unit) Sources() []string {
-	if u.cfg == nil || u.cfg.Terraform == nil || u.cfg.Terraform.Source == nil {
+	cfg := u.Config()
+	if cfg == nil || cfg.Terraform == nil || cfg.Terraform.Source == nil {
 		return []string{}
 	}
 
-	return []string{*u.cfg.Terraform.Source}
+	return []string{*cfg.Terraform.Source}
 }
 
 // DiscoveryContext returns the discovery context for this component.
 func (u *Unit) DiscoveryContext() *DiscoveryContext {
+	u.rLock()
+	defer u.rUnlock()
+
 	return u.discoveryContext
 }
 
 // SetDiscoveryContext sets the discovery context for this component.
 func (u *Unit) SetDiscoveryContext(ctx *DiscoveryContext) {
+	u.lock()
+	defer u.unlock()
+
 	u.discoveryContext = ctx
 }
 
 // Origin returns the origin of the discovery context for this component.
 func (u *Unit) Origin() Origin {
-	if u.discoveryContext == nil {
+	dCtx := u.DiscoveryContext()
+	if dCtx == nil {
 		return OriginUnknown
 	}
 
-	return u.discoveryContext.Origin()
+	return dCtx.Origin()
 }
 
 // lock locks the Unit.
@@ -240,31 +297,30 @@ func (u *Unit) Dependents() Components {
 //
 //	Unit /path/to/unit (excluded: false, assume applied: false, dependencies: [/dep1, /dep2])
 func (u *Unit) String() string {
-	// Snapshot values under read lock to avoid data races
-	u.rLock()
-	defer u.rUnlock()
+	// Snapshot values via accessors (each takes the read lock) to avoid data
+	// races without holding the lock across calls into other components.
+	dependencies := u.Dependencies()
+	deps := make([]string, 0, len(dependencies))
 
-	path := u.DisplayPath()
-	deps := make([]string, 0, len(u.dependencies))
-
-	for _, dep := range u.dependencies {
+	for _, dep := range dependencies {
 		deps = append(deps, dep.DisplayPath())
 	}
 
 	return fmt.Sprintf(
 		"Unit %s (excluded: %v, dependencies: [%s])",
-		path, u.excluded, strings.Join(deps, ", "),
+		u.DisplayPath(), u.Excluded(), strings.Join(deps, ", "),
 	)
 }
 
 // DisplayPath returns the path relative to DiscoveryContext.WorkingDir for display purposes.
 // Falls back to the original path if relative path calculation fails or WorkingDir is empty.
 func (u *Unit) DisplayPath() string {
-	if u.discoveryContext == nil || u.discoveryContext.WorkingDir == "" {
+	dCtx := u.DiscoveryContext()
+	if dCtx == nil || dCtx.WorkingDir == "" {
 		return u.path
 	}
 
-	if rel, err := filepath.Rel(u.discoveryContext.WorkingDir, u.path); err == nil {
+	if rel, err := filepath.Rel(dCtx.WorkingDir, u.path); err == nil {
 		return rel
 	}
 
@@ -320,7 +376,7 @@ func (u *Unit) planFilePath(rootWorkingDir, outputFolder, fileName string) strin
 	// Use discoveryContext.WorkingDir as base (always populated).
 	// This is critical for git-based filters where units are discovered in temporary worktrees.
 	// Using rootWorkingDir would cause relative paths to escape the outputFolder.
-	relPath, err := filepath.Rel(u.discoveryContext.WorkingDir, u.path)
+	relPath, err := filepath.Rel(u.DiscoveryContext().WorkingDir, u.path)
 	if err != nil {
 		relPath = u.path
 	}

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -629,16 +629,41 @@ func (p *GraphPhase) processUpstreamCandidate(
 		return nil
 	}
 
-	unit, ok := candidate.(*component.Unit)
+	if _, ok := candidate.(*component.Unit); !ok {
+		return nil
+	}
+
+	graphState := state.graphTraversalState
+
+	// Canonicalize before parsing so the config cached on the canonical Unit is
+	// reused across all graph targets, instead of re-parsing a fresh copy of
+	// every walked config once per target.
+	canonicalCandidate, created := graphState.threadSafeComponents.EnsureComponent(candidate)
+	if created {
+		if dCtx := state.target.DiscoveryContext(); dCtx != nil {
+			canonicalCandidate.SetDiscoveryContext(graphDiscoveryContext(dCtx))
+		}
+	}
+
+	unit, ok := canonicalCandidate.(*component.Unit)
 	if !ok {
 		return nil
 	}
 
-	ctx = contextWithParsePhase(ctx, parsePhaseTagGraphDependents)
-	graphState := state.graphTraversalState
+	// The walk found the actual config file on disk, while a canonical created
+	// earlier from a dependency path only guessed the default filename. Align
+	// the canonical before parsing so the discovered file is the one parsed.
+	if !created && unit.Config() == nil {
+		if walked, ok := candidate.(*component.Unit); ok &&
+			walked.ConfigFile() != "" && walked.ConfigFile() != unit.ConfigFile() {
+			unit.SetConfigFile(walked.ConfigFile())
+		}
+	}
 
-	if err := ensureParsed(ctx, l, candidate, graphState.opts, graphState.discovery); err != nil {
-		if !state.graphTraversalState.discovery.suppressParseErrors {
+	ctx = contextWithParsePhase(ctx, parsePhaseTagGraphDependents)
+
+	if err := ensureParsed(ctx, l, canonicalCandidate, graphState.opts, graphState.discovery); err != nil {
+		if !graphState.discovery.suppressParseErrors {
 			state.errMu.Lock()
 
 			*state.errs = append(*state.errs, err)
@@ -651,7 +676,7 @@ func (p *GraphPhase) processUpstreamCandidate(
 
 	cfg := unit.Config()
 
-	deps, err := extractDependencyPaths(cfg, candidate)
+	deps, err := extractDependencyPaths(cfg, canonicalCandidate)
 	if err != nil {
 		state.errMu.Lock()
 
@@ -664,7 +689,7 @@ func (p *GraphPhase) processUpstreamCandidate(
 
 	var stackErr error
 
-	deps, stackErr = stackDependencyPaths(ctx, l, vfs.NewOSFS(), state.graphTraversalState.opts, deps)
+	deps, stackErr = stackDependencyPaths(ctx, l, vfs.NewOSFS(), graphState.opts, deps)
 	if stackErr != nil {
 		state.errMu.Lock()
 		*state.errs = append(*state.errs, stackErr)
@@ -673,31 +698,13 @@ func (p *GraphPhase) processUpstreamCandidate(
 		return nil
 	}
 
-	canonicalCandidate, created := state.graphTraversalState.threadSafeComponents.EnsureComponent(candidate)
-	if created {
-		dCtx := state.target.DiscoveryContext()
-		if dCtx != nil {
-			copiedCtx := dCtx.CopyWithNewOrigin(component.OriginGraphDiscovery)
-
-			// Clear the Ref and related args for graph-discovered components.
-			// They shouldn't inherit the git ref from the target, as this would
-			// cause them to match git filters and become targets themselves.
-			copiedCtx.Ref = ""
-			copiedCtx.Args = slices.DeleteFunc(copiedCtx.Args, func(arg string) bool {
-				return arg == "-destroy"
-			})
-
-			canonicalCandidate.SetDiscoveryContext(copiedCtx)
-		}
-	}
-
 	dependsOnTarget := false
+	parentCtx := canonicalCandidate.DiscoveryContext()
 
 	for _, dep := range deps {
-		depComponent := componentFromDependencyPath(dep, state.graphTraversalState.threadSafeComponents)
-		depComponent, _ = state.graphTraversalState.threadSafeComponents.EnsureComponent(depComponent)
+		depComponent := componentFromDependencyPath(dep, graphState.threadSafeComponents)
+		depComponent, _ = graphState.threadSafeComponents.EnsureComponent(depComponent)
 
-		parentCtx := canonicalCandidate.DiscoveryContext()
 		if parentCtx != nil && isExternal(parentCtx.WorkingDir, dep) {
 			if ext, ok := depComponent.(*component.Unit); ok {
 				ext.SetExternal()
@@ -759,17 +766,7 @@ func (p *GraphPhase) resolveDependency(
 
 	addedComponent, created := threadSafeComponents.EnsureComponent(depComponent)
 	if created {
-		copiedCtx := parentCtx.CopyWithNewOrigin(component.OriginGraphDiscovery)
-
-		// Clear the Ref and related args for graph-discovered dependencies.
-		// They shouldn't inherit the git ref from the parent, as this would
-		// cause them to match git filters and become targets themselves.
-		copiedCtx.Ref = ""
-		copiedCtx.Args = slices.DeleteFunc(copiedCtx.Args, func(arg string) bool {
-			return arg == "-destroy"
-		})
-
-		depComponent.SetDiscoveryContext(copiedCtx)
+		depComponent.SetDiscoveryContext(graphDiscoveryContext(parentCtx))
 	}
 
 	if isExternal(parentCtx.WorkingDir, depPath) {
@@ -781,4 +778,19 @@ func (p *GraphPhase) resolveDependency(
 	parent.AddDependency(addedComponent)
 
 	return addedComponent, nil
+}
+
+// graphDiscoveryContext copies dCtx for a graph-discovered component.
+// The Ref and related args are cleared: graph-discovered components shouldn't
+// inherit the git ref from the component that led to them, as this would cause
+// them to match git filters and become targets themselves.
+func graphDiscoveryContext(dCtx *component.DiscoveryContext) *component.DiscoveryContext {
+	copiedCtx := dCtx.CopyWithNewOrigin(component.OriginGraphDiscovery)
+
+	copiedCtx.Ref = ""
+	copiedCtx.Args = slices.DeleteFunc(copiedCtx.Args, func(arg string) bool {
+		return arg == "-destroy"
+	})
+
+	return copiedCtx
 }

--- a/internal/discovery/phase_graph_parse_cache_test.go
+++ b/internal/discovery/phase_graph_parse_cache_test.go
@@ -1,0 +1,212 @@
+package discovery_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+// syncBuffer is a bytes.Buffer safe for concurrent writes from logger goroutines.
+type syncBuffer struct {
+	buf bytes.Buffer
+	mu  sync.Mutex
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.String()
+}
+
+// TestGraphPhase_DependentFiltersReuseParsedConfigs verifies that passing multiple
+// dependents filters (...target) does not re-parse every discovered config once per
+// target. The dependency graph is parsed once up front, and the per-target upstream
+// walks must reuse those cached configs instead of parsing fresh component copies.
+//
+// Regression test for https://github.com/gruntwork-io/terragrunt/issues/6323
+// (runtime of `terragrunt find` grew linearly with the number of --filter flags).
+func TestGraphPhase_DependentFiltersReuseParsedConfigs(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	// Initialize a git repository so the graph phase performs the upstream dependent walk.
+	cmd := exec.CommandContext(t.Context(), "git", "init")
+	cmd.Dir = tmpDir
+	cmd.Env = os.Environ()
+	require.NoError(t, cmd.Run())
+
+	// Two independent dependency chains plus standalone units that depend on nothing.
+	// Standalone units are the interesting case: they are not dependents of any target,
+	// so every per-target upstream walk inspects (and used to re-parse) them.
+	testFiles := map[string]string{
+		filepath.Join(tmpDir, "vpc", "terragrunt.hcl"): ``,
+		filepath.Join(tmpDir, "db", "terragrunt.hcl"): `
+dependency "vpc" {
+	config_path = "../vpc"
+}
+`,
+		filepath.Join(tmpDir, "cache", "terragrunt.hcl"): ``,
+		filepath.Join(tmpDir, "web", "terragrunt.hcl"): `
+dependency "cache" {
+	config_path = "../cache"
+}
+`,
+		filepath.Join(tmpDir, "standalone-a", "terragrunt.hcl"): ``,
+		filepath.Join(tmpDir, "standalone-b", "terragrunt.hcl"): ``,
+	}
+
+	for path, content := range testFiles {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	}
+
+	out := &syncBuffer{}
+	formatter := format.NewFormatter(format.NewKeyValueFormatPlaceholders())
+	formatter.SetDisabledColors(true)
+	l := log.New(log.WithLevel(log.DebugLevel), log.WithFormatter(formatter), log.WithOutput(out))
+
+	opts := &options.TerragruntOptions{
+		WorkingDir:     tmpDir,
+		RootWorkingDir: tmpDir,
+	}
+
+	filters, err := filter.ParseFilterQueries(l, []string{"...vpc", "...cache"})
+	require.NoError(t, err)
+
+	d := discovery.NewDiscovery(tmpDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
+		WithFilters(filters)
+
+	components, err := d.Discover(t.Context(), l, opts)
+	require.NoError(t, err)
+
+	paths := components.Paths()
+	assert.Contains(t, paths, filepath.Join(tmpDir, "vpc"))
+	assert.Contains(t, paths, filepath.Join(tmpDir, "db"))
+	assert.Contains(t, paths, filepath.Join(tmpDir, "cache"))
+	assert.Contains(t, paths, filepath.Join(tmpDir, "web"))
+
+	// Each config must be parsed at most once for the whole discovery, regardless
+	// of how many dependents filters were passed.
+	parseCounts := make(map[string]int)
+
+	for line := range strings.SplitSeq(out.String(), "\n") {
+		_, after, found := strings.Cut(line, "Discovery: parsing ")
+		if !found {
+			continue
+		}
+
+		path, _, _ := strings.Cut(after, " (")
+		parseCounts[path]++
+	}
+
+	require.NotEmpty(t, parseCounts, "expected at least one parse to be logged")
+
+	for path, count := range parseCounts {
+		assert.LessOrEqual(
+			t, count, 1,
+			"config %s was parsed %d times; parsed configs must be reused across filter targets",
+			path, count,
+		)
+	}
+}
+
+// TestGraphPhase_UpstreamWalkConcurrentTargets runs discovery from a subdirectory of a
+// git repository with many dependents filters, so concurrent per-target upstream walks
+// encounter the same configs above the working directory. Those configs are not parsed
+// by the upfront dependency-graph build, so this exercises concurrent ensureParsed calls
+// on shared canonical components. Run with -race to validate synchronization.
+func TestGraphPhase_UpstreamWalkConcurrentTargets(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	cmd := exec.CommandContext(t.Context(), "git", "init")
+	cmd.Dir = tmpDir
+	cmd.Env = os.Environ()
+	require.NoError(t, cmd.Run())
+
+	// Working directory is a subdirectory of the git repo.
+	workDir := filepath.Join(tmpDir, "live")
+
+	targetNames := []string{"t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7"}
+	filterStrings := make([]string, 0, len(targetNames))
+
+	for _, name := range targetNames {
+		dir := filepath.Join(workDir, name)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "terragrunt.hcl"), []byte(``), 0644))
+
+		filterStrings = append(filterStrings, "..."+name)
+	}
+
+	// Units above the working directory: walked (and parsed) only during the
+	// per-target upstream walks, concurrently across targets. One of them depends
+	// on a target so the upstream walk has a real dependent to find.
+	outside := map[string]string{
+		filepath.Join(tmpDir, "shared-a", "terragrunt.hcl"): ``,
+		filepath.Join(tmpDir, "shared-b", "terragrunt.hcl"): ``,
+		filepath.Join(tmpDir, "shared-c", "terragrunt.hcl"): ``,
+		filepath.Join(tmpDir, "consumer", "terragrunt.hcl"): `
+dependency "t0" {
+	config_path = "../live/t0"
+}
+`,
+	}
+
+	for path, content := range outside {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	}
+
+	l := logger.CreateLogger()
+	opts := &options.TerragruntOptions{
+		WorkingDir:     workDir,
+		RootWorkingDir: workDir,
+	}
+
+	filters, err := filter.ParseFilterQueries(l, filterStrings)
+	require.NoError(t, err)
+
+	d := discovery.NewDiscovery(workDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workDir}).
+		WithFilters(filters)
+
+	components, err := d.Discover(t.Context(), l, opts)
+	require.NoError(t, err)
+
+	paths := components.Paths()
+	for _, name := range targetNames {
+		assert.Contains(t, paths, filepath.Join(workDir, name))
+	}
+
+	assert.Contains(
+		t, paths, filepath.Join(tmpDir, "consumer"),
+		"dependent above the working directory must be discovered",
+	)
+}

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -124,7 +124,11 @@ func ensureParsed(
 		return nil
 	}
 
-	return parseComponent(ctx, l, c, opts, discovery)
+	// EnsureConfig serializes concurrent callers so the same unit is never
+	// parsed twice (e.g. multiple graph targets walking the same configs).
+	return unit.EnsureConfig(func() error {
+		return parseComponent(ctx, l, c, opts, discovery)
+	})
 }
 
 // ParsePhase parses HCL configurations for filter evaluation.

--- a/internal/filter/evaluator_test.go
+++ b/internal/filter/evaluator_test.go
@@ -38,54 +38,34 @@ func TestEvaluate_PathFilter(t *testing.T) {
 			name:   "exact path match",
 			filter: mustPath(t, "./apps/app1"),
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[0],
 			},
 		},
 		{
 			name:   "glob with single wildcard",
 			filter: mustPath(t, "./apps/*"),
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/app2").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/legacy").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[0],
+				components[1],
+				components[2],
 			},
 		},
 		{
 			name:   "glob with single wildcard and partial match",
 			filter: mustPath(t, "./apps/app*"),
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/app2").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[0],
+				components[1],
 			},
 		},
 		{
 			name:   "glob with recursive wildcard",
 			filter: mustPath(t, "./apps/**"),
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/app2").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/legacy").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/subdir/nested").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[0],
+				components[1],
+				components[2],
+				components[5],
 			},
 		},
 		{
@@ -128,15 +108,15 @@ func TestEvaluate_AttributeFilter(t *testing.T) {
 			name:   "name filter single match",
 			filter: mustAttr(t, "name", "db"),
 			expected: []component.Component{
-				component.NewUnit("./libs/db"),
+				components[2],
 			},
 		},
 		{
 			name:   "name filter multiple matches",
 			filter: mustAttr(t, "name", "app"),
 			expected: []component.Component{
-				component.NewUnit("./apps/app"),
-				component.NewUnit("./libs/app"),
+				components[0],
+				components[1],
 			},
 		},
 		{
@@ -148,17 +128,17 @@ func TestEvaluate_AttributeFilter(t *testing.T) {
 			name:   "type filter unit",
 			filter: mustAttr(t, "type", "unit"),
 			expected: []component.Component{
-				component.NewUnit("./apps/app"),
-				component.NewUnit("./libs/app"),
-				component.NewUnit("./libs/db"),
-				component.NewUnit("./libs/api"),
+				components[0],
+				components[1],
+				components[2],
+				components[3],
 			},
 		},
 		{
 			name:   "type filter stack",
 			filter: mustAttr(t, "type", "stack"),
 			expected: []component.Component{
-				component.NewStack("./libs/api"),
+				components[4],
 			},
 		},
 	}
@@ -212,16 +192,16 @@ func TestEvaluate_AttributeFilter_Reading(t *testing.T) {
 			name:   "exact file path match - single match",
 			filter: mustAttr(t, "reading", "database.hcl"),
 			expected: []component.Component{
-				component.NewUnit("./libs/db").WithReading("database.hcl"),
+				components[3],
 			},
 		},
 		{
 			name:   "exact file path match - multiple matches",
 			filter: mustAttr(t, "reading", "shared.hcl"),
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithReading("shared.hcl", "shared.tfvars"),
-				component.NewUnit("./apps/app2").WithReading("shared.hcl", "common/variables.hcl"),
-				component.NewUnit("./apps/app4").WithReading("shared.hcl", "shared.tfvars", "extra.hcl"),
+				components[0],
+				components[1],
+				components[5],
 			},
 		},
 		{
@@ -233,26 +213,26 @@ func TestEvaluate_AttributeFilter_Reading(t *testing.T) {
 			name:   "glob pattern with single wildcard - *.hcl",
 			filter: mustAttr(t, "reading", "*.hcl"),
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithReading("shared.hcl", "shared.tfvars"),
-				component.NewUnit("./apps/app2").WithReading("shared.hcl", "common/variables.hcl"),
-				component.NewUnit("./libs/db").WithReading("database.hcl"),
-				component.NewUnit("./apps/app4").WithReading("shared.hcl", "shared.tfvars", "extra.hcl"),
+				components[0],
+				components[1],
+				components[3],
+				components[5],
 			},
 		},
 		{
 			name:   "glob pattern with prefix - shared*",
 			filter: mustAttr(t, "reading", "shared*"),
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithReading("shared.hcl", "shared.tfvars"),
-				component.NewUnit("./apps/app2").WithReading("shared.hcl", "common/variables.hcl"),
-				component.NewUnit("./apps/app4").WithReading("shared.hcl", "shared.tfvars", "extra.hcl"),
+				components[0],
+				components[1],
+				components[5],
 			},
 		},
 		{
 			name:   "glob pattern with double wildcard - **/variables.hcl",
 			filter: mustAttr(t, "reading", "**/variables.hcl"),
 			expected: []component.Component{
-				component.NewUnit("./apps/app2").WithReading("shared.hcl", "common/variables.hcl"),
+				components[1],
 			},
 		},
 		{
@@ -264,7 +244,7 @@ func TestEvaluate_AttributeFilter_Reading(t *testing.T) {
 			name:   "glob pattern with question mark - config.???l",
 			filter: mustAttr(t, "reading", "config.???l"),
 			expected: []component.Component{
-				component.NewUnit("./apps/app3").WithReading("config.yaml", "settings.json"),
+				components[2],
 			},
 		},
 	}
@@ -397,15 +377,9 @@ func TestEvaluate_PrefixExpression(t *testing.T) {
 				Right:    mustAttr(t, "name", "legacy"),
 			},
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/app2").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./libs/db").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[0],
+				components[1],
+				components[3],
 			},
 		},
 		{
@@ -415,15 +389,9 @@ func TestEvaluate_PrefixExpression(t *testing.T) {
 				Right:    mustPath(t, "./apps/legacy"),
 			},
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/app2").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./libs/db").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[0],
+				components[1],
+				components[3],
 			},
 		},
 		{
@@ -433,9 +401,7 @@ func TestEvaluate_PrefixExpression(t *testing.T) {
 				Right:    mustPath(t, "./apps/*"),
 			},
 			expected: []component.Component{
-				component.NewUnit("./libs/db").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[3],
 			},
 		},
 		{
@@ -498,9 +464,7 @@ func TestEvaluate_InfixExpression(t *testing.T) {
 				Right:    mustAttr(t, "name", "app1"),
 			},
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[0],
 			},
 		},
 		{
@@ -520,9 +484,7 @@ func TestEvaluate_InfixExpression(t *testing.T) {
 				Right:    mustAttr(t, "name", "app1"),
 			},
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[0],
 			},
 		},
 		{
@@ -582,12 +544,8 @@ func TestEvaluate_ComplexExpressions(t *testing.T) {
 				},
 			},
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/app2").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[0],
+				components[1],
 			},
 		},
 		{
@@ -601,21 +559,11 @@ func TestEvaluate_ComplexExpressions(t *testing.T) {
 				},
 			},
 			expected: []component.Component{
-				component.NewUnit("./apps/app2").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/legacy").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./libs/db").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./libs/api").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./special/unit").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[1],
+				components[2],
+				components[3],
+				components[4],
+				components[5],
 			},
 		},
 		{
@@ -630,9 +578,7 @@ func TestEvaluate_ComplexExpressions(t *testing.T) {
 				Right:    mustAttr(t, "name", "app1"),
 			},
 			expected: []component.Component{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				components[0],
 			},
 		},
 	}

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -48,99 +48,65 @@ func TestFilter_ParseAndEvaluate(t *testing.T) {
 			name:         "simple name filter",
 			filterString: "app1",
 			expected: component.Components{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				testComponents[0],
 			},
 		},
 		{
 			name:         "attribute filter",
 			filterString: "name=db",
 			expected: component.Components{
-				component.NewUnit("./libs/db").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				testComponents[3],
 			},
 		},
 		{
 			name:         "path filter with wildcard",
 			filterString: "./apps/*",
 			expected: component.Components{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/app2").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/legacy").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				testComponents[0],
+				testComponents[1],
+				testComponents[2],
 			},
 		},
 		{
 			name:         "negated filter",
 			filterString: "!legacy",
 			expected: component.Components{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/app2").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./libs/db").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./libs/api").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./services/web").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./services/worker").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				testComponents[0],
+				testComponents[1],
+				testComponents[3],
+				testComponents[4],
+				testComponents[5],
+				testComponents[6],
 			},
 		},
 		{
 			name:         "intersection of path and name",
 			filterString: "./apps/* | app1",
 			expected: component.Components{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				testComponents[0],
 			},
 		},
 		{
 			name:         "intersection with negation",
 			filterString: "./apps/* | !legacy",
 			expected: component.Components{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./apps/app2").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				testComponents[0],
+				testComponents[1],
 			},
 		},
 		{
 			name:         "chained intersections",
 			filterString: "./apps/* | !legacy | app1",
 			expected: component.Components{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				testComponents[0],
 			},
 		},
 		{
 			name:         "recursive wildcard",
 			filterString: "./services/**",
 			expected: component.Components{
-				component.NewUnit("./services/web").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./services/worker").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				testComponents[5],
+				testComponents[6],
 			},
 		},
 		{
@@ -207,9 +173,7 @@ func TestFilter_Apply(t *testing.T) {
 			filterString: "app1",
 			components:   testComponents,
 			expected: component.Components{
-				component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				testComponents[0],
 			},
 		},
 		{
@@ -217,12 +181,8 @@ func TestFilter_Apply(t *testing.T) {
 			filterString: "./libs/*",
 			components:   testComponents,
 			expected: component.Components{
-				component.NewUnit("./libs/db").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
-				component.NewUnit("./libs/api").WithDiscoveryContext(&component.DiscoveryContext{
-					WorkingDir: ".",
-				}),
+				testComponents[3],
+				testComponents[4],
 			},
 		},
 		{
@@ -397,12 +357,8 @@ func TestFilter_EdgeCasesAndErrorHandling(t *testing.T) {
 		}
 
 		expected := component.Components{
-			component.NewUnit("./apps/app1").WithDiscoveryContext(&component.DiscoveryContext{
-				WorkingDir: ".",
-			}),
-			component.NewUnit("./apps/app2").WithDiscoveryContext(&component.DiscoveryContext{
-				WorkingDir: ".",
-			}),
+			testComponents[0],
+			testComponents[1],
 		}
 
 		for _, tt := range tests {

--- a/internal/filter/filters_test.go
+++ b/internal/filter/filters_test.go
@@ -146,15 +146,9 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := component.Components{
-			component.NewUnit("./apps/app1"),
-			component.NewUnit("./apps/app2"),
-			component.NewUnit("./apps/legacy"),
-		}
-
-		for _, c := range expected {
-			c.SetDiscoveryContext(&component.DiscoveryContext{
-				WorkingDir: ".",
-			})
+			components[0],
+			components[1],
+			components[2],
 		}
 
 		assert.ElementsMatch(t, expected, result)
@@ -171,14 +165,8 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := component.Components{
-			component.NewUnit("./apps/app1"),
-			component.NewUnit("./libs/db"),
-		}
-
-		for _, c := range expected {
-			c.SetDiscoveryContext(&component.DiscoveryContext{
-				WorkingDir: ".",
-			})
+			components[0],
+			components[3],
 		}
 
 		assert.ElementsMatch(t, expected, result)
@@ -195,15 +183,9 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := component.Components{
-			component.NewUnit("./apps/app1"),
-			component.NewUnit("./apps/app2"),
-			component.NewUnit("./apps/legacy"),
-		}
-
-		for _, c := range expected {
-			c.SetDiscoveryContext(&component.DiscoveryContext{
-				WorkingDir: ".",
-			})
+			components[0],
+			components[1],
+			components[2],
 		}
 
 		assert.ElementsMatch(t, expected, result)
@@ -222,14 +204,8 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := component.Components{
-			component.NewUnit("./apps/app1"),
-			component.NewUnit("./apps/app2"),
-		}
-
-		for _, c := range expected {
-			c.SetDiscoveryContext(&component.DiscoveryContext{
-				WorkingDir: ".",
-			})
+			components[0],
+			components[1],
 		}
 
 		assert.ElementsMatch(t, expected, result)
@@ -246,13 +222,7 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := component.Components{
-			component.NewUnit("./apps/app1"),
-		}
-
-		for _, c := range expected {
-			c.SetDiscoveryContext(&component.DiscoveryContext{
-				WorkingDir: ".",
-			})
+			components[0],
 		}
 
 		assert.ElementsMatch(t, expected, result)
@@ -269,15 +239,9 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := component.Components{
-			component.NewUnit("./apps/app1"),
-			component.NewUnit("./apps/app2"),
-			component.NewUnit("./libs/api"),
-		}
-
-		for _, c := range expected {
-			c.SetDiscoveryContext(&component.DiscoveryContext{
-				WorkingDir: ".",
-			})
+			components[0],
+			components[1],
+			components[4],
 		}
 
 		assert.ElementsMatch(t, expected, result)
@@ -299,15 +263,9 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := component.Components{
-			component.NewUnit("./apps/app1"),
-			component.NewUnit("./apps/app2"),
-			component.NewUnit("./libs/db"),
-		}
-
-		for _, c := range expected {
-			c.SetDiscoveryContext(&component.DiscoveryContext{
-				WorkingDir: ".",
-			})
+			components[0],
+			components[1],
+			components[3],
 		}
 
 		assert.ElementsMatch(t, expected, result)


### PR DESCRIPTION
## Description

Fixes #6323.

Running `terragrunt find` with N `...<unit>` dependents filters re-parsed every discovered config once per filter target, so runtime grew linearly with the number of filters (~5–6s per added filter on an 814-unit repository; ~34 minutes for a CI invocation passing ~290 filters).

**Root cause:** discovery already parses every config once up front in `buildDependencyGraph`, but each filter target's upstream dependent walk (`discoverDependentsUpstream` → `processUpstreamCandidate`) parsed a fresh, non-canonical `Unit` created during the walk and only canonicalized it via `EnsureComponent` *after* parsing. The config cache lives on the canonical `Unit`, so it never engaged: instrumented counts showed 1625 parses at N=1 and 3241 at N=3 (~808 extra parses — a full repo re-parse — per added filter), with zero cache hits.

**Fix:**

- `processUpstreamCandidate` now canonicalizes the walked candidate **before** parsing, so every graph target reuses the configs parsed by the upfront dependency-graph build (or by another target's walk). When an unparsed canonical was created earlier from a dependency path, its guessed config filename is aligned to the file the walk actually found.
- Sharing canonical `Unit`s across concurrently processed targets requires synchronization that was previously missing: the mutable `Unit`/`Stack` fields (config, discovery context, config filename, external, reading, excluded) are now guarded by the existing component mutex, and parsing is serialized with a per-`Unit` parse gate (`EnsureConfig`) so a config is parsed at most once. This also fixes a pre-existing unsynchronized publication of the discovery context in the upstream walk that `go test -race` flags on unpatched code (see `TestGraphPhase_UpstreamWalkConcurrentTargets`).
- Filter tests that share component fixtures across parallel subtests now assert on the fixture instances themselves instead of deep-equal copies: with synchronized accessors, `reflect.DeepEqual` could observe transient lock state on a live component and flake.

**Results** on the reproducing repository (814 units, real-world config-resolution cost):

| Filters in one call | Before | After |
|---|---|---|
| N=1 | ~14s | ~10s |
| N=5 | ~35s | ~11s |
| N=10 | ~60s | ~10s |
| N=20 | ~118s | ~11s |

`find` output is byte-identical to the previous implementation (verified by diffing sorted result paths at N=5 against an unpatched build).

New regression tests:
- `TestGraphPhase_DependentFiltersReuseParsedConfigs` — fails on unpatched code (each config parsed once per target), passes with the fix (each config parsed at most once).
- `TestGraphPhase_UpstreamWalkConcurrentTargets` — concurrent per-target upstream walks over configs above the working directory; run with `-race` (flags both the pre-existing discovery-context race and the config-cache race on unpatched code).

## Test output

```
$ go test -race ./internal/discovery/ ./internal/component/ ./internal/filter/ -count=1
ok      github.com/gruntwork-io/terragrunt/internal/discovery   4.327s
ok      github.com/gruntwork-io/terragrunt/internal/component   1.125s
ok      github.com/gruntwork-io/terragrunt/internal/filter      1.452s

$ go test -short -race ./internal/... -count=1
(all packages pass; the only failures are pre-existing `internal/cas` tests that
require the repository's git metadata, which was unavailable in the sandboxed
container — they pass when it is mounted)

$ golangci-lint run ./internal/component/... ./internal/discovery/... ./internal/filter/...
0 issues.
```

The filter package was additionally stress-run 25× under `-race` with zero failures to verify the parallel-subtest flake fix.

## Backwards compatibility

No CLI or behavior changes: `find` output is byte-identical for the same inputs. The changes are internal to discovery/component (parse-dedup plus synchronization of component accessors).

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs. (N/A — no user-facing behavior change)
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks (`goimports` clean; `tofu-fmt` N/A).
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race conditions during concurrent discovery by serializing config parsing and making component state access thread-safe for consistent results.
  * Ensured canonical handling of discovered dependencies so discovery behaves consistently across concurrent walks.

* **Tests**
  * Added regression tests validating concurrent discovery and that parsed configs are reused across multiple targets/filters.

* **Documentation**
  * Added changelog entry describing the performance improvement when using many dependents filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->