### PR TITLE
fix: CAS integration with committed module lockfiles

### DIFF
--- a/docs/src/data/changelog/v1.1.0/cas-generate-overwrite-permission-denied.mdx
+++ b/docs/src/data/changelog/v1.1.0/cas-generate-overwrite-permission-denied.mdx
@@ -3,11 +3,14 @@ version: "v1.1.0"
 category: "bug-fixes"
 ---
 
-#### Fix permission denied when generated files overwrite CAS-materialized files
+#### Fix `permission denied` when generated files overwrite CAS-materialized files
 
-Files Terragrunt generates over a CAS-materialized source no longer fail with `permission denied` when the
-source ships its own copy: `generate` blocks with `if_exists = "overwrite"` (for example a module-shipped
-`versions.tf`), unit values written to `terragrunt.values.hcl`, and autoinclude files written to
-`terragrunt.autoinclude.hcl`. The read-only file is replaced with a writable one, and the shared CAS store
-is never modified. Committed `.terraform.lock.hcl` files were already handled correctly and are now covered
-by a regression test.
+With CAS enabled, Terragrunt fetches sources as read-only files. Writing a generated file over one of
+them no longer fails with `permission denied`:
+
+- Files from `generate` blocks with `if_exists = "overwrite"`, when the module ships the target file (for example, its own `versions.tf`).
+- `terragrunt.values.hcl`, when the unit or stack source already contains one.
+- `terragrunt.autoinclude.hcl`, when the unit or stack source already contains one.
+- `.terraform.lock.hcl`, when the provider cache server updates a committed lock file during `init -upgrade`.
+
+The read-only file is replaced with a writable one, and the shared CAS store is never modified.

--- a/internal/tf/getproviders/lock.go
+++ b/internal/tf/getproviders/lock.go
@@ -6,6 +6,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -45,6 +48,11 @@ func UpdateLockfile(ctx context.Context, workingDir string, providers []Provider
 
 	if err := updateLockfile(ctx, file, providers); err != nil {
 		return err
+	}
+
+	// CAS may materialize the lock file as a read-only hard link, so remove it before writing
+	if err := os.Remove(filename); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("failed to remove lock file %s before writing: %w", filename, err)
 	}
 
 	const ownerWriteGlobalReadPerms = 0644

--- a/internal/tf/getproviders/lock_update_test.go
+++ b/internal/tf/getproviders/lock_update_test.go
@@ -1,0 +1,90 @@
+package getproviders_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/tf/getproviders"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const readOnlyLockfileContents = `provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.2"
+  constraints = "3.2.2"
+  hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+  ]
+}
+`
+
+// TestUpdateLockfileReplacesReadOnlyLockfile verifies that updating a lock
+// file CAS materialized as read-only replaces it instead of failing with a
+// permission error.
+func TestUpdateLockfileReplacesReadOnlyLockfile(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("read-only permission bits are not meaningfully observable on Windows")
+	}
+
+	workingDir := helpers.TmpDirWOSymlinks(t)
+	lockfilePath := filepath.Join(workingDir, tf.TerraformLockFile)
+
+	require.NoError(t, os.WriteFile(lockfilePath, []byte(readOnlyLockfileContents), 0644))
+	require.NoError(t, os.Chmod(lockfilePath, 0444))
+
+	require.NoError(t, getproviders.UpdateLockfile(t.Context(), workingDir, nil))
+
+	content, err := os.ReadFile(lockfilePath)
+	require.NoError(t, err)
+	assert.Equal(t, readOnlyLockfileContents, string(content))
+
+	info, err := os.Stat(lockfilePath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode().Perm()&0200, "rewritten lock file must be owner-writable")
+}
+
+// TestUpdateLockfileDoesNotMutateHardlinkedStore verifies that updating a
+// lock file hard-linked into the CAS store breaks the link instead of
+// mutating the shared blob.
+func TestUpdateLockfileDoesNotMutateHardlinkedStore(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("read-only permission bits are not meaningfully observable on Windows")
+	}
+
+	testDir := helpers.TmpDirWOSymlinks(t)
+	workingDir := filepath.Join(testDir, "working")
+	require.NoError(t, os.Mkdir(workingDir, 0755))
+
+	storePath := filepath.Join(testDir, "store-blob")
+	lockfilePath := filepath.Join(workingDir, tf.TerraformLockFile)
+
+	require.NoError(t, os.WriteFile(storePath, []byte(readOnlyLockfileContents), 0644))
+	require.NoError(t, os.Chmod(storePath, 0444))
+	require.NoError(t, os.Link(storePath, lockfilePath))
+
+	storeInfoBefore, err := os.Stat(storePath)
+	require.NoError(t, err)
+
+	require.NoError(t, getproviders.UpdateLockfile(t.Context(), workingDir, nil))
+
+	storeContent, err := os.ReadFile(storePath)
+	require.NoError(t, err)
+	assert.Equal(t, readOnlyLockfileContents, string(storeContent), "store blob content must stay intact")
+
+	storeInfoAfter, err := os.Stat(storePath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0444), storeInfoAfter.Mode().Perm(), "store blob must stay read-only")
+
+	targetInfo, err := os.Stat(lockfilePath)
+	require.NoError(t, err)
+	assert.False(t, os.SameFile(storeInfoBefore, targetInfo),
+		"lock file must get a fresh inode instead of sharing the store blob")
+	assert.NotZero(t, targetInfo.Mode().Perm()&0200, "rewritten lock file must be owner-writable")
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes CAS integration with committed lockfiles in modules.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved permission denied errors when generated files overwrite read-only CAS-materialized files, including specific generate block cases, `terragrunt.values.hcl`, `terragrunt.autoinclude.hcl`, and `.terraform.lock.hcl` during init -upgrade operations.

* **Documentation**
  * Updated v1.1.0 changelog with refined description of the permission denied error fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->