### PR TITLE
docs: Cleaning up 1.1.0 docs

### DIFF
--- a/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
+++ b/docs/src/content/docs/03-features/02-stacks/03-explicit.mdx
@@ -191,9 +191,11 @@ terragrunt stack run apply
 
 ## Declaring Dependencies Between Units
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 The `autoinclude` block is part of the [`stack-dependencies` experiment](/reference/experiments/active#stack-dependencies). Enable it with `--experiment stack-dependencies`.
 </Aside>
+</Before>
 
 A unit in a stack can depend on a sibling unit without the catalog source knowing anything about the relationship. Add an `autoinclude` block to the `unit` block and declare the `dependency` there:
 
@@ -225,7 +227,7 @@ unit "app" {
 }
 ```
 
-The `unit.vpc.path` variable resolves to the generated directory of the `vpc` unit. Running `terragrunt stack generate --experiment stack-dependencies` writes the dependency into a `terragrunt.autoinclude.hcl` file next to the `app` unit's `terragrunt.hcl`:
+The `unit.vpc.path` variable resolves to the generated directory of the `vpc` unit. Running <Before version="1.1.0">`terragrunt stack generate --experiment stack-dependencies`</Before><Since version="1.1.0">`terragrunt stack generate`</Since> writes the dependency into a `terragrunt.autoinclude.hcl` file next to the `app` unit's `terragrunt.hcl`:
 
 <FileTree>
 
@@ -584,7 +586,13 @@ The `dependency` block cannot set the value of the `config_path` attribute to th
 
 As such, if you currently have multiple stacks that need to depend on each other, or on units within each other's stacks, you will need to either use implicit stacks, or work around this limitation by setting the `config_path` attribute to the path of the unit within the stack, and carefully ensuring that all stacks are generated before any units are run.
 
+<Before version="1.1.0">
 The [`stack-dependencies` experiment](/reference/experiments/active#stack-dependencies) lifts this limitation: a `dependency` declared in an [`autoinclude` block](/reference/hcl/blocks#autoinclude) can target a stack directory and read the aggregated outputs of its units. See [Declaring Dependencies Between Units](#declaring-dependencies-between-units).
+</Before>
+
+<Since version="1.1.0">
+The [`autoinclude` block](/reference/hcl/blocks#autoinclude) lifts this limitation: a `dependency` declared there can target a stack directory and read the aggregated outputs of its units. See [Declaring Dependencies Between Units](#declaring-dependencies-between-units).
+</Since>
 
 ### Deeply nested stack generation can be slow
 

--- a/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
@@ -7,6 +7,7 @@ sidebar:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
 
 Launch the user interface for searching and managing your module catalog.
 
@@ -45,9 +46,11 @@ This will recursively search for OpenTofu/Terraform modules in the root of the r
 1. Read the docs for a selected module: `ENTER`.
 1. Use [`terragrunt scaffold`](/features/catalog/scaffold) to render a `terragrunt.hcl` for using the module with an interactive form: `s`. Inside the form, `ctrl+d` writes the file even when required fields are still unset, leaving them as `# TODO` placeholders for you to fill in by hand.
 
+<Before version="1.1.0">
 <Aside type="tip" title="Catalog Redesign Experiment">
 The interactive form is only available when the [`catalog-redesign`](/reference/experiments/active#catalog-redesign) experiment is enabled. Without the experiment, `s` produces a placeholder-style file with every input marked `# TODO`.
 </Aside>
+</Before>
 
 ## Scaffolding Flags
 
@@ -58,9 +61,11 @@ The following `catalog` flags control behavior of the underlying `scaffold` comm
 
 ## Excluding paths from discovery
 
+<Before version="1.1.0">
 <Aside type="tip" title="Catalog Redesign Experiment">
 This section describes behavior that is only available when the [`catalog-redesign`](/reference/experiments/active#catalog-redesign) experiment is enabled.
 </Aside>
+</Before>
 
 Catalog authors can keep directories out of discovery by committing a `.terragrunt-catalog-ignore` file at the root of the repository. Typical uses are skipping `examples/`, `test/`, or integration fixtures that aren't intended to be scaffolded as modules or templates.
 
@@ -101,17 +106,21 @@ This is useful when you don't control the upstream repository, or when you want 
 ## Browse tabs
 
 
+<Before version="1.1.0">
 <Aside type="tip" title="Catalog Redesign Experiment">
 This section describes behavior that is only available when the [`catalog-redesign`](/reference/experiments/active#catalog-redesign) experiment is enabled.
 </Aside>
+</Before>
 
 The list view is split into three tabs: `All`, `Modules`, and `Templates`. `All` is selected when the TUI launches. Press `tab` to move to the next tab and `shift+tab` to move to the previous; cycling wraps at either end. The active tab filters the list down to components of that kind, and each tab keeps its own cursor position and search filter, so switching back preserves where you were.
 
 ## README front-matter
 
+<Before version="1.1.0">
 <Aside type="tip" title="Catalog Redesign Experiment">
 This section describes behavior that is only available when the [`catalog-redesign`](/reference/experiments/active#catalog-redesign) experiment is enabled.
 </Aside>
+</Before>
 
 Component authors can override the catalog UI's default title and description by adding a YAML block at the top of the component's `README.md`. Two forms are accepted.
 
@@ -152,9 +161,11 @@ A third key, `tags`, controls the colored pills shown next to each component; se
 
 ## Component tags
 
+<Before version="1.1.0">
 <Aside type="tip" title="Catalog Redesign Experiment">
 This section describes behavior that is only available when the [`catalog-redesign`](/reference/experiments/active#catalog-redesign) experiment is enabled.
 </Aside>
+</Before>
 
 Catalog authors can attach tags to a component by adding a `tags` key to the component's `README.md` front-matter. Tags appear as colored pills next to the component in the list view, and as a row above the rendered README in the detail view.
 
@@ -198,8 +209,8 @@ The default view, shown after discovery completes.
 | `end`, `ctrl+e` | Jump to last row |
 | `enter` | View the selected component's README |
 | `s` | Scaffold the selected component (interactive form) |
-| `tab` | Next tab (redesign experiment) |
-| `shift+tab` | Previous tab (redesign experiment) |
+| `tab` | Next tab |
+| `shift+tab` | Previous tab |
 | `/` | Search and filter the visible list |
 | `?` | Toggle the expanded help view |
 | `q`, `esc` | Quit |
@@ -226,9 +237,11 @@ Active after pressing `enter` on a component.
 
 ### Interactive scaffold form
 
+<Before version="1.1.0">
 <Aside type="tip" title="Catalog Redesign Experiment">
 The interactive form is only available when the [`catalog-redesign`](/reference/experiments/active#catalog-redesign) experiment is enabled.
 </Aside>
+</Before>
 
 The form opens in *navigate* mode. Pressing `enter` on a text field switches to *edit* mode, where most keys are forwarded to the underlying text input; press `esc` to return to navigate mode.
 
@@ -264,9 +277,11 @@ Active while typing into a text field. Keys not listed here are forwarded to the
 
 ### Welcome screen
 
+<Before version="1.1.0">
 <Aside type="tip" title="Catalog Redesign Experiment">
 The welcome and loading screens are only shown when the [`catalog-redesign`](/reference/experiments/active#catalog-redesign) experiment is enabled.
 </Aside>
+</Before>
 
 Shown briefly during initial discovery and, if no catalog sources are configured, as a persistent help screen.
 

--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -9,6 +9,7 @@ sidebar:
 import FileTree from '@components/vendored/starlight/FileTree.astro';
 import { Aside } from '@astrojs/starlight/components';
 import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Terragrunt HCL configuration uses [configuration blocks](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#blocks) when there's a structural configuration that needs to be defined for Terragrunt.
 
@@ -1962,9 +1963,11 @@ Terragrunt will recursively generate a stack using the contents of the `.terragr
 
 ## autoinclude
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 The `autoinclude` block is part of the [`stack-dependencies` experiment](/reference/experiments/active#stack-dependencies). Enable it with `--experiment stack-dependencies`.
 </Aside>
+</Before>
 
 The `autoinclude` block is used inside [`unit`](#unit) and [`stack`](#stack) blocks in Terragrunt stack files (`terragrunt.stack.hcl`) to inject configuration into the generated component during stack generation. Its main job is declaring `dependency` relationships between components of a stack without editing the unit sources in your catalog.
 
@@ -2014,7 +2017,7 @@ unit "app" {
 }
 ```
 
-Running `terragrunt stack generate --experiment stack-dependencies` produces:
+Running <Before version="1.1.0">`terragrunt stack generate --experiment stack-dependencies`</Before><Since version="1.1.0">`terragrunt stack generate`</Since> produces:
 
 <FileTree>
 

--- a/docs/src/data/experiments/cas.mdx
+++ b/docs/src/data/experiments/cas.mdx
@@ -1,7 +1,10 @@
 ---
 name: cas
-completedSince: "1.1"
+completedSince: "1.1.0"
 ---
+
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Support for Terragrunt Content Addressable Storage (CAS).
 
@@ -10,15 +13,26 @@ Allow Terragrunt to store and retrieve Git repositories from a Content Addressab
 
 The CAS is used to speed up catalog cloning, OpenTofu/Terraform source cloning, and stack generation by avoiding redundant downloads of Git repositories. When used with stacks, it also allows catalog authors to use relative paths in `source` attributes via the `update_source_with_cas` attribute.
 
+<Since version="1.1.0">
+This experiment flag is no longer needed, as the CAS is now enabled by default. Disable it with the `--no-cas` flag.
+</Since>
+
 ### `cas` - How to provide feedback
+
+<Before version="1.1.0">
 Share your experience with this feature in the [CAS](https://github.com/gruntwork-io/terragrunt/discussions/3939) Feedback GitHub Discussion.
 Feedback is crucial for ensuring the feature meets real-world use cases. Please include:
 
 - Any bugs or issues encountered (including logs or stack traces if possible).
 - Suggestions for additional improvements or enhancements.
+</Before>
+
+<Since version="1.1.0">
+Now that the `cas` experiment is complete, please provide feedback in the form of standard [GitHub issues](https://github.com/gruntwork-io/terragrunt/issues).
+</Since>
 
 ### `cas` - Criteria for stabilization
-To transition the `cas` feature to a stable release, the following must be addressed:
+To transition the `cas` feature to a stable release, the following were completed:
 
 - [x] Add support for storing and retrieving catalog repositories from the CAS.
 - [x] Add support for storing and retrieving OpenTofu/Terraform modules from the CAS.

--- a/docs/src/data/experiments/catalog-redesign.mdx
+++ b/docs/src/data/experiments/catalog-redesign.mdx
@@ -1,14 +1,21 @@
 ---
 name: catalog-redesign
 since: "1.0.2"
-completedSince: "1.1"
+completedSince: "1.1.0"
 ---
+
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Redesigned `terragrunt catalog` TUI with whole-repository discovery, tabbed browsing, and an interactive scaffolding form.
 
 ### `catalog-redesign` - What it does
 
 Replaces the existing `terragrunt catalog` experience with a redesigned TUI that removes the need for manual configuration. The new catalog discovers modules and templates across the whole repository, lets you browse them in tabbed views, and scaffolds a selected component through an interactive form.
+
+<Since version="1.1.0">
+This experiment flag is no longer needed, as the redesigned TUI is now the default `terragrunt catalog` experience.
+</Since>
 
 Discovery walks the entire repository instead of only a `modules/` directory, so modules and templates can live anywhere. Boilerplate templates are discovered as a distinct component kind alongside OpenTofu/Terraform modules and labeled as templates in the UI. Catalog authors can commit a `.terragrunt-catalog-ignore` file at the repo root to exclude directories such as `examples/` or `test/` from discovery. See [Excluding paths from discovery](/features/catalog/tui#excluding-paths-from-discovery) for the supported pattern syntax.
 
@@ -20,11 +27,17 @@ Pressing `s` on a selected component opens an in-TUI form that prompts for every
 
 ### `catalog-redesign` - How to provide feedback
 
+<Before version="1.1.0">
 Provide your feedback on the [`catalog-redesign` GitHub Discussion](https://github.com/gruntwork-io/terragrunt/discussions/6223).
+</Before>
+
+<Since version="1.1.0">
+Now that the `catalog-redesign` experiment is complete, please provide feedback in the form of standard [GitHub issues](https://github.com/gruntwork-io/terragrunt/issues).
+</Since>
 
 ### `catalog-redesign` - Criteria for stabilization
 
-To transition the `catalog-redesign` feature to a stable release, the following must be addressed:
+To transition the `catalog-redesign` feature to a stable release, the following were completed:
 
 - [x] Multiple catalog browse views (`All`, `Modules`, `Templates` tabs) are implemented and functional.
 - [x] Catalog launches without requiring manual configuration (no pre-existing `catalog` block needed).
@@ -34,4 +47,4 @@ To transition the `catalog-redesign` feature to a stable release, the following 
 - [x] Component type (module, unit, stack, template) is clearly indicated in the UI.
 - [x] An interactive scaffold form prompts for each variable a component exposes and generates `terragrunt.hcl`/`terragrunt.values.hcl`.
 - [x] Integration tests cover the core catalog workflows.
-- [ ] Positive feedback from users using the redesigned catalog in production environments.
+- [x] Positive feedback from users using the redesigned catalog in production environments.

--- a/docs/src/data/experiments/dag-queue-display.mdx
+++ b/docs/src/data/experiments/dag-queue-display.mdx
@@ -1,22 +1,43 @@
 ---
 name: dag-queue-display
 since: "1.0.1"
-completedSince: "1.1"
+completedSince: "1.1.0"
 ---
+
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Display the run queue as a DAG tree showing dependency hierarchy.
 
 ### `dag-queue-display` - What it does
+<Before version="1.1.0">
 By default, Terragrunt displays the run queue as a flat list of units before execution. When this experiment is enabled, the queue is rendered as a tree that visualizes dependency relationships between units. Independent units appear as siblings at the root, while dependent units are nested under their dependencies.
+</Before>
+
+<Since version="1.1.0">
+The run queue is rendered as a tree that visualizes dependency relationships between units, instead of the flat list Terragrunt displayed previously. Independent units appear as siblings at the root, while dependent units are nested under their dependencies. This experiment flag is no longer needed, as the tree display is now the default.
+</Since>
 
 The tree also changes its header message based on execution direction:
 
 - **Apply/Plan**: "starting with dependencies and then their dependents"
 - **Destroy**: "starting with dependents and then their dependencies"
 
+<Before version="1.1.0">
+
 ```bash
 terragrunt run --all --experiment dag-queue-display -- plan
 ```
+
+</Before>
+
+<Since version="1.1.0">
+
+```bash
+terragrunt run --all -- plan
+```
+
+</Since>
 
 Example output:
 
@@ -31,11 +52,18 @@ The following units will be run, starting with dependencies and then their depen
 ```
 
 ### `dag-queue-display` - How to provide feedback
+
+<Before version="1.1.0">
 Provide your feedback on the [DAG Queue Display](https://github.com/gruntwork-io/terragrunt/discussions/5783) GitHub Discussion.
+</Before>
+
+<Since version="1.1.0">
+Now that the `dag-queue-display` experiment is complete, please provide feedback in the form of standard [GitHub issues](https://github.com/gruntwork-io/terragrunt/issues).
+</Since>
 
 ### `dag-queue-display` - Criteria for stabilization
-To transition the `dag-queue-display` feature to a stable release, the following must be addressed, at a minimum:
+To transition the `dag-queue-display` feature to a stable release, the following were completed:
 
-- [ ] Community feedback on the tree visualization format
-- [ ] Confirm readability with large dependency graphs
+- [x] Community feedback on the tree visualization format
+- [x] Confirm readability with large dependency graphs
 - [x] Confirm compatibility with CI/CD log viewers (color and Unicode handling)

--- a/docs/src/data/experiments/hook-context-env.mdx
+++ b/docs/src/data/experiments/hook-context-env.mdx
@@ -1,6 +1,5 @@
 ---
 name: hook-context-env
-status: active
 since: "1.0.8"
 ---
 

--- a/docs/src/data/experiments/mark-many-as-read.mdx
+++ b/docs/src/data/experiments/mark-many-as-read.mdx
@@ -1,33 +1,52 @@
 ---
 name: mark-many-as-read
 since: "1.0.3"
-completedSince: "1.1"
+completedSince: "1.1.0"
 ---
+
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Mark many files as read in one step, so reading-based filter expressions cascade changes from shared files to the units that consume them.
 
 ### `mark-many-as-read` - What it does
 
+<Before version="1.1.0">
 Enabling the experiment activates two behaviors:
+</Before>
+
+<Since version="1.1.0">
+This experiment flag is no longer needed; the two behaviors it gated are now enabled by default:
+</Since>
 
 1. When a unit's `terraform` block points at a local module source, Terragrunt walks that directory and records every `*.tf`, `*.tf.json`, `*.hcl`, `*.tofu`, and `*.tofu.json` file as read for the unit. Non-source files such as `README.md` are skipped. Remote sources (Git, registry, S3, etc.) are not walked.
-2. The `mark_glob_as_read(pattern)` HCL function becomes available. It expands a glob using [`gobwas/glob`](https://github.com/gobwas/glob) syntax and marks every matching file as read, returning the list of absolute paths that matched. Without the experiment enabled, calling the function returns an error. See the [HCL reference](/reference/hcl/functions/#mark_glob_as_read) for pattern syntax and examples.
+2. The `mark_glob_as_read(pattern)` HCL function. It expands a glob using [`gobwas/glob`](https://github.com/gobwas/glob) syntax and marks every matching file as read, returning the list of absolute paths that matched. <Before version="1.1.0">Without the experiment enabled, calling the function returns an error. </Before>See the [HCL reference](/reference/hcl/functions/#mark_glob_as_read) for pattern syntax and examples.
 
 Both behaviors feed the same reading tracker that powers the [`reading=` filter attribute](/features/filter/attributes#reading-based-expressions), so a change to a local module file or a globbed configuration file is picked up by `--filter 'reading=<path>'` and matches every unit that reads it.
+
+<Before version="1.1.0">
 
 ```bash
 terragrunt run --all --experiment mark-many-as-read -- plan
 ```
 
+</Before>
+
 ### `mark-many-as-read` - How to provide feedback
 
+<Before version="1.1.0">
 Provide your feedback on the [`mark-many-as-read` GitHub Discussion](https://github.com/gruntwork-io/terragrunt/discussions/6225).
+</Before>
+
+<Since version="1.1.0">
+Now that the `mark-many-as-read` experiment is complete, please provide feedback in the form of standard [GitHub issues](https://github.com/gruntwork-io/terragrunt/issues).
+</Since>
 
 ### `mark-many-as-read` - Criteria for stabilization
 
-To transition the `mark-many-as-read` feature to a stable release, the following must be addressed:
+To transition the `mark-many-as-read` feature to a stable release, the following were completed:
 
 - [x] Confirm local module walking handles nested modules sensibly across macOS, Linux, and Windows.
 - [x] Confirm glob semantics match user expectations for common patterns, especially `**` with a wildcard trailing segment.
-- [ ] Positive feedback from users relying on reading-based filters in production pipelines.
+- [x] Positive feedback from users relying on reading-based filters in production pipelines.
 - [x] Integration tests covering the interaction between module walking, `mark_glob_as_read`, and `--filter 'reading=...'`.

--- a/docs/src/data/experiments/opt-out-auth.mdx
+++ b/docs/src/data/experiments/opt-out-auth.mdx
@@ -1,17 +1,28 @@
 ---
 name: opt-out-auth
 since: "1.0.6"
-completedSince: "1.1"
+completedSince: "1.1.0"
 ---
+
+import Since from '@components/Since.astro';
+import Before from '@components/Before.astro';
 
 Opt out of running `--auth-provider-cmd` during the discovery phase.
 
 ### `opt-out-auth` - What it does
 By default, Terragrunt runs `--auth-provider-cmd` once per parsed component during the discovery phase, so configuration parsing can reliably resolve HCL functions such as `get_aws_account_id` and `run_cmd`. On large repositories, this dominates wall-clock time because the auth command runs for every discovered unit rather than only the subset that will actually run.
 
+<Before version="1.1.0">
 Enabling this experiment unlocks the `--no-discovery-auth-provider-cmd` flag (env: `TG_NO_DISCOVERY_AUTH_PROVIDER_CMD`), which skips those discovery-time auth invocations. The auth provider command still runs normally for the units that actually execute.
+</Before>
+
+<Since version="1.1.0">
+The `--no-discovery-auth-provider-cmd` flag (env: `TG_NO_DISCOVERY_AUTH_PROVIDER_CMD`) skips those discovery-time auth invocations. The auth provider command still runs normally for the units that actually execute. This experiment flag is no longer needed, as `--no-discovery-auth-provider-cmd` is now available by default.
+</Since>
 
 Units whose discovery-relevant blocks depend on credentials produced by `--auth-provider-cmd` will fail to parse with the flag set. Use it when you know parsing will resolve successfully without any prior authentication.
+
+<Before version="1.1.0">
 
 ```bash
 terragrunt run --all \
@@ -21,13 +32,33 @@ terragrunt run --all \
   plan
 ```
 
+</Before>
+
+<Since version="1.1.0">
+
+```bash
+terragrunt run --all \
+  --no-discovery-auth-provider-cmd \
+  --queue-include-units-reading=./changed-file.txt \
+  plan
+```
+
+</Since>
+
 ### `opt-out-auth` - How to provide feedback
+
+<Before version="1.1.0">
 Provide your feedback on the [`opt-out-auth` GitHub Discussion](https://github.com/gruntwork-io/terragrunt/discussions/6224).
+</Before>
+
+<Since version="1.1.0">
+Now that the `opt-out-auth` experiment is complete, please provide feedback in the form of standard [GitHub issues](https://github.com/gruntwork-io/terragrunt/issues).
+</Since>
 
 ### `opt-out-auth` - Criteria for stabilization
-To transition the `opt-out-auth` feature to a stable release, the following must be addressed, at a minimum:
+To transition the `opt-out-auth` feature to a stable release, the following were completed:
 
-- [ ] Confirm the discovery-phase opt-out covers the auth scenarios users rely on without surprising parse failures.
-- [ ] Measure the wall-clock improvement on large `run --all` invocations with reading-based filters.
-- [ ] Decide whether additional phases warrant their own opt-out flags.
-- [ ] Community feedback on real-world usage.
+- [x] Confirm the discovery-phase opt-out covers the auth scenarios users rely on without surprising parse failures.
+- [x] Measure the wall-clock improvement on large `run --all` invocations with reading-based filters.
+- [x] Decide whether additional phases warrant their own opt-out flags.
+- [x] Community feedback on real-world usage.

--- a/docs/src/data/experiments/optional-hooks.mdx
+++ b/docs/src/data/experiments/optional-hooks.mdx
@@ -1,6 +1,5 @@
 ---
 name: optional-hooks
-status: active
 ---
 
 Support for disabling Terragrunt hooks during `run`.

--- a/docs/src/data/experiments/stack-dependencies.mdx
+++ b/docs/src/data/experiments/stack-dependencies.mdx
@@ -1,7 +1,7 @@
 ---
 name: stack-dependencies
 since: "1.0.1"
-completedSince: "1.1"
+completedSince: "1.1.0"
 ---
 
 import Since from '@components/Since.astro';
@@ -11,14 +11,23 @@ import { Aside } from '@astrojs/starlight/components';
 Support for the `autoinclude` block in `terragrunt.stack.hcl` files, enabling dependency relationships and configuration overrides during stack generation.
 
 ### `stack-dependencies` - What it does
-When enabled, this experiment adds support for the `autoinclude` block nested inside `unit` and `stack` blocks in `terragrunt.stack.hcl` files. The `autoinclude` block allows users to define `dependency` blocks and arbitrary configuration that gets generated into an autoinclude file during stack generation. This file is automatically merged into the unit/stack configuration when parsed.
+
+<Before version="1.1.0">
+When enabled, this experiment adds support for the `autoinclude` block nested inside `unit` and `stack` blocks in `terragrunt.stack.hcl` files.
+</Before>
+
+<Since version="1.1.0">
+This experiment flag is no longer needed, as the `autoinclude` block is now available by default. The block nests inside `unit` and `stack` blocks in `terragrunt.stack.hcl` files.
+</Since>
+
+The `autoinclude` block allows users to define `dependency` blocks and arbitrary configuration that gets generated into an autoinclude file during stack generation. This file is automatically merged into the unit/stack configuration when parsed.
 
 The generated filename depends on the component kind:
 
 - **Unit autoincludes** are written as `terragrunt.autoinclude.hcl` next to the unit's `terragrunt.hcl`.
 - **Stack autoincludes** are written as `terragrunt.autoinclude.stack.hcl` next to the nested stack's `terragrunt.stack.hcl`. The `.stack.hcl` suffix mirrors `terragrunt.stack.hcl` so tooling (LSP, `read_terragrunt_config()`, indexers) can identify the file's purpose from its name alone.
 
-This experiment enables:
+The feature also includes:
 
 - **`unit.<name>.path`** and **`stack.<name>.path`** variables for referencing sibling component paths, both inside `autoinclude` blocks and in a unit or stack block's `values` (so a parent stack can pass a component path down to a child stack)
 - **`dependency` blocks targeting stack directories**: aggregated outputs from all units in the stack (`dependency.stack_name.outputs.unit_name.output_key`)
@@ -75,12 +84,23 @@ unit "app" {
 }
 ```
 
+<Before version="1.1.0">
+
 ```bash
 terragrunt run --all --experiment stack-dependencies -- plan
 ```
 
+</Before>
+
 ### `stack-dependencies` - How to provide feedback
+
+<Before version="1.1.0">
 Provide your feedback on the [Stack Dependencies RFC](https://github.com/gruntwork-io/terragrunt/issues/5663) GitHub Issue.
+</Before>
+
+<Since version="1.1.0">
+Now that the `stack-dependencies` experiment is complete, please provide feedback in the form of standard [GitHub issues](https://github.com/gruntwork-io/terragrunt/issues).
+</Since>
 
 ### `stack-dependencies` - Implementation roadmap
 
@@ -108,7 +128,7 @@ Provide your feedback on the [Stack Dependencies RFC](https://github.com/gruntwo
 <Since version="1.0.7">
 
 - [x] The `.terragrunt-stack-origin` marker file is no longer written when nested stack files are copied into `.terragrunt-stack/<name>/`. Use `update_source_with_cas = true` <Before version="1.1.0">(with the `cas` experiment enabled) </Before>on `unit` and `stack` blocks to keep relative `source` paths working in catalog stack files; relative attributes are rewritten to `cas::` references at generation time so the generated tree is self-contained.
-- [ ] Community feedback on `autoinclude` syntax and merge behavior
-- [ ] Validate performance at scale
+- [x] Community feedback on `autoinclude` syntax and merge behavior
+- [x] Validate performance at scale
 
 </Since>

--- a/docs/src/data/flags/cas-clone-depth.mdx
+++ b/docs/src/data/flags/cas-clone-depth.mdx
@@ -8,10 +8,18 @@ env:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
+import Since from '@components/Since.astro';
 
+<Before version="1.1.0">
 <Aside type="tip" title="Experimental">
 This flag only has an effect when the [`cas`](/reference/experiments/active#cas) experiment is enabled. Enable it with `--experiment=cas` or `TG_EXPERIMENT=cas`.
 </Aside>
+</Before>
+
+<Since version="1.1.0">
+This flag has no effect when the CAS is disabled with `--no-cas`.
+</Since>
 
 Controls the `--depth` value the CAS (Content Addressable Storage) uses when cloning a Git source. The default of `1` performs a shallow clone of the latest commit. Negative values clone the full history by omitting `--depth` entirely; zero is rejected because Git requires a positive depth.
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Sets up the experiment docs for 1.1.0.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated documentation to clarify which features are now available by default in version 1.1.0
* Refreshed command examples and usage guidance, removing references to deprecated experimental flags
* Revised feedback and support channels across feature documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->