### PR TITLE
docs: Adding immutable releases docs

### DIFF
--- a/docs/src/content/docs/01-getting-started/03-install.mdx
+++ b/docs/src/content/docs/01-getting-started/03-install.mdx
@@ -7,6 +7,7 @@ sidebar:
 ---
 
 import InstallTabs from '@components/InstallTabs.astro'
+import Before from '@components/Before.astro'
 import { Aside, Code, Tabs, TabItem } from '@astrojs/starlight/components'
 import { getLatestRelease } from '@lib/github';
 export const releaseData = await getLatestRelease('gruntwork-io', 'terragrunt');
@@ -86,6 +87,34 @@ cosign verify-blob SHA256SUMS \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp "github.com/gruntwork-io/terragrunt"
 ```
+
+### Verifying releases with the GitHub CLI
+
+<Before version="1.1.0">
+<Aside type="note" title="Coming in v1.1.0">
+  Terragrunt adopts immutable releases starting with `v1.1.0`. The verification below will be supported once `v1.1.0` is published.
+</Aside>
+</Before>
+
+Terragrunt releases starting with `v1.1.0` are published as [immutable releases](/process/releases#immutable-releases), and each one includes a release attestation: a signed record binding the release tag, commit SHA, and asset digests. The [GitHub CLI](https://cli.github.com/) (version 2.81.0 or later) can check a release and your downloaded files against that attestation.
+
+To confirm a release exists and is immutable:
+
+```bash
+gh release verify v1.1.0 --repo gruntwork-io/terragrunt
+```
+
+To confirm a downloaded file exactly matches the published release asset:
+
+```bash
+gh release verify-asset v1.1.0 terragrunt_darwin_arm64.tar.gz --repo gruntwork-io/terragrunt
+```
+
+This complements the checksum and signature checks above: the attestation proves your download matches what was published on GitHub and that the release cannot have been replaced after publishing, while the GPG signature proves Gruntwork produced it.
+
+<Aside type="note">
+  `gh release verify-asset` cannot verify the auto-generated source code zip or tarball, since GitHub creates those on download. Releases before `v1.1.0` predate immutability and cannot be verified this way; use the checksum and signature checks instead.
+</Aside>
 
 ### Convenience Scripts
 

--- a/docs/src/content/docs/07-process/03-releases.mdx
+++ b/docs/src/content/docs/07-process/03-releases.mdx
@@ -7,6 +7,8 @@ sidebar:
 ---
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Terragrunt releases use [semantic versions (semver)](https://semver.org/).
 
@@ -22,9 +24,13 @@ Terragrunt uses [GitHub's immutable releases](https://docs.github.com/en/code-se
 
 To support immutability, releases are built as **drafts** first. All artifacts are uploaded and verified before the release is published. Once published, the git tag is created and the release is locked.
 
-<Aside type="note" title="Not yet enabled">
-  Immutable releases are not yet turned on for the `gruntwork-io/terragrunt` repository. The release workflow has been updated to support them, and maintainers want to run a few releases through the new workflow before enabling the setting on GitHub.
-</Aside>
+<Before version="1.1.0">
+Immutable releases are not yet enabled for the repository. The release workflow already supports them, and the setting will be turned on starting with `v1.1.0`.
+</Before>
+
+<Since version="1.1.0">
+Releases starting with `v1.1.0` are immutable. Releases published before then predate the setting being enabled on the repository, so they are not locked.
+</Since>
 
 ## When to Cut a New Release
 

--- a/docs/src/data/changelog/v1.1.0/immutable-releases.mdx
+++ b/docs/src/data/changelog/v1.1.0/immutable-releases.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.0"
+category: "process-updates"
+---
+
+#### Immutable releases
+
+Starting with this release, Terragrunt releases are published as [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) on GitHub. Once a release is published, its tag and assets can no longer be modified or deleted, so the binary you download is guaranteed to be the same binary that was uploaded when the release was published.
+
+See the [releases process documentation](/process/releases#immutable-releases) for details, and [Verifying releases with the GitHub CLI](/getting-started/install#verifying-releases-with-the-github-cli) for how to check a download against the release attestation.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds docs on immutable releases.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for verifying Terragrunt releases using GitHub CLI commands, now available starting with v1.1.0.
  * Updated documentation to clarify that immutable releases are enabled starting with v1.1.0; releases published before this version are not locked.
  * Added changelog entry documenting the immutable releases feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->